### PR TITLE
Fix link to VSTS builds in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Arcade is intended to provide well-understood and consistent mechanisms for cons
 ## Build & Test Status
 
 VSTS [![Build Status](https://dotnet.visualstudio.com/_apis/public/build/definitions/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/17/badge
-)](https://dotnet.visualstudio.com/DotNet-Public/_build/index?definitionId=17&branchName=master)
+)](https://dotnet.visualstudio.com/public/_build/index?definitionId=17&branchName=master)
 
 Jenkins
 


### PR DESCRIPTION
The old link pointed to a private project, the new one is public.