### PR TITLE
Make .editorconfig and .gitattributes agree on line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,10 +1,12 @@
 root = true
 
 [*]
-end_of_line = lf
 insert_final_newline = true
 charset = utf-8
 indent_style = space
+
+[*.{sh}]
+end_of_line = lf
 
 [*.{cs}]
 indent_size = 4


### PR DESCRIPTION
For .sh, both should agree on "lf"
For everything else, attributes is "auto", so editorconfig should have no opinion, so it it matches your OS