### PR TITLE
Set CIBuild variable

### DIFF
--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -250,6 +250,7 @@ function Build([string] $buildDriver, [string]$buildArgs) {
     /p:Sign=$sign `
     /p:Publish=$publish `
     /p:ContinuousIntegrationBuild=$ci `
+    /p:CIBuild=$ci `
     $properties
 
   if ($lastExitCode -ne 0) {

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -280,6 +280,7 @@ function Build {
     /p:Sign=$sign \
     /p:Publish=$publish \
     /p:ContinuousIntegrationBuild=$ci \
+    /p:CIBuild=$ci \
     $properties
   local lastexitcode=$?
 


### PR DESCRIPTION
This is still needed until we bump the arcade version used to build arcade.