### PR TITLE
remove global _ToolsetProj variable during validateSDK Step 2

### DIFF
--- a/eng/validate-sdk.ps1
+++ b/eng/validate-sdk.ps1
@@ -88,8 +88,9 @@ try {
   StopDotnetIfRunning
   
   Write-Host "Building with updated dependencies"
-
-  . .\common\build.ps1 -configuration $configuration @Args  /p:AdditionalRestoreSources=$packagesSource
+  # Clear this global variable so that we don't use the cached toolset that we restored in Step 1.
+  Remove-Variable _ToolsetBuildProj -Scope Global
+  & .\common\build.ps1 -configuration $configuration @Args  /p:AdditionalRestoreSources=$packagesSource
 }
 catch {
   Write-Host $_


### PR DESCRIPTION
Fixes #1737 and thus Arcade's official build.

The existence of the variable was causing the toolset to not be restored again with the updated versions. 

