### PR TITLE
Update VSTSOnboarding.md: Hosted Mac "Preview" => "Internal"

### DIFF
--- a/Documentation/VSTS/VSTSOnboarding.md
+++ b/Documentation/VSTS/VSTSOnboarding.md
@@ -42,7 +42,7 @@ Current machine pool recommendations:
 | ---------- | -------------------- | -------------------------- |
 | Windows_NT | dotnet-external-temp |                            |
 | Linux      | Hosted Ubuntu 1604   | dnceng-linux-external-temp |
-| OSX        | Hosted Mac Preview   | |
+| OSX        | Hosted Mac Internal  | |
 
 ### Internal
 


### PR DESCRIPTION
There doesn't appear to be a "Hosted Mac Preview" pool/queue: https://dev.azure.com/dnceng/public/_settings/agentqueues