### PR TITLE
Fix suffix on net47 test task dll

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/Microsoft.DotNet.CoreFxTesting.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/Microsoft.DotNet.CoreFxTesting.props
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <MSBuildTestAssemblyPath Condition="'$(MSBuildRuntimeType)' == 'core'">$(MSBuildThisFileDirectory)\..\tools\netcoreapp2.1\Microsoft.DotNet.CoreFxTesting.dll</MSBuildTestAssemblyPath>
-    <MSBuildTestAssemblyPath Condition="'$(MSBuildRuntimeType)' != 'core'">$(MSBuildThisFileDirectory)\..\tools\net472\Microsoft.DotNet.CoreFxTesting.exe</MSBuildTestAssemblyPath>
+    <MSBuildTestAssemblyPath Condition="'$(MSBuildRuntimeType)' != 'core'">$(MSBuildThisFileDirectory)\..\tools\net472\Microsoft.DotNet.CoreFxTesting.dll</MSBuildTestAssemblyPath>
 
     <TestCoreDir>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'core'))</TestCoreDir>
     <TestAssetsDir>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'assets'))</TestAssetsDir>


### PR DESCRIPTION
Confirmed that this allows it to find the dll.