### PR TITLE
Add common arcade test targets

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/Microsoft.DotNet.CoreFxTesting.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/Microsoft.DotNet.CoreFxTesting.targets
@@ -72,10 +72,10 @@
   <Import Condition="'$(BuildingUAPVertical)' == 'true'" Project="$(MSBuildThisFileDirectory)Resources.uap.targets" />
 
   <!-- Performance test data upload to Benchview. -->
-  <Import Condition="'$(EnableBenchviewTarget)' == 'true' AND '$(Performance)' == 'true' AND '$(SkipTests)' != 'true'" Project="$([MSBuild]::NormalizePath('$(TestCoreDir)', 'performance', 'Benchview.targets'))" />
+  <Import Condition="'$(EnableBenchviewTarget)' == 'true'" Project="$([MSBuild]::NormalizePath('$(TestCoreDir)', 'performance', 'Benchview.targets'))" />
 
   <!-- Full coverage report. -->
-  <Import Condition="'$(EnableFullCoverageReportTarget)' == 'true' AND '$(SkipCoverageReport)' != 'true' AND '$(Coverage)' == 'true' AND '$(SkipTests)' != 'true'" Project="$([MSBuild]::NormalizePath('$(TestCoreDir)', 'coverage', 'CoverageReport.targets'))" />
+  <Import Condition="'$(EnableFullCoverageReportTarget)' == 'true' AND '$(SkipCoverageReport)' != 'true' AND '$(Coverage)' == 'true'" Project="$([MSBuild]::NormalizePath('$(TestCoreDir)', 'coverage', 'CoverageReport.targets'))" />
 
   <!-- Import the core testing infrastructure only for test projects. -->
   <Import Condition="'$(IsTestProject)' == 'true' AND '$(IsTestSupportProject)' != 'true'"  Project="$(TestCoreDir)Core.targets" />

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.props
@@ -44,7 +44,7 @@
 
   <!--
     Performance test support.
-    Supported runners: xunit-performance, BenchmarkDotNet.
+    Supported runners: xunit-performance.
   -->
   <Import Condition="'$(IsPerformanceTestProject)' == 'true'" Project="$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', 'performance', 'Performance.props'))" />
 

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.props
@@ -24,7 +24,6 @@
       $(TestDependsOn);
       GenerateRunScript;
       RunTests;
-      ArchiveTestBuild;
     </TestDependsOn>
   </PropertyGroup>
 
@@ -45,7 +44,7 @@
 
   <!--
     Performance test support.
-    Supported runners: xunit-performance.
+    Supported runners: xunit-performance, BenchmarkDotNet.
   -->
   <Import Condition="'$(IsPerformanceTestProject)' == 'true'" Project="$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', 'performance', 'Performance.props'))" />
 

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
@@ -10,7 +10,7 @@
     <RunWorkingDirectory>$(TestPath)</RunWorkingDirectory>
 
     <!-- Publish the test data as part of the build to enable VS test runs. -->
-    <PrepareForRunDependsOn>$(PrepareForRunDependsOn);PublishSupplementalTestData;ArchiveTestBuild;</PrepareForRunDependsOn>
+    <PrepareForRunDependsOn>$(PrepareForRunDependsOn);PublishSupplementalTestData;ArchiveTests;</PrepareForRunDependsOn>
     <!-- Clean leftovers not tracked by FileWrites. -->
     <CleanDependsOn>$(CleanDependsOn);CleanTestPath;</CleanDependsOn>
   </PropertyGroup>
@@ -63,8 +63,8 @@
   </Target>
 
   <!-- Archive test binaries along with supporting files. -->
-  <Target Name="ArchiveTestBuild"
-          Condition="'$(ArchiveTests)' == 'true'"
+  <Target Name="ArchiveTests"
+          Condition="'$(ArchiveTests)' == 'true' OR $(MSBuildProjectName.EndsWith('.$(ArchiveTests)'))"
           DependsOnTargets="GenerateRunScript">
 
     <Error Condition="'$(TestArchiveTestsDir)' == ''" Text="TestArchiveTestsDir property to archive the test folder must be set." />
