### PR TITLE
Fix task directory

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Configuration/src/build/BinPlace.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Configuration/src/build/BinPlace.targets
@@ -46,7 +46,7 @@
     </Copy>
   </Target>
 
-  <UsingTask TaskName="SaveItems" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="SaveItems" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)"/>
   <Target Name="BinPlaceProps"
           Condition="'@(PackageFileDir)' != ''"
           DependsOnTargets="GetBinPlaceItems"
@@ -92,8 +92,8 @@
 
     <SaveItems ItemName="%(_packageFileDir.SaveItemName)"
                Items="@(_itemsToSave)"
-               Files="%(_packageFileDir.Identity)\$(_propsFilename).props">
-      <Output TaskParameter="Files" ItemName="FileWrites" />
+               File="%(_packageFileDir.Identity)\$(_propsFilename).props">
+      <Output TaskParameter="File" ItemName="FileWrites" />
     </SaveItems>
   </Target>
 
@@ -116,7 +116,7 @@
     </ItemGroup>
   </Target>
 
-  <UsingTask TaskName="FindBestConfigurations" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="FindBestConfigurations" AssemblyFile="$(DotNetBuildTasksConfigurationDll)"/>
   <Target Name="GetBinPlaceConfiguration" DependsOnTargets="GetBuildConfigurations">
     <!-- find which, if any, build configuration of this project is best
          for each binplace configuration -->

--- a/src/Microsoft.DotNet.Build.Tasks.Configuration/src/build/Microsoft.DotNet.Build.Tasks.Configuration.props
+++ b/src/Microsoft.DotNet.Build.Tasks.Configuration/src/build/Microsoft.DotNet.Build.Tasks.Configuration.props
@@ -4,6 +4,9 @@
   <PropertyGroup>
     <BuildConfigurationFolder Condition="'$(BuildConfigurationFolder)' == ''">$(ToolSetCommonDirectory)configuration\</BuildConfigurationFolder>
     <BuildConfigurationImportFile>$(BuildConfigurationFolder)configuration.props</BuildConfigurationImportFile>
+    <DotNetBuildTasksConfigurationDir Condition="'$(DotNetBuildTasksConfigurationDir)' == '' AND '$(MSBuildRuntimeType)' == 'core'">..\tools\netcoreapp2.1\</DotNetBuildTasksConfigurationDir>
+    <DotNetBuildTasksConfigurationDir Condition="'$(DotNetBuildTasksConfigurationDir)' == '' AND '$(MSBuildRuntimeType)' != 'core'">..\tools\net461\</DotNetBuildTasksConfigurationDir>
+    <DotNetBuildTasksConfigurationDll Condition="'$(DotNetBuildTasksConfigurationDll)' == ''">$(DotNetBuildTasksConfigurationDir)Microsoft.DotNet.Build.Tasks.Configuration.dll</DotNetBuildTasksConfigurationDll>
   </PropertyGroup>
 
   <!-- first pull in the project-specific BuildConfigurations -->

--- a/src/Microsoft.DotNet.Build.Tasks.Configuration/src/build/Microsoft.DotNet.Build.Tasks.Configuration.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Configuration/src/build/Microsoft.DotNet.Build.Tasks.Configuration.targets
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- All Rights Reserved. Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
-  <UsingTask TaskName="GenerateConfigurationProps" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
-  <UsingTask TaskName="FindBestConfigurations" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="GenerateConfigurationProps" AssemblyFile="$(DotNetBuildTasksConfigurationDll)"/>
+  <UsingTask TaskName="FindBestConfigurations" AssemblyFile="$(DotNetBuildTasksConfigurationDll)"/>
 
   <PropertyGroup>
     <_traversalBuildConfigurations>$(BuildConfiguration)</_traversalBuildConfigurations>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.common.targets
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PackagingTaskDir Condition="'$(PackagingTaskDir)' == '' AND '$(RunningOnCore)' == 'true'">$(MSBuildThisFileDirectory)../tools/netcoreapp2.1/</PackagingTaskDir>
-    <PackagingTaskDir Condition="'$(PackagingTaskDir)' == '' AND '$(RunningOnCore)' != 'true'">$(MSBuildThisFileDirectory)../tools/net461/</PackagingTaskDir>
+    <PackagingTaskDir Condition="'$(PackagingTaskDir)' == '' AND '$(MSBuildRuntimeType)' == 'core'">$(MSBuildThisFileDirectory)../tools/netcoreapp2.1/</PackagingTaskDir>
+    <PackagingTaskDir Condition="'$(PackagingTaskDir)' == '' AND '$(MSBuildRuntimeType)' != 'core'">$(MSBuildThisFileDirectory)../tools/net461/</PackagingTaskDir>
     <RuntimeIdGraphDefinitionFile Condition="'$(RuntimeIdGraphDefinitionFile)' == ''">$(MSBuildThisFileDirectory)runtime.json</RuntimeIdGraphDefinitionFile>
 
     <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(BaseOutputPath)pkg/</PackageOutputPath>


### PR DESCRIPTION
I was still using buildtasks path.  Fixed this up.  SaveItems is now coming from Arcade SDK.  Also fixing RunningOnCore which was defined by BuildTools.