### PR TITLE
Add binlog to publishbuildassets

### DIFF
--- a/eng/common/PublishBuildAssets.cmd
+++ b/eng/common/PublishBuildAssets.cmd
@@ -1,3 +1,3 @@
 @echo off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0Build.ps1""" -msbuildEngine dotnet -restore -execute /p:PublishBuildAssets=true /p:SdkTaskProjects=PublishBuildAssets.proj %*"
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0Build.ps1""" -msbuildEngine dotnet -restore -execute -binaryLog /p:PublishBuildAssets=true /p:SdkTaskProjects=PublishBuildAssets.proj %*"
 exit /b %ErrorLevel%

--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -1,10 +1,4 @@
 parameters:
-  # Optional: dependencies of the job
-  dependsOn: ''
-
-  # Optional: A defined YAML pool - https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=vsts&tabs=schema#pool
-  pool: {}
-
   configuration: 'Debug'
 
   # Optional: condition for the job to run
@@ -12,6 +6,15 @@ parameters:
 
   # Optional: 'true' if future jobs should run even if this job fails
   continueOnError: false
+
+  # Optional: dependencies of the job
+  dependsOn: ''
+
+  # Optional: Include PublishBuildArtifacts task
+  enablePublishBuildArtifacts: false
+
+  # Optional: A defined YAML pool - https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=vsts&tabs=schema#pool
+  pool: {}
 
   # Optional: should run as a public build even in the internal project
   #           if 'true', the build won't run any of the internal only steps, even if it is running in non-public projects.
@@ -49,3 +52,12 @@ jobs:
       displayName: Publish Build Assets
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}
+    - ${{ if eq(parameters.enablePublishBuildArtifacts, 'true') }}:
+      - task: PublishBuildArtifacts@1
+        displayName: Publish Logs to VSTS
+        inputs:
+          PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
+          PublishLocation: Container
+          ArtifactName: $(Agent.Os)_PublishBuildAssets
+        continueOnError: true
+        condition: always()      

--- a/eng/common/templates/jobs/jobs.yml
+++ b/eng/common/templates/jobs/jobs.yml
@@ -73,3 +73,5 @@ jobs:
       pool:
         vmImage: vs2017-win2016
       runAsPublic: ${{ parameters.runAsPublic }}
+      enablePublishBuildArtifacts: ${{ parameters.enablePublishBuildArtifacts }}
+


### PR DESCRIPTION
Updates "publish build assets" to produce a binlog and update builds to publish that log. as an artifact.

See https://dnceng.visualstudio.com/internal/_build/results?buildId=57223 for the internal build where we publish the binlogs to Windows_NT_PublishBuildAssets artifact.

This will help diagnose issues (which provide no useful information) such as ...

```
2018-12-12T18:12:43.8851498Z eng\common\publishbuildassets.cmd /p:ManifestsPath='F:\vsagent\-containerSas\100\s/artifacts/AssetManifest/' /p:BuildAssetRegistryToken=*** /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com /p:Configuration=Release
2018-12-12T18:12:43.9422922Z ##[command]"C:\Windows\system32\cmd.exe" /D /E:ON /V:OFF /S /C "CALL "F:\vsagent\-containerSas\_temp\f49595fd-480e-43a2-96f6-89aee46ca21e.cmd""
2018-12-12T18:12:45.2186656Z dotnet-install: Downloading link: https://dotnetcli.azureedge.net/dotnet/Sdk/3.0.100-preview-009750/dotnet-sdk-3.0.100-preview-009750-win-x64.zip
2018-12-12T18:12:47.2281472Z dotnet-install: Extracting zip from https://dotnetcli.azureedge.net/dotnet/Sdk/3.0.100-preview-009750/dotnet-sdk-3.0.100-preview-009750-win-x64.zip
2018-12-12T18:13:24.5894811Z dotnet-install: Adding to current process PATH: "F:\vsagent\-containerSas\100\s\.dotnet\". Note: This change will not be visible if PowerShell was run as a child process.
2018-12-12T18:13:24.5918225Z dotnet-install: Installation finished
2018-12-12T18:13:25.6864533Z Build failed.
2018-12-12T18:13:25.8196863Z ##[error]Cmd.exe exited with code '1'.
```

which getting a binlog showed to be "error MSB4236: The SDK 'Microsoft.DotNet.Arcade.Sdk' specified could not be found."

PTAL @jcagme 

FYI @natemcmaster @ryanbrandenburg 