### PR TITLE
Patch Arcade SDK Versioning to follow the new plan

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
@@ -13,6 +13,7 @@
 
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
     <EnableGeneratedPackageContent>false</EnableGeneratedPackageContent>
+    <Version>1.10.1-dev</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
@@ -13,7 +13,6 @@
 
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
     <EnableGeneratedPackageContent>false</EnableGeneratedPackageContent>
-    <Version>1.10.1-dev</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.props
@@ -3,10 +3,13 @@
 <Project>
 
   <!--
-    Note, the plan to implement this was discussed here: https://github.com/dotnet/arcade/pull/108
+    https://github.com/dotnet/arcade/pull/108
     
     Properties:
-      PB_IsStable                 Tells whether this is a stable build or not.
+      PB_IsStable                 If specified then NuGet package version suffixes used by the repo are overridden by the orchestrated build like so:
+                                     if 'true' then version suffixes have format '{base version}.{PB_VersionStamp}', 
+                                     if 'false' then version suffixes have format '{base version}.{PB_VersionStamp}.{build number}'
+                                     For SemanticVersioning 1.0 dots ('.') are replaced by dashes ('-').
       PB_VersionStamp             NuGet package pre-release version label e.g. 'beta', 'preview1', etc. May be empty.
       OfficialBuildId             Contains the build id if this is an official build, otherwise must be empty.
   -->
@@ -14,12 +17,13 @@
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
 
+    <_PreReleaseLabel>$(PreReleaseVersionLabel)</_PreReleaseLabel>
     <_PreReleaseLabel Condition="'$(PB_VersionStamp)' != ''">$(PB_VersionStamp)</_PreReleaseLabel>
     <_PreReleaseLabel Condition="'$(CIBuild)' == 'true'">ci</_PreReleaseLabel>
     <_PreReleaseLabel Condition="'$(_PreReleaseLabel)' == ''">dev</_PreReleaseLabel>
 
-    <_BuildId>$(OfficialBuildId)</_BuildId>
-    <_BuildId Condition="'$(_BuildId)' == ''">$([System.DateTime]::Now.ToString(yyyyMMdd)).1</_BuildId>
+    <_BuildNumber>$(OfficialBuildId)</_BuildNumber>
+    <_BuildNumber Condition="'$(_BuildNumber)' == ''">$([System.DateTime]::Now.ToString(yyyyMMdd)).1</_BuildNumber>
 
     <!--
         Split the build parts out from the BuildNumber which is given to us by MicroBuild in the format of yyyymmdd.nn
@@ -32,23 +36,23 @@
         in the case of 20160615, we will set BuildNumberFiveDigitDateStamp to 60615. Further, if this would result in a number like 71201 or 81201, we
         decrement the year and add 12 to the month to extend the time. 
     -->
-    <_BuildNumberFiveDigitDateStamp>$([MSBuild]::Subtract($(_BuildId.Split($([System.Convert]::ToString(`.`).ToCharArray())).GetValue($([System.Convert]::ToInt32(0)))), 20100000))</_BuildNumberFiveDigitDateStamp>
+    <_BuildNumberFiveDigitDateStamp>$([MSBuild]::Subtract($(_BuildNumber.Split($([System.Convert]::ToString(`.`).ToCharArray())).GetValue($([System.Convert]::ToInt32(0)))), 20100000))</_BuildNumberFiveDigitDateStamp>
     <_BuildNumberFiveDigitDateStampYearsToOffset>$([System.Math]::Max($([System.Convert]::ToInt32($([MSBuild]::Subtract($([MSBuild]::Divide($(_BuildNumberFiveDigitDateStamp), 10000)), 6)))), 0))</_BuildNumberFiveDigitDateStampYearsToOffset>
     <_BuildNumberFiveDigitDateStamp>$([MSBuild]::Subtract($([System.Convert]::ToInt32($(_BuildNumberFiveDigitDateStamp))), $([MSBuild]::Multiply($(_BuildNumberFiveDigitDateStampYearsToOffset), 8800))))</_BuildNumberFiveDigitDateStamp>
