### PR TITLE
Add tasks

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,6 +28,7 @@
     <MoqVersion>4.8.3</MoqVersion>
     <MonoOptionsVersion>5.3.0.1</MonoOptionsVersion>
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
+    <NuGetVersioningVersion>4.4.0</NuGetVersioningVersion>
     <NuGetVersion>4.4.0</NuGetVersion>
     <OctokitVersion>0.30.0</OctokitVersion>
     <DotNetSleetLibVersion>2.2.73</DotNetSleetLibVersion>

--- a/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
+    <PackageReference Include="NuGet.Versioning" Version="$(NuGetVersioningVersion)" />
     <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/CheckRequiredDotNetVersion.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/CheckRequiredDotNetVersion.cs
@@ -1,0 +1,111 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NuGet.Versioning;
+
+namespace Microsoft.DotNet.Arcade.Sdk
+{
+    public class CheckRequiredDotNetVersion : Task
+    {
+        private static readonly string s_cacheKey = "CheckRequiredDotNetVersion-6ED0A075-A4B3-46B1-97D4-448558D515D3";
+
+        private sealed class CacheEntry
+        {
+            public readonly DateTime LastWrite;
+            public readonly bool Success;
+
+            public CacheEntry(DateTime lastWrite, bool success)
+            {
+                LastWrite = lastWrite;
+                Success = success;
+            }
+        }
+
+        [Required]
+        public string RepositoryRoot { get; set; }
+
+        [Required]
+        public string SdkVersion { get; set; }
+
+        public override bool Execute()
+        {
+            if (!SemanticVersion.TryParse(SdkVersion, out var currentSdkVersion))
+            {
+                Log.LogError($"Invalid version: {SdkVersion}");
+                return false;
+            }
+
+            var globalJsonPath = Path.Combine(RepositoryRoot, "global.json");
+            DateTime lastWrite;
+            try
+            {
+                lastWrite = File.GetLastWriteTimeUtc(globalJsonPath);
+            }
+            catch (Exception e)
+            {
+                Log.LogError($"Error accessing file '{globalJsonPath}': {e.Message}");
+                return false;
+            }
+
+            var cachedResult = (CacheEntry)BuildEngine4.GetRegisteredTaskObject(s_cacheKey, RegisteredTaskObjectLifetime.Build);
+            if (cachedResult != null && lastWrite == cachedResult.LastWrite)
+            {
+                // Error has already been reported if the current SDK version is not sufficient.
+                if (!cachedResult.Success)
+                {
+                    Log.LogMessage(MessageImportance.Low, $"Previous .NET Core SDK version check failed.");
+                }
+
+                return cachedResult.Success;
+            }
+
+            bool execute()
+            {
+                string globalJson;
+                try
+                {
+                    globalJson = File.ReadAllText(globalJsonPath);
+                }
+                catch (Exception e)
+                {
+                    Log.LogError($"Error reading file '{globalJsonPath}': {e.Message}");
+                    return false;
+                }
+
+                // avoid Newtonsoft.Json dependency
+                var match = Regex.Match(globalJson, $@"""dotnet""\s*:\s*""([^""]+)""");
+                if (!match.Success)
+                {
+                    Log.LogError($"Unable to determine dotnet version from file '{globalJsonPath}'.");
+                    return false;
+                }
+
+                var minSdkVersionStr = match.Groups[1].Value;
+                if (!SemanticVersion.TryParse(minSdkVersionStr, out var minSdkVersion))
+                {
+                    Log.LogError($"DotNet version specified in '{globalJsonPath}' is invalid: {minSdkVersionStr}.");
+                    return false;
+                }
+
+                if (currentSdkVersion < minSdkVersion)
+                {
+                    Log.LogError($"The .NET Core SDK version {currentSdkVersion} is below the minimum required version {minSdkVersion}. You can install newer .NET Core SDK from https://www.microsoft.com/net/download.");
+                    return false;
+                }
+
+                return true;
+            }
+
+            bool success = execute();
+            BuildEngine4.RegisterTaskObject(s_cacheKey, new CacheEntry(lastWrite, success), RegisteredTaskObjectLifetime.Build, allowEarlyCollection: true);
+            return success;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/CompareVersions.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/CompareVersions.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NuGet.Versioning;
+
+namespace Microsoft.DotNet.Arcade.Sdk
+{
+    public class CompareVersions : Task
+    {
+        [Required]
+        public string Left { get; set; }
+
+        [Required]
+        public string Right { get; set; }
+
+        [Output]
+        public int Result { get; set; }
+
+        public override bool Execute()
+        {
+            ExecuteImpl();
+            return !Log.HasLoggedErrors;
+        }
+
+        private void ExecuteImpl()
+        {
+            if (!SemanticVersion.TryParse(Left, out var left))
+            {
+                Log.LogError($"Invalid version: '{Left}'");
+                return;
+            }
+
+            if (!SemanticVersion.TryParse(Right, out var right))
+            {
+                Log.LogError($"Invalid version: '{Right}'");
+                return;
+            }
+
+            Result = left.CompareTo(right);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GetAssemblyFullName.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GetAssemblyFullName.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.Arcade.Sdk
+{
+    public class GetAssemblyFullName : Task
+    {
+        [Required]
+        public ITaskItem[] Items { get; set; }
+
+        [Required]
+        public string PathMetadata { get; set; }
+
+        [Required]
+        public string FullNameMetadata { get; set; }
+
+        [Output]
+        public ITaskItem[] ItemsWithFullName { get; set; }
+
+        public override bool Execute()
+        {
+            ItemsWithFullName = Items;
+
+            foreach (var item in Items)
+            {
+                item.SetMetadata(FullNameMetadata, AssemblyName.GetAssemblyName(item.GetMetadata(PathMetadata)).FullName);
+            }
+
+            return true;
+        }
+    }
+}
+

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/SingleError.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/SingleError.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.Arcade.Sdk
+{
+    public sealed class SingleError : Task
+    {
+        private static readonly string s_cacheKeyPrefix = "SingleError-F88E25C6-1488-4E81-A458-A0921794E6E3:";
+
+        [Required]
+        public string Text { get; set; }
+
+        public override bool Execute()
+        {
+            var key = s_cacheKeyPrefix + Text;
+
+            var errorReportedSentinel = BuildEngine4.GetRegisteredTaskObject(key, RegisteredTaskObjectLifetime.Build);
+            if (errorReportedSentinel != null)
+            {
+                Log.LogMessage(MessageImportance.Low, Text);
+                return false;
+            }
+
+            BuildEngine4.RegisterTaskObject(key, new object(), RegisteredTaskObjectLifetime.Build, allowEarlyCollection: true);
+            Log.LogError(Text);
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/Unsign.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/Unsign.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Reflection.PortableExecutable;
+using System.Threading;
+
+namespace Microsoft.DotNet.Arcade.Sdk
+{
+#if NET461
+    [LoadInSeparateAppDomain]
+    public sealed class Unsign : AppDomainIsolatedTask
+    {
+        static Unsign() => AssemblyResolution.Initialize();
+#else
+    public class Unsign : Task
+    {
+#endif
+        [Required]
+        public string FilePath { get; set; }
+
+        public override bool Execute()
+        {
+#if NET461
+            AssemblyResolution.Log = Log;
+#endif
+            try
+            {
+                ExecuteImpl();
+                return !Log.HasLoggedErrors;
+            }
+            finally
+            {
+#if NET461
+                AssemblyResolution.Log = null;
+#endif
+            }
+        }
+
+        private void ExecuteImpl()
+        {
+            using (var stream = File.Open(FilePath, FileMode.Open, FileAccess.ReadWrite, FileShare.Read))
+            using (var peReader = new PEReader(stream))
+            {
+                var headers = peReader.PEHeaders;
+                var entry = headers.PEHeader.CertificateTableDirectory;
+                if (entry.Size == 0)
+                {
+                    return;
+                }
+
+                using (var writer = new BinaryWriter(stream))
+                {
+                    int certificateTableDirectoryOffset = (headers.PEHeader.Magic == PEMagic.PE32Plus) ? 144 : 128;
+                    stream.Position = peReader.PEHeaders.PEHeaderStartOffset + certificateTableDirectoryOffset;
+
+                    writer.Write((long)0);
+                    writer.Flush();
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
@@ -6,12 +6,14 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.Unsign" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
+
   <!--
     Required properties:
       IbcOptimizationDataDir           The directory containing IBC optimization data.
   -->
   <PropertyGroup>
-    <_OptimizationDataFile>$([System.IO.Path]::GetFullPath('$(IbcOptimizationDataDir)$(TargetName).pgo'))</_OptimizationDataFile>
+    <_PreviousOptimizedFile>$([System.IO.Path]::Combine($(IbcOptimizationDataDir), '$(TargetName).pgo'))</_PreviousOptimizedFile>
     <PostCompileBinaryModificationSentinelFile>$(IntermediateOutputPath)$(TargetFileName).pcbm</PostCompileBinaryModificationSentinelFile>
   </PropertyGroup>
 
@@ -21,8 +23,9 @@
   -->
   <Target Name="PostCompileBinaryModification"
           AfterTargets="CoreCompile"
-          DependsOnTargets="ApplyOptimizations"
-          Inputs="@(IntermediateAssembly)"
+          DependsOnTargets="_InitializeAssemblyOptimizationWithTargetAssembly;ApplyOptimizations"
+          Condition="'$(IsWpfTempProject)' != 'true' and Exists('$(_PreviousOptimizedFile)')"
+          Inputs="$(MSBuildAllProjects);@(IntermediateAssembly)"
           Outputs="@(IntermediateAssembly);$(PostCompileBinaryModificationSentinelFile)">
 
     <!-- Write out a sentinel timestamp file to prevent unnecessary work in incremental builds. -->
@@ -33,24 +36,53 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="_InitializeAssemblyOptimizationWithTargetAssembly">
+    <ItemGroup>
+      <OptimizeAssembly Include="@(IntermediateAssembly)" PreviousOptimizedFile="$(_PreviousOptimizedFile)" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Merges optimization data to assemblies specified in OptimizeAssembly item group.
+
+    Non-incremental. Calling targets need to handle incremental build if necessary.
+    Runs during any CI build. Performs the actual merge only when IBCMerge tool is available. It is expected to be available in an official build.
+  -->
+  <Target Name="_CalculateIbcArgs">
+    <ItemGroup>
+      <OptimizeAssembly>
+        <!--
+          -delete to delete data previously embedded in the binary. This is a no-op for binaries produced by this build, but is needed for dependencies such as System.Reflection.Metadata.
+          -incremental to map data stored in the optimized binary, which comes from a previous build, to the new build of the binary.
+        -->
+        <_IbcArgs>-q -f -partialNGEN -minify -delete -mo "%(OptimizeAssembly.Identity)" -incremental "%(OptimizeAssembly.PreviousOptimizedFile)"</_IbcArgs>
+      </OptimizeAssembly>
+    </ItemGroup>
+  </Target>
+
   <Target Name="ApplyOptimizations"
-          Condition="Exists('$(_OptimizationDataFile)')"
-          Inputs="@(IntermediateAssembly)"
-          Outputs="@(IntermediateAssembly);$(PostCompileBinaryModificationSentinelFile)">
+          DependsOnTargets="_CalculateIbcArgs"
+          Condition="'@(OptimizeAssembly)' != '' and '$(Configuration)' == 'Release' and '$(ContinuousIntegrationBuild)' == 'true'">
 
     <PropertyGroup>
-      <_RunIbc>false</_RunIbc>
-      <_RunIbc Condition="'$(Configuration)' == 'Release' and '$(OfficialBuild)' == 'true'">true</_RunIbc>
-
       <_IbcMergePath>$(NuGetPackageRoot)microsoft.dotnet.ibcmerge\$(MicrosoftDotNetIBCMergeVersion)\lib\net45\ibcmerge.exe</_IbcMergePath>
-      <_IbcMergeCommandLineArgs>-q -f -partialNGEN -minify -mo "@(IntermediateAssembly)" -incremental "$(_OptimizationDataFile)"</_IbcMergeCommandLineArgs>
+
+      <_RunIbcMerge>false</_RunIbcMerge>
+      <_RunIbcMerge Condition="'$(OfficialBuild)' == 'true' or Exists('$(_IbcMergePath)')">true</_RunIbcMerge>
     </PropertyGroup>
 
-    <Message Text="IBCMerge tool will be run in an official build with arguments: $(_IbcMergeCommandLineArgs)" Condition="'$(_RunIbc)' != 'true'" Importance="normal"/>
+    <Message Text='IBCMerge tool will be run in an official build with arguments: %(OptimizeAssembly._IbcArgs)'
+             Condition="'$(_RunIbcMerge)' != 'true'" 
+             Importance="normal"/>
 
-    <Exec Command='"$(_IbcMergePath)" $(_IbcMergeCommandLineArgs)' ConsoleToMSBuild="true" Condition="'$(_RunIbc)' == 'true'">
+    <Exec Command='"$(_IbcMergePath)" %(OptimizeAssembly._IbcArgs)' 
+          ConsoleToMSBuild="true"
+          Condition="'$(_RunIbcMerge)' == 'true'">
       <Output TaskParameter="ConsoleOutput" PropertyName="IbcMergeOutput" />
     </Exec>
+
+    <!-- Remove Authenticode signing record if present. -->
+    <Microsoft.DotNet.Arcade.Sdk.Unsign FilePath="%(OptimizeAssembly.Identity)" />
 
     <Message Text="$(IbcMergeOutput)" />
   </Target>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
@@ -58,6 +58,12 @@
     </PropertyGroup>
   </Target>
 
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.CheckRequiredDotNetVersion" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
+
+  <Target Name="_CheckRequiredDotNetVersion" BeforeTargets="BeforeBuild">
+    <Microsoft.DotNet.Arcade.Sdk.CheckRequiredDotNetVersion RepositoryRoot="$(RepoRoot)" SdkVersion="$(NETCoreSdkVersion)" />
+  </Target>
+
   <!--
     GenerateNativeVersionFile target is a standalone target intended to be pulled into a build once as
     a pre-step before kicking off a native build. It will generate a _version.h or _version.c depending


### PR DESCRIPTION
Add CheckRequiredDotNetVersion task that checks that the build is using the correct SDK version.
Add CompareVersions task that compares semantic versions.
Add GetAssemblyFullName that reads assembly name from file.
Add SingleError task that reports an error at most as many times as there are nodes building the solution.
Add Unsign task that unsigns a signed PE file. Useful for re-signing, e.g. when IBCMerge updates PE resources.

The above tasks are required to move Roslyn to Arcade.