### PR TITLE
Create new task in Tasks.Feed that publish packages based on publishing manifest

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/build/Microsoft.DotNet.Build.Tasks.Feed.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/build/Microsoft.DotNet.Build.Tasks.Feed.targets
@@ -49,7 +49,7 @@
   <UsingTask TaskName="ParseBlobUrl" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
   <UsingTask TaskName="PushToBlobFeed" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
   <UsingTask TaskName="PushToAzureDevOpsArtifacts" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
-  <UsingTask TaskName="PushToStaticFeed" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
+  <UsingTask TaskName="PushArtifactsInManifestToFeed" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
   <UsingTask TaskName="ExecWithRetriesForNuGetPush" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
   
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/build/Microsoft.DotNet.Build.Tasks.Feed.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/build/Microsoft.DotNet.Build.Tasks.Feed.targets
@@ -49,6 +49,7 @@
   <UsingTask TaskName="ParseBlobUrl" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
   <UsingTask TaskName="PushToBlobFeed" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
   <UsingTask TaskName="PushToAzureDevOpsArtifacts" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
+  <UsingTask TaskName="PushToStaticFeed" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
   <UsingTask TaskName="ExecWithRetriesForNuGetPush" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
   
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Xml.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks.Feed
 {
@@ -19,14 +20,14 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public const string AssetsVirtualDir = "assets/";
 
-        public static void CreateBuildManifest(TaskLoggingHelper log, 
-            IEnumerable<BlobArtifactModel> blobArtifacts, 
-            IEnumerable<PackageArtifactModel> packageArtifacts, 
-            string assetManifestPath, 
-            string manifestRepoUri, 
-            string manifestBuildId, 
-            string manifestBranch, 
-            string manifestCommit, 
+        public static void CreateBuildManifest(TaskLoggingHelper log,
+            IEnumerable<BlobArtifactModel> blobArtifacts,
+            IEnumerable<PackageArtifactModel> packageArtifacts,
+            string assetManifestPath,
+            string manifestRepoUri,
+            string manifestBuildId,
+            string manifestBranch,
+            string manifestCommit,
             string manifestBuildData)
         {
             log.LogMessage(MessageImportance.High, $"Creating build manifest file '{assetManifestPath}'...");
@@ -49,6 +50,20 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             Directory.CreateDirectory(dirPath);
 
             File.WriteAllText(assetManifestPath, buildModel.ToXml().ToString());
+        }
+
+        public static BuildModel ManifestFileToModel(string assetManifestPath, TaskLoggingHelper log)
+        {
+            try
+            {
+                return BuildModel.Parse(XElement.Load(assetManifestPath));
+            }
+            catch (Exception e)
+            {
+                log.LogError($"Could not parse asset manifest file: {assetManifestPath}");
+                log.LogErrorFromException(e);
+                return null;
+            }
         }
 
         public static PackageArtifactModel CreatePackageArtifactModel(ITaskItem item)

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushArtifactsInManifestToFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushArtifactsInManifestToFeed.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
     /// The intended use of this task is to push artifacts described in
     /// a build manifest to a static package feed.
     /// </summary>
-    public class PushToStaticFeed : MSBuild.Task
+    public class PushArtifactsInManifestToFeed : MSBuild.Task
     {
         /// <summary>
         /// Target to where the assets should be published.
@@ -84,11 +84,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             {
                 Log.LogMessage(MessageImportance.High, "Performing push feeds.");
 
-                if (string.IsNullOrEmpty(ExpectedFeedUrl) || string.IsNullOrEmpty(AccountKey))
+                if (string.IsNullOrWhiteSpace(ExpectedFeedUrl) || string.IsNullOrWhiteSpace(AccountKey))
                 {
                     Log.LogError($"{nameof(ExpectedFeedUrl)} / {nameof(AccountKey)} is not set properly.");
                 }
-                else if (string.IsNullOrEmpty(AssetManifestPath) || !File.Exists(AssetManifestPath))
+                else if (string.IsNullOrWhiteSpace(AssetManifestPath) || !File.Exists(AssetManifestPath))
                 {
                     Log.LogError($"Problem reading asset manifest path from {AssetManifestPath}");
                 }
@@ -102,6 +102,13 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 }
 
                 var buildModel = BuildManifestUtil.ManifestFileToModel(AssetManifestPath, Log);
+
+                // Parsing the manifest may fail for several reasons
+                if (Log.HasLoggedErrors)
+                {
+                    return false;
+                }
+
                 var blobFeedAction = new BlobFeedAction(ExpectedFeedUrl, AccountKey, Log);
                 var pushOptions = new PushOptions
                 {
@@ -111,9 +118,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                 if (buildModel.Artifacts.Packages.Any())
                 {
-                    if (string.IsNullOrEmpty(PackageAssetsBasePath) || !Directory.Exists(PackageAssetsBasePath))
+                    if (!Directory.Exists(PackageAssetsBasePath))
                     {
-                        Log.LogError($"Invalid {nameof(PackageAssetsBasePath)} was informed: {PackageAssetsBasePath}");
+                        Log.LogError($"Invalid {nameof(PackageAssetsBasePath)} was supplied: {PackageAssetsBasePath}");
                         return false;
                     }
 
@@ -127,9 +134,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                 if (buildModel.Artifacts.Blobs.Any())
                 {
-                    if (string.IsNullOrEmpty(BlobAssetsBasePath) || !Directory.Exists(BlobAssetsBasePath))
+                    if (!Directory.Exists(BlobAssetsBasePath))
                     {
-                        Log.LogError($"Invalid {nameof(BlobAssetsBasePath)} was informed: {BlobAssetsBasePath}");
+                        Log.LogError($"Invalid {nameof(BlobAssetsBasePath)} was supplied: {BlobAssetsBasePath}");
                         return false;
                     }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBlobFeed.cs
@@ -91,7 +91,10 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                     if (PublishFlatContainer)
                     {
-                        await blobFeedAction.PublishToFlatContainerAsync(ItemsToPush, MaxClients, UploadTimeoutInMinutes, pushOptions);
+                        await blobFeedAction.PublishToFlatContainerAsync(ItemsToPush, 
+                            MaxClients, 
+                            UploadTimeoutInMinutes, 
+                            pushOptions);
                         blobArtifacts = ConcatBlobArtifacts(blobArtifacts, ItemsToPush);
                     }
                     else
@@ -113,7 +116,10 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         var packagePaths = packageItems.Select(i => i.ItemSpec);
 
                         await blobFeedAction.PushToFeedAsync(packagePaths, pushOptions);
-                        await blobFeedAction.PublishToFlatContainerAsync(symbolItems, MaxClients, UploadTimeoutInMinutes, pushOptions);
+                        await blobFeedAction.PublishToFlatContainerAsync(symbolItems, 
+                            MaxClients, 
+                            UploadTimeoutInMinutes, 
+                            pushOptions);
 
                         packageArtifacts = ConcatPackageArtifacts(packageArtifacts, packageItems);
                         blobArtifacts = ConcatBlobArtifacts(blobArtifacts, symbolItems);

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBlobFeed.cs
@@ -75,6 +75,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 else
                 {
                     BlobFeedAction blobFeedAction = new BlobFeedAction(ExpectedFeedUrl, AccountKey, Log);
+                    var pushOptions = new PushOptions
+                    {
+                        AllowOverwrite = Overwrite,
+                        PassIfExistingItemIdentical = PassIfExistingItemIdentical
+                    };
 
                     IEnumerable<BlobArtifactModel> blobArtifacts = Enumerable.Empty<BlobArtifactModel>();
                     IEnumerable<PackageArtifactModel> packageArtifacts = Enumerable.Empty<PackageArtifactModel>();
@@ -86,7 +91,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                     if (PublishFlatContainer)
                     {
-                        await PublishToFlatContainerAsync(ItemsToPush, blobFeedAction);
+                        await blobFeedAction.PublishToFlatContainerAsync(ItemsToPush, MaxClients, UploadTimeoutInMinutes, pushOptions);
                         blobArtifacts = ConcatBlobArtifacts(blobArtifacts, ItemsToPush);
                     }
                     else
@@ -107,21 +112,21 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                         var packagePaths = packageItems.Select(i => i.ItemSpec);
 
-                        await blobFeedAction.PushToFeedAsync(packagePaths, CreatePushOptions());
-                        await PublishToFlatContainerAsync(symbolItems, blobFeedAction);
+                        await blobFeedAction.PushToFeedAsync(packagePaths, pushOptions);
+                        await blobFeedAction.PublishToFlatContainerAsync(symbolItems, MaxClients, UploadTimeoutInMinutes, pushOptions);
 
                         packageArtifacts = ConcatPackageArtifacts(packageArtifacts, packageItems);
                         blobArtifacts = ConcatBlobArtifacts(blobArtifacts, symbolItems);
                     }
 
-                    BuildManifestUtil.CreateBuildManifest(Log, 
-                        blobArtifacts, 
+                    BuildManifestUtil.CreateBuildManifest(Log,
+                        blobArtifacts,
                         packageArtifacts,
-                        AssetManifestPath, 
-                        ManifestRepoUri, 
+                        AssetManifestPath,
+                        ManifestRepoUri,
                         ManifestBuildId,
-                        ManifestBranch, 
-                        ManifestCommit, 
+                        ManifestBranch,
+                        ManifestCommit,
                         ManifestBuildData);
                 }
             }
@@ -131,28 +136,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             }
 
             return !Log.HasLoggedErrors;
-        }
-
-        private async Task PublishToFlatContainerAsync(IEnumerable<ITaskItem> taskItems, BlobFeedAction blobFeedAction)
-        {
-            if (taskItems.Any())
-            {
-                using (var clientThrottle = new SemaphoreSlim(this.MaxClients, this.MaxClients))
-                {
-                    Log.LogMessage(MessageImportance.High, $"Uploading {taskItems.Count()} items:");
-                    await Task.WhenAll(taskItems.Select(
-                        item =>
-                        {
-                            Log.LogMessage(MessageImportance.High, $"Async uploading {item.ItemSpec}");
-                            return blobFeedAction.UploadAssetAsync(
-                                item,
-                                clientThrottle,
-                                UploadTimeoutInMinutes,
-                                CreatePushOptions());
-                        }
-                    ));
-                }
-            }
         }
 
         private static IEnumerable<PackageArtifactModel> ConcatPackageArtifacts(
@@ -170,15 +153,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             return artifacts.Concat(items
                 .Select(BuildManifestUtil.CreateBlobArtifactModel)
                 .Where(blob => blob != null));
-        }
-
-        private PushOptions CreatePushOptions()
-        {
-            return new PushOptions
-            {
-                AllowOverwrite = Overwrite,
-                PassIfExistingItemIdentical = PassIfExistingItemIdentical
-            };
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToStaticFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToStaticFeed.cs
@@ -1,0 +1,161 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using MSBuild = Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.Build.Tasks.Feed
+{
+    /// <summary>
+    /// The intended use of this task is to push artifacts described in
+    /// a build manifest to a static package feed.
+    /// </summary>
+    public class PushToStaticFeed : MSBuild.Task
+    {
+        /// <summary>
+        /// Target to where the assets should be published.
+        /// E.g., https://blab.blob.core.windows.net/container/index.json
+        /// </summary>
+        [Required]
+        public string ExpectedFeedUrl { get; set; }
+
+        /// <summary>
+        /// Account key to the feed storage.
+        /// </summary>
+        [Required]
+        public string AccountKey { get; set; }
+
+        /// <summary>
+        /// When set to true packages with the same name will be overriden on 
+        /// the target feed.
+        /// </summary>
+        public bool Overwrite { get; set; }
+
+        /// <summary>
+        /// Enables idempotency when Overwrite is false.
+        /// 
+        /// false: (default) Attempting to upload an item that already exists fails.
+        /// 
+        /// true: When an item already exists, download the existing blob to check if it's
+        /// byte-for-byte identical to the one being uploaded. If so, pass. If not, fail.
+        /// </summary>
+        public bool PassIfExistingItemIdentical { get; set; }
+
+        /// <summary>
+        /// Maximum number of concurrent pushes of assets to the flat container.
+        /// </summary>
+        public int MaxClients { get; set; } = 8;
+
+        /// <summary>
+        /// Maximum allowed timeout per upload request to the flat container.
+        /// </summary>
+        public int UploadTimeoutInMinutes { get; set; } = 5;
+
+        /// <summary>
+        /// Full path to the assets to publish manifest.
+        /// </summary>
+        [Required]
+        public string AssetManifestPath { get; set; }
+
+        /// <summary>
+        /// Full path to the folder containing blob assets.
+        /// </summary>
+        public string BlobAssetsBasePath { get; set; }
+
+        /// <summary>
+        /// Full path to the folder containing package assets.
+        /// </summary>
+        public string PackageAssetsBasePath { get; set; }
+
+        public override bool Execute()
+        {
+            return ExecuteAsync().GetAwaiter().GetResult();
+        }
+
+        public async Task<bool> ExecuteAsync()
+        {
+            try
+            {
+                Log.LogMessage(MessageImportance.High, "Performing push feeds.");
+
+                if (string.IsNullOrEmpty(ExpectedFeedUrl) || string.IsNullOrEmpty(AccountKey))
+                {
+                    Log.LogError($"{nameof(ExpectedFeedUrl)} / {nameof(AccountKey)} is not set properly.");
+                }
+                else if (string.IsNullOrEmpty(AssetManifestPath) || !File.Exists(AssetManifestPath))
+                {
+                    Log.LogError($"Problem reading asset manifest path from {AssetManifestPath}");
+                }
+                else if (MaxClients <= 0)
+                {
+                    Log.LogError($"{nameof(MaxClients)} should be greater than zero.");
+                }
+                else if (UploadTimeoutInMinutes <= 0)
+                {
+                    Log.LogError($"{nameof(UploadTimeoutInMinutes)} should be greater than zero.");
+                }
+
+                var buildModel = BuildManifestUtil.ManifestFileToModel(AssetManifestPath, Log);
+                var blobFeedAction = new BlobFeedAction(ExpectedFeedUrl, AccountKey, Log);
+                var pushOptions = new PushOptions
+                {
+                    AllowOverwrite = Overwrite,
+                    PassIfExistingItemIdentical = PassIfExistingItemIdentical
+                };
+
+                if (buildModel.Artifacts.Packages.Any())
+                {
+                    if (string.IsNullOrEmpty(PackageAssetsBasePath) || !Directory.Exists(PackageAssetsBasePath))
+                    {
+                        Log.LogError($"Invalid {nameof(PackageAssetsBasePath)} was informed: {PackageAssetsBasePath}");
+                        return false;
+                    }
+
+                    PackageAssetsBasePath = PackageAssetsBasePath.TrimEnd(Path.DirectorySeparatorChar,
+                        Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+
+                    var packages = buildModel.Artifacts.Packages.Select(p => $"{PackageAssetsBasePath}{p.Id}.{p.Version}.nupkg");
+
+                    await blobFeedAction.PushToFeedAsync(packages, pushOptions);
+                }
+
+                if (buildModel.Artifacts.Blobs.Any())
+                {
+                    if (string.IsNullOrEmpty(BlobAssetsBasePath) || !Directory.Exists(BlobAssetsBasePath))
+                    {
+                        Log.LogError($"Invalid {nameof(BlobAssetsBasePath)} was informed: {BlobAssetsBasePath}");
+                        return false;
+                    }
+
+                    BlobAssetsBasePath = BlobAssetsBasePath.TrimEnd(Path.DirectorySeparatorChar,
+                        Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+
+                    var blobs = buildModel.Artifacts.Blobs
+                        .Select(blob =>
+                        {
+                            var fileName = Path.GetFileName(blob.Id);
+                            return new MSBuild.TaskItem($"{BlobAssetsBasePath}{fileName}", new Dictionary<string, string>
+                            {
+                                {"RelativeBlobPath", $"{BuildManifestUtil.AssetsVirtualDir}{blob.Id}"}
+                            });
+                        })
+                        .ToArray();
+
+                    await blobFeedAction.PublishToFlatContainerAsync(blobs, MaxClients, UploadTimeoutInMinutes, pushOptions);
+                }
+            }
+            catch (Exception e)
+            {
+                Log.LogErrorFromException(e, true);
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+    }
+}


### PR DESCRIPTION
Closes: #1587

This PR create a new MSBuild task in Tasks.Feed that is able to parse a build assets manifest and publish the assets to a static feed. 

This task is part of the work on redesigning [the publishing mechanism](https://github.com/dotnet/arcade/issues/1179). In the future, Arcade `publish.proj` will use `PushToAzureDevOpsArtifacts` to publish build assets to AzDO pipeline artifacts and create a build manifest. After a build complete a release pipeline will be triggered by Maestro, that release pipeline will read the build manifest and use this new task (and others) to publish the assets to some target location.

**What changed:**

- Tasks.Feed.targets : just added code to export the new task
- BlobFeedAction.cs : moved the `PublishToFlatContainerAsync` routine that was in PublishToBlobFeed in there because it will also be used by the new task.
- PushToStaticFeed.cs : new task that reads the manifest and publish the assets.
- PushToBlobFeed.cs : moved the `PublishToFlatContainerAsync` routine to BlobFeedAction.cs
- BuildManifestUtil.cs : added a method to read a manifest file and parse it to a BuildModel object.