### PR TITLE
Make arcade use refactored sign tool

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -53,7 +53,7 @@
     <MicrosoftDiaSymReaderPdb2PdbVersion Condition="'$(MicrosoftDiaSymReaderPdb2PdbVersion)' == ''">1.1.0-beta1-62506-02</MicrosoftDiaSymReaderPdb2PdbVersion>
     <RoslynToolsModifyVsixManifestVersion Condition="'$(RoslynToolsModifyVsixManifestVersion)' == ''">1.0.0-beta2-63208-02</RoslynToolsModifyVsixManifestVersion>
     <RoslynToolsNuGetRepackVersion Condition="'$(RoslynToolsNuGetRepackVersion)' == ''">1.0.0-beta2-63208-02</RoslynToolsNuGetRepackVersion>
-    <MicrosoftDotNetSignToolVersion Condition="'$(MicrosoftDotNetSignToolVersion)' == ''">1.0.0-prerelease-63201-04</MicrosoftDotNetSignToolVersion>
+    <MicrosoftDotNetSignToolVersion Condition="'$(MicrosoftDotNetSignToolVersion)' == ''">1.0.0-beta.18421.2</MicrosoftDotNetSignToolVersion>
     <XliffTasksVersion Condition="'$(XliffTasksVersion)' == ''">0.2.0-beta-63004-01</XliffTasksVersion>
     <XUnitVersion Condition="'$(XUnitVersion)' == ''">2.3.1</XUnitVersion>
     <XUnitRunnerConsoleVersion Condition="'$(XUnitRunnerConsoleVersion)' == ''">$(XUnitVersion)</XUnitRunnerConsoleVersion>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -38,8 +38,8 @@
 
     <ItemGroup>
       <!-- List of container files that will be opened and checked for files that need to be signed. -->
-      <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.nupkg"></ItemsToSign>
-      <ItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.vsix"></ItemsToSign>
+      <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.nupkg" />
+      <ItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.vsix" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -45,7 +45,6 @@
     <ItemGroup>
       <!-- Default certificate/strong-name to be used for all files with PKT=="31bf3856ad364e35". -->
       <StrongNameSignInfo Include="MsSharedLib72" PublicKeyToken="31bf3856ad364e35" CertificateName="MicrosoftSHA2" />
-      <StrongNameSignInfo Include="MsSharedLib72" PublicKeyToken="xxxxxx" CertificateName="Microsoft402" />
     </ItemGroup>
 
     <Microsoft.DotNet.SignTool.SignToolTask

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -36,15 +36,31 @@
       <DesktopMSBuildPath Condition="$(DesktopMSBuildRequired)">$(VSInstallDir)\MSBuild\15.0\Bin\msbuild.exe</DesktopMSBuildPath>
     </PropertyGroup>
 
+    <ItemGroup>
+      <!-- List of container files that will be opened and checked for files that need to be signed. -->
+      <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.nupkg"></ItemsToSign>
+      <ItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.vsix"></ItemsToSign>
+    </ItemGroup>
+
+    <ItemGroup>
+      <!-- Default certificate/strong-name to be used for all files with PKT=="31bf3856ad364e35". -->
+      <StrongNameSignInfo Include="MsSharedLib72" PublicKeyToken="31bf3856ad364e35" CertificateName="MicrosoftSHA2" />
+      <StrongNameSignInfo Include="MsSharedLib72" PublicKeyToken="xxxxxx" CertificateName="Microsoft402" />
+    </ItemGroup>
+
     <Microsoft.DotNet.SignTool.SignToolTask
-       DryRun="$(DryRun)"
-       TestSign="$(TestSign)"
-       ConfigFilePath="$(ConfigFilePath)"
-       MSBuildPath="$(DesktopMSBuildPath)"
-       OutputDir="$(ArtifactsConfigurationDir)"
-       TempDir="$(ArtifactsTmpDir)"
-       LogDir="$(ArtifactsLogDir)"
-       MicroBuildCorePath="$(NuGetPackageRoot)microbuild.core\$(MicroBuildCoreVersion)"/>
+        DryRun="$(DryRun)"
+        TestSign="$(TestSign)"
+        ItemsToSign="@(ItemsToSign)"
+        StrongNameSignInfo="@(StrongNameSignInfo)"
+        FileSignInfo="@(FileSignInfo)"
+        TempDir="$(ArtifactsTmpDir)"
+        LogDir="$(ArtifactsLogDir)"
+        PublishUrl="$(PublishUrl)"
+        OrchestrationManifestPath="$(OrchestrationManifestPath)"
+        MSBuildPath="$(DesktopMSBuildPath)"
+        MicroBuildCorePath="$(NuGetPackageRoot)microbuild.core\$(MicroBuildCoreVersion)"/>
+       
   </Target>
 
 </Project>


### PR DESCRIPTION
Closes: #464 

**Changes made:**
- DefaultVersion.props : just hitting SignToolVersion up
- Sign.proj : 
  - Collect the list of containers 
  - Create the list of <PKT, Certificate, StrongName>
  - Patch how SignToolTask is called