### PR TITLE
Refactor + enable dotnet.visualstudio.com signing.

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -3,12 +3,12 @@ phases:
     parameters:
       name: Windows_NT
       queue:
-        ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'PullRequest') }}:
+        # For public or PR jobs, use the hosted pool.  For internal jobs use the internal pool.
+        # Will eventually change this to two BYOC pools.
+        ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
           name: Hosted VS2017
-        ${{ if notIn(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'PullRequest') }}:        
-          name: DotNetCore-Build
-          demands:
-          - agent.os -equals Windows_NT        
+        ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+          name: DotNetCore-Windows
         parallel: 2
         matrix:
           Build_Debug:
@@ -17,21 +17,23 @@ phases:
             _SignType: test
           Build_Release:
             _BuildConfig: Release
-            ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'PullRequest') }}:
+            # PRs or external builds are not signed.
+            ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
               _PublishType: none
               _SignType: test
-            ${{ if notIn(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'PullRequest') }}:
+            ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
               _PublishType: blob
               _SignType: real
   
   - template: /eng/build.yml
     parameters:
       name: Linux
-      queue: 
-        ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'PullRequest') }}:
+      queue:
+        # Temporarily, use the linux pool while the hosted preview doesn't have docker support.
+        ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
           name: DotNetCore-Linux
-        ${{ if notIn(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'PullRequest') }}:        
-          name: DotNetCore-Test
+        ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+          name: DotNetCore-Linux
         demands:
           - agent.os -equals Linux
         parallel: 2
@@ -39,13 +41,10 @@ phases:
           Build_Debug:
             _BuildConfig: Debug
             _PublishType: none
-            _SignType: test
+            _SignType: none
           Build_Release:
             _BuildConfig: Release
             _PublishType: none
-            ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'PullRequest') }}:
-              _SignType: test
-            ${{ if notIn(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'PullRequest') }}:
-              _SignType: real
+            _SignType: none
       variables:
         _PREVIEW_VSTS_DOCKER_IMAGE: microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-0cd4667-20170319080304

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -52,13 +52,13 @@ phases:
         _SignArgs: ''
         _HelixSource: pr/dotnet/arcade/$(Build.SourceBranch)
 
-    steps:
-    - task: AzureKeyVault@1
-      inputs:
-        azureSubscription: 'DotNet-Engineering-Services_KeyVault'
-        KeyVaultName: EngKeyVault
-        SecretsFilter: 'dotnetfeed-storage-access-key-1,microsoft-symbol-server-pat,symweb-symbol-server-pat'
-      condition: and(succeeded(), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'))
+    ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}
+      steps:
+      - task: AzureKeyVault@1
+        inputs:
+          azureSubscription: 'DotNet-Engineering-Services_KeyVault'
+          KeyVaultName: EngKeyVault
+          SecretsFilter: 'dotnetfeed-storage-access-key-1,microsoft-symbol-server-pat,symweb-symbol-server-pat'
 
     # Use utility script to run script command dependent on agent OS
     - script: eng\common\cibuild.cmd
@@ -79,19 +79,20 @@ phases:
       displayName: Build / Publish
       condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
 
-    # Internal only build steps (until publishing artifacts in public CI is supported)
-    - task: CopyFiles@2
-      displayName: Gather Logs
-      inputs:
-        SourceFolder: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
-        TargetFolder: '$(Build.StagingDirectory)/BuildLogs'
-      continueOnError: true
-      condition: and(succeededOrFailed(), ne(variables['System.TeamProject'], 'public'))
-    - task: PublishBuildArtifacts@1
-      displayName: Publish Logs to VSTS
-      inputs:
-        PathtoPublish: '$(Build.StagingDirectory)/BuildLogs'
-        PublishLocation: Container
-        ArtifactName: $(Agent.Os)_$(Agent.JobName)
-      continueOnError: true
-      condition: and(succeededOrFailed(), ne(variables['System.TeamProject'], 'public'))
+    # Internal only build steps (until publishing artifacts in public CI is supported
+    ${{ if ne(variables['System.TeamProject'], 'public') }}
+      - task: CopyFiles@2
+        displayName: Gather Logs
+        inputs:
+          SourceFolder: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
+          TargetFolder: '$(Build.StagingDirectory)/BuildLogs'
+        continueOnError: true
+        condition: succeededOrFailed()
+      - task: PublishBuildArtifacts@1
+        displayName: Publish Logs to VSTS
+        inputs:
+          PathtoPublish: '$(Build.StagingDirectory)/BuildLogs'
+          PublishLocation: Container
+          ArtifactName: $(Agent.Os)_$(Agent.JobName)
+        continueOnError: true
+        condition: succeededOrFailed()

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -36,7 +36,7 @@ phases:
         # This should be changed to an isolated blob feed per-build.
         # Right now a manual build of a random branch would get published alongside the normal branch artifacts.
         _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-        _TeamName: DotNetCore
