### PR TITLE
Improvements in Test target, dotnet location

### DIFF
--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -395,3 +395,37 @@ By default Portable and Embedded PDBs produced by _shipping_ projects are conver
 
 `true` (default) if the PDBs produced by the project should be converted to Windows PDB and published to Microsoft symbol servers.
 Set to `false` to override the default (uncommon).
+
+
+#### `SkipTests` (bool)
+
+Set to `true` in project to skip running tests.
+
+#### `TestArchitectures` (list of strings) [deprecated]
+
+List of test architectures (`x64`, `x86`) to run tests on.
+If not specified by the project defaults to the value of `PlatformTarget` property, or `x64` if `Platform` is `AnyCPU` or unspecified.
+
+For example, a project that targets `AnyCPU` can opt-into running tests using both 32-bit and 64-bit test runners on .NET Framework by setting `TestArchitectures` to `x64;x86`.
+
+> Considering removing this. Repos commonly use distinct 64-bit and 32-bit (and other) legs of their CI builds to test multiple architectures, which makes this setting is redundant.
+
+#### `TestTargetFrameworks` (list of strings)
+
+By default, the test runner will run tests for all frameworks a test project targets. Use `TestTargetFrameworks` to reduce the set of frameworks to run against.
+
+For example, consider a project that has `<TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>`. To only run .NET Core tests run 
+
+```
+msbuild Project.UnitTests.csproj /p:TestTargetFrameworks=netcoreapp2.1
+```
+
+#### `TestRuntime` (string)
+
+Runtime to use for running tests. Currently supported values are: `Core` (.NET Core), `Full` (.NET Framework) and `Mono` (Mono runtime).
+
+For example, the following runs .NET Framework tests using Mono runtime:
+
+```
+msbuild Project.UnitTests.csproj /p:TestTargetFrameworks=net472 /p:TestRuntime=Mono
+```

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets
@@ -53,23 +53,4 @@
     <RootNamespace />
   </PropertyGroup>
 
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.LocateDotNet" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
-
-  <Target Name="InitializeDotNetToolPath" Condition="'$(DotNetTool)' == ''">
-    <!-- Respect environment variable for the .NET install directory if set; otherwise, use the repo default location -->
-    <PropertyGroup>
-      <_DotNetRoot>$(DOTNET_INSTALL_DIR)</_DotNetRoot>
-      <_DotNetRoot Condition="'$(_DotNetRoot)' == ''">$(RepoRoot).dotnet\</_DotNetRoot>
-      <_DotNetRoot Condition="!HasTrailingSlash('$(_DotNetRoot)')">$(_DotNetRoot)\</_DotNetRoot>
-
-      <DotNetTool Condition="'$(OS)' == 'Windows_NT'">$(_DotNetRoot)dotnet.exe</DotNetTool>
-      <DotNetTool Condition="'$(OS)' != 'Windows_NT'">$(_DotNetRoot)dotnet</DotNetTool>
-    </PropertyGroup>
-
-    <!-- Find dotnet on PATHs -->
-    <Microsoft.DotNet.Arcade.Sdk.LocateDotNet RepositoryRoot="$(RepoRoot)" Condition="!Exists('$(DotNetTool)')">
-      <Output TaskParameter="DotNetPath" PropertyName="DotNetTool" />
-    </Microsoft.DotNet.Arcade.Sdk.LocateDotNet>
-  </Target>
-
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Performance.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Performance.targets
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <!-- The 'PerformanceTest' target is only viable for repos building their own performance-test harness. -->
-  <Target Name="PerformanceTest" DependsOnTargets="InitializeDotNetToolPath" Condition="'$(IsPerformanceTestProject)' == 'true'">
+  <Target Name="PerformanceTest" Condition="'$(IsPerformanceTestProject)' == 'true'">
     <PropertyGroup>
       <PerfIterations Condition="'$(PerfIterations)' == ''">10</PerfIterations>
       <PerfOutputDirectory Condition="'$(PerfOutputDirectory)' == ''">$(ArtifactsTestResultsDir)Performance</PerfOutputDirectory>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props
