### PR TITLE
Add string.Empty as default value for PR column

### DIFF
--- a/src/Microsoft.DotNet.GitSync.CommitManager/CommitEntity.cs
+++ b/src/Microsoft.DotNet.GitSync.CommitManager/CommitEntity.cs
@@ -14,6 +14,7 @@ namespace Microsoft.DotNet.GitSync.CommitManager
             this.PartitionKey = targetRepo;
             this.RowKey = commitId;
             this.Branch = branch;
+            this.PR = string.Empty;
         }
 
         public CommitEntity() { }


### PR DESCRIPTION
Setting the default value for ```PR``` as ```null``` was leading to the entities not having ```PR``` column.
So changing the default value to ```string.Empty``` rather than adding a new column later in the mirroing tool.