### PR TITLE
Add additional support to SignTool

### DIFF
--- a/src/Microsoft.DotNet.SignTool/src/Configuration.cs
+++ b/src/Microsoft.DotNet.SignTool/src/Configuration.cs
@@ -77,6 +77,12 @@ namespace Microsoft.DotNet.SignTool
         /// sign already signed binaries.
         /// </summary>
         private readonly string[] _dualCertificates;
+
+        /// <summary>
+        /// Use the content hash in the path of the extracted file paths. 
+        /// The default is to use a unique content id based on the number of items extracted.
+        /// </summary>
+        private readonly bool _useHashInExtractionPath; 
         
         /// <summary>
         /// A list of files whose content needs to be overwritten by signed content from a different file.
@@ -86,7 +92,7 @@ namespace Microsoft.DotNet.SignTool
 
         public Configuration(string tempDir, string[] itemsToSign, Dictionary<string, SignInfo> strongNameInfo,
             Dictionary<ExplicitCertificateKey, string> fileSignInfo, Dictionary<string, SignInfo> extensionSignInfo,
-            string[] dualCertificates, TaskLoggingHelper log)
+            string[] dualCertificates, TaskLoggingHelper log, bool useHashInExtractionPath = false)
         {
             Debug.Assert(tempDir != null);
             Debug.Assert(itemsToSign != null && !itemsToSign.Any(i => i == null));
@@ -94,6 +100,7 @@ namespace Microsoft.DotNet.SignTool
             Debug.Assert(fileSignInfo != null);
 
             _pathToContainerUnpackingDirectory = Path.Combine(tempDir, "ContainerSigning");
+            _useHashInExtractionPath = useHashInExtractionPath;
             _log = log;
             _strongNameInfo = strongNameInfo;
             _fileSignInfo = fileSignInfo;
@@ -106,6 +113,39 @@ namespace Microsoft.DotNet.SignTool
             _dualCertificates = dualCertificates ?? new string[0];
             _whichPackagesTheFileIsIn = new Dictionary<SignedFileContentKey, HashSet<string>>();
             _errors = new Dictionary<SigningToolErrorCode, HashSet<SignedFileContentKey>>();
+        }
+
+        internal void ReadExistingContainerSigningCache()
+        {
+            _log.LogMessage("Loading existing files from cache");
+            foreach (var file in Directory.EnumerateFiles(_pathToContainerUnpackingDirectory, "*.*", SearchOption.AllDirectories))
+            {
+                string cacheRelative = file.Replace(_pathToContainerUnpackingDirectory + Path.DirectorySeparatorChar, "");
+                int indexOfHash = cacheRelative.IndexOf(Path.DirectorySeparatorChar);
+
+                if (indexOfHash <= 0)
+                {
+                    continue;
+                }
+
+                // When reading from an existing cache use the already computed hash from the directory
+                // structure instead of computing it from the file because things like signing 
+                // might have changed the hash but we want to still use the same hash of the unsigned
+                // file that originally built the cache. 
+                string stringHash = cacheRelative.Substring(0, indexOfHash);
+
+                try
+                {
+                    ImmutableArray<byte> contentHash = ContentUtil.StringToHash(stringHash);
+                }
+                catch {
+                    _log.LogMessage($"Failed to parse the content hash from path '{file}' so skipping it.");
+                    continue;
+                }
+
+                TrackFile(file, ContentUtil.StringToHash(stringHash), false);
+            }
+            _log.LogMessage("Done loading existing files from cache");
         }
 
         internal BatchSignInput GenerateListOfFiles()
@@ -157,6 +197,7 @@ namespace Microsoft.DotNet.SignTool
 
         private FileSignInfo TrackFile(string fullPath, ImmutableArray<byte> contentHash, bool isNested)
         {
+            _log.LogMessage($"Tracking file '{fullPath}' isNested={isNested}");
             var fileSignInfo = ExtractSignInfo(fullPath, contentHash);
 
             var key = new SignedFileContentKey(contentHash, Path.GetFileName(fullPath));
@@ -181,6 +222,7 @@ namespace Microsoft.DotNet.SignTool
                 }
             }
 
+            _log.LogMessage($"Caching file {key.FileName}");
             _filesByContentKey.Add(key, fileSignInfo);
 
             if (fileSignInfo.SignInfo.ShouldSign || fileSignInfo.IsZipContainer())
@@ -462,8 +504,10 @@ namespace Microsoft.DotNet.SignTool
                         // if we already encountered file that hash the same content we can reuse its signed version when repackaging the container.
                         var fileName = Path.GetFileName(relativePath);
                         if (!_filesByContentKey.TryGetValue(new SignedFileContentKey(contentHash, fileName), out var fileSignInfo))
