### PR TITLE
Warn about GitHub UI when it can't merge commit

### DIFF
--- a/scripts/GitHubMergeBranches.ps1
+++ b/scripts/GitHubMergeBranches.ps1
@@ -405,7 +405,9 @@ git push git@github.com:$prOwnerName/$prRepoName ${mergeBranchName}
             $mergeInstructions = @"
 ## Instructions for merging
 
-This repo does not appear to allow merge commits from the GitHub UI, so you will need to update this PR with a merge commit before closing this PR.
+This repo does not appear to allow merge commits from the GitHub UI. Do *not* use the GitHub UI to merge this PR.
+
+You will need to update this PR with a merge commit before closing this PR.
 
 `````` sh
 git fetch


### PR DESCRIPTION
A warning appears when you *are* able to use a dropdown to select a merge commit, but no such warning exists when the GitHub UI prevents merge commits. This commit adds a warning.

I noticed this when I saw https://github.com/dotnet/corefx/pull/34429. (Right on the heels of a squash merge.)

Before:

> ## Instructions for merging
> 
> This repo does not appear to allow merge commits from the GitHub UI, so you will need to update this PR with a merge commit before closing this PR.

After:

> ## Instructions for merging
> 
> This repo does not appear to allow merge commits from the GitHub UI. Do *not* use the GitHub UI to merge this PR.
> 
> You will need to update this PR with a merge commit before closing this PR.

Still not hard to miss, but worth bringing back parity IMO.

---

For comparison, when you can use the dropdown, this is what it looks like:

> ## Instructions for merging
> 
> This PR will not be auto-merged. When pull request checks pass, please complete this PR by creating a merge commit, *not* a squash or rebase commit.
> 
> <img alt="merge button instructions" src="https://i.imgur.com/GepcNJV.png" width="300" />

Maybe we should have a similar image of a merge button with a big ❌ through it? 😄 