### PR TITLE
Modify CheckHelixJobStatus to check work item exit codes

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/CheckHelixJobStatus.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CheckHelixJobStatus.cs
@@ -126,7 +126,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             try
             {
                 WorkItemDetails details = await HelixApi.RetryAsync(
-                    () => HelixApi.WorkItem.DetailsAsync(jobName, workItemName),
+                    () => HelixApi.WorkItem.DetailsAsync(workItemName, jobName),
                     LogExceptionRetry);
                 string message = $"Work item {workItemName} in job {jobName} has {details.State} with exit code {details.ExitCode}";
                 if (IsFailed(details))

--- a/src/Microsoft.DotNet.Helix/Sdk/CheckHelixJobStatus.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CheckHelixJobStatus.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.DotNet.Helix.Client.Models;
 
 namespace Microsoft.DotNet.Helix.Sdk
 {
@@ -124,19 +125,29 @@ namespace Microsoft.DotNet.Helix.Sdk
             await Task.Yield();
             try
             {
-                var details = await HelixApi.RetryAsync(
+                WorkItemDetails details = await HelixApi.RetryAsync(
                     () => HelixApi.WorkItem.DetailsAsync(jobName, workItemName),
                     LogExceptionRetry);
-                if (details.State == "Failed")
+                string message = $"Work item {workItemName} in job {jobName} has {details.State} with exit code {details.ExitCode}";
+                if (IsFailed(details))
                 {
-                    Log.LogError(
-                        $"Work item {workItemName} on job {jobName} has failed with exit code {details.ExitCode}.");
+                    Log.LogError(message);
+                }
+                else
+                {
+                    Log.LogMessage(MessageImportance.Low, message);
                 }
             }
             catch (Exception ex)
             {
                 Log.LogError($"Unable to get work item status for '{workItemName}', assuming failure. Exception: {ex}");
             }
+        }
+
+        private bool IsFailed(WorkItemDetails details)
+        {
+            // The State property will not be populated with "Failed" if kusto hasn't finished ingesting data. Check the ExitCode also.
+            return details.State == "Failed" || details.ExitCode != 0;
         }
     }
 }


### PR DESCRIPTION
This change modifies the CheckHelixJobStatus task to
check for ExitCode == 0 as well as State != 'Failed'
If kusto hasn't finished its processing then the State field
will only have 'Finished'