### PR TITLE
Increase Windows build timeout

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,7 @@ jobs:
     helixRepo: dotnet/arcade
     jobs:
     - job: Windows_NT
+      timeoutInMinutes: 90
       pool:
         # For public or PR jobs, use the hosted pool.  For internal jobs use the internal pool.
         # Will eventually change this to two BYOC pools.


### PR DESCRIPTION
This makes me sad, and we should follow up to remove this or figure out how to improve build time, but the combination of the Windows release build leg being used to build / re-build Arcade sdk (for self-validation), sign, and publish; means that it is extremely difficult to get a successful build to complete under 60 minutes, which leads to timeouts.  Perhaps just move the validatesdk build leg to Windows debug?

FYI @riarenas @jcagme @markwilkie 