### PR TITLE
Updating the signing plugin version to 1.1.61

### DIFF
--- a/eng/common/templates/phases/base.yml
+++ b/eng/common/templates/phases/base.yml
@@ -85,7 +85,7 @@ phases:
       - task: MicroBuildSigningPlugin@2
         displayName: Install MicroBuild plugin
         inputs:
-          version: 1.1.35
+          version: 1.1.61
           signType: $(_SignType)
           zipSources: false
           feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json


### PR DESCRIPTION
This is needed to skip strong name validation, as that is not a thing on core and also because this has updated certificates.