### PR TITLE
Allow artifacts and dotnet installation directory to be overridden

### DIFF
--- a/Documentation/RepoToolset/MigrationToArcade.md
+++ b/Documentation/RepoToolset/MigrationToArcade.md
@@ -13,11 +13,7 @@ Below is a list of changes required to migrate to Arcade.
 
 ### Shipping vs NonShipping packages
 
-Shipping packages are the ones that are pushed to NuGet.org, non-shipping are pushed to myget or Azure blob feed only.
-  1. Set IsShipping property to false in 
-     - projects that produce NuGet packages that are not shipping on NuGet.org or other official channel (like part of an official installer), 
-     - projects that produce VSIX packages that are only used only within the repository (e.g. to facilitate integration tests or VS F5) and not expected to be installed by customers,
-     - Test/build utility projects (test projects are automatically marked as non-shipping).
+  1. Set IsShipping property according to the Arcade SDK [guidelines](https://github.com/dotnet/arcade/blob/master/Documentation/ArcadeSdk.md#isshipping-bool).
   2. Update package directory used by `NuGetPublisher@0` task in `.vsts-ci.yml`
      - Add `*Shipping` subdir, which will match `Shipping` and `NonShipping` like so:
        searchPattern: `artifacts\$(BuildConfiguration)\packages\*Shipping\*.nupkg`

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -50,6 +50,10 @@ function InitializeDotNetCli([bool]$install) {
     $dotnetRoot = $env:DOTNET_INSTALL_DIR
   } else {
     $dotnetRoot = Join-Path $RepoRoot ".dotnet"
+    if ($env:ARCADE_DOTNET_DIR -ne $null)
+    {
+      $dotnetRoot = $env:ARCADE_DOTNET_DIR
+    }
     $env:DOTNET_INSTALL_DIR = $dotnetRoot
 
     if (-not (Test-Path(Join-Path $env:DOTNET_INSTALL_DIR "sdk\$dotnetSdkVersion"))) {
@@ -342,6 +346,11 @@ function MsBuild() {
 $RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
 $EngRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
 $ArtifactsDir = Join-Path $RepoRoot "artifacts"
+if ($env:ARCADE_ARTIFACTS_DIR -ne $null)
+{
+  $ArtifactsDir = [System.IO.Path]::GetFullPath($env:ARCADE_ARTIFACTS_DIR) + "\"
+  $env:ArtifactsDir = $ArtifactsDir
+}
 $ToolsetDir = Join-Path $ArtifactsDir "toolset"
 $ToolsDir = Join-Path $RepoRoot ".tools"
 $LogDir = Join-Path (Join-Path $ArtifactsDir "log") $configuration

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -15,6 +15,11 @@ useInstalledDotNetCli=${useInstalledDotNetCli:-true}
 repo_root="$scriptroot/../.."
 eng_root="$scriptroot/.."
 artifacts_dir="$repo_root/artifacts"
+if [[ -n "${ARCADE_ARTIFACTS_DIR:-}" ]]; then
+  artifacts_dir="$ARCADE_ARTIFACTS_DIR"
+  export ArtifactsDir="$artifacts_dir"
+fi
+
 toolset_dir="$artifacts_dir/toolset"
 log_dir="$artifacts_dir/log/$configuration"
 temp_dir="$artifacts_dir/tmp/$configuration"
@@ -89,6 +94,10 @@ function InitializeDotNetCli {
     dotnet_root="$DOTNET_INSTALL_DIR"
   else
     dotnet_root="$repo_root/.dotnet"
+    if [[ -n "${ARCADE_DOTNET_DIR:-}" ]]; then
+      dotnet_root="$ARCADE_DOTNET_DIR"
+    fi
+
     export DOTNET_INSTALL_DIR="$dotnet_root"
 
     if [[ ! -d "$DOTNET_INSTALL_DIR/sdk/$dotnet_sdk_version" ]]; then


### PR DESCRIPTION
Fixes #1293 

This allows the DOTNET_INSTALL_DIR and the artifacts directory to be overridden with the `ARCADE_DOTNET_DIR` and `ARCADE_ARTIFACTS_DIR` environment variables.

This allows building in the same repo from different operating systems (for example, via Docker or a Virtual Machine) without them conflicting with each other.