### PR TITLE
Deal with case when owner and/or repo is null

### DIFF
--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -405,6 +405,13 @@ namespace Microsoft.DotNet.DarcLib
 
             (string owner, string repo) = ParseRepoUri(repoUri);
 
+            if (string.IsNullOrEmpty(owner) || string.IsNullOrEmpty(repo))
+            {
+                _logger.LogInformation($"'owner' or 'repository' couldn't be inferred from '{repoUri}'. " +
+                    $"Not getting files from 'eng/common...'");
+                return new List<GitFile>();
+            }
+
             TreeResponse pathTree = await GetTreeForPathAsync(owner, repo, commit, path);
 
             TreeResponse recursiveTree = await GetRecursiveTreeAsync(owner, repo, pathTree.Sha);

--- a/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Darc/src/DarcLib/GitHubClient.cs
@@ -172,11 +172,14 @@ namespace Microsoft.DotNet.DarcLib
 
                 try
                 {
-                    string repoPath = LibGit2Sharp.Repository.Clone(repoUri, tempRepoFolder, new LibGit2Sharp.CloneOptions
-                    {
-                        BranchName = branch,
-                        Checkout = true
-                    });
+                    string repoPath = LibGit2Sharp.Repository.Clone(
+                        repoUri, 
+                        tempRepoFolder, 
+                        new LibGit2Sharp.CloneOptions
+                        {
+                            BranchName = branch,
+                            Checkout = true
+                        });
 
                     using (LibGit2Sharp.Repository localRepo = new LibGit2Sharp.Repository(repoPath))
                     {


### PR DESCRIPTION
When doing `darc update-dependencies` and passing `--packages-folder` we extract the Uri from the nuspec. In local dev builds the repository uri looks like "https://github.com/jcagme/arcade.git" but in official builds is just "https://github.com//". The second one does not include an owner nor a repo name so when we try to extract them we return null values for both.

When we try to get the contents of `eng/common` we need to pass the `owner` and `repo` which are null hence `TreeResponse pathTree = await GetTreeForPathAsync(owner, repo, commit, path);` fails.

Since, currently, we only use `--packages-folder` for self validation I consider that is ok to move on without the contents of  `eng/common` since the "important" version changes are actually done.