### PR TITLE
NuGet package licenses

### DIFF
--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -359,6 +359,12 @@ It is a common practice to specify properties applicable to all (most) projects 
 
   <!-- Public keys used by InternalsVisibleTo project items -->
   <MoqPublicKey>00240000048000009400...</MoqPublicKey> 
+
+  <!-- 
+    Specify license used for packages produced by the repository.
+    Use PackageLicenseExpressionInternal for closed-source licenses.
+   -->
+  <PackageLicenseExpression>MIT</PackageLicenseExpression>
 </PropertyGroup>
 ```
 
@@ -371,6 +377,20 @@ It is a common practice to specify properties applicable to all (most) projects 
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 </Project>
 ```
+
+### /License.txt
+
+The root of the repository shall include a license file named `license.txt`, `license.md` or `license` (any casing is allowed).
+It is expected that all packages built from the repository have the same license, which is the license declared in the repository root license file.
+
+If the repository uses open source license it shall specify the license name globally using `PackageLicenseExpression` property, e.g. in [Directory.Build.props](https://github.com/dotnet/arcade/blob/master/Documentation/ArcadeSdk.md#directorybuildprops).
+If the repository uses a closed source license it shall specify the license name using `PackageLicenseExpressionInternal` property. In this case the closed source license file is automatically added to any package build by the repository.
+
+If `PackageLicenseExpression(Internal)` property is set Arcade SDK validates that the content of the license file in the repository root matches the content of 
+the [well-known license file](https://github.com/dotnet/arcade/tree/master/src/Microsoft.DotNet.Arcade.Sdk/tools/Licenses) that corresponds to the value of the license expression.
+This validation can be suppressed by setting `SuppressLicenseValidation` to `true` if necessary (not recommended).
+
+See [NuGet documentation](https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#packing-a-license-expression-or-a-license-file) for details.
 
 ### Source Projects
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "2.1.401"
+    "dotnet": "2.1.503"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19162.7",

--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/GetLicenseFilePathTests.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/GetLicenseFilePathTests.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace Microsoft.DotNet.Arcade.Sdk.Tests
+{
+    public class GetLicenseFilePathTests
+    {
+        [Theory]
+        [InlineData("licenSe.TXT")]
+        [InlineData("license.md")]
+        [InlineData("LICENSE")]
+        public void GetLicenseFilePath(string licenseFileName)
+        {
+            var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(dir);
+            var licensePath = Path.Combine(dir, licenseFileName);
+
+            File.WriteAllText(licensePath, "");
+
+            var task = new GetLicenseFilePath()
+            {
+                Directory = dir
+            };
+
+            bool result = task.Execute();
+            Assert.Equal(licensePath, task.Path);
+            Assert.True(result);
+
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/ValidateLicenseTests.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/ValidateLicenseTests.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace Microsoft.DotNet.Arcade.Sdk.Tests
+{
+    public class ValidateLicenseTests
+    {
+        [Fact]
+        public void LinesEqual()
+        {
+            Assert.False(ValidateLicense.LinesEqual(new[] { "a" }, new[] { "b" }));
+            Assert.False(ValidateLicense.LinesEqual(new[] { "a" }, new[] { "A" }));
+            Assert.False(ValidateLicense.LinesEqual(new[] { "a" }, new[] { "a", "b" }));
+            Assert.False(ValidateLicense.LinesEqual(new[] { "a" }, new[] { "a", "*ignore-line*" }));
+            Assert.False(ValidateLicense.LinesEqual(new[] { "*ignore-line*" }, new[] { "a" }));
+            Assert.True(ValidateLicense.LinesEqual(new[] { "a" }, new[] { "*ignore-line*" }));
+
+            Assert.True(ValidateLicense.LinesEqual(new[] { "a", "    ", "   b", "xxx", "\t \t" }, new[] { "a", "b    ", "*ignore-line*" }));
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
@@ -1,8 +1,8 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
 
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
@@ -1,5 +1,4 @@
-﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
-
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
@@ -26,6 +25,10 @@
     <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.DotNet.Arcade.Sdk.Tests"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GetLicenseFilePath.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GetLicenseFilePath.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.Arcade.Sdk
+{
+    /// <summary>
+    /// Finds a license file in the given directory.
+    /// File is considered a license file if its name matches 'license(.txt|.md|)', ignoring case.
+    /// </summary>
+    public class GetLicenseFilePath : Task
+    {
+        /// <summary>
+        /// Full path to the directory to search for the license file.
+        /// </summary>
+        [Required]
+        public string Directory { get; set; }
+
+        /// <summary>
+        /// Full path to the license file, or empty if it is not found.
+        /// </summary>
+        [Output]
+        public string Path { get; private set; }
+
+        public override bool Execute()
+        {
+            ExecuteImpl();
+            return !Log.HasLoggedErrors;
+        }
+
+        private void ExecuteImpl()
+        {
+            const string fileName = "license";
+
+#if NET472
+            IEnumerable<string> enumerateFiles(string extension) =>
+                System.IO.Directory.EnumerateFiles(Directory, fileName + extension, SearchOption.TopDirectoryOnly);
+#else
+            var options = new EnumerationOptions
+            {
+                MatchCasing = MatchCasing.CaseInsensitive,
+                RecurseSubdirectories = false,
+                MatchType = MatchType.Simple
+            };
+
+            options.AttributesToSkip |= FileAttributes.Directory;
+
+            IEnumerable<string> enumerateFiles(string extension) =>
+                System.IO.Directory.EnumerateFileSystemEntries(Directory, fileName + extension, options);
+#endif
+            var matches = 
+                (from extension in new[] { ".txt", ".md", "" }
+                 from path in enumerateFiles(extension)
+                 select path).ToArray();
+
+            if (matches.Length == 0)
+            {
+                Log.LogError($"No license file found in '{Directory}'.");
+            }
+            else if (matches.Length > 1)
+            {
+                Log.LogError($"Multiple license files found in '{Directory}': '{string.Join("', '", matches)}'.");
+            }
+            else 
+            {
+                Path = matches[0];
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/ValidateLicense.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/ValidateLicense.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.Arcade.Sdk
+{
+    /// <summary>
+    /// Checks that the content of two license files is the same modulo line breaks, leading and trailing whitespace.
+    /// </summary>
+    public class ValidateLicense : Task
+    {
+        /// <summary>
+        /// Full path to the file that contains the license text to be validated.
+        /// </summary>
+        [Required]
+        public string LicensePath { get; set; }
+
+        /// <summary>
+        /// Full path to the file that contains expected license text.
+        /// </summary>
+        [Required]
+        public string ExpectedLicensePath { get; set; }
+
+        public override bool Execute()
+        {
+            ExecuteImpl();
+            return !Log.HasLoggedErrors;
+        }
+
+        private void ExecuteImpl()
+        {
+            var actualLines = File.ReadAllLines(LicensePath, Encoding.UTF8);
+            var expectedLines = File.ReadAllLines(ExpectedLicensePath, Encoding.UTF8);
+
+            if (!LinesEqual(actualLines, expectedLines))
+            {
+                Log.LogError($"License file content '{LicensePath}' doesn't match the expected license '{ExpectedLicensePath}'.");
+            }
+        }
+
+        internal static bool LinesEqual(IEnumerable<string> actual, IEnumerable<string> expected)
+        {
+            IEnumerable<string> normalize(IEnumerable<string> lines)
+                => from line in lines
+                   where !string.IsNullOrWhiteSpace(line)
+                   select line.Trim();
+
+            var normalizedActual = normalize(actual).ToArray();
+            var normalizedExpected = normalize(expected).ToArray();
+
+            if (normalizedActual.Length != normalizedExpected.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < normalizedActual.Length; i++)
+            {
+                if (normalizedExpected[i] == "*ignore-line*")
+                {
+                    continue;
+                }
+
+                if (normalizedActual[i] != normalizedExpected[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+    }
+}

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/BuildTasks.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/BuildTasks.props
@@ -3,6 +3,6 @@
 <Project>
   <PropertyGroup>
     <ArcadeSdkBuildTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)net472\Microsoft.DotNet.Arcade.Sdk.dll</ArcadeSdkBuildTasksAssembly>
-    <ArcadeSdkBuildTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)netcoreapp2.0\Microsoft.DotNet.Arcade.Sdk.dll</ArcadeSdkBuildTasksAssembly>
+    <ArcadeSdkBuildTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)netcoreapp2.1\Microsoft.DotNet.Arcade.Sdk.dll</ArcadeSdkBuildTasksAssembly>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets
@@ -5,45 +5,8 @@
     Import NuGet targets to WPF temp projects (workaround for https://github.com/dotnet/sourcelink/issues/91) 
   -->
   <Import Project="$(_WpfTempProjectNuGetFilePathNoExt).targets" Condition="'$(_WpfTempProjectNuGetFilePathNoExt)' != '' and Exists('$(_WpfTempProjectNuGetFilePathNoExt).targets')"/>
-
-  <PropertyGroup>
-    <DeployProjectOutput Condition="'$(DeployProjectOutput)' == ''">$(__DeployProjectOutput)</DeployProjectOutput>
-    
-    <!-- Run Deploy step by default when the solution is build directly via msbuild (from command line or VS). -->
-    <DeployProjectOutput Condition="'$(DeployProjectOutput)' == ''">true</DeployProjectOutput>
-  </PropertyGroup>
-
-  <!-- Default empty deploy target. -->
-  <Target Name="Deploy" AfterTargets="Build" Condition="'$(DeployProjectOutput)' == 'true'" />
-
-  <PropertyGroup>
-    <!--
-      Unless specified otherwise project is assumed to produce artifacts (assembly, package, vsix, etc.) that ship.
-      Test projects automatically set IsShipping to false.
-
-      Some projects may produce packages that contain shipping assemblies but the packages themselves do not ship.
-      Thes projects shall specify IsShippingPackage=false and leave IsShipping unset (will default to true).
-
-      Targets that need to determine whether an artifact is shipping shall use the artifact specific IsShippingXxx property,
-      if available for the kind of artifact they operate on.
-    -->
-    <IsShipping Condition="'$(IsShipping)' == ''">true</IsShipping>
-
-    <IsShippingAssembly Condition="'$(IsShippingAssembly)' == ''">$(IsShipping)</IsShippingAssembly>
-    <IsShippingPackage Condition="'$(IsShippingPackage)' == ''">$(IsShipping)</IsShippingPackage>
-    <IsShippingVsix Condition="'$(IsShippingVsix)' == ''">$(IsShipping)</IsShippingVsix>
-
-    <!--
-      Set PackageOutputPath based on the IsShippingPackage flag set by projects.
-      This distinction allows publishing tools to determine which assets to publish to official channels.
-    -->
-    <PackageOutputPath Condition="'$(IsShippingPackage)' == 'true'">$(ArtifactsShippingPackagesDir)</PackageOutputPath>
-    <PackageOutputPath Condition="'$(IsShippingPackage)' != 'true'">$(ArtifactsNonShippingPackagesDir)</PackageOutputPath>
-
-    <IsSwixProject>false</IsSwixProject>
-    <IsSwixProject Condition="'$(VisualStudioInsertionComponent)' != '' and '$(IsVsixProject)' != 'true'">true</IsSwixProject>
-  </PropertyGroup>
-
+  
+  <Import Project="ProjectDefaults.targets"/>
   <Import Project="StrongName.targets"/>
   <Import Project="GenerateInternalsVisibleTo.targets" />
   <Import Project="GenerateResxSource.targets" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Licenses/Apache-2.0.txt
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Licenses/Apache-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Licenses/MIT.txt
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Licenses/MIT.txt
@@ -1,0 +1,23 @@
+The MIT License (MIT)
+
+*ignore-line*
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Licenses/MicrosoftDotNetLibrary.txt
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Licenses/MicrosoftDotNetLibrary.txt
@@ -1,0 +1,205 @@
+﻿# MICROSOFT SOFTWARE LICENSE TERMS
+
+# MICROSOFT .NET LIBRARY
+
+These license terms are an agreement between Microsoft Corporation (or based on
+where you live, one of its affiliates) and you. They apply to the software
+named above. The terms also apply to any Microsoft services or updates for the
+software, except to the extent those have different terms.
+
+IF YOU COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE RIGHTS BELOW.
+
+1. INSTALLATION AND USE RIGHTS. 
+You may install and use any number of copies of the software to design, develop
+and test you're applications. You may modify, copy, distribute or deploy any
+.js files contained in the software as part of your applications. 
+
+2. THIRD PARTY COMPONENTS. The software may include third party components with
+separate legal notices or governed by other agreements, as may be described in
+the ThirdPartyNotices file(s) accompanying the software.
+
+3. ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.
+  a. DISTRIBUTABLE CODE.  In addition to the .js files described above, the
+     software is comprised of Distributable Code. "Distributable Code" is 
+     code that you are permitted to distribute in programs you develop if you
+     comply with the terms below.
+
+    i. Right to Use and Distribute. 
+       - You may copy and distribute the object code form of the software.
+       - Third Party Distribution. You may permit distributors of your programs
+         to copy and distribute the Distributable Code as part of those
+         programs.
+
+    ii. Distribution Requirements. For any Distributable Code you distribute, 
+        you must
+       - use the Distributable Code in your programs and not as a standalone
+         distribution;
+       - require distributors and external end users to agree to terms that
+         protect it at least as much as this agreement;
+       - display your valid copyright notice on your programs; and
+       - indemnify, defend, and hold harmless Microsoft from any claims,
+         including attorneys' fees, related to the distribution or use of
+         your applications, except to the extent that any claim is based solely
+         on the Distributable Code.
+
+    iii. Distribution Restrictions. You may not
+       - alter any copyright, trademark or patent notice in the Distributable
+         Code;
+       - use Microsoft's trademarks in your programs' names or in a way that
+         suggests your programs come from or are endorsed by Microsoft;
+       - include Distributable Code in malicious, deceptive or unlawful
+         programs; or
+       - modify or distribute the source code of any Distributable Code so
+         that any part of it becomes subject to an Excluded License. 
+         An Excluded License is one that requires, as a condition of use,
+         modification or distribution, that
+       - the code be disclosed or distributed in source code form; or
+       - others have the right to modify it.
+
+4. DATA.
+  a. Data Collection. The software may collect information about you and your 
+     use of the software, and send that to Microsoft. Microsoft may use this 
+     information to provide services and improve our products and services.
+     You may opt-out of many of these scenarios, but not all, as described in
+     the product documentation.  There are also some features in the software
+     that may enable you and Microsoft to collect data from users of your 
+     applications. If you use these features, you must comply with applicable
+     law, including providing appropriate notices to users of your applications
+     together with a copy of Microsoft's privacy statement. Our privacy
+     statement is located at https://go.microsoft.com/fwlink/?LinkID=824704.
+     You can learn more about data collection and use in the help documentation
+     and our privacy statement. Your use of the software operates as your
+     consent to these practices.
+  b. Processing of Personal Data. To the extent Microsoft is a processor or
+     subprocessor of personal data in connection with the software, Microsoft 
+     makes the commitments in the European Union General Data Protection
+     Regulation Terms of the Online Services Terms to all customers effective 
+     May 25, 2018, at http://go.microsoft.com/?linkid=9840733.
+
+5. SCOPE OF LICENSE. The software is licensed, not sold. This agreement only
+   gives you some rights to use the software. Microsoft reserves all other 
+   rights. Unless applicable law gives you more rights despite this limitation,
+   you may use the software only as expressly permitted in this agreement.
+   In doing so, you must comply with any technical limitations in the software
+   that only allow you to use it in certain ways. You may not
+  - work around any technical limitations in the software;
+  - reverse engineer, decompile or disassemble the software, or otherwise
+    attempt to derive the source code for the software, except and to the
+    extent required by third party licensing terms governing use of certain
+    open source components that may be included in the software;
+  - remove, minimize, block or modify any notices of Microsoft or its suppliers
+    in the software; 
+  - use the software in any way that is against the law; or
+  - share, publish, rent or lease the software, provide the software as a
+    stand-alone offering for others to use, or transfer the software or this
+    agreement to any third party.
+
+6. EXPORT RESTRICTIONS. You must comply with all domestic and international
+   export laws and regulations that apply to the software, which include
+   restrictions on destinations, end users, and end use. For further
+   information on export restrictions, visit www.microsoft.com/exporting.  
+
+7. SUPPORT SERVICES. Because this software is "as is," we may not provide
+   support services for it.
+
+8. ENTIRE AGREEMENT. This agreement, and the terms for supplements, updates,
+   Internet-based services and support services that you use, are the entire
+   agreement for the software and support services.
+
+9. APPLICABLE LAW.  If you acquired the software in the United States,
+   Washington law applies to interpretation of and claims for breach of this
+   agreement, and the laws of the state where you live apply to all other
+   claims. If you acquired the software in any other country, its laws apply.
+
+10. CONSUMER RIGHTS; REGIONAL VARIATIONS. This agreement describes certain legal
+    rights. You may have other rights, including consumer rights, under
+    the laws of your state or country. Separate and apart from your relationship
+    with Microsoft, you may also have rights with respect to the party from
+    which you acquired the software. This agreement does not change those other
+    rights if the laws of your state or country do not permit it to do so.
+    For example, if you acquired the software in one of the below regions, or
+    mandatory country law applies, then the following provisions apply to you:
+  a) Australia. You have statutory guarantees under the Australian Consumer Law
+     and nothing in this agreement is intended to affect those rights.
+  b) Canada. If you acquired this software in Canada, you may stop receiving
+     updates by turning off the automatic update feature, disconnecting your
+     device from the Internet (if and when you re-connect to the Internet,
+     however, the software will resume checking for and installing updates),
+     or uninstalling the software. The product documentation, if any, may also
+     specify how to turn off updates for your specific device or software.
+  c) Germany and Austria.
+     (i) Warranty. The software will perform substantially as described in any
+         Microsoft materials that accompany it. However, Microsoft gives no
+         contractual guarantee in relation to the software.
+     (ii) Limitation of Liability. In case of intentional conduct, gross
+          negligence, claims based on the Product Liability Act, as well as in
+          case of death or personal or physical injury, Microsoft is liable
+          according to the statutory law.
+
+  Subject to the foregoing clause (ii), Microsoft will only be liable for slight
+  negligence if Microsoft is in breach of such material contractual obligations,
+  the fulfillment of which facilitate the due performance of this agreement, the
+  breach of which would endanger the purpose of this agreement and the
+  compliance with which a party may constantly trust in (so-called 
+  "cardinal obligations"). In other cases of slight negligence, Microsoft will
+  not be liable for slight negligence
+
+11. DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED "AS-IS." YOU BEAR THE RISK
+    OF USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES OR CONDITIONS.
+    TO THE EXTENT PERMITTED UNDER YOUR LOCAL LAWS, MICROSOFT EXCLUDES THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NON-INFRINGEMENT. 
+
+12. LIMITATION ON AND EXCLUSION OF REMEDIES AND DAMAGES. YOU CAN RECOVER FROM
+    MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00. YOU CANNOT
+    RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS, SPECIAL,
+    INDIRECT OR INCIDENTAL DAMAGES.
+
+This limitation applies to (a) anything related to the software, services,
+content (including code) on third party Internet sites, or third party
+applications; and (b) claims for breach of contract, breach of warranty,
+guarantee or condition, strict liability, negligence, or other tort to the
+extent permitted by applicable law.
+
+It also applies even if Microsoft knew or should have known about the possibility
+of the damages. The above limitation or exclusion may not apply to you because
+your state or country may not allow the exclusion or limitation of incidental,
+consequential or other damages.
+Please note: As this software is distributed in Quebec, Canada, some of the
+clauses in this agreement are provided below in French.
+ 
+Remarque : Ce logiciel étant distribué au Québec, Canada, certaines des clauses
+dans ce contrat sont fournies ci-dessous en français.
+ 
+EXONÉRATION DE GARANTIE. Le logiciel visé par une licence est offert «tel quel».
+Toute utilisation de ce logiciel est à votre seule risque et péril. Microsoft 
+n'accorde aucune autre garantie expresse. Vous pouvez bénéficier de droits
+additionnels en vertu du droit local sur la protection des consommateurs,
+que ce contrat ne peut modifier. La ou elles sont permises par le droit locale,
+les garanties implicites de qualité marchande, d'adéquation à un usage
+particulier et d'absence de contrefaçon sont exclues.
+ 
+LIMITATION DES DOMMAGES-INTÉRÊTS ET EXCLUSION DE RESPONSABILITÉ POUR LES 
+DOMMAGES. Vous pouvez obtenir de Microsoft et de ses fournisseurs une
+indemnisation en cas de dommages directs uniquement à hauteur de 5,00 $ US.
+Vous ne pouvez prétendre à aucune indemnisation pour les autres dommages,
+y compris les dommages spéciaux, indirects ou accessoires et pertes de
+bénéfices.
+ 
+Cette limitation concerne:
+- tout ce qui est relié au logiciel, aux services ou au contenu (y compris le
+  code) figurant sur des sites Internet tiers ou dans des programmes tiers; et
+- les réclamations au titre de violation de contrat ou de garantie, ou au titre
+  de responsabilité stricte, de négligence ou d'une autre faute dans la limite
+  autorisée par la loi en vigueur.
+ 
+Elle s'applique également, même si Microsoft connaissait ou devrait connaître
+l'éventualité d'un tel dommage. Si votre pays n'autorise pas l'exclusion ou
+la limitation de responsabilité pour les dommages indirects, accessoires ou 
+de quelque nature que ce soit, il se peut que la limitation ou l'exclusion 
+ci-dessus ne s'appliquera pas à votre égard.
+ 
+EFFET JURIDIQUE. Le présent contrat décrit certains droits juridiques. Vous
+pourriez avoir d'autres droits prévus par les lois de votre pays. Le présent
+contrat ne modifie pas les droits que vous confèrent les lois de votre pays si
+celles-ci ne le permettent pas.

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
@@ -8,12 +8,12 @@
     <HighEntropyVA>true</HighEntropyVA>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Company>Microsoft Corporation</Company>
-    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <CopyrightMicrosoft>© Microsoft Corporation. All rights reserved.</CopyrightMicrosoft>
+    <CopyrightNetFoundation>© .NET Foundation and Contributors</CopyrightNetFoundation>
     <Authors>Microsoft</Authors>
     <Serviceable>true</Serviceable>
     <DevelopmentDependency>false</DevelopmentDependency>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageLicenseUrl>http://go.microsoft.com/fwlink/?LinkId=529443</PackageLicenseUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
 
     <!-- Disable the message indicating we are using a preview SDK. That is understood and by design -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.targets
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project>
+  <PropertyGroup>
+    <DeployProjectOutput Condition="'$(DeployProjectOutput)' == ''">$(__DeployProjectOutput)</DeployProjectOutput>
+    
+    <!-- Run Deploy step by default when the solution is build directly via msbuild (from command line or VS). -->
+    <DeployProjectOutput Condition="'$(DeployProjectOutput)' == ''">true</DeployProjectOutput>
+  </PropertyGroup>
+
+  <!-- Default empty deploy target. -->
+  <Target Name="Deploy" AfterTargets="Build" Condition="'$(DeployProjectOutput)' == 'true'" />
+
+  <PropertyGroup>
+    <!--
+      Unless specified otherwise project is assumed to produce artifacts (assembly, package, vsix, etc.) that ship.
+      Test projects automatically set IsShipping to false.
+
+      Some projects may produce packages that contain shipping assemblies but the packages themselves do not ship.
+      Thes projects shall specify IsShippingPackage=false and leave IsShipping unset (will default to true).
+
+      Targets that need to determine whether an artifact is shipping shall use the artifact specific IsShippingXxx property,
+      if available for the kind of artifact they operate on.
+    -->
+    <IsShipping Condition="'$(IsShipping)' == ''">true</IsShipping>
+
+    <IsShippingAssembly Condition="'$(IsShippingAssembly)' == ''">$(IsShipping)</IsShippingAssembly>
+    <IsShippingPackage Condition="'$(IsShippingPackage)' == ''">$(IsShipping)</IsShippingPackage>
+    <IsShippingVsix Condition="'$(IsShippingVsix)' == ''">$(IsShipping)</IsShippingVsix>
+
+    <!--
+      Set PackageOutputPath based on the IsShippingPackage flag set by projects.
+      This distinction allows publishing tools to determine which assets to publish to official channels.
+    -->
+    <PackageOutputPath Condition="'$(IsShippingPackage)' == 'true'">$(ArtifactsShippingPackagesDir)</PackageOutputPath>
+    <PackageOutputPath Condition="'$(IsShippingPackage)' != 'true'">$(ArtifactsNonShippingPackagesDir)</PackageOutputPath>
+
+    <IsSwixProject>false</IsSwixProject>
+    <IsSwixProject Condition="'$(VisualStudioInsertionComponent)' != '' and '$(IsVsixProject)' != 'true'">true</IsSwixProject>
+  </PropertyGroup>
+
+  <!--
+    Closed source license must be added to the package. 
+    NuGet.org accepts only OSI or FSF approved licenses when using license type expression. 
+  -->
+  <PropertyGroup Condition="'$(PackageLicenseExpressionInternal)' != '' and '$(IsPackable)' == 'true' and '$(PackageLicenseFile)' == ''">
+    <PackageLicenseFile>License.txt</PackageLicenseFile>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(PackageLicenseExpressionInternal)' != '' and '$(IsPackable)' == 'true'">
+    <None Include="$(MSBuildThisFileDirectory)Licenses\$(PackageLicenseExpressionInternal).txt" Pack="true" PackagePath="$(PackageLicenseFile)"/>
+  </ItemGroup>
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
@@ -37,4 +37,16 @@
     </ItemGroup>
   </Target>
 
+  <!--
+    Validates repository-wide requirements.
+    MSBuild only evaluates the target project once per each set of values of global properties and caches the results.
+  -->
+  <Target Name="_RepositoryValidation" BeforeTargets="Build" Condition="'$(ContinuousIntegrationBuild)' == 'true'">
+    <MSBuild Projects="$(MSBuildThisFileDirectory)RepositoryValidation.proj"
+             Targets="Validate"
+             RemoveProperties="TargetFramework;Platform"
+             Properties="RepoRoot=$(RepoRoot);PackageLicenseExpression=$(PackageLicenseExpression);PackageLicenseExpressionInternal=$(PackageLicenseExpressionInternal);SuppressLicenseValidation=$(SuppressLicenseValidation)"
+             UseResultsCache="true" />
+  </Target>
+
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryValidation.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryValidation.proj
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project DefaultTargets="Validate">
+
+  <Import Project="BuildTasks.props" />
+
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.ValidateLicense" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GetLicenseFilePath" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
+
+  <Target Name="Validate" DependsOnTargets="_ValidateLicenseFile" >
+    <Message Text="Repository validated." Importance="low" />
+  </Target>
+
+  <Target Name="_ValidateLicenseFile" Condition="('$(PackageLicenseExpression)' != '' or '$(PackageLicenseExpressionInternal)' != '') and '$(SuppressLicenseValidation)' != 'true'">
+
+    <Error Text="Can't specify value for both PackageLicenseExpression ('$(PackageLicenseExpression)') and PackageLicenseExpressionInternal ('$(PackageLicenseExpressionInternal)')"
+           Condition="'$(PackageLicenseExpression)' != '' and '$(PackageLicenseExpressionInternal)' != ''"/>
+
+    <PropertyGroup>
+      <_LicenseExpression>$(PackageLicenseExpression)</_LicenseExpression>
+      <_LicenseExpression Condition="'$(_LicenseExpression)' == ''">$(PackageLicenseExpressionInternal)</_LicenseExpression>
+
+      <_ExpectedLicensePath>$(MSBuildThisFileDirectory)Licenses\$(_LicenseExpression).txt</_ExpectedLicensePath>
+    </PropertyGroup>
+
+    <Error Text="Unknown license expression: '$(_LicenseExpression)'."
+           Condition="!Exists('$(_ExpectedLicensePath)')"/>
+
+    <Microsoft.DotNet.Arcade.Sdk.GetLicenseFilePath Directory="$(RepoRoot)">
+      <Output TaskParameter="Path" PropertyName="_RepositoryLicensePath"/>
+    </Microsoft.DotNet.Arcade.Sdk.GetLicenseFilePath>
+
+    <Microsoft.DotNet.Arcade.Sdk.ValidateLicense LicensePath="$(_RepositoryLicensePath)" 
+                                                 ExpectedLicensePath="$(_ExpectedLicensePath)" />
+  </Target>
+
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -60,32 +60,67 @@
   -->
   <Target Name="InitializeStandardNuspecProperties"
           BeforeTargets="GenerateNuspec"
-          DependsOnTargets="_InitializeNuspecRepositoryInformationPropertiesWorkaround">
+          DependsOnTargets="_InitializeNuspecRepositoryInformationPropertiesWorkaround"
+          Condition="'$(IsPackable)' == 'true'">
 
     <PropertyGroup>
+      <PackageId Condition="'$(NuspecPackageId)' != ''">$(NuspecPackageId)</PackageId>
       <PackageProjectUrl Condition="'$(PackageProjectUrl)' == ''">$(RepositoryUrl)</PackageProjectUrl>
     </PropertyGroup>
 
     <Error Text="PackageDescription must be specified" Condition="'$(PackageDescription)' == ''"/>
     <Error Text="PackageProjectUrl must be specified" Condition="'$(PackageProjectUrl)' == ''"/>
+    <Error Text="RepositoryUrl must be specified" Condition="'$(RepositoryUrl)' == ''"/>
+    <Error Text="RepositoryCommit must be specified" Condition="'$(RepositoryCommit)' == ''"/>
+    <Error Text="RepositoryType must be specified" Condition="'$(RepositoryType)' == ''"/>
+    <Error Text="Either PackageLicenseExpression or PackageLicenseFile must be specified" Condition="'$(PackageLicenseExpression)' == '' and '$(PackageLicenseFile)' == ''"/>
+
+    <PropertyGroup Condition="'$(NuspecFile)' != '' and '$(NuspecProperties)' == ''">
+      <_LicenseElement/>
+      <_LicenseElement Condition="'$(PackageLicenseExpression)' != ''">
+        <license type="expression">$(PackageLicenseExpression)</license>
+      </_LicenseElement>
+      <_LicenseElement Condition="'$(PackageLicenseFile)' != ''">
+        <license type="file">$(PackageLicenseFile)</license>
+      </_LicenseElement>
+
+      <_TagsElement/>
+      <_TagsElement Condition="'$(PackageTags)' != ''">
+        <tags>$(PackageTags)</tags>
+      </_TagsElement>
+
+      <_IconUrlElement/>
+      <_IconUrlElement Condition="'$(PackageIconUrl)' != ''">
+        <iconUrl>$(PackageIconUrl)</iconUrl>
+      </_IconUrlElement>
+
+      <_ReleaseNotesElement/>
+      <_ReleaseNotesElement Condition="'$(PackageReleaseNotes)' != ''">
+        <releaseNotes>$(PackageReleaseNotes)</releaseNotes>
+      </_ReleaseNotesElement>
+
+      <_CommonMetadataElements>
+        <id>$(PackageId)</id>
+        <description>$(PackageDescription)</description>
+        <version>$(Version)</version>
+        <authors>$(Authors)</authors>
+        <requireLicenseAcceptance>$(PackageRequireLicenseAcceptance)</requireLicenseAcceptance>
+        $(_TagsElement)
+        $(_LicenseElement)
+        $(_IconUrlElement)
+        $(_ReleaseNotesElement)
+        <projectUrl>$(PackageProjectUrl)</projectUrl>
+        <copyright>$(Copyright)</copyright>
+        <developmentDependency>$(DevelopmentDependency)</developmentDependency>
+        <serviceable>$(Serviceable)</serviceable>
+        <repository type="$(RepositoryType)" url="$(RepositoryUrl)" commit="$(RepositoryCommit)" />
+      </_CommonMetadataElements>
+    </PropertyGroup>
 
     <ItemGroup Condition="'$(NuspecFile)' != '' and '$(NuspecProperties)' == ''">
+      <NuspecProperty Include="CommonMetadataElements=$(_CommonMetadataElements)"/>
       <NuspecProperty Include="PackageId=$(PackageId)"/>
-      <NuspecProperty Include="Authors=$(Authors)"/>
-      <NuspecProperty Include="PackageDescription=$(PackageDescription)"/>
-      <NuspecProperty Include="Copyright=$(Copyright)"/>
       <NuspecProperty Include="Version=$(PackageVersion)"/>
-      <NuspecProperty Include="Serviceable=$(Serviceable)"/>
-      <NuspecProperty Include="DevelopmentDependency=$(DevelopmentDependency)"/>
-      <NuspecProperty Include="RequireLicenseAcceptance=$(PackageRequireLicenseAcceptance)"/>
-      <NuspecProperty Include="PackageLicenseUrl=$(PackageLicenseUrl)"/>
-      <NuspecProperty Include="PackageProjectUrl=$(PackageProjectUrl)"/>
-      <NuspecProperty Include="PackageIconUrl=$(PackageIconUrl)" Condition="'$(PackageIconUrl)' != ''" />
-      <NuspecProperty Include="PackageReleaseNotes=$(PackageReleaseNotes)" Condition="'$(PackageReleaseNotes)' != ''" />
-      <NuspecProperty Include="PackageTags=$(PackageTags.Replace(';', ' '))" Condition="'$(PackageTags)' != ''" />
-      <NuspecProperty Include="RepositoryUrl=$(RepositoryUrl)" Condition="'$(RepositoryUrl)' != ''" />
-      <NuspecProperty Include="RepositoryType=$(RepositoryType)" Condition="'$(RepositoryType)' != ''" />
-      <NuspecProperty Include="RepositoryCommit=$(RepositoryCommit)" Condition="'$(RepositoryCommit)' != ''" />
       <NuspecProperty Include="ProjectDirectory=$(MSBuildProjectDirectory)"/>
     </ItemGroup>
     <PropertyGroup Condition="'$(NuspecFile)' != '' and '$(NuspecProperties)' == ''">
@@ -115,10 +150,4 @@
   <PropertyGroup Condition="'$(NuspecPackageId)' != ''">
     <PackageId>*$(MSBuildProjectName)*</PackageId>
   </PropertyGroup>
-
-  <Target Name="_SetPackageId" BeforeTargets="InitializeStandardNuspecProperties;GenerateNuSpec" Condition="'$(NuspecPackageId)' != ''">
-    <PropertyGroup>
-      <PackageId>$(NuspecPackageId)</PackageId>
-    </PropertyGroup>
-  </Target>
 </Project>


### PR DESCRIPTION
**This change must be merged _after_ Preview 3, since it depends on changes to repos consuming Acade that were made to their master branches.**

Updates the dotnet cli used for build to 2.1.503, which brings in new NuGet license features.
Removes the need for suppressing NU5125.

Since they are no longer passing `PackageLicenseUrl` this is a breaking change for projects that depend on Arcade targets when generating packages from .nuspec files.

NuGet supports `PackageLicenseExpression` or `PackageLicenseFile` (see [docs](https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#packing-a-license-expression-or-a-license-file)). The former is essentially a well-known identifier for a license, such as `MIT` or `Apache-2.0` for our repos. The later means including the license file in the package. The expression is preferable, since one doesn't need to check that the license file is exactly what it's supposed to be.

How do we make sure that the license file in the repo root matches the license specified by `PackageLicenseExpression` in Directory.Build.props file? This PR implements a simple content check for the licenses we need - it includes the expected license text files in Arcade SDK and then we compare the content and it must match modulo line breaks, whitespace. We require the license file in the root to be named `license(.txt|.md|)`, ignoring case.

Each repository must specify either `PackageLicenseExpression` or `PackageLicenseExpressionInternal`. The former when an OSS license is used the later when closed source license is used.

The PR updates helpers for building packages from .nuspec. Instead of passing each msbuild property thru as a nuspec property and then listing all the metadata elements manually in the nuspec [like so](https://github.com/dotnet/sourcelink/blob/master/src/Microsoft.Build.Tasks.Git.Operations/Microsoft.Build.Tasks.Git.nuspec#L4-L15) Arcade now defines a single property `CommonMetadataElements` that includes all the common nuspec metadata and can be used in the nuspec simply like so:

```xml
  <metadata>
    $CommonMetadataElements$
  </metadata>
```

Fixes https://github.com/dotnet/arcade/issues/1955.
Fixes https://github.com/dotnet/arcade/issues/1373.
Fixes https://github.com/dotnet/arcade/issues/16.