### PR TITLE
Ensuring NativeVersionFile is unique

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
@@ -69,7 +69,7 @@
     </PropertyGroup>
 
    <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
-      <NativeVersionFile Condition="'$(NativeVersionFile)' == ''">$(ArtifactsObjDir)_version.h</NativeVersionFile>
+      <NativeVersionFile Condition="'$(NativeVersionFile)' == ''">$(IntermediateOutputPath)_version.h</NativeVersionFile>
       <_WindowsFileVersion>$(FileVersion.Replace('.', ','))</_WindowsFileVersion>
       <_Windows_VER_DEBUG>0</_Windows_VER_DEBUG>
       <_Windows_VER_DEBUG Condition="'$(Configuration)'=='Debug'">VS_FF_DEBUG</_Windows_VER_DEBUG>


### PR DESCRIPTION
Fixing #2064 

NativeVersionFile property needs to be set to a project-specific intermediate output path (i.e. each project needs to have it's copy of the generated file).