@@ -82,6 +82,8 @@
   </Target>
 
   <Target Name="GenerateRunScript"
+          Inputs="unused"
+          Outputs="$(RunScriptOutputPath)"
           DependsOnTargets="$(GenerateRunScriptDependsOn)">
 
     <PropertyGroup>

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
@@ -83,8 +83,6 @@
   </Target>
 
   <Target Name="GenerateRunScript"
-          Inputs="unused"
-          Outputs="$(RunScriptOutputPath)"
           DependsOnTargets="$(GenerateRunScriptDependsOn)">
 
     <PropertyGroup>

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
@@ -10,7 +10,7 @@
     <RunWorkingDirectory>$(TestPath)</RunWorkingDirectory>
 
     <!-- Publish the test data as part of the build to enable VS test runs. -->
-    <PrepareForRunDependsOn>$(PrepareForRunDependsOn);PublishSupplementalTestData;ArchiveTests;</PrepareForRunDependsOn>
+    <PrepareForRunDependsOn>$(PrepareForRunDependsOn);PublishSupplementalTestData;</PrepareForRunDependsOn>
     <!-- Clean leftovers not tracked by FileWrites. -->
     <CleanDependsOn>$(CleanDependsOn);CleanTestPath;</CleanDependsOn>
   </PropertyGroup>
@@ -65,6 +65,7 @@
   <!-- Archive test binaries along with supporting files. -->
   <Target Name="ArchiveTests"
           Condition="'$(ArchiveTests)' == 'true' OR $(MSBuildProjectName.EndsWith('.$(ArchiveTests)'))"
+          AfterTargets="PrepareForRun"
           DependsOnTargets="GenerateRunScript">
 
     <Error Condition="'$(TestArchiveTestsDir)' == ''" Text="TestArchiveTestsDir property to archive the test folder must be set." />

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
@@ -10,8 +10,7 @@
     <RunWorkingDirectory>$(TestPath)</RunWorkingDirectory>
 
     <!-- Publish the test data as part of the build to enable VS test runs. -->
-    <PrepareForRunDependsOn>$(PrepareForRunDependsOn);PublishSupplementalTestData;</PrepareForRunDependsOn>
-    <PrepareForRunDependsOn Condition="'$(ArchiveTests)' == 'true'">$(PrepareForRunDependsOn);ArchiveTestBuild;</PrepareForRunDependsOn>
+    <PrepareForRunDependsOn>$(PrepareForRunDependsOn);PublishSupplementalTestData;ArchiveTestBuild;</PrepareForRunDependsOn>
     <!-- Clean leftovers not tracked by FileWrites. -->
     <CleanDependsOn>$(CleanDependsOn);CleanTestPath;</CleanDependsOn>
   </PropertyGroup>
@@ -65,6 +64,7 @@
 
   <!-- Archive test binaries along with supporting files. -->
   <Target Name="ArchiveTestBuild"
+          Condition="'$(ArchiveTests)' == 'true'"
           DependsOnTargets="GenerateRunScript">
 
     <Error Condition="'$(TestArchiveTestsDir)' == ''" Text="TestArchiveTestsDir property to archive the test folder must be set." />
@@ -172,7 +172,7 @@
 
     <Message Condition="'%(UnsupportedPlatformsItems.Identity)' == '$(TargetOS)'"
              Text="Skipping tests in $(AssemblyName) because it is not supported on $(TargetOS)" />
-    
+
     <Message Condition="'$(ConfigurationErrorMsg)' != ''"
              Text="Skipping tests in $(AssemblyName) because there is no configuration compatible with the current BuildConfiguration." />
 
@@ -240,7 +240,7 @@
 
   <!--
     Performance test support.
-    Supported runners: xunit-performance, BenchmarkDotNet.
+    Supported runners: xunit-performance.
   -->
   <Import Condition="'$(IsPerformanceTestProject)' == 'true'" Project="$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', 'performance', 'Performance.targets'))" />
 

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
@@ -64,7 +64,7 @@
 
   <!-- Archive test binaries along with supporting files. -->
   <Target Name="ArchiveTests"
