### PR TITLE
SignTool error logs: Display list of packages that a file is contained in

### DIFF
--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -357,10 +357,10 @@ namespace Microsoft.DotNet.SignTool.Tests
             },
             expectedWarnings: new[]
             {
-                $@"SIGN001: Signing 3rd party library '{Path.Combine(_tmpDir, "ContainerSigning", "B306A318B3A11BF342995F6A1FC5AADF5DB4DD49F4EFF7E013D31208DD58EBDC", "ProjectOne.dll")}' with Microsoft certificate 'OverriddenCertificate'. The library is considered 3rd party library due to its copyright: ''.",
-                $@"SIGN001: Signing 3rd party library '{Path.Combine(_tmpDir, "ContainerSigning", "8492D8CE69F362AAB589989D6B9687C53B732E73493492D06A5650A86B6D4D20", "ProjectOne.dll")}' with Microsoft certificate 'OverriddenCertificate'. The library is considered 3rd party library due to its copyright: ''.",
-                $@"SIGN001: Signing 3rd party library '{Path.Combine(_tmpDir, "ContainerSigning", "CC1D99EE8C2F627E77D019E94B06EBB6D87A4D19E65DDAEF62B6137E49167BAF", "ProjectOne.dll")}' with Microsoft certificate 'OverriddenCertificate'. The library is considered 3rd party library due to its copyright: ''.",
-                $@"SIGN001: Signing 3rd party library '{Path.Combine(_tmpDir, "ContainerSigning", "47F202CA51AD708535A01E96B95027042F8448333D86FA7D5F8D66B67644ACEC", "ProjectOne.dll")}' with Microsoft certificate 'OverriddenCertificate'. The library is considered 3rd party library due to its copyright: ''."
+                $@"SIGN001: Signing 3rd party library '{Path.Combine(_tmpDir, "ContainerSigning", "B306A318B3A11BF342995F6A1FC5AADF5DB4DD49F4EFF7E013D31208DD58EBDC", "lib/net461/ProjectOne.dll")}' with Microsoft certificate 'OverriddenCertificate'. The library is considered 3rd party library due to its copyright: ''.",
+                $@"SIGN001: Signing 3rd party library '{Path.Combine(_tmpDir, "ContainerSigning", "8492D8CE69F362AAB589989D6B9687C53B732E73493492D06A5650A86B6D4D20", "lib/netcoreapp2.0/ProjectOne.dll")}' with Microsoft certificate 'OverriddenCertificate'. The library is considered 3rd party library due to its copyright: ''.",
+                $@"SIGN001: Signing 3rd party library '{Path.Combine(_tmpDir, "ContainerSigning", "CC1D99EE8C2F627E77D019E94B06EBB6D87A4D19E65DDAEF62B6137E49167BAF", "lib/netcoreapp2.1/ProjectOne.dll")}' with Microsoft certificate 'OverriddenCertificate'. The library is considered 3rd party library due to its copyright: ''.",
+                $@"SIGN001: Signing 3rd party library '{Path.Combine(_tmpDir, "ContainerSigning", "47F202CA51AD708535A01E96B95027042F8448333D86FA7D5F8D66B67644ACEC", "lib/netstandard2.0/ProjectOne.dll")}' with Microsoft certificate 'OverriddenCertificate'. The library is considered 3rd party library due to its copyright: ''."
             });
         }
 
@@ -398,7 +398,7 @@ namespace Microsoft.DotNet.SignTool.Tests
             }, 
             expectedWarnings: new[] 
             {
-                $@"SIGN001: Signing 3rd party library '{Path.Combine(_tmpDir, "ContainerSigning", "9F8CCEE4CECF286C80916F13EAB8DF1FC6C9BED5F81E3AFF26747C008D265E5C", "ContainerOne.dll")}' with Microsoft certificate 'ArcadeCertTest'. The library is considered 3rd party library due to its copyright: ''."
+                $@"SIGN001: Signing 3rd party library '{Path.Combine(_tmpDir, "ContainerSigning", "9F8CCEE4CECF286C80916F13EAB8DF1FC6C9BED5F81E3AFF26747C008D265E5C", "lib/netcoreapp2.0/ContainerOne.dll")}' with Microsoft certificate 'ArcadeCertTest'. The library is considered 3rd party library due to its copyright: ''."
             });
         }
 
