### PR TITLE
[Maestro] Include the build id in the asset query

### DIFF
--- a/src/Maestro/Maestro.Web/Api/v2018_07_16/Models/Asset.cs
+++ b/src/Maestro/Maestro.Web/Api/v2018_07_16/Models/Asset.cs
@@ -20,6 +20,7 @@ namespace Maestro.Web.Api.v2018_07_16.Models
             Id = other.Id;
             Name = other.Name;
             Version = other.Version;
+            BuildId = other.BuildId;
             Locations = other.Locations?.Select(al => new AssetLocation(al)).ToList();
         }
 
@@ -28,6 +29,8 @@ namespace Maestro.Web.Api.v2018_07_16.Models
         public string Name { get; }
 
         public string Version { get; }
+
+        public int BuildId { get; set; }
 
         public List<AssetLocation> Locations { get; }
     }


### PR DESCRIPTION
Useful to be able to look up the build from the asset, and thus determine what sha the asset came from.