### PR TITLE
buildReason not needed

### DIFF
--- a/.vsts-code-mirror.yml
+++ b/.vsts-code-mirror.yml
@@ -6,7 +6,6 @@ phases:
 - template: /eng/common/templates/phases/base.yml
   parameters:
     agentsOS: Windows_NT
-    buildReason: IndividualCI
     phaseName: Mirror_GitHub_to_VSTS
     phase:
       queue:


### PR DESCRIPTION
buildReason is no longer a required parameter of [base.yml](https://github.com/dotnet/arcade/blob/master/eng/common/templates/phases/base.yml)