### PR TITLE
Add plus sign and commas as separators options for HelixTargetQueues

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MultiQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MultiQueue.targets
@@ -43,14 +43,21 @@
 
   <PropertyGroup>
     <WaitForWorkItemCompletion Condition="'$(WaitForWorkItemCompletion)' != 'false'">true</WaitForWorkItemCompletion>
+
+    <!-- Split up HelixTargetQueues list
+         In order to support all delimiters (commas, plus and semicolons).
+         Note that queues will never have ',', '+' or ';' in their name, and this greatly simplifies providing a queue list in *nix.
+    -->
+    <_ProcessedTargetQueues>$([System.String]::Copy('$(HelixTargetQueues)').Replace(',',';').Replace('+',';'))</_ProcessedTargetQueues>
   </PropertyGroup>
 
   <ItemGroup>
-    <HelixTargetQueue Include="$(HelixTargetQueues)" />
+    <!-- This Split() is needed since the semicolon in ProcessedTargetQueues is now a literal -->
+    <HelixTargetQueue Include="$(_ProcessedTargetQueues.Split(';'))" />
   </ItemGroup>
 
   <Target Name="ValidateTargetQueues">
-    <Error Condition="'$(HelixTargetQueues)' == ''" Text="You must specify at least one target queue to send a job to helix. Use HelixTargetQueues property for multiple or HelixTargetQueue for a single queue." />
+    <Error Condition="'@(HelixTargetQueue)' == ''" Text="You must specify at least one target queue to send a job to helix. Use HelixTargetQueues property for multiple or HelixTargetQueue for a single queue." />
   </Target>
 
   <Target Name="Test"


### PR DESCRIPTION
Since the item group is created out from a property if we try to provide multiple queues from the command line as a parameter, we would need to split the queues using `;` however bash and batch interpret `;` as separators. Even though we could escape them, escaping is different in between platforms. 

With this we would give people the flexibility to use `,` or `+` as their separators as well. The reason why this needs to be done in the SDK is because if we declared `HelixTargetQueues` ourselves in a project using string.Replace in msbuild the `;` would become a string literal and when building the `HelixTargetQueue` item:

`HelixTargetQueue Include="$(HelixTargetQueues)"`

It would be interpreted as just 1 item so the HelixTargetQueue will only contain 1 queue which will be invalid because it will have `;` in its name. i.e (queue1;queue2;queue3) rather than having 3 different items with each queue as its identity.

