### PR TITLE
Refactor base and telemetry templates for repository reuse

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -23,12 +23,11 @@ phases:
           ${{ if notIn(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'PullRequest') }}:
             _PublishType: blob
             _SignType: real
-
+            _UseEsrpSigning: true
 
 - template: /eng/build.yml
   parameters:
     agentOs: Linux
-    dockerImage: microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-0cd4667-20170319080304
     queue: 
       ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'PullRequest') }}:
         name: DotNetCore-Linux
@@ -49,3 +48,5 @@ phases:
             _SignType: test
           ${{ if notIn(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'PullRequest') }}:
             _SignType: real
+    variables:
+      _PREVIEW_VSTS_DOCKER_IMAGE: microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-0cd4667-20170319080304

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -1,114 +1,109 @@
-# build.yml
-# Description: Defines the build phase
-# Parameters:
-#   agentOs: [Windows_NT (default), Linux, OSX] Used in templates to define variables which are OS specific
-#   dockerImage: If defined, specifies docker image to run build steps in
-#   matrix: build matrix
-#   queueName: agent pool name
-#   enableTelemetry: send telemetry if build is not a PR or CI build
-
 parameters:
+  # [Windows_NT (default), Linux, OSX] Used in templates to define variables which are OS specific
   agentOs: Windows_NT
-  dockerImage: ''
+  # send telemetry if build is not a PR or CI build  
   enableTelemetry: true
+  # queue YAML object - https://github.com/Microsoft/vsts-agent/blob/master/docs/preview/yamlgettingstarted-schema.md#queue
   queue: {}
-  useEsrpSigning: true
+  # variables YAML object - https://github.com/Microsoft/vsts-agent/blob/master/docs/preview/yamlgettingstarted-schema.md#phase
+  variables: {}
 
 phases:
 - template: /eng/common/templates/phases/base.yml
   parameters:
     agentOs: ${{ parameters.agentOs }}
-    buildConfig: $(_BuildConfig)
-    phaseName: ${{ parameters.agentOs }}
-    dockerImage: ${{ parameters.dockerImage }}
+
     enableTelemetry: ${{ parameters.enableTelemetry }}
+
     fetchDepth: 5
