### PR TITLE
Remove usages of ImportNetSdkFromRepoToolset

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <PropertyGroup>
-    <ImportNetSdkFromRepoToolset>false</ImportNetSdkFromRepoToolset>
-  </PropertyGroup>
-
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
   <PropertyGroup>

--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -306,10 +306,6 @@ It is a common practice to specify properties applicable to all (most) projects 
 
 ```xml
 <PropertyGroup>  
-  <PropertyGroup>
-    <ImportNetSdkFromRepoToolset>false</ImportNetSdkFromRepoToolset>
-  </PropertyGroup>
-
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />    
 
   <!-- Public keys used by InternalsVisibleTo project items -->

--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/testassets/MinimalRepo/Directory.Build.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/testassets/MinimalRepo/Directory.Build.props
@@ -1,8 +1,4 @@
 <Project>
-  <PropertyGroup>
-    <ImportNetSdkFromRepoToolset>false</ImportNetSdkFromRepoToolset>
-  </PropertyGroup>
-
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/testassets/RepoWithConditionalProjectsToBuild/Directory.Build.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/testassets/RepoWithConditionalProjectsToBuild/Directory.Build.props
@@ -1,8 +1,4 @@
 <Project>
-  <PropertyGroup>
-    <ImportNetSdkFromRepoToolset>false</ImportNetSdkFromRepoToolset>
-  </PropertyGroup>
-
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
   <PropertyGroup>


### PR DESCRIPTION
This property does not appear to be used anywhere anymore. We couldn't find references to it anywhere in Arcade itself. They appear to have been removed in https://github.com/dotnet/arcade/commit/c53e1ce277343f33810433bb3f95fe70177b7516

cc @bricelam 