### PR TITLE
Check for signing marker on NuGet, VSIX and PS files

### DIFF
--- a/src/Microsoft.DotNet.SignTool.Tests/FakeSignTool.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/FakeSignTool.cs
@@ -54,5 +54,20 @@ namespace Microsoft.DotNet.SignTool
                 stream.Write(_stamp, 0, _stamp.Length);
             }
         }
+
+        public override bool VerifySignedPowershellFile(string filePath)
+        {
+            return true;
+        }
+
+        public override bool VerifySignedNugetFileMarker(string filePath)
+        {
+            return true;
+        }
+
+        public override bool VerifySignedVSIXFileMarker(string filePath)
+        {
+            return true;
+        }
     }
 }

--- a/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
+++ b/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.SignTool
         private readonly SignTool _signTool;
         private readonly string[] _itemsToSkipStrongNameCheck;
 
-        internal BatchSignUtil(IBuildEngine buildEngine, TaskLoggingHelper log, SignTool signTool, 
+        internal BatchSignUtil(IBuildEngine buildEngine, TaskLoggingHelper log, SignTool signTool,
             BatchSignInput batchData, string[] itemsToSkipStrongNameCheck)
         {
             _signTool = signTool;
@@ -66,7 +66,11 @@ namespace Microsoft.DotNet.SignTool
             }
 
             // Validate the signing worked and produced actual signed binaries in all locations.
-            VerifyAfterSign(_log);
+            // This is a recursive process since we process nested containers.
+            foreach (var file in _batchData.FilesToSign)
+            {
+                VerifyAfterSign(file);
+            }
 
             if (_log.HasLoggedErrors)
             {
@@ -263,49 +267,60 @@ namespace Microsoft.DotNet.SignTool
             }
         }
 
-        private void VerifyAfterSign(TaskLoggingHelper log)
+        private void VerifyAfterSign(FileSignInfo file)
         {
-            foreach (var file in _batchData.FilesToSign)
+            if (file.IsPEFile())
             {
-                if (file.IsPEFile())
+                using (var stream = File.OpenRead(file.FullPath))
                 {
-                    using (var stream = File.OpenRead(file.FullPath))
+                    if (!_signTool.VerifySignedPEFile(stream))
                     {
-                        if (!_signTool.VerifySignedPEFile(stream))
-                        {
-                            log.LogError($"Assembly {file} is not signed properly");
-                        }
+                        _log.LogError($"Assembly {file.FullPath} is not signed properly");
                     }
                 }
-                else if (file.IsZipContainer())
+            }
+            else if (Path.GetExtension(file.FullPath).Equals(".ps1", StringComparison.OrdinalIgnoreCase)
+                || Path.GetExtension(file.FullPath).Equals(".psd1", StringComparison.OrdinalIgnoreCase)
+                || Path.GetExtension(file.FullPath).Equals(".psm1", StringComparison.OrdinalIgnoreCase))
+            {
+                if (!_signTool.VerifySignedPowershellFile(file.FullPath))
                 {
-                    var zipData = _batchData.ZipDataMap[file.ContentHash];
+                    _log.LogError($"Powershell file {file.FullPath} does not have a signature mark.");
+                }
+            }
+            else if (file.IsZipContainer())
+            {
+                var zipData = _batchData.ZipDataMap[file.ContentHash];
+                bool signedContainer = false;
 
-                    using (var archive = new ZipArchive(File.OpenRead(file.FullPath), ZipArchiveMode.Read))
+                using (var archive = new ZipArchive(File.OpenRead(file.FullPath), ZipArchiveMode.Read))
+                {
+                    foreach (ZipArchiveEntry entry in archive.Entries)
                     {
-                        foreach (ZipArchiveEntry entry in archive.Entries)
+                        string relativeName = entry.FullName;
+
+                        if (file.IsNupkg() && _signTool.VerifySignedNugetFileMarker(relativeName))
                         {
-                            string relativeName = entry.FullName;
-                            var zipPart = zipData.FindNestedPart(relativeName);
-                            if (!zipPart.HasValue || !zipPart.Value.FileSignInfo.IsPEFile())
-                            {
-                                continue;
-                            }
-
-                            // PEReader requires a seekable stream
-                            var peStream = new MemoryStream((int)entry.Length);
-                            using (var stream = entry.Open())
-                            {
-                                stream.CopyTo(peStream);
-                                peStream.Position = 0;
-                            }
-
-                            if (!_signTool.VerifySignedPEFile(peStream))
-                            {
-                                log.LogError($"Zip container {file} has part {relativeName} which is not signed.");
-                            }
+                            signedContainer = true;
                         }
+                        else if (file.IsVsix() && _signTool.VerifySignedVSIXFileMarker(relativeName))
+                        {
+                            signedContainer = true;
+                        }
+
+                        var zipPart = zipData.FindNestedPart(relativeName);
+                        if (!zipPart.HasValue)
+                        {
+                            continue;
+                        }
+
+                        VerifyAfterSign(zipPart.Value.FileSignInfo);
                     }
+                }
+
+                if ((file.IsNupkg() || file.IsVsix()) && !signedContainer)
+                {
+                    _log.LogError($"Container {file.FullPath} does not have signature marker.");
                 }
             }
         }

