### PR TITLE
Allow for darc version to be specified by Microsoft.DotNet.Darc package

### DIFF
--- a/eng/common/darc-init.ps1
+++ b/eng/common/darc-init.ps1
@@ -12,11 +12,21 @@ function InstallDarcCli {
     Invoke-Expression "& `"$dotnet`" tool uninstall $darcCliPackageName -g"
   }
 
-  $toolsetVersion = $GlobalJson.'msbuild-sdks'.'Microsoft.DotNet.Arcade.Sdk'
+  # Preference the "Microsoft.DotNet.Darc" tool in global json.
+  # If it exists, use that as the version, otherwise use the arcade sdk version.
+  # TODO: This should eventually be replaced with a call to the build asset registry,
+  # when anonymous access is available for get-builds. Then, we should grab the latest
+  # build number from the prod channel, or the latest int build number if an additional
+  # parameter (e.g. -prerelease) is provided to the script.
+  if (Get-Member -InputObject $GlobalJson.tools -Name "Microsoft.DotNet.Darc") {
+    $darcVersion = $GlobalJson.'tools'.'Microsoft.DotNet.Darc'
+  } else {
+    $darcVersion = $GlobalJson.'msbuild-sdks'.'Microsoft.DotNet.Arcade.Sdk'
+  }
 
-  Write-Host "Installing Darc CLI version $toolsetVersion..."
+  Write-Host "Installing Darc CLI version $darcVersion..."
   Write-Host "You may need to restart your command window if this is the first dotnet tool you have installed."
-  Invoke-Expression "& `"$dotnet`" tool install $darcCliPackageName --version $toolsetVersion -v $verbosity -g"
+  Invoke-Expression "& `"$dotnet`" tool install $darcCliPackageName --version $darcVersion -v $verbosity -g"
 }
 
 InstallDarcCli

--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "tools": {
-    "dotnet": "2.1.401"
+    "dotnet": "2.1.401",
+    "Microsoft.DotNet.Darc": "1.0.0-beta.18618.7"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.18618.7"


### PR DESCRIPTION
Darc is moving to arcade services, and so will no longer be bound to the arcade sdk version. Preference using Microsoft.DotNet.Darc in global.json.