### PR TITLE
Add new send-to-helix.yml template

### DIFF
--- a/eng/common/templates/steps/send-to-helix.yml
+++ b/eng/common/templates/steps/send-to-helix.yml
@@ -1,0 +1,77 @@
+parameters:
+  HelixSource: 'pr/dotnet-github-anon-kaonashi-bot'     # required
+  HelixType: ̓'tests/default/'                           # required
+  HelixBuild: $(Build.BuildNumber)                      # required
+  HelixTargetQueues: ''                                 # required
+  HelixAccessToken: ''                                  # required
+  HelixPreCommands: ''
+  HelixPostCommands: ''
+  WorkItemDirectory: ''
+  WorkItemCommand: ''
+  CorrelationPayloadDirectory: ''
+  XUnitProjects: ''
+  XUnitTargetFramework: ''
+  XUnitRunnerVersion: ''
+  IncludeDotNetCli: false
+  DotNetCliPackageType: ''
+  DotNetCliVersion: ''
+  EnableXUnitReporter: false
+  WaitForWorkItemCompletion: true
+  condition: succeeded()
+  continueOnError: false
+
+steps:
+  - script: powershell eng/common/tools.ps1
+    displayName: Install tools (Windows)
+    condition: and(${{ parameters.condition }}, eq(variables['Agent.Os'], 'Windows_NT'))
+  - script: scriptroot="$BUILD_SOURCEDIRECTORY/eng"; source eng/common/tools.sh
+    displayName: Install tools (Unix)
+    condition: and(${{ parameters.condition }}, ne(variables['Agent.Os'], 'Windows_NT'))
+  - script: .dotnet\dotnet msbuild %BUILD_SOURCESDIRECTORY%\eng\common\helixpublish.proj /bl:%BUILD_SOURCESDIRECTORY%\artifacts\log\%BuildConfig%\SendToHelix.binlog
+    displayName: Send job to Helix (Windows)
+    env:
+      BuildConfig: $(_BuildConfig)
+      HelixSource: ${{ parameters.HelixSource }}
+      HelixType: ${{ parameters.HelixType }}
+      HelixBuild: ${{ parameters.HelixBuild }}
+      HelixTargetQueues: ${{ parameters.HelixTargetQueues }}
+      HelixAccessToken: ${{ parameters.HelixAccessToken }}
+      HelixPreCommands: ${{ parameters.HelixPreCommands }}
+      HelixPostCommands: ${{ parameters.HelixPostCommands }}
+      WorkItemDirectory: ${{ parameters.WorkItemDirectory }}
+      WorkItemCommand: ${{ parameters.WorkItemCommand }}
+      CorrelationPayloadDirectory: ${{ parameters.CorrelationPayloadDirectory }}
+      XUnitProjects: ${{ parameters.XUnitProjects }}
+      XUnitTargetFramework: ${{ parameters.XUnitTargetFramework }}
+      XUnitRunnerVersion: ${{ parameters.XUnitRunnerVersion }}
+      IncludeDotNetCli: ${{ parameters.IncludeDotNetCli }}
+      DotNetCliPackageType: ${{ parameters.DotNetCliPackageType }}
+      DotNetCliVersion: ${{ parameters.DotNetCliVersion }}
+      EnableXUnitReporter: ${{ parameters.EnableXUnitReporter }}
+      WaitForWorkItemCompletion: ${{ parameters.WaitForWorkItemCompletion }}
+    condition: and(${{ parameters.condition }}, eq(variables['Agent.Os'], 'Windows_NT'))
+    continueOnError: ${{ parameters.continueOnError }}
+  - script: .dotnet/dotnet msbuild $BUILD_SOURCESDIRECTORY/eng/common/helixpublish.proj /bl:$BUILD_SOURCESDIRECTORY/artifacts/log/$BuildConfig/SendToHelix.binlog
+    displayName: Send job to Helix (Unix)
+    env:
+      BuildConfig: $(_BuildConfig)
+      HelixSource: ${{ parameters.HelixSource }}
+      HelixType: ${{ parameters.HelixType }}
+      HelixBuild: ${{ parameters.HelixBuild }}
+      HelixTargetQueues: ${{ parameters.HelixTargetQueues }}
+      HelixAccessToken: ${{ parameters.HelixAccessToken }}
+      HelixPreCommands: ${{ parameters.HelixPreCommands }}
+      HelixPostCommands: ${{ parameters.HelixPostCommands }}
+      WorkItemDirectory: ${{ parameters.WorkItemDirectory }}
+      WorkItemCommand: ${{ parameters.WorkItemCommand }}
+      CorrelationPayloadDirectory: ${{ parameters.CorrelationPayloadDirectory }}
+      XUnitProjects: ${{ parameters.XUnitProjects }}
+      XUnitTargetFramework: ${{ parameters.XUnitTargetFramework }}
+      XUnitRunnerVersion: ${{ parameters.XUnitRunnerVersion }}
+      IncludeDotNetCli: ${{ parameters.IncludeDotNetCli }}
+      DotNetCliPackageType: ${{ parameters.DotNetCliPackageType }}
+      DotNetCliVersion: ${{ parameters.DotNetCliVersion }}
+      EnableXUnitReporter: ${{ parameters.EnableXUnitReporter }}
+      WaitForWorkItemCompletion: ${{ parameters.WaitForWorkItemCompletion }}
+    condition: and(${{ parameters.condition }}, ne(variables['Agent.Os'], 'Windows_NT'))
+    continueOnError: ${{ parameters.continueOnError }}

