### PR TITLE
Fix swagger client generation to give better messages for errors

### DIFF
--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Aggregate.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Aggregate.cs
@@ -241,19 +241,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedAnalysisSummaryRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<AggregateWorkItemSummary>
                 {
                     Request = _req,
@@ -339,19 +339,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedBuildHistoryRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<IImmutableList<BuildHistoryItem>>
                 {
                     Request = _req,
@@ -449,19 +449,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedBuildRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<BuildAggregation>
                 {
                     Request = _req,
@@ -579,19 +579,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedJobSummaryRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<IImmutableList<AggregatedWorkItemCounts>>
                 {
                     Request = _req,
@@ -697,19 +697,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedWorkItemSummaryRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<IImmutableList<AggregatedWorkItemCounts>>
                 {
                     Request = _req,
@@ -852,19 +852,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedAnalysisDetailRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<IImmutableList<AggregateAnalysisDetail>>
                 {
                     Request = _req,
@@ -955,19 +955,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedPropertiesRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<IImmutableDictionary<string, PropertiesResponse>>
                 {
                     Request = _req,
@@ -1032,19 +1032,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedInvestigation_ContinueRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<InvestigationResult>
                 {
                     Request = _req,
@@ -1174,19 +1174,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedInvestigationRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<InvestigationResult>
                 {
                     Request = _req,
@@ -1311,19 +1311,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedHistoryRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<IImmutableList<HistoricalAnalysisItem>>
                 {
                     Request = _req,
@@ -1400,19 +1400,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, _requestContent),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, _requestContent),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedMultiSourceRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<MultiSourceResponse>
                 {
                     Request = _req,

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Analysis.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Analysis.cs
@@ -146,19 +146,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, _requestContent),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, _requestContent),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedSetReasonRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse
                 {
                     Request = _req,
@@ -255,19 +255,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedGetDetailsRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<GetDetailsResponse>
                 {
                     Request = _req,

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Information.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Information.cs
@@ -84,19 +84,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedQueueInfoRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<QueueInfo>
                 {
                     Request = _req,
@@ -152,19 +152,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedQueueInfoListRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<IImmutableList<QueueInfo>>
                 {
                     Request = _req,

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Machine.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Machine.cs
@@ -97,19 +97,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedGetMachineStatusRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<MachineInformation>
                 {
                     Request = _req,
@@ -204,19 +204,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, _requestContent),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, _requestContent),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedChangeStateRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<ChangeStateResponse>
                 {
                     Request = _req,

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/CancelResponse.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/CancelResponse.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Immutable;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.Helix.Client.Models
+{
+    public partial class CancelResponse
+    {
+        public CancelResponse()
+        {
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Repository.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Repository.cs
@@ -78,19 +78,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedGetRepositoriesRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<ViewConfiguration>
                 {
                     Request = _req,

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/ScaleSets.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/ScaleSets.cs
@@ -96,19 +96,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedGetDetailedVMScalingHistoryRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<IImmutableList<DetailedVMScalingHistory>>
                 {
                     Request = _req,
@@ -176,19 +176,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedGetAggregatedVMScalingHistoryRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<IImmutableList<AggregatedVMScalingHistory>>
                 {
                     Request = _req,

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Storage.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Storage.cs
@@ -88,19 +88,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedListRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<IImmutableList<ContainerInformation>>
                 {
                     Request = _req,
@@ -177,19 +177,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, _requestContent),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, _requestContent),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedNewRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<ContainerInformation>
                 {
                     Request = _req,
@@ -266,19 +266,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, _requestContent),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, _requestContent),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedExtendExpirationRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<ContainerInformation>
                 {
                     Request = _req,

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Telemetry.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Telemetry.cs
@@ -154,19 +154,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, _requestContent),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, _requestContent),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedStartJobRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<string>
                 {
                     Request = _req,
@@ -247,19 +247,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedStartBuildWorkItemRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<string>
                 {
                     Request = _req,
@@ -368,19 +368,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedFinishBuildWorkItemRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse
                 {
                     Request = _req,
@@ -460,19 +460,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedStartXUnitWorkItemRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<string>
                 {
                     Request = _req,
@@ -581,19 +581,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedFinishXUnitWorkItemRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse
                 {
                     Request = _req,
@@ -696,19 +696,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedWarningRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse
                 {
                     Request = _req,
@@ -811,19 +811,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedErrorRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse
                 {
                     Request = _req,
@@ -926,19 +926,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedLogRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse
                 {
                     Request = _req,

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/WorkItem.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/WorkItem.cs
@@ -13,6 +13,12 @@ namespace Microsoft.DotNet.Helix.Client
 {
     public partial interface IWorkItem
     {
+        Task<System.IO.Stream> ConsoleLogAsync(
+            string id,
+            string job,
+            CancellationToken cancellationToken = default
+        );
+
         Task<IImmutableList<WorkItemSummary>> ListAsync(
             string job,
             CancellationToken cancellationToken = default
@@ -36,6 +42,92 @@ namespace Microsoft.DotNet.Helix.Client
         public HelixApi Client { get; }
 
         partial void HandleFailedRequest(RestApiException ex);
+
+        partial void HandleFailedConsoleLogRequest(RestApiException ex);
+
+        public async Task<System.IO.Stream> ConsoleLogAsync(
+            string id,
+            string job,
+            CancellationToken cancellationToken = default
+        )
+        {
+            using (var _res = await ConsoleLogInternalAsync(
+                id,
+                job,
+                cancellationToken
+            ).ConfigureAwait(false))
+            {
+                return _res.Body;
+            }
+        }
+
+        internal async Task<HttpOperationResponse<System.IO.Stream>> ConsoleLogInternalAsync(
+            string id,
+            string job,
+            CancellationToken cancellationToken = default
+        )
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+
+            if (string.IsNullOrEmpty(job))
+            {
+                throw new ArgumentNullException(nameof(job));
+            }
+
+
+            var _path = "/api/2018-03-14/jobs/{job}/workitems/{id}/console";
+            _path = _path.Replace("{job}", Client.Serialize(job));
+            _path = _path.Replace("{id}", Client.Serialize(id));
+
+            var _query = new QueryBuilder();
+
+            var _uriBuilder = new UriBuilder(Client.BaseUri);
+            _uriBuilder.Path = _uriBuilder.Path.TrimEnd('/') + _path;
+            _uriBuilder.Query = _query.ToString();
+            var _url = _uriBuilder.Uri;
+
+            HttpRequestMessage _req = null;
+            HttpResponseMessage _res = null;
+            try
+            {
+                _req = new HttpRequestMessage(HttpMethod.Get, _url);
+
+                if (Client.Credentials != null)
+                {
+                    await Client.Credentials.ProcessHttpRequestAsync(_req, cancellationToken).ConfigureAwait(false);
+                }
+
+                _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
+                string _responseContent;
+                if (!_res.IsSuccessStatusCode)
+                {
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
+                    HandleFailedConsoleLogRequest(ex);
+                    HandleFailedRequest(ex);
+                    Client.OnFailedRequest(ex);
+                    throw ex;
+                }
+                var _responseStream = await _res.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                return new HttpOperationResponse<System.IO.Stream>
+                {
+                    Request = _req,
+                    Response = _res,
+                    Body = _responseStream
+                };
+            }
+            catch (Exception)
+            {
+                _req?.Dispose();
+                _res?.Dispose();
+                throw;
+            }
+        }
 
         partial void HandleFailedListRequest(RestApiException ex);
 
@@ -86,19 +178,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedListRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<IImmutableList<WorkItemSummary>>
                 {
                     Request = _req,
@@ -172,19 +264,19 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                var _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    var ex = new RestApiException
-                    {
-                        Request = new HttpRequestMessageWrapper(_req, null),
-                        Response = new HttpResponseMessageWrapper(_res, _responseContent),
-                    };
+                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var ex = new RestApiException(
+                        new HttpRequestMessageWrapper(_req, null),
+                        new HttpResponseMessageWrapper(_res, _responseContent));
                     HandleFailedDetailsRequest(ex);
                     HandleFailedRequest(ex);
                     Client.OnFailedRequest(ex);
                     throw ex;
                 }
+                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<WorkItemDetails>
                 {
                     Request = _req,

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CmdLine/Microsoft.DotNet.SwaggerGenerator.CmdLine.csproj
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CmdLine/Microsoft.DotNet.SwaggerGenerator.CmdLine.csproj
@@ -11,6 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.0.2" />
     <PackageReference Include="Mono.Options" Version="$(MonoOptionsVersion)" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CmdLine/Program.cs
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CmdLine/Program.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.DotNet.SwaggerGenerator.Modeler;
+using Microsoft.Extensions.Logging;
 using Mono.Options;
 using Newtonsoft.Json;
 using Swashbuckle.AspNetCore.Swagger;
@@ -75,13 +76,15 @@ namespace Microsoft.DotNet.SwaggerGenerator.CmdLine
                 MissingArgument(nameof(output));
             }
 
+            ILogger logger = new LoggerFactory().AddConsole().CreateLogger("dotnet-swaggergen");
+
             SwaggerDocument document = await GetSwaggerDocument(input);
 
             var generator = new ServiceClientModelFactory(generatorOptions);
             ServiceClientModel model = generator.Create(document);
 
             var codeFactory = new ServiceClientCodeFactory();
-            List<CodeFile> code = codeFactory.GenerateCode(model, generatorOptions);
+            List<CodeFile> code = codeFactory.GenerateCode(model, generatorOptions, logger);
 
             var outputDirectory = new DirectoryInfo(output);
             outputDirectory.Create();

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/CSharp.cs
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/CSharp.cs
@@ -98,6 +98,11 @@ namespace Microsoft.DotNet.SwaggerGenerator.Languages
                     return "Newtonsoft.Json.Linq.JToken";
                 }
 
+                if (reference == TypeReference.File)
+                {
+                    return "System.IO.Stream";
+                }
+
                 if (reference == TypeReference.Byte)
                 {
                     // TODO: implement this

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/ServiceClient.hb
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/ServiceClient.hb
@@ -172,42 +172,40 @@ namespace {{pascalCaseNs Namespace}}
             ContractResolver = new AllPropertiesContractResolver(),
         };
 
-        public HttpRequestMessageWrapper Request { get; set; }
-
-        private string RequestString
+        private static string FormatMessage(HttpResponseMessageWrapper response)
         {
-            get => JsonConvert.SerializeObject(Request, SerializerSettings);
-            set => Request = JsonConvert.DeserializeObject<HttpRequestMessageWrapper>(value, SerializerSettings);
+            var result = $"The response contained an invalid status code {(int)response.StatusCode} {response.ReasonPhrase}";
+            if (!string.IsNullOrEmpty(response.Content))
+            {
+                result += "\n\nBody: ";
+                result += response.Content.Length < 300 ? response.Content : response.Content.Substring(0, 300);
+            }
+            return result;
         }
 
-        public HttpResponseMessageWrapper Response { get; set; }
+        public HttpRequestMessageWrapper Request { get; }
 
-        private string ResponseString
-        {
-            get => JsonConvert.SerializeObject(Response, SerializerSettings);
-            set => Response = JsonConvert.DeserializeObject<HttpResponseMessageWrapper>(value, SerializerSettings);
-        }
+        public HttpResponseMessageWrapper Response { get; }
 
-        public RestApiException()
-            :this("An Unexpected error occured when processing the request.")
-        {
-        }
-
-        public RestApiException(string message)
-            :this(message, null)
+        public RestApiException(HttpRequestMessageWrapper request, HttpResponseMessageWrapper response)
+           :this(FormatMessage(response), request, response)
         {
         }
 
-        public RestApiException(string message, Exception innerException)
-            :base(message, innerException)
+        public RestApiException(string message, HttpRequestMessageWrapper request, HttpResponseMessageWrapper response)
+           :base(message)
         {
+            Request = request;
+            Response = response;
         }
 
         protected RestApiException(SerializationInfo info, StreamingContext context)
             :base(info, context)
         {
-            RequestString = info.GetString("Request");
-            ResponseString = info.GetString("Response");
+            var requestString = info.GetString("Request");
+            var responseString = info.GetString("Response");
+            Request = JsonConvert.DeserializeObject<HttpRequestMessageWrapper>(requestString, SerializerSettings);
+            Response = JsonConvert.DeserializeObject<HttpResponseMessageWrapper>(responseString, SerializerSettings);
         }
 
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
@@ -217,8 +215,11 @@ namespace {{pascalCaseNs Namespace}}
                 throw new ArgumentNullException(nameof(info));
             }
 
-            info.AddValue("Request", RequestString);
-            info.AddValue("Response", ResponseString);
+            var requestString = JsonConvert.SerializeObject(Request, SerializerSettings);
+            var responseString = JsonConvert.SerializeObject(Response, SerializerSettings);
+
+            info.AddValue("Request", requestString);
+            info.AddValue("Response", responseString);
             base.GetObjectData(info, context);
         }
     }
@@ -226,22 +227,18 @@ namespace {{pascalCaseNs Namespace}}
     [Serializable]
     public partial class RestApiException<T> : RestApiException
     {
-        public T Body { get; set; }
+        public T Body { get; }
 
-
-        public RestApiException()
-            :this("An Unexpected error occured when processing the request.")
+        public RestApiException(HttpRequestMessageWrapper request, HttpResponseMessageWrapper response, T body)
+           :base(request, response)
         {
+            Body = body;
         }
 
-        public RestApiException(string message)
-            :this(message, null)
+        public RestApiException(string message, HttpRequestMessageWrapper request, HttpResponseMessageWrapper response, T body)
+           :base(message, request, response)
         {
-        }
-
-        public RestApiException(string message, Exception innerException)
-            :base(message, innerException)
-        {
+            Body = body;
         }
 
         protected RestApiException(SerializationInfo info, StreamingContext context)
@@ -300,6 +297,5 @@ namespace {{pascalCaseNs Namespace}}
           }
           return builder.ToString();
         }
-
     }
 }

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Modeler/Disposable.cs
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Modeler/Disposable.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Microsoft.DotNet.SwaggerGenerator.Modeler
 {
@@ -13,16 +13,11 @@ namespace Microsoft.DotNet.SwaggerGenerator.Modeler
 
         public void Dispose()
         {
-            _onDispose();
+            _onDispose?.Invoke();
         }
 
         public static IDisposable Create(Action onDispose)
         {
-            if (onDispose == null)
-            {
-                throw new ArgumentNullException(nameof(onDispose));
-            }
-
             return new Disposable(onDispose);
         }
     }

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Modeler/MethodModel.cs
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Modeler/MethodModel.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Net.Http;
@@ -31,6 +31,8 @@ namespace Microsoft.DotNet.SwaggerGenerator.Modeler
         public TypeReference ErrorType { get; }
 
         public bool ResponseIsVoid => ResponseType == TypeReference.Void;
+
+        public bool ResponseIsFile => ResponseType == TypeReference.File;
 
         public IEnumerable<ParameterModel> ConstantParameters =>
             Parameters.Where(p => p.Type is TypeReference.ConstantTypeReference).OrderBy(p => p.Name);

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Modeler/TypeReference.cs
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Modeler/TypeReference.cs
@@ -19,6 +19,7 @@ namespace Microsoft.DotNet.SwaggerGenerator.Modeler
         public static readonly TypeReference Byte = new PrimitiveTypeReference("byte", false);
         public static readonly TypeReference Date = new PrimitiveTypeReference("date", false);
         public static readonly TypeReference DateTime = new PrimitiveTypeReference("date-time", false);
+        public static readonly TypeReference File = new PrimitiveTypeReference("file", true);
         public static readonly TypeReference Void = new PrimitiveTypeReference("void", false);
         public static readonly TypeReference Any = new PrimitiveTypeReference("any", true);
 

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/ServiceClientCodeFactory.cs
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/ServiceClientCodeFactory.cs
@@ -1,13 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Text;
 using HandlebarsDotNet;
 using Microsoft.DotNet.SwaggerGenerator.Languages;
 using Microsoft.DotNet.SwaggerGenerator.Modeler;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.SwaggerGenerator
 {
@@ -20,14 +19,17 @@ namespace Microsoft.DotNet.SwaggerGenerator
             ServiceClientModel clientModel,
             GeneratorOptions options,
             Templates templates,
-            Language language)
+            Language language,
+            ILogger logger)
         {
             _language = language;
             ClientModel = clientModel;
             Options = options;
             Templates = templates;
+            Logger = logger;
         }
 
+        public ILogger Logger { get; }
         public ServiceClientModel ClientModel { get; }
         public GeneratorOptions Options { get; }
         public Templates Templates { get; }
@@ -43,7 +45,9 @@ namespace Microsoft.DotNet.SwaggerGenerator
 
             if (_files.TryGetValue(filePath, out CodeFile file) && !append)
             {
-                throw new InvalidOperationException($"File '{filePath}' already exists.");
+                string message = $"File '{filePath}' already exists.";
+                Logger.LogError(message);
+                throw new InvalidOperationException(message);
             }
 
             if (file == null)
@@ -60,7 +64,7 @@ namespace Microsoft.DotNet.SwaggerGenerator
 
     public class ServiceClientCodeFactory
     {
-        public List<CodeFile> GenerateCode(ServiceClientModel model, GeneratorOptions options)
+        public List<CodeFile> GenerateCode(ServiceClientModel model, GeneratorOptions options, ILogger logger)
         {
             Language language = Language.Get(options.LanguageName);
 
@@ -72,7 +76,7 @@ namespace Microsoft.DotNet.SwaggerGenerator
 
             RegisterTemplates(hb, templates);
 
-            var context = new GenerateCodeContext(model, options, templates, language);
+            var context = new GenerateCodeContext(model, options, templates, language, logger);
             language.GenerateCode(context);
 
             return context.Files.Values.ToList();

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/ServiceClientCodeFactory.cs
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/ServiceClientCodeFactory.cs
@@ -45,9 +45,7 @@ namespace Microsoft.DotNet.SwaggerGenerator
 
             if (_files.TryGetValue(filePath, out CodeFile file) && !append)
             {
-                string message = $"File '{filePath}' already exists.";
-                Logger.LogError(message);
-                throw new InvalidOperationException(message);
+                throw new InvalidOperationException($"File '{filePath}' was already generated.");
             }
 
             if (file == null)

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.MSBuild/GenerateSwaggerCode.cs
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.MSBuild/GenerateSwaggerCode.cs
@@ -52,14 +52,18 @@ namespace Microsoft.DotNet.SwaggerGenerator.MSBuild
                 ClientName = ClientName
             };
 
+            Log.LogMessage(MessageImportance.Low, $"Reading swagger document {SwaggerDocumentUri}");
             SwaggerDocument document = await GetSwaggerDocument(SwaggerDocumentUri);
 
+            Log.LogMessage(MessageImportance.Low, $"Generating client code model");
             var generator = new ServiceClientModelFactory(options);
             ServiceClientModel model = generator.Create(document);
 
+            Log.LogMessage(MessageImportance.Low, $"Generating code files for language '{options.LanguageName}'");
             var codeFactory = new ServiceClientCodeFactory();
-            List<CodeFile> code = codeFactory.GenerateCode(model, options);
+            List<CodeFile> code = codeFactory.GenerateCode(model, options, new MSBuildLogger(Log));
 
+            Log.LogMessage(MessageImportance.High, $"Generating {SwaggerDocumentUri} -> {OutputDirectory}");
             var outputDirectory = new DirectoryInfo(OutputDirectory);
             outputDirectory.Create();
 
@@ -69,7 +73,7 @@ namespace Microsoft.DotNet.SwaggerGenerator.MSBuild
                 string fullPath = Path.Combine(outputDirectory.FullName, path);
                 var file = new FileInfo(fullPath);
                 file.Directory.Create();
-                Log.LogMessage(MessageImportance.Normal, $"Generating file '{file.FullName}'");
+                Log.LogMessage(MessageImportance.Normal, $"Writing file '{file.FullName}'");
                 File.WriteAllText(file.FullName, contents);
                 generatedFiles.Add(new TaskItem(file.FullName));
             }

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.MSBuild/MSBuildLogger.cs
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.MSBuild/MSBuildLogger.cs
@@ -1,0 +1,55 @@
+using System;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.DotNet.SwaggerGenerator.Modeler;
+using Microsoft.Extensions.Logging;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
+
+namespace Microsoft.DotNet.SwaggerGenerator.MSBuild
+{
+    internal class MSBuildLogger : ILogger
+    {
+        private readonly TaskLoggingHelper _log;
+
+        public MSBuildLogger(TaskLoggingHelper log)
+        {
+            _log = log;
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            var message = formatter(state, exception);
+            switch (logLevel)
+            {
+                case LogLevel.Critical:
+                    _log.LogCriticalMessage(null, null, null, null, 0, 0, 0, 0, message);
+                    break;
+                case LogLevel.Error:
+                    _log.LogError(message);
+                    break;
+                case LogLevel.Warning:
+                    _log.LogWarning(message);
+                    break;
+                case LogLevel.Information:
+                    _log.LogMessage(MessageImportance.High, message);
+                    break;
+                case LogLevel.Debug:
+                    _log.LogMessage(MessageImportance.Normal, message);
+                    break;
+                case LogLevel.Trace:
+                    _log.LogMessage(MessageImportance.Low, message);
+                    break;
+            }
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            return Disposable.Create(null);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.MSBuild/build/Microsoft.DotNet.SwaggerGenerator.MSBuild.targets
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.MSBuild/build/Microsoft.DotNet.SwaggerGenerator.MSBuild.targets
@@ -11,7 +11,11 @@
       RootNamespace="$(RootNamespace)"
       ClientName="$(SwaggerClientName)"
       OutputDirectory="$(SwaggerOutputDirectory)">
-      <Output TaskParameter="GeneratedFiles" ItemName="SwaggerGeneratedFiles"/>
+      <Output TaskParameter="GeneratedFiles" ItemName="SwaggerGeneratedFile"/>
     </GenerateSwaggerCode>
+    <ItemGroup>
+      <_StaleSwaggerGeneratedFile Include="$(SwaggerOutputDirectory)/**/*" Exclude="@(SwaggerGeneratedFile)"/>
+    </ItemGroup>
+    <Delete Files="@(_StaleSwaggerGeneratedFile)" TreatErrorsAsWarnings="true"/>
   </Target>
 </Project>


### PR DESCRIPTION
This change updates the swagger client generation for the helix api to
produce better error messages for failing responses from the server.

This change includes regenerating the helix api from the changed generator.