### PR TITLE
Parse args before defining properties

### DIFF
--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -33,12 +33,6 @@ properties=''
 repo_root="$scriptroot/../.."
 eng_root="$scriptroot/.."
 artifacts_dir="$repo_root/artifacts"
-artifacts_configuration_dir="$artifacts_dir/$configuration"
-toolset_dir="$artifacts_dir/toolset"
-log_dir="$artifacts_configuration_dir/log"
-build_log="$log_dir/Build.binlog"
-toolset_restore_log="$log_dir/ToolsetRestore.binlog"
-temp_dir="$artifacts_configuration_dir/tmp"
 
 global_json_file="$repo_root/global.json"
 build_driver=""
@@ -131,6 +125,13 @@ while (($# > 0)); do
       ;;
   esac
 done
+
+artifacts_configuration_dir="$artifacts_dir/$configuration"
+toolset_dir="$artifacts_dir/toolset"
+log_dir="$artifacts_configuration_dir/log"
+build_log="$log_dir/Build.binlog"
+toolset_restore_log="$log_dir/ToolsetRestore.binlog"
+temp_dir="$artifacts_configuration_dir/tmp"
 
 # ReadJson [filename] [json key]
 # Result: Sets 'readjsonvalue' to the value of the provided json key


### PR DESCRIPTION
I scoped the "gather logs" step of the Arcade build to only capture files from `artifacts\configuration\log`, and then started seeing a warning on Linux Release legs because it couldn't find logs.

https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/results?buildId=1884119&view=logs

Looks like some properties which were dependent on command-line options were being defined before the args were processed so the values were wrong (logs on Linux Release were going into the `artifacts\Debug\log` folder).

FYI @alexperovich 