### PR TITLE
Add property to opt-out of NuGet's implementation of restore

### DIFF
--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -137,8 +137,6 @@ By default, Arcade builds solutions in the root of the repo.  Overriding the def
   </Project>
   ```
 
-  CoreFx does not use the default build projects in its repo - [example](https://github.com/dotnet/corefx/blob/66392f577c7852092f668876822b6385bcafbd44/eng/Build.props)
-
 Note: listing both project files formats (such as .csproj) and solution files (.sln) at the same time is not currently supported.
 
 #### Example: specifying a solution to build
@@ -189,6 +187,26 @@ You can use custom MSBuild properties to control the list of projects which buil
   </ItemGroup>
 </Project>
 ```
+
+#### Example: custom implementations of 'Restore'
+
+By default, Arcade assumes that the 'Restore' target on projects is implemented using NuGet's restore. If that is not the case, you can opt-out of some Arcade
+optimizations by setting 'RestoreUsingNuGetTargets' to false.
+
+```xml
+<!-- eng/Build.props -->
+<Project>
+  <PropertyGroup>
+    <RestoreUsingNuGetTargets>false</RestoreUsingNuGetTargets>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectToBuild Include="$(RepoRoot)src\dir.proj" />
+  </ItemGroup>
+</Project>
+```
+
+CoreFx does not use the default build projects in its repo - [example](https://github.com/dotnet/corefx/blob/66392f577c7852092f668876822b6385bcafbd44/eng/Build.props).
+
 
 ### /eng/Versions.props: A single file listing component versions and used tools
 

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -80,7 +80,11 @@ function Build {
   $bl = if ($binaryLog) { "/bl:" + (Join-Path $LogDir "Build.binlog") } else { "" }
 
   if ($projects) {
-    $properties += "/p:Projects=$projects"
+    # Re-assign properties to a new variable because PowerShell doesn't let us append properties directly for unclear reasons.
+    # Explicitly set the type as string[] because otherwise PowerShell would make this char[] if $properties is empty.
+    [string[]] $msbuildArgs = $properties
+    $msbuildArgs += "/p:Projects=$projects"
+    $properties = $msbuildArgs
   }
 
   MSBuild $toolsetBuildProj `

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -197,7 +197,8 @@
     <PropertyGroup>
       <!-- Normalize paths to avoid false warnings by NuGet about missing project references. -->
       <ProjectToBuildList>@(ProjectToBuild->'%(FullPath)')</ProjectToBuildList>
-      <_BuildSolutions Condition="'$(_BuildSolutions)' == ''">@(ProjectToBuild->AnyHaveMetadataValue('Extension', '.sln'))</_BuildSolutions>
+      <_BuildSolutions>@(ProjectToBuild->AnyHaveMetadataValue('Extension', '.sln'))</_BuildSolutions>
+      <RestoreUsingNuGetTargets Condition="'$(RestoreUsingNuGetTargets)' == '' AND '$(_BuildSolutions)' == 'false'">true</RestoreUsingNuGetTargets>
     </PropertyGroup>
 
     <Error Condition="'$(_BuildSolutions)' == 'true' and '@(_ProjectToBuildExtension)' != '' "
@@ -215,10 +216,10 @@
           Condition="'$(_RestoreTools)' == 'true' and '$(_QuietRestore)' == 'true'" StandardOutputImportance="normal" />
 
     <Exec Command='$(_MSBuildCmd) "@(ProjectToBuild)" /nologo /m /v:quiet /t:Restore $(_SolutionBuildPropsCmdLine) /p:__BuildPhase=SolutionRestore'
-          Condition="'$(_BuildSolutions)' != 'false' and '$(Restore)' == 'true' and '$(_QuietRestore)' == 'true'" StandardOutputImportance="normal" />
+          Condition="'$(RestoreUsingNuGetTargets)' != 'true' and '$(Restore)' == 'true' and '$(_QuietRestore)' == 'true'" StandardOutputImportance="normal" />
 
     <Exec Command='$(_MSBuildCmd) "$(NuGetRestoreTargets)" "/p:RestoreGraphProjectInput:$(ProjectToBuildList)" /nologo /m /v:quiet /t:Restore $(_SolutionBuildPropsCmdLine) /p:__BuildPhase=SolutionRestore'
-          Condition="'$(_BuildSolutions)' == 'false' and '$(Restore)' == 'true' and '$(_QuietRestore)' == 'true'" StandardOutputImportance="normal" />
+          Condition="'$(RestoreUsingNuGetTargets)' == 'true' and '$(Restore)' == 'true' and '$(_QuietRestore)' == 'true'" StandardOutputImportance="normal" />
 
     <!--
       Restore built-in tools.
@@ -240,14 +241,17 @@
              RemoveProperties="$(_RemoveProps)"
              Targets="Restore"
              BuildInParallel="true"
-             Condition="'$(_BuildSolutions)' != 'false' and '$(SdkTaskProjects)' == '' and '$(Restore)' == 'true' and '$(_QuietRestore)' != 'true'"/>
+             Condition="'$(RestoreUsingNuGetTargets)' != 'true' and '$(SdkTaskProjects)' == '' and '$(Restore)' == 'true' and '$(_QuietRestore)' != 'true'"/>
 
-    <!-- Invoke restore using NuGet.targets directly. This avoids duplicate calls to RestoreTask and race conditions on writing restore results to disk. -->
+    <!--
+      Workaround for https://github.com/NuGet/Home/issues/7648.
+      Invoke restore using NuGet.targets directly. This avoids duplicate calls to RestoreTask and race conditions on writing restore results to disk.
+    -->
     <MSBuild Projects="$(NuGetRestoreTargets)"
              Properties="@(_SolutionBuildProps);RestoreGraphProjectInput=$(ProjectToBuildList);__BuildPhase=SolutionRestore"
              RemoveProperties="$(_RemoveProps)"
              Targets="Restore"
-             Condition="'$(_BuildSolutions)' == 'false' and '$(SdkTaskProjects)' == '' and '$(Restore)' == 'true' and '$(_QuietRestore)' != 'true'"/>
+             Condition="'$(RestoreUsingNuGetTargets)' == 'true' and '$(SdkTaskProjects)' == '' and '$(Restore)' == 'true' and '$(_QuietRestore)' != 'true'"/>
 
     <!--
       Build solution.


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/arcade/pull/1567

It appears the corefx repo, and perhaps others, do not actually use NuGet for their 'restore' target. #1567 broke these repos. This adds a property to opt-out of using NuGet.

cc @ViktorHofer @safern 