### PR TITLE
Add a task for generating the build manifest which doesn't require publishing credentials

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/build/Microsoft.DotNet.Build.Tasks.Feed.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/build/Microsoft.DotNet.Build.Tasks.Feed.targets
@@ -45,6 +45,7 @@
   </PropertyGroup>
   <UsingTask TaskName="ConfigureInputFeeds" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
   <UsingTask TaskName="CopyBlobDirectory" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
+  <UsingTask TaskName="GenerateBuildManifest" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
   <UsingTask TaskName="GetBlobFeedPackageList" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
   <UsingTask TaskName="ParseBlobUrl" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
   <UsingTask TaskName="PushToBlobFeed" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
@@ -9,15 +9,12 @@ using Microsoft.DotNet.VersionTools.BuildManifest.Model;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Xml.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks.Feed
 {
     public static class BuildManifestUtil
     {
-        private static readonly char[] ManifestDataPairSeparators = { ';' };
-
         public const string AssetsVirtualDir = "assets/";
 
         public static void CreateBuildManifest(TaskLoggingHelper log,
@@ -28,14 +25,76 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             string manifestBuildId,
             string manifestBranch,
             string manifestCommit,
-            string manifestBuildData)
+            string[] manifestBuildData)
         {
-            log.LogMessage(MessageImportance.High, $"Creating build manifest file '{assetManifestPath}'...");
+            CreateModel(blobArtifacts, packageArtifacts, manifestBuildId, manifestBuildData, manifestRepoUri, manifestBranch, manifestCommit)
+                .WriteAsXml(assetManifestPath, log);
+        }
 
+        public static void WriteAsXml(this BuildModel buildModel, string filePath, TaskLoggingHelper log)
+        {
+            log.LogMessage(MessageImportance.High, $"Creating build manifest file '{filePath}'...");
+            string dirPath = Path.GetDirectoryName(filePath);
+
+            Directory.CreateDirectory(dirPath);
+
+            File.WriteAllText(filePath, buildModel.ToXml().ToString());
+        }
+               
+        public static BuildModel CreateModelFromItems(ITaskItem[] artifacts, string buildId, string[] BuildProperties, string repoUri, string repoBranch, string repoCommit)
+        {
+            if (artifacts == null)
+            {
+                throw new ArgumentNullException(nameof(artifacts));
+            }
+
+            var blobArtifacts = new List<BlobArtifactModel>();
+            var packageArtifacts = new List<PackageArtifactModel>();
+
+            foreach (var artifact in artifacts)
+            {
+                var isSymbolsPackage = artifact.ItemSpec.EndsWith(".symbols.nupkg", StringComparison.OrdinalIgnoreCase)
+                    || artifact.ItemSpec.EndsWith(".snupkg", StringComparison.OrdinalIgnoreCase);
+
+                if (artifact.ItemSpec.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase) && !isSymbolsPackage)
+                {
+                    packageArtifacts.Add(BuildManifestUtil.CreatePackageArtifactModel(artifact));
+                }
+                else
+                {
+                    if (isSymbolsPackage)
+                    {
+                        string fileName = Path.GetFileName(artifact.ItemSpec);
+                        artifact.SetMetadata("RelativeBlobPath", $"{BuildManifestUtil.AssetsVirtualDir}symbols/{fileName}");
+                    }
+
+                    blobArtifacts.Add(BuildManifestUtil.CreateBlobArtifactModel(artifact));
+                }
+            }
+
+            var buildModel = BuildManifestUtil.CreateModel(
+                blobArtifacts,
+                packageArtifacts,
+                buildId,
+                BuildProperties,
+                repoUri,
+                repoBranch,
+                repoCommit);
+            return buildModel;
+        }
+
+        private static BuildModel CreateModel(IEnumerable<BlobArtifactModel> blobArtifacts,
+            IEnumerable<PackageArtifactModel> packageArtifacts,
+            string manifestBuildId,
+            string[] manifestBuildData,
+            string manifestRepoUri,
+            string manifestBranch,
+            string manifestCommit)
+        {
             BuildModel buildModel = new BuildModel(
                     new BuildIdentity
                     {
-                        Attributes = ParseManifestMetadataString(manifestBuildData),
+                        Attributes = MSBuildListSplitter.GetNamedProperties(manifestBuildData),
                         Name = manifestRepoUri,
                         BuildId = manifestBuildId,
                         Branch = manifestBranch,
@@ -44,12 +103,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
             buildModel.Artifacts.Blobs.AddRange(blobArtifacts);
             buildModel.Artifacts.Packages.AddRange(packageArtifacts);
-
-            string dirPath = Path.GetDirectoryName(assetManifestPath);
-
-            Directory.CreateDirectory(dirPath);
-
-            File.WriteAllText(assetManifestPath, buildModel.ToXml().ToString());
+            return buildModel;
         }
 
         public static BuildModel ManifestFileToModel(string assetManifestPath, TaskLoggingHelper log)
@@ -94,34 +148,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             return null;
         }
 
-        private static Dictionary<string, string> ParseCustomAttributes(ITaskItem item)
+        private static IDictionary<string, string> ParseCustomAttributes(ITaskItem item)
         {
-            return ParseManifestMetadataString(item.GetMetadata("ManifestArtifactData"));
-        }
-
-        private static Dictionary<string, string> ParseManifestMetadataString(string data)
-        {
-            if (string.IsNullOrEmpty(data))
-            {
-                return new Dictionary<string, string>();
-            }
-
-            return data.Split(ManifestDataPairSeparators, StringSplitOptions.RemoveEmptyEntries)
-                .Select(pair =>
-                {
-                    int keyValueSeparatorIndex = pair.IndexOf('=');
-                    if (keyValueSeparatorIndex > 0)
-                    {
-                        return new
-                        {
-                            Key = pair.Substring(0, keyValueSeparatorIndex).Trim(),
-                            Value = pair.Substring(keyValueSeparatorIndex + 1).Trim()
-                        };
-                    }
-                    return null;
-                })
-                .Where(pair => pair != null)
-                .ToDictionary(pair => pair.Key, pair => pair.Value);
+            return MSBuildListSplitter.GetNamedProperties(item.GetMetadata("ManifestArtifactData"));
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/GenerateBuildManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/GenerateBuildManifest.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using System;
+using MSBuild = Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.Build.Tasks.Feed
+{
+    /// <summary>
+    /// This task generates an XML build manifest for a list of packages and files.
+    /// </summary>
+    public class GenerateBuildManifest : MSBuild.Task
+    {
+        /// <summary>
+        /// An list of files produced by the build.
+        /// <para>
+        /// Supported metadata values:
+        /// 
+        ///   * RelativeBlobPath = the expect path of a blob once it has been pushed to blob storage
+        ///   * ManifestArtifactData = an arbitrary key=value list of properties
+        /// </para>
+        /// </summary>
+        [Required]
+        public ITaskItem[] Artifacts { get; set; }
+
+        /// <summary>
+        /// The location where the build XML file will be generated
+        /// </summary>
+        [Required]
+        public string OutputPath { get; set; }
+
+        /// <summary>
+        /// The CI build ID.
+        /// </summary>
+        public string BuildId { get; set; } = "no build id provided";
+
+        /// <summary>
+        /// Named properties, and abitrary list of metadata about the current build.
+        /// </summary>
+        public string[] BuildData { get; set; }
+
+        /// <summary>
+        /// The URI of the source code repostory used to produce the artifacts.
+        /// </summary>
+        public string RepoUri { get; set; }
+
+        /// <summary>
+        /// The branch name of the source code used to produce the artifacts.
+        /// </summary>
+        public string RepoBranch { get; set; }
+
+        /// <summary>
+        /// The commit hash of the source code used to produce the artifacts.
+        /// </summary>
+        public string RepoCommit { get; set; }
+
+        public override bool Execute()
+        {
+            try
+            {
+                var buildModel = BuildManifestUtil.CreateModelFromItems(Artifacts, BuildId, BuildData, RepoUri, RepoBranch, RepoCommit);
+
+                buildModel.WriteAsXml(OutputPath, Log);
+            }
+            catch (Exception e)
+            {
+                Log.LogErrorFromException(e, true);
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public string ManifestCommit { get; set; }
 
-        public string ManifestBuildData { get; set; }
+        public string[] ManifestBuildData { get; set; }
 
         public string AssetManifestPath { get; set; }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBlobFeed.cs
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public string ManifestCommit { get; set; }
 
-        public string ManifestBuildData { get; set; }
+        public string[] ManifestBuildData { get; set; }
 
         public string AssetManifestPath { get; set; }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/MSBuildListSplitter.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/MSBuildListSplitter.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Build.Tasks.Feed
+{
+    internal static class MSBuildListSplitter
+    {
+        public static IDictionary<string, string> GetNamedProperties(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            return GetNamedProperties(input.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries));
+        }
+
+        public static IDictionary<string, string> GetNamedProperties(string[] input)
+        {
+            var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (input == null)
+            {
+                return values;
+            }
+
+            foreach (var item in input)
+            {
+                var splitIdx = item.IndexOf('=');
+                if (splitIdx < 0)
+                {
+                    continue;
+                }
+
+                var key = item.Substring(0, splitIdx).Trim();
+                if (string.IsNullOrEmpty(key))
+                {
+                    continue;
+                }
+
+                var value = item.Substring(splitIdx + 1);
+                values[key] = value;
+            }
+
+            return values;
+        }
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/dotnet/arcade/issues/1675

I am intentionally just adding this task without tying it into the Arcade SDK. Arcade's publish.proj targets need to be refactored for #1179 anyways, so I'm not going to mess with it. In aspnet, we'll use this task in our own targets so we can generate the BAR manifest for publishing to darc.