### PR TITLE
Make GenerateReferenceAssemblySource target an opt-in

### DIFF
--- a/src/Microsoft.DotNet.GenAPI/build/Microsoft.DotNet.GenAPI.targets
+++ b/src/Microsoft.DotNet.GenAPI/build/Microsoft.DotNet.GenAPI.targets
@@ -16,7 +16,7 @@
     <!-- Sequence ourselves last in PrepareForRun
          This ensures the output has been copied to TargetPath, but still permits
          us to participate in FileWrites. -->
-    <PrepareForRunDependsOn>
+    <PrepareForRunDependsOn Condition="'$(RunGenerateReferenceAssemblySource)' == 'true'">
       $(PrepareForRunDependsOn);
       GenerateReferenceAssemblySource;
     </PrepareForRunDependsOn>

--- a/src/Microsoft.DotNet.GenAPI/build/Microsoft.DotNet.GenAPI.targets
+++ b/src/Microsoft.DotNet.GenAPI/build/Microsoft.DotNet.GenAPI.targets
@@ -16,7 +16,7 @@
     <!-- Sequence ourselves last in PrepareForRun
          This ensures the output has been copied to TargetPath, but still permits
          us to participate in FileWrites. -->
-    <PrepareForRunDependsOn Condition="'$(RunGenerateReferenceAssemblySource)' == 'true'">
+    <PrepareForRunDependsOn Condition="'$(GenerateReferenceAssemblySource)' == 'true'">
       $(PrepareForRunDependsOn);
       GenerateReferenceAssemblySource;
     </PrepareForRunDependsOn>


### PR DESCRIPTION
This will disable the Desktop GenApi target unless the user opts-in by setting `RunGenerateReferenceAssemblySource=true`

@weshaggard PTAL