### PR TITLE
Calculate OutDir for MicroBuild task.

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -33,8 +33,6 @@
     Sign                            "true" to sign built binaries
     Publish                         "true" to publish artifacts (e.g. symbols)
     PublishBuildAssets                 "true" to push build and asset information to the Build Asset Registry
-    
-    SuppressPackageVersionRewrite   "true" to suppress rewrite of PackageVersions.props file. Temporary switch to allow repos to migrate to the official format of the version properties.
   -->
 
   <!--
@@ -51,7 +49,6 @@
     <_RemoveProps>Projects;Restore;QuietRestore;Build;Rebuild;Deploy;Test;IntegrationTest;PerformanceTest;Pack;Sign;Publish</_RemoveProps>
   </PropertyGroup>
 
-  <Import Project="BuildTasks.props"/>
   <Import Project="RepoLayout.props"/>
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.SignTool.Tests
             // The path to MSBuild will always be null in these tests, this will force
             // the signing logic to call our FakeBuildEngine.BuildProjectFile with a path
             // to the XML that store the content of the would be Microbuild sign request.
-            var signToolArgs = new SignToolArgs(_tmpDir, microBuildCorePath: "MicroBuildCorePath", testSign: true, msBuildPath: null, _tmpDir);
+            var signToolArgs = new SignToolArgs(_tmpDir, microBuildCorePath: "MicroBuildCorePath", testSign: true, msBuildPath: null, _tmpDir, enclosingDir: "");
 
             var signTool = new ValidationOnlySignTool(signToolArgs);
             var signingInput = new Configuration(signToolArgs.TempDir, itemsToSign, strongNameSignInfo, signingOverridingInfos, task.Log).GenerateListOfFiles();

--- a/src/Microsoft.DotNet.SignTool/src/SignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignTool.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.SignTool
 
         public bool Sign(IBuildEngine buildEngine, int round, IEnumerable<FileSignInfo> filesToSign)
         {
-            var signingDir = Path.Combine(TempDir, "Signing");
+            var signingDir = Path.Combine(_args.TempDir, "Signing");
             var buildFilePath = Path.Combine(signingDir, $"Round{round}.proj");
             var content = GenerateBuildFileContent(filesToSign);
 
@@ -50,8 +50,8 @@ namespace Microsoft.DotNet.SignTool
             // Setup the code to get the NuGet package root.
             var signKind = _args.TestSign ? "test" : "real";
             AppendLine(builder, depth: 1, text: @"<PropertyGroup>");
-            AppendLine(builder, depth: 2, text: $@"<OutDir>{TempDir}</OutDir>");
-            AppendLine(builder, depth: 2, text: $@"<IntermediateOutputPath>{TempDir}</IntermediateOutputPath>");
+            AppendLine(builder, depth: 2, text: $@"<OutDir>{_args.EnclosingDir}</OutDir>");
+            AppendLine(builder, depth: 2, text: $@"<IntermediateOutputPath>{_args.TempDir}</IntermediateOutputPath>");
             AppendLine(builder, depth: 2, text: $@"<SignType>{signKind}</SignType>");
             AppendLine(builder, depth: 1, text: @"</PropertyGroup>");
 

--- a/src/Microsoft.DotNet.SignTool/src/SignToolArgs.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolArgs.cs
@@ -11,14 +11,16 @@ namespace Microsoft.DotNet.SignTool
         internal bool TestSign { get; }
         internal string MSBuildPath { get; }
         internal string LogDir { get; }
+        internal string EnclosingDir { get; }
 
-        internal SignToolArgs(string tempPath, string microBuildCorePath, bool testSign, string msBuildPath, string logDir)
+        internal SignToolArgs(string tempPath, string microBuildCorePath, bool testSign, string msBuildPath, string logDir, string enclosingDir)
         {
             TempDir = tempPath;
             MicroBuildCorePath = microBuildCorePath;
             TestSign = testSign;
             MSBuildPath = msBuildPath;
             LogDir = logDir;
+            EnclosingDir = enclosingDir;
         }
     }
 }

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -68,6 +68,7 @@ namespace Microsoft.DotNet.SignTool
         /// <summary>
         /// Directory to write log to. Required if <see cref="DryRun"/> is <c>false</c>.
         /// </summary>
