### PR TITLE
Patches SignTool to recognize files that are Authenticode signed

### DIFF
--- a/src/Microsoft.DotNet.SignTool/src/Configuration.cs
+++ b/src/Microsoft.DotNet.SignTool/src/Configuration.cs
@@ -108,7 +108,7 @@ namespace Microsoft.DotNet.SignTool
             {
                 using (var stream = File.OpenRead(fileFullPath))
                 {
-                    if (ContentUtil.IsAssemblyStrongNameSigned(stream))
+                    if (ContentUtil.IsAuthenticodeSigned(stream))
                     {
                         return SignInfo.AlreadySigned;
                     }

--- a/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
@@ -83,7 +83,7 @@ namespace Microsoft.DotNet.SignTool
                 return true;
             }
 
-            return ContentUtil.IsAssemblyStrongNameSigned(assemblyStream);
+            return ContentUtil.IsAuthenticodeSigned(assemblyStream);
         }
     }
 }


### PR DESCRIPTION
Closes: #513

Changes:

- Configuration.cs: 
  - Patched to call the new method
- ContentUtil.cs: 
  - Added the new method
  - Removed the old one because it wasn't being used anywhere now
- RealSignTool.cs:
  - Patched to call the new method
