### PR TITLE
Fix uap build and outer build condition cleanup

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/Microsoft.DotNet.CoreFxTesting.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/Microsoft.DotNet.CoreFxTesting.targets
@@ -62,10 +62,10 @@
   <Import Condition="'$(BuildingUAPVertical)' == 'true'" Project="$(MSBuildThisFileDirectory)Resources.uap.targets" />
 
   <!-- Performance test data upload to Benchview. -->
-  <Import Condition="'$(EnableBenchviewTarget)' == 'true'" Project="$([MSBuild]::NormalizePath('$(TestComponentsDir)', 'performance', 'Benchview.targets'))" />
+  <Import Condition="'$(EnableBenchviewTarget)' == 'true' AND '$(Performance)' == 'true' AND '$(SkipTests)' != 'true'" Project="$([MSBuild]::NormalizePath('$(TestComponentsDir)', 'performance', 'Benchview.targets'))" />
 
   <!-- Full coverage report. -->
-  <Import Condition="'$(EnableFullCoverageReportTarget)' == 'true'" Project="$([MSBuild]::NormalizePath('$(TestComponentsDir)', 'coverage', 'CoverageReport.targets'))" />
+  <Import Condition="'$(EnableFullCoverageReportTarget)' == 'true' AND '$(Coverage)' == 'true' AND '$(SkipTests)' != 'true'" Project="$([MSBuild]::NormalizePath('$(TestComponentsDir)', 'coverage', 'CoverageReport.targets'))" />
 
   <!-- Import the core testing infrastructure only for test projects. -->
   <Import Condition="'$(IsTestProject)' == 'true' AND '$(IsTestSupportProject)' != 'true'"  Project="$(TestCoreDir)Core.targets" />

--- a/src/Microsoft.DotNet.CoreFxTesting/build/Resources.uap.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/Resources.uap.targets
@@ -2,9 +2,31 @@
 <!-- All Rights Reserved. Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
 
+  <UsingTask TaskName="ExtractResWResourcesFromAssemblies" AssemblyFile="$(MSBuildTestAssemblyPath)" />
+
   <PropertyGroup>
+    <_MakePriExecutable>$(TestAssetsDir)makepri.exe</_MakePriExecutable>
+    <_MakePriConfigTemplate>$(TestAssetsDir)MakePriConfigFile.xml</_MakePriConfigTemplate>
+
+    <_CommonPriFile Condition="'$(_CommonPriFile)' == ''">$(RuntimePath)resw/resources.pri</_CommonPriFile>
+    <_MakePriHelpersDir>$(IntermediateOutputPath)makepri</_MakePriHelpersDir>
+    <_MakePriConfigFile>$(_MakePriHelpersDir)/ModifiedConfigFile.xml</_MakePriConfigFile>
+    <_ReswListFile>$(_MakePriHelpersDir)/reswlist.RESFILES</_ReswListFile>
+    <_PriListFile>$(_MakePriHelpersDir)/prilist.RESFILES</_PriListFile>
+    <_ExternalReswOutputPath>$(ResourcesFolderPath)/external/</_ExternalReswOutputPath>
+    <_TestSpecificPriFile>$(TestPath)resources.pri</_TestSpecificPriFile>
+
     <CompileDependsOn>CopyResxFilesToReswFiles;$(CompileDependsOn);</CompileDependsOn>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <_AllRuntimeDllFiles Include="$(RuntimePath)\*.dll" Exclude="$(RuntimePath)\Microsoft.VisualStudio.TestPlatform.*dll;$(RuntimePath)\Microsoft.TestPlatform.*dll" />
+    <_ExternalReswFiles Include="$(_ExternalReswOutputPath)*.resw" Exclude="$(RuntimePath)\Microsoft.VisualStudio.TestPlatform.*resw;$(RuntimePath)\Microsoft.TestPlatform.*resw" />
+
+    <!-- The first time the CreateReswFilesForExternalDependencies target is executed the itemgroup _ExternalReswFiles will be empty
+    and that will avoid the target from executing, so we add a dummy file if they are empty so that the target is executed the first time. -->
+    <_ExternalReswFiles Condition="@(_ExternalReswFiles) == ''" Include="$(_ExternalReswOutputPath)dummy.resw" />
+  </ItemGroup>
 
   <Target Name="CalculateResourcesFileNames">
 
