### PR TITLE
Revert #1233.

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
@@ -58,12 +58,6 @@
     </PropertyGroup>
   </Target>
 
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.CheckRequiredDotNetVersion" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
-
-  <Target Name="_CheckRequiredDotNetVersion" BeforeTargets="BeforeBuild">
-    <Microsoft.DotNet.Arcade.Sdk.CheckRequiredDotNetVersion RepositoryRoot="$(RepoRoot)" SdkVersion="$(NETCoreSdkVersion)" />
-  </Target>
-
   <!--
     GenerateNativeVersionFile target is a standalone target intended to be pulled into a build once as
     a pre-step before kicking off a native build. It will generate a _version.h or _version.c depending


### PR DESCRIPTION
Breaks corefx and it's unknown why this change is necessary. https://github.com/dotnet/arcade/issues/1276