### PR TITLE
Remove wrong trace event setup logic

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/performance/Performance.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/performance/Performance.props
@@ -7,7 +7,7 @@
     <TestsSuccessfulSemaphoreName>performance.passed</TestsSuccessfulSemaphoreName>
 
     <!-- Validate configurations and fail early if conditions are not met. -->
-    <RunTestsDependsOn>ValidatePerfConfigurations;$(RunTestsDependsOn);PublishPerfRunnerDependencies;</RunTestsDependsOn>
+    <RunTestsDependsOn>ValidatePerfConfigurations;$(RunTestsDependsOn);</RunTestsDependsOn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/performance/Performance.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/performance/Performance.targets
@@ -31,22 +31,6 @@
 
   </Target>
 
-  <Target Name ="PublishPerfRunnerDependencies">
-
-    <PropertyGroup>
-      <TraceEventDir Condition="'$(TraceEventDir)' == ''">$([MSBuild]::NormalizeDirectory('$(RuntimePath)', 'Microsoft.Diagnostics.Tracing.TraceEvent'))</TraceEventDir>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <TraceEventNativeFiles Include="$(TraceEventDir)\**\*.*" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(TraceEventNativeFiles)"
-          DestinationFiles="@(TraceEventNativeFiles -> '$([MSBuild]::NormalizePath('$(TestPath)', '%(RecursiveDir)', '%(Filename)%(Extension)'))')"
-          SkipUnchangedFiles="true" />
-  
-  </Target>
-
   <!-- Use arcade's perf test target name. -->
   <Target Name="PerformanceTest" DependsOnTargets="Test" />
 


### PR DESCRIPTION
The right way to bootstrap the TraceEvent native dependencies: https://github.com/dotnet/corefx/pull/34353/commits/5a7510fd807e3e7e923a5fb85336275141737c2b. That's one of the two reasons why perf tests are failing currently.