### PR TITLE
Add Arcade.Sdk packages

### DIFF
--- a/Build.cmd
+++ b/Build.cmd
@@ -1,3 +1,3 @@
 @echo off
-powershell -ExecutionPolicy ByPass %~dp0eng\common\Build.ps1 -restore -build %*
+powershell -ExecutionPolicy ByPass -NoProfile %~dp0eng\common\Build.ps1 -restore -build %*
 exit /b %ErrorLevel%

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
+    <RepositoryRoot>$(MSBuildThisFileDirectory)</RepositoryRoot>
+  </PropertyGroup>
+  <Import Project="$(MSBuildThisFileDirectory)\src\Microsoft.DotNet.Arcade.Sdk\Package.props"/>
+
+  <Import Project="$(MSBuildThisFileDirectory)\eng\Versions.props" />
+
+  <PropertyGroup>
     <RepositoryUrl>https://github.com/dotnet/arcade</RepositoryUrl>
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
-    <PackageLicenseUrl>$(RepositoryUrl)/LICENSE.txt</PackageLicenseUrl>
+    <PackageLicenseUrl>$(RepositoryUrl)/tree/master/LICENSE.txt</PackageLicenseUrl>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,7 +4,15 @@
           BeforeTargets="GenerateNuSpec"
           Condition="'$(NuspecFile)' != ''">
     <PropertyGroup>
-      <NuspecProperties>$(NuspecProperties);version=$(Version);licenseUrl=$(PackageLicenseUrl);repoUrl=$(RepositoryUrl);copyright=$(Copyright);ArtifactsBinDir=$(ArtifactsBinDir)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);version=$(Version);licenseUrl=$(PackageLicenseUrl);repoUrl=$(RepositoryUrl);copyright=$(Copyright);ArtifactsBinDir=$(OutputPath)</NuspecProperties>
     </PropertyGroup>
   </Target>
+
+  <ItemGroup>
+    <None Include="$(RepositoryRoot)LICENSE.TXT;$(RepositoryRoot)THIRD-PARTY-NOTICES.TXT" Pack="true" PackagePath="%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)eng\sdk-tools\Sdk.targets" Condition="'$(IsSdk)' == 'true'"/>
+
+  <Import Project="$(MSBuildThisFileDirectory)\src\Microsoft.DotNet.Arcade.Sdk\Package.targets"/>
 </Project>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -4,11 +4,13 @@
     <add key="disableSourceControlIntegration" value="true" />
   </solution>
   <config>
+    <add key="globalPackagesFolder" value="packages" />
     <add key="repositoryPath" value="packages" />
   </config>
   <packageSources>
     <clear />
     <add key="myget.org roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
   </packageSources>
 </configuration>

--- a/build.proj
+++ b/build.proj
@@ -1,0 +1,4 @@
+<Project>
+  <Import Project="src\Microsoft.DotNet.Arcade.Traversal\Package.props"/>
+  <Import Project="src\Microsoft.DotNet.Arcade.Traversal\Package.targets"/>
+</Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,11 +21,4 @@
     <MicrosoftBuildFrameworkVersion>15.1.548</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildUtilitiesCoreVersion>15.1.548</MicrosoftBuildUtilitiesCoreVersion>
   </PropertyGroup>
-
-  <PropertyGroup>
-    <RestoreSources>
-      $(RestoreSources);
-      https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
-    </RestoreSources>
-  </PropertyGroup>
 </Project>

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -37,9 +37,8 @@ phases:
           _TeamName: DotNetCore
           _UseEsrpSigning: ${{ parameters.useEsrpSigning }}
         ${{ if notIn(parameters.buildReason, 'IndividualCI', 'BatchedCI', 'PullRequest') }}:
-          _PublishArgs: /p:PB_PublishBlobFeedKey=$(dotnetfeed-storage-access-key-1) 
-            /p:PB_PublishBlobFeedUrl=$(_PublishBlobFeedUrl) 
-            /p:PB_PublishType=$(_PublishType) 
+          _PublishArgs: /p:BlobFeedKey=$(dotnetfeed-storage-access-key-1) 
+            /p:BlobFeedUrl=$(_PublishBlobFeedUrl) 
         ${{ if in(parameters.buildReason, 'IndividualCI', 'BatchedCI', 'PullRequest') }}:
           _PublishArgs: ''
 

--- a/eng/common/CIBuild.cmd
+++ b/eng/common/CIBuild.cmd
@@ -1,3 +1,3 @@
 @echo off
