### PR TITLE
Make SignTool ignore .dylib files.

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -19,12 +19,11 @@
       The certificate can be overriden using the StrongNameSignInfo or the FileSignInfo item group.
     -->
     <FileExtensionSignInfo Include=".jar" CertificateName="MicrosoftJAR" />
-    <FileExtensionSignInfo Include=".dylib" CertificateName="Apple" />
     <FileExtensionSignInfo Include=".js;.ps1;.psd1;.psm1;.psc1" CertificateName="Microsoft400" />
     <FileExtensionSignInfo Include=".dll;.exe" CertificateName="MicrosoftSHA2" />
     <FileExtensionSignInfo Include=".nupkg" CertificateName="NuGet" />
     <FileExtensionSignInfo Include=".vsix" CertificateName="VsixSHA2" />
-    <FileExtensionSignInfo Include=".zip" CertificateName="None" />
+    <FileExtensionSignInfo Include=".zip;.dylib" CertificateName="None" />
   </ItemGroup>
 
   <!-- Allow repository to customize signing configuration -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -23,7 +23,7 @@
     <FileExtensionSignInfo Include=".dll;.exe" CertificateName="MicrosoftSHA2" />
     <FileExtensionSignInfo Include=".nupkg" CertificateName="NuGet" />
     <FileExtensionSignInfo Include=".vsix" CertificateName="VsixSHA2" />
-    <FileExtensionSignInfo Include=".zip;.dylib" CertificateName="None" />
+    <FileExtensionSignInfo Include=".zip" CertificateName="None" />
   </ItemGroup>
 
   <!-- Allow repository to customize signing configuration -->


### PR DESCRIPTION
Fixes: #858 

We don't need to sign .dylib files for now, so let's ignore them and not fail the build.