### PR TITLE
Update StartHere.md

### DIFF
--- a/Documentation/StartHere.md
+++ b/Documentation/StartHere.md
@@ -80,6 +80,16 @@ some highlights:
     5. Add dotnet-core feed to
        [NuGet.config](https://github.com/dotnet/arcade-minimalci-sample/blob/master/NuGet.config).
     6. Must have a root project/solution file for the repo to build.
+    7. Additional package feeds can be added to the `eng\Version.props` file, e.g.
+       ```
+       <PropertyGroup>
+         <RestoreSources>
+           $(RestoreSources);
+           https://www.myget.org/F/nugetbuild/api/v3/index.json;
+           https://dotnet.myget.org/F/dotnet-web/api/v3/index.json
+         </RestoreSources>
+       </PropertyGroup>
+       ```
 
     **Using Arcade packages** - See [documentation](CorePackages/) for
     information on specific packages.


### PR DESCRIPTION
Ran into this when I was porting the WebSDK and setting up the CI build. Figured we should maybe call it out in the getting started page