### PR TITLE
Allow for changing the msbuild to be used for the build in arcade

### DIFF
--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -185,17 +185,9 @@ function InitializeBuildTool {
   
   InitializeDotNetCli $restore
 
-  # return value
+  # return values
   _InitializeBuildTool="$_InitializeDotNetCli/dotnet"  
-}
-
-function InitializeMSBuildToUse {
-  if [[ -n "${_InitializeMSBuildToUse:-}" ]]; then
-    return
-  fi
-
-  # return value
-  _InitializeMSBuildToUse="msbuild"
+  _InitializeBuildToolCommand="msbuild"
 }
 
 function GetNuGetPackageCachePath {
@@ -288,7 +280,7 @@ function MSBuild {
     warnaserror_switch="/warnaserror"
   fi
 
-  "$_InitializeBuildTool" "$_InitializeMSBuildToUse" /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse $warnaserror_switch /p:TreatWarningsAsErrors=$warn_as_error "$@"
+  "$_InitializeBuildTool" "$_InitializeBuildToolCommand" /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse $warnaserror_switch /p:TreatWarningsAsErrors=$warn_as_error "$@"
   lastexitcode=$?
 
   if [[ $lastexitcode != 0 ]]; then

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -189,6 +189,15 @@ function InitializeBuildTool {
   _InitializeBuildTool="$_InitializeDotNetCli/dotnet"  
 }
 
+function InitializeMSBuildToUse {
+  if [[ -n "${_InitializeMSBuildToUse:-}" ]]; then
+    return
+  fi
+
+  # return value
+  _InitializeMSBuildToUse="msbuild"
+}
+
 function GetNuGetPackageCachePath {
   if [[ -z ${NUGET_PACKAGES:-} ]]; then
     if [[ "$use_global_nuget_cache" == true ]]; then
@@ -279,7 +288,7 @@ function MSBuild {
     warnaserror_switch="/warnaserror"
   fi
 
-  "$_InitializeBuildTool" msbuild /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse $warnaserror_switch /p:TreatWarningsAsErrors=$warn_as_error "$@"
+  "$_InitializeBuildTool" "$_InitializeMSBuildToUse" /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse $warnaserror_switch /p:TreatWarningsAsErrors=$warn_as_error "$@"
   lastexitcode=$?
 
   if [[ $lastexitcode != 0 ]]; then


### PR DESCRIPTION
In the powershell script, you can change both the path as well as the command to be used. This was not totally possible in the shell script. This change allows for that to happen.

This is needed at least on msbuild where we want to point to our custom bustom msbuild build to use.