### PR TITLE
Force lowercase in MC link parameters

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/HelixWait.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/HelixWait.cs
@@ -94,7 +94,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                     return "Mission Control (generation of MC link failed -- JSON parsing error)";
                 }
 
-                return $"https://mc.dot.net/#/user/{userName}/{Source}/{Type}/{Build}";
+                return $"https://mc.dot.net/#/user/{userName}/{Source.ToLowerInvariant()}/{Type.ToLowerInvariant()}/{Build.ToLowerInvariant()}";
             }
         }
     }


### PR DESCRIPTION
Fixes an issue Santi was hitting [here](https://github.com/dotnet/arcade/pull/1208#discussion_r231298881).