+        TeamName: DotNetCore
         _SignArgs: /p:DotNetSignType=$(_SignType)
         _PublishArgs: /p:PB_PublishBlobFeedKey=$(dotnetfeed-storage-access-key-1) 
           /p:PB_PublishBlobFeedUrl=$(_PublishBlobFeedUrl) 

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -53,7 +53,7 @@ phases:
         _HelixSource: pr/dotnet/arcade/$(Build.SourceBranch)
 
     steps:
-      ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         - task: AzureKeyVault@1
           inputs:
             azureSubscription: 'DotNet-Engineering-Services_KeyVault'
@@ -80,7 +80,7 @@ phases:
       condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
 
     # Internal only build steps (until publishing artifacts in public CI is supported
-    ${{ if ne(variables['System.TeamProject'], 'public') }}:
+    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
       - task: CopyFiles@2
         displayName: Gather Logs
         inputs:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -53,13 +53,12 @@ phases:
         _HelixSource: pr/dotnet/arcade/$(Build.SourceBranch)
 
     steps:
-    
-    ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - task: AzureKeyVault@1
-        inputs:
-          azureSubscription: 'DotNet-Engineering-Services_KeyVault'
-          KeyVaultName: EngKeyVault
-          SecretsFilter: 'dotnetfeed-storage-access-key-1,microsoft-symbol-server-pat,symweb-symbol-server-pat'
+      ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        - task: AzureKeyVault@1
+          inputs:
+            azureSubscription: 'DotNet-Engineering-Services_KeyVault'
+            KeyVaultName: EngKeyVault
+            SecretsFilter: 'dotnetfeed-storage-access-key-1,microsoft-symbol-server-pat,symweb-symbol-server-pat'
 
     # Use utility script to run script command dependent on agent OS
     - script: eng\common\cibuild.cmd

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -9,6 +9,13 @@ parameters:
   # variables YAML object - https://github.com/Microsoft/vsts-agent/blob/master/docs/preview/yamlgettingstarted-schema.md#phase
   variables: {}
 
+# Common conditionals:  There are a number of common conditionals that are useful.  Generally these are used to decide what resources can be accessed,
+#                       or what logic should be applied based on the context the build is being run in.
+#   - eq/ne(variables['Agent.Os'], 'Windows_NT') - Running/not running on a windows machine
+#   - eq/ne(variables['System.TeamProject'], 'public') - Running/not running on the dotnet public VSTS project 
+#   - and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest') - Not running in public and not a pull request.
+#   - or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest') - Running in public or a pull request.
+
 phases:
 - template: /eng/common/templates/phases/base.yml
   parameters:
@@ -24,70 +31,67 @@ phases:
       ${{ insert }}: ${{ parameters.variables }}
       _HelixType: build/product
       _HelixBuildConfig: $(_BuildConfig)
-      ${{ if notIn(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'PullRequest') }}:
+      # Only enable publishing in non-public, non PR scenarios.
+      ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        # This should be changed to an isolated blob feed per-build.
+        # Right now a manual build of a random branch would get published alongside the normal branch artifacts.
         _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
         _TeamName: DotNetCore
+        _SignArgs: /p:DotNetSignType=$(_SignType)
         _PublishArgs: /p:PB_PublishBlobFeedKey=$(dotnetfeed-storage-access-key-1) 
           /p:PB_PublishBlobFeedUrl=$(_PublishBlobFeedUrl) 
-          /p:PB_PublishType=$(_PublishType) 
+          /p:PB_PublishType=$(_PublishType)
+          /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+          /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
         _HelixSource: official/dotnet/arcade/$(Build.SourceBranch)
-      ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'PullRequest') }}:
+        _OfficialBuildIdArgs: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+      # else
+      ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         _PublishArgs: ''
+        _OfficialBuildIdArgs: ''
+        _SignArgs: ''
         _HelixSource: pr/dotnet/arcade/$(Build.SourceBranch)
 
     steps:
