### PR TITLE
Added support for rebase and merge and merge commit

### DIFF
--- a/src/Microsoft.DotNet.GitSync.CommitManager/CommandLineOptions.cs
+++ b/src/Microsoft.DotNet.GitSync.CommitManager/CommandLineOptions.cs
@@ -22,11 +22,5 @@ namespace Microsoft.DotNet.GitSync.CommitManager
 
         [Option('c', "commit", Required = true, HelpText = "Sha of the Commit")]
         public string Commit { get; set; }
-
-        [Option('m', "message", Required = true, HelpText = "Commit Message")]
-        public string Message { get; set; }
-
-        [Option('a', "author", Default = "dotnet-bot", HelpText = "Author")]
-        public string Author { get; set; }
     }
 }


### PR DESCRIPTION
Rebase and merge commit push events contains multiple commits which will need to be mirrored to the other repo. So we are concatenating all the commits in a list in maestro and sending to this app.


Tested it on vsts with maestro.