### PR TITLE
Enable public telemetry

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -1,6 +1,6 @@
 parameters:
   name: ''
-  # send telemetry if build is not a public build  
+  # send telemetry
   enableTelemetry: true
   # install Microbuild plugin if not a public build
   enableMicrobuild: true

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -79,7 +79,7 @@ phases:
       displayName: Build / Publish
       condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
 
-    # Internal only build steps (until publishing artifacts in public CI is supported.
+    # Internal only build steps (until publishing artifacts in public CI is supported).
     - ${{ if ne(variables['System.TeamProject'], 'public') }}:
       - task: CopyFiles@2
         displayName: Gather Logs

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -67,7 +67,7 @@ phases:
         $(_PublishArgs)
         $(_SignArgs)
         $(_OfficialBuildIdArgs)
-      displayName: Build / Publish
+      displayName: Windows Build / Publish
       condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'))
         
     - script: eng/common/cibuild.sh
@@ -76,7 +76,7 @@ phases:
         $(_PublishArgs)
         $(_SignArgs)
         $(_OfficialBuildIdArgs)
-      displayName: Build / Publish
+      displayName: Unix Build / Publish
       condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
 
     # Internal only build steps (until publishing artifacts in public CI is supported).

--- a/eng/common/templates/phases/base.yml
+++ b/eng/common/templates/phases/base.yml
@@ -50,13 +50,11 @@ phases:
       fetchDepth: ${{ parameters.fetchDepth }}
 
   - ${{ if eq(parameters.enableTelemetry, 'true') }}:
-    # Remove this condition once telemetry can be sent from public CI.
-    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      - template: /eng/common/templates/steps/telemetry-start.yml
-        parameters:
-          buildConfig: ${{ parameters.variables._HelixBuildConfig }}
-          helixSource: ${{ parameters.variables._HelixSource }}
-          helixType: ${{ parameters.variables._HelixType }}
+    - template: /eng/common/templates/steps/telemetry-start.yml
+      parameters:
+        buildConfig: ${{ parameters.variables._HelixBuildConfig }}
+        helixSource: ${{ parameters.variables._HelixSource }}
+        helixType: ${{ parameters.variables._HelixType }}
 
   - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
     # Internal only resource, and Microbuild signing shouldn't be applied to PRs.
@@ -86,9 +84,7 @@ phases:
           TeamName: $(_TeamName)
 
   - ${{ if eq(parameters.enableTelemetry, 'true') }}:
-    # Remove this condition once telemetry can be sent from public CI.
-    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      - template: /eng/common/templates/steps/telemetry-end.yml
-        parameters:
-          helixSource: ${{ parameters.variables._HelixSource }}
-          helixType: ${{ parameters.variables._HelixType }}
+    - template: /eng/common/templates/steps/telemetry-end.yml
+      parameters:
+        helixSource: ${{ parameters.variables._HelixSource }}
+        helixType: ${{ parameters.variables._HelixType }}

--- a/eng/common/templates/steps/telemetry-end.yml
+++ b/eng/common/templates/steps/telemetry-end.yml
@@ -36,7 +36,7 @@ steps:
       echo "##$vstsLogOutput"
       exit 1
     fi
-  displayName: Send Build End Telemetry
+  displayName: Send Unix Build End Telemetry
   env:
     # defined via VSTS variables in start-job.sh
     Helix_JobToken: $(Helix_JobToken)
@@ -59,7 +59,7 @@ steps:
       Write-Error $_.Exception
       exit 1
     }
-  displayName: Send Build End Telemetry
+  displayName: Send Windows Build End Telemetry
   env:
     # defined via VSTS variables in start-job.ps1
     Helix_JobToken: $(Helix_JobToken)

--- a/eng/common/templates/steps/telemetry-start.yml
+++ b/eng/common/templates/steps/telemetry-start.yml
@@ -65,7 +65,7 @@ steps:
     # Set the Helix_JobToken variable
     export Helix_JobToken=`echo $curlResult | xargs echo` # Strip Quotes
     echo "##vso[task.setvariable variable=Helix_JobToken;issecret=true;]$Helix_JobToken"
-  displayName: Send Job Start Telemetry
+  displayName: Send Unix Job Start Telemetry
   env:
     HelixApiAccessToken: $(HelixApiAccessToken)
     Source: ${{ parameters.helixSource }}
@@ -105,7 +105,7 @@ steps:
 
     export Helix_WorkItemId=`echo $curlResult | xargs echo` # Strip Quotes
     echo "##vso[task.setvariable variable=Helix_WorkItemId]$Helix_WorkItemId"
