### PR TITLE
Add WorkItemTimeout option for send-to-helix

### DIFF
--- a/Documentation/AzureDevOps/SendingJobsToHelix.md
+++ b/Documentation/AzureDevOps/SendingJobsToHelix.md
@@ -95,6 +95,9 @@ The list of available Helix queues can be found [here](https://helix.dot.net/api
       XUnitPublishTargetFramework: netcoreapp2.1 # specify your publish target framework here
       XUnitRuntimeTargetFramework: netcoreapp2.0 # specify the framework you want to use for the xUnit runner
       XUnitRunnerVersion: 2.4.1 # specify the version of xUnit runner you wish to use here
+      # WorkItemDirectory: '' -- payload directory to zip up and send to Helix; requires WorkItemCommand; incompatible with XUnitProjects
+      # WorkItemCommand: '' -- a command to execute on the payload; requires WorkItemDirectory; incompatible with XUnitProjects
+      # WorkItemTimeout: '' -- a timeout for the work item command; requires WorkItemDirectory; incompatible with XUnitProjects
       IncludeDotNetCli: true
       DotNetCliPackageType: sdk
       DotNetCliVersion: 2.1.403 # full list of versions here: https://raw.githubusercontent.com/dotnet/core/master/release-notes/releases.json

--- a/Documentation/AzureDevOps/SendingJobsToHelix.md
+++ b/Documentation/AzureDevOps/SendingJobsToHelix.md
@@ -97,7 +97,7 @@ The list of available Helix queues can be found [here](https://helix.dot.net/api
       XUnitRunnerVersion: 2.4.1 # specify the version of xUnit runner you wish to use here
       # WorkItemDirectory: '' -- payload directory to zip up and send to Helix; requires WorkItemCommand; incompatible with XUnitProjects
       # WorkItemCommand: '' -- a command to execute on the payload; requires WorkItemDirectory; incompatible with XUnitProjects
-      # WorkItemTimeout: '' -- a timeout for the work item command; requires WorkItemDirectory; incompatible with XUnitProjects
+      # WorkItemTimeout: '' -- a timeout in milliseconds for the work item command; requires WorkItemDirectory; incompatible with XUnitProjects
       IncludeDotNetCli: true
       DotNetCliPackageType: sdk
       DotNetCliVersion: 2.1.403 # full list of versions here: https://raw.githubusercontent.com/dotnet/core/master/release-notes/releases.json

--- a/eng/common/helixpublish.proj
+++ b/eng/common/helixpublish.proj
@@ -14,6 +14,7 @@
     <HelixWorkItem Include="WorkItem" Condition="'$(WorkItemDirectory)' != ''">
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
       <Command>$(WorkItemCommand)</Command>
+      <Timeout Condition="'$(WorkItemTimeout)' != ''">$(WorkItemTimeout)</Timeout>
     </HelixWorkItem>
   </ItemGroup>
 

--- a/eng/common/templates/steps/send-to-helix.yml
+++ b/eng/common/templates/steps/send-to-helix.yml
@@ -8,7 +8,7 @@ parameters:
   HelixPostCommands: ''              # optional -- commands to run after Helix work item execution
   WorkItemDirectory: ''              # optional -- a payload directory to zip up and send to Helix; requires WorkItemCommand; incompatible with XUnitProjects
   WorkItemCommand: ''                # optional -- a command to execute on the payload; requires WorkItemDirectory; incompatible with XUnitProjects
-  WorkItemTimeout: ''                # optional -- a timeout for the work item command; requires WorkItemDirectory; incompatible with XUnitProjects
+  WorkItemTimeout: ''                # optional -- a timeout in milliseconds for the work item command; requires WorkItemDirectory; incompatible with XUnitProjects
   CorrelationPayloadDirectory: ''    # optional -- a directory to zip up and send to Helix as a correlation payload
   XUnitProjects: ''                  # optional -- semicolon delimited list of XUnitProjects to parse and send to Helix; requires XUnitRuntimeTargetFramework, XUnitPublishTargetFramework, XUnitRunnerVersion, and IncludeDotNetCli=true
   XUnitPublishTargetFramework: ''    # optional -- framework to use to publish your xUnit projects

--- a/eng/common/templates/steps/send-to-helix.yml
+++ b/eng/common/templates/steps/send-to-helix.yml
@@ -8,6 +8,7 @@ parameters:
   HelixPostCommands: ''              # optional -- commands to run after Helix work item execution
   WorkItemDirectory: ''              # optional -- a payload directory to zip up and send to Helix; requires WorkItemCommand; incompatible with XUnitProjects
   WorkItemCommand: ''                # optional -- a command to execute on the payload; requires WorkItemDirectory; incompatible with XUnitProjects
+  WorkItemTimeout: ''                # optional -- a timeout for the work item command; requires WorkItemDirectory; incompatible with XUnitProjects
   CorrelationPayloadDirectory: ''    # optional -- a directory to zip up and send to Helix as a correlation payload
   XUnitProjects: ''                  # optional -- semicolon delimited list of XUnitProjects to parse and send to Helix; requires XUnitRuntimeTargetFramework, XUnitPublishTargetFramework, XUnitRunnerVersion, and IncludeDotNetCli=true
   XUnitPublishTargetFramework: ''    # optional -- framework to use to publish your xUnit projects
@@ -37,6 +38,7 @@ steps:
       HelixPostCommands: ${{ parameters.HelixPostCommands }}
       WorkItemDirectory: ${{ parameters.WorkItemDirectory }}
       WorkItemCommand: ${{ parameters.WorkItemCommand }}
+      WorkItemTimeout: ${{ parameters.WorkItemTimeout }}
       CorrelationPayloadDirectory: ${{ parameters.CorrelationPayloadDirectory }}
       XUnitProjects: ${{ parameters.XUnitProjects }}
       XUnitPublishTargetFramework: ${{ parameters.XUnitPublishTargetFramework }}
@@ -64,6 +66,7 @@ steps:
       HelixPostCommands: ${{ parameters.HelixPostCommands }}
       WorkItemDirectory: ${{ parameters.WorkItemDirectory }}
       WorkItemCommand: ${{ parameters.WorkItemCommand }}
+      WorkItemTimeout: ${{ parameters.WorkItemTimeout }}
       CorrelationPayloadDirectory: ${{ parameters.CorrelationPayloadDirectory }}
       XUnitProjects: ${{ parameters.XUnitProjects }}
       XUnitPublishTargetFramework: ${{ parameters.XUnitPublishTargetFramework }}


### PR DESCRIPTION
The Helix api allows us to specify a work item timeout in the proj file, but the send-to-helix template does not expose this option. This change exposes WorkItemTimeout so that jobs that need to run longer than the default (300s) don't timeout.