### PR TITLE
Check exclusions before invoking verifiers

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/Verification/Exclusions.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Exclusions.cs
@@ -79,7 +79,7 @@ namespace Microsoft.SignCheck.Verification
         /// <returns></returns>
         public bool IsExcluded(string path, string parent, string containerPath)
         {
-            return (Count > 0) && (IsParentExcluded(path) || IsFileExcluded(parent) || IsFileExcluded(containerPath));
+            return (Count > 0) && (IsParentExcluded(parent) || IsFileExcluded(path) || IsFileExcluded(containerPath));
         }
 
         /// <summary>

--- a/src/SignCheck/Microsoft.SignCheck/Verification/Exclusions.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Exclusions.cs
@@ -71,6 +71,18 @@ namespace Microsoft.SignCheck.Verification
         }
 
         /// <summary>
+        /// Return true if an exclusion matches the file path, parent file container or the path in the container
+        /// </summary>
+        /// <param name="path">The path of the file on disk.</param>
+        /// <param name="parent">The parent (container) of the file.</param>
+        /// <param name="containerPath">The path of the file in the container. May be null if the file is not embedded in a container.</param>
+        /// <returns></returns>
+        public bool IsExcluded(string path, string parent, string containerPath)
+        {
+            return (Count > 0) && (IsFileExcluded(path) || IsFileExcluded(parent) || IsFileExcluded(containerPath));
+        }
+
+        /// <summary>
         /// Returns true if any <see cref="Exclusion.FilePatterns"/> matches the value of <paramref name="path"/>.
         /// </summary>
         /// <param name="path">The value to match against any <see cref="Exclusion.FilePatterns"/>.</param>

--- a/src/SignCheck/Microsoft.SignCheck/Verification/Exclusions.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Exclusions.cs
@@ -79,7 +79,7 @@ namespace Microsoft.SignCheck.Verification
         /// <returns></returns>
         public bool IsExcluded(string path, string parent, string containerPath)
         {
-            return (Count > 0) && (IsFileExcluded(path) || IsFileExcluded(parent) || IsFileExcluded(containerPath));
+            return (Count > 0) && (IsParentExcluded(path) || IsFileExcluded(parent) || IsFileExcluded(containerPath));
         }
 
         /// <summary>

--- a/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationResult.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationResult.cs
@@ -258,5 +258,23 @@ namespace Microsoft.SignCheck.Verification
 
             return signatureVerificationResult;
         }
+
+        /// <summary>
+        /// Creates a SignatureVerificationResult for an excluded file type or file extension.
+        /// </summary>
+        /// <param name="path">The path to the excluded file.</param>
+        /// <param name="parent">The parent container of the excluded file</param>
+        /// <returns></returns>
+        public static SignatureVerificationResult ExcludedFileResult(string path, string parent)
+        {
+            var signatureVerificationResult = new SignatureVerificationResult(path, parent)
+            {
+                IsExcluded = true
+            };
+
+            signatureVerificationResult.AddDetail(DetailKeys.File, SignCheckResources.DetailExcluded);
+
+            return signatureVerificationResult;
+        }
     }
 }


### PR DESCRIPTION
Exclusions should be checked prior to invoking a file verifier. This also avoids issues when a file that's excluded is in the folder being scanned and that file is being written to by another process. An example of this is excluding bin logs from msbuild. Because the file extension is not a well known extension, the tool will try to determine the file type by scanning the file's header for different signatures. This can result in access violations.