-    <_BuildNumberBuildOfTheDayPadded>$(_BuildId.Split($([System.Convert]::ToString(`.`).ToCharArray())).GetValue($([System.Convert]::ToInt32(1))).PadLeft($([System.Convert]::ToInt32(2)), $([System.Convert]::ToChar(`0`))))</_BuildNumberBuildOfTheDayPadded>
+    <_BuildNumberBuildOfTheDayPadded>$(_BuildNumber.Split($([System.Convert]::ToString(`.`).ToCharArray())).GetValue($([System.Convert]::ToInt32(1))).PadLeft($([System.Convert]::ToInt32(2)), $([System.Convert]::ToChar(`0`))))</_BuildNumberBuildOfTheDayPadded>
     
-    <!-- This handles the Dev/Daily case of the versioning plan. -->
+    <!-- This handles the Dev/Daily case of the versioning specification. -->
     <VersionSuffix Condition="'$(PB_IsStable)' != 'true'">$(_PreReleaseLabel).$(_BuildNumberFiveDigitDateStamp).$(_BuildNumberBuildOfTheDayPadded)</VersionSuffix>
 
-    <!-- This handles the 'Final Prerelease' case of the versioning plan. -->
+    <!-- This handles the 'Final Prerelease' case of the versioning specification. -->
     <VersionSuffix Condition="'$(PB_IsStable)' == 'true' and '$(PB_VersionStamp)' != ''">$(PB_VersionStamp).final</VersionSuffix>
 
-    <!-- This handles the 'Stable' case of the versioning plan. -->
+    <!-- This handles the 'Stable' case of the versioning specification. -->
     <!-- For this case the version suffix is empty. -->
     <VersionSuffix Condition="'$(PB_IsStable)' == 'true' and '$(PB_VersionStamp)' == ''"></VersionSuffix>
 
     <!-- We support SemanticVersioning 1.0; For that we need to replace {'.', '+'} by {'-'} -->
-    <VersionSuffix Condition="'$(SemanticVersioningV1)' == 'true'">$(VersionSuffix.Replace('.', '-'))</VersionSuffix>
+    <VersionSuffix Condition="'$(DotNetSemanticVersioningV1)' == 'true'">$(VersionSuffix.Replace('.', '-'))</VersionSuffix>
   </PropertyGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.props
@@ -13,6 +13,7 @@
       PB_VersionStamp             NuGet package pre-release version label e.g. 'beta', 'preview1', etc. May be empty.
       OfficialBuildId             Contains the build id if this is an official build, otherwise must be empty.
       CIBuild                     "true" if this is a CI build.
+      DotNetSemanticVersioningV1  "true" if the Version needs to respect SemVer 1.0. Default is false, which means format following SemVer 2.0.
   -->
     
   <PropertyGroup>
@@ -40,7 +41,10 @@
     <_BuildNumberFiveDigitDateStamp>$([MSBuild]::Subtract($(_BuildNumber.Split($([System.Convert]::ToString(`.`).ToCharArray())).GetValue($([System.Convert]::ToInt32(0)))), 20100000))</_BuildNumberFiveDigitDateStamp>
     <_BuildNumberFiveDigitDateStampYearsToOffset>$([System.Math]::Max($([System.Convert]::ToInt32($([MSBuild]::Subtract($([MSBuild]::Divide($(_BuildNumberFiveDigitDateStamp), 10000)), 6)))), 0))</_BuildNumberFiveDigitDateStampYearsToOffset>
     <_BuildNumberFiveDigitDateStamp>$([MSBuild]::Subtract($([System.Convert]::ToInt32($(_BuildNumberFiveDigitDateStamp))), $([MSBuild]::Multiply($(_BuildNumberFiveDigitDateStampYearsToOffset), 8800))))</_BuildNumberFiveDigitDateStamp>
