### PR TITLE
Update coverage filters

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/Microsoft.DotNet.CoreFxTesting.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/Microsoft.DotNet.CoreFxTesting.targets
@@ -65,7 +65,7 @@
   <Import Condition="'$(EnableBenchviewTarget)' == 'true' AND '$(Performance)' == 'true' AND '$(SkipTests)' != 'true'" Project="$([MSBuild]::NormalizePath('$(TestCoreDir)', 'performance', 'Benchview.targets'))" />
 
   <!-- Full coverage report. -->
-  <Import Condition="'$(EnableFullCoverageReportTarget)' == 'true' AND '$(SkipCoverageReport)' != 'true' AND '$(Coverage)' == 'true' AND '$(SkipTests)' != 'true'" Project="$([MSBuild]::NormalizePath('$(TestCoreDir)', 'coverage', 'CoverageReport.targets'))" />
+  <Import Condition="'$(EnableFullCoverageReportTarget)' == 'true' AND '$(GenerateCoverageReport)' == 'true' AND '$(Coverage)' == 'true' AND '$(SkipTests)' != 'true'" Project="$([MSBuild]::NormalizePath('$(TestCoreDir)', 'coverage', 'CoverageReport.targets'))" />
 
   <!-- Import the core testing infrastructure only for test projects. -->
   <Import Condition="'$(IsTestProject)' == 'true' AND '$(IsTestSupportProject)' != 'true'"  Project="$(TestCoreDir)Core.targets" />

--- a/src/Microsoft.DotNet.CoreFxTesting/build/Microsoft.DotNet.CoreFxTesting.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/Microsoft.DotNet.CoreFxTesting.targets
@@ -65,7 +65,7 @@
   <Import Condition="'$(EnableBenchviewTarget)' == 'true' AND '$(Performance)' == 'true' AND '$(SkipTests)' != 'true'" Project="$([MSBuild]::NormalizePath('$(TestCoreDir)', 'performance', 'Benchview.targets'))" />
 
   <!-- Full coverage report. -->
-  <Import Condition="'$(EnableFullCoverageReportTarget)' == 'true' AND '$(Coverage)' == 'true' AND '$(SkipTests)' != 'true'" Project="$([MSBuild]::NormalizePath('$(TestCoreDir)', 'coverage', 'CoverageReport.targets'))" />
+  <Import Condition="'$(EnableFullCoverageReportTarget)' == 'true' AND '$(SkipCoverageReport)' != 'true' AND '$(Coverage)' == 'true' AND '$(SkipTests)' != 'true'" Project="$([MSBuild]::NormalizePath('$(TestCoreDir)', 'coverage', 'CoverageReport.targets'))" />
 
   <!-- Import the core testing infrastructure only for test projects. -->
   <Import Condition="'$(IsTestProject)' == 'true' AND '$(IsTestSupportProject)' != 'true'"  Project="$(TestCoreDir)Core.targets" />

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/coverage/Coverage.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/coverage/Coverage.props
@@ -12,9 +12,4 @@
     <GenerateRunScriptDependsOn>$(GenerateRunScriptDependsOn);SetupCoverageFilter</GenerateRunScriptDependsOn>
   </PropertyGroup>
 
-  <!-- Interlocked is used to record code hits in Coverlet. Measuring it itself would cause an infinite loop. -->
-  <ItemGroup>
-    <CoverageExclude Include="[System.Private.CoreLib]System.Threading.Interlocked" />
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/coverage/Coverage.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/coverage/Coverage.props
@@ -12,4 +12,9 @@
     <GenerateRunScriptDependsOn>$(GenerateRunScriptDependsOn);SetupCoverageFilter</GenerateRunScriptDependsOn>
   </PropertyGroup>
 
+  <!-- Interlocked is used to record code hits in Coverlet. Measuring it itself would cause an infinite loop. -->
+  <ItemGroup>
+    <CoverageExclude Include="[System.Private.CoreLib]System.Threading.Interlocked" />
+  </ItemGroup>
+
 </Project>

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/coverage/Coverage.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/coverage/Coverage.targets
@@ -7,20 +7,24 @@
     <CoverageExecutablePath Condition="'$(CoverageExecutablePath)' == ''">$(GlobalToolsDir)coverlet</CoverageExecutablePath>
     <RunArguments>"$(TestAssembly)" --target "$(RunCommand)" --targetargs "$(RunArguments)" --format "$(CoverageFormat)" --output "$(CoverageOutputPath)" --threshold "$(CoverageThreshold)" --threshold-type "$(CoverageThresholdType)"</RunArguments>
     <RunArguments Condition="'$(CoverageSourceLink)' == 'true'">$(RunArguments) --use-source-link</RunArguments>
-    <RunArguments Condition="'$(CoverageExclude)' != ''">$(RunArguments) --exclude "$(CoverageExclude)"</RunArguments>
     <RunCommand>$(CoverageExecutablePath)</RunCommand>
   </PropertyGroup>
 
   <Target Name="SetupCoverageFilter">
 
-    <PropertyGroup>
-      <CoverageExcludeByFile>--exclude-by-file @(CoverageExcludeFile -> '"%(Identity)"', ' --exclude-by-file ')</CoverageExcludeByFile>
-      <RunArguments>$(RunArguments) $(CoverageExcludeByFile)</RunArguments>
+    <PropertyGroup Condition="'@(CoverageExcludeFile -> Count())' &gt; 0">
+      <CoverageExcludeByFileFilter>--exclude-by-file @(CoverageExcludeFile -> '"%(Identity)"', ' --exclude-by-file ')</CoverageExcludeByFileFilter>
+      <RunArguments>$(RunArguments) $(CoverageExcludeByFileFilter)</RunArguments>
     </PropertyGroup>
 
-    <PropertyGroup>
+    <PropertyGroup Condition="'@(CoverageProbePath -> Count())' &gt; 0">
       <IncludeDirectoriesFilter>--include-directory @(CoverageProbePath -> '"$(RunScriptHostDir)%(Identity)"', ' --include-directory ')</IncludeDirectoriesFilter>
       <RunArguments>$(RunArguments) $(IncludeDirectoriesFilter)</RunArguments>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'@(CoverageExclude -> Count())' &gt; 0">
+      <CoverageExcludeFilter>--exclude @(CoverageExclude -> '"%(Identity)"', ' --exclude ')</CoverageExcludeFilter>
+      <RunArguments>$(RunArguments) $(CoverageExcludeFilter)</RunArguments>
     </PropertyGroup>
 
     <!-- 
@@ -50,6 +54,6 @@
 
   </Target>
 
-  <Import Project="$(MSBuildThisFileDirectory)CoverageReport.targets" />
+  <Import Condition="'$(SkipCoverageReport)' != 'true'" Project="$(MSBuildThisFileDirectory)CoverageReport.targets" />
 
 </Project>

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/coverage/Coverage.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/coverage/Coverage.targets
@@ -12,17 +12,17 @@
 
   <Target Name="SetupCoverageFilter">
 
-    <PropertyGroup Condition="'@(CoverageExcludeFile -> Count())' &gt; 0">
+    <PropertyGroup Condition="'@(CoverageExcludeFile)' != ''">
       <CoverageExcludeByFileFilter>--exclude-by-file @(CoverageExcludeFile -> '"%(Identity)"', ' --exclude-by-file ')</CoverageExcludeByFileFilter>
       <RunArguments>$(RunArguments) $(CoverageExcludeByFileFilter)</RunArguments>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'@(CoverageProbePath -> Count())' &gt; 0">
+    <PropertyGroup Condition="'@(CoverageProbePath)' != ''">
       <IncludeDirectoriesFilter>--include-directory @(CoverageProbePath -> '"$(RunScriptHostDir)%(Identity)"', ' --include-directory ')</IncludeDirectoriesFilter>
       <RunArguments>$(RunArguments) $(IncludeDirectoriesFilter)</RunArguments>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'@(CoverageExclude -> Count())' &gt; 0">
+    <PropertyGroup Condition="'@(CoverageExclude)' != ''">
       <CoverageExcludeFilter>--exclude @(CoverageExclude -> '"%(Identity)"', ' --exclude ')</CoverageExcludeFilter>
       <RunArguments>$(RunArguments) $(CoverageExcludeFilter)</RunArguments>
     </PropertyGroup>

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/coverage/Coverage.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/coverage/Coverage.targets
@@ -54,6 +54,6 @@
 
   </Target>
 
-  <Import Condition="'$(SkipCoverageReport)' != 'true'" Project="$(MSBuildThisFileDirectory)CoverageReport.targets" />
+  <Import Condition="'$(GenerateCoverageReport)' == 'true'" Project="$(MSBuildThisFileDirectory)CoverageReport.targets" />
 
 </Project>


### PR DESCRIPTION
Allows more coverage filters, i.e. better exclude filters. Prepares for Corelib support. Also adds a SkipCoverageReport option to disable on CI.