### PR TITLE
Remove VSTS from publish build artifacts step

### DIFF
--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -169,7 +169,7 @@ jobs:
 
   - ${{ if eq(parameters.enablePublishBuildArtifacts, 'true') }}:
     - task: PublishBuildArtifacts@1
-      displayName: Publish Logs to VSTS
+      displayName: Publish Logs
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
         PublishLocation: Container


### PR DESCRIPTION
VSTS no longer makes sense after they re-branded it to Azure DevOps.

Maybe `Publish Logs` is enough, or we could name it, `Publish Logs as Artifacts` or, `Publish Logs to Artifacts Container`