### PR TITLE
Fix logic for running ApiCompat/GenApi

### DIFF
--- a/src/Microsoft.DotNet.ApiCompat/build/Microsoft.DotNet.ApiCompat.targets
+++ b/src/Microsoft.DotNet.ApiCompat/build/Microsoft.DotNet.ApiCompat.targets
@@ -8,7 +8,7 @@
     <_ApiCompatPath Condition="'$(MSBuildRuntimeType)' != 'core'">$(MSBuildThisFileDirectory)\..\tools\net472\Microsoft.DotNet.ApiCompat.exe</_ApiCompatPath>
 
     <_ApiCompatCommand Condition="'$(MSBuildRuntimeType)' == 'core'">$(ToolHostCmd) "$(_ApiCompatPath)"</_ApiCompatCommand>
-    <_ApiCompatCommand Condition="'$(MSBuildRuntimeType)' != 'core' AND '$(OS)' == 'Windows_NT'">$(_ApiCompatPath)</_ApiCompatCommand>
+    <_ApiCompatCommand Condition="'$(MSBuildRuntimeType)' != 'core' AND '$(OS)' == 'Windows_NT'">"$(_ApiCompatPath)"</_ApiCompatCommand>
     <_ApiCompatCommand Condition="'$(MSBuildRuntimeType)' != 'core' AND '$(OS)' != 'Windows_NT'">mono --runtime=v4.0.30319 "$(_ApiCompatPath)"</_ApiCompatCommand>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.ApiCompat/build/Microsoft.DotNet.ApiCompat.targets
+++ b/src/Microsoft.DotNet.ApiCompat/build/Microsoft.DotNet.ApiCompat.targets
@@ -8,7 +8,7 @@
     <_ApiCompatPath Condition="'$(MSBuildRuntimeType)' != 'core'">$(MSBuildThisFileDirectory)\..\tools\net472\Microsoft.DotNet.ApiCompat.exe</_ApiCompatPath>
 
     <_ApiCompatCommand Condition="'$(MSBuildRuntimeType)' == 'core'">$(ToolHostCmd) "$(_ApiCompatPath)"</_ApiCompatCommand>
-    <_ApiCompatCommand Condition="'$(MSBuildRuntimeType)' != 'core' AND '$(OS)' == 'Windows_NT'">"$(_ApiCompatPath)"</_ApiCompatCommand>
+    <_ApiCompatCommand Condition="'$(MSBuildRuntimeType)' != 'core' AND '$(OS)' == 'Windows_NT'">$(_ApiCompatPath)</_ApiCompatCommand>
     <_ApiCompatCommand Condition="'$(MSBuildRuntimeType)' != 'core' AND '$(OS)' != 'Windows_NT'">mono --runtime=v4.0.30319 "$(_ApiCompatPath)"</_ApiCompatCommand>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.ApiCompat/build/Microsoft.DotNet.ApiCompat.targets
+++ b/src/Microsoft.DotNet.ApiCompat/build/Microsoft.DotNet.ApiCompat.targets
@@ -8,8 +8,8 @@
     <_ApiCompatPath Condition="'$(MSBuildRuntimeType)' != 'core'">$(MSBuildThisFileDirectory)\..\tools\net472\Microsoft.DotNet.ApiCompat.exe</_ApiCompatPath>
 
     <_ApiCompatCommand Condition="'$(MSBuildRuntimeType)' == 'core'">$(ToolHostCmd) "$(_ApiCompatPath)"</_ApiCompatCommand>
