### PR TITLE
Set Language unconditionally if the project's extension is well-known

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
@@ -44,7 +44,7 @@
     <DebugType Condition="'$(OfficialBuild)' != 'true'">embedded</DebugType>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Language)' == ''">
+  <PropertyGroup>
     <Language Condition="'$(MSBuildProjectExtension)' == '.csproj'">C#</Language>
     <Language Condition="'$(MSBuildProjectExtension)' == '.vbproj'">VB</Language>
     <Language Condition="'$(MSBuildProjectExtension)' == '.fsproj'">F#</Language>


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/458