### PR TITLE
Define feed package to version 2.2.0-prerelease

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- This repo version -->
     <VersionBase>1.0.0</VersionBase>
-    <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>prerelease</PreReleaseVersionLabel>
 
     <!-- Opt-out repo features -->
     <UsingToolXliff>false</UsingToolXliff>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -4,6 +4,10 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.5;$(NetFxTfm)</TargetFrameworks>
 
+    <!-- Workaround for repotoolset applying uniform versioning to the entire repo https://github.com/dotnet/roslyn-tools/issues/189 -->
+    <VersionSubstring>$([System.Text.RegularExpressions.Regex]::Replace($(Version), $(VersionBase), ""))</VersionSubstring>
+    <VersionBase>2.2.0</VersionBase>
+    <Version>$(VersionBase)$(VersionSubstring)</Version>
     <IsPackable>true</IsPackable>
     <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
     <NuspecBasePath>$(MSBuildProjectDirectory)</NuspecBasePath>


### PR DESCRIPTION
This is kind of an ugly workaround to version the feed package as discussed in https://github.com/dotnet/arcade/issues/48#issuecomment-371594831.

@tmat, if there's a better way to do this at the moment, I'm happy to go with a supported method.