### PR TITLE
Add Microsoft.DotNet.Build.Tasks.VisualStudio package.

### DIFF
--- a/Arcade.sln
+++ b/Arcade.sln
@@ -79,6 +79,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.SourceRewr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.XUnitConsoleRunner", "src\Microsoft.DotNet.XUnitConsoleRunner\src\Microsoft.DotNet.XUnitConsoleRunner.csproj", "{2D6BC91D-5D19-4611-B111-FA70C4E8E90D}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "VisualStudio", "VisualStudio", "{80888CDA-37DC-4061-AF5F-7237BF16A320}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Build.Tasks.VisualStudio", "src\Microsoft.DotNet.Build.Tasks.VisualStudio\Microsoft.DotNet.Build.Tasks.VisualStudio.csproj", "{3CCA947D-B466-4481-BC78-43CE98A8A3A7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Build.Tasks.VisualStudio.Tests", "src\Microsoft.DotNet.Build.Tasks.VisualStudio.Tests\Microsoft.DotNet.Build.Tasks.VisualStudio.Tests.csproj", "{86D901E6-C054-445B-92EC-E267EBB16278}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -477,6 +483,30 @@ Global
 		{2D6BC91D-5D19-4611-B111-FA70C4E8E90D}.Release|x64.Build.0 = Release|Any CPU
 		{2D6BC91D-5D19-4611-B111-FA70C4E8E90D}.Release|x86.ActiveCfg = Release|Any CPU
 		{2D6BC91D-5D19-4611-B111-FA70C4E8E90D}.Release|x86.Build.0 = Release|Any CPU
+		{3CCA947D-B466-4481-BC78-43CE98A8A3A7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3CCA947D-B466-4481-BC78-43CE98A8A3A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3CCA947D-B466-4481-BC78-43CE98A8A3A7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3CCA947D-B466-4481-BC78-43CE98A8A3A7}.Debug|x64.Build.0 = Debug|Any CPU
+		{3CCA947D-B466-4481-BC78-43CE98A8A3A7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3CCA947D-B466-4481-BC78-43CE98A8A3A7}.Debug|x86.Build.0 = Debug|Any CPU
+		{3CCA947D-B466-4481-BC78-43CE98A8A3A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3CCA947D-B466-4481-BC78-43CE98A8A3A7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3CCA947D-B466-4481-BC78-43CE98A8A3A7}.Release|x64.ActiveCfg = Release|Any CPU
+		{3CCA947D-B466-4481-BC78-43CE98A8A3A7}.Release|x64.Build.0 = Release|Any CPU
+		{3CCA947D-B466-4481-BC78-43CE98A8A3A7}.Release|x86.ActiveCfg = Release|Any CPU
+		{3CCA947D-B466-4481-BC78-43CE98A8A3A7}.Release|x86.Build.0 = Release|Any CPU
+		{86D901E6-C054-445B-92EC-E267EBB16278}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86D901E6-C054-445B-92EC-E267EBB16278}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86D901E6-C054-445B-92EC-E267EBB16278}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{86D901E6-C054-445B-92EC-E267EBB16278}.Debug|x64.Build.0 = Debug|Any CPU
+		{86D901E6-C054-445B-92EC-E267EBB16278}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{86D901E6-C054-445B-92EC-E267EBB16278}.Debug|x86.Build.0 = Debug|Any CPU
+		{86D901E6-C054-445B-92EC-E267EBB16278}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{86D901E6-C054-445B-92EC-E267EBB16278}.Release|Any CPU.Build.0 = Release|Any CPU
+		{86D901E6-C054-445B-92EC-E267EBB16278}.Release|x64.ActiveCfg = Release|Any CPU
+		{86D901E6-C054-445B-92EC-E267EBB16278}.Release|x64.Build.0 = Release|Any CPU
+		{86D901E6-C054-445B-92EC-E267EBB16278}.Release|x86.ActiveCfg = Release|Any CPU
+		{86D901E6-C054-445B-92EC-E267EBB16278}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -494,6 +524,8 @@ Global
 		{5ED29E38-A65D-4123-BFED-799ADA885F08} = {86AEE6AF-16D7-47FD-8D3E-6B87B249208D}
 		{BA4250FD-9258-4469-A16D-48A0CAF5A2F8} = {C53DD924-C212-49EA-9BC4-1827421361EF}
 		{DC0D0EE5-1C0C-4D3E-BA0B-D6A59717DA94} = {6BE49638-F842-4329-BE8A-30C0F30CCAA5}
