### PR TITLE
New publishing flow: Initial location of assets will be build artifacts

### DIFF
--- a/eng/common/PublishToPackageFeed.proj
+++ b/eng/common/PublishToPackageFeed.proj
@@ -10,15 +10,25 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildThisFileDirectory)MicrosoftDotNetBuildTasksFeedVersion.props" />
+  <Import Project="$(MSBuildThisFileDirectory)DefaultVersions.props" Condition="Exists('$(MSBuildThisFileDirectory)DefaultVersions.props')" />
+  <Import Project="$(MSBuildThisFileDirectory)Versions.props" Condition="Exists('$(MSBuildThisFileDirectory)Versions.props')" />
+  
   <Import Project="$(NuGetPackageRoot)microsoft.dotnet.build.tasks.feed\$(MicrosoftDotNetBuildTasksFeedVersion)\build\Microsoft.DotNet.Build.Tasks.Feed.targets" />
 
   <Target Name="PublishToFeed">
     <Error Condition="'$(TargetStaticFeed)' == ''" Text="TargetStaticFeed: Target feed for publishing assets wasn't provided." />
     <Error Condition="'$(AccountKeyToStaticFeed)' == ''" Text="AccountKeyToStaticFeed: Account key for target feed wasn't provided." />
-    <Error Condition="'$(FullPathAssetManifest)' == ''" Text="Full path to asset manifest wasn't provided." />
-    <Error Condition="'$(FullPathBlobBasePath)' == '' AND '$(FullPathPackageBasePath)' == ''" Text="A valid full path to BlobBasePath of PackageBasePath is required." />
+    <Error Condition="'$(ManifestsBasePath)' == ''" Text="Full path to asset manifests directory wasn't provided." />
+    <Error Condition="'$(BlobBasePath)' == '' AND '$(PackageBasePath)' == ''" Text="A valid full path to BlobBasePath of PackageBasePath is required." />
 
+    <ItemGroup>
+      <!-- Include all manifests found in the manifest folder. -->
+      <ManifestFiles Include="$(ManifestsBasePath)*.xml" />
+    </ItemGroup>
+
+    <Error Condition="'@(ManifestFiles)' == ''" Text="No manifest file was found in the provided path: $(ManifestsBasePath)" />
+	
+    <!-- Iterate publishing assets from each manifest file. -->
     <PushArtifactsInManifestToFeed
       ExpectedFeedUrl="$(TargetStaticFeed)"
       AccountKey="$(AccountKeyToStaticFeed)"
@@ -26,9 +36,9 @@
       PassIfExistingItemIdentical="$(PassIfExistingItemIdentical)"
       MaxClients="$(MaxParallelUploads)"
       UploadTimeoutInMinutes="$(MaxUploadTimeoutInMinutes)"
-      AssetManifestPath="$(FullPathAssetManifest)"
-      BlobAssetsBasePath="$(FullPathBlobBasePath)"
-      PackageAssetsBasePath="$(FullPathPackageBasePath)" />
+      AssetManifestPath="%(ManifestFiles.Identity)"
+      BlobAssetsBasePath="$(BlobBasePath)"
+      PackageAssetsBasePath="$(PackageBasePath)" />
   </Target>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -16,8 +16,8 @@
     <OfficialBuild Condition="'$(OfficialBuildId)' != ''">true</OfficialBuild>
   </PropertyGroup>
 
-  <Import Project="$(VersionsPropsPath)"/>
-  <Import Project="Version.props"/>
+  <Import Project="$(VersionsPropsPath)" Condition="Exists('$(VersionsPropsPath)')"/>
+  <Import Project="Version.props" Condition="Exists('Version.props')"/>
 
   <PropertyGroup>
     <!-- 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -70,7 +70,6 @@
       </ItemsToPushToBlobFeed>
     </ItemGroup>
 
-
     <!--
     Begin:
       Work in progress drop-in replacement for PushToBlobFeed task below.
@@ -103,6 +102,7 @@
       The GitHub information will be extracted based on the Azure DevOps repository.
     -->
     <ItemGroup>
