### PR TITLE
Add GenerateDepsJson to Microsoft.DotNet.CoreFxTesting

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,6 +24,7 @@
     <MicrosoftDotNetVersionToolsVersion>2.2.0-preview1-02815-01</MicrosoftDotNetVersionToolsVersion>
     <MicrosoftIdentityModelClientsActiveDirectoryVersion>3.19.8</MicrosoftIdentityModelClientsActiveDirectoryVersion>
     <MicrosoftRestClientRuntimeVersion>2.3.13</MicrosoftRestClientRuntimeVersion>
+    <MicrosoftExtensionsDependencyModelVersion>2.1.0</MicrosoftExtensionsDependencyModelVersion>
     <MicrosoftExtensionsFileSystemGlobbingVersion>2.0.0</MicrosoftExtensionsFileSystemGlobbingVersion>
     <MicrosoftNETCorePlatformsVersion>2.1.0</MicrosoftNETCorePlatformsVersion>
     <MicrosoftNetTestSdkVersion>15.7.2</MicrosoftNetTestSdkVersion>

--- a/src/Microsoft.DotNet.CoreFxTesting/GenerateTestSharedFrameworkDepsFile.cs
+++ b/src/Microsoft.DotNet.CoreFxTesting/GenerateTestSharedFrameworkDepsFile.cs
@@ -1,0 +1,101 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Microsoft.Extensions.DependencyModel;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public partial class GenerateTestSharedFrameworkDepsFile : BuildTask
+    {
+        // we don't care about these values in the deps file
+        const string rid = "rid";
+        const string tfm = "netcoreapp0.0";
+        const string fullTfm = ".NETCoreApp,Version=v0.0";
+
+        [Required]
+        public string SharedFrameworkDirectory { get; set; }
+
+        public override bool Execute()
+        {
+            var sharedFxDir = new DirectoryInfo(SharedFrameworkDirectory);
+            if (!sharedFxDir.Exists)
+            {
+                Log.LogError($"{nameof(SharedFrameworkDirectory)} '{SharedFrameworkDirectory}' does not exist.");
+                return false;
+            }
+
+            // directory is the version folder, parent is the shared framework name.
+            string sharedFxVersion = sharedFxDir.Name;
+            string sharedFxName = sharedFxDir.Parent.Name;
+
+            var ignoredExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ".pdb",
+                ".json",
+                ".config",
+                ".xml"
+            };
+
+            var isAssemblyTofileNames = Directory.EnumerateFiles(SharedFrameworkDirectory)
+                .Where(file => !ignoredExtensions.Contains(Path.GetExtension(file)))
+                .ToLookup(file => IsManagedAssembly(file), file => Path.GetFileName(file));
+
+            var managedFileNames = isAssemblyTofileNames[true];
+            var nativeFileNames = isAssemblyTofileNames[false];
+
+            var runtimeLibraries = new[]
+            {
+                new RuntimeLibrary(
+                    type:"package",
+                    name: sharedFxName,
+                    version: sharedFxVersion,
+                    hash: "hash",
+                    runtimeAssemblyGroups: new[] { new RuntimeAssetGroup(string.Empty, managedFileNames.Select(f => $"runtimes/{rid}/lib/{tfm}/{f}")) },
+                    nativeLibraryGroups: new[] { new RuntimeAssetGroup(string.Empty, nativeFileNames.Select(f => $"runtimes/{rid}/native/{f}")) },
+                    resourceAssemblies: Enumerable.Empty<ResourceAssembly>(),
+                    dependencies: Enumerable.Empty<Dependency>(),
+                    serviceable: true)
+            };
+
+            var targetInfo = new TargetInfo(fullTfm, rid, "runtimeSignature", isPortable: false);
+
+            var dependencyContext = new DependencyContext(
+                targetInfo,
+                CompilationOptions.Default,
+                Enumerable.Empty<CompilationLibrary>(),
+                runtimeLibraries,
+                Enumerable.Empty<RuntimeFallbacks>());
+
+            using (var depsFileStream = File.Create(Path.Combine(SharedFrameworkDirectory, $"{sharedFxName}.deps.json")))
+            {
+                new DependencyContextWriter().Write(dependencyContext, depsFileStream);
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private static bool IsManagedAssembly(string file)
+        {
+            bool result = false;
+            try
+            {
+                using (var peReader = new PEReader(File.OpenRead(file)))
+                {
+                    result = peReader.HasMetadata && peReader.GetMetadataReader().IsAssembly;
+                }
+            }
+            catch (BadImageFormatException)
+            { }
+
+            return result;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.CoreFxTesting/Microsoft.DotNet.CoreFxTesting.csproj
+++ b/src/Microsoft.DotNet.CoreFxTesting/Microsoft.DotNet.CoreFxTesting.csproj
@@ -11,10 +11,20 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" Condition="'$(TargetFramework)' == 'net472'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
   </ItemGroup>
 
   <Import Project="$(RepoRoot)eng\BuildTask.targets" />
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <Compile Include="..\Common\AssemblyResolver.cs" />
+    <Compile Include="..\Common\BuildTask.Desktop.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Common\BuildTask.cs" />
+  </ItemGroup>
+  
   <ItemGroup>
     <None Include="build\assets\**" Pack="True" PackagePath="build\assets\" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.CoreFxTesting/build/Microsoft.DotNet.CoreFxTesting.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/Microsoft.DotNet.CoreFxTesting.targets
@@ -58,6 +58,16 @@
 
   </Target>
 
+  <!-- 
+    Shared framework deps file generation.
+    Produces a test shared-framework deps file.
+    To use invoke target directly specifying NETCoreAppTestSharedFrameworkPath property.
+  -->
+  <UsingTask TaskName="GenerateTestSharedFrameworkDepsFile" AssemblyFile="$(MSBuildTestAssemblyPath)"/>
+  <Target Name="GenerateTestSharedFrameworkDepsFile" Condition="'$(GenerateTestSharedFrameworkDepsFile)' == 'true'">
+    <GenerateTestSharedFrameworkDepsFile SharedFrameworkDirectory="$(NETCoreAppTestSharedFrameworkPath)" />
+  </Target>
+
   <!-- UAP resource generation needed by both source and test projects. -->
   <Import Condition="'$(BuildingUAPVertical)' == 'true'" Project="$(MSBuildThisFileDirectory)Resources.uap.targets" />
 


### PR DESCRIPTION
I rewrote the deps file generation from buildtools: https://github.com/dotnet/buildtools/blob/master/src/Microsoft.DotNet.Build.Tasks/GenerateDepsJson.cs

Rather than munging an existing deps file using json.net we just emit a minimal deps file using the same dependency-model code used by the SDK. 

CoreFx changes: https://github.com/dotnet/corefx/pull/34973