### PR TITLE
Add retry to Helix job sending

### DIFF
--- a/src/Microsoft.DotNet.Helix/Client/CSharp/Generated/HelixApi.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/Generated/HelixApi.cs
@@ -23,8 +23,11 @@ namespace Microsoft.DotNet.Helix.Client
     /// passed either in the form of a query parameter named 'access_token', or
     /// as a header in the form 'Authentication: token APIKEY', where APIKEY is
     /// your key. You can obtain your API key from /UserProfileAll API's that
-    /// deal with jobs have optional authentication. Any anonmyous access will
-    /// be scoped to a limited set of jobs.
+    /// deal with jobs have optional authentication. Any anonymous access will
+    /// be scoped to a limited set of jobs. The 'Telemetry' endpoint only
+    /// requires authentication on the initial POST, subsequent calls that pass
+    /// the token inherit the authentication from the initial token, so don't
+    /// need the api_key passed.
     /// </summary>
     public partial class HelixApi : ServiceClient<HelixApi>, IHelixApi
     {

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/Generated/IHelixApi.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/Generated/IHelixApi.cs
@@ -18,8 +18,11 @@ namespace Microsoft.DotNet.Helix.Client
     /// passed either in the form of a query parameter named 'access_token', or
     /// as a header in the form 'Authentication: token APIKEY', where APIKEY is
     /// your key. You can obtain your API key from /UserProfileAll API's that
-    /// deal with jobs have optional authentication. Any anonmyous access will
-    /// be scoped to a limited set of jobs.
+    /// deal with jobs have optional authentication. Any anonymous access will
+    /// be scoped to a limited set of jobs. The 'Telemetry' endpoint only
+    /// requires authentication on the initial POST, subsequent calls that pass
+    /// the token inherit the authentication from the initial token, so don't
+    /// need the api_key passed.
     /// </summary>
     public partial interface IHelixApi : System.IDisposable
     {

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/Generated/Models/JobCreationRequest.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/Generated/Models/JobCreationRequest.cs
@@ -53,7 +53,11 @@ namespace Microsoft.DotNet.Helix.Client.Models
         /// run</param>
         /// <param name="attempt">Identifier for a given attempt. Must be
         /// lexically sortable.</param>
-        public JobCreationRequest(string source, string type, string build, IDictionary<string, string> properties, string listUri, string queueId, string resultsUri, string resultsUriRSAS, string resultsUriWSAS, string creator = default(string), string pullRequestId = default(string), int? maxRetryCount = default(int?), string attempt = default(string))
+        /// <param name="jobStartIdentifier">Unique string sent with job; if
+        /// included, users can safely re-post jobs
+        /// supplying the same value, and the API will indicate success if the
+        /// job was successfully enqueued once.</param>
+        public JobCreationRequest(string source, string type, string build, IDictionary<string, string> properties, string listUri, string queueId, string resultsUri, string resultsUriRSAS, string resultsUriWSAS, string creator = default(string), string pullRequestId = default(string), int? maxRetryCount = default(int?), string attempt = default(string), string jobStartIdentifier = default(string))
         {
             Source = source;
             Type = type;
@@ -68,6 +72,7 @@ namespace Microsoft.DotNet.Helix.Client.Models
             PullRequestId = pullRequestId;
             MaxRetryCount = maxRetryCount;
             Attempt = attempt;
+            JobStartIdentifier = jobStartIdentifier;
             CustomInit();
         }
 
@@ -161,6 +166,15 @@ namespace Microsoft.DotNet.Helix.Client.Models
         /// </summary>
         [JsonProperty(PropertyName = "Attempt")]
         public string Attempt { get; set; }
+
+        /// <summary>
+        /// Gets or sets unique string sent with job; if included, users can
+        /// safely re-post jobs
+        /// supplying the same value, and the API will indicate success if the
+        /// job was successfully enqueued once.
+        /// </summary>
+        [JsonProperty(PropertyName = "JobStartIdentifier")]
+        public string JobStartIdentifier { get; set; }
 
         /// <summary>
         /// Validate the object.

--- a/src/Microsoft.DotNet.Helix/Client/generator/generated/docs.json
+++ b/src/Microsoft.DotNet.Helix/Client/generator/generated/docs.json
@@ -3,7 +3,7 @@
   "info": {
     "version": "2018-03-14",
     "title": "Helix API (2018-03-14)",
-    "description": "This API provides mechanisms for creating Helix jobs and querying their state and final results. Any API method that requires authentication (indicated in the description of each method) requires an API key to be passed either in the form of a query parameter named 'access_token', or as a header in the form 'Authentication: token APIKEY', where APIKEY is your key. You can obtain your API key from /UserProfileAll API's that deal with jobs have optional authentication. Any anonmyous access will be scoped to a limited set of jobs."
+    "description": "This API provides mechanisms for creating Helix jobs and querying their state and final results. Any API method that requires authentication (indicated in the description of each method) requires an API key to be passed either in the form of a query parameter named 'access_token', or as a header in the form 'Authentication: token APIKEY', where APIKEY is your key. You can obtain your API key from /UserProfileAll API's that deal with jobs have optional authentication. Any anonymous access will be scoped to a limited set of jobs. The 'Telemetry' endpoint only requires authentication on the initial POST, subsequent calls that pass the token inherit the authentication from the initial token, so don't need the api_key passed."
   },
   "host": "helix.dot.net",
   "schemes": [
@@ -1367,12 +1367,7 @@
               "type": "string"
             }
           }
-        },
-        "security": [
-          {
-            "access_token": []
-          }
-        ]
+        }
       }
     },
     "/api/2018-03-14/telemetry/job/build": {
@@ -2475,6 +2470,10 @@
         },
         "Attempt": {
           "description": "Identifier for a given attempt. Must be lexically sortable.",
+          "type": "string"
+        },
+        "JobStartIdentifier": {
+          "description": "Unique string sent with job; if included, users can safely re-post jobs \r\nsupplying the same value, and the API will indicate success if the job was successfully enqueued once.",
           "type": "string"
         }
       }