-    <_BuildNumberBuildOfTheDayPadded>$(_BuildNumber.Split($([System.Convert]::ToString(`.`).ToCharArray())).GetValue($([System.Convert]::ToInt32(1))).PadLeft($([System.Convert]::ToInt32(2)), $([System.Convert]::ToChar(`0`))))</_BuildNumberBuildOfTheDayPadded>
+
+    <!-- The padding is only needed on SemVer 1.0 -->
+    <_BuildNumberBuildOfTheDayPadded>$(_BuildNumber.Split($([System.Convert]::ToString(`.`).ToCharArray())).GetValue($([System.Convert]::ToInt32(1))))</_BuildNumberBuildOfTheDayPadded>
+    <_BuildNumberBuildOfTheDayPadded Condition="'$(DotNetSemanticVersioningV1)' == 'true'">$(_BuildNumberBuildOfTheDayPadded.PadLeft($([System.Convert]::ToInt32(2)), $([System.Convert]::ToChar(`0`))))</_BuildNumberBuildOfTheDayPadded>
     
     <!-- This handles the Dev/Daily case of the versioning specification. -->
     <VersionSuffix Condition="'$(PB_IsStable)' != 'true'">$(_PreReleaseLabel).$(_BuildNumberFiveDigitDateStamp).$(_BuildNumberBuildOfTheDayPadded)</VersionSuffix>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.props
@@ -2,15 +2,24 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
 
+  <!--
+    Note, the plan to implement this was discussed here: https://github.com/dotnet/arcade/pull/108
+    
+    Properties:
+      PB_IsStable                 Tells whether this is a stable build or not.
+      PB_VersionStamp             NuGet package pre-release version label e.g. 'beta', 'preview1', etc. May be empty.
+      OfficialBuildId             Contains the build id if this is an official build, otherwise must be empty.
+  -->
+    
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
 
-    <PreReleaseLabel Condition="'$(PB_VersionStamp)' != ''">$(PB_VersionStamp)</PreReleaseLabel>
-    <PreReleaseLabel Condition="'$(CIBuild)' == 'true'">ci</PreReleaseLabel>
-    <PreReleaseLabel Condition="'$(PreReleaseLabel)' == ''">dev</PreReleaseLabel>
+    <_PreReleaseLabel Condition="'$(PB_VersionStamp)' != ''">$(PB_VersionStamp)</_PreReleaseLabel>
+    <_PreReleaseLabel Condition="'$(CIBuild)' == 'true'">ci</_PreReleaseLabel>
+    <_PreReleaseLabel Condition="'$(_PreReleaseLabel)' == ''">dev</_PreReleaseLabel>
 
-    <BuildId>$(OfficialBuildId)</BuildId>
-    <BuildId Condition="'$(BuildId)' == ''">$([System.DateTime]::Now.ToString(yyyyMMdd)).0</BuildId>
+    <_BuildId>$(OfficialBuildId)</_BuildId>
+    <_BuildId Condition="'$(_BuildId)' == ''">$([System.DateTime]::Now.ToString(yyyyMMdd)).1</_BuildId>
 
     <!--
         Split the build parts out from the BuildNumber which is given to us by MicroBuild in the format of yyyymmdd.nn
@@ -23,13 +32,13 @@
         in the case of 20160615, we will set BuildNumberFiveDigitDateStamp to 60615. Further, if this would result in a number like 71201 or 81201, we
         decrement the year and add 12 to the month to extend the time. 
     -->
-    <_BuildNumberFiveDigitDateStamp>$([MSBuild]::Subtract($(BuildId.Split($([System.Convert]::ToString(`.`).ToCharArray())).GetValue($([System.Convert]::ToInt32(0)))), 20100000))</_BuildNumberFiveDigitDateStamp>
+    <_BuildNumberFiveDigitDateStamp>$([MSBuild]::Subtract($(_BuildId.Split($([System.Convert]::ToString(`.`).ToCharArray())).GetValue($([System.Convert]::ToInt32(0)))), 20100000))</_BuildNumberFiveDigitDateStamp>
     <_BuildNumberFiveDigitDateStampYearsToOffset>$([System.Math]::Max($([System.Convert]::ToInt32($([MSBuild]::Subtract($([MSBuild]::Divide($(_BuildNumberFiveDigitDateStamp), 10000)), 6)))), 0))</_BuildNumberFiveDigitDateStampYearsToOffset>
     <_BuildNumberFiveDigitDateStamp>$([MSBuild]::Subtract($([System.Convert]::ToInt32($(_BuildNumberFiveDigitDateStamp))), $([MSBuild]::Multiply($(_BuildNumberFiveDigitDateStampYearsToOffset), 8800))))</_BuildNumberFiveDigitDateStamp>
