### PR TITLE
Do not make new subscriptions batchable by default

### DIFF
--- a/src/Maestro/Maestro.Web/Api/v2018_07_16/Models/SubscriptionPolicy.cs
+++ b/src/Maestro/Maestro.Web/Api/v2018_07_16/Models/SubscriptionPolicy.cs
@@ -32,7 +32,7 @@ namespace Maestro.Web.Api.v2018_07_16.Models
                 : ImmutableList<MergePolicy>.Empty;
         }
 
-        public bool Batchable { get; set; } = true;
+        public bool Batchable { get; set; } = false;
 
         [Required]
         public UpdateFrequency UpdateFrequency { get; set; }


### PR DESCRIPTION
Until we have a proper Maestro-Int/Maestro-Prod + Darc rollout story, Darc lags behind Maestro in implementation. If subscriptions are batchable by default, the darc tooling cannot create new subscriptions with any merge policies.