### PR TITLE
Bootstrapper improvements.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,12 @@ indent_style = space
 
 [*.{sh}]
 end_of_line = lf
+indent_size = 2
+tab_width = 2
+
+[*.{ps1}]
+indent_size = 2
+tab_width = 2
 
 [*.{cs}]
 indent_size = 4

--- a/Build.cmd
+++ b/Build.cmd
@@ -1,3 +1,2 @@
 @echo off
 powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\common\Build.ps1""" -restore -build %*"
-exit /b %ErrorLevel%

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,9 +15,7 @@
       Tools and packages produced by this repository support infrastructure and are not shipping on NuGet or via any other official channel.
     -->
     <IsShipping>false</IsShipping>
-  </PropertyGroup>
 
-  <PropertyGroup>
     <!-- 
       'NetFxTfm' is the standard desktop Target Framework Moniker which this repo's packages are targeting
       ie.  Place 'NetFxTfm' in the 'TargetFramework' property of a csproj like <TargetFrameworks>$(NetFxTfm);netcoreapp2.0</TargetFrameworks> 

--- a/Restore.cmd
+++ b/Restore.cmd
@@ -1,3 +1,2 @@
 @echo off
 powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\common\Build.ps1""" -restore %*"
-exit /b %ErrorLevel%

