### PR TITLE
Fix wrong environment script for Benchview upload

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/performance/Performance.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/performance/Performance.targets
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(LogToBenchview)' == 'true'">
-    <PostRunScriptCommands Condition="'$(TargetOS)' != 'Windows_NT'" Include="if exist &quot;$(RunId)-$(AssemblyName).xml&quot; (" />
-    <PostRunScriptCommands Condition="'$(TargetOS)' == 'Windows_NT'" Include="if [ -f &quot;$(RunId)-$(AssemblyName).xml&quot; ]; then" />
+    <PostRunScriptCommands Condition="'$(TargetOS)' == 'Windows_NT'" Include="if exist &quot;$(RunId)-$(AssemblyName).xml&quot; (" />
+    <PostRunScriptCommands Condition="'$(TargetOS)' != 'Windows_NT'" Include="if [ -f &quot;$(RunId)-$(AssemblyName).xml&quot; ]; then" />
     <PostRunScriptCommands Include="$(MeasurementPyCommand)" />
-    <PostRunScriptCommands Condition="'$(TargetOS)' != 'Windows_NT'" Include=")" />
-    <PostRunScriptCommands Condition="'$(TargetOS)' == 'Windows_NT'" Include="fi" />
+    <PostRunScriptCommands Condition="'$(TargetOS)' == 'Windows_NT'" Include=")" />
+    <PostRunScriptCommands Condition="'$(TargetOS)' != 'Windows_NT'" Include="fi" />
   </ItemGroup>
 
   <Target Name="ValidatePerfConfigurations">


### PR DESCRIPTION
Fixes benchmark runs that are currently failing because of wrong commands on Windows vs Unix.

https://ci2.dot.net/job/dotnet_corefx/job/perf/job/master/job/perf_windows_nt_release/