### PR TITLE
UWP AppData results path & processorArchitecture

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
@@ -4,10 +4,11 @@
 
   <PropertyGroup Condition="'$(BuildingUAPVertical)' == 'true'">
     <!--
-      Inside an AppContainer we can't write into the WorkingDirectory. As the UAP Runner has
-      the capability to write to the user's documents folder, we use that instead.
+      Inside an AppContainer we can't write into the WorkingDirectory. As System.IO is used
+      to write the results file we can't use the documents folder either. Therefore we write
+      into the app's local state directory which doesn't need a StorageFolder broker.
     -->
-    <UAPResultsPathCmd Condition="'$(UAPResultsPathCmd)' == ''">&quot;%USERPROFILE%\Documents\$(AssemblyName).xml&quot;</UAPResultsPathCmd>
+    <UAPResultsPathCmd Condition="'$(UAPResultsPathCmd)' == ''">&quot;%LOCALAPPDATA%\Packages\5cd54353-3ed7-4a6e-a72f-db349f28867c_*\LocalState\$(AssemblyName).xml&quot;</UAPResultsPathCmd>
   </PropertyGroup>
 
   <!-- General xunit options -->

--- a/src/Microsoft.DotNet.Uap.TestTools/AppxManifest.xml
+++ b/src/Microsoft.DotNet.Uap.TestTools/AppxManifest.xml
@@ -7,7 +7,7 @@
 
     For more information on package manifest files, see http://go.microsoft.com/fwlink/?LinkID=241727
   -->
-  <Identity Name="5cd54353-3ed7-4a6e-a72f-db349f28867c" Publisher="CN=dotnet" Version="1.0.0.0" ProcessorArchitecture="x64" />
+  <Identity Name="5cd54353-3ed7-4a6e-a72f-db349f28867c" Publisher="CN=dotnet" Version="1.0.0.0" ProcessorArchitecture="$processorArchitecture$" />
   <mp:PhoneIdentity PhoneProductId="5cd54353-3ed7-4a6e-a72f-db349f28867c" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Microsoft.DotNet.XUnitRunnerUap</DisplayName>
@@ -27,22 +27,6 @@
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
       </uap:VisualElements>
       <Extensions>
-        <uap:Extension Category="windows.fileTypeAssociation">
-          <uap:FileTypeAssociation Name="xml">
-            <uap:DisplayName>xml</uap:DisplayName>
-            <uap:SupportedFileTypes>
-              <uap:FileType>.xml</uap:FileType>
-            </uap:SupportedFileTypes>
-          </uap:FileTypeAssociation>
-        </uap:Extension>
-        <uap:Extension Category="windows.fileTypeAssociation">
-          <uap:FileTypeAssociation Name="logs">
-            <uap:DisplayName>Log file</uap:DisplayName>
-            <uap:SupportedFileTypes>
-              <uap:FileType>.txt</uap:FileType>
-            </uap:SupportedFileTypes>
-          </uap:FileTypeAssociation>
-        </uap:Extension>
         <uap5:Extension Category="windows.appExecutionAlias" Executable="Microsoft.DotNet.XUnitRunnerUap.exe" EntryPoint="Microsoft.DotNet.XUnitRunnerUap.Program">
           <uap5:AppExecutionAlias desktop4:Subsystem="console" iot2:Subsystem="console">
             <uap5:ExecutionAlias Alias="XUnitRunnerUap.exe" />

--- a/src/Microsoft.DotNet.Uap.TestTools/Microsoft.DotNet.XUnitRunnerUap/Microsoft.DotNet.XUnitRunnerUap.csproj
+++ b/src/Microsoft.DotNet.Uap.TestTools/Microsoft.DotNet.XUnitRunnerUap/Microsoft.DotNet.XUnitRunnerUap.csproj
@@ -5,7 +5,8 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == '' OR '$(Platform)' == 'AnyCPU'">x64</Platform>
     <ProjectGuid>{552DECA2-68D7-4506-86DE-E808D1E60FB6}</ProjectGuid>