-    helixType: build/product
-    ${{ if notIn(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'PullRequest') }}:
-      helixSource: official/dotnet/arcade/$(Build.SourceBranch)
-    ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'PullRequest') }}:
-      helixSource: pr/dotnet/arcade/$(Build.SourceBranch)
-    phase:
-      queue: ${{ parameters.queue }}
-      variables: 
-        ${{ if notIn(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'PullRequest') }}:
-          _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-          _TeamName: DotNetCore
-          _UseEsrpSigning: ${{ parameters.useEsrpSigning }}
-        ${{ if notIn(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'PullRequest') }}:
-          _PublishArgs: /p:PB_PublishBlobFeedKey=$(dotnetfeed-storage-access-key-1) 
-            /p:PB_PublishBlobFeedUrl=$(_PublishBlobFeedUrl) 
-            /p:PB_PublishType=$(_PublishType) 
-        ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'PullRequest') }}:
-          _PublishArgs: ''
-      steps:
-      - template: /eng/common/templates/steps/run-on-windows.yml
-        parameters:
-          agentOs: ${{ parameters.agentOs }} 
-          steps:
-          - template: /eng/common/templates/steps/build-reason.yml
-            parameters:
-              conditions: not IndividualCI,BatchedCI,PullRequest
-              steps:
-              - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
-                displayName: Install MicroBuild plugin
-                inputs:
-                  signType: $(_SignType)
-                  zipSources: false
-                  esrpSigning: $(_UseEsrpSigning)
-                env:
-                  TeamName: $(_TeamName)
-                continueOnError: false
-                condition: and(succeeded(), in(variables._SignType, 'real', 'test'))
-              - task: AzureKeyVault@1
-                inputs:
-                  azureSubscription: 'DotNet-Engineering-Services_KeyVault'
-                  KeyVaultName: EngKeyVault
-                  SecretsFilter: 'dotnetfeed-storage-access-key-1'
-                condition: succeeded()
-          - script: eng\common\cibuild.cmd
-              -configuration $(_BuildConfig) 
-              -prepareMachine
-              /p:SignType=$(_SignType)
-              $(_PublishArgs)
-            name: Build_Publish
-            displayName: Build / Publish
-            env:
-              OfficialBuildId: $(BUILD.BUILDNUMBER)
-            condition: succeeded()
-      - template: /eng/common/templates/steps/run-on-unix.yml
-        parameters:
-          agentOs: ${{ parameters.agentOs }}
-          steps:
-          - script: eng/common/cibuild.sh
-              --configuration $(_BuildConfig) 
-              --prepareMachine
-              /p:SignType=$(_SignType)
-              $(_PublishArgs)
-            name: Build_Publish
-            displayName: Build / Publish
-            env:
-              OfficialBuildId: $(BUILD.BUILDNUMBER)
-            condition: succeeded()
-      - template: /eng/common/templates/steps/build-reason.yml
-        parameters:
-          conditions: not IndividualCI,BatchedCI,PullRequest
-          steps:
-          - task: CopyFiles@2
-            displayName: Gather Logs
-            inputs:
-              SourceFolder: '$(Build.SourcesDirectory)/artifacts/$(_BuildConfig)/log'
-              TargetFolder: '$(Build.StagingDirectory)/BuildLogs'
-            continueOnError: true
-            condition: succeededOrFailed()
-          - task: PublishBuildArtifacts@1
-            displayName: Publish Logs to VSTS
-            inputs:
-              PathtoPublish: '$(Build.StagingDirectory)/BuildLogs'
-              PublishLocation: Container
-              ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
-                ArtifactName: Windows_NT_$(Agent.JobName)
-              ${{ if ne(parameters.agentOs, 'Windows_NT') }}:
-                ArtifactName: Linux_$(Agent.JobName)
-            continueOnError: true
-            condition: succeededOrFailed()
+    
+    name: ${{ parameters.agentOs }}
+
+    queue: ${{ parameters.queue }}
+
+    variables: 
+      ${{ insert }}: ${{ parameters.variables }}
+      _HelixType: build/product
+      _HelixBuildConfig: $(_BuildConfig)
+      ${{ if notIn(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'PullRequest') }}:
+        _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+        _TeamName: DotNetCore
+        _PublishArgs: /p:PB_PublishBlobFeedKey=$(dotnetfeed-storage-access-key-1) 
+          /p:PB_PublishBlobFeedUrl=$(_PublishBlobFeedUrl) 
+          /p:PB_PublishType=$(_PublishType) 
+        _HelixSource: official/dotnet/arcade/$(Build.SourceBranch)
+      ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'PullRequest') }}:
+        _PublishArgs: ''
+        _HelixSource: pr/dotnet/arcade/$(Build.SourceBranch)
+
+    steps:
+    # Internal only build steps
+    - template: /eng/common/templates/steps/build-reason.yml
+      parameters:
+        conditions: not IndividualCI,BatchedCI,PullRequest
+        steps:
+        - template: /eng/common/templates/steps/run-on-windows.yml
+          parameters:
+            agentOs: ${{ parameters.agentOs }} 
+            steps:
+            - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
+              displayName: Install MicroBuild plugin
+              inputs:
+                signType: $(_SignType)
+                zipSources: false
+                esrpSigning: $(_UseEsrpSigning)
+              env:
+                TeamName: $(_TeamName)
+              continueOnError: false
+              condition: and(succeeded(), in(variables['_SignType'], 'real', 'test'))
+            - task: AzureKeyVault@1
+              inputs:
+                azureSubscription: 'DotNet-Engineering-Services_KeyVault'
+                KeyVaultName: EngKeyVault
+                SecretsFilter: 'dotnetfeed-storage-access-key-1'
+              condition: succeeded()
+
+    # Use utility script to run script command dependent on agent OS
+    - template: /eng/common/templates/steps/run-script-ifequalelse.yml
+      parameters:
+        parameter1: Windows_NT
+        parameter2: ${{ parameters.agentOs }}
+        ifScript: eng\common\cibuild.cmd
+          -configuration $(_BuildConfig) 
+          -prepareMachine
+          /p:SignType=$(_SignType)
+          $(_PublishArgs)
+        elseScript: eng/common/cibuild.sh
+          --configuration $(_BuildConfig) 
+          --prepareMachine
+          /p:SignType=$(_SignType)
+          $(_PublishArgs)
+        name: Build_Publish
+        displayName: Build / Publish
+        env:
+          OfficialBuildId: $(BUILD.BUILDNUMBER)
+        condition: succeeded()
+
+    # Internal only build steps (until publishing artifacts in public CI is supported)
+    - template: /eng/common/templates/steps/build-reason.yml
+      parameters:
+        conditions: not IndividualCI,BatchedCI,PullRequest
+        steps:
+        - task: CopyFiles@2
+          displayName: Gather Logs
+          inputs:
+            SourceFolder: '$(Build.SourcesDirectory)/artifacts/$(_BuildConfig)/log'
+            TargetFolder: '$(Build.StagingDirectory)/BuildLogs'
+          continueOnError: true
+          condition: succeededOrFailed()
+        - task: PublishBuildArtifacts@1
+          displayName: Publish Logs to VSTS
+          inputs:
+            PathtoPublish: '$(Build.StagingDirectory)/BuildLogs'
+            PublishLocation: Container
+            ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
+              ArtifactName: Windows_NT_$(Agent.JobName)
+            ${{ if ne(parameters.agentOs, 'Windows_NT') }}:
+              ArtifactName: Linux_$(Agent.JobName)
+          continueOnError: true
+          condition: succeededOrFailed()

