### PR TITLE
Support config definition

### DIFF
--- a/eng/common/templates/phases/publish-build-assets.yml
+++ b/eng/common/templates/phases/publish-build-assets.yml
@@ -1,11 +1,14 @@
 parameters:
   dependsOn: ''
   queue: {}
+  configuration: ''
 phases:
   - phase: Asset_Registry_Publish
     displayName: Publish to Build Asset Registry
     dependsOn: ${{ parameters.dependsOn }}
     queue: ${{ parameters.queue }}
+    variables:
+      config: ${{ parameters.configuration }}
     steps:
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         - task: DownloadBuildArtifacts@0
@@ -20,8 +23,16 @@ phases:
             KeyVaultName: EngKeyVault
             SecretsFilter: 'MaestroAccessToken'
           condition: succeeded()
-        - script: eng\common\publishbuildassets.cmd
-            /p:ManifestsPath='$(Build.StagingDirectory)/Download/AssetManifests'
-            /p:BuildAssetRegistryToken=$(MaestroAccessToken)
-            /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
-          displayName: Publish Build Assets
+        - ${{ if ne(parameters.configuration, '') }}:
+          - script: eng\common\publishbuildassets.cmd
+              /p:ManifestsPath='$(Build.StagingDirectory)/Download/AssetManifests'
+              /p:BuildAssetRegistryToken=$(MaestroAccessToken)
+              /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
+              /p:Configuration=$(config)
+            displayName: Publish Build Assets
+        - ${{ if eq(parameters.configuration, '') }}:
+          - script: eng\common\publishbuildassets.cmd
+              /p:ManifestsPath='$(Build.StagingDirectory)/Download/AssetManifests'
+              /p:BuildAssetRegistryToken=$(MaestroAccessToken)
+              /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
+            displayName: Publish Build Assets

--- a/eng/common/templates/phases/publish-build-assets.yml
+++ b/eng/common/templates/phases/publish-build-assets.yml
@@ -1,7 +1,7 @@
 parameters:
   dependsOn: ''
   queue: {}
-  configuration: ''
+  configuration: 'Debug'
 phases:
   - phase: Asset_Registry_Publish
     displayName: Publish to Build Asset Registry
@@ -23,16 +23,9 @@ phases:
             KeyVaultName: EngKeyVault
             SecretsFilter: 'MaestroAccessToken'
           condition: succeeded()
-        - ${{ if ne(parameters.configuration, '') }}:
-          - script: eng\common\publishbuildassets.cmd
+        - script: eng\common\publishbuildassets.cmd
               /p:ManifestsPath='$(Build.StagingDirectory)/Download/AssetManifests'
               /p:BuildAssetRegistryToken=$(MaestroAccessToken)
               /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
               /p:Configuration=$(config)
-            displayName: Publish Build Assets
-        - ${{ if eq(parameters.configuration, '') }}:
-          - script: eng\common\publishbuildassets.cmd
-              /p:ManifestsPath='$(Build.StagingDirectory)/Download/AssetManifests'
-              /p:BuildAssetRegistryToken=$(MaestroAccessToken)
-              /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
             displayName: Publish Build Assets

--- a/eng/common/templates/phases/publish-build-assets.yml
+++ b/eng/common/templates/phases/publish-build-assets.yml
@@ -1,11 +1,16 @@
 parameters:
   dependsOn: ''
   queue: {}
+  configuration: 'Debug'
+  condition: succeeded()
+  continueOnError: false
 phases:
   - phase: Asset_Registry_Publish
     displayName: Publish to Build Asset Registry
     dependsOn: ${{ parameters.dependsOn }}
     queue: ${{ parameters.queue }}
+    variables:
+      config: ${{ parameters.configuration }}
     steps:
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         - task: DownloadBuildArtifacts@0
@@ -24,5 +29,7 @@ phases:
               /p:ManifestsPath='$(Build.StagingDirectory)/Download/AssetManifests'
               /p:BuildAssetRegistryToken=$(MaestroAccessToken)
               /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
-              /p:Configuration=Debug
+              /p:Configuration=$(config)
             displayName: Publish Build Assets
+          condition: ${{ parameters.condition }}
+          continueOnError: ${{ parameters.continueOnError }}

--- a/eng/common/templates/phases/publish-build-assets.yml
+++ b/eng/common/templates/phases/publish-build-assets.yml
@@ -1,14 +1,11 @@
 parameters:
   dependsOn: ''
   queue: {}
-  configuration: 'Debug'
 phases:
   - phase: Asset_Registry_Publish
     displayName: Publish to Build Asset Registry
     dependsOn: ${{ parameters.dependsOn }}
     queue: ${{ parameters.queue }}
-    variables:
-      config: ${{ parameters.configuration }}
     steps:
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         - task: DownloadBuildArtifacts@0
@@ -27,5 +24,5 @@ phases:
               /p:ManifestsPath='$(Build.StagingDirectory)/Download/AssetManifests'
               /p:BuildAssetRegistryToken=$(MaestroAccessToken)
               /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
-              /p:Configuration=$(config)
+              /p:Configuration=Debug
             displayName: Publish Build Assets


### PR DESCRIPTION
There are teams which have specific configurations in their solutions. This change allows the publish assets task to pass a defined configuration that will be used during restore.

