### PR TITLE
Fix HelixWait and refactor out FindDotNetCliPackage task

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/FindDotNetCliPackage.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/FindDotNetCliPackage.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.DotNet.Helix.Sdk
+{
+    public class FindDotNetCliPackage : Microsoft.Build.Utilities.Task
+    {
+        private static readonly HttpClient _client = new HttpClient();
+        private const string DotNetCoreReleasesUrl = "https://raw.githubusercontent.com/dotnet/core/master/release-notes/releases.json";
+
+        [Required]
+        public string Version { get; set; }
+
+        [Required]
+        public string Runtime { get; set; }
+
+        /// <summary>
+        ///   'sdk' or 'runtime'
+        /// </summary>
+        [Required]
+        public string PackageType { get; set; }
+
+        [Output]
+        public string PackageUri { get; set; }
+
+        public override bool Execute()
+        {
+            ExecuteAsync().GetAwaiter().GetResult();
+            return !Log.HasLoggedErrors;
+        }
+
+        private async Task ExecuteAsync()
+        {
+            var releases = await GetDotNetCliReleasesAsync();
+            var type = PackageType;
+
+            if (!releases.TryGetValue((type, Version), out var release))
+            {
+                Log.LogError($"Unable to find dotnet cli {type} version {Version}");
+                return;
+            }
+
+            var uriId = type + "-" + Runtime;
+            if (!release.TryGetValue(uriId, out var uri))
+            {
+                Log.LogError($"Dotnet cli {type} version {Version} does not contain a package for {uriId}");
+                return;
+            }
+
+            Log.LogMessage($"Retrieved dotnet cli {type} version {Version} package uri {uri}");
+            PackageUri = uri;
+        }
+
+        private async Task<Dictionary<(string type, string version), Dictionary<string, string>>> GetDotNetCliReleasesAsync()
+        {
+            var result = new Dictionary<(string type, string version), Dictionary<string, string>>();
+            using (var stream = await _client.GetStreamAsync(DotNetCoreReleasesUrl))
+            using (var tReader = new StreamReader(stream))
+            using (var reader = new JsonTextReader(tReader))
+            {
+                var releases = JArray.Load(reader);
+                Log.LogMessage(releases.ToString());
+                foreach (var release in releases.OfType<JObject>())
+                {
+                    var data = release.Properties()
+                        .Where(p => p.Name.StartsWith("runtime") || p.Name.StartsWith("sdk"))
+                        .ToDictionary(p => p.Name, p => p.Value.ToObject<string>());
+                    if (release.TryGetValue("version-sdk", out JToken sdkVersion))
+                    {
+                        result[("sdk", sdkVersion.ToString())] = data;
+                    }
+
+                    if (release.TryGetValue("version-runtime", out JToken runtimeVersion))
+                    {
+                        result[("runtime", runtimeVersion.ToString())] = data;
+                    }
+                }
+            }
+
+            Log.LogMessage(JObject.FromObject(result).ToString());
+            return result;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Helix/Sdk/HelixWait.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/HelixWait.cs
@@ -19,53 +19,36 @@ namespace Microsoft.DotNet.Helix.Sdk
         [Required]
         public ITaskItem[] Jobs { get; set; }
 
-        protected async override Task ExecuteCore()
+        protected override async Task ExecuteCore()
         {
-            bool finished = false;
-            while (!finished)
-            {
-                finished = await WorkItemsFinished();
+            // Wait 1 second to allow helix to register the job creation
+            await Task.Delay(1000);
 
-                await Task.Delay(10000); // Don't overload that Helix API
-            }
+            List<string> jobNames = Jobs.Select(j => j.GetMetadata("Identity")).ToList();
+
+            await Task.WhenAll(jobNames.Select(WaitForHelixJobAsync));
         }
 
-        private async Task<bool> WorkItemsFinished()
+        private async Task WaitForHelixJobAsync(string jobName)
         {
-            foreach (var job in Jobs)
+            await Task.Yield();
+            Log.LogMessage($"Waiting for completion of job {jobName}");
+
+            while (true)
             {
-                var workItemSummary = await HelixApi.Aggregate.JobSummaryMethodAsync(new string[] { "job.source" }, 1, filtername:job.GetMetadata("Identity"));
-                if (workItemSummary.Count < 1)
+                var workItems = await HelixApi.WorkItem.ListAsync(jobName);
+                var waitingCount = workItems.Count(wi => wi.State == "Waiting");
+                var runningCount = workItems.Count(wi => wi.State == "Running");
+                var finishedCount = workItems.Count(wi => wi.State == "Finished");
+                if (waitingCount == 0 && runningCount == 0)
                 {
-                    Log.LogError($"Job {job.GetMetadata("Identity")} not found -- did you authorize this task properly?");
-                    return true;
+                    Log.LogMessage($"Job {jobName} is completed with {finishedCount} finished work items.");
+                    return;
                 }
 
-                int? pass, fail;
-                workItemSummary[0].Data.WorkItemStatus.TryGetValue("pass", out pass);
-                workItemSummary[0].Data.WorkItemStatus.TryGetValue("fail", out fail);
-
-                if ((fail ?? 0) > 0)  // If a work item has failed, we don't need to wait anymore and can just state that a workitem has fireballed
-                {
-                    Log.LogError("One or more work items failed. See Mission Control for more information.");
-                    return true;
-                }
-                else if ((pass ?? 0) < Convert.ToInt32(job.GetMetadata("WorkItemCount")))  // if the workitems haven't finished, we need to keep waiting
-                {
-                    return false;
-                }
-                else  // if they have finished, we should check to see if any of the tests failed. if they have, we can stop early
-                {
-                    int? testFailures;
-                    workItemSummary[0].Data.Analysis[0].Status.TryGetValue("fail", out testFailures);
-                    if ((testFailures ?? 0) > 0)
-                    {
-                        Log.LogError("One or more tests have failed. See Mission Control for more information.");
-                        return true;
-                    }
-                }
+                Log.LogMessage($"Job {jobName} is not yet completed with Waiting: {waitingCount}, Running: {runningCount}, Finished: {finishedCount}");
+                await Task.Delay(10000);
             }
-            return true;
         }
     }
 }

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
@@ -42,6 +42,11 @@
 
   <PropertyGroup>
     <EnableXUnitReporter Condition=" '$(EnableXUnitReporter)' != 'true' ">false</EnableXUnitReporter>
+
+    <IncludeDotNetCli Condition=" '$(IncludeDotNetCli)' != 'true' ">false</IncludeDotNetCli>
+    <DotNetCliPackageType Condition=" '$(DotNetCliPackageType)' == '' ">runtime</DotNetCliPackageType>
+    <DotNetCliVersion Condition=" '$(DotNetCliVersion)' == '' AND '$(DotNetCliPackageType)' == 'runtime' ">2.1.5</DotNetCliVersion>
+    <DotNetCliVersion Condition=" '$(DotNetCliVersion)' == '' AND '$(DotNetCliPackageType)' == 'sdk' ">2.1.403</DotNetCliVersion>
   </PropertyGroup>
 
   <Choose>
@@ -57,14 +62,53 @@
     </Otherwise>
   </Choose>
 
-  <Target Name="AddDotNetSdk" Condition="$(IncludeDotNetSdkVersion)!='' Or $(IncludeDotNetRuntimeVersion)!=''" BeforeTargets="AddXUnitReporter">
+  <!--
+    Select DotNetCliRuntime based on TargetQueue if it isn't set
+    TODO: Use the Helix Queue Info api to determine this information
+  -->
+  <Choose>
+    <When Condition=" '$(DotNetCliRuntime)' != '' ">
+    </When>
+    <When Condition="$(HelixTargetQueue.ToLowerInvariant().StartsWith('windows'))">
+      <PropertyGroup>
+        <DotNetCliRuntime>win-x64</DotNetCliRuntime>
+      </PropertyGroup>
+    </When>
+    <When Condition="$(HelixTargetQueue.ToLowerInvariant().StartsWith('osx'))">
+      <PropertyGroup>
+        <DotNetCliRuntime>mac-x64</DotNetCliRuntime>
+      </PropertyGroup>
+    </When>
+    <When Condition="$(HelixTargetQueue.ToLowerInvariant().Contains('arm32'))">
+      <PropertyGroup>
+        <DotNetCliRuntime>linux-arm-32</DotNetCliRuntime>
+      </PropertyGroup>
+    </When>
+    <When Condition="$(HelixTargetQueue.ToLowerInvariant().Contains('arm64'))">
+      <PropertyGroup>
+        <DotNetCliRuntime>linux-arm-64</DotNetCliRuntime>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <DotNetCliRuntime>linux-x64</DotNetCliRuntime>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
+  <Target Name="AddDotNetSdk" Condition="$(IncludeDotNetCli)" BeforeTargets="Test">
+    <FindDotNetCliPackage Version="$(DotNetCliVersion)" Runtime="$(DotNetCliRuntime)" PackageType="$(DotNetCliPackageType)">
+      <Output TaskParameter="PackageUri" PropertyName="DotNetCliPackageUri"/>
+    </FindDotNetCliPackage>
     <ItemGroup>
-      <HelixCorrelationPayload Include="ignore">
-        <SdkVersion>$(IncludeDotNetSdkVersion)</SdkVersion>
-        <RuntimeVersion>$(IncludeDotNetRuntimeVersion)</RuntimeVersion>
-        <TargetQueue>$(HelixTargetQueue)</TargetQueue>
+      <HelixCorrelationPayload Include="dotnet-cli">
+        <Uri>$(DotNetCliPackageUri)</Uri>
       </HelixCorrelationPayload>
     </ItemGroup>
+    <PropertyGroup>
+      <HelixPreCommands Condition="$(IsPosixShell)">$(HelixPreCommands);export PATH=$HELIX_CORRELATION_PAYLOAD:$PATH</HelixPreCommands>
+      <HelixPreCommands Condition="!$(IsPosixShell)">$(HelixPreCommands);set PATH=%HELIX_CORRELATION_PAYLOAD%%3B%PATH%</HelixPreCommands> <!-- %3B is an escaped ; -->
+    </PropertyGroup>
   </Target>
   
   <Target Name="AddXUnitReporter" Condition="$(EnableXUnitReporter)" BeforeTargets="Test">
@@ -79,6 +123,9 @@
 
   <Target Name="Test"
     DependsOnTargets="$(TestDependsOn)" Returns="@(SentJob)">
+    <PropertyGroup Condition="$(IsPosixShell)">
+      <HelixPreCommands>set -x;$(HelixPreCommands)</HelixPreCommands>
+    </PropertyGroup>
     <SendHelixJob Source="$(HelixSource)"
                   Type="$(HelixType)"
                   Build="$(HelixBuild)"

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MultiQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MultiQueue.targets
@@ -40,6 +40,10 @@
     </CleanDependsOn>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <WaitForWorkItemCompletion Condition="'$(WaitForWorkItemCompletion)' != 'false'">true</WaitForWorkItemCompletion>
+  </PropertyGroup>
+
   <ItemGroup>
     <HelixTargetQueue Include="$(HelixTargetQueues)" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.props
@@ -12,5 +12,6 @@
   </PropertyGroup>
 
   <UsingTask TaskName="SendHelixJob" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)"/>
+  <UsingTask TaskName="FindDotNetCliPackage" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)"/>
   <UsingTask TaskName="HelixWait" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)"/>
 </Project>


### PR DESCRIPTION
This change fixes the HelixWait task to correctly wait until all
workitems in all jobs are finished. I also moved the .Net Cli uri
finding logic into its own task and enabled users to specify the
runtime of dotnet cli to download.