@@ -532,30 +532,30 @@ namespace Microsoft.DotNet.SignTool.Tests
             ValidateGeneratedProject(itemsToSign, strongNameSignInfo, fileSignInfo, s_fileExtensionSignInfo, new[]
             {
 $@"
-<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "3D4466713FF60CA2747166CD22B097B67DAFC7F3487B7F7725945502D66D0B65", "NativeLibrary.dll")}"">
+<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "3D4466713FF60CA2747166CD22B097B67DAFC7F3487B7F7725945502D66D0B65", "lib/native/NativeLibrary.dll")}"">
   <Authenticode>Microsoft400</Authenticode>
 </FilesToSign>
-<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "B306A318B3A11BF342995F6A1FC5AADF5DB4DD49F4EFF7E013D31208DD58EBDC", "ProjectOne.dll")}"">
+<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "B306A318B3A11BF342995F6A1FC5AADF5DB4DD49F4EFF7E013D31208DD58EBDC", "lib/net461/ProjectOne.dll")}"">
   <Authenticode>3PartySHA2</Authenticode>
   <StrongName>ArcadeStrongTest</StrongName>
 </FilesToSign>
-<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "9F8CCEE4CECF286C80916F13EAB8DF1FC6C9BED5F81E3AFF26747C008D265E5C", "ContainerTwo.dll")}"">
+<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "9F8CCEE4CECF286C80916F13EAB8DF1FC6C9BED5F81E3AFF26747C008D265E5C", "lib/netcoreapp2.0/ContainerTwo.dll")}"">
   <Authenticode>3PartySHA2</Authenticode>
   <StrongName>ArcadeStrongTest</StrongName>
 </FilesToSign>
-<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "8492D8CE69F362AAB589989D6B9687C53B732E73493492D06A5650A86B6D4D20", "ProjectOne.dll")}"">
+<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "8492D8CE69F362AAB589989D6B9687C53B732E73493492D06A5650A86B6D4D20", "lib/netcoreapp2.0/ProjectOne.dll")}"">
   <Authenticode>3PartySHA2</Authenticode>
   <StrongName>ArcadeStrongTest</StrongName>
 </FilesToSign>
-<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "CC1D99EE8C2F627E77D019E94B06EBB6D87A4D19E65DDAEF62B6137E49167BAF", "ProjectOne.dll")}"">
+<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "CC1D99EE8C2F627E77D019E94B06EBB6D87A4D19E65DDAEF62B6137E49167BAF", "lib/netcoreapp2.1/ProjectOne.dll")}"">
   <Authenticode>3PartySHA2</Authenticode>
   <StrongName>ArcadeStrongTest</StrongName>
 </FilesToSign>
-<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "47F202CA51AD708535A01E96B95027042F8448333D86FA7D5F8D66B67644ACEC", "ProjectOne.dll")}"">
+<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "47F202CA51AD708535A01E96B95027042F8448333D86FA7D5F8D66B67644ACEC", "lib/netstandard2.0/ProjectOne.dll")}"">
   <Authenticode>3PartySHA2</Authenticode>
   <StrongName>ArcadeStrongTest</StrongName>
 </FilesToSign>
-<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "9F8CCEE4CECF286C80916F13EAB8DF1FC6C9BED5F81E3AFF26747C008D265E5C", "ContainerOne.dll")}"">
+<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "9F8CCEE4CECF286C80916F13EAB8DF1FC6C9BED5F81E3AFF26747C008D265E5C", "lib/netcoreapp2.0/ContainerOne.dll")}"">
   <Authenticode>3PartySHA2</Authenticode>
   <StrongName>ArcadeStrongTest</StrongName>
 </FilesToSign>",
@@ -679,15 +679,15 @@ $@"
             ValidateGeneratedProject(itemsToSign, strongNameSignInfo, fileSignInfo, s_fileExtensionSignInfo, new[]
             {
 $@"
-<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "B306A318B3A11BF342995F6A1FC5AADF5DB4DD49F4EFF7E013D31208DD58EBDC", "ProjectOne.dll")}"">
+<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "B306A318B3A11BF342995F6A1FC5AADF5DB4DD49F4EFF7E013D31208DD58EBDC", "lib/net461/ProjectOne.dll")}"">
   <Authenticode>3PartySHA2</Authenticode>
   <StrongName>ArcadeStrongTest</StrongName>
 </FilesToSign>
