### PR TITLE
Not throwing if a Mirror commit is already present in the table

### DIFF
--- a/src/Microsoft.DotNet.GitSync.CommitManager/Microsoft.DotNet.GitSync.CommitManager.csproj
+++ b/src/Microsoft.DotNet.GitSync.CommitManager/Microsoft.DotNet.GitSync.CommitManager.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
+    <PackageReference Include="NLog" Version="4.5.6" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.5.0" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.GitSync.CommitManager/Program.cs
+++ b/src/Microsoft.DotNet.GitSync.CommitManager/Program.cs
@@ -45,10 +45,20 @@ namespace Microsoft.DotNet.GitSync.CommitManager
             {
                 foreach (var commitId in commitList.Split(";"))
                 {
-                    CommitEntity entry = new CommitEntity(sourceRepo, repo, commitId, branch);
-                    TableOperation insertOperation = TableOperation.Insert(entry);
-                    await s_table.CommitTable.ExecuteAsync(insertOperation);
-                    Console.WriteLine($"Commit {commitId} added to table to get mirrored from {sourceRepo} to {repo}");
+                    TableOperation checkEntity = TableOperation.Retrieve(repo, commitId);
+                    TableResult commits = await s_table.CommitTable.ExecuteAsync(checkEntity);
+
+                    if (commits.Result == null)
+                    {
+                        CommitEntity entry = new CommitEntity(sourceRepo, repo, commitId, branch);
+                        TableOperation insertOperation = TableOperation.Insert(entry);
+                        await s_table.CommitTable.ExecuteAsync(insertOperation);
+                        Console.WriteLine($"Commit {commitId} added to table to get mirrored from {sourceRepo} to {repo}");
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Commit {commitId} already exists in the table for {repo}");
+                    }
                 }
             }
         }


### PR DESCRIPTION
This change is to make sure we go through all the commits in the input, rather than throwing if we find some commit is already present in the azure table.

Will reduce the chance of failure in the build defination

Update 
```
18:26:47  WARN  The commit eb6210c060afa3bc7defd5ad1facd8a94f7ec82063 already exists in coreclr
18:26:48  WARN  The commit eb6210c060afa3bc7defd5ad1facd8a94f7ec82063 already exists in corert
```