### PR TITLE
HarvestPackage fix for case-sensitive filesystems

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
@@ -416,8 +416,12 @@
     <Error Condition="'$(HarvestVersion)' == '' AND '@(HarvestIncludePaths)' != ''"
            Text="HarvestIncludePaths was specified but no previous stable version of this package was found." />
 
+    <PropertyGroup>
+      <IdToLower>$(Id.ToLowerInvariant())</IdToLower>
+    </PropertyGroup>
+
     <!-- Harvest files from old package and determine support using both runtime and additional packages -->
-    <HarvestPackage PackageId="$(Id)"
+    <HarvestPackage PackageId="$(IdToLower)"
                     PackageVersion="$(HarvestVersion)"
                     PackagesFolder="$(PackagesDir)"
                     Files="@(File)"


### PR DESCRIPTION
Package IDs are lowercased by NuGet when setting up the package cache. On case-insensitive filesystems, it's fine to still access package contents by the mixed-case ID, but on e.g. Linux, the ID must be lowercased first.

I would consider this a workaround rather than a fix. The true package id is really mixed-case, so this introduces a parameter naming error by setting PackageId="$(IdToLower)".

---

Fixes https://github.com/dotnet/arcade/issues/1655. Not ideal, but submitting as a PR in case it seems ok to merge anyway.