### PR TITLE
Allow setting maxcpucount in build script

### DIFF
--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -130,6 +130,9 @@ while [[ $# > 0 ]]; do
     /p:*)
       properties="$properties $1"
       ;;
+    /m:*)
+      properties="$properties $1"
+      ;;
     *)
       echo "Invalid argument: $1"
       usage


### PR DESCRIPTION
This is needed for the perf runs. The change is only required for the Unix script as the powershell script assumes that all unknown arguments are "properties".

cc @wtgodbe 
