### PR TITLE
Mac-->OSX for dotnet cli downloader

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
@@ -21,7 +21,7 @@
     </When>
     <When Condition="$(HelixTargetQueue.ToLowerInvariant().StartsWith('osx'))">
       <PropertyGroup>
-        <DotNetCliRuntime>mac-x64</DotNetCliRuntime>
+        <DotNetCliRuntime>osx-x64</DotNetCliRuntime>
       </PropertyGroup>
     </When>
     <When Condition="$(HelixTargetQueue.ToLowerInvariant().Contains('arm32'))">


### PR DESCRIPTION
Fixing a bug I found in the cli downloader; the OSX runtime packages are named with `osx` rather than `mac`.