--- a/src/Microsoft.DotNet.SignTool/src/Configuration.cs
+++ b/src/Microsoft.DotNet.SignTool/src/Configuration.cs
@@ -77,7 +77,7 @@ namespace Microsoft.DotNet.SignTool
             string[] dualCertificates, TaskLoggingHelper log)
         {
             Debug.Assert(tempDir != null);
-            Debug.Assert(itemsToSign != null && !itemsToSign.Any(i => i == null));
+   Debug.Assert(itemsToSign != null && !itemsToSign.Any(i => i == null));
             Debug.Assert(strongNameInfo != null);
             Debug.Assert(fileSignInfo != null);
 

--- a/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
@@ -7,6 +7,7 @@ using Microsoft.Build.Utilities;
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Reflection.PortableExecutable;
 
 namespace Microsoft.DotNet.SignTool
@@ -115,6 +116,21 @@ namespace Microsoft.DotNet.SignTool
             process.WaitForExit();
 
             return process.ExitCode == 0;
+        }
+
+        public override bool VerifySignedPowershellFile(string filePath)
+        {
+            return File.ReadLines(filePath).Contains("# SIG # Begin Signature Block");
+        }
+
+        public override bool VerifySignedNugetFileMarker(string filePath)
+        {
+            return filePath.EndsWith(".signature.p7s", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override bool VerifySignedVSIXFileMarker(string filePath)
+        {
+            return filePath.IndexOf("package/services/digital-signature/", StringComparison.OrdinalIgnoreCase) >= 0;
         }
     }
 }

--- a/src/Microsoft.DotNet.SignTool/src/SignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignTool.cs
@@ -29,6 +29,9 @@ namespace Microsoft.DotNet.SignTool
         public abstract void RemovePublicSign(string assemblyPath);
 
         public abstract bool VerifySignedPEFile(Stream stream);
+        public abstract bool VerifySignedPowershellFile(string filePath);
+        public abstract bool VerifySignedNugetFileMarker(string filePath);
+        public abstract bool VerifySignedVSIXFileMarker(string filePath);
 
         public abstract bool VerifyStrongNameSign(string fileFullPath);
 

--- a/src/Microsoft.DotNet.SignTool/src/ValidationOnlySignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ValidationOnlySignTool.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.SignTool
     {
         internal bool TestSign { get; }
 
-        internal ValidationOnlySignTool(SignToolArgs args, TaskLoggingHelper log) 
+        internal ValidationOnlySignTool(SignToolArgs args, TaskLoggingHelper log)
             : base(args, log)
         {
             TestSign = args.TestSign;
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.SignTool
         {
         }
 
-        public override bool VerifySignedPEFile(Stream assemblyStream) 
+        public override bool VerifySignedPEFile(Stream assemblyStream)
             => true;
 
         public override bool VerifyStrongNameSign(string fileFullPath)
@@ -42,6 +42,21 @@ namespace Microsoft.DotNet.SignTool
             {
                 return true;
             }
+        }
+
+        public override bool VerifySignedPowershellFile(string filePath)
+        {
+            return true;
+        }
+
+        public override bool VerifySignedNugetFileMarker(string filePath)
+        {
+            return true;
+        }
+
+        public override bool VerifySignedVSIXFileMarker(string filePath)
+        {
+            return true;
         }
     }
 }


### PR DESCRIPTION
**Closes:** #958 

[Plan was shown here.](https://github.com/dotnet/arcade/issues/958#issuecomment-441136416) Improving support for checking that some common file types are signed. Doesn't validate the certificate. Only the presence of a signing marker.

**Changes:**
- BatchSignUtil.cs : Adding check for validating (PS, NuGet and VSIX) files; Fix the routine to consider nested packages.
- SignTool.cs : Add new abstract methods for verifying the new file extensions.
- RealSignTool.cs : Implement the new abstract methods of the base class.
- FakeSignTool.cs : Just override base class methods.
- ValidationOnlySignTool.cs : Just override base class methods.