### PR TITLE
Have VersionResourceSerializer take Version objects

### DIFF
--- a/src/Microsoft.DotNet.GenFacades/GenFacades.cs
+++ b/src/Microsoft.DotNet.GenFacades/GenFacades.cs
@@ -666,18 +666,19 @@ namespace Microsoft.DotNet.GenFacades
             private void AddWin32VersionResource(string contractLocation, Assembly facade)
             {
                 var versionInfo = FileVersionInfo.GetVersionInfo(contractLocation);
+                Version version = new Version(versionInfo.FileMajorPart, versionInfo.FileMinorPart, versionInfo.FileBuildPart, versionInfo.FilePrivatePart);
                 var versionSerializer = new VersionResourceSerializer(
                     true,
                     versionInfo.Comments,
                     versionInfo.CompanyName,
                     versionInfo.FileDescription,
-                    _assemblyFileVersion == null ? versionInfo.FileVersion : _assemblyFileVersion.ToString(),
+                    version,
                     versionInfo.InternalName,
                     versionInfo.LegalCopyright,
                     versionInfo.LegalTrademarks,
                     versionInfo.OriginalFilename,
                     versionInfo.ProductName,
-                    _assemblyFileVersion == null ? versionInfo.ProductVersion : _assemblyFileVersion.ToString(),
+                    version,
                     facade.Version);
 
                 using (var stream = new MemoryStream())

--- a/src/Microsoft.DotNet.GenFacades/GenFacades.cs
+++ b/src/Microsoft.DotNet.GenFacades/GenFacades.cs
@@ -666,19 +666,20 @@ namespace Microsoft.DotNet.GenFacades
             private void AddWin32VersionResource(string contractLocation, Assembly facade)
             {
                 var versionInfo = FileVersionInfo.GetVersionInfo(contractLocation);
-                Version version = new Version(versionInfo.FileMajorPart, versionInfo.FileMinorPart, versionInfo.FileBuildPart, versionInfo.FilePrivatePart);
+                Version fileVersion = new Version(versionInfo.FileMajorPart, versionInfo.FileMinorPart, versionInfo.FileBuildPart, versionInfo.FilePrivatePart);
+                Version productVersion = new Version(versionInfo.ProductMajorPart, versionInfo.ProductMinorPart, versionInfo.ProductBuildPart, versionInfo.ProductPrivatePart);
                 var versionSerializer = new VersionResourceSerializer(
                     true,
                     versionInfo.Comments,
                     versionInfo.CompanyName,
                     versionInfo.FileDescription,
-                    version,
+                    fileVersion,
                     versionInfo.InternalName,
                     versionInfo.LegalCopyright,
                     versionInfo.LegalTrademarks,
                     versionInfo.OriginalFilename,
                     versionInfo.ProductName,
-                    version,
+                    productVersion,
                     facade.Version);
 
                 using (var stream = new MemoryStream())

--- a/src/Microsoft.DotNet.GenFacades/VersionResourceSerializer.cs
+++ b/src/Microsoft.DotNet.GenFacades/VersionResourceSerializer.cs
@@ -20,14 +20,14 @@ namespace Microsoft.DotNet.GenFacades
         private readonly string _commentsContents;
         private readonly string _companyNameContents;
         private readonly string _fileDescriptionContents;
-        private readonly Version _fileVersionContents;
+        private readonly Version _fileVersion;
         private readonly string _internalNameContents;
         private readonly string _legalCopyrightContents;
         private readonly string _legalTrademarksContents;
         private readonly string _originalFileNameContents;
         private readonly string _productNameContents;
-        private readonly Version _productVersionContents;
-        private readonly Version _assemblyVersionContents;
+        private readonly Version _productVersion;
+        private readonly Version _assemblyVersion;
 
         private const string vsVersionInfoKey = "VS_VERSION_INFO";
         private const string varFileInfoKey = "VarFileInfo";
@@ -47,14 +47,14 @@ namespace Microsoft.DotNet.GenFacades
             _commentsContents = comments;
             _companyNameContents = companyName;
             _fileDescriptionContents = fileDescription;
-            _fileVersionContents = fileVersion;
+            _fileVersion = fileVersion;
             _internalNameContents = internalName;
             _legalCopyrightContents = legalCopyright;
             _legalTrademarksContents = legalTrademark;
             _originalFileNameContents = originalFileName;
             _productNameContents = productName;
-            _productVersionContents = productVersion;
-            _assemblyVersionContents = assemblyVersion;
+            _productVersion = productVersion;
+            _assemblyVersion = assemblyVersion;
             _langIdAndCodePageKey = System.String.Format("{0:x4}{1:x4}", 0 /*langId*/, CP_WINUNICODE /*codepage*/);
         }
 
@@ -66,14 +66,14 @@ namespace Microsoft.DotNet.GenFacades
             if (_commentsContents != null) yield return new KeyValuePair<string, string>("Comments", _commentsContents);
             if (_companyNameContents != null) yield return new KeyValuePair<string, string>("CompanyName", _companyNameContents);
             if (_fileDescriptionContents != null) yield return new KeyValuePair<string, string>("FileDescription", _fileDescriptionContents);
-            if (_fileVersionContents != null) yield return new KeyValuePair<string, string>("FileVersion", _fileVersionContents.ToString());
+            if (_fileVersion != null) yield return new KeyValuePair<string, string>("FileVersion", _fileVersion.ToString());
             if (_internalNameContents != null) yield return new KeyValuePair<string, string>("InternalName", _internalNameContents);
             if (_legalCopyrightContents != null) yield return new KeyValuePair<string, string>("LegalCopyright", _legalCopyrightContents);
             if (_legalTrademarksContents != null) yield return new KeyValuePair<string, string>("LegalTrademarks", _legalTrademarksContents);
             if (_originalFileNameContents != null) yield return new KeyValuePair<string, string>("OriginalFilename", _originalFileNameContents);
             if (_productNameContents != null) yield return new KeyValuePair<string, string>("ProductName", _productNameContents);
-            if (_productVersionContents != null) yield return new KeyValuePair<string, string>("ProductVersion", _productVersionContents.ToString());
-            if (_assemblyVersionContents != null) yield return new KeyValuePair<string, string>("Assembly Version", _assemblyVersionContents.ToString());
+            if (_productVersion != null) yield return new KeyValuePair<string, string>("ProductVersion", _productVersion.ToString());
+            if (_assemblyVersion != null) yield return new KeyValuePair<string, string>("Assembly Version", _assemblyVersion.ToString());
         }
 
         private uint FileType { get { return (_isDll) ? VFT_DLL : VFT_APP; } }