-          Condition="'$(ArchiveTests)' == 'true' OR $(MSBuildProjectName.EndsWith('.$(ArchiveTests)'))"
+          Condition="'$(ArchiveTests.ToLower())' == 'all' OR $(MSBuildProjectName.EndsWith('.$(ArchiveTests)'))"
           AfterTargets="PrepareForRun"
           DependsOnTargets="GenerateRunScript">
 

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
@@ -11,6 +11,8 @@
 
     <!-- Publish the test data as part of the build to enable VS test runs. -->
     <PrepareForRunDependsOn>$(PrepareForRunDependsOn);PublishSupplementalTestData;</PrepareForRunDependsOn>
+    <PrepareForRunDependsOn Condition="'$(ArchiveTests)' == 'true'">$(PrepareForRunDependsOn);ArchiveTestBuild;</PrepareForRunDependsOn>
+    <PrepareForRunDependsOn Condition="'$(GenerateTestScripts)' == 'true'">$(PrepareForRunDependsOn);GenerateRunScript;</PrepareForRunDependsOn>
     <!-- Clean leftovers not tracked by FileWrites. -->
     <CleanDependsOn>$(CleanDependsOn);CleanTestPath;</CleanDependsOn>
   </PropertyGroup>
@@ -64,8 +66,7 @@
 
   <!-- Archive test binaries along with supporting files. -->
   <Target Name="ArchiveTestBuild"
-          DependsOnTargets="GenerateRunScript"
-          Condition="'$(ArchiveTests)' == 'true'">
+          DependsOnTargets="GenerateRunScript">
 
     <Error Condition="'$(TestArchiveTestsDir)' == ''" Text="TestArchiveTestsDir property to archive the test folder must be set." />
 
@@ -171,19 +172,15 @@
     <Message Text="ValidateTestPlatform found TargetOS of [$(TargetOS)]." Importance="Low" />
 
     <Message Condition="'%(UnsupportedPlatformsItems.Identity)' == '$(TargetOS)'"
-      Text="Skipping tests in $(AssemblyName) because it is not supported on $(TargetOS)" />
-
+             Text="Skipping tests in $(AssemblyName) because it is not supported on $(TargetOS)" />
+    
     <Message Condition="'$(ConfigurationErrorMsg)' != ''"
-      Text="Skipping tests in $(AssemblyName) because there is no configuration compatible with the current BuildConfiguration." />
+             Text="Skipping tests in $(AssemblyName) because there is no configuration compatible with the current BuildConfiguration." />
 
   </Target>
 
-  <!--
-    SkipTests is a global property used in CI runs. Skips the test execution but
-    still generates the test execution script and archives the test dir for Helix consumption.
-  -->
   <Target Name="RunTests"
-          Condition="'$(SkipTests)' != 'true' OR '$(TestDisabled)' == 'true'"
+          Condition="'$(TestDisabled)' != 'true'"
           DependsOnTargets="$(RunTestsDependsOn)"
           Inputs="@(RunTestsInputs)"
           Outputs="@(RunTestsOutputs)">
@@ -216,11 +213,6 @@
 
   </Target>
 
-  <!-- Main test targets -->
-  <Target Name="Test" DependsOnTargets="$(TestDependsOn)" Condition="'$(DisableTestTargets)' != 'true'" />
-  <Target Name="BuildAndTest" DependsOnTargets="Build;Test" />
-  <Target Name="RebuildAndTest" DependsOnTargets="Rebuild;Test" />
-
   <Import Condition="'$(BuildingUAPVertical)' == 'true'" Project="$(MSBuildThisFileDirectory)Core.uap.targets" />
 
   <!--
@@ -249,7 +241,7 @@
 
   <!--
     Performance test support.
