### PR TITLE
Add support for suppressing warning messages

### DIFF
--- a/src/Microsoft.DotNet.SignTool/src/SignToolConstants.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolConstants.cs
@@ -11,6 +11,9 @@ namespace Microsoft.DotNet.SignTool
     {
         public const string IgnoreFileCertificateSentinel = "None";
 
+        public enum SigningToolMSGCodes { SIGN001, SIGN002 };
+
+
         /// <summary>
         /// List of known signable extensions. Copied, removing duplicates, from here:
         /// https://microsoft.sharepoint.com/teams/codesigninfo/Wiki/Signable%20Files.aspx


### PR DESCRIPTION
**Closes**: #1295 

With this change SignTool will support the user to specify warning messages that should be disabled in the scope of a specific file or the whole signing process. For instance, first candidate for this is the SIGN001 warning.

**Changes**:
- SignToolTests.cs : Two new test cases added
- SignToolConstants.cs : Moved definition of error messages here
- Configuration.cs : Receive the new parameters and check the suppress condition.
- SignToolTask.cs : Receive & parse the new parameter / attribute.
