### PR TITLE
Reduce AssemblySearchPaths to minimal set of directories

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
@@ -50,6 +50,7 @@
       list as they will not be the same from machine to machine.
     -->
     <AssemblySearchPaths>
+      {HintPathFromItem};
       {TargetFrameworkDirectory};
       {RawFileName};
     </AssemblySearchPaths>    

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
@@ -42,6 +42,17 @@
     -->
     <DebugType>portable</DebugType>
     <DebugType Condition="'$(OfficialBuild)' != 'true'">embedded</DebugType>
+    
+    <!-- 
+      This controls the places MSBuild will consult to resolve assembly references.  This is 
+      kept as minimal as possible to make our build reliable from machine to machine.  Global
+      locations such as GAC, AssemblyFoldersEx, etc ... are deliberately removed from this 
+      list as they will not be the same from machine to machine.
+    -->
+    <AssemblySearchPaths>
+      {TargetFrameworkDirectory};
+      {RawFileName};
+    </AssemblySearchPaths>    
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Language)' == ''">


### PR DESCRIPTION
This setting is copied from Roslyn build.