### PR TITLE
Basic get-channels and refactoring

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/EncodedFile.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/EncodedFile.cs
@@ -29,12 +29,11 @@ namespace Microsoft.DotNet.Darc.Helpers
             }
         }
 
-        public static JToken Read(string fileName)
+        public static string Read(string fileName)
         {
             string encodedString = File.ReadAllText(Path.Combine(Constants.DarcDirectory, fileName));
             byte[] encodedBytes = Convert.FromBase64String(encodedString);
-            string decodedString = Encoding.UTF8.GetString(encodedBytes);
-            return JToken.Parse(decodedString);
+            return Encoding.UTF8.GetString(encodedBytes);
         }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/LocalCommands.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/LocalCommands.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
+using Microsoft.DotNet.Darc.Options;
+using Microsoft.DotNet.DarcLib;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -10,8 +12,53 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.DotNet.Darc.Helpers
 {
-    public static class LocalCommands
+    internal static class LocalCommands
     {
+        /// <summary>
+        /// Retrieve the settings from the combination of the command line
+        /// options and the user's darc settings file.
+        /// </summary>
+        /// <param name="options">Command line options</param>
+        /// <returns>Darc settings for use in remote commands</returns>
+        /// <remarks>The command line takes precedence over the darc settings file.</remarks>
+        public static DarcSettings GetSettings(CommandLineOptions options, ILogger logger)
+        {
+            DarcSettings darcSettings = new DarcSettings();
+            darcSettings.GitType = GitRepoType.None;
+
+            try
+            {
+                LocalSettings localSettings = LocalSettings.LoadSettings();
+                darcSettings.BuildAssetRegistryBaseUri = localSettings.BuildAssetRegistryBaseUri;
+                darcSettings.BuildAssetRegistryPassword = localSettings.BuildAssetRegistryPassword;
+            }
+            catch (FileNotFoundException)
+            {
+                // Doesn't have a settings file, which is not an error
+            }
+            catch (Exception e)
+            {
+                logger.LogWarning(e, $"Failed to load the darc settings file, may be corrupted");
+            }
+
+            // Override if non-empty on command line
+            darcSettings.BuildAssetRegistryBaseUri = OverrideIfSet(darcSettings.BuildAssetRegistryBaseUri,
+                                                                   options.BuildAssetRegistryBaseUri);
+            darcSettings.BuildAssetRegistryPassword = OverrideIfSet(darcSettings.BuildAssetRegistryPassword, 
+                                                                    options.BuildAssetRegistryPassword);
+
+            // Current the darc settings only has one PAT type which is interpreted differently based
+            // on the git type (Azure DevOps vs. GitHub).  For now, leave this setting empty until
+            // we know what we are talking to.
+
+            return darcSettings;
+        }
+
+        private static string OverrideIfSet(string currentSetting, string commandLineSetting)
+        {
+            return !string.IsNullOrEmpty(commandLineSetting) ? commandLineSetting : currentSetting;
+        }
+
         public static string GetEditorPath(ILogger logger)
         {
             string editor = ExecuteCommand("git.exe", "config --get core.editor", logger);

--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/LocalCommands.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/LocalCommands.cs
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.Darc.Helpers
             darcSettings.BuildAssetRegistryPassword = OverrideIfSet(darcSettings.BuildAssetRegistryPassword, 
                                                                     options.BuildAssetRegistryPassword);
 
-            // Current the darc settings only has one PAT type which is interpreted differently based
+            // Currently the darc settings only has one PAT type which is interpreted differently based
             // on the git type (Azure DevOps vs. GitHub).  For now, leave this setting empty until
             // we know what we are talking to.
 

--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/LocalSettings.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/LocalSettings.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Darc.Helpers
 
         public static LocalSettings LoadSettings()
         {
-            String settings = EncodedFile.Read(Constants.SettingsFileName);
+            string settings = EncodedFile.Read(Constants.SettingsFileName);
             return JsonConvert.DeserializeObject<LocalSettings>(settings);
         }
     }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/LocalSettings.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/LocalSettings.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using System;
+
+namespace Microsoft.DotNet.Darc.Helpers
+{
+    /// <summary>
+    /// Reads and writes the settings file
+    /// </summary>
+    internal class LocalSettings
+    {
+        public string BuildAssetRegistryPassword { get; set; }
+
+        public string GitHubToken { get; set; }
+
+        public string AzureDevOpsToken { get; set; }
+
+        public string BuildAssetRegistryBaseUri { get; set; } = "https://maestro-prod.westus2.cloudapp.azure.com/";
+
+        /// <summary>
+        /// Saves the settings in the settings files
+        /// </summary>
+        /// <param name="logger"></param>
+        /// <returns></returns>
+        public int SaveSettings(ILogger logger)
+        {
+            string settings = JsonConvert.SerializeObject(this);
+            return EncodedFile.Create(Constants.SettingsFileName, settings, logger);
+        }
+
+        public static LocalSettings LoadSettings()
+        {
+            String settings = EncodedFile.Read(Constants.SettingsFileName);
+            return JsonConvert.DeserializeObject<LocalSettings>(settings);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Helpers/UxManager.cs
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.Darc.Helpers
 
             try
             {
-                string path = Path.Join(_gitDir, popUp.Path);
+                string path = Path.Combine(_gitDir, popUp.Path);
                 string dirPath = Path.GetDirectoryName(path);
 
                 Directory.CreateDirectory(dirPath);

--- a/src/Microsoft.DotNet.Darc/src/Darc/Models/PopUps/AuthenticateEditorPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Models/PopUps/AuthenticateEditorPopUp.cs
@@ -1,10 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.)
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.Darc.Helpers;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
@@ -13,53 +13,112 @@ namespace Microsoft.DotNet.Darc.Models
     internal class AuthenticateEditorPopUp : EditorPopUp
     {
         private readonly ILogger _logger;
-        private static readonly IList<Line> _contents = new ReadOnlyCollection<Line>(new List<Line>
-            {
-                new Line("bar_password=<token-from-https://maestro-prod.westus2.cloudapp.azure.com/>"),
-                new Line("github_token=<github-personal-access-token>"),
-                new Line("vsts_token=<vsts-personal-access-token>"),
-                new Line(""),
-                new Line("Storing the required tokens...", true),
-                new Line("Set 'bar_password', 'github_token' and 'vsts_token' depending on what you need", true),
-            });
 
+        private const string barPasswordElement = "bar_password";
+        private const string githubTokenElement = "github_token";
+        private const string azureDevOpsTokenElement = "azure_devops_token";
+        private const string barBaseUriElement = "build_asset_registry_base_uri";
 
         public AuthenticateEditorPopUp(string path, ILogger logger)
-            : base(path, _contents)
+            : base(path)
         {
             _logger = logger;
+            try
+            {
+                // Load current settings
+                settings = LocalSettings.LoadSettings();
+            }
+            catch (Exception e)
+            {
+                // Failed to load the settings file.  Quite possible it just doesn't exist.
+                // In this case, just initialize the settings to empty
+                _logger.LogTrace($"Couldn't load or locate the settings file ({e.Message}).  Initializing empty settings file");
+                settings = new LocalSettings();
+            }
+
+            // Initialize line contents.
+            Contents = new ReadOnlyCollection<Line>(new List<Line>
+            {
+                new Line($"{barPasswordElement}={GetCurrentSettingForDisplay(settings.BuildAssetRegistryPassword, "<token-from-https://maestro-prod.westus2.cloudapp.azure.com/>", true)}"),
+                new Line($"{githubTokenElement}={GetCurrentSettingForDisplay(settings.GitHubToken, "<github-personal-access-token>", true)}"),
+                new Line($"{azureDevOpsTokenElement}={GetCurrentSettingForDisplay(settings.AzureDevOpsToken, "<azure-devops-personal-access-token>", true)}"),
+                new Line($"{barBaseUriElement}={GetCurrentSettingForDisplay(settings.BuildAssetRegistryBaseUri, "<alternate build asset registry uri if needed, otherwise leave as is>", false)}"),
+                new Line(""),
+                new Line("Storing the required settings...", true),
+                new Line($"Set elements above depending on what you need", true),
+            });
         }
 
-        public string BarPassword { get; set; }
-
-        public string GitHubToken { get; set; }
-
-        public string VstsToken { get; set; }
+        public LocalSettings settings { get; set; }
 
         public override bool Validate()
         {
             // No real validation required since none of the fields are mandatory
             return true;
         }
+        
+        /// <summary>
+        /// Retrieve the string that should be displayed to the user.
+        /// </summary>
+        /// <param name="currentValue">Current value of the setting</param>
+        /// <param name="defaultValue">Default value if the current setting value is empty</param>
+        /// <param name="isSecret">If secret and current value is empty, should display ***</param>
+        /// <returns>String to display</returns>
+        private string GetCurrentSettingForDisplay(string currentValue, string defaultValue, bool isSecret)
+        {
+            if (!string.IsNullOrEmpty(currentValue))
+            {
+                return isSecret ? "***" : currentValue;
+            }
+            else
+            {
+                return defaultValue;
+            }
+        }
+
+        /// <summary>
+        /// Parses a setting and returns the value to save.
+        /// </summary>
+        /// <param name="inputSetting">Input string from the file</param>
+        /// <returns>
+        ///     - Original setting if the setting is secret and value is still all ***
+        ///     - Empty string if the setting starts+ends with <>
+        ///     - New value if anything else.
+        /// </returns>
+        private string ParseSetting(string inputSetting, string originalSetting, bool isSecret)
+        {
+            string trimmedSetting = inputSetting.Trim();
+            if (trimmedSetting.StartsWith('<') && trimmedSetting.EndsWith('>'))
+            {
+                return string.Empty;
+            }
+            // If the setting is secret and only contains *, then keep it the same as the input setting
+            if (isSecret && trimmedSetting.Length > 0 && trimmedSetting.Replace("*", "") == string.Empty)
+            {
+                return originalSetting;
+            }
+            return trimmedSetting;
+        }
 
         public override int ProcessContents(IList<Line> contents)
         {
-            int result = 0;
-
             foreach (Line line in contents)
             {
                 string[] keyValue = line.Text.Split("=");
 
                 switch (keyValue[0])
                 {
-                    case "bar_password":
-                        BarPassword = keyValue[1];
+                    case barPasswordElement:
+                        settings.BuildAssetRegistryPassword = ParseSetting(keyValue[1], settings.BuildAssetRegistryPassword, true);
                         break;
-                    case "github_token":
-                        GitHubToken = keyValue[1];
+                    case githubTokenElement:
+                        settings.GitHubToken = ParseSetting(keyValue[1], settings.BuildAssetRegistryPassword, true);
                         break;
-                    case "vsts_token":
-                        VstsToken = keyValue[1];
+                    case azureDevOpsTokenElement:
+                        settings.AzureDevOpsToken = ParseSetting(keyValue[1], settings.BuildAssetRegistryPassword, true);
+                        break;
+                    case barBaseUriElement:
+                        settings.BuildAssetRegistryBaseUri = ParseSetting(keyValue[1], settings.BuildAssetRegistryBaseUri, false);
                         break;
                     default:
                         _logger.LogWarning($"'{keyValue[0]}' is an unknown field in the authentication scope");
@@ -69,14 +128,10 @@ namespace Microsoft.DotNet.Darc.Models
 
             if (!Validate())
             {
-                result = Constants.ErrorCode;
+                return Constants.ErrorCode;
             }
 
-            string settings = JsonConvert.SerializeObject(this);
-
-            result = EncodedFile.Create(Constants.SettingsFileName, settings, _logger);
-
-            return 0;
+            return settings.SaveSettings(_logger);
         }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Models/PopUps/AuthenticateEditorPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Models/PopUps/AuthenticateEditorPopUp.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.)
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Microsoft.DotNet.Darc/src/Darc/Models/PopUps/EditorPopUp.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Models/PopUps/EditorPopUp.cs
@@ -16,6 +16,11 @@ namespace Microsoft.DotNet.Darc.Models
             Contents = contents;
         }
 
+        public EditorPopUp(string path)
+        {
+            Path = path;
+        }
+
         [JsonIgnore]
         public string Path { get; set; }
 

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AddOperation.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.Darc.Options;
+using System;
+
+namespace Microsoft.DotNet.Darc.Operations
+{
+    internal class AddOperation : Operation
+    {
+        AddCommandLineOptions _options;
+        public AddOperation(AddCommandLineOptions options)
+            : base(options)
+        {
+            _options = options;
+        }
+
+        public override int Execute()
+        {
+            throw new NotImplementedException("Add operation not yet implemented");
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/AuthenticateOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/AuthenticateOperation.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.Darc.Helpers;
+using Microsoft.DotNet.Darc.Models;
+using Microsoft.DotNet.Darc.Options;
+
+namespace Microsoft.DotNet.Darc.Operations
+{
+    internal class AuthenticateOperation : Operation
+    {
+        AuthenticateCommandLineOptions _options;
+        public AuthenticateOperation(AuthenticateCommandLineOptions options)
+            : base(options)
+        {
+            _options = options;
+        }
+
+        /// <summary>
+        /// Implements the 'authenticate' verb
+        /// </summary>
+        /// <param name="options"></param>
+        public override int Execute()
+        {
+            // If clear was passed, then clear the options (no popup)
+            if (_options.Clear)
+            {
+                LocalSettings defaultSettings = new LocalSettings();
+                defaultSettings.SaveSettings(Logger);
+                return 0;
+            }
+            else
+            {
+                AuthenticateEditorPopUp initEditorPopUp = new AuthenticateEditorPopUp("authenticate-settings/authenticate-todo", Logger);
+
+                UxManager uxManager = new UxManager(Logger);
+
+                return uxManager.PopUp(initEditorPopUp);
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetChannelsOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetChannelsOperation.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.Darc.Helpers;
+using Microsoft.DotNet.Darc.Options;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.Extensions.Logging;
+using System;
+
+namespace Microsoft.DotNet.Darc.Operations
+{
+    internal class GetChannelsOperation : Operation
+    {
+        GetChannelsCommandLineOptions _options;
+        public GetChannelsOperation(GetChannelsCommandLineOptions options)
+            : base(options)
+        {
+            _options = options;
+        }
+
+        /// <summary>
+        /// Retrieve information about channels
+        /// </summary>
+        /// <param name="options">Command line options</param>
+        /// <returns>Process exit code.</returns>
+        public override int Execute()
+        {
+            try
+            {
+                DarcSettings darcSettings = LocalCommands.GetSettings(_options, Logger);
+                // No need to set up a git type or PAT here.
+                Remote remote = new Remote(darcSettings, Logger);
+
+                var allChannels = remote.GetChannelsAsync().Result;
+
+                // Write out a simple list of each channel's name
+                foreach (var channel in allChannels)
+                {
+                    Console.WriteLine(channel.Name);
+                }
+
+                return 0;
+            }
+            catch (Exception e)
+            {
+                Logger.LogError(e, "Error: Failed to retrieve channels");
+                return Constants.ErrorCode;
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetOperation.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.Darc.Options;
+using Microsoft.DotNet.DarcLib;
+using System;
+
+namespace Microsoft.DotNet.Darc.Operations
+{
+    internal class GetOperation : Operation
+    {
+        GetCommandLineOptions _options;
+        public GetOperation(GetCommandLineOptions options)
+            : base(options)
+        {
+            _options = options;
+        }
+
+        /// <summary>
+        /// Implements the 'get' verb
+        /// </summary>
+        /// <param name="options"></param>
+        public override int Execute()
+        {
+            Local local = new Local(_options.LocalDirectory, Logger);
+            var allDependencies = local.GetDependencies().Result;
+            foreach (var dependency in allDependencies)
+            {
+                Console.WriteLine($"{dependency.Name} {dependency.Version} from {dependency.RepoUri}@{dependency.Commit}");
+            }
+            return 0;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/Operations.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/Operations.cs
@@ -2,60 +2,24 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.Darc.Helpers;
-using Microsoft.DotNet.Darc.Models;
 using Microsoft.DotNet.Darc.Options;
-using Microsoft.DotNet.DarcLib;
 using Microsoft.Extensions.Logging;
 using System;
 
-namespace Microsoft.DotNet.Darc
+namespace Microsoft.DotNet.Darc.Operations
 {
-    internal static class Operations
+    internal abstract class Operation : IDisposable
     {
-        /// <summary>
-        /// Implements the 'authenticate' verb
-        /// </summary>
-        /// <param name="options"></param>
-        public static int AuthenticateOperation(AuthenticateCommandLineOptions options)
+        protected ILoggerFactory _loggerFactory;
+        private ILogger _logger;
+
+        protected ILogger Logger { get { return _logger; } }
+
+        public Operation(CommandLineOptions options)
         {
-            ILogger logger = GetLogger(options);
-
-            AuthenticateEditorPopUp initEditorPopUp = new AuthenticateEditorPopUp("authenticate-settings/authenticate-todo", logger);
-
-            UxManager uxManager = new UxManager(logger);
-
-            return uxManager.PopUp(initEditorPopUp);
-        }
-
-        /// <summary>
-        /// Implements the 'get' verb
-        /// </summary>
-        /// <param name="options"></param>
-        public static int GetOperation(GetCommandLineOptions options)
-        {
-            Local local = new Local(options.LocalDirectory, GetLogger(options));
-            var allDependencies = local.GetDependencies().Result;
-            foreach (var dependency in allDependencies)
-            {
-                Console.WriteLine($"{dependency.Name} {dependency.Version} from {dependency.RepoUri}@{dependency.Commit}");
-            }
-            return 0;
-        }
-
-        public static int AddOperation(AddCommandLineOptions options)
-        {
-            throw new NotImplementedException("Add operation not yet implemented");
-        }
-
-        /// <summary>
-        /// Retrieve the console logger for the CLI.
-        /// </summary>
-        /// <returns>New logger</returns>
-        /// <remarks>Because the internal logging in DarcLib tends to be chatty and non-useful,
-        /// we remap the --verbose switch onto 'info', --debug onto highest level, and the default level onto warning</remarks>
-        private static ILogger GetLogger(CommandLineOptions options)
-        {
+            // Because the internal logging in DarcLib tends to be chatty and non-useful,
+            // we remap the --verbose switch onto 'info', --debug onto highest level, and the
+            // default level onto warning
             LogLevel level = LogLevel.Warning;
             if (options.Debug)
             {
@@ -65,8 +29,32 @@ namespace Microsoft.DotNet.Darc
             {
                 level = LogLevel.Information;
             }
-            ILoggerFactory loggerFactory = new LoggerFactory().AddConsole(level);
-            return loggerFactory.CreateLogger<Program>();
+            _loggerFactory = new LoggerFactory().AddConsole(level);
+            _logger = _loggerFactory.CreateLogger<Operation>();
         }
+
+        public abstract int Execute();
+
+        #region IDisposable Support
+        private bool disposedValue = false; // To detect redundant calls
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    _loggerFactory.Dispose();
+                }
+
+                disposedValue = true;
+            }
+        }
+        
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+        #endregion
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/AuthenticateCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/AuthenticateCommandLineOptions.cs
@@ -9,5 +9,7 @@ namespace Microsoft.DotNet.Darc.Options
     [Verb("authenticate", HelpText = "Stores the VSTS and GitHub tokens required for remote operations")]
     internal class AuthenticateCommandLineOptions : CommandLineOptions
     {
+        [Option("clear", HelpText = "Clear any settings to defaults")]
+        public bool Clear { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/CommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/CommandLineOptions.cs
@@ -8,11 +8,17 @@ namespace Microsoft.DotNet.Darc.Options
 {
     abstract class CommandLineOptions
     {
-        [Option('p', "password", HelpText = "GitHub PAT used to authenticate against Maestro/BAR REST APIs if necessary.")]
-        public string Password { get; set; }
+        [Option('p', "password", HelpText = "BAR password")]
+        public string BuildAssetRegistryPassword { get; set; }
 
-        [Option('t', "token", HelpText = "Token used to authenticate VSTS or GitHub if necessary.")]
-        public string Token { get; set; }
+        [Option("github-pat", HelpText = "Token used to authenticate GitHub")]
+        public string GitHubPat { get; set; }
+
+        [Option("azdev-pat", HelpText = "Token used to authenticate to Azure DevOps")]
+        public string AzureDevOpsPat { get; set; }
+
+        [Option("bar-uri", HelpText = "URI of the build asset registry service to use.")]
+        public string BuildAssetRegistryBaseUri { get; set; }
 
         [Option("verbose", HelpText = "Turn on verbose output")]
         public bool Verbose { get; set; }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/GetChannelsCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/GetChannelsCommandLineOptions.cs
@@ -6,7 +6,7 @@ using CommandLine;
 
 namespace Microsoft.DotNet.Darc.Options
 {
-    [Verb("get-channels", HelpText = "Query information about dependencies")]
+    [Verb("get-channels", HelpText = "Get a list of channels")]
     internal class GetChannelsCommandLineOptions : CommandLineOptions
     {
     }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/GetChannelsCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/GetChannelsCommandLineOptions.cs
@@ -2,13 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Microsoft.DotNet.DarcLib
+using CommandLine;
+
+namespace Microsoft.DotNet.Darc.Options
 {
-    public enum GitRepoType
+    [Verb("get-channels", HelpText = "Query information about dependencies")]
+    internal class GetChannelsCommandLineOptions : CommandLineOptions
     {
-        GitHub,
-        Vsts,
-        Local,
-        None
     }
 }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Properties/launchSettings.json
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "Microsoft.DotNet.Darc": {
+      "commandName": "Project"
+    }
+  }
+}

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -29,20 +29,40 @@ namespace Microsoft.DotNet.DarcLib
             {
                 _gitClient = new GitHubClient(settings.PersonalAccessToken, _logger);
             }
-            else
+            else if (settings.GitType == GitRepoType.Vsts)
             {
                 _gitClient = new VstsClient(settings.PersonalAccessToken, _logger);
             }
 
-            _fileManager = new GitFileManager(_gitClient, _logger);
-            if (!string.IsNullOrEmpty(settings.BuildAssetRegistryBaseUri))
+            // Only initialize the file manager if we have a git client, which excludes "None"
+            if (_gitClient != null)
             {
-                _barClient = ApiFactory.GetAuthenticated(settings.BuildAssetRegistryBaseUri, settings.BuildAssetRegistryPassword);
+                _fileManager = new GitFileManager(_gitClient, _logger);
             }
-            else
+
+            // Initialize the bar client if there is a password
+            if (!string.IsNullOrEmpty(settings.BuildAssetRegistryPassword))
             {
-                _barClient = ApiFactory.GetAuthenticated(settings.BuildAssetRegistryPassword);
+                if (!string.IsNullOrEmpty(settings.BuildAssetRegistryBaseUri))
+                {
+                    _barClient = ApiFactory.GetAuthenticated(settings.BuildAssetRegistryBaseUri, settings.BuildAssetRegistryPassword);
+                }
+                else
+                {
+                    _barClient = ApiFactory.GetAuthenticated(settings.BuildAssetRegistryPassword);
+                }
             }
+        }
+
+        /// <summary>
+        /// Retrieve the list of channels from the build asset registry.
+        /// </summary>
+        /// <param name="classification">Optional classification to get</param>
+        /// <returns></returns>
+        public async Task<IEnumerable<Channel>> GetChannelsAsync(string classification = null)
+        {
+            CheckForValidBarClient();
+            return await _barClient.Channels.GetAsync(classification);
         }
 
         /// <summary>
@@ -53,16 +73,19 @@ namespace Microsoft.DotNet.DarcLib
         /// <returns>Newly created channel</returns>
         public async Task<Channel> CreateChannelAsync(string name, string classification)
         {
+            CheckForValidBarClient();
             return await _barClient.Channels.CreateChannelAsync(name, classification);
         }
 
         public async Task<IEnumerable<Subscription>> GetSubscriptionsAsync(string sourceRepo = null, string targetRepo = null, int? channelId = null)
         {
+            CheckForValidBarClient();
             return await _barClient.Subscriptions.GetAllSubscriptionsAsync(sourceRepo, targetRepo, channelId);
         }
 
         public async Task<Subscription> GetSubscriptionAsync(string subscriptionId)
         {
+            CheckForValidBarClient();
             Guid subscriptionGuid;
             if (!Guid.TryParse(subscriptionId, out subscriptionGuid))
             {
@@ -73,6 +96,7 @@ namespace Microsoft.DotNet.DarcLib
 
         public async Task<Subscription> CreateSubscriptionAsync(string channelName, string sourceRepo, string targetRepo, string targetBranch, string updateFrequency, string mergePolicy)
         {
+            CheckForValidBarClient();
             SubscriptionData subscriptionData = new SubscriptionData()
             {
                 ChannelName = channelName,
@@ -90,6 +114,7 @@ namespace Microsoft.DotNet.DarcLib
 
         public async Task<string> CreatePullRequestAsync(string repoUri, string branch, string assetsProducedInCommit, IEnumerable<Microsoft.DotNet.DarcLib.AssetData> assets, string pullRequestBaseBranch = null, string pullRequestTitle = null, string pullRequestDescription = null)
         {
+            CheckForValidGitClient();
             _logger.LogInformation($"Create pull request to update dependencies in repo '{repoUri}' and branch '{branch}'...");
 
             IEnumerable<DependencyDetail> itemsToUpdate = await GetRequiredUpdatesAsync(repoUri, branch, assetsProducedInCommit, assets);
@@ -116,6 +141,7 @@ namespace Microsoft.DotNet.DarcLib
 
         public async Task<IList<Check>> GetPullRequestChecksAsync(string pullRequestUrl)
         {
+            CheckForValidGitClient();
             _logger.LogInformation($"Getting status checks for pull request '{pullRequestUrl}'...");
 
             IList<Check> checks = await _gitClient.GetPullRequestChecksAsync(pullRequestUrl);
@@ -125,26 +151,31 @@ namespace Microsoft.DotNet.DarcLib
 
         public async Task<IEnumerable<int>> SearchPullRequestsAsync(string repoUri, string pullRequestBranch, PrStatus status, string keyword = null, string author = null)
         {
+            CheckForValidGitClient();
             return await _gitClient.SearchPullRequestsAsync(repoUri, pullRequestBranch, status, keyword, author);
         }
 
         public Task<IList<Commit>> GetPullRequestCommitsAsync(string pullRequestUrl)
         {
+            CheckForValidGitClient();
             return _gitClient.GetPullRequestCommitsAsync(pullRequestUrl);
         }
 
         public Task<string> CreatePullRequestCommentAsync(string pullRequestUrl, string message)
         {
+            CheckForValidGitClient();
             return _gitClient.CreatePullRequestCommentAsync(pullRequestUrl, message);
         }
 
         public Task UpdatePullRequestCommentAsync(string pullRequestUrl, string commentId, string message)
         {
+            CheckForValidGitClient();
             return _gitClient.UpdatePullRequestCommentAsync(pullRequestUrl, commentId, message);
         }
 
         public async Task<PrStatus> GetPullRequestStatusAsync(string pullRequestUrl)
         {
+            CheckForValidGitClient();
             _logger.LogInformation($"Getting the status of pull request '{pullRequestUrl}'...");
 
             PrStatus status = await _gitClient.GetPullRequestStatusAsync(pullRequestUrl);
@@ -156,6 +187,7 @@ namespace Microsoft.DotNet.DarcLib
 
         public async Task<string> UpdatePullRequestAsync(string pullRequestUrl, string assetsProducedInCommit, string branch, IEnumerable<Microsoft.DotNet.DarcLib.AssetData> assetsToUpdate, string pullRequestTitle = null, string pullRequestDescription = null)
         {
+            CheckForValidGitClient();
             _logger.LogInformation($"Updating pull request '{pullRequestUrl}'...");
 
             string linkToPr = null;
@@ -176,6 +208,7 @@ namespace Microsoft.DotNet.DarcLib
 
         public async Task MergePullRequestAsync(string pullRequestUrl, MergePullRequestParameters parameters)
         {
+            CheckForValidGitClient();
             _logger.LogInformation($"Merging pull request '{pullRequestUrl}'...");
 
             await _gitClient.MergePullRequestAsync(pullRequestUrl, parameters ?? new MergePullRequestParameters());
@@ -183,16 +216,48 @@ namespace Microsoft.DotNet.DarcLib
             _logger.LogInformation($"Merging pull request '{pullRequestUrl}' succeeded!");
         }
 
+        /// <summary>
+        /// Called prior to operations requiring the BAR.  Throws if a bar client isn't available.
+        /// </summary>
+        private void CheckForValidBarClient()
+        {
+            if (_barClient == null)
+            {
+                throw new ArgumentException("Must supply a build asset registry password");
+            }
+        }
+
+        /// <summary>
+        /// Called prior to operations requiring the BAR.  Throws if a git client isn't available;
+        /// </summary>
+        private void CheckForValidGitClient()
+        {
+            if (_gitClient == null)
+            {
+                throw new ArgumentException($"Must supply a valid GitHub/Azure DevOps PAT");
+            }
+        }
+
         private void ValidateSettings(DarcSettings settings)
         {
-            if (string.IsNullOrEmpty(settings.PersonalAccessToken))
+            // Should have a git repo type of AzureDevOps, GitHub, or None.
+            if (settings.GitType == GitRepoType.GitHub || settings.GitType == GitRepoType.Vsts)
             {
-                throw new ArgumentException("The personal access token is missing...");
+                // PAT is required for these types.
+                if (string.IsNullOrEmpty(settings.PersonalAccessToken))
+                {
+                    throw new ArgumentException("The personal access token is missing...");
+                }
+            }
+            else if (settings.GitType != GitRepoType.None)
+            {
+                throw new ArgumentException($"Unexpected git repo type: {settings.GitType}");
             }
         }
 
         private async Task<IEnumerable<DependencyDetail>> GetRequiredUpdatesAsync(string repoUri, string branch, string assetsProducedInCommit, IEnumerable<Microsoft.DotNet.DarcLib.AssetData> assets)
         {
+            CheckForValidGitClient();
             _logger.LogInformation($"Check if repo '{repoUri}' and branch '{branch}' needs updates...");
 
             List<DependencyDetail> toUpdate = new List<DependencyDetail>();
@@ -220,6 +285,7 @@ namespace Microsoft.DotNet.DarcLib
 
         private async Task<List<GitFile>> GetScriptFilesAsync(string repoUri, string commit)
         {
+            CheckForValidGitClient();
             _logger.LogInformation($"Generating commits for script files");
 
             List<GitFile> files = await _gitClient.GetFilesForCommitAsync(repoUri, commit, "eng/common");
@@ -231,6 +297,7 @@ namespace Microsoft.DotNet.DarcLib
 
         private async Task CommitFilesForPullRequestAsync(string repoUri, string branch, string assetsProducedInCommit, IEnumerable<DependencyDetail> itemsToUpdate, string pullRequestBaseBranch = null)
         {
+            CheckForValidGitClient();
             GitFileContentContainer fileContainer = await _fileManager.UpdateDependencyFiles(itemsToUpdate, repoUri, branch);
             List<GitFile> filesToCommit = fileContainer.GetFilesToCommitMap(pullRequestBaseBranch);
 


### PR DESCRIPTION
Implements a basic get-channels (get a list of channels). Simply calls the GET channels API and prints the results.

Additionally, performs the following refactorings + fixes
- Authenticate operation now has '--clear', which removes settings
- Authenticate operation now loads current settings when displaying the popup, and *'s out secrets.
- Factored out the local settings into a separate class which the authenticate and other operations act on.  Implements a load operation that takes into account the local command line, which should override the settings file.
- Factored out the operations into separate classes, so that I could easily implement IDisposable on them.  IDisposable disposes the logger factory.
- Factor out the calls to the operations into a separate method in Program, so that Dispose can be called explicitly.  This is necessary because of a bug which means that the logger factory is not disposed on process exit. If it's not disposed, then the console log is often incomplete.
- Added a "none" type for the git repo type.  If not provided with a repo type, then the Remote class does not attempt to initialize the git client.  Initializing is not necessary for many operations.
- Add checks for appropriate BAR/Git clients on operations that need them.