### PR TITLE
Packing DarcLib

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Microsoft.DotNet.DarcLib.csproj
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Microsoft.DotNet.DarcLib.csproj
@@ -5,6 +5,9 @@
     <LangVersion>7.1</LangVersion>
     <NoWarn>$(NoWarn);NU1701</NoWarn>
     <SignAssembly>false</SignAssembly>
+    <IsPackable>true</IsPackable>
+    <Description>Darc Library</Description>
+    <PackageTags>Arcade Darc Dependency Flow</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
When we do `dotnet tool install` we go and try fetching all the dependencies from feeds is not present in the NugetFallbackFolder so we need `DarcLib` to also be published