--- a/src/Microsoft.DotNet.Helix/JobSender/IJobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/IJobDefinition.cs
@@ -1,3 +1,4 @@
+using Microsoft.WindowsAzure.Storage;
 using System;
 using System.Threading.Tasks;
 
@@ -17,6 +18,6 @@ namespace Microsoft.DotNet.Helix.Client
         IJobDefinition WithContainerName(string targetContainerName);
         IJobDefinition WithStorageAccountConnectionString(string accountConnectionString);
         IJobDefinition WithMaxRetryCount(int? maxRetryCount);
-        Task<ISentJob> SendAsync();
+        Task<ISentJob> SendAsync(Action<LogLevel, string> log = null);
     }
 }

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Helix.Client
             Properties = new ReadOnlyDictionary<string, string>(_properties);
             JobApi = jobApi;
             _jobStartIdentifier = Guid.NewGuid().ToString("N");
-            HelixApi = ((IServiceOperations<HelixApi>) JobApi).Client;
+            HelixApi = ((IServiceOperations<HelixApi>)JobApi).Client;
         }
 
         public IHelixApi HelixApi { get; }
@@ -192,8 +192,10 @@ namespace Microsoft.DotNet.Helix.Client
                 }
                 catch (HttpRequestException e)
                 {
-                    log?.Invoke(LogLevel.Informational, $"Exception thrown attempting to submit job to Helix. Job will retry.\nException details: {e.Message}");
+                    log?.Invoke(LogLevel.Informational, $"HttpRequestException thrown attempting to submit job to Helix. Job will retry.\nException details: {e.Message}");
                 }
+
+                await Task.Delay((counter + 1) * 1000);
             }
             // if we went through all attempts and keepTrying is still true, we failed to send the job
             if (keepTrying)

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -182,7 +182,7 @@ namespace Microsoft.DotNet.Helix.Client
                     // check to see if this is really an HttpClient timeout
                     if (e.CancellationToken != cancellationToken)
                     {
-                        log?.Invoke(LogLevel.Warning, $"HttpClient timeout occurred while attempting to post new job to '{TargetQueueId}', will retry. Job Start Identifier: ${_jobStartIdentifier}");
+                        log?.Invoke(LogLevel.Informational, $"HttpClient timeout occurred while attempting to post new job to '{TargetQueueId}', will retry. Job Start Identifier: ${_jobStartIdentifier}");
                     }
                     else
                     {
@@ -192,7 +192,7 @@ namespace Microsoft.DotNet.Helix.Client
                 }
                 catch (HttpRequestException e)
                 {
-                    log?.Invoke(LogLevel.Warning, $"Exception thrown attempting to submit job to Helix. Job will retry.\nException details: {e.Message}");
+                    log?.Invoke(LogLevel.Informational, $"Exception thrown attempting to submit job to Helix. Job will retry.\nException details: {e.Message}");
                 }
             }
             // if we went through all attempts and keepTrying is still true, we failed to send the job

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -194,7 +194,7 @@ namespace Microsoft.DotNet.Helix.Client
                     log?.Invoke(LogLevel.Informational, $"HttpRequestException thrown attempting to submit job to Helix. Job will retry.\nException details: {e.Message}");
                 }
 
