### PR TITLE
Remove dependency on EnsureBuildToolsRuntime

### DIFF
--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.targets
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <FillPartialFacadeDependsOn>
-      EnsureBuildToolsRuntime
-    </FillPartialFacadeDependsOn>
-  </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsPartialFacadeAssembly)' == 'true' AND '$(IsReferenceAssembly)' != 'true'">
     <!-- Tell ResolveMatchingContract to run and resolve contract to project reference -->


### PR DESCRIPTION
Removes a dependency on a Buildtools-specific target from GenFacades. For https://github.com/dotnet/arcade/issues/1374

CC @ericstj 