### PR TITLE
Versioning

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,49 @@
-* text=auto
-*.sh eol=lf
-*.bin binary
+###############################################################################
+# Set default behavior to:
+#   automatically normalize line endings on check-in, and
+#   convert to Windows-style line endings on check-out
+###############################################################################
+* text=auto encoding=UTF-8
+*.sh text eol=lf
+
+###############################################################################
+# Set file behavior to:
+#   treat as text, and
+#   diff as C# source code
+###############################################################################
+*.cs        		text		diff=csharp
+
+###############################################################################
+# Set file behavior to:
+#   treat as text
+###############################################################################
+*.cmd       		text
+*.config    		text
+*.csproj    		text
+*.groovy			text
+*.json      		text
+*.md        		text
+*.nuspec			text
+*.pkgdef			text
+*.proj				text
+*.projitems			text
+*.props     		text
+*.ps1       		text
+*.resx				text
+*.ruleset			text
+*.shproj			text
+*.sln       		text
+*.targets   		text
+*.vb				text
+*.vbproj			text
+*.vcxproj			text
+*.vcxproj.filters	text
+*.vsct				text
+*.vsixmanifest		text
+
+###############################################################################
+# Set file behavior to:
+#   treat as binary
+###############################################################################
+*.png				binary
+*.snk       		binary

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -63,10 +63,6 @@
     PB_PublishBlobFeedUrl          {''|URL}                       Target feed URL.
     PB_PublishBlobFeedKey          {''|string}                    Account key.
     PB_SigningOrchestrationConfig  {''|string}                    Path to output Json for orchestrated-type signing (produce manifest that can be consumed later.)
-    PB_IsStable                    {''|'true'|'false'}            If specified then NuGet package version suffixes used by the repo are overridden by the orchestrated build like so:
-                                                                  if 'true' then version suffixes have format '{base version}-{PB_VersionStamp}', 
-                                                                  if 'false' then version suffixes have format '{base version}-{PB_VersionStamp}-{build number}'
-    PB_VersionStamp                {''|string}                    NuGet package pre-release version label e.g. 'beta', 'preview1', etc. May be empty.
   -->
   <PropertyGroup>
     <RealSign>false</RealSign>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/BuildReleasePackages.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/BuildReleasePackages.targets
@@ -12,9 +12,11 @@
 
   <UsingTask TaskName="Roslyn.Tools.UpdatePackageVersionTask" AssemblyFile="$(_NuGetRepackAssembly)" />
 
-  <Target Name="PackageReleasePackages" AfterTargets="Pack" Condition="'$(PB_IsStable)' == ''">
-    <Error Text="PreReleaseVersionLabel must be non-empty when using NuGet Repack tool." Condition="'$(PreReleaseVersionLabel)' == ''" />
+  <Target Name="PackageReleasePackages" AfterTargets="Pack" Condition="'$(DotNetFinalVersionKind)' == ''">
     <Message Text="Building release versions of NuGet packages" Importance="high" />
+
+    <Error Text="PreReleaseVersionLabel must be non-empty when using NuGet Repack tool." Condition="'$(PreReleaseVersionLabel)' == ''" />
+    <Error Text="NuGet Repack tool does not support SemVer2" Condition="'$(SemanticVersioningV1)' != 'true'"/>
 
     <ItemGroup>
       <_BuiltPackages Include="$(ArtifactsShippingPackagesDir)*.nupkg" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -13,7 +13,7 @@
 
   <PropertyGroup>
     <OfficialBuild>false</OfficialBuild>
-    <OfficialBuild Condition="'$(BUILD_BUILDNUMBER)' != ''">true</OfficialBuild>
+    <OfficialBuild Condition="'$(OfficialBuildId)' != ''">true</OfficialBuild>
   </PropertyGroup>
 
   <Import Project="$(VersionsPropsPath)" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.props
@@ -3,61 +3,90 @@
 <Project>
 
   <!--
-    https://github.com/dotnet/arcade/pull/108
+    Specification: https://github.com/dotnet/arcade/blob/master/Documentation/Versioning.md
     
     Properties:
