### PR TITLE
Add chmod +x to HELIX_WORKITEM_PAYLOAD sh scripts in execute.sh to avoid access denied

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/CommandPayload.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CommandPayload.cs
@@ -35,6 +35,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             {
                 name = $"scripts/{Guid.NewGuid():N}/execute.sh";
                 contents.Append("#!/bin/sh\n");
+                contents.Append("chmod +x $HELIX_WORKITEM_PAYLOAD/*.sh\n");
                 foreach (var command in commands)
                 {
                     contents.Append(command + "\n");


### PR DESCRIPTION
This is what the old infrastructure use to do. Right now if I try to submit a job using the Helix SDK I get: 
```
/home/helixbot/dotnetbuild/work/aeb41923-59d8-4149-8619-9b8939427db1/Payload/scripts/1fcadae017264d3880aa181a91ff607b/execute.sh: 2: /home/helixbot/dotnetbuild/work/aeb41923-59d8-4149-8619-9b8939427db1/Payload/scripts/1fcadae017264d3880aa181a91ff607b/execute.sh: ./RunTests.sh: Permission denied
```

Previously the command passed was:
```
chmod +x $HELIX_WORKITEM_PAYLOAD/*.sh && $HELIX_PYTHONPATH $HELIX_CORRELATION_PAYLOAD/RunnerScripts/scriptrunner/scriptrunner.py --script RunTests.sh $HELIX_CORRELATION_PAYLOAD
```