### PR TITLE
Avoid opening zip archives in update mode unless repacking

### DIFF
--- a/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
+++ b/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
@@ -240,8 +240,7 @@ namespace Microsoft.DotNet.SignTool
                 {
                     var zipData = _batchData.ZipDataMap[file.ContentHash];
 
-                    using (Stream zipStream = File.Open(file.FullPath, FileMode.Open))
-                    using (var archive = new ZipArchive(zipStream, ZipArchiveMode.Update, leaveOpen: true))
+                    using (var archive = new ZipArchive(File.OpenRead(file.FullPath), ZipArchiveMode.Read))
                     {
                         foreach (ZipArchiveEntry entry in archive.Entries)
                         {
@@ -252,7 +251,7 @@ namespace Microsoft.DotNet.SignTool
                                 continue;
                             }
 
-                            using (Stream stream = entry.Open())
+                            using (var stream = entry.Open())
                             {
                                 if (!_signTool.VerifySignedPEFile(stream))
                                 {

--- a/src/Microsoft.DotNet.SignTool/src/Configuration.cs
+++ b/src/Microsoft.DotNet.SignTool/src/Configuration.cs
@@ -264,65 +264,59 @@ namespace Microsoft.DotNet.SignTool
         {
             Debug.Assert(zipFileSignInfo.IsZipContainer());
 
-            FileStream zipStream = null;
             try
             {
-                // The stream needs to be read/write and the archive needs to be update so
-                // the below entry stream is seekable. Because of this the zip archives should
-                // not be disposed which would attempt to write any changes to the input file. It
-                // isn't neccesary either because the actual file stream is closed.
-                zipStream = File.Open(zipFileSignInfo.FullPath, FileMode.Open);
-                var archive = new ZipArchive(zipStream, ZipArchiveMode.Update, leaveOpen: true);
-                var nestedParts = new List<ZipPart>();
-
-                foreach (ZipArchiveEntry entry in archive.Entries)
+                using (var archive = new ZipArchive(File.OpenRead(zipFileSignInfo.FullPath), ZipArchiveMode.Read))
                 {
-                    string relativePath = entry.FullName;
+                    var nestedParts = new List<ZipPart>();
 
-                    if (!FileSignInfo.IsSignableFile(relativePath))
+                    foreach (ZipArchiveEntry entry in archive.Entries)
                     {
-                        continue;
-                    }
+                        string relativePath = entry.FullName;
 
-                    Stream stream = entry.Open();
-                    stream.Position = 0;
-                    var contentHash = ContentUtil.GetContentHash(stream);
-
-                    // if we already encountered file that hash the same content we can reuse its signed version when repackaging the container.
-                    if (!_filesByContentHash.TryGetValue(contentHash, out var fileSignInfo))
-                    {
-                        string tempDir = Path.Combine(_pathToContainerUnpackingDirectory, ContentUtil.HashToString(contentHash));
-                        string tempPath = Path.Combine(tempDir, Path.GetFileName(relativePath));
-                        Directory.CreateDirectory(tempDir);
-                        using (var tempFileStream = File.OpenWrite(tempPath))
+                        if (!FileSignInfo.IsSignableFile(relativePath))
                         {
-                            stream.Position = 0;
-                            stream.CopyTo(tempFileStream);
-                            tempFileStream.Close();
+                            continue;
                         }
 
-                        fileSignInfo = TrackFile(tempPath, contentHash);
+                        ImmutableArray<byte> contentHash;
+                        using (var stream = entry.Open())
+                        {
+                            contentHash = ContentUtil.GetContentHash(stream);
+                        }
+
+                        // if we already encountered file that hash the same content we can reuse its signed version when repackaging the container.
+                        if (!_filesByContentHash.TryGetValue(contentHash, out var fileSignInfo))
+                        {
+                            string tempDir = Path.Combine(_pathToContainerUnpackingDirectory, ContentUtil.HashToString(contentHash));
+                            string tempPath = Path.Combine(tempDir, Path.GetFileName(relativePath));
+                            Directory.CreateDirectory(tempDir);
+
+                            using (var stream = entry.Open())
+                            using (var tempFileStream = File.OpenWrite(tempPath))
+                            {
+                                stream.CopyTo(tempFileStream);
+                            }
+
+                            fileSignInfo = TrackFile(tempPath, contentHash);
+                        }
+
+                        if (fileSignInfo.SignInfo.ShouldSign)
+                        {
+                            nestedParts.Add(new ZipPart(relativePath, fileSignInfo));
+                        }
                     }
 
-                    if (fileSignInfo.SignInfo.ShouldSign)
-                    {
-                        nestedParts.Add(new ZipPart(relativePath, fileSignInfo));
-                    }
+                    zipData = new ZipData(zipFileSignInfo, nestedParts.ToImmutableArray());
+
+                    return true;
                 }
-
-                zipData = new ZipData(zipFileSignInfo, nestedParts.ToImmutableArray());
-
-                return true;
             }
             catch (Exception e)
             {
                 _log.LogErrorFromException(e);
                 zipData = null;
                 return false;
-            }
-            finally
-            {
-                zipStream?.Close();
             }
         }
     }

--- a/src/Microsoft.DotNet.SignTool/src/ZipData.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ZipData.cs
@@ -89,11 +89,11 @@ namespace Microsoft.DotNet.SignTool
                         continue;
                     }
 
-                    using (var stream = File.OpenRead(signedPart.Value.FileSignInfo.FullPath))
+                    using (var signedStream = File.OpenRead(signedPart.Value.FileSignInfo.FullPath))
                     using (var partStream = part.GetStream(FileMode.Open, FileAccess.ReadWrite))
                     {
-                        stream.CopyTo(partStream);
-                        partStream.SetLength(stream.Length);
+                        signedStream.CopyTo(partStream);
+                        partStream.SetLength(signedStream.Length);
                     }
                 }
             }
@@ -104,8 +104,7 @@ namespace Microsoft.DotNet.SignTool
         /// </summary>
         private void RepackRawZip()
         {
-            using (Stream zipStream = File.Open(FileSignInfo.FullPath, FileMode.Open))
-            using (var archive = new ZipArchive(zipStream, ZipArchiveMode.Update, leaveOpen: true))
+            using (var archive = new ZipArchive(File.Open(FileSignInfo.FullPath, FileMode.Open), ZipArchiveMode.Update))
             {
                 foreach (ZipArchiveEntry entry in archive.Entries)
                 {
@@ -116,11 +115,11 @@ namespace Microsoft.DotNet.SignTool
                         continue;
                     }
 
-                    using (var stream = File.OpenRead(signedPart.Value.FileSignInfo.FullPath))
+                    using (var signedStream = File.OpenRead(signedPart.Value.FileSignInfo.FullPath))
                     using (var entryStream = entry.Open())
                     {
-                        stream.CopyTo(entryStream);
-                        entryStream.SetLength(stream.Length);
+                        signedStream.CopyTo(entryStream);
+                        entryStream.SetLength(signedStream.Length);
                     }
                 }
             }


### PR DESCRIPTION
Attempt to fix VSIX corruption:

> C:\Users\dlab14\.nuget\packages\microbuild.plugins.swixbuild\1.0.422\build\Microsoft.VisualStudio.Setup.Tools.targets(308,5): Error : Failed to get signer for 'E:\A\_work\389\s\Binaries\Release\Vsix\PortableFacades\PortableFacades.vsix': File contains corrupted data. [E:\A\_work\389\s\src\Setup\DevDivVsix\PortableFacades\PortableFacades.vsmanproj]