### PR TITLE
Set DOTNET_MULTILEVEL_LOOKUP and DOTNET_ROOT helix

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/GenerateRunScript.cs
+++ b/src/Microsoft.DotNet.CoreFxTesting/GenerateRunScript.cs
@@ -62,9 +62,13 @@ namespace Microsoft.DotNet.Build.Tasks
             string lineFeed = isUnix ? "\n" : "\r\n";
 
             var runCommandsBuilder = new StringBuilder();
-            foreach (string runCommand in RunCommands)
+            for (int i = 0; i < RunCommands.Length; i++)
             {
-                runCommandsBuilder.Append($"{runCommand}{lineFeed}");
+                runCommandsBuilder.Append(RunCommands[i]);
+                if (i < RunCommands.Length - 1)
+                {
+                    runCommandsBuilder.Append(lineFeed);
+                }
             }
             templateContent = templateContent.Replace("[[RunCommands]]", runCommandsBuilder.ToString());
 

--- a/src/Microsoft.DotNet.CoreFxTesting/build/assets/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/assets/RunnerTemplate.Unix.txt
@@ -4,10 +4,14 @@ export RUNTIME_PATH=${1%/}
 export EXECUTION_DIR=$(dirname "$0")
 
 :: Point to the locally installed SDK.
-export DOTNET_ROOT=$2
+if [ ! -z "$2" ]; then
+  export DOTNET_ROOT=$2
+fi
 
 :: Global tools path
-export GLOBAL_TOOLS_DIR=$3
+if [ ! -z "$3" ]; then
+  export GLOBAL_TOOLS_DIR=$3
+fi
 
 :: Don't use a globally installed SDK.
 export DOTNET_MULTILEVEL_LOOKUP=0

--- a/src/Microsoft.DotNet.CoreFxTesting/build/assets/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/assets/RunnerTemplate.Unix.txt
@@ -3,6 +3,18 @@
 export RUNTIME_PATH=${1%/}
 export EXECUTION_DIR=$(dirname "$0")
 
+:: Point to the locally installed SDK.
+export DOTNET_ROOT=$2
+
+:: Global tools path
+export GLOBAL_TOOLS_DIR=$3
+
+:: Don't use a globally installed SDK.
+export DOTNET_MULTILEVEL_LOOKUP=0
+
+:: Roll forward on [major], [minor] and [patch].
+export DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX=2
+
 exitcode_list[0]="Exited Successfully"
 exitcode_list[130]="SIGINT  Ctrl-C occurred. Likely tests timed out."
 exitcode_list[131]="SIGQUIT Ctrl-\ occurred. Core dumped."

--- a/src/Microsoft.DotNet.CoreFxTesting/build/assets/RunnerTemplate.Windows.txt
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/assets/RunnerTemplate.Windows.txt
@@ -13,10 +13,14 @@ if %RUNTIME_PATH:~-1%==\ set RUNTIME_PATH=%RUNTIME_PATH:~0,-1%
 set EXECUTION_DIR=%~dp0
 
 :: Point to the locally installed SDK.
+if not "%~2" == "" (
 set DOTNET_ROOT=%~2
+)
 
 :: Global tools path
+if not "%~3" == "" (
 set GLOBAL_TOOLS_DIR=%~3
+)
 
 :: Don't use a globally installed SDK.
 set DOTNET_MULTILEVEL_LOOKUP=0

--- a/src/Microsoft.DotNet.CoreFxTesting/build/assets/RunnerTemplate.Windows.txt
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/assets/RunnerTemplate.Windows.txt
@@ -1,15 +1,27 @@
-﻿@ECHO OFF
-SETLOCAL enabledelayedexpansion
+﻿@echo off
+setlocal enabledelayedexpansion
 
-SET RUNTIME_PATH=%1
+set RUNTIME_PATH=%1
 set RUNTIME_PATH=%RUNTIME_PATH:/=\%
