### PR TITLE
Remove RecursiveDir from source file

### DIFF
--- a/src/Microsoft.DotNet.SourceRewriter/build/Microsoft.DotNet.SourceRewriter.targets
+++ b/src/Microsoft.DotNet.SourceRewriter/build/Microsoft.DotNet.SourceRewriter.targets
@@ -22,7 +22,7 @@
     those files into internal types instead.-->
   <Target Name="GenerateInternalTypesSource" Condition="'$(GenerateInternalTypesSource)' == 'true' AND '@(SourcePackageFiles)' != ''">
     <ItemGroup>
-      <_NewSourcesToPackage Include="@(SourcePackageFiles -> '$(IntermediateOutputPath)%(RecursiveDir)%(FileName)%(Extension)')">
+      <_NewSourcesToPackage Include="@(SourcePackageFiles -> '$(IntermediateOutputPath)%(FileName)%(Extension)')">
         <OriginalIdentity>%(Identity)</OriginalIdentity>
       </_NewSourcesToPackage>
       <SourcePackageFiles Remove="@(SourcePackageFiles)" />


### PR DESCRIPTION
cc: @ericstj @ahsonkhan 

After moving the rewriting task to a tool instead, the code in the tool was changed so that all of the rewritten files will be dropped in the folder specified, which means that we shouldn't expect the recursive dir to be preserved. We need this in order to be able to generate the source package successfully.