### PR TITLE
reference run-time variables for telem properties

### DIFF
--- a/eng/common/templates/phases/base.yml
+++ b/eng/common/templates/phases/base.yml
@@ -52,9 +52,9 @@ phases:
   - ${{ if eq(parameters.enableTelemetry, 'true') }}:
     - template: /eng/common/templates/steps/telemetry-start.yml
       parameters:
-        buildConfig: ${{ parameters.variables._HelixBuildConfig }}
-        helixSource: ${{ parameters.variables._HelixSource }}
-        helixType: ${{ parameters.variables._HelixType }}
+        buildConfig: $(_HelixBuildConfig)
+        helixSource: $(_HelixSource)
+        helixType: $(_HelixType)
 
   - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
     # Internal only resource, and Microbuild signing shouldn't be applied to PRs.
@@ -86,5 +86,5 @@ phases:
   - ${{ if eq(parameters.enableTelemetry, 'true') }}:
     - template: /eng/common/templates/steps/telemetry-end.yml
       parameters:
-        helixSource: ${{ parameters.variables._HelixSource }}
-        helixType: ${{ parameters.variables._HelixType }}
+        helixSource: $(_HelixSource)
+        helixType: $(_HelixType)


### PR DESCRIPTION
… instead of the compile-time variables parameter object.  This allows you to define the required variables in a matrix, phases level variables, or anywhere else as a "variables" object instead of limiting to referencing the variables parameter object.