@@ -38,6 +38,23 @@
     <RepoRoot Condition="'$(RepoRoot)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'global.json'))\</RepoRoot>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(DotNetTool)' == ''">
+    <!-- Respect environment variable for the .NET install directory if set; otherwise, use the repo default location -->
+    <_DotNetRoot>$(DOTNET_INSTALL_DIR)</_DotNetRoot>
+    <_DotNetRoot Condition="'$(_DotNetRoot)' == ''">$(RepoRoot).dotnet\</_DotNetRoot>
+    <_DotNetRoot Condition="!HasTrailingSlash('$(_DotNetRoot)')">$(_DotNetRoot)\</_DotNetRoot>
+
+    <!-- Let the exec task find dotnet on PATH -->
+    <_DotNetRoot Condition="!Exists($(_DotNetRoot))"/>
+
+    <DotNetTool Condition="'$(OS)' == 'Windows_NT'">$(_DotNetRoot)dotnet.exe</DotNetTool>
+    <DotNetTool Condition="'$(OS)' != 'Windows_NT'">$(_DotNetRoot)dotnet</DotNetTool>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(MonoTool)' == ''">
+    <MonoTool>mono</MonoTool>
+  </PropertyGroup>
+
   <PropertyGroup>
     <!-- TODO: remove condition once all repos update their dir structure (https://github.com/dotnet/roslyn-tools/issues/177) -->
     <RepositoryEngineeringDir Condition="Exists('$(RepoRoot)eng')">$(RepoRoot)eng\</RepositoryEngineeringDir>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.targets
@@ -8,11 +8,17 @@
 
   <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
     <AutoGenerateBindingRedirects Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">true</AutoGenerateBindingRedirects>
+
     <_GetTestsToRunTarget Condition="'$(TargetFrameworks)' == ''">_InnerGetTestsToRun</_GetTestsToRunTarget>
     <_GetTestsToRunTarget Condition="'$(TargetFrameworks)' != ''">_OuterGetTestsToRun</_GetTestsToRunTarget>
+
+    <!-- The runtime to run tests on: 'Core', 'Mono', 'Full' (dekstop FX). -->
+    <TestRuntime Condition="'$(TestRuntime)' == '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">Core</TestRuntime>
+    <TestRuntime Condition="'$(TestRuntime)' == '' and '$(MSBuildRuntimeType)' == 'Mono'">Mono</TestRuntime>
+    <TestRuntime Condition="'$(TestRuntime)' == '' and '$(OS)' == 'Windows_NT'">Full</TestRuntime>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TestArchitectures)' == ''">
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true' and '$(TestArchitectures)' == ''">
     <TestArchitectures>$(PlatformTarget)</TestArchitectures>
     <TestArchitectures Condition="'$(PlatformTarget)' == '' or '$(PlatformTarget)' == 'AnyCpu'">x64</TestArchitectures>
   </PropertyGroup>
@@ -29,11 +35,12 @@
           Inputs="*%(_TestArchitectureItems.Identity)"
           Outputs="*%(_TestArchitectureItems.Identity)"
           Returns="@(TestToRun)"
-          Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' or '$(OS)' == 'Windows_NT' or '$(MSBuildRuntimeType)' == 'Mono'">
+          Condition="'$(TestRuntime)' != '' and '$(SkipTests)' != 'true' and
+                     ('$(TestTargetFrameworks)' == '' or $([System.String]::new(';$(TestTargetFrameworks);').Contains(';$(TargetFramework);')))">
 
     <PropertyGroup>
       <_TestArchitecture>%(_TestArchitectureItems.Identity)</_TestArchitecture>