-<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "47F202CA51AD708535A01E96B95027042F8448333D86FA7D5F8D66B67644ACEC", "ProjectOne.dll")}"">
+<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "47F202CA51AD708535A01E96B95027042F8448333D86FA7D5F8D66B67644ACEC", "lib/netstandard2.0/ProjectOne.dll")}"">
   <Authenticode>3PartySHA2</Authenticode>
   <StrongName>ArcadeStrongTest</StrongName>
 </FilesToSign>
-<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "8492D8CE69F362AAB589989D6B9687C53B732E73493492D06A5650A86B6D4D20", "ProjectOne.dll")}"">
+<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "8492D8CE69F362AAB589989D6B9687C53B732E73493492D06A5650A86B6D4D20", "Contents/Common7/IDE/PrivateAssemblies/ProjectOne.dll")}"">
   <Authenticode>3PartySHA2</Authenticode>
   <StrongName>ArcadeStrongTest</StrongName>
 </FilesToSign>",
@@ -736,15 +736,15 @@ $@"
             ValidateGeneratedProject(itemsToSign, strongNameSignInfo, fileSignInfo, s_fileExtensionSignInfo, new[]
             {
 $@"
-<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "8492D8CE69F362AAB589989D6B9687C53B732E73493492D06A5650A86B6D4D20", "ProjectOne.dll")}"">
+<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "8492D8CE69F362AAB589989D6B9687C53B732E73493492D06A5650A86B6D4D20", "Contents/Common7/IDE/PrivateAssemblies/ProjectOne.dll")}"">
   <Authenticode>3PartySHA2</Authenticode>
   <StrongName>ArcadeStrongTest</StrongName>
 </FilesToSign>
-<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "B306A318B3A11BF342995F6A1FC5AADF5DB4DD49F4EFF7E013D31208DD58EBDC", "ProjectOne.dll")}"">
+<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "B306A318B3A11BF342995F6A1FC5AADF5DB4DD49F4EFF7E013D31208DD58EBDC", "lib/net461/ProjectOne.dll")}"">
   <Authenticode>3PartySHA2</Authenticode>
   <StrongName>ArcadeStrongTest</StrongName>
 </FilesToSign>
-<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "47F202CA51AD708535A01E96B95027042F8448333D86FA7D5F8D66B67644ACEC", "ProjectOne.dll")}"">
+<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "47F202CA51AD708535A01E96B95027042F8448333D86FA7D5F8D66B67644ACEC", "lib/netstandard2.0/ProjectOne.dll")}"">
   <Authenticode>3PartySHA2</Authenticode>
   <StrongName>ArcadeStrongTest</StrongName>
 </FilesToSign>",
@@ -798,15 +798,15 @@ $@"
             ValidateGeneratedProject(itemsToSign, strongNameSignInfo, fileSignInfo, s_fileExtensionSignInfo, new[]
             {
 $@"
-<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "8492D8CE69F362AAB589989D6B9687C53B732E73493492D06A5650A86B6D4D20", "ProjectOne.dll")}"">
+<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "8492D8CE69F362AAB589989D6B9687C53B732E73493492D06A5650A86B6D4D20", "Contents/Common7/IDE/PrivateAssemblies/ProjectOne.dll")}"">
   <Authenticode>3PartySHA2</Authenticode>
   <StrongName>ArcadeStrongTest</StrongName>
 </FilesToSign>
-<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "B306A318B3A11BF342995F6A1FC5AADF5DB4DD49F4EFF7E013D31208DD58EBDC", "ProjectOne.dll")}"">
+<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "B306A318B3A11BF342995F6A1FC5AADF5DB4DD49F4EFF7E013D31208DD58EBDC", "lib/net461/ProjectOne.dll")}"">
   <Authenticode>3PartySHA2</Authenticode>
   <StrongName>ArcadeStrongTest</StrongName>
 </FilesToSign>
