### PR TITLE
Enable repos to use an archive wildcard and pass correlation payload to msbuild

### DIFF
--- a/eng/common/helixpublish.proj
+++ b/eng/common/helixpublish.proj
@@ -1,15 +1,26 @@
 <Project Sdk="Microsoft.DotNet.Helix.Sdk">
 
-  <ItemGroup>
-    <HelixCorrelationPayload Include="$(CorrelationPayloadDirectory)">
-      <PayloadDirectory>%(Identity)</PayloadDirectory>
-    </HelixCorrelationPayload>
-  </ItemGroup>
-
-  <ItemGroup>
+  <ItemGroup Condition="'$(WorkItemDirectory)' != ''">
     <HelixWorkItem Include="WorkItem">
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
       <Command>$(WorkItemCommand)</Command>
     </HelixWorkItem>
   </ItemGroup>
+
+  <ItemGroup Condition="'$(HelixCorrelationPayload)' != ''">
+    <HelixCorrelationPayload Include="$(HelixCorrelationPayload)" />
+  </ItemGroup>
+
+  <Target Name="BuildHelixWorkItem"
+          Condition="'$(WorkItemArchiveWildCard)' != ''"
+          BeforeTargets="Test">
+    <ItemGroup>
+      <_WorkItem Include="$(WorkItemArchiveWildCard)" Exclude="$(HelixCorrelationPayload)" />
+
+      <HelixWorkItem Include="@(_WorkItem -> '%(FileName)')">
+        <PayloadArchive>%(Identity)</PayloadArchive>
+        <Command>$(WorkItemCommand)</Command>
+      </HelixWorkItem>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/eng/common/templates/steps/helix-publish.yml
+++ b/eng/common/templates/steps/helix-publish.yml
@@ -7,8 +7,9 @@ parameters:
   HelixPreCommands: ''
   HelixPostCommands: ''
   WorkItemDirectory: ''
+  WorkItemArchiveWildCard: ''
   WorkItemCommand: ''
-  CorrelationPayloadDirectory: ''
+  HelixCorrelationPayload: ''
   IncludeDotNetCli: false
   DotNetCliPackageType: ''
   DotNetCliVersion: ''
@@ -18,6 +19,12 @@ parameters:
   continueOnError: false
 
 steps:
+  - ${{ if ne(variables['Agent.OS'], 'Windows_NT') }}:
+    - script: PATH=$(Build.SourcesDirectory)/.dotnet:$PATH
+      displayName: Add dotnet to PATH
+  - ${{ if eq(variables['Agent.OS'], 'Windows_NT') }}:
+    - script: set PATH=$(Build.SourcesDirectory)\.dotnet;%PATH%
+      displayName: Add dotnet to PATH
   - task: DotNetCoreCLI@2
     inputs:
       command: custom
@@ -33,6 +40,7 @@ steps:
       HelixAccessToken: ${{ parameters.HelixAccessToken }}
       HelixPreCommands: ${{ parameters.HelixPreCommands }}
       HelixPostCommands: ${{ parameters.HelixPostCommands }}
+      HelixCorrelationPayload: ${{ parameters.HelixCorrelationPayload }}
       WorkItemDirectory: ${{ parameters.WorkItemDirectory }}
       WorkItemCommand: ${{ parameters.WorkItemCommand }}
       IncludeDotNetCli: ${{ parameters.IncludeDotNetCli }}
@@ -40,5 +48,6 @@ steps:
       DotNetCliVersion: ${{ parameters.DotNetCliVersion }}
       EnableXUnitReporter: ${{ parameters.EnableXUnitReporter }}
       WaitForWorkItemCompletion: ${{ parameters.WaitForWorkItemCompletion }}
+      WorkItemArchiveWildCard: ${{ parameters.WorkItemArchiveWildCard }}
     condition: ${{ parameters.condition }}
     continueOnError: ${{ parameters.continueOnError }}

--- a/eng/common/templates/steps/helix-publish.yml
+++ b/eng/common/templates/steps/helix-publish.yml
@@ -20,34 +20,48 @@ parameters:
 
 steps:
   - ${{ if ne(variables['Agent.OS'], 'Windows_NT') }}:
