### PR TITLE
Remove package dependencies from Microsoft.DotNet.SignCheck

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
+++ b/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
@@ -7,6 +7,8 @@
     <Configurations>Release;Debug</Configurations>
     <SignAssembly>false</SignAssembly>
     <RootNamespace>Microsoft.SignCheck</RootNamespace>
+    <!-- This assembly is bundled in the Microsoft.DotNet.SignCheck package and is not mean to be used as a class library package. -->
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup Label="Nuget Package Settings">
     <IsTool>true</IsTool>

--- a/src/SignCheck/SignCheck/Microsoft.DotNet.SignCheck.csproj
+++ b/src/SignCheck/SignCheck/Microsoft.DotNet.SignCheck.csproj
@@ -19,15 +19,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.2.0" />
+    <PackageReference Include="CommandLineParser" Version="2.2.0" PrivateAssets="All" Publish="true" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.SignCheck\Microsoft.DotNet.SignCheckLibrary.csproj" />
+    <ProjectReference Include="..\Microsoft.SignCheck\Microsoft.DotNet.SignCheckLibrary.csproj" PrivateAssets="All" Publish="true" />
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="System.Net" />
+    <Reference Include="System.Net" Pack="false" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Follow up to #1294 

This tool is a "fat package" - it brings all its dependencies with it. This prevents nuspec generation from putting additional `<dependency>` elements in the package metadata, which causes unnecessary packages to be pulled down during restore.