### PR TITLE
Fix issue where batching of xunit projects is only happening per project identity

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xunit-runner/XUnitRunner.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xunit-runner/XUnitRunner.targets
@@ -19,7 +19,7 @@
   <Target Name="RestoreXUnitProjects"
           Condition="'@(XUnitProject)' != ''"
           BeforeTargets="Restore"
-          Outputs="%(XUnitProject.Identity)">
+          Outputs="%(XUnitProject.Identity)%(XUnitProject.TargetFramework)%(XUnitProject.RuntimeTargetFramework)%(XUnitProject.AdditionalProperties)">
     <MSBuild Projects="%(XUnitProject.Identity)"
              Targets="Restore"
              Properties="CustomAfterMicrosoftCommonTargets=$(_XUnitPublishTargetsPath);%(XUnitProject.AdditionalProperties)">
@@ -29,7 +29,7 @@
   <Target Name="BuildXUnitProjects"
           Condition="'@(XUnitProject)' != ''"
           BeforeTargets="CoreBuild"
-          Outputs="%(XUnitProject.Identity)">
+          Outputs="%(XUnitProject.Identity)%(XUnitProject.TargetFramework)%(XUnitProject.RuntimeTargetFramework)%(XUnitProject.AdditionalProperties)">
     <PropertyGroup>
       <_CurrentXUnitProject>%(XUnitProject.Identity)</_CurrentXUnitProject>
       <_CurrentPublishTargetFramework>%(XUnitProject.TargetFramework)</_CurrentPublishTargetFramework>


### PR DESCRIPTION
cc: @alexperovich 

Currently, if you want to build the same xunit project but targeting different frameworks/RIDs, batching won't work on the BuildXunitProjects target, since it will really just merge all the properties together and perform only one build per distinct combination of project names. With the proposed change, the batching will happen now per distinct project name, target framework, runtime framework and additional properties combo which is really what we want. Dotnet/iot test project targets multiple rids, so we need this feature.