### PR TITLE
Use documents folder as results path for UapRunner

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
@@ -8,7 +8,7 @@
     <TestAssembly Condition="'$(TestAssembly)' == ''">$(TargetFileName)</TestAssembly>
     <TestPath Condition="'$(TestPath)' == ''">$(OutDir)</TestPath>
     <RunWorkingDirectory>$(TestPath)</RunWorkingDirectory>
-    
+
     <!-- Publish the test data as part of the build to enable VS test runs. -->
     <PrepareForRunDependsOn>$(PrepareForRunDependsOn);PublishSupplementalTestData;</PrepareForRunDependsOn>
     <!-- Clean leftovers not tracked by FileWrites. -->
@@ -18,20 +18,17 @@
   <!-- RunScript -->
   <PropertyGroup>
     <RunScriptInputName Condition="'$(TargetOS)' == 'Windows_NT'">RunnerTemplate.Windows.txt</RunScriptInputName>
-    <RunScriptInputName Condition="'$(TargetOS)' != 'Windows_NT'">RunnerTemplate.Unix.txt</RunScriptInputName>     
+    <RunScriptInputName Condition="'$(TargetOS)' != 'Windows_NT'">RunnerTemplate.Unix.txt</RunScriptInputName>
     <RunScriptInputPath>$(TestAssetsDir)$(RunScriptInputName)</RunScriptInputPath>
 
     <RunScriptOutputName Condition="'$(TargetOS)' == 'Windows_NT'">RunTests.cmd</RunScriptOutputName>
-    <RunScriptOutputName Condition="'$(TargetOS)' != 'Windows_NT'">RunTests.sh</RunScriptOutputName>     
+    <RunScriptOutputName Condition="'$(TargetOS)' != 'Windows_NT'">RunTests.sh</RunScriptOutputName>
     <RunScriptOutputPath>$([MSBuild]::NormalizePath('$(TestPath)', '$(RunScriptOutputName)'))</RunScriptOutputPath>
 
     <RunScriptHostDir Condition="'$(BuildingNETCoreAppVertical)' == 'true' AND '$(TargetOS)' == 'Windows_NT'">%RUNTIME_PATH%\</RunScriptHostDir>
     <RunScriptHostDir Condition="'$(BuildingNETCoreAppVertical)' == 'true' AND '$(TargetOS)' != 'Windows_NT'">$RUNTIME_PATH/</RunScriptHostDir>
     <RunScriptHost Condition="'$(BuildingNETCoreAppVertical)' == 'true' AND '$(TargetOS)' == 'Windows_NT'">$(RunScriptHostDir)dotnet.exe</RunScriptHost>
     <RunScriptHost Condition="'$(BuildingNETCoreAppVertical)' == 'true' AND '$(TargetOS)' != 'Windows_NT'">$(RunScriptHostDir)dotnet</RunScriptHost>
-
-    <!-- In UAP we don't want the repro steps printed. -->
-    <RunScriptOutputEchoes Condition="'$(BuildingUAPVertical)' != 'true'">true</RunScriptOutputEchoes>
   </PropertyGroup>
 
   <Target Name="PublishSupplementalTestData"
@@ -62,7 +59,7 @@
 
   </Target>
 
-  <!-- 
+  <!--
     Archive test binaries along with supporting files.
 
     Inputs:
@@ -80,8 +77,8 @@
           SkipUnchangedFiles="true" />
 
     <MakeDir Directories="$(TestArchiveTestsDir)" />
-    <ZipDirectory SourceDirectory="$(TestPath)" 
-                  DestinationFile="$([MSBuild]::NormalizePath('$(TestArchiveTestsDir)', '$(TestProjectName).zip'))" 
+    <ZipDirectory SourceDirectory="$(TestPath)"
+                  DestinationFile="$([MSBuild]::NormalizePath('$(TestArchiveTestsDir)', '$(TestProjectName).zip'))"
                   Overwrite="true" />
 
   </Target>
@@ -100,12 +97,12 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(UseDotNetNativeToolchain)' == 'true' AND '$(ArchGroup)' == 'arm'">
-      <!-- 
+      <!--
         Currently (and probably forever) we can't build AOT on ARM,
         So if we're running on ARM, what we really want to do is encapsulate
         the test command into a script that can be run on another machine
       -->
