### PR TITLE
extend ConditionalFact and ConditionalTheory to support dynamic skip

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ConditionalFactDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ConditionalFactDiscoverer.cs
@@ -22,7 +22,8 @@ namespace Microsoft.DotNet.XUnitExtensions
         public override IEnumerable<IXunitTestCase> Discover(
             ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
         {
-            IEnumerable<IXunitTestCase> testCases = base.Discover(discoveryOptions, testMethod, factAttribute);
+            IEnumerable<IXunitTestCase> testCases = base.Discover(discoveryOptions, testMethod, factAttribute).Select(tc => new SkippedFactTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod));
+
             return ConditionalTestDiscoverer.Discover(discoveryOptions, _diagnosticMessageSink, testMethod, testCases, factAttribute.GetConstructorArguments().ToArray());
         }
     }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ConditionalTheoryDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ConditionalTheoryDiscoverer.cs
@@ -22,7 +22,8 @@ namespace Microsoft.DotNet.XUnitExtensions
         public override IEnumerable<IXunitTestCase> Discover(
             ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
         {
-            IEnumerable<IXunitTestCase> testCases = base.Discover(discoveryOptions, testMethod, theoryAttribute);
+            IEnumerable<IXunitTestCase> testCases = base.Discover(discoveryOptions, testMethod, theoryAttribute).Select(tc => new SkippedTheoryTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod));
+
             return ConditionalTestDiscoverer.Discover(discoveryOptions, _diagnosticMessageSink, testMethod, testCases, theoryAttribute.GetConstructorArguments().ToArray());
         }
     }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/SkippedFactTestCase.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/SkippedFactTestCase.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.DotNet.XUnitExtensions
