### PR TITLE
Adding basic support for an ilproj sdk.

### DIFF
--- a/Arcade.sln
+++ b/Arcade.sln
@@ -26,6 +26,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.GitSync", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Arcade.Sdk", "src\Microsoft.DotNet.Arcade.Sdk\Microsoft.DotNet.Arcade.Sdk.csproj", "{747A5C75-6069-4C45-8049-AEAA1D864105}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Sdk.IL", "src\Microsoft.DotNet.Sdk.IL\Microsoft.DotNet.Sdk.IL.csproj", "{8C198813-9420-45A0-84A2-ABA4EA517794}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -144,6 +146,18 @@ Global
 		{747A5C75-6069-4C45-8049-AEAA1D864105}.Release|x64.Build.0 = Release|Any CPU
 		{747A5C75-6069-4C45-8049-AEAA1D864105}.Release|x86.ActiveCfg = Release|Any CPU
 		{747A5C75-6069-4C45-8049-AEAA1D864105}.Release|x86.Build.0 = Release|Any CPU
+		{8C198813-9420-45A0-84A2-ABA4EA517794}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8C198813-9420-45A0-84A2-ABA4EA517794}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8C198813-9420-45A0-84A2-ABA4EA517794}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8C198813-9420-45A0-84A2-ABA4EA517794}.Debug|x64.Build.0 = Debug|Any CPU
+		{8C198813-9420-45A0-84A2-ABA4EA517794}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8C198813-9420-45A0-84A2-ABA4EA517794}.Debug|x86.Build.0 = Debug|Any CPU
+		{8C198813-9420-45A0-84A2-ABA4EA517794}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8C198813-9420-45A0-84A2-ABA4EA517794}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8C198813-9420-45A0-84A2-ABA4EA517794}.Release|x64.ActiveCfg = Release|Any CPU
+		{8C198813-9420-45A0-84A2-ABA4EA517794}.Release|x64.Build.0 = Release|Any CPU
+		{8C198813-9420-45A0-84A2-ABA4EA517794}.Release|x86.ActiveCfg = Release|Any CPU
+		{8C198813-9420-45A0-84A2-ABA4EA517794}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -157,6 +171,7 @@ Global
 		{91FCE4C5-E83B-4C81-B0ED-3EAE417CBBE0} = {A564AF6E-6E4E-44EA-B2D7-C909C6687763}
 		{FE2D1224-2C69-48E2-AEE6-F524AEACF567} = {730AF68A-22FD-4372-9341-5F67D7701DA7}
 		{747A5C75-6069-4C45-8049-AEAA1D864105} = {730AF68A-22FD-4372-9341-5F67D7701DA7}
+		{8C198813-9420-45A0-84A2-ABA4EA517794} = {730AF68A-22FD-4372-9341-5F67D7701DA7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {06E6CFF5-C54E-4623-9587-71A9E3F041D9}

--- a/src/Microsoft.DotNet.Sdk.IL/Microsoft.DotNet.Sdk.IL.csproj
+++ b/src/Microsoft.DotNet.Sdk.IL/Microsoft.DotNet.Sdk.IL.csproj
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.0</TargetFrameworks>
+    <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
+    <IsPackable>true</IsPackable>
+    <Description>This package provides support for building IL projects.</Description>
+    <DevelopmentDependency>true</DevelopmentDependency>
+    <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
+    <EnableGeneratedPackageContent>false</EnableGeneratedPackageContent>
+    <IncludePublishOutput>false</IncludePublishOutput>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="sdk/*.*" Pack="true" PackagePath="sdk/%(Filename)%(Extension)" />
+    <None Include="build/*.*" Pack="true" PackagePath="build/%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <Import Project="$(RepoRoot)eng\Sdk.targets" />
+
+</Project>

--- a/src/Microsoft.DotNet.Sdk.IL/build/Microsoft.NET.Sdk.IL.props
+++ b/src/Microsoft.DotNet.Sdk.IL/build/Microsoft.NET.Sdk.IL.props
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+***********************************************************************************************
+Microsoft.NET.Sdk.IL.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved. 
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildThisFileFullPath);$(MSBuildAllProjects)</MSBuildAllProjects>
+  </PropertyGroup>
+
+</Project>

