### PR TITLE
Adding GenerateSourceWithPublicTypesAsInternal task

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateSourceWithPublicTypesAsInternal.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateSourceWithPublicTypesAsInternal.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging
+{
+    public class GenerateSourceWithPublicTypesAsInternal : BuildTask
+    {
+        /// <summary>
+        /// Collection that will hold the map of the paths to the original files, and the path to the generated ones which will be rewritten.
+        /// </summary>
+        private Dictionary<string, string> _sourceFiles;
+
+        [Required]
+        public ITaskItem[] Files
+        {
+            get;
+            set;
+        }
+
+        public override bool Execute()
+        {
+            _sourceFiles = new Dictionary<string, string>();
+            foreach (ITaskItem file in Files)
+            {
+                string sourcePath = file.GetMetadata("SourcePath");
+                string destinationPath = file.GetMetadata("DestinationPath");
+                if (string.IsNullOrEmpty(sourcePath) || string.IsNullOrEmpty(destinationPath))
+                {
+                    Log.LogError($"Item {file.GetMetadata("Identity")} doesn't define SourcePath or DestinationPath metdata.");
+                }
+                _sourceFiles.Add(sourcePath, destinationPath);
+            }
+
+            var sourceTrees = GetSourceTrees();
+            foreach (SyntaxTree sourceTree in sourceTrees)
+            {
+                PublicTypesToInternalRewriter rewriter = new PublicTypesToInternalRewriter();
+                SyntaxNode newRootNode = rewriter.Visit(sourceTree.GetRoot());
+
+                File.WriteAllText(sourceTree.FilePath, newRootNode.ToFullString());
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private IEnumerable<SyntaxTree> GetSourceTrees()
+        {
+            List<SyntaxTree> result = new List<SyntaxTree>();
+            foreach (var sourceFile in _sourceFiles)
+            {
+                string rawText = File.ReadAllText(sourceFile.Key);
+                SyntaxTree tree = CSharpSyntaxTree.ParseText(rawText).WithFilePath(sourceFile.Value);
+                result.Add(tree);
+            }
+            return result;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateSourceWithPublicTypesAsInternal.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateSourceWithPublicTypesAsInternal.cs
@@ -46,9 +46,10 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             {
                 PublicTypesToInternalRewriter rewriter = new PublicTypesToInternalRewriter();
                 SyntaxNode newRootNode = rewriter.Visit(sourceTree.GetRoot());
-                if (!Directory.Exists(Path.GetDirectoryName(sourceTree.FilePath)))
+                string directoryPath = Path.GetDirectoryName(sourceTree.FilePath);
+                if (!Directory.Exists(directoryPath))
                 {
-                    Directory.CreateDirectory(Path.GetDirectoryName(sourceTree.FilePath));
+                    Directory.CreateDirectory(directoryPath);
                 }
                 File.WriteAllText(sourceTree.FilePath, newRootNode.ToFullString());
             }

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;$(NetFxTfm)</TargetFrameworks>
@@ -57,6 +57,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
+    <!--Need to reference version 2.8.2 of CodeAnalysis so that we don't have downgrade issues with System.Reflection.Metadata version-->
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.8.2" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="NuGet.Commands" Version="$(NuGetVersion)" />
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetVersion)" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PublicTypesToInternalRewriter.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PublicTypesToInternalRewriter.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging
+{
+    internal class PublicTypesToInternalRewriter : CSharpSyntaxRewriter
+    {
+        public PublicTypesToInternalRewriter()
+            : base(false) { }
+
+        public override SyntaxNode VisitStructDeclaration(StructDeclarationSyntax node)
+        {
+            return base.VisitStructDeclaration((StructDeclarationSyntax)ChangePublicDeclarationToInternal(node));
+        }
+
+        public override SyntaxNode VisitInterfaceDeclaration(InterfaceDeclarationSyntax node)
+        {
+            return base.VisitInterfaceDeclaration((InterfaceDeclarationSyntax)ChangePublicDeclarationToInternal(node));
+        }
+
+        public override SyntaxNode VisitEnumDeclaration(EnumDeclarationSyntax node)
+        {
+            return base.VisitEnumDeclaration((EnumDeclarationSyntax)ChangePublicDeclarationToInternal(node));
+        }
+
+        public override SyntaxNode VisitClassDeclaration(ClassDeclarationSyntax node)
+        {
+            return base.VisitClassDeclaration((ClassDeclarationSyntax)ChangePublicDeclarationToInternal(node));
+        }
+
+        private SyntaxNode ChangePublicDeclarationToInternal(BaseTypeDeclarationSyntax node)
+        {
+            SyntaxToken publicToken;
+            if (HasPublicModifier(node, out publicToken))
+            {
+                return node.ReplaceToken(publicToken, SyntaxFactory.Token(SyntaxKind.InternalKeyword)
+                                                                    .WithLeadingTrivia(publicToken.LeadingTrivia)
+                                                                    .WithTrailingTrivia(publicToken.TrailingTrivia));
+            }
+            else
+            {
+                return node;
+            }
+        }
+
+        private bool HasPublicModifier(BaseTypeDeclarationSyntax token, out SyntaxToken publicToken)
+        {
+            foreach (var modifier in token.Modifiers)
+            {
+                if (modifier.Text.ToLowerInvariant() == "public")
+                {
+                    publicToken = modifier;
+                    return true;
+                }
+            }
+            publicToken = default(SyntaxToken);
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PublicTypesToInternalRewriter.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PublicTypesToInternalRewriter.cs
@@ -35,8 +35,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
         private SyntaxNode ChangePublicDeclarationToInternal(BaseTypeDeclarationSyntax node)
         {
-            SyntaxToken publicToken;
-            if (HasPublicModifier(node, out publicToken))
+            if (HasPublicModifier(node, out SyntaxToken publicToken))
             {
                 return node.ReplaceToken(publicToken, SyntaxFactory.Token(SyntaxKind.InternalKeyword)
                                                                     .WithLeadingTrivia(publicToken.LeadingTrivia)
@@ -50,9 +49,9 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
         private bool HasPublicModifier(BaseTypeDeclarationSyntax token, out SyntaxToken publicToken)
         {
-            foreach (var modifier in token.Modifiers)
+            foreach (SyntaxToken modifier in token.Modifiers)
             {
-                if (modifier.Text.ToLowerInvariant() == "public")
+                if (modifier.Text == "public")
                 {
                     publicToken = modifier;
                     return true;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.common.targets
@@ -27,6 +27,7 @@
   <UsingTask TaskName="GeneratePackageReport" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="GenerateRuntimeGraph" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="GenerateRuntimeDependencies" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="GenerateSourceWithPublicTypesAsInternal" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll" />
   <UsingTask TaskName="GetApplicableAssetsFromPackages" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="GetAssemblyReferences" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="GetInboxFrameworks" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
@@ -493,7 +493,7 @@
       take the source files that need to be packaged, and it will use
       a roslyn-based task to convert all of the public exposed types on
       those files into internal types instead.-->
-  <Target Name="GenerateInternalTypesSource" Condition="'$(GenerateInternalTypesSource)' == 'true'">
+  <Target Name="GenerateInternalTypesSource" Condition="'$(GenerateInternalTypesSource)' == 'true' AND '@(SourcePackageFiles)' != ''">
     <ItemGroup>
       <_NewSourcesToPackage Include="@(SourcePackageFiles)">
         <SourcePath>%(Identity)</SourcePath>
@@ -516,8 +516,11 @@
       all source files that need to be packaged into it. Each source file must have the 
       PackagePath metadata defined, which is the location of where the source file will
       end up in the package-->
-  <Target Name="AddSourceToFilesToPackage" BeforeTargets="GetFiles" DependsOnTargets="GenerateInternalTypesSource" Condition="'@(SourcePackageFiles)' != ''">
-    <Error Condition="'%(SourcePackageFiles.PackagePath)' == ''" Text="Item &quot;%(SourcePackageFiles.Identity)&quot; does not define required metadata &quot;PackagePath&quot;" />
+  <Target Name="AddSourceToFilesToPackage" BeforeTargets="GetFiles"
+                                           DependsOnTargets="GenerateInternalTypesSource"
+                                           Condition="'@(SourcePackageFiles)' != ''">
+    <Error Condition="'%(SourcePackageFiles.PackagePath)' == ''"
+           Text="Item &quot;%(SourcePackageFiles.Identity)&quot; does not define required metadata &quot;PackagePath&quot;" />
 
     <ItemGroup>
       <File Include="@(SourcePackageFiles)">

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
@@ -487,6 +487,44 @@
       </PackageFile>
     </ItemGroup>
   </Target>
+
+  <!--This target will run when building a source package and
+      property GenerateInternalTypesSource is set to true. It will
+      take the source files that need to be packaged, and it will use
+      a roslyn-based task to convert all of the public exposed types on
+      those files into internal types instead.-->
+  <Target Name="GenerateInternalTypesSource" Condition="'$(GenerateInternalTypesSource)' == 'true'">
+    <ItemGroup>
+      <_NewSourcesToPackage Include="@(SourcePackageFiles)">
+        <SourcePath>%(Identity)</SourcePath>
+        <DestinationPath>$(IntermediateOutputPath)%(RecursiveDir)%(FileName)%(Extension)</DestinationPath>
+      </_NewSourcesToPackage>
+
+      <SourcePackageFiles Remove="@(SourcePackageFiles)" />
+      <SourcePackageFiles Include="@(_NewSourcesToPackage -> '%(DestinationPath)')">
+        <OriginalIdentity>%(Identity)</OriginalIdentity>
+      </SourcePackageFiles>
+      <FileWrites Include="@(SourcePackageFiles)" />
+    </ItemGroup>
+
+    <GenerateSourceWithPublicTypesAsInternal
+                            Files="@(SourcePackageFiles)" />
+  </Target>
+  
+  <!--Target that will add the specified source files into the package.
+      In order for this target to run, define SourcePackageFiles item by includding
+      all source files that need to be packaged into it. Each source file must have the 
+      PackagePath metadata defined, which is the location of where the source file will
+      end up in the package-->
+  <Target Name="AddSourceToFilesToPackage" BeforeTargets="GetFiles" DependsOnTargets="GenerateInternalTypesSource" Condition="'@(SourcePackageFiles)' != ''">
+    <Error Condition="'%(SourcePackageFiles.PackagePath)' == ''" Text="Item &quot;%(SourcePackageFiles.Identity)&quot; does not define required metadata &quot;PackagePath&quot;" />
+
+    <ItemGroup>
+      <File Include="@(SourcePackageFiles)">
+        <TargetPath>%(SourcePackageFiles.PackagePath)</TargetPath>
+      </File>
+    </ItemGroup>
+  </Target>
   <!-- END files-->
 
   <!-- BEGIN dependencies-->


### PR DESCRIPTION
cc: @ericstj @ahsonkhan @safern 

Adding Task that will generate a copy of the specified files while rewriting all public types to internal so that they can be packaged as a source package. We will use this as part of creating our System.Text.Json source package.

NOTE: This can still be considered as WIP since I need to add the targets that we will call from the build here as well, so that will be part of this PR.