### PR TITLE
Swix fixes

### DIFF
--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -381,7 +381,7 @@ VSIX packages are built to `VSSetup` directory.
 
 ## Visual Studio Insertion components (optional)
 
-Repository that builds VS insertion components must set `VisualStudioDropName` global property (see [Common steps in Azure DevOps pipeline](Common-steps-in-Azure-DevOps-pipeline))
+Repository that builds VS insertion components must set `VisualStudioDropName` global property (see [Common steps in Azure DevOps pipeline](common-steps-in-azure-devops-pipeline))
 
 To include the output VSIX of a project in Visual Studio insertion, set the `VisualStudioInsertionComponent` property.
 Multiple VSIXes can specify the same component name, in which case their manifests will be merged into a single insertion unit.

--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -260,7 +260,7 @@ Targets executed in a step right after the solution is built.
 
 Targets executed in a step right after artifacts has been signed.
 
-### /global.json, /nuget.config: SDK configuration
+### /global.json, /NuGet.config: SDK configuration
 
 `/global.json` file is present and specifies the version of the dotnet and `Microsoft.DotNet.Arcade.Sdk` SDKs.
 
@@ -370,9 +370,8 @@ Building Visual Studio components is an opt-in feature of the Arcade SDK. Proper
 
 Set `VSSDKTargetPlatformRegRootSuffix` property to specify the root suffix of the VS hive to deploy to.
 
-If `source.extension.vsixmanifest` is present next to a project file the project is by default considered to be a VSIX producing project. 
+If `source.extension.vsixmanifest` is present next to a project file the project is by default considered to be a VSIX producing project (`IsVsixProject` property is set to true). 
 A package reference to `Microsoft.VSSDK.BuildTools` is automatically added to such project. 
-A project that needs `Microsoft.VSSDK.BuildTools` for generating pkgdef file needs to include the PackageReference explicitly.
 
 Arcade SDK include build target for generating VS Template VSIXes. Adding `VSTemplate` items to project will trigger the target.
 
@@ -382,12 +381,15 @@ VSIX packages are built to `VSSetup` directory.
 
 ## Visual Studio Insertion components (optional)
 
-To include the output VSIX of a project in Visual Studio Insertion, set the `VisualStudioInsertionComponent` property.
+Repository that builds VS insertion components must set `VisualStudioDropName` global property (see [Common steps in Azure DevOps pipeline](Common-steps-in-Azure-DevOps-pipeline))
+
+To include the output VSIX of a project in Visual Studio insertion, set the `VisualStudioInsertionComponent` property.
 Multiple VSIXes can specify the same component name, in which case their manifests will be merged into a single insertion unit.
 
 The Visual Studio insertion manifests and VSIXes are generated during Pack task into `VSSetup\Insertion` directory, where they are picked by by MicroBuild Azure DevOps publishing task during official builds.
 
 Arcade SDK also enables building VS Setup Components from .swr files (as opposed to components comprised of one or more VSIXes).
+Projects that set `VisualStudioInsertionComponent` but do not have `source.extension.vsixmanifest` are considered to be _swix projects_ (`IsSwixProject` property is set to true).
 
 Use `SwrProperty` and `SwrFile` items to define a property that will be substituted in .swr files for given value and the set of .swr files, respectively.
 
@@ -429,11 +431,16 @@ folder "InstallDir:MSBuild\Microsoft\VisualStudio\Managed"
   file source="$(VisualStudioXamlRulesDir)Microsoft.Managed.DesignTime.targets"
 ```
 
-## MicroBuild
+## Common steps in Azure DevOps pipeline
 
-The repository shall define a YAML Pipeline that uses MicroBuild (e.g. `azure-pipelines.yml`).
+The steps below assume the following variables to be defined:
 
-The following step shall be included in the definition:
+- `SignType` - the signing type: "real" (default) or "test"
+- `BuildConfiguration` - the build configuration "Debug" or "Release"
+- `OperatingSystemName` - "Windows", "Linux", etc.
+- `VisualStudioDropName` - VS insertion component drop name (if the repository builds these), usually `Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)`
+
+### Signing plugin installation
 
 ```yml
 - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