-      <_TestOutPathNoExt>$(ArtifactsTestResultsDir)$(MSBuildProjectName)_$(TargetFramework)_$(_TestArchitecture)</_TestOutPathNoExt>
+      <_ResultFileNameNoExt>$(MSBuildProjectName)_$(TargetFramework)_$(_TestArchitecture)</_ResultFileNameNoExt>
     </PropertyGroup>
 
     <Error Text="Architecture specified in TestArchitectures is not supported: '$(_TestArchitecture)'" File="XUnit"
@@ -43,12 +50,13 @@
       <TestToRun Include="$(TargetPath)">
         <TargetFramework>$(TargetFramework)</TargetFramework>
         <TargetFrameworkIdentifier>$(TargetFrameworkIdentifier)</TargetFrameworkIdentifier>
+        <TestRuntime>$(TestRuntime)</TestRuntime>
         <Architecture>$(_TestArchitecture)</Architecture>
         <EnvironmentDisplay>$(TargetFramework)|$(_TestArchitecture)</EnvironmentDisplay>
-        <ResultsFilePathWithoutExtension>$(_TestOutPathNoExt)</ResultsFilePathWithoutExtension>
-        <ResultsStdOutPath>$(_TestOutPathNoExt).log</ResultsStdOutPath>
-        <ResultsXmlPath>$(_TestOutPathNoExt).xml</ResultsXmlPath>
-        <ResultsHtmlPath>$(_TestOutPathNoExt).html</ResultsHtmlPath>
+        <ResultsFilePathWithoutExtension>$(_ResultFileNameNoExt)</ResultsFilePathWithoutExtension>
+        <ResultsXmlPath>$(ArtifactsTestResultsDir)$(_ResultFileNameNoExt).xml</ResultsXmlPath>
+        <ResultsHtmlPath>$(ArtifactsTestResultsDir)$(_ResultFileNameNoExt).html</ResultsHtmlPath>
+        <ResultsStdOutPath>$(ArtifactsLogDir)$(_ResultFileNameNoExt).log</ResultsStdOutPath>
       </TestToRun>
     </ItemGroup>
   </Target>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -49,7 +49,7 @@
     <DeterministicSourcePaths>false</DeterministicSourcePaths>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(IsWpfTempProject)' == 'true' and '$(TargetFrameworkIdentifier)' == '.NETFramework'">
+  <PropertyGroup Condition="'$(IsWpfTempProject)' == 'true' and '$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(UsingToolNetFrameworkReferenceAssemblies)' == 'true'">
     <TargetFrameworkRootPath>$(NuGetPackageRoot)microsoft.netframework.referenceassemblies.$(TargetFramework)\$(MicrosoftNetFrameworkReferenceAssembliesVersion)\build</TargetFrameworkRootPath>
     <EnableFrameworkPathOverride>false</EnableFrameworkPathOverride>
     <NoStdLib>true</NoStdLib>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
@@ -39,42 +39,79 @@
     <PropertyGroup>
       <_TestEnvironment>%(TestToRun.EnvironmentDisplay)</_TestEnvironment>
       <_TestAssembly>%(TestToRun.Identity)</_TestAssembly>
-      <_RunOnCore>false</_RunOnCore>
-      <_RunOnCore Condition="'%(TestToRun.TargetFrameworkIdentifier)' == '.NETCoreApp'">true</_RunOnCore>
+      <_TestRuntime>%(TestToRun.TestRuntime)</_TestRuntime>
     </PropertyGroup>
 
-    <PropertyGroup Condition="$(_RunOnCore)">
+    <PropertyGroup Condition="'$(_TestRuntime)' == 'Core'">
       <_TargetFileNameNoExt>$([System.IO.Path]::GetFileNameWithoutExtension('$(_TestAssembly)'))</_TargetFileNameNoExt>
       <_TargetDir>$([System.IO.Path]::GetDirectoryName('$(_TestAssembly)'))\</_TargetDir>
       <_CoreRuntimeConfigPath>$(_TargetDir)$(_TargetFileNameNoExt).runtimeconfig.json</_CoreRuntimeConfigPath>
       <_CoreDepsPath>$(_TargetDir)$(_TargetFileNameNoExt).deps.json</_CoreDepsPath>
