### PR TITLE
Set DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.props
@@ -12,8 +12,13 @@
     <RunScriptCommands Include="set DEVPATH=%RUNTIME_PATH%" />
   </ItemGroup>
 
-  <!-- Set DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX to route global tools shims to the correct host. -->
+  <!--
+    Set DOTNET_ROOT and DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX to route global tools shims to the correct host and runtime.
+    On Helix we currently depend on a globally installed SDK.
+  -->
   <ItemGroup Condition="'$(BuildingNETCoreAppVertical)' == 'true'">
+    <RunScriptCommands Condition="'$(TargetOS)' == 'Windows_NT' AND '$(DotNetRoot)' != ''" Include="set DOTNET_ROOT=$(DotNetRoot)" />
+    <RunScriptCommands Condition="'$(TargetOS)' != 'Windows_NT' AND '$(DotNetRoot)' != ''" Include="export DOTNET_ROOT=$(DotNetRoot)" />
     <RunScriptCommands Condition="'$(TargetOS)' == 'Windows_NT'" Include="set DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX=$(TestRollForwardPolicy)" />
     <RunScriptCommands Condition="'$(TargetOS)' != 'Windows_NT'" Include="export DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX=$(TestRollForwardPolicy)" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.props
@@ -12,10 +12,10 @@
     <RunScriptCommands Include="set DEVPATH=%RUNTIME_PATH%" />
   </ItemGroup>
 
-  <!-- Set DOTNET_ROOT to route global tools shims to the correct host. -->
+  <!-- Set DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX to route global tools shims to the correct host. -->
   <ItemGroup Condition="'$(BuildingNETCoreAppVertical)' == 'true'">
-    <RunScriptCommands Condition="'$(TargetOS)' == 'Windows_NT'" Include="set DOTNET_ROOT=$(RunScriptHostDir)" />
-    <RunScriptCommands Condition="'$(TargetOS)' != 'Windows_NT'" Include="export DOTNET_ROOT=$(RunScriptHostDir)" />
+    <RunScriptCommands Condition="'$(TargetOS)' == 'Windows_NT'" Include="set DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX=$(TestRollForwardPolicy)" />
+    <RunScriptCommands Condition="'$(TargetOS)' != 'Windows_NT'" Include="export DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX=$(TestRollForwardPolicy)" />
   </ItemGroup>
   
   <!-- Binplace dirs for supplemental test data. -->

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
@@ -32,6 +32,9 @@
     <RunScriptHost Condition="'$(TargetOS)' != 'Windows_NT'">$(RunScriptHostDir)dotnet</RunScriptHost>
     
     <GlobalToolsDir Condition="'$(ArchiveTests)' == 'true'">$(RunScriptHostDir)</GlobalToolsDir>
+
+    <!-- Roll forward on [major], [minor] and [patch] by default. -->
+    <TestRollForwardPolicy Condition="'$(TestRollForwardPolicy)' == ''">2</TestRollForwardPolicy>
   </PropertyGroup>
 
   <Target Name="PublishSupplementalTestData"


### PR DESCRIPTION
Set DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX to allow major version
upgrades, needed for global tools in corefx.

Fixes https://github.com/dotnet/corefx/issues/35010