### PR TITLE
Make check of signing marker for PowerShell files ignore case

### DIFF
--- a/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
@@ -120,7 +120,7 @@ namespace Microsoft.DotNet.SignTool
 
         public override bool VerifySignedPowerShellFile(string filePath)
         {
-            return File.ReadLines(filePath).Contains("# SIG # Begin Signature Block");
+            return File.ReadLines(filePath).Any(line => line.IndexOf("# SIG # Begin Signature Block", StringComparison.OrdinalIgnoreCase) >= 0);
         }
 
         public override bool VerifySignedNugetFileMarker(string filePath)


### PR DESCRIPTION
Closes: #1637 

Turns out that this might have different cases.

Noted the error on this build: https://dnceng.visualstudio.com/internal/_build/results?buildId=60771&view=logs&jobId=2d2b3007-3c5c-5840-9bb0-2b1ea49925f3&taskId=16be6190-c20b-50b6-8210-aa45e5159981&lineStart=759&lineEnd=775&colStart=1&colEnd=2