-      <_TestRunnerCommand>"$(DotNetTool)" exec --depsfile "$(_CoreDepsPath)" --runtimeconfig "$(_CoreRuntimeConfigPath)" "$(NuGetPackageRoot)xunit.runner.console/$(XUnitVersion)/tools/netcoreapp2.0/xunit.console.dll" "$(_TestAssembly)" -noautoreporters -xml "%(TestToRun.ResultsXmlPath)" -html "%(TestToRun.ResultsHtmlPath)" $(XUnitRunnerAdditionalArguments)</_TestRunnerCommand>
+      <_TestRunner>$(DotNetTool)</_TestRunner>
+      <_TestRunnerArgs>exec --depsfile "$(_CoreDepsPath)" --runtimeconfig "$(_CoreRuntimeConfigPath)" "$(NuGetPackageRoot)xunit.runner.console/$(XUnitVersion)/tools/netcoreapp2.0/xunit.console.dll" "$(_TestAssembly)" -noautoreporters -xml "%(TestToRun.ResultsXmlPath)" -html "%(TestToRun.ResultsHtmlPath)" $(XUnitRunnerAdditionalArguments)</_TestRunnerArgs>
     </PropertyGroup>
 
-    <PropertyGroup Condition="!$(_RunOnCore)">
+    <PropertyGroup Condition="'$(_TestRuntime)' != 'Core'">
       <_XUnitConsoleExe>xunit.console.exe</_XUnitConsoleExe>
       <_XUnitConsoleExe Condition="'%(TestToRun.Architecture)' == 'x86'">xunit.console.x86.exe</_XUnitConsoleExe>
-      <_TestRunnerCommand>"$(NuGetPackageRoot)xunit.runner.console\$(XUnitVersion)\tools\net452\$(_XUnitConsoleExe)" "$(_TestAssembly)" -noshadow -xml "%(TestToRun.ResultsXmlPath)" -html "%(TestToRun.ResultsHtmlPath)" $(XUnitRunnerAdditionalArguments)</_TestRunnerCommand>
+      <_XUnitConsoleExePath>$(NuGetPackageRoot)xunit.runner.console\$(XUnitVersion)\tools\net452\$(_XUnitConsoleExe)</_XUnitConsoleExePath>
+
+      <_TestRunnerArgs>"$(_TestAssembly)" -noshadow -xml "%(TestToRun.ResultsXmlPath)" -html "%(TestToRun.ResultsHtmlPath)" $(XUnitRunnerAdditionalArguments)</_TestRunnerArgs>
+      <_TestRunnerArgs Condition="'$(_TestRuntime)' == 'Mono'">"$(_XUnitConsoleExePath)" $(_TestRunnerArgs)</_TestRunnerArgs>
+
+      <_TestRunner Condition="'$(_TestRuntime)' == 'Mono'">$(MonoTool)</_TestRunner>
+      <_TestRunner Condition="'$(_TestRuntime)' != 'Mono'">$(_XUnitConsoleExePath)</_TestRunner>
     </PropertyGroup>
 
-    <MakeDir Directories="$(ArtifactsTestResultsDir)"/>
-    <Delete Files="%(TestToRun.ResultsFilePathWithoutExtension).*" />
+    <Error Text="File not found: '$(_TestRunner)'" Condition="!Exists('$(_TestRunner)')"/>
+
+    <PropertyGroup>
+      <_TestRunnerCommand>"$(_TestRunner)" $(_TestRunnerArgs)</_TestRunnerCommand>
+
+      <!-- 
+        Redirect std output of the runner.
+        Note that xUnit outputs failure info to both STDOUT (stack trace, message) and STDERR (failed test name) 
+      -->
+      <_TestRunnerCommand Condition="'$(TestCaptureOutput)' != 'false'">$(_TestRunnerCommand) > "%(TestToRun.ResultsStdOutPath)" 2>&amp;1</_TestRunnerCommand>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_OutputFiles Include="%(TestToRun.ResultsXmlPath)" />
+      <_OutputFiles Include="%(TestToRun.ResultsHtmlPath)" />
+      <_OutputFiles Include="%(TestToRun.ResultsLogPath)" />
+    </ItemGroup>
+
+    <MakeDir Directories="@(_OutputFiles->'%(RootDir)%(Directory)')"/>
+    <Delete Files="@(_OutputFiles)" />
 
     <Message Text="Running tests: $(_TestAssembly) [$(_TestEnvironment)]" Importance="high"/>