-    <_BuildNumberBuildOfTheDayPadded>$(BuildId.Split($([System.Convert]::ToString(`.`).ToCharArray())).GetValue($([System.Convert]::ToInt32(1))).PadLeft($([System.Convert]::ToInt32(2)), $([System.Convert]::ToChar(`0`))))</_BuildNumberBuildOfTheDayPadded>
+    <_BuildNumberBuildOfTheDayPadded>$(_BuildId.Split($([System.Convert]::ToString(`.`).ToCharArray())).GetValue($([System.Convert]::ToInt32(1))).PadLeft($([System.Convert]::ToInt32(2)), $([System.Convert]::ToChar(`0`))))</_BuildNumberBuildOfTheDayPadded>
     
     <!-- This handles the Dev/Daily case of the versioning plan. -->
-    <VersionSuffix Condition="'$(PB_IsStable)' != 'true'">$(PreReleaseLabel).$(_BuildNumberFiveDigitDateStamp).$(_BuildNumberBuildOfTheDayPadded)</VersionSuffix>
+    <VersionSuffix Condition="'$(PB_IsStable)' != 'true'">$(_PreReleaseLabel).$(_BuildNumberFiveDigitDateStamp).$(_BuildNumberBuildOfTheDayPadded)</VersionSuffix>
 
     <!-- This handles the 'Final Prerelease' case of the versioning plan. -->
     <VersionSuffix Condition="'$(PB_IsStable)' == 'true' and '$(PB_VersionStamp)' != ''">$(PB_VersionStamp).final</VersionSuffix>
@@ -38,8 +47,8 @@
     <!-- For this case the version suffix is empty. -->
     <VersionSuffix Condition="'$(PB_IsStable)' == 'true' and '$(PB_VersionStamp)' == ''"></VersionSuffix>
 
-    <!-- We support SemanticVersioning 1.0; For that we need to replace {'+', '.'} by {'-'} -->
-    <VersionSuffix Condition="'$(SemanticVersioningV1)' == 'true'">$(VersionSuffix.Replace('+', '-').Replace('.', '-'))</VersionSuffix>
+    <!-- We support SemanticVersioning 1.0; For that we need to replace {'.', '+'} by {'-'} -->
+    <VersionSuffix Condition="'$(SemanticVersioningV1)' == 'true'">$(VersionSuffix.Replace('.', '-'))</VersionSuffix>
   </PropertyGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.props
@@ -9,11 +9,8 @@
     <PreReleaseLabel Condition="'$(CIBuild)' == 'true'">ci</PreReleaseLabel>
     <PreReleaseLabel Condition="'$(PreReleaseLabel)' == ''">dev</PreReleaseLabel>
 
-    <!-- First 8 chars from the SHA -->
-    <ShortSha>$(SourceRevisionId.Substring(0, 8))</ShortSha>
-
-    <BuildId Condition="'$(OfficialBuild)' == 'true'">$(OfficialBuildId)</BuildId>
-    <BuildId Condition="'$(OfficialBuild)' != 'true'">$([System.DateTime]::Now.ToString(yyyyMMdd)).0</BuildId>
+    <BuildId>$(OfficialBuildId)</BuildId>
+    <BuildId Condition="'$(BuildId)' == ''">$([System.DateTime]::Now.ToString(yyyyMMdd)).0</BuildId>
 
     <!--
         Split the build parts out from the BuildNumber which is given to us by MicroBuild in the format of yyyymmdd.nn

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.props
@@ -12,6 +12,7 @@
                                      For SemanticVersioning 1.0 dots ('.') are replaced by dashes ('-').
       PB_VersionStamp             NuGet package pre-release version label e.g. 'beta', 'preview1', etc. May be empty.
       OfficialBuildId             Contains the build id if this is an official build, otherwise must be empty.
+      CIBuild                     "true" if this is a CI build.
   -->
     
   <PropertyGroup>
@@ -19,8 +20,8 @@
 
     <_PreReleaseLabel>$(PreReleaseVersionLabel)</_PreReleaseLabel>
     <_PreReleaseLabel Condition="'$(PB_VersionStamp)' != ''">$(PB_VersionStamp)</_PreReleaseLabel>
