### PR TITLE
Include default xunit.runner.json that disables shadowCopy in unit test projects that target .NET Framework.

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.props
@@ -44,4 +44,6 @@
     <TestRunnerName Condition="'$(UsingToolXUnit)' == 'true'">XUnit</TestRunnerName>
   </PropertyGroup>
 
+  <!-- Import specialized props files of supported test runners -->
+  <Import Project="$(MSBuildThisFileDirectory)$(TestRunnerName)\$(TestRunnerName).props" Condition="'$(TestRunnerName)' != '' and Exists('$(MSBuildThisFileDirectory)$(TestRunnerName)\$(TestRunnerName).props')"/>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.targets
@@ -65,5 +65,6 @@
     </MSBuild>
   </Target>
 
-  <Import Project="XUnit.targets" Condition="'$(TestRunnerName)' == 'XUnit'"/>
+  <!-- Import specialized targets files of supported test runners -->
+  <Import Project="$(MSBuildThisFileDirectory)$(TestRunnerName)\$(TestRunnerName).targets" Condition="'$(TestRunnerName)' != '' and Exists('$(MSBuildThisFileDirectory)$(TestRunnerName)\$(TestRunnerName).targets')"/>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.props
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- All Rights Reserved. Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project>
+
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- 
+      Default settings file for Desktop FX that sets shadowCopy to false, to allow loading public-signed assemblies to xunit AppDomain.
+    -->
+    <XUnitDesktopSettingsFile>$(MSBuildThisFileDirectory)xunit.runner.json</XUnitDesktopSettingsFile>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
@@ -12,6 +12,21 @@
     <PackageReference Include="xunit.runner.console" Version="$(XUnitRunnerConsoleVersion)" IsImplicitlyDefined="true" PrivateAssets="all"/>
   </ItemGroup>
 
+  <!--
+    Include settings file (xunit.runner.json) if specified.
+  -->
+  <ItemGroup>
+    <None Include="$(XUnitDesktopSettingsFile)"
+          CopyToOutputDirectory="PreserveNewest"
+          Visible="false"
+          Condition="'$(XUnitDesktopSettingsFile)' != '' and '$(TargetFrameworkIdentifier)' == '.NETFramework'" />
+
+    <None Include="$(XUnitCoreSettingsFile)"
+          CopyToOutputDirectory="PreserveNewest"
+          Visible="false"
+          Condition="'$(XUnitCoreSettingsFile)' != '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
+  </ItemGroup>
+
   <!-- 
     Include '*' target to force running tests even if the input assemblies haven't changed and the outputs are present.
     This matches the common expectations that test command always runs all tests in scope.

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/xunit.runner.json
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "shadowCopy": false 
+}


### PR DESCRIPTION
ShadowCopy does not work with public-signed binaries.

Fixes https://github.com/dotnet/roslyn-tools/issues/388