### PR TITLE
Remove use of RunningOnUnix

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/PackageLibs.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/PackageLibs.targets
@@ -139,8 +139,8 @@
     <!-- Be explicit about path seperators for the target path for source files. When building packages on *nix, the use of the DOS seperator
          was causing us to include source files in our packages in a folder called src\src, instead of them being stripped. -->
     <PropertyGroup>
-      <SourceFileTargetPathPrefix Condition="'$(RunningOnUnix)' != 'true'">src\</SourceFileTargetPathPrefix>
-      <SourceFileTargetPathPrefix Condition="'$(RunningOnUnix)' == 'true'">src/</SourceFileTargetPathPrefix>
+      <SourceFileTargetPathPrefix Condition="'$(OS)' == 'Windows_NT'">src\</SourceFileTargetPathPrefix>
+      <SourceFileTargetPathPrefix Condition="'$(OS)' != 'Windows_NT'">src/</SourceFileTargetPathPrefix>
     </PropertyGroup>
 
     <!-- *** include assets *** -->

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.targets
@@ -70,7 +70,7 @@
     <PropertyGroup>
       <ProducePdb>true</ProducePdb>
       <!-- Partial facade PDB generation only functions on Windows -->
-      <ProducePdb Condition="'$(DebugSymbols)' == 'false' OR '$(RunningOnUnix)' == 'true'">false</ProducePdb>
+      <ProducePdb Condition="'$(DebugSymbols)' == 'false' OR '$(OS)' != 'Windows_NT'">false</ProducePdb>
       <GenFacadesIgnoreMissingTypes Condition="'$(GenFacadesIgnoreMissingTypes)' == ''">false</GenFacadesIgnoreMissingTypes>
       <GenFacadesIgnoreBuildAndRevisionMismatch Condition="'$(GenFacadesIgnoreBuildAndRevisionMismatch)' == ''">false</GenFacadesIgnoreBuildAndRevisionMismatch>
     </PropertyGroup>


### PR DESCRIPTION
This property was defined by buildtools and didn't add anything over the
MSBuild properties that already exist.