### PR TITLE
Fix SignTool check for managed module

### DIFF
--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -430,6 +430,41 @@ namespace Microsoft.DotNet.SignTool.Tests
         }
 
         [Fact]
+        public void CrossGenNative()
+        {
+            // List of files to be considered for signing
+            var itemsToSign = new[]
+            {
+                GetResourcePath("CoreLibCrossARM.dll")
+            };
+
+            // Default signing information
+            var strongNameSignInfo = new Dictionary<string, SignInfo>()
+            {
+                { "581d91ccdfc4ea9c", new SignInfo("ArcadeCertTest", "ArcadeStrongTest") }
+            };
+
+            // Overriding information
+            var fileSignInfo = new Dictionary<ExplicitCertificateKey, string>()
+            {
+                { new ExplicitCertificateKey("EmptyPKT.dll"), "3PartySHA2" }
+            };
+
+            ValidateFileSignInfos(itemsToSign, strongNameSignInfo, fileSignInfo, s_fileExtensionSignInfo, new[]
+            {
+                "File 'CoreLibCrossARM.dll' Certificate='Microsoft400'",
+            });
+
+            ValidateGeneratedProject(itemsToSign, strongNameSignInfo, fileSignInfo, s_fileExtensionSignInfo, new[]
+            {
+$@"<FilesToSign Include=""{Path.Combine(_tmpDir, "CoreLibCrossARM.dll")}"">
+  <Authenticode>Microsoft400</Authenticode>
+</FilesToSign>",
+            });
+        }
+
+
+        [Fact]
         public void DefaultCertificateForAssemblyWithoutStrongName()
         {
             // List of files to be considered for signing

--- a/src/Microsoft.DotNet.SignTool/src/Configuration.cs
+++ b/src/Microsoft.DotNet.SignTool/src/Configuration.cs
@@ -361,20 +361,19 @@ namespace Microsoft.DotNet.SignTool
 
         private static void GetPEInfo(string fullPath, out bool isManaged, out string publicKeyToken, out string targetFramework, out string copyright)
         {
-            AssemblyName assemblyName = ContentUtil.GetAssemblyName(fullPath);
+            isManaged = ContentUtil.IsManaged(fullPath);
 
-            if (assemblyName == null)
+            if (!isManaged)
             {
-                isManaged = false;
                 publicKeyToken = string.Empty;
                 targetFramework = string.Empty;
                 copyright = string.Empty;
                 return;
             }
 
+            AssemblyName assemblyName = ContentUtil.GetAssemblyName(fullPath);
             var pktBytes = assemblyName.GetPublicKeyToken();
 
-            isManaged = true;
             publicKeyToken = (pktBytes == null || pktBytes.Length == 0) ? string.Empty : string.Join("", pktBytes.Select(b => b.ToString("x2")));
             GetTargetFrameworkAndCopyright(fullPath, out targetFramework, out copyright);
         }

--- a/src/Microsoft.DotNet.SignTool/src/Configuration.cs
+++ b/src/Microsoft.DotNet.SignTool/src/Configuration.cs
@@ -371,7 +371,7 @@ namespace Microsoft.DotNet.SignTool
                 return;
             }
 
-            AssemblyName assemblyName = ContentUtil.GetAssemblyName(fullPath);
+            AssemblyName assemblyName = AssemblyName.GetAssemblyName(fullPath);
             var pktBytes = assemblyName.GetPublicKeyToken();
 
             publicKeyToken = (pktBytes == null || pktBytes.Length == 0) ? string.Empty : string.Join("", pktBytes.Select(b => b.ToString("x2")));

--- a/src/Microsoft.DotNet.SignTool/src/ContentUtil.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ContentUtil.cs
@@ -67,72 +67,15 @@ namespace Microsoft.DotNet.SignTool
             return (header.Flags & CorFlags.StrongNameSigned) == CorFlags.StrongNameSigned;
         }
 
-        public static AssemblyName GetAssemblyName(string fullFilePath)
+        public static bool IsManaged(string filePath)
         {
-            try
+            using (var stream = new FileStream(filePath, FileMode.Open))
+            using (var peReader = new PEReader(stream))
             {
-                return AssemblyName.GetAssemblyName(fullFilePath);
+                var corEntry = peReader.PEHeaders.PEHeader.CorHeaderTableDirectory;
+
+                return corEntry.RelativeVirtualAddress == 0x2008 && corEntry.Size == 0x48;
             }
-            catch
-            {
-                return null;
-            }
-        }
-
-        public static bool IsManaged(string fullFilePath)
-        {
-            uint peHeader;
-            uint peHeaderSignature;
-            ushort machine;
-            ushort sections;
-            uint timestamp;
-            uint pSymbolTable;
-            uint noOfSymbol;
-            ushort optionalHeaderSize;
-            ushort characteristics;
-            ushort dataDictionaryStart;
-            uint[] dataDictionaryRVA = new uint[16];
-            uint[] dataDictionarySize = new uint[16];
-
-            Stream fs = new FileStream(fullFilePath, FileMode.Open, FileAccess.Read);
-            BinaryReader reader = new BinaryReader(fs);
-
-            //PE Header starts @ 0x3C (60). Its a 4 byte header.
-            fs.Position = 0x3C;
-            peHeader = reader.ReadUInt32();
-
-            //Moving to PE Header start location...
-            fs.Position = peHeader;
-            peHeaderSignature = reader.ReadUInt32();
-
-            if (peHeaderSignature != 0x00004550)
-            {
-                return false;
-            }
-
-            machine = reader.ReadUInt16();
-            sections = reader.ReadUInt16();
-            timestamp = reader.ReadUInt32();
-            pSymbolTable = reader.ReadUInt32();
-            noOfSymbol = reader.ReadUInt32();
-            optionalHeaderSize = reader.ReadUInt16();
-            characteristics = reader.ReadUInt16();
-
-            dataDictionaryStart = Convert.ToUInt16(Convert.ToUInt16(fs.Position) + 0x60);
-            fs.Position = dataDictionaryStart;
-            for (int i = 0; i < 15; i++)
-            {
-                dataDictionaryRVA[i] = reader.ReadUInt32();
-                dataDictionarySize[i] = reader.ReadUInt32();
-            }
-            fs.Close();
-
-            if (dataDictionaryRVA[14] != 0x2008 || dataDictionarySize[14] != 0x48)
-            {
-                return false;
-            }
-
-            return true;
         }
 
         public static bool IsAuthenticodeSigned(Stream assemblyStream)

--- a/src/Microsoft.DotNet.SignTool/src/FileSignInfo.cs
+++ b/src/Microsoft.DotNet.SignTool/src/FileSignInfo.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.SignTool
 
         internal bool IsPEFile() => IsPEFile(FileName);
 
-        internal bool IsManaged() => ContentUtil.GetAssemblyName(FullPath) != null;
+        internal bool IsManaged() => ContentUtil.IsManaged(FullPath);
 
         internal bool IsVsix() => IsVsix(FileName);
 


### PR DESCRIPTION
Closes: #1582 

Please see [comment here](https://github.com/dotnet/arcade/issues/1582#issuecomment-453287180) for an explanation of what is being implemented here.

[Comments here](https://github.com/dotnet/coreclr/blob/234bbb509e9ea8b08787fcd509edd6141e37d751/src/inc/corhdr.h#L177) might also be useful.