### PR TITLE
Fix handling of PackageTags

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -83,7 +83,7 @@
       <NuspecProperty Include="PackageProjectUrl=$(PackageProjectUrl)"/>
       <NuspecProperty Include="PackageIconUrl=$(PackageIconUrl)" Condition="'$(PackageIconUrl)' != ''" />
       <NuspecProperty Include="PackageReleaseNotes=$(PackageReleaseNotes)" Condition="'$(PackageReleaseNotes)' != ''" />
-      <NuspecProperty Include="PackageTags=$(PackageTags)" Condition="'$(PackageTags)' != ''" />
+      <NuspecProperty Include="PackageTags=$(PackageTags.Replace(';', ' '))" Condition="'$(PackageTags)' != ''" />
       <NuspecProperty Include="RepositoryUrl=$(RepositoryUrl)" Condition="'$(RepositoryUrl)' != ''" />
       <NuspecProperty Include="RepositoryType=$(RepositoryType)" Condition="'$(RepositoryType)' != ''" />
       <NuspecProperty Include="RepositoryCommit=$(RepositoryCommit)" Condition="'$(RepositoryCommit)' != ''" />


### PR DESCRIPTION
When the PackageTags property has semicolons, the NuspecProperties items are malformed causing this error:

> error NU5029: NuspecProperties should be in the form of "key1=value1;key2=value2".