### PR TITLE
Fix a lie in build.sh help

### DIFF
--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -10,7 +10,7 @@ set -e
 usage()
 {
   echo "Common settings:"
-  echo "  --configuration <value>    Build configuration: 'Debug' or 'Release' (short: --c)"
+  echo "  --configuration <value>    Build configuration: 'Debug' or 'Release' (short: -c)"
   echo "  --verbosity <value>        Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
   echo "  --binaryLog                Create MSBuild binary log (short: -bl)"
   echo ""


### PR DESCRIPTION
The short form recognized in CoreFX build scripts is `-c`. I assume it's similar elsewhere.