### PR TITLE
Create MSBuild project that will be used by publishing release pipeline

### DIFF
--- a/eng/common/PublishToPackageFeed.proj
+++ b/eng/common/PublishToPackageFeed.proj
@@ -10,20 +10,16 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- Which version of the Tasks.Feed package should be used. -->
-    <MicrosoftDotNetBuildTasksFeedVersion Condition="'$(MicrosoftDotNetBuildTasksFeedVersion)' == ''">2.2.0-beta.18614.10</MicrosoftDotNetBuildTasksFeedVersion>
-  </PropertyGroup>
-
+  <Import Project="$(MSBuildThisFileDirectory)MicrosoftDotNetBuildTasksFeedVersion.props" />
   <Import Project="$(NuGetPackageRoot)microsoft.dotnet.build.tasks.feed\$(MicrosoftDotNetBuildTasksFeedVersion)\build\Microsoft.DotNet.Build.Tasks.Feed.targets" />
 
   <Target Name="PublishToFeed">
-    <Error Condition="'$(TargetStaticFeed)' == ''" Text="TargetStaticFeed: Target feed for publishing assets wasn't informed." />
-    <Error Condition="'$(AccountKeyToStaticFeed)' == ''" Text="AccountKeyToStaticFeed: Account key for target feed wasn't informed." />
-    <Error Condition="'$(FullPathAssetManifest)' == ''" Text="Full path to asset manifest wasn't informed." />
+    <Error Condition="'$(TargetStaticFeed)' == ''" Text="TargetStaticFeed: Target feed for publishing assets wasn't provided." />
+    <Error Condition="'$(AccountKeyToStaticFeed)' == ''" Text="AccountKeyToStaticFeed: Account key for target feed wasn't provided." />
+    <Error Condition="'$(FullPathAssetManifest)' == ''" Text="Full path to asset manifest wasn't provided." />
     <Error Condition="'$(FullPathBlobBasePath)' == '' AND '$(FullPathPackageBasePath)' == ''" Text="A valid full path to BlobBasePath of PackageBasePath is required." />
 
-    <PushToStaticFeed
+    <PushArtifactsInManifestToFeed
       ExpectedFeedUrl="$(TargetStaticFeed)"
       AccountKey="$(AccountKeyToStaticFeed)"
       Overwrite="$(OverrideAssetsWithSameName)"

--- a/eng/common/PublishToPackageFeed.proj
+++ b/eng/common/PublishToPackageFeed.proj
@@ -1,0 +1,41 @@
+<!--
+  This MSBuild file is intended to be used as the body of the default 
+  publishing release pipeline. The release pipeline will use this file
+  to invoke the PushToStaticFeed task that will read the build asset
+  manifest and publish the assets described in the manifest to
+  informed target feeds.
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Which version of the Tasks.Feed package should be used. -->
+    <MicrosoftDotNetBuildTasksFeedVersion Condition="'$(MicrosoftDotNetBuildTasksFeedVersion)' == ''">2.2.0-beta.18614.10</MicrosoftDotNetBuildTasksFeedVersion>
+  </PropertyGroup>
+
+  <Import Project="$(NuGetPackageRoot)microsoft.dotnet.build.tasks.feed\$(MicrosoftDotNetBuildTasksFeedVersion)\build\Microsoft.DotNet.Build.Tasks.Feed.targets" />
+
+  <Target Name="PublishToFeed">
+    <Error Condition="'$(TargetStaticFeed)' == ''" Text="TargetStaticFeed: Target feed for publishing assets wasn't informed." />
+    <Error Condition="'$(AccountKeyToStaticFeed)' == ''" Text="AccountKeyToStaticFeed: Account key for target feed wasn't informed." />
+    <Error Condition="'$(FullPathAssetManifest)' == ''" Text="Full path to asset manifest wasn't informed." />
+    <Error Condition="'$(FullPathBlobBasePath)' == '' AND '$(FullPathPackageBasePath)' == ''" Text="A valid full path to BlobBasePath of PackageBasePath is required." />
+
+    <PushToStaticFeed
+      ExpectedFeedUrl="$(TargetStaticFeed)"
+      AccountKey="$(AccountKeyToStaticFeed)"
+      Overwrite="$(OverrideAssetsWithSameName)"
+      PassIfExistingItemIdentical="$(PassIfExistingItemIdentical)"
+      MaxClients="$(MaxParallelUploads)"
+      UploadTimeoutInMinutes="$(MaxUploadTimeoutInMinutes)"
+      AssetManifestPath="$(FullPathAssetManifest)"
+      BlobAssetsBasePath="$(FullPathBlobBasePath)"
+      PackageAssetsBasePath="$(FullPathPackageBasePath)" />
+  </Target>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="$(MicrosoftDotNetBuildTasksFeedVersion)" />
+  </ItemGroup>
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -68,6 +68,19 @@
       </ItemsToPushToBlobFeed>
     </ItemGroup>
 
