### PR TITLE
Update arcade version to get update-dependencies functionality

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,9 +2,9 @@
 <Dependencies>
   <ProductDependencies></ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.18522.6">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.18523.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>dd701110d79bb60c84a141ab9017320ed2df0b41</Sha>
+      <Sha>303ce96504a1659dcdad5f9a667de18ead9a1a79</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/global.json
+++ b/global.json
@@ -3,6 +3,6 @@
     "dotnet": "2.1.400-preview-009088"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.18522.6"
+    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.18523.3"
   }
 }


### PR DESCRIPTION
This update was done locally using:

```
darc update-dependencies --channel ".NET Tools - Latest"
```