--- a/eng/common/templates/phases/base.yml
+++ b/eng/common/templates/phases/base.yml
@@ -1,58 +1,66 @@
-# base.yml
-# Description: Expands a phase object, applying telemetry, docker info, etc...
-# Parameters:
-#   agentOs: [Windows_NT (default), Linux, OSX] Used in templates to define variables which are OS specific
-#   buildConfig: buildConfiguration property provided to telemetry
-#   dockerImage: If defined, specifies docker image to run build steps in
-#   enableTelemetry: send telemetry if build is not a PR or CI build
-#   fetchDepth: Limit fetching to the specified number of commits from the tip of each remote branch history
-#   helixSource: telemetry source to report
-#   helixType: telemetry type to report
-#   phaseName: name of phase
-#   phase: defined phase object
-
 parameters:
-  agentOs: Windows_NT
-  buildConfig: ''
+  # Optional: Clean sources before building
   clean: true
-  dockerImage: ''
-  enableTelemetry: ''
+
+  # Optional: Git fetch depth
   fetchDepth: ''
-  helixSource: 'undefined_defaulted_in_base.yml'
-  helixType: 'undefined_defaulted_in_base.yml'
-  phaseName: ''
-  phase: {}
+
+  # Optional: name of the phase (not specifying phase name may cause name collisions)
+  name: ''
+
+  # Required: A defined YAML queue
+  queue: {}
+
+  # Required: build steps
+  steps: []
+
+  # Optional: variables
+  variables: {}
+
+  ## Telemetry variables
+
+  # Required: determines whether to run cmd or sh telemetry files
+  agentOs: Windows_NT
+
+  # Optional: enable sending telemetry
+  #           if enabled, these "variables" must be specified in the variables object
+  #             _HelixBuildConfig - differentiate between Debug, Release, other
+  #             _HelixSource - Example: build/product
+  #             _HelixType - Example: official/dotnet/arcade/$(Build.SourceBranch)
+  enableTelemetry: false
 
 phases:
-- phase: ${{ parameters.phaseName }}
-  queue: ${{ parameters.phase.queue }}
-  ${{ if and(ne(parameters.phase.variables, ''), eq(parameters.dockerImage, '')) }}:
-    variables: ${{ parameters.phase.variables }}
-  ${{ if ne(parameters.dockerImage, '') }}:
-    variables:
-      _PREVIEW_VSTS_DOCKER_IMAGE: ${{ parameters.dockerImage }}
-      ${{ insert }}: ${{ parameters.phase.variables }}
+- phase: ${{ parameters.name }}
+
+  queue: ${{ parameters.queue }}
+
+  ${{ if ne(parameters.variables, '') }}:
+    variables: ${{ parameters.variables }}
+
   steps:
   - checkout: self
     clean: ${{ parameters.clean }}
     ${{ if ne(parameters.fetchDepth, '') }}:
       fetchDepth: ${{ parameters.fetchDepth }}
