### PR TITLE
Fix errors causing SignCheck.exe to fail on launch

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,4 +1,12 @@
 <Project>
+  <ItemGroup>
+    <!-- 
+      Suppresses code signing on this file because it causes a false-positive on SIGN001. This assembly comes from https://www.nuget.org/packages/Microsoft.VisualStudio.OLE.Interop/, but isn't code signed.
+      TODO: Make SIGN001 suppressable.
+    -->
+    <FileSignInfo Include="Microsoft.VisualStudio.OLE.Interop.dll" CertificateName="None" />
+  </ItemGroup>
+
   <!--
     These are third party libraries that we use in Arcade. We need to sign them even if they
     are already signed. However, they must be signed with a 3rd party certificate.
@@ -15,5 +23,15 @@
     <FileSignInfo Include="Mono.Options.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Newtonsoft.Json.Bson.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="SevenZip.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="winterop.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="wix.dll" CertificateName="3PartySHA2" />
+
+    <!-- Despite being called "Microsoft.*", these are not produced by Microsoft. These assemblies come from the Wix toolset project. -->
+    <FileSignInfo Include="Microsoft.Deployment.Compression.Cab.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Microsoft.Deployment.Compression.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Microsoft.Deployment.Resources.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Microsoft.Deployment.WindowsInstaller.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Microsoft.Deployment.WindowsInstaller.Package.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
 </Project>

--- a/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
+++ b/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
@@ -6,6 +6,7 @@
     <Platforms>x86</Platforms>
     <Configurations>Release;Debug</Configurations>
     <SignAssembly>false</SignAssembly>
+    <RootNamespace>Microsoft.SignCheck</RootNamespace>
   </PropertyGroup>
   <PropertyGroup Label="Nuget Package Settings">
     <IsTool>true</IsTool>

--- a/src/SignCheck/README.md
+++ b/src/SignCheck/README.md
@@ -1,0 +1,48 @@
+SignCheck
+=========
+
+This console tool scans files, archives, and packages to ensure their contents have Authenticode signatures.
+
+### Usage
+
+```
+Microsoft.DotNet.SignCheck.exe [options]
+
+Options:
+
+  -e, --error-log-file              Log errors to a separate file. If the file already exists it will be overwritten.
+
+  -f, --file-status                 Report the status of a speficic set of files. Any combination of the following values are allowed. 
+                                    Values are separated by a ','.
+                                    
+                                    'UnsignedFiles', 'SignedFiles', 'SkippedFiles', 'ExcludedFiles', 'AllFiles'. Default is 'UnsignedFiles'
+
+  -g, --generate-exclusions-file    Name of the exclusions file to generate. The entries in the file are generated using reported 
+                                    unsigned files. If the file already exists it will be overwritten.
+
+  -i, --input-files                 A list of files to scan. Wildcards (* and ?) are supported. You can specify groups of files, 
+                                    e.g. C:\Dir1\Dir*\File?.EXE or a URL (http or https).
+
+  -j, --verify-jar                  Enable JAR signature verification. By default, .jar files are no verified.
+
+  -l, --log-file                    Output results to the specified log file. If the file already exists it will be overwritten.
+
+  -m, --verify-xml                  Enable XML signature verification. By default, .xml files are not verified.
+
+  -p, --skip-timestamp              Ignore timestamp checks for AuthentiCode signatures.
+
+  -r, --recursive                   Traverse subdirectories or container files such as .zip, .nupkg, .cab, and .msi
+
+  -s, --verify-strongname           Enable strongname checks for managed code files (.exe and .dll)
+
+  -t, --traverse-subfolders         Traverse subfolders to find files matching wildcard patterns used by the --input-files option.
+
+  -v, --verbosity                   Set the verbosity level: Minimum, Normal, Detailed, Diagnostic.
+
+  -x, --exclusions-file             Path to a file containing a list of files to ignore when verification fails. Exclusions are not 
+                                    reported as errors.
+
+  --help                            Display this help screen.
+
+  --version                         Display version information.
+```

--- a/src/SignCheck/SignCheck/Microsoft.DotNet.SignCheck.csproj
+++ b/src/SignCheck/SignCheck/Microsoft.DotNet.SignCheck.csproj
@@ -11,6 +11,7 @@
     <IsPackable>true</IsPackable>
     <Description>Build artifact signing validation tool</Description>
     <PackageTags>Arcade Signing Validation Tool</PackageTags>
+    <RootNamespace>SignCheck</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup Label="Nuget Package Settings">
@@ -19,13 +20,6 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.2.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="$(OutputPath)\*.dll">
-      <PackagePath>tools/</PackagePath>
-      <Pack>true</Pack>
-    </None>
   </ItemGroup>
 
   <ItemGroup>
@@ -50,4 +44,14 @@
       <LastGenOutput>SignCheckResources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
+
+  <!-- This glob must run after the build and before _GetPackageFiles to ensure all dependencies end up in the .nupkg file. -->
+  <Target Name="CollectAllBuildOutputForPack" BeforeTargets="_GetPackageFiles" DependsOnTargets="CopyFilesToOutputDirectory">
+    <ItemGroup>
+      <!-- Exclude TargetPath to avoid NU5118: duplicate files -->
+      <Content Include="$(TargetDir)**\*" Exclude="$(TargetPath)">
+        <PackagePath>tools/</PackagePath>
+      </Content>
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
Apparently no one has tried using Microsoft.DotNet.SignCheck yet because it straight-up crashes on launch. I believe these packaging and build changes should resolve that

Changes:
* Ensure the package contains all dependencies (resolves FileNotFoundException)
* Fix the rootnamespace (resolves MissingManifestResourceException)
* Bonus: Add description to the README