-    <_ApiCompatCommand Condition="'$(MSBuildRuntimeType)' == 'core' AND '$(OS)' == 'Windows_NT'">"$(_ApiCompatPath)"</_ApiCompatCommand>
-    <_ApiCompatCommand Condition="'$(MSBuildRuntimeType)' == 'core' AND '$(OS)' != 'Windows_NT'">mono --runtime=v4.0.30319 "$(_ApiCompatPath)"</_ApiCompatCommand>
+    <_ApiCompatCommand Condition="'$(MSBuildRuntimeType)' != 'core' AND '$(OS)' == 'Windows_NT'">"$(_ApiCompatPath)"</_ApiCompatCommand>
+    <_ApiCompatCommand Condition="'$(MSBuildRuntimeType)' != 'core' AND '$(OS)' != 'Windows_NT'">mono --runtime=v4.0.30319 "$(_ApiCompatPath)"</_ApiCompatCommand>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.GenAPI/build/Microsoft.DotNet.GenAPI.targets
+++ b/src/Microsoft.DotNet.GenAPI/build/Microsoft.DotNet.GenAPI.targets
@@ -10,7 +10,7 @@
     <_GenAPIPath Condition="'$(MSBuildRuntimeType)' != 'core'">$(MSBuildThisFileDirectory)\..\tools\net472\Microsoft.DotNet.GenAPI.exe</_GenAPIPath>
 
     <_GenAPICommand Condition="'$(MSBuildRuntimeType)' == 'core'">$(ToolHostCmd) "$(_GenAPIPath)"</_GenAPICommand>
-    <_GenAPICommand Condition="'$(MSBuildRuntimeType)' != 'core' AND '$(OS)' == 'Windows_NT'">$(_GenAPIPath)</_GenAPICommand>
+    <_GenAPICommand Condition="'$(MSBuildRuntimeType)' != 'core' AND '$(OS)' == 'Windows_NT'">"$(_GenAPIPath)"</_GenAPICommand>
     <_GenAPICommand Condition="'$(MSBuildRuntimeType)' != 'core' AND '$(OS)' != 'Windows_NT'">mono --runtime=v4.0.30319 "$(_GenAPIPath)"</_GenAPICommand>
 
     <!-- Sequence ourselves last in PrepareForRun

--- a/src/Microsoft.DotNet.GenAPI/build/Microsoft.DotNet.GenAPI.targets
+++ b/src/Microsoft.DotNet.GenAPI/build/Microsoft.DotNet.GenAPI.targets
@@ -10,8 +10,8 @@
     <_GenAPIPath Condition="'$(MSBuildRuntimeType)' != 'core'">$(MSBuildThisFileDirectory)\..\tools\net472\Microsoft.DotNet.GenAPI.exe</_GenAPIPath>
 
     <_GenAPICommand Condition="'$(MSBuildRuntimeType)' == 'core'">$(ToolHostCmd) "$(_GenAPIPath)"</_GenAPICommand>
-    <_GenAPICommand Condition="'$(MSBuildRuntimeType)' == 'core' AND '$(OS)' == 'Windows_NT'">"$(_GenAPIPath)"</_GenAPICommand>
-    <_GenAPICommand Condition="'$(MSBuildRuntimeType)' == 'core' AND '$(OS)' != 'Windows_NT'">mono --runtime=v4.0.30319 "$(_GenAPIPath)"</_GenAPICommand>
+    <_GenAPICommand Condition="'$(MSBuildRuntimeType)' != 'core' AND '$(OS)' == 'Windows_NT'">$(_GenAPIPath)</_GenAPICommand>
+    <_GenAPICommand Condition="'$(MSBuildRuntimeType)' != 'core' AND '$(OS)' != 'Windows_NT'">mono --runtime=v4.0.30319 "$(_GenAPIPath)"</_GenAPICommand>
 
     <!-- Sequence ourselves last in PrepareForRun
          This ensures the output has been copied to TargetPath, but still permits


### PR DESCRIPTION
I previously messed up the logic for running the `GenApi`/`ApiCompat` commands. The matrix should be as follows:

- Running on core, Windows: `dotnet netcoreapp2.1\GenApi.dll`
- Running on core, non-Windows: `dotnet netcoreapp2.1\GenApi.dll`
- Not running on core, Windows: `net472\GenApi.exe`
- Not running on core, non-Windows: `mono net472\GenApi.exe`

(Per https://github.com/dotnet/arcade/pull/776#discussion_r218566571)

This should fix the logic so that we run the right commands in the right places

@weshaggard PTAL