### PR TITLE
Add runAsPublic parameter to templates

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,8 +1,8 @@
 variables:
   _HelixType: build/product
-  ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.Repository.Provider'], 'GitHub')) }}:
+  ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
     _HelixSource: pr/dotnet/arcade/$(Build.SourceBranch)
-  ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.Repository.Provider'], 'GitHub')) }}:
+  ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     _TeamName: DotNetCore
     _HelixSource: official/dotnet/arcade/$(Build.SourceBranch)
 
@@ -18,9 +18,9 @@ phases:
       queue:
         # For public or PR jobs, use the hosted pool.  For internal jobs use the internal pool.
         # Will eventually change this to two BYOC pools.
-        ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.Repository.Provider'], 'GitHub')) }}:
+        ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
           name: dotnet-external-temp
-        ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.Repository.Provider'], 'GitHub')) }}:
+        ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
           name: dotnet-internal-temp
         parallel: 2
         matrix:
@@ -32,11 +32,11 @@ phases:
           Build_Release:
             _BuildConfig: Release
             # PRs or external builds are not signed.
-            ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.Repository.Provider'], 'GitHub')) }}:
+            ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
               _PublishType: none
               _SignType: test
               _DotNetPublishToBlobFeed : false
-            ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.Repository.Provider'], 'GitHub')) }}:
+            ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
               _PublishType: blob
               _SignType: real
               _DotNetPublishToBlobFeed : true
@@ -46,9 +46,9 @@ phases:
       name: Linux
       queue:
         container: LinuxContainer
-        ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.Repository.Provider'], 'GitHub')) }}:
+        ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
           name: dnceng-linux-external-temp
-        ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.Repository.Provider'], 'GitHub')) }}:
+        ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
           name: dnceng-linux-internal-temp
         parallel: 2
         matrix:
@@ -63,7 +63,7 @@ phases:
             _SignType: none
             _DotNetPublishToBlobFeed : false
 
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.Repository.Provider'], 'GitHub')) }}:
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - template: /eng/common/templates/phases/publish-build-assets.yml
       parameters:
         dependsOn:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -17,7 +17,6 @@ parameters:
 #   - eq/ne(variables['System.TeamProject'], 'public') - Running/not running on the dotnet public VSTS project 
 #   - and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest') - Not running in public and not a pull request.
 #   - or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest') - Running in public or a pull request.
-#   - parameters.runAsPublic - Run this build as if it was a public build. No internal resources will be used regardless of the VSTS project.
 
 phases:
 - template: /eng/common/templates/phases/base.yml

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -36,7 +36,7 @@ phases:
       ${{ insert }}: ${{ parameters.variables }}
       _HelixBuildConfig: $(_BuildConfig)
       # Only enable publishing in non-public, non PR scenarios.