@@ -444,15 +451,26 @@ The following step shall be included in the definition:
   condition: and(succeeded(), ne(variables['SignType'], ''))
 ```
 
+### Official build script
+
 ```yml
 - script: eng\common\CIBuild.cmd 
           -configuration $(BuildConfiguration)
           /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+          /p:VisualStudioDropName=$(VisualStudioDropName) # required if repository builds VS insertion components
           /p:DotNetSignType=$(SignType)
           /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
           /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
   displayName: Build
 ```
+
+The Build Pipeline needs to link the following variable group:
+
+- DotNet-Symbol-Publish 
+  - `microsoft-symbol-server-pat`
+  - `symweb-symbol-server-pat`
+
+### Publishing test results
 
 ```yml
 - task: PublishTestResults@1
@@ -462,18 +480,33 @@ The following step shall be included in the definition:
     testResultsFiles: 'artifacts/$(BuildConfiguration)/TestResults/*.xml'
     mergeTestResults: true
     testRunTitle: 'Unit Tests'
-  condition: succeededOrFailed()
+  condition: always()
 ```
 
-The above build steps assume the following variables to be defined:
+### Publishing logs
 
-- `SignType`, which specified the kind signing type: "real" (default) or "test"
+```yml
+- task: PublishBuildArtifacts@1
+    displayName: Publish Logs
+    inputs:
+      PathtoPublish: '$(Build.SourcesDirectory)\artifacts\log\$(BuildConfiguration)'
+      ArtifactName: '$(OperatingSystemName) $(BuildConfiguration)'
+    continueOnError: true
+    condition: not(succeeded())
+```
 
-The Build Pipeline also needs to link the following variable group:
+### Publishing VS insertion artifacts to a drop
 
-- DotNet-Symbol-Publish 
-  - `microsoft-symbol-server-pat`
-  - `symweb-symbol-server-pat`
+This step is required for repositories that build VS insertion components.
+
+```yml
+- task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1
+  displayName: Upload VSTS Drop
+  inputs:
+    DropName: $(VisualStudioDropName)
+    DropFolder: 'artifacts\VSSetup\$(BuildConfiguration)\Insertion'
+    condition: succeeded()
+```
 
 ## Project Properties Defined by the SDK
 

--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -381,7 +381,7 @@ VSIX packages are built to `VSSetup` directory.
 
 ## Visual Studio Insertion components (optional)
 
-Repository that builds VS insertion components must set `VisualStudioDropName` global property (see [Common steps in Azure DevOps pipeline](common-steps-in-azure-devops-pipeline))
+Repository that builds VS insertion components must set `VisualStudioDropName` global property (see [Common steps in Azure DevOps pipeline](#common-steps-in-azure-devops-pipeline))
 
 To include the output VSIX of a project in Visual Studio insertion, set the `VisualStudioInsertionComponent` property.
 Multiple VSIXes can specify the same component name, in which case their manifests will be merged into a single insertion unit.

--- a/Documentation/RepoToolset/MigrationToArcade.md
+++ b/Documentation/RepoToolset/MigrationToArcade.md
@@ -32,7 +32,7 @@ Below is a list of changes required to migrate to Arcade.
 ### New `-publish` build parameter
 A new option `-publish` was added to `build.ps1` script that needs to be set for CI builds. If the repo uses a custom `CIBuild.cmd` pass `-publish` when invoking `build.ps1`. See [CIBuild.cmd](https://github.com/dotnet/symreader/blob/master/eng/common/CIBuild.cmd#L2).
 
-## Arcade.SDK
+## Arcade.SDK 
 
 ### Global.json
 ```
