### PR TITLE
Making Bi-Directional Repo Pairs dynamic

### DIFF
--- a/src/Microsoft.DotNet.GitSync.CommitManager/Table.cs
+++ b/src/Microsoft.DotNet.GitSync.CommitManager/Table.cs
@@ -9,13 +9,16 @@ namespace Microsoft.DotNet.GitSync.CommitManager
 {
     internal class Table
     {
-        public Table(string accountName, string accountKey, string tableName)
+        public Table(string accountName, string accountKey, string tableName, string repoTableName)
         {
             CloudStorageAccount storageAccount = CloudStorageAccount.Parse("DefaultEndpointsProtocol=https;AccountName=" + accountName + ";AccountKey=" + accountKey + ";TableEndpoint=https://" + accountName + ".table.cosmosdb.azure.com:443/;");
             CloudTableClient tableClient = storageAccount.CreateCloudTableClient();
             CommitTable = tableClient.GetTableReference(tableName);
+            RepoTable = tableClient.GetTableReference(repoTableName);
         }
 
         public CloudTable CommitTable { get; set; }
+
+        public CloudTable RepoTable { get; set; }
     }
 }


### PR DESCRIPTION
It will make the use of this tool for other people\teams simpler. They will only have to do setup stuff. no code changes will be required.
In case we have to add more repos to a particular instance of the tool, we don't have edit the code as we are doing here 
https://github.com/dotnet/arcade/pull/1630