### PR TITLE
Fix version of MicroBuild signing plugin

### DIFF
--- a/eng/common/templates/phases/base.yml
+++ b/eng/common/templates/phases/base.yml
@@ -85,6 +85,7 @@ phases:
       - task: MicroBuildSigningPlugin@2
         displayName: Install MicroBuild plugin
         inputs:
+          version: 1.1.35
           signType: $(_SignType)
           zipSources: false
           feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json


### PR DESCRIPTION
Latest version of the plugin was causing problems during 'test signing'. This PR fix the build to use the previous version until it gets fixed.