-      ${{ if and(not(parameters.runAsPublic), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      ${{ if and(not(parameters.runAsPublic), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.Repository.Provider'], 'GitHub')) }}:
         # This should be changed to an isolated blob feed per-build.
         # Right now a manual build of a random branch would get published alongside the normal branch artifacts.
         _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
@@ -48,13 +48,13 @@ phases:
           /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
         _OfficialBuildIdArgs: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
       # else
-      ${{ if or(parameters.runAsPublic, eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+      ${{ if or(parameters.runAsPublic, eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.Repository.Provider'], 'GitHub')) }}:
         _PublishArgs: ''
         _OfficialBuildIdArgs: ''
         _SignArgs: ''
 
     steps:
-    - ${{ if and(not(parameters.runAsPublic), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - ${{ if and(not(parameters.runAsPublic), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.Repository.Provider'], 'GitHub')) }}:
         - task: AzureKeyVault@1
           inputs:
             azureSubscription: 'DotNet-Engineering-Services_KeyVault'

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -17,7 +17,7 @@ parameters:
 #   - eq/ne(variables['System.TeamProject'], 'public') - Running/not running on the dotnet public VSTS project 
 #   - and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest') - Not running in public and not a pull request.
 #   - or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest') - Running in public or a pull request.
-#   - not(parameters.runAsPublic) - Run this build as if it was a public build. No internal resources will be used regardless of the VSTS project.
+#   - parameters.runAsPublic - Run this build as if it was a public build. No internal resources will be used regardless of the VSTS project.
 
 phases:
 - template: /eng/common/templates/phases/base.yml
@@ -36,7 +36,7 @@ phases:
       ${{ insert }}: ${{ parameters.variables }}
       _HelixBuildConfig: $(_BuildConfig)
       # Only enable publishing in non-public, non PR scenarios.
-      ${{ if and(not(parameters.runAsPublic), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.Repository.Provider'], 'GitHub')) }}:
+      ${{ if and(not(parameters.runAsPublic), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         # This should be changed to an isolated blob feed per-build.
         # Right now a manual build of a random branch would get published alongside the normal branch artifacts.
         _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
@@ -48,13 +48,13 @@ phases:
           /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
         _OfficialBuildIdArgs: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
       # else
-      ${{ if or(parameters.runAsPublic, eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.Repository.Provider'], 'GitHub')) }}:
+      ${{ if or(parameters.runAsPublic, eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         _PublishArgs: ''
         _OfficialBuildIdArgs: ''
         _SignArgs: ''
 
     steps:
-    - ${{ if and(not(parameters.runAsPublic), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.Repository.Provider'], 'GitHub')) }}:
+    - ${{ if and(not(parameters.runAsPublic), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         - task: AzureKeyVault@1
           inputs:
             azureSubscription: 'DotNet-Engineering-Services_KeyVault'

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -8,6 +8,8 @@ parameters:
   queue: {}
   # variables YAML object - https://github.com/Microsoft/vsts-agent/blob/master/docs/preview/yamlgettingstarted-schema.md#phase
   variables: {}
+  # run this build as a public build, even in the internal project
+  runAsPublic: false
 
 # Common conditionals:  There are a number of common conditionals that are useful.  Generally these are used to decide what resources can be accessed,
 #                       or what logic should be applied based on the context the build is being run in.
@@ -15,7 +17,7 @@ parameters:
 #   - eq/ne(variables['System.TeamProject'], 'public') - Running/not running on the dotnet public VSTS project 
 #   - and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest') - Not running in public and not a pull request.
 #   - or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest') - Running in public or a pull request.
-#   - eq(variables['Build.Repository.Provider'], 'GitHub') - Build source is in GitHub (even if the project is private)
+#   - not(parameters.runAsPublic) - Run this build as if it was a public build. No internal resources will be used regardless of the VSTS project.
 
 phases:
 - template: /eng/common/templates/phases/base.yml
@@ -28,11 +30,13 @@ phases:
 
     queue: ${{ parameters.queue }}
 
+    runAsPublic: ${{ parameters.runAsPublic }}
+
     variables: 
       ${{ insert }}: ${{ parameters.variables }}
       _HelixBuildConfig: $(_BuildConfig)
       # Only enable publishing in non-public, non PR scenarios.
-      ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.Repository.Provider'], 'GitHub')) }}:
+      ${{ if and(not(parameters.runAsPublic), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         # This should be changed to an isolated blob feed per-build.
         # Right now a manual build of a random branch would get published alongside the normal branch artifacts.
         _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
@@ -44,13 +48,13 @@ phases:
           /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
         _OfficialBuildIdArgs: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
       # else
-      ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.Repository.Provider'], 'GitHub')) }}:
+      ${{ if or(parameters.runAsPublic, eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         _PublishArgs: ''
         _OfficialBuildIdArgs: ''
         _SignArgs: ''
 
     steps:
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.Repository.Provider'], 'GitHub')) }}:
+    - ${{ if and(not(parameters.runAsPublic), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         - task: AzureKeyVault@1
           inputs:
             azureSubscription: 'DotNet-Engineering-Services_KeyVault'

--- a/eng/common/templates/phases/base.yml
+++ b/eng/common/templates/phases/base.yml
@@ -64,7 +64,7 @@ phases:
 
   - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
     # Internal only resource, and Microbuild signing shouldn't be applied to PRs.
-    - ${{ if and(not(parameters.runAsPublic), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.Repository.Provider'], 'GitHub')) }}:
+    - ${{ if and(not(parameters.runAsPublic), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - task: MicroBuildSigningPlugin@2
         displayName: Install MicroBuild plugin
         inputs:
@@ -82,7 +82,7 @@ phases:
 
   - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
     # Internal only resources
-    - ${{ if and(not(parameters.runAsPublic), ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Repository.Provider'], 'GitHub')) }}:
+    - ${{ if and(not(parameters.runAsPublic), ne(variables['System.TeamProject'], 'public')) }}:
       - task: MicroBuildCleanup@1
         displayName: Execute Microbuild cleanup tasks  
         condition: and(always(), in(variables['_SignType'], 'real', 'test'), eq(variables['Agent.Os'], 'Windows_NT'))
@@ -95,7 +95,7 @@ phases:
         helixSource: $(_HelixSource)
         helixType: $(_HelixType)
 
-  - ${{ if and(not(parameters.runAsPublic), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.Repository.Provider'], 'GitHub')) }}:
+  - ${{ if and(not(parameters.runAsPublic), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - task: CopyFiles@2
       displayName: Gather Asset Manifests
       inputs:

--- a/eng/common/templates/phases/base.yml
+++ b/eng/common/templates/phases/base.yml
@@ -18,7 +18,7 @@ parameters:
   variables: {}
 
   # Optional: should run as a public build even in the internal project
-  #           if 'true', the build won't have access to internal resources
+  #           if 'true', the build won't run any of the internal only steps, even if it is running in non-public projects.
   runAsPublic: false
 
   ## Telemetry variables
@@ -82,7 +82,7 @@ phases:
 
   - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
     # Internal only resources
-    - ${{ if and(not(parameters.runAsPublic), ne(variables['System.TeamProject'], 'public')) }}:
+    - ${{ if and(not(parameters.runAsPublic), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - task: MicroBuildCleanup@1
         displayName: Execute Microbuild cleanup tasks  
         condition: and(always(), in(variables['_SignType'], 'real', 'test'), eq(variables['Agent.Os'], 'Windows_NT'))

--- a/eng/common/templates/phases/base.yml
+++ b/eng/common/templates/phases/base.yml
@@ -17,6 +17,10 @@ parameters:
   # Optional: variables
   variables: {}
 
+  # Optional: should run as a public build even in the internal project
+  #           if 'true', the build won't have access to internal resources
+  runAsPublic: false
+
   ## Telemetry variables
 
   # Optional: enable sending telemetry
@@ -56,10 +60,11 @@ phases:
         buildConfig: $(_HelixBuildConfig)
         helixSource: $(_HelixSource)
         helixType: $(_HelixType)
+        runAsPublic: ${{ parameters.runAsPublic }}
 
   - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
     # Internal only resource, and Microbuild signing shouldn't be applied to PRs.
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.Repository.Provider'], 'GitHub')) }}:
+    - ${{ if and(not(parameters.runAsPublic), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.Repository.Provider'], 'GitHub')) }}:
       - task: MicroBuildSigningPlugin@2
         displayName: Install MicroBuild plugin
         inputs:
@@ -77,7 +82,7 @@ phases:
 
   - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
     # Internal only resources
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Repository.Provider'], 'GitHub')) }}:
+    - ${{ if and(not(parameters.runAsPublic), ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Repository.Provider'], 'GitHub')) }}:
       - task: MicroBuildCleanup@1
         displayName: Execute Microbuild cleanup tasks  
         condition: and(always(), in(variables['_SignType'], 'real', 'test'), eq(variables['Agent.Os'], 'Windows_NT'))
@@ -90,7 +95,7 @@ phases:
         helixSource: $(_HelixSource)
         helixType: $(_HelixType)
 
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.Repository.Provider'], 'GitHub')) }}:
+  - ${{ if and(not(parameters.runAsPublic), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.Repository.Provider'], 'GitHub')) }}:
     - task: CopyFiles@2
       displayName: Gather Asset Manifests
       inputs:

--- a/eng/common/templates/phases/publish-build-assets.yml
+++ b/eng/common/templates/phases/publish-build-assets.yml
@@ -13,7 +13,7 @@ phases:
     variables:
       config: ${{ parameters.configuration }}
     steps:
-      - ${{ if and(not(parameters.runAsPublic), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.Repository.Provider'], 'GitHub')) }}:
+      - ${{ if and(not(parameters.runAsPublic), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         - task: DownloadBuildArtifacts@0
           displayName: Download artifact
           inputs:

--- a/eng/common/templates/phases/publish-build-assets.yml
+++ b/eng/common/templates/phases/publish-build-assets.yml
@@ -4,6 +4,7 @@ parameters:
   configuration: 'Debug'
   condition: succeeded()
   continueOnError: false
+  runAsPublic: false
 phases:
   - phase: Asset_Registry_Publish
     displayName: Publish to Build Asset Registry
@@ -12,7 +13,7 @@ phases:
     variables:
       config: ${{ parameters.configuration }}
     steps:
-      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.Repository.Provider'], 'GitHub')) }}:
+      - ${{ if and(not(parameters.runAsPublic), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.Repository.Provider'], 'GitHub')) }}:
         - task: DownloadBuildArtifacts@0
           displayName: Download artifact
           inputs:

--- a/eng/common/templates/steps/telemetry-start.yml
+++ b/eng/common/templates/steps/telemetry-start.yml
@@ -5,7 +5,7 @@ parameters:
   runAsPublic: false
 
 steps:
-- ${{ if and(not(parameters.runAsPublic), not(eq(variables['System.TeamProject'], 'public')), ne(variables['Build.Repository.Provider'], 'GitHub')) }}:
+- ${{ if and(not(parameters.runAsPublic), not(eq(variables['System.TeamProject'], 'public'))) }}:
   - task: AzureKeyVault@1
     inputs:
       azureSubscription: 'HelixProd_KeyVault'

--- a/eng/common/templates/steps/telemetry-start.yml
+++ b/eng/common/templates/steps/telemetry-start.yml
@@ -2,9 +2,10 @@ parameters:
   helixSource: 'undefined_defaulted_in_telemetry.yml'
   helixType: 'undefined_defaulted_in_telemetry.yml'
   buildConfig: ''
+  runAsPublic: false
 
 steps:
-- ${{ if and(not(eq(variables['System.TeamProject'], 'public')), ne(variables['Build.Repository.Provider'], 'GitHub')) }}:
+- ${{ if and(not(parameters.runAsPublic), not(eq(variables['System.TeamProject'], 'public')), ne(variables['Build.Repository.Provider'], 'GitHub')) }}:
   - task: AzureKeyVault@1
     inputs:
       azureSubscription: 'HelixProd_KeyVault'


### PR DESCRIPTION
fixes #1241

Adds runAsPublic parameter to:

* base.yml
* publish-build-assets.yml
* telemetry-start.yml
* eng/build.yml

Setting this parameter to 'true' when calling the templates will treat the build as if it was running in the public project, and will prevent access to internal only resources.

Validated by setting the parameter to true in [this commit](https://dnceng.visualstudio.com/internal/_git/d551d0d5-053b-400b-99d7-56e9c6c469c4/commit/f4d66baee21565dc8c77c4cdabe60b0980c9ae77/
) and running this build: https://dnceng.visualstudio.com/internal/_build/results?buildId=39127&view=logs
which didn't trigger any of the internal only checks.
