### PR TITLE
Update dependencies from a packages folder and based on name and version

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
-  <ProductDependencies></ProductDependencies>
+  <ProductDependencies>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="2.2.0-beta.18551.8">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>3919b63dedd65c22154483afed5cfe7df73c9562</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.Maestro.Tasks" Version="1.0.0-beta.18551.8">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>3919b63dedd65c22154483afed5cfe7df73c9562</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.SignTool" Version="1.0.0-beta.18551.8">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>3919b63dedd65c22154483afed5cfe7df73c9562</Sha>
+    </Dependency>
+  </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.18530.4">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,9 +9,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>3919b63dedd65c22154483afed5cfe7df73c9562</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SignTool" Version="1.0.0-beta.18551.8">
+    <Dependency Name="Microsoft.DotNet.SignTool" Version="1.0.0-beta.18511.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>3919b63dedd65c22154483afed5cfe7df73c9562</Sha>
+      <Sha>1460f84770741629185f493eedddd1c10b40ab2b</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,8 +44,8 @@
     <XUnitVersion>2.4.1-pre.build.4059</XUnitVersion>
     <XUnitVSRunnerVersion>2.4.1-pre.build.4059</XUnitVSRunnerVersion>
     <MicrosoftDotNetBuildTasksFeedVersion>2.2.0-beta.18551.8</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetMaestroTasksVersion>2.2.0-beta.18551.8</MicrosoftDotNetMaestroTasksVersion>
-    <MicrosoftDotNetSignToolVersion>2.2.0-beta.18551.8</MicrosoftDotNetSignToolVersion>
+    <MicrosoftDotNetMaestroTasksVersion>1.0.0-beta.18551.8</MicrosoftDotNetMaestroTasksVersion>
+    <MicrosoftDotNetSignToolVersion>1.0.0-beta.18551.8</MicrosoftDotNetSignToolVersion>
     <!-- 3rd Part Packages Public Keys -->
     <DynamicProxyGenAsm2Key>0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7</DynamicProxyGenAsm2Key>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -45,7 +45,7 @@
     <XUnitVSRunnerVersion>2.4.1-pre.build.4059</XUnitVSRunnerVersion>
     <MicrosoftDotNetBuildTasksFeedVersion>2.2.0-beta.18551.8</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetMaestroTasksVersion>1.0.0-beta.18551.8</MicrosoftDotNetMaestroTasksVersion>
-    <MicrosoftDotNetSignToolVersion>1.0.0-beta.18551.8</MicrosoftDotNetSignToolVersion>
+    <MicrosoftDotNetSignToolVersion>1.0.0-beta.18511.3</MicrosoftDotNetSignToolVersion>
     <!-- 3rd Part Packages Public Keys -->
     <DynamicProxyGenAsm2Key>0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7</DynamicProxyGenAsm2Key>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -43,6 +43,9 @@
     <WindowsAzureStorageVersion>8.5.0</WindowsAzureStorageVersion>
     <XUnitVersion>2.4.1-pre.build.4059</XUnitVersion>
     <XUnitVSRunnerVersion>2.4.1-pre.build.4059</XUnitVSRunnerVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>2.2.0-beta.18551.8</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetMaestroTasksVersion>2.2.0-beta.18551.8</MicrosoftDotNetMaestroTasksVersion>
+    <MicrosoftDotNetSignToolVersion>2.2.0-beta.18551.8</MicrosoftDotNetSignToolVersion>
     <!-- 3rd Part Packages Public Keys -->
     <DynamicProxyGenAsm2Key>0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7</DynamicProxyGenAsm2Key>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateDependenciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateDependenciesOperation.cs
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.Darc.Operations
 
                 if (!string.IsNullOrEmpty(_options.Name) && !string.IsNullOrEmpty(_options.Version))
                 {
-                    DependencyDetail dependency = dependencies.FirstOrDefault();
+                    DependencyDetail dependency = dependencies.First();
                     dependency.Version = _options.Version;
                     dependenciesToUpdate.Add(dependency);
 
@@ -165,12 +165,12 @@ namespace Microsoft.DotNet.Darc.Operations
                     // find matching dependencies so we should let the user know.
                     if (someUpToDate)
                     {
-                        Console.WriteLine($"All dependencies from channel '{_options.Channel}' are up to date.");
+                        Console.WriteLine($"All dependencies are up to date.");
                         return Constants.SuccessCode;
                     }
                     else
                     {
-                        Console.WriteLine($"Found no dependencies to update on channel '{_options.Channel}'.");
+                        Console.WriteLine($"Found no dependencies to update.");
                         return Constants.ErrorCode;
                     }
                 }
@@ -215,7 +215,7 @@ namespace Microsoft.DotNet.Darc.Operations
                 throw new DarcException($"Packages folder '{pathToFolder}' does not exist.");
             }
 
