### PR TITLE
Pass parameters through base job template

### DIFF
--- a/eng/common/templates/phases/base.yml
+++ b/eng/common/templates/phases/base.yml
@@ -7,6 +7,8 @@ parameters:
 
   # Optional: name of the phase (not specifying phase name may cause name collisions)
   name: ''
+  # Optional: display name of the phase
+  displayName: ''
 
   # Required: A defined YAML queue
   queue: {}
@@ -37,6 +39,7 @@ parameters:
 
 phases:
 - phase: ${{ parameters.name }}
+  displayName: ${{ parameters.displayName }}
 
   queue: ${{ parameters.queue }}
 

--- a/eng/common/templates/phases/base.yml
+++ b/eng/common/templates/phases/base.yml
@@ -10,6 +10,9 @@ parameters:
   # Optional: display name of the phase
   displayName: ''
 
+  # Optional: condition for the job to run
+  condition: ''
+
   # Optional: dependencies of the phase
   dependsOn: ''
 
@@ -51,6 +54,9 @@ phases:
   ${{ if ne(parameters.variables, '') }}:
     variables: 
       ${{ insert }}: ${{ parameters.variables }}
+
+  ${{ if ne(parameters.condition, '') }}:
+    condition: ${{ parameters.condition }}
 
   ${{ if ne(parameters.dependsOn, '') }}:
     dependsOn: ${{ parameters.dependsOn }}

--- a/eng/common/templates/phases/base.yml
+++ b/eng/common/templates/phases/base.yml
@@ -49,17 +49,17 @@ phases:
   ${{ if ne(parameters.displayName, '') }}:
     displayName: ${{ parameters.displayName }}
 
-  queue: ${{ parameters.queue }}
-
-  ${{ if ne(parameters.variables, '') }}:
-    variables: 
-      ${{ insert }}: ${{ parameters.variables }}
-
   ${{ if ne(parameters.condition, '') }}:
     condition: ${{ parameters.condition }}
 
   ${{ if ne(parameters.dependsOn, '') }}:
     dependsOn: ${{ parameters.dependsOn }}
+
+  queue: ${{ parameters.queue }}
+
+  ${{ if ne(parameters.variables, '') }}:
+    variables:
+      ${{ insert }}: ${{ parameters.variables }}
 
   steps:
   - checkout: self

--- a/eng/common/templates/phases/base.yml
+++ b/eng/common/templates/phases/base.yml
@@ -10,6 +10,9 @@ parameters:
   # Optional: display name of the phase
   displayName: ''
 
+  # Optional: dependencies of the phase
+  dependsOn: ''
+
   # Required: A defined YAML queue
   queue: {}
 
@@ -39,13 +42,18 @@ parameters:
 
 phases:
 - phase: ${{ parameters.name }}
-  displayName: ${{ parameters.displayName }}
+
+  ${{ if ne(parameters.displayName, '') }}:
+    displayName: ${{ parameters.displayName }}
 
   queue: ${{ parameters.queue }}
 
   ${{ if ne(parameters.variables, '') }}:
     variables: 
       ${{ insert }}: ${{ parameters.variables }}
+
+  ${{ if ne(parameters.dependsOn, '') }}:
+    dependsOn: ${{ parameters.dependsOn }}
 
   steps:
   - checkout: self


### PR DESCRIPTION
This makes it possible for users of the template to specify their own display names, conditions, and job dependencies. See https://github.com/dotnet/arcade/pull/1193 for some discussion on the display names.
