### PR TITLE
More fixes for validateSDK self build

### DIFF
--- a/eng/validate-sdk.ps1
+++ b/eng/validate-sdk.ps1
@@ -64,7 +64,7 @@ try {
   $packagesSource = Join-Path (Join-Path (Join-Path $validateSdkDir "packages") $configuration) "NonShipping"
   $nugetConfigPath = Join-Path $RepoRoot "NuGet.config"
   
-  . .\common\build.ps1 -restore -build -pack -configuration $configuration
+  . .\common\build.ps1 -ci -restore -build -pack -configuration $configuration
   
   # This is a temporary solution. When https://github.com/dotnet/arcade/issues/1293 is closed
   # we'll be able to pass a container name to build.ps1 which will put the outputs in the
@@ -90,7 +90,7 @@ try {
   Write-Host "Building with updated dependencies"
   # Clear this global variable so that we don't use the cached toolset that we restored in Step 1.
   Remove-Variable _ToolsetBuildProj -Scope Global
-  & .\common\build.ps1 -configuration $configuration @Args  /p:AdditionalRestoreSources=$packagesSource
+  & .\common\build.ps1 -configuration $configuration @Args /p:AdditionalRestoreSources=$packagesSource
 }
 catch {
   Write-Host $_


### PR DESCRIPTION
another fix for https://github.com/dotnet/arcade/issues/1737

If we don't pass the ci flag to build.ps1, we generate packages 1.0.0dev of arcade sdk. This is a package that is already in the sleet feeds, and there's a posibility that nuget will restore the incorrect version.

Internal build that validates this change: https://dnceng.visualstudio.com/internal/_build/results?buildId=69589 (Windows Release build

@chcosta 