-  - template: /eng/common/templates/steps/build-reason.yml
-    parameters:
-      conditions: not IndividualCI,BatchedCI,PullRequest
-      steps:
-      - ${{ if eq(parameters.enableTelemetry, 'true') }}:
-        - template: /eng/common/templates/steps/telemetry.yml
-          parameters:
-            agentOs: ${{ parameters.agentOs }}
-            buildConfig: ${{ parameters.buildConfig }}
-            helixSource: ${{ parameters.helixSource }}
-            helixType: ${{ parameters.helixType }}
-            steps: ${{ parameters.phase.steps }}
-      - ${{ if not(eq(parameters.enableTelemetry, 'true')) }}:
-        - ${{ parameters.phase.steps }}
-  - template: /eng/common/templates/steps/build-reason.yml
-    parameters:
-      conditions: IndividualCI,BatchedCI,PullRequest
-      steps:
-      - ${{ parameters.phase.steps }}
+
+  - ${{ if eq(parameters.enableTelemetry, 'true') }}:
+    # Remove this condition once telemetry can be sent from public CI
+    - ${{ if notIn(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'PullRequest') }}:
+      - template: /eng/common/templates/steps/telemetry-start.yml
+        parameters:
+          agentOs: ${{ parameters.agentOs }}
+          buildConfig: ${{ parameters.variables._HelixBuildConfig }}
+          helixSource: ${{ parameters.variables._HelixSource }}
+          helixType: ${{ parameters.variables._HelixType }}
+
+  # Run provided build steps
+  - ${{ parameters.steps }}
+
+  - ${{ if eq(parameters.enableTelemetry, 'true') }}:
+    # Remove this condition once telemetry can be sent from public CI
+    - ${{ if notIn(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'PullRequest') }}:
+      - template: /eng/common/templates/steps/telemetry-end.yml
+        parameters:
+          agentOs: ${{ parameters.agentOs }}
+          helixSource: ${{ parameters.variables._HelixSource }}
+          helixType: ${{ parameters.variables._HelixType }}

--- a/eng/common/templates/steps/run-script-ifequalelse.yml
+++ b/eng/common/templates/steps/run-script-ifequalelse.yml
@@ -1,0 +1,33 @@
+parameters:
+  # if parameter1 equals parameter 2, run 'ifScript' command, else run 'elsescript' command
+  parameter1: ''
+  parameter2: ''
+  ifScript: ''
+  elseScript: ''
+
+  # name of script step
+  name: Script
+
+  # display name of script step
+  displayName: If-Equal-Else Script
+
+  # environment
+  env: {}
+
+  # conditional expression for step execution
+  condition: ''
+
+steps:
+- ${{ if and(ne(parameters.ifScript, ''), eq(parameters.parameter1, parameters.parameter2)) }}:
+  - script: ${{ parameters.ifScript }}
+    name: ${{ parameters.name }}
+    displayName: ${{ parameters.displayName }}
+    env: ${{ parameters.env }}
+    condition: ${{ parameters.condition }}
+
+- ${{ if and(ne(parameters.elseScript, ''), ne(parameters.parameter1, parameters.parameter2)) }}:
+  - script: ${{ parameters.elseScript }}
+    name: ${{ parameters.name }}
+    displayName: ${{ parameters.displayName }}
+    env: ${{ parameters.env }}
+    condition: ${{ parameters.condition }}

--- a/eng/common/templates/steps/telemetry-end.yml
+++ b/eng/common/templates/steps/telemetry-end.yml
@@ -1,0 +1,36 @@
+
+parameters:
+  agentOs: Windows_NT
+  helixSource: 'undefined_defaulted_in_telemetry.yml'
+  helixType: 'undefined_defaulted_in_telemetry.yml'
+
+steps:
+- template: /eng/common/templates/steps/run-on-unix.yml
+  parameters:
+    agentOs: ${{ parameters.agentOs }}
+    steps:
+      - bash: |
+          /bin/bash ./telemetry/build/end.sh
+        workingDirectory: $(Build.SourcesDirectory)/eng/common
+        displayName: Send Build End Telemetry
+        env:
+          # defined via VSTS variables in start-job.sh
+          Helix_JobToken: $(Helix_JobToken)
+          Helix_WorkItemId: $(Helix_WorkItemId)
+        condition: always()
+- template: /eng/common/templates/steps/run-on-windows.yml
+  parameters:
+    agentOs: ${{ parameters.agentOs }}
+    steps:
+      - powershell: |
+          ./telemetry/build/end.ps1
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+        workingDirectory: $(Build.SourcesDirectory)/eng/common
+        displayName: Send Build End Telemetry
+        env:
+          # defined via VSTS variables in start-job.ps1
+          Helix_JobToken: $(Helix_JobToken)
+          Helix_WorkItemId: $(Helix_WorkItemId)
+        condition: always()

