### PR TITLE
Refactor build scripts

### DIFF
--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -59,52 +59,39 @@ if ($help -or (($properties -ne $null) -and ($properties.Contains("/help") -or $
   exit 0
 }
 
-function Stop-Processes() {
-  Write-Host "Killing running build processes..."
-  Get-Process -Name "msbuild" -ErrorAction SilentlyContinue | Stop-Process
-  Get-Process -Name "dotnet" -ErrorAction SilentlyContinue | Stop-Process
-  Get-Process -Name "vbcscompiler" -ErrorAction SilentlyContinue | Stop-Process
-}
-
 try {
   if ($projects -eq "") {
     $projects = Join-Path $RepoRoot "*.sln"
   }
 
   $msbuildArgs = (@"
-    $ToolsetBuildProj
-    /p:Configuration=$configuration
-    /p:Projects=$projects
-    /p:RepoRoot=$RepoRoot
-    /p:Restore=$restore
-    /p:DeployDeps=$deployDeps
-    /p:Build=$build
-    /p:Rebuild=$rebuild
-    /p:Deploy=$deploy
-    /p:Test=$test
-    /p:Pack=$pack
-    /p:IntegrationTest=$integrationTest
-    /p:PerformanceTest=$performanceTest
-    /p:Sign=$sign
-    /p:Publish=$publish
-    /p:PublishBuildAssets=$publishBuildAssets
-    /p:ContinuousIntegrationBuild=$ci
-    /p:CIBuild=$ci
-    $properties
-"@).Replace("`r`n","").Replace("    ", " ");
+$ToolsetBuildProj
+/p:Configuration=$configuration
+/p:Projects=$projects
+/p:RepoRoot=$RepoRoot
+/p:Restore=$restore
+/p:DeployDeps=$deployDeps
+/p:Build=$build
+/p:Rebuild=$rebuild
+/p:Deploy=$deploy
+/p:Test=$test
+/p:Pack=$pack
+/p:IntegrationTest=$integrationTest
+/p:PerformanceTest=$performanceTest
+/p:Sign=$sign
+/p:Publish=$publish
+/p:PublishBuildAssets=$publishBuildAssets
+/p:ContinuousIntegrationBuild=$ci
+/p:CIBuild=$ci
+$properties
+"@).Replace([Environment]::NewLine," ")
 
   Invoke-Expression "& `"$PSScriptRoot\msbuild.ps1`" $msbuildArgs"
-  exit $lastExitCode
+  ExitWithExitCode $lastExitCode
 }
 catch {
   Write-Host $_
   Write-Host $_.Exception
   Write-Host $_.ScriptStackTrace
-  exit 1
+  ExitWithExitCode 1
 }
-finally {
-  if ($ci -and $prepareMachine) {
-    Stop-Processes
-  }
-}
-

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -21,9 +21,7 @@ Param(
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 
-set-strictmode -version 2.0
-$ErrorActionPreference = "Stop"
-[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+. $PSScriptRoot\init-tools.ps1
 
 function Print-Usage() {
     Write-Host "Common settings:"
@@ -61,207 +59,6 @@ if ($help -or (($properties -ne $null) -and ($properties.Contains("/help") -or $
   exit 0
 }
 
-function Create-Directory([string[]] $path) {
-  if (!(Test-Path $path)) {
-    New-Item -path $path -force -itemType "Directory" | Out-Null
-  }
-}
-
-function InitializeDotNetCli {
-  # Don't resolve runtime, shared framework, or SDK from other locations to ensure build determinism
-  $env:DOTNET_MULTILEVEL_LOOKUP=0
-  
-  # Disable first run since we do not need all ASP.NET packages restored.
-  $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-
-  # Source Build uses DotNetCoreSdkDir variable
-  if ($env:DotNetCoreSdkDir -ne $null) {
-    $env:DOTNET_INSTALL_DIR = $env:DotNetCoreSdkDir
-  }
-
-  # Use dotnet installation specified in DOTNET_INSTALL_DIR if it contains the required SDK version, 
-  # otherwise install the dotnet CLI and SDK to repo local .dotnet directory to avoid potential permission issues.
-  if (($env:DOTNET_INSTALL_DIR -ne $null) -and (Test-Path(Join-Path $env:DOTNET_INSTALL_DIR "sdk\$($GlobalJson.tools.dotnet)"))) {
-    $dotnetRoot = $env:DOTNET_INSTALL_DIR
-  } else {
-    $dotnetRoot = Join-Path $RepoRoot ".dotnet"
-    $env:DOTNET_INSTALL_DIR = $dotnetRoot
-    
-    if ($restore) {
-      InstallDotNetSdk $dotnetRoot $GlobalJson.tools.dotnet
-    }
-  }
-
-  return $dotnetRoot
-}
-
-function GetDotNetInstallScript([string] $dotnetRoot) {
-  $installScript = "$dotnetRoot\dotnet-install.ps1"
-  if (!(Test-Path $installScript)) { 
-    Create-Directory $dotnetRoot
-    Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile $installScript
-  }
-
-  return $installScript
-}
-
-function InstallDotNetSdk([string] $dotnetRoot, [string] $version) {
-  $installScript = GetDotNetInstallScript $dotnetRoot
-  
-  & $installScript -Version $version -InstallDir $dotnetRoot
-  if ($lastExitCode -ne 0) {
-    Write-Host "Failed to install dotnet cli (exit code '$lastExitCode')." -ForegroundColor Red
-    exit $lastExitCode
-  }
-}
-
-function InitializeVisualStudioBuild {
-  $inVSEnvironment = !($env:VS150COMNTOOLS -eq $null) -and (Test-Path $env:VS150COMNTOOLS)
-
-  if ($inVSEnvironment) {
-    $vsInstallDir = Join-Path $env:VS150COMNTOOLS "..\.."
-  } else {    
-    $vsInstallDir = LocateVisualStudio
-  
-    $env:VS150COMNTOOLS = Join-Path $vsInstallDir "Common7\Tools\"
-    $env:VSSDK150Install = Join-Path $vsInstallDir "VSSDK\"
-    $env:VSSDKInstall = Join-Path $vsInstallDir "VSSDK\"
-  }
-
-  return $vsInstallDir;
-}
-
-function LocateVisualStudio {
-  $vswhereVersion = $GlobalJson.tools.vswhere
-  $toolsRoot = Join-Path $RepoRoot ".tools"
-  $vsWhereDir = Join-Path $toolsRoot "vswhere\$vswhereVersion"
-  $vsWhereExe = Join-Path $vsWhereDir "vswhere.exe"
-
-  if (!(Test-Path $vsWhereExe)) {
-    Create-Directory $vsWhereDir
-    Write-Host "Downloading vswhere"
-    Invoke-WebRequest "https://github.com/Microsoft/vswhere/releases/download/$vswhereVersion/vswhere.exe" -OutFile $vswhereExe
-  }
-
-  $vsInstallDir = & $vsWhereExe -latest -prerelease -property installationPath -requires Microsoft.Component.MSBuild -requires Microsoft.VisualStudio.Component.VSSDK -requires Microsoft.Net.Component.4.6.TargetingPack -requires Microsoft.VisualStudio.Component.Roslyn.Compiler -requires Microsoft.VisualStudio.Component.VSSDK
-
-  if ($lastExitCode -ne 0) {
-    Write-Host "Failed to locate Visual Studio (exit code '$lastExitCode')." -ForegroundColor Red
-    exit $lastExitCode
-  }
-
-  return $vsInstallDir
-}
-
-function GetBuildCommand() {
-  $tools = $GlobalJson.tools
-
-  if ((Get-Member -InputObject $tools -Name "dotnet") -ne $null) {  
-    $dotnetRoot = InitializeDotNetCli
-
-    # by default build with dotnet cli:
-    $buildDriver = Join-Path $dotnetRoot "dotnet.exe"
-    $buildArgs = "msbuild"
-  }
-
-  if ((Get-Member -InputObject $tools -Name "vswhere") -ne $null) {    
-    $vsInstallDir = InitializeVisualStudioBuild
-    
-    # Presence of vswhere.version indicates the repo needs to build using VS msbuild:
-    $buildDriver = Join-Path $vsInstallDir "MSBuild\15.0\Bin\msbuild.exe"
-    $buildArgs = "/nodeReuse:$(!$ci)"
-  }
-
-  if ($buildDriver -eq $null) {
-    Write-Host "/global.json must either specify 'tools.dotnet' or 'tools.vswhere'." -ForegroundColor Red
-    exit 1
-  }
-
-  if ($ci) {
-    Write-Host "Using $buildDriver"
-  }
-
-  return $buildDriver, $buildArgs
-}
-
-function InitializeToolset([string] $buildDriver, [string]$buildArgs) {
-  $toolsetVersion = $GlobalJson.'msbuild-sdks'.'Microsoft.DotNet.Arcade.Sdk'
-  $toolsetLocationFile = Join-Path $ToolsetDir "$toolsetVersion.txt"
-
-  if (Test-Path $toolsetLocationFile) {
-    $path = Get-Content $toolsetLocationFile -TotalCount 1
-    if (Test-Path $path) {
-      $global:ToolsetBuildProj = $path
-      return
-    }
-  }
-    
-  if (-not $restore) {
-    Write-Host  "Toolset version $toolsetVersion has not been restored."
-    exit 1
-  }
-
-  $proj = Join-Path $ToolsetDir "restore.proj"  
-
-  '<Project Sdk="Microsoft.DotNet.Arcade.Sdk"/>' | Set-Content $proj
-  & $buildDriver $buildArgs $proj /t:__WriteToolsetLocation /m /nologo /clp:None /warnaserror /bl:$ToolsetRestoreLog /v:$verbosity /p:__ToolsetLocationOutputFile=$toolsetLocationFile
-    
-  if ($lastExitCode -ne 0) {
-    Write-Host "Failed to restore toolset (exit code '$lastExitCode')." -ForegroundColor Red
-    Write-Host "Build log: $ToolsetRestoreLog" -ForegroundColor DarkGray
-    exit $lastExitCode
-  }
-
-  $path = Get-Content $toolsetLocationFile -TotalCount 1
-  if (!(Test-Path $path)) {
-    throw "Invalid toolset path: $path"
-  }
-
-  $global:ToolsetBuildProj = $path
-}
-
-function InitializeCustomToolset {
-  if (-not $restore) {
-    return
-  }
-
-  $script = Join-Path $EngRoot "RestoreToolset.ps1"
-
-  if (Test-Path $script) {
-    . $script
-  }
-}
-
-function Build([string] $buildDriver, [string]$buildArgs) {
-  & $buildDriver $buildArgs $ToolsetBuildProj `
-    /m /nologo /clp:Summary /warnaserror `
-    /v:$verbosity `
-    /bl:$BuildLog `
-    /p:Configuration=$configuration `
-    /p:Projects=$projects `
-    /p:RepoRoot=$RepoRoot `
-    /p:Restore=$restore `
-    /p:DeployDeps=$deployDeps `
-    /p:Build=$build `
-    /p:Rebuild=$rebuild `
-    /p:Deploy=$deploy `
-    /p:Test=$test `
-    /p:Pack=$pack `
-    /p:IntegrationTest=$integrationTest `
-    /p:PerformanceTest=$performanceTest `
-    /p:Sign=$sign `
-    /p:Publish=$publish `
-    /p:PublishBuildAssets=$publishBuildAssets `
-    /p:ContinuousIntegrationBuild=$ci `
-    /p:CIBuild=$ci `
-    $properties
-
-  if ($lastExitCode -ne 0) {
-    Write-Host "Build log: $BuildLog" -ForegroundColor DarkGray
-    exit $lastExitCode
-  }
-}
-
 function Stop-Processes() {
   Write-Host "Killing running build processes..."
   Get-Process -Name "msbuild" -ErrorAction SilentlyContinue | Stop-Process
@@ -270,40 +67,34 @@ function Stop-Processes() {
 }
 
 try {
-  $RepoRoot = Join-Path $PSScriptRoot "..\.."
-  $EngRoot = Join-Path $PSScriptRoot ".."
-  $ArtifactsDir = Join-Path $RepoRoot "artifacts"
-  $ToolsetDir = Join-Path $ArtifactsDir "toolset"
-  $LogDir = Join-Path (Join-Path $ArtifactsDir "log") $configuration
-  $BuildLog = Join-Path $LogDir "Build.binlog"
-  $ToolsetRestoreLog = Join-Path $LogDir "ToolsetRestore.binlog"
-  $TempDir = Join-Path (Join-Path $ArtifactsDir "tmp") $configuration
-  $GlobalJson = Get-Content -Raw -Path (Join-Path $RepoRoot "global.json") | ConvertFrom-Json
-  
   if ($projects -eq "") {
     $projects = Join-Path $RepoRoot "*.sln"
   }
 
-  if ($env:NUGET_PACKAGES -eq $null) {
-    # Use local cache on CI to ensure deterministic build,
-    # use global cache in dev builds to avoid cost of downloading packages.
-    $env:NUGET_PACKAGES = if ($ci) { Join-Path $RepoRoot ".packages" } 
-                          else { Join-Path $env:UserProfile ".nuget\packages" }
-  }
+  $msbuildArgs = (@"
+    $ToolsetBuildProj
+    /p:Configuration=$configuration
+    /p:Projects=$projects
+    /p:RepoRoot=$RepoRoot
+    /p:Restore=$restore
+    /p:DeployDeps=$deployDeps
+    /p:Build=$build
+    /p:Rebuild=$rebuild
+    /p:Deploy=$deploy
+    /p:Test=$test
+    /p:Pack=$pack
+    /p:IntegrationTest=$integrationTest
+    /p:PerformanceTest=$performanceTest
+    /p:Sign=$sign
+    /p:Publish=$publish
+    /p:PublishBuildAssets=$publishBuildAssets
+    /p:ContinuousIntegrationBuild=$ci
+    /p:CIBuild=$ci
+    $properties
+"@).Replace("`r`n","").Replace("    ", " ");
 
-  Create-Directory $ToolsetDir
-  Create-Directory $LogDir
-  
-  if ($ci) {
-    Create-Directory $TempDir
-    $env:TEMP = $TempDir
-    $env:TMP = $TempDir
-  }
-
-  $driver, $args = GetBuildCommand
-  InitializeToolset $driver $args
-  InitializeCustomToolset
-  Build $driver $args
+  Invoke-Expression "& `"$PSScriptRoot\msbuild.ps1`" $msbuildArgs"
+  exit $lastExitCode
 }
 catch {
   Write-Host $_
@@ -312,7 +103,6 @@ catch {
   exit 1
 }
 finally {
-  Pop-Location
   if ($ci -and $prepareMachine) {
     Stop-Processes
   }

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -91,6 +91,10 @@ while (($# > 0)); do
       solution=$2
       shift 2
       ;;
+    --projects)
+      projects=$2
+      shift 2
+      ;;
     --test)
       test=true
       shift 1
@@ -118,154 +122,13 @@ while (($# > 0)); do
   esac
 done
 
-repo_root="$scriptroot/../.."
-eng_root="$scriptroot/.."
-artifacts_dir="$repo_root/artifacts"
-toolset_dir="$artifacts_dir/toolset"
-log_dir="$artifacts_dir/log/$configuration"
-build_log="$log_dir/Build.binlog"
-toolset_restore_log="$log_dir/ToolsetRestore.binlog"
-temp_dir="$artifacts_dir/tmp/$configuration"
+. $scriptroot/init-tools.sh
 
-global_json_file="$repo_root/global.json"
-build_driver=""
-toolset_build_proj=""
+if [[ -z $projects ]]; then
+  projects="$repo_root/*.sln"
+fi
 
-# ReadVersionFromJson [json key]
-function ReadGlobalVersion {
-  local key=$1
-
-  local unamestr="$(uname)"
-  local sedextended='-r'
-  if [[ "$unamestr" == 'Darwin' ]]; then
-    sedextended='-E'
-  fi;
-
-  local version="$(grep -m 1 "\"$key\"" $global_json_file | sed $sedextended 's/^ *//;s/.*: *"//;s/",?//')"
-  if [[ ! "$version" ]]; then
-    echo "Error: Cannot find \"$key\" in $global_json_file" >&2;
-    ExitWithExitCode 1
-  fi;
-
-  # return value
-  echo "$version"
-}
-
-function InitializeDotNetCli {
-  # Disable first run since we want to control all package sources
-  export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-
-  # Don't resolve runtime, shared framework, or SDK from other locations to ensure build determinism
-  export DOTNET_MULTILEVEL_LOOKUP=0
-
-  # Source Build uses DotNetCoreSdkDir variable
-  if [[ -n "$DotNetCoreSdkDir" ]]; then
-    export DOTNET_INSTALL_DIR="$DotNetCoreSdkDir"
-  fi
-
-  
-  local dotnet_sdk_version=`ReadGlobalVersion "dotnet"`
-  local dotnet_root=""
-
-  # Use dotnet installation specified in DOTNET_INSTALL_DIR if it contains the required SDK version, 
-  # otherwise install the dotnet CLI and SDK to repo local .dotnet directory to avoid potential permission issues.
-  if [[ -d "$DOTNET_INSTALL_DIR/sdk/$dotnet_sdk_version" ]]; then
-    dotnet_root="$DOTNET_INSTALL_DIR"
-  else
-    dotnet_root="$repo_root/.dotnet"
-    export DOTNET_INSTALL_DIR="$dotnet_root"
-
-    if [[ "$restore" == true ]]; then
-      InstallDotNetSdk $dotnet_root $dotnet_sdk_version
-    fi
-  fi
-
-  build_driver="$dotnet_root/dotnet"
-}
-
-function InstallDotNetSdk {
-  local root=$1
-  local version=$2
-
-  local install_script=`GetDotNetInstallScript $root`
-
-  bash "$install_script" --version $version --install-dir $root
-  local lastexitcode=$?
-
-  if [[ $lastexitcode != 0 ]]; then
-    echo "Failed to install dotnet SDK (exit code '$lastexitcode')."
-    ExitWithExitCode $lastexitcode
-  fi
-}
-
-function GetDotNetInstallScript {
-  local root=$1
-  local install_script="$root/dotnet-install.sh"
-
-  if [[ ! -a "$install_script" ]]; then
-    mkdir -p "$root"
-
-    # Use curl if available, otherwise use wget
-    if command -v curl > /dev/null; then
-      curl "https://dot.net/v1/dotnet-install.sh" -sSL --retry 10 --create-dirs -o "$install_script"
-    else
-      wget -q -O "$install_script" "https://dot.net/v1/dotnet-install.sh"
-    fi
-  fi
-
-  # return value
-  echo "$install_script"
-}
-
-function InitializeToolset {
-  local toolset_version=`ReadGlobalVersion "Microsoft.DotNet.Arcade.Sdk"`
-  local toolset_location_file="$toolset_dir/$toolset_version.txt"
-
-  if [[ -a "$toolset_location_file" ]]; then
-    local path=`cat $toolset_location_file`
-    if [[ -a "$path" ]]; then
-      toolset_build_proj=$path
-      return
-    fi
-  fi  
-
-  if [[ "$restore" != true ]]; then
-    echo "Toolset version $toolsetVersion has not been restored."
-    ExitWithExitCode 2
-  fi
-  
-  local proj="$toolset_dir/restore.proj"
-
-  echo '<Project Sdk="Microsoft.DotNet.Arcade.Sdk"/>' > $proj
-  "$build_driver" msbuild $proj /t:__WriteToolsetLocation /m /nologo /clp:None /warnaserror /bl:$toolset_restore_log /v:$verbosity /p:__ToolsetLocationOutputFile=$toolset_location_file 
-  local lastexitcode=$?
-
-  if [[ $lastexitcode != 0 ]]; then
-    echo "Failed to restore toolset (exit code '$lastexitcode'). See log: $toolset_restore_log"
-    ExitWithExitCode $lastexitcode
-  fi
-
-  toolset_build_proj=`cat $toolset_location_file`
-
-  if [[ ! -a "$toolset_build_proj" ]]; then
-    echo "Invalid toolset path: $toolset_build_proj"
-    ExitWithExitCode 3
-  fi
-}
-
-function InitializeCustomToolset {
-  local script="$eng_root/RestoreToolset.sh"
-
-  if [[ -a "$script" ]]; then
-    . "$script"
-  fi
-}
-
-function Build {
-  "$build_driver" msbuild $toolset_build_proj \
-    /m /nologo /clp:Summary /warnaserror \
-    /v:$verbosity \
-    /bl:$build_log \
+$scriptroot/msbuild.sh $toolset_build_proj \
     /p:Configuration=$configuration \
     /p:Projects=$projects \
     /p:RepoRoot="$repo_root" \
@@ -282,61 +145,5 @@ function Build {
     /p:ContinuousIntegrationBuild=$ci \
     /p:CIBuild=$ci \
     $properties
-  local lastexitcode=$?
 
-  if [[ $lastexitcode != 0 ]]; then
-    echo "Failed to build $toolset_build_proj"
-    ExitWithExitCode $lastexitcode
-  fi
-}
-
-function ExitWithExitCode {
-  if [[ "$ci" == true && "$prepare_machine" == true ]]; then
-    StopProcesses
-  fi
-  exit $1
-}
-
-function StopProcesses {
-  echo "Killing running build processes..."
-  pkill -9 "dotnet"
-  pkill -9 "vbcscompiler"
-}
-
-function Main {
-  # HOME may not be defined in some scenarios, but it is required by NuGet
-  if [[ -z $HOME ]]; then
-    export HOME="$repo_root/artifacts/.home/"
-    mkdir -p "$HOME"
-  fi
-
-  if [[ -z $projects ]]; then
-    projects="$repo_root/*.sln"
-  fi
-
-  if [[ -z $NUGET_PACKAGES ]]; then
-    if [[ $ci ]]; then
-      export NUGET_PACKAGES="$repo_root/.packages"
-    else
-      export NUGET_PACKAGES="$HOME/.nuget/packages"
-    fi
-  fi
-
-  mkdir -p "$toolset_dir"
-  mkdir -p "$log_dir"
-  
-  if [[ $ci ]]; then
-    mkdir -p "$temp_dir"
-    export TEMP="$temp_dir"
-    export TMP="$temp_dir"
-  fi
-
-  InitializeDotNetCli
-  InitializeToolset
-  InitializeCustomToolset
-
-  Build
-  ExitWithExitCode $?
-}
-
-Main
+ExitWithExitCode $?

--- a/eng/common/init-tools.ps1
+++ b/eng/common/init-tools.ps1
@@ -1,6 +1,7 @@
 # Initialize variables if they aren't already defined
 
 $ci = if (Test-Path variable:ci) { $ci } else { $false }
+$configuration = if (Test-Path variable:configuration) { $configuration } else { "Debug" }
 $nodereuse = if (Test-Path variable:nodereuse) { $nodereuse } else { $true }
 $prepareMachine = if (Test-Path variable:prepareMachine) { $prepareMachine } else { $false }
 $restore = if (Test-Path variable:restore) { $restore } else { $true }
@@ -213,8 +214,8 @@ try {
   $EngRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
   $ArtifactsDir = Join-Path $RepoRoot "artifacts"
   $ToolsetDir = Join-Path $ArtifactsDir "toolset"
-  $LogDir = Join-Path $ArtifactsDir "log"
-  $TempDir = Join-Path $ArtifactsDir "tmp"
+  $LogDir = Join-Path (Join-Path $ArtifactsDir "log") $configuration
+  $TempDir = Join-Path (Join-Path $ArtifactsDir "tmp") $configuration
   $GlobalJson = Get-Content -Raw -Path (Join-Path $RepoRoot "global.json") | ConvertFrom-Json
 
   if ($env:NUGET_PACKAGES -eq $null) {

--- a/eng/common/init-tools.ps1
+++ b/eng/common/init-tools.ps1
@@ -1,0 +1,219 @@
+# Initialize variables if they aren't already defined
+$ci = if (Test-Path variable:ci) { $ci } else { $false }
+$restore = if (Test-Path variable:restore) { $restore } else { $true }
+
+set-strictmode -version 2.0
+$ErrorActionPreference = "Stop"
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+function Create-Directory([string[]] $path) {
+  if (!(Test-Path $path)) {
+    New-Item -path $path -force -itemType "Directory" | Out-Null
+  }
+}
+
+function InitializeDotNetCli {
+  # Don't resolve runtime, shared framework, or SDK from other locations to ensure build determinism
+  $env:DOTNET_MULTILEVEL_LOOKUP=0
+
+  # Disable first run since we do not need all ASP.NET packages restored.
+  $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
+  # Source Build uses DotNetCoreSdkDir variable
+  if ($env:DotNetCoreSdkDir -ne $null) {
+    $env:DOTNET_INSTALL_DIR = $env:DotNetCoreSdkDir
+  }
+
+  # Use dotnet installation specified in DOTNET_INSTALL_DIR if it contains the required SDK version,
+  # otherwise install the dotnet CLI and SDK to repo local .dotnet directory to avoid potential permission issues.
+  if (($env:DOTNET_INSTALL_DIR -ne $null) -and (Test-Path(Join-Path $env:DOTNET_INSTALL_DIR "sdk\$($GlobalJson.tools.dotnet)"))) {
+    $dotnetRoot = $env:DOTNET_INSTALL_DIR
+  } else {
+    $dotnetRoot = Join-Path $RepoRoot ".dotnet"
+    $env:DOTNET_INSTALL_DIR = $dotnetRoot
+
+    if ($restore) {
+      InstallDotNetSdk $dotnetRoot $GlobalJson.tools.dotnet
+    }
+  }
+
+  return $dotnetRoot
+}
+
+function GetDotNetInstallScript([string] $dotnetRoot) {
+  $installScript = "$dotnetRoot\dotnet-install.ps1"
+  if (!(Test-Path $installScript)) {
+    Create-Directory $dotnetRoot
+    Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile $installScript
+  }
+
+  return $installScript
+}
+
+function InstallDotNetSdk([string] $dotnetRoot, [string] $version) {
+  $installScript = GetDotNetInstallScript $dotnetRoot
+
+  & $installScript -Version $version -InstallDir $dotnetRoot
+  if ($lastExitCode -ne 0) {
+    Write-Host "Failed to install dotnet cli (exit code '$lastExitCode')." -ForegroundColor Red
+    exit $lastExitCode
+  }
+}
+
+function InitializeVisualStudioBuild {
+  $inVSEnvironment = !($env:VS150COMNTOOLS -eq $null) -and (Test-Path $env:VS150COMNTOOLS)
+
+  if ($inVSEnvironment) {
+    $vsInstallDir = Join-Path $env:VS150COMNTOOLS "..\.."
+  } else {
+    $vsInstallDir = LocateVisualStudio
+
+    $env:VS150COMNTOOLS = Join-Path $vsInstallDir "Common7\Tools\"
+    $env:VSSDK150Install = Join-Path $vsInstallDir "VSSDK\"
+    $env:VSSDKInstall = Join-Path $vsInstallDir "VSSDK\"
+  }
+
+  return $vsInstallDir;
+}
+
+function LocateVisualStudio {
+  $vswhereVersion = $GlobalJson.tools.vswhere
+  $toolsRoot = Join-Path $RepoRoot ".tools"
+  $vsWhereDir = Join-Path $toolsRoot "vswhere\$vswhereVersion"
+  $vsWhereExe = Join-Path $vsWhereDir "vswhere.exe"
+
+  if (!(Test-Path $vsWhereExe)) {
+    Create-Directory $vsWhereDir
+    Write-Host "Downloading vswhere"
+    Invoke-WebRequest "https://github.com/Microsoft/vswhere/releases/download/$vswhereVersion/vswhere.exe" -OutFile $vswhereExe
+  }
+
+  $vsInstallDir = & $vsWhereExe -latest -prerelease -property installationPath -requires Microsoft.Component.MSBuild -requires Microsoft.VisualStudio.Component.VSSDK -requires Microsoft.Net.Component.4.6.TargetingPack -requires Microsoft.VisualStudio.Component.Roslyn.Compiler -requires Microsoft.VisualStudio.Component.VSSDK
+
+  if ($lastExitCode -ne 0) {
+    Write-Host "Failed to locate Visual Studio (exit code '$lastExitCode')." -ForegroundColor Red
+    exit $lastExitCode
+  }
+
+  return $vsInstallDir
+}
+
+function InitializeTools() {
+  $tools = $GlobalJson.tools
+
+  if ((Get-Member -InputObject $tools -Name "dotnet") -ne $null) {
+    $dotnetRoot = InitializeDotNetCli
+
+    # by default build with dotnet cli:
+    $script:buildDriver = Join-Path $dotnetRoot "dotnet.exe"
+    $script:buildArgs = "msbuild"
+  }
+
+  if ((Get-Member -InputObject $tools -Name "vswhere") -ne $null) {
+    $vsInstallDir = InitializeVisualStudioBuild
+
+    # Presence of vswhere.version indicates the repo needs to build using VS msbuild:
+    $script:buildDriver = Join-Path $vsInstallDir "MSBuild\15.0\Bin\msbuild.exe"
+    $script:buildArgs = "/nodeReuse:$(!$ci)"
+  }
+
+  if ($buildDriver -eq $null) {
+    Write-Host "/global.json must either specify 'tools.dotnet' or 'tools.vswhere'." -ForegroundColor Red
+    exit 1
+  }
+
+  InitializeToolSet $script:buildDriver $script:buildArgs
+  InitializeCustomToolset
+}
+
+function GetBuildCommand() {
+  if ($ci) {
+    Write-Host "Using $buildDriver"
+  }
+
+  return $script:buildDriver, $script:buildArgs
+}
+
+function InitializeToolset([string] $buildDriver, [string]$buildArgs) {
+  $toolsetVersion = $GlobalJson.'msbuild-sdks'.'Microsoft.DotNet.Arcade.Sdk'
+  $toolsetLocationFile = Join-Path $ToolsetDir "$toolsetVersion.txt"
+
+  if (Test-Path $toolsetLocationFile) {
+    $path = Get-Content $toolsetLocationFile -TotalCount 1
+    if (Test-Path $path) {
+      $global:ToolsetBuildProj = $path
+      return
+    }
+  }
+
+  if (-not $restore) {
+    Write-Host  "Toolset version $toolsetVersion has not been restored."
+    exit 1
+  }
+
+  $proj = Join-Path $ToolsetDir "restore.proj"
+
+  '<Project Sdk="Microsoft.DotNet.Arcade.Sdk"/>' | Set-Content $proj
+  & $buildDriver $buildArgs $proj /t:__WriteToolsetLocation /m /nologo /clp:None /warnaserror /bl:$ToolsetRestoreLog /v:$verbosity /p:__ToolsetLocationOutputFile=$toolsetLocationFile
+
+  if ($lastExitCode -ne 0) {
+    Write-Host "Failed to restore toolset (exit code '$lastExitCode')." -ForegroundColor Red
+    Write-Host "Build log: $ToolsetRestoreLog" -ForegroundColor DarkGray
+    exit $lastExitCode
+  }
+
+  $path = Get-Content $toolsetLocationFile -TotalCount 1
+  if (!(Test-Path $path)) {
+    throw "Invalid toolset path: $path"
+  }
+
+  $global:ToolsetBuildProj = $path
+}
+
+function InitializeCustomToolset {
+  if (-not $restore) {
+    return
+  }
+
+  $script = Join-Path $EngRoot "RestoreToolset.ps1"
+
+  if (Test-Path $script) {
+    . $script
+  }
+}
+
+try {
+  $RepoRoot = Join-Path $PSScriptRoot "..\.."
+  $EngRoot = Join-Path $PSScriptRoot ".."
+  $ArtifactsDir = Join-Path $RepoRoot "artifacts"
+  $ToolsetDir = Join-Path $ArtifactsDir "toolset"
+  $LogDir = Join-Path $ArtifactsDir "log"
+  $ToolsetRestoreLog = Join-Path $LogDir "ToolsetRestore.binlog"
+  $TempDir = Join-Path $ArtifactsDir "tmp"
+  $GlobalJson = Get-Content -Raw -Path (Join-Path $RepoRoot "global.json") | ConvertFrom-Json
+
+  if ($env:NUGET_PACKAGES -eq $null) {
+    # Use local cache on CI to ensure deterministic build,
+    # use global cache in dev builds to avoid cost of downloading packages.
+    $env:NUGET_PACKAGES = if ($ci) { Join-Path $RepoRoot ".packages" }
+                          else { Join-Path $env:UserProfile ".nuget\packages" }
+  }
+
+  Create-Directory $ToolsetDir
+  Create-Directory $LogDir
+
+  if ($ci) {
+    Create-Directory $TempDir
+    $env:TEMP = $TempDir
+    $env:TMP = $TempDir
+  }
+
+  InitializeTools
+}
+catch {
+  Write-Host $_
+  Write-Host $_.Exception
+  Write-Host $_.ScriptStackTrace
+  exit 1
+}
+

--- a/eng/common/init-tools.sh
+++ b/eng/common/init-tools.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-restore=${restore:-true}
 ci=${ci:-false}
 prepare_machine=${prepare_machine:-false}
+restore=${restore:-true}
 
 repo_root="$scriptroot/../.."
 eng_root="$scriptroot/.."

--- a/eng/common/init-tools.sh
+++ b/eng/common/init-tools.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+
+restore=${restore:-true}
+ci=${ci:-false}
+prepare_machine=${prepare_machine:-false}
+
+repo_root="$scriptroot/../.."
+eng_root="$scriptroot/.."
+artifacts_dir="$repo_root/artifacts"
+toolset_dir="$artifacts_dir/toolset"
+log_dir="$artifacts_dir/log"
+build_log="$log_dir/Build.binlog"
+toolset_restore_log="$log_dir/ToolsetRestore.binlog"
+temp_dir="$artifacts_dir/tmp"
+
+global_json_file="$repo_root/global.json"
+build_driver=""
+toolset_build_proj=""
+
+# ReadVersionFromJson [json key]
+function ReadGlobalVersion {
+  local key=$1
+
+  local unamestr="$(uname)"
+  local sedextended='-r'
+  if [[ "$unamestr" == 'Darwin' ]]; then
+    sedextended='-E'
+  fi;
+
+  local version="$(grep -m 1 "\"$key\"" $global_json_file | sed $sedextended 's/^ *//;s/.*: *"//;s/",?//')"
+  if [[ ! "$version" ]]; then
+    echo "Error: Cannot find \"$key\" in $global_json_file" >&2;
+    ExitWithExitCode 1
+  fi;
+  # return value
+  echo "$version"
+}
+
+function InitializeDotNetCli {
+  # Disable first run since we want to control all package sources
+  export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
+  # Don't resolve runtime, shared framework, or SDK from other locations to ensure build determinism
+  export DOTNET_MULTILEVEL_LOOKUP=0
+
+  # Source Build uses DotNetCoreSdkDir variable
+  if [[ -n "$DotNetCoreSdkDir" ]]; then
+    export DOTNET_INSTALL_DIR="$DotNetCoreSdkDir"
+  fi
+
+
+  local dotnet_sdk_version=`ReadGlobalVersion "dotnet"`
+  local dotnet_root=""
+
+  # Use dotnet installation specified in DOTNET_INSTALL_DIR if it contains the required SDK version,
+  # otherwise install the dotnet CLI and SDK to repo local .dotnet directory to avoid potential permission issues.
+  if [[ -d "$DOTNET_INSTALL_DIR/sdk/$dotnet_sdk_version" ]]; then
+    dotnet_root="$DOTNET_INSTALL_DIR"
+  else
+    dotnet_root="$repo_root/.dotnet"
+    export DOTNET_INSTALL_DIR="$dotnet_root"
+
+    if [[ "$restore" == true ]]; then
+      InstallDotNetSdk $dotnet_root $dotnet_sdk_version
+    fi
+  fi
+
+  build_driver="$dotnet_root/dotnet"
+}
+
+function InstallDotNetSdk {
+  local root=$1
+  local version=$2
+
+  local install_script=`GetDotNetInstallScript $root`
+
+  bash "$install_script" --version $version --install-dir $root
+  local lastexitcode=$?
+
+  if [[ $lastexitcode != 0 ]]; then
+    echo "Failed to install dotnet SDK (exit code '$lastexitcode')."
+    ExitWithExitCode $lastexitcode
+  fi
+}
+
+function GetDotNetInstallScript {
+  local root=$1
+  local install_script="$root/dotnet-install.sh"
+
+  if [[ ! -a "$install_script" ]]; then
+    mkdir -p "$root"
+
+    # Use curl if available, otherwise use wget
+    if command -v curl > /dev/null; then
+      curl "https://dot.net/v1/dotnet-install.sh" -sSL --retry 10 --create-dirs -o "$install_script"
+    else
+      wget -q -O "$install_script" "https://dot.net/v1/dotnet-install.sh"
+    fi
+  fi
+
+  # return value
+  echo "$install_script"
+}
+
+function InitializeToolset {
+  local toolset_version=`ReadGlobalVersion "Microsoft.DotNet.Arcade.Sdk"`
+  local toolset_location_file="$toolset_dir/$toolset_version.txt"
+
+  if [[ -a "$toolset_location_file" ]]; then
+    local path=`cat $toolset_location_file`
+    if [[ -a "$path" ]]; then
+      toolset_build_proj=$path
+      return
+    fi
+  fi
+
+  if [[ "$restore" != true ]]; then
+    echo "Toolset version $toolsetVersion has not been restored."
+    ExitWithExitCode 2
+  fi
+
+  local proj="$toolset_dir/restore.proj"
+
+  echo '<Project Sdk="Microsoft.DotNet.Arcade.Sdk"/>' > $proj
+  "$build_driver" msbuild $proj /t:__WriteToolsetLocation /m /nologo /clp:None /warnaserror /bl:$toolset_restore_log /v:$verbosity /p:__ToolsetLocationOutputFile=$toolset_location_file
+  local lastexitcode=$?
+
+  if [[ $lastexitcode != 0 ]]; then
+    echo "Failed to restore toolset (exit code '$lastexitcode'). See log: $toolset_restore_log"
+    ExitWithExitCode $lastexitcode
+  fi
+
+  toolset_build_proj=`cat $toolset_location_file`
+
+  if [[ ! -a "$toolset_build_proj" ]]; then
+    echo "Invalid toolset path: $toolset_build_proj"
+    ExitWithExitCode 3
+  fi
+}
+
+function InitializeCustomToolset {
+  local script="$eng_root/RestoreToolset.sh"
+
+  if [[ -a "$script" ]]; then
+    . "$script"
+  fi
+}
+
+function InitializeTools {
+  InitializeDotNetCli
+  InitializeToolset
+  InitializeCustomToolset
+}
+
+function ExitWithExitCode {
+  if [[ "$ci" == true && "$prepare_machine" == true ]]; then
+    StopProcesses
+  fi
+  exit $1
+}
+
+function StopProcesses {
+  echo "Killing running build processes..."
+  pkill -9 "dotnet"
+  pkill -9 "vbcscompiler"
+}
+
+# HOME may not be defined in some scenarios, but it is required by NuGet
+if [[ -z $HOME ]]; then
+  export HOME="$repo_root/artifacts/.home/"
+  mkdir -p "$HOME"
+fi
+
+if [[ -z $NUGET_PACKAGES ]]; then
+  if [[ $ci ]]; then
+    export NUGET_PACKAGES="$repo_root/.packages"
+  else
+    export NUGET_PACKAGES="$HOME/.nuget/packages"
+  fi
+fi
+
+mkdir -p "$toolset_dir"
+mkdir -p "$log_dir"
+
+if [[ $ci ]]; then
+  mkdir -p "$temp_dir"
+  export TEMP="$temp_dir"
+  export TMP="$temp_dir"
+fi
+
+InitializeTools

--- a/eng/common/init-tools.sh
+++ b/eng/common/init-tools.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 ci=${ci:-false}
+configuration=${configuration:-'Debug'}
 nodereuse=${nodereuse:-true}
 prepare_machine=${prepare_machine:-false}
 restore=${restore:-true}
@@ -10,8 +11,8 @@ repo_root="$scriptroot/../.."
 eng_root="$scriptroot/.."
 artifacts_dir="$repo_root/artifacts"
 toolset_dir="$artifacts_dir/toolset"
-log_dir="$artifacts_dir/log"
-temp_dir="$artifacts_dir/tmp"
+log_dir="$artifacts_dir/log/$configuration"
+temp_dir="$artifacts_dir/tmp/$configuration"
 
 global_json_file="$repo_root/global.json"
 build_driver=""

--- a/eng/common/msbuild.ps1
+++ b/eng/common/msbuild.ps1
@@ -3,6 +3,8 @@ Param(
   [string] $verbosity = "minimal",
   [bool] $warnaserror = $true,
   [bool] $nodereuse = $true,
+  [switch] $ci,
+  [switch] $prepareMachine,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 
@@ -27,12 +29,11 @@ try {
   if ($lastExitCode -ne 0) {
     Write-Host "Build failed see log: $buildLog" -ForegroundColor DarkGray
   }
-
-  exit $lastExitCode
+  ExitWithExitCode $lastExitCode
 }
 catch {
   Write-Host $_
   Write-Host $_.Exception
   Write-Host $_.ScriptStackTrace
-  exit 1
+  ExitWithExitCode 1
 }

--- a/eng/common/msbuild.ps1
+++ b/eng/common/msbuild.ps1
@@ -5,30 +5,13 @@ Param(
   [bool] $nodereuse = $true,
   [switch] $ci,
   [switch] $prepareMachine,
-  [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
+  [Parameter(ValueFromRemainingArguments=$true)][String[]]$extraArgs
 )
 
 . $PSScriptRoot\init-tools.ps1
 
 try {
-  $buildDriver, $buildArgs = GetBuildCommand
-
-  $buildlog = Join-Path $LogDir "Build.binlog"
-
-  $warnaserrorflag = if ($warnaserror) { "/warnaserror" }
-  $nodereuseflag = if ($nodereuse) { "/nr:true" } else { "/nr:false" }
-
-  & $buildDriver $buildArgs `
-    /m /nologo /clp:Summary `
-    /v:$verbosity `
-    /bl:$buildlog `
-    $warnaserrorflag `
-    $nodereuseflag `
-    @properties
-
-  if ($lastExitCode -ne 0) {
-    Write-Host "Build failed see log: $buildLog" -ForegroundColor DarkGray
-  }
+  MSBuild @extraArgs
   ExitWithExitCode $lastExitCode
 }
 catch {

--- a/eng/common/msbuild.ps1
+++ b/eng/common/msbuild.ps1
@@ -1,0 +1,38 @@
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+  [string] $verbosity = "minimal",
+  [bool] $warnaserror = $true,
+  [bool] $nodereuse = $true,
+  [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
+)
+
+. $PSScriptRoot\init-tools.ps1
+
+try {
+  $buildDriver, $buildArgs = GetBuildCommand
+
+  $buildlog = Join-Path $LogDir "Build.binlog"
+
+  $warnaserrorflag = if ($warnaserror) { "/warnaserror" }
+  $nodereuseflag = if ($nodereuse) { "/nr:true" } else { "/nr:false" }
+
+  & $buildDriver $buildArgs `
+    /m /nologo /clp:Summary `
+    /v:$verbosity `
+    /bl:$buildlog `
+    $warnaserrorflag `
+    $nodereuseflag `
+    @properties
+
+  if ($lastExitCode -ne 0) {
+    Write-Host "Build failed see log: $buildLog" -ForegroundColor DarkGray
+  }
+
+  exit $lastExitCode
+}
+catch {
+  Write-Host $_
+  Write-Host $_.Exception
+  Write-Host $_.ScriptStackTrace
+  exit 1
+}

--- a/eng/common/msbuild.sh
+++ b/eng/common/msbuild.sh
@@ -13,10 +13,7 @@ done
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 
 verbosity='minimal'
-warnaserrorflag=''
-nodereuseflag='/nr:true'
-properties=''
-
+extraargs=''
 
 while (($# > 0)); do
   lowerI="$(echo $1 | awk '{print tolower($0)}')"
@@ -26,15 +23,11 @@ while (($# > 0)); do
       shift 2
       ;;
     --warnaserror)
-      if [[ $2 != 0 ]]; then
-        warnaserrorflag="/warnaserror"
-      fi
+      warnaserror=$2
       shift 2
       ;;
     --nodereuse)
-      if [[ $2 == 0 ]]; then
-        nodereuseflag="/nr:false"
-      fi
+      nodereuse=$2
       shift 2
       ;;
     --ci)
@@ -46,7 +39,7 @@ while (($# > 0)); do
       shift 1
       ;;
       *)
-      properties="$properties $1"
+      extraargs="$extraargs $1"
       shift 1
       ;;
   esac
@@ -54,18 +47,5 @@ done
 
 . $scriptroot/init-tools.sh
 
-"$build_driver" msbuild \
-  /m /nologo /clp:Summary \
-  /v:$verbosity \
-  /bl:$build_log \
-  $warnaserrorflag \
-  $nodereuseflag \
-  $properties
-
-lastexitcode=$?
-
-if [[ $lastexitcode != 0 ]]; then
-  echo "Build failed see log: $build_log"
-fi
-
-ExitWithExitCode $lastexitcode
+MSBuild $extraargs
+ExitWithExitCode $?

--- a/eng/common/msbuild.sh
+++ b/eng/common/msbuild.sh
@@ -12,7 +12,6 @@ while [[ -h "$source" ]]; do
 done
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 
-projects=''
 verbosity='minimal'
 warnaserrorflag=''
 nodereuseflag='/nr:true'

--- a/eng/common/msbuild.sh
+++ b/eng/common/msbuild.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+source="${BASH_SOURCE[0]}"
+
+# resolve $source until the file is no longer a symlink
+while [[ -h "$source" ]]; do
+  scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+  source="$(readlink "$source")"
+  # if $source was a relative symlink, we need to resolve it relative to the path where the
+  # symlink file was located
+  [[ $source != /* ]] && source="$scriptroot/$source"
+done
+scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+
+projects=''
+verbosity='minimal'
+warnaserrorflag=''
+nodereuseflag='/nr:true'
+properties=''
+
+
+while (($# > 0)); do
+  lowerI="$(echo $1 | awk '{print tolower($0)}')"
+  case $lowerI in
+    --verbosity)
+      verbosity=$2
+      shift 2
+      ;;
+    --warnaserror)
+      if [[ $2 != 0 ]]; then
+        warnaserrorflag="/warnaserror"
+      fi
+      shift 2
+      ;;
+    --nodereuse)
+      if [[ $2 == 0 ]]; then
+        nodereuseflag="/nr:false"
+      fi
+      shift 2
+      ;;
+    --ci)
+      ci=true
+      shift 1
+      ;;
+    --preparemachine)
+      prepare_machine=true
+      shift 1
+      ;;
+      *)
+      properties="$properties $1"
+      shift 1
+      ;;
+  esac
+done
+
+. $scriptroot/init-tools.sh
+
+"$build_driver" msbuild \
+  /m /nologo /clp:Summary \
+  /v:$verbosity \
+  /bl:$build_log \
+  $warnaserrorflag \
+  $nodereuseflag \
+  $properties
+
+lastexitcode=$?
+
+if [[ $lastexitcode != 0 ]]; then
+  echo "Build failed see log: $build_log"
+fi
+
+ExitWithExitCode $lastexitcode


### PR DESCRIPTION
This change splits build.ps1/sh into three scripts:

1) init-tools.ps1/sh which is sets up the toolset and is intended
to be sourced into wrapper scripts for initializing.
2) msbuild.ps1/sh which allows for directly calling msbuild with
the bootstrapped toolset
3) build.ps1/sh does what it used to using the new refactored
build scripts.

This allows for more scenarios to be able to run on top of the
bootstrapped toolset beyond just the root level build.

@tmat @mmitche PTAL