-      PB_IsStable                 If specified then NuGet package version suffixes used by the repo are overridden by the orchestrated build like so:
-                                     if 'true' then version suffixes have format '{base version}.{PB_VersionStamp}', 
-                                     if 'false' then version suffixes have format '{base version}.{PB_VersionStamp}.{build number}'
-                                     For SemanticVersioning 1.0 dots ('.') are replaced by dashes ('-').
-      PB_VersionStamp             NuGet package pre-release version label e.g. 'beta', 'preview1', etc. May be empty.
-      OfficialBuildId             Contains the build id if this is an official build, otherwise must be empty.
-      CIBuild                     "true" if this is a CI build.
-      DotNetSemanticVersioningV1  "true" if the Version needs to respect SemVer 1.0. Default is false, which means format following SemVer 2.0.
+      SemanticVersioningV1  "true" if the Version needs to respect SemVer 1.0. Default is false, which means format following SemVer 2.0.
+      
+    Global settings:
+      DotNetUseShippingVersions   
+        - "true" to produce shipping versions in non-official builds, instead of default fixed dummy version number (42.42.42.42).
+        - A builds target that produces MSI shall fail if DotNetUseShippingVersions == false, since MSIs require increasing file versions to function properly.
   -->
     
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
 
+  <Choose>
+    <When Condition="'$(OfficialBuild)' == 'true' or '$(DotNetUseShippingVersions)' == 'true'">
+      <PropertyGroup>
+        <!--
+          Building MSIs from dev build requires file versions to be increasing. 
+          Use the current date in non-official builds. Note that this reduces the deterministic properties of the build 
+          and should only be enabled used when it's necessary to test-install the MSIs produced by the build.
+        -->
+        <_BuildNumber>$(OfficialBuildId)</_BuildNumber>
+        <_BuildNumber Condition="'$(OfficialBuildId)' == ''">$([System.DateTime]::Now.ToString(yyyyMMdd)).1</_BuildNumber>
+
+        <!--
+          Split the build parts out from the BuildNumber which is given to us by VSTS in the format of yyyymmdd.nn
+          where VersionSuffixDateStamp is mmmdd (such as 60615) and VersionSuffixBuildOfTheDay is nn (which represents the nth build
+          started that day). So the first build of the day, 20160615.1, will produce something similar to VersionSuffixDateStamp: 60615,
+          BuildNumberBuildOfTheDayPadded: 01; and the 12th build of the day, 20160615.12, will produce VersionSuffixDateStamp: 60615, 
+          VersionSuffixBuildOfTheDay: 12
+
+          Additionally, in order ensure the value fits in the 16-bit PE header fields, we will only take the last five digits of the BuildNumber, so
+          in the case of 20160615, we will set VersionSuffixDateStamp to 60615. Further, if this would result in a number like 71201 or 81201, we
+          decrement the year and add 12 to the month to extend the time. 
+        -->
+        <_BuildNumberFiveDigitDateStamp>$([MSBuild]::Subtract($(_BuildNumber.Split($([System.Convert]::ToString(`.`).ToCharArray())).GetValue($([System.Convert]::ToInt32(0)))), 20100000))</_BuildNumberFiveDigitDateStamp>
+        <_BuildNumberFiveDigitDateStampYearsToOffset>$([System.Math]::Max($([System.Convert]::ToInt32($([MSBuild]::Subtract($([MSBuild]::Divide($(_BuildNumberFiveDigitDateStamp), 10000)), 6)))), 0))</_BuildNumberFiveDigitDateStampYearsToOffset>
+    
+        <VersionSuffixDateStamp>$([MSBuild]::Subtract($([System.Convert]::ToInt32($(_BuildNumberFiveDigitDateStamp))), $([MSBuild]::Multiply($(_BuildNumberFiveDigitDateStampYearsToOffset), 8800))))</VersionSuffixDateStamp>
+        <VersionSuffixBuildOfTheDay>$(_BuildNumber.Split($([System.Convert]::ToString(`.`).ToCharArray())).GetValue($([System.Convert]::ToInt32(1))))</VersionSuffixBuildOfTheDay>
+        <VersionSuffixBuildOfTheDayPadded>$(_BuildNumberBuildOfTheDay.PadLeft($([System.Convert]::ToInt32(2)), $([System.Convert]::ToChar(`0`))))</VersionSuffixBuildOfTheDayPadded>
+
+        <_BuildNumberSuffix Condition="'$(SemanticVersioningV1)' != 'true'">.$(VersionSuffixDateStamp).$(VersionSuffixBuildOfTheDay)</_BuildNumberSuffix>
+        <_BuildNumberSuffix Condition="'$(SemanticVersioningV1)' == 'true'">-$(VersionSuffixDateStamp)-$(VersionSuffixBuildOfTheDayPadded)</_BuildNumberSuffix>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <VersionSuffixDateStamp/>
+        <VersionSuffixBuildOfTheDay/>
+        <VersionSuffixBuildOfTheDayPadded/>
+        <_BuildNumberSuffix/>
+
+        <!--
+          Don't include a commit SHA to AssemblyInformationalVersion. 
+          It would reduce the possibility of sharing otherwise unchanged build artifacts across deterministic builds.
+        -->
+        <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  
+  <PropertyGroup>
     <_PreReleaseLabel>$(PreReleaseVersionLabel)</_PreReleaseLabel>