--- a/eng/common/templates/steps/telemetry-start.yml
+++ b/eng/common/templates/steps/telemetry-start.yml
@@ -1,0 +1,81 @@
+
+parameters:
+  agentOs: Windows_NT
+  helixSource: 'undefined_defaulted_in_telemetry.yml'
+  helixType: 'undefined_defaulted_in_telemetry.yml'
+  buildConfig: ''
+
+steps:
+- template: /eng/common/templates/steps/run-on-unix.yml
+  parameters:
+    agentOs: ${{ parameters.agentOs }}
+    steps:
+      - task: AzureKeyVault@1
+        inputs:
+          azureSubscription: 'HelixProd_KeyVault'
+          KeyVaultName: HelixProdKV
+          SecretsFilter: 'HelixApiAccessToken'
+        condition: always()
+      - bash: |
+          /bin/bash ./telemetry/start-job.sh --source "$Source" --type "$Type" --build "$Build" --queue-id "$QueueId" --attempt "$Attempt" -p "operatingSystem=$OperatingSystem" -p "configuration=$Configuration"
+        workingDirectory: $(Build.SourcesDirectory)/eng/common
+        displayName: Send Job Start Telemetry
+        env:
+          HelixApiAccessToken: $(HelixApiAccessToken)
+          Source: ${{ parameters.helixSource }}
+          Type: ${{ parameters.helixType }}
+          Build: $(Build.BuildNumber)
+          QueueId: ${{ parameters.agentOs }}
+          Attempt: 1
+          OperatingSystem: ${{ parameters.agentOs }}
+          Configuration: ${{ parameters.buildConfig }}
+        condition: always()
+      - bash: |
+          /bin/bash ./telemetry/build/start.sh --build-uri "$BuildUri"
+        workingDirectory: $(Build.SourcesDirectory)/eng/common
+        displayName: Send Build Start Telemetry
+        env:
+          BuildUri: $(System.TaskDefinitionsUri)$(System.TeamProject)/_build/index?buildId=$(Build.BuildId)&_a=summary
+          # defined via VSTS variables in start-job.sh
+          Helix_JobToken: $(Helix_JobToken)
+        condition: always()
+
+- template: /eng/common/templates/steps/run-on-windows.yml
+  parameters:
+    agentOs: ${{ parameters.agentOs }}
+    steps:
+      - task: AzureKeyVault@1
+        inputs:
+          azureSubscription: 'HelixProd_KeyVault'
+          KeyVaultName: HelixProdKV
+          SecretsFilter: 'HelixApiAccessToken'
+        condition: always()
+      - powershell: |
+          ./telemetry/start-job.ps1 -Source $env:Source -Type $env:Type -Build $env:Build -QueueId $env:QueueId -Attempt $env:Attempt -Properties @{ operatingSystem=$env:OperatingSystem; configuration=$env:Configuration } -Verbose
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+        workingDirectory: $(Build.SourcesDirectory)/eng/common
+        displayName: Send Job Start Telemetry
+        env:
+          HelixApiAccessToken: $(HelixApiAccessToken)
+          Source: ${{ parameters.helixSource }}
+          Type: ${{ parameters.helixType }}
+          Build: $(Build.BuildNumber)
+          QueueId: ${{ parameters.agentOs }}
+          Attempt: 1
+          OperatingSystem: ${{ parameters.agentOs }}
+          Configuration: ${{ parameters.buildConfig }}
+        condition: always()
+      - powershell: |
+          ./telemetry/build/start.ps1 -BuildUri $env:BuildUri
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+        workingDirectory: $(Build.SourcesDirectory)/eng/common
+        displayName: Send Build Start Telemetry
+        env:
+          BuildUri: $(System.TaskDefinitionsUri)$(System.TeamProject)/_build/index?buildId=$(Build.BuildId)&_a=summary
+          # defined via VSTS variables in start-job.ps1
+          Helix_JobToken: $(Helix_JobToken)
+        condition: always()


### PR DESCRIPTION
- Separate telemetry template into a telemetry-start and telemetry-end template

- Simplify the base template
  - Remove docker as a built in concept to the template and just rely on variables
  - Move other values from parameters to required variables (particularly those for variables)

- Change header comment format so it's closer to the parameter it represents (makes editing simpler since you don't have to remember to go look at the header block for the relevant usage comment

- Add a utility template that allows you to run either a Windows script or a Unix script

Judging based on usage I've seen when teams are implementing VSTS CI, it will be easier to plug into this "base.yml" template which requires less specific parameters be provided or a phase defined.  This aligns closer with the sample work.

I debated flattening build.yml and .vsts-ci.yml, but didn't pull the trigger on that change.

Validated this works with an internal build - https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=1895284&_a=summary&view=logs

