### PR TITLE
SignTool: fix for error about missing sn.exe even when it is not required

### DIFF
--- a/src/Microsoft.DotNet.SignTool.Tests/FakeBuildEngine.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/FakeBuildEngine.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Xml.Linq;
-using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.SignTool.Tests
 {
@@ -27,6 +27,16 @@ namespace Microsoft.DotNet.SignTool.Tests
             new List<BuildWarningEventArgs>();
 
         public readonly List<ImmutableArray<XElement>> FilesToSign = new List<ImmutableArray<XElement>>();
+        private readonly ITestOutputHelper _output;
+
+        public FakeBuildEngine()
+        {
+        }
+
+        public FakeBuildEngine(ITestOutputHelper output)
+        {
+            _output = output;
+        }
 
         public bool BuildProjectFile(string projectFileName, string[] targetNames, IDictionary globalProperties, IDictionary targetOutputs)
         {
@@ -75,21 +85,41 @@ namespace Microsoft.DotNet.SignTool.Tests
 
         public void LogCustomEvent(CustomBuildEventArgs e)
         {
+            if (_output != null)
+            {
+                _output.WriteLine(e.Message ?? string.Empty);
+            }
+
             LogCustomEvents.Add(e);
         }
 
         public void LogErrorEvent(BuildErrorEventArgs e)
         {
+            if (_output != null)
+            {
+                _output.WriteLine($"error {e.Code}: {e.Message}");
+            }
+
             LogErrorEvents.Add(e);
         }
 
         public void LogMessageEvent(BuildMessageEventArgs e)
         {
+            if (_output != null)
+            {
+                _output.WriteLine(e.Message ?? string.Empty);
+            }
+
             LogMessageEvents.Add(e);
         }
 
         public void LogWarningEvent(BuildWarningEventArgs e)
         {
+            if (_output != null)
+            {
+                _output.WriteLine($"warning {e.Code}: {e.Message}");
+            }
+
             LogWarningEvents.Add(e);
         }
 

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -182,7 +182,12 @@ namespace Microsoft.DotNet.SignTool
                     return;
                 }
 
-                if (!isValidSNPath && StrongNameSignInfo?.Where(ti => ti?.ItemSpec?.EndsWith(".snk") ?? false) != null)
+                var strongNameLocally = StrongNameSignInfo != null 
+                    && StrongNameSignInfo
+                        .Where(ti => !string.IsNullOrEmpty(ti.ItemSpec) && ti.ItemSpec.EndsWith(".snk", StringComparison.OrdinalIgnoreCase))
+                        .Any();
+
+                if (!isValidSNPath && strongNameLocally)
                 {
                     Log.LogError($"An incorrect full path to 'sn.exe' was specified: {SNBinaryPath}");
                     return;


### PR DESCRIPTION
The ASP.NET Core started failing because `sn.exe` could not be found, even though we don't need it.

The fix: changed the condition to `StrongNameSignInfo.Where().Any()`, not `StrongNameSignInfo.Where() != null`.

Other changes:
* Add optional ctor parameter to `FakeBuildEngine` to log to Xunit's output.
* Added a unit test and more logging to tests (I added these while I was trying to debug the tool to figure out what was going wrong. Left them in as they can be generally useful when looking at build failures on CI or in Test Explorer)