+      <NewManifestBuildData Include="InitialAssetsLocation=$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)$(SYSTEM_TEAMPROJECT)/_apis/build/builds/$(BUILD_BUILDID)/artifacts" />
       <NewManifestBuildData Include="AzureDevOpsBuildId=$(BUILD_BUILDID)" />
       <NewManifestBuildData Include="AzureDevOpsBuildDefinitionId=$(SYSTEM_DEFINITIONID)" />
       <NewManifestBuildData Include="AzureDevOpsAccount=$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI.replace('https://dev.azure.com/', '').replace('/', ''))" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -25,6 +25,8 @@
     <PublishToSymbolServer>false</PublishToSymbolServer>
     <PublishToSymbolServer Condition="'$(UsingToolSymbolUploader)' == 'true' and '$(AzureFeedUrl)' == '' and '$(ContinuousIntegrationBuild)' == 'true'">true</PublishToSymbolServer>
     <AssetManifestFilePath>$(ArtifactsLogDir)AssetManifest\$(OS)-$(PlatformName).xml</AssetManifestFilePath>
+
+    <PipelineArtifactsAssetManifestFilePath>$(ArtifactsLogDir)PipelineArtifactsPublishingManifests\$(OS)-$(PlatformName)-$(AGENT_JOBNAME).xml</PipelineArtifactsAssetManifestFilePath>
   </PropertyGroup>
 
   <Import Project="$(NuGetPackageRoot)microsoft.dotnet.build.tasks.feed\$(MicrosoftDotNetBuildTasksFeedVersion)\build\Microsoft.DotNet.Build.Tasks.Feed.targets" Condition="$(PublishToAzure)"/>
@@ -75,27 +77,6 @@
       Work in progress drop-in replacement for PushToBlobFeed task below.
       This is part of the work on https://github.com/dotnet/arcade/issues/1179
     -->
-    
-    <!--
-      The publishing pipeline (implemented by PublishToPackageFeed.proj) will use the Tasks.Feed package
-      to publish packages. The version of Tasks.Feed used will come either from Version.props or from
-      DefaultVersions.props
-    -->
-
-    <Message
-      Text="##vso[artifact.upload containerfolder=PipelineArtifactsPublishingManifests;artifactname=PipelineArtifactsPublishingManifests]$(RepositoryEngineeringDir)common\PublishToPackageFeed.proj"
-      Condition="$(PublishToAzure) and '$(PushToAzureDevOps)' == 'true'"
-      Importance="high" />
-    
-    <Message
-      Text="##vso[artifact.upload containerfolder=PipelineArtifactsPublishingManifests;artifactname=PipelineArtifactsPublishingManifests]$(MSBuildThisFileDirectory)DefaultVersions.props"
-      Condition="$(PublishToAzure) and '$(PushToAzureDevOps)' == 'true' and Exists('$(MSBuildThisFileDirectory)DefaultVersions.props')"
-      Importance="high" />
-    
-    <Message
-      Text="##vso[artifact.upload containerfolder=PipelineArtifactsPublishingManifests;artifactname=PipelineArtifactsPublishingManifests]$(RepositoryEngineeringDir)Versions.props"
-      Condition="$(PublishToAzure) and '$(PushToAzureDevOps)' == 'true' and Exists('$(RepositoryEngineeringDir)Versions.props')"
-      Importance="high" />
 
     <!--
       The new Maestro/BAR build model keeps separate Azure DevOps and GitHub build information.
@@ -120,9 +101,35 @@
       ManifestBuildId="$(BUILD_BUILDNUMBER)"
       ManifestCommit="$(BUILD_SOURCEVERSION)"
       PublishFlatContainer="false"
-      AssetManifestPath="$(ArtifactsLogDir)PipelineArtifactsPublishingManifests\$(OS)-$(PlatformName)-$(AGENT_JOBNAME).xml"
+      AssetManifestPath="$(PipelineArtifactsAssetManifestFilePath)"
       Condition="$(PublishToAzure) and '$(PushToAzureDevOps)' == 'true'"/>
 
