### PR TITLE
Allow tool restore during source-build and find source-built tool packages

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -87,12 +87,8 @@
       <_QuietRestore>false</_QuietRestore>
       <_QuietRestore Condition="'$(ContinuousIntegrationBuild)' != 'true' and '$(QuietRestore)' == 'true'">true</_QuietRestore>
 
-      <!--
-        Do not restore toolset tools when building from source.
-        The tools are not needed and not all of them are actually available.
-      -->
       <_RestoreTools>false</_RestoreTools>
-      <_RestoreTools Condition="'$(Restore)' == 'true' and '$(DotNetBuildFromSource)' != 'true'">true</_RestoreTools>
+      <_RestoreTools Condition="'$(Restore)' == 'true'">true</_RestoreTools>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <RestoreSources/>
+    <RestoreSources>$(DotNetRestoreSources)</RestoreSources>
     <RestoreSources>
       $(RestoreSources);
       https://api.nuget.org/v3/index.json;


### PR DESCRIPTION
This allows source-build to build e.g. `Microsoft.DotNet.Build.Tasks.Packaging` using an Arcade submodule then have CoreFX use it. Also, some tools *are* necessary like `Microsoft.DotNet.GenFacades` in CoreFX.

I'm open to other ways of doing this, but this is confirmed to work for us to build CoreFX on Arcade and seems like a nice simple approach. (https://github.com/dotnet/source-build/pull/916.)

If a tool restore ends up restoring more than necessary in the source-build scenario it seems reasonable to me to just adapt these conditions (and/or the ones in the repos themselves):

https://github.com/dotnet/arcade/blob/fe25f076bdd44568aa6334d4266e6553719cf91d/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj#L47-L49

/cc @markwilkie 