@@ -44,6 +66,73 @@
 
     <!-- We need to touch the copied files so that the target that uses them can track the inputs and outputs with the copied timestamp -->
     <Touch Files="@(FilesCreated)" />
+
+  </Target>
+
+  <!-- This target creates the necessary config file in order to create the UAP runner's resources.pri file using MakePri.exe -->
+  <Target Name="CreateMakePriConfigFileFromTemplate"
+          Inputs="$(_MakePriConfigTemplate)"
+          Outputs="$(_MakePriConfigFile)">
+
+    <MakeDir Directories="$(_MakePriHelpersDir)" />
+
+    <WriteLinesToFile File="$(_MakePriConfigFile)"
+                      Lines="$([System.IO.File]::ReadAllText('$(_MakePriConfigTemplate)').Replace('{reswfilelist}', '$(_ReswListFile)').Replace('{prireslist}', '$(_PriListFile)'))"
+                      Overwrite="true" />
+
+    <ItemGroup>
+      <FileWrites Include="$(_MakePriConfigFile)" />
+    </ItemGroup>
+
+  </Target>
+
+  <Target Name="CreateReswFilesForExternalDependencies"
+          Condition="'$(ShouldSkipExternalResources)' != 'true'"
+          Inputs="@(_AllRuntimeDllFiles)"
+          Outputs="@(_ExternalReswFiles)">
+
+    <ExtractResWResourcesFromAssemblies InputAssemblies="@(_AllRuntimeDllFiles)"
+                                        OutputPath="$(_ExternalReswOutputPath)"
+                                        InternalReswDirectory="$(ResourcesFolderPath)" />
+
+  </Target>
+
+  <!-- This target gets all the resw files to be used to create the UAP runner's resources.pri file -->
+  <Target Name="CalculateResWFiles"
+          DependsOnTargets="CreateReswFilesForExternalDependencies">
+
+    <ItemGroup>
+      <_TestResWFiles Include="$(TestResourcesFolderPath)\*.resw" Exclude="$(TestResourcesFolderPath)\Microsoft.VisualStudio.TestPlatform.*resw;$(TestResourcesFolderPath)\Microsoft.TestPlatform.*resw" />
+      <_CommonResWFiles Include="$(ResourcesFolderPath)\**\*.resw" Exclude="$(ResourcesFolderPath)\**\Microsoft.VisualStudio.TestPlatform.*resw;$(ResourcesFolderPath)\**\Microsoft.TestPlatform.*resw" />
+    </ItemGroup>
+  </Target>
+
+  <!-- This target creates a resources.pri file that contains all the framework resources, this is a common file used by all of our test assemblies that have no specific resources. -->
+  <Target Name="MakeCommonResourcesPriFile"
+          DependsOnTargets="CalculateResWFiles;CreateMakePriConfigFileFromTemplate"
+          Inputs="@(_CommonResWFiles)"
+          Outputs="$(_CommonPriFile)">
+
+    <!-- We write the list of resw files that have to be indexed by makepri.exe -->
+    <WriteLinesToFile File="$(_ReswListFile)"
+                      Lines="@(_CommonResWFiles)"
+                      Overwrite="true" />
+
+    <!-- We write the list of base pri files to merge with the resw files by makepri.exe -->
+    <WriteLinesToFile File="$(_PriListFile)"
+                      Lines="$(TestHostRootPath)\Runner\resources.pri"
+                      Overwrite="true" />
+
+    <PropertyGroup>
+      <_MakePriCommand>$(_MakePriExecutable) versioned /o /pr "$(TestHostRootPath)\Runner" /cf "$(_MakePriConfigFile)" /of "$(_CommonPriFile)" /if "$(TestHostRootPath)\Runner\resources.pri"</_MakePriCommand>
+    </PropertyGroup>
+
+    <!-- We call MakePri.exe to create common resources.pri file -->
+    <Exec Command="$(_MakePriCommand)" StandardOutputImportance="Low" StdErrEncoding="Unicode"/>
+
+    <ItemGroup>
+      <FileWrites Include="$(_CommonPriFile)" />
+    </ItemGroup>
 
   </Target>
 