+    <!--
+      The publishing pipeline (implemented by PublishToPackageFeed.proj) will use the Tasks.Feed package
+      to publish packages. The version of Tasks.Feed used will come either from Version.props or from
+      DefaultVersions.props
+    -->
+
+    <Message
+      Text="##vso[artifact.upload containerfolder=PipelineArtifactsPublishingManifests;artifactname=PipelineArtifactsPublishingManifests]$(RepositoryEngineeringDir)common\PublishToPackageFeed.proj"
+      Condition="$(PublishToAzure) and '$(PushToAzureDevOps)' == 'true'"
+      Importance="high" />
+
+    <Message
+      Text="##vso[artifact.upload containerfolder=PipelineArtifactsPublishingManifests;artifactname=PipelineArtifactsPublishingManifests]$(MSBuildThisFileDirectory)DefaultVersions.props"
+      Condition="$(PublishToAzure) and '$(PushToAzureDevOps)' == 'true' and Exists('$(MSBuildThisFileDirectory)DefaultVersions.props')"
+      Importance="high" />
+
+    <Message
+      Text="##vso[artifact.upload containerfolder=PipelineArtifactsPublishingManifests;artifactname=PipelineArtifactsPublishingManifests]$(RepositoryEngineeringDir)Versions.props"
+      Condition="$(PublishToAzure) and '$(PushToAzureDevOps)' == 'true' and Exists('$(RepositoryEngineeringDir)Versions.props')"
+      Importance="high" />
+
+    <Message
+      Text="##vso[artifact.upload containerfolder=PipelineArtifactsPublishingManifests;artifactname=PipelineArtifactsPublishingManifests]$(PipelineArtifactsAssetManifestFilePath)"
+      Condition="$(PublishToAzure) and '$(PushToAzureDevOps)' == 'true'"
+      Importance="high" />
+    
     <!--
     End:
       Work in progress drop-in replacement for PushToBlobFeed task below.

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -70,11 +70,24 @@
       </ItemsToPushToBlobFeed>
     </ItemGroup>
 
+
+    <!--
+    Begin:
+      Work in progress drop-in replacement for PushToBlobFeed task below.
+      This is part of the work on https://github.com/dotnet/arcade/issues/1179
+    -->
+    
     <!--
       The publishing pipeline (implemented by PublishToPackageFeed.proj) will use the Tasks.Feed package
       to publish packages. The version of Tasks.Feed used will come either from Version.props or from
       DefaultVersions.props
     -->
+
+    <Message
+      Text="##vso[artifact.upload containerfolder=PipelineArtifactsPublishingManifests;artifactname=PipelineArtifactsPublishingManifests]$(RepositoryEngineeringDir)common\PublishToPackageFeed.proj"
+      Condition="$(PublishToAzure) and '$(PushToAzureDevOps)' == 'true'"
+      Importance="high" />
+    
     <Message
       Text="##vso[artifact.upload containerfolder=PipelineArtifactsPublishingManifests;artifactname=PipelineArtifactsPublishingManifests]$(MSBuildThisFileDirectory)DefaultVersions.props"
       Condition="$(PublishToAzure) and '$(PushToAzureDevOps)' == 'true' and Exists('$(MSBuildThisFileDirectory)DefaultVersions.props')"
@@ -85,18 +98,23 @@
       Condition="$(PublishToAzure) and '$(PushToAzureDevOps)' == 'true' and Exists('$(RepositoryEngineeringDir)Versions.props')"
       Importance="high" />
 
-    <Message
-      Text="##vso[artifact.upload containerfolder=PipelineArtifactsPublishingManifests;artifactname=PipelineArtifactsPublishingManifests]$(RepositoryEngineeringDir)common\PublishToPackageFeed.proj"
-      Condition="$(PublishToAzure) and '$(PushToAzureDevOps)' == 'true'"
-      Importance="high" />
-
     <!--