-    Supported runners: xunit-performance.
+    Supported runners: xunit-performance, BenchmarkDotNet.
   -->
   <Import Condition="'$(IsPerformanceTestProject)' == 'true'" Project="$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', 'performance', 'Performance.targets'))" />
 

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
@@ -12,7 +12,6 @@
     <!-- Publish the test data as part of the build to enable VS test runs. -->
     <PrepareForRunDependsOn>$(PrepareForRunDependsOn);PublishSupplementalTestData;</PrepareForRunDependsOn>
     <PrepareForRunDependsOn Condition="'$(ArchiveTests)' == 'true'">$(PrepareForRunDependsOn);ArchiveTestBuild;</PrepareForRunDependsOn>
-    <PrepareForRunDependsOn Condition="'$(GenerateTestScripts)' == 'true'">$(PrepareForRunDependsOn);GenerateRunScript;</PrepareForRunDependsOn>
     <!-- Clean leftovers not tracked by FileWrites. -->
     <CleanDependsOn>$(CleanDependsOn);CleanTestPath;</CleanDependsOn>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/performance/Performance.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/performance/Performance.targets
@@ -7,9 +7,6 @@
   <Import Condition="'$(IsBenchmarkDotNetProject)' == 'true'" Project="$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', 'runner', 'BenchmarkDotNet.targets'))" />
 
   <PropertyGroup>
-    <!-- Disable test targets if global property performance is set to false. -->
-    <DisableTestTargets Condition="'$(Performance)' == 'false'">true</DisableTestTargets>
-
     <MeasurementPyCommand>$(PythonCommand) "$(BenchviewDir)measurement.py" xunit "$(RunId)-$(AssemblyName).xml" --better desc --drop-first-value --append -o "$(RepoRoot)measurement.json" || $(CliExitErrorCommand)</MeasurementPyCommand>
   </PropertyGroup>
 
@@ -22,9 +19,6 @@
   </ItemGroup>
 
   <Target Name="ValidatePerfConfigurations">
-
-    <Warning Condition="!$(ConfigurationGroup.ToLower().Contains('release'))"
-             Text="You are running performance tests in a configuration other than Release. Your results may be unreliable." />
 
     <Error Condition="'$(PerformanceType)' != 'Diagnostic' AND '$(PerformanceType)' != 'Profile'"
            Text="Invalid Performance Type value specified: $(PerformanceType)" />
@@ -47,5 +41,10 @@
       </PropertyGroup>
     </When>
   </Choose>
+
+  <!-- Main test targets -->
+  <Target Name="PerformanceTest" DependsOnTargets="$(TestDependsOn)" Condition="'$(IsPerformanceTestProject)' == 'true'" />
+  <Target Name="BuildAndPerformanceTest" DependsOnTargets="Build;PerformanceTest" Condition="'$(IsPerformanceTestProject)' == 'true'" />
+  <Target Name="RebuildAndPerformanceTest" DependsOnTargets="Rebuild;PerformanceTest" Condition="'$(IsPerformanceTestProject)' == 'true'" />
 
 </Project>

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/performance/runner/BenchmarkDotNet.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/performance/runner/BenchmarkDotNet.targets
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <!-- Helix dependencies -->
-  <ItemGroup Condition="'$(ArchiveTests)' == 'true' AND '$(IncludePerformanceTestFrameworkReferences)' == 'true'">
+  <ItemGroup Condition="'$(IncludePerformanceTestFrameworkReferences)' == 'true'">
     <TestArchiveDependencies Include="$(RuntimePath)BenchmarkDotNet.dll" />
     <TestArchiveDependencies Include="$(RuntimePath)BenchmarkDotNet.Diagnostics.Windows.dll" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/performance/runner/xunit-performance.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/performance/runner/xunit-performance.targets
@@ -43,8 +43,8 @@
     <TestArchiveDependencies Include="$(RuntimePath)xunit.assert.dll" />
     <TestArchiveDependencies Include="$(RuntimePath)xunit.core.dll" />
     <TestArchiveDependencies Include="$(RuntimePath)xunit.abstractions.dll" />