-    <_PreReleaseLabel Condition="'$(PB_VersionStamp)' != ''">$(PB_VersionStamp)</_PreReleaseLabel>
-    <_PreReleaseLabel Condition="'$(OfficialBuildId)' == '' and '$(CIBuild)' == 'true'">ci</_PreReleaseLabel>
-    <_PreReleaseLabel Condition="'$(OfficialBuildId)' == '' and '$(CIBuild)' != 'true'">dev</_PreReleaseLabel>
-
-    <_BuildNumber>$(OfficialBuildId)</_BuildNumber>
-    <_BuildNumber Condition="'$(_BuildNumber)' == ''">$([System.DateTime]::Now.ToString(yyyyMMdd)).1</_BuildNumber>
+    <_PreReleaseLabel Condition="'$(CIBuild)' == 'true' and '$(OfficialBuild)' != 'true'">ci</_PreReleaseLabel>
+    <_PreReleaseLabel Condition="'$(CIBuild)' != 'true'">dev</_PreReleaseLabel>
 
     <!--
-        Split the build parts out from the BuildNumber which is given to us by MicroBuild in the format of yyyymmdd.nn
-        where BuildNumberFiveDigitDateStamp is mmmdd (such as 60615) and BuildNumberBuildOfTheDay is nn (which represents the nth build
-        started that day). So the first build of the day, 20160615.1, will produce something similar to BuildNumberFiveDigitDateStamp: 60615,
-        BuildNumberBuildOfTheDayPadded: 01; and the 12th build of the day, 20160615.12, will produce BuildNumberFiveDigitDateStamp: 60615, 
-        BuildNumberBuildOfTheDay: 12
-
-        Additionally, in order ensure the value fits in the 16-bit PE header fields, we will only take the last five digits of the BuildNumber, so
-        in the case of 20160615, we will set BuildNumberFiveDigitDateStamp to 60615. Further, if this would result in a number like 71201 or 81201, we
-        decrement the year and add 12 to the month to extend the time. 
+      If DotNetFinalVersionKind is specified, overrides the package version produced by the build like so:
+        ""           1.2.3-beta.12345.67+sha
+        "prerelease" 1.2.3-beta+sha
+        "release"    1.2.3
     -->