+		{3CCA947D-B466-4481-BC78-43CE98A8A3A7} = {80888CDA-37DC-4061-AF5F-7237BF16A320}
+		{86D901E6-C054-445B-92EC-E267EBB16278} = {80888CDA-37DC-4061-AF5F-7237BF16A320}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {32B9C883-432E-4FC8-A1BF-090EB033DD5B}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,6 +6,7 @@
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>
+    <LangVersion>Latest</LangVersion>
 
     <!--
       Tools and packages produced by this repository support infrastructure and are not shipping on NuGet or via any other official channel.

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Common\TestUtilities\AssertEx.cs" Link="TestUtilities\AssertEx.cs" />
+    <Compile Include="..\Common\TestUtilities\DiffUtil.cs" Link="TestUtilities\DiffUtil.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.DotNet.Build.Tasks.VisualStudio\Microsoft.DotNet.Build.Tasks.VisualStudio.csproj" />
+
+    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests/OptProf/FindLatestDropTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests/OptProf/FindLatestDropTests.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace Microsoft.DotNet.Build.Tasks.VisualStudio.UnitTests
+{
+    public class FindLatestDropTests
+    {
+        [Fact]
+        public void GetLatestDropName()
+        {
+            Assert.Equal("OptimizationData/dotnet/roslyn/master-vs-deps/41416da1e8531ab0f4e5e7dc67318237323acf23/202326/813349/1", 
+                FindLatestDrop.GetLatestDropName(@"
+[
+  {
+    ""CreatedDateUtc"": ""2018-11-27T08:09:10.9866839Z"",
+    ""DeletePending"": false,
+    ""Name"": ""OptimizationData/dotnet/roslyn/master-vs-deps/af42e741da717a6c0bf9877ae61f8f955f9917cc/201492/808117/1"",
+    ""UploadComplete"": true
+  },
+  {
+    ""CreatedDateUtc"": ""2018-11-28T14:54:59.5832452Z"",
+    ""DeletePending"": false,
+    ""Name"": ""OptimizationData/dotnet/roslyn/master-vs-deps/41416da1e8531ab0f4e5e7dc67318237323acf23/202326/813349/1"",
+    ""UploadComplete"": true
+  },
+  {
+    ""CreatedDateUtc"": ""2018-11-27T23:58:42.9833879Z"",
+    ""DeletePending"": false,
+    ""Name"": ""OptimizationData/dotnet/roslyn/master-vs-deps/11593212665e99186ec0c6c157018f5733925b8e/202008/811476/1"",
+    ""UploadComplete"": true
+  }
+]
+"));
+
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests/OptProf/GenerateTrainingInputFilesTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests/OptProf/GenerateTrainingInputFilesTests.cs
@@ -1,0 +1,170 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json.Linq;
+using System;
+using System.IO;
+using System.IO.Compression;
+using TestUtilities;
+using Xunit;
+
+namespace Microsoft.DotNet.Build.Tasks.VisualStudio.UnitTests
+{
+    public class GenerateTrainingInputFilesTests
+    {
+        private readonly string s_optProfJson = @"
+{
+  ""products"": [
+    {
+      ""name"": ""Setup.vsix"",
+      ""tests"": [
+        {
+          ""container"": ""DDRIT.RPS.CSharp"",
+          ""testCases"": [
+            ""DDRIT.RPS.CSharp.CSharpTest.EditingAndDesigner""
+          ]
+    }
+      ]
+    }
+  ],
+  ""assemblies"": [
+    {
+      ""assembly"": ""System.Collections.Immutable.dll"",
+      ""instrumentationArguments"": [
+        {
+          ""relativeInstallationFolder"": ""Common7/IDE/PrivateAssemblies"",
+          ""instrumentationExecutable"": ""Common7/IDE/vsn.exe""
+        },
+        {
+          ""relativeInstallationFolder"": ""MSBuild/15.0/Bin/Roslyn"",
+          ""instrumentationExecutable"": ""Common7/IDE/zzz.exe""
+        }
+      ],
+      ""tests"": [
+        {
+          ""container"": ""DDRIT.RPS.CSharp"",
+          ""testCases"": [
+            ""DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging""
+          ]
+        }
+      ]
+    }
+  ]
+}
+";
+        private readonly string s_manifestJson = @"
+{
+  ""id"": ""Setup"",
+  ""version"": ""42.42.42.4242424"",
+  ""type"": ""Vsix"",
+  ""vsixId"": ""0b5e8ddb-f12d-4131-a71d-77acc26a798f"",
+  ""extensionDir"": ""[installdir]\\Common7\\IDE\\CommonExtensions\\Microsoft\\ManagedLanguages\\VBCSharp\\LanguageServices"",
+  ""files"": [
+    {
+      ""fileName"": ""/extension.vsixmanifest"",
+    },
+    {
+      ""fileName"": ""/SQLitePCLRaw.batteries_green.dll"",
+    },
+    {
+      ""fileName"": ""/x/y/z/Microsoft.CodeAnalysis.CSharp.dll"",
+      ""ngen"": true,
+      ""ngenArchitecture"": ""All"",
+      ""ngenApplication"": """",
+      ""ngenPriority"": 3
+    }
+  ]
+}
+";
+
+        private static void CreateVsix(string vsixPath, string manifestContent)
+        {
+            using (var fileStream = new FileStream(vsixPath, FileMode.CreateNew))
+            {
+                using (var archive = new ZipArchive(fileStream, ZipArchiveMode.Create))
+                {
+                    var entry = archive.CreateEntry("manifest.json");
+                    using (var writer = new StreamWriter(entry.Open()))
+                    {
+                        writer.Write(manifestContent);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void Execute()
+        {
+            var temp = Path.GetTempPath();
+            var dir = Path.Combine(temp, Guid.NewGuid().ToString());
+            Directory.CreateDirectory(dir);
+
+            var configPath = Path.Combine(dir, "OptProf.json");
+            File.WriteAllText(configPath, s_optProfJson);
+
+            var insertionDir = Path.Combine(dir, "Insertion");
+            Directory.CreateDirectory(insertionDir);
+            CreateVsix(Path.Combine(insertionDir, "Setup.vsix"), manifestContent: s_manifestJson);
+
+            var outputDir = Path.Combine(dir, "Output");
+
+            var task = new GenerateTrainingInputFiles()
+            {
+                ConfigurationFile = configPath,
+                InsertionDirectory = insertionDir,
+                OutputDirectory = outputDir
+            };
+
+            bool result = task.Execute();
+
+            var entries = Directory.GetFileSystemEntries(outputDir, "*.*", SearchOption.AllDirectories);
+            AssertEx.SetEqual(new[] 
+            {
+                Path.Combine(outputDir, @"DDRIT.RPS.CSharp"),
+                Path.Combine(outputDir, @"DDRIT.RPS.CSharp\Configurations"),
+                Path.Combine(outputDir, @"DDRIT.RPS.CSharp\Configurations\DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging"),
+                Path.Combine(outputDir, @"DDRIT.RPS.CSharp\Configurations\DDRIT.RPS.CSharp.CSharpTest.EditingAndDesigner"),
+                Path.Combine(outputDir, @"DDRIT.RPS.CSharp\Configurations\DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging\System.Collections.Immutable.0.IBC.json"),
+                Path.Combine(outputDir, @"DDRIT.RPS.CSharp\Configurations\DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging\System.Collections.Immutable.1.IBC.json"),
+                Path.Combine(outputDir, @"DDRIT.RPS.CSharp\Configurations\DDRIT.RPS.CSharp.CSharpTest.EditingAndDesigner\xyzMicrosoft.CodeAnalysis.CSharp.0.IBC.json")
+            }, entries);
+
+
+            var json = File.ReadAllText(Path.Combine(outputDir, @"DDRIT.RPS.CSharp\Configurations\DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging\System.Collections.Immutable.0.IBC.json"));
+            Assert.Equal(
+@"{
+  ""Technology"": ""IBC"",
+  ""RelativeInstallationPath"": ""Common7\\IDE\\PrivateAssemblies\\System.Collections.Immutable.dll"",
+  ""InstrumentationArguments"": ""/ExeConfig:\""%VisualStudio.InstallationUnderTest.Path%\\Common7\\IDE\\vsn.exe\""""
+}
+", json);
+
+            JObject.Parse(json);
+
+            json = File.ReadAllText(Path.Combine(outputDir, @"DDRIT.RPS.CSharp\Configurations\DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging\System.Collections.Immutable.1.IBC.json"));
+            Assert.Equal(
+@"{
+  ""Technology"": ""IBC"",
+  ""RelativeInstallationPath"": ""MSBuild\\15.0\\Bin\\Roslyn\\System.Collections.Immutable.dll"",
+  ""InstrumentationArguments"": ""/ExeConfig:\""%VisualStudio.InstallationUnderTest.Path%\\Common7\\IDE\\zzz.exe\""""
+}
+", json);
+
+            JObject.Parse(json);
+
+            json = File.ReadAllText(Path.Combine(outputDir, @"DDRIT.RPS.CSharp\Configurations\DDRIT.RPS.CSharp.CSharpTest.EditingAndDesigner\xyzMicrosoft.CodeAnalysis.CSharp.0.IBC.json"));
+            Assert.Equal(
+@"{
+  ""Technology"": ""IBC"",
+  ""RelativeInstallationPath"": ""Common7\\IDE\\CommonExtensions\\Microsoft\\ManagedLanguages\\VBCSharp\\LanguageServices\\xyzMicrosoft.CodeAnalysis.CSharp.dll"",
+  ""InstrumentationArguments"": ""/ExeConfig:\""%VisualStudio.InstallationUnderTest.Path%\\Common7\\IDE\\vsn.exe\""""
+}
+", json);
+            JObject.Parse(json);
+
+            Assert.True(result);
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests/OptProf/GetRunSettingsSessionConfigurationTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests/OptProf/GetRunSettingsSessionConfigurationTests.cs
@@ -1,0 +1,332 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace Microsoft.DotNet.Build.Tasks.VisualStudio.UnitTests
+{
+    public class GetRunSettingsSessionConfigurationTests
+    {
+        private const string products_only_expectedContainerString = "  <TestContainer FileName=\"DDRIT.RPS.CSharp.dll\" />\r\n  <TestContainer FileName=\"VSPE.dll\" />";
+        private const string products_only_expectedTestCaseFilterString = "FullyQualifiedName=DDRIT.RPS.CSharp.CSharpTest.EditingAndDesigner|FullyQualifiedName=VSPE.OptProfTests.vs_perf_designtime_ide_searchtest|FullyQualifiedName=VSPE.OptProfTests.vs_perf_designtime_editor_intellisense_globalcompletionlist_cs|FullyQualifiedName=VSPE.OptProfTests.vs_asl_cs_scenario|FullyQualifiedName=VSPE.OptProfTests.vs_ddbvtqa_vbwi|FullyQualifiedName=VSPE.OptProfTests.vs_asl_vb_scenario|FullyQualifiedName=VSPE.OptProfTests.vs_env_solution_createnewproject_vb_winformsapp|FullyQualifiedName=DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging";
+        private const string products_only = @"
+{
+  ""products"": [
+    {
+      ""name"": ""Roslyn.VisualStudio.Setup.vsix"",
+      ""tests"": [
+        {
+          ""container"": ""DDRIT.RPS.CSharp"",
+          ""testCases"": [
+            ""DDRIT.RPS.CSharp.CSharpTest.EditingAndDesigner""
+          ]
+    },
+        {
+          ""container"": ""VSPE"",
+          ""testCases"": [
+            ""VSPE.OptProfTests.vs_perf_designtime_ide_searchtest"",
+            ""VSPE.OptProfTests.vs_perf_designtime_editor_intellisense_globalcompletionlist_cs"",
+            ""VSPE.OptProfTests.vs_asl_cs_scenario"",
+            ""VSPE.OptProfTests.vs_ddbvtqa_vbwi"",
+            ""VSPE.OptProfTests.vs_asl_vb_scenario"",
+            ""VSPE.OptProfTests.vs_env_solution_createnewproject_vb_winformsapp""
+          ]
+}
+      ]
+    },
+    {
+      ""name"": ""ExpressionEvaluatorPackage.vsix"",
+      ""tests"": [
+        {
+          ""container"": ""DDRIT.RPS.CSharp"",
+          ""testCases"": [
+            ""DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging""
+          ]
+        }
+      ]
+    },
+    {
+      ""name"": ""Microsoft.CodeAnalysis.Compilers.vsix"",
+      ""tests"": [
+        {
+          ""container"": ""DDRIT.RPS.CSharp"",
+          ""testCases"": [
+            ""DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging""
+          ]
+        }
+      ]
+    },
+    {
+      ""name"": ""Roslyn.VisualStudio.InteractiveComponents.vsix"",
+      ""tests"": [
+        {
+          ""container"": ""DDRIT.RPS.CSharp"",
+          ""testCases"": [
+            ""DDRIT.RPS.CSharp.CSharpTest.EditingAndDesigner""
+          ]
+        }
+      ]
+    }
+  ]
+}
+";
+
+        private const string assemblies_only_expectedContainerString = "  <TestContainer FileName=\"DDRIT.RPS.CSharp.dll\" />";
+        private const string assemblies_only_expectedTestCaseFilterString = "FullyQualifiedName=DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging";
+        private const string assemblies_only = @"
+{
+  ""assemblies"" : [
+    {
+      ""assembly"": ""System.Collections.Immutable.dll"",
+      ""instrumentationArguments"": [
+        {
+          ""relativeInstallationFolder"": ""Common7/IDE/PrivateAssemblies"",
+          ""instrumentationExecutable"": ""Common7/IDE/vsn.exe""
+        },
+        {
+          ""relativeInstallationFolder"": ""MSBuild/15.0/Bin/Roslyn"",
+          ""instrumentationExecutable"": ""Common7/IDE/vsn.exe""
+        },
+        {
+          ""relativeInstallationFolder"": ""MSBuild/Current/Bin"",
+          ""instrumentationExecutable"": ""Common7/IDE/vsn.exe""
+        },
+        {
+          ""relativeInstallationFolder"": ""MSBuild/Current/Bin/amd64"",
+          ""instrumentationExecutable"": ""Common7/IDE/vsn.exe""
+        },
+        {
+          ""relativeInstallationFolder"": ""Common7/IDE/Extensions/TestPlatform"",
+          ""instrumentationExecutable"": ""Common7/IDE/vsn.exe""
+        }
+      ],
+      ""tests"": [
+        {
+          ""container"": ""DDRIT.RPS.CSharp"",
+          ""testCases"": [
+            ""DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging""
+          ]
+        }
+      ]
+    },
+    {
+      ""assembly"": ""System.Reflection.Metadata.dll"",
+      ""instrumentationArguments"": [
+        {
+          ""relativeInstallationFolder"": ""Common7/IDE/PrivateAssemblies"",
+          ""instrumentationExecutable"": ""Common7/IDE/vsn.exe""
+        },
+        {
+          ""relativeInstallationFolder"": ""MSBuild/15.0/Bin/Roslyn"",
+          ""instrumentationExecutable"": ""Common7/IDE/vsn.exe""
+        },
+        {
+          ""relativeInstallationFolder"": ""Common7/IDE/Extensions/TestPlatform"",
+          ""instrumentationExecutable"": ""Common7/IDE/vsn.exe""
+        }
+      ],
+      ""tests"": [
+        {
+          ""container"": ""DDRIT.RPS.CSharp"",
+          ""testCases"": [
+            ""DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging""
+          ]
+        }
+      ]
+    }
+  ]
+}
+";
+
+        private const string products_and_assemblies_expectedContainerString = "  <TestContainer FileName=\"DDRIT.RPS.CSharp.dll\" />\r\n  <TestContainer FileName=\"VSPE.dll\" />";
+        private const string products_and_assemblies_expectedTestCaseFilterString = "FullyQualifiedName=DDRIT.RPS.CSharp.CSharpTest.EditingAndDesigner|FullyQualifiedName=VSPE.OptProfTests.vs_perf_designtime_ide_searchtest|FullyQualifiedName=VSPE.OptProfTests.vs_perf_designtime_editor_intellisense_globalcompletionlist_cs|FullyQualifiedName=VSPE.OptProfTests.vs_asl_cs_scenario|FullyQualifiedName=VSPE.OptProfTests.vs_ddbvtqa_vbwi|FullyQualifiedName=VSPE.OptProfTests.vs_asl_vb_scenario|FullyQualifiedName=VSPE.OptProfTests.vs_env_solution_createnewproject_vb_winformsapp|FullyQualifiedName=DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging";
+        private const string products_and_assemblies = @"
+{
+  ""products"": [
+    {
+      ""name"": ""Roslyn.VisualStudio.Setup.vsix"",
+      ""tests"": [
+        {
+          ""container"": ""DDRIT.RPS.CSharp"",
+          ""testCases"": [
+            ""DDRIT.RPS.CSharp.CSharpTest.EditingAndDesigner""
+          ]
+    },
+        {
+          ""container"": ""VSPE"",
+          ""testCases"": [
+            ""VSPE.OptProfTests.vs_perf_designtime_ide_searchtest"",
+            ""VSPE.OptProfTests.vs_perf_designtime_editor_intellisense_globalcompletionlist_cs"",
+            ""VSPE.OptProfTests.vs_asl_cs_scenario"",
+            ""VSPE.OptProfTests.vs_ddbvtqa_vbwi"",
+            ""VSPE.OptProfTests.vs_asl_vb_scenario"",
+            ""VSPE.OptProfTests.vs_env_solution_createnewproject_vb_winformsapp""
+          ]
+}
+      ]
+    },
+    {
+      ""name"": ""ExpressionEvaluatorPackage.vsix"",
+      ""tests"": [
+        {
+          ""container"": ""DDRIT.RPS.CSharp"",
+          ""testCases"": [
+            ""DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging""
+          ]
+        }
+      ]
+    },
+    {
+      ""name"": ""Microsoft.CodeAnalysis.Compilers.vsix"",
+      ""tests"": [
+        {
+          ""container"": ""DDRIT.RPS.CSharp"",
+          ""testCases"": [
+            ""DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging""
+          ]
+        }
+      ]
+    },
+    {
+      ""name"": ""Roslyn.VisualStudio.InteractiveComponents.vsix"",
+      ""tests"": [
+        {
+          ""container"": ""DDRIT.RPS.CSharp"",
+          ""testCases"": [
+            ""DDRIT.RPS.CSharp.CSharpTest.EditingAndDesigner""
+          ]
+        }
+      ]
+    }
+  ],
+  ""assemblies"" : [
+    {
+      ""assembly"": ""System.Collections.Immutable.dll"",
+      ""instrumentationArguments"": [
+        {
+          ""relativeInstallationFolder"": ""Common7/IDE/PrivateAssemblies"",
+          ""instrumentationExecutable"" : ""Common7/IDE/vsn.exe""
+        },
+        {
+          ""relativeInstallationFolder"": ""MSBuild/15.0/Bin/Roslyn"",
+          ""instrumentationExecutable"" : ""Common7/IDE/vsn.exe""
+        },
+        {
+          ""relativeInstallationFolder"": ""MSBuild/Current/Bin"",
+          ""instrumentationExecutable"" : ""Common7/IDE/vsn.exe""
+        },
+        {
+          ""relativeInstallationFolder"": ""MSBuild/Current/Bin/amd64"",
+          ""instrumentationExecutable"" : ""Common7/IDE/vsn.exe""
+        },
+        {
+          ""relativeInstallationFolder"": ""Common7/IDE/Extensions/TestPlatform"",
+          ""instrumentationExecutable"" : ""Common7/IDE/vsn.exe""
+        }
+      ],
+      ""tests"": [
+        {
+          ""container"": ""DDRIT.RPS.CSharp"",
+          ""testCases"": [
+            ""DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging""
+          ]
+        }
+      ]
+    },
+    {
+      ""assembly"": ""System.Reflection.Metadata.dll"",
+      ""instrumentationArguments"": [
+        {
+          ""relativeInstallationFolder"": ""Common7/IDE/PrivateAssemblies"",
+          ""instrumentationExecutable"" : ""Common7/IDE/vsn.exe""
+        },
+        {
+          ""relativeInstallationFolder"": ""MSBuild/15.0/Bin/Roslyn"",
+          ""instrumentationExecutable"" : ""Common7/IDE/vsn.exe""
+        },
+        {
+          ""relativeInstallationFolder"": ""Common7/IDE/Extensions/TestPlatform"",
+          ""instrumentationExecutable"" : ""Common7/IDE/vsn.exe""
+        }
+      ],
+      ""tests"": [
+        {
+          ""container"": ""DDRIT.RPS.CSharp"",
+          ""testCases"": [
+            ""DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging""
+          ]
+        }
+      ]
+    }
+  ]
+}
+";
+
+        [Theory]
+        [InlineData(@"[{""BuildDrop"": ""https://vsdrop.corp.microsoft.com/file/v1/Products/42.42.42.42/42.42.42.42""}]", "Tests/42.42.42.42/42.42.42.42")]
+        public static void TestsCorrectJsonFiles(string jsonString, string expectedUrl)
+        {
+            Assert.Equal(expectedUrl, GetRunSettingsSessionConfiguration.GetTestsDropName(jsonString));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(@"[{""BuildDrop"": ""https://vsdrop.corp.microsoft.com/file/v1/Tests/42.42.42.42/42.42.42.42""}]")]
+        [InlineData(@"Products/42.42.42.42/42.42.42.42")]
+        public static void TestsIncorrectJsonFiles(string jsonString)
+        {
+            Assert.Throws<InvalidDataException>(() => GetRunSettingsSessionConfiguration.GetTestsDropName(jsonString));
+        }
+
+        [Fact]
+        public void Execute()
+        {
+            var temp = Path.GetTempPath();
+            var dir = Path.Combine(temp, Guid.NewGuid().ToString());
+            Directory.CreateDirectory(dir);
+
+            var configPath = Path.Combine(dir, "OptProf.json");
+            File.WriteAllText(configPath, products_only);
+
+            var bootstrapperPath = Path.Combine(dir, "BootstrapperInfo.json");
+            File.WriteAllText(bootstrapperPath, @"[{""BuildDrop"": ""https://vsdrop.corp.microsoft.com/file/v1/Products/42.42.42.42/42.42.42.42""}]");
+
+            var task = new GetRunSettingsSessionConfiguration()
+            {
+                ConfigurationFile = configPath,
+                ProductDropName = "Products/abc",
+                BootstrapperInfoPath = bootstrapperPath
+            };
+
+            bool result = task.Execute();
+            Assert.Equal(
+$@"<TestStores>
+  <TestStore Uri=""vstsdrop:ProfilingInputs/abc"" />
+  <TestStore Uri=""vstsdrop:Tests/42.42.42.42/42.42.42.42"" />
+</TestStores>
+<TestContainers>
+  <TestContainer FileName=""DDRIT.RPS.CSharp.dll"" />
+  <TestContainer FileName=""VSPE.dll"" />
+</TestContainers>
+<TestCaseFilter>FullyQualifiedName=DDRIT.RPS.CSharp.CSharpTest.EditingAndDesigner|FullyQualifiedName=VSPE.OptProfTests.vs_perf_designtime_ide_searchtest|FullyQualifiedName=VSPE.OptProfTests.vs_perf_designtime_editor_intellisense_globalcompletionlist_cs|FullyQualifiedName=VSPE.OptProfTests.vs_asl_cs_scenario|FullyQualifiedName=VSPE.OptProfTests.vs_ddbvtqa_vbwi|FullyQualifiedName=VSPE.OptProfTests.vs_asl_vb_scenario|FullyQualifiedName=VSPE.OptProfTests.vs_env_solution_createnewproject_vb_winformsapp|FullyQualifiedName=DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging</TestCaseFilter>", task.SessionConfiguration);
+
+            Assert.True(result);
+
+            Directory.Delete(dir, recursive: true);
+        }
+
+        [Theory]
+        [InlineData(products_only, products_only_expectedContainerString, products_only_expectedTestCaseFilterString)]
+        [InlineData(assemblies_only, assemblies_only_expectedContainerString, assemblies_only_expectedTestCaseFilterString)]
+        [InlineData(products_and_assemblies, products_and_assemblies_expectedContainerString, products_and_assemblies_expectedTestCaseFilterString)]
+        public void TestProductsOnly(string configJson, string expectedContainerString, string expectedTestCaseFilterString)
+        {
+            var (actualContainerString, actualTestCaseFilterString) = GetRunSettingsSessionConfiguration.GetTestContainersAndFilters(configJson, "config.json");
+            Assert.Equal(expectedContainerString, actualContainerString);
+            Assert.Equal(expectedTestCaseFilterString, actualTestCaseFilterString);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/Microsoft.DotNet.Build.Tasks.VisualStudio.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/Microsoft.DotNet.Build.Tasks.VisualStudio.csproj
@@ -1,0 +1,24 @@
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+
+    <!-- Using an explicit nuspec file since NuGet Pack target currently doesn't support including dependencies in tools packages -->
+    <IsPackable>true</IsPackable>
+    <PackageDescription>Arcade SDK build tasks for Visual Studio profile guided optimization training</PackageDescription>
+    <PackageTags>Roslyn Build Task OptProf Optimization Training</PackageTags>
+    <DevelopmentDependency>true</DevelopmentDependency>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.DotNet.Build.Tasks.VisualStudio.Tests" />
+  </ItemGroup>
+
+  <Import Project="$(RepoRoot)eng\BuildTask.targets" />
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/FindLatestDrop.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/FindLatestDrop.cs
@@ -1,0 +1,64 @@
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks.VisualStudio
+{
+    /// <summary>
+    /// Find the latest drop in a JSON list of VS drops.
+    /// </summary>
+    public sealed class FindLatestDrop : Task
+    {
+        /// <summary>
+        /// Full path to JSON file containing list of drops.
+        /// </summary>
+        [Required]
+        public string DropListPath { get; set; }
+
+        /// <summary>
+        /// The name of the latest drop.
+        /// </summary>
+        [Output]
+        public string DropName { get; private set; }
+
+        public override bool Execute()
+        {
+            ExecuteImpl();
+            return !Log.HasLoggedErrors;
+        }
+
+        private void ExecuteImpl()
+        {
+            try
+            {
+                DropName = GetLatestDropName(File.ReadAllText(DropListPath));
+            }
+            catch (Exception e)
+            {
+                Log.LogError($"Error parsing file '{DropListPath}': {e.Message}");
+                return;
+            }
+        }
+
+        internal static string GetLatestDropName(string json)
+        {
+            JObject candidate = null;
+            DateTime latest = default;
+            foreach (JObject item in JArray.Parse(json))
+            {
+                var dt = DateTime.Parse((string)item["CreatedDateUtc"]);
+                if (candidate == null || (bool)candidate["UploadComplete"] && !(bool)candidate["DeletePending"] && dt > latest)
+                {
+                    candidate = item;
+                    latest = dt;
+                }
+            }
+
+            return (string)candidate["Name"];
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GenerateTrainingInputFiles.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GenerateTrainingInputFiles.cs
@@ -1,0 +1,152 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks.VisualStudio
+{
+    /// <summary>
+    /// Generates OptProf training input files for VS components listed in OptProf.json file and 
+    /// their VSIX files located in the specified directory.
+    /// </summary>
+    public sealed class GenerateTrainingInputFiles : Task
+    {
+        /// <summary>
+        /// Absolute path to the OptProf.json config file.
+        /// </summary>
+        [Required]
+        public string ConfigurationFile { get; set; }
+
+        /// <summary>
+        /// Absolute path to the directory that contains VSIXes that will be inserted.
+        /// </summary>
+        [Required]
+        public string InsertionDirectory { get; set; }
+
+        /// <summary>
+        /// Directory to output the results optprof data to.
+        /// </summary>
+        [Required]
+        public string OutputDirectory { get; set; }
+
+        public override bool Execute()
+        {
+            ExecuteImpl();
+            return !Log.HasLoggedErrors;
+        }
+
+        private void ExecuteImpl()
+        {
+            OptProfTrainingConfiguration config;
+            try
+            {
+                config = OptProfTrainingConfiguration.Deserialize(File.ReadAllText(ConfigurationFile, Encoding.UTF8));
+            }
+            catch (Exception e)
+            {
+                Log.LogError($"Unable to open the config file '{ConfigurationFile}': {e.Message}");
+                return;
+            }
+
+            if (config.Products == null)
+            {
+                Log.LogError($"Invalid configuration file format: missing 'products' element in '{ConfigurationFile}'.");
+            }
+
+            if (config.Assemblies == null)
+            {
+                Log.LogError($"Invalid configuration file format: missing 'assemblies' element in '{ConfigurationFile}'.");
+            }
+
+            if (!Directory.Exists(InsertionDirectory))
+            {
+                Log.LogError($"Directory specified in InsertionDirectory does not exist: '{InsertionDirectory}'.");
+            }
+
+            if (Log.HasLoggedErrors)
+            {
+                return;
+            }
+
+            // Handle product entries
+            foreach (var product in config.Products)
+            {
+                string vsixFilePath = Path.Combine(InsertionDirectory, product.Name);
+
+                var jsonManifest = ReadVsixJsonManifest(vsixFilePath);
+                var ibcEntries = IbcEntry.GetEntriesFromVsixJsonManifest(jsonManifest).ToArray();
+
+                WriteEntries(product.Tests, ibcEntries);
+            }
+
+            // Handle assembly entries
+            foreach (var assembly in config.Assemblies)
+            {
+                var assemblyEntries = IbcEntry.GetEntriesFromAssembly(assembly).ToArray();
+                WriteEntries(assembly.Tests, assemblyEntries);
+            }
+        }
+
+        private static JObject ReadVsixJsonManifest(string vsixPath)
+        {
+            using (var archive = new ZipArchive(File.Open(vsixPath, FileMode.Open), ZipArchiveMode.Read))
+            {
+                var entry = archive.GetEntry("manifest.json");
+
+                using (var stream = entry.Open())
+                {
+                    using (var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 2048, leaveOpen: true))
+                    {
+                        var content = reader.ReadToEnd();
+                        return JObject.Parse(content);
+                    }
+                }
+            }
+        }
+
+        private void WriteEntries(OptProfTrainingTest[] tests, IbcEntry[] ibcEntries)
+        {
+            foreach (var test in tests)
+            {
+                var configurationsDir = Path.Combine(OutputDirectory, test.Container, "Configurations");
+                foreach (var fullyQualifiedName in test.TestCases)
+                {
+                    WriteEntries(ibcEntries, Path.Combine(configurationsDir, fullyQualifiedName));
+                }
+            }
+        }
+
+        private static void WriteEntries(IbcEntry[] ibcEntries, string outDir)
+        {
+            Directory.CreateDirectory(outDir);
+
+            foreach (var entry in ibcEntries)
+            {
+                var index = 0;
+                var filename = Path.GetFileNameWithoutExtension(entry.RelativeInstallationPath) + "." + index + ".IBC.json";
+                var fullFilename = Path.Combine(outDir, filename);
+
+                while (File.Exists(fullFilename))
+                {
+                    index++;
+                    filename = Path.GetFileNameWithoutExtension(entry.RelativeInstallationPath) + "." + index + ".IBC.json";
+                    fullFilename = Path.Combine(outDir, filename);
+                }
+
+                using (var writer = new StreamWriter(File.Open(fullFilename, FileMode.Create, FileAccess.Write, FileShare.Read)))
+                {
+                    writer.WriteLine(entry.ToJson().ToString());
+                }
+
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GetRunSettingsSessionConfiguration.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GetRunSettingsSessionConfiguration.cs
@@ -1,0 +1,159 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks.VisualStudio
+{
+    /// <summary>
+    /// Calculates the SessionConfiguration to be used in .runsettings for OptProf training 
+    /// based on given OptProf.json configuration and VS bootstrapper information.
+    /// </summary>
+    public sealed class GetRunSettingsSessionConfiguration : Task
+    {
+        /// <summary>
+        /// Absolute path to the OptProf.json config file.
+        /// </summary>
+        [Required]
+        public string ConfigurationFile { get; set; }
+
+        /// <summary>
+        /// Product drop name, e.g. 'Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
+        /// </summary>
+        [Required]
+        public string ProductDropName { get; set; }
+
+        /// <summary>
+        /// Path to the BootstrapperInfo.json
+        /// </summary>
+        [Required]
+        public string BootstrapperInfoPath { get; set; }
+
+        /// <summary>
+        /// Contents of SessionConfiguration node of the .runsettings file.
+        /// </summary>
+        [Output]
+        public string SessionConfiguration { get; private set; }
+
+        public override bool Execute()
+        {
+            ExecuteImpl();
+            return !Log.HasLoggedErrors;
+        }
+
+        private void ExecuteImpl()
+        {
+            try
+            {
+                var profilingInputsDropName = GetProfilingInputsDropName(ProductDropName);
+                var buildDropName = GetTestsDropName(File.ReadAllText(BootstrapperInfoPath, Encoding.UTF8));
+                var (testContainersString, testCaseFilterString) = GetTestContainersAndFilters(File.ReadAllText(ConfigurationFile, Encoding.UTF8), ConfigurationFile);
+
+                SessionConfiguration = 
+$@"<TestStores>
+  <TestStore Uri=""vstsdrop:{profilingInputsDropName}"" />
+  <TestStore Uri=""vstsdrop:{buildDropName}"" />
+</TestStores>
+<TestContainers>
+{testContainersString}
+</TestContainers>
+<TestCaseFilter>{testCaseFilterString}</TestCaseFilter>";
+            }
+            catch (ApplicationException e)
+            {
+                Log.LogError(e.Message);
+            }
+        }
+
+        internal static string GetTestsDropName(string bootstrapperInfoJson)
+        {
+            try
+            {
+                var jsonContent = JToken.Parse(bootstrapperInfoJson);
+                var dropUrl = (string)((JArray)jsonContent).First["BuildDrop"];
+
+                const string prefix = "https://vsdrop.corp.microsoft.com/file/v1/Products/";
+                if (!dropUrl.StartsWith(prefix, StringComparison.Ordinal))
+                {
+                    throw new ApplicationException($"Invalid drop URL: '{dropUrl}'");
+                }
+
+                return $"Tests/{dropUrl.Substring(prefix.Length)}";
+            }
+            catch (Exception e)
+            {                
+                throw new InvalidDataException(
+                    $"Unable to read boostrapper info: {e.Message}{Environment.NewLine}" +
+                    $"Content of BootstrapperInfo.json:{Environment.NewLine}" +
+                    $"{bootstrapperInfoJson}");
+            }
+        }
+
+        private static string GetProfilingInputsDropName(string vsDropName)
+        {
+            const string prefix = "Products/";
+            if (!vsDropName.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                throw new ApplicationException("Invalid value of vsDropName argument: must start with 'Products/'.");
+            }
+
+            return "ProfilingInputs/" + vsDropName.Substring(prefix.Length);
+        }
+
+        internal static (string containers, string filters) GetTestContainersAndFilters(string configJson, string configPath)
+        {
+            try
+            {
+                var config = OptProfTrainingConfiguration.Deserialize(configJson);
+                return (GetTestContainers(config), GetTestFilters(config));
+            }
+            catch (Exception e)
+            {
+                throw new ApplicationException($"Unable to read config file '{configPath}': {e.Message}");
+            }
+        }
+
+        private static string GetTestContainers(OptProfTrainingConfiguration config)
+        {
+            var productContainers = config.Products?.Any() == true
+              ? config.Products.SelectMany(x => x.Tests.Select(y => y.Container + ".dll"))
+              : Enumerable.Empty<string>();
+
+            var assemblyContainers = config.Assemblies?.Any() == true
+                ? config.Assemblies.SelectMany(x => x.Tests.Select(y => y.Container + ".dll"))
+                : Enumerable.Empty<string>();
+
+            return string.Join(
+                Environment.NewLine,
+                productContainers
+                    .Concat(assemblyContainers)
+                    .Distinct()
+                    .Select(x => $@"  <TestContainer FileName=""{x}"" />"));
+        }
+
+        private static string GetTestFilters(OptProfTrainingConfiguration config)
+        {
+            var productTests = config.Products?.Any() == true
+                ? config.Products.SelectMany(x => x.Tests.SelectMany(y => y.TestCases))
+                : Enumerable.Empty<string>();
+
+            var assemblyTests = config.Assemblies?.Any() == true
+                ? config.Assemblies.SelectMany(x => x.Tests.SelectMany(y => y.TestCases))
+                : Enumerable.Empty<string>();
+
+            return string.Join(
+                "|",
+                productTests
+                    .Concat(assemblyTests)
+                    .Distinct()
+                    .Select(x => $"FullyQualifiedName={x}"));
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/IbcEntry.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/IbcEntry.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks.VisualStudio
+{
+    internal struct IbcEntry
+    {
+        private const string TechnologyName = "IBC";
+        private const string VSInstallationRootVar = "%VisualStudio.InstallationUnderTest.Path%";
+        private const string DefaultNgenApplication = VSInstallationRootVar + "\\Common7\\IDE\\vsn.exe";
+
+        public readonly string RelativeInstallationPath;
+        public readonly string InstrumentationArguments;
+
+        public IbcEntry(string relativeInstallationPath, string ngenApplicationPath)
+        {
+            string commandLineArg(string name, string value) => $"/{name}:\"{value}\"";
+
+            RelativeInstallationPath = relativeInstallationPath;
+            InstrumentationArguments = commandLineArg("ExeConfig", ngenApplicationPath);
+        }
+
+        public JObject ToJson()
+            => new JObject(
+                new JProperty("Technology", TechnologyName),
+                new JProperty("RelativeInstallationPath", RelativeInstallationPath),
+                new JProperty("InstrumentationArguments", InstrumentationArguments));
+
+
+        public static IEnumerable<IbcEntry> GetEntriesFromAssembly(AssemblyOptProfTraining assembly)
+        {
+            foreach (var args in assembly.InstrumentationArguments)
+            {
+                yield return new IbcEntry(
+                    relativeInstallationPath: args.RelativeInstallationFolder.Replace("/", "\\") + $"\\{assembly.Assembly}",
+                    ngenApplicationPath: Path.Combine(VSInstallationRootVar, args.InstrumentationExecutable.Replace("/", "\\")));
+            }
+        }
+
+        public static IEnumerable<IbcEntry> GetEntriesFromVsixJsonManifest(JObject json)
+        {
+            bool isNgened(JToken file)
+                => file["ngen"] != null || file["ngenPriority"] != null || file["ngenArchitecture"] != null || file["ngenApplication"] != null;
+
+            bool isPEFile(string filePath)
+            {
+                string ext = Path.GetExtension(filePath);
+                return StringComparer.OrdinalIgnoreCase.Equals(ext, ".dll") ||
+                       StringComparer.OrdinalIgnoreCase.Equals(ext, ".exe");
+            }
+
+            string replacePrefix(string path, string prefix, string replacement)
+                => path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) ? replacement + path.Substring(prefix.Length) : path;
+
+            if (json["extensionDir"] != null)
+            {
+                var extensionDir = replacePrefix((string)json["extensionDir"], "[installdir]\\", "");
+                return from file in (JArray)json["files"]
+                       let fileName = (string)file["fileName"]
+                       where isNgened(file) && isPEFile(fileName)
+                       let filePath = $"{extensionDir}\\{fileName.Replace("/", string.Empty)}"
+                       select new IbcEntry(filePath, DefaultNgenApplication);
+            }
+            else
+            {
+                return from file in (JArray)json["files"]
+                       let fileName = (string)file["fileName"]
+                       let ngenApplication = (string)file["ngenApplication"]
+                       where isNgened(file) && isPEFile(fileName)
+                       let filePath = fileName.Replace("/Contents/", string.Empty).Replace("/", "\\")
+                       select new IbcEntry(filePath, (ngenApplication != null) ? replacePrefix(ngenApplication, "[installdir]", VSInstallationRootVar) : DefaultNgenApplication);
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/AssemblyOptProfTraining.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/AssemblyOptProfTraining.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.Build.Tasks.VisualStudio
+{
+    internal sealed class AssemblyOptProfTraining
+    {
+        [JsonProperty(PropertyName = "assembly")]
+        public string Assembly { get; set; }
+
+        [JsonProperty(PropertyName = "instrumentationArguments")]
+        public OptProfInstrumentationArgument[] InstrumentationArguments { get; set; }
+
+        [JsonProperty(PropertyName = "tests")]
+        public OptProfTrainingTest[] Tests { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/JsonSerializerExtensions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/JsonSerializerExtensions.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json;
+using System.IO;
+
+namespace Microsoft.DotNet.Build.Tasks.VisualStudio
+{
+    internal static class JsonSerializerExtensions
+    {
+        public static T Deserialize<T>(this JsonSerializer serializer, TextReader reader) 
+            => (T)serializer.Deserialize(reader, typeof(T));
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/OptProfInstrumentationArgument.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/OptProfInstrumentationArgument.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.using Newtonsoft.Json;
+
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.Build.Tasks.VisualStudio
+{
+    internal sealed class OptProfInstrumentationArgument
+    {
+        [JsonProperty(PropertyName = "relativeInstallationFolder", Order = 3)]
+        public string RelativeInstallationFolder { get; set; }
+
+        [JsonProperty(PropertyName = "instrumentationExecutable", Order = 3)]
+        public string InstrumentationExecutable { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/OptProfTrainingConfiguration.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/OptProfTrainingConfiguration.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json;
+using System.IO;
+
+namespace Microsoft.DotNet.Build.Tasks.VisualStudio
+{
+    internal sealed class OptProfTrainingConfiguration
+    {
+        [JsonProperty(PropertyName = "products")]
+        public ProductOptProfTraining[] Products { get; set; }
+
+        [JsonProperty(PropertyName = "assemblies")]
+        public AssemblyOptProfTraining[] Assemblies { get; set; }
+
+        public static OptProfTrainingConfiguration Deserialize(string json)
+            => JsonSerializer.CreateDefault().Deserialize<OptProfTrainingConfiguration>(new StringReader(json));
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/OptProfTrainingTest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/OptProfTrainingTest.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.Build.Tasks.VisualStudio
+{
+    internal sealed class OptProfTrainingTest
+    {
+        [JsonProperty(PropertyName = "container", Order = 3)]
+        public string Container { get; set; }
+
+        [JsonProperty(PropertyName = "testCases", Order = 3)]
+        public string[] TestCases { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/ProductOptProfTraining.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/ProductOptProfTraining.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.Build.Tasks.VisualStudio
+{
+    internal sealed class ProductOptProfTraining
+    {
+        [JsonProperty(PropertyName = "name")]
+        public string Name { get; set; }
+
+        [JsonProperty(PropertyName = "tests")]
+        public OptProfTrainingTest[] Tests { get; set; }
+    }
+}

--- a/tests/UnitTests.proj
+++ b/tests/UnitTests.proj
@@ -23,6 +23,9 @@
 
     <!-- Remove the arcade sdk tests project because it depends heavily on machine/repo state and doesn't work properly in helix yet -->
     <XUnitProject Remove="..\src\Microsoft.DotNet.Arcade.Sdk.Tests\Microsoft.DotNet.Arcade.Sdk.Tests.csproj"/>
+
+    <!-- Exclude tests that do not target .NET Core -->
+    <XUnitProject Remove="..\src\Microsoft.DotNet.Build.Tasks.VisualStudio.Tests\Microsoft.DotNet.Build.Tasks.VisualStudio.Tests.csproj"/>
   </ItemGroup>
 
   <!-- Use the locally built version of Helix Tasks temporaraily -->


### PR DESCRIPTION
Implements builds tasks necessary for consumption of IBC data generated by VS IBC training process and for generating inputs to this process.

This is a port of functionality previously implemented in https://github.com/dotnet/roslyn-tools/tree/master/src/OptProf as command line tools.