### PR TITLE
Improve the AzDO MC Link

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/HelixWait.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/HelixWait.cs
@@ -36,9 +36,8 @@ namespace Microsoft.DotNet.Helix.Sdk
             // Wait 1 second to allow helix to register the job creation
             await Task.Delay(1000);
 
-            Source = Uri.EscapeUriString(Source);
-            Type = Uri.EscapeUriString(Type);
-
+            Source = Uri.EscapeDataString(Source).Replace('%', '~');
+            Type = Uri.EscapeDataString(Type).Replace('%', '~');
             string mcUri = await GetMissionControlResultUri();
             Log.LogMessage(MessageImportance.High, $"Results will be available from {mcUri}");
 
@@ -95,7 +94,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                     return "Mission Control (generation of MC link failed -- JSON parsing error)";
                 }
 
-                return $"https://mc.dot.net/#/user/{userName}/builds/{Source}/{Type}/{Build}";
+                return $"https://mc.dot.net/#/user/{userName}/{Source}/{Type}/{Build}";
             }
         }
     }

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MultiQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MultiQueue.targets
@@ -59,6 +59,6 @@
           AfterTargets="Test"
           Condition="$(WaitForWorkItemCompletion)">
     <Message Importance="High" Text="Waiting on job completion..." />
-    <HelixWait Jobs="@(SentJobs)" AccessToken="$(HelixAccessToken)" />
+    <HelixWait Jobs="@(SentJobs)" AccessToken="$(HelixAccessToken)" Source="$(HelixSource)" Type="$(HelixType)" Build="$(HelixBuild)" />
   </Target>
 </Project>


### PR DESCRIPTION
Improve the link to Mission Control that is outputted by the job waiter in the AzDO logs. This constructs the deep link.