### PR TITLE
Fix Signing for Powershell files

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -20,7 +20,7 @@
     -->
     <FileExtensionSignInfo Include=".jar" CertificateName="MicrosoftJAR" />
     <FileExtensionSignInfo Include=".dylib" CertificateName="Apple" />
-    <FileExtensionSignInfo Include=".js;.ps1;.psd1;.psm1;.psc1" CertificateName="Microsoft" />
+    <FileExtensionSignInfo Include=".js;.ps1;.psd1;.psm1;.psc1" CertificateName="Microsoft400" />
     <FileExtensionSignInfo Include=".dll;.exe" CertificateName="MicrosoftSHA2" />
     <FileExtensionSignInfo Include=".nupkg" CertificateName="NuGet" />
     <FileExtensionSignInfo Include=".vsix" CertificateName="VsixSHA2" />


### PR DESCRIPTION
Fixes: #825 

As per talk with Trevor Short the correct certificate to be used for these file types is Microsoft400. 