-    <_PreReleaseLabel Condition="'$(CIBuild)' == 'true'">ci</_PreReleaseLabel>
-    <_PreReleaseLabel Condition="'$(_PreReleaseLabel)' == ''">dev</_PreReleaseLabel>
+    <_PreReleaseLabel Condition="'$(OfficialBuildId)' == '' and '$(CIBuild)' == 'true'">ci</_PreReleaseLabel>
+    <_PreReleaseLabel Condition="'$(OfficialBuildId)' == '' and '$(CIBuild)' != 'true'">dev</_PreReleaseLabel>
 
     <_BuildNumber>$(OfficialBuildId)</_BuildNumber>
     <_BuildNumber Condition="'$(_BuildNumber)' == ''">$([System.DateTime]::Now.ToString(yyyyMMdd)).1</_BuildNumber>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.props
@@ -2,58 +2,47 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
 
-  <!--
-  
-  Optional environment variables:
-    BUILD_BUILDNUMBER           Environment variable set by microbuild (format: "yyyymmdd.nn")
-  
-  Optional environment variables:
-    PB_IsStable                 If specified then NuGet package version suffixes used by the repo are overridden by the orchestrated build like so:
-                                   if 'true' then version suffixes have format '{base version}-{PB_VersionStamp}', 
-                                   if 'false' then version suffixes have format '{base version}-{PB_VersionStamp}-{build number}'
-    PB_VersionStamp             NuGet package pre-release version label e.g. 'beta', 'preview1', etc. May be empty.
-
-  -->
-
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+
+    <PreReleaseLabel Condition="'$(PB_VersionStamp)' != ''">$(PB_VersionStamp)</PreReleaseLabel>
+    <PreReleaseLabel Condition="'$(CIBuild)' == 'true'">ci</PreReleaseLabel>
+    <PreReleaseLabel Condition="'$(PreReleaseLabel)' == ''">dev</PreReleaseLabel>
+
+    <!-- First 8 chars from the SHA -->
+    <ShortSha>$(SourceRevisionId.Substring(0, 8))</ShortSha>
+
+    <BuildId Condition="'$(OfficialBuild)' == 'true'">$(OfficialBuildId)</BuildId>
+    <BuildId Condition="'$(OfficialBuild)' != 'true'">$([System.DateTime]::Now.ToString(yyyyMMdd)).0</BuildId>
+
+    <!--
+        Split the build parts out from the BuildNumber which is given to us by MicroBuild in the format of yyyymmdd.nn
+        where BuildNumberFiveDigitDateStamp is mmmdd (such as 60615) and BuildNumberBuildOfTheDay is nn (which represents the nth build
+        started that day). So the first build of the day, 20160615.1, will produce something similar to BuildNumberFiveDigitDateStamp: 60615,
+        BuildNumberBuildOfTheDayPadded: 01; and the 12th build of the day, 20160615.12, will produce BuildNumberFiveDigitDateStamp: 60615, 
+        BuildNumberBuildOfTheDay: 12
+
+        Additionally, in order ensure the value fits in the 16-bit PE header fields, we will only take the last five digits of the BuildNumber, so
+        in the case of 20160615, we will set BuildNumberFiveDigitDateStamp to 60615. Further, if this would result in a number like 71201 or 81201, we
+        decrement the year and add 12 to the month to extend the time. 
+    -->
+    <_BuildNumberFiveDigitDateStamp>$([MSBuild]::Subtract($(BuildId.Split($([System.Convert]::ToString(`.`).ToCharArray())).GetValue($([System.Convert]::ToInt32(0)))), 20100000))</_BuildNumberFiveDigitDateStamp>
+    <_BuildNumberFiveDigitDateStampYearsToOffset>$([System.Math]::Max($([System.Convert]::ToInt32($([MSBuild]::Subtract($([MSBuild]::Divide($(_BuildNumberFiveDigitDateStamp), 10000)), 6)))), 0))</_BuildNumberFiveDigitDateStampYearsToOffset>
+    <_BuildNumberFiveDigitDateStamp>$([MSBuild]::Subtract($([System.Convert]::ToInt32($(_BuildNumberFiveDigitDateStamp))), $([MSBuild]::Multiply($(_BuildNumberFiveDigitDateStampYearsToOffset), 8800))))</_BuildNumberFiveDigitDateStamp>
+    <_BuildNumberBuildOfTheDayPadded>$(BuildId.Split($([System.Convert]::ToString(`.`).ToCharArray())).GetValue($([System.Convert]::ToInt32(1))).PadLeft($([System.Convert]::ToInt32(2)), $([System.Convert]::ToChar(`0`))))</_BuildNumberBuildOfTheDayPadded>
+    
+    <!-- This handles the Dev/Daily case of the versioning plan. -->
+    <VersionSuffix Condition="'$(PB_IsStable)' != 'true'">$(PreReleaseLabel).$(_BuildNumberFiveDigitDateStamp).$(_BuildNumberBuildOfTheDayPadded)</VersionSuffix>
+
+    <!-- This handles the 'Final Prerelease' case of the versioning plan. -->
+    <VersionSuffix Condition="'$(PB_IsStable)' == 'true' and '$(PB_VersionStamp)' != ''">$(PB_VersionStamp).final</VersionSuffix>
+
+    <!-- This handles the 'Stable' case of the versioning plan. -->
+    <!-- For this case the version suffix is empty. -->
+    <VersionSuffix Condition="'$(PB_IsStable)' == 'true' and '$(PB_VersionStamp)' == ''"></VersionSuffix>
+
+    <!-- We support SemanticVersioning 1.0; For that we need to replace {'+', '.'} by {'-'} -->
+    <VersionSuffix Condition="'$(SemanticVersioningV1)' == 'true'">$(VersionSuffix.Replace('+', '-').Replace('.', '-'))</VersionSuffix>
   </PropertyGroup>
