### PR TITLE
Add new task so we can publish to AzDO pipeline artifacts

### DIFF
--- a/Documentation/AzureDevOps/SendingJobsToHelix.md
+++ b/Documentation/AzureDevOps/SendingJobsToHelix.md
@@ -83,6 +83,8 @@ The simplest Helix use-case is zipping up a single folder containing your projec
 
 Simply specify the xUnit project(s) you wish to run (semicolon delimited) with the `XUnitProjects` parameter. Then, specify the `XUnitPublishTargetFramework` (the framework you want to publish your xUnit projects as, e.g. `netcoreapp2.1`), `XUnitRuntimeTargetFramework` (the framework version of xUnit you want to use from the xUnit nuget package, e.g. `netcoreapp2.0`) and the `XUnitRunnerVersion` (the version of the xUnit nuget package you want to use, e.g. `2.4.1`). Finally, set `IncludeDotNetCli` to true and specify which `DotNetCliPackageType` (`sdk` or `runtime`) and `DotNetCliVersion` you wish to use. (For a full list of .NET CLI versions/package types, see these links: [3.0](https://dotnet.microsoft.com/download/dotnet-core/3.0), [2.1](https://dotnet.microsoft.com/download/dotnet-core/2.1), [2.2](https://dotnet.microsoft.com/download/dotnet-core/2.2).)
 
+The list of available Helix queues can be found [here](https://helix.dot.net/api/2018-03-14/info/queues).
+
 ```yaml
   - template: /eng/common/templates/steps/send-to-helix.yml
     parameters:
@@ -102,7 +104,8 @@ Simply specify the xUnit project(s) you wish to run (semicolon delimited) with t
       DotNetCliVersion: 2.1.403 # full list of versions here: https://raw.githubusercontent.com/dotnet/core/master/release-notes/releases.json
       EnableXUnitReporter: true # required for reporting out xUnit test results to Mission Control
       # WaitForWorkItemCompletion: true -- defaults to true
-      IsExternal: true # for specifying external jobs -- set this true whenever you would use the anon-kaonashi token for HelixAccessToken
+      IsExternal: true # for specifying external jobs -- set this true whenever you would use the anon-kaonashi token for HelixAccessToken; true requires Creator
+      Creator: arcade # specify an appropriate Creator here -- required for IsExternal true
       # condition: succeeded() - defaults to succeeded()
 ```
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -19,12 +19,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public const string AssetsVirtualDir = "assets/";
 
-        public static void CreateBuildManifest(
-            TaskLoggingHelper log,
-            IEnumerable<BlobArtifactModel> blobArtifacts,
-            IEnumerable<PackageArtifactModel> packageArtifacts,
-            string assetManifestPath, string manifestRepoUri, string manifestBuildId,
-            string manifestBranch, string manifestCommit, string manifestBuildData)
+        public static void CreateBuildManifest(TaskLoggingHelper log, IEnumerable<BlobArtifactModel> blobArtifacts, IEnumerable<PackageArtifactModel> packageArtifacts, string assetManifestPath, string manifestRepoUri, string manifestBuildId, string manifestBranch, string manifestCommit, string manifestBuildData)
         {
             log.LogMessage(MessageImportance.High, $"Creating build manifest file '{assetManifestPath}'...");
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
@@ -19,7 +19,15 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public const string AssetsVirtualDir = "assets/";
 
-        public static void CreateBuildManifest(TaskLoggingHelper log, IEnumerable<BlobArtifactModel> blobArtifacts, IEnumerable<PackageArtifactModel> packageArtifacts, string assetManifestPath, string manifestRepoUri, string manifestBuildId, string manifestBranch, string manifestCommit, string manifestBuildData)
+        public static void CreateBuildManifest(TaskLoggingHelper log, 
+            IEnumerable<BlobArtifactModel> blobArtifacts, 
+            IEnumerable<PackageArtifactModel> packageArtifacts, 
+            string assetManifestPath, 
+            string manifestRepoUri, 
+            string manifestBuildId, 
+            string manifestBranch, 
+            string manifestCommit, 
+            string manifestBuildData)
         {
             log.LogMessage(MessageImportance.High, $"Creating build manifest file '{assetManifestPath}'...");
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
@@ -1,0 +1,109 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.DotNet.VersionTools.Automation;
+using Microsoft.DotNet.VersionTools.BuildManifest.Model;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks.Feed
+{
+    public static class BuildManifestUtil
+    {
+        private static readonly char[] ManifestDataPairSeparators = { ';' };
+
+        public const string AssetsVirtualDir = "assets/";
+
+        public static void CreateBuildManifest(
+            TaskLoggingHelper log,
+            IEnumerable<BlobArtifactModel> blobArtifacts,
+            IEnumerable<PackageArtifactModel> packageArtifacts,
+            string assetManifestPath, string manifestRepoUri, string manifestBuildId,
+            string manifestBranch, string manifestCommit, string manifestBuildData)
+        {
+            log.LogMessage(MessageImportance.High, $"Creating build manifest file '{assetManifestPath}'...");
+
+            BuildModel buildModel = new BuildModel(
+                    new BuildIdentity
+                    {
+                        Attributes = ParseManifestMetadataString(manifestBuildData),
+                        Name = manifestRepoUri,
+                        BuildId = manifestBuildId,
+                        Branch = manifestBranch,
+                        Commit = manifestCommit
+                    });
+
+            buildModel.Artifacts.Blobs.AddRange(blobArtifacts);
+            buildModel.Artifacts.Packages.AddRange(packageArtifacts);
+
+            string dirPath = Path.GetDirectoryName(assetManifestPath);
+
+            Directory.CreateDirectory(dirPath);
+
+            File.WriteAllText(assetManifestPath, buildModel.ToXml().ToString());
+        }
+
+        public static PackageArtifactModel CreatePackageArtifactModel(ITaskItem item)
+        {
+            NupkgInfo info = new NupkgInfo(item.ItemSpec);
+
+            return new PackageArtifactModel
+            {
+                Attributes = ParseCustomAttributes(item),
+                Id = info.Id,
+                Version = info.Version
+            };
+        }
+
+        public static BlobArtifactModel CreateBlobArtifactModel(ITaskItem item)
+        {
+            string path = item.GetMetadata("RelativeBlobPath");
+
+            // Only include assets in the manifest if they're in "assets/".
+            if (path?.StartsWith(AssetsVirtualDir, StringComparison.Ordinal) == true)
+            {
+                return new BlobArtifactModel
+                {
+                    Attributes = ParseCustomAttributes(item),
+                    Id = path.Substring(AssetsVirtualDir.Length)
+                };
+            }
+            return null;
+        }
+
+        private static Dictionary<string, string> ParseCustomAttributes(ITaskItem item)
+        {
+            return ParseManifestMetadataString(item.GetMetadata("ManifestArtifactData"));
+        }
+
+        private static Dictionary<string, string> ParseManifestMetadataString(string data)
+        {
+            if (string.IsNullOrEmpty(data))
+            {
+                return new Dictionary<string, string>();
+            }
+
+            return data.Split(ManifestDataPairSeparators, StringSplitOptions.RemoveEmptyEntries)
+                .Select(pair =>
+                {
+                    int keyValueSeparatorIndex = pair.IndexOf('=');
+                    if (keyValueSeparatorIndex > 0)
+                    {
+                        return new
+                        {
+                            Key = pair.Substring(0, keyValueSeparatorIndex).Trim(),
+                            Value = pair.Substring(keyValueSeparatorIndex + 1).Trim()
+                        };
+                    }
+                    return null;
+                })
+                .Where(pair => pair != null)
+                .ToDictionary(pair => pair.Key, pair => pair.Value);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
@@ -1,0 +1,96 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.DotNet.VersionTools.BuildManifest.Model;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using MSBuild = Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.Build.Tasks.Feed
+{
+    public class PushToAzureDevOpsArtifacts : MSBuild.Task
+    {
+        [Required]
+        public ITaskItem[] ItemsToPush { get; set; }
+
+        public bool PublishFlatContainer { get; set; }
+
+        public string ManifestRepoUri { get; set; }
+
+        public string ManifestBuildId { get; set; } = "no build id provided";
+
+        public string ManifestBranch { get; set; }
+
+        public string ManifestCommit { get; set; }
+
+        public string ManifestBuildData { get; set; }
+
+        public string AssetManifestPath { get; set; }
+
+        public override bool Execute()
+        {
+            try
+            {
+                Log.LogMessage(MessageImportance.High, "Performing push to Azure DevOps artifacts storage.");
+
+                if (ItemsToPush == null)
+                {
+                    Log.LogError($"No items to push. Please check ItemGroup ItemsToPush.");
+                }
+                else
+                {
+                    IEnumerable<BlobArtifactModel> blobArtifacts = Enumerable.Empty<BlobArtifactModel>();
+                    IEnumerable<PackageArtifactModel> packageArtifacts = Enumerable.Empty<PackageArtifactModel>();
+
+                    if (PublishFlatContainer)
+                    {
+                        blobArtifacts = ItemsToPush.Select(BuildManifestUtil.CreateBlobArtifactModel).Where(blob => blob != null);
+                    }
+                    else
+                    {
+                        ITaskItem[] symbolItems = ItemsToPush
+                            .Where(i => i.ItemSpec.Contains("symbols.nupkg"))
+                            .Select(i =>
+                            {
+                                string fileName = Path.GetFileName(i.ItemSpec);
+                                i.SetMetadata("RelativeBlobPath", $"{BuildManifestUtil.AssetsVirtualDir}symbols/{fileName}");
+                                return i;
+                            })
+                            .ToArray();
+
+                        ITaskItem[] packageItems = ItemsToPush
+                            .Where(i => !symbolItems.Contains(i))
+                            .ToArray();
+
+                        foreach (var packagePath in packageItems)
+                        {
+                            Log.LogMessage(MessageImportance.High, $"##vso[artifact.upload containerfolder=PackageArtifacts;artifactname=PackageArtifacts]{packagePath.ItemSpec}");
+                        }
+
+                        foreach (var symbolPath in symbolItems)
+                        {
+                            Log.LogMessage(MessageImportance.High, $"##vso[artifact.upload containerfolder=BlobArtifacts;artifactname=BlobArtifacts]{symbolPath.ItemSpec}");
+                        }
+
+                        packageArtifacts = packageItems.Select(BuildManifestUtil.CreatePackageArtifactModel);
+                        blobArtifacts = symbolItems.Select(BuildManifestUtil.CreateBlobArtifactModel).Where(blob => blob != null);
+                    }
+
+                    BuildManifestUtil.CreateBuildManifest(Log, blobArtifacts, packageArtifacts,
+                        AssetManifestPath, ManifestRepoUri, ManifestBuildId,
+                        ManifestBranch, ManifestCommit, ManifestBuildData);
+                }
+            }
+            catch (Exception e)
+            {
+                Log.LogErrorFromException(e, true);
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
@@ -68,21 +68,29 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                         foreach (var packagePath in packageItems)
                         {
-                            Log.LogMessage(MessageImportance.High, $"##vso[artifact.upload containerfolder=PackageArtifacts;artifactname=PackageArtifacts]{packagePath.ItemSpec}");
+                            Log.LogMessage(MessageImportance.High, 
+                                $"##vso[artifact.upload containerfolder=PackageArtifacts;artifactname=PackageArtifacts]{packagePath.ItemSpec}");
                         }
 
                         foreach (var symbolPath in symbolItems)
                         {
-                            Log.LogMessage(MessageImportance.High, $"##vso[artifact.upload containerfolder=BlobArtifacts;artifactname=BlobArtifacts]{symbolPath.ItemSpec}");
+                            Log.LogMessage(MessageImportance.High, 
+                                $"##vso[artifact.upload containerfolder=BlobArtifacts;artifactname=BlobArtifacts]{symbolPath.ItemSpec}");
                         }
 
                         packageArtifacts = packageItems.Select(BuildManifestUtil.CreatePackageArtifactModel);
                         blobArtifacts = symbolItems.Select(BuildManifestUtil.CreateBlobArtifactModel).Where(blob => blob != null);
                     }
 
-                    BuildManifestUtil.CreateBuildManifest(Log, blobArtifacts, packageArtifacts,
-                        AssetManifestPath, ManifestRepoUri, ManifestBuildId,
-                        ManifestBranch, ManifestCommit, ManifestBuildData);
+                    BuildManifestUtil.CreateBuildManifest(Log, 
+                        blobArtifacts, 
+                        packageArtifacts,
+                        AssetManifestPath, 
+                        ManifestRepoUri, 
+                        ManifestBuildId,
+                        ManifestBranch, 
+                        ManifestCommit, 
+                        ManifestBuildData);
                 }
             }
             catch (Exception e)

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBlobFeed.cs
@@ -114,9 +114,15 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         blobArtifacts = ConcatBlobArtifacts(blobArtifacts, symbolItems);
                     }
 
-                    BuildManifestUtil.CreateBuildManifest(Log, blobArtifacts, packageArtifacts,
-                        AssetManifestPath, ManifestRepoUri, ManifestBuildId,
-                        ManifestBranch, ManifestCommit, ManifestBuildData);
+                    BuildManifestUtil.CreateBuildManifest(Log, 
+                        blobArtifacts, 
+                        packageArtifacts,
+                        AssetManifestPath, 
+                        ManifestRepoUri, 
+                        ManifestBuildId,
+                        ManifestBranch, 
+                        ManifestCommit, 
+                        ManifestBuildData);
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
Closes: #1540 

This PR add a new MSBuild task `PushToAzureDevOpsArtifacts` to Tasks.Feed package. The new task has mostly the same interface as `PushToBlobFeed` and works mostly the same. Only exception is that the new task will publish to Azure Pipelines artifacts storage instead of feeds.

My plan is to have this task working side by side with PushToBlobFeed and then when the refactoring of publishing is completed we just remove the call to `PushToBlobFeed` in Publish.proj.

**Changes:**
- BuildManifestUtil.cs : utility methods for creating/managing build manifest.
- PushToAzureDevOpsArtifacts.cs : build task that is able to publish to azure artifacts and create build manifest.
- PushToBlobFeed.cs : just some change to use the new BuildManifestUtil class.