### PR TITLE
Fix reportgenerator crash with wrong targetdir

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/_common/components/coverage/CoverageReport.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/_common/components/coverage/CoverageReport.targets
@@ -4,7 +4,12 @@
 
   <PropertyGroup>
     <CoverageReportInputPath Condition="'$(CoverageReportInputPath)' == ''">$(CoverageOutputPath)</CoverageReportInputPath>
-    <CoverageReportDir Condition="'$(CoverageReportDir)' == ''">$([MSBuild]::NormalizeDirectory('$(TestPath)', 'report'))</CoverageReportDir>
+    <!-- 
+      Report generator currently crashes if the targetdir contains a trailing slash.
+      https://github.com/danielpalme/ReportGenerator/issues/184
+      Replace with NormalizeDirectory instead of NormalizePath when fixed.
+    -->
+    <CoverageReportDir Condition="'$(CoverageReportDir)' == ''">$([MSBuild]::NormalizePath('$(TestPath)', 'report'))</CoverageReportDir>
     <CoverageReportTypes Condition="'$(CoverageReportTypes)' == ''">Html</CoverageReportTypes>
     <CoverageReportVerbosity Condition="'$(CoverageReportVerbosity)' == ''">Info</CoverageReportVerbosity>
     <CoverageReportResultsPath>$([MSBuild]::NormalizePath('$(CoverageReportDir)', 'index.htm'))</CoverageReportResultsPath>


### PR DESCRIPTION
A trailing slash unfortunately makes ReportGenerator crash. Introduced with a previous change.