### PR TITLE
Use File.OpenRead for ArchivePayload

### DIFF
--- a/src/Microsoft.DotNet.Helix/JobSender/Payloads/ArchivePayload.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/Payloads/ArchivePayload.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Helix.Client
 
         public async Task<string> UploadAsync(IBlobContainer payloadContainer)
         {
-            using (var stream = new FileStream(Archive.FullName, FileMode.Open))
+            using (var stream = File.OpenRead(Archive.FullName))
             {
                 Uri zipUri = await payloadContainer.UploadFileAsync(stream, $"{Archive.Name}");
                 return zipUri.AbsoluteUri;


### PR DESCRIPTION
Noticed in https://dnceng.visualstudio.com/public/_build/results?buildId=50922&view=logs that it is impossible to submit simultaneously several Helix jobs that consume same PayloadArchive (either in correlation payload or work item payload). This is due to the file being open with ReadWrite access during uploading.

```
2018-12-01T03:06:28.0037854Z C:\Users\vsagent\.nuget\packages\microsoft.dotnet.helix.sdk\1.0.0-beta.18571.7\tools\Microsoft.DotNet.Helix.Sdk.MonoQueue.targets(83,5): error : IOException: The process cannot access the file 'F:\vsagent\67\s\bin\tests\Windows_NT.x64.Checked\archive\Core_Root\Core_Root_.zip' because it is being used by another process. [F:\vsagent\67\s\tests\helixpublishwitharcade.proj]
2018-12-01T03:06:28.1044521Z C:\Users\vsagent\.nuget\packages\microsoft.dotnet.helix.sdk\1.0.0-beta.18571.7\tools\Microsoft.DotNet.Helix.Sdk.MonoQueue.targets(83,5): error :    at System.IO.FileStream.ValidateFileHandle(SafeFileHandle fileHandle) [F:\vsagent\67\s\tests\helixpublishwitharcade.proj]
2018-12-01T03:06:28.1807173Z C:\Users\vsagent\.nuget\packages\microsoft.dotnet.helix.sdk\1.0.0-beta.18571.7\tools\Microsoft.DotNet.Helix.Sdk.MonoQueue.targets(83,5): error :    at System.IO.FileStream.CreateFileOpenHandle(FileMode mode, FileShare share, FileOptions options) [F:\vsagent\67\s\tests\helixpublishwitharcade.proj]
2018-12-01T03:06:28.3033886Z C:\Users\vsagent\.nuget\packages\microsoft.dotnet.helix.sdk\1.0.0-beta.18571.7\tools\Microsoft.DotNet.Helix.Sdk.MonoQueue.targets(83,5): error :    at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options) [F:\vsagent\67\s\tests\helixpublishwitharcade.proj]
2018-12-01T03:06:28.4947191Z C:\Users\vsagent\.nuget\packages\microsoft.dotnet.helix.sdk\1.0.0-beta.18571.7\tools\Microsoft.DotNet.Helix.Sdk.MonoQueue.targets(83,5): error :    at Microsoft.DotNet.Helix.Client.ArchivePayload.UploadAsync(IBlobContainer payloadContainer) in /_/src/Microsoft.DotNet.Helix/JobSender/Payloads/ArchivePayload.cs:line 23 [F:\vsagent\67\s\tests\helixpublishwitharcade.proj]
2018-12-01T03:06:28.5998220Z C:\Users\vsagent\.nuget\packages\microsoft.dotnet.helix.sdk\1.0.0-beta.18571.7\tools\Microsoft.DotNet.Helix.Sdk.MonoQueue.targets(83,5): error :    at Microsoft.DotNet.Helix.Client.JobDefinition.SendAsync() in /_/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs:line 133 [F:\vsagent\67\s\tests\helixpublishwitharcade.proj]
2018-12-01T03:06:28.7092028Z C:\Users\vsagent\.nuget\packages\microsoft.dotnet.helix.sdk\1.0.0-beta.18571.7\tools\Microsoft.DotNet.Helix.Sdk.MonoQueue.targets(83,5): error :    at Microsoft.DotNet.Helix.Sdk.SendHelixJob.ExecuteCore() in /_/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs:line 168 [F:\vsagent\67\s\tests\helixpublishwitharcade.proj]
2018-12-01T03:06:28.8184477Z C:\Users\vsagent\.nuget\packages\microsoft.dotnet.helix.sdk\1.0.0-beta.18571.7\tools\Microsoft.DotNet.Helix.Sdk.MonoQueue.targets(83,5): error :    at Microsoft.DotNet.Helix.Sdk.HelixTask.Execute() in /_/src/Microsoft.DotNet.Helix/Sdk/HelixTask.cs:line 41 [F:\vsagent\67\s\tests\helixpublishwitharcade.proj]
2018-12-01T03:06:28.9121940Z C:\Users\vsagent\.nuget\packages\microsoft.dotnet.helix.sdk\1.0.0-beta.18571.7\tools\Microsoft.DotNet.Helix.Sdk.MonoQueue.targets(83,5): error :  [F:\vsagent\67\s\tests\helixpublishwitharcade.proj]
```