### PR TITLE
Make ArcadeSDK pass DoStrongNameCheck parameter to SignToolTask

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -79,6 +79,7 @@
     <Microsoft.DotNet.SignTool.SignToolTask
         DryRun="$(_DryRun)"
         TestSign="$(_TestSign)"
+        DoStrongNameCheck="$(DoStrongNameCheck)"
         CertificatesSignInfo="$(CertificatesSignInfo)"
         ItemsToSign="@(ItemsToSign)"
         StrongNameSignInfo="@(StrongNameSignInfo)"


### PR DESCRIPTION
I missed adding this new parameter to the SDK. 

The default for the parameter is `false` so that it won't be disruptive to onboarded repos. 