-  displayName: Send Build Start Telemetry
+  displayName: Send Unix Build Start Telemetry
   env:
     BuildUri: $(System.TaskDefinitionsUri)$(System.TeamProject)/_build/index?buildId=$(Build.BuildId)&_a=summary
     Helix_JobToken: $(Helix_JobToken)
@@ -130,7 +130,7 @@ steps:
     $jobToken = Invoke-RestMethod -Uri "https://helix.dot.net/api/2018-03-14/telemetry/job$($accessTokenParameter)" -Method Post -ContentType "application/json" -Body $jobInfoJson
     $env:Helix_JobToken = $jobToken
     Write-Host "##vso[task.setvariable variable=Helix_JobToken;issecret=true;]$env:Helix_JobToken"
-  displayName: Send Job Start Telemetry
+  displayName: Send Windows Job Start Telemetry
   env:
     HelixApiAccessToken: $(HelixApiAccessToken)
     Source: ${{ parameters.helixSource }}
@@ -147,7 +147,7 @@ steps:
   
     $env:Helix_WorkItemId = $workItemId
     Write-Host "##vso[task.setvariable variable=Helix_WorkItemId]$env:Helix_WorkItemId"
-  displayName: Send Build Start Telemetry
+  displayName: Send Windows Build Start Telemetry
   env:
     BuildUri: $(System.TaskDefinitionsUri)$(System.TeamProject)/_build/index?buildId=$(Build.BuildId)&_a=summary
     Helix_JobToken: $(Helix_JobToken)

--- a/eng/common/templates/steps/telemetry-start.yml
+++ b/eng/common/templates/steps/telemetry-start.yml
@@ -4,12 +4,13 @@ parameters:
   buildConfig: ''
 
 steps:
-- task: AzureKeyVault@1
-  inputs:
-    azureSubscription: 'HelixProd_KeyVault'
-    KeyVaultName: HelixProdKV
-    SecretsFilter: 'HelixApiAccessToken'
-  condition: always()
+- ${{ if not(eq(variables['System.TeamProject'], 'public')) }}:
+  - task: AzureKeyVault@1
+    inputs:
+      azureSubscription: 'HelixProd_KeyVault'
+      KeyVaultName: HelixProdKV
+      SecretsFilter: 'HelixApiAccessToken'
+    condition: always()
 - bash: |
     # create a temporary file
     jobInfo=`mktemp`
@@ -32,11 +33,16 @@ steps:
     # create a temporary file for curl output
     res=`mktemp`
 
+    accessTokenParameter=''
+    if [[ ! "$HelixApiAccessToken" == "" ]]; then
+      accessTokenParameter="?access_token=$HelixApiAccessToken"
+    fi
+
     curlResult=`
       cat $jobInfo |\
       curl --verbose --output $res --write-out "%{http_code}" \
       -H 'Content-Type: application/json' \
-      -X POST "https://helix.dot.net/api/2018-03-14/telemetry/job?access_token=$HelixApiAccessToken" -d @-`
+      -X POST "https://helix.dot.net/api/2018-03-14/telemetry/job$accessTokenParameter" -d @-`
     curlStatus=$?
 
     if [ $curlStatus -eq 0 ]; then
@@ -117,8 +123,11 @@ steps:
     
     $jobInfoJson = $jobInfo | ConvertTo-Json
 
+    if ($env:HelixApiAccessToken) {
+      $accessTokenParameter="?access_token=$($env:HelixApiAccessToken)"
+    }
     Write-Host "Job Info: $jobInfoJson"
-    $jobToken = Invoke-RestMethod -Uri "https://helix.dot.net/api/2018-03-14/telemetry/job?access_token=$($env:HelixApiAccessToken)" -Method Post -ContentType "application/json" -Body $jobInfoJson
+    $jobToken = Invoke-RestMethod -Uri "https://helix.dot.net/api/2018-03-14/telemetry/job$($accessTokenParameter)" -Method Post -ContentType "application/json" -Body $jobInfoJson
     $env:Helix_JobToken = $jobToken
     Write-Host "##vso[task.setvariable variable=Helix_JobToken;issecret=true;]$env:Helix_JobToken"
   displayName: Send Job Start Telemetry


### PR DESCRIPTION
Validating internal builds with https://dotnet.visualstudio.com/internal/_build/results?buildId=15377&_a=summary&view=logs

I'll use this PR to validate public telemetry

