### PR TITLE
Add helixapiaccesstoken variable group for internal builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,10 +38,8 @@ jobs:
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         # DotNet-Blob-Feed provides: dotnetfeed-storage-access-key-1
         # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
-        # DotNet-HelixApi-Access provides: HelixApiAccessToken
         - group: DotNet-Blob-Feed
         - group: Publish-Build-Assets
-        - group: DotNet-HelixApi-Access
         - _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
         - _InternalBuildArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
             /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,8 +38,10 @@ jobs:
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         # DotNet-Blob-Feed provides: dotnetfeed-storage-access-key-1
         # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
+        # DotNet-HelixApi-Access provides: HelixApiAccessToken
         - group: DotNet-Blob-Feed
         - group: Publish-Build-Assets
+        - group: DotNet-HelixApi-Access
         - _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
         - _InternalBuildArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
             /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -108,6 +108,10 @@ jobs:
         - name: ${{ pair.key }}
           value: ${{ pair.value }}
 
+  # DotNet-HelixApi-Access provides 'HelixApiAccessToken' for internal builds
+  - ${{ if and(eq(parameters.enableTelemetry, 'true'), eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - group: DotNet-HelixApi-Access
+
   ${{ if ne(parameters.workspace, '') }}:
     workspace: ${{ parameters.workspace }}
 


### PR DESCRIPTION
Automatically adds variablegroup for sending telemetry for internal builds.

Validated with an internal build at https://dev.azure.com/dnceng/internal/_build/results?buildId=101274

I'll use this PR to validate public builds.