### PR TITLE
Use anonymous API auth for .Open queues

### DIFF
--- a/src/HelixPoolProvider/HelixPoolProvider/Config.cs
+++ b/src/HelixPoolProvider/HelixPoolProvider/Config.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.HelixPoolProvider
         public string ApiAuthorizationPat => GetSecret(_configuration[$"{nameof(ApiAuthorizationPat)}-Key"]);
         public bool ApiAuthorizationPatIsConfigured => TryGetSecret(_configuration[$"{nameof(ApiAuthorizationPat)}-Key"], out string secretValue);
         public AllowableHelixQueues AllowedTargetQueues => Enum.Parse<AllowableHelixQueues>(_configuration[nameof(AllowedTargetQueues)]);
-
+        public string HelixCreator => _configuration[nameof(HelixCreator)];
         public int TimeoutInMinutes => Int32.Parse(_configuration[nameof(TimeoutInMinutes)]);
         public string HelixEndpoint => _configuration[nameof(HelixEndpoint)];
         public int MaxParallelism => Int32.Parse(_configuration[nameof(MaxParallelism)]);

--- a/src/HelixPoolProvider/HelixPoolProvider/Models/AgentDataItem.cs
+++ b/src/HelixPoolProvider/HelixPoolProvider/Models/AgentDataItem.cs
@@ -14,5 +14,7 @@ namespace Microsoft.DotNet.HelixPoolProvider.Models
         public string queueId { get; set; }
         [Required]
         public string workItemId { get; set; }
+        [Required]
+        public bool isPublicQueue { get; set; }
     }
 }

--- a/src/HelixPoolProvider/HelixPoolProvider/appsettings.dncenginternal-int.json
+++ b/src/HelixPoolProvider/HelixPoolProvider/appsettings.dncenginternal-int.json
@@ -4,6 +4,7 @@
   "ApiAuthorizationPat-Key": "https://helixstagingkv.vault.azure.net/secrets/helixpoolprovider-dnceng-ApiAuthorizationPat",
   "SharedSecret-Key": "https://helixstagingkv.vault.azure.net/secrets/helixpoolprovider-dncenginternal-SharedSecret",
   "AllowedTargetQueues": "OnlyInternal",
+  "HelixCreator": "helixpoolprovider-dncengpublic-int",
   "TimeoutInMinutes": 60,
   "HelixEndpoint": "https://helix.dot.net",
   "MaxParallelism": 1000,

--- a/src/HelixPoolProvider/HelixPoolProvider/appsettings.dncengpublic-int.json
+++ b/src/HelixPoolProvider/HelixPoolProvider/appsettings.dncengpublic-int.json
@@ -4,6 +4,7 @@
   "ApiAuthorizationPat-Key": "https://helixstagingkv.vault.azure.net/secrets/helixpoolprovider-dnceng-ApiAuthorizationPat",
   "SharedSecret-Key": "https://helixstagingkv.vault.azure.net/secrets/helixpoolprovider-dncengpublic-SharedSecret",
   "AllowedTargetQueues": "NoInternal",
+  "HelixCreator": "helixpoolprovider-dncengpublic-int",
   "TimeoutInMinutes": 60,
   "HelixEndpoint": "https://helix.dot.net",
   "MaxParallelism": 1000,


### PR DESCRIPTION
- Due to helix api changes, need to use anonymous acces for .Open queues
- Specify a creator
- Improve logging