### PR TITLE
Improve error reporting when toolset restore fails

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -417,15 +417,15 @@ function InitializeToolset() {
 
   $proj = Join-Path $ToolsetDir "restore.proj"
   $bl = if ($binaryLog) { "/bl:" + (Join-Path $LogDir "ToolsetRestore.binlog") } else { "" }
-  
+
   '<Project Sdk="Microsoft.DotNet.Arcade.Sdk"/>' | Set-Content $proj
-  MSBuild $proj $bl /t:__WriteToolsetLocation /noconsolelogger /p:__ToolsetLocationOutputFile=$toolsetLocationFile
-  
+  MSBuild $proj $bl /t:__WriteToolsetLocation /clp:ErrorsOnly`;NoSummary /p:__ToolsetLocationOutputFile=$toolsetLocationFile
+
   $path = Get-Content $toolsetLocationFile -TotalCount 1
   if (!(Test-Path $path)) {
     throw "Invalid toolset path: $path"
   }
-  
+
   return $global:_ToolsetBuildProj = $path
 }
 

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -238,11 +238,15 @@ function InitializeToolset {
     ExitWithExitCode 2
   fi
 
-  local toolset_restore_log="$log_dir/ToolsetRestore.binlog"
   local proj="$toolset_dir/restore.proj"
 
+  local bl=""
+  if [[ "$binary_log" == true ]]; then
+    bl="/bl:$log_dir/ToolsetRestore.binlog"
+  fi
+  
   echo '<Project Sdk="Microsoft.DotNet.Arcade.Sdk"/>' > "$proj"
-  MSBuild "$proj" /t:__WriteToolsetLocation /noconsolelogger /bl:"$toolset_restore_log" /p:__ToolsetLocationOutputFile="$toolset_location_file"
+  MSBuild "$proj" $bl /t:__WriteToolsetLocation /clp:ErrorsOnly\;NoSummary /p:__ToolsetLocationOutputFile="$toolset_location_file"
 
   local toolset_build_proj=`cat "$toolset_location_file"`
 


### PR DESCRIPTION
Currently we only report "Build failed" on Windows and the bash script does not respect `bl` parameter (binlog). Fix both.