--- a/eng/common/templates/steps/send-to-helix.yml
+++ b/eng/common/templates/steps/send-to-helix.yml
@@ -1,6 +1,6 @@
 parameters:
   HelixSource: 'pr/dotnet-github-anon-kaonashi-bot'     # required
-  HelixType: ̓'tests/default/'                           # required
+  HelixType: 'tests/default/'                           # required
   HelixBuild: $(Build.BuildNumber)                      # required
   HelixTargetQueues: ''                                 # required
   HelixAccessToken: ''                                  # required

--- a/eng/common/templates/steps/send-to-helix.yml
+++ b/eng/common/templates/steps/send-to-helix.yml
@@ -1,9 +1,9 @@
 parameters:
-  HelixSource: 'pr/dotnet-github-anon-kaonashi-bot'     # required
-  HelixType: 'tests/default/'                           # required
-  HelixBuild: $(Build.BuildNumber)                      # required
-  HelixTargetQueues: ''                                 # required
-  HelixAccessToken: ''                                  # required
+  HelixSource: 'pr/default'          # required
+  HelixType: ̓'tests/default/'        # required
+  HelixBuild: $(Build.BuildNumber)   # required
+  HelixTargetQueues: ''              # required
+  HelixAccessToken: ''               # required
   HelixPreCommands: ''
   HelixPostCommands: ''
   WorkItemDirectory: ''
@@ -21,13 +21,7 @@ parameters:
   continueOnError: false
 
 steps:
-  - script: powershell eng/common/tools.ps1
-    displayName: Install tools (Windows)
-    condition: and(${{ parameters.condition }}, eq(variables['Agent.Os'], 'Windows_NT'))
-  - script: scriptroot="$BUILD_SOURCEDIRECTORY/eng"; source eng/common/tools.sh
-    displayName: Install tools (Unix)
-    condition: and(${{ parameters.condition }}, ne(variables['Agent.Os'], 'Windows_NT'))
-  - script: .dotnet\dotnet msbuild %BUILD_SOURCESDIRECTORY%\eng\common\helixpublish.proj /bl:%BUILD_SOURCESDIRECTORY%\artifacts\log\%BuildConfig%\SendToHelix.binlog
+  - script: '%BUILD_SOURCESDIRECTORY%\eng\common\msbuild.ps1 %BUILD_SOURCESDIRECTORY%\eng\common\helixpublish.proj /bl:%BUILD_SOURCESDIRECTORY%\artifacts\log\%BuildConfig%\SendToHelix.binlog'
     displayName: Send job to Helix (Windows)
     env:
       BuildConfig: $(_BuildConfig)
@@ -51,7 +45,7 @@ steps:
       WaitForWorkItemCompletion: ${{ parameters.WaitForWorkItemCompletion }}
     condition: and(${{ parameters.condition }}, eq(variables['Agent.Os'], 'Windows_NT'))
     continueOnError: ${{ parameters.continueOnError }}
-  - script: .dotnet/dotnet msbuild $BUILD_SOURCESDIRECTORY/eng/common/helixpublish.proj /bl:$BUILD_SOURCESDIRECTORY/artifacts/log/$BuildConfig/SendToHelix.binlog
+  - script: $BUILD_SOURCESDIRECTORY/eng/common/msbuild.sh $BUILD_SOURCESDIRECTORY/eng/common/helixpublish.proj /bl:$BUILD_SOURCESDIRECTORY/artifacts/log/$BuildConfig/SendToHelix.binlog
     displayName: Send job to Helix (Unix)
     env:
       BuildConfig: $(_BuildConfig)


### PR DESCRIPTION
This replaces the old `helix-publish.yml` template which (in addition to being poorly named) relied on AzDO tasks that we don't want to use going forward.

We will be keeping the `helix-publish.yml` template for the foreseeable future to avoid breaking changes.