### PR TITLE
Maestro returns 404 if a build of a repo doesn't exist in a channel

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateDependenciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateDependenciesOperation.cs
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.Darc.Operations
 
                     // Limit the number of BAR queries by grabbing the repo URIs and making a hash set.
                     var repositoryUrisForQuery = dependencies.Select(dependency => dependency.RepoUri).ToHashSet();
-                    ConcurrentDictionary<string, Task<Build>> buildDictionary = new ConcurrentDictionary<string, Task<Build>>();
+                    ConcurrentDictionary<string, Task<Build>> getLatestBuildTaskDictionary = new ConcurrentDictionary<string, Task<Build>>();
 
                     Channel channelInfo = await channel;
                     if (channelInfo == null)
@@ -104,7 +104,7 @@ namespace Microsoft.DotNet.Darc.Operations
                     foreach (string repoToQuery in repositoryUrisForQuery)
                     {
                         var latestBuild = remote.GetLatestBuildAsync(repoToQuery, channelInfo.Id.Value);
-                        buildDictionary.TryAdd(repoToQuery, latestBuild);
+                        getLatestBuildTaskDictionary.TryAdd(repoToQuery, latestBuild);
                     }
 
                     // Now walk dependencies again and attempt the update
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.Darc.Operations
                         Build build;
                         try
                         {
-                            build = await buildDictionary[dependency.RepoUri];
+                            build = await getLatestBuildTaskDictionary[dependency.RepoUri];
                         }
                         catch (ApiErrorException e) when (e.Response.StatusCode == System.Net.HttpStatusCode.NotFound)
                         {

--- a/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateDependenciesOperation.cs
+++ b/src/Microsoft.DotNet.Darc/src/Darc/Operations/UpdateDependenciesOperation.cs
@@ -110,8 +110,12 @@ namespace Microsoft.DotNet.Darc.Operations
                     // Now walk dependencies again and attempt the update
                     foreach (DependencyDetail dependency in dependencies)
                     {
-                        Build build = await buildDictionary[dependency.RepoUri];
-                        if (build == null)
+                        Build build;
+                        try
+                        {
+                            build = await buildDictionary[dependency.RepoUri];
+                        }
+                        catch (ApiErrorException e) when (e.Response.StatusCode == System.Net.HttpStatusCode.NotFound)
                         {
                             Logger.LogTrace($"No build of '{dependency.RepoUri}' found on channel '{_options.Channel}'.");
                             continue;


### PR DESCRIPTION
Catch this 404 instead of testing the output build against null