### PR TITLE
Allow GenFacades to support Desktop msbuild

### DIFF
--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.targets
@@ -31,7 +31,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <_MicrosoftDotNetGenFacadesTaskDir>$(MSBuildThisFileDirectory)../tools/netcoreapp2.1/</_MicrosoftDotNetGenFacadesTaskDir>
+    <_MicrosoftDotNetGenFacadesTaskDir Condition="'$(MSBuildRuntimeType)' == 'core'">$(MSBuildThisFileDirectory)../tools/netcoreapp2.1/</_MicrosoftDotNetGenFacadesTaskDir>
+    <_MicrosoftDotNetGenFacadesTaskDir Condition="'$(MSBuildRuntimeType)' != 'core'">$(MSBuildThisFileDirectory)../tools/net472/</_MicrosoftDotNetGenFacadesTaskDir>
   </PropertyGroup>
 
   <UsingTask TaskName="GenFacadesTask" AssemblyFile="$(_MicrosoftDotNetGenFacadesTaskDir)Microsoft.DotNet.GenFacades.dll" />


### PR DESCRIPTION
For https://github.com/dotnet/arcade/issues/1010

This will allow the GenFacade tool to run on Desktop msbuild

CC @ericstj @weshaggard 