-      Work in progress drop-in replacement for PushToBlobFeed task below.
-      This is part of the work on https://github.com/dotnet/arcade/issues/1179
+      The new Maestro/BAR build model keeps separate Azure DevOps and GitHub build information.
+      The GitHub information will be extracted based on the Azure DevOps repository.
     -->
+    <ItemGroup>
+      <NewManifestBuildData Include="AzureDevOpsBuildId=$(BUILD_BUILDID)" />
+      <NewManifestBuildData Include="AzureDevOpsBuildDefinitionId=$(SYSTEM_DEFINITIONID)" />
+      <NewManifestBuildData Include="AzureDevOpsAccount=$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI.replace('https://dev.azure.com/', '').replace('/', ''))" />
+      <NewManifestBuildData Include="AzureDevOpsProject=$(SYSTEM_TEAMPROJECT)" />
+      <NewManifestBuildData Include="AzureDevOpsBuildNumber=$(BUILD_BUILDNUMBER)" />
+      <NewManifestBuildData Include="AzureDevOpsRepository=$(BUILD_REPOSITORY_URI)" />
+      <NewManifestBuildData Include="AzureDevOpsBranch=$(BUILD_SOURCEBRANCH)" />
+    </ItemGroup>
+
     <PushToAzureDevOpsArtifacts 
       ItemsToPush="@(ItemsToPushToBlobFeed)"
-      ManifestBuildData="Location=$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_apis/build/builds/$(Build.BuildId)/artifacts"
+      ManifestBuildData="@(NewManifestBuildData)"
       ManifestRepoUri="$(BUILD_REPOSITORY_URI)"
       ManifestBranch="$(BUILD_SOURCEBRANCH)"
       ManifestBuildId="$(BUILD_BUILDNUMBER)"
@@ -104,7 +122,13 @@
       PublishFlatContainer="false"
       AssetManifestPath="$(ArtifactsLogDir)PipelineArtifactsPublishingManifests\$(OS)-$(PlatformName)-$(AGENT_JOBNAME).xml"
       Condition="$(PublishToAzure) and '$(PushToAzureDevOps)' == 'true'"/>
-    
+
+    <!--
+    End:
+      Work in progress drop-in replacement for PushToBlobFeed task below.
+      This is part of the work on https://github.com/dotnet/arcade/issues/1179
+    -->
+
     <PushToBlobFeed 
       ExpectedFeedUrl="$(AzureFeedUrl)"
       AccountKey="$(AzureAccountKey)"

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -78,6 +78,22 @@
       This is part of the work on https://github.com/dotnet/arcade/issues/1179
     -->
 
+    <!-- 
+      Sadly AzDO doesn't have a variable to tell the account name. Also
+      the format of CollectionURI is not precise across different agent 
+      configurations. Code below takes care of extracting the account 
+      name from the CollectionURI in different formats.
+    -->
+    <PropertyGroup>
+      <CollectionUri>$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)</CollectionUri>
+      
+			<!-- When we have dev.azure.com/<account>/ -->
+      <AzureDevOpsAccount Condition="$(CollectionUri.IndexOf('dev.azure.com')) >= 0">$(url.Split('/')[3])</AzureDevOpsAccount>
+		
+			<!-- When we have <account>.visualstudio.com -->
+      <AzureDevOpsAccount Condition="$(CollectionUri.IndexOf('visualstudio.com')) >= 0">$(url.Split('.')[0].Split('/')[2])</AzureDevOpsAccount>
+    </PropertyGroup>
+
     <!--
       The new Maestro/BAR build model keeps separate Azure DevOps and GitHub build information.
       The GitHub information will be extracted based on the Azure DevOps repository.
@@ -86,7 +102,7 @@
       <NewManifestBuildData Include="InitialAssetsLocation=$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)$(SYSTEM_TEAMPROJECT)/_apis/build/builds/$(BUILD_BUILDID)/artifacts" />
       <NewManifestBuildData Include="AzureDevOpsBuildId=$(BUILD_BUILDID)" />
       <NewManifestBuildData Include="AzureDevOpsBuildDefinitionId=$(SYSTEM_DEFINITIONID)" />
