### PR TITLE
Fixing build Failure For Vsts

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
     <PackageReference Include="Microsoft.SourceLink.Vsts.Git" Version="$(MicrosoftSourceLinkVersion)" PrivateAssets="all" />
   </ItemGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,6 +12,10 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.Vsts.Git" Version="$(MicrosoftSourceLinkVersion)" PrivateAssets="all" />
+  </ItemGroup>
+
   <PropertyGroup>
     <!-- 'NetFxTfm' is the standard desktop Target Framework Moniker which this repo's packages are targeting
          ie.  Place 'NetFxTfm' in the 'TargetFramework' property of a csproj like <TargetFrameworks>netcoreapp2.0;$(NetFxTfm)</TargetFrameworks> -->


### PR DESCRIPTION
The GitSyncCommitManager was failing with error that ``` SourceRoot.SourceLinkUrl is empty```