### PR TITLE
Delimit semicolon in file version contents

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
@@ -140,7 +140,7 @@ static char sccsid[] __attribute__((used)) = "@(#)Version $(FileVersion)$(_Sourc
 
     <WriteLinesToFile
       File="$(NativeVersionFile)"
-      Lines="$(_NativeVersionFileContents)"
+      Lines="$(_NativeVersionFileContents.Replace(';', '%3B'))"
       Overwrite="true" />
 
     <ItemGroup>


### PR DESCRIPTION
msbuild uses semicolon as an item separator so we need to
delimit it to avoid it removing them from from the source
we are generating.

cc @ericstj 