### PR TITLE
Unblock dotnet/sdk build with small fixes

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -138,7 +138,7 @@ function InitializeDotNetCli([bool]$install) {
 
   # Add dotnet to PATH. This prevents any bare invocation of dotnet in custom
   # build steps from using anything other than what we've downloaded.
-  # It also  ensures that VS msbuild will use the downloaded sdk targets.
+  # It also ensures that VS msbuild will use the downloaded sdk targets.
   $env:PATH = "$dotnetRoot;$env:PATH"
 
   return $global:_DotNetInstallDir = $dotnetRoot
@@ -174,13 +174,13 @@ function InstallDotNetSdk([string] $dotnetRoot, [string] $version) {
 # Returns full path to msbuild.exe.
 # Throws on failure.
 #
-function InitializeVisualStudioMSBuild([bool]$install, [object]$vs = $null) {
+function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements = $null) {
   if (Test-Path variable:global:_MSBuildExe) {
     return $global:_MSBuildExe
   }
 
-  if (!$vs) { $vs = $GlobalJson.tools.vs }
-  $vsMinVersionStr = if ($vs.version) { $vs.version } else { "15.9" }
+  if (!$vsRequirements) { $vsRequirements = $GlobalJson.tools.vs }
+  $vsMinVersionStr = if ($vsRequirements.version) { $vsRequirements.version } else { "15.9" }
   $vsMinVersion = [Version]::new($vsMinVersionStr) 
 
   # Try msbuild command available in the environment.
@@ -197,7 +197,7 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vs = $null) {
   }
 
   # Locate Visual Studio installation or download x-copy msbuild.
-  $vsInfo = LocateVisualStudio $vs
+  $vsInfo = LocateVisualStudio $vsRequirements
   if ($vsInfo -ne $null) {
     $vsInstallDir = $vsInfo.installationPath
     $vsMajorVersion = $vsInfo.installationVersion.Split('.')[0]
@@ -261,7 +261,7 @@ function InstallXCopyMSBuild([string] $packageVersion) {
 # Returns JSON describing the located VS instance (same format as returned by vswhere), 
 # or $null if no instance meeting the requirements is found on the machine.
 #
-function LocateVisualStudio([object]$vs = $null){
+function LocateVisualStudio([object]$vsRequirements = $null){
   if (Get-Member -InputObject $GlobalJson.tools -Name "vswhere") {
     $vswhereVersion = $GlobalJson.tools.vswhere
   } else {
@@ -277,16 +277,16 @@ function LocateVisualStudio([object]$vs = $null){
     Invoke-WebRequest "https://github.com/Microsoft/vswhere/releases/download/$vswhereVersion/vswhere.exe" -OutFile $vswhereExe
   }
 
-  if (!$vs) { $vs = $GlobalJson.tools.vs }
+  if (!$vsRequirements) { $vsRequirements = $GlobalJson.tools.vs }
   $args = @("-latest", "-prerelease", "-format", "json", "-requires", "Microsoft.Component.MSBuild")
   
-  if (Get-Member -InputObject $vs -Name "version") { 
+  if (Get-Member -InputObject $vsRequirements -Name "version") {
     $args += "-version"
-    $args += $vs.version
+    $args += $vsRequirements.version
   }
 
-  if (Get-Member -InputObject $vs -Name "components") { 
-    foreach ($component in $vs.components) {
+  if (Get-Member -InputObject $vsRequirements -Name "components") {
+    foreach ($component in $vsRequirements.components) {
       $args += "-requires"
       $args += $component
     }    

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -174,12 +174,13 @@ function InstallDotNetSdk([string] $dotnetRoot, [string] $version) {
 # Returns full path to msbuild.exe.
 # Throws on failure.
 #
-function InitializeVisualStudioMSBuild([bool]$install) {
+function InitializeVisualStudioMSBuild([bool]$install, [object]$vs = $null) {
   if (Test-Path variable:global:_MSBuildExe) {
     return $global:_MSBuildExe
   }
 
-  $vsMinVersionStr = if ($GlobalJson.tools.vs.version) { $GlobalJson.tools.vs.version } else { "15.9" }
+  if (!$vs) { $vs = $GlobalJson.tools.vs }
+  $vsMinVersionStr = if ($vs.version) { $vs.version } else { "15.9" }
   $vsMinVersion = [Version]::new($vsMinVersionStr) 
 
   # Try msbuild command available in the environment.
@@ -196,7 +197,7 @@ function InitializeVisualStudioMSBuild([bool]$install) {
   }
 
   # Locate Visual Studio installation or download x-copy msbuild.
-  $vsInfo = LocateVisualStudio  
+  $vsInfo = LocateVisualStudio $vs
   if ($vsInfo -ne $null) {
     $vsInstallDir = $vsInfo.installationPath
     $vsMajorVersion = $vsInfo.installationVersion.Split('.')[0]
@@ -260,7 +261,7 @@ function InstallXCopyMSBuild([string] $packageVersion) {
 # Returns JSON describing the located VS instance (same format as returned by vswhere), 
 # or $null if no instance meeting the requirements is found on the machine.
 #
-function LocateVisualStudio {
+function LocateVisualStudio([object]$vs = $null){
   if (Get-Member -InputObject $GlobalJson.tools -Name "vswhere") {
     $vswhereVersion = $GlobalJson.tools.vswhere
   } else {
@@ -276,7 +277,7 @@ function LocateVisualStudio {
     Invoke-WebRequest "https://github.com/Microsoft/vswhere/releases/download/$vswhereVersion/vswhere.exe" -OutFile $vswhereExe
   }
 
-  $vs = $GlobalJson.tools.vs
+  if (!$vs) { $vs = $GlobalJson.tools.vs }
   $args = @("-latest", "-prerelease", "-format", "json", "-requires", "Microsoft.Component.MSBuild")
   
   if (Get-Member -InputObject $vs -Name "version") { 

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -136,6 +136,11 @@ function InitializeDotNetCli([bool]$install) {
     $env:DOTNET_INSTALL_DIR = $dotnetRoot
   }
 
+  # Add dotnet to PATH. This prevents any bare invocation of dotnet in custom
+  # build steps from using anything other than what we've downloaded.
+  # It also  ensures that VS msbuild will use the downloaded sdk targets.
+  $env:PATH = "$dotnetRoot;$env:PATH"
+
   return $global:_DotNetInstallDir = $dotnetRoot
 }
 

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -179,7 +179,7 @@ function InitializeVisualStudioMSBuild([bool]$install) {
     return $global:_MSBuildExe
   }
 
-  $vsMinVersionStr = if (!$GlobalJson.tools.vs.version) { $GlobalJson.tools.vs.version } else { "15.9" }
+  $vsMinVersionStr = if ($GlobalJson.tools.vs.version) { $GlobalJson.tools.vs.version } else { "15.9" }
   $vsMinVersion = [Version]::new($vsMinVersionStr) 
 
   # Try msbuild command available in the environment.

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -136,6 +136,10 @@ function InitializeDotNetCli {
     fi
   fi
 
+  # Add dotnet to PATH. This prevents any bare invocation of dotnet in custom
+  # build steps from using anything other than what we've downloaded.
+  export PATH="$dotnet_root:$PATH"
+
   # return value
   _InitializeDotNetCli="$dotnet_root"
 }


### PR DESCRIPTION
1. dotnet was not added to PATH so building with full msbuild would not use a dotnet that was downloaded based on global.json
2. The condition for default minimum VS version was inverted, it would ignore the version in global.json and use 15.9 always.
3. Make it possible to locate a given version of VS for other purposes without requiring it and using it for all builds


