### PR TITLE
Add support for OptionalRules

### DIFF
--- a/src/Microsoft.Cci.Extensions/Differs/ExportDifferenceRuleAttribute.cs
+++ b/src/Microsoft.Cci.Extensions/Differs/ExportDifferenceRuleAttribute.cs
@@ -25,5 +25,6 @@ namespace Microsoft.Cci.Differs
 
         public bool NonAPIConformanceRule { get; set; }
         public bool MdilServicingRule { get; set; }
+        public bool OptionalRule { get; set; }
     }
 }

--- a/src/Microsoft.Cci.Extensions/Differs/IDifferenceRule.cs
+++ b/src/Microsoft.Cci.Extensions/Differs/IDifferenceRule.cs
@@ -15,5 +15,20 @@ namespace Microsoft.Cci.Differs
     public interface IDifferenceRuleMetadata
     {
         bool MdilServicingRule { get; }
+
+        bool OptionalRule { get; }
     }
+
+#if COREFX
+    /// <summary>
+    /// Metadata views must be concrete types rather than interfaces.
+    /// </summary>
+    /// <remarks>https://github.com/MicrosoftArchive/mef/blob/master/Wiki/MetroChanges.md#format-of-metadata-views</remarks>
+    public class DifferenceRuleMetadata : IDifferenceRuleMetadata
+    {
+        public bool MdilServicingRule { get; set; }
+
+        public bool OptionalRule { get; set; }
+    }
+#endif
 }

--- a/src/Microsoft.DotNet.ApiCompat/Rules/Compat/ParameterNamesCannotChange.cs
+++ b/src/Microsoft.DotNet.ApiCompat/Rules/Compat/ParameterNamesCannotChange.cs
@@ -8,8 +8,7 @@ using Microsoft.Cci.Extensions;
 
 namespace Microsoft.Cci.Differs.Rules
 {
-    // @todo: Candidate for strict mode.
-    //[ExportDifferenceRule]
+    [ExportDifferenceRule(OptionalRule = true)]
     internal class ParameterNamesCannotChange : CompatDifferenceRule
     {
         public override DifferenceType Diff(IDifferences differences, ITypeDefinitionMember impl, ITypeDefinitionMember contract)

--- a/src/Microsoft.DotNet.ApiCompat/build/Microsoft.DotNet.ApiCompat.targets
+++ b/src/Microsoft.DotNet.ApiCompat/build/Microsoft.DotNet.ApiCompat.targets
@@ -55,6 +55,7 @@
       <ApiCompatArgs>$(ApiCompatArgs) -contractDepends:"@(_ContractDependencyDirectories, ','),"</ApiCompatArgs>
       <ApiCompatArgs>$(ApiCompatArgs) -implDirs:"$(IntermediateOutputPath),@(_DependencyDirectories, ','),"</ApiCompatArgs>
       <ApiCompatArgs Condition="'$(ApiCompatExcludeAttributeList)' != ''">$(ApiCompatArgs) -excludeAttributes:"$(ApiCompatExcludeAttributeList)"</ApiCompatArgs>
+      <ApiCompatArgs Condition="'$(ApiCompatEnforceOptionalRules)' == 'true'">$(ApiCompatArgs) -enforceOptionalRules</ApiCompatArgs>
       <ApiCompatArgs Condition="'$(BaselineAllAPICompatError)'!='true' and Exists('$(ApiCompatBaseline)')">$(ApiCompatArgs) -baseline:"$(ApiCompatBaseline)"</ApiCompatArgs>
       <ApiCompatBaselineAll Condition="'$(BaselineAllAPICompatError)'=='true'">&gt; $(ApiCompatBaseline)</ApiCompatBaselineAll>
       <ApiCompatExitCode>0</ApiCompatExitCode>
@@ -107,6 +108,7 @@
       <MatchingRefApiCompatArgs>$(MatchingRefApiCompatArgs) -implDirs:"@(_ImplementationDependencyDirectories, ','),"</MatchingRefApiCompatArgs>
       <MatchingRefApiCompatArgs>$(MatchingRefApiCompatArgs) -rhs:reference</MatchingRefApiCompatArgs>
       <MatchingRefApiCompatArgs Condition="'$(ApiCompatExcludeAttributeList)' != ''">$(MatchingRefApiCompatArgs) -excludeAttributes:"$(ApiCompatExcludeAttributeList)"</MatchingRefApiCompatArgs>
+      <MatchingRefApiCompatArgs Condition="'$(ApiCompatEnforceOptionalRules)' == 'true'">$(MatchingRefApiCompatArgs) -enforceOptionalRules</MatchingRefApiCompatArgs>
       <MatchingRefApiCompatArgs Condition="'$(BaselineAllMatchingRefApiCompatError)'!='true' and Exists('$(MatchingRefApiCompatBaseline)')">$(MatchingRefApiCompatArgs) -baseline:"$(MatchingRefApiCompatBaseline)"</MatchingRefApiCompatArgs>
       <MatchingRefApiCompatBaselineAll Condition="'$(BaselineAllMatchingRefApiCompatError)'=='true'">&gt; $(MatchingRefApiCompatBaseline)</MatchingRefApiCompatBaselineAll>
 


### PR DESCRIPTION
* Introduce new ExportDifferenceRule metadata property, "OptionalRule",
to be able to mark/decorate rules as "optional" using:
```csharp
[ExportDifferenceRule (OptionalRule = true)]
```
OptionalRule is False by default.
* Exporting of OptionalRules is driven by the presence ofi
"enforceOptionalRules" flag. That way, rules marked as "optional"
wouldn't be enabled/exported by default.
* Users will still be able to disable rules (optional or not) using the
baseline filter.