### PR TITLE
Make global tools work with helix

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.props
@@ -11,6 +11,12 @@
   <ItemGroup Condition="'$(BuildingNETFxVertical)' == 'true'">
     <RunScriptCommands Include="set DEVPATH=%RUNTIME_PATH%" />
   </ItemGroup>
+
+  <!-- Set DOTNET_ROOT to route global tools shims to the correct host. -->
+  <ItemGroup Condition="'$(BuildingNETCoreAppVertical)' == 'true'">
+    <RunScriptCommands Condition="'$(TargetOS)' == 'Windows_NT'" Include="set DOTNET_ROOT=$(RunScriptHostDir)" />
+    <RunScriptCommands Condition="'$(TargetOS)' != 'Windows_NT'" Include="export DOTNET_ROOT=$(RunScriptHostDir)" />
+  </ItemGroup>
   
   <!-- Binplace dirs for supplemental test data. -->
   <ItemGroup>

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
@@ -15,7 +15,6 @@
     <CleanDependsOn>$(CleanDependsOn);CleanTestPath;</CleanDependsOn>
   </PropertyGroup>
 
-  <!-- RunScript -->
   <PropertyGroup>
     <RunScriptInputName Condition="'$(TargetOS)' == 'Windows_NT'">RunnerTemplate.Windows.txt</RunScriptInputName>
     <RunScriptInputName Condition="'$(TargetOS)' != 'Windows_NT'">RunnerTemplate.Unix.txt</RunScriptInputName>
@@ -24,11 +23,15 @@
     <RunScriptOutputName Condition="'$(TargetOS)' == 'Windows_NT'">RunTests.cmd</RunScriptOutputName>
     <RunScriptOutputName Condition="'$(TargetOS)' != 'Windows_NT'">RunTests.sh</RunScriptOutputName>
     <RunScriptOutputPath>$([MSBuild]::NormalizePath('$(TestPath)', '$(RunScriptOutputName)'))</RunScriptOutputPath>
+  </PropertyGroup>
 
-    <RunScriptHostDir Condition="'$(BuildingNETCoreAppVertical)' == 'true' AND '$(TargetOS)' == 'Windows_NT'">%RUNTIME_PATH%\</RunScriptHostDir>
-    <RunScriptHostDir Condition="'$(BuildingNETCoreAppVertical)' == 'true' AND '$(TargetOS)' != 'Windows_NT'">$RUNTIME_PATH/</RunScriptHostDir>
-    <RunScriptHost Condition="'$(BuildingNETCoreAppVertical)' == 'true' AND '$(TargetOS)' == 'Windows_NT'">$(RunScriptHostDir)dotnet.exe</RunScriptHost>
-    <RunScriptHost Condition="'$(BuildingNETCoreAppVertical)' == 'true' AND '$(TargetOS)' != 'Windows_NT'">$(RunScriptHostDir)dotnet</RunScriptHost>
+  <PropertyGroup Condition="'$(BuildingNETCoreAppVertical)' == 'true'">
+    <RunScriptHostDir Condition="'$(TargetOS)' == 'Windows_NT'">%RUNTIME_PATH%\</RunScriptHostDir>
+    <RunScriptHostDir Condition="'$(TargetOS)' != 'Windows_NT'">$RUNTIME_PATH/</RunScriptHostDir>
+    <RunScriptHost Condition="'$(TargetOS)' == 'Windows_NT'">$(RunScriptHostDir)dotnet.exe</RunScriptHost>
+    <RunScriptHost Condition="'$(TargetOS)' != 'Windows_NT'">$(RunScriptHostDir)dotnet</RunScriptHost>
+    
+    <GlobalToolsDir Condition="'$(ArchiveTests)' == 'true'">$(RunScriptHostDir)</GlobalToolsDir>
   </PropertyGroup>
 
   <Target Name="PublishSupplementalTestData"
@@ -59,12 +62,7 @@
 
   </Target>
 
-  <!--
-    Archive test binaries along with supporting files.
-
-    Inputs:
-      - TestArchiveTestsDir: Expected to bet set in Directory.Build.props.
-  -->
+  <!-- Archive test binaries along with supporting files. -->
   <Target Name="ArchiveTestBuild"
           DependsOnTargets="GenerateRunScript"
           Condition="'$(ArchiveTests)' == 'true'">
@@ -257,7 +255,7 @@
 
   <!--
     Code Coverage support.
-    Supported runners: OpenCover.
+    Supported runners: coverlet.
 
     Inputs:
       - Coverage: Expected to be passed in as a global property.


### PR DESCRIPTION
We specify DOTNET_ROOT as otherwise a global tool's shim runs against the globally installed SDK host. Default the global tools dir to the runtime directory of if ArchiveTests equals true.