### PR TITLE
Python 3 support

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xunit-reporter/xunit-reporter.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xunit-reporter/xunit-reporter.py
@@ -2,7 +2,6 @@
 
 import re
 import os
-import urlparse
 import helix.azure_storage
 import helix.event
 import helix.settings
@@ -72,7 +71,7 @@ def main():
 
     log.info("Uploading results from {}".format(results_path))
 
-    with file(results_path) as result_file:
+    with open(results_path) as result_file:
         test_count = 0
         total_regex = re.compile(r'total="(\d+)"')
         for line in result_file:


### PR DESCRIPTION
To make the reporter work on Python 3:
Removed urlparse as we don't use it and it changed in Python 3
Replacing file with open as file was removed in Python 3 and open is available in Python 2 & 3