### PR TITLE
Arcade sdk doc

### DIFF
--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -26,6 +26,7 @@ Packages which are always included when consuming the SDK. Functionality of thes
 * Publishing
 * Helix related
 * Versioning
+
 // TODO: add missing. Also I know there has been some talks about making Versioning non-mandatory
 
 ### Level 2
@@ -55,4 +56,4 @@ The SDK supports the concept of "graduation" where if a package in a lower level
 ## Requirements
 
 Each package in the SDK is and will be governed by the same set of requirements all packages under Arcade currently are. You can find more details about these requirements
-[here](https://github.com/dotnet/arcade/blob/master/Documentation/Overview.md#toolset-nuget-package-requirements)
+[here](https://github.com/dotnet/arcade/blob/master/Documentation/Overview.md#toolset-nuget-package-requirements).

--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -1,7 +1,6 @@
 # Arcade SDK
 
-The primary goal of the SDK is to provide a set of tools which are shared across all participating repos and actually, in order for a repo to be fully onboarded to Arcade
-it has to consume the SDK.
+The primary goal of the SDK is to provide a set of tools which are shared across all participating repos. It is mandatory for tier 1 repos to consume the SDK.
 
 ## Origin
 
@@ -9,51 +8,21 @@ The initial version of the SDK is a port from RepoToolset but will be changing a
 
 ## What shared tools should be part of the SDK and which should not?
 
-If a tool provides functionality which is meant to be used by all of the tier one repos then we should consider adding it to the SDK. If this functionality will only work
-for a couple of repos then we could still include it as optional or leave it out of the SDK.
-
-// TODO: close on what is the bar in order for a package to be included (or not) to the SDK
-
-## Levels
-
-The SDK has 4 different levels of packages depending on how mandatory these are:
-
-### Level 1
-
-Packages which are always included when consuming the SDK. Functionality of these include:
+If a tool provides functionality which is meant to be used by all of the tier one repos then we should add it to the SDK. Samples of these are:
 
 * Signing
 * Publishing
-* Helix related
+* Helix telemetry and jobs
 * Versioning
 
-// TODO: add missing. Also I know there has been some talks about making Versioning non-mandatory
+If the provided functionality will only work for a couple of repos then these will have to be manually referenced in a project. Samples include:
 
-### Level 2
+* VSIX extension creation
+* Unit tests
 
-Packages which are referenced or represent a dependency from packages in Level 1. These include:
-
-* Newtonsoft.Json
-* NuGet.Packaging
-* WindowsAzure.Storage
-* etc.
- 
-### Level 3
-
-Optional packages.
-
-// TODO: provide details on how would this be done in the SDK. i.e. by adding a reference to a file which if it's there then the packages will be included if not nothing
-happens?
-
-### Level 4
-
-Packages defined in each repo.
-
-// TODO: provide details on how would this be done in the SDK.
-
-The SDK supports the concept of "graduation" where if a package in a lower level starts to be used more by more repos then it will be moved to lower levels making it more mandatory with each move.
+The SDK supports the concept of "graduation" where if an optional package starts to be used more by more repos then it will be "promoted" to mandatory.
 
 ## Requirements
 
-Each package in the SDK is and will be governed by the same set of requirements all packages under Arcade currently are. You can find more details about these requirements
+Each package in the SDK complies with the same set of requirements as all packages under Arcade. You can find more details about these requirements
 [here](https://github.com/dotnet/arcade/blob/master/Documentation/Overview.md#toolset-nuget-package-requirements).

--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -1,17 +1,17 @@
 # Arcade SDK
 
-The primary goal of the SDK is to provide a set of tools which are shared across all participating repos. It is mandatory for [Tier 1 Repos](https://github.com/dotnet/arcade/blob/master/Documentation/TierOneRepos.md) to
+The primary goal of the SDK is to provide a set of tools which are shared across all participating repos. It is mandatory for [Tier 1 Repos](TierOneRepos.md) to
 consume the SDK.
 
 ## Origin
 
-The initial version of the SDK is a port from [RepoToolset](https://github.com/dotnet/roslyn-tools/tree/master/src/RepoToolset) but will be changing as we add more packages and functionality to it.
+The initial version of the SDK is a port from [RepoToolset](../../../../roslyn-tools/tree/master/src/RepoToolset) but will be changing as we add more packages and functionality to it.
 
 ## What shared tools should be part of the SDK and which should not?
 
 ### Required
 
-If a tool provides functionality which is meant to be used by all of the [Tier 1 Repos](https://github.com/dotnet/arcade/blob/master/Documentation/TierOneRepos.md) then we should add it to the SDK. 
+If a tool provides functionality which is meant to be used by all of the [Tier 1 Repos](TierOneRepos.md) then we should add it to the SDK. 
 
 ### Optional
 
@@ -40,4 +40,4 @@ needed in that repo. Included are:
 ## Requirements
 
 Each package in the SDK complies with the same set of requirements as all packages under Arcade. You can find more details about these requirements
-[here](https://github.com/dotnet/arcade/blob/master/Documentation/Overview.md#toolset-nuget-package-requirements).
+[here](Overview.md#toolset-nuget-package-requirements).

--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -1,0 +1,58 @@
+# Arcade SDK
+
+The primary goal of the SDK is to provide a set of tools which are shared across all participating repos and actually, in order for a repo to be fully onboarded to Arcade
+it has to consume the SDK.
+
+## Origin
+
+The initial version of the SDK is a port from RepoToolset but will be changing as we add more packages and functionality to it.
+
+## What shared tools should be part of the SDK and which should not?
+
+If a tool provides functionality which is meant to be used by all of the tier one repos then we should consider adding it to the SDK. If this functionality will only work
+for a couple of repos then we could still include it as optional or leave it out of the SDK.
+
+// TODO: close on what is the bar in order for a package to be included (or not) to the SDK
+
+## Levels
+
+The SDK has 4 different levels of packages depending on how mandatory these are:
+
+### Level 1
+
+Packages which are always included when consuming the SDK. Functionality of these include:
+
+* Signing
+* Publishing
+* Helix related
+* Versioning
+// TODO: add missing. Also I know there has been some talks about making Versioning non-mandatory
+
+### Level 2
+
+Packages which are referenced or represent a dependency from packages in Level 1. These include:
+
+* Newtonsoft.Json
+* NuGet.Packaging
+* WindowsAzure.Storage
+* etc.
+ 
+### Level 3
+
+Optional packages.
+
+// TODO: provide details on how would this be done in the SDK. i.e. by adding a reference to a file which if it's there then the packages will be included if not nothing
+happens?
+
+### Level 4
+
+Packages defined in each repo.
+
+// TODO: provide details on how would this be done in the SDK.
+
+The SDK supports the concept of "graduation" where if a package in a lower level starts to be used more by more repos then it will be moved to lower levels making it more mandatory with each move.
+
+## Requirements
+
+Each package in the SDK is and will be governed by the same set of requirements all packages under Arcade currently are. You can find more details about these requirements
+[here](https://github.com/dotnet/arcade/blob/master/Documentation/Overview.md#toolset-nuget-package-requirements)

--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -20,7 +20,10 @@ If the provided functionality will only work for a couple of repos then these wi
 * VSIX extension creation
 * Unit tests
 
-The SDK supports the concept of "graduation" where if an optional package starts to be used more by more repos then it will be "promoted" to mandatory.
+If an optional package gets to be used by all tier 1 repos then it will be "promoted" to mandatory.
+
+All the packages contained in the SDK are just `PackageReference`s and not the actual package bits. We should maintain this approach
+unless there is no way to just reference the package.
 
 ## Requirements
 

--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -1,29 +1,41 @@
 # Arcade SDK
 
-The primary goal of the SDK is to provide a set of tools which are shared across all participating repos. It is mandatory for tier 1 repos to consume the SDK.
+The primary goal of the SDK is to provide a set of tools which are shared across all participating repos. It is mandatory for [Tier 1 Repos](https://github.com/dotnet/arcade/blob/master/Documentation/TierOneRepos.md) to
+consume the SDK.
 
 ## Origin
 
-The initial version of the SDK is a port from RepoToolset but will be changing as we add more packages and functionality to it.
+The initial version of the SDK is a port from [RepoToolset](https://github.com/dotnet/roslyn-tools/tree/master/src/RepoToolset) but will be changing as we add more packages and functionality to it.
 
 ## What shared tools should be part of the SDK and which should not?
 
-If a tool provides functionality which is meant to be used by all of the tier one repos then we should add it to the SDK. Samples of these are:
+### Required
 
-* Signing
-* Publishing
-* Helix telemetry and jobs
-* Versioning
+If a tool provides functionality which is meant to be used by all of the [Tier 1 Repos](https://github.com/dotnet/arcade/blob/master/Documentation/TierOneRepos.md) then we should add it to the SDK. 
 
-If the provided functionality will only work for a couple of repos then these will have to be manually referenced in a project. Samples include:
+### Optional
+
+If the provided functionality will only work for a couple of repos then these won't be part of the SDK and will have to be manually referenced in a project.
+
+## Levels
+
+1. **Required** files/targets contained directly in SDK. These are required by all repos and the ammount should be minimal. These include:
+
+* version.targets
+* sign.proj
+* toolset.proj
+
+2. **Required** `PackageReference`s in the SDK. These are required by all repos and the ammount should be minimal but only the references are included, not the actual
+files. Samples are:
+
+* Signtool
+* Microbuild
+
+3. **Opt-in** `PackageReference`s that are added via a `props` file in a repo that the SDK imports if it is present. These `PackageReference`s are for all unique packages
+needed in that repo. Included are:
 
 * VSIX extension creation
 * Unit tests
-
-If an optional package gets to be used by all tier 1 repos then it will be "promoted" to mandatory.
-
-All the packages contained in the SDK are just `PackageReference`s and not the actual package bits. We should maintain this approach
-unless there is no way to just reference the package.
 
 ## Requirements
 


### PR DESCRIPTION
This represent the initial documentation for the Arcade SDK.

One of the goals at the end of the PR is to have a more solid list of the packages that should be included in the SDK as well as filling missing points in the doc