-      <NewManifestBuildData Include="AzureDevOpsAccount=$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI.replace('https://dev.azure.com/', '').replace('/', ''))" />
+      <NewManifestBuildData Include="AzureDevOpsAccount=$(AzureDevOpsAccount)" />
       <NewManifestBuildData Include="AzureDevOpsProject=$(SYSTEM_TEAMPROJECT)" />
       <NewManifestBuildData Include="AzureDevOpsBuildNumber=$(BUILD_BUILDNUMBER)" />
       <NewManifestBuildData Include="AzureDevOpsRepository=$(BUILD_REPOSITORY_URI)" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -71,18 +71,18 @@
     </ItemGroup>
 
     <!--
-      This file will be used by the publishing release pipeline to parse the asset manifest
-      and push the assets to target feeds.
+      The publishing pipeline (implemented by PublishToPackageFeed.proj) will use the Tasks.Feed package
+      to publish packages. The version of Tasks.Feed used will come either from Version.props or from
+      DefaultVersions.props
     -->
-    <WriteLinesToFile
-      File="$(MSBuildThisFileDirectory)MicrosoftDotNetBuildTasksFeedVersion.props"
-      Lines="&lt;Project>&lt;PropertyGroup>&lt;MicrosoftDotNetBuildTasksFeedVersion>$(MicrosoftDotNetBuildTasksFeedVersion)&lt;/MicrosoftDotNetBuildTasksFeedVersion>&lt;/PropertyGroup>&lt;/Project>"
-      Overwrite="true"
-      Encoding="Unicode" />
-
     <Message
-      Text="##vso[artifact.upload containerfolder=PipelineArtifactsPublishingManifests;artifactname=PipelineArtifactsPublishingManifests]$(MSBuildThisFileDirectory)MicrosoftDotNetBuildTasksFeedVersion.props"
-      Condition="$(PublishToAzure) and '$(PushToAzureDevOps)' == 'true'"
+      Text="##vso[artifact.upload containerfolder=PipelineArtifactsPublishingManifests;artifactname=PipelineArtifactsPublishingManifests]$(MSBuildThisFileDirectory)DefaultVersions.props"
+      Condition="$(PublishToAzure) and '$(PushToAzureDevOps)' == 'true' and Exists('$(MSBuildThisFileDirectory)DefaultVersions.props')"
+      Importance="high" />
+    
+    <Message
+      Text="##vso[artifact.upload containerfolder=PipelineArtifactsPublishingManifests;artifactname=PipelineArtifactsPublishingManifests]$(RepositoryEngineeringDir)Versions.props"
+      Condition="$(PublishToAzure) and '$(PushToAzureDevOps)' == 'true' and Exists('$(RepositoryEngineeringDir)Versions.props')"
       Importance="high" />
 
     <Message
@@ -96,7 +96,7 @@
     -->
     <PushToAzureDevOpsArtifacts 
       ItemsToPush="@(ItemsToPushToBlobFeed)"
-      ManifestBuildData="Location=$(AzureFeedUrl)"
+      ManifestBuildData="Location=$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_apis/build/builds/$(Build.BuildId)/artifacts"
       ManifestRepoUri="$(BUILD_REPOSITORY_URI)"
       ManifestBranch="$(BUILD_SOURCEBRANCH)"
       ManifestBuildId="$(BUILD_BUILDNUMBER)"


### PR DESCRIPTION
Closes: #1542 
Relates to: #1544

- Soon Maestro/BAR will store additional information about Builds. I'm adding AzureDevOps build info properties to the build manifest so that later `PushMetadataToBuildAssetRegistry` can send that to Maestro.
- In the new publishing flow the initial location of an asset will be registered as an AzDO build artifact location.
- Make the release pipeline use the same version of Tasks.Feed as the build pipeline used to produce the artifacts.
- Make the release pipeline able to process all manifests in a directory.