### PR TITLE
Add an "ExcludeFromManifest" option to manifest generation

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -64,7 +64,7 @@
     <XUnitVersion Condition="'$(XUnitVersion)' == ''">2.4.1-pre.build.4059</XUnitVersion>
     <XUnitRunnerConsoleVersion Condition="'$(XUnitRunnerConsoleVersion)' == ''">$(XUnitVersion)</XUnitRunnerConsoleVersion>
     <XUnitRunnerVisualStudioVersion Condition="'$(XUnitRunnerVisualStudioVersion)' == ''">$(XUnitVersion)</XUnitRunnerVisualStudioVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion Condition="'$(MicrosoftDotNetBuildTasksFeedVersion)' == ''">2.2.0-beta.19061.8</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion Condition="'$(MicrosoftDotNetBuildTasksFeedVersion)' == ''">2.2.0-beta.19072.10</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftSourceLinkVersion Condition="'$(MicrosoftSourceLinkVersion)' == ''">1.0.0-beta2-18618-05</MicrosoftSourceLinkVersion>
     <MicrosoftSymbolUploaderBuildTaskVersion Condition="'$(MicrosoftSymbolUploaderBuildTaskVersion)' == ''">1.0.0-beta-63604-05</MicrosoftSymbolUploaderBuildTaskVersion>
     <VSWhereVersion Condition="'$(VSWhereVersion)' == ''">2.5.2</VSWhereVersion>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
@@ -53,6 +53,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
             foreach (var artifact in artifacts)
             {
+                if (string.Equals(artifact.GetMetadata("ExcludeFromManifest"), "true", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
                 var isSymbolsPackage = artifact.ItemSpec.EndsWith(".symbols.nupkg", StringComparison.OrdinalIgnoreCase)
                     || artifact.ItemSpec.EndsWith(".snupkg", StringComparison.OrdinalIgnoreCase);
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
@@ -52,7 +52,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     }
                     else
                     {
-                        ITaskItem[] symbolItems = ItemsToPush
+                        var itemsToPushNoExcludes = ItemsToPush.
+                            Where(i => !string.Equals(i.GetMetadata("ExcludeFromManifest"), "true", StringComparison.OrdinalIgnoreCase));
+                        ITaskItem[] symbolItems = itemsToPushNoExcludes
                             .Where(i => i.ItemSpec.Contains("symbols.nupkg"))
                             .Select(i =>
                             {
@@ -62,7 +64,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                             })
                             .ToArray();
 
-                        ITaskItem[] packageItems = ItemsToPush
+                        ITaskItem[] packageItems = itemsToPushNoExcludes
                             .Where(i => !symbolItems.Contains(i))
                             .ToArray();
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBlobFeed.cs
@@ -168,6 +168,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             IEnumerable<ITaskItem> items)
         {
             return artifacts.Concat(items
+                .Where(i => !string.Equals(i.GetMetadata("ExcludeFromManifest"), "true", StringComparison.OrdinalIgnoreCase))
                 .Select(BuildManifestUtil.CreatePackageArtifactModel));
         }
 
@@ -176,6 +177,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             IEnumerable<ITaskItem> items)
         {
             return artifacts.Concat(items
+                .Where(i => !string.Equals(i.GetMetadata("ExcludeFromManifest"), "true", StringComparison.OrdinalIgnoreCase))
                 .Select(BuildManifestUtil.CreateBlobArtifactModel)
                 .Where(blob => blob != null));
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/1842

Unblocks core-sdk publishing.  Validated in https://dev.azure.com/dnceng/internal/_build/results?buildId=78284

Allows us to do https://github.com/chcosta/core-sdk/blob/publish-to-bar/eng/Publishing.props#L35, to prevent a file from being included in a manifest.

@jcagme @JohnTortugo , I updated `PushToAzureDevOpsArtifacts.cs` in this change for consistency, but that code will need to be refactored when that file does more than just manifest generation because the goal is to allow the items to be published, but not included in the manifest (as-is, they would be excluded from both).