### PR TITLE
Protect RUNTIME_PATH not depend on trailing slash

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/_common/Core.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/_common/Core.targets
@@ -25,8 +25,8 @@
     <RunScriptOutputName Condition="'$(TargetOS)' != 'Windows_NT'">RunTests.sh</RunScriptOutputName>     
     <RunScriptOutputPath>$([MSBuild]::NormalizePath('$(TestPath)', '$(RunScriptOutputName)'))</RunScriptOutputPath>
 
-    <RunScriptHostDir Condition="'$(BuildingNETCoreAppVertical)' == 'true' AND '$(TargetOS)' == 'Windows_NT'">%RUNTIME_PATH%</RunScriptHostDir>
-    <RunScriptHostDir Condition="'$(BuildingNETCoreAppVertical)' == 'true' AND '$(TargetOS)' != 'Windows_NT'">$RUNTIME_PATH</RunScriptHostDir>
+    <RunScriptHostDir Condition="'$(BuildingNETCoreAppVertical)' == 'true' AND '$(TargetOS)' == 'Windows_NT'">%RUNTIME_PATH%\</RunScriptHostDir>
+    <RunScriptHostDir Condition="'$(BuildingNETCoreAppVertical)' == 'true' AND '$(TargetOS)' != 'Windows_NT'">$RUNTIME_PATH/</RunScriptHostDir>
     <RunScriptHost Condition="'$(BuildingNETCoreAppVertical)' == 'true' AND '$(TargetOS)' == 'Windows_NT'">$(RunScriptHostDir)dotnet.exe</RunScriptHost>
     <RunScriptHost Condition="'$(BuildingNETCoreAppVertical)' == 'true' AND '$(TargetOS)' != 'Windows_NT'">$(RunScriptHostDir)dotnet</RunScriptHost>
 

--- a/src/Microsoft.DotNet.CoreFxTesting/build/_common/Core.uap.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/_common/Core.uap.targets
@@ -3,9 +3,9 @@
 <Project>
 
   <PropertyGroup>
-    <RunnerDir>%RUNTIME_PATH%Runner\</RunnerDir>
-    <LauncherPath>%RUNTIME_PATH%Launcher\WindowsStoreAppLauncher.exe</LauncherPath>
-    <_RuntimePath>%RUNTIME_PATH%UAPLayout\</_RuntimePath>
+    <RunnerDir>%RUNTIME_PATH%\Runner\</RunnerDir>
+    <LauncherPath>%RUNTIME_PATH%\Launcher\WindowsStoreAppLauncher.exe</LauncherPath>
+    <_RuntimePath>%RUNTIME_PATH%\UAPLayout\</_RuntimePath>
 
     <RunTestsDependsOn>CheckUAPToolsInstalled;$(RunTestsDependsOn);MakeTestSpecificResourcesPriFile</RunTestsDependsOn>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.CoreFxTesting/build/_common/assets/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/_common/assets/RunnerTemplate.Unix.txt
@@ -1,6 +1,6 @@
 ﻿#!/usr/bin/env bash
 
-export RUNTIME_PATH=$1
+export RUNTIME_PATH=${1%/}
 export EXECUTION_DIR=$(dirname "$0")
 
 exitcode_list[0]="Exited Successfully"

--- a/src/Microsoft.DotNet.CoreFxTesting/build/_common/assets/RunnerTemplate.Windows.txt
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/_common/assets/RunnerTemplate.Windows.txt
@@ -3,6 +3,7 @@ SETLOCAL enabledelayedexpansion
 
 SET RUNTIME_PATH=%1
 set RUNTIME_PATH=%RUNTIME_PATH:/=\%
+IF %RUNTIME_PATH:~-1%==\ SET RUNTIME_PATH=%RUNTIME_PATH:~0,-1%
 IF DEFINED RUNTIME_PATH ( echo Using %RUNTIME_PATH% as the test runtime folder.) ELSE (
 echo Please specify a test runtime folder using the RUNTIME_PATH parameter
 goto ShowUsage

--- a/src/Microsoft.DotNet.CoreFxTesting/build/_common/components/test/Test.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/_common/components/test/Test.targets
@@ -113,7 +113,7 @@
 
         <RemoteExecutorConsoleAppName>RemoteExecutorConsoleApp.exe</RemoteExecutorConsoleAppName>
         <RemoteExecutorConsoleAppNameWithoutExtension>RemoteExecutorConsoleApp</RemoteExecutorConsoleAppNameWithoutExtension>
-        <_TestILCFolder>%RUNTIME_PATH%TestILC</_TestILCFolder>
+        <_TestILCFolder>%RUNTIME_PATH%\TestILC</_TestILCFolder>
         <ILCBuildType Condition="'$(ILCBuildType)' == ''">ret</ILCBuildType>
         <_UseSharedAssemblies Condition="'$(EnableMultiFileILCTests)' == 'true'">-useSharedAssemblies</_UseSharedAssemblies>
         <_ILCWin32 Condition="'$(BuildingUAPAOTVertical)' != 'true'">-win32</_ILCWin32>


### PR DESCRIPTION
Blame me. I should have listened to @safern.