### PR TITLE
Throw exception rather than log error

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
@@ -126,15 +126,12 @@ namespace Microsoft.DotNet.DarcLib
                 {
                     if (versionList.Count == 0)
                     {
-                        _logger.LogError($"No dependencies named '{itemToUpdate.Name}' found.");
+                        throw new DarcException($"No dependencies named '{itemToUpdate.Name}' found.");
                     }
                     else
                     {
-                        _logger.LogError(
-                            "The use of the same asset, even with a different version, is currently not supported.");
+                        throw new DarcException("The use of the same asset, even with a different version, is currently not supported.");
                     }
-
-                    return null;
                 }
 
                 XmlNode nodeToUpdate =


### PR DESCRIPTION
Corefx had a duplicated dependency, which was causing an error in DarcLib.  This is the correct behavior, but the lack of throwing an exception meant that the error propagated into a null ref exception later on.  These should be exceptions, not errors.