### PR TITLE
Enable signing

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -20,7 +20,6 @@ phases:
   - checkout: self
     clean: true
     fetchDepth: 1
-    # Install Microbuild signing plugin
   - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
     displayName: Install MicroBuild plugin
     inputs:


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/51

Enables signing (ESRP) in VSTS.

Only test signs for Debug.  Real signing on Debug was tripling build time and we don't publish Debug bits.

Uses Hosted Linux pool because Linux builds are docker based.

This change also gathers logs which get published to VSTS.  It's kind of ugly adding the logic into this YAML file, but I think that once templating is enabled we can separate that bit out into a shared library which will make the config file cleaner and archiving build logs more consistent (across repos).

FYI, @markwilkie @jaredpar 