### PR TITLE
Add condition to CreateXunitWorkItems target to only run when there are XunitProject

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
@@ -147,7 +147,9 @@
     </ItemGroup>
   </Target>
   
-  <Target Name="CreateXUnitWorkItems" BeforeTargets="Test">    
+  <Target Name="CreateXUnitWorkItems" Condition="'@(XunitProject)' != ''" BeforeTargets="Test">    
+    <Error Condition="'$(XUnitTargetFramework)' == ''" Message="XUnitTargetFramework property value should be specified." />
+    
     <CreateXUnitWorkItems XUnitProjects="@(XUnitProject)" XUnitTargetFramework="$(XUnitTargetFramework)" IsPosixShell="$(IsPosixShell)" >
       <Output TaskParameter="XUnitWorkItems" ItemName="HelixWorkItem"/>
     </CreateXUnitWorkItems>


### PR DESCRIPTION
If I don't want to run using XunitWorkItems, I will not populate the XunitProject property at all. This will try to run the target to create xunit work items and will fail with error: 

```
 D:\a\1\s\.packages\microsoft.dotnet.helix.sdk\1.0.0-beta.18571.2\tools\Microsoft.DotNet.Helix.Sdk.MonoQueue.targets(151,5): error MSB4044: The "CreateXUnitWorkItems" task was not given a value for the required parameter "XUnitTargetFramework". [D:\a\1\s\eng\sendtohelix.proj]
```

Also, error if `XunitTargetFramework` is not set to have a better error message. 