--- a/src/Microsoft.DotNet.CoreFxTesting/build/_common/Core.uap.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/_common/Core.uap.targets
@@ -2,8 +2,6 @@
 <!-- All Rights Reserved. Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
 
-  <UsingTask TaskName="ExtractResWResourcesFromAssemblies" AssemblyFile="$(MSBuildTestAssemblyPath)" />
-
   <PropertyGroup>
     <RunnerDir>$([MSBuild]::NormalizePath('$(TestHostRootPath)', 'Runner'))</RunnerDir>
     <LauncherPath>%RUNTIME_PATH%\Launcher\WindowsStoreAppLauncher.exe</LauncherPath>
@@ -11,102 +9,12 @@
 
     <RunTestsDependsOn>CheckUAPToolsInstalled;$(RunTestsDependsOn);MakeTestSpecificResourcesPriFile</RunTestsDependsOn>
   </PropertyGroup>
-  
-  <!-- Properties needed to create resources.pri -->
-  <PropertyGroup>
-    <_MakePriExecutable>$(TestAssetsDir)makepri.exe</_MakePriExecutable>
-    <_MakePriConfigTemplate>$(TestAssetsDir)MakePriConfigFile.xml</_MakePriConfigTemplate>
-
-    <_CommonPriFile Condition="'$(_CommonPriFile)' == ''">$(RuntimePath)resw/resources.pri</_CommonPriFile>
-    <_TestSpecificPriFile>$(TestPath)resources.pri</_TestSpecificPriFile>
-    <_MakePriHelpersDir>$(IntermediateOutputPath)makepri</_MakePriHelpersDir>
-    <_MakePriConfigFile>$(_MakePriHelpersDir)/ModifiedConfigFile.xml</_MakePriConfigFile>
-    <_ReswListFile>$(_MakePriHelpersDir)/reswlist.RESFILES</_ReswListFile>
-    <_PriListFile>$(_MakePriHelpersDir)/prilist.RESFILES</_PriListFile>
-    <_ExternalReswOutputPath>$(ResourcesFolderPath)/external/</_ExternalReswOutputPath>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <_AllRuntimeDllFiles Include="$(RuntimePath)\*.dll" Exclude="$(RuntimePath)\Microsoft.VisualStudio.TestPlatform.*dll;$(RuntimePath)\Microsoft.TestPlatform.*dll" />
-    <_ExternalReswFiles Include="$(_ExternalReswOutputPath)*.resw" Exclude="$(RuntimePath)\Microsoft.VisualStudio.TestPlatform.*resw;$(RuntimePath)\Microsoft.TestPlatform.*resw" />
-
-    <!-- The first time the CreateReswFilesForExternalDependencies target is executed the itemgroup _ExternalReswFiles will be empty
-    and that will avoid the target from executing, so we add a dummy file if they are empty so that the target is executed the first time. -->
-    <_ExternalReswFiles Condition="@(_ExternalReswFiles) == ''" Include="$(_ExternalReswOutputPath)dummy.resw" />
-  </ItemGroup>
 
   <Target Name="CheckUAPToolsInstalled">
 
     <!-- For UAP, make sure the Runner and Launcher folder exist, otherwise the tests cannot run -->
     <Error Condition="!Exists('$(TestHostRootPath)\Runner') OR !Exists('$(TestHostRootPath)\Launcher')"
            Text="We cannot run the tests for UAP because either the Runner or the Launcher could not be found. You need to specify the UAPToolsFolder property when calling build.cmd to fix this." />
