### PR TITLE
Making SignTool able to locally strong-name sign binaries.

### DIFF
--- a/src/Microsoft.DotNet.SignTool.Tests/FakeSignTool.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/FakeSignTool.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Packaging;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.SignTool
 {
@@ -14,8 +15,8 @@ namespace Microsoft.DotNet.SignTool
     {
         private static readonly byte[] _stamp = Guid.NewGuid().ToByteArray();
 
-        internal FakeSignTool(SignToolArgs args)
-            : base(args)
+        internal FakeSignTool(SignToolArgs args, TaskLoggingHelper log)
+            : base(args, log)
         {
         }
 

--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -188,7 +188,7 @@ namespace Microsoft.DotNet.SignTool.Tests
             // The path to MSBuild will always be null in these tests, this will force
             // the signing logic to call our FakeBuildEngine.BuildProjectFile with a path
             // to the XML that store the content of the would be Microbuild sign request.
-            var signToolArgs = new SignToolArgs(_tmpDir, microBuildCorePath: "MicroBuildCorePath", testSign: true, msBuildPath: null, _tmpDir, enclosingDir: "");
+            var signToolArgs = new SignToolArgs(_tmpDir, microBuildCorePath: "MicroBuildCorePath", testSign: true, msBuildPath: null, _tmpDir, enclosingDir: "", "");
 
             var signTool = new FakeSignTool(signToolArgs);
             var signingInput = new Configuration(signToolArgs.TempDir, itemsToSign, strongNameSignInfo, fileSignInfo, extensionsSignInfo, dualCertificates, task.Log).GenerateListOfFiles();

--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -190,7 +190,7 @@ namespace Microsoft.DotNet.SignTool.Tests
             // to the XML that store the content of the would be Microbuild sign request.
             var signToolArgs = new SignToolArgs(_tmpDir, microBuildCorePath: "MicroBuildCorePath", testSign: true, msBuildPath: null, _tmpDir, enclosingDir: "", "");
 
-            var signTool = new FakeSignTool(signToolArgs);
+            var signTool = new FakeSignTool(signToolArgs, task.Log);
             var signingInput = new Configuration(signToolArgs.TempDir, itemsToSign, strongNameSignInfo, fileSignInfo, extensionsSignInfo, dualCertificates, task.Log).GenerateListOfFiles();
             var util = new BatchSignUtil(task.BuildEngine, task.Log, signTool, signingInput);
 

--- a/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
+++ b/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.SignTool
             // Next sign all of the files
             if (!SignFiles())
             {
-                _log.LogError("Error during execution of Microbuild signing process.");
+                _log.LogError("Error during execution of signing process.");
                 return;
             }
 

--- a/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -29,7 +30,7 @@ namespace Microsoft.DotNet.SignTool
 
         internal bool TestSign { get; }
 
-        internal RealSignTool(SignToolArgs args) : base(args)
+        internal RealSignTool(SignToolArgs args, TaskLoggingHelper log) : base(args, log)
         {
             TestSign = args.TestSign;
             _msbuildPath = args.MSBuildPath;
@@ -55,7 +56,13 @@ namespace Microsoft.DotNet.SignTool
 
             process.WaitForExit();
 
-            return process.ExitCode == 0;
+            if (process.ExitCode != 0)
+            {
+                _log.LogError($"Failed to execute MSBuild on the project file {projectFilePath}");
+                return false;
+            }
+
+            return true;
         }
 
         public override void RemovePublicSign(string assemblyPath)

--- a/src/Microsoft.DotNet.SignTool/src/SignInfo.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignInfo.cs
@@ -35,6 +35,8 @@ namespace Microsoft.DotNet.SignTool
 
         internal bool IsAlreadySigned { get; }
 
+        public bool ShouldLocallyStrongNameSign => !string.IsNullOrEmpty(StrongName) && StrongName.EndsWith(".snk", StringComparison.OrdinalIgnoreCase);
+
         public bool ShouldSign => !IsAlreadySigned && !ShouldIgnore;
 
         public SignInfo(string certificate, string strongName, bool shouldIgnore, bool isAlreadySigned)

--- a/src/Microsoft.DotNet.SignTool/src/SignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignTool.cs
@@ -9,19 +9,21 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.SignTool
 {
     internal abstract class SignTool
     {
         private readonly SignToolArgs _args;
-
+        internal readonly TaskLoggingHelper _log;
         internal string TempDir => _args.TempDir;
         internal string MicroBuildCorePath => _args.MicroBuildCorePath;
 
-        internal SignTool(SignToolArgs args)
+        internal SignTool(SignToolArgs args, TaskLoggingHelper log)
         {
             _args = args;
+            _log = log;
         }
 
         public abstract void RemovePublicSign(string assemblyPath);
@@ -44,6 +46,7 @@ namespace Microsoft.DotNet.SignTool
                 {
                     if (!File.Exists(_args.SNBinaryPath) || !_args.SNBinaryPath.EndsWith("sn.exe"))
                     {
+                        _log.LogError($"Found file that need to be strong-name sign ({file.FullPath}) but path to 'sn.exe' wasn't specified.");
                         return false;
                     }
 
@@ -60,6 +63,7 @@ namespace Microsoft.DotNet.SignTool
 
                     if (process.ExitCode != 0)
                     {
+                        _log.LogError($"Failed to strong-name sign file {file.FullPath}");
                         return false;
                     }
                 }

--- a/src/Microsoft.DotNet.SignTool/src/SignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignTool.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.SignTool
             {
                 if (file.SignInfo.ShouldLocallyStrongNameSign)
                 {
-                    if (!File.Exists(_args.SNBinaryPath))
+                    if (!File.Exists(_args.SNBinaryPath) || !_args.SNBinaryPath.EndsWith("sn.exe"))
                     {
                         return false;
                     }

--- a/src/Microsoft.DotNet.SignTool/src/SignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignTool.cs
@@ -156,7 +156,7 @@ namespace Microsoft.DotNet.SignTool
             {
                 AppendLine(builder, depth: 2, text: $@"<FilesToSign Include=""{fileToSign.FullPath}"">");
                 AppendLine(builder, depth: 3, text: $@"<Authenticode>{fileToSign.SignInfo.Certificate}</Authenticode>");
-                if (fileToSign.SignInfo.StrongName != null)
+                if (fileToSign.SignInfo.StrongName != null && !fileToSign.SignInfo.StrongName.EndsWith(".snk", StringComparison.OrdinalIgnoreCase))
                 {
                     AppendLine(builder, depth: 3, text: $@"<StrongName>{fileToSign.SignInfo.StrongName}</StrongName>");
                 }

--- a/src/Microsoft.DotNet.SignTool/src/SignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignTool.cs
@@ -42,6 +42,11 @@ namespace Microsoft.DotNet.SignTool
             {
                 if (file.SignInfo.ShouldLocallyStrongNameSign)
                 {
+                    if (!File.Exists(_args.SNBinaryPath))
+                    {
+                        return false;
+                    }
+
                     // sn -R <path_to_file> <path_to_snk>
                     var process = Process.Start(new ProcessStartInfo()
                     {
@@ -156,7 +161,7 @@ namespace Microsoft.DotNet.SignTool
             {
                 AppendLine(builder, depth: 2, text: $@"<FilesToSign Include=""{fileToSign.FullPath}"">");
                 AppendLine(builder, depth: 3, text: $@"<Authenticode>{fileToSign.SignInfo.Certificate}</Authenticode>");
-                if (fileToSign.SignInfo.StrongName != null && !fileToSign.SignInfo.StrongName.EndsWith(".snk", StringComparison.OrdinalIgnoreCase))
+                if (fileToSign.SignInfo.StrongName != null && !fileToSign.SignInfo.ShouldLocallyStrongNameSign)
                 {
                     AppendLine(builder, depth: 3, text: $@"<StrongName>{fileToSign.SignInfo.StrongName}</StrongName>");
                 }

--- a/src/Microsoft.DotNet.SignTool/src/SignToolArgs.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolArgs.cs
@@ -10,10 +10,11 @@ namespace Microsoft.DotNet.SignTool
         internal string MicroBuildCorePath { get; }
         internal bool TestSign { get; }
         internal string MSBuildPath { get; }
+        internal string SNBinaryPath { get; }
         internal string LogDir { get; }
         internal string EnclosingDir { get; }
 
-        internal SignToolArgs(string tempPath, string microBuildCorePath, bool testSign, string msBuildPath, string logDir, string enclosingDir)
+        internal SignToolArgs(string tempPath, string microBuildCorePath, bool testSign, string msBuildPath, string logDir, string enclosingDir, string snBinaryPath)
         {
             TempDir = tempPath;
             MicroBuildCorePath = microBuildCorePath;
@@ -21,6 +22,7 @@ namespace Microsoft.DotNet.SignTool
             MSBuildPath = msBuildPath;
             LogDir = logDir;
             EnclosingDir = enclosingDir;
+            SNBinaryPath = snBinaryPath;
         }
     }
 }

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -79,11 +79,16 @@ namespace Microsoft.DotNet.SignTool
         ///     DualSigningAllowed:boolean - Tells whether this certificate can be used to sign already signed files.
         /// </summary>
         public ITaskItem[] CertificatesSignInfo { get; set; }
-        
+
         /// <summary>
         /// Path to msbuild.exe. Required if <see cref="DryRun"/> is <c>false</c>.
         /// </summary>
         public string MSBuildPath { get; set; }
+
+        /// <summary>
+        /// Path to sn.exe. Required if strong name signing files locally is needed.
+        /// </summary>
+        public string SNBinaryPath { get; set; }
 
         /// <summary>
         /// Directory to write log to.
@@ -137,7 +142,7 @@ namespace Microsoft.DotNet.SignTool
 
             if (Log.HasLoggedErrors) return;
 
-            var signToolArgs = new SignToolArgs(TempDir, MicroBuildCorePath, TestSign, MSBuildPath, LogDir, enclosingDir);
+            var signToolArgs = new SignToolArgs(TempDir, MicroBuildCorePath, TestSign, MSBuildPath, LogDir, enclosingDir, SNBinaryPath);
             var signTool = DryRun ? new ValidationOnlySignTool(signToolArgs) : (SignTool)new RealSignTool(signToolArgs);
             var signingInput = new Configuration(TempDir, ItemsToSign, strongNameInfo, fileSignInfo, extensionSignInfo, dualCertificates, Log).GenerateListOfFiles();
 

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -143,7 +143,7 @@ namespace Microsoft.DotNet.SignTool
             if (Log.HasLoggedErrors) return;
 
             var signToolArgs = new SignToolArgs(TempDir, MicroBuildCorePath, TestSign, MSBuildPath, LogDir, enclosingDir, SNBinaryPath);
-            var signTool = DryRun ? new ValidationOnlySignTool(signToolArgs) : (SignTool)new RealSignTool(signToolArgs);
+            var signTool = DryRun ? new ValidationOnlySignTool(signToolArgs, Log) : (SignTool)new RealSignTool(signToolArgs, Log);
             var signingInput = new Configuration(TempDir, ItemsToSign, strongNameInfo, fileSignInfo, extensionSignInfo, dualCertificates, Log).GenerateListOfFiles();
 
             if (Log.HasLoggedErrors) return;

--- a/src/Microsoft.DotNet.SignTool/src/ValidationOnlySignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ValidationOnlySignTool.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.SignTool
 {
@@ -15,8 +16,8 @@ namespace Microsoft.DotNet.SignTool
     {
         internal bool TestSign { get; }
 
-        internal ValidationOnlySignTool(SignToolArgs args) 
-            : base(args)
+        internal ValidationOnlySignTool(SignToolArgs args, TaskLoggingHelper log) 
+            : base(args, log)
         {
             TestSign = args.TestSign;
         }


### PR DESCRIPTION
This is to address the need, initially manifested by @weshaggard , of locally strong-name signing files. This is needed because:

- It may happens that some binary (already signed) files need to be changed - i.e., to include optimization data.
- The remote signing service currently doesn't sign using non protected keys.

The issue was discussed here: #1204 

**Changes:**

SignToolTests.cs : Patching parameter passing.
SignInfo.cs : added property to tell if the file needs to be locally signed.
SignTool.cs : added a new routine that will call "sn.exe" to sign files locally.
SignToolArgs.cs : parameter to store "sn.exe" path.
SignToolTask.cs : added a parameter to receive "sn.exe" path.