### PR TITLE
Add spec for the 'Build Asset Registry'

### DIFF
--- a/Documentation/Maestro/BuildAssetRegistry.md
+++ b/Documentation/Maestro/BuildAssetRegistry.md
@@ -23,8 +23,11 @@ The database containing build asset version information, channels, and subscript
 1. Get repositories that subscribe to updates from a [Repository] intended for a [Channel]
     * Used by [Darc] to flow dependencies when a [Build] is assigned to a [Channel]
 
-1. Get dependencies of a build
-    * Used by [MC] to show dependency tree for a build
+1. Get a Specific [Build]
+    * Used by [MC]
+
+1. Get dependencies of a [Build]
+    * Used by [MC] to show dependency tree for a [Build]
 
 ### Add
 
@@ -71,6 +74,7 @@ A Channel contains a set of builds
 ```csharp
 class Channel {
     string Name;
+    string Classification; // "Official", "DevBuild", "PR Validation", ...
     List<Build> Builds;
 }
 ```
@@ -105,6 +109,7 @@ A feed or other publish mechanism where a specific [Asset] can be found.
 ```csharp
 class AssetLocation {
     string Location;
+    LocationType Type; // "NuGet Feed", "Blob Container", ...
 }
 ```
 

--- a/Documentation/Maestro/BuildAssetRegistry.md
+++ b/Documentation/Maestro/BuildAssetRegistry.md
@@ -6,6 +6,7 @@ The database containing build asset version information, channels, and subscript
 * [Build]s can be assigned to one or more [Channel]\(s)
 * [Channel]s and [Build]s can be either private or public
 * Public Repositories cannot subscribe to private [Channel]s
+* Private [Build]s cannot be assigned to a Public [Channel]
 * [MC] can get full dependency graph of a [Build]
 
 ## Scenarios
@@ -19,8 +20,8 @@ The database containing build asset version information, channels, and subscript
 1. Get latest [Build] of a repository for a channel
     * Used by [Darc] to determine if a dependency needs to be updated
 
-1. Get repositories that subscribe to a Repository/Channel
-    * Used by [Darc] for push trigger dependency flow
+1. Get repositories that subscribe to updates from a [Repository] intended for a [Channel]
+    * Used by [Darc] to flow dependencies when a [Build] is assigned to a [Channel]
 
 1. Get dependencies of a build
     * Used by [MC] to show dependency tree for a build
@@ -39,7 +40,7 @@ The database containing build asset version information, channels, and subscript
     * Used by [Maestro] based on repo policy
     * Used by [Darc] when asked by devs
 
-1. Create/Edit/Delete existing [Subscription]\(s) and/or [Channel]\(s)
+1. Create/Edit/Delete existing [Subscription]\(s), [Channel]\(s) and [Build]\(s)
     * Used by users
 
 ## Definitions