-
-  <Choose>
-    <When Condition="'$(OfficialBuild)' == 'true'">
-      <PropertyGroup>
-        <!--
-            Split the build parts out from the BuildNumber which is given to us by MicroBuild in the format of yyyymmdd.nn
-            where BuildNumberFiveDigitDateStamp is mmmdd (such as 60615) and BuildNumberBuildOfTheDay is nn (which represents the nth build
-            started that day). So the first build of the day, 20160615.1, will produce something similar to BuildNumberFiveDigitDateStamp: 60615,
-            BuildNumberBuildOfTheDayPadded: 01;and the 12th build of the day, 20160615.12, will produce BuildNumberFiveDigitDateStamp: 60615, BuildNumberBuildOfTheDay: 12
-
-            Additionally, in order ensure the value fits in the 16-bit PE header fields, we will only take the last five digits of the BuildNumber, so
-            in the case of 20160615, we will set BuildNumberFiveDigitDateStamp to 60615. Further, if this would result in a number like 71201 or 81201, we
-            decrement the year and add 12 to the month to extend the time. 
-        -->
-        <_BuildNumberFiveDigitDateStamp>$([MSBuild]::Subtract($(BUILD_BUILDNUMBER.Split($([System.Convert]::ToString(`.`).ToCharArray())).GetValue($([System.Convert]::ToInt32(0)))), 20100000))</_BuildNumberFiveDigitDateStamp>
-        <_BuildNumberFiveDigitDateStampYearsToOffset>$([System.Math]::Max($([System.Convert]::ToInt32($([MSBuild]::Subtract($([MSBuild]::Divide($(_BuildNumberFiveDigitDateStamp), 10000)), 6)))), 0))</_BuildNumberFiveDigitDateStampYearsToOffset>
-        <_BuildNumberFiveDigitDateStamp>$([MSBuild]::Subtract($([System.Convert]::ToInt32($(_BuildNumberFiveDigitDateStamp))), $([MSBuild]::Multiply($(_BuildNumberFiveDigitDateStampYearsToOffset), 8800))))</_BuildNumberFiveDigitDateStamp>
-        <_BuildNumberBuildOfTheDayPadded>$(BUILD_BUILDNUMBER.Split($([System.Convert]::ToString(`.`).ToCharArray())).GetValue($([System.Convert]::ToInt32(1))).PadLeft($([System.Convert]::ToInt32(2)), $([System.Convert]::ToChar(`0`))))</_BuildNumberBuildOfTheDayPadded>
-
-        <VersionSuffix Condition="'$(PB_IsStable)' == 'true'">$(PB_VersionStamp)</VersionSuffix>
-        <VersionSuffix Condition="'$(PB_IsStable)' == 'false'">$(PB_VersionStamp)-$(_BuildNumberFiveDigitDateStamp)-$(_BuildNumberBuildOfTheDayPadded)</VersionSuffix>
-        <VersionSuffix Condition="'$(PB_IsStable)' == '' and '$(PreReleaseVersionLabel)' != ''">$(PreReleaseVersionLabel)-$(_BuildNumberFiveDigitDateStamp)-$(_BuildNumberBuildOfTheDayPadded)</VersionSuffix>
-      </PropertyGroup>
-    </When>
-
-    <When Condition="'$(CIBuild)' == 'true'">
-      <PropertyGroup>
-        <VersionSuffix>ci</VersionSuffix>
-      </PropertyGroup>
-    </When>
-
-    <Otherwise>
-      <PropertyGroup>
-        <VersionSuffix>dev</VersionSuffix>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
 
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
@@ -3,12 +3,11 @@
 <Project>
 
   <!--