+    <!--
+      This file will be used by the publishing release pipeline to parse the asset manifest
+      and push the assets to target feeds.
+    -->
+    <Message
+      Text="##vso[artifact.upload containerfolder=PipelineArtifactsPublishingManifests;artifactname=PipelineArtifactsPublishingManifests]$(RepositoryEngineeringDir)common\PublishToPackageFeed.proj"
+      Condition="$(PublishToAzure) and '$(PushToAzureDevOps)' == 'true'"
+      Importance="high" />
+    
+    <!--
+      Work in progress drop-in replacement for PushToBlobFeed task below.
+      This is part of the work on https://github.com/dotnet/arcade/issues/1179
+    -->
     <PushToAzureDevOpsArtifacts 
       ItemsToPush="@(ItemsToPushToBlobFeed)"
       ManifestBuildData="Location=$(AzureFeedUrl)"

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -72,11 +72,22 @@
       This file will be used by the publishing release pipeline to parse the asset manifest
       and push the assets to target feeds.
     -->
+    <WriteLinesToFile
+      File="$(MSBuildThisFileDirectory)MicrosoftDotNetBuildTasksFeedVersion.props"
+      Lines="&lt;Project>&lt;PropertyGroup>&lt;MicrosoftDotNetBuildTasksFeedVersion>$(MicrosoftDotNetBuildTasksFeedVersion)&lt;/MicrosoftDotNetBuildTasksFeedVersion>&lt;/PropertyGroup>&lt;/Project>"
+      Overwrite="true"
+      Encoding="Unicode" />
+
+    <Message
+      Text="##vso[artifact.upload containerfolder=PipelineArtifactsPublishingManifests;artifactname=PipelineArtifactsPublishingManifests]$(MSBuildThisFileDirectory)MicrosoftDotNetBuildTasksFeedVersion.props"
+      Condition="$(PublishToAzure) and '$(PushToAzureDevOps)' == 'true'"
+      Importance="high" />
+
     <Message
       Text="##vso[artifact.upload containerfolder=PipelineArtifactsPublishingManifests;artifactname=PipelineArtifactsPublishingManifests]$(RepositoryEngineeringDir)common\PublishToPackageFeed.proj"
       Condition="$(PublishToAzure) and '$(PushToAzureDevOps)' == 'true'"
       Importance="high" />
-    
+
     <!--
       Work in progress drop-in replacement for PushToBlobFeed task below.
       This is part of the work on https://github.com/dotnet/arcade/issues/1179


### PR DESCRIPTION
This PR adds a new file called `PublishToPackageFeed.proj` under the `\eng\common\` folder. The intent for creating this file is that it will be used by the publishing release pipeline when publishing assets to feeds.

This part of the following flow:

- `PushToAzureDevOpsArtifacts` pushes assets to azure pipeline storage (i.e., private intermediary storage). This step is done.
- Maestro++ trigger a release pipeline associated with the build that pushed the packages above.
- **This PR + creation of the release pipeline:** The release pipeline uses `PublishToPackageFeed.proj` to parse the build manifest and push assets to final target feed location.