### PR TITLE
Consume raw IBC data in ApplyOptimizations target

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.Unsign" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GroupItemsBy" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
 
   <!--
     Required properties:
       IbcOptimizationDataDir           The directory containing IBC optimization data.
   -->
   <PropertyGroup>
-    <_PreviousOptimizedFile>$([System.IO.Path]::Combine($(IbcOptimizationDataDir), '$(TargetName).pgo'))</_PreviousOptimizedFile>
     <PostCompileBinaryModificationSentinelFile>$(IntermediateOutputPath)$(TargetFileName).pcbm</PostCompileBinaryModificationSentinelFile>
   </PropertyGroup>
 
@@ -38,7 +38,77 @@
 
   <Target Name="_InitializeAssemblyOptimizationWithTargetAssembly">
     <ItemGroup>
-      <OptimizeAssembly Include="@(IntermediateAssembly)" PreviousOptimizedFile="$(_PreviousOptimizedFile)" />
+      <OptimizeAssembly Include="@(IntermediateAssembly)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_LocateIbcMerge">
+    <PropertyGroup>
+      <_IbcMergePath>$(NuGetPackageRoot)microsoft.dotnet.ibcmerge\$(MicrosoftDotNetIBCMergeVersion)\lib\net45\ibcmerge.exe</_IbcMergePath>
+
+      <_RunIbcMerge>false</_RunIbcMerge>
+      <_RunIbcMerge Condition="'$(OfficialBuild)' == 'true' or Exists('$(_IbcMergePath)')">true</_RunIbcMerge>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="_CalculateIbcMergeInvocations">
+    <ItemGroup>
+      <!--
+        Find all .ibc files generated for assemblies to optimize.
+
+        The optimization data directory has the following structure:
+          $(IbcOptimizationDataDir)\path\{AssemblyFileName}\{AssemblyFileName}
+          $(IbcOptimizationDataDir)\path\{AssemblyFileName}\Scenario1.ibc
+          $(IbcOptimizationDataDir)\path\{AssemblyFileName}\Scenario2.ibc
+
+        One assembly might be copied to multiple subdirectories (e.g. in MSBuild and in IDE). 
+        We assume that these copies are the same and merge all scenarios together.
+        We could produce multiple different assemblies with IBC data embedded if there 
+        was a significant benefit in optimizing them separately.
+        This would however require a more complicated setup authoring.
+      -->
+      <_IbcFile Include="$(IbcOptimizationDataDir)\**\%(OptimizeAssembly.FileName)%(OptimizeAssembly.Extension)\*.ibc" OptimizeAssemblyPath="%(OptimizeAssembly.Identity)"/>
+
+      <_IbcFile>
+        <PreviousAssemblyDir>$([System.IO.Path]::GetDirectoryName('%(Identity)'))</PreviousAssemblyDir>
+        <AssemblyFileName>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName('%(Identity)'))))</AssemblyFileName>
+      </_IbcFile>
+
+      <_IbcFileByAssemblyName Include="@(_IbcFile->'%(AssemblyFileName)')"
+                              IbcFiles="%(_IbcFile.Identity)"
+                              PreviousAssemblyPath="%(_IbcFile.PreviousAssemblyDir)\%(_IbcFile.AssemblyFileName)"
+                              PreviousAssemblyCopyPath="$(ArtifactsTmpDir)OptimizedAssemblies\$([System.Guid]::NewGuid())"
+                              OptimizeAssemblyPath="%(_IbcFile.OptimizeAssemblyPath)" />
+    </ItemGroup>
+
+    <Microsoft.DotNet.Arcade.Sdk.GroupItemsBy Items="@(_IbcFileByAssemblyName)" GroupMetadata="IbcFiles">
+      <Output TaskParameter="GroupedItems" ItemName="_AssemblyWithRawIbcData" />
+    </Microsoft.DotNet.Arcade.Sdk.GroupItemsBy>
+
+    <ItemGroup>
+      <_AssemblyWithoutRawIbcData Include="@(_AssemblyWithRawIbcData)" Condition="'%(_AssemblyWithRawIbcData.IbcFiles)' == ''" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <_IbcMergeInvocation Include="%(_AssemblyWithRawIbcData.AssemblyFileName) [MergeRawToPrevious]">
+        <CopyFilesSource>%(_AssemblyWithRawIbcData.PreviousAssemblyPath)</CopyFilesSource>
+        <CopyFilesDestination>%(_AssemblyWithRawIbcData.PreviousAssemblyCopyPath)</CopyFilesDestination>
+
+        <!--
+          -delete to delete data previously embedded in the binary. 
+        -->
+        <IbcMergeArgs>-q -f -partialNGEN -minify -delete -mo "%(_AssemblyWithRawIbcData.PreviousAssemblyCopyPath)" "$([MSBuild]::ValueOrDefault('%(_AssemblyWithRawIbcData.IbcFiles)', '').Replace(';', '" "'))"</IbcMergeArgs>
+      </_IbcMergeInvocation>
+
+      <_IbcMergeInvocation Include="%(_AssemblyWithRawIbcData.AssemblyFileName) [MergePreviousToCurrent]">
+        <!--
+          -delete to delete data previously embedded in the binary. This is a no-op for binaries produced by this build, but is needed for dependencies such as System.Reflection.Metadata.
+          -incremental to map data stored in the optimized binary, which comes from a previous build, to the new build of the binary.
+        -->
+        <IbcMergeArgs>-q -f -partialNGEN -minify -delete -mo "%(_AssemblyWithRawIbcData.OptimizeAssemblyPath)" -incremental "%(_AssemblyWithRawIbcData.PreviousAssemblyCopyPath)"</IbcMergeArgs>
+
+        <UnsignFile>%(_AssemblyWithRawIbcData.OptimizeAssemblyPath)</UnsignFile>
+      </_IbcMergeInvocation>
     </ItemGroup>
   </Target>
 