-IF %RUNTIME_PATH:~-1%==\ SET RUNTIME_PATH=%RUNTIME_PATH:~0,-1%
-IF DEFINED RUNTIME_PATH ( echo Using %RUNTIME_PATH% as the test runtime folder.) ELSE (
+if %RUNTIME_PATH:~-1%==\ set RUNTIME_PATH=%RUNTIME_PATH:~0,-1%
+if not defined RUNTIME_PATH (
 echo Please specify a test runtime folder using the RUNTIME_PATH parameter
 goto ShowUsage
 )
+
 set EXECUTION_DIR=%~dp0
-echo Executing in %EXECUTION_DIR% 
+
+:: Point to the locally installed SDK.
+set DOTNET_ROOT=%~2
+
+:: Global tools path
+set GLOBAL_TOOLS_DIR=%~3
+
+:: Don't use a globally installed SDK.
+set DOTNET_MULTILEVEL_LOOKUP=0
+
+:: Roll forward on [major], [minor] and [patch].
+set DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX=2
 
 :: ========================= BEGIN Test Execution ============================= 
 echo ----- start %TIME% ===============  To repro directly: ===================================================== 
@@ -18,7 +30,7 @@ echo pushd %EXECUTION_DIR%
 echo popd
 echo ===========================================================================================================
 pushd %EXECUTION_DIR%
-echo on
+@echo on
 [[RunCommands]]
 @echo off
 popd

--- a/src/Microsoft.DotNet.CoreFxTesting/build/assets/RunnerTemplate.Windows.txt
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/assets/RunnerTemplate.Windows.txt
@@ -2,12 +2,13 @@
 setlocal enabledelayedexpansion
 
 set RUNTIME_PATH=%1
-set RUNTIME_PATH=%RUNTIME_PATH:/=\%
-if %RUNTIME_PATH:~-1%==\ set RUNTIME_PATH=%RUNTIME_PATH:~0,-1%
 if not defined RUNTIME_PATH (
 echo Please specify a test runtime folder using the RUNTIME_PATH parameter
 goto ShowUsage
 )
+
+set RUNTIME_PATH=%RUNTIME_PATH:/=\%
+if %RUNTIME_PATH:~-1%==\ set RUNTIME_PATH=%RUNTIME_PATH:~0,-1%
 
 set EXECUTION_DIR=%~dp0
 

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.props
@@ -11,22 +11,6 @@
   <ItemGroup Condition="'$(BuildingNETFxVertical)' == 'true'">
     <RunScriptCommands Include="set DEVPATH=%RUNTIME_PATH%" />
   </ItemGroup>
-
-  <ItemGroup Condition="'$(BuildingNETCoreAppVertical)' == 'true'">
-    <!-- Don't use the globally installed SDK. -->
-    <RunScriptCommands Condition="'$(TargetOS)' == 'Windows_NT'" Include="set DOTNET_MULTILEVEL_LOOKUP=0" />
-    <RunScriptCommands Condition="'$(TargetOS)' != 'Windows_NT'" Include="export DOTNET_MULTILEVEL_LOOKUP=0" />
-
-    <!-- Point to the locally installed SDK. -->
-    <RunScriptCommands Condition="'$(TargetOS)' == 'Windows_NT' AND '$(ArchiveTests)' != 'true'" Include="set DOTNET_ROOT=$(DotNetRoot)" />
-    <RunScriptCommands Condition="'$(TargetOS)' != 'Windows_NT' AND '$(ArchiveTests)' != 'true'" Include="export DOTNET_ROOT=$(DotNetRoot)" />
-    <RunScriptCommands Condition="'$(TargetOS)' == 'Windows_NT' AND '$(ArchiveTests)' == 'true'" Include="set DOTNET_ROOT=$(RunScriptHostDir)" />
-    <RunScriptCommands Condition="'$(TargetOS)' != 'Windows_NT' AND '$(ArchiveTests)' == 'true'" Include="export DOTNET_ROOT=$(RunScriptHostDir)" />
-
-    <!-- Make DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX configurable i.e. for major version upgrades. -->
-    <RunScriptCommands Condition="'$(TargetOS)' == 'Windows_NT'" Include="set DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX=$(TestRollForwardPolicy)" />
-    <RunScriptCommands Condition="'$(TargetOS)' != 'Windows_NT'" Include="export DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX=$(TestRollForwardPolicy)" />
-  </ItemGroup>
   
   <!-- Binplace dirs for supplemental test data. -->
   <ItemGroup>

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.props
@@ -12,13 +12,18 @@
     <RunScriptCommands Include="set DEVPATH=%RUNTIME_PATH%" />
   </ItemGroup>
 
-  <!--
-    Set DOTNET_ROOT and DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX to route global tools shims to the correct host and runtime.
-    On Helix we currently depend on a globally installed SDK.
-  -->
   <ItemGroup Condition="'$(BuildingNETCoreAppVertical)' == 'true'">
+    <!-- Don't use the globally installed SDK. -->
+    <RunScriptCommands Condition="'$(TargetOS)' == 'Windows_NT'" Include="set DOTNET_MULTILEVEL_LOOKUP=0" />
+    <RunScriptCommands Condition="'$(TargetOS)' != 'Windows_NT'" Include="export DOTNET_MULTILEVEL_LOOKUP=0" />
+
+    <!-- Point to the locally installed SDK. -->
     <RunScriptCommands Condition="'$(TargetOS)' == 'Windows_NT' AND '$(ArchiveTests)' != 'true'" Include="set DOTNET_ROOT=$(DotNetRoot)" />
     <RunScriptCommands Condition="'$(TargetOS)' != 'Windows_NT' AND '$(ArchiveTests)' != 'true'" Include="export DOTNET_ROOT=$(DotNetRoot)" />
+    <RunScriptCommands Condition="'$(TargetOS)' == 'Windows_NT' AND '$(ArchiveTests)' == 'true'" Include="set DOTNET_ROOT=$(RunScriptHostDir)" />
+    <RunScriptCommands Condition="'$(TargetOS)' != 'Windows_NT' AND '$(ArchiveTests)' == 'true'" Include="export DOTNET_ROOT=$(RunScriptHostDir)" />
+
+    <!-- Make DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX configurable i.e. for major version upgrades. -->
     <RunScriptCommands Condition="'$(TargetOS)' == 'Windows_NT'" Include="set DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX=$(TestRollForwardPolicy)" />
     <RunScriptCommands Condition="'$(TargetOS)' != 'Windows_NT'" Include="export DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX=$(TestRollForwardPolicy)" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
@@ -30,8 +30,10 @@
     <RunScriptHostDir Condition="'$(TargetOS)' != 'Windows_NT'">$RUNTIME_PATH/</RunScriptHostDir>
     <RunScriptHost Condition="'$(TargetOS)' == 'Windows_NT'">$(RunScriptHostDir)dotnet.exe</RunScriptHost>
     <RunScriptHost Condition="'$(TargetOS)' != 'Windows_NT'">$(RunScriptHostDir)dotnet</RunScriptHost>
-    
-    <GlobalToolsDir Condition="'$(ArchiveTests)' == 'true'">$(RunScriptHostDir)</GlobalToolsDir>
+
+    <!-- Overwrite the global tools path for helix submissions. -->
+    <GlobalToolsDir Condition="'$(TargetOS)' == 'Windows_NT' AND '$(ArchiveTests)' == 'true'">$(RunScriptHostDir)tools\</GlobalToolsDir>
+    <GlobalToolsDir Condition="'$(TargetOS)' != 'Windows_NT' AND '$(ArchiveTests)' == 'true'">$(RunScriptHostDir)tools/</GlobalToolsDir>
 
     <!-- Roll forward on [major], [minor] and [patch] by default. -->
     <TestRollForwardPolicy Condition="'$(TestRollForwardPolicy)' == ''">2</TestRollForwardPolicy>

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
@@ -23,20 +23,15 @@
     <RunScriptOutputName Condition="'$(TargetOS)' == 'Windows_NT'">RunTests.cmd</RunScriptOutputName>
     <RunScriptOutputName Condition="'$(TargetOS)' != 'Windows_NT'">RunTests.sh</RunScriptOutputName>
     <RunScriptOutputPath>$([MSBuild]::NormalizePath('$(TestPath)', '$(RunScriptOutputName)'))</RunScriptOutputPath>
-  </PropertyGroup>
 
-  <PropertyGroup Condition="'$(BuildingNETCoreAppVertical)' == 'true'">
     <RunScriptHostDir Condition="'$(TargetOS)' == 'Windows_NT'">%RUNTIME_PATH%\</RunScriptHostDir>
     <RunScriptHostDir Condition="'$(TargetOS)' != 'Windows_NT'">$RUNTIME_PATH/</RunScriptHostDir>
+
     <RunScriptHost Condition="'$(TargetOS)' == 'Windows_NT'">$(RunScriptHostDir)dotnet.exe</RunScriptHost>
     <RunScriptHost Condition="'$(TargetOS)' != 'Windows_NT'">$(RunScriptHostDir)dotnet</RunScriptHost>
 
-    <!-- Overwrite the global tools path for helix submissions. -->
-    <GlobalToolsDir Condition="'$(TargetOS)' == 'Windows_NT' AND '$(ArchiveTests)' == 'true'">$(RunScriptHostDir)tools\</GlobalToolsDir>
-    <GlobalToolsDir Condition="'$(TargetOS)' != 'Windows_NT' AND '$(ArchiveTests)' == 'true'">$(RunScriptHostDir)tools/</GlobalToolsDir>
-
-    <!-- Roll forward on [major], [minor] and [patch] by default. -->
-    <TestRollForwardPolicy Condition="'$(TestRollForwardPolicy)' == ''">2</TestRollForwardPolicy>
+    <RunScriptGlobalToolsDir Condition="'$(TargetOS)' == 'Windows_NT'">%GLOBAL_TOOLS_DIR%</RunScriptGlobalToolsDir>
+    <RunScriptGlobalToolsDir Condition="'$(TargetOS)' != 'Windows_NT'">$GLOBAL_TOOLS_DIR</RunScriptGlobalToolsDir>
   </PropertyGroup>
 
   <Target Name="PublishSupplementalTestData"
@@ -194,7 +189,7 @@
           Outputs="@(RunTestsOutputs)">
 
     <!-- Invoke the run script with the test host as the runtime path. -->
-    <Exec Command="$(RunScriptOutputPath) $(TestHostRootPath)"
+    <Exec Command="$(RunScriptOutputPath) $(TestHostRootPath) $(DotNetRoot) $(GlobalToolsDir)"
           ContinueOnError="true"
           IgnoreStandardErrorWarningFormat="true">
       <Output PropertyName="TestRunExitCode" TaskParameter="ExitCode" />

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/coverage/Coverage.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/coverage/Coverage.targets
@@ -4,7 +4,7 @@
 
   <!-- Wrap RunCommand and RunArguments inside code coverage invocation. -->
   <PropertyGroup>
-    <CoverageExecutablePath Condition="'$(CoverageExecutablePath)' == ''">$(GlobalToolsDir)coverlet</CoverageExecutablePath>
+    <CoverageExecutablePath Condition="'$(CoverageExecutablePath)' == ''">$(RunScriptGlobalToolsDir)coverlet</CoverageExecutablePath>
     <RunArguments>"$(TestAssembly)" --target "$(RunCommand)" --targetargs "$(RunArguments)" --format "$(CoverageFormat)" --output "$(CoverageOutputPath)" --threshold "$(CoverageThreshold)" --threshold-type "$(CoverageThresholdType)"</RunArguments>
     <RunArguments Condition="'$(CoverageSourceLink)' == 'true'">$(RunArguments) --use-source-link</RunArguments>
     <RunCommand>$(CoverageExecutablePath)</RunCommand>

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/coverage/CoverageReport.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/coverage/CoverageReport.targets
@@ -9,7 +9,7 @@
     <CoverageReportTypes Condition="'$(CoverageReportTypes)' == ''">Html</CoverageReportTypes>
     <CoverageReportVerbosity Condition="'$(CoverageReportVerbosity)' == ''">Info</CoverageReportVerbosity>
     <CoverageReportResultsPath>$([MSBuild]::NormalizePath('$(CoverageReportDir)', 'index.htm'))</CoverageReportResultsPath>
-    <CoverageReportExecutablePath Condition="'$(CoverageReportExecutablePath)' == ''">$(GlobalToolsDir)reportgenerator</CoverageReportExecutablePath>
+    <CoverageReportExecutablePath Condition="'$(CoverageReportExecutablePath)' == ''">$(RunScriptGlobalToolsDir)reportgenerator</CoverageReportExecutablePath>
 
     <CoverageReportCommandLine>$(CoverageReportExecutablePath) "-reports:$(CoverageReportInputPath)" "-targetdir:$(CoverageReportDir)" "-reporttypes:$(CoverageReportTypes)" "-verbosity:$(CoverageReportVerbosity)"</CoverageReportCommandLine>
     <CoverageReportOpenCommandLine Condition="'$(PopCoverageReport)' == 'true' AND '$(TargetOS)' == 'Windows_NT'">start $(CoverageReportResultsPath)</CoverageReportOpenCommandLine>


### PR DESCRIPTION
Relates to https://github.com/dotnet/corefx/pull/35208

Changes:
- Set DOTNET_MULTILEVEL_LOOKUP to isolate our test runs from globally installed SDKs. Also set DOTNET_ROOT for helix as we now include a runtime for global/repo tools.
- Build consistent runscripts. This changes the run script generation to be consistent between local and helix runs. Generating different scripts based on the targets is problematic.
- Consistency code cleanup in the run script templates.