### PR TITLE
Add displayName parameter to base template

### DIFF
--- a/eng/common/templates/phases/base.yml
+++ b/eng/common/templates/phases/base.yml
@@ -7,6 +7,8 @@ parameters:
 
   # Optional: name of the phase (not specifying phase name may cause name collisions)
   name: ''
+  # Optional: display name of the phase
+  displayName: ''
 
   # Required: A defined YAML queue
   queue: {}
@@ -37,6 +39,7 @@ parameters:
 
 phases:
 - phase: ${{ parameters.name }}
+  displayName: ${{ parameters.displayName }}
 
   queue: ${{ parameters.queue }}
 


### PR DESCRIPTION
This makes it possible for users of the template to specify a prettier job name to be shown in the UI.