### PR TITLE
Pass configuration as property

### DIFF
--- a/eng/common/templates/phases/publish-build-assets.yml
+++ b/eng/common/templates/phases/publish-build-assets.yml
@@ -29,10 +29,10 @@ phases:
           condition: ${{ parameters.condition }}
           continueOnError: ${{ parameters.continueOnError }}
         - script: eng\common\publishbuildassets.cmd
-            -configuration $(_BuildConfig)
             /p:ManifestsPath='$(Build.StagingDirectory)/Download/AssetManifests'
             /p:BuildAssetRegistryToken=$(MaestroAccessToken)
             /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
+            /p:Configuration=$(_BuildConfig)
           displayName: Publish Build Assets
           condition: ${{ parameters.condition }}
           continueOnError: ${{ parameters.continueOnError }}


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/1847

Validation of https://github.com/dotnet/arcade/pull/1595, did not include validating the deprecated "phases" templates.  Passing "configuration" to `publishbuildassets` is not supported.

This change aligns the [job](https://github.com/dotnet/arcade/blob/master/eng/common/templates/job/publish-build-assets.yml#L47-L51) and [phase](https://github.com/dotnet/arcade/blob/master/eng/common/templates/phases/publish-build-assets.yml#L31-L35) templates.

FYI @nguerrera 