### PR TITLE
General push assets to bar fixes

### DIFF
--- a/eng/common/PublishBuildAssets.cmd
+++ b/eng/common/PublishBuildAssets.cmd
@@ -1,0 +1,3 @@
+@echo off
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0Build.ps1""" -restore -publishBuildAssets %*"
+exit /b %ErrorLevel%

--- a/eng/common/PushBuildAssets.cmd
+++ b/eng/common/PushBuildAssets.cmd
@@ -1,3 +1,0 @@
-@echo off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0Build.ps1""" -restore -pushBuildAssets %*"
-exit /b %ErrorLevel%

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -14,7 +14,7 @@ Param(
   [switch] $sign,
   [switch] $pack,
   [switch] $publish,
-  [switch] $pushBuildAssets,
+  [switch] $publishBuildAssets,
   [switch] $ci,
   [switch] $prepareMachine,
   [switch] $help,
@@ -44,7 +44,7 @@ function Print-Usage() {
     Write-Host "  -performanceTest        Run all performance tests in the solution"
     Write-Host "  -sign                   Sign build outputs"
     Write-Host "  -publish                Publish artifacts (e.g. symbols)"
-    Write-Host "  -pushBuildAssets        Push assets to BAR"
+    Write-Host "  -publishBuildAssets        Push assets to BAR"
     Write-Host ""
 
     Write-Host "Advanced settings:"
@@ -251,7 +251,7 @@ function Build([string] $buildDriver, [string]$buildArgs) {
     /p:PerformanceTest=$performanceTest `
     /p:Sign=$sign `
     /p:Publish=$publish `
-    /p:PushBuildAssets=$pushBuildAssets `
+    /p:PublishBuildAssets=$publishBuildAssets `
     /p:ContinuousIntegrationBuild=$ci `
     /p:CIBuild=$ci `
     $properties

--- a/eng/common/templates/phases/publish-build-asset.yml
+++ b/eng/common/templates/phases/publish-build-asset.yml
@@ -19,7 +19,7 @@ phases:
             KeyVaultName: EngKeyVault
             SecretsFilter: 'MaestroAccessToken'
           condition: succeeded()
-        - script: eng\common\pushbuildassets.cmd
+        - script: eng\common\publishbuildassets.cmd
             /p:ManifestZipFilePath='$(Build.StagingDirectory)/Download/AssetManifests'
             /p:BuildAssetRegistryToken=$(MaestroAccessToken)
             /p:MaestroApiEndpoint=https://maestro-int.westus2.cloudapp.azure.com

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -1,11 +1,14 @@
 <!-- All Rights Reserved. Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project DefaultTargets="Execute" TreatAsLocalProperty="RepoRoot">
   <!--
+  
   Required parameters:
     RepoRoot                        Repository root.
     Projects                        List of projects to build. Semicolon separated, may include globs.
+  
   Optional parameters:              
     Configuration                   Build configuration: "Debug", "Release", etc.
+  
     DotNetRestoreSourcePropsPath    Overrides of ResourceSources (list of NuGet feeds to download dependencies from)
     DotNetBuildFromSource           Building the entire stack from source with no external dependencies.
     DotNetBuildOffline              Building without access to NuGet servers.
@@ -16,6 +19,7 @@
     DotNetSymbolServerTokenSymWeb   Personal access token for SymWeb symbol server. Available from variable group DotNet-Symbol-Publish.
     DotNetSymbolExpirationInDays    Symbol expiration time in days (defaults to 10 years).
     DotNetSignType                  Specifies the signing type: 'real' (default), 'test'.
+  
     ContinuousIntegrationBuild      "true" when building on a CI server (PR build or official build)
     Restore                         "true" to restore toolset and solution
     QuietRestore                    "true" to suppress Restore output.
@@ -29,6 +33,7 @@
     Sign                            "true" to sign built binaries
     Publish                         "true" to publish artifacts (e.g. symbols)
     PushBuildAssets                 "true" to push build and asset information to the Build Asset Registry
+    
     SuppressPackageVersionRewrite   "true" to suppress rewrite of PackageVersions.props file. Temporary switch to allow repos to migrate to the official format of the version properties.
   -->
 
@@ -53,8 +58,8 @@
     <_PublishToBlobStorage>false</_PublishToBlobStorage>
     <_PublishToBlobStorage Condition="'$(DotNetPublishToBlobFeed)' == 'true'">true</_PublishToBlobStorage>
     
-    <_PushAssetsToBar>false</_PushAssetsToBar>
-    <_PushAssetsToBar Condition="'$(PushBuildAssets)' == 'true'">true</_PushAssetsToBar>
+    <_PushAssetsToRegistry>false</_PushAssetsToRegistry>
+    <_PushAssetsToRegistry Condition="'$(PushBuildAssets)' == 'true'">true</_PushAssetsToRegistry>
 
     <_DotNetOutputBlobFeedDir>$(DotNetOutputBlobFeedDir)</_DotNetOutputBlobFeedDir>
     <_DotNetOutputBlobFeedDir Condition="'$(_DotNetOutputBlobFeedDir)' != '' and !HasTrailingSlash('$(_DotNetOutputBlobFeedDir)')">$(_DotNetOutputBlobFeedDir)\</_DotNetOutputBlobFeedDir>
@@ -110,7 +115,7 @@
       <_RestoreToolsProps Include="BaseIntermediateOutputPath=$(ArtifactsToolsetDir)Common"/>
       <_RestoreToolsProps Include="ExcludeRestorePackageImports=true"/>
       <_RestoreToolsProps Include="PublishingToBlobStorage=$(_PublishToBlobStorage)"/>
-      <_RestoreToolsProps Include="PushAssetsToBar=$(_PushAssetsToBar)"/>
+      <_RestoreToolsProps Include="PushAssetsToRegistry=$(_PushAssetsToRegistry)"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -1,14 +1,11 @@
 <!-- All Rights Reserved. Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project DefaultTargets="Execute" TreatAsLocalProperty="RepoRoot">
   <!--
-
   Required parameters:
     RepoRoot                        Repository root.
     Projects                        List of projects to build. Semicolon separated, may include globs.
-
   Optional parameters:              
     Configuration                   Build configuration: "Debug", "Release", etc.
-
     DotNetRestoreSourcePropsPath    Overrides of ResourceSources (list of NuGet feeds to download dependencies from)
     DotNetBuildFromSource           Building the entire stack from source with no external dependencies.
     DotNetBuildOffline              Building without access to NuGet servers.
@@ -19,7 +16,6 @@
     DotNetSymbolServerTokenSymWeb   Personal access token for SymWeb symbol server. Available from variable group DotNet-Symbol-Publish.
     DotNetSymbolExpirationInDays    Symbol expiration time in days (defaults to 10 years).
     DotNetSignType                  Specifies the signing type: 'real' (default), 'test'.
-
     ContinuousIntegrationBuild      "true" when building on a CI server (PR build or official build)
     Restore                         "true" to restore toolset and solution
     QuietRestore                    "true" to suppress Restore output.
@@ -33,7 +29,6 @@
     Sign                            "true" to sign built binaries
     Publish                         "true" to publish artifacts (e.g. symbols)
     PushBuildAssets                 "true" to push build and asset information to the Build Asset Registry
-
     SuppressPackageVersionRewrite   "true" to suppress rewrite of PackageVersions.props file. Temporary switch to allow repos to migrate to the official format of the version properties.
   -->
 
@@ -57,6 +52,9 @@
   <PropertyGroup>
     <_PublishToBlobStorage>false</_PublishToBlobStorage>
     <_PublishToBlobStorage Condition="'$(DotNetPublishToBlobFeed)' == 'true'">true</_PublishToBlobStorage>
+    
+    <_PushAssetsToBar>false</_PushAssetsToBar>
+    <_PushAssetsToBar Condition="'$(PushBuildAssets)' == 'true'">true</_PushAssetsToBar>
 
     <_DotNetOutputBlobFeedDir>$(DotNetOutputBlobFeedDir)</_DotNetOutputBlobFeedDir>
     <_DotNetOutputBlobFeedDir Condition="'$(_DotNetOutputBlobFeedDir)' != '' and !HasTrailingSlash('$(_DotNetOutputBlobFeedDir)')">$(_DotNetOutputBlobFeedDir)\</_DotNetOutputBlobFeedDir>
@@ -112,6 +110,7 @@
       <_RestoreToolsProps Include="BaseIntermediateOutputPath=$(ArtifactsToolsetDir)Common"/>
       <_RestoreToolsProps Include="ExcludeRestorePackageImports=true"/>
       <_RestoreToolsProps Include="PublishingToBlobStorage=$(_PublishToBlobStorage)"/>
+      <_RestoreToolsProps Include="PushAssetsToBar=$(_PushAssetsToBar)"/>
     </ItemGroup>
 
     <ItemGroup>
@@ -129,7 +128,7 @@
     
     <ItemGroup>
       <_PushProps Include="@(_CommonProps)"/>
-      <_PushProps Include="ManifestZipFilePath=$(ManifestZipFilePath)"/>
+      <_PushProps Include="ManifestsPath=$(ManifestsPath)"/>
       <_PushProps Include="BuildAssetRegistryToken=$(BuildAssetRegistryToken)"/>
       <_PushProps Include="MaestroApiEndpoint=$(MaestroApiEndpoint)"/>
     </ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -32,7 +32,7 @@
     Pack                            "true" to build NuGet packages and VS insertion manifests
     Sign                            "true" to sign built binaries
     Publish                         "true" to publish artifacts (e.g. symbols)
-    PushBuildAssets                 "true" to push build and asset information to the Build Asset Registry
+    PublishBuildAssets                 "true" to push build and asset information to the Build Asset Registry
     
     SuppressPackageVersionRewrite   "true" to suppress rewrite of PackageVersions.props file. Temporary switch to allow repos to migrate to the official format of the version properties.
   -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -58,8 +58,8 @@
     <_PublishToBlobStorage>false</_PublishToBlobStorage>
     <_PublishToBlobStorage Condition="'$(DotNetPublishToBlobFeed)' == 'true'">true</_PublishToBlobStorage>
     
-    <_PushAssetsToRegistry>false</_PushAssetsToRegistry>
-    <_PushAssetsToRegistry Condition="'$(PushBuildAssets)' == 'true'">true</_PushAssetsToRegistry>
+    <_PublishingAssetsToRegistry>false</_PublishingAssetsToRegistry>
+    <_PublishingAssetsToRegistry Condition="'$(PublishBuildAssets)' == 'true'">true</_PublishingAssetsToRegistry>
 
     <_DotNetOutputBlobFeedDir>$(DotNetOutputBlobFeedDir)</_DotNetOutputBlobFeedDir>
     <_DotNetOutputBlobFeedDir Condition="'$(_DotNetOutputBlobFeedDir)' != '' and !HasTrailingSlash('$(_DotNetOutputBlobFeedDir)')">$(_DotNetOutputBlobFeedDir)\</_DotNetOutputBlobFeedDir>
@@ -115,7 +115,7 @@
       <_RestoreToolsProps Include="BaseIntermediateOutputPath=$(ArtifactsToolsetDir)Common"/>
       <_RestoreToolsProps Include="ExcludeRestorePackageImports=true"/>
       <_RestoreToolsProps Include="PublishingToBlobStorage=$(_PublishToBlobStorage)"/>
-      <_RestoreToolsProps Include="PushAssetsToRegistry=$(_PushAssetsToRegistry)"/>
+      <_RestoreToolsProps Include="PublishingAssetsToRegistry=$(_PublishingAssetsToRegistry)"/>
     </ItemGroup>
 
     <ItemGroup>
@@ -130,7 +130,9 @@
       <_SolutionBuildProps Include="__DeployProjectOutput=$(Deploy)" Condition="'$(Deploy)' != ''"/>
     </ItemGroup>
 
-    
+    <!--
+        These are set in the eng\common\templates\phases\publish-build-asset.yml template
+    -->
     <ItemGroup>
       <_PushProps Include="@(_CommonProps)"/>
       <_PushProps Include="ManifestsPath=$(ManifestsPath)"/>
@@ -215,9 +217,9 @@
              Targets="Publish"
              Condition="'$(Publish)' == 'true'"/>
              
-    <MSBuild Projects="PushBuildAssets.proj"
+    <MSBuild Projects="PublishBuildAssets.proj"
              Properties="@(_PushProps)"
-             Targets="PushBuildAssets"
-             Condition="'$(PushBuildAssets)' == 'true'" />
+             Targets="PublishBuildAssets"
+             Condition="'$(PublishBuildAssets)' == 'true'" />
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -58,7 +58,7 @@
     <XUnitVersion Condition="'$(XUnitVersion)' == ''">2.4.1-pre.build.4059</XUnitVersion>
     <XUnitRunnerConsoleVersion Condition="'$(XUnitRunnerConsoleVersion)' == ''">$(XUnitVersion)</XUnitRunnerConsoleVersion>
     <XUnitRunnerVisualStudioVersion Condition="'$(XUnitRunnerVisualStudioVersion)' == ''">$(XUnitVersion)</XUnitRunnerVisualStudioVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion Condition="'$(MicrosoftDotNetBuildTasksFeedVersion)' == ''">2.2.0-beta.18427.18</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion Condition="'$(MicrosoftDotNetBuildTasksFeedVersion)' == ''">2.2.0-beta.18430.2</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftSourceLinkVersion Condition="'$(MicrosoftSourceLinkVersion)' == ''">1.0.0-beta-63201-01</MicrosoftSourceLinkVersion>
     <MicrosoftSymbolUploaderBuildTaskVersion Condition="'$(MicrosoftSymbolUploaderBuildTaskVersion)' == ''">1.0.0-beta-63008-01</MicrosoftSymbolUploaderBuildTaskVersion>
     <VSWhereVersion Condition="'$(VSWhereVersion)' == ''">2.5.2</VSWhereVersion>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -27,7 +27,7 @@
     
     <PublishToSymbolServer>false</PublishToSymbolServer>
     <PublishToSymbolServer Condition="'$(UsingToolSymbolUploader)' == 'true' and '$(AzureFeedUrl)' == '' and '$(ContinuousIntegrationBuild)' == 'true'">true</PublishToSymbolServer>
-    <AssetManifestFilePath>$(ArtifactsLogDir)AssetManifest\$(OS)-$(PlatformName)-asset-manifest.xml</AssetManifestFilePath>
+    <AssetManifestFilePath>$(ArtifactsLogDir)AssetManifest\$(OS)-$(PlatformName).xml</AssetManifestFilePath>
   </PropertyGroup>
 
   <Import Project="$(NuGetPackageRoot)microsoft.dotnet.build.tasks.feed\$(MicrosoftDotNetBuildTasksFeedVersion)\build\Microsoft.DotNet.Build.Tasks.Feed.targets" Condition="$(PublishToAzure)"/>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/PublishBuildAssets.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/PublishBuildAssets.proj
@@ -1,5 +1,5 @@
 <!-- All Rights Reserved. Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
-<Project DefaultTargets="PushBuildAssets">
+<Project DefaultTargets="PublishBuildAssets">
   <!--
     Required variables:
       ManifestsPath                     Path to file containing manifest files.
@@ -16,7 +16,7 @@
   
   <UsingTask TaskName="PushMetadataToBuildAssetRegistry" AssemblyFile="$(_MicrosoftDotNetMaestroTasksDir)Microsoft.DotNet.Maestro.Tasks.dll"/>
   
-  <Target Name="PushBuildAssets">
+  <Target Name="PublishBuildAssets">
     <Error Text="The ManifestsPath  property must be set on the command line." Condition="'$(ManifestsPath)' == ''" />
     <Error Text="The BuildAssetRegistryToken property must be set on the command line." Condition="'$(BuildAssetRegistryToken)' == ''" />
     <Error Text="The MaestroApiEndpoint property must be set on the command line." Condition="'$(MaestroApiEndpoint)' == ''" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/PushBuildAssets.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/PushBuildAssets.proj
@@ -5,8 +5,6 @@
       ManifestsPath                     Path to file containing manifest files.
       BuildAssetRegistryToken           Token required to insert metadata into BAR.
       MaestroApiEndpoint            	Maestro's endpoint.
-    Optional variables:                 
-      AssetLocationType                 Type of location where the assets are stored. Default is 'Blob'.
   -->
 
   <Import Project="BuildStep.props" />
@@ -23,13 +21,8 @@
     <Error Text="The BuildAssetRegistryToken property must be set on the command line." Condition="'$(BuildAssetRegistryToken)' == ''" />
     <Error Text="The MaestroApiEndpoint property must be set on the command line." Condition="'$(MaestroApiEndpoint)' == ''" />
     
-    <PropertyGroup>
-        <AssetLocationType Condition=" '$(AssetLocationType)'=='' ">NugetFeed</AssetLocationType>
-    </PropertyGroup>
-    
     <PushMetadataToBuildAssetRegistry ManifestsPath="$(ManifestsPath)"
                     BuildAssetRegistryToken="$(BuildAssetRegistryToken)"
-                    MaestroApiEndpoint="$(MaestroApiEndpoint)" 
-                    AssetLocationType="$(AssetLocationType)"/>
+                    MaestroApiEndpoint="$(MaestroApiEndpoint)" />
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/PushBuildAssets.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/PushBuildAssets.proj
@@ -2,26 +2,32 @@
 <Project DefaultTargets="PushBuildAssets">
   <!--
     Required variables:
-      ManifestZipFilePath               Path to file containing manifest files.
+      ManifestsPath                     Path to file containing manifest files.
       BuildAssetRegistryToken           Token required to insert metadata into BAR.
       MaestroApiEndpoint            	Maestro's endpoint.
-
     Optional variables:                 
       AssetLocationType                 Type of location where the assets are stored. Default is 'Blob'.
   -->
 
   <Import Project="BuildStep.props" />
-
+  
+  <PropertyGroup>
+    <_MicrosoftDotNetMaestroTasksDir>$(MSBuildThisFileDirectory)../tools/net461/</_MicrosoftDotNetMaestroTasksDir>
+    <_MicrosoftDotNetMaestroTasksDir Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)../tools/netcoreapp2.0/</_MicrosoftDotNetMaestroTasksDir>
+  </PropertyGroup>
+  
+  <UsingTask TaskName="PushMetadataToBuildAssetRegistry" AssemblyFile="$(_MicrosoftDotNetMaestroTasksDir)Microsoft.DotNet.Maestro.Tasks.dll"/>
+  
   <Target Name="PushBuildAssets">
-    <Error Text="The ManifestZipFilePath  property must be set on the command line." Condition="'$(ManifestZipFilePath)' == ''" />
+    <Error Text="The ManifestsPath  property must be set on the command line." Condition="'$(ManifestsPath)' == ''" />
     <Error Text="The BuildAssetRegistryToken property must be set on the command line." Condition="'$(BuildAssetRegistryToken)' == ''" />
     <Error Text="The MaestroApiEndpoint property must be set on the command line." Condition="'$(MaestroApiEndpoint)' == ''" />
     
     <PropertyGroup>
-        <AssetLocationType Condition=" '$(AssetLocationType)'=='' ">Blob</AssetLocationType>
+        <AssetLocationType Condition=" '$(AssetLocationType)'=='' ">NugetFeed</AssetLocationType>
     </PropertyGroup>
     
-    <PushMetadataToBuildAssetRegistry ManifestZipFilePath="$(ManifestZipFilePath)"
+    <PushMetadataToBuildAssetRegistry ManifestsPath="$(ManifestsPath)"
                     BuildAssetRegistryToken="$(BuildAssetRegistryToken)"
                     MaestroApiEndpoint="$(MaestroApiEndpoint)" 
                     AssetLocationType="$(AssetLocationType)"/>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -49,7 +49,8 @@
     <PackageReference Include="Microsoft.DotNet.SignTool" Version="$(MicrosoftDotNetSignToolVersion)" IsImplicitlyDefined="true" />
     <PackageReference Include="RoslynTools.ModifyVsixManifest" Version="$(RoslynToolsModifyVsixManifestVersion)" Condition="'$(UsingToolVSSDK)' == 'true'" IsImplicitlyDefined="true" />
     <PackageReference Include="Microsoft.SymbolUploader.Build.Task" Version="$(MicrosoftSymbolUploaderBuildTaskVersion)" Condition="'$(UsingToolSymbolUploader)' == 'true'" IsImplicitlyDefined="true" />
-  </ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Maestro.Tasks" Version="$(MicrosoftDotNetMaestroTasksVersion)" Condition="'$(PushAssetsToBar)' == 'true'" IsImplicitlyDefined="true" />  
+</ItemGroup>
 
   <!-- Repository extensibility point -->
   <Import Project="$(RepositoryEngineeringDir)Tools.props" Condition="Exists('$(RepositoryEngineeringDir)Tools.props')" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -49,8 +49,8 @@
     <PackageReference Include="Microsoft.DotNet.SignTool" Version="$(MicrosoftDotNetSignToolVersion)" IsImplicitlyDefined="true" />
     <PackageReference Include="RoslynTools.ModifyVsixManifest" Version="$(RoslynToolsModifyVsixManifestVersion)" Condition="'$(UsingToolVSSDK)' == 'true'" IsImplicitlyDefined="true" />
     <PackageReference Include="Microsoft.SymbolUploader.Build.Task" Version="$(MicrosoftSymbolUploaderBuildTaskVersion)" Condition="'$(UsingToolSymbolUploader)' == 'true'" IsImplicitlyDefined="true" />
-    <PackageReference Include="Microsoft.DotNet.Maestro.Tasks" Version="$(MicrosoftDotNetMaestroTasksVersion)" Condition="'$(PushAssetsToBar)' == 'true'" IsImplicitlyDefined="true" />  
-</ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Maestro.Tasks" Version="$(MicrosoftDotNetMaestroTasksVersion)" Condition="'$(PushAssetsToRegistry)' == 'true'" IsImplicitlyDefined="true" />  
+  </ItemGroup>
 
   <!-- Repository extensibility point -->
   <Import Project="$(RepositoryEngineeringDir)Tools.props" Condition="Exists('$(RepositoryEngineeringDir)Tools.props')" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -49,7 +49,7 @@
     <PackageReference Include="Microsoft.DotNet.SignTool" Version="$(MicrosoftDotNetSignToolVersion)" IsImplicitlyDefined="true" />
     <PackageReference Include="RoslynTools.ModifyVsixManifest" Version="$(RoslynToolsModifyVsixManifestVersion)" Condition="'$(UsingToolVSSDK)' == 'true'" IsImplicitlyDefined="true" />
     <PackageReference Include="Microsoft.SymbolUploader.Build.Task" Version="$(MicrosoftSymbolUploaderBuildTaskVersion)" Condition="'$(UsingToolSymbolUploader)' == 'true'" IsImplicitlyDefined="true" />
-    <PackageReference Include="Microsoft.DotNet.Maestro.Tasks" Version="$(MicrosoftDotNetMaestroTasksVersion)" Condition="'$(PushAssetsToRegistry)' == 'true'" IsImplicitlyDefined="true" />  
+    <PackageReference Include="Microsoft.DotNet.Maestro.Tasks" Version="$(MicrosoftDotNetMaestroTasksVersion)" Condition="'$(PublishingAssetsToRegistry)' == 'true'" IsImplicitlyDefined="true" />  
   </ItemGroup>
 
   <!-- Repository extensibility point -->

--- a/src/Microsoft.DotNet.Maestro.Tasks/src/Models/Manifest.cs
+++ b/src/Microsoft.DotNet.Maestro.Tasks/src/Models/Manifest.cs
@@ -16,28 +16,42 @@ namespace Microsoft.DotNet.Maestro.Tasks
         [XmlElement(ElementName = "Blob")]
         public List<Blob> Blobs { get; set; }
 
-        public string Commit { get; set; }
-
-        public string Branch { get; set; }
-       
-        public string BuildId { get; set; }
-
+        [XmlAttribute(AttributeName = "Name")]
         public string Name { get; set; }
 
+        [XmlAttribute(AttributeName = "BuildId")]
+        public string BuildId { get; set; }
+
+        [XmlAttribute(AttributeName = "Branch")]
+        public string Branch { get; set; }
+
+        [XmlAttribute(AttributeName = "Commit")]
+        public string Commit { get; set; }
+
+        [XmlAttribute(AttributeName = "Location")]
         public string Location { get; set; }
     }
 
+    [XmlRoot(ElementName = "Package")]
     public class Package
     {
-        public string NonShipping { get; set; }
+        [XmlAttribute(AttributeName = "Id")]
+        public string Id { get; set; }
 
+        [XmlAttribute(AttributeName = "Version")]
         public string Version { get; set; }
 
-        public string Id { get; set; }
+        [XmlAttribute(AttributeName = "NonShipping")]
+        public string NonShipping { get; set; }
     }
 
+    [XmlRoot(ElementName = "Blob")]
     public class Blob
     {
+        [XmlAttribute(AttributeName = "Id")]
         public string Id { get; set; }
+
+        [XmlAttribute(AttributeName = "NonShipping")]
+        public string NonShipping { get; set; }
     }
 }


### PR DESCRIPTION
This fixes some things on how we push data to the BAR now that it is deployed. Also, checks for the origin of the repo URL and transforms it, from VSTS -> GitHub if the commit exists in GH so the dependencies flow as planned 