### PR TITLE
Accept ItemGroup with certificate descriptors

### DIFF
--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -88,7 +88,7 @@ namespace Microsoft.DotNet.SignTool.Tests
             Dictionary<ExplicitCertificateKey, string> signingOverridingInfos,
             Dictionary<string, SignInfo> extensionsSignInfo,
             string[] expectedXmlElementsPerSingingRound,
-            List<string> dualCertificates = default)
+            string[] dualCertificates = null)
         {
             var buildEngine = new FakeBuildEngine();
 
@@ -122,7 +122,7 @@ namespace Microsoft.DotNet.SignTool.Tests
             Dictionary<string, SignInfo> extensionsSignInfo,
             string[] expected,
             string[] expectedCopyFiles = null,
-            List<string> dualCertificates = default)
+            string[] dualCertificates = null)
         {
             var task = new SignToolTask { BuildEngine = new FakeBuildEngine() };
             var signingInput = new Configuration(_tmpDir, itemsToSign, strongNameSignInfo, signingOverridingInfos, extensionsSignInfo, dualCertificates, task.Log).GenerateListOfFiles();
@@ -142,7 +142,7 @@ namespace Microsoft.DotNet.SignTool.Tests
             var FileSignInfo = new Dictionary<ExplicitCertificateKey, string>();
 
             var task = new SignToolTask { BuildEngine = new FakeBuildEngine() };
-            var signingInput = new Configuration(_tmpDir, ExplicitSignItems, StrongNameSignInfo, FileSignInfo, s_fileExtensionSignInfo, new List<string>(), task.Log).GenerateListOfFiles();
+            var signingInput = new Configuration(_tmpDir, ExplicitSignItems, StrongNameSignInfo, FileSignInfo, s_fileExtensionSignInfo, null, task.Log).GenerateListOfFiles();
 
             Assert.Empty(signingInput.FilesToSign);
             Assert.Empty(signingInput.ZipDataMap);
@@ -724,7 +724,7 @@ $@"
                 GetResourcePath("SignedLibrary.dll")
             };
 
-            var dualCertificates = new List<string>() {
+            var dualCertificates = new string[] {
                 "DualCertificateName"
             };
 
@@ -739,8 +739,7 @@ $@"
             {
                 $"File 'SignedLibrary.dll' TargetFramework='.NETCoreApp,Version=v2.0' Certificate='{dualCertificates.First()}'",
             },
-            null,
-            dualCertificates);
+            dualCertificates : dualCertificates);
         }
     }
 }

--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -87,7 +87,8 @@ namespace Microsoft.DotNet.SignTool.Tests
             Dictionary<string, SignInfo> strongNameSignInfo,
             Dictionary<ExplicitCertificateKey, string> signingOverridingInfos,
             Dictionary<string, SignInfo> extensionsSignInfo,
