### PR TITLE
SignTool validate if all files are strong name signed

### DIFF
--- a/Documentation/CorePackages/Signing.md
+++ b/Documentation/CorePackages/Signing.md
@@ -18,13 +18,16 @@ This is a MSBuild custom task that provides batch signing and simple verificatio
 | ---------------------- | -------- | ------------------------------------------------------------ |
 | DryRun                 | bool     | When true the list of files to be signed will be created but won't be sent to the signing server. Default is false. |
 | TestSign               | bool     | When true the binaries will be test signed. The default is to real sign. |
+| DoStrongNameCheck      | bool     | When true binaries will be checked for valid strong name signature. The default is false. |
 | **ItemsToSign**        | Array    | This is a list of *full path* to files that need to be signed. Container files will be expanded to look for nested files that need to be signed. |
+| **ItemsToSkipStrongNameCheck** | Array  | This is a list of *file names* that should be skipped when performing strong-name check. |
 | StrongNameSignInfo     | Array    | Should store the default certificate name and strong name to be used for a given Public Key Token. See details below. |
 | FileSignInfo           | Array    | Used to override the default certificate information for specific files and target frameworks combinations. If not specified default information is used or error occurs. See details below. |
 | FileExtensionSignInfo  | Array    | This is a mapping between extension (in the format ".ext") to default sign information for those kind of files. Overriding of the default sign info is done using the other parameters. |
 | CertificatesSignInfo   | Array    | List of certificate names that can be flagged using the `DualSigningAllowed` attribute as dual certificates. |
 | **MicroBuildCorePath** | Dir Path | Path to MicroBuild.Core package directory.                   |
 | MSBuildPath            | Exe path | Path to the MSBuild.exe binary used to run the signing process on MicroBuild. |
+| SNBinaryPath           | Exe path | Path to the sn.exe binary used to strong-name sign / validate signature of managed files. |
 | **TempDir**            | Dir path | Used to store temporary files during the process of calling MicroBuild signing. |
 | LogDir                 | Dir path | MSBuild binary log information from the signing rounds will be stored in this directory. |
 
@@ -32,7 +35,7 @@ This is a MSBuild custom task that provides batch signing and simple verificatio
 
 ​	Items in bold are required: `ItemsToSign`, `MicroBuildCorePath` and `TempDir`.
 
-​	`MSBuildPath` and `LogDir` are only required if `DryRun == false`.
+​	`MSBuildPath`, `SNBinaryPath` and `LogDir` are only required if `DryRun == false`.
 
 
 # Arguments Metadata

--- a/src/Microsoft.DotNet.SignTool.Tests/FakeSignTool.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/FakeSignTool.cs
@@ -31,6 +31,11 @@ namespace Microsoft.DotNet.SignTool
                    ByteSequenceComparer.Equals(buffer, _stamp);
         }
 
+        public override bool VerifyStrongNameSign(string fileFullPath)
+        {
+            return true;
+        }
+
         public override bool RunMSBuild(IBuildEngine buildEngine, string projectFilePath, string binLogPath)
             => buildEngine.BuildProjectFile(projectFilePath, null, null, null);
 

--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -194,7 +194,7 @@ namespace Microsoft.DotNet.SignTool.Tests
             var signingInput = new Configuration(signToolArgs.TempDir, itemsToSign, strongNameSignInfo, fileSignInfo, extensionsSignInfo, dualCertificates, task.Log).GenerateListOfFiles();
             var util = new BatchSignUtil(task.BuildEngine, task.Log, signTool, signingInput, new string[] { });
 
-            util.Go();
+            util.Go(false);
 
             Assert.Same(ByteSequenceComparer.Instance, signingInput.ZipDataMap.KeyComparer);
 

--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -192,7 +192,7 @@ namespace Microsoft.DotNet.SignTool.Tests
 
             var signTool = new FakeSignTool(signToolArgs, task.Log);
             var signingInput = new Configuration(signToolArgs.TempDir, itemsToSign, strongNameSignInfo, fileSignInfo, extensionsSignInfo, dualCertificates, task.Log).GenerateListOfFiles();
-            var util = new BatchSignUtil(task.BuildEngine, task.Log, signTool, signingInput);
+            var util = new BatchSignUtil(task.BuildEngine, task.Log, signTool, signingInput, new string[] { });
 
             util.Go();
 
