### PR TITLE
Do not initialize properties that are already initialized by the .NET Core SDK to the same default values

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
@@ -92,18 +92,7 @@
     <!-- C# specific settings -->
     <When Condition="'$(Language)' == 'C#'">
       <PropertyGroup>
-        <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
         <NoWarn>$(NoWarn);1701;1702;1705;1591</NoWarn>
-      </PropertyGroup>
-
-      <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-        <DebugSymbols>true</DebugSymbols>
-        <DefineConstants>DEBUG;TRACE</DefineConstants>
-      </PropertyGroup>
-
-      <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-        <DefineConstants>TRACE</DefineConstants>
-        <Optimize>true</Optimize>
       </PropertyGroup>
     </When>
 
@@ -112,22 +101,8 @@
       <PropertyGroup>
         <MyType>Empty</MyType>
         <OptionCompare>Binary</OptionCompare>
-        <OptionExplicit>On</OptionExplicit>
-        <OptionInfer>On</OptionInfer>
         <OptionStrict>On</OptionStrict>
-        <VBRuntime>Embed</VBRuntime>
         <RemoveIntegerChecks>true</RemoveIntegerChecks>
-      </PropertyGroup>
-
-      <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-        <DebugSymbols>true</DebugSymbols>
-        <DefineDebug>true</DefineDebug>
-        <DefineTrace>true</DefineTrace>
-      </PropertyGroup>
-
-      <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-        <DefineTrace>true</DefineTrace>
-        <Optimize>true</Optimize>
       </PropertyGroup>
     </When>
 


### PR DESCRIPTION
[CheckForOverflowUnderflow](https://github.com/dotnet/sdk/blob/ab2176b3447e3e7820b5a340408110b6d498f907/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props#L104)

[DebugSymbols](https://github.com/dotnet/sdk/blob/ab2176b3447e3e7820b5a340408110b6d498f907/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props#L42)

[DefineConstants](https://github.com/dotnet/sdk/blob/ab2176b3447e3e7820b5a340408110b6d498f907/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CSharp.targets#L17-L32)

[Optimize](https://github.com/dotnet/sdk/blob/ab2176b3447e3e7820b5a340408110b6d498f907/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props#L41-L47)

[OptionExplicit](https://github.com/dotnet/sdk/blob/ab2176b3447e3e7820b5a340408110b6d498f907/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.props#L19)

[OptionInfer](https://github.com/dotnet/sdk/blob/ab2176b3447e3e7820b5a340408110b6d498f907/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.props#L22)

[VBRuntime](https://github.com/dotnet/sdk/blob/ab2176b3447e3e7820b5a340408110b6d498f907/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.props#L15)

[DefineTrace, DefineDebug](https://github.com/dotnet/sdk/blob/ab2176b3447e3e7820b5a340408110b6d498f907/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.props#L28-L34)

