### PR TITLE
Change "Version" to "PackageVersion" in Versions.props

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
@@ -49,11 +49,13 @@ namespace Microsoft.DotNet.DarcLib
             }
             else
             {
-                await _fileManager.AddDependencyToVersionProps(
-                    Path.Combine(_repo, VersionFiles.VersionProps),
+                await _fileManager.AddDependencyToVersionsProps(
+                    _repo,
+                    null,
                     dependency);
                 await _fileManager.AddDependencyToVersionDetails(
-                    Path.Combine(_repo, VersionFiles.VersionDetailsXml),
+                    _repo,
+                    null,
                     dependency,
                     dependencyType);
             }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/DependencyOperations.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/DependencyOperations.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.DarcLib
             {
                 {
                     KnownDependencyType.GlobalJson,
-                    new Func<GitFileManager, string, DependencyDetail, Task>(UpdateGlobalJson)
+                    new Func<GitFileManager, string, string, DependencyDetail, Task>(UpdateGlobalJson)
                 }
             };
 
@@ -42,6 +42,7 @@ namespace Microsoft.DotNet.DarcLib
         public static async Task UpdateGlobalJson(
             GitFileManager fileManager,
             string repository,
+            string branch,
             DependencyDetail dependency)
         {
             var dependencyMapping = new Dictionary<string, string>
@@ -58,12 +59,14 @@ namespace Microsoft.DotNet.DarcLib
             string parent = dependencyMapping[dependency.Name];
 
             await fileManager.AddDependencyToGlobalJson(
-                Path.Combine(repository, VersionFiles.GlobalJson),
+                repository,
+                branch,
                 parent,
                 dependency.Name,
                 dependency.Version);
             await fileManager.AddDependencyToVersionDetails(
-                Path.Combine(repository, VersionFiles.VersionDetailsXml),
+                repository,
+                branch,
                 dependency,
                 DependencyType.Toolset);
         }

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
@@ -161,7 +161,7 @@ namespace Microsoft.DotNet.DarcLib
             DependencyDetail dependency,
             DependencyType dependencyType)
         {
-            XmlDocument versionDetails = await ReadVersionDetailsXmlAsync(repo, null);
+            XmlDocument versionDetails = await ReadVersionDetailsXmlAsync(repo, branch);
 
             XmlNode newDependency = versionDetails.CreateElement("Dependency");
 
@@ -214,12 +214,13 @@ namespace Microsoft.DotNet.DarcLib
         ///     See https://github.com/dotnet/arcade/blob/master/Documentation/DependencyDescriptionFormat.md for more
         ///     information.
         /// </summary>
-        /// <param name="repo">Path to Versions.props file</param>
+        /// <param name="repo">Repository root path or URI.</param>
+        /// <param name="branch">Repository branch.</param>
         /// <param name="dependency">Dependency information to add.</param>
         /// <returns>Async task.</returns>
         public async Task AddDependencyToVersionsProps(string repo, string branch, DependencyDetail dependency)
         {
-            XmlDocument versionProps = await ReadVersionPropsAsync(repo, null);
+            XmlDocument versionProps = await ReadVersionPropsAsync(repo, branch);
             
             string packageNameElementName = VersionFiles.GetVersionPropsPackageElementName(dependency.Name);
             string packageVersionElementName = VersionFiles.GetVersionPropsPackageVersionElementName(dependency.Name);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/VersionFiles.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/VersionFiles.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.DarcLib
         public const string VersionDetailsXml = "eng/Version.Details.xml";
         public const string VersionProps = "eng/Versions.props";
         public const string GlobalJson = "global.json";
-        public const string VersionPropsVersionElementSuffix = "PackageVersion";
+        public const string VersionPropsVersionElementSuffix = "Version";
         public const string VersionPropsPackageElementSuffix = "Package";
 
         public static string GetVersionPropsPackageVersionElementName(string dependencyName)

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/VersionFiles.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/VersionFiles.cs
@@ -15,10 +15,16 @@ namespace Microsoft.DotNet.DarcLib
         public const string VersionDetailsXml = "eng/Version.Details.xml";
         public const string VersionProps = "eng/Versions.props";
         public const string GlobalJson = "global.json";
+        public const string VersionPropsVersionElementSuffix = "PackageVersion";
+        public const string VersionPropsPackageElementSuffix = "Package";
 
-        public static string CalculateVersionPropsElementName(string dependencyName)
+        public static string GetVersionPropsPackageVersionElementName(string dependencyName)
         {
-            return $"{dependencyName.Replace(".", string.Empty)}Version";
+            return $"{dependencyName.Replace(".", string.Empty)}{VersionPropsVersionElementSuffix}";
+        }
+        public static string GetVersionPropsPackageElementName(string dependencyName)
+        {
+            return $"{dependencyName.Replace(".", string.Empty)}{VersionPropsPackageElementSuffix}";
         }
 
         public static string CalculateGlobalJsonElementName(string dependencyName)

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/VersionFiles.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/VersionFiles.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.DarcLib
         public const string VersionDetailsXml = "eng/Version.Details.xml";
         public const string VersionProps = "eng/Versions.props";
         public const string GlobalJson = "global.json";
-        public const string VersionPropsVersionElementSuffix = "Version";
+        public const string VersionPropsVersionElementSuffix = "PackageVersion";
         public const string VersionPropsPackageElementSuffix = "Package";
 
         public static string GetVersionPropsPackageVersionElementName(string dependencyName)


### PR DESCRIPTION
We use PackageVersion in most places, so let's be consistent.  Also includes the following fixes:
- Add shouldn't pass paths to files explicitly
- Version.Details.xml should add the dependency node if it doesn't exist.
- Versions.props should add property groups where needed, should also update a package name property if possible.  This is not yet done for update.  Work is covered in https://github.com/dotnet/arcade/issues/1095 for general refactoring.
- Use local-name xpath queries so that projects that use a default xmlns (common for MSBuild) update correctly.