@@ -255,7 +255,8 @@ namespace Microsoft.DotNet.SignTool.Tests
                 TempDir = "TempDir",
                 DryRun = false,
                 TestSign = true,
-                MSBuildPath = CreateTestResource("msbuild.fake")
+                MSBuildPath = CreateTestResource("msbuild.fake"),
+                SNBinaryPath = CreateTestResource("fake.sn.exe")
             };
 
             Assert.True(task.Execute());

--- a/src/Microsoft.DotNet.SignTool/FEATURES.txt
+++ b/src/Microsoft.DotNet.SignTool/FEATURES.txt
@@ -1,0 +1,1 @@
+- Support for validating that files are correctly strong-name signed.

--- a/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
+++ b/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
@@ -23,16 +23,16 @@ namespace Microsoft.DotNet.SignTool
         private readonly IBuildEngine _buildEngine;
         private readonly BatchSignInput _batchData;
         private readonly SignTool _signTool;
-        private readonly string[] _relaxStrongNameCheck;
+        private readonly string[] _itemsToSkipStrongNameCheck;
 
         internal BatchSignUtil(IBuildEngine buildEngine, TaskLoggingHelper log, SignTool signTool, 
-            BatchSignInput batchData, string[] relaxStrongNameCheck)
+            BatchSignInput batchData, string[] itemsToSkipStrongNameCheck)
         {
             _signTool = signTool;
             _batchData = batchData;
             _log = log;
             _buildEngine = buildEngine;
-            _relaxStrongNameCheck = relaxStrongNameCheck;
+            _itemsToSkipStrongNameCheck = itemsToSkipStrongNameCheck;
         }
 
         internal void Go()
@@ -311,12 +311,13 @@ namespace Microsoft.DotNet.SignTool
         {
             foreach (var file in _batchData.FilesToSign)
             {
-                if (_relaxStrongNameCheck.Contains(file.FileName))
+                if (_itemsToSkipStrongNameCheck.Contains(file.FileName))
                 {
+                    _log.LogMessage($"Skipping strong-name validation for {file.FullPath}.");
                     continue;
                 }
 
-                if (file.IsPEFile() && !_signTool.VerifyStrongNameSign(file.FullPath))
+                if (!string.IsNullOrEmpty(file.SignInfo.StrongName) && !_signTool.VerifyStrongNameSign(file.FullPath))
                 {
                     _log.LogError($"Assembly {file.FullPath} is not strong-name signed correctly.");
                 }

--- a/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
+++ b/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.SignTool
             _itemsToSkipStrongNameCheck = itemsToSkipStrongNameCheck;
         }
 
-        internal void Go()
+        internal void Go(bool doStrongNameCheck)
         {
             VerifyCertificates(_log);
 
@@ -60,7 +60,10 @@ namespace Microsoft.DotNet.SignTool
             }
 
             // Check that all files have a strong name signature
-            VerifyStrongNameSigning();
+            if (doStrongNameCheck)
+            {
+                VerifyStrongNameSigning();
+            }
 
             // Validate the signing worked and produced actual signed binaries in all locations.
             VerifyAfterSign(_log);
@@ -317,7 +320,7 @@ namespace Microsoft.DotNet.SignTool
                     continue;
                 }
 
-                if (!string.IsNullOrEmpty(file.SignInfo.StrongName) && !_signTool.VerifyStrongNameSign(file.FullPath))
+                if (file.IsManaged() && !_signTool.VerifyStrongNameSign(file.FullPath))
                 {
                     _log.LogError($"Assembly {file.FullPath} is not strong-name signed correctly.");
                 }