@@ -48,46 +118,26 @@
     Non-incremental. Calling targets need to handle incremental build if necessary.
     Runs during any CI build. Performs the actual merge only when IBCMerge tool is available. It is expected to be available in an official build.
   -->
-  <Target Name="_CalculateIbcArgs">
-    <ItemGroup>
-      <OptimizeAssembly>
-        <!--
-          -delete to delete data previously embedded in the binary. This is a no-op for binaries produced by this build, but is needed for dependencies such as System.Reflection.Metadata.
-          -incremental to map data stored in the optimized binary, which comes from a previous build, to the new build of the binary.
-        -->
-        <_IbcArgs>-q -f -partialNGEN -minify -delete -mo "%(OptimizeAssembly.Identity)" -incremental "%(OptimizeAssembly.PreviousOptimizedFile)"</_IbcArgs>
-      </OptimizeAssembly>
-    </ItemGroup>
-  </Target>
-
   <Target Name="ApplyOptimizations"
-          DependsOnTargets="_CalculateIbcArgs"
+          DependsOnTargets="_LocateIbcMerge;_CalculateIbcMergeInvocations"
           Condition="'@(OptimizeAssembly)' != '' and '$(Configuration)' == 'Release' and '$(ContinuousIntegrationBuild)' == 'true' and '$(ApplyPartialNgenOptimization)' == 'true'">
 
-    <PropertyGroup>
-      <_IbcMergePath>$(NuGetPackageRoot)microsoft.dotnet.ibcmerge\$(MicrosoftDotNetIBCMergeVersion)\lib\net45\ibcmerge.exe</_IbcMergePath>
-
-      <_RunIbcMerge>false</_RunIbcMerge>
-      <_RunIbcMerge Condition="'$(OfficialBuild)' == 'true' or Exists('$(_IbcMergePath)')">true</_RunIbcMerge>
-    </PropertyGroup>
-
-    <Message Text='IBCMerge tool will be run in an official build with arguments: %(OptimizeAssembly._IbcArgs)'
+    <Message Text='IBCMerge tool will be run in an official build with arguments: %(_IbcMergeInvocation.IbcMergeArgs)'
              Condition="'$(_RunIbcMerge)' != 'true'" 
              Importance="normal"/>
 
-    <Warning Text="Optimization data expected but not found at '%(OptimizeAssembly.PreviousOptimizedFile)'"
-             Condition="'$(_RunIbcMerge)' != 'true' and !Exists(%(OptimizeAssembly.PreviousOptimizedFile))" />
+    <Copy SourceFiles="%(_IbcMergeInvocation.CopyFilesSource)" 
+          DestinationFiles="%(_IbcMergeInvocation.CopyFilesDestination)" 
+          Condition="'%(_IbcMergeInvocation.CopyFilesSource)' != ''" />
 
-    <Exec Command='"$(_IbcMergePath)" %(OptimizeAssembly._IbcArgs)' 
-          ConsoleToMSBuild="true"
-          Condition="'$(_RunIbcMerge)' == 'true'">
-      <Output TaskParameter="ConsoleOutput" PropertyName="IbcMergeOutput" />
+    <Exec Command='"$(_IbcMergePath)" %(_IbcMergeInvocation.IbcMergeArgs)' ConsoleToMSBuild="true" Condition="'$(_RunIbcMerge)' == 'true'">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_IbcMergeOutput" />
     </Exec>
 
-    <!-- Remove Authenticode signing record if present. -->
-    <Microsoft.DotNet.Arcade.Sdk.Unsign FilePath="%(OptimizeAssembly.Identity)" />
+    <Message Text="$(_IbcMergeOutput)" Importance="low" />
 
-    <Message Text="$(IbcMergeOutput)" />
+    <!-- Remove Authenticode signing record if present. -->
+    <Microsoft.DotNet.Arcade.Sdk.Unsign FilePath="%(_IbcMergeInvocation.UnsignFile)" Condition="'%(_IbcMergeInvocation.UnsignFile)' != ''" />
   </Target>
 
 </Project>


### PR DESCRIPTION
`ApplyOptimizations` target now expects the `$(IbcOptimizationDataDir)` directory to have the following structure:

```
$(IbcOptimizationDataDir)\**\{AssemblyFileName}\{AssemblyFileName}
$(IbcOptimizationDataDir)\**\{AssemblyFileName}\Scenario1.ibc
$(IbcOptimizationDataDir)\**\{AssemblyFileName}\Scenario2.ibc
...
$(IbcOptimizationDataDir)\**\{AssemblyFileName}\ScenarioN.ibc
```

The assemblies are those that were used in the training run that produced the IBC data.

One assembly might be present in multiple subdirectories.
We assume that these files are copies of the same assembly and merge all their scenarios together.

We could produce multiple different assemblies with IBC data embedded if there was a significant benefit in optimizing them separately. This would however require a more complicated setup authoring though.

`ApplyOptimizations` target first merges all IBC data to the binary they were produced from and then runs incremental IBC merge to translate the data to the binary being built currently.
