### PR TITLE
Clear disabled package sources 

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,4 +9,7 @@
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
 </configuration>


### PR DESCRIPTION
I was consistently hitting an issue because I often disable the `dotnet-core` feed in my user settings.

Fixes #987 (actually just works around it).