### PR TITLE
Log error when there is no target queues specified to send a job to Helix

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MultiQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MultiQueue.targets
@@ -27,7 +27,8 @@
     </ResolveReferencesDependsOn>
 
     <TestDependsOn>
-      Build
+      Build;
+      ValidateTargetQueues
     </TestDependsOn>
 
     <CleanDependsOn>
@@ -47,6 +48,10 @@
   <ItemGroup>
     <HelixTargetQueue Include="$(HelixTargetQueues)" />
   </ItemGroup>
+
+  <Target Name="ValidateTargetQueues">
+    <Error Condition="'$(HelixTargetQueues)' == ''" Text="You must specify at least one target queue to send a job to helix. Use HelixTargetQueues property for multiple or HelixTargetQueue for a single queue." />
+  </Target>
 
   <Target Name="Test"
           DependsOnTargets="$(TestDependsOn)">


### PR DESCRIPTION
Currently if you don't specify a target queue you get the following error:
```
C:\Users\safern\.nuget\packages\microsoft.dotnet.helix.sdk\1.0.0-beta.18529.4\tools\Microsoft.DotNet.Helix.Sdk.MultiQ
ueue.targets(53,5): error MSB4006: There is a circular dependency in the target dependency graph involving target "Test
". [E:\repos\corefx3\corefx\eng\sendtohelix.proj]
```

Which if you're not familiar with MSBuild and how to investigate this error, it seems hard to diagnose, rather than just getting the real error, which happens because the HelixTargetQueues and HelixTargetQueue are empty and causes a cycle within the Test target in MultiQueue.targets