### PR TITLE
TMF change on Tasks.Feed

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;$(NetFxTfm)</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;$(NetFxTfm)</TargetFrameworks>
 
     <VersionPrefix>2.2.0</VersionPrefix>
 


### PR DESCRIPTION
This change aligns the Task.Feed project with the TMF plans for task projects. Also fixes build breaks when using `Microsoft.DotNet.Build.Tasks.Feed` versions older than `2.2.0-beta.18431.6`