-powershell -ExecutionPolicy ByPass %~dp0Build.ps1 -restore -build -test -sign -pack -ci %*
+powershell -ExecutionPolicy ByPass -NoProfile %~dp0Build.ps1 -restore -build -test -sign -pack -ci %*
 exit /b %ErrorLevel%

--- a/eng/sdk-tools/Sdk.targets
+++ b/eng/sdk-tools/Sdk.targets
@@ -1,0 +1,114 @@
+<Project>
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageType>MSBuildSdk</PackageType>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Framework" Version="14.3.0" Publish="false" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="14.3.0" Publish="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="**/*.props;**/*.targets" Pack="true">
+      <PackagePath>tools/%(RecursiveDir)%(Filename)%(Extension)</PackagePath>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="@(PackageReference)">
+      <PrivateAssets>All</PrivateAssets>
+      <Publish Condition=" '%(PackageReference.Publish)' != 'false' ">true</Publish>
+    </PackageReference>
+    <ProjectReference Update="@(ProjectReference)">
+      <PrivateAssets>All</PrivateAssets>
+      <Publish Condition=" '%(ProjectReference.Publish)' != 'false' ">true</Publish>
+    </ProjectReference>
+    <Reference Update="@(Reference)">
+      <Pack>false</Pack>
+    </Reference>
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(IncludePublishOutput)' != 'false'">
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);CollectAssets</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+  <Target Name="CollectAssets" DependsOnTargets="Publish">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="@(ResolvedFileToPublish->'$([MSBuild]::NormalizeDirectory($(PublishDir)))%(RelativePath)')">
+        <PackagePath>tools/$(TargetFramework)/any/%(ResolvedFileToPublish.RelativePath)</PackagePath>
+      </TfmSpecificPackageFile>
+    </ItemGroup>
+  </Target>
+
+  <ItemGroup>
+    <GeneratedPackageContent Include="$(IntermediateOutputPath)Sdk.props">
+      <PackagePath>sdk/Sdk.props</PackagePath>
+      <Content>
+<![CDATA[<Project>
+  <PropertyGroup>
+    <MSBuildAllProjects>%24(MSBuildAllProjects)%3B%24(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+  <Import Project="%24(MSBuildThisFileDirectory)..\tools\Package.props" />
+</Project>]]>
+      </Content>
+    </GeneratedPackageContent>
+    <GeneratedPackageContent Include="$(IntermediateOutputPath)Sdk.targets">
+      <PackagePath>sdk/Sdk.targets</PackagePath>
+      <Content>
+<![CDATA[<Project>
+  <PropertyGroup>
+    <MSBuildAllProjects>%24(MSBuildAllProjects)%3B%24(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+  <Import Project="%24(MSBuildThisFileDirectory)..\tools\Package.targets" />
+</Project>]]>
+      </Content>
+    </GeneratedPackageContent>
+    <GeneratedPackageContent Include="$(IntermediateOutputPath)%24(PackageId).props" Pack="true">
+      <PackagePath>build/$(PackageId).props</PackagePath>
+      <Content>
+<![CDATA[<Project>
+  <PropertyGroup>
+    <MSBuildAllProjects>%24(MSBuildAllProjects)%3B%24(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+  <Import Project="%24(MSBuildThisFileDirectory)..\tools\Package.props" />
+</Project>]]>
+      </Content>
+    </GeneratedPackageContent>
+    <GeneratedPackageContent Include="$(IntermediateOutputPath)%24(PackageId).targets" Pack="true">
+      <PackagePath>build/$(PackageId).targets</PackagePath>
+      <Content>
+<![CDATA[<Project>
+  <PropertyGroup>
+    <MSBuildAllProjects>%24(MSBuildAllProjects)%3B%24(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+  <Import Project="%24(MSBuildThisFileDirectory)..\tools\Package.targets" />
+</Project>]]>
+      </Content>
+    </GeneratedPackageContent>
+  </ItemGroup>
+
+  <Target Name="GeneratePackageContent" Inputs="$(MSBuildAllProjects);$(MSBuildProjectFullPath)" Outputs="%(GeneratedPackageContent.Identity)">
+    <WriteLinesToFile
+      File="@(GeneratedPackageContent)"
+      Lines="%(GeneratedPackageContent.Content)"
+      Overwrite="true"
+      Encoding="UTF-8"/>
+  </Target>
+
+  <Target Name="GetPackageContent"
+          DependsOnTargets="GeneratePackageContent"
+          BeforeTargets="_GetPackageFiles">
+    <ItemGroup>
+      <None Include="@(GeneratedPackageContent)" Pack="true"/>
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/global.json
+++ b/global.json
@@ -1,8 +1,8 @@
 {
     "sdk": {
-        "version": "2.1.100-preview-007366"
+        "version": "2.1.300"
     },
     "msbuild-sdks": {
-        "RoslynTools.RepoToolset": "1.0.0-beta2-62719-04"
+        "Microsoft.Build.Traversal": "1.0.34"
     }
 }

--- a/netci.groovy
+++ b/netci.groovy
@@ -54,8 +54,8 @@ static addBuildSteps(def job, def projectName, def os, def configName, def isPR)
       def osBase = os
       def machineAffinity = 'latest-or-auto'
 
-      def filesToArchive = "**/artifacts/${configName}/**"
-      def filesToExclude = "**/artifacts/${configName}/obj/**"
+      def filesToArchive = "**/artifacts/**"
+      def filesToExclude = "**/artifacts/obj/**"
 
       def jobName = getJobName(os, configName)
       def fullJobName = Utilities.getFullJobName(projectName, jobName, isPR)

--- a/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsSdk>true</IsSdk>
+    <IncludePublishOutput>false</IncludePublishOutput>
+    <TargetFrameworks>netstandard2.0;$(NetFxTfm)</TargetFrameworks>
+    <Description>This package is an sdk used for building projects in a repository consuming https://github.com/dotnet/arcade.</Description>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/Package.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/Package.props
@@ -10,6 +10,6 @@
     <NoWarn>NU5105</NoWarn>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildThisFileDirectory)RepoLayout.props" />
-  <Import Project="$(MSBuildThisFileDirectory)ProjectDefaults.props" />
+  <Import Project="RepoLayout.props" />
+  <Import Project="ProjectDefaults.props" />
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/Package.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/Package.props
@@ -1,0 +1,15 @@
+<Project>
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Temporary Versioning until @JohnTortugo finishes the versioning package -->
+    <VersionSuffix>$([System.DateTime]::Now.Ticks)</VersionSuffix>
+    <VersionSuffix>$(VersionSuffix.Substring(0, 10))</VersionSuffix>
+    <NoWarn>NU5105</NoWarn>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)RepoLayout.props" />
+  <Import Project="$(MSBuildThisFileDirectory)ProjectDefaults.props" />
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/Package.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/Package.targets
@@ -1,0 +1,10 @@
+<Project>
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <Target Name="Sign">
+    <!-- TODO: Add signing -->
+    <Message Text="TODO: Add signing" Importance="High" />
+  </Target>
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/ProjectDefaults.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/ProjectDefaults.props
@@ -1,0 +1,42 @@
+<Project>
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <NeutralLanguage>en-US</NeutralLanguage>
+    <Company>Microsoft Corporation</Company>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <Authors>Microsoft</Authors>
+    <Serviceable>true</Serviceable>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+
+    <!-- By default do not build nuget package for a project. Project may override. -->
+    <IsPackable>false</IsPackable>
+
+    <!-- 
+      Official build:
+       - Build standalone Portable PDBs to reduce the size of the binaries.
+       - Convert Portable PDBs to Windows PDBs and publish the converted PDBs to Symbol Store to allow WinDBG, 
+         Watson and other tools to find symbol format they understand.
+        
+      Jenkins build:
+       - Embed PDBs to make it easier to debug Jenkins crash dumps.
+       
+      Developer build:
+       - Embed PDBs to be consistent with Jenkins builds.
+
+      TODO:
+      - Live Unit Testing doesn't support embedded PDBs:
+         https://github.com/dotnet/testimpact/issues/1877      
+    -->
+    <DebugType>portable</DebugType>
+    <DebugType Condition="'$(OfficialBuild)' != 'true' and '$(BuildingForLiveUnitTesting)' != 'true'">embedded</DebugType>
+
+    <EnableSourceLink Condition="'$(CIBuild)' == 'true'">true</EnableSourceLink>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != '' AND $(TargetFramework.StartsWith('net4'))">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-alpha-003" PrivateAssets="All" />
+  </ItemGroup>
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/Readme.md
+++ b/src/Microsoft.DotNet.Arcade.Sdk/Readme.md
@@ -1,0 +1,26 @@
+# Microsoft.DotNet.Arcade.Sdk
+MSBuild Sdk package for use with arcade-consuming projects
+
+## Usage
+Update the following files in your repository
+
+### Directory.Build.props
+```xml
+<Project>
+  <PropertyGroup>
+    <RepositoryRoot>$(MSBuildThisFileDirectory)</RepositoryRoot>
+  </PropertyGroup>
+  <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk"/>
+
+  <!-- ... Other Content ... -->
+</Project>
+```
+
+### Directory.Build.targets
+```xml
+<Project>
+  <!-- ... Other Content ... -->
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk"/>
+</Project>
+```

--- a/src/Microsoft.DotNet.Arcade.Sdk/RepoLayout.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/RepoLayout.props
@@ -1,0 +1,15 @@
+<Project>
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <BuildArtifactDirectory Condition="'$(BuildArtifactDirectory)' == ''">$(RepositoryRoot)artifacts\</BuildArtifactDirectory>
+    <ProjectRelativePath>$([MSBuild]::MakeRelative('$(RepositoryRoot)', '$(MSBuildProjectDirectory)\$(MSBuildProjectName)\'))</ProjectRelativePath>
+
+    <BaseIntermediateOutputPath>$(BuildArtifactDirectory)obj\$(ProjectRelativePath)</BaseIntermediateOutputPath>
+    <BaseOutputPath>$(BuildArtifactDirectory)bin\$(ProjectRelativePath)</BaseOutputPath>
+
+    <PackageOutputPath>$(BuildArtifactDirectory)packages\</PackageOutputPath>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Traversal/Microsoft.DotNet.Arcade.Traversal.csproj
+++ b/src/Microsoft.DotNet.Arcade.Traversal/Microsoft.DotNet.Arcade.Traversal.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsSdk>true</IsSdk>
+    <IncludePublishOutput>false</IncludePublishOutput>
+    <TargetFrameworks>netstandard2.0;$(NetFxTfm)</TargetFrameworks>
+    <Description>This package is an sdk used for traversal projects in a repository consuming https://github.com/dotnet/arcade.</Description>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Traversal/Package.props
+++ b/src/Microsoft.DotNet.Arcade.Traversal/Package.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+
+    <IsTraversal>true</IsTraversal>
+    <SkipNonexistentTargets>true</SkipNonexistentTargets>
+  </PropertyGroup>
+  <Import Project="Sdk.props" Sdk="Microsoft.Build.Traversal" />
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Traversal/Package.targets
+++ b/src/Microsoft.DotNet.Arcade.Traversal/Package.targets
@@ -1,0 +1,66 @@
+<Project>
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="2.2.0-preview1-02719-02" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(EnableDefaultItems)' != 'false'">
+    <ProjectReference Include="**\*.csproj" />
+    <ProjectReference Include="**\*.vbproj" />
+  </ItemGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.Build.Traversal" />
+
+  <PropertyGroup>
+    <PackDependsOn>
+      Build
+    </PackDependsOn>
+  </PropertyGroup>
+
+  <Target Name="Pack"
+          DependsOnTargets="$(PackDependsOn)">
+    <MSBuild Projects="@(PreTraversalProject)"
+             Targets="Pack"
+             Properties="$(PreTraversalGlobalProperties)"
+             Condition=" '@(PreTraversalProject)' != '' "
+             BuildInParallel="$(BuildInParallel)"
+             SkipNonexistentProjects="$(SkipNonexistentProjects)"
+             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
+
+    <MSBuild Projects="@(PreTraversalPackProject)"
+             Targets="Pack"
+             Properties="$(PreTraversalPackGlobalProperties)"
+             Condition=" '@(PreTraversalPackProject)' != '' "
+             BuildInParallel="$(BuildInParallel)"
+             SkipNonexistentProjects="$(SkipNonexistentProjects)"
+             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
+
+    <MSBuild Projects="@(_MSBuildProjectReferenceExistent)"
+             Targets="Pack"
+             Properties="$(TraversalGlobalProperties);$(TraversalPackGlobalProperties)"
+             BuildInParallel="$(BuildInParallel)"
+             SkipNonexistentProjects="$(SkipNonexistentProjects)"
+             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
+
+    <MSBuild Projects="@(PostTraversalPackProject)"
+             Targets="Pack"
+             Properties="$(PostTraversalPackGlobalProperties)"
+             Condition=" '@(PostTraversalPackProject)' != '' "
+             BuildInParallel="$(BuildInParallel)"
+             SkipNonexistentProjects="$(SkipNonexistentProjects)"
+             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
+
+    <MSBuild Projects="@(PostTraversalProject)"
+             Targets="Pack"
+             Properties="$(PostTraversalGlobalProperties)"
+             Condition=" '@(PostTraversalProject)' != '' "
+             BuildInParallel="$(BuildInParallel)"
+             SkipNonexistentProjects="$(SkipNonexistentProjects)"
+             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
+  </Target>
+
+  <Import Project="$(MSBuildThisFileDirectory)Publish.targets" />
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Traversal/Publish.targets
+++ b/src/Microsoft.DotNet.Arcade.Traversal/Publish.targets
@@ -1,0 +1,16 @@
+<Project>
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <Target Name="Publish">
+    <ItemGroup>
+      <PackagesToPublish Include="$(PackageOutputPath)*.nupkg"/>
+    </ItemGroup>
+
+    <PushToBlobFeed
+      ExpectedFeedUrl="$(BlobFeedUrl)"
+      AccountKey="$(BlobFeedKey)"
+      ItemsToPush="@(PackagesToPublish)"/>
+  </Target>
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Traversal/Readme.md
+++ b/src/Microsoft.DotNet.Arcade.Traversal/Readme.md
@@ -1,0 +1,13 @@
+
+# Microsoft.DotNet.Arcade.Traversal.Sdk
+MSBuild Sdk package for use in repository traversal projects
+
+## Usage
+Update the following file in your repository
+
+### build.proj
+```xml
+<Project Sdk="Microsoft.DotNet.Arcade.Traversal.Sdk">
+  <!-- ... Other Content ... -->
+</Project>
+```

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="RoslynTools.RepoToolset">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.5;$(NetFxTfm)</TargetFrameworks>
@@ -36,12 +36,12 @@
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetVersioningVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.4.1" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.4.0-beta-24813-03" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
-    <PackageReference Include="Microsoft.Build.Framework" Version="0.1.0-preview-00022" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="0.1.0-preview-00022" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="14.3.0" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="14.3.0" />
     <PackageReference Include="System.IO.Compression" Version="4.1.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.3.0" />
     <PackageReference Include="System.Xml.XmlDocument" Version="4.0.1" />

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.nuspec
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.nuspec
@@ -24,8 +24,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="$ArtifactsBinDir$Microsoft.DotNet.Build.Tasks.Feed\netstandard1.5\*.dll" target="build\netstandard1.5" />
-    <file src="$ArtifactsBinDir$Microsoft.DotNet.Build.Tasks.Feed\net45\*.dll" target="build\net46" />
+    <file src="$ArtifactsBinDir$netstandard1.5\*.dll" target="build\netstandard1.5" />
+    <file src="$ArtifactsBinDir$net45\*.dll" target="build\net46" />
     <file src="build\**" target="build" />
     <file src="sdk\**" target="sdk" />
     <file src="..\..\LICENSE.TXT" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/Microsoft.DotNet.Build.Tasks.Packaging.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/Microsoft.DotNet.Build.Tasks.Packaging.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="RoslynTools.RepoToolset">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
@@ -132,14 +132,6 @@
     <!-- Package Content -->
     <Content Include="$(MSBuildThisFileDirectory)build\*.targets">
       <PackagePath>build\%(Filename).targets</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\LICENSE.TXT">
-      <PackagePath>LICENSE.TXT</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\THIRD-PARTY-NOTICES.TXT">
-      <PackagePath>THIRD-PARTY-NOTICES.TXT</PackagePath>
       <Pack>true</Pack>
     </Content>
   </ItemGroup>

--- a/src/Microsoft.DotNet.GitSync.CommitManager/Microsoft.DotNet.GitSync.CommitManager.csproj
+++ b/src/Microsoft.DotNet.GitSync.CommitManager/Microsoft.DotNet.GitSync.CommitManager.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="RoslynTools.RepoToolset">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/Microsoft.DotNet.Helix.Client.csproj
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/Microsoft.DotNet.Helix.Client.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="RoslynTools.RepoToolset">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.4;$(NetFxTfm)</TargetFrameworks>
@@ -9,10 +9,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="$(MicrosoftRestClientRuntimeVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="$(RepoRoot)LICENSE.TXT;$(RepoRoot)THIRD-PARTY-NOTICES.TXT" Pack="true" PackagePath="%(Filename)%(Extension)" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Helix/Sdk/Microsoft.DotNet.Helix.Sdk.csproj
+++ b/src/Microsoft.DotNet.Helix/Sdk/Microsoft.DotNet.Helix.Sdk.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="RoslynTools.RepoToolset">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;$(NetFxTfm)</TargetFrameworks>


### PR DESCRIPTION
This change adds project and traversal Sdks as part of the Arcade Sdk
I also updated the repository build files to use the new Sdks

Right now I have referenced the Arcade Sdk targets files directly, once
the shape of the props/targets files has been approved I will publish
bootstrapping versions of the files into the arcade feed and reference
them as packages.