### PR TITLE
Update to use latest MicroBuild signing plugin.

### DIFF
--- a/eng/common/templates/phases/base.yml
+++ b/eng/common/templates/phases/base.yml
@@ -60,7 +60,7 @@ phases:
   - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
     # Internal only resource, and Microbuild signing shouldn't be applied to PRs.
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - task: MicroBuildSigningPlugin@1
+      - task: MicroBuildSigningPlugin@2
         displayName: Install MicroBuild plugin
         inputs:
           signType: $(_SignType)


### PR DESCRIPTION
Closes: dotnet/core-eng#4454

MicroBuild team released a new version of the signing plugin. This PR is to make Arcade use the latest version of the plugin.