### PR TITLE
Pack Darc project as tool

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Microsoft.DotNet.Darc.csproj
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Microsoft.DotNet.Darc.csproj
@@ -8,6 +8,8 @@
     <IsPackable>true</IsPackable>
     <Description>Darc CLI</Description>
     <PackageTags>Arcade Darc CLI Dependency Flow</PackageTags>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>darc</ToolCommandName>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In order for the darc bootstrap scripts to fully function we need at least one version of the darc package to be packed as tool.