@@ -60,7 +61,7 @@ class Subscription {
 Represents the policies that are applied to a [Subscription].
 ```csharp
 class SubscriptionPolicy {
-    UpdatePolicy UpdatePolicy; // "every day", "every build", ...
+    UpdateFrequency UpdateFrequency; // "every day", "every build", ...
     MergePolicy MergePolicy; // "when green", "unit tests passed", "never", ...
 }
 ```
@@ -79,7 +80,7 @@ Identifies a specific build of a repository.
 ```csharp
 class Build {
     string Repository;
-    string RefSpec;
+    string Committish;
     string BuildNumber;
     DateTimeOffset DateProduced;
     List<Channel> Channels;
@@ -94,11 +95,16 @@ A specific Asset including when it was produced and where it can be found.
 class Asset {
   string Name;
   string Version;
-  string Repository;
-  string RefSpec;
   Build ProducedBy;
-  string DateProduced;
-  string Location;
+  List<AssetLocation> Locations;
+}
+```
+
+### Asset Location
+A feed or other publish mechanism where a specific [Asset] can be found.
+```csharp
+class AssetLocation {
+    string Location;
 }
 ```
 
@@ -107,6 +113,6 @@ class Asset {
 [Build]: #build
 [Asset]: #asset
 [Dependency]: #dependency
-[Maestro]: Maestro.md
-[DARC]: Darc.md
+[Maestro]: ../Maestro.md
+[DARC]: ../Darc.md
 [MC]: https://mc.dot.net/

--- a/Documentation/Maestro/BuildAssetRegistry.md
+++ b/Documentation/Maestro/BuildAssetRegistry.md
@@ -84,7 +84,7 @@ class Build {
     string BuildNumber;
     DateTimeOffset DateProduced;
     List<Channel> Channels;
-    List<AssetIdentifier> Assets;
+    List<Asset> Assets;
     List<Build> Dependencies;
 }
 ```

--- a/Documentation/Maestro/BuildAssetRegistry.md
+++ b/Documentation/Maestro/BuildAssetRegistry.md
@@ -83,7 +83,7 @@ Identifies a specific build of a repository.
 ```csharp
 class Build {
     string Repository;
-    string Committish;
+    string Commit;
     string BuildNumber;
     DateTimeOffset DateProduced;
     List<Channel> Channels;

--- a/Documentation/Maestro/BuildAssetRegistry.md
+++ b/Documentation/Maestro/BuildAssetRegistry.md
@@ -1,0 +1,112 @@
+# Build Asset Registry
+
+The database containing build asset version information, channels, and subscriptions used by [DARC], [Maestro], and [MC]
+
+## Requirements
+* [Build]s can be assigned to one or more [Channel]\(s)
+* [Channel]s and [Build]s can be either private or public
+* Public Repositories cannot subscribe to private [Channel]s
+* [MC] can get full dependency graph of a [Build]
+
+## Scenarios
+
+1. [Query](#query)
+1. [Add](#add)
+1. [Update](#update)
+
+### Query
+
+1. Get latest [Build] of a repository for a channel
+    * Used by [Darc] to determine if a dependency needs to be updated
+
+1. Get repositories that subscribe to a Repository/Channel
+    * Used by [Darc] for push trigger dependency flow
+
+1. Get dependencies of a build
+    * Used by [MC] to show dependency tree for a build
+
+### Add
+
+1. Push new [Asset] and [Build] information
+    * Used by repository build once new assets are ready for consumption
+
+1. Create new [Channel]\(s) and [Subscription]\(s)
+    * Used by [Maestro] and [Darc] for product release, feature branch creation, and dev PR scenarios
+
+### Update
+
+1. Assign existing [Build] to a [Channel]
+    * Used by [Maestro] based on repo policy
+    * Used by [Darc] when asked by devs
+
+1. Create/Edit/Delete existing [Subscription]\(s) and/or [Channel]\(s)
+    * Used by users
+
+## Definitions
+
+### Subscription
+Represents a specific repository branch's desire to receive updates from another repository on a specific [Channel].
+```csharp
+class Subscription {
+    string ChannelName;
+    string SourceRepository;
+    string TargetRepository;
+    string TargetBranch;
+    SubscriptionPolicy Policy;
+}
+```
+
+### Subscription Policy
+Represents the policies that are applied to a [Subscription].
+```csharp
+class SubscriptionPolicy {
+    UpdatePolicy UpdatePolicy; // "every day", "every build", ...
+    MergePolicy MergePolicy; // "when green", "unit tests passed", "never", ...
+}
+```
+
+### Channel
+A Channel contains a set of builds
+```csharp
+class Channel {
+    string Name;
+    List<Build> Builds;
+}
+```
+
+### Build
+Identifies a specific build of a repository.
+```csharp
+class Build {
+    string Repository;
+    string RefSpec;
+    string BuildNumber;
+    DateTimeOffset DateProduced;
+    List<Channel> Channels;
+    List<AssetIdentifier> Assets;
+    List<Build> Dependencies;
+}
+```
+
+### Asset
+A specific Asset including when it was produced and where it can be found.
+```csharp
+class Asset {
+  string Name;
+  string Version;
+  string Repository;
+  string RefSpec;
+  Build ProducedBy;
+  string DateProduced;
+  string Location;
+}
+```
+
+[Subscription]: #subscription
+[Channel]: #channel
+[Build]: #build
+[Asset]: #asset
+[Dependency]: #dependency
+[Maestro]: Maestro.md
+[DARC]: Darc.md
+[MC]: https://mc.dot.net/

--- a/Documentation/Maestro/BuildAssetRegistry.md
+++ b/Documentation/Maestro/BuildAssetRegistry.md
@@ -75,7 +75,6 @@ A Channel contains a set of builds
 class Channel {
     string Name;
     string Classification; // "Official", "DevBuild", "PR Validation", ...
-    List<Build> Builds;
 }
 ```
 


### PR DESCRIPTION
This is the spec for the data store that Maestro, Darc, and MC will use for storing build asset and subscription information.