### PR TITLE
Make Arcade SDK optionally use PublishToAzureDevOps publish task

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -68,7 +68,7 @@
     <XUnitVersion Condition="'$(XUnitVersion)' == ''">2.4.1-pre.build.4059</XUnitVersion>
     <XUnitRunnerConsoleVersion Condition="'$(XUnitRunnerConsoleVersion)' == ''">$(XUnitVersion)</XUnitRunnerConsoleVersion>
     <XUnitRunnerVisualStudioVersion Condition="'$(XUnitRunnerVisualStudioVersion)' == ''">$(XUnitVersion)</XUnitRunnerVisualStudioVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion Condition="'$(MicrosoftDotNetBuildTasksFeedVersion)' == ''">2.2.0-beta.18611.12</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion Condition="'$(MicrosoftDotNetBuildTasksFeedVersion)' == ''">2.2.0-beta.18612.4</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftSourceLinkVersion Condition="'$(MicrosoftSourceLinkVersion)' == ''">1.0.0-beta-63401-01</MicrosoftSourceLinkVersion>
     <MicrosoftSymbolUploaderBuildTaskVersion Condition="'$(MicrosoftSymbolUploaderBuildTaskVersion)' == ''">1.0.0-beta-63604-05</MicrosoftSymbolUploaderBuildTaskVersion>
     <VSWhereVersion Condition="'$(VSWhereVersion)' == ''">2.5.2</VSWhereVersion>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -68,7 +68,7 @@
     <XUnitVersion Condition="'$(XUnitVersion)' == ''">2.4.1-pre.build.4059</XUnitVersion>
     <XUnitRunnerConsoleVersion Condition="'$(XUnitRunnerConsoleVersion)' == ''">$(XUnitVersion)</XUnitRunnerConsoleVersion>
     <XUnitRunnerVisualStudioVersion Condition="'$(XUnitRunnerVisualStudioVersion)' == ''">$(XUnitVersion)</XUnitRunnerVisualStudioVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion Condition="'$(MicrosoftDotNetBuildTasksFeedVersion)' == ''">2.2.0-beta.18475.5</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion Condition="'$(MicrosoftDotNetBuildTasksFeedVersion)' == ''">2.2.0-beta.18611.12</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftSourceLinkVersion Condition="'$(MicrosoftSourceLinkVersion)' == ''">1.0.0-beta-63401-01</MicrosoftSourceLinkVersion>
     <MicrosoftSymbolUploaderBuildTaskVersion Condition="'$(MicrosoftSymbolUploaderBuildTaskVersion)' == ''">1.0.0-beta-63604-05</MicrosoftSymbolUploaderBuildTaskVersion>
     <VSWhereVersion Condition="'$(VSWhereVersion)' == ''">2.5.2</VSWhereVersion>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -70,7 +70,7 @@
 
     <PushToAzureDevOpsArtifacts 
       ItemsToPush="@(ItemsToPushToBlobFeed)"
-      ManifestBuildData="Location=$(AzureFeedUrl);ShortBuildId=$(BUILD_BUILDID)"
+      ManifestBuildData="Location=$(AzureFeedUrl)"
       ManifestRepoUri="$(BUILD_REPOSITORY_URI)"
       ManifestBranch="$(BUILD_SOURCEBRANCH)"
       ManifestBuildId="$(BUILD_BUILDNUMBER)"

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -68,16 +68,27 @@
       </ItemsToPushToBlobFeed>
     </ItemGroup>
 
