### PR TITLE
Add check for BadImageFormatException

### DIFF
--- a/src/Microsoft.DotNet.SignTool/src/ContentUtil.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ContentUtil.cs
@@ -69,12 +69,19 @@ namespace Microsoft.DotNet.SignTool
 
         public static bool IsManaged(string filePath)
         {
-            using (var stream = new FileStream(filePath, FileMode.Open))
-            using (var peReader = new PEReader(stream))
+            try
             {
-                var corEntry = peReader.PEHeaders.PEHeader.CorHeaderTableDirectory;
+                using (var stream = new FileStream(filePath, FileMode.Open))
+                using (var peReader = new PEReader(stream))
+                {
+                    var corEntry = peReader.PEHeaders.PEHeader.CorHeaderTableDirectory;
 
-                return corEntry.RelativeVirtualAddress == 0x2008 && corEntry.Size == 0x48;
+                    return corEntry.RelativeVirtualAddress == 0x2008 && corEntry.Size == 0x48;
+                }
+            }
+            catch (BadImageFormatException)
+            {
+                return false;
             }
         }
 


### PR DESCRIPTION
While checking for IsManaged assembly for strong name
validation we need to correctly handle when a file isn't a
valid PE image.

Fixes #1871 

PTAL @JohnTortugo 