-    # Internal only build steps
-    - template: /eng/common/templates/steps/build-reason.yml
-      parameters:
-        conditions: not IndividualCI,BatchedCI,PullRequest
-        steps:
-        - task: AzureKeyVault@1
-          inputs:
-            azureSubscription: 'DotNet-Engineering-Services_KeyVault'
-            KeyVaultName: EngKeyVault
-            SecretsFilter: 'dotnetfeed-storage-access-key-1'
-          condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'))
+    - task: AzureKeyVault@1
+      inputs:
+        azureSubscription: 'DotNet-Engineering-Services_KeyVault'
+        KeyVaultName: EngKeyVault
+        SecretsFilter: 'dotnetfeed-storage-access-key-1,microsoft-symbol-server-pat,symweb-symbol-server-pat'
+      condition: and(succeeded(), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'))
 
     # Use utility script to run script command dependent on agent OS
     - script: eng\common\cibuild.cmd
         -configuration $(_BuildConfig) 
         -prepareMachine
-        /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-        /p:DotNetSignType=$(_SignType)
-        /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-        /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
         $(_PublishArgs)
+        $(_SignArgs)
+        $(_OfficialBuildIdArgs)
       displayName: Build / Publish
       condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'))
         
     - script: eng/common/cibuild.sh
         --configuration $(_BuildConfig) 
         --prepareMachine
-        /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-        /p:DotNetSignType=$(_SignType)
-        /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-        /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
         $(_PublishArgs)
+        $(_SignArgs)
+        $(_OfficialBuildIdArgs)
       displayName: Build / Publish
       condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
 
     # Internal only build steps (until publishing artifacts in public CI is supported)
-    - template: /eng/common/templates/steps/build-reason.yml
-      parameters:
-        conditions: not IndividualCI,BatchedCI,PullRequest
-        steps:
-        - task: CopyFiles@2
-          displayName: Gather Logs
-          inputs:
-            SourceFolder: '$(Build.SourcesDirectory)/artifacts/$(_BuildConfig)/log'
-            TargetFolder: '$(Build.StagingDirectory)/BuildLogs'
-          continueOnError: true
-          condition: succeededOrFailed()
-        - task: PublishBuildArtifacts@1
-          displayName: Publish Logs to VSTS
-          inputs:
-            PathtoPublish: '$(Build.StagingDirectory)/BuildLogs'
-            PublishLocation: Container
-            ArtifactName: $(Agent.Os)_$(Agent.JobName)
-          continueOnError: true
-          condition: succeededOrFailed()
+    - task: CopyFiles@2
+      displayName: Gather Logs
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
+        TargetFolder: '$(Build.StagingDirectory)/BuildLogs'
+      continueOnError: true
+      condition: and(succeededOrFailed(), ne(variables['System.TeamProject'], 'public'))
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Logs to VSTS
+      inputs:
+        PathtoPublish: '$(Build.StagingDirectory)/BuildLogs'
+        PublishLocation: Container
+        ArtifactName: $(Agent.Os)_$(Agent.JobName)
+      continueOnError: true
+      condition: and(succeededOrFailed(), ne(variables['System.TeamProject'], 'public'))

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -36,8 +36,8 @@ phases:
         # This should be changed to an isolated blob feed per-build.
         # Right now a manual build of a random branch would get published alongside the normal branch artifacts.
         _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-        TeamName: DotNetCore
-        _SignArgs: /p:DotNetSignType=$(_SignType)
+        _TeamName: DotNetCore
+        _SignArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
         _PublishArgs: /p:PB_PublishBlobFeedKey=$(dotnetfeed-storage-access-key-1) 
           /p:PB_PublishBlobFeedUrl=$(_PublishBlobFeedUrl) 
           /p:PB_PublishType=$(_PublishType)

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -60,7 +60,7 @@ phases:
             KeyVaultName: EngKeyVault
             SecretsFilter: 'dotnetfeed-storage-access-key-1,microsoft-symbol-server-pat,symweb-symbol-server-pat'
 
-    # Use utility script to run script command dependent on agent OS
+    # Use utility script to run script command dependent on agent OS.
     - script: eng\common\cibuild.cmd
         -configuration $(_BuildConfig) 
         -prepareMachine
@@ -79,7 +79,7 @@ phases:
       displayName: Build / Publish
       condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
 
-    # Internal only build steps (until publishing artifacts in public CI is supported
+    # Internal only build steps (until publishing artifacts in public CI is supported.
     - ${{ if ne(variables['System.TeamProject'], 'public') }}:
       - task: CopyFiles@2
         displayName: Gather Logs

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -52,7 +52,7 @@ phases:
         _SignArgs: ''
         _HelixSource: pr/dotnet/arcade/$(Build.SourceBranch)
 
-    ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}
+    ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       steps:
       - task: AzureKeyVault@1
         inputs:
@@ -80,7 +80,7 @@ phases:
       condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
 
     # Internal only build steps (until publishing artifacts in public CI is supported
