### PR TITLE
Remove unneeded sources

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -22,8 +22,6 @@
     <RestoreSources>
       $(RestoreSources);
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
-      https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json;
-      https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
     </RestoreSources>
   </PropertyGroup>  
 </Project>


### PR DESCRIPTION
I've added the missing packages to dotnetfeed

https://github.com/dotnet/arcade/issues/10

We can still looking at consuming a newer version of Microsoft.Build.Framework, and Microsoft.Build.Utilities.Core, but we no longer need these extra sources.