### PR TITLE
Make SignTool accept empty list of files to sign & warn about it

### DIFF
--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -94,6 +94,12 @@ namespace Microsoft.DotNet.SignTool
                 return;
             }
 
+            if (ItemsToSign.Count() == 0)
+            {
+                Log.LogWarning($"An empty list of files to sign was passed as parameter.");
+                return;
+            }
+
             var enclosingDir = GetEnclosingDirectoryOfItemsToSign();
             var defaultSignInfoForPublicKeyToken = ParseStrongNameSignInfo();
             var explicitCertificates = ParseFileSignInfo();

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -101,6 +101,9 @@ namespace Microsoft.DotNet.SignTool
             }
 
             var enclosingDir = GetEnclosingDirectoryOfItemsToSign();
+
+            if (Log.HasLoggedErrors) return;
+
             var defaultSignInfoForPublicKeyToken = ParseStrongNameSignInfo();
             var explicitCertificates = ParseFileSignInfo();
             var fileExtensionSignInfo = ParseFileExtensionSignInfo();
@@ -143,9 +146,10 @@ namespace Microsoft.DotNet.SignTool
                 Array.Resize(ref result, getCommonPrefixLength(result, directoryParts));
             }
 
-            if (result.Length == 0)
+            if (result == null || result.Length == 0)
             {
                 Log.LogError($"All {nameof(ItemsToSign)} must be within the cone of a single directory.");
+                return string.Empty;
             }
 
             return string.Join(Path.DirectorySeparatorChar.ToString(), result);


### PR DESCRIPTION
Closes: #759

If the list is empty there is nothing to do, so I just log a warning and return from the task without failing its execution.