### PR TITLE
Remove NerdBank.GitVersioning reference

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
+++ b/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="NuGet.Versioning" Version="4.7.0" />
     <PackageReference Include="System.IO.Packaging" Version="4.5.0" />
     <PackageReference Include="WiX" Version="3.11.1" />
-    <PackageReference Include="NerdBank.GitVersioning" Version="2.1.17" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="$(WixInstallPath)\Microsoft.Deployment.Resources.dll" />


### PR DESCRIPTION
It was not intended to be included.

Noticed because it caused a local build failure on my usual Docker image: fixes https://github.com/dotnet/arcade/issues/1180.