### PR TITLE
Normalize configuration strings to contain defaults and apply insignificant properties

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Configuration/src/Configuration/Configuration.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Configuration/src/Configuration/Configuration.cs
@@ -206,5 +206,14 @@ namespace Microsoft.DotNet.Build.Tasks.Configuration
             return GetConfigurationString(true, true, out unused);
         }
 
+        /// <summary>
+        /// Returns a string that doesn't omit default values
+        /// </summary>
+        /// <returns> a string that doesn't omit default values</returns>
+        public string ToFullString()
+        {
+            var unused = false;
+            return GetConfigurationString(false, true, out unused);
+        }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Configuration/src/Configuration/ConfigurationFactory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Configuration/src/Configuration/ConfigurationFactory.cs
@@ -190,7 +190,7 @@ namespace Microsoft.DotNet.Build.Tasks.Configuration
 
                 var defaultValue = property.DefaultValue;
 
-                if (baseConfiguration != null && property.Independent)
+                if (baseConfiguration != null && property.Insignificant)
                 {
                     if (baseConfiguration.Values == null || 
                         baseConfiguration.Values.Length < propertyIndex || 

--- a/src/Microsoft.DotNet.Build.Tasks.Configuration/src/FindBestConfigurations.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Configuration/src/FindBestConfigurations.cs
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.Build.Tasks.Configuration
                     }
 
                     Log.LogMessage(LogImportance.Low, $"Chose configuration {bestConfiguration}");
-                    var bestConfigurationItem = new TaskItem(bestConfiguration.ToString(), (IDictionary)bestConfiguration.GetProperties());
+                    var bestConfigurationItem = new TaskItem(bestConfiguration.ToFullString(), (IDictionary)bestConfiguration.GetProperties());
 
                     // preserve metadata on the configuration that selected this
                     configurationItem.CopyMetadataTo(bestConfigurationItem);

--- a/src/Microsoft.DotNet.Build.Tasks.Configuration/src/GenerateConfigurationProps.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Configuration/src/GenerateConfigurationProps.cs
@@ -246,7 +246,7 @@ namespace Microsoft.DotNet.Build.Tasks.Configuration
                 whenConfigurationElement.AppendChild(setConfigurationPropertyGroup);
 
                 // set project configuration
-                setConfigurationPropertyGroup.AddProperty(ConfigurationProperty, compatibleConfiguration.GetDefaultConfigurationString());
+                setConfigurationPropertyGroup.AddProperty(ConfigurationProperty, compatibleConfiguration.ToFullString());
             }
 
             var configurationOtherwiseElement = configurationSpecificProps.CreateOtherwiseElement();

--- a/src/Microsoft.DotNet.Build.Tasks.Configuration/src/NormalizeConfigurations.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Configuration/src/NormalizeConfigurations.cs
@@ -1,0 +1,47 @@
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.DotNet.Build.Tasks.Configuration
+{
+    /// <summary>
+    /// Normalize configurations by applying any insignificant properties from BuildConfigurations and expanding defaults
+    /// </summary>
+    public class NormalizeConfigurations : ConfigurationTask
+    {
+        [Required]
+        public string BuildConfiguration { get; set; }
+
+        [Required]
+        public ITaskItem[] Configurations { get; set; }
+
+        [Output]
+        public ITaskItem[] NormalizedConfigurations { get; set; }
+
+        public override bool Execute()
+        {
+            LoadConfiguration();
+
+            var buildConfiguration = ConfigurationFactory.ParseConfiguration(BuildConfiguration);
+
+            var normalizedConfigurations = new List<ITaskItem>();
+
+            foreach(var configurationItem in Configurations.Where(c => !string.IsNullOrWhiteSpace(c.ItemSpec)))
+            {
+                // parse the specified configuration applying any independent properties from the BuildConfiguration.
+                var configuration = ConfigurationFactory.ParseConfiguration(configurationItem.ItemSpec, baseConfiguration:buildConfiguration);
+
+                // reuse original item as we must preserve the OriginalItemSpec metadata
+                configurationItem.ItemSpec = configuration.ToFullString();
+                normalizedConfigurations.Add(configurationItem);
+            }
+
+            NormalizedConfigurations = normalizedConfigurations.ToArray();
+
+            return !Log.HasLoggedErrors;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Configuration/src/NormalizeConfigurations.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Configuration/src/NormalizeConfigurations.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System;

--- a/src/Microsoft.DotNet.Build.Tasks.Configuration/src/build/BinPlace.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Configuration/src/build/BinPlace.targets
@@ -118,12 +118,19 @@
 
   <UsingTask TaskName="FindBestConfigurations" AssemblyFile="$(DotNetBuildTasksConfigurationDll)"/>
   <Target Name="GetBinPlaceConfiguration" DependsOnTargets="GetBuildConfigurations">
+    <NormalizeConfigurations Properties="@(Property)"
+                             PropertyValues="@(PropertyValue)"
+                             BuildConfiguration="$(Configuration)"
+                             Configurations="@(BinPlaceConfiguration)">
+      <Output TaskParameter="NormalizedConfigurations" ItemName="_normalizedBinPlaceConfiguration" />
+    </NormalizeConfigurations>
+    
     <!-- find which, if any, build configuration of this project is best
          for each binplace configuration -->
     <FindBestConfigurations Properties="@(Property)"
                             PropertyValues="@(PropertyValue)"
                             SupportedConfigurations="$(_AllBuildConfigurations)"
-                            Configurations="@(BinPlaceConfiguration)">
+                            Configurations="@(_normalizedBinPlaceConfiguration)">
       <Output TaskParameter="BestConfigurations" ItemName="_bestBinlaceConfigurations" />
     </FindBestConfigurations>
 

--- a/src/Microsoft.DotNet.Build.Tasks.Configuration/src/build/BinPlace.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Configuration/src/build/BinPlace.targets
@@ -128,7 +128,7 @@
     </FindBestConfigurations>
 
     <ItemGroup>
-      <_currentBinPlaceConfigurations Include="@(_bestBinlaceConfigurations)" Condition="'%(Identity)' == '$(Configuration)' OR '%(Identity)-$(ConfigurationGroup)' == '$(Configuration)'" />
+      <_currentBinPlaceConfigurations Include="@(_bestBinlaceConfigurations)" Condition="'%(Identity)' == '$(Configuration)'" />
 
       <BinPlaceDir Condition="'$(BinPlaceTest)' == 'true'" Include="@(_currentBinPlaceConfigurations->'%(TestPath)')" />
       <BinPlaceDir Condition="'$(BinPlaceRuntime)' == 'true'" Include="@(_currentBinPlaceConfigurations->'%(RuntimePath)')" />

--- a/src/Microsoft.DotNet.Build.Tasks.Configuration/src/build/Microsoft.DotNet.Build.Tasks.Configuration.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Configuration/src/build/Microsoft.DotNet.Build.Tasks.Configuration.targets
@@ -3,6 +3,7 @@
 <Project>
   <UsingTask TaskName="GenerateConfigurationProps" AssemblyFile="$(DotNetBuildTasksConfigurationDll)"/>
   <UsingTask TaskName="FindBestConfigurations" AssemblyFile="$(DotNetBuildTasksConfigurationDll)"/>
+  <UsingTask TaskName="NormalizeConfigurations" AssemblyFile="$(DotNetBuildTasksConfigurationDll)"/>
 
   <PropertyGroup>
     <_traversalBuildConfigurations>$(BuildConfiguration)</_traversalBuildConfigurations>
@@ -17,8 +18,20 @@
              Projects="@(Project)"
              Condition="'$(BuildAllConfigurations)' == 'true'">
       <Output TaskParameter="TargetOutputs"
-              ItemName="_projectBuildConfigurations" />
+              ItemName="_projectBuildConfigurationsExact" />
     </MSBuild>
+    
+    <ItemGroup>
+      <!-- we need to ignore placeholder build configurations that start with _ -->
+      <_projectBuildConfigurationsExact Remove="@(_projectBuildConfigurationsExact)" Condition="$([System.String]::Copy('%(Identity)').StartsWith('_'))" />      
+    </ItemGroup>
+
+    <NormalizeConfigurations Properties="@(Property)"
+                             PropertyValues="@(PropertyValue)"
+                             BuildConfiguration="$(BuildConfiguration)"
+                             Configurations="@(_projectBuildConfigurationsExact)">
+      <Output TaskParameter="NormalizedConfigurations" ItemName="_projectBuildConfigurations" />
+    </NormalizeConfigurations>
 
     <ItemGroup>
       <!-- assign configuration as a separate step to prevent batching during the transform which can reorder the list.
@@ -26,9 +39,6 @@
       <_projectBuildConfigurations>
         <AdditionalProperties>Configuration=%(Identity);%(_projectBuildConfigurations.AdditionalProperties)</AdditionalProperties>
       </_projectBuildConfigurations>
-
-      <!-- we need to ignore placeholder build configurations that start with _ -->
-      <_projectBuildConfigurations Remove="@(_projectBuildConfigurations)" Condition="$([System.String]::Copy('%(Identity)').StartsWith('_'))" />
 
       <!-- transform back to project -->
       <_projectWithConfiguration Include="@(_projectBuildConfigurations->'%(OriginalItemSpec)')" />
@@ -46,8 +56,20 @@
     <MSBuild Targets="GetPackageConfigurations"
              Projects="@(_NonPkgProjProjectReference)">
       <Output TaskParameter="TargetOutputs"
-              ItemName="_NonPkgProjProjectReferenceBuildConfigurations" />
+              ItemName="_NonPkgProjProjectReferenceBuildConfigurationsExact" />
     </MSBuild>
+    
+    <ItemGroup>
+      <!-- we need to ignore placeholder build configurations that start with _ -->
+      <_NonPkgProjProjectReferenceBuildConfigurationsExact Remove="@(_NonPkgProjProjectReferenceBuildConfigurationsExact)" Condition="$([System.String]::Copy('%(Identity)').StartsWith('_'))" />
+    </ItemGroup>
+
+    <NormalizeConfigurations Properties="@(Property)"
+                             PropertyValues="@(PropertyValue)"
+                             BuildConfiguration="$(BuildConfiguration)"
+                             Configurations="@(_NonPkgProjProjectReferenceBuildConfigurationsExact)">
+      <Output TaskParameter="NormalizedConfigurations" ItemName="_NonPkgProjProjectReferenceBuildConfigurations" />
+    </NormalizeConfigurations>
 
     <ItemGroup>
       <!-- assign configuration as a separate step to prevent batching during the transform which can reorder the list.
@@ -55,9 +77,6 @@
       <_NonPkgProjProjectReferenceBuildConfigurations>
         <AdditionalProperties>Configuration=%(Identity);%(_NonPkgProjProjectReferenceBuildConfigurations.AdditionalProperties)</AdditionalProperties>
       </_NonPkgProjProjectReferenceBuildConfigurations>
-
-      <!-- we need to ignore placeholder build configurations that start with _ -->
-      <_NonPkgProjProjectReferenceBuildConfigurations Remove="@(_NonPkgProjProjectReferenceBuildConfigurations)" Condition="$([System.String]::Copy('%(Identity)').StartsWith('_'))" />
 
       <!-- transform back to project -->
       <_NonPkgProjProjectReferenceWitnConfiguration Include="@(_NonPkgProjProjectReferenceBuildConfigurations->'%(OriginalItemSpec)')" />
@@ -158,7 +177,7 @@
     <!-- Find the best configuration for the current Project's Configuration -->
     <FindBestConfigurations Properties="@(Property)"
                             PropertyValues="@(PropertyValue)"
-                            SupportedConfigurations="$(_ProjectReferenceBuildConfigurations)"
+                            SupportedConfigurations="$(_projectReferenceBuildConfigurations)"
                             Configurations="$(Configuration)">
       <Output TaskParameter="BestConfigurations" PropertyName="_projectReferenceConfiguration" />
     </FindBestConfigurations>
@@ -174,11 +193,18 @@
 
   <Target Name="_getAllBuildConfigurations">
     <ItemGroup>
-      <_buildConfigurations Include="$(BuildConfigurations)" />
+      <_buildConfigurationsExact Include="$(BuildConfigurations)" />
       <!-- For BuildAllConfigurations we need to ignore any placeholder build configuration that starts with _ -->
-      <_buildConfigurations Remove="@(_buildConfigurations)" Condition="$([System.String]::Copy('%(Identity)').StartsWith('_'))" />
-      <_buildConfigurations Condition="'@(_buildConfigurations)' == ''" Include="$(_traversalBuildConfigurations)" />
+      <_buildConfigurationsExact Remove="@(_buildConfigurationsExact)" Condition="$([System.String]::Copy('%(Identity)').StartsWith('_'))" />
+      <_buildConfigurationsExact Condition="'@(_buildConfigurationsExact)' == ''" Include="$(_traversalBuildConfigurations)" />
     </ItemGroup>
+
+    <NormalizeConfigurations Properties="@(Property)"
+                             PropertyValues="@(PropertyValue)"
+                             BuildConfiguration="$(Configuration)"
+                             Configurations="@(_buildConfigurationsExact)">
+      <Output TaskParameter="NormalizedConfigurations" ItemName="_buildConfigurations" />
+    </NormalizeConfigurations>
   </Target>
 
   <Target Name="BuildAllConfigurations" DependsOnTargets="_getAllBuildConfigurations">


### PR DESCRIPTION
The configuration system allows for "insignificant" properties.  These are properties that aren't considered as required for configurations to be compatible.  It lets us allow folks to specify configurations without expanding debug/release in the buildconfiguration properties.  The configuration system also allows for defaults: values which are omitted from configuration strings.

These two features were combining to make inconsistent behavior when we traverse projects vs building directly.  When building directly we'd always create "full" configuration strings with default values and insignificant properties.  When traversing  we'd do one of two things: 1) use the configuration verbatim in the case we weren't selecting the "best" configuration, omitting both defaults and insignificant properties 2) select the best configuration and omit the defaults.

To fix 1 I made sure that we normalize the configuration strings that we get from the project: adding in any defaults and inheriting insignificant properties from some base configuration.

To fix 2 the latter I made sure that FindBestConfiguration includes the default values in the configuration strings it emits.

Related #1434 Fixes https://github.com/dotnet/corefx/issues/33465

FWIW this has always been a problem since we created the config system initially.  We never noticed it because we never used the Configuration property to build out paths, we used all the *Group properties instead.  We also never had a build traversal that would see the different global properties.  My first attempt at the fix was to always append ConfigurationGroup to Configuration if it was missing, this fixed the paths but caused binclash issues since global properties would be different during the traversal (P2Ps would get the insignificant property added, whereas direct traversal did not).  This fix is better since it ensures the Configuration strings are fully normalized before they are ever used.