### PR TITLE
Fix wrong Microsoft.NET.Test.Sdk.targets reference for Unix & add code coverage report output logging

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/_common/components/coverage/CoverageReport.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/_common/components/coverage/CoverageReport.targets
@@ -4,10 +4,10 @@
 
   <PropertyGroup>
     <CoverageReportInputPath Condition="'$(CoverageReportInputPath)' == ''">$(CoverageOutputPath)</CoverageReportInputPath>
-    <CoverageReportDir Condition="'$(CoverageReportDir)' == ''">report</CoverageReportDir>
+    <CoverageReportDir Condition="'$(CoverageReportDir)' == ''">$([MSBuild]::NormalizeDirectory('$(TestPath)', 'report'))</CoverageReportDir>
     <CoverageReportTypes Condition="'$(CoverageReportTypes)' == ''">Html</CoverageReportTypes>
     <CoverageReportVerbosity Condition="'$(CoverageReportVerbosity)' == ''">Info</CoverageReportVerbosity>
-    <CoverageReportResultsPath>$(CoverageReportDir)\index.htm</CoverageReportResultsPath>
+    <CoverageReportResultsPath>$([MSBuild]::NormalizePath('$(CoverageReportDir)', 'index.htm'))</CoverageReportResultsPath>
     <CoverageReportExecutablePath Condition="'$(CoverageReportExecutablePath)' == ''">$(GlobalToolsDir)reportgenerator</CoverageReportExecutablePath>
 
     <CoverageReportCommandLine>$(CoverageReportExecutablePath) "-reports:$(CoverageReportInputPath)" "-targetdir:$(CoverageReportDir)" "-reporttypes:$(CoverageReportTypes)" "-verbosity:$(CoverageReportVerbosity)"</CoverageReportCommandLine>
@@ -26,8 +26,9 @@
           Outputs="$(CoverageReportResultsPath)"
           Condition="'$(GenerateFullCoverageReport)' == 'true'">
 
-    <Exec Command="$(CoverageReportCommandLine)"
-          ContinueOnError="ErrorAndContinue" />
+    <Exec Command="$(CoverageReportCommandLine)" />
+
+    <Message Importance="High" Text="Coverage report created: $(CoverageReportResultsPath)" />
 
     <Exec Command="$(CoverageReportOpenCommandLine)"
           Condition="'$(CoverageReportOpenCommandLine)' != ''" />

--- a/src/Microsoft.DotNet.CoreFxTesting/build/_common/components/vstest/VSTest.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/_common/components/vstest/VSTest.targets
@@ -3,7 +3,7 @@
 <Project>
 
   <!-- TODO: Fix VB test project reference to Test SDK. -->
-  <Import Condition="'$(Language)' != 'VB' AND ('$(BuildingNETCoreAppVertical)' == 'true' OR '$(BuildingNETFxVertical)' == 'true')" Project="$(RuntimePath)Microsoft.Net.Test.Sdk.targets" />
+  <Import Condition="'$(Language)' != 'VB' AND ('$(BuildingNETCoreAppVertical)' == 'true' OR '$(BuildingNETFxVertical)' == 'true')" Project="$(RuntimePath)Microsoft.NET.Test.Sdk.targets" />
 
   <Choose>
     <When Condition="'$(BuildingNETCoreAppVertical)' == 'true'">  


### PR DESCRIPTION
The casing was wrong which causes issues on Unix.

cc @danmosemsft 