### PR TITLE
Add eng/Empty.targets hook for extra targets and suppress Publish by default

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Empty.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Empty.targets
@@ -18,5 +18,18 @@
   <Target Name="Build"/>
   <Target Name="Test"/>
   <Target Name="Pack"/>
+  <Target Name="Publish"/>
+
+  <!--
+    Implement this file to specify more targets that must be suppressed to allow projects to
+    participate in the build without doing anything.
+
+    For example, if a project specifies '<Target Name="CustomTarget" BeforeTargets="Build"> ...', it
+    could cause failures if it relies on Restore assets that were suppressed. The custom target must
+    also be suppressed to prevent build failure. The repo would create eng/Empty.targets and add a
+    line '<Target Name="CustomTarget" />'.
+  -->
+  <Import Project="$(RepositoryEngineeringDir)Empty.targets"
+          Condition="Exists('$(RepositoryEngineeringDir)Empty.targets')"/>
 
 </Project>


### PR DESCRIPTION
Incorporates two source-build patches:

* [patches/arcade/0006-Add-support-for-repo-specific-Empty.targets.patch](https://github.com/dotnet/source-build/blob/2cb8a79cdc6c045564ef36f3dfaa519eccca19f8/patches/arcade/0006-Add-support-for-repo-specific-Empty.targets.patch)
  * This PR modifies it slightly, moving the import into `Empty.targets` to remove the need for duplicated conditions.
* [patches/arcade/0007-Suppress-Publish-target.patch](https://github.com/dotnet/source-build/blob/2cb8a79cdc6c045564ef36f3dfaa519eccca19f8/patches/arcade/0007-Suppress-Publish-target.patch)

Example usage:
* [patches/cli/0003-Add-repo-specific-target-emptying-file.patch](https://github.com/dotnet/source-build/blob/2cb8a79cdc6c045564ef36f3dfaa519eccca19f8/patches/cli/0003-Add-repo-specific-target-emptying-file.patch)

This will also allow testing out solutions to https://github.com/dotnet/arcade/issues/1183 without having to uptake an Arcade dev build.

(Still waiting for https://github.com/dotnet/arcade/pull/1491 to remove some other patches.)

/cc @markwilkie 