-                await Task.Delay((int)(Math.Pow(rand.NextDouble() * counter, 1.3) * 1000));
+                await Task.Delay(GetTimeout(counter));
             }
             // if we went through all attempts and keepTrying is still true, we failed to send the job
             if (newJob == null)
@@ -205,7 +205,7 @@ namespace Microsoft.DotNet.Helix.Client
             return new SentJob(JobApi, newJob);
         }
 
-        private int getTimeout(int times)
+        private int GetTimeout(int times)
         {
             Random rand = new Random();
             double factor = 1.3;

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -18,6 +18,7 @@ namespace Microsoft.DotNet.Helix.Client
     {
         private readonly Dictionary<string, string> _properties;
         private readonly List<WorkItemDefinition> _workItems;
+        private readonly string _jobStartIdentifier;
 
         public JobDefinition(IJob jobApi)
         {
@@ -26,6 +27,7 @@ namespace Microsoft.DotNet.Helix.Client
             _properties = new Dictionary<string, string>();
             Properties = new ReadOnlyDictionary<string, string>(_properties);
             JobApi = jobApi;
+            _jobStartIdentifier = Guid.NewGuid().ToString("N");
             HelixApi = ((IServiceOperations<HelixApi>) JobApi).Client;
         }
 

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -121,7 +121,7 @@ namespace Microsoft.DotNet.Helix.Client
             return this;
         }
 
-        public async Task<ISentJob> SendAsync(Action<LogLevel, string> log)
+        public async Task<ISentJob> SendAsync(Action<LogLevel, string> log = null)
         {
             IBlobHelper storage;
             if (string.IsNullOrEmpty(StorageAccountConnectionString))
@@ -182,7 +182,7 @@ namespace Microsoft.DotNet.Helix.Client
                     // check to see if this is really an HttpClient timeout
                     if (e.CancellationToken != cancellationToken)
                     {
-                        log(LogLevel.Warning, $"HttpClient timeout occurred while attempting to post new job to '{TargetQueueId}', will retry. Job Start Identifier: ${_jobStartIdentifier}");
+                        log?.Invoke(LogLevel.Warning, $"HttpClient timeout occurred while attempting to post new job to '{TargetQueueId}', will retry. Job Start Identifier: ${_jobStartIdentifier}");
                     }
                     else
                     {
@@ -192,13 +192,13 @@ namespace Microsoft.DotNet.Helix.Client
                 }
                 catch (HttpRequestException e)
                 {
-                    log(LogLevel.Warning, $"Exception thrown attempting to submit job to Helix. Job will retry.\nException details: {e.Message}");
+                    log?.Invoke(LogLevel.Warning, $"Exception thrown attempting to submit job to Helix. Job will retry.\nException details: {e.Message}");
                 }
             }
             // if we went through all attempts and keepTrying is still true, we failed to send the job
             if (keepTrying)
             {
-                log(LogLevel.Error, $"Unable to publish to queue '{TargetQueueId} after {MAX_RETRIES} attempts.");
+                log?.Invoke(LogLevel.Error, $"Unable to publish to queue '{TargetQueueId} after {MAX_RETRIES} attempts.");
             }
 
             return new SentJob(JobApi, newJob);

--- a/src/Microsoft.DotNet.Helix/Sdk/HelixWait.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/HelixWait.cs
@@ -83,20 +83,25 @@ namespace Microsoft.DotNet.Helix.Sdk
                 catch (TaskCanceledException e)
                 {
                     failureRetries++;
-                    Log.LogWarning($"Caught TaskCanceledException while querying the Helix WorkItem List API for {jobName}. Retrying.");
-                    Log.LogWarningFromException(e);
+                    Log.LogMessage($"Caught TaskCanceledException while querying the Helix WorkItem List API for {jobName}. Retrying.");
+                    Log.LogMessage($"Exception Message: {e.Message}");
+                    Log.LogMessage($"Stack Trace:\n{e.StackTrace}");
                 }
                 catch (HttpRequestException e)
                 {
                     failureRetries++;
-                    Log.LogWarning($"Caught HttpRequestException while querying the Helix WorkItem List API for {jobName}. Retrying.");
-                    Log.LogWarningFromException(e);
+                    Log.LogMessage($"Caught HttpRequestException while querying the Helix WorkItem List API for {jobName}. Retrying.");
+
+                    Log.LogMessage($"Exception Message: {e.Message}");
+                    Log.LogMessage($"Stack Trace:\n{e.StackTrace}");
                 }
                 catch (NullReferenceException e)
                 {
                     failureRetries++;
-                    Log.LogWarning($"Caught NullReferenceException while querying the Helix WorkItem List API for {jobName}. Retrying.");
-                    Log.LogWarningFromException(e);
+                    Log.LogMessage($"Caught NullReferenceException while querying the Helix WorkItem List API for {jobName}. Retrying.");
+                    Log.LogMessage($"Exception Message: {e.Message}");
+                    Log.LogMessage($"Stack Trace:\n{e.StackTrace}");
+                    Log.LogMessage($"Inner Exception:\n{e.InnerException?.Message}");
                 }
                 if (failureRetries > MAX_FAILURE_RETRIES)
                 {
@@ -125,18 +130,21 @@ namespace Microsoft.DotNet.Helix.Sdk
                 }
                 catch (TaskCanceledException e)
                 {
-                    Log.LogWarning($"Caught TaskCanceled Exception while querying the Helix WorkItem Details API for work item {workItemId} of job {jobName}. Retrying.");
-                    Log.LogWarningFromException(e);
+                    Log.LogMessage($"Caught TaskCanceled Exception while querying the Helix WorkItem Details API for work item {workItemId} of job {jobName}. Retrying.");
+                    Log.LogMessage($"Exception Message: {e.Message}");
+                    Log.LogMessage($"Stack Trace:\n{e.StackTrace}");
                 }
                 catch (HttpRequestException e)
                 {
-                    Log.LogWarning($"Caught HttpRequestException while querying the Helix WorkItem Details API for work item {workItemId} of job {jobName}. Retrying.");
-                    Log.LogWarningFromException(e);
+                    Log.LogMessage($"Caught HttpRequestException while querying the Helix WorkItem Details API for work item {workItemId} of job {jobName}. Retrying.");
+                    Log.LogMessage($"Exception Message: {e.Message}");
+                    Log.LogMessage($"Stack Trace:\n{e.StackTrace}");
                 }
                 catch (NullReferenceException e)
                 {
-                    Log.LogWarning($"Caught NullReferenceException while querying the Helix WorkItem Details API for work item {workItemId} of job {jobName}. Retrying.");
-                    Log.LogWarningFromException(e);
+                    Log.LogMessage($"Caught NullReferenceException while querying the Helix WorkItem Details API for work item {workItemId} of job {jobName}. Retrying.");
+                    Log.LogMessage($"Exception Message: {e.Message}");
+                    Log.LogMessage($"Stack Trace:\n{e.StackTrace}");
                 }
                 await Task.Delay(1000);
             }

