### PR TITLE
Remove internal feed

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -5,7 +5,6 @@
   </solution>
   <packageSources>
     <clear />
-    <add key="arcade" value="https://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json" />
     <add key="arcade" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>

--- a/global.json
+++ b/global.json
@@ -3,6 +3,6 @@
         "version": "2.1.300"
     },
     "msbuild-sdks": {
-        "Microsoft.DotNet.Arcade.Sdk": "1.0.0-bootstrap-1"
+        "Microsoft.DotNet.Arcade.Sdk": "1.0.0-prerelease-63123-07"
     }
 }


### PR DESCRIPTION
I triggered an internal build and the packages are now in the dotnet-core feed.