### PR TITLE
Include all blobs in the build manifest

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
@@ -136,16 +136,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         {
             string path = item.GetMetadata("RelativeBlobPath");
 
-            // Only include assets in the manifest if they're in "assets/".
-            if (path?.StartsWith(AssetsVirtualDir, StringComparison.Ordinal) == true)
+            return new BlobArtifactModel
             {
-                return new BlobArtifactModel
-                {
-                    Attributes = ParseCustomAttributes(item),
-                    Id = path.Substring(AssetsVirtualDir.Length)
-                };
-            }
-            return null;
+                Attributes = ParseCustomAttributes(item),
+                Id = path
+            };
         }
 
         private static IDictionary<string, string> ParseCustomAttributes(ITaskItem item)


### PR DESCRIPTION
Not just those in the assets/ virtual directory. This could change later with release pipelines, where we publish everything initially to assets/, then specify where the desired final location is, but for now many repos need to publish to other storage accounts in specific locations.