@@ -82,10 +82,10 @@ namespace Microsoft.DotNet.GenFacades
         {
             writer.Write((DWORD)0xFEEF04BD);
             writer.Write((DWORD)0x00010000);
-            writer.Write((DWORD)(_fileVersionContents.Major << 16) | (uint)_fileVersionContents.Minor);
-            writer.Write((DWORD)(_fileVersionContents.Build << 16) | (uint)_fileVersionContents.Revision);
-            writer.Write((DWORD)(_productVersionContents.Major << 16) | (uint)_productVersionContents.Minor);
-            writer.Write((DWORD)(_productVersionContents.Build << 16) | (uint)_productVersionContents.Revision);
+            writer.Write((DWORD)(_fileVersion.Major << 16) | (uint)_fileVersion.Minor);
+            writer.Write((DWORD)(_fileVersion.Build << 16) | (uint)_fileVersion.Revision);
+            writer.Write((DWORD)(_productVersion.Major << 16) | (uint)_productVersion.Minor);
+            writer.Write((DWORD)(_productVersion.Build << 16) | (uint)_productVersion.Revision);
             writer.Write((DWORD)0x0000003F);   //VS_FFI_FILEFLAGSMASK  (EDMAURER) really? all these bits are valid?
             writer.Write((DWORD)0);    //file flags
             writer.Write((DWORD)0x00000004);   //VOS__WINDOWS32

--- a/src/Microsoft.DotNet.GenFacades/VersionResourceSerializer.cs
+++ b/src/Microsoft.DotNet.GenFacades/VersionResourceSerializer.cs
@@ -20,13 +20,13 @@ namespace Microsoft.DotNet.GenFacades
         private readonly string _commentsContents;
         private readonly string _companyNameContents;
         private readonly string _fileDescriptionContents;
-        private readonly string _fileVersionContents;
+        private readonly Version _fileVersionContents;
         private readonly string _internalNameContents;
         private readonly string _legalCopyrightContents;
         private readonly string _legalTrademarksContents;
         private readonly string _originalFileNameContents;
         private readonly string _productNameContents;
-        private readonly string _productVersionContents;
+        private readonly Version _productVersionContents;
         private readonly Version _assemblyVersionContents;
 
         private const string vsVersionInfoKey = "VS_VERSION_INFO";
@@ -39,8 +39,8 @@ namespace Microsoft.DotNet.GenFacades
         private const ushort sizeVS_FIXEDFILEINFO = sizeof(DWORD) * 13;
         private readonly bool _isDll;
 
-        internal VersionResourceSerializer(bool isDll, string comments, string companyName, string fileDescription, string fileVersion,
-            string internalName, string legalCopyright, string legalTrademark, string originalFileName, string productName, string productVersion,
+        internal VersionResourceSerializer(bool isDll, string comments, string companyName, string fileDescription, Version fileVersion,
+            string internalName, string legalCopyright, string legalTrademark, string originalFileName, string productName, Version productVersion,
             Version assemblyVersion)
         {
             _isDll = isDll;
@@ -66,13 +66,13 @@ namespace Microsoft.DotNet.GenFacades
             if (_commentsContents != null) yield return new KeyValuePair<string, string>("Comments", _commentsContents);
             if (_companyNameContents != null) yield return new KeyValuePair<string, string>("CompanyName", _companyNameContents);
             if (_fileDescriptionContents != null) yield return new KeyValuePair<string, string>("FileDescription", _fileDescriptionContents);
-            if (_fileVersionContents != null) yield return new KeyValuePair<string, string>("FileVersion", _fileVersionContents);
+            if (_fileVersionContents != null) yield return new KeyValuePair<string, string>("FileVersion", _fileVersionContents.ToString());
             if (_internalNameContents != null) yield return new KeyValuePair<string, string>("InternalName", _internalNameContents);
             if (_legalCopyrightContents != null) yield return new KeyValuePair<string, string>("LegalCopyright", _legalCopyrightContents);
             if (_legalTrademarksContents != null) yield return new KeyValuePair<string, string>("LegalTrademarks", _legalTrademarksContents);
             if (_originalFileNameContents != null) yield return new KeyValuePair<string, string>("OriginalFilename", _originalFileNameContents);
             if (_productNameContents != null) yield return new KeyValuePair<string, string>("ProductName", _productNameContents);
-            if (_productVersionContents != null) yield return new KeyValuePair<string, string>("ProductVersion", _productVersionContents);
+            if (_productVersionContents != null) yield return new KeyValuePair<string, string>("ProductVersion", _productVersionContents.ToString());
             if (_assemblyVersionContents != null) yield return new KeyValuePair<string, string>("Assembly Version", _assemblyVersionContents.ToString());
         }
 
@@ -80,24 +80,12 @@ namespace Microsoft.DotNet.GenFacades
 
         private void WriteVSFixedFileInfo(BinaryWriter writer)
         {
-            //There's nothing guaranteeing that these are n.n.n.n format.
-            //The documentation says that if they're not that format the behavior is undefined.
-            Version fileVersion;
-            // For the File & Product Version, we take the first portion of the string before any whitespace,
-            // in case there is extraneous information (e.g. '@BuiltBy') after the version number.
-            if (!Version.TryParse(_fileVersionContents.Split(null)[0], out fileVersion))
-                throw new ArgumentException($"error: File Version could not be parsed: {_fileVersionContents}");
-
-            Version productVersion;
-            if (!Version.TryParse(_productVersionContents.Split(null)[0], out productVersion))
-                throw new ArgumentException($"error: Product Version could not be parsed: {_productVersionContents}");
-
             writer.Write((DWORD)0xFEEF04BD);
             writer.Write((DWORD)0x00010000);
-            writer.Write((DWORD)(fileVersion.Major << 16) | (uint)fileVersion.Minor);
-            writer.Write((DWORD)(fileVersion.Build << 16) | (uint)fileVersion.Revision);
-            writer.Write((DWORD)(productVersion.Major << 16) | (uint)productVersion.Minor);
-            writer.Write((DWORD)(productVersion.Build << 16) | (uint)productVersion.Revision);
+            writer.Write((DWORD)(_fileVersionContents.Major << 16) | (uint)_fileVersionContents.Minor);
+            writer.Write((DWORD)(_fileVersionContents.Build << 16) | (uint)_fileVersionContents.Revision);
+            writer.Write((DWORD)(_productVersionContents.Major << 16) | (uint)_productVersionContents.Minor);
+            writer.Write((DWORD)(_productVersionContents.Build << 16) | (uint)_productVersionContents.Revision);
             writer.Write((DWORD)0x0000003F);   //VS_FFI_FILEFLAGSMASK  (EDMAURER) really? all these bits are valid?
             writer.Write((DWORD)0);    //file flags
             writer.Write((DWORD)0x00000004);   //VOS__WINDOWS32


### PR DESCRIPTION
This allows us to stop using the string->Version parsing logic in Version.cs - rather we construct a Version object from FileVersionInfo's 4 parts of the version number.

@weshaggard PTAL