-    <PushToBlobFeed ExpectedFeedUrl="$(AzureFeedUrl)"
-                    AccountKey="$(AzureAccountKey)"
-                    ItemsToPush="@(ItemsToPushToBlobFeed)"
-                    ManifestBuildData="Location=$(AzureFeedUrl)"
-                    ManifestRepoUri="$(BUILD_REPOSITORY_URI)"
-                    ManifestBranch="$(BUILD_SOURCEBRANCH)"
-                    ManifestBuildId="$(BUILD_BUILDNUMBER)"
-                    ManifestCommit="$(BUILD_SOURCEVERSION)" 
-                    AssetManifestPath="$(AssetManifestFilePath)"
-                    Condition="$(PublishToAzure)"/>
+    <PushToAzureDevOpsArtifacts 
+      ItemsToPush="@(ItemsToPushToBlobFeed)"
+      ManifestBuildData="Location=$(AzureFeedUrl)"
+      ManifestRepoUri="$(BUILD_REPOSITORY_URI)"
+      ManifestBranch="$(BUILD_SOURCEBRANCH)"
+      ManifestBuildId="$(BUILD_BUILDNUMBER)"
+      ManifestCommit="$(BUILD_SOURCEVERSION)"
+      AssetManifestPath="$(ArtifactsLogDir)BuildAssetManifest\$(OS)-$(PlatformName).xml"
+      Condition="$(PublishToAzure) AND '$(PushToAzureDevOps)' == 'true'"/>
+    
+    <PushToBlobFeed 
+      ExpectedFeedUrl="$(AzureFeedUrl)"
+      AccountKey="$(AzureAccountKey)"
+      ItemsToPush="@(ItemsToPushToBlobFeed)"
+      ManifestBuildData="Location=$(AzureFeedUrl)"
+      ManifestRepoUri="$(BUILD_REPOSITORY_URI)"
+      ManifestBranch="$(BUILD_SOURCEBRANCH)"
+      ManifestBuildId="$(BUILD_BUILDNUMBER)"
+      ManifestCommit="$(BUILD_SOURCEVERSION)" 
+      AssetManifestPath="$(AssetManifestFilePath)"
+      Condition="$(PublishToAzure)"/>
 
     <!-- Source Build local storage -->    
     <Copy SourceFiles="@(PackagesToPublish)" DestinationFolder="$(DotNetOutputBlobFeedDir)packages" Condition="$(PublishToSourceBuildStorage)" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -75,7 +75,8 @@
       ManifestBranch="$(BUILD_SOURCEBRANCH)"
       ManifestBuildId="$(BUILD_BUILDNUMBER)"
       ManifestCommit="$(BUILD_SOURCEVERSION)"
-      AssetManifestPath="$(ArtifactsLogDir)BuildAssetManifest\$(OS)-$(PlatformName).xml"
+      PublishFlatContainer="false"
+      AssetManifestPath="$(ArtifactsLogDir)PipelineArtifactsPublishingManifests\$(OS)-$(PlatformName)-$(AGENT_JOBNAME).xml"
       Condition="$(PublishToAzure) and '$(PushToAzureDevOps)' == 'true'"/>
     
     <PushToBlobFeed 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -70,7 +70,7 @@
 
     <PushToAzureDevOpsArtifacts 
       ItemsToPush="@(ItemsToPushToBlobFeed)"
-      ManifestBuildData="Location=$(AzureFeedUrl)"
+      ManifestBuildData="Location=$(AzureFeedUrl);ShortBuildId=$(BUILD_BUILDID)"
       ManifestRepoUri="$(BUILD_REPOSITORY_URI)"
       ManifestBranch="$(BUILD_SOURCEBRANCH)"
       ManifestBuildId="$(BUILD_BUILDNUMBER)"

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -76,7 +76,7 @@
       ManifestBuildId="$(BUILD_BUILDNUMBER)"
       ManifestCommit="$(BUILD_SOURCEVERSION)"
       AssetManifestPath="$(ArtifactsLogDir)BuildAssetManifest\$(OS)-$(PlatformName).xml"
-      Condition="$(PublishToAzure) AND '$(PushToAzureDevOps)' == 'true'"/>
+      Condition="$(PublishToAzure) and '$(PushToAzureDevOps)' == 'true'"/>
     
     <PushToBlobFeed 
       ExpectedFeedUrl="$(AzureFeedUrl)"


### PR DESCRIPTION
Closes: #1551 

Changes: Make `Publish.proj` optionally *also* call `PushToAzureDevOpsArtifacts` task.