--- a/src/Microsoft.DotNet.Helix/Sdk/HelixWait.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/HelixWait.cs
@@ -92,6 +92,12 @@ namespace Microsoft.DotNet.Helix.Sdk
                     Log.LogWarning($"Caught HttpRequestException while querying the Helix WorkItem List API for {jobName}. Retrying.");
                     Log.LogWarningFromException(e);
                 }
+                catch (NullReferenceException e)
+                {
+                    failureRetries++;
+                    Log.LogWarning($"Caught NullReferenceException while querying the Helix WorkItem List API for {jobName}. Retrying.");
+                    Log.LogWarningFromException(e);
+                }
                 if (failureRetries > MAX_FAILURE_RETRIES)
                 {
                     Log.LogError($"Exceeded maximum {MAX_FAILURE_RETRIES} failure retries while querying the Helix WorkItem List API for {jobName}. Quitting.");
@@ -125,6 +131,11 @@ namespace Microsoft.DotNet.Helix.Sdk
                 catch (HttpRequestException e)
                 {
                     Log.LogWarning($"Caught HttpRequestException while querying the Helix WorkItem Details API for work item {workItemId} of job {jobName}. Retrying.");
+                    Log.LogWarningFromException(e);
+                }
+                catch (NullReferenceException e)
+                {
+                    Log.LogWarning($"Caught NullReferenceException while querying the Helix WorkItem Details API for work item {workItemId} of job {jobName}. Retrying.");
                     Log.LogWarningFromException(e);
                 }
                 await Task.Delay(1000);

--- a/src/Microsoft.DotNet.Helix/Sdk/HelixWait.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/HelixWait.cs
@@ -87,7 +87,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                     if (e.CancellationToken != cancellationToken)
                     {
                         // This was an HTTP timeout; log and retry
-                        Log.LogMessage($"An HttpRequest timeout occurred while querying the Helix WorkItem List API for {jobName}. Retrying.");
+                        Log.LogMessage($"An HttpClient timeout occurred while querying the Helix WorkItem List API for {jobName}. Retrying.");
                         Log.LogMessage($"Exception Message: {e.Message}");
                         Log.LogMessage($"Stack Trace:\n{e.StackTrace}");
                     }
@@ -143,7 +143,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                     if (e.CancellationToken != cancellationToken)
                     {
                         // An HTTP timeout occurred; log and retry
-                        Log.LogMessage($"An HttpRequest timeout occurred while querying the Helix WorkItem Details API for work item {workItemId} of job {jobName}. Retrying.");
+                        Log.LogMessage($"An HttpClient timeout occurred while querying the Helix WorkItem Details API for work item {workItemId} of job {jobName}. Retrying.");
                         Log.LogMessage($"Exception Message: {e.Message}");
                         Log.LogMessage($"Stack Trace:\n{e.StackTrace}");
                     }
@@ -165,7 +165,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                     Log.LogMessage($"Exception Message: {e.Message}");
                     Log.LogMessage($"Stack Trace:\n{e.StackTrace}");
                 }
