### PR TITLE
Add missing parameters to Tasks.Feed PublishPackagesToBlobFeed & PublishFilesToBlobFeed targets

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/build/Microsoft.DotNet.Build.Tasks.Feed.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/build/Microsoft.DotNet.Build.Tasks.Feed.targets
@@ -61,9 +61,9 @@
   </PropertyGroup>
 
   <Target Name="PublishPackagesToBlobFeed" DependsOnTargets="@(PublishPackagesToBlobFeedDependsOn)" >
-    <Error Text="The ExpectedFeedUrl  property must be set on the command line."
+    <Error Text="The ExpectedFeedUrl property wasn't supplied."
           Condition="'$(ExpectedFeedUrl)' == ''" />
-    <Error Text="The AccountKey property must be set on the command line."
+    <Error Text="The AccountKey property wasn't supplied."
           Condition="'$(AccountKey)' == ''" />
 
     <ItemGroup>
@@ -79,18 +79,18 @@
                     ItemsToPush="@(_ItemsToPush)"
                     Overwrite="$(PushToBlobFeed_Overwrite)"
                     MaxClients="$(PushToBlobFeed_MaxClients)"
-                    ManifestName="$(ManifestName)"
                     ManifestBuildId="$(ManifestBuildId)"
                     ManifestBranch="$(ManifestBranch)"
                     ManifestCommit="$(ManifestCommit)"
                     ManifestBuildData="$(ManifestBuildData)"
-                    SkipCreateManifest="$(SkipCreateManifest)" />
+                    ManifestRepoUri="$(ManifestRepoUri)"
+                    AssetManifestPath="$(AssetManifestFilePath)" />
   </Target>
 
   <Target Name="PublishFilesToBlobFeed">
-    <Error Text="The ExpectedFeedUrl  property must be set on the command line."
+    <Error Text="The ExpectedFeedUrl property wasn't supplied."
           Condition="'$(ExpectedFeedUrl)' == ''" />
-    <Error Text="The AccountKey property must be set on the command line."
+    <Error Text="The AccountKey property wasn't supplied."
           Condition="'$(AccountKey)' == ''" />
 
     <ItemGroup>
@@ -110,12 +110,13 @@
                     PublishFlatContainer="true"
                     Overwrite="$(PushToBlobFeed_Overwrite)"
                     MaxClients="$(PushToBlobFeed_MaxClients)"
-                    ManifestName="$(ManifestName)"
                     ManifestBuildId="$(ManifestBuildId)"
                     ManifestBranch="$(ManifestBranch)"
                     ManifestCommit="$(ManifestCommit)"
                     ManifestBuildData="$(ManifestBuildData)"
-                    SkipCreateManifest="$(SkipCreateManifest)" />
+                    SkipCreateManifest="$(SkipCreateManifest)"
+                    ManifestRepoUri="$(ManifestRepoUri)"
+                    AssetManifestPath="$(AssetManifestFilePath)" />
 
   </Target>
 


### PR DESCRIPTION
Closes: #1555 

Added the missing parameters and removed one that actually didn't exist in the task, namely `ManifestName`. I decided not to add further validation of these parameters in the task because 1) we are in the process of moving to a different publishing flow and 2) I'm afraid of breaking changes.. 