--- a/src/Microsoft.DotNet.SignTool/src/Configuration.cs
+++ b/src/Microsoft.DotNet.SignTool/src/Configuration.cs
@@ -253,13 +253,9 @@ namespace Microsoft.DotNet.SignTool
 
         private static void GetPEInfo(string fullPath, out bool isManaged, out string publicKeyToken, out string targetFramework, out string copyright)
         {
-            AssemblyName assemblyName;
-            try
-            {
-                assemblyName = AssemblyName.GetAssemblyName(fullPath);
-                isManaged = true;
-            }
-            catch
+            AssemblyName assemblyName = ContentUtil.GetAssemblyName(fullPath);
+
+            if (assemblyName == null)
             {
                 isManaged = false;
                 publicKeyToken = string.Empty;
@@ -270,6 +266,7 @@ namespace Microsoft.DotNet.SignTool
 
             var pktBytes = assemblyName.GetPublicKeyToken();
 
+            isManaged = true;
             publicKeyToken = (pktBytes == null || pktBytes.Length == 0) ? string.Empty : string.Join("", pktBytes.Select(b => b.ToString("x2")));
             GetTargetFrameworkAndCopyright(fullPath, out targetFramework, out copyright);
         }

--- a/src/Microsoft.DotNet.SignTool/src/ContentUtil.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ContentUtil.cs
@@ -11,6 +11,7 @@ using System.Reflection.PortableExecutable;
 using System.Reflection.Metadata;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Reflection;
 
 namespace Microsoft.DotNet.SignTool
 {
@@ -54,6 +55,18 @@ namespace Microsoft.DotNet.SignTool
 
             CorHeader header = peReader.PEHeaders.CorHeader;
             return (header.Flags & CorFlags.StrongNameSigned) == CorFlags.StrongNameSigned;
+        }
+
+        public static AssemblyName GetAssemblyName(string fullFilePath)
+        {
+            try
+            {
+                return AssemblyName.GetAssemblyName(fullFilePath);
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         public static bool IsAuthenticodeSigned(Stream assemblyStream)

--- a/src/Microsoft.DotNet.SignTool/src/FileSignInfo.cs
+++ b/src/Microsoft.DotNet.SignTool/src/FileSignInfo.cs
@@ -43,6 +43,8 @@ namespace Microsoft.DotNet.SignTool
 
         internal bool IsPEFile() => IsPEFile(FileName);
 
+        internal bool IsManaged() => ContentUtil.GetAssemblyName(FullPath) != null;
+
         internal bool IsVsix() => IsVsix(FileName);
 
         internal bool IsNupkg() => IsNupkg(FileName);

--- a/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
@@ -96,6 +96,12 @@ namespace Microsoft.DotNet.SignTool
 
         public override bool VerifyStrongNameSign(string fileFullPath)
         {
+            // The assembly won't verify by design when doing test signing.
+            if (TestSign)
+            {
+                return true;
+            }
+
             var process = Process.Start(new ProcessStartInfo()
             {
                 FileName = _snPath,

--- a/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
@@ -18,6 +18,7 @@ namespace Microsoft.DotNet.SignTool
     {
         private readonly string _msbuildPath;
         private readonly string _logDir;
+        private readonly string _snPath;
 
         /// <summary>
         /// The number of bytes from the start of the <see cref="CorHeader"/> to its <see cref="CorFlags"/>.
@@ -34,6 +35,7 @@ namespace Microsoft.DotNet.SignTool
         {
             TestSign = args.TestSign;
             _msbuildPath = args.MSBuildPath;
+            _snPath = args.SNBinaryPath;
             _logDir = args.LogDir;
         }
 
@@ -90,6 +92,23 @@ namespace Microsoft.DotNet.SignTool
             }
 
             return ContentUtil.IsAuthenticodeSigned(assemblyStream);
+        }
+
+        public override bool VerifyStrongNameSign(string fileFullPath)
+        {
+            var process = Process.Start(new ProcessStartInfo()
+            {
+                FileName = _snPath,
+                Arguments = $@"-v ""{fileFullPath}"" > nul",
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardError = false,
+                RedirectStandardOutput = false
+            });
+
+            process.WaitForExit();
+
+            return process.ExitCode == 0;
         }
     }
 }

--- a/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
@@ -99,7 +99,7 @@ namespace Microsoft.DotNet.SignTool
             var process = Process.Start(new ProcessStartInfo()
             {
                 FileName = _snPath,
-                Arguments = $@"-v ""{fileFullPath}"" > nul",
+                Arguments = $@"-vf ""{fileFullPath}"" > nul",
                 UseShellExecute = false,
                 CreateNoWindow = true,
                 RedirectStandardError = false,

--- a/src/Microsoft.DotNet.SignTool/src/SignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignTool.cs
@@ -30,6 +30,8 @@ namespace Microsoft.DotNet.SignTool
 
         public abstract bool VerifySignedPEFile(Stream stream);
 
+        public abstract bool VerifyStrongNameSign(string fileFullPath);
+
         public abstract bool RunMSBuild(IBuildEngine buildEngine, string projectFilePath, string binLogPath);
 
         public bool Sign(IBuildEngine buildEngine, int round, IEnumerable<FileSignInfo> files)

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -142,7 +142,7 @@ namespace Microsoft.DotNet.SignTool
 
             if (!DryRun)
             {
-                var isValidSNPath = string.IsNullOrEmpty(SNBinaryPath) || !File.Exists(SNBinaryPath) || !SNBinaryPath.EndsWith("sn.exe");
+                var isValidSNPath = !string.IsNullOrEmpty(SNBinaryPath) && File.Exists(SNBinaryPath) && SNBinaryPath.EndsWith("sn.exe");
 
                 if (DoStrongNameCheck && !isValidSNPath)
                 {
@@ -150,7 +150,7 @@ namespace Microsoft.DotNet.SignTool
                     return;
                 }
 
-                if (StrongNameSignInfo?.Where(ti => ti?.ItemSpec?.EndsWith(".snk") ?? false) != null && !isValidSNPath)
+                if (!isValidSNPath && StrongNameSignInfo?.Where(ti => ti?.ItemSpec?.EndsWith(".snk") ?? false) != null)
                 {
                     Log.LogError($"An incorrect full path to 'sn.exe' was specified: {SNBinaryPath}");
                     return;

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.SignTool
         /// List of file names that should be ignored when checking
         /// for correcteness of strong name signature.
         /// </summary>
-        public string[] RelaxStrongNameCheck { get; set; }
+        public string[] ItemsToSkipStrongNameCheck { get; set; }
 
         /// <summary>
         /// Mapping relating PublicKeyToken, CertificateName and Strong Name. 
@@ -159,7 +159,7 @@ namespace Microsoft.DotNet.SignTool
 
             if (Log.HasLoggedErrors) return;
 
-            var util = new BatchSignUtil(BuildEngine, Log, signTool, signingInput, RelaxStrongNameCheck);
+            var util = new BatchSignUtil(BuildEngine, Log, signTool, signingInput, ItemsToSkipStrongNameCheck);
 
             if (Log.HasLoggedErrors) return;
 

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -52,6 +52,12 @@ namespace Microsoft.DotNet.SignTool
         public string[] ItemsToSign { get; set; }
 
         /// <summary>
+        /// List of file names that should be ignored when checking
+        /// for correcteness of strong name signature.
+        /// </summary>
+        public string[] RelaxStrongNameCheck { get; set; }
+
+        /// <summary>
         /// Mapping relating PublicKeyToken, CertificateName and Strong Name. 
         /// Metadata required: PublicKeyToken, CertificateName and Include (which will be the Strong Name)
         /// During signing Certificate and Strong Name will be looked up here based on PublicKeyToken.
@@ -128,6 +134,12 @@ namespace Microsoft.DotNet.SignTool
                 Log.LogWarning($"An empty list of files to sign was passed as parameter.");
             }
 
+            if (!DryRun && (string.IsNullOrEmpty(SNBinaryPath) || !File.Exists(SNBinaryPath) || !SNBinaryPath.EndsWith("sn.exe")))
+            {
+                Log.LogError($"An incorrect full path to 'sn.exe' was specified: {SNBinaryPath}");
+                return;
+            }
+
             var enclosingDir = GetEnclosingDirectoryOfItemsToSign();
 
             PrintConfigInformation();
@@ -147,7 +159,7 @@ namespace Microsoft.DotNet.SignTool
 
             if (Log.HasLoggedErrors) return;
 
-            var util = new BatchSignUtil(BuildEngine, Log, signTool, signingInput);
+            var util = new BatchSignUtil(BuildEngine, Log, signTool, signingInput, RelaxStrongNameCheck);
 
             if (Log.HasLoggedErrors) return;
 

--- a/src/Microsoft.DotNet.SignTool/src/ValidationOnlySignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ValidationOnlySignTool.cs
@@ -29,6 +29,9 @@ namespace Microsoft.DotNet.SignTool
         public override bool VerifySignedPEFile(Stream assemblyStream) 
             => true;
 
+        public override bool VerifyStrongNameSign(string fileFullPath)
+            => true;
+
         public override bool RunMSBuild(IBuildEngine buildEngine, string projectFilePath, string binLogPath)
         {
             if (TestSign)


### PR DESCRIPTION
Closes: #1198 

I won't merge this before I configure CoreFX to locally strong name sign all files needed and ignore those that don't. 

However, I'd much appreciate if you guys could take a look at how I'm implementing this check.