### PR TITLE
wip: Generate SVG badge with version information

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ Arcade is intended to provide well-understood and consistent mechanisms for cons
 VSTS [![Build Status](https://dev.azure.com/dnceng/_apis/public/build/definitions/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/17/badge
 )](https://dev.azure.com/dnceng/public/_build/index?definitionId=17&branchName=master)
 
+### Latest build
+
+Channel        | Latest Build
+---------------|:---------------
+master         | [![badge][master-badge]][master-version-txt]
+
+[master-badge]: https://dotnetfeed.blob.core.windows.net/dotnet-core/arcade/channels/master/badge.svg
+[master-version-txt]: https://dotnetfeed.blob.core.windows.net/dotnet-core/arcade/channels/master/version.txt
+
 ## Getting Started
 
 Packages are published daily to our tools feed:

--- a/eng/AfterSolutionBuild.targets
+++ b/eng/AfterSolutionBuild.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="Build">
+    <MSBuild Projects="$(MSBuildThisFileDirectory)badge.proj" Targets="Build" />
+  </Target>
+</Project>

--- a/eng/badge.proj
+++ b/eng/badge.proj
@@ -1,0 +1,48 @@
+<Project>
+  <PropertyGroup>
+    <!-- Workaround for Imports in ProjectDefaults.props which requires Language to be set. -->
+    <Language>SVG</Language>
+    <!-- Workaround for resx targets which produce errors for unsupported languages -->
+    <DisableResxSourceGeneration>true</DisableResxSourceGeneration>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+
+  <Target Name="GenerateSvgBadge" AfterTargets="Build" DependsOnTargets="GetPackageVersion">
+  
+    <Error Text="Could not determine a value for required property 'PackageVersion'" Condition="'$(PackageVersion)' == ''" />
+
+    <PropertyGroup>
+      <SvgBadgeLabel>version</SvgBadgeLabel>
+      <SvgBadgeValue>$(PackageVersion)</SvgBadgeValue>
+      <SvgBadgeColor>#007EC6</SvgBadgeColor>
+      <SvgBadgeWidth>$([MSBuild]::Add(56, $([MSBuild]::Multiply($(PackageVersion.Length), 6.67))))</SvgBadgeWidth>
+      <SvgBadgeContent>
+<![CDATA[
+<svg xmlns="http://www.w3.org/2000/svg" width="$(SvgBadgeWidth)" height="20">
+    <g>
+        <rect width="$(SvgBadgeWidth)" height="20" rx="0" fill="#007EC6" />
+        <rect width="52" height="20" rx="0" fill="#555"  />
+    </g>
+    <g fill="#fff" text-anchor="left" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="6" y="15" fill="#010101" fill-opacity=".3">$(SvgBadgeLabel)</text>
+        <text x="6" y="14">$(SvgBadgeLabel)</text>
+        <text x="60" y="15" fill="#010101" fill-opacity=".3">$(SvgBadgeValue)</text>
+        <text x="60" y="14">$(SvgBadgeValue)</text>
+    </g>
+</svg>
+]]>
+      </SvgBadgeContent>
+    </PropertyGroup>
+    
+    <WriteLinesToFile File="$(ArtifactsDir)badge.xml" Lines="$(SvgBadgeContent)" Overwrite="true" />
+    <WriteLinesToFile File="$(ArtifactsDir)latest.txt" Lines="$(PackageVersion)" Overwrite="true" />
+  </Target>
+
+  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
+
+  <!-- Dummy targets required to make Microsoft.Common.targets happy -->
+  <Target Name="CreateManifestResourceNames" />
+  <Target Name="CoreCompile" />
+  <Target Name="CopyFilesToOutputDirectory" />
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
@@ -72,6 +72,11 @@
       <PackageVersion Condition="'$(SemanticVersioningV1)' != 'true'">$(Version)+$(_ShortSha)</PackageVersion>
       <PackageVersion Condition="'$(SemanticVersioningV1)' == 'true'">$(Version)-$(_ShortSha)</PackageVersion>
     </PropertyGroup>
+
+    <!-- Ensure PackageVersion is always set when this target runs -->
+    <PropertyGroup Condition="'$(PackageVersion)' == ''">
+      <PackageVersion>$(Version)</PackageVersion>
+    </PropertyGroup>
   </Target>
 
 </Project>


### PR DESCRIPTION
Generate an SVG badge on build that contains the package version. This can be uploaded to an Azure blob store and referenced from README.

TODO:
- [ ] Figure out how to get the value of PackageVersion. It's currently always empty when I run build.cmd
- [ ] Upload badge.svg and latest.txt (must be uploaded with `--content-cache-control="no-cache, no-store, must-revalidate")