### PR TITLE
Allow passing of arguments to mono executable

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
@@ -57,7 +57,7 @@
       <_XUnitConsoleExePath>$(NuGetPackageRoot)xunit.runner.console\$(XUnitVersion)\tools\net452\$(_XUnitConsoleExe)</_XUnitConsoleExePath>
 
       <_TestRunnerArgs>"$(_TestAssembly)" -noshadow -xml "%(TestToRun.ResultsXmlPath)" -html "%(TestToRun.ResultsHtmlPath)" $(_TestRunnerAdditionalArguments)</_TestRunnerArgs>
-      <_TestRunnerArgs Condition="'$(_TestRuntime)' == 'Mono'">"$(_XUnitConsoleExePath)" $(_TestRunnerArgs)</_TestRunnerArgs>
+      <_TestRunnerArgs Condition="'$(_TestRuntime)' == 'Mono'">$(MonoToolArgs) "$(_XUnitConsoleExePath)" $(_TestRunnerArgs)</_TestRunnerArgs>
 
       <_TestRunner Condition="'$(_TestRuntime)' == 'Mono'">$(MonoTool)</_TestRunner>
       <_TestRunner Condition="'$(_TestRuntime)' != 'Mono'">$(_XUnitConsoleExePath)</_TestRunner>


### PR DESCRIPTION
For roslyn Mono runs, we have a need to be able to insert arguments between the Mono tool and the test executable that is being run https://github.com/dotnet/roslyn/pull/32885

This PR adds an optional extra variable `$(MonoToolArgs)` that is prepended to the TestRunnerArgs for Mono runs, allowing us to specify any extra arguments to pass to the mono runtime itself rather than Xunit. 