### PR TITLE
Fix relative path zip error

### DIFF
--- a/src/Microsoft.DotNet.Helix/JobSender/Payloads/DirectoryPayload.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/Payloads/DirectoryPayload.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Helix.Client
 
                     foreach (FileInfo file in DirectoryInfo.EnumerateFiles("*", SearchOption.AllDirectories))
                     {
-                        string relativePath = file.FullName.Substring(basePath.Length);
+                        string relativePath = file.FullName.Substring(basePath.Length+1); // +1 prevents it from including the leading backslash
                         zip.CreateEntryFromFile(file.FullName, relativePath);
                     }
                 }


### PR DESCRIPTION
Fix a bug that occurs when the Helix job sender zips up directories and accidentally includes a trailing backslash which makes the path resolve to the root drive.