### PR TITLE
switch bool to string, change defaults, rework bl logic set by ci flag

### DIFF
--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -17,7 +17,7 @@ Param(
   [switch] $sign,
   [switch] $pack,
   [switch] $publish,
-  [switch][Alias('bl')]$binaryLog,
+  [string][Alias('bl')]$binaryLog,
   [switch] $ci,
   [switch] $prepareMachine,
   [switch] $help,
@@ -30,7 +30,7 @@ function Print-Usage() {
     Write-Host "Common settings:"
     Write-Host "  -configuration <value>  Build configuration: 'Debug' or 'Release' (short: -c)"
     Write-Host "  -verbosity <value>      Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
-    Write-Host "  -binaryLog              Output binary log (short: -bl)"
+    Write-Host "  -binaryLog <value>      Output binary log; specify name of Binary Log in the form <value>.binlog (short: -bl)"
     Write-Host "  -help                   Print help and exit"
     Write-Host ""
 
@@ -74,7 +74,14 @@ function Build {
   $toolsetBuildProj = InitializeToolset
   InitializeCustomToolset
 
-  $bl = if ($binaryLog) { "/bl:" + (Join-Path $LogDir "Build.binlog") } else { "" }
+  $bl = ""
+  # if flag is present
+  if ($null -ne $binaryLog)
+  { 
+    # if value is set, then use it; otherwise default to Build.binlog
+    $binaryLogName = if ("" -eq $binaryLog) { "Build" } else { $binaryLog }
+    $bl = "/bl:" + (Join-Path $LogDir ($binaryLogName + ".binlog")) 
+  }
 
   if ($projects) {
     # Re-assign properties to a new variable because PowerShell doesn't let us append properties directly for unclear reasons.
@@ -104,13 +111,14 @@ function Build {
 }
 
 try {
-  if ($help -or (($properties -ne $null) -and ($properties.Contains("/help") -or $properties.Contains("/?")))) {
+  if ($help -or (($null -ne $properties) -and ($properties.Contains("/help") -or $properties.Contains("/?")))) {
     Print-Usage
     exit 0
   }
 
   if ($ci) {
-    $binaryLog = $true
+    # if binarylog value is given, do not overwrite it
+    $binaryLog = if ($null -eq $binaryLog) { "" } else { $binaryLog }
     $nodeReuse = $false
   }
 

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -7,9 +7,9 @@
 # Build configuration. Common values include 'Debug' and 'Release', but the repository may use other names.
 [string]$configuration = if (Test-Path variable:configuration) { $configuration } else { "Debug" }
 
-# Set to true to output binary log from msbuild. Note that emitting binary log slows down the build.
+# Binary log name; give to output binary log from msbuild. Note that emitting binary log slows down the build.
 # Binary log must be enabled on CI.
-[bool]$binaryLog = if (Test-Path variable:binaryLog) { $binaryLog } else { $ci }
+[string]$binaryLog = if (Test-Path variable:binaryLog) { $binaryLog } else { if ($ci) { "" } else { $null } }
 
 # Turns on machine preparation/clean up code that changes the machine state (e.g. kills build processes).
 [bool]$prepareMachine = if (Test-Path variable:prepareMachine) { $prepareMachine } else { $false }
@@ -406,7 +406,15 @@ function InitializeToolset() {
   $buildTool = InitializeBuildTool
 
   $proj = Join-Path $ToolsetDir "restore.proj"
-  $bl = if ($binaryLog) { "/bl:" + (Join-Path $LogDir "ToolsetRestore.binlog") } else { "" }
+  
+  $bl = ""
+  # if flag is present
+  if ($null -ne $binaryLog) 
+  { 
+    # if value is set, then use it; otherwise default to ToolsetRestore.binlog
+    $binaryLogName = if ("" -eq $binaryLog) { "ToolsetRestore" } else { $binaryLog }
+    $bl = "/bl:" + (Join-Path $LogDir ($binaryLogName + ".binlog")) 
+  }
   
   '<Project Sdk="Microsoft.DotNet.Arcade.Sdk"/>' | Set-Content $proj
   MSBuild $proj $bl /t:__WriteToolsetLocation /noconsolelogger /p:__ToolsetLocationOutputFile=$toolsetLocationFile
@@ -440,8 +448,8 @@ function Stop-Processes() {
 #
 function MSBuild() {
   if ($ci) {
-    if (!$binaryLog) {
-      throw "Binary log must be enabled in CI build."
+    if ($null -eq $binaryLog) {
+      throw "Binary log must not be null in CI build."
     }
 
     if ($nodeReuse) {


### PR DESCRIPTION
Changes include:
* change binaryLog param from `bool` to `string`
* rework `-CI` flag logic to set $bl to "" instead of $true
* add logic to name .binlog the value given by the `-bl` flag; defaults to Build.binlog in build.ps1 and ToolsetRestore.binlog in tools.ps1
* swap null check for properties (`$null` should be on left of -ne)

Worth noting:
* existing build systems using -bl flag will be forced to specify a value and will be sown the following error:
```cmd
"Missing an argument for parameter 'binaryLog'"
```