-
-  </Target>
-
-  <Target Name="CreateReswFilesForExternalDependencies"
-          Condition="'$(ShouldSkipExternalResources)' != 'true'"
-          Inputs="@(_AllRuntimeDllFiles)"
-          Outputs="@(_ExternalReswFiles)">
-
-    <ExtractResWResourcesFromAssemblies InputAssemblies="@(_AllRuntimeDllFiles)"
-                                        OutputPath="$(_ExternalReswOutputPath)"
-                                        InternalReswDirectory="$(ResourcesFolderPath)" />
-
-  </Target>
-
-  <!-- This target the necessary config file in order to create the UAP runner's resources.pri file using MakePri.exe -->
-  <Target Name="CreateMakePriConfigFileFromTemplate"
-          Inputs="$(_MakePriConfigTemplate)"
-          Outputs="$(_MakePriConfigFile)">
-
-    <MakeDir Directories="$(_MakePriHelpersDir)" />
-
-    <WriteLinesToFile File="$(_MakePriConfigFile)"
-                      Lines="$([System.IO.File]::ReadAllText('$(_MakePriConfigTemplate)').Replace('{reswfilelist}', '$(_ReswListFile)').Replace('{prireslist}', '$(_PriListFile)'))"
-                      Overwrite="true" />
-
-    <ItemGroup>
-      <FileWrites Include="$(_MakePriConfigFile)" />
-    </ItemGroup>
-
-  </Target>
-
-  <!-- This target gets all the resw files to be used to create the UAP runner's resources.pri file -->
-  <Target Name="CalculateResWFiles"
-          DependsOnTargets="CreateReswFilesForExternalDependencies">
-
-    <ItemGroup>
-      <_TestResWFiles Include="$(TestResourcesFolderPath)\*.resw" Exclude="$(TestResourcesFolderPath)\Microsoft.VisualStudio.TestPlatform.*resw;$(TestResourcesFolderPath)\Microsoft.TestPlatform.*resw" />
-      <_CommonResWFiles Include="$(ResourcesFolderPath)\**\*.resw" Exclude="$(ResourcesFolderPath)\**\Microsoft.VisualStudio.TestPlatform.*resw;$(ResourcesFolderPath)\**\Microsoft.TestPlatform.*resw" />
-    </ItemGroup>
-  </Target>
-
-  <!-- This target creates a resources.pri file that contains all the framework resources, this is a common file used by all of our test assemblies that have no specific resources. -->
-  <Target Name="MakeCommonResourcesPriFile"
-          DependsOnTargets="CalculateResWFiles;CreateMakePriConfigFileFromTemplate"
-          Inputs="@(_CommonResWFiles)"
-          Outputs="$(_CommonPriFile)">
-
-    <!-- We write the list of resw files that have to be indexed by makepri.exe -->
-    <WriteLinesToFile File="$(_ReswListFile)"
-                      Lines="@(_CommonResWFiles)"
-                      Overwrite="true" />
-
-    <!-- We write the list of base pri files to merge with the resw files by makepri.exe -->
-    <WriteLinesToFile File="$(_PriListFile)"
-                      Lines="$(TestHostRootPath)\Runner\resources.pri"
-                      Overwrite="true" />
-
-    <PropertyGroup>
-      <_MakePriCommand>$(_MakePriExecutable) versioned /o /pr "$(TestHostRootPath)\Runner" /cf "$(_MakePriConfigFile)" /of "$(_CommonPriFile)" /if "$(TestHostRootPath)\Runner\resources.pri"</_MakePriCommand>
-    </PropertyGroup>
-
-    <!-- We call MakePri.exe to create common resources.pri file -->
-    <Exec Command="$(_MakePriCommand)" StandardOutputImportance="Low" StdErrEncoding="Unicode"/>
-
-    <ItemGroup>
-      <FileWrites Include="$(_CommonPriFile)" />
-    </ItemGroup>
 
   </Target>
 

--- a/src/Microsoft.DotNet.CoreFxTesting/build/_common/components/coverage/Coverage.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/_common/components/coverage/Coverage.targets
@@ -43,7 +43,7 @@
 
     <!--
       By default, code coverage data is only gathered for the assembly being tested.
-      CodeCoverageAssemblies can be passed in to the build to gather coverage on additional assemblies.
+      CoverageAssemblies can be passed in to the build to gather coverage on additional assemblies.
     -->
     <ItemGroup>
       <_CoverageAssemblies Include="$(AssemblyBeingTested)" />


### PR DESCRIPTION
- Move `MakeCommonResourcesPriFile` to shared file (for outer and inner build) to be able to run also in tests.builds after the sources are compiled and resx are available.
- Guard outer build targets with respective conditions (Performance, Coverage & SkipTests).