-
   Optional properties:
-    OfficialBuild               "true" if this is an official build
+    OfficialBuildId             Contains the build id if this is an official build, otherwise must be empty.
     CIBuild                     "true" if this is a CI build
     UseShippingAssemblyVersion  "true" to set assembly version in a dev build to a shipping one instead of 42.42.42.42
-
+    UseShippingFileVersion      "true" to set file version in a dev build to a shipping one instead of 42.42.42.42
   -->
 
   <PropertyGroup>
@@ -16,20 +15,26 @@
   </PropertyGroup>
 
   <Target Name="_InitializeAssemblyVersion" BeforeTargets="GetAssemblyVersion">
-    <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">
+    <PropertyGroup Condition="'$(OfficialBuildId)' != ''">
       <FileVersion>$(VersionPrefix).$(_BuildNumberFiveDigitDateStamp)</FileVersion>
       <InformationalVersion>$(Version)</InformationalVersion>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(OfficialBuild)' != 'true'">
+    <PropertyGroup Condition="'$(OfficialBuildId)' == ''">
       <AssemblyVersion Condition="'$(UseShippingAssemblyVersion)' != 'true' and '$(CIBuild)' != 'true'">42.42.42.42</AssemblyVersion>
-      <FileVersion>42.42.42.42</FileVersion>
-      <InformationalVersion>$(FileVersion)</InformationalVersion>
+      <FileVersion Condition="'$(UseShippingFileVersion)' != 'true' and '$(CIBuild)' != 'true'">42.42.42.42</FileVersion>
+      <InformationalVersion>42.42.42.42</InformationalVersion>
     </PropertyGroup>
   </Target>
 
   <Target Name="_InitializePackageVersion" BeforeTargets="GenerateNuSpec" DependsOnTargets="InitializeSourceControlInformation">
-    <PackageVersion>$(Version)+$(ShortSha)</PackageVersion>
+    <PropertyGroup>
+      <!-- First 8 chars from the SHA -->
+      <ShortSha>$(SourceRevisionId)</ShortSha>
+      <ShortSha Condition="$(SourceRevisionId.Length) &gt; 7">$(SourceRevisionId.Substring(0, 8))</ShortSha>
+
+      <PackageVersion>$(Version)+$(ShortSha)</PackageVersion>
+    </PropertyGroup>
   </Target>
   
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
@@ -27,5 +27,9 @@
       <InformationalVersion>$(FileVersion)</InformationalVersion>
     </PropertyGroup>
   </Target>
+
+  <Target Name="_InitializePackageVersion" BeforeTargets="GenerateNuSpec" DependsOnTargets="InitializeSourceControlInformation">
+    <PackageVersion>$(Version)+$(ShortSha)</PackageVersion>
+  </Target>
   
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
@@ -3,11 +3,12 @@
 <Project>
 
   <!--
-  Optional properties:
-    OfficialBuildId             Contains the build id if this is an official build, otherwise must be empty.
-    CIBuild                     "true" if this is a CI build
-    UseShippingAssemblyVersion  "true" to set assembly version in a dev build to a shipping one instead of 42.42.42.42
-    UseShippingFileVersion      "true" to set file version in a dev build to a shipping one instead of 42.42.42.42
+    Properties:
+      OfficialBuildId             Contains the build id if this is an official build, otherwise must be empty.
+      SourceRevisionId            Contains the SHA of the repo being built.
+      CIBuild                     "true" if this is a CI build
+      UseShippingAssemblyVersion  "true" to set assembly version in a dev build to a shipping one instead of 42.42.42.42
+      UseShippingFileVersion      "true" to set file version in a dev build to a shipping one instead of 42.42.42.42
   -->
 
   <PropertyGroup>