@@ -125,3 +125,8 @@ The following applies to CI build definition, not PR validation build definition
 
 <Target Name="_CorePublish" DependsOnTargets="Publish" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
 ```
+
+## Arcade SDK (19055.1)
+
+- MicroBuildSwixPlugin installation step not required anymore: https://github.com/dotnet/arcade/pull/1692
+- A project that generates pkgdef file but does not produce a VSIX container does _not_ need to include the `Microsoft.VSSDK.BuildTools` PackageReference explicitly anymore.

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets
@@ -33,6 +33,9 @@
 
     <PackageOutputPath Condition="'$(IsShipping)' == 'true'">$(ArtifactsShippingPackagesDir)</PackageOutputPath>
     <PackageOutputPath Condition="'$(IsShipping)' != 'true'">$(ArtifactsNonShippingPackagesDir)</PackageOutputPath>
+
+    <IsSwixProject>false</IsSwixProject>
+    <IsSwixProject Condition="'$(VisualStudioInsertionComponent)' != '' and '$(IsVsixProject)' != 'true'">true</IsSwixProject>
   </PropertyGroup>
 
   <Import Project="StrongName.targets"/>
@@ -45,7 +48,7 @@
 
   <Import Project="Performance.targets" Condition="'$(DisableArcadeTestFramework)' != 'true'" />
   <Import Project="Localization.targets" Condition="'$(UsingToolXliff)' == 'true'"/>
-  <Import Project="VisualStudio.targets" Condition="'$(UsingToolVSSDK)' == 'true' and '$(DesignTimeBuild)' != 'true' and '$(BuildingForLiveUnitTesting)' != 'true' and '$(MSBuildRuntimeType)' != 'Core'"/>
+  <Import Project="VisualStudio.targets" Condition="'$(UsingToolVSSDK)' == 'true' and ('$(IsVsixProject)' == 'true' or '$(IsSwixProject)' == 'true' or '$(GeneratePkgDefFile)' == 'true') and '$(DesignTimeBuild)' != 'true' and '$(BuildingForLiveUnitTesting)' != 'true' and '$(MSBuildRuntimeType)' != 'Core'"/>
   <Import Project="OptimizationData.targets" Condition="'$(UsingToolIbcOptimization)' == 'true' and '$(IbcOptimizationDataDir)' != ''"/>
   <Import Project="SymStore.targets" Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(OS)' == 'Windows_NT'"/>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.props
@@ -14,12 +14,6 @@
     <IsVsixProject Condition="Exists('$(VsixSourceManifestPath)')">true</IsVsixProject>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(IsVsixProject)' == 'true'">
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="$(MicrosoftVSSDKBuildToolsVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
-    <PackageReference Include="RoslynTools.ModifyVsixManifest" Version="$(RoslynToolsModifyVsixManifestVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
-    <PackageReference Include="MicroBuild.Plugins.SwixBuild" Version="$(MicroBuildPluginsSwixBuildVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
-  </ItemGroup>
-
   <PropertyGroup Condition="'$(IsVsixProject)' == 'true'">
     <BuildForLiveUnitTesting>false</BuildForLiveUnitTesting>
     <DeployExtension>false</DeployExtension>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.targets
@@ -63,9 +63,19 @@
       <NgenArchitecture Condition="'%(NgenArchitecture)' == '' and '%(Ngen)' != 'false'">All</NgenArchitecture>
       <NgenPriority Condition="'%(NgenPriority)' == '' and '%(Ngen)' != 'false'">3</NgenPriority>
     </ProjectReference>
+
+    <PackageReference Include="MicroBuild.Plugins.SwixBuild" Version="$(MicroBuildPluginsSwixBuildVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
 
-  <!-- 
+  <ItemGroup Condition="'$(IsVsixProject)' == 'true'">
+    <PackageReference Include="RoslynTools.ModifyVsixManifest" Version="$(RoslynToolsModifyVsixManifestVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IsVsixProject)' == 'true' or '$(GeneratePkgDefFile)' == 'true'">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="$(MicrosoftVSSDKBuildToolsVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
+  </ItemGroup>
+
+  <!--
     Assemblies that are NGEN'd should be loaded to Load context, otherwise NGEN would not work.
     UseCodebase causes assemblies to be loaded to LoadFrom context, so it's incompatible with NGEN setting.
   -->
@@ -183,12 +193,16 @@
           DependsOnTargets="_CalculateSwixBuildOutputs;_WriteComponentStubFile"
           AfterTargets="Build"
           Outputs="$(_SwixBuildOutputs)"
-          Condition="'@(SwrFile)' != ''">
+          Condition="'$(IsSwixProject)' == 'true'">
+
+    <Error Text="Visual Studio insertion component must either have extension.vsixmanifest or specify SwrFile items"
+           Condition="'@(SwrFile)' == ''" />
 
     <PropertyGroup>
       <_SwrProperties>@(SwrProperty)</_SwrProperties>
       <_SwrFiles>@(SwrFile->'%(FullPath)')</_SwrFiles>
     </PropertyGroup>
+
     <ItemGroup>
       <_SwixArgs Include="SwrProperties=$([MSBuild]::Escape($(_SwrProperties)))"/>
       <_SwixArgs Include="SwrFiles=$([MSBuild]::Escape($(_SwrFiles)))"/>


### PR DESCRIPTION
Implicitly include reference to `Microsoft.VSSDK.BuildTools` when `GeneratePkgDefFile` is true.
Implicitly include reference to `MicroBuild.Plugins.SwixBuild` to projects that produce VS insertion components from swr files.