### PR TITLE
#1362 - skip Strongname check on non-managed PE files

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/Verification/PortableExecutableVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/PortableExecutableVerifier.cs
@@ -80,6 +80,10 @@ namespace Microsoft.SignCheck.Verification
                     svr.AddDetail(DetailKeys.StrongName, SignCheckResources.DetailNativeImage);
                 }
             }
+            else
+            {
+                svr.IsNativeImage = true;
+            }
         }
     }
 }


### PR DESCRIPTION
Fix for #1362 to skip SN checks on non-managed PE files.