### PR TITLE
Reverting back to using AzureCosmosDb

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -46,6 +46,11 @@
   </PropertyGroup>
   
   <PropertyGroup>
+    <MicrosoftAzureDocumentDBVersion>1.22.0</MicrosoftAzureDocumentDBVersion>
+    <MicrosoftAzureCosmosDBTableVersion>1.1.2</MicrosoftAzureCosmosDBTableVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <MicrosoftAspNetCoreAllVersion>2.0.0</MicrosoftAspNetCoreAllVersion>
     <MicrosoftDotNetGitHubIssueLabelerAssetsVersion>1.0.0</MicrosoftDotNetGitHubIssueLabelerAssetsVersion>
     <MicrosoftMLVersion>0.3.0</MicrosoftMLVersion>

--- a/src/Microsoft.DotNet.GitSync/Microsoft.DotNet.GitSync.csproj
+++ b/src/Microsoft.DotNet.GitSync/Microsoft.DotNet.GitSync.csproj
@@ -9,8 +9,8 @@
     <PackageReference Include="CredentialManagement" Version="$(CredentialManagementVersion)" />
     <PackageReference Include="LibGit2Sharp" Version="$(LibGit2SharpVersion)" />
     <PackageReference Include="log4net" Version="$(log4netVersion)" />
-    <PackageReference Include="WindowsAzure.Storage" Version="$(WindowsAzureStorageVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="$(MicrosoftAzureDocumentDBVersion)" />
+    <PackageReference Include="Microsoft.Azure.CosmosDB.Table" Version="$(MicrosoftAzureCosmosDBTableVersion)" />
     <PackageReference Include="Octokit" Version="$(OctokitVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.GitSync/Program.cs
+++ b/src/Microsoft.DotNet.GitSync/Program.cs
@@ -17,8 +17,8 @@ using Octokit;
 using Commit = LibGit2Sharp.Commit;
 using Credentials = Octokit.Credentials;
 using Repository = LibGit2Sharp.Repository;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Table;
+using Microsoft.Azure.Storage;
+using Microsoft.Azure.CosmosDB.Table;
 
 namespace Microsoft.DotNet.GitSync
 {

--- a/src/Microsoft.DotNet.GitSync/Program.cs
+++ b/src/Microsoft.DotNet.GitSync/Program.cs
@@ -605,6 +605,7 @@ namespace Microsoft.DotNet.GitSync
                             {
                                 RetrieveOrInsert(repository.Name, branch, commit.Sha, targetRepo);
                             }
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
using this ```WindowsAzure.Storage``` was missing commits.
And sometimes was throwing ```WebRequestsException``` due to too many requests.
The error was not getting repro with my git credentials and local machine.

These failures are not encountered while using AzureCosmosDbTable package probably because the back end database is azure cosmos db rather than windows storage.

this line is added because the default package that gets installed lead to runtime failure
```
<MicrosoftAzureDocumentDBVersion>1.22.0</MicrosoftAzureDocumentDBVersion>
```