### PR TITLE
Fix helix xunit test execution

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="$(XUnitVersion)" IsImplicitlyDefined="true" PrivateAssets="all"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioVersion)" IsImplicitlyDefined="true" PrivateAssets="all"/>
-    <PackageReference Include="xunit.runner.console" Version="$(XUnitRunnerConsoleVersion)" IsImplicitlyDefined="true" PrivateAssets="all"/>
+    <PackageReference Include="xunit" Version="$(XUnitVersion)" IsImplicitlyDefined="true"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioVersion)" IsImplicitlyDefined="true"/>
+    <PackageReference Include="xunit.runner.console" Version="$(XUnitRunnerConsoleVersion)" IsImplicitlyDefined="true"/>
   </ItemGroup>
 
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="$(XUnitVersion)" IsImplicitlyDefined="true"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioVersion)" IsImplicitlyDefined="true"/>
-    <PackageReference Include="xunit.runner.console" Version="$(XUnitRunnerConsoleVersion)" IsImplicitlyDefined="true"/>
+    <PackageReference Include="xunit" Version="$(XUnitVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true"/>
+    <PackageReference Include="xunit.runner.console" Version="$(XUnitRunnerConsoleVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true"/>
   </ItemGroup>
 
   <!--

--- a/src/Microsoft.DotNet.Helix/Sdk/AzureDevOpsTask.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/AzureDevOpsTask.cs
@@ -60,7 +60,7 @@ namespace Microsoft.DotNet.Helix.AzureDevOps
             }
             catch (Exception ex)
             {
-                Log.LogErrorFromException(ex);
+                Log.LogErrorFromException(ex, true);
             }
 
             return !Log.HasLoggedErrors;

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXUnitWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXUnitWorkItems.cs
@@ -37,6 +37,8 @@ namespace Microsoft.DotNet.Helix.Sdk
         [Required]
         public bool IsPosixShell { get; set; }
 
+        public string XUnitArguments { get; set; }
+
         /// <summary>
         /// An array of ITaskItems of type HelixWorkItem
         /// </summary>
@@ -99,7 +101,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             string correlationPayload = IsPosixShell ? "$HELIX_CORRELATION_PAYLOAD" : "%HELIX_CORRELATION_PAYLOAD%";
             string xUnitRunner = $"{correlationPayload}/tools/{runtimeTargetFramework}/{runnerName}";
 
-            string command = $"{driver}{xUnitRunner} {assemblyName} -xml testResults.xml {arguments}";
+            string command = $"{driver}{xUnitRunner}{(XUnitArguments != null ? " " + XUnitArguments : "")} {assemblyName} -xml testResults.xml {arguments}";
 
             Log.LogMessage($"Creating work item with properties Identity: {assemblyName}, PayloadDirectory: {publishDirectory}, Command: {command}");
 

--- a/src/Microsoft.DotNet.Helix/Sdk/StopAzurePipelinesTestRun.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/StopAzurePipelinesTestRun.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.Helix.AzureDevOps
                 var data = JObject.Parse(await res.Content.ReadAsStringAsync());
                 if (data["runStatistics"] is JArray runStatistics)
                 {
-                    var failed = runStatistics.Children().First(stat => stat["outcome"]?.ToString() == "Failed");
+                    var failed = runStatistics.Children().FirstOrDefault(stat => stat["outcome"]?.ToString() == "Failed");
                     if (failed != null)
                     {
                         Log.LogError($"Test run {TestRunId} has one or more failing tests.");

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xunit-runner/XUnitPublish.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xunit-runner/XUnitPublish.targets
@@ -1,3 +1,3 @@
 <Project>
-  <Target Name="PublishWithOutput" DependsOnTargets="Restore;Publish" Returns="$([System.IO.Path]::GetFullPath('$(PublishDir)'))" />
+  <Target Name="PublishWithOutput" DependsOnTargets="Publish" Returns="$([System.IO.Path]::GetFullPath('$(PublishDir)'))" />
 </Project>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xunit-runner/XUnitRunner.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xunit-runner/XUnitRunner.targets
@@ -6,6 +6,8 @@
     <XUnitRunnerVersion Condition="'$(XUnitRunnerVersion)' == ''">2.4.1</XUnitRunnerVersion>
 
     <_XUnitPublishTargetsPath>$(MSBuildThisFileDirectory)XUnitPublish.targets</_XUnitPublishTargetsPath>
+
+    <XUnitArguments Condition="'$(XUnitArguments)' == ''">-nocolor<XUnitArguments>
   </PropertyGroup>
 
   <ItemGroup Condition="'@(XUnitProject)' != ''">
@@ -24,6 +26,8 @@
       <_CurrentRuntimeTargetFramework Condition="'$(_CurrentRuntimeTargetFramework)' == ''">$(XUnitRuntimeTargetFramework)</_CurrentRuntimeTargetFramework>
       <_CurrentAdditionalProperties>%(XUnitProject.AdditionalProperties)</_CurrentAdditionalProperties>
     </PropertyGroup>
+    <MSBuild Projects="$(_CurrentXUnitProject)" Targets="Restore" Properties="CustomAfterMicrosoftCommonTargets=$(_XUnitPublishTargetsPath);$(_CurrentAdditionalProperties)">
+    </MSBuild>
     <MSBuild Projects="$(_CurrentXUnitProject)" Targets="PublishWithOutput" Properties="CustomAfterMicrosoftCommonTargets=$(_XUnitPublishTargetsPath);TargetFramework=$(_CurrentPublishTargetFramework);$(_CurrentAdditionalProperties)">
       <Output TaskParameter="TargetOutputs" PropertyName="_PublishOutputDir" />
     </MSBuild>
@@ -42,7 +46,7 @@
   </Target>
   
   <Target Name="CreateXUnitWorkItems" Condition="'@(XUnitProject)' != ''" BeforeTargets="Test">    
-    <CreateXUnitWorkItems XUnitProjects="@(XUnitProject)" IsPosixShell="$(IsPosixShell)" >
+    <CreateXUnitWorkItems XUnitProjects="@(XUnitProject)" IsPosixShell="$(IsPosixShell)" XUnitArguments="$(XUnitArguments)">
       <Output TaskParameter="XUnitWorkItems" ItemName="HelixWorkItem"/>
     </CreateXUnitWorkItems>
   </Target>


### PR DESCRIPTION
This change updates the build process for XUnit projects referenced from
a helix SDK project to run restore without specifying TargetFramework
and then Publish with the selected TargetFramework

I also added `Publish="true"` to the default xunit `PackageReference`s
so that the xunit binaries get included in publish output that is sent
to helix.

I also fixed a few minor issues
- Use FirstOrDefault rather than First
- Add Global XUnitArguments and default it to `-nocolor` to remove color codes from console output.