### PR TITLE
Work around Microsoft/msbuild#3345

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MultiQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MultiQueue.targets
@@ -62,15 +62,22 @@
 
   <Import Project="$(_HelixMultiQueueTargets)" Condition="'$(_HelixMultiQueueTargets)' != ''"/>
 
-  <Target Name="Test"
+  <Target Name="CoreTest"
           DependsOnTargets="$(TestDependsOn)">
     <MSBuild Projects="$(MSBuildProjectFile)" Targets="Test" Properties="HelixTargetQueue=%(HelixTargetQueue.Identity);%(HelixTargetQueue.AdditionalProperties)">
       <Output TaskParameter="TargetOutputs" ItemName="SentJobs" />
     </MSBuild>
   </Target>
 
+  <!-- Work around https://github.com/Microsoft/msbuild/issues/3345
+       (failures in AfterTargets of the entry target don't fail the build)
+       by ensuring that the entry-point target Test has simple dependencies
+       and hooking Wait to CoreTest instead of the entry-point. -->
+  <Target Name="Test"
+          DependsOnTargets="CoreTest" />
+
   <Target Name="Wait"
-          AfterTargets="Test"
+          AfterTargets="CoreTest"
           Condition="$(WaitForWorkItemCompletion)">
     <Message Importance="High" Text="Waiting on job completion..." />
     <HelixWait Jobs="@(SentJobs)" AccessToken="$(HelixAccessToken)" Source="$(HelixSource)" Type="$(HelixType)" Build="$(HelixBuild)" IsExternal="$(IsExternal)" Creator="$(Creator)" />


### PR DESCRIPTION
`helix.proj` is built with the target `Test`, but does important work
in `Wait`. Since that target was hooked to `Test` by an `AfterTargets`,
it hit a bug in MSBuild that failed `AfterTargets` targets don't fail a
build that builds the target they hook.

Restructure the targets (transparently to callers) to avoid that
situation and observe failures in `Wait`.