-    ${{ if ne(variables['System.TeamProject'], 'public') }}
+    ${{ if ne(variables['System.TeamProject'], 'public') }}:
       - task: CopyFiles@2
         displayName: Gather Logs
         inputs:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -52,8 +52,9 @@ phases:
         _SignArgs: ''
         _HelixSource: pr/dotnet/arcade/$(Build.SourceBranch)
 
+    steps:
+    
     ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      steps:
       - task: AzureKeyVault@1
         inputs:
           azureSubscription: 'DotNet-Engineering-Services_KeyVault'

--- a/eng/common/templates/phases/base.yml
+++ b/eng/common/templates/phases/base.yml
@@ -32,8 +32,8 @@ parameters:
   #             _SignType - 'test' or 'real'
   enableMicrobuild: false
 
-  # Build.Reason for anonymous builds - https://docs.microsoft.com/en-us/vsts/pipelines/build/variables?view=vsts#build-variables
-  publicBuildReasons: PullRequest
+# Internal resources (telemetry, microbuild) can only be accessed from non-public projects,
+# and some (Microbuild) should only be applied to non-PR cases for internal builds.
 
 phases:
 - phase: ${{ parameters.name }}
@@ -50,8 +50,8 @@ phases:
       fetchDepth: ${{ parameters.fetchDepth }}
 
   - ${{ if eq(parameters.enableTelemetry, 'true') }}:
-    # Remove this condition once telemetry can be sent from public CI
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), not(contains(parameters.publicBuildReasons, variables['Build.Reason'] ))) }}:
+    # Remove this condition once telemetry can be sent from public CI.
+    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
       - template: /eng/common/templates/steps/telemetry-start.yml
         parameters:
           buildConfig: ${{ parameters.variables._HelixBuildConfig }}
@@ -59,12 +59,16 @@ phases:
           helixType: ${{ parameters.variables._HelixType }}
 
   - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), not(contains(parameters.publicBuildReasons, variables['Build.Reason'] ))) }}:
-      - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
+    # Internal only resource, and Microbuild signing shouldn't be applied to PRs
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - task: MicroBuildSigningPlugin@1
         displayName: Install MicroBuild plugin
         inputs:
           signType: $(_SignType)
           zipSources: false
+          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+            feedSource: https://dotnet.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+          
         env:
           TeamName: $(_TeamName)
         continueOnError: false
@@ -74,16 +78,17 @@ phases:
   - ${{ parameters.steps }}
 
   - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), not(contains(parameters.publicBuildReasons, variables['Build.Reason'] ))) }}:
-      - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
+    # Internal only resources
+    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+      - task: MicroBuildCleanup@1
         displayName: Execute Microbuild cleanup tasks  
         condition: and(always(), in(variables['_SignType'], 'real', 'test'), eq(variables['Agent.Os'], 'Windows_NT'))
         env:
           TeamName: $(_TeamName)
 
   - ${{ if eq(parameters.enableTelemetry, 'true') }}:
-    # Remove this condition once telemetry can be sent from public CI
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), not(contains(parameters.publicBuildReasons, variables['Build.Reason'] ))) }}:
+    # Remove this condition once telemetry can be sent from public CI.
+    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
       - template: /eng/common/templates/steps/telemetry-end.yml
         parameters:
           helixSource: ${{ parameters.variables._HelixSource }}

--- a/eng/common/templates/phases/base.yml
+++ b/eng/common/templates/phases/base.yml
@@ -59,15 +59,14 @@ phases:
           helixType: ${{ parameters.variables._HelixType }}
 
   - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
-    # Internal only resource, and Microbuild signing shouldn't be applied to PRs
+    # Internal only resource, and Microbuild signing shouldn't be applied to PRs.
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - task: MicroBuildSigningPlugin@1
         displayName: Install MicroBuild plugin
         inputs:
           signType: $(_SignType)
           zipSources: false
-          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            feedSource: https://dotnet.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+          feedSource: https://dotnet.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
           
         env:
           TeamName: $(_TeamName)


### PR DESCRIPTION
- Enable real signing against dotnet.visualstudio.com for Windows master
- Builds should sign/publish in non-PR + non-Public scenarios.
- Switch away from devdiv.visualstudio.com build
- Factor out publish, official build id, and sign args into variables for clarity.
- Remove usage of build-reason template in favor of explicit conditions (need more than just build.reason)
- Update build.yml to reflect new build log structure.
- Use shorthand task name for Microbuild plugins
- Update log structure
- Shifts official builds to dotnet.visualstudio.com