-            IEnumerable<string> packages = Directory.GetFiles(pathToFolder);
+            IEnumerable<string> packages = Directory.GetFiles(pathToFolder, "*.nupkg");
 
             foreach (string package in packages)
             {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateDependenciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateDependenciesOperation.cs
@@ -125,7 +125,9 @@ namespace Microsoft.DotNet.Darc.Operations
                         }
 
                         if (buildAsset.Version == dependency.Version &&
-                            buildAsset.Name == dependency.Name)
+                            buildAsset.Name == dependency.Name &&
+                            build.Repository == dependency.RepoUri &&
+                            build.Commit == dependency.Commit)
                         {
                             // No changes
                             someUpToDate = true;

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/UpdateDependenciesCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/UpdateDependenciesCommandLineOptions.cs
@@ -10,11 +10,19 @@ namespace Microsoft.DotNet.Darc.Options
     [Verb("update-dependencies", HelpText = "Update local dependencies from a channel.")]
     class UpdateDependenciesCommandLineOptions : CommandLineOptions
     {
-        [Option('c', "channel", Required = true, HelpText = "Channel to pull dependencies from.")]
+        [Option('c', "channel", HelpText = "Channel to pull dependencies from.")]
         public string Channel { get; set; }
 
-        [Option('n', "name", HelpText = "Optional name of dependency to update.  Otherwise all dependencies existing on 'channel' are updated.")]
+        [Option('n', "name", HelpText = "Optional name of dependency to update.  Otherwise all " +
+            "dependencies existing on 'channel' are updated.")]
         public string Name { get; set; }
+
+        [Option('v', "version", HelpText = "If name is provided this version in the update.")]
+        public string Version { get; set; }
+
+        [Option("packages-folder", HelpText = "An optional path to a folder which contains the packages." +
+            "which version will be used to update the dependencies.")]
+        public string PackagesFolder { get; set; }
 
         [Option("dry-run", HelpText = "Show what will be updated, but make no changes.")]
         public bool DryRun { get; set; }

--- a/src/Microsoft.DotNet.Darc/src/Darc/Options/UpdateDependenciesCommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Options/UpdateDependenciesCommandLineOptions.cs
@@ -17,11 +17,11 @@ namespace Microsoft.DotNet.Darc.Options
             "dependencies existing on 'channel' are updated.")]
         public string Name { get; set; }
 
-        [Option('v', "version", HelpText = "If name is provided this version in the update.")]
+        [Option('v', "version", HelpText = "The new version of dependency --name.")]
         public string Version { get; set; }
 
-        [Option("packages-folder", HelpText = "An optional path to a folder which contains the packages." +
-            "which version will be used to update the dependencies.")]
+        [Option("packages-folder", HelpText = "An optional path to a folder which contains the NuGet " +
+            "packages whose versions will be used to update existing dependencies.")]
         public string PackagesFolder { get; set; }
 
         [Option("dry-run", HelpText = "Show what will be updated, but make no changes.")]

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs
@@ -75,8 +75,18 @@ namespace Microsoft.DotNet.DarcLib
 
             if (arcadeItem != null)
             {
-                List<GitFile> engCommonFiles = await remote.GetCommonScriptFilesAsync(arcadeItem.RepoUri, arcadeItem.Commit);
-                filesToUpdate.AddRange(engCommonFiles);
+                try
+                {
+                    List<GitFile> engCommonFiles = await remote.GetCommonScriptFilesAsync(arcadeItem.RepoUri, arcadeItem.Commit);
+                    filesToUpdate.AddRange(engCommonFiles);
+                }
+                catch (Exception exc) when 
+                (exc.Message == "Not Found")
+                {
+                    _logger.LogWarning("Could not update 'eng/common'. Most likely this is a scenario " +
+                        "where a packages folder was passed and the commit which generated them is not " +
+                        "yet pushed.");
+                }
             }
 
             // Push on local does not commit.

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs
@@ -2,15 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Xml;
-using System.Xml.XPath;
-using Microsoft.Extensions.Logging;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.DotNet.DarcLib
 {

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/PackagesHelper.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/PackagesHelper.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using NuGet.Packaging;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+
+namespace Microsoft.DotNet.DarcLib.Helpers
+{
+    public class PackagesHelper
+    {
+        public static ManifestMetadata GetManifestMetadata(string packagePath)
+        {
+            ManifestMetadata manifestMetadata = null;
+            string tmpFolder = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+            try
+            {
+                ZipFile.ExtractToDirectory(packagePath, tmpFolder);
+                string nuspecPath = Directory.GetFiles(tmpFolder, "*.nuspec").FirstOrDefault();
+
+                if (!string.IsNullOrEmpty(nuspecPath))
+                {
+                    using (Stream stream = new MemoryStream(File.ReadAllBytes(nuspecPath)))
+                    {
+                        Manifest manifest = Manifest.ReadFrom(stream, false);
+                        manifestMetadata = manifest.Metadata;
+                    }
+                }
+            }
+            finally
+            {
+                Directory.Delete(tmpFolder, true);
+            }
+
+            return manifestMetadata;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/Microsoft.DotNet.DarcLib.csproj
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/Microsoft.DotNet.DarcLib.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.138.0-preview" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="NuGet.Packaging" Version="4.8.0" />
     <PackageReference Include="Octokit" Version="0.32.0" />
 
     <!--


### PR DESCRIPTION
For self-build we need to update local dependencies based on the generated folders of a build so we support passing a path to that folder and constructing the base dependencies from there. Also, now we support moving dependency X from version V1 to a passed in version V2