### PR TITLE
Add retries to test cleanup

### DIFF
--- a/test/Microsoft.DotNet.Build.Tasks.IO.Tests/TestHelpers.cs
+++ b/test/Microsoft.DotNet.Build.Tasks.IO.Tests/TestHelpers.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+
+namespace Microsoft.DotNet.Build.Tasks.IO.Tests
+{
+    public class TestHelpers
+    {
+        public static void DeleteDirectory(string path)
+        {
+            var retries = 10;
+            while (retries > 0)
+            {
+                retries--;
+                try
+                {
+                    Directory.Delete(path, recursive: true);
+                    return;
+                }
+                catch (IOException ex)
+                {
+                    if (retries > 0)
+                    {
+                        Thread.Sleep(TimeSpan.FromMilliseconds(100));
+                    }
+                    else
+                    {
+                        IList<string> lockedFiles;
+                        try
+                        {
+                            lockedFiles = Directory.EnumerateFileSystemEntries(path, "*", SearchOption.AllDirectories).ToList();
+                        }
+                        catch
+                        {
+                            // throw original exception if we can't figure out which files still exist
+                            throw ex;
+                        }
+
+                        var sb = new StringBuilder("Failed to cleanup files:");
+                        foreach (var file in lockedFiles)
+                        {
+                            sb.AppendLine(file);
+                        }
+                        throw new IOException(sb.ToString(), ex);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.DotNet.Build.Tasks.IO.Tests/UnzipArchiveTest.cs
+++ b/test/Microsoft.DotNet.Build.Tasks.IO.Tests/UnzipArchiveTest.cs
@@ -191,7 +191,7 @@ namespace Microsoft.DotNet.Build.Tasks.IO.Tests
 
         public void Dispose()
         {
-            Directory.Delete(_tempDir, recursive: true);
+            TestHelpers.DeleteDirectory(_tempDir);
         }
     }
 }

--- a/test/Microsoft.DotNet.Build.Tasks.IO.Tests/ZipArchiveTest.cs
+++ b/test/Microsoft.DotNet.Build.Tasks.IO.Tests/ZipArchiveTest.cs
@@ -274,7 +274,7 @@ namespace Microsoft.DotNet.Build.Tasks.IO.Tests
 
         public void Dispose()
         {
-            Directory.Delete(_tempDir, recursive: true);
+            TestHelpers.DeleteDirectory(_tempDir);
         }
     }
 }


### PR DESCRIPTION
Resolves #76 

As far as I can tell, the intermittent failures are due to Windows Defender briefly locking the files creating during tests. This adds some retries and a slight delay during test cleanup to allow the OS to free handles on files.