--- a/Test.cmd
+++ b/Test.cmd
@@ -1,3 +1,2 @@
 @echo off
 powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\common\Build.ps1""" -test %*"
-exit /b %ErrorLevel%

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -49,14 +49,8 @@
     <MicrosoftDotNetBuildTasksFeedVersion>2.2.0-beta.18607.6</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetMaestroTasksVersion>1.0.0-beta.18607.6</MicrosoftDotNetMaestroTasksVersion>
     <MicrosoftDotNetSignToolVersion>1.0.0-beta.18607.6</MicrosoftDotNetSignToolVersion>
-    <!-- 3rd Part Packages Public Keys -->
-    <DynamicProxyGenAsm2Key>0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7</DynamicProxyGenAsm2Key>
-  </PropertyGroup>
-  <PropertyGroup>
     <MicrosoftAzureDocumentDBVersion>1.22.0</MicrosoftAzureDocumentDBVersion>
     <MicrosoftAzureCosmosDBTableVersion>1.1.2</MicrosoftAzureCosmosDBTableVersion>
-  </PropertyGroup>
-  <PropertyGroup>
     <MicrosoftAspNetCoreAllVersion>2.0.0</MicrosoftAspNetCoreAllVersion>
     <MicrosoftDotNetGitHubIssueLabelerAssetsVersion>1.2.0</MicrosoftDotNetGitHubIssueLabelerAssetsVersion>
     <MicrosoftMLVersion>0.4.0</MicrosoftMLVersion>
@@ -69,7 +63,7 @@
       $(RestoreSources);
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
       https://dotnet.myget.org/F/symreader-converter/api/v3/index.json;
-      https:%2F%2Fdotnet.myget.org/F/symreader/api/v3/index.json
+      https://dotnet.myget.org/F/symreader/api/v3/index.json
     </RestoreSources>
   </PropertyGroup>
 </Project>

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -1,15 +1,15 @@
 [CmdletBinding(PositionalBinding=$false)]
 Param(
-  [string] $configuration = "Debug",
+  [string][Alias('c')]$configuration = "Debug",
   [string] $projects = "",
-  [string] $verbosity = "minimal",
+  [string][Alias('v')]$verbosity = "minimal",
   [string] $msbuildEngine = $null,
   [bool] $warnAsError = $true,
   [bool] $nodeReuse = $true,
   [switch] $execute,
-  [switch] $restore,
+  [switch][Alias('r')]$restore,
   [switch] $deployDeps,
-  [switch] $build,
+  [switch][Alias('b')]$build,
   [switch] $rebuild,
   [switch] $deploy,
   [switch] $test,
@@ -30,15 +30,15 @@ Param(
 
 function Print-Usage() {
     Write-Host "Common settings:"
-    Write-Host "  -configuration <value>  Build configuration Debug, Release"
-    Write-Host "  -verbosity <value>      Msbuild verbosity (q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic])"
-    Write-Host "  -binaryLog              Output binary log"
+    Write-Host "  -configuration <value>  Build configuration: 'Debug' or 'Release' (short: -c)"
+    Write-Host "  -verbosity <value>      Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
+    Write-Host "  -binaryLog              Output binary log (short: -bl)"
     Write-Host "  -help                   Print help and exit"
     Write-Host ""
 
     Write-Host "Actions:"
-    Write-Host "  -restore                Restore dependencies"
-    Write-Host "  -build                  Build solution"
+    Write-Host "  -restore                Restore dependencies (short: -r)"
+    Write-Host "  -build                  Build solution (short: -b)"
     Write-Host "  -rebuild                Rebuild solution"
     Write-Host "  -deploy                 Deploy built VSIXes"
     Write-Host "  -deployDeps             Deploy dependencies (e.g. VSIXes for integration tests)"
@@ -48,7 +48,7 @@ function Print-Usage() {
     Write-Host "  -performanceTest        Run all performance tests in the solution"
     Write-Host "  -sign                   Sign build outputs"
     Write-Host "  -publish                Publish artifacts (e.g. symbols)"
-    Write-Host "  -publishBuildAssets        Push assets to BAR"
+    Write-Host "  -publishBuildAssets     Push assets to BAR"
     Write-Host ""
 
     Write-Host "Advanced settings:"

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -42,7 +42,6 @@ while [[ -h "$source" ]]; do
 done
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 
-help=false
 restore=false
 build=false
 rebuild=false

--- a/eng/common/darc-init.ps1
+++ b/eng/common/darc-init.ps1
@@ -3,7 +3,9 @@ $verbosity = "m"
 
 function InstallDarcCli {
   $darcCliPackageName = "microsoft.dotnet.darc"
-  $dotnet = "$env:DOTNET_INSTALL_DIR\dotnet.exe"
+
+  $dotnetRoot = InitializeDotNetCli -install:$true
+  $dotnet = "$dotnetRoot\dotnet.exe"
   $toolList = Invoke-Expression "& `"$dotnet`" tool list -g"
 
   if ($toolList -like "*$darcCliPackageName*") {
@@ -17,5 +19,4 @@ function InstallDarcCli {
   Invoke-Expression "& `"$dotnet`" tool install $darcCliPackageName --version $toolsetVersion -v $verbosity -g"
 }
 
-InitializeTools
 InstallDarcCli

--- a/eng/common/darc-init.sh
+++ b/eng/common/darc-init.sh
@@ -17,10 +17,14 @@ verbosity=m
 
 function InstallDarcCli {
   local darc_cli_package_name="microsoft.dotnet.darc"
-  local uninstall_command=`$DOTNET_INSTALL_DIR/dotnet tool uninstall $darc_cli_package_name -g`
-  local tool_list=$($DOTNET_INSTALL_DIR/dotnet tool list -g)
+
+  InitializeDotNetCli
+  local dotnet_root=$_InitializeDotNetCli
+
+  local uninstall_command=`$dotnet_root/dotnet tool uninstall $darc_cli_package_name -g`
+  local tool_list=$($dotnet_root/dotnet tool list -g)
   if [[ $tool_list = *$darc_cli_package_name* ]]; then
-    echo $($DOTNET_INSTALL_DIR/dotnet tool uninstall $darc_cli_package_name -g)
+    echo $($dotnet_root/dotnet tool uninstall $darc_cli_package_name -g)
   fi
 
   ReadGlobalVersion "Microsoft.DotNet.Arcade.Sdk"
@@ -28,8 +32,7 @@ function InstallDarcCli {
 
   echo "Installing Darc CLI version $toolset_version..."
   echo "You may need to restart your command shell if this is the first dotnet tool you have installed."
-  echo $($DOTNET_INSTALL_DIR/dotnet tool install $darc_cli_package_name --version $toolset_version -v $verbosity -g)
+  echo $($dotnet_root/dotnet tool install $darc_cli_package_name --version $toolset_version -v $verbosity -g)
 }
 
-InitializeTools
 InstallDarcCli

--- a/eng/common/msbuild.ps1
+++ b/eng/common/msbuild.ps1
@@ -1,8 +1,8 @@
 [CmdletBinding(PositionalBinding=$false)]
 Param(
   [string] $verbosity = "minimal",
-  [bool] $warnaserror = $true,
-  [bool] $nodereuse = $true,
+  [bool] $warnAsError = $true,
+  [bool] $nodeReuse = $true,
   [switch] $ci,
   [switch] $prepareMachine,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$extraArgs
@@ -11,13 +11,13 @@ Param(
 . $PSScriptRoot\tools.ps1
 
 try {
-  InitializeTools
   MSBuild @extraArgs
-  ExitWithExitCode $lastExitCode
-}
+} 
 catch {
   Write-Host $_
   Write-Host $_.Exception
   Write-Host $_.ScriptStackTrace
   ExitWithExitCode 1
 }
+
+ExitWithExitCode 0

--- a/eng/common/msbuild.sh
+++ b/eng/common/msbuild.sh
@@ -13,10 +13,10 @@ done
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 
 verbosity='minimal'
-warnaserror=true
-nodereuse=true
+warn_as_error=true
+node_reuse=true
 prepare_machine=false
-extraargs=''
+extra_args=''
 
 while (($# > 0)); do
   lowerI="$(echo $1 | awk '{print tolower($0)}')"
@@ -26,11 +26,11 @@ while (($# > 0)); do
       shift 2
       ;;
     --warnaserror)
-      warnaserror=$2
+      warn_as_error=$2
       shift 2
       ;;
     --nodereuse)
-      nodereuse=$2
+      node_reuse=$2
       shift 2
       ;;
     --ci)
@@ -42,7 +42,7 @@ while (($# > 0)); do
       shift 1
       ;;
       *)
-      extraargs="$extraargs $1"
+      extra_args="$extra_args $1"
       shift 1
       ;;
   esac
@@ -50,6 +50,5 @@ done
 
 . "$scriptroot/tools.sh"
 
-InitializeTools
-MSBuild $extraargs
-ExitWithExitCode $?
+MSBuild $extra_args
+ExitWithExitCode 0

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -1,17 +1,43 @@
-# Initialize variables if they aren't already defined
+# Initialize variables if they aren't already defined.
+# These may be defined as parameters of the importing script, or set after importing this script.
 
-$ci = if (Test-Path variable:ci) { $ci } else { $false }
-$configuration = if (Test-Path variable:configuration) { $configuration } else { "Debug" }
-$binaryLog = if (Test-Path variable:binaryLog) { $binaryLog } else { $ci }
-$nodereuse = if (Test-Path variable:nodereuse) { $nodereuse } else { !$ci }
-$prepareMachine = if (Test-Path variable:prepareMachine) { $prepareMachine } else { $false }
-$restore = if (Test-Path variable:restore) { $restore } else { $true }
-$verbosity = if (Test-Path variable:verbosity) { $verbosity } else { "minimal" }
-$warnaserror = if (Test-Path variable:warnaserror) { $warnaserror } else { $true }
-$msbuildEngine = if (Test-Path variable:msbuildEngine) { $msbuildEngine } else { $null }
-$useInstalledDotNetCli = if (Test-Path variable:useInstalledDotNetCli) { $useInstalledDotNetCli } else { $true }
+# CI mode - set to true on CI server for PR validation build or official build.
+[bool]$ci = if (Test-Path variable:ci) { $ci } else { $false }
 
-$ProcessesToStopOnExit = @("msbuild", "dotnet", "vbcscompiler")
+# Build configuration. Common values include 'Debug' and 'Release', but the repository may use other names.
+[string]$configuration = if (Test-Path variable:configuration) { $configuration } else { "Debug" }
+
+# Set to true to output binary log from msbuild. Note that emitting binary log slows down the build.
+# Binary log must be enabled on CI.
+[bool]$binaryLog = if (Test-Path variable:binaryLog) { $binaryLog } else { $ci }
+
+# Turns on machine preparation/clean up code that changes the machine state (e.g. kills build processes).
+[bool]$prepareMachine = if (Test-Path variable:prepareMachine) { $prepareMachine } else { $false }
+
+# True to restore toolsets and dependencies.
+[bool]$restore = if (Test-Path variable:restore) { $restore } else { $true }
+
+# Adjusts msbuild verbosity level.
+[string]$verbosity = if (Test-Path variable:verbosity) { $verbosity } else { "minimal" }
+
+# Set to true to reuse msbuild nodes. Recommended to not reuse on CI.
+[bool]$nodeReuse = if (Test-Path variable:nodeReuse) { $nodeReuse } else { !$ci }
+
+# Configures warning treatment in msbuild.
+[bool]$warnAsError = if (Test-Path variable:warnAsError) { $warnAsError } else { $true }
+
+# Specifies which msbuild engine to use for build: 'vs', 'dotnet' or unspecified (determined based on presence of tools.vs in global.json).
+[string]$msbuildEngine = if (Test-Path variable:msbuildEngine) { $msbuildEngine } else { $null }
+
+# True to attempt using .NET Core already that meets requirements specified in global.json 
+# installed on the machine instead of downloading one.
+[bool]$useInstalledDotNetCli = if (Test-Path variable:useInstalledDotNetCli) { $useInstalledDotNetCli } else { $true }
+
+# True to use global NuGet cache instead of restoring packages to repository-local directory.
+[bool]$useGlobalNuGetCache = if (Test-Path variable:useGlobalNuGetCache) { $useGlobalNuGetCache } else { !$ci }
+
+# An array of names of processes to stop on script exit if prepareMachine is true.
+$processesToStopOnExit = if (Test-Path variable:processesToStopOnExit) { $processesToStopOnExit } else { @("msbuild", "dotnet", "vbcscompiler") }
 
 set-strictmode -version 2.0
 $ErrorActionPreference = "Stop"
@@ -323,10 +349,26 @@ function GetDefaultMSBuildEngine() {
   ExitWithExitCode 1
 }
 
+function GetNuGetPackageCachePath() {
+  if ($env:NUGET_PACKAGES -eq $null) {
+    # Use local cache on CI to ensure deterministic build,
+    # use global cache in dev builds to avoid cost of downloading packages.
+    if ($useGlobalNuGetCache) {
+      $env:NUGET_PACKAGES = Join-Path $env:UserProfile ".nuget\packages"
+    } else {
+      $env:NUGET_PACKAGES = Join-Path $RepoRoot ".packages"
+    }
+  }
+
+  return $env:NUGET_PACKAGES
+}
+
 function InitializeToolset() {
   if (Test-Path global:_ToolsetBuildProj) {
     return $global:_ToolsetBuildProj
   }
+
+  $nugetCache = GetNuGetPackageCachePath
 
   $toolsetVersion = $GlobalJson.'msbuild-sdks'.'Microsoft.DotNet.Arcade.Sdk'
   $toolsetLocationFile = Join-Path $ToolsetDir "$toolsetVersion.txt"
@@ -368,7 +410,7 @@ function ExitWithExitCode([int] $exitCode) {
 
 function Stop-Processes() {
   Write-Host "Killing running build processes..."
-  foreach ($processName in $ProcessesToStopOnExit) {
+  foreach ($processName in $processesToStopOnExit) {
     Get-Process -Name $processName -ErrorAction SilentlyContinue | Stop-Process
   }
 }
@@ -379,11 +421,21 @@ function Stop-Processes() {
 # Terminates the script if the build fails.
 #
 function MSBuild() {
+  if ($ci) {
+    if (!$binaryLog) {
+      throw "Binary log must be enabled in CI build."
+    }
+
+    if ($nodeReuse) {
+      throw "Node reuse must be disabled in CI build."
+    }
+  }
+
   $buildTool = InitializeBuildTool
 
-  $cmdArgs = "$($buildTool.Command) /m /nologo /clp:Summary /v:$verbosity /nr:$nodereuse"
+  $cmdArgs = "$($buildTool.Command) /m /nologo /clp:Summary /v:$verbosity /nr:$nodeReuse"
 
-  if ($warnaserror) { 
+  if ($warnAsError) { 
     $cmdArgs += " /warnaserror /p:TreatWarningsAsErrors=true" 
   }
 
@@ -433,18 +485,11 @@ $LogDir = Join-Path (Join-Path $ArtifactsDir "log") $configuration
 $TempDir = Join-Path (Join-Path $ArtifactsDir "tmp") $configuration
 $GlobalJson = Get-Content -Raw -Path (Join-Path $RepoRoot "global.json") | ConvertFrom-Json
 
-if ($env:NUGET_PACKAGES -eq $null) {
-  # Use local cache on CI to ensure deterministic build,
-  # use global cache in dev builds to avoid cost of downloading packages.
-  $env:NUGET_PACKAGES = if ($ci) { Join-Path $RepoRoot ".packages" }
-                        else { Join-Path $env:UserProfile ".nuget\packages" }
-}
-
 Create-Directory $ToolsetDir
+Create-Directory $TempDir
 Create-Directory $LogDir
 
 if ($ci) {
-  Create-Directory $TempDir
   $env:TEMP = $TempDir
   $env:TMP = $TempDir
 }

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -71,6 +71,11 @@ function InitializeDotNetCli([bool]$install) {
   # Disable first run since we do not need all ASP.NET packages restored.
   $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
+  # Disable telemetry on CI.
+  if ($ci) {
+    $env:DOTNET_CLI_TELEMETRY_OPTOUT=1
+  }
+
   # Source Build uses DotNetCoreSdkDir variable
   if ($env:DotNetCoreSdkDir -ne $null) {
     $env:DOTNET_INSTALL_DIR = $env:DotNetCoreSdkDir

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -2,6 +2,7 @@
 
 $ci = if (Test-Path variable:ci) { $ci } else { $false }
 $configuration = if (Test-Path variable:configuration) { $configuration } else { "Debug" }
+$binaryLog = if (Test-Path variable:binaryLog) { $binaryLog } else { $ci }
 $nodereuse = if (Test-Path variable:nodereuse) { $nodereuse } else { !$ci }
 $prepareMachine = if (Test-Path variable:prepareMachine) { $prepareMachine } else { $false }
 $restore = if (Test-Path variable:restore) { $restore } else { $true }
@@ -9,6 +10,8 @@ $verbosity = if (Test-Path variable:verbosity) { $verbosity } else { "minimal" }
 $warnaserror = if (Test-Path variable:warnaserror) { $warnaserror } else { $true }
 $msbuildEngine = if (Test-Path variable:msbuildEngine) { $msbuildEngine } else { $null }
 $useInstalledDotNetCli = if (Test-Path variable:useInstalledDotNetCli) { $useInstalledDotNetCli } else { $true }
+
+$ProcessesToStopOnExit = @("msbuild", "dotnet", "vbcscompiler")
 
 set-strictmode -version 2.0
 $ErrorActionPreference = "Stop"
@@ -25,7 +28,43 @@ function Unzip([string]$zipfile, [string]$outpath) {
   [System.IO.Compression.ZipFile]::ExtractToDirectory($zipfile, $outpath)
 }
 
+# This will exec a process using the console and return it's exit code.
+# This will not throw when the process fails.
+# Returns process exit code.
+function Exec-Process([string]$command, [string]$commandArgs) {
+  $startInfo = New-Object System.Diagnostics.ProcessStartInfo
+  $startInfo.FileName = $command
+  $startInfo.Arguments = $commandArgs
+  $startInfo.UseShellExecute = $false
+  $startInfo.WorkingDirectory = Get-Location
+
+  $process = New-Object System.Diagnostics.Process
+  $process.StartInfo = $startInfo
+  $process.Start() | Out-Null
+
+  $finished = $false
+  try {
+    while (-not $process.WaitForExit(100)) { 
+      # Non-blocking loop done to allow ctr-c interrupts
+    }
+
+    $finished = $true
+    return $global:LASTEXITCODE = $process.ExitCode
+  }
+  finally {
+    # If we didn't finish then an error occured or the user hit ctrl-c.  Either
+    # way kill the process
+    if (-not $finished) {
+      $process.Kill()
+    }
+  }
+}
+
 function InitializeDotNetCli([bool]$install) {
+  if (Test-Path global:_DotNetInstallDir) {
+    return $global:_DotNetInstallDir
+  }
+
   # Don't resolve runtime, shared framework, or SDK from other locations to ensure build determinism
   $env:DOTNET_MULTILEVEL_LOOKUP=0
 
@@ -39,7 +78,10 @@ function InitializeDotNetCli([bool]$install) {
 
   # Find the first path on %PATH% that contains the dotnet.exe
   if ($useInstalledDotNetCli -and ($env:DOTNET_INSTALL_DIR -eq $null)) {
-    $env:DOTNET_INSTALL_DIR = ${env:PATH}.Split(';') | where { ($_ -ne "") -and (Test-Path (Join-Path $_ "dotnet.exe")) }
+    $dotnetCmd = Get-Command "dotnet.exe" -ErrorAction SilentlyContinue
+    if ($dotnetCmd -ne $null) {
+      $env:DOTNET_INSTALL_DIR = Split-Path $dotnetCmd.Path -Parent
+    }
   }
 
   $dotnetSdkVersion = $GlobalJson.tools.dotnet
@@ -50,9 +92,8 @@ function InitializeDotNetCli([bool]$install) {
     $dotnetRoot = $env:DOTNET_INSTALL_DIR
   } else {
     $dotnetRoot = Join-Path $RepoRoot ".dotnet"
-    $env:DOTNET_INSTALL_DIR = $dotnetRoot
 
-    if (-not (Test-Path(Join-Path $env:DOTNET_INSTALL_DIR "sdk\$dotnetSdkVersion"))) {
+    if (-not (Test-Path(Join-Path $dotnetRoot "sdk\$dotnetSdkVersion"))) {
       if ($install) {
         InstallDotNetSdk $dotnetRoot $dotnetSdkVersion
       } else {
@@ -60,9 +101,11 @@ function InitializeDotNetCli([bool]$install) {
         ExitWithExitCode 1
       }
     }
+
+    $env:DOTNET_INSTALL_DIR = $dotnetRoot
   }
 
-  return $dotnetRoot
+  return $global:_DotNetInstallDir = $dotnetRoot
 }
 
 function GetDotNetInstallScript([string] $dotnetRoot) {
@@ -95,7 +138,11 @@ function InstallDotNetSdk([string] $dotnetRoot, [string] $version) {
 # Returns full path to msbuild.exe.
 # Throws on failure.
 #
-function InitializeVisualStudioMSBuild {
+function InitializeVisualStudioMSBuild([bool]$install) {
+  if (Test-Path global:_MSBuildExe) {
+    return $global:_MSBuildExe
+  }
+
   $vsMinVersionStr = if (!$GlobalJson.tools.vs.version) { $GlobalJson.tools.vs.version } else { "15.9" }
   $vsMinVersion = [Version]::new($vsMinVersionStr) 
 
@@ -104,7 +151,7 @@ function InitializeVisualStudioMSBuild {
     $msbuildCmd = Get-Command "msbuild.exe" -ErrorAction SilentlyContinue
     if ($msbuildCmd -ne $null) {
       if ($msbuildCmd.Version -ge $vsMinVersion) {
-        return $msbuildCmd.Path
+        return $global:_MSBuildExe = $msbuildCmd.Path
       }
 
       # Report error - the developer environment is initialized with incompatible VS version.
@@ -119,7 +166,7 @@ function InitializeVisualStudioMSBuild {
     $vsMajorVersion = $vsInfo.installationVersion.Split('.')[0]
 
     InitializeVisualStudioEnvironmentVariables $vsInstallDir $vsMajorVersion
-  } else {
+  } elseif ($install) {
 
     if (Get-Member -InputObject $GlobalJson.tools -Name "xcopy-msbuild") {
       $xcopyMSBuildVersion = $GlobalJson.tools.'xcopy-msbuild'
@@ -130,10 +177,12 @@ function InitializeVisualStudioMSBuild {
     }
 
     $vsInstallDir = InstallXCopyMSBuild $xcopyMSBuildVersion
+  } else {
+    throw "Unable to find Visual Studio that has required version and components installed"
   }
 
   $msbuildVersionDir = if ([int]$vsMajorVersion -lt 16) { "$vsMajorVersion.0" } else { "Current" }
-  return Join-Path $vsInstallDir "MSBuild\$msbuildVersionDir\Bin\msbuild.exe"
+  return $global:_MSBuildExe = Join-Path $vsInstallDir "MSBuild\$msbuildVersionDir\Bin\msbuild.exe"
 }
 
 function InitializeVisualStudioEnvironmentVariables([string] $vsInstallDir, [string] $vsMajorVersion) {
@@ -216,36 +265,19 @@ function LocateVisualStudio {
   return $vsInfo[0]
 }
 
-function ConfigureTools { 
-  # Include custom tools configuration
-  $script = Join-Path $EngRoot "configure-toolset.ps1"
-
-  if (Test-Path $script) {
-    . $script
-  }
-}
-
-function InitializeTools() {
-  ConfigureTools
-
-  $tools = $GlobalJson.tools
-
-  # Initialize dotnet cli if listed in 'tools'
-  $dotnetRoot = $null
-  if (Get-Member -InputObject $tools -Name "dotnet") {
-    $dotnetRoot = InitializeDotNetCli -install:$restore
+function InitializeBuildTool() {
+  if (Test-Path global:_BuildTool) {
+    return $global:_BuildTool
   }
 
   if (-not $msbuildEngine) {
-    # Presence of tools.vs indicates the repo needs to build using VS msbuild on Windows.
-    if (Get-Member -InputObject $tools -Name "vs") {
-      $msbuildEngine = "vs"
-    } elseif ($dotnetRoot -ne $null) {
-      $msbuildEngine = "dotnet"
-    } else {
-      Write-Host "-msbuildEngine must be specified, or /global.json must specify 'tools.dotnet' or 'tools.vs'." -ForegroundColor Red
-      ExitWithExitCode 1
-    }
+    $msbuildEngine = GetDefaultMSBuildEngine
+  }
+
+  # Initialize dotnet cli if listed in 'tools'
+  $dotnetRoot = $null
+  if (Get-Member -InputObject $GlobalJson.tools -Name "dotnet") {
+    $dotnetRoot = InitializeDotNetCli -install:$restore
   }
 
   if ($msbuildEngine -eq "dotnet") {
@@ -254,34 +286,50 @@ function InitializeTools() {
       ExitWithExitCode 1
     }
 
-    $script:buildDriver = Join-Path $dotnetRoot "dotnet.exe"
-    $script:buildArgs = "msbuild"
+    $buildTool = @{ Path = Join-Path $dotnetRoot "dotnet.exe"; Command = "msbuild" }
   } elseif ($msbuildEngine -eq "vs") {
     try {
-      $script:buildDriver = InitializeVisualStudioMSBuild
-      $script:buildArgs = ""
-    } catch { 
+      $msbuildPath = InitializeVisualStudioMSBuild -install:$restore
+    } catch {
       Write-Host $_ -ForegroundColor Red
       ExitWithExitCode 1
     }
+
+    $buildTool = @{ Path = $msbuildPath; Command = "" }
   } else {
     Write-Host "Unexpected value of -msbuildEngine: '$msbuildEngine'." -ForegroundColor Red
     ExitWithExitCode 1
   }
 
-  InitializeToolSet $script:buildDriver $script:buildArgs
-  InitializeCustomToolset
+  return $global:_BuildTool = $buildTool
 }
 
-function InitializeToolset([string] $buildDriver, [string]$buildArgs) {
+function GetDefaultMSBuildEngine() {
+  # Presence of tools.vs indicates the repo needs to build using VS msbuild on Windows.
+  if (Get-Member -InputObject $GlobalJson.tools -Name "vs") {
+    return "vs"
+  }
+  
+  if (Get-Member -InputObject $GlobalJson.tools -Name "dotnet") {
+    return "dotnet"
+  }
+
+  Write-Host "-msbuildEngine must be specified, or /global.json must specify 'tools.dotnet' or 'tools.vs'." -ForegroundColor Red
+  ExitWithExitCode 1
+}
+
+function InitializeToolset() {
+  if (Test-Path global:_ToolsetBuildProj) {
+    return $global:_ToolsetBuildProj
+  }
+
   $toolsetVersion = $GlobalJson.'msbuild-sdks'.'Microsoft.DotNet.Arcade.Sdk'
   $toolsetLocationFile = Join-Path $ToolsetDir "$toolsetVersion.txt"
 
   if (Test-Path $toolsetLocationFile) {
     $path = Get-Content $toolsetLocationFile -TotalCount 1
     if (Test-Path $path) {
-      $script:ToolsetBuildProj = $path
-      return
+      return $global:_ToolsetBuildProj = $path
     }
   }
 
@@ -290,35 +338,20 @@ function InitializeToolset([string] $buildDriver, [string]$buildArgs) {
     ExitWithExitCode 1
   }
 
-  $ToolsetRestoreLog = Join-Path $LogDir "ToolsetRestore.binlog"
+  $buildTool = InitializeBuildTool
+
   $proj = Join-Path $ToolsetDir "restore.proj"
-
+  $bl = if ($binaryLog) { "/bl:" + (Join-Path $LogDir "ToolsetRestore.binlog") } else { "" }
+  
   '<Project Sdk="Microsoft.DotNet.Arcade.Sdk"/>' | Set-Content $proj
-  MSBuild $proj /t:__WriteToolsetLocation /clp:None /bl:$ToolsetRestoreLog /p:__ToolsetLocationOutputFile=$toolsetLocationFile
-
-  if ($lastExitCode -ne 0) {
-    Write-Host "Failed to restore toolset (exit code '$lastExitCode'). See log: $ToolsetRestoreLog" -ForegroundColor Red
-    ExitWithExitCode $lastExitCode
-  }
-
+  MSBuild $proj $bl /t:__WriteToolsetLocation /noconsolelogger /p:__ToolsetLocationOutputFile=$toolsetLocationFile
+  
   $path = Get-Content $toolsetLocationFile -TotalCount 1
   if (!(Test-Path $path)) {
     throw "Invalid toolset path: $path"
   }
-
-  $script:ToolsetBuildProj = $path
-}
-
-function InitializeCustomToolset {
-  if (-not $restore) {
-    return
-  }
-
-  $script = Join-Path $EngRoot "restore-toolset.ps1"
-
-  if (Test-Path $script) {
-    . $script
-  }
+  
+  return $global:_ToolsetBuildProj = $path
 }
 
 function ExitWithExitCode([int] $exitCode) {
@@ -330,14 +363,60 @@ function ExitWithExitCode([int] $exitCode) {
 
 function Stop-Processes() {
   Write-Host "Killing running build processes..."
-  Get-Process -Name "msbuild" -ErrorAction SilentlyContinue | Stop-Process
-  Get-Process -Name "dotnet" -ErrorAction SilentlyContinue | Stop-Process
-  Get-Process -Name "vbcscompiler" -ErrorAction SilentlyContinue | Stop-Process
+  foreach ($processName in $ProcessesToStopOnExit) {
+    Get-Process -Name $processName -ErrorAction SilentlyContinue | Stop-Process
+  }
 }
 
-function MsBuild() {
-  $warnaserrorSwitch = if ($warnaserror) { "/warnaserror" } else { "" }
-  & $buildDriver $buildArgs $warnaserrorSwitch /m /nologo /clp:Summary /v:$verbosity /nr:$nodereuse $args
+#
+# Executes msbuild (or 'dotnet msbuild') with arguments passed to the function.
+# The arguments are automatically quoted.
+# Terminates the script if the build fails.
+#
+function MSBuild() {
+  $buildTool = InitializeBuildTool
+
+  $cmdArgs = "$($buildTool.Command) /m /nologo /clp:Summary /v:$verbosity /nr:$nodereuse"
+
+  if ($warnaserror) { 
+    $cmdArgs += " /warnaserror /p:TreatWarningsAsErrors=true" 
+  }
+
+  foreach ($arg in $args) {
+    if ($arg -ne $null -and $arg.Trim() -ne "") {
+      $cmdArgs += " `"$arg`""
+    }
+  }
+  
+  $exitCode = Exec-Process $buildTool.Path $cmdArgs
+
+  if ($exitCode -ne 0) {
+    Write-Host "Build failed." -ForegroundColor Red
+
+    $buildLog = GetMSBuildBinaryLogCommandLineArgument $args
+    if ($buildLog -ne $null) {      
+      Write-Host "See log: $buildLog" -ForegroundColor DarkGray 
+    }
+
+    ExitWithExitCode $exitCode
+  }
+}
+
+function GetMSBuildBinaryLogCommandLineArgument($arguments) {  
+  foreach ($argument in $arguments) {
+    if ($argument -ne $null) {
+      $arg = $argument.Trim()
+      if ($arg.StartsWith("/bl:", "OrdinalIgnoreCase")) {
+        return $arg.Substring("/bl:".Length)
+      } 
+        
+      if ($arg.StartsWith("/binaryLogger:", "OrdinalIgnoreCase")) {
+        return $arg.Substring("/binaryLogger:".Length)
+      }
+    }
+  }
+
+  return $null
 }
 
 $RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -289,9 +289,10 @@ function MSBuild {
 }
 
 ResolvePath "${BASH_SOURCE[0]}"
+_script_dir=`dirname "$_ResolvePath"`
 
-eng_root="$( cd -P "$( dirname "$_ResolvePath" )/.." && pwd )"
-repo_root="$( cd -P "$( dirname "$_ResolvePath" )/../.." && pwd )"
+eng_root=`cd -P "$_script_dir/.." && pwd`
+repo_root=`cd -P "$_script_dir/../.." && pwd`
 artifacts_dir="$repo_root/artifacts"
 toolset_dir="$artifacts_dir/toolset"
 log_dir="$artifacts_dir/log/$configuration"

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -73,6 +73,11 @@ function InitializeDotNetCli {
   # Disable first run since we want to control all package sources
   export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
+  # Disable telemetry on CI
+  if [[ $ci == true ]]; then
+    export DOTNET_CLI_TELEMETRY_OPTOUT=1
+  fi
+
   # LTTNG is the logging infrastructure used by Core CLR. Need this variable set
   # so it doesn't output warnings to the console.
   export LTTNG_HOME="$HOME"

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -45,8 +45,10 @@ else
   use_global_nuget_cache=${use_global_nuget_cache:-true}
 fi
 
-repo_root="$scriptroot/../.."
-eng_root="$scriptroot/.."
+ResolvePath "${BASH_SOURCE[0]}"
+
+eng_root="$_ResolvePath/.."
+repo_root="$eng_root/.."
 artifacts_dir="$repo_root/artifacts"
 toolset_dir="$artifacts_dir/toolset"
 log_dir="$artifacts_dir/log/$configuration"

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -45,21 +45,10 @@ else
   use_global_nuget_cache=${use_global_nuget_cache:-true}
 fi
 
-ResolvePath "${BASH_SOURCE[0]}"
-
-eng_root="$_ResolvePath/.."
-repo_root="$eng_root/.."
-artifacts_dir="$repo_root/artifacts"
-toolset_dir="$artifacts_dir/toolset"
-log_dir="$artifacts_dir/log/$configuration"
-temp_dir="$artifacts_dir/tmp/$configuration"
-
-global_json_file="$repo_root/global.json"
-
+# Resolve any symlinks in the given path.
 function ResolvePath {
   local path=$1
 
-  # resolve $path until the file is no longer a symlink
   while [[ -h $path ]]; do
     local dir="$( cd -P "$( dirname "$path" )" && pwd )"
     path="$(readlink "$path")"
@@ -298,6 +287,17 @@ function MSBuild {
     ExitWithExitCode $lastexitcode
   fi
 }
+
+ResolvePath "${BASH_SOURCE[0]}"
+
+eng_root="$( cd -P "$( dirname "$_ResolvePath" )/.." && pwd )"
+repo_root="$( cd -P "$( dirname "$_ResolvePath" )/../.." && pwd )"
+artifacts_dir="$repo_root/artifacts"
+toolset_dir="$artifacts_dir/toolset"
+log_dir="$artifacts_dir/log/$configuration"
+temp_dir="$artifacts_dir/tmp/$configuration"
+
+global_json_file="$repo_root/global.json"
 
 # HOME may not be defined in some scenarios, but it is required by NuGet
 if [[ -z $HOME ]]; then

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -3,19 +3,46 @@
 # Stop script if unbound variable found (use ${var:-} if intentional)
 set -u
 
-ci=${ci:-false}
-configuration=${configuration:-'Debug'}
-binary_log=${binary_log:-$ci}
-prepare_machine=${prepare_machine:-false}
-restore=${restore:-true}
-verbosity=${verbosity:-'minimal'}
-warnaserror=${warnaserror:-true}
-useInstalledDotNetCli=${useInstalledDotNetCli:-true}
+# Initialize variables if they aren't already defined.
 
+# CI mode - set to true on CI server for PR validation build or official build.
+ci=${ci:-false}
+
+# Build configuration. Common values include 'Debug' and 'Release', but the repository may use other names.
+configuration=${configuration:-'Debug'}
+
+# Set to true to output binary log from msbuild. Note that emitting binary log slows down the build.
+# Binary log must be enabled on CI.
+binary_log=${binary_log:-$ci}
+
+# Turns on machine preparation/clean up code that changes the machine state (e.g. kills build processes).
+prepare_machine=${prepare_machine:-false}
+
+# True to restore toolsets and dependencies.
+restore=${restore:-true}
+
+# Adjusts msbuild verbosity level.
+verbosity=${verbosity:-'minimal'}
+
+# Set to true to reuse msbuild nodes. Recommended to not reuse on CI.
 if [[ "$ci" == true ]]; then
-  nodereuse=${nodereuse:-false}
+  node_reuse=${node_reuse:-false}
 else
-  nodereuse=${nodereuse:-true}
+  node_reuse=${node_reuse:-true}
+fi
+
+# Configures warning treatment in msbuild.
+warn_as_error=${warn_as_error:-true}
+
+# True to attempt using .NET Core already that meets requirements specified in global.json 
+# installed on the machine instead of downloading one.
+use_installed_dotnet_cli=${use_installed_dotnet_cli:-true}
+
+# True to use global NuGet cache instead of restoring packages to repository-local directory.
+if [[ "$ci" == true ]]; then
+  use_global_nuget_cache=${use_global_nuget_cache:-false}
+else
+  use_global_nuget_cache=${use_global_nuget_cache:-true}
 fi
 
 repo_root="$scriptroot/../.."
@@ -88,7 +115,7 @@ function InitializeDotNetCli {
   fi
 
   # Find the first path on $PATH that contains the dotnet.exe
-  if [[ "$useInstalledDotNetCli" == true && -z "${DOTNET_INSTALL_DIR:-}" ]]; then
+  if [[ "$use_installed_dotnet_cli" == true && -z "${DOTNET_INSTALL_DIR:-}" ]]; then
     local dotnet_path=`command -v dotnet`
     if [[ -n "$dotnet_path" ]]; then
       ResolvePath "$dotnet_path"
@@ -171,10 +198,25 @@ function InitializeBuildTool {
   _InitializeBuildTool="$_InitializeDotNetCli/dotnet"  
 }
 
+function GetNuGetPackageCachePath {
+  if [[ -z ${NUGET_PACKAGES:-} ]]; then
+    if [[ "$use_global_nuget_cache" == true ]]; then
+      export NUGET_PACKAGES="$HOME/.nuget/packages"
+    else
+      export NUGET_PACKAGES="$repo_root/.packages"
+    fi
+  fi
+
+  # return value
+  _GetNuGetPackageCachePath=$NUGET_PACKAGES
+}
+
 function InitializeToolset {
   if [[ -n "${_InitializeToolset:-}" ]]; then
     return
   fi
+
+  GetNuGetPackageCachePath
 
   ReadGlobalVersion "Microsoft.DotNet.Arcade.Sdk"
 
@@ -227,14 +269,26 @@ function StopProcesses {
 }
 
 function MSBuild {
+  if [[ "$ci" == true ]]; then
+    if [[ "$binary_log" != true ]]; then
+      echo "Binary log must be enabled in CI build." >&2
+      ExitWithExitCode 1
+    fi
+
+    if [[ "$node_reuse" == true ]]; then
+      echo "Node reuse must be disabled in CI build." >&2
+      ExitWithExitCode 1
+    fi
+  fi
+
   InitializeBuildTool
 
   local warnaserror_switch=""
-  if [[ $warnaserror == true ]]; then
+  if [[ $warn_as_error == true ]]; then
     warnaserror_switch="/warnaserror"
   fi
 
-  "$_InitializeBuildTool" msbuild /m /nologo /clp:Summary /v:$verbosity /nr:$nodereuse $warnaserror_switch /p:TreatWarningsAsErrors=$warnaserror "$@"
+  "$_InitializeBuildTool" msbuild /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse $warnaserror_switch /p:TreatWarningsAsErrors=$warn_as_error "$@"
   lastexitcode=$?
 
   if [[ $lastexitcode != 0 ]]; then
@@ -249,19 +303,11 @@ if [[ -z $HOME ]]; then
   mkdir -p "$HOME"
 fi
 
-if [[ -z ${NUGET_PACKAGES:-} ]]; then
-  if [[ $ci == true ]]; then
-    export NUGET_PACKAGES="$repo_root/.packages"
-  else
-    export NUGET_PACKAGES="$HOME/.nuget/packages"
-  fi
-fi
-
 mkdir -p "$toolset_dir"
+mkdir -p "$temp_dir"
 mkdir -p "$log_dir"
 
 if [[ $ci == true ]]; then
-  mkdir -p "$temp_dir"
   export TEMP="$temp_dir"
   export TMP="$temp_dir"
 fi

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -23,7 +23,6 @@
 
     ContinuousIntegrationBuild      "true" when building on a CI server (PR build or official build)
     Restore                         "true" to restore toolset and solution
-    QuietRestore                    "true" to suppress Restore output.
     Build                           "true" to build solution
     Rebuild                         "true" to rebuild solution
     Execute                         "true" to execute an sdk project "execute" target
@@ -34,6 +33,10 @@
     Pack                            "true" to build NuGet packages and VS insertion manifests
     Sign                            "true" to sign built binaries
     Publish                         "true" to publish artifacts (e.g. symbols)
+
+    Workaround for https://github.com/NuGet/Home/issues/4695
+    QuietRestore                    "true" to suppress Restore output.
+    QuietRestoreBinaryLog           "true" to produce binary log for Restore.
   -->
 
   <!--
@@ -56,7 +59,7 @@
     <_RepoRootOriginal>$(RepoRoot)</_RepoRootOriginal>
     <RepoRoot>$([System.IO.Path]::GetFullPath('$(RepoRoot)/'))</RepoRoot>
 
-    <_RemoveProps>Projects;Restore;QuietRestore;Build;Rebuild;Deploy;Test;IntegrationTest;PerformanceTest;Pack;Sign;Publish;Execute</_RemoveProps>
+    <_RemoveProps>Projects;Restore;QuietRestore;QuietRestoreBinaryLog;Build;Rebuild;Deploy;Test;IntegrationTest;PerformanceTest;Pack;Sign;Publish;Execute</_RemoveProps>
   </PropertyGroup>
 
   <Import Project="RepoLayout.props"/>
@@ -80,7 +83,7 @@
 
     <PropertyGroup>
       <_MSBuildCmd Condition="'$(MSBuildRuntimeType)' != 'Core'">"$(MSBuildBinPath)\MSBuild.exe" /nodeReuse:false</_MSBuildCmd>
-      <_MSBuildCmd Condition="'$(MSBuildRuntimeType)' == 'Core'">"$(MSBuildBinPath)\..\..\dotnet" msbuild</_MSBuildCmd>
+      <_MSBuildCmd Condition="'$(MSBuildRuntimeType)' == 'Core'">"$(DotNetTool)" msbuild</_MSBuildCmd>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -107,6 +110,7 @@
       <!-- Used for sdk projects to perform some task -->
       <_SolutionBuildTargets Include="Execute" Condition="'$(Execute)' == 'true' and '$(SdkTaskProjects)' != ''" />
     </ItemGroup>
+
     <ItemGroup>
       <_CommonProps Include="Configuration=$(Configuration)"/>
       <_CommonProps Include="ContinuousIntegrationBuild=$(ContinuousIntegrationBuild)"/>
@@ -145,13 +149,20 @@
     </ItemGroup>
 
     <ItemGroup>
-      <_SolutionBuildPropsArgs Include="@(_SolutionBuildProps->'/p:%(Identity)')" />
-      <_RestoreToolsPropArgs Include="@(_RestoreToolsProps->'/p:%(Identity)')" />
+      <_SolutionBuildPropsArgs Include="@(_SolutionBuildProps->'/p:%(Identity)\')" Condition="$([MSBuild]::ValueOrDefault(%(_SolutionBuildProps.Identity), '').EndsWith('\'))" />
+      <_SolutionBuildPropsArgs Include="@(_SolutionBuildProps->'/p:%(Identity)')" Condition="!$([MSBuild]::ValueOrDefault(%(_SolutionBuildProps.Identity), '').EndsWith('\'))" />
+      <_RestoreToolsPropArgs Include="@(_RestoreToolsProps->'/p:%(Identity)\')" Condition="$([MSBuild]::ValueOrDefault(%(_RestoreToolsProps.Identity), '').EndsWith('\'))" />
+      <_RestoreToolsPropArgs Include="@(_RestoreToolsProps->'/p:%(Identity)')" Condition="!$([MSBuild]::ValueOrDefault(%(_RestoreToolsProps.Identity), '').EndsWith('\'))" />
     </ItemGroup>
 
     <PropertyGroup>
-      <_SolutionBuildPropsCmdLine>@(_SolutionBuildPropsArgs, ' ')</_SolutionBuildPropsCmdLine>
-      <_RestoreToolsPropsCmdLine>@(_RestoreToolsPropArgs, ' ')</_RestoreToolsPropsCmdLine>
+      <_SolutionBuildPropsCmdLine>"@(_SolutionBuildPropsArgs, '" "')"</_SolutionBuildPropsCmdLine>
+      <_RestoreToolsPropsCmdLine>"@(_RestoreToolsPropArgs, '" "')"</_RestoreToolsPropsCmdLine>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(QuietRestoreBinaryLog)' == 'true'">
+      <_SolutionBuildPropsCmdLine>$(_SolutionBuildPropsCmdLine) /bl:"$(ArtifactsLogDir)RestoreRepoTools.binlog"</_SolutionBuildPropsCmdLine>
+      <_RestoreToolsPropsCmdLine>$(_RestoreToolsPropsCmdLine) /bl:"$(ArtifactsLogDir)Restore.binlog"</_RestoreToolsPropsCmdLine>
     </PropertyGroup>
 
     <!--
@@ -162,11 +173,11 @@
 
     <MakeDir Directories="$(ArtifactsLogDir)" Condition="'$(Restore)' == 'true' and '$(_QuietRestore)' == 'true'" />
 
-    <Exec Command='$(_MSBuildCmd) "$(MSBuildProjectDirectory)\Tools.proj" /bl:"$(ArtifactsLogDir)RestoreRepoTools.binlog" /nologo /m /v:quiet /t:Restore $(_RestoreToolsPropsCmdLine)'
+    <Exec Command='$(_MSBuildCmd) "$(MSBuildProjectDirectory)\Tools.proj" /nologo /m /v:quiet /t:Restore $(_RestoreToolsPropsCmdLine)'
           Condition="'$(_RestoreTools)' == 'true' and '$(_QuietRestore)' == 'true'" StandardOutputImportance="normal" />
 
-    <Exec Command='$(_MSBuildCmd) "@(ProjectToBuild)" /bl:"$(ArtifactsLogDir)Restore.binlog" /nologo /m /v:quiet /t:Restore $(_SolutionBuildPropsCmdLine) /p:__BuildPhase=SolutionRestore'
-          Condition="'$(SdkTaskProjects)' == '' and '$(Restore)' == 'true' and '$(_QuietRestore)' == 'true'" StandardOutputImportance="normal" />
+    <Exec Command='$(_MSBuildCmd) "@(ProjectToBuild)" /nologo /m /v:quiet /t:Restore $(_SolutionBuildPropsCmdLine) /p:__BuildPhase=SolutionRestore'
+          Condition="'$(Restore)' == 'true' and '$(_QuietRestore)' == 'true'" StandardOutputImportance="normal" />
 
     <!--
       Restore built-in tools.

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props
@@ -30,7 +30,7 @@
     <!-- Respect environment variable for the NuGet Packages Root if set; otherwise, use the current default location -->
     <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == ''">$(NUGET_PACKAGES)</NuGetPackageRoot>
     <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == '' AND '$(OS)' == 'Windows_NT'">$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
-    <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == '' AND '$(OS)' != 'Windows_NT'">$([System.Environment]::GetFolderPath(SpecialFolder.Personal))\.nuget\packages\</NuGetPackageRoot>
+    <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == '' AND '$(OS)' != 'Windows_NT'">$(HOME)/.nuget/packages/</NuGetPackageRoot>
     <NuGetPackageRoot Condition="!HasTrailingSlash('$(NuGetPackageRoot)')">$(NuGetPackageRoot)\</NuGetPackageRoot>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props
@@ -5,17 +5,6 @@
      Properties describing the layout of the repo.
   -->
 
-  <!-- 
-    Repositories are required to follow the following conventions:
-      
-    - global.json file in the repository root
-      This file specifies the version of Arcade SDK like so:
-      "msbuild-sdks": { "Microsoft.DotNet.Arcade.Sdk": "version" }
-      
-    - build/Versions.props 
-      Specifies versions of dependencies
-  -->
-
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>


### PR DESCRIPTION
Memoize results of Initialize* functions.
Move build customization hooks to build.ps1.
Make binary log off by default since it slows down build. It's on in CI build.
Fixes to quiet restore workaround.

Fixes https://github.com/dotnet/arcade/issues/1251