+{
+    /// <summary>Wraps RunAsync for ConditionalFact.</summary>
+    public class SkippedFactTestCase : XunitTestCase
+    {
+        [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes", error: true)]
+        public SkippedFactTestCase() { }
+
+        public SkippedFactTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod, object[] testMethodArguments = null)
+            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments) { }
+
+        public override async Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink,
+                                                        IMessageBus messageBus,
+                                                        object[] constructorArguments,
+                                                        ExceptionAggregator aggregator,
+                                                        CancellationTokenSource cancellationTokenSource)
+        {
+            SkippedTestMessageBus skipMessageBus = new SkippedTestMessageBus(messageBus);
+            var result = await base.RunAsync(diagnosticMessageSink, skipMessageBus, constructorArguments, aggregator, cancellationTokenSource);
+            if (skipMessageBus.SkippedTestCount > 0)
+            {
+                result.Failed -= skipMessageBus.SkippedTestCount;
+                result.Skipped += skipMessageBus.SkippedTestCount;
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XUnitExtensions/src/SkippedTestCase.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/SkippedTestCase.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -13,102 +12,6 @@ using Xunit.Sdk;
 
 namespace Microsoft.DotNet.XUnitExtensions
 {
-
-    public class SkipTestException : Exception
-    {
-        public SkipTestException(string reason)
-            : base(reason) { }
-    }
-
-    /// <summary>Implements message buss to communicate tests skipped via SkipTestException.</summary>
-    public class ConditionalTestMessageBus : IMessageBus
-    {
-        readonly IMessageBus innerBus;
-
-        public ConditionalTestMessageBus(IMessageBus innerBus)
-        {
-            this.innerBus = innerBus;
-        }
-
-        public int SkippedTestCount { get; private set; }
-
-        public void Dispose() { }
-
-        public bool QueueMessage(IMessageSinkMessage message)
-        {
-            var testFailed = message as ITestFailed;
-
-            if (testFailed != null)
-            {
-                var exceptionType = testFailed.ExceptionTypes.FirstOrDefault();
-                if (exceptionType == typeof(SkipTestException).FullName)
-                {
-                    SkippedTestCount++;
-                    return innerBus.QueueMessage(new TestSkipped(testFailed.Test, testFailed.Messages.FirstOrDefault()));
-                }
-            }
-
-            // Nothing we care about, send it on its way
-            return innerBus.QueueMessage(message);
-        }
-    }
-
-    /// <summary>Wraps RunAsync for ConditionalTheory.</summary>
-    public class SkippedTheoryTestCase : XunitTheoryTestCase
-    {
-        [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
-        public SkippedTheoryTestCase() { }
-
-        public SkippedTheoryTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod)
-            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod) { }
-
-        public override async Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink,
-                                                        IMessageBus messageBus,
-                                                        object[] constructorArguments,
-                                                        ExceptionAggregator aggregator,
-                                                        CancellationTokenSource cancellationTokenSource)
-        {
-            // Duplicated code from SkippableFactTestCase. I'm sure we could find a way to de-dup with some thought.
-            var skipMessageBus = new ConditionalTestMessageBus(messageBus);
-            var result = await base.RunAsync(diagnosticMessageSink, skipMessageBus, constructorArguments, aggregator, cancellationTokenSource);
-            if (skipMessageBus.SkippedTestCount > 0)
-            {
-                result.Failed -= skipMessageBus.SkippedTestCount;
-                result.Skipped += skipMessageBus.SkippedTestCount;
-            }
-
-            return result;
-        }
-    }
-
-    /// <summary>Wraps RunAsync for ConditionalFact.</summary>
-    public class SkippedFactTestCase : XunitTestCase
-    {
-        [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
-        public SkippedFactTestCase() { }
-
-        public SkippedFactTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod, object[] testMethodArguments = null)
-            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments) { }
-
-        public override async Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink,
-                                                        IMessageBus messageBus,
-                                                        object[] constructorArguments,
-                                                        ExceptionAggregator aggregator,
-                                                        CancellationTokenSource cancellationTokenSource)
-        {
-            // Duplicated code from SkippableFactTestCase. I'm sure we could find a way to de-dup with some thought.
-            var skipMessageBus = new ConditionalTestMessageBus(messageBus);
-            var result = await base.RunAsync(diagnosticMessageSink, skipMessageBus, constructorArguments, aggregator, cancellationTokenSource);
-            if (skipMessageBus.SkippedTestCount > 0)
-            {
-                result.Failed -= skipMessageBus.SkippedTestCount;
-                result.Skipped += skipMessageBus.SkippedTestCount;
-            }
-
-            return result;
-        }
-    }
-
     /// <summary>Wraps another test case that should be skipped.</summary>
     internal sealed class SkippedTestCase : LongLivedMarshalByRefObject, IXunitTestCase
     {

--- a/src/Microsoft.DotNet.XUnitExtensions/src/SkippedTestMessageBus.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/SkippedTestMessageBus.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.DotNet.XUnitExtensions
+{
+    public class SkipTestException : Exception
+    {
+        public SkipTestException(string reason)
+            : base(reason) { }
+    }
+
+    /// <summary>Implements message bus to communicate tests skipped via SkipTestException.</summary>
+    public class SkippedTestMessageBus : IMessageBus
+    {
+        readonly IMessageBus innerBus;
+
+        public SkippedTestMessageBus(IMessageBus innerBus)
+        {
+            this.innerBus = innerBus;
+        }
+
+        public int SkippedTestCount { get; private set; }
+
+        public void Dispose() { }
+
+        public bool QueueMessage(IMessageSinkMessage message)
+        {
+            var testFailed = message as ITestFailed;
+
+            if (testFailed != null)
+            {
+                var exceptionType = testFailed.ExceptionTypes.FirstOrDefault();
+                if (exceptionType == typeof(SkipTestException).FullName)
+                {
+                    SkippedTestCount++;
+                    return innerBus.QueueMessage(new TestSkipped(testFailed.Test, testFailed.Messages.FirstOrDefault()));
+                }
+            }
+
+            // Nothing we care about, send it on its way
+            return innerBus.QueueMessage(message);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XUnitExtensions/src/SkippedTheoryTestCase.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/SkippedTheoryTestCase.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.DotNet.XUnitExtensions
+{
+    /// <summary>Wraps RunAsync for ConditionalTheory.</summary>
+    public class SkippedTheoryTestCase : XunitTheoryTestCase
+    {
+        [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes", error: true)]
+        public SkippedTheoryTestCase() { }
+
+        public SkippedTheoryTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod)
+            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod) { }
+
+        public override async Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink,
+                                                        IMessageBus messageBus,
+                                                        object[] constructorArguments,
+                                                        ExceptionAggregator aggregator,
+                                                        CancellationTokenSource cancellationTokenSource)
+        {
+            SkippedTestMessageBus skipMessageBus = new SkippedTestMessageBus(messageBus);
+            var result = await base.RunAsync(diagnosticMessageSink, skipMessageBus, constructorArguments, aggregator, cancellationTokenSource);
+            if (skipMessageBus.SkippedTestCount > 0)
+            {
+                result.Failed -= skipMessageBus.SkippedTestCount;
+                result.Skipped += skipMessageBus.SkippedTestCount;
+            }
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
We can already implement custom function to skip tests in specific cases. That however must be static method and that has some limitations. HTTP in corefx for example uses tests where interesting variable like UseSocketsHttpHandler are set on instance derived from base tests. With this change, we can do something like:

```c#
-            if (IsCurlHandler) return;
+            if (IsCurlHandler) {
+                throw new SkipTestException("Not supported with CurlHandler");
+            }
```

And when executed it can produce  something like:
```
System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpCookieProtocolTests.GetAsyncWithRedirect_SetCookieContainer_CorrectCookiesSent [STARTING]
System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpCookieProtocolTests.GetAsyncWithRedirect_SetCookieContainer_CorrectCookiesSent [FINISHED] Time: 0.1237862s
System.Net.Http.Functional.Tests.PlatformHandler_HttpCookieProtocolTests.GetAsyncWithRedirect_SetCookieContainer_CorrectCookiesSent [STARTING]
System.Net.Http.Functional.Tests.PlatformHandler_HttpCookieProtocolTests.GetAsyncWithRedirect_SetCookieContainer_CorrectCookiesSent [SKIP]
System.Net.Http.Functional.Tests.PlatformHandler_HttpCookieProtocolTests.GetAsyncWithRedirect_SetCookieContainer_CorrectCookiesSent [FINISHED] Time: 0.0003453s
```


Also testResult.xml would have expected output as 
```
      <test name="System.Net.Http.Functional.Tests.PlatformHandler_HttpCookieProtocolTests.GetAsyncWithRedirect_SetCookieContainer_CorrectCookiesSent" type="System.Net.Http.Functional.Tests.PlatformHandler_HttpCookieProtocolTests" method="GetAsyncWithRedirect_SetCookieContainer_CorrectCookiesSent" time="0" result="Skip">
      <test name="System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpCookieProtocolTests.GetAsyncWithRedirect_SetCookieContainer_CorrectCookiesSent" type="System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpCookieProtocolTests" method="GetAsyncWithRedirect_SetCookieContainer_CorrectCookiesSent" time="0.1237862" result="Pass" />

``` 

and we could properly track skipped tests instead of reporting lame pass. 



  