-
-    <!-- Note that xUnit outputs failure info to both STDOUT (stack trace, message) and STDERR (failed test name) -->
-    <Exec Command='$(_TestRunnerCommand) > "%(TestToRun.ResultsStdOutPath)" 2>&amp;1'
-          LogStandardErrorAsError="false"
-          WorkingDirectory="$(_TargetDir)"
-          IgnoreExitCode="true">
-
+    <Exec Command='$(_TestRunnerCommand)' LogStandardErrorAsError="false" WorkingDirectory="$(_TargetDir)" IgnoreExitCode="true">
       <Output TaskParameter="ExitCode" PropertyName="_TestErrorCode" />
     </Exec>
 
-    <WriteLinesToFile File="%(TestToRun.ResultsStdOutPath)" Overwrite="false" Lines=";=== COMMAND LINE ===;$(_TestRunnerCommand)" />
+    <!--
+      Add command line to the log.
+    -->
+    <WriteLinesToFile File="%(TestToRun.ResultsStdOutPath)" 
+                      Overwrite="false" 
+                      Lines=";=== COMMAND LINE ===;$(_TestRunnerCommand)"
+                      Condition="'$(TestCaptureOutput)' != 'false'" />
 
+    <!--
+      Report test status.
+    -->
     <Message Text="Tests succeeded: $(_TestAssembly) [$(_TestEnvironment)]" Condition="'$(_TestErrorCode)' == '0'" Importance="high" />
-    <Error Text="%(TestToRun.ResultsHtmlPath) [$(_TestEnvironment)]" Condition="'$(_TestErrorCode)' != '0'" File="XUnit" ContinueOnError="true" />
+
+    <PropertyGroup>
+      <_ResultsFileToDisplay>%(TestToRun.ResultsHtmlPath)</_ResultsFileToDisplay>
+      <_ResultsFileToDisplay Condition="!Exists('$(_ResultsFileToDisplay)')">%(TestToRun.ResultsStdOutPath)</_ResultsFileToDisplay>
+    </PropertyGroup>
+
+    <Error Text="Tests failed: $(_ResultsFileToDisplay) [$(_TestEnvironment)]" Condition="'$(_TestErrorCode)' != '0'" File="XUnit" ContinueOnError="true" />
+
+    <ItemGroup>
+      <FileWrites Include="@(_OutputFiles)"/>
+    </ItemGroup>
   </Target>
 
   <!-- Workaround for https://github.com/xunit/xunit/issues/1651 -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
@@ -32,7 +32,6 @@
     This matches the common expectations that test command always runs all tests in scope.
   -->
   <Target Name="RunTests"
-          DependsOnTargets="InitializeDotNetToolPath"
           Inputs="@(TestToRun);*"
           Outputs="%(TestToRun.LogPath);%(TestToRun.ResultsXmlPath);%(TestToRun.ResultsHtmlPath)">
 


### PR DESCRIPTION
Add TestRuntime - this enables the runner to run on .NET Core, full framework and Mono.
Add TestCaptureOutput - controls whether test runner std output is redirected to a file.
Add TestTargetFrameworks - allows to select subset of target frameworks to run on.

Instead if dotnet location is not specified explicitly via DOTNET_INSTALL_DIR or found in .dotnet subdirectory,
set DotNetTool to "dotnet" and let the Exec task find it on PATH.