-                await Task.Delay(1000);
+                await Task.Delay((i + 1) * 1000);
             }
             Log.LogError($"Exceeded maximum {MAX_FAILURE_RETRIES} failure retries while querying the Helix WorkItem Details API for work item {workItemId} of job {jobName}");
             return;

--- a/src/Microsoft.DotNet.Helix/Sdk/HelixWait.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/HelixWait.cs
@@ -165,7 +165,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                     Log.LogMessage($"Exception Message: {e.Message}");
                     Log.LogMessage($"Stack Trace:\n{e.StackTrace}");
                 }
-                await Task.Delay((i + 1) * 1000);
+                await Task.Delay(GetTimeout(i));
             }
             Log.LogError($"Exceeded maximum {MAX_FAILURE_RETRIES} failure retries while querying the Helix WorkItem Details API for work item {workItemId} of job {jobName}");
             return;
@@ -215,6 +215,15 @@ namespace Microsoft.DotNet.Helix.Sdk
                     return $"https://mc.dot.net/#/user/{userName}/{Source}/{Type}/{Build}";
                 }
             }
+        }
+
+        private int GetTimeout(int times)
+        {
+            Random rand = new Random();
+            double factor = 1.3;
+            var min = Math.Pow(factor, times) * 1000;
+            var max = Math.Pow(factor, times + 1) * 1000;
+            return rand.Next((int)min, (int)max);
         }
     }
 }

--- a/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Helix.Client;
+using Microsoft.WindowsAzure.Storage;
 using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.Helix.Sdk
@@ -205,8 +206,24 @@ namespace Microsoft.DotNet.Helix.Sdk
 
                 Log.LogMessage(MessageImportance.Normal, "Sending Job...");
 
-                ISentJob job = await def.SendAsync();
+                ISentJob job = await def.SendAsync(LogWithinJobSender);
                 JobCorrelationId = job.CorrelationId;
+            }
+        }
+
+        private void LogWithinJobSender(LogLevel level, string message)
+        {
+            switch (level)
+            {
+                case LogLevel.Error:
+                    Log.LogError(message);
+                    break;
+                case LogLevel.Warning:
+                    Log.LogWarning(message);
+                    break;
+                default:
+                    Log.LogMessage(message);
+                    break;
             }
         }
 


### PR DESCRIPTION
The idea here is to mimic the functionality that @MattGal implemented in buildtools: https://github.com/dotnet/buildtools/blob/master/src/Microsoft.DotNet.Build.CloudTestTasks/SendJobsToHelix.cs#L106

Additionally, the HelixWait retry logic added should address #1286, #1492, and #1493.