-    - script: PATH=$(Build.SourcesDirectory)/.dotnet:$PATH
-      displayName: Add dotnet to PATH
+    - script: eng/common/msbuild.sh
+              eng/common/helixpublish.proj /t:test
+      displayName: Send job to Helix
+      condition: ${{ parameters.condition }}
+      continueOnError: ${{ parameters.continueOnError }}
+      env:
+        HelixSource: ${{ parameters.HelixSource }}
+        HelixType: ${{ parameters.HelixType }}
+        HelixBuild: ${{ parameters.HelixBuild }}
+        HelixTargetQueues: ${{ parameters.HelixTargetQueues }}
+        HelixAccessToken: ${{ parameters.HelixAccessToken }}
+        HelixPreCommands: ${{ parameters.HelixPreCommands }}
+        HelixPostCommands: ${{ parameters.HelixPostCommands }}
+        HelixCorrelationPayload: ${{ parameters.HelixCorrelationPayload }}
+        WorkItemDirectory: ${{ parameters.WorkItemDirectory }}
+        WorkItemCommand: ${{ parameters.WorkItemCommand }}
+        IncludeDotNetCli: ${{ parameters.IncludeDotNetCli }}
+        DotNetCliPackageType: ${{ parameters.DotNetCliPackageType }}
+        DotNetCliVersion: ${{ parameters.DotNetCliVersion }}
+        EnableXUnitReporter: ${{ parameters.EnableXUnitReporter }}
+        WaitForWorkItemCompletion: ${{ parameters.WaitForWorkItemCompletion }}
+        WorkItemArchiveWildCard: ${{ parameters.WorkItemArchiveWildCard }}
   - ${{ if eq(variables['Agent.OS'], 'Windows_NT') }}:
-    - script: set PATH=$(Build.SourcesDirectory)\.dotnet;%PATH%
-      displayName: Add dotnet to PATH
-  - task: DotNetCoreCLI@2
-    inputs:
-      command: custom
-      projects: eng/common/helixpublish.proj
-      custom: msbuild
-      arguments: '/t:test /p:Language=msbuild'
-    displayName: Send job to Helix
-    env:
-      HelixSource: ${{ parameters.HelixSource }}
-      HelixType: ${{ parameters.HelixType }}
-      HelixBuild: ${{ parameters.HelixBuild }}
-      HelixTargetQueues: ${{ parameters.HelixTargetQueues }}
-      HelixAccessToken: ${{ parameters.HelixAccessToken }}
-      HelixPreCommands: ${{ parameters.HelixPreCommands }}
-      HelixPostCommands: ${{ parameters.HelixPostCommands }}
-      HelixCorrelationPayload: ${{ parameters.HelixCorrelationPayload }}
-      WorkItemDirectory: ${{ parameters.WorkItemDirectory }}
-      WorkItemCommand: ${{ parameters.WorkItemCommand }}
-      IncludeDotNetCli: ${{ parameters.IncludeDotNetCli }}
-      DotNetCliPackageType: ${{ parameters.DotNetCliPackageType }}
-      DotNetCliVersion: ${{ parameters.DotNetCliVersion }}
-      EnableXUnitReporter: ${{ parameters.EnableXUnitReporter }}
-      WaitForWorkItemCompletion: ${{ parameters.WaitForWorkItemCompletion }}
-      WorkItemArchiveWildCard: ${{ parameters.WorkItemArchiveWildCard }}
-    condition: ${{ parameters.condition }}
-    continueOnError: ${{ parameters.continueOnError }}
+    - script: eng\common\msbuild.ps1
+              eng\common\helixpublish.proj /t:test
+      displayName: Send job to Helix
+      condition: ${{ parameters.condition }}
+      continueOnError: ${{ parameters.continueOnError }}
+      env:
+        HelixSource: ${{ parameters.HelixSource }}
+        HelixType: ${{ parameters.HelixType }}
+        HelixBuild: ${{ parameters.HelixBuild }}
+        HelixTargetQueues: ${{ parameters.HelixTargetQueues }}
+        HelixAccessToken: ${{ parameters.HelixAccessToken }}
+        HelixPreCommands: ${{ parameters.HelixPreCommands }}
+        HelixPostCommands: ${{ parameters.HelixPostCommands }}
+        HelixCorrelationPayload: ${{ parameters.HelixCorrelationPayload }}
+        WorkItemDirectory: ${{ parameters.WorkItemDirectory }}
+        WorkItemCommand: ${{ parameters.WorkItemCommand }}
+        IncludeDotNetCli: ${{ parameters.IncludeDotNetCli }}
+        DotNetCliPackageType: ${{ parameters.DotNetCliPackageType }}
+        DotNetCliVersion: ${{ parameters.DotNetCliVersion }}
+        EnableXUnitReporter: ${{ parameters.EnableXUnitReporter }}
+        WaitForWorkItemCompletion: ${{ parameters.WaitForWorkItemCompletion }}
+        WorkItemArchiveWildCard: ${{ parameters.WorkItemArchiveWildCard }}


### PR DESCRIPTION
This change is doing the following:

- Conditioning the default `WorkItem` created from `WorkItemDirectory` which can actually be empty.
- Changed the name from `CorrelationPayloadDirectory` to `HelixCorrelationPayload` as it actually can be a URI, Directory or File
- Within `HelixCorrelationPayload` item PayloadDirectory is actually not used, the task uses FullPath or URI metadata to get the full path.
- Enable repos to pass in a WildCard to create multiple workitems from archives.
- Add .dotnet repo folder from the root before running dotnet msbuild to call the `helixpublish.proj` since not all the machines guarantee to have dotnet installed (specially docker containers).

Questions:

Should we allow users to pass in a URI CorrelationPayload and if it is not '' add it to the metadata item as well? In the `SendHelixJob` task it looks for it: https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs#L335