-                        {
-                            string tempPath = Path.Combine(_pathToContainerUnpackingDirectory, _filesByContentKey.Count().ToString(), relativePath);
+                        { 
+                            string extractPathRoot = _useHashInExtractionPath ? ContentUtil.HashToString(contentHash) : _filesByContentKey.Count().ToString();
+                            string tempPath = Path.Combine(_pathToContainerUnpackingDirectory, extractPathRoot, relativePath);
+                            _log.LogMessage($"Extracting file '{fileName}' from '{zipFileSignInfo.FullPath}' to '{tempPath}'.");
 
                             Directory.CreateDirectory(Path.GetDirectoryName(tempPath));
 

--- a/src/Microsoft.DotNet.SignTool/src/ContentUtil.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ContentUtil.cs
@@ -36,6 +36,16 @@ namespace Microsoft.DotNet.SignTool
         public static string HashToString(ImmutableArray<byte> hash)
             => BitConverter.ToString(hash.ToArray()).Replace("-", "");
 
+        public static ImmutableArray<byte> StringToHash(string hash)
+        {
+            int NumberChars = hash.Length;
+            byte[] bytes = new byte[NumberChars / 2];
+            for (int i = 0; i < NumberChars; i += 2)
+                bytes[i / 2] = Convert.ToByte(hash.Substring(i, 2), 16);
+            return bytes.ToImmutableArray<byte>();
+
+        }
+
         /// <summary>
         /// Returns true if the PE file meets all of the pre-conditions to be Open Source Signed.
         /// Returns false and logs msbuild errors otherwise.

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -39,6 +39,25 @@ namespace Microsoft.DotNet.SignTool
         public bool DoStrongNameCheck { get; set; }
 
         /// <summary>
+        /// By default in non-DryRun cases we verify the vsix and nuget packages contain a signature file
+        /// This option disables that check in cases you want to sign the container at a later step. 
+        /// </summary>
+        public bool SkipZipContainerSignatureMarkerCheck { get; set; }
+
+        /// <summary>
+        /// For some cases you may need to run the sign tool more than once and if you do you want to
+        /// share the same cache directory which contains already signed binaries. In those cases
+        /// set this property to true to reuse that file cache.
+        /// </summary>
+        public bool ReadExistingContainerSigningCache { get; set; }
+
+        /// <summary>
+        /// Use the content hash in the path of the extracted file paths. 
+        /// The default is to use a unique content id based on the number of items extracted.
+        /// </summary>
+        public bool UseHashInExtractionPath { get; set; }
+
+        /// <summary>
         /// Working directory used for storing files created during signing.
         /// </summary>
         [Required]
@@ -172,11 +191,20 @@ namespace Microsoft.DotNet.SignTool
 
             var signToolArgs = new SignToolArgs(TempDir, MicroBuildCorePath, TestSign, MSBuildPath, LogDir, enclosingDir, SNBinaryPath);
             var signTool = DryRun ? new ValidationOnlySignTool(signToolArgs, Log) : (SignTool)new RealSignTool(signToolArgs, Log);
-            var signingInput = new Configuration(TempDir, ItemsToSign, strongNameInfo, fileSignInfo, extensionSignInfo, dualCertificates, Log).GenerateListOfFiles();
+            var configuration = new Configuration(TempDir, ItemsToSign, strongNameInfo, fileSignInfo, extensionSignInfo, dualCertificates, Log, useHashInExtractionPath: UseHashInExtractionPath);
+
+            if (ReadExistingContainerSigningCache)
+            {
+                configuration.ReadExistingContainerSigningCache();
+            }
+
+            var signingInput = configuration.GenerateListOfFiles();
 
             if (Log.HasLoggedErrors) return;
 
             var util = new BatchSignUtil(BuildEngine, Log, signTool, signingInput, ItemsToSkipStrongNameCheck);
+
+            util.SkipZipContainerSignatureMarkerCheck = this.SkipZipContainerSignatureMarkerCheck;
 
             if (Log.HasLoggedErrors) return;
 

--- a/src/Microsoft.DotNet.SignTool/src/SignedFileContentKey.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignedFileContentKey.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.SignTool
     /// </summary>
     internal struct SignedFileContentKey : IEquatable<SignedFileContentKey>
     {
-        public readonly ImmutableArray<byte> ContentHash;
+        public readonly string StringHash;
         public readonly string FileName;
 
         public SignedFileContentKey(ImmutableArray<byte> contentHash, string fileName)
@@ -23,7 +23,13 @@ namespace Microsoft.DotNet.SignTool
             Debug.Assert(!contentHash.IsDefault);
             Debug.Assert(fileName != null);
 
-            ContentHash = contentHash;
+            StringHash = ContentUtil.HashToString(contentHash);
+            FileName = fileName;
+        }
+
+        public SignedFileContentKey(string stringHash, string fileName)
+        {
+            StringHash = stringHash;
             FileName = fileName;
         }
 
@@ -31,10 +37,10 @@ namespace Microsoft.DotNet.SignTool
             => obj is SignedFileContentKey key && Equals(key);
 
         public override int GetHashCode()
-            => Hash.Combine(FileName, ByteSequenceComparer.GetHashCode(ContentHash));
+            => Hash.Combine(FileName, StringHash.GetHashCode());
 
         bool IEquatable<SignedFileContentKey>.Equals(SignedFileContentKey other)
-            => FileName == other.FileName && ByteSequenceComparer.Equals(ContentHash, other.ContentHash);
+            => FileName == other.FileName && StringHash == other.StringHash;
 
         public static bool operator ==(SignedFileContentKey key1, SignedFileContentKey key2)
             => key1.Equals(key2);


### PR DESCRIPTION
This change adds the following:
1) Fixes issue with null list of strong name files to skip verification
2) Adds option to use content hash in extraction path for package extraction
3) Adds option to skip validation of container verification
4) Adds option to read and reuse extracted package caches across runs
5) Adds some additional logging messages to know the files we are working with

This enables someone to run the signtool task more then once and use features
of the signtool task like unpacking and repacking as well as signing validation
while not necessarily using microbuild to sign. Ideally this functionality would
be factored out into separate tasks but for now it accomplishes the job.

For my current team we are using a process along the lines of:
1) Use signtool in DryRun=true mode to extract a set of binaries from packages
2) Use external signing service sign binaries in the cache
3) Use signtool in real mode with the new reuse cache option which
will cause the repackaging and signing validation to run (excluding
package siging validation). Note we also need to dummy out the microbuild
targets to make the msbuild sign job a no-op.
4) Use external signing service to sign packages.

PTAL @JohnTortugo @tmat 
cc @markwilkie @kurtzeborn