@@ -30,11 +31,13 @@
   <Target Name="_InitializePackageVersion" BeforeTargets="GenerateNuSpec" DependsOnTargets="InitializeSourceControlInformation">
     <PropertyGroup>
       <!-- First 8 chars from the SHA -->
-      <ShortSha>$(SourceRevisionId)</ShortSha>
-      <ShortSha Condition="$(SourceRevisionId.Length) &gt; 7">$(SourceRevisionId.Substring(0, 8))</ShortSha>
+      <_ShortSha>$(SourceRevisionId)</_ShortSha>
+      <_ShortSha Condition="$(SourceRevisionId.Length) &gt; 7">$(SourceRevisionId.Substring(0, 8))</_ShortSha>
 
-      <PackageVersion>$(Version)+$(ShortSha)</PackageVersion>
+      <!-- We support SemanticVersioning 1.0; For that we need to replace {'.', '+'} by {'-'} -->
+      <PackageVersion Condition="'$(SemanticVersioningV1)' != 'true'">$(Version)+$(_ShortSha)</PackageVersion>
+      <PackageVersion Condition="'$(SemanticVersioningV1)' == 'true'">$(Version)-$(_ShortSha)</PackageVersion>
     </PropertyGroup>
   </Target>
-  
+
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
@@ -23,7 +23,7 @@
 
     <PropertyGroup Condition="'$(OfficialBuildId)' == ''">
       <AssemblyVersion Condition="'$(UseShippingAssemblyVersion)' != 'true' and '$(CIBuild)' != 'true'">42.42.42.42</AssemblyVersion>
-      <FileVersion Condition="'$(UseShippingFileVersion)' != 'true' and '$(CIBuild)' != 'true'">42.42.42.42</FileVersion>
+      <FileVersion>42.42.42.42</FileVersion>
       <InformationalVersion>42.42.42.42</InformationalVersion>
     </PropertyGroup>
   </Target>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
@@ -35,8 +35,8 @@
       <_ShortSha Condition="$(SourceRevisionId.Length) &gt; 7">$(SourceRevisionId.Substring(0, 8))</_ShortSha>
 
       <!-- We support SemanticVersioning 1.0; For that we need to replace {'.', '+'} by {'-'} -->
-      <PackageVersion Condition="'$(SemanticVersioningV1)' != 'true'">$(Version)+$(_ShortSha)</PackageVersion>
-      <PackageVersion Condition="'$(SemanticVersioningV1)' == 'true'">$(Version)-$(_ShortSha)</PackageVersion>
+      <PackageVersion Condition="'$(DotNetSemanticVersioningV1)' != 'true'">$(Version)+$(_ShortSha)</PackageVersion>
+      <PackageVersion Condition="'$(DotNetSemanticVersioningV1)' == 'true'">$(Version)-$(_ShortSha)</PackageVersion>
     </PropertyGroup>
   </Target>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
@@ -9,6 +9,7 @@
       CIBuild                     "true" if this is a CI build
       UseShippingAssemblyVersion  "true" to set assembly version in a dev build to a shipping one instead of 42.42.42.42
       UseShippingFileVersion      "true" to set file version in a dev build to a shipping one instead of 42.42.42.42
+      DotNetSemanticVersioningV1  "true" if the Version needs to respect SemVer 1.0. Default is false, which means format following SemVer 2.0.
   -->
 
   <PropertyGroup>


### PR DESCRIPTION
As discussed by e-mail - let me know if you want me to forward the thread:

- We aren't going to use Tasks to fetch the SHA or Commit date anymore; Those are going to be passed as parameters, respectively: SourceRevisionId and OfficialBuildId

- When OfficialBuildId/SourceRevisionId aren't informed we are going to use the current date for ShortDate and NOSHA for SHA

- SHA won't be included in the VersionSuffix

- A new target was added to compute PackageVersion, it executes before GenerateNuSpec target and depends on InitializeSourceControlInformation