+        [Required]
         public string LogDir { get; set; }
 
         public override bool Execute()
@@ -78,27 +79,19 @@ namespace Microsoft.DotNet.SignTool
 
         public void ExecuteImpl()
         {
-            if (!DryRun)
+            if (!DryRun && typeof(object).Assembly.GetName().Name != "mscorlib" && !File.Exists(MSBuildPath))
             {
-                if (typeof(object).Assembly.GetName().Name != "mscorlib" && !File.Exists(MSBuildPath))
-                {
-                    Log.LogError($"MSBuild was not found at this path: '{MSBuildPath}'.");
-                    return;
-                }
-
-                if (string.IsNullOrEmpty(LogDir) || !Directory.Exists(LogDir))
-                {
-                    Log.LogError($"Invalid LogDir informed: {LogDir}");
-                    return;
-                }
+                Log.LogError($"MSBuild was not found at this path: '{MSBuildPath}'.");
+                return;
             }
 
+            var enclosingDir = GetEnclosingDirectoryOfItemsToSign();
             var defaultSignInfoForPublicKeyToken = ParseStrongNameSignInfo();
             var explicitCertificates = ParseFileSignInfo();
 
             if (Log.HasLoggedErrors) return;
 
-            var signToolArgs = new SignToolArgs(TempDir, MicroBuildCorePath, TestSign, MSBuildPath, LogDir);
+            var signToolArgs = new SignToolArgs(TempDir, MicroBuildCorePath, TestSign, MSBuildPath, LogDir, enclosingDir);
             var signTool = DryRun ? new ValidationOnlySignTool(signToolArgs) : (SignTool)new RealSignTool(signToolArgs);
             var signingInput = new Configuration(TempDir, ItemsToSign, defaultSignInfoForPublicKeyToken, explicitCertificates, Log).GenerateListOfFiles();
 
@@ -109,6 +102,52 @@ namespace Microsoft.DotNet.SignTool
             if (Log.HasLoggedErrors) return;
 
             util.Go();
+        }
+
+        private string GetEnclosingDirectoryOfItemsToSign()
+        {
+            var separators = new[] { '/', '\\' };
+            string[] result = null;
+
+            foreach (var path in ItemsToSign)
+            {
+                if (!Path.IsPathRooted(path))
+                {
+                    Log.LogError($"Paths specified in {nameof(ItemsToSign)} must be absolute: '{path}'.");
+                    continue;
+                }
+
+                var directoryParts = Path.GetFullPath(Path.GetDirectoryName(path)).Split(separators);
+                if (result == null)
+                {
+                    result = directoryParts;
+                    continue;
+                }
+
+                Array.Resize(ref result, getCommonPrefixLength(result, directoryParts));
+            }
+
+            if (result.Length == 0)
+            {
+                Log.LogError($"All {nameof(ItemsToSign)} must be within the cone of a single directory.");
+            }
+
+            return string.Join(Path.DirectorySeparatorChar.ToString(), result);
+
+            int getCommonPrefixLength(string[] dir1, string[] dir2)
+            {
+                int min = Math.Min(dir1.Length, dir2.Length);
+
+                for (int i = 0; i < min; i++)
+                {
+                    if (dir1[i] != dir2[i])
+                    {
+                        return i;
+                    }
+                }
+
+                return min;
+            }
         }
 
         private Dictionary<string, SignInfo> ParseStrongNameSignInfo()

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.SignTool
         public string MSBuildPath { get; set; }
 
         /// <summary>
-        /// Directory to write log to. Required if <see cref="DryRun"/> is <c>false</c>.
+        /// Directory to write log to.
         /// </summary>
         [Required]
         public string LogDir { get; set; }


### PR DESCRIPTION
Signing requires that any files to be signed live somewhere under `$(OutDir)` or `$(IntermediateOutputPath)` set in the signing project.