### PR TITLE
Fix build break, property typo

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,7 @@ jobs:
       - _Script: eng\common\cibuild.cmd
       - _ValidateSdkArgs: ''
       - _InternalBuildArgs: ''
+      - HelixApiAccessToken: ''
 
       # Only enable publishing in non-public, non PR scenarios.
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -100,6 +101,7 @@ jobs:
         ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
           name: dnceng-linux-internal-temp
       variables:
+      - HelixApiAccessToken: ''
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         - group: DotNet-HelixApi-Access
       strategy:

--- a/tests/UnitTests.proj
+++ b/tests/UnitTests.proj
@@ -1,7 +1,7 @@
 <Project DefaultTargets="Test">
   <!-- <Import Sdk="Microsoft.DotNet.Helix.Sdk" Project="Sdk.props"/> -->
   <Import Project="$(MSBuildThisFileDirectory)\..\src\Microsoft.DotNet.Helix\Sdk\sdk\Sdk.props"/>
-  
+
   <PropertyGroup>
     <HelixSource>pr/dotnet/arcade/$(BUILD_SOURCEBRANCH)/</HelixSource>
     <HelixType>test/product/</HelixType>
@@ -32,18 +32,18 @@
     <MicrosoftDotNetHelixSdkTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)../artifacts/bin/Microsoft.DotNet.Helix.Sdk/$(_BuildConfig)/net472/publish/Microsoft.DotNet.Helix.Sdk.dll</MicrosoftDotNetHelixSdkTasksAssembly>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(HelixAcccessToken)' != '' ">
+  <ItemGroup Condition=" '$(HelixessToken)' != '' ">
     <HelixTargetQueue Include="Ubuntu.1604.Amd64"/>
     <HelixTargetQueue Include="Windows.10.Amd64"/>
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(HelixAcccessToken)' == '' ">
+  <PropertyGroup Condition=" '$(HelixAccessToken)' == '' ">
     <IsExternal>true</IsExternal>
     <Creator>$(BUILD_SOURCEVERSIONAUTHOR)</Creator>
     <Creator Condition=" '$(Creator)' == ''">anon</Creator>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(HelixAcccessToken)' == '' ">
+  <ItemGroup Condition=" '$(HelixAccessToken)' == '' ">
     <HelixTargetQueue Include="Ubuntu.1604.Amd64.Open"/>
     <HelixTargetQueue Include="Windows.10.Amd64.Open"/>
   </ItemGroup>

--- a/tests/UnitTests.proj
+++ b/tests/UnitTests.proj
@@ -32,7 +32,7 @@
     <MicrosoftDotNetHelixSdkTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)../artifacts/bin/Microsoft.DotNet.Helix.Sdk/$(_BuildConfig)/net472/publish/Microsoft.DotNet.Helix.Sdk.dll</MicrosoftDotNetHelixSdkTasksAssembly>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(HelixessToken)' != '' ">
+  <ItemGroup Condition=" '$(HelixAccessToken)' != '' ">
     <HelixTargetQueue Include="Ubuntu.1604.Amd64"/>
     <HelixTargetQueue Include="Windows.10.Amd64"/>
   </ItemGroup>


### PR DESCRIPTION
Fixes

https://github.com/dotnet/arcade/issues/1754

A couple of other notes for @alexperovich :

- Is this intentional? https://github.com/dotnet/arcade/blob/master/tests/UnitTests.proj#L3  This makes local repros more difficult as restoring the Helix Sdk manually is not an intuitive step here.  That in combination with...

- https://github.com/dotnet/arcade/blob/master/tests/UnitTests.proj#L29-L33, makes the problem even more annoying.  Can we remove this?  Why can't we use the defaults from the sdk and we should absolutely not be using the "_BuildConfig" property to define the configuration as that's just a yaml representation of the configuration which is explicitly intended not to collide with anything in the build.  This is a bad coupling.
