### PR TITLE
add linux infrastructure for native asset bootstrapping

### DIFF
--- a/eng/common/init-tools-native.sh
+++ b/eng/common/init-tools-native.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+
+source="${BASH_SOURCE[0]}"
+scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+
+base_uri='https://netcorenativeassets.blob.core.windows.net/resource-packages/external'
+install_directory=''
+clean=false
+force=false
+download_retries=5
+retry_wait_time_seconds=30
+global_json_file="${scriptroot}/../../global.json"
+declare -A native_assets
+
+. $scriptroot/native/common-library.sh
+
+while (($# > 0)); do
+  lowerI="$(echo $1 | awk '{print tolower($0)}')"
+  case $lowerI in
+    --baseuri)
+      base_uri=$2
+      shift 2
+      ;;
+    --installdirectory)
+      install_directory=$2
+      shift 2
+      ;;
+    --clean)
+      clean=true
+      shift 1
+      ;;
+    --force)
+      force=true
+      shift 1
+      ;;
+    --downloadretries)
+      download_retries=$2
+      shift 2
+      ;;
+    --retrywaittimeseconds)
+      retry_wait_time_seconds=$2
+      shift 2
+      ;;
+    --help)
+      echo "Common settings:"
+      echo "  --installdirectory                  Directory to install native toolset."
+      echo "                                      This is a command-line override for the default"
+      echo "                                      Install directory precedence order:"
+      echo "                                          - InstallDirectory command-line override"
+      echo "                                          - NETCOREENG_INSTALL_DIRECTORY environment variable"
+      echo "                                          - (default) %USERPROFILE%/.netcoreeng/native"
+      echo ""
+      echo "  --clean                             Switch specifying not to install anything, but cleanup native asset folders"
+      echo "  --force                             Clean and then install tools"
+      echo "  --help                              Print help and exit"
+      echo ""
+      echo "Advanced settings:"
+      echo "  --baseuri <value>                   Base URI for where to download native tools from"
+      echo "  --downloadretries <value>           Number of times a download should be attempted"
+      echo "  --retrywaittimeseconds <value>      Wait time between download attempts"
+      echo ""
+      exit 0
+      ;;
+  esac
+done
+
+function ReadGlobalJsonNativeTools {
+  # Get the native-tools section from the global.json.
+  local native_tools_section=$(cat $global_json_file | awk '/"native-tools"/,/}/')
+  # Only extract the contents of the object.
+  local native_tools_list=$(echo $native_tools_section | awk -F"[{}]" '{print $2}')
+  native_tools_list=${native_tools_list//[\" ]/}
+  native_tools_list=${native_tools_list//,/$'\n'}
+
+  local old_IFS=$IFS
+  while read -r line; do
+    # Lines are of the form: 'tool:version'
+    IFS=:
+    while read -r key value; do
+     native_assets[$key]=$value
+    done <<< "$line"
+  done <<< "$native_tools_list"
+  IFS=$old_IFS
+
+  return 0;
+}
+
+native_base_dir=$install_directory
+if [[ -z $install_directory ]]; then
+  native_base_dir=$(GetNativeInstallDirectory)
+fi
+
+install_bin="${native_base_dir}/bin"
+
+ReadGlobalJsonNativeTools
+
+if [[ ${#native_assets[@]} -eq 0 ]]; then
+  echo "No native tools defined in global.json"
+  exit 0;
+else
+  native_installer_dir="$scriptroot/native"
+  for tool in "${!native_assets[@]}"
+  do
+    tool_version=${native_assets[$tool]}
+    installer_name="install-$tool.sh"
+    installer_command="$native_installer_dir/$installer_name"
+    installer_command+=" --baseuri $base_uri"
+    installer_command+=" --installpath $install_bin"
+    installer_command+=" --version $tool_version"
+
+    if [[ $force = true ]]; then
+      installer_command+=" --force"
+    fi
+
+    if [[ $clean = true ]]; then
+      installer_command+=" --clean"
+    fi
+
+    echo "Installing $tool version $tool_version"
+    echo "Executing '$installer_command'"
+    $installer_command
+
+    if [[ $? != 0 ]]; then
+      echo "Execution Failed" >&2
+      exit 1
+    fi
+  done
+fi
+
+if [[ ! -z $clean ]]; then
+  exit 0
+fi
+
+if [[ -d $install_bin ]]; then
+  echo "Native tools are available from $install_bin"
+  if [[ !-z BUILD_BUILDNUMBER ]]; then
+    echo "##vso[task.prependpath]$install_bin"
+  fi
+else
+  echo "Native tools install directory does not exist, installation failed" >&2
+  exit 1
+fi
+
+exit 0
+

--- a/eng/common/native/CommonLibrary.psm1
+++ b/eng/common/native/CommonLibrary.psm1
@@ -309,7 +309,7 @@ function Expand-Zip {
 
   Write-Verbose "Extracting '$ZipPath' to '$OutputDirectory'"
   try {
-    if ((Test-Path $OutputDirectory) -And (-Not $Overwrite)) {
+    if ((Test-Path $OutputDirectory) -And (-Not $Force)) {
       Write-Host "Directory '$OutputDirectory' already exists, skipping extract"
       return $True
     }

--- a/eng/common/native/common-library.sh
+++ b/eng/common/native/common-library.sh
@@ -56,7 +56,7 @@ function GetCurrentOS {
   local unameOut="$(uname -s)"
   case $unameOut in
     Linux*)     echo "Linux";;
-    Darwin*)    echo "Mac";;
+    Darwin*)    echo "MacOS";;
   esac
   return 0
 }

--- a/eng/common/native/common-library.sh
+++ b/eng/common/native/common-library.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+
+function GetNativeInstallDirectory {
+  local install_dir
+
+  if [[ -z $NETCOREENG_INSTALL_DIRECTORY ]]; then
+    install_dir=$HOME/.netcoreeng/native/
+  else
+    install_dir=$NETCOREENG_INSTALL_DIRECTORY
+  fi
+
+  echo $install_dir
+  return 0
+}
+
+function GetTempDirectory {
+
+  echo $(GetNativeInstallDirectory)temp/
+  return 0
+}
+
+function ExpandZip {
+  local zip_path=$1
+  local output_directory=$2
+  local force=${3:-false}
+
+  echo "Extracting $zip_path to $output_directory"
+  if [[ -d $output_directory ]] && [[ $force = false ]]; then
+    echo "Directory '$output_directory' already exists, skipping extract"
+    return 0
+  fi
+
+  if [[ -d $output_directory ]]; then
+    echo "'Force flag enabled, but '$output_directory' exists. Removing directory"
+    rm -rf $output_directory
+    if [[ $? != 0 ]]; then
+      echo Unable to remove '$output_directory'>&2
+      return 1
+    fi
+  fi
+
+  echo "Creating directory: '$output_directory'"
+  mkdir -p $output_directory
+
+  echo "Extracting archive"
+  tar -xf $zip_path -C $output_directory
+  if [[ $? != 0 ]]; then
+    echo "Unable to extract '$zip_path'" >&2
+    return 1
+  fi
+
+  return 0
+}
+
+function GetCurrentOS {
+  local unameOut="$(uname -s)"
+  case $unameOut in
+    Linux*)     echo "Linux";;
+    Darwin*)    echo "Mac";;
+  esac
+  return 0
+}
+
+function GetFile {
+  local uri=$1
+  local path=$2
+  local force=${3:-false}
+  local download_retries=${4:-5}
+  local retry_wait_time_seconds=${5:-30}
+
+  if [[ -f $path ]]; then
+    if [[ $force = false ]]; then
+      echo "File '$path' already exists. Skipping download"
+      return 0
+    else
+      rm -rf $path
+    fi
+  fi
+
+  if [[ -f $uri ]]; then
+    echo "'$uri' is a file path, copying file to '$path'"
+    cp $uri $path
+    return $?
+  fi
+
+  echo "Downloading $uri"
+  # Use curl if available, otherwise use wget
+  if command -v curl > /dev/null; then
+    curl "$uri" -sSL --retry $download_retries --retry-delay $retry_wait_time_seconds --create-dirs -o "$path" --fail
+  else
+    wget -q -O "$path" "$uri" --tries="$download_retries"
+  fi
+
+  return $?
+}
+
+function GetTempPathFileName {
+  local path=$1
+
+  local temp_dir=$(GetTempDirectory)
+  local temp_file_name=$(basename $path)
+  echo $temp_dir$temp_file_name
+  return 0
+}
+
+function DownloadAndExtract {
+  local uri=$1
+  local installDir=$2
+  local force=${3:-false}
+  local download_retries=${4:-5}
+  local retry_wait_time_seconds=${5:-30}
+
+  local temp_tool_path=$(GetTempPathFileName $uri)
+
+  echo "downloading to: $temp_tool_path"
+
+  # Download file
+  GetFile "$uri" "$temp_tool_path" $force $download_retries $retry_wait_time_seconds
+  if [[ $? != 0 ]]; then
+    echo "Failed to download '$uri' to '$temp_tool_path'." >&2
+    return 1
+  fi
+
+  # Extract File
+  echo "extracting from  $temp_tool_path to $installDir"
+  ExpandZip "$temp_tool_path" "$installDir" $force $download_retries $retry_wait_time_seconds
+  if [[ $? != 0 ]]; then
+    echo "Failed to extract '$temp_tool_path' to '$installDir'." >&2
+    return 1
+  fi
+
+  return 0
+}
+
+function NewScriptShim {
+  local shimpath=$1
+  local tool_file_path=$2
+  local force=${3:-false}
+
+  echo "Generating '$shimpath' shim"
+  if [[ -f $shimpath ]]; then
+    if [[ $force = false ]]; then
+      echo "File '$shimpath' already exists." >&2
+      return 1
+    else
+      rm -rf $shimpath
+    fi
+  fi
+  
+  if [[ ! -f $tool_file_path ]]; then
+    echo "Specified tool file path:'$tool_file_path' does not exist" >&2
+    return 1
+  fi
+
+  local shim_contents=$'#!/usr/bin/env bash\n'
+  shim_contents+="SHIMARGS="$'$1\n'
+  shim_contents+="$tool_file_path"$' $SHIMARGS\n'
+
+  # Write shim file
+  echo "$shim_contents" > $shimpath
+
+  chmod +x $shimpath
+
+  echo "Finished generating shim '$shimpath'"
+
+  return $?
+}
+

--- a/eng/common/native/install-cmake.sh
+++ b/eng/common/native/install-cmake.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+source="${BASH_SOURCE[0]}"
+scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+
+. $scriptroot/common-library.sh
+
+base_uri=
+install_path=
+version=
+clean=false
+force=false
+download_retries=5
+retry_wait_time_seconds=30
+
+while (($# > 0)); do
+  lowerI="$(echo $1 | awk '{print tolower($0)}')"
+  case $lowerI in
+    --baseuri)
+      base_uri=$2
+      shift 2
+      ;;
+    --installpath)
+      install_path=$2
+      shift 2
+      ;;
+    --version)
+      version=$2
+      shift 2
+      ;;
+    --clean)
+      clean=true
+      shift 1
+      ;;
+    --force)
+      force=true
+      shift 1
+      ;;
+    --downloadretries)
+      download_retries=$2
+      shift 2
+      ;;
+    --retrywaittimeseconds)
+      retry_wait_time_seconds=$2
+      shift 2
+      ;;
+    --help)
+      echo "Common settings:"
+      echo "  --baseuri <value>        Base file directory or Url wrom which to acquire tool archives"
+      echo "  --installpath <value>    Base directory to install native tool to"
+      echo "  --clean                  Don't install the tool, just clean up the current install of the tool"
+      echo "  --force                  Force install of tools even if they previously exist"
+      echo "  --help                   Print help and exit"
+      echo ""
+      echo "Advanced settings:"
+      echo "  --downloadretries        Total number of retry attempts"
+      echo "  --retrywaittimeseconds   Wait time between retry attempts in seconds"
+      echo ""
+      exit 0
+      ;;
+  esac
+done
+
+tool_name="cmake"
+tool_os=$(GetCurrentOS)
+tool_folder=$(echo $tool_os | awk '{print tolower($0)}')
+tool_arch="x86_64"
+tool_name_moniker="$tool_name-$version-$tool_os-$tool_arch"
+tool_install_directory="$install_path/$tool_name/$version"
+tool_file_path="$tool_install_directory/$tool_name_moniker/bin/$tool_name"
+shim_path="$install_path/$tool_name.sh"
+uri="${base_uri}/$tool_folder/cmake/$tool_name_moniker.tar.gz"
+
+# Clean up tool and installers
+if [[ $clean = true ]]; then
+  echo "Cleaning $tool_install_directory"
+  if [[ -d $tool_install_directory ]]; then
+    rm -rf $tool_install_directory
+  fi
+
+  echo "Cleaning $shim_path"
+  if [[ -f $shim_path ]]; then
+    rm -rf $shim_path
+  fi
+
+  tool_temp_path=$(GetTempPathFileName $uri)
+  echo "Cleaning $tool_temp_path"
+  if [[ -f $tool_temp_path ]]; then
+    rm -rf $tool_temp_path
+  fi
+
+  exit 0
+fi
+
+# Install tool
+if [[ -f $tool_file_path ]] && [[ $force = false ]]; then
+  echo "$tool_name ($version) already exists, skipping install"
+  exit 0
+fi
+
+DownloadAndExtract $uri $tool_install_directory $force $download_retries $retry_wait_time_seconds
+
+if [[ $? != 0 ]]; then
+  echo "Installation failed" >&2
+  exit 1
+fi
+
+# Generate Shim
+# Always rewrite shims so that we are referencing the expected version
+NewScriptShim $shim_path $tool_file_path true
+
+if [[ $? != 0 ]]; then
+  echo "Shim generation failed" >&2
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
Adds:
* Common Library
* Init-tools-native entry point
* CMake example

Tested by adding CMake to the global.json and building arcade on Ubuntu.
Tried to follow the same patterns we use in existing sh files, as well as following the same pattern that the PS1 bootstrapping scripts use.

~~Still needs fixing of the parsing of the Native-tools node in global.json before it can be merged~~