-<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "47F202CA51AD708535A01E96B95027042F8448333D86FA7D5F8D66B67644ACEC", "ProjectOne.dll")}"">
+<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "47F202CA51AD708535A01E96B95027042F8448333D86FA7D5F8D66B67644ACEC", "lib/netstandard2.0/ProjectOne.dll")}"">
   <Authenticode>3PartySHA2</Authenticode>
   <StrongName>ArcadeStrongTest</StrongName>
 </FilesToSign>",
@@ -851,7 +851,7 @@ $@"
             ValidateGeneratedProject(itemsToSign, strongNameSignInfo, fileSignInfo, s_fileExtensionSignInfo, new[]
             {
 $@"
-<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "8492D8CE69F362AAB589989D6B9687C53B732E73493492D06A5650A86B6D4D20", "ProjectOne.dll")}"">
+<FilesToSign Include=""{Path.Combine(_tmpDir, "ContainerSigning", "8492D8CE69F362AAB589989D6B9687C53B732E73493492D06A5650A86B6D4D20", "Contents/Common7/IDE/PrivateAssemblies/ProjectOne.dll")}"">
   <Authenticode>3PartySHA2</Authenticode>
   <StrongName>ArcadeStrongTest</StrongName>
 </FilesToSign>",
@@ -1043,9 +1043,9 @@ $@"
             expectedWarnings: new[]
             {
                 $@"SIGN001: Signing 3rd party library '{Path.Combine(_tmpDir, "EmptyPKT.dll")}' with Microsoft certificate 'DLLCertificate'. The library is considered 3rd party library due to its copyright: ''.",
-                $@"SIGN001: Signing 3rd party library '{Path.Combine(_tmpDir, "ContainerSigning", "B306A318B3A11BF342995F6A1FC5AADF5DB4DD49F4EFF7E013D31208DD58EBDC", "ProjectOne.dll")}' with Microsoft certificate 'DLLCertificate3'. The library is considered 3rd party library due to its copyright: ''.",
-                $@"SIGN001: Signing 3rd party library '{Path.Combine(_tmpDir, "ContainerSigning", "47F202CA51AD708535A01E96B95027042F8448333D86FA7D5F8D66B67644ACEC", "ProjectOne.dll")}' with Microsoft certificate 'DLLCertificate4'. The library is considered 3rd party library due to its copyright: ''.",
-                $@"SIGN001: Signing 3rd party library '{Path.Combine(_tmpDir, "ContainerSigning", "8492D8CE69F362AAB589989D6B9687C53B732E73493492D06A5650A86B6D4D20", "ProjectOne.dll")}' with Microsoft certificate 'DLLCertificate5'. The library is considered 3rd party library due to its copyright: ''.",
+                $@"SIGN001: Signing 3rd party library '{Path.Combine(_tmpDir, "ContainerSigning", "B306A318B3A11BF342995F6A1FC5AADF5DB4DD49F4EFF7E013D31208DD58EBDC", "lib/net461/ProjectOne.dll")}' with Microsoft certificate 'DLLCertificate3'. The library is considered 3rd party library due to its copyright: ''.",
+                $@"SIGN001: Signing 3rd party library '{Path.Combine(_tmpDir, "ContainerSigning", "47F202CA51AD708535A01E96B95027042F8448333D86FA7D5F8D66B67644ACEC", "lib/netstandard2.0/ProjectOne.dll")}' with Microsoft certificate 'DLLCertificate4'. The library is considered 3rd party library due to its copyright: ''.",
+                $@"SIGN001: Signing 3rd party library '{Path.Combine(_tmpDir, "ContainerSigning", "8492D8CE69F362AAB589989D6B9687C53B732E73493492D06A5650A86B6D4D20", "Contents/Common7/IDE/PrivateAssemblies/ProjectOne.dll")}' with Microsoft certificate 'DLLCertificate5'. The library is considered 3rd party library due to its copyright: ''.",
                 $@"SIGN001: Signing 3rd party library '{Path.Combine(_tmpDir, "ContainerSigning", "DCD5A867480FEE469A37FF890446F4A34B7770EDDE4DD939A0313F1D3B3AAF99", "Simple.dll")}' with Microsoft certificate 'DLLCertificate2'. The library is considered 3rd party library due to its copyright: ''."
             });
         }

