### PR TITLE
Skip deleting signing dir temp directory

### DIFF
--- a/src/Microsoft.DotNet.SignTool/src/SignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignTool.cs
@@ -138,7 +138,14 @@ namespace Microsoft.DotNet.SignTool
             {
                 if (Directory.Exists(signingDir))
                 {
-                    Directory.Delete(signingDir, recursive: true);
+                    try
+                    {
+                        Directory.Delete(signingDir, recursive: true);
+                    }
+                    catch (Exception e)
+                    {
+                        _log.LogWarning($"Couldn't delete temp signing dir {signingDir}. Ignoring.");
+                    }
                 }
             }
 

--- a/src/Microsoft.DotNet.SignTool/src/SignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignTool.cs
@@ -85,66 +85,49 @@ namespace Microsoft.DotNet.SignTool
             var nonOSXSigningStatus = true;
             var osxSigningStatus = true;
 
-            try
+            Directory.CreateDirectory(signingDir);
+
+            if (nonOSXFilesToSign.Any())
             {
-                Directory.CreateDirectory(signingDir);
+                var nonOSXBuildFilePath = Path.Combine(signingDir, $"Round{round}.proj");
+                var nonOSXProjContent = GenerateBuildFileContent(filesToSign);
 
-                if (nonOSXFilesToSign.Any())
+                File.WriteAllText(nonOSXBuildFilePath, nonOSXProjContent);
+                nonOSXSigningStatus = RunMSBuild(buildEngine, nonOSXBuildFilePath, Path.Combine(_args.LogDir, $"Signing{round}.binlog"));
+            }
+
+            if (osxFilesToSign.Any())
+            {
+                // The OSX signing target requires all files to be in the same folder.
+                // Also all files on the folder will be signed using the same certificate.
+                // Therefore below we group the files to be signed by certificate.
+                var filesGroupedByCertificate = osxFilesToSign.GroupBy(fsi => fsi.SignInfo.Certificate);
+
+                var osxFilesZippingDir = Path.Combine(_args.TempDir, "OSXFilesZippingDir");
+
+                Directory.CreateDirectory(osxFilesZippingDir);
+
+                foreach (var osxFileGroup in filesGroupedByCertificate)
                 {
-                    var nonOSXBuildFilePath = Path.Combine(signingDir, $"Round{round}.proj");
-                    var nonOSXProjContent = GenerateBuildFileContent(filesToSign);
+                    var certificate = osxFileGroup.Key;
+                    var osxBuildFilePath = Path.Combine(signingDir, $"Round{round}-OSX-Cert{certificate}.proj");
+                    var osxProjContent = GenerateOSXBuildFileContent(osxFilesZippingDir, certificate);
 
-                    File.WriteAllText(nonOSXBuildFilePath, nonOSXProjContent);
-                    nonOSXSigningStatus = RunMSBuild(buildEngine, nonOSXBuildFilePath, Path.Combine(_args.LogDir, $"Signing{round}.binlog"));
-                }
+                    File.WriteAllText(osxBuildFilePath, osxProjContent);
 
-                if (osxFilesToSign.Any())
-                {
-                    // The OSX signing target requires all files to be in the same folder.
-                    // Also all files on the folder will be signed using the same certificate.
-                    // Therefore below we group the files to be signed by certificate.
-                    var filesGroupedByCertificate = osxFilesToSign.GroupBy(fsi => fsi.SignInfo.Certificate);
-
-                    var osxFilesZippingDir = Path.Combine(_args.TempDir, "OSXFilesZippingDir");
-
-                    Directory.CreateDirectory(osxFilesZippingDir);
-
-                    foreach (var osxFileGroup in filesGroupedByCertificate)
+                    foreach (var item in osxFileGroup)
                     {
-                        var certificate = osxFileGroup.Key;
-                        var osxBuildFilePath = Path.Combine(signingDir, $"Round{round}-OSX-Cert{certificate}.proj");
-                        var osxProjContent = GenerateOSXBuildFileContent(osxFilesZippingDir, certificate);
+                        File.Copy(item.FullPath, Path.Combine(osxFilesZippingDir, item.FileName), overwrite: true);
+                    }
 
-                        File.WriteAllText(osxBuildFilePath, osxProjContent);
+                    osxSigningStatus = RunMSBuild(buildEngine, osxBuildFilePath, Path.Combine(_args.LogDir, $"Signing{round}-OSX.binlog"));
 
+                    if (osxSigningStatus)
+                    {
                         foreach (var item in osxFileGroup)
                         {
-                            File.Copy(item.FullPath, Path.Combine(osxFilesZippingDir, item.FileName), overwrite: true);
+                            File.Copy(Path.Combine(osxFilesZippingDir, item.FileName), item.FullPath, overwrite: true);
                         }
-
-                        osxSigningStatus = RunMSBuild(buildEngine, osxBuildFilePath, Path.Combine(_args.LogDir, $"Signing{round}-OSX.binlog"));
-
-                        if (osxSigningStatus)
-                        {
-                            foreach (var item in osxFileGroup)
-                            {
-                                File.Copy(Path.Combine(osxFilesZippingDir, item.FileName), item.FullPath, overwrite: true);
-                            }
-                        }
-                    }
-                }
-            }
-            finally
-            {
-                if (Directory.Exists(signingDir))
-                {
-                    try
-                    {
-                        Directory.Delete(signingDir, recursive: true);
-                    }
-                    catch (Exception e)
-                    {
-                        _log.LogWarning($"Couldn't delete temp signing dir {signingDir}. Ignoring.");
                     }
                 }
             }


### PR DESCRIPTION
This was causing error with recent MicroBuild deployments. As a hot fix we aren't going to delete the file immediately after each signing round. These folders are eventually deleted anyway by the cleanup steps of the build.