-    <OutputType>AppContainerExe</OutputType>
+    <OutputType>Exe</OutputType>
+    <WindowsAppContainer>true</WindowsAppContainer>
     <SubsystemVersion>6.02</SubsystemVersion>
     <AppxPackage>True</AppxPackage>
     <TargetFrameworkIdentifier>.NETCore</TargetFrameworkIdentifier>

--- a/src/Microsoft.DotNet.Uap.TestTools/Microsoft.DotNet.XUnitRunnerUap/Package.appxmanifest
+++ b/src/Microsoft.DotNet.Uap.TestTools/Microsoft.DotNet.XUnitRunnerUap/Package.appxmanifest
@@ -37,7 +37,7 @@
       EntryPoint="Microsoft.DotNet.XUnitRunnerUap.Program"
       desktop4:SupportsMultipleInstances="true" 
       desktop4:Subsystem="console" 
-      iot2:SupportsMultipleInstances="true" 
+      iot2:SupportsMultipleInstances="true"
       iot2:Subsystem="console">
 
       <uap:VisualElements
@@ -54,23 +54,6 @@
       </uap:VisualElements>
 
       <Extensions>
-        <uap:Extension Category="windows.fileTypeAssociation">
-          <uap:FileTypeAssociation Name="xml">
-            <uap:DisplayName>xml</uap:DisplayName>
-            <uap:SupportedFileTypes>
-              <uap:FileType>.xml</uap:FileType>
-            </uap:SupportedFileTypes>
-          </uap:FileTypeAssociation>
-        </uap:Extension>
-        <uap:Extension Category="windows.fileTypeAssociation">
-          <uap:FileTypeAssociation Name="logs">
-            <uap:DisplayName>Log file</uap:DisplayName>
-            <uap:SupportedFileTypes>
-              <uap:FileType>.txt</uap:FileType>
-            </uap:SupportedFileTypes>
-          </uap:FileTypeAssociation>
-        </uap:Extension>
-
         <uap5:Extension 
           Category="windows.appExecutionAlias" 
 	        Executable="Microsoft.DotNet.XUnitRunnerUap.exe" 

--- a/src/Microsoft.DotNet.Uap.TestTools/buildAndUpdate.bat
+++ b/src/Microsoft.DotNet.Uap.TestTools/buildAndUpdate.bat
@@ -78,6 +78,7 @@ setlocal
     xcopy /y %_mainSource%\Microsoft.DotNet.XUnitRunnerUap.exe %_dest%\
     xcopy /y %_mainSource%\resources.pri %_dest%\
     xcopy /y .\AppxManifest.xml %_dest%\
+    powershell -Command "(gc %_dest%\AppxManifest.xml) -replace '\$processorArchitecture\$', '%_platform%' | Out-File -encoding ASCII %_dest%\AppxManifest.xml"
     xcopy /y "%_source%\Microsoft.VCLibs.%_platform%.Debug.14.00\%_platform%\*.dll" "%_dest%\"    
 
     IF "%_platform%" == "arm64" (
@@ -87,6 +88,7 @@ setlocal
         xcopy /y %_mainSource%\entrypoint\Microsoft.DotNet.XUnitRunnerUap.exe %_dest%\entrypoint\
         xcopy /y %_mainSource%\Properties\Default.rd.xml %_dest%\Properties\
         xcopy /y %_mainSource%\WinMetadata\Windows.winmd %_dest%\WinMetadata\
+        xcopy /y "%_source%\Microsoft.NET.CoreFramework.Debug.2.2\%_platform%\System.Private.ServiceModel.dll" %_dest%\
         xcopy /y "%_source%\Microsoft.NET.CoreFramework.Debug.2.2\%_platform%\System.ServiceModel.dll" %_dest%\
         xcopy /y "%_source%\Microsoft.NET.CoreFramework.Debug.2.2\%_platform%\System.ServiceModel.Duplex.dll" %_dest%\
         xcopy /y "%_source%\Microsoft.NET.CoreFramework.Debug.2.2\%_platform%\System.ServiceModel.Http.dll" %_dest%\


### PR DESCRIPTION
Change the test results xml path to the UWP app's local appdata folder
as the documents folder requires a storage broker (Windows.Storage).

Also set the processorArchitecture attribute in the AppManifest
correctly so that the app successfully registerson platforms other
than x64.