--- a/src/Microsoft.DotNet.Sdk.IL/build/Microsoft.NET.Sdk.IL.targets
+++ b/src/Microsoft.DotNet.Sdk.IL/build/Microsoft.NET.Sdk.IL.targets
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+***********************************************************************************************
+Microsoft.NET.Sdk.IL.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved. 
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildThisFileFullPath);$(MSBuildAllProjects)</MSBuildAllProjects>
+    <DefaultLanguageSourceExtension>.il</DefaultLanguageSourceExtension>
+    <Language>IL</Language>
+    <TargetRuntime>Managed</TargetRuntime>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <_OSPlatform Condition="$([MSBuild]::IsOSPlatform('windows'))">win</_OSPlatform>
+    <_OSPlatform Condition="$([MSBuild]::IsOSPlatform('linux'))">linux</_OSPlatform>
+    <_OSPlatform Condition="$([MSBuild]::IsOSPlatform('osx'))">osx</_OSPlatform>
+    <_OSArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</_OSArchitecture>
+
+    <MicrosoftNetCoreIlasmPackageRuntimeId Condition="'$(MicrosoftNetCoreIlasmPackageRuntimeId)' == ''">$(_OSPlatform)-$(_OSArchitecture.ToLower())</MicrosoftNetCoreIlasmPackageRuntimeId>
+    <MicrosoftNetCoreIlasmPackageVersion Condition="'$(MicrosoftNetCoreIlasmPackageVersion)' == ''">2.0.8</MicrosoftNetCoreIlasmPackageVersion>
+    <MicrosoftNetCoreIlasmPackageName>runtime.$(MicrosoftNetCoreIlasmPackageRuntimeId).microsoft.netcore.ilasm</MicrosoftNetCoreIlasmPackageName>
+    <MicrosoftNetCoreRuntimeCoreClrPackageName>runtime.$(MicrosoftNetCoreIlasmPackageRuntimeId).microsoft.netcore.runtime.coreclr</MicrosoftNetCoreRuntimeCoreClrPackageName>
+
+    <ToolsDir Condition="'$(ToolsDir)' == ''">$([System.IO.Path]::Combine($([System.IO.Path]::GetTempPath()), $([System.IO.Path]::GetRandomFileName())))</ToolsDir>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="$(MicrosoftNetCoreIlasmPackageName)" Version="$(MicrosoftNetCoreIlasmPackageVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
+    <PackageReference Include="$(MicrosoftNetCoreRuntimeCoreClrPackageName)" Version="$(MicrosoftNetCoreIlasmPackageVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <CreateManifestResourceNamesDependsOn></CreateManifestResourceNamesDependsOn>
+  </PropertyGroup>
+
+  <Target Name="CreateManifestResourceNames"
+          Condition="'@(EmbeddedResource)' != ''"
+          DependsOnTargets="$(CreateManifestResourceNamesDependsOn)">
+    <!-- Required by Microsoft.Common.targets -->
+  </Target>
+
+  <Target Name="CoreCompile"
+          Inputs="$(MSBuildAllProjects);
+                  @(Compile)"
+          Outputs="@(IntermediateAssembly)"
+          Returns=""
+          DependsOnTargets="$(CoreCompileDependsOn)">
+    <ItemGroup>
+      <_IlasmSourceFiles Include="$(NuGetPackageRoot)\$(MicrosoftNetCoreIlasmPackageName)\$(MicrosoftNetCoreIlasmPackageVersion)\runtimes\$(MicrosoftNetCoreIlasmPackageRuntimeId)\native\**\*" />
+      <_IlasmSourceFiles Include="$(NuGetPackageRoot)\$(MicrosoftNetCoreRuntimeCoreClrPackageName)\$(MicrosoftNetCoreIlasmPackageVersion)\runtimes\$(MicrosoftNetCoreIlasmPackageRuntimeId)\native\**\*" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_IlasmDir>$(ToolsDir)\ilasm</_IlasmDir>
+
+      <_OutputTypeArgument Condition="'$(OutputType)' == 'Library'">-DLL</_OutputTypeArgument>
+      <_OutputTypeArgument Condition="'$(OutputType)' == 'Exe'">-EXE</_OutputTypeArgument>
+
+      <_KeyFileArgument Condition="'$(KeyOriginatorFile)' != ''">-KEY=$(KeyOriginatorFile)</_KeyFileArgument>
+
+      <_IlasmSwitches>-QUIET -NOLOGO</_IlasmSwitches> 
+      <_IlasmSwitches Condition="'$(FoldIdenticalMethods)' == 'True'">$(_IlasmSwitches) -FOLD</_IlasmSwitches>
+      <_IlasmSwitches Condition="'$(SizeOfStackReserve)' != ''">$(_IlasmSwitches) -STACK=$(SizeOfStackReserve)</_IlasmSwitches>
+      <_IlasmSwitches Condition="'$(DebugType)' == 'Full'">$(_IlasmSwitches) -DEBUG</_IlasmSwitches>
+      <_IlasmSwitches Condition="'$(DebugType)' == 'Impl'">$(_IlasmSwitches) -DEBUG=IMPL</_IlasmSwitches>
+      <_IlasmSwitches Condition="'$(DebugType)' == 'PdbOnly'">$(_IlasmSwitches) -DEBUG=OPT</_IlasmSwitches>
+      <_IlasmSwitches Condition="'$(Optimize)' == 'True'">$(_IlasmSwitches) -OPTIMIZE</_IlasmSwitches>
+    </PropertyGroup>
+
+    <!-- Having to copy these binaries is really inefficient. https://github.com/dotnet/coreclr/issues/18892 tracks making the ilasm tool self-contained  -->
+    <MakeDir Directories="$(_IlasmDir)" />
+    <Copy DestinationFolder="$(_IlasmDir)" SourceFiles="@(_IlasmSourceFiles)" />
+
+    <Exec Command="$(_IlasmDir)\ilasm $(_IlasmSwitches) $(_OutputTypeArgument) $(IlasmFlags) -OUTPUT=@(IntermediateAssembly) $(_KeyFileArgument) @(Compile, ' ')">
+      <Output TaskParameter="ExitCode" PropertyName="_ILAsmExitCode" />
+    </Exec>
+
+    <Error Text="ILAsm failed" Condition="'$(_ILAsmExitCode)' != '0'" />
+
+    <CallTarget Targets="$(TargetsTriggeredByCompilation)" Condition="'$(TargetsTriggeredByCompilation)' != ''"/>
+  </Target>
+
+  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
+
+</Project>

--- a/src/Microsoft.DotNet.Sdk.IL/sdk/Sdk.props
+++ b/src/Microsoft.DotNet.Sdk.IL/sdk/Sdk.props
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+***********************************************************************************************
+Sdk.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved. 
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildThisFileFullPath);$(MSBuildAllProjects)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  <Import Project="$(MSBuildThisFileDirectory)..\build\Microsoft.NET.Sdk.IL.props" Condition="'$(MSBuildProjectExtension)' == '.ilproj'" />
+
+</Project>

--- a/src/Microsoft.DotNet.Sdk.IL/sdk/Sdk.targets
+++ b/src/Microsoft.DotNet.Sdk.IL/sdk/Sdk.targets
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+***********************************************************************************************
+Sdk.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved. 
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildThisFileFullPath);$(MSBuildAllProjects)</MSBuildAllProjects>
+    <LanguageTargets Condition="'$(MSBuildProjectExtension)' == '.ilproj'">$(MSBuildThisFileDirectory)..\build\Microsoft.NET.Sdk.IL.targets</LanguageTargets>
+  </PropertyGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
+</Project>


### PR DESCRIPTION
This adds the basic support for an ilproj sdk. The IL compilation target was taken from the CoreFX `IL.targets`