### PR TITLE
[Darc CLI] Get default channel associations

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDefaultChannelsOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/GetDefaultChannelsOperation.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.Darc.Helpers;
+using Microsoft.DotNet.Darc.Options;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.Maestro.Client.Models;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Darc.Operations
+{
+    /// <summary>
+    /// Implements an operation to get information about the default channel associations.
+    /// </summary>
+    internal class GetDefaultChannelsOperation : Operation
+    {
+        GetDefaultChannelCommandLineOptions _options;
+        public GetDefaultChannelsOperation(GetDefaultChannelCommandLineOptions options)
+            : base(options)
+        {
+            _options = options;
+        }
+
+        /// <summary>
+        /// Retrieve information about the default association between builds of a specific branch/repo
+        /// and a channel.
+        /// </summary>
+        /// <returns></returns>
+        public override async Task<int> ExecuteAsync()
+        {
+            try
+            {
+                DarcSettings darcSettings = LocalCommands.GetSettings(_options, Logger);
+                // No need to set up a git type or PAT here.
+                Remote remote = new Remote(darcSettings, Logger);
+
+                var defaultChannels = (await remote.GetDefaultChannelsAsync()).Where(defaultChannel =>
+                {
+                    return (string.IsNullOrEmpty(_options.SourceRepository) ||
+                        defaultChannel.Repository.Contains(_options.SourceRepository, StringComparison.OrdinalIgnoreCase)) &&
+                    (string.IsNullOrEmpty(_options.Branch) ||
+                        defaultChannel.Branch.Contains(_options.Branch, StringComparison.OrdinalIgnoreCase)) &&
+                    (string.IsNullOrEmpty(_options.Channel) ||
+                        defaultChannel.Channel.Name.Contains(_options.Channel, StringComparison.OrdinalIgnoreCase));
+                });
+
+                if (defaultChannels.Count() == 0)
+                {
+                    Console.WriteLine("No matching channels were found.");
+                }
+
+                // Write out a simple list of each channel's name
+                foreach (var defaultChannel in defaultChannels)
+                {
+                    Console.WriteLine($"{defaultChannel.Repository} @ {defaultChannel.Branch} -> {defaultChannel.Channel.Name}");
+                }
+
+                return Constants.SuccessCode;
+            }
+            catch (Exception e)
+            {
+                Logger.LogError(e, "Error: Failed to retrieve default channel information.");
+                return Constants.ErrorCode;
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/GetDefaultChannelsCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/GetDefaultChannelsCommandLineOptions.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommandLine;
+
+namespace Microsoft.DotNet.Darc.Options
+{
+    [Verb("get-default-channels", HelpText = "Gets a list of repo+branch combinations and their associated default channels for builds.")]
+    internal class GetDefaultChannelCommandLineOptions : CommandLineOptions
+    {
+        [Option("source-repo", HelpText = "Filter by a specific source repository. Matches on substring.")]
+        public string SourceRepository { get; set; }
+        [Option("branch", HelpText = "Filter by a branch. Matches on substring.")]
+        public string Branch { get; set; }
+        [Option("channel", HelpText = "Filter by a channel name. Matches on substring.")]
+        public string Channel { get; set; }
+
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/Darc/Program.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Program.cs
@@ -19,7 +19,8 @@ namespace Microsoft.DotNet.Darc
                                                  GetChannelsCommandLineOptions,
                                                  GetSubscriptionsCommandLineOptions,
                                                  AddSubscriptionCommandLineOptions,
-                                                 DeleteSubscriptionCommandLineOptions>(args)
+                                                 DeleteSubscriptionCommandLineOptions,
+                                                 GetDefaultChannelCommandLineOptions>(args)
                 .MapResult(
                     (AuthenticateCommandLineOptions opts) => { return RunOperation(new AuthenticateOperation(opts)); },
                     (GetDependenciesCommandLineOptions opts) => { return RunOperation(new GetDependenciesOperation(opts)); },
@@ -28,6 +29,7 @@ namespace Microsoft.DotNet.Darc
                     (GetSubscriptionsCommandLineOptions opts) => { return RunOperation(new GetSubscriptionsOperation(opts)); },
                     (AddSubscriptionCommandLineOptions opts) => { return RunOperation(new AddSubscriptionOperation(opts)); },
                     (DeleteSubscriptionCommandLineOptions opts) => { return RunOperation(new DeleteSubscriptionOperation(opts)); },
+                    (GetDefaultChannelCommandLineOptions opts) => { return RunOperation(new GetDefaultChannelsOperation(opts)); },
                     (errs => 1));
         }
 

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Remote.cs
@@ -55,6 +55,19 @@ namespace Microsoft.DotNet.DarcLib
         }
 
         /// <summary>
+        /// Retrieve a list of default channel associations.
+        /// </summary>
+        /// <param name="repository">Optionally filter by repository</param>
+        /// <param name="branch">Optionally filter by branch</param>
+        /// <param name="channelId">Optionally filter by channel ID</param>
+        /// <returns>Collection of default channels.</returns>
+        public async Task<IEnumerable<DefaultChannel>> GetDefaultChannelsAsync(string repository = null, string branch = null, int? channelId = null)
+        {
+            CheckForValidBarClient();
+            return await _barClient.DefaultChannels.ListAsync(repository, branch, channelId);
+        }
+
+        /// <summary>
         /// Retrieve the list of channels from the build asset registry.
         /// </summary>
         /// <param name="classification">Optional classification to get</param>

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/IRemote.cs
@@ -10,6 +10,8 @@ namespace Microsoft.DotNet.DarcLib
 {
     public interface IRemote
     {
+        Task<IEnumerable<DefaultChannel>> GetDefaultChannelsAsync(string repository = null, string branch = null, int? channelId = null);
+
         Task<Channel> CreateChannelAsync(string name, string classification);
 
         Task<IEnumerable<Subscription>> GetSubscriptionsAsync(string sourceRepo = null, string targetRepo = null, int? channelId = null);


### PR DESCRIPTION
Add get-default-channels verb to the darc CLI.  Retrieves the default channel associations present in the BAR, optionally filtered.