### PR TITLE
Publishing: Support for multiple build manifests

### DIFF
--- a/eng/common/PublishToPackageFeed.proj
+++ b/eng/common/PublishToPackageFeed.proj
@@ -16,9 +16,17 @@
   <Target Name="PublishToFeed">
     <Error Condition="'$(TargetStaticFeed)' == ''" Text="TargetStaticFeed: Target feed for publishing assets wasn't provided." />
     <Error Condition="'$(AccountKeyToStaticFeed)' == ''" Text="AccountKeyToStaticFeed: Account key for target feed wasn't provided." />
-    <Error Condition="'$(FullPathAssetManifest)' == ''" Text="Full path to asset manifest wasn't provided." />
-    <Error Condition="'$(FullPathBlobBasePath)' == '' AND '$(FullPathPackageBasePath)' == ''" Text="A valid full path to BlobBasePath of PackageBasePath is required." />
+    <Error Condition="'$(ManifestsBasePath)' == ''" Text="Full path to asset manifests directory wasn't provided." />
+    <Error Condition="'$(BlobBasePath)' == '' AND '$(PackageBasePath)' == ''" Text="A valid full path to BlobBasePath of PackageBasePath is required." />
 
+    <ItemGroup>
+      <!-- Include all manifests found in the manifest folder. -->
+      <ManifestFiles Include="$(ManifestsBasePath)*.xml" />
+    </ItemGroup>
+
+    <Error Condition="'@(ManifestFiles)' == ''" Text="No manifest file was found in the provided path: $(ManifestsBasePath)" />
+	
+    <!-- Iterate publishing assets from each manifest file. -->
     <PushArtifactsInManifestToFeed
       ExpectedFeedUrl="$(TargetStaticFeed)"
       AccountKey="$(AccountKeyToStaticFeed)"
@@ -26,9 +34,9 @@
       PassIfExistingItemIdentical="$(PassIfExistingItemIdentical)"
       MaxClients="$(MaxParallelUploads)"
       UploadTimeoutInMinutes="$(MaxUploadTimeoutInMinutes)"
-      AssetManifestPath="$(FullPathAssetManifest)"
-      BlobAssetsBasePath="$(FullPathBlobBasePath)"
-      PackageAssetsBasePath="$(FullPathPackageBasePath)" />
+      AssetManifestPath="%(ManifestFiles.Identity)"
+      BlobAssetsBasePath="$(BlobBasePath)"
+      PackageAssetsBasePath="$(PackageBasePath)" />
   </Target>
 
   <ItemGroup>


### PR DESCRIPTION
With this change the publishing release pipeline will be able to work with eventual multiple build manifests. 

