### PR TITLE
Configure Arcade to sign known 3rd party libraries

### DIFF
--- a/Documentation/CorePackages/Signing.md
+++ b/Documentation/CorePackages/Signing.md
@@ -79,7 +79,12 @@ The Arcade SDK include a set of predefined configurations for the SignTool in th
 
 #### Signing 3rd Party Binaries
 
-Any 3rd party assembly which you distribute on public Microsoft feeds is supposed to be signed with the "3PartySHA2" certificate - a dual certificate. Arcade is configured to sign some known 3rd party libraries that we use with such dual certificate. In case you need to sign other 3rd party files take a look [how Arcade does it](../../src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj).
+Any 3rd party assembly which is distributed on public Microsoft feeds is 
+supposed to be signed with the "3PartySHA2" certificate - a dual certificate. 
+Arcade itself use this SignTool and as such the Arcade SDK is configured to
+dual sign 3rd party libraries that it uses. In case you need to sign other 
+3rd party files take a look [how Arcade does it](../../src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj)
+and put your custom configuration in the repo's `Signing.props` file.
 
 
 ## Usage Examples

--- a/Documentation/CorePackages/Signing.md
+++ b/Documentation/CorePackages/Signing.md
@@ -77,6 +77,11 @@ At the end, if the file is signable but no signing information was determined fo
 
 The Arcade SDK include a set of predefined configurations for the SignTool in the [Sign.proj](../../src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj) file. However, you can override/remove/update any of these configurations by including a file named `Signing.props` in the `\eng\` folder of your repository. See examples on the next section.
 
+#### Signing 3rd Party Binaries
+
+Any 3rd party assembly which you distribute on public Microsoft feeds is supposed to be signed with the "3PartySHA2" certificate - a dual certificate. Arcade is configured to sign some known 3rd party libraries that we use with such dual certificate. In case you need to sign other 3rd party files take a look [how Arcade does it](../../src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj).
+
+
 ## Usage Examples
 
 #### 1. Use the SDK predefined configuration

--- a/Documentation/CorePackages/Signing.md
+++ b/Documentation/CorePackages/Signing.md
@@ -81,11 +81,9 @@ The Arcade SDK include a set of predefined configurations for the SignTool in th
 
 Any 3rd party assembly which is distributed on public Microsoft feeds is 
 supposed to be signed with the "3PartySHA2" certificate - a dual certificate. 
-Arcade itself use this SignTool and as such the Arcade SDK is configured to
-dual sign 3rd party libraries that it uses. In case you need to sign other 
-3rd party files take a look [how Arcade does it](../../src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj)
-and put your custom configuration in the repo's `Signing.props` file.
-
+Arcade itself use the SignTool and as such the Arcade SDK is configured to
+dual sign 3rd party libraries that it uses. In case you need to sign 
+3rd party files take a look at [how Arcade does it](../../eng/Signing.props).
 
 ## Usage Examples
 

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -15,5 +15,5 @@
     <FileSignInfo Include="Mono.Options.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Newtonsoft.Json.Bsondll" CertificateName="3PartySHA2" />
-  <ItemGroup>
+  </ItemGroup>
 </Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,0 +1,19 @@
+<Project>
+  <!--
+    These are third party libraries that we use in Arcade. We need to sign them even if they
+    are already signed. However, they must be signed with a 3rd party certificate.
+  -->
+  <ItemGroup>
+    <FileSignInfo Include="AWSSDK.Core.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="AWSSDK.S3.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="CommandLine.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Handlebars.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="SleetLib.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Swashbuckle.AspNetCore.Swagger.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Octokit.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="YamlDotNet.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Mono.Options.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Newtonsoft.Json.Bsondll" CertificateName="3PartySHA2" />
+  <ItemGroup>
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -35,6 +35,22 @@
     <FileExtensionSignInfo Include=".nupkg" CertificateName="NuGet" />
     <FileExtensionSignInfo Include=".vsix" CertificateName="VsixSHA2" />
     <FileExtensionSignInfo Include=".zip" CertificateName="None" />
+
+    <!--
+      These are third party libraries that we use in Arcade. We need to sign them even if they
+      are already signed. However, they must be signed with a 3rd party certificate.
+    -->
+    <FileSignInfo Include="AWSSDK.Core.dll" CertificateName="3PartyDual" />
+    <FileSignInfo Include="AWSSDK.S3.dll" CertificateName="3PartyDual" />
+    <FileSignInfo Include="CommandLine.dll" CertificateName="3PartyDual" />
+    <FileSignInfo Include="Handlebars.dll" CertificateName="3PartyDual" />
+    <FileSignInfo Include="SleetLib.dll" CertificateName="3PartyDual" />
+    <FileSignInfo Include="Swashbuckle.AspNetCore.Swagger.dll" CertificateName="3PartyDual" />
+    <FileSignInfo Include="Octokit.dll" CertificateName="3PartyDual" />
+    <FileSignInfo Include="YamlDotNet.dll" CertificateName="3PartyDual" />
+    <FileSignInfo Include="Mono.Options.dll" CertificateName="3PartyDual" />
+    <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="3PartyDual" />
+    <FileSignInfo Include="Newtonsoft.Json.Bsondll" CertificateName="3PartyDual" />
   </ItemGroup>
 
   <!-- Allow repository to customize signing configuration -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -30,27 +30,11 @@
       The certificate can be overriden using the StrongNameSignInfo or the FileSignInfo item group.
     -->
     <FileExtensionSignInfo Include=".jar" CertificateName="MicrosoftJAR" />
-    <FileExtensionSignInfo Include=".js;.ps1;.psd1;.psm1;.psc1" CertificateName="Microsoft400" />
+    <FileExtensionSignInfo Include=".js;.ps1;.psd1;.psm1;.psc1;.py" CertificateName="Microsoft400" />
     <FileExtensionSignInfo Include=".dll;.exe" CertificateName="Microsoft400" />
     <FileExtensionSignInfo Include=".nupkg" CertificateName="NuGet" />
     <FileExtensionSignInfo Include=".vsix" CertificateName="VsixSHA2" />
     <FileExtensionSignInfo Include=".zip" CertificateName="None" />
-
-    <!--
-      These are third party libraries that we use in Arcade. We need to sign them even if they
-      are already signed. However, they must be signed with a 3rd party certificate.
-    -->
-    <FileSignInfo Include="AWSSDK.Core.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="AWSSDK.S3.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="CommandLine.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="Handlebars.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="SleetLib.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="Swashbuckle.AspNetCore.Swagger.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="Octokit.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="YamlDotNet.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="Mono.Options.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="Newtonsoft.Json.Bsondll" CertificateName="3PartySHA2" />
   </ItemGroup>
 
   <!-- Allow repository to customize signing configuration -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -40,17 +40,17 @@
       These are third party libraries that we use in Arcade. We need to sign them even if they
       are already signed. However, they must be signed with a 3rd party certificate.
     -->
-    <FileSignInfo Include="AWSSDK.Core.dll" CertificateName="3PartyDual" />
-    <FileSignInfo Include="AWSSDK.S3.dll" CertificateName="3PartyDual" />
-    <FileSignInfo Include="CommandLine.dll" CertificateName="3PartyDual" />
-    <FileSignInfo Include="Handlebars.dll" CertificateName="3PartyDual" />
-    <FileSignInfo Include="SleetLib.dll" CertificateName="3PartyDual" />
-    <FileSignInfo Include="Swashbuckle.AspNetCore.Swagger.dll" CertificateName="3PartyDual" />
-    <FileSignInfo Include="Octokit.dll" CertificateName="3PartyDual" />
-    <FileSignInfo Include="YamlDotNet.dll" CertificateName="3PartyDual" />
-    <FileSignInfo Include="Mono.Options.dll" CertificateName="3PartyDual" />
-    <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="3PartyDual" />
-    <FileSignInfo Include="Newtonsoft.Json.Bsondll" CertificateName="3PartyDual" />
+    <FileSignInfo Include="AWSSDK.Core.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="AWSSDK.S3.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="CommandLine.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Handlebars.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="SleetLib.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Swashbuckle.AspNetCore.Swagger.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Octokit.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="YamlDotNet.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Mono.Options.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Newtonsoft.Json.Bsondll" CertificateName="3PartySHA2" />
   </ItemGroup>
 
   <!-- Allow repository to customize signing configuration -->


### PR DESCRIPTION
Closes: #1257 

Fixes errors like the ones present here: https://dnceng.visualstudio.com/public/_build/results?buildId=39754&view=logs

I still need to add a configuration for signing `.py` files.

Edit: Talked with Trevor Short and he suggested using Microsoft400 for .py files.