### PR TITLE
Update infrastructure to Arcade 63208-02

### DIFF
--- a/Build.cmd
+++ b/Build.cmd
@@ -1,3 +1,3 @@
 @echo off
-powershell -ExecutionPolicy ByPass -NoProfile %~dp0eng\common\Build.ps1 -restore -build %*
+powershell -ExecutionPolicy ByPass -command "& """%~dp0eng\common\Build.ps1""" -restore -build %*"
 exit /b %ErrorLevel%

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,11 +10,12 @@
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
 
-  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
-    <PackageReference Include="Microsoft.SourceLink.Vsts.Git" Version="$(MicrosoftSourceLinkVersion)" PrivateAssets="all" />
-  </ItemGroup>
+    <!--
+      Tools and packages produced by this repository support infrastructure and are not shipping on NuGet or via any other official channel.
+    -->
+    <IsShipping>false</IsShipping>
+  </PropertyGroup>
 
   <PropertyGroup>
     <!-- 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,12 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
-
-  <Target Name="_InitializeNuspecProperties"
-          BeforeTargets="GenerateNuSpec"
-          Condition="'$(NuspecFile)' != ''">
-    <PropertyGroup>
-      <NuspecProperties>$(NuspecProperties);version=$(Version);licenseUrl=$(PackageLicenseUrl);repoUrl=$(RepositoryUrl);copyright=$(Copyright);ArtifactsBinDir=$(ArtifactsBinDir)</NuspecProperties>
-    </PropertyGroup>
-  </Target>
 </Project>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,10 +3,9 @@
   <solution>
     <add key="disableSourceControlIntegration" value="true" />
   </solution>
+  <!-- Only specify feed for Arcade SDK (see https://github.com/Microsoft/msbuild/issues/2982) -->
   <packageSources>
     <clear />
-    <add key="arcade" value="https://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json" />
-    <add key="arcade" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="roslyn-tools" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
   </packageSources>
 </configuration>

--- a/Restore.cmd
+++ b/Restore.cmd
@@ -1,3 +1,3 @@
 @echo off
-powershell -ExecutionPolicy ByPass %~dp0eng\common\Build.ps1 -restore %*
+powershell -ExecutionPolicy ByPass -command "& """%~dp0eng\common\Build.ps1""" -restore %*"
 exit /b %ErrorLevel%

--- a/eng/SignToolData.json
+++ b/eng/SignToolData.json
@@ -33,7 +33,7 @@
       "certificate": null,
       "strongName": null,
       "values": [
-        "packages/*.nupkg"
+        "packages/NonShipping/*.nupkg"
       ]
     }
   ],

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
   <PropertyGroup>
     <!-- This repo version -->
     <VersionPrefix>1.0.0</VersionPrefix>
-    <PreReleaseVersionLabel>prerelease</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
 
     <!-- Opt-out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
-    <UsingToolMicrosoftNetCompilers>false</UsingToolMicrosoftNetCompilers>
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
 
     <!-- Libs -->

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -69,17 +69,21 @@ phases:
         ifScript: eng\common\cibuild.cmd
           -configuration $(_BuildConfig) 
           -prepareMachine
-          /p:SignType=$(_SignType)
+          /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+          /p:DotNetSignType=$(_SignType)
+          /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+          /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
           $(_PublishArgs)
         elseScript: eng/common/cibuild.sh
           --configuration $(_BuildConfig) 
           --prepareMachine
-          /p:SignType=$(_SignType)
+          /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+          /p:DotNetSignType=$(_SignType)
+          /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+          /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
           $(_PublishArgs)
         name: Build_Publish
         displayName: Build / Publish
-        env:
-          OfficialBuildId: $(BUILD.BUILDNUMBER)
         condition: succeeded()
 
     # Internal only build steps (until publishing artifacts in public CI is supported)

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -79,14 +79,14 @@ function InitializeDotNetCli {
 
   # Use dotnet installation specified in DOTNET_INSTALL_DIR if it contains the required SDK version, 
   # otherwise install the dotnet CLI and SDK to repo local .dotnet directory to avoid potential permission issues.
-  if (($env:DOTNET_INSTALL_DIR -ne $null) -and (Test-Path(Join-Path $env:DOTNET_INSTALL_DIR "sdk\$($GlobalJson.sdk.version)"))) {
+  if (($env:DOTNET_INSTALL_DIR -ne $null) -and (Test-Path(Join-Path $env:DOTNET_INSTALL_DIR "sdk\$($GlobalJson.tools.dotnet)"))) {
     $dotnetRoot = $env:DOTNET_INSTALL_DIR
   } else {
     $dotnetRoot = Join-Path $RepoRoot ".dotnet"
     $env:DOTNET_INSTALL_DIR = $dotnetRoot
     
     if ($restore) {
-      InstallDotNetSdk $dotnetRoot $GlobalJson.sdk.version
+      InstallDotNetSdk $dotnetRoot $GlobalJson.tools.dotnet
     }
   }
 
@@ -130,7 +130,7 @@ function InitializeVisualStudioBuild {
 }
 
 function LocateVisualStudio {
-  $vswhereVersion = $GlobalJson.vswhere.version
+  $vswhereVersion = $GlobalJson.tools.vswhere
   $toolsRoot = Join-Path $RepoRoot ".tools"
   $vsWhereDir = Join-Path $toolsRoot "vswhere\$vswhereVersion"
   $vsWhereExe = Join-Path $vsWhereDir "vswhere.exe"
@@ -152,7 +152,9 @@ function LocateVisualStudio {
 }
 
 function GetBuildCommand() {
-  if ((Get-Member -InputObject $GlobalJson -Name "sdk") -ne $null) {  
+  $tools = $GlobalJson.tools
+
+  if ((Get-Member -InputObject $tools -Name "dotnet") -ne $null) {  
     $dotnetRoot = InitializeDotNetCli
 
     # by default build with dotnet cli:
@@ -160,7 +162,7 @@ function GetBuildCommand() {
     $buildArgs = "msbuild"
   }
 
-  if ((Get-Member -InputObject $GlobalJson -Name "vswhere") -ne $null) {    
+  if ((Get-Member -InputObject $tools -Name "vswhere") -ne $null) {    
     $vsInstallDir = InitializeVisualStudioBuild
     
     # Presence of vswhere.version indicates the repo needs to build using VS msbuild:
@@ -169,7 +171,7 @@ function GetBuildCommand() {
   }
 
   if ($buildDriver -eq $null) {
-    Write-Host "/global.json must either specify 'sdk.version' or 'vswhere.version'." -ForegroundColor Red
+    Write-Host "/global.json must either specify 'tools.dotnet' or 'tools.vswhere'." -ForegroundColor Red
     exit 1
   }
 

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -33,6 +33,12 @@ properties=''
 repo_root="$scriptroot/../.."
 eng_root="$scriptroot/.."
 artifacts_dir="$repo_root/artifacts"
+artifacts_configuration_dir="$artifacts_dir/$configuration"
+toolset_dir="$artifacts_dir/toolset"
+log_dir="$artifacts_configuration_dir/log"
+build_log="$log_dir/Build.binlog"
+toolset_restore_log="$log_dir/ToolsetRestore.binlog"
+temp_dir="$artifacts_configuration_dir/tmp"
 
 global_json_file="$repo_root/global.json"
 build_driver=""
@@ -126,20 +132,9 @@ while (($# > 0)); do
   esac
 done
 
-artifacts_configuration_dir="$artifacts_dir/$configuration"
-toolset_dir="$artifacts_dir/toolset"
-log_dir="$artifacts_configuration_dir/log"
-build_log="$log_dir/Build.binlog"
-toolset_restore_log="$log_dir/ToolsetRestore.binlog"
-temp_dir="$artifacts_configuration_dir/tmp"
-
-# ReadJson [filename] [json key]
-# Result: Sets 'readjsonvalue' to the value of the provided json key
-# Note: this method may return unexpected results if there are duplicate
-# keys in the json
-function ReadJson {
-  local file=$1
-  local key=$2
+# ReadVersionFromJson [json key]
+function ReadGlobalVersion {
+  local key=$1
 
   local unamestr="$(uname)"
   local sedextended='-r'
@@ -147,11 +142,14 @@ function ReadJson {
     sedextended='-E'
   fi;
 
-  readjsonvalue="$(grep -m 1 "\"$key\"" $file | sed $sedextended 's/^ *//;s/.*: *"//;s/",?//')"
-  if [[ ! "$readjsonvalue" ]]; then
-    echo "Error: Cannot find \"$key\" in $file" >&2;
+  local version="$(grep -m 1 "\"$key\"" $global_json_file | sed $sedextended 's/^ *//;s/.*: *"//;s/",?//')"
+  if [[ ! "$version" ]]; then
+    echo "Error: Cannot find \"$key\" in $global_json_file" >&2;
     ExitWithExitCode 1
   fi;
+
+  # return value
+  echo "$version"
 }
 
 function InitializeDotNetCli {
@@ -166,8 +164,8 @@ function InitializeDotNetCli {
     export DOTNET_INSTALL_DIR="$DotNetCoreSdkDir"
   fi
 
-  ReadJson "$global_json_file" "version"
-  local dotnet_sdk_version="$readjsonvalue"
+  
+  local dotnet_sdk_version=`ReadGlobalVersion "dotnet"`
   local dotnet_root=""
 
   # Use dotnet installation specified in DOTNET_INSTALL_DIR if it contains the required SDK version, 
@@ -221,8 +219,7 @@ function GetDotNetInstallScript {
 }
 
 function InitializeToolset {
-  ReadJson $global_json_file "Microsoft.DotNet.Arcade.Sdk"
-  local toolset_version=$readjsonvalue
+  local toolset_version=`ReadGlobalVersion "Microsoft.DotNet.Arcade.Sdk"`
   local toolset_location_file="$toolset_dir/$toolset_version.txt"
 
   if [[ -a "$toolset_location_file" ]]; then

--- a/global.json
+++ b/global.json
@@ -1,8 +1,8 @@
 {
-    "sdk": {
-        "version": "2.1.300"
-    },
-    "msbuild-sdks": {
-        "Microsoft.DotNet.Arcade.Sdk": "1.0.0-bootstrap-1"
-    }
+  "tools": {
+    "dotnet": "2.1.400-preview-009088"
+  },
+  "msbuild-sdks": {
+    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-prerelease-63208-02"
+  }
 }

--- a/restore.sh
+++ b/restore.sh
@@ -2,15 +2,15 @@
 
 source="${BASH_SOURCE[0]}"
 
-# resolve $source until the file is no longer a symlink
-while [[ -h $source ]]; do 
+# resolve $SOURCE until the file is no longer a symlink
+while [[ -h $source ]]; do
   scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
   source="$(readlink "$source")"
-  
-  # if $source was a relative symlink, we need to resolve it relative to the path where the 
+
+  # if $source was a relative symlink, we need to resolve it relative to the path where the
   # symlink file was located
   [[ $source != /* ]] && source="$scriptroot/$source"
 done
-scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 
-. "$scriptroot/eng/common/build.sh" --restore $@
+scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+"$scriptroot/eng/common/build.sh" --restore $@


### PR DESCRIPTION
The new Arcade build implements the final versioning scheme. To avoid collisions with previously released packages I have also changed the prerelease label from `prerelease` to `beta`.

Fixes https://github.com/dotnet/arcade/issues/320