### PR TITLE
Remove ConvertCommonMetadataToAdditionalProperties dependency

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
@@ -139,7 +139,6 @@
        Walking the closure is very expensive for many of our packages and is unecessary since we are very
        strict about assets that are included in the package.  -->
   <Target Name="_GetProjectClosure"
-          DependsOnTargets="ConvertCommonMetadataToAdditionalProperties"
           Returns="@(_ProjectReferenceClosure)">
 
     <!-- Get closure of indirect references if they opt-in -->


### PR DESCRIPTION
This target set additional global properties on project references,
however we stopped using this long ago as global properties became
dangerous due to introducing race conditions in the build.

This target is also one I'm not preserving from buildtools.