### PR TITLE
Call CheckHelixJobStatus only when WaitForWorkItemCompletion is true

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MultiQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MultiQueue.targets
@@ -69,6 +69,7 @@
   <Target Name="CheckHelixJobStatus"
           BeforeTargets="AfterTest">
     <CheckHelixJobStatus
+      Condition="$(WaitForWorkItemCompletion)"
       AccessToken="$(HelixAccessToken)"
       BaseUri="$(HelixBaseUri)"
       Jobs="@(SentJob)"


### PR DESCRIPTION
We currently don't wait for items in our official builds. If we update the Helix SDK, we would get this change: https://github.com/dotnet/arcade/pull/1862 -- which causes CheckHelixJobStatus task to be executed even that we're not waiting. 

This task, throws an error if the job is not completed when it is executed: https://github.com/dotnet/arcade/blob/da9afa93dc5af1f258a80ebad9ede4b52730fabc/src/Microsoft.DotNet.Helix/Sdk/CheckHelixJobStatus.cs#L41-L43

therefore, since we didn't wait, it is called right away after the job creation, and throws an error immediately.

Or maybe the right fix, would be to only execute/call the task when `FailOnWorkItemFailure` or `FailOnMissionControlTestFailure` is true. 