### PR TITLE
Fix small errors in Buildtools ports

### DIFF
--- a/src/Microsoft.DotNet.ApiCompat/build/Microsoft.DotNet.ApiCompat.targets
+++ b/src/Microsoft.DotNet.ApiCompat/build/Microsoft.DotNet.ApiCompat.targets
@@ -10,6 +10,7 @@
     <_ApiCompatCommand Condition="'$(MSBuildRuntimeType)' == 'core'">$(ToolHostCmd) "$(_ApiCompatPath)"</_ApiCompatCommand>
     <_ApiCompatCommand Condition="'$(MSBuildRuntimeType)' == 'core' AND '$(OS)' == 'Windows_NT'">"$(_ApiCompatPath)"</_ApiCompatCommand>
     <_ApiCompatCommand Condition="'$(MSBuildRuntimeType)' == 'core' AND '$(OS)' != 'Windows_NT'">mono --runtime=v4.0.30319 "$(_ApiCompatPath)"</_ApiCompatCommand>
+  </PropertyGroup>
 
   <PropertyGroup>
     <RunApiCompat Condition="'$(RunApiCompat)'==''">false</RunApiCompat>

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.targets
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <_MicrosoftDotNetGenFacadesTaskDir>$(MSBuildThisFileDirectory)../tools/netstandard2.0/</_MicrosoftDotNetGenFacadesTaskDir>
+    <_MicrosoftDotNetGenFacadesTaskDir>$(MSBuildThisFileDirectory)../tools/netcoreapp2.1/</_MicrosoftDotNetGenFacadesTaskDir>
   </PropertyGroup>
 
   <UsingTask TaskName="GenFacadesTask" AssemblyFile="$(_MicrosoftDotNetGenFacadesTaskDir)Microsoft.DotNet.GenFacades.dll" />


### PR DESCRIPTION
1. Add a closing tag to a `PropertyGroup` in `ApiCompat`
2. Change the location of the GenFacades task from `netstandard2.0` to `netcoreapp2.1`

CC @weshaggard 