### PR TITLE
Finalize VS insertion component manifest in non-official builds

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.InsertionManifests.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.InsertionManifests.targets
@@ -22,6 +22,11 @@
       <_ComponentName>$(_ComponentDir.TrimEnd('\'))</_ComponentName>
     </PropertyGroup>
 
+    <Message Text="Generating manifest for VS component '$(_ComponentName)'" Importance="high"/>
+
+    <Error Condition="'$(VisualStudioDropName)' == '' and '$(OfficialBuild)' == 'true'"
+           Text="Property VisualStudioDropName must be specified in official build that produces Visual Studio insertion components." />
+
     <ItemGroup>
       <_Args Include="OfficialBuild=$(OfficialBuild)" />
       <_Args Include="ComponentName=$(_ComponentName)"/>
@@ -29,9 +34,8 @@
       <_Args Include="ComponentIntermediateOutputPath=$(VisualStudioSetupIntermediateOutputPath)$(_ComponentName)\"/>
       <_Args Include="SwixBuildPath=$(NuGetPackageRoot)microbuild.plugins.swixbuild\$(MicroBuildPluginsSwixBuildVersion)\"/>
       <_Args Include="ManifestBuildVersion=$(VsixVersion)" />
+      <_Args Include="VisualStudioDropName=$(VisualStudioDropName)" />
     </ItemGroup>
-
-    <Message Text="Generating manifest for VS component '$(_ComponentName)'" Importance="high"/>
 
     <MSBuild Projects="VisualStudio.SetupPackage.vsmanproj" Properties="@(_Args)"/>
   </Target>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.swixproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.swixproj
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!-- All Rights Reserved. Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!-- All Rights Reserved. Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
   <!--
@@ -7,6 +8,10 @@
       SetupOutputPath                 Directory to drop Willow manifests to.
       ComponentIntermediateOutputPath Intermediate directory where the component is being built.
       SwixBuildPath                   SwixBuild package path.
+      VisualStudioDropName            The name of Visual Studio drop, e.g. 
+                                      "Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)"
+                                      The manifest will be published with URI
+                                      https://vsdrop.corp.microsoft.com/file/v1/$(VisualStudioDropName)
   -->
 
   <PropertyGroup>
@@ -18,14 +23,16 @@
   <Import Project="$(SwixBuildPath)build\MicroBuild.Plugins.*.props" />
 
   <PropertyGroup>
-    <FinalizeManifest>false</FinalizeManifest>
-    <FinalizeManifest Condition="'$(OfficialBuild)' == 'true'">true</FinalizeManifest>
-
+    <FinalizeManifest>true</FinalizeManifest>
     <FinalizeSkipLayout>true</FinalizeSkipLayout>
     <IsPackage>true</IsPackage>
     <TargetName>$(ComponentName)</TargetName>
     <OutputPath>$(SetupOutputPath)</OutputPath>
     <IntermediateOutputPath>$(ComponentIntermediateOutputPath)</IntermediateOutputPath>
+
+    <!-- Note that the url is expected to end with ';' (%3B) -->
+    <ManifestPublishUrl Condition="'$(VisualStudioDropName)' != ''">https://vsdrop.corp.microsoft.com/file/v1/$(VisualStudioDropName)%3B</ManifestPublishUrl>
+    <ManifestPublishUrl Condition="'$(VisualStudioDropName)' == ''">http://localhost/non-official-build%3B</ManifestPublishUrl>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This also removes the previous requirement to install Swix plugin via `MicroBuildSwixPlugin` task.

The following is thus not needed anymore in YAML definition:

```yml
- task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@1
  displayName: Install Swix Plugin
```

Instead, the definition shall define a variable `VisualStudioDropName`:

```yml
VisualStudioDropName: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
```

and then pass it to the build script when running an official build:

```yml
- script: eng\common\CIBuild.cmd 
            ...
            /p:OfficialBuildId=$(Build.BuildNumber)
            /p:VisualStudioDropName=$(VisualStudioDropName)
            ...
```

The value is also needed in `MicroBuildUploadVstsDropFolder` pipeline task that uploads the VSIXes to VSTS drops:

```yml
- task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1
  displayName: Upload VSTS Drop
  inputs:
    DropName: $(VisualStudioDropName)
    DropFolder: 'artifacts\VSSetup\$(BuildConfiguration)\Insertion'
    condition: succeeded()
```

If the `VisualStudioDropName` is not set (in local build) the URL in the manifest will be set to a dummy value.

Fixes https://github.com/dotnet/arcade/issues/1681