### PR TITLE
Update octokit version and add support for automated deployment

### DIFF
--- a/src/Maestro/DependencyUpdater/PackageRoot/ServiceManifest.xml
+++ b/src/Maestro/DependencyUpdater/PackageRoot/ServiceManifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 
 <ServiceManifest Name="DependencyUpdaterPkg"
-                 Version="1.0.40"
+                 Version="1.0.41"
                  xmlns="http://schemas.microsoft.com/2011/01/fabric"
                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -12,7 +12,7 @@
   </ServiceTypes>
 
   <!-- Code package is your service executable. -->
-  <CodePackage Name="Code" Version="1.0.40">
+  <CodePackage Name="Code" Version="1.0.41">
     <EntryPoint>
       <ExeHost>
         <Program>DependencyUpdater.exe</Program>
@@ -25,7 +25,7 @@
 
   <!-- Config package is the contents of the Config directoy under PackageRoot that contains an 
        independently-updateable and versioned set of custom configuration settings for your service. -->
-  <ConfigPackage Name="Config" Version="1.0.40" />
+  <ConfigPackage Name="Config" Version="1.0.41" />
 
   <Resources>
     <Endpoints>

--- a/src/Maestro/Maestro.Data/BuildAssetRegistryContext.cs
+++ b/src/Maestro/Maestro.Data/BuildAssetRegistryContext.cs
@@ -24,8 +24,18 @@ namespace Maestro.Data
     {
         public BuildAssetRegistryContext CreateDbContext(string[] args)
         {
-            DbContextOptions options = new DbContextOptionsBuilder().UseSqlServer(
-                    @"Data Source=localhost\SQLEXPRESS;Initial Catalog=BuildAssetRegistry;Integrated Security=true")
+            var connectionString =
+                @"Data Source=localhost\SQLEXPRESS;Initial Catalog=BuildAssetRegistry;Integrated Security=true";
+
+            var envVarConnectionString = Environment.GetEnvironmentVariable("BUILD_ASSET_REGISTRY_DB_CONNECTION_STRING");
+            if (!string.IsNullOrEmpty(envVarConnectionString))
+            {
+                Console.WriteLine("Using Connection String from environment.");
+                connectionString = envVarConnectionString;
+            }
+
+            DbContextOptions options = new DbContextOptionsBuilder()
+                .UseSqlServer(connectionString)
                 .Options;
             return new BuildAssetRegistryContext(
                 new HostingEnvironment {EnvironmentName = EnvironmentName.Development},

--- a/src/Maestro/Maestro.GitHub/Maestro.GitHub.csproj
+++ b/src/Maestro/Maestro.GitHub/Maestro.GitHub.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="GitHubJwt" Version="0.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.0" />
-    <PackageReference Include="Octokit" Version="0.31.0" />
+    <PackageReference Include="Octokit" Version="0.32.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Maestro/Maestro.Web/Controllers/WebHooksController.cs
+++ b/src/Maestro/Maestro.Web/Controllers/WebHooksController.cs
@@ -48,7 +48,9 @@ namespace Maestro.Web.Controllers
                 case "deleted":
                     await RemoveInstallationRepositoriesAsync(payload.Installation.Id);
                     break;
-                case "created":
+                case "created": // installation was created
+                case "removed": // repository removed from installation
+                case "added":   // repository added to installation
                     await SynchronizeInstallationRepositoriesAsync(payload.Installation.Id);
                     break;
                 default:

--- a/src/Maestro/Maestro.Web/Maestro.Web.csproj
+++ b/src/Maestro/Maestro.Web/Maestro.Web.csproj
@@ -53,7 +53,7 @@
     <PackageReference Include="Microsoft.ServiceFabric.Services" Version="3.2.162" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.1.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.0" />
-    <PackageReference Include="Octokit" Version="0.31.0" />
+    <PackageReference Include="Octokit" Version="0.32.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Maestro/Maestro.Web/PackageRoot/ServiceManifest.xml
+++ b/src/Maestro/Maestro.Web/PackageRoot/ServiceManifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 
 <ServiceManifest Name="Maestro.WebPkg"
-                 Version="1.0.40"
+                 Version="1.0.41"
                  xmlns="http://schemas.microsoft.com/2011/01/fabric"
                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -12,7 +12,7 @@
   </ServiceTypes>
 
   <!-- Code package is your service executable. -->
-  <CodePackage Name="Code" Version="1.0.40">
+  <CodePackage Name="Code" Version="1.0.41">
     <EntryPoint>
       <ExeHost>
         <Program>Maestro.Web.exe</Program>
@@ -26,7 +26,7 @@
 
   <!-- Config package is the contents of the Config directoy under PackageRoot that contains an 
        independently-updateable and versioned set of custom configuration settings for your service. -->
-  <ConfigPackage Name="Config" Version="1.0.40" />
+  <ConfigPackage Name="Config" Version="1.0.41" />
 
   <Resources>
     <Endpoints>

--- a/src/Maestro/Maestro.sln.DotSettings
+++ b/src/Maestro/Maestro.sln.DotSettings
@@ -5,4 +5,7 @@
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/MAX_INITIALIZER_ELEMENTS_ON_LINE/@EntryValue">1</s:Int64>
 	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">Licensed to the .NET Foundation under one or more agreements.&#xD;
 The .NET Foundation licenses this file to you under the MIT license.&#xD;
-See the LICENSE file in the project root for more information.</s:String></wpf:ResourceDictionary>
+See the LICENSE file in the project root for more information.</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Maestro/MaestroApplication/ApplicationPackageRoot/ApplicationManifest.xml
+++ b/src/Maestro/MaestroApplication/ApplicationPackageRoot/ApplicationManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<ApplicationManifest xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ApplicationTypeName="MaestroApplicationType" ApplicationTypeVersion="1.0.40" xmlns="http://schemas.microsoft.com/2011/01/fabric">
+<ApplicationManifest xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ApplicationTypeName="MaestroApplicationType" ApplicationTypeVersion="1.0.41" xmlns="http://schemas.microsoft.com/2011/01/fabric">
   <Parameters>
     <Parameter Name="DependencyUpdater_MinReplicaSetSize" DefaultValue="3" />
     <Parameter Name="DependencyUpdater_PartitionCount" DefaultValue="1" />
@@ -18,20 +18,20 @@
        should match the Name and Version attributes of the ServiceManifest element defined in the 
        ServiceManifest.xml file. -->
   <ServiceManifestImport>
-    <ServiceManifestRef ServiceManifestName="SubscriptionActorServicePkg" ServiceManifestVersion="1.0.40" />
+    <ServiceManifestRef ServiceManifestName="SubscriptionActorServicePkg" ServiceManifestVersion="1.0.41" />
     <EnvironmentOverrides CodePackageRef="Code">
       <EnvironmentVariable Name="ASPNETCORE_ENVIRONMENT" Value="[Environment]" />
     </EnvironmentOverrides>
   </ServiceManifestImport>
   <ServiceManifestImport>
-    <ServiceManifestRef ServiceManifestName="DependencyUpdaterPkg" ServiceManifestVersion="1.0.40" />
+    <ServiceManifestRef ServiceManifestName="DependencyUpdaterPkg" ServiceManifestVersion="1.0.41" />
     <ConfigOverrides />
     <EnvironmentOverrides CodePackageRef="Code">
       <EnvironmentVariable Name="ASPNETCORE_ENVIRONMENT" Value="[Environment]" />
     </EnvironmentOverrides>
   </ServiceManifestImport>
   <ServiceManifestImport>
-    <ServiceManifestRef ServiceManifestName="Maestro.WebPkg" ServiceManifestVersion="1.0.40" />
+    <ServiceManifestRef ServiceManifestName="Maestro.WebPkg" ServiceManifestVersion="1.0.41" />
     <ConfigOverrides />
     <ResourceOverrides>
       <Endpoints>

--- a/src/Maestro/SubscriptionActorService/PackageRoot/ServiceManifest.xml
+++ b/src/Maestro/SubscriptionActorService/PackageRoot/ServiceManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<ServiceManifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SubscriptionActorServicePkg" Version="1.0.40" xmlns="http://schemas.microsoft.com/2011/01/fabric">
+<ServiceManifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SubscriptionActorServicePkg" Version="1.0.41" xmlns="http://schemas.microsoft.com/2011/01/fabric">
   <ServiceTypes>
     <StatefulServiceType ServiceTypeName="SubscriptionActorServiceType" HasPersistedState="true">
       <Extensions>
@@ -30,7 +30,7 @@
       </Extensions>
     </StatefulServiceType>
   </ServiceTypes>
-  <CodePackage Name="Code" Version="1.0.40">
+  <CodePackage Name="Code" Version="1.0.41">
     <EntryPoint>
       <ExeHost>
         <Program>SubscriptionActorService.exe</Program>
@@ -40,7 +40,7 @@
       <EnvironmentVariable Name="ASPNETCORE_ENVIRONMENT" Value="Development" />
     </EnvironmentVariables>
   </CodePackage>
-  <ConfigPackage Name="Config" Version="1.0.40" />
+  <ConfigPackage Name="Config" Version="1.0.41" />
   <Resources>
     <Endpoints>
       <Endpoint Name="SubscriptionActorServiceEndpointV2" />

--- a/src/Maestro/update-database.ps1
+++ b/src/Maestro/update-database.ps1
@@ -1,0 +1,43 @@
+
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory=$true)]
+  $migrationsDll,
+  [Parameter(Mandatory=$false)]
+  $startupDll
+)
+
+function removeDllExtension {
+  param($path)
+
+  if ($path.EndsWith(".dll")) {
+    $path = $path.Substring(0, $path.Length - ".dll".Length)
+  }
+  return $path
+}
+
+function Get-EfDllPath {
+  $dotnetLocation = Split-Path -Parent (Get-Command dotnet).Path
+  $sdkVersion = dotnet --version
+  $sdkToolsPath = Join-Path $dotnetLocation sdk $sdkVersion DotnetTools
+  $dotnetEfToolPath = Join-Path $sdkToolsPath dotnet-ef
+  $dotnetEfVersion = ls $dotnetEfToolPath | select -ExpandProperty Name | sort -Descending | select -First 1
+
+  return (Join-Path $dotnetEfToolPath $dotnetEfVersion tools netcoreapp2.1 any tools netcoreapp2.0 any ef.dll)
+}
+
+$migrationsNamespace = removeDllExtension $migrationsDll
+
+
+if (-not $startupDll) {
+  $startupDll = $migrationsDll
+}
+
+$depsJson = (removeDllExtension $startupDll) + ".deps.json"
+$runtimeConfig = (removeDllExtension $startupDll) + ".runtimeconfig.json"
+
+$efDll = Get-EfDllPath
+Write-Verbose "Using ef.dll from path $efDll"
+
+
+dotnet exec --depsfile $depsJson --runtimeconfig $runtimeConfig $efDll database update --assembly $migrationsDll --startup-assembly $startupDll --root-namespace $migrationsNamespace --project-dir . --verbose

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Microsoft.DotNet.DarcLib.csproj
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Microsoft.DotNet.DarcLib.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.138.0-preview" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Octokit" Version="0.31.0" />
+    <PackageReference Include="Octokit" Version="0.32.0" />
 
     <!--
       Needed to appease Microsoft.TeamFoundationServer.Client package


### PR DESCRIPTION
The 0.31.0 version of octokit uses a deprecated api path, 0.32.0 has the fix.
I added support to the design time dbcontext factory for an environment variable connection string and added an update-database script to enable automated deployment of the sql db.