--- a/src/Microsoft.DotNet.SignTool/src/Configuration.cs
+++ b/src/Microsoft.DotNet.SignTool/src/Configuration.cs
@@ -112,7 +112,7 @@ namespace Microsoft.DotNet.SignTool
         {
             foreach (var fullPath in _itemsToSign)
             {
-                var fileUniqueKey = new SignedFileContentKey(fullPath);
+                var fileUniqueKey = new SignedFileContentKey(ContentUtil.GetContentHash(fullPath), fullPath);
 
                 if (!_whichPackagesTheFileIsIn.TryGetValue(fileUniqueKey, out var packages))
                 {

--- a/src/Microsoft.DotNet.SignTool/src/Configuration.cs
+++ b/src/Microsoft.DotNet.SignTool/src/Configuration.cs
@@ -23,6 +23,8 @@ namespace Microsoft.DotNet.SignTool
 
         private readonly string[] _itemsToSign;
 
+        private enum SigningToolErrorCode { ERR001 };
+
         /// <summary>
         /// This store content information for container files.
         /// Key is the content hash of the file.
@@ -61,6 +63,16 @@ namespace Microsoft.DotNet.SignTool
         private readonly Dictionary<SignedFileContentKey, FileSignInfo> _filesByContentKey;
 
         /// <summary>
+        /// For each uniquely identified file keeps track of all containers where the file appeared.
+        /// </summary>
+        private readonly Dictionary<SignedFileContentKey, HashSet<string>> _whichPackagesTheFileIsIn;
+
+        /// <summary>
+        /// Keeps track of all files that produced a given error code.
+        /// </summary>
+        private readonly Dictionary<SigningToolErrorCode, HashSet<SignedFileContentKey>> _errors;
+
+        /// <summary>
         /// This is a list of the friendly name of certificates that can be used to
         /// sign already signed binaries.
         /// </summary>
@@ -92,13 +104,52 @@ namespace Microsoft.DotNet.SignTool
             _filesByContentKey = new Dictionary<SignedFileContentKey, FileSignInfo>();
             _itemsToSign = itemsToSign;
             _dualCertificates = dualCertificates ?? new string[0];
+            _whichPackagesTheFileIsIn = new Dictionary<SignedFileContentKey, HashSet<string>>();
+            _errors = new Dictionary<SigningToolErrorCode, HashSet<SignedFileContentKey>>();
         }
 
         internal BatchSignInput GenerateListOfFiles()
         {
             foreach (var fullPath in _itemsToSign)
             {
+                var fileUniqueKey = new SignedFileContentKey(fullPath);
+
+                if (!_whichPackagesTheFileIsIn.TryGetValue(fileUniqueKey, out var packages))
+                {
+                    packages = new HashSet<string>();
+                }
+
+                packages.Add(fullPath);
+                _whichPackagesTheFileIsIn[fileUniqueKey] = packages;
+
                 TrackFile(fullPath, ContentUtil.GetContentHash(fullPath), isNested: false);
+            }
+
+            if (_errors.Any())
+            {
+                // Iterate over each pair of <error code, unique file identity>. 
+                // We can be sure here that the same file won't have the same error code twice.
+                foreach (var errorGroup in _errors)
+                {
+                    switch (errorGroup.Key)
+                    {
+                        case SigningToolErrorCode.ERR001:
+                            _log.LogError("Could not determine certificate name for signable file(s):");
+                            break;
+                    }
+
+                    // For each file that had that error
+                    foreach (var erroedFile in errorGroup.Value)
+                    {
+                        _log.LogError($"\tFile: {erroedFile.FileName}");
+
+                        // Get a list of all containers where the file showed up
+                        foreach (var containerName in _whichPackagesTheFileIsIn[erroedFile])
+                        {
+                            _log.LogError($"\t\t{containerName}");
+                        }
+                    }
+                }
             }
 
             return new BatchSignInput(_filesToSign.ToImmutableArray(), _zipDataMap.ToImmutableDictionary(ByteSequenceComparer.Instance), _filesToCopy.ToImmutableArray());
@@ -231,7 +282,7 @@ namespace Microsoft.DotNet.SignTool
 
             if (SignToolConstants.SignableExtensions.Contains(extension) || SignToolConstants.SignableOSXExtensions.Contains(extension))
             {
-                _log.LogError($"Couldn't determine certificate name for signable file: {fullPath}");
+                LogError(SigningToolErrorCode.ERR001, new SignedFileContentKey(fullPath));
             }
             else
             {
@@ -243,6 +294,17 @@ namespace Microsoft.DotNet.SignTool
 
         private void LogWarning(string code, string message)
             => _log.LogWarning(subcategory: null, warningCode: code, helpKeyword: null, file: null, lineNumber: 0, columnNumber: 0, endLineNumber: 0, endColumnNumber: 0, message: message);
+
+        private void LogError(SigningToolErrorCode code, SignedFileContentKey targetFile)
+        {
+            if (!_errors.TryGetValue(code, out var filesErrored))
+            {
+                filesErrored = new HashSet<SignedFileContentKey>();
+            }
+
+            filesErrored.Add(targetFile);
+            _errors[code] = filesErrored;
+        }
 
         private static bool IsMicrosoftLibrary(string copyright)
             => copyright.Contains("Microsoft");
@@ -383,9 +445,19 @@ namespace Microsoft.DotNet.SignTool
                             contentHash = ContentUtil.GetContentHash(stream);
                         }
 
+                        var fileName = Path.GetFileName(relativePath);
+                        var fileUniqueKey = new SignedFileContentKey(contentHash, fileName);
+
+                        if (!_whichPackagesTheFileIsIn.TryGetValue(fileUniqueKey, out var packages))
+                        {
+                            packages = new HashSet<string>();
+                        }
+
+                        packages.Add(zipFileSignInfo.FileName);
+                        _whichPackagesTheFileIsIn[fileUniqueKey] = packages;
+
                         // if we already encountered file that hash the same content we can reuse its signed version when repackaging the container.
-                        string fileName = Path.GetFileName(relativePath);
-                        if (!_filesByContentKey.TryGetValue(new SignedFileContentKey(contentHash, fileName), out var fileSignInfo))
+                        if (!_filesByContentKey.TryGetValue(fileUniqueKey, out var fileSignInfo))
                         {
                             string tempDir = Path.Combine(_pathToContainerUnpackingDirectory, ContentUtil.HashToString(contentHash));
                             string tempPath = Path.Combine(tempDir, Path.GetFileName(relativePath));

--- a/src/Microsoft.DotNet.SignTool/src/Configuration.cs
+++ b/src/Microsoft.DotNet.SignTool/src/Configuration.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.SignTool
 
         private readonly string[] _itemsToSign;
 
-        private enum SigningToolErrorCode { ERR001 };
+        private enum SigningToolErrorCode { SIGN002 };
 
         /// <summary>
         /// This store content information for container files.
@@ -133,7 +133,7 @@ namespace Microsoft.DotNet.SignTool
                 {
                     switch (errorGroup.Key)
                     {
-                        case SigningToolErrorCode.ERR001:
+                        case SigningToolErrorCode.SIGN002:
                             _log.LogError("Could not determine certificate name for signable file(s):");
                             break;
                     }
@@ -286,7 +286,7 @@ namespace Microsoft.DotNet.SignTool
                 var contentHash = ContentUtil.GetContentHash(fullPath);
                 var tempDir = Path.Combine(_pathToContainerUnpackingDirectory, ContentUtil.HashToString(contentHash));
                 var relativePath = fullPath.Replace($@"{tempDir}\", "");
-                LogError(SigningToolErrorCode.ERR001, new SignedFileContentKey(contentHash, relativePath));
+                LogError(SigningToolErrorCode.SIGN002, new SignedFileContentKey(contentHash, relativePath));
             }
             else
             {

--- a/src/Microsoft.DotNet.SignTool/src/Configuration.cs
+++ b/src/Microsoft.DotNet.SignTool/src/Configuration.cs
@@ -112,8 +112,7 @@ namespace Microsoft.DotNet.SignTool
         {
             foreach (var fullPath in _itemsToSign)
             {
-                var contentHash = ContentUtil.GetContentHash(fullPath);
-                var fileUniqueKey = new SignedFileContentKey(contentHash, fullPath);
+                var fileUniqueKey = new SignedFileContentKey(fullPath);
 
                 if (!_whichPackagesTheFileIsIn.TryGetValue(fileUniqueKey, out var packages))
                 {
@@ -123,7 +122,7 @@ namespace Microsoft.DotNet.SignTool
                 packages.Add(fullPath);
                 _whichPackagesTheFileIsIn[fileUniqueKey] = packages;
 
-                TrackFile(fullPath, contentHash, isNested: false);
+                TrackFile(fullPath, ContentUtil.GetContentHash(fullPath), isNested: false);
             }
 
             if (_errors.Any())
@@ -283,12 +282,7 @@ namespace Microsoft.DotNet.SignTool
 
             if (SignToolConstants.SignableExtensions.Contains(extension) || SignToolConstants.SignableOSXExtensions.Contains(extension))
             {
-                // Extract the relative path inside the package / otherwise just return the full path of the file
-                var contentHash = ContentUtil.GetContentHash(fullPath);
-                var tempDir = Path.Combine(_pathToContainerUnpackingDirectory, ContentUtil.HashToString(contentHash));
-                var relativePath = fullPath.Replace(tempDir, "");
-
-                LogError(SigningToolErrorCode.ERR001, new SignedFileContentKey(contentHash, relativePath));
+                LogError(SigningToolErrorCode.ERR001, new SignedFileContentKey(fullPath));
             }
             else
             {

--- a/src/Microsoft.DotNet.SignTool/src/SignedFileContentKey.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignedFileContentKey.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 
 namespace Microsoft.DotNet.SignTool
@@ -26,14 +25,6 @@ namespace Microsoft.DotNet.SignTool
 
             ContentHash = contentHash;
             FileName = fileName;
-        }
-
-        public SignedFileContentKey(string fullPath)
-        {
-            Debug.Assert(fullPath != null);
-
-            ContentHash = ContentUtil.GetContentHash(fullPath);
-            FileName = Path.GetFileName(fullPath);
         }
 
         public override bool Equals(object obj)

--- a/src/Microsoft.DotNet.SignTool/src/SignedFileContentKey.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignedFileContentKey.cs
@@ -28,14 +28,6 @@ namespace Microsoft.DotNet.SignTool
             FileName = fileName;
         }
 
-        public SignedFileContentKey(string fullPath)
-        {
-            Debug.Assert(fullPath != null);
-
-            ContentHash = ContentUtil.GetContentHash(fullPath);
-            FileName = Path.GetFileName(fullPath);
-        }
-
         public override bool Equals(object obj)
             => obj is SignedFileContentKey key && Equals(key);
 

--- a/src/Microsoft.DotNet.SignTool/src/SignedFileContentKey.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignedFileContentKey.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 
 namespace Microsoft.DotNet.SignTool
@@ -25,6 +26,14 @@ namespace Microsoft.DotNet.SignTool
 
             ContentHash = contentHash;
             FileName = fileName;
+        }
+
+        public SignedFileContentKey(string fullPath)
+        {
+            Debug.Assert(fullPath != null);
+
+            ContentHash = ContentUtil.GetContentHash(fullPath);
+            FileName = Path.GetFileName(fullPath);
         }
 
         public override bool Equals(object obj)

--- a/src/Microsoft.DotNet.SignTool/src/SignedFileContentKey.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignedFileContentKey.cs
@@ -28,6 +28,14 @@ namespace Microsoft.DotNet.SignTool
             FileName = fileName;
         }
 
+        public SignedFileContentKey(string fullPath)
+        {
+            Debug.Assert(fullPath != null);
+
+            ContentHash = ContentUtil.GetContentHash(fullPath);
+            FileName = Path.GetFileName(fullPath);
+        }
+
         public override bool Equals(object obj)
             => obj is SignedFileContentKey key && Equals(key);
 


### PR DESCRIPTION
Closes: #1272 

**Goal:** when printing error messages also print all the packages that a file appears in so that the user can easily locate in which package(s) the file was found.

Changes:

- **SignToolTests.cs:** patched tests output to include the relative path of the files.
- **Configuration.cs:** 
  - keep track of the packages that each file appears in; 
  - keep tracks of which files produced an specific error. 
  - print errors at the end.

These changes were tested here: https://dnceng.visualstudio.com/internal/_build/results?buildId=47746&view=logs where you can also see the format of the output.