### PR TITLE
Adding "Log.ErrorMessage" when the signing process fails

### DIFF
--- a/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
+++ b/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
@@ -46,6 +46,7 @@ namespace Microsoft.DotNet.SignTool
             // Next sign all of the files
             if (!SignFiles())
             {
+                _log.LogError("Error during execution of Microbuild signing process.");
                 return;
             }
 


### PR DESCRIPTION
Closes: #546 

The "Windows_NT Build_Release" build here (https://dotnet.visualstudio.com/internal/_build/results?buildId=15729&view=logs) failed because the agent didn't had the certificate to sign the files. However, the SignToolTask failed to report the error back and thus the build was marked as success.

The fail occurs because:

RealSignTool.cs:59 returns false because the process failed
SignTool.cs:41 returns false due the same reason
BatchSignUtil.cs:97 also returns false
BatchSignUtil.cs:47 also returns false
SignToolTask.cs:11 returns false
**SignToolTask.cs:76 returns TRUE because none of the methods above logged the error on the "Log" object.**