-    <TestArchiveDependencies Include="$(RuntimePath)xunit.performance.api" />
-    <TestArchiveDependencies Include="$(RuntimePath)xunit.performance.core" />
+    <TestArchiveDependencies Include="$(RuntimePath)xunit.performance.api.dll" />
+    <TestArchiveDependencies Include="$(RuntimePath)xunit.performance.core.dll" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/performance/runner/xunit-performance.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/performance/runner/xunit-performance.targets
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <!-- Helix dependencies -->
-  <ItemGroup Condition="'$(ArchiveTests)' == 'true' AND '$(IncludePerformanceTestFrameworkReferences)' == 'true'">
+  <ItemGroup Condition="'$(IncludePerformanceTestFrameworkReferences)' == 'true'">
     <TestArchiveDependencies Include="$(RuntimePath)Microsoft.DotNet.XUnitExtensions.dll" />
     <TestArchiveDependencies Include="$(RuntimePath)xunit.assert.dll" />
     <TestArchiveDependencies Include="$(RuntimePath)xunit.core.dll" />

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.props
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <!-- Helix dependencies -->
-  <ItemGroup Condition="'$(ArchiveTests)' == 'true' AND '$(IncludeTestFrameworkReferences)' == 'true'">
+  <ItemGroup Condition="'$(IncludeTestFrameworkReferences)' == 'true'">
     <TestArchiveDependencies Include="$(RuntimePath)Microsoft.DotNet.XUnitExtensions.dll" />
     <TestArchiveDependencies Include="$(RuntimePath)xunit.assert.dll" />
     <TestArchiveDependencies Include="$(RuntimePath)xunit.core.dll" />

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
@@ -38,7 +38,7 @@
     <_withoutCategories Condition="'$(WithoutCategories)' != ''">;$(WithoutCategories.Trim(';'))</_withoutCategories>
     <!-- Default non categories -->
     <_withoutCategories Condition="!$(_withCategories.Contains('failing'))">$(_withoutCategories);failing</_withoutCategories>
-    <_withoutCategories Condition="'$(Outerloop)' != 'true'">$(_withoutCategories);Outerloop</_withoutCategories>
+    <_withoutCategories Condition="'$(OuterLoop)' != 'true'">$(_withoutCategories);OuterLoop</_withoutCategories>
     <RunArguments>$(RunArguments)$(_withCategories.Replace(';', ' -trait category='))</RunArguments>
     <RunArguments>$(RunArguments)$(_withoutCategories.Replace(';', ' -notrait category='))</RunArguments>
 

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
@@ -150,4 +150,13 @@
 
   </Choose>
 
+  <!-- Main test targets -->
+  <Target Name="Test" DependsOnTargets="$(TestDependsOn)" Condition="'$(IsUnitTestProject)' == 'true'" />
+  <Target Name="BuildAndTest" DependsOnTargets="Build;Test" Condition="'$(IsUnitTestProject)' == 'true'" />
+  <Target Name="RebuildAndTest" DependsOnTargets="Rebuild;Test" Condition="'$(IsUnitTestProject)' == 'true'" />
+
+  <Target Name="IntegrationTest" DependsOnTargets="$(TestDependsOn)" Condition="'$(IsIntegrationTestProject)' == 'true'" />
+  <Target Name="BuildAndIntegrationTest" DependsOnTargets="Build;IntegrationTest" Condition="'$(IsIntegrationTestProject)' == 'true'" />
+  <Target Name="RebuildAndIntegrationTest" DependsOnTargets="Rebuild;IntegrationTest" Condition="'$(IsIntegrationTestProject)' == 'true'" />
+
 </Project>


### PR DESCRIPTION
Relates to https://github.com/dotnet/corefx/pull/34385

Changes:
- All test assets required for helix runs can now be generated as part of the test project build by settings `/p:ArchiveTests=Tests|IntegrationTests|PerformanceTests|(Packages)|All`.
- Remove `$(SkipTests)` property which is not needed anymore as the test targets should only be used if you REALLY want to run tests.
- Remove `$(Performance)` property which is not needed anymore as performance tests now have a unique target and performance related msbuild files are only imported if `IsPerformanceTestProject´ equals true.
- Add test targets depending on the project: `/t:Test`, `/t:IntegrationTest` and `/t:PerformanceTest`. These are the common arcade targets that are expected to be present in the respective test project type.