-      <RunScriptCommand>echo $(RunScriptCommand)> .\RunContinuation.cmd</RunScriptCommand>  
+      <RunScriptCommand>echo $(RunScriptCommand)> .\RunContinuation.cmd</RunScriptCommand>
     </PropertyGroup>
 
     <ItemGroup>
@@ -127,8 +124,7 @@
     <GenerateRunScript
       RunCommands="@(RunScriptCommands)"
       TemplatePath="$(RunScriptInputPath)"
-      OutputPath ="$(RunScriptOutputPath)"
-      OutputEchoes="$(RunScriptOutputEchoes)" />
+      OutputPath ="$(RunScriptOutputPath)" />
 
     <Exec Condition="'$(TargetOS)' != 'Windows_NT'" Command="chmod +x $(RunScriptOutputPath)" />
 
@@ -173,19 +169,19 @@
     <PropertyGroup>
       <TestDisabled Condition="'%(UnsupportedPlatformsItems.Identity)' == '$(TargetOS)' OR '$(ConfigurationErrorMsg)' != ''">true</TestDisabled>
     </PropertyGroup>
-    
+
     <Message Text="ValidateTestPlatform found TargetOS of [$(TargetOS)]." Importance="Low" />
-    
+
     <Message Condition="'%(UnsupportedPlatformsItems.Identity)' == '$(TargetOS)'"
       Text="Skipping tests in $(AssemblyName) because it is not supported on $(TargetOS)" />
-    
+
     <Message Condition="'$(ConfigurationErrorMsg)' != ''"
       Text="Skipping tests in $(AssemblyName) because there is no configuration compatible with the current BuildConfiguration." />
 
   </Target>
 
-  <!-- 
-    SkipTests is a global property used in CI runs. Skips the test execution but 
+  <!--
+    SkipTests is a global property used in CI runs. Skips the test execution but
     still generates the test execution script and archives the test dir for Helix consumption.
   -->
   <Target Name="RunTests"
@@ -211,12 +207,12 @@
 
   </Target>
 
-  <!-- 
+  <!--
     Add a manual clean step for TestPath.
     Necessary as we are copying files into the TestPath as part of the Test Target after the build.
   -->
   <Target Name="CleanTestPath" Condition="Exists('$(TestPath)')">
-    
+
     <RemoveDir Directories="$(TestPath)"
                ContinueOnError="WarnAndContinue" />
 
@@ -228,7 +224,7 @@
   <Target Name="RebuildAndTest" DependsOnTargets="Rebuild;Test" />
 
   <Import Condition="'$(BuildingUAPVertical)' == 'true'" Project="$(MSBuildThisFileDirectory)Core.uap.targets" />
-  
+
   <!--
     LaunchSettings.json support.
     Generates launchSettings.json files during compilation or on demand.

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
@@ -2,10 +2,19 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
 
+  <PropertyGroup Condition="'$(BuildingUAPVertical)' == 'true'">
+    <!--
+      Inside an AppContainer we can't write into the WorkingDirectory. As the UAP Runner has
+      the capability to write to the user's documents folder, we use that instead.
+    -->
+    <UAPResultsPathCmd Condition="'$(UAPResultsPathCmd)' == ''">&quot;%USERPROFILE%\Documents\$(AssemblyName).xml&quot;</UAPResultsPathCmd>
+  </PropertyGroup>
+
   <!-- General xunit options -->
   <PropertyGroup>
     <RunArguments>$(TestAssembly)</RunArguments>
-    <RunArguments>$(RunArguments) -xml $(TestResultsName)</RunArguments>
+    <RunArguments Condition="'$(BuildingUAPVertical)' != 'true'">$(RunArguments) -xml $(TestResultsName)</RunArguments>
+    <RunArguments Condition="'$(BuildingUAPVertical)' == 'true'">$(RunArguments) -xml $(UAPResultsPathCmd)</RunArguments>
     <RunArguments>$(RunArguments) -nologo</RunArguments>
     <RunArguments>$(RunArguments) -notrait category=non$(_bc_TargetGroup)tests</RunArguments>
 