-    <_BuildNumberFiveDigitDateStamp>$([MSBuild]::Subtract($(_BuildNumber.Split($([System.Convert]::ToString(`.`).ToCharArray())).GetValue($([System.Convert]::ToInt32(0)))), 20100000))</_BuildNumberFiveDigitDateStamp>
-    <_BuildNumberFiveDigitDateStampYearsToOffset>$([System.Math]::Max($([System.Convert]::ToInt32($([MSBuild]::Subtract($([MSBuild]::Divide($(_BuildNumberFiveDigitDateStamp), 10000)), 6)))), 0))</_BuildNumberFiveDigitDateStampYearsToOffset>
-    <_BuildNumberFiveDigitDateStamp>$([MSBuild]::Subtract($([System.Convert]::ToInt32($(_BuildNumberFiveDigitDateStamp))), $([MSBuild]::Multiply($(_BuildNumberFiveDigitDateStampYearsToOffset), 8800))))</_BuildNumberFiveDigitDateStamp>
-
-    <!-- The padding is only needed on SemVer 1.0 -->
-    <_BuildNumberBuildOfTheDayPadded>$(_BuildNumber.Split($([System.Convert]::ToString(`.`).ToCharArray())).GetValue($([System.Convert]::ToInt32(1))))</_BuildNumberBuildOfTheDayPadded>
-    <_BuildNumberBuildOfTheDayPadded Condition="'$(DotNetSemanticVersioningV1)' == 'true'">$(_BuildNumberBuildOfTheDayPadded.PadLeft($([System.Convert]::ToInt32(2)), $([System.Convert]::ToChar(`0`))))</_BuildNumberBuildOfTheDayPadded>
+    <VersionSuffix Condition="'$(DotNetFinalVersionKind)' == 'release'"/>
+    <VersionSuffix Condition="'$(DotNetFinalVersionKind)' == 'prerelease'">$(_PreReleaseLabel)</VersionSuffix>
+    <VersionSuffix Condition="'$(DotNetFinalVersionKind)' == ''">$(_PreReleaseLabel)$(_BuildNumberSuffix)</VersionSuffix>
     
-    <!-- This handles the Dev/Daily case of the versioning specification. -->
-    <VersionSuffix Condition="'$(PB_IsStable)' != 'true'">$(_PreReleaseLabel).$(_BuildNumberFiveDigitDateStamp).$(_BuildNumberBuildOfTheDayPadded)</VersionSuffix>
-
-    <!-- This handles the 'Final Prerelease' case of the versioning specification. -->
-    <VersionSuffix Condition="'$(PB_IsStable)' == 'true' and '$(PB_VersionStamp)' != ''">$(PB_VersionStamp).final</VersionSuffix>
-
-    <!-- This handles the 'Stable' case of the versioning specification. -->
-    <!-- For this case the version suffix is empty. -->
-    <VersionSuffix Condition="'$(PB_IsStable)' == 'true' and '$(PB_VersionStamp)' == ''"></VersionSuffix>
-
-    <!-- We support SemanticVersioning 1.0; For that we need to replace {'.', '+'} by {'-'} -->
-    <VersionSuffix Condition="'$(DotNetSemanticVersioningV1)' == 'true'">$(VersionSuffix.Replace('.', '-'))</VersionSuffix>
+    <!-- 
+      Disable NuGet Pack warning that the version is SemVer 2.0.
+      SemVer 2.0 is supported by Nuget since 3.0.0 (July 2015) in some capacity, and fully since 3.5.0 (October 2016).
+    -->
+    <NoWarn Condition="'$(SemanticVersioningV1)' != 'true'">$(NoWarn);NU5105</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
@@ -3,13 +3,10 @@
 <Project>
 
   <!--
+    Specification: https://github.com/dotnet/arcade/blob/master/Documentation/Versioning.md
+ 
     Properties:
-      OfficialBuildId             Contains the build id if this is an official build, otherwise must be empty.
-      SourceRevisionId            Contains the SHA of the repo being built.
-      CIBuild                     "true" if this is a CI build
-      UseShippingAssemblyVersion  "true" to set assembly version in a dev build to a shipping one instead of 42.42.42.42
-      UseShippingFileVersion      "true" to set file version in a dev build to a shipping one instead of 42.42.42.42
-      DotNetSemanticVersioningV1  "true" if the Version needs to respect SemVer 1.0. Default is false, which means format following SemVer 2.0.
+      SemanticVersioningV1        "true" if the Version needs to respect SemVer 1.0. Default is false, which means format following SemVer 2.0.
   -->
 
   <PropertyGroup>
@@ -17,27 +14,43 @@
   </PropertyGroup>
 
   <Target Name="_InitializeAssemblyVersion" BeforeTargets="GetAssemblyVersion">
-    <PropertyGroup Condition="'$(OfficialBuildId)' != ''">
-      <FileVersion>$(VersionPrefix).$(_BuildNumberFiveDigitDateStamp)</FileVersion>
-      <InformationalVersion>$(Version)</InformationalVersion>
+    <Error Text="Invalid format of OfficialBuildId: '$(OfficialBuildId)'" 
+           Condition="$(VersionSuffixDateStamp) != '' and ($(VersionSuffixDateStamp.Length) != 5 or $(VersionSuffixBuildOfTheDayPadded.Length) != 2)"/>
+   
+    <PropertyGroup Condition="'$(VersionSuffixDateStamp)' != ''">
+      <FileVersion>$(VersionPrefix).$(VersionSuffixDateStamp)</FileVersion>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(OfficialBuildId)' == ''">
-      <AssemblyVersion Condition="'$(UseShippingAssemblyVersion)' != 'true' and '$(CIBuild)' != 'true'">42.42.42.42</AssemblyVersion>
-      <FileVersion>42.42.42.42</FileVersion>
-      <InformationalVersion>42.42.42.42</InformationalVersion>
+    <PropertyGroup Condition="'$(VersionSuffixDateStamp)' == ''">
+      <!--
+        Set FileVersion to a distinct version that's greater than any shipping version.
+        This makes it possible to install binaries produced by a dev build over product binaries,
+        provided that the installer only requires higher version. 
+      -->
+      <FileVersion>42.42.42.42424</FileVersion>
+      
+      <!--
+        Respect version explicitly set by the project.
+        The default .NET Core SDK implementation sets AssemblyVersion from NuGet package version, 
+        which we want to override in dev builds.
+      -->
+      <AssemblyVersion Condition="'$(AssemblyVersion)' == ''">42.42.42.42</AssemblyVersion>
     </PropertyGroup>
   </Target>
 
-  <Target Name="_InitializePackageVersion" BeforeTargets="GenerateNuSpec" DependsOnTargets="InitializeSourceControlInformation">
-    <PropertyGroup>
-      <!-- First 8 chars from the SHA -->
+  <!-- 
+    Append short commit SHA to PackageVersion.
+  -->
+  <Target Name="_InitializePackageVersion" 
+          BeforeTargets="GenerateNuSpec" 
+          DependsOnTargets="InitializeSourceControlInformation"
+          Condition="'$(DotNetFinalVersionKind)' != 'release'">
+    <PropertyGroup Condition="'$(SourceRevisionId)' != ''">
       <_ShortSha>$(SourceRevisionId)</_ShortSha>
       <_ShortSha Condition="$(SourceRevisionId.Length) &gt; 7">$(SourceRevisionId.Substring(0, 8))</_ShortSha>
 
-      <!-- We support SemanticVersioning 1.0; For that we need to replace {'.', '+'} by {'-'} -->
-      <PackageVersion Condition="'$(DotNetSemanticVersioningV1)' != 'true'">$(Version)+$(_ShortSha)</PackageVersion>
-      <PackageVersion Condition="'$(DotNetSemanticVersioningV1)' == 'true'">$(Version)-$(_ShortSha)</PackageVersion>
+      <PackageVersion Condition="'$(SemanticVersioningV1)' != 'true'">$(Version)+$(_ShortSha)</PackageVersion>
+      <PackageVersion Condition="'$(SemanticVersioningV1)' == 'true'">$(Version)-$(_ShortSha)</PackageVersion>
     </PropertyGroup>
   </Target>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.InsertionManifests.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.InsertionManifests.targets
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
@@ -16,7 +16,6 @@
   <Target Name="GenerateVisualStudioInsertionManifests"
           AfterTargets="Pack"
           Outputs="%(_StubDirs.Identity)"
-          DependsOnTargets="GetVsixVersion"
           Condition="'@(_StubDirs)' != ''">
     <PropertyGroup>
       <_ComponentDir>%(_StubDirs.Identity)</_ComponentDir>
@@ -28,7 +27,7 @@
       <_Args Include="SetupOutputPath=$(VisualStudioSetupInsertionPath)"/>
       <_Args Include="ComponentIntermediateOutputPath=$(VisualStudioSetupIntermediateOutputPath)$(_ComponentName)\"/>
       <_Args Include="SwixBuildPath=$(NuGetPackageRoot)microbuild.plugins.swixbuild\$(MicroBuildPluginsSwixBuildVersion)\"/>
-      <_Args Include="ManifestBuildVersion=$(_VsixVersion)" />
+      <_Args Include="ManifestBuildVersion=$(VsixVersion)" />
     </ItemGroup>
 
     <Message Text="Generating manifest for VS component '$(_ComponentName)'" Importance="high"/>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
@@ -31,7 +31,7 @@
     <MergeManifest Include="@(_PackageStubFiles->'$(SetupOutputPath)%(Filename).json')"/>
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(BUILD_BUILDNUMBER)' == ''">
+  <PropertyGroup Condition="'$(OfficialBuild)' != 'true'">
     <FinalizeManifest>false</FinalizeManifest>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.props
@@ -6,6 +6,11 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <VsixVersion Condition="'$(VersionSuffixDateStamp)' != ''">$(VersionPrefix).$(VersionSuffixDateStamp)$(VersionSuffixBuildOfTheDayPadded)</VsixVersion>
+    <VsixVersion Condition="'$(VersionSuffixDateStamp)' == ''">42.42.42.9999999</VsixVersion>
+  </PropertyGroup>
+  
   <!-- VSIX settings -->
   <PropertyGroup>
     <VsixSourceManifestPath>$(MSBuildProjectDirectory)\source.extension.vsixmanifest</VsixSourceManifestPath>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.targets
@@ -246,11 +246,10 @@
   <!--
     Export VSIX version. This target is to be used in vsixmanifest files.
   -->
-  <Target Name="GetVsixVersion" Outputs="$(_VsixVersion)">
-    <PropertyGroup>
-      <_VsixVersion Condition="'$(OfficialBuild)' == 'true'">$(VersionPrefix).$(_BuildNumberFiveDigitDateStamp)$(_BuildNumberBuildOfTheDayPadded)</_VsixVersion>
-      <_VsixVersion Condition="'$(OfficialBuild)' != 'true'">42.42.42.42</_VsixVersion>
-    </PropertyGroup>
+  <Target Name="GetVsixVersion" Outputs="$(VsixVersion)">
+    <Error Text="Invalid format of OfficialBuildId: '$(OfficialBuildId)'"
+           Condition="$(VersionSuffixDateStamp) != '' and ($(VersionSuffixDateStamp.Length) != 5 or $(VersionSuffixBuildOfTheDayPadded.Length) != 2)"/>
+
   </Target>
 
 </Project>


### PR DESCRIPTION
Finishes versioning. 

Fixes https://github.com/dotnet/arcade/issues/316, item 2 in https://github.com/dotnet/arcade/issues/309.

- Keeps `OfficialBuild` boolean and sets it based on the value of `OfficialBuildId`. Previously I proposed replacing it with `OfficialBuildId != ''` but it turns out using the boolean is more readable.

- Rename `DotNetSemanticVersioningV1` to `SemanticVersioningV1` since we expect this value to be set by the project (or in the repo props files) not as a `/p:` parameter to the build

**DotNetFinalVersionKind**

Overrides the format of `PackageVersion`

| DotNetFinalVersionKind | PackageVersion |
|--------------------------|------------------|
|“”	| “1.2.3-beta.12345.67+sha”|
|“prerelease”	| “1.2.3-beta+sha”|
| “release”| 	“1.2.3”|


**DotNetUseShippingVersions**

-	We define a bool variable `DotNetUseShippingVersions` that will determine whether versions should be shipping or fixed to a high version number (42.42.42.42).
-	`DotNetUseShippingVersions = false` by default, can be passed to the build /p:DotNetBuildShippingVersions=… 
-	If `DotNetUseShippingVersions == true`
    - If `OfficialBuildId != ""` then the build number in version suffix gets initialized from `OfficialBuildId`
    - If `OfficialBuildId == ""` then the build number in version suffix gets initialized from the current date.
-	If `DotNetUseShippingVersions == false`
   - Build number will not be included in package version, assembly and file versions will be fixed 
-	A builds target that produces MSI will require `DotNetBuildShippingVersions == true`, and fail otherwise
-	Official build will set `DotNetUseShippingVersions = true`
-	PR validation build that does not need to install MSI will use the default DotNetUseShippingVersions = false
-	PR validation build that runs integration tests that need to install MSI will pass `/DotNetUseShippingVersions=true`.
  - The same can be done by a dev who wants to build MSI locally.
  - We can have a helper batch file for convenience in repos that this is a common practice: BuildSetup.cmd 
-	Dev build will use the default `DotNetUseShippingVersions = false`