-            string[] expectedXmlElementsPerSingingRound)
+            string[] expectedXmlElementsPerSingingRound,
+            List<string> dualCertificates = default)
         {
             var buildEngine = new FakeBuildEngine();
 
@@ -99,7 +100,7 @@ namespace Microsoft.DotNet.SignTool.Tests
             var signToolArgs = new SignToolArgs(_tmpDir, microBuildCorePath: "MicroBuildCorePath", testSign: true, msBuildPath: null, _tmpDir, enclosingDir: "");
 
             var signTool = new FakeSignTool(signToolArgs);
-            var signingInput = new Configuration(signToolArgs.TempDir, itemsToSign, strongNameSignInfo, signingOverridingInfos, extensionsSignInfo, task.Log).GenerateListOfFiles();
+            var signingInput = new Configuration(signToolArgs.TempDir, itemsToSign, strongNameSignInfo, signingOverridingInfos, extensionsSignInfo, dualCertificates, task.Log).GenerateListOfFiles();
             var util = new BatchSignUtil(task.BuildEngine, task.Log, signTool, signingInput);
 
             util.Go();
@@ -120,10 +121,11 @@ namespace Microsoft.DotNet.SignTool.Tests
             Dictionary<ExplicitCertificateKey, string> signingOverridingInfos,
             Dictionary<string, SignInfo> extensionsSignInfo,
             string[] expected,
-            string[] expectedCopyFiles = null)
+            string[] expectedCopyFiles = null,
+            List<string> dualCertificates = default)
         {
             var task = new SignToolTask { BuildEngine = new FakeBuildEngine() };
-            var signingInput = new Configuration(_tmpDir, itemsToSign, strongNameSignInfo, signingOverridingInfos, extensionsSignInfo, task.Log).GenerateListOfFiles();
+            var signingInput = new Configuration(_tmpDir, itemsToSign, strongNameSignInfo, signingOverridingInfos, extensionsSignInfo, dualCertificates, task.Log).GenerateListOfFiles();
 
             AssertEx.Equal(expected, signingInput.FilesToSign.Select(f => f.ToString()));
             AssertEx.Equal(expectedCopyFiles ?? Array.Empty<string>(), signingInput.FilesToCopy.Select(f => $"{f.Key} -> {f.Value}"));
@@ -140,7 +142,7 @@ namespace Microsoft.DotNet.SignTool.Tests
             var FileSignInfo = new Dictionary<ExplicitCertificateKey, string>();
 
             var task = new SignToolTask { BuildEngine = new FakeBuildEngine() };
-            var signingInput = new Configuration(_tmpDir, ExplicitSignItems, StrongNameSignInfo, FileSignInfo, s_fileExtensionSignInfo, task.Log).GenerateListOfFiles();
+            var signingInput = new Configuration(_tmpDir, ExplicitSignItems, StrongNameSignInfo, FileSignInfo, s_fileExtensionSignInfo, new List<string>(), task.Log).GenerateListOfFiles();
 
             Assert.Empty(signingInput.FilesToSign);
             Assert.Empty(signingInput.ZipDataMap);
@@ -714,7 +716,7 @@ $@"
         }
 
         [Fact]
-        public void ValidateAppendingCertificate_MicrosoftDual()
+        public void ValidateAppendingCertificate()
         {
             // List of files to be considered for signing
             var itemsToSign = new[]
@@ -722,39 +724,23 @@ $@"
                 GetResourcePath("SignedLibrary.dll")
             };
 
+            var dualCertificates = new List<string>() {
+                "DualCertificateName"
+            };
+
             var signingInformation = new Dictionary<string, SignInfo>()
             {
-                { "31bf3856ad364e35", new SignInfo(SignToolConstants.Certificate_Microsoft3rdPartyAppComponentDual, null) }
+                { "31bf3856ad364e35", new SignInfo(dualCertificates.First(), null) }
             };
 
             var signingOverridingInformation = new Dictionary<ExplicitCertificateKey, string>();
 
             ValidateFileSignInfos(itemsToSign, signingInformation, signingOverridingInformation, s_fileExtensionSignInfo, new[]
             {
-                $"File 'SignedLibrary.dll' TargetFramework='.NETCoreApp,Version=v2.0' Certificate='{SignToolConstants.Certificate_Microsoft3rdPartyAppComponentDual}'",
-            });
-        }
-
-        [Fact]
-        public void ValidateAppendingCertificate_MicrosoftSHA2()
-        {
-            // List of files to be considered for signing
-            var itemsToSign = new[]
-            {
-                GetResourcePath("SignedLibrary.dll")
-            };
-
-            var signingInformation = new Dictionary<string, SignInfo>()
-            {
-                { "31bf3856ad364e35", new SignInfo(SignToolConstants.Certificate_Microsoft3rdPartyAppComponentSha2, null) }
-            };
-
-            var signingOverridingInformation = new Dictionary<ExplicitCertificateKey, string>();
-
-            ValidateFileSignInfos(itemsToSign, signingInformation, signingOverridingInformation, s_fileExtensionSignInfo, new[]
-            {
-                $"File 'SignedLibrary.dll' TargetFramework='.NETCoreApp,Version=v2.0' Certificate='{SignToolConstants.Certificate_Microsoft3rdPartyAppComponentSha2}'",
-            });
+                $"File 'SignedLibrary.dll' TargetFramework='.NETCoreApp,Version=v2.0' Certificate='{dualCertificates.First()}'",
+            },
+            null,
+            dualCertificates);
         }
     }
 }

--- a/src/Microsoft.DotNet.SignTool/src/Configuration.cs
+++ b/src/Microsoft.DotNet.SignTool/src/Configuration.cs
@@ -60,13 +60,20 @@ namespace Microsoft.DotNet.SignTool
         private readonly Dictionary<SignedFileContentKey, FileSignInfo> _filesByContentKey;
 
         /// <summary>
+        /// This is a list of the friendly name of certificates that can be used to
+        /// sign already signed binaries.
+        /// </summary>
+        private readonly List<string> _dualCertificates;
+        
+        /// <summary>
         /// A list of files whose content needs to be overwritten by signed content from a different file.
         /// Copy the content of file with full path specified in Key to file with full path specified in Value.
         /// </summary>
         internal List<KeyValuePair<string, string>> _filesToCopy;
 
         public Configuration(string tempDir, string[] explicitSignList, Dictionary<string, SignInfo> defaultSignInfoForPublicKeyToken, 
-            Dictionary<ExplicitCertificateKey, string> explicitCertificates, Dictionary<string, SignInfo> extensionSignInfo, TaskLoggingHelper log)
+            Dictionary<ExplicitCertificateKey, string> explicitCertificates, Dictionary<string, SignInfo> extensionSignInfo, 
+            List<string> dualCertificates, TaskLoggingHelper log)
         {
             Debug.Assert(tempDir != null);
             Debug.Assert(explicitSignList != null && !explicitSignList.Any(i => i == null));
@@ -83,6 +90,7 @@ namespace Microsoft.DotNet.SignTool
             _zipDataMap = new Dictionary<ImmutableArray<byte>, ZipData>(ByteSequenceComparer.Instance);
             _filesByContentKey = new Dictionary<SignedFileContentKey, FileSignInfo>();
             _explicitSignList = explicitSignList;
+            _dualCertificates = dualCertificates;
         }
 
         internal BatchSignInput GenerateListOfFiles()
@@ -175,9 +183,7 @@ namespace Microsoft.DotNet.SignTool
 
             if (hasSignInfo)
             {
-                if (isAlreadySigned &&
-                    !signInfo.Certificate.Equals(SignToolConstants.Certificate_Microsoft3rdPartyAppComponentDual, StringComparison.OrdinalIgnoreCase) &&
-                    !signInfo.Certificate.Equals(SignToolConstants.Certificate_Microsoft3rdPartyAppComponentSha2, StringComparison.OrdinalIgnoreCase))
+                if (isAlreadySigned && !_dualCertificates.Contains(signInfo.Certificate))
                 {
                     return new FileSignInfo(fullPath, hash, SignInfo.AlreadySigned);
                 }

--- a/src/Microsoft.DotNet.SignTool/src/Configuration.cs
+++ b/src/Microsoft.DotNet.SignTool/src/Configuration.cs
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.SignTool
         /// This is a list of the friendly name of certificates that can be used to
         /// sign already signed binaries.
         /// </summary>
-        private readonly List<string> _dualCertificates;
+        private readonly string[] _dualCertificates;
         
         /// <summary>
         /// A list of files whose content needs to be overwritten by signed content from a different file.
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.SignTool
 
         public Configuration(string tempDir, string[] explicitSignList, Dictionary<string, SignInfo> defaultSignInfoForPublicKeyToken, 
             Dictionary<ExplicitCertificateKey, string> explicitCertificates, Dictionary<string, SignInfo> extensionSignInfo, 
-            List<string> dualCertificates, TaskLoggingHelper log)
+            string[] dualCertificates, TaskLoggingHelper log)
         {
             Debug.Assert(tempDir != null);
             Debug.Assert(explicitSignList != null && !explicitSignList.Any(i => i == null));
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.SignTool
             _zipDataMap = new Dictionary<ImmutableArray<byte>, ZipData>(ByteSequenceComparer.Instance);
             _filesByContentKey = new Dictionary<SignedFileContentKey, FileSignInfo>();
             _explicitSignList = explicitSignList;
-            _dualCertificates = dualCertificates;
+            _dualCertificates = dualCertificates ?? new string[0];
         }
 
         internal BatchSignInput GenerateListOfFiles()

--- a/src/Microsoft.DotNet.SignTool/src/SignToolConstants.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolConstants.cs
@@ -7,10 +7,5 @@ namespace Microsoft.DotNet.SignTool
     internal static class SignToolConstants
     {
         public const string IgnoreFileCertificateSentinel = "None";
-
-        // These certificate are special because they are used when we want 
-        // to sign a file that is already signed.
-        public const string Certificate_Microsoft3rdPartyAppComponentDual = "3PartyDual";
-        public const string Certificate_Microsoft3rdPartyAppComponentSha2 = "3PartySHA2";
     }
 }

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -148,13 +148,13 @@ namespace Microsoft.DotNet.SignTool
             util.Go();
         }
 
-        private List<string> ParseCertificateInfo()
+        private string[] ParseCertificateInfo()
         {
             var dualCertificates = CertificatesSignInfo?
                 .Where(item => item.GetMetadata("DualSigningAllowed").Equals("true", StringComparison.OrdinalIgnoreCase))
                 .Select(item => item.ItemSpec);
 
-            return dualCertificates?.ToList() ?? new List<string>();
+            return dualCertificates?.ToArray();
         }
 
         private string GetEnclosingDirectoryOfItemsToSign()

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -151,7 +151,7 @@ namespace Microsoft.DotNet.SignTool
         private List<string> ParseCertificateInfo()
         {
             var dualCertificates = CertificatesSignInfo?
-                .Where(item => item.GetMetadata("DualSigningAllowed")?.Equals("true", StringComparison.OrdinalIgnoreCase) ?? false)
+                .Where(item => item.GetMetadata("DualSigningAllowed").Equals("true", StringComparison.OrdinalIgnoreCase))
                 .Select(item => item.ItemSpec);
 
             return dualCertificates?.ToList() ?? new List<string>();

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.SignTool
         /// Currently attributes are: 
         ///     DualSigningAllowed:boolean - Tells whether this certificate can be used to sign already signed files.
         /// </summary>
-        public ITaskItem[] CertificatesSignInfo { get; private set; }
+        public ITaskItem[] CertificatesSignInfo { get; set; }
         
         /// <summary>
         /// Path to msbuild.exe. Required if <see cref="DryRun"/> is <c>false</c>.
@@ -151,7 +151,7 @@ namespace Microsoft.DotNet.SignTool
         private List<string> ParseCertificateInfo()
         {
             var dualCertificates = CertificatesSignInfo?
-                .Where(item => item.GetMetadata("DualSigningAllowed").Equals("true", StringComparison.OrdinalIgnoreCase))
+                .Where(item => item.GetMetadata("DualSigningAllowed")?.Equals("true", StringComparison.OrdinalIgnoreCase) ?? false)
                 .Select(item => item.ItemSpec);
 
             return dualCertificates?.ToList() ?? new List<string>();


### PR DESCRIPTION
Closes: #900 

**Changes:**

- **SignToolContants.cs :** just removed the hard coded names that we used to use.
- **Configuration.cs :** changed to accept new parameter and also consider it when the file is already signed.
- **SignToolTask.cs :** accept and parse new parameter
- **SignToolTests.cs :** inform the new parameter when constructing the Configuration object. Adjust the existing tests for dual certificates.