@@ -31,7 +40,7 @@
     <_withoutCategories Condition="'$(Outerloop)' != 'true'">$(_withoutCategories);Outerloop</_withoutCategories>
     <RunArguments>$(RunArguments)$(_withCategories.Replace(';', ' -trait category='))</RunArguments>
     <RunArguments>$(RunArguments)$(_withoutCategories.Replace(';', ' -notrait category='))</RunArguments>
-    
+
     <!-- User passed in options. -->
     <RunArguments Condition="'$(XUnitOptions)' != ''">$(RunArguments) $(XUnitOptions)</RunArguments>
   </PropertyGroup>
@@ -51,7 +60,7 @@
   <!-- Setup run commands. -->
   <Choose>
 
-    <When Condition="'$(BuildingNETCoreAppVertical)' == 'true'">  
+    <When Condition="'$(BuildingNETCoreAppVertical)' == 'true'">
       <PropertyGroup>
         <TestRunnerName>xunit.console.dll</TestRunnerName>
         <TestRunnerNameWithoutExtension>$([System.IO.Path]::GetFileNameWithoutExtension('$(TestRunnerName)'))</TestRunnerNameWithoutExtension>
@@ -61,21 +70,18 @@
       </PropertyGroup>
     </When>
 
-    <When Condition="'$(BuildingNETFxVertical)' == 'true'">  
+    <When Condition="'$(BuildingNETFxVertical)' == 'true'">
       <PropertyGroup>
         <TestRunnerName>xunit.console.exe</TestRunnerName>
         <RunCommand>$(TestRunnerName)</RunCommand>
       </PropertyGroup>
     </When>
 
-    <When Condition="'$(BuildingUAPVertical)' == 'true'">  
+    <When Condition="'$(BuildingUAPVertical)' == 'true'">
       <PropertyGroup>
         <!-- Globally registered UWP console app. -->
         <TestRunnerName>XUnitRunnerUap</TestRunnerName>
         <RunCommand>$(TestRunnerName)</RunCommand>
-        
-        <!-- The location where the logs will be written by the test runner -->
-        <UAPResultsFolder Condition="'$(UAPResultsFolder)' == ''">%USERPROFILE%\Documents\TestResults\</UAPResultsFolder>
       </PropertyGroup>
 
       <ItemGroup>
@@ -91,7 +97,7 @@
         <!-- Install -->
         <RunScriptCommands Include="call &quot;$(LauncherPath)&quot; -install appxmanifest.xml $(TestAssembly)" />
         <RunScriptCommands Include="echo." />
-        
+
         <!-- Uninstall -->
         <PostRunScriptCommands Include="echo." />
         <!-- Save error level as the uninstall command overwrites the global one. -->
@@ -99,15 +105,15 @@
         <PostRunScriptCommands Include="call &quot;$(LauncherPath)&quot; -uninstall appxmanifest.xml $(TestAssembly)" />
 
         <!-- Copy the log files and the results files from the Documents folder to the test folder -->
-        <PostRunScriptCommands Include="move /Y &quot;$(UAPResultsFolder)$(TestAssembly).xml&quot; .\$(TestResultsName)" />
+        <PostRunScriptCommands Include="move /Y $(UAPResultsPathCmd) .\$(TestResultsName)" />
       </ItemGroup>
     </When>
 
-    <When Condition="'$(UseDotNetNativeToolchain)' == 'true'">  
+    <When Condition="'$(UseDotNetNativeToolchain)' == 'true'">
       <PropertyGroup>
         <TestRunnerName>xunit.console.exe</TestRunnerName>
         <RunCommand>$(TestRunnerName)</RunCommand>
-        
+
         <!-- We use the netcoreapp runner for ILC but change its extension to .exe to satisfy ILC. -->
         <OriginalTestRunnerName>xunit.console.dll</OriginalTestRunnerName>
 


### PR DESCRIPTION
As we are now using the same xunit runner for all configurations
we don't hardcode the results path for UWP inside the runner anymore
and can just pass it as an args instead as it should've been from the
beginning.

Remove the workaround to not output echo steps for UWP and correctly
escape the ampersand and pipe bracket characters so that they are
not executed.

_Please disable the white space differ for this change._