### PR TITLE
Add task to download files from helix results container

### DIFF
--- a/src/HelixPoolProvider/HelixPoolProvider/HelixJobCreator.cs
+++ b/src/HelixPoolProvider/HelixPoolProvider/HelixJobCreator.cs
@@ -98,6 +98,7 @@ namespace Microsoft.DotNet.HelixPoolProvider
                     .WithContainerName(_configuration.ContainerName)
                     .WithCorrelationPayloadUris(AgentPayloadUri)
                     .WithStorageAccountConnectionString(_configuration.ConnectionString)
+                    .WithResultsStorageAccountConnectionString(_configuration.ConnectionString)
                     .DefineWorkItem(_agentRequestItem.agentId)
                     .WithCommand(ConstructCommand())
                     .WithFiles(credentialsPath, agentSettingsPath, StartupScriptPath)

--- a/src/HelixPoolProvider/HelixPoolProvider/HelixJobCreator.cs
+++ b/src/HelixPoolProvider/HelixPoolProvider/HelixJobCreator.cs
@@ -98,7 +98,6 @@ namespace Microsoft.DotNet.HelixPoolProvider
                     .WithContainerName(_configuration.ContainerName)
                     .WithCorrelationPayloadUris(AgentPayloadUri)
                     .WithStorageAccountConnectionString(_configuration.ConnectionString)
-                    .WithResultsStorageAccountConnectionString(_configuration.ConnectionString)
                     .DefineWorkItem(_agentRequestItem.agentId)
                     .WithCommand(ConstructCommand())
                     .WithFiles(credentialsPath, agentSettingsPath, StartupScriptPath)

--- a/src/Microsoft.DotNet.Helix/JobSender/IJobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/IJobDefinition.cs
@@ -19,6 +19,7 @@ namespace Microsoft.DotNet.Helix.Client
         IJobDefinition WithStorageAccountConnectionString(string accountConnectionString);
         IJobDefinition WithResultsContainerName(string resultsContainerName);
         IJobDefinition WithResultsStorageAccountConnectionString(string resultsAccountConnectionString);
+        IJobDefinition WithDefaultResultsContainer();
         IJobDefinition WithMaxRetryCount(int? maxRetryCount);
         Task<ISentJob> SendAsync(Action<string> log = null);
     }

--- a/src/Microsoft.DotNet.Helix/JobSender/ISentJob.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/ISentJob.cs
@@ -5,5 +5,6 @@ namespace Microsoft.DotNet.Helix.Client
     public interface ISentJob
     {
         string CorrelationId { get; }
+        string ResultsContainerUri { get; }
     }
 }

--- a/src/Microsoft.DotNet.Helix/JobSender/ISentJob.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/ISentJob.cs
@@ -6,5 +6,6 @@ namespace Microsoft.DotNet.Helix.Client
     {
         string CorrelationId { get; }
         string ResultsContainerUri { get; }
+        string ResultsContainerReadSAS { get; }
     }
 }

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -21,6 +21,7 @@ namespace Microsoft.DotNet.Helix.Client
     {
         private readonly Dictionary<string, string> _properties;
         private readonly List<WorkItemDefinition> _workItems;
+        private bool _withDefaultResultsContainer;
 
         public JobDefinition(IJob jobApi)
         {
@@ -133,6 +134,12 @@ namespace Microsoft.DotNet.Helix.Client
             return this;
         }
 
+        public IJobDefinition WithDefaultResultsContainer()
+        {
+            _withDefaultResultsContainer = true;
+            return this;
+        }
+
         public async Task<ISentJob> SendAsync(Action<string> log = null)
         {
             IBlobHelper storage;
@@ -148,15 +155,16 @@ namespace Microsoft.DotNet.Helix.Client
             IBlobContainer storageContainer = await storage.GetContainerAsync(TargetContainerName);
             var jobList = new List<JobListEntry>();
 
-            IBlobContainer resultsStorageContainer;
-            if (string.IsNullOrEmpty(ResultsStorageAccountConnectionString))
+            IBlobContainer resultsStorageContainer = null;
+            if (!string.IsNullOrEmpty(ResultsStorageAccountConnectionString))
             {
-                resultsStorageContainer = await storage.GetContainerAsync(TargetResultsContainerName);
-            }
-            else
-            {
+
                 IBlobHelper resultsStorage = new ConnectionStringBlobHelper(ResultsStorageAccountConnectionString);
                 resultsStorageContainer = await resultsStorage.GetContainerAsync(TargetResultsContainerName);
+            }
+            else if (_withDefaultResultsContainer)
+            {
+                resultsStorageContainer = await storage.GetContainerAsync(TargetResultsContainerName);
             }
 
             List<string> correlationPayloadUris =
@@ -191,14 +199,14 @@ namespace Microsoft.DotNet.Helix.Client
                         Creator = Creator,
                         MaxRetryCount = MaxRetryCount ?? 0,
                         JobStartIdentifier = jobStartIdentifier,
-                        ResultsUri = resultsStorageContainer.Uri,
-                        ResultsUriRSAS = resultsStorageContainer.ReadSas,
-                        ResultsUriWSAS = resultsStorageContainer.WriteSas,
+                        ResultsUri = resultsStorageContainer?.Uri,
+                        ResultsUriRSAS = resultsStorageContainer?.ReadSas,
+                        ResultsUriWSAS = resultsStorageContainer?.WriteSas,
                     }),
                 ex => log?.Invoke($"Starting job failed with {ex}\nRetrying..."));
 
 
-            return new SentJob(JobApi, newJob, resultsStorageContainer.Uri);
+            return new SentJob(JobApi, newJob, resultsStorageContainer?.Uri, string.IsNullOrEmpty(Creator) ? resultsStorageContainer?.ReadSas : string.Empty);
         }
 
         public IJobDefinitionWithTargetQueue WithBuild(string buildNumber)

--- a/src/Microsoft.DotNet.Helix/JobSender/SentJob.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/SentJob.cs
@@ -9,13 +9,15 @@ namespace Microsoft.DotNet.Helix.Client
 {
     internal class SentJob : ISentJob
     {
-        public SentJob(IJob jobApi, JobCreationResult newJob)
+        public SentJob(IJob jobApi, JobCreationResult newJob, string resultsContainerUri)
         {
             JobApi = jobApi;
             CorrelationId = newJob.Name;
+            ResultsContainerUri = resultsContainerUri;
         }
 
         public IJob JobApi { get; }
         public string CorrelationId { get; }
+        public string ResultsContainerUri { get; }
     }
 }

--- a/src/Microsoft.DotNet.Helix/JobSender/SentJob.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/SentJob.cs
@@ -9,15 +9,17 @@ namespace Microsoft.DotNet.Helix.Client
 {
     internal class SentJob : ISentJob
     {
-        public SentJob(IJob jobApi, JobCreationResult newJob, string resultsContainerUri)
+        public SentJob(IJob jobApi, JobCreationResult newJob, string resultsContainerUri, string resultsContainerReadSAS)
         {
             JobApi = jobApi;
             CorrelationId = newJob.Name;
             ResultsContainerUri = resultsContainerUri;
+            ResultsContainerReadSAS = resultsContainerReadSAS;
         }
 
         public IJob JobApi { get; }
         public string CorrelationId { get; }
         public string ResultsContainerUri { get; }
+        public string ResultsContainerReadSAS { get; }
     }
 }

--- a/src/Microsoft.DotNet.Helix/Sdk/DownloadFromResultsContainer.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/DownloadFromResultsContainer.cs
@@ -101,7 +101,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                     }
                     catch (StorageException e)
                     {
-                        Log.LogWarning($"Failed to download {file} from results container: {e.Message}");
+                        Log.LogWarning($"Failed to download {workItemName}/{file} blob from results container: {e.Message}");
                     }
                 }
             };

--- a/src/Microsoft.DotNet.Helix/Sdk/DownloadFromResultsContainer.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/DownloadFromResultsContainer.cs
@@ -1,0 +1,104 @@
+using Microsoft.Build.Framework;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Helix.Sdk
+{
+    public class DownloadFromResultsContainer : BaseTask
+    {
+        [Required]
+        public ITaskItem[] WorkItems { get; set; }
+
+        [Required]
+        public string ResultsContainer { get; set; }
+
+        [Required]
+        public string PathToDownload { get; set; }
+
+        [Required]
+        public string JobId { get; set; }
+
+        [Required]
+        public ITaskItem[] MetadataToWrite { get; set; }
+
+        private const string MetadataFile = "metadata.txt";
+
+        public override bool Execute()
+        {
+            if (string.IsNullOrEmpty(ResultsContainer))
+            {
+                LogRequiredParameterError(nameof(ResultsContainer));
+            }
+
+            if (string.IsNullOrEmpty(PathToDownload))
+            {
+                LogRequiredParameterError(nameof(PathToDownload));
+            }
+
+            if (string.IsNullOrEmpty(JobId))
+            {
+                LogRequiredParameterError(nameof(JobId));
+            }
+
+            if (!Log.HasLoggedErrors)
+            {
+                Log.LogMessage(MessageImportance.High, $"Downloading result files for job {JobId}");
+                ExecuteCore().GetAwaiter().GetResult();
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private async Task ExecuteCore()
+        {
+            DirectoryInfo directory = Directory.CreateDirectory(Path.Combine(PathToDownload, JobId));
+            using (FileStream stream = File.Open(Path.Combine(directory.FullName, MetadataFile), FileMode.Create, FileAccess.Write))
+            using (var writer = new StreamWriter(stream))
+            {
+                foreach (ITaskItem metadata in MetadataToWrite)
+                {
+                    await writer.WriteLineAsync(metadata.GetMetadata("Identity"));
+                }
+            }
+
+            ResultsContainer = ResultsContainer.EndsWith("/") ? ResultsContainer : ResultsContainer + "/";
+            await Task.WhenAll(WorkItems.Select(wi => DownloadFilesForWorkItem(wi, directory.FullName)));
+            return;
+        }
+
+        private async Task DownloadFilesForWorkItem(ITaskItem workItem, string directoryPath)
+        {
+            if (workItem.GetRequiredMetadata(Log, "DownloadFilesFromResults", out string files))
+            {
+                string workItemName = workItem.GetMetadata("Identity");
+                string[] filesToDownload = files.Split(';');
+
+                DirectoryInfo destinationDir = Directory.CreateDirectory(Path.Combine(directoryPath, workItemName));
+                foreach (var file in filesToDownload)
+                {
+                    try
+                    {
+                        string destinationFile = Path.Combine(destinationDir.FullName, file);
+                        Log.LogMessage(MessageImportance.Normal, $"Downloading {file} => {destinationFile}...");
+                        CloudBlob blob = new CloudBlob(new Uri($"{ResultsContainer}{workItemName}/{file}"));
+                        await blob.DownloadToFileAsync(destinationFile, FileMode.Create);
+                    }
+                    catch (StorageException e)
+                    {
+                        Log.LogWarning($"Failed to download {file} from results container: {e.Message}");
+                    }
+                }
+            };
+            return;
+        }
+
+        private void LogRequiredParameterError(string parameter)
+        {
+            Log.LogError($"Required parameter {nameof(parameter)} string was null or empty");
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
@@ -69,6 +69,12 @@ namespace Microsoft.DotNet.Helix.Sdk
         public string JobCorrelationId { get; set; }
 
         /// <summary>
+        ///   When the task finishes, the results container uri should be available in case we want to download files.
+        /// </summary>
+        [Output]
+        public string ResultsContainerUri { get; set; }
+
+        /// <summary>
         ///   A collection of commands that will run for each work item before any work item commands.
         ///   Use ';' to separate commands and escape a ';' with ';;'
         /// </summary>
@@ -209,6 +215,7 @@ namespace Microsoft.DotNet.Helix.Sdk
 
                 ISentJob job = await def.SendAsync(msg => Log.LogMessage(msg));
                 JobCorrelationId = job.CorrelationId;
+                ResultsContainerUri = job.ResultsContainerUri;
             }
 
             string mcUri = await GetMissionControlResultUri();

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
@@ -44,6 +44,10 @@
     <PropertyGroup Condition="$(IsPosixShell)">
       <HelixPreCommands>set -x;$(HelixPreCommands)</HelixPreCommands>
     </PropertyGroup>
+    <PropertyGroup>
+      <_usingDownloadResultsFeature>false</_usingDownloadResultsFeature>
+      <_usingDownloadResultsFeature Condition="'@(HelixWorkItem -> HasMetadata('DownloadFilesFromResults'))' != ''">true</_usingDownloadResultsFeature>
+    </PropertyGroup>
     <SendHelixJob Source="$(HelixSource)"
                   Type="$(HelixType)"
                   Build="$(HelixBuild)"
@@ -57,15 +61,18 @@
                   PostCommands="$(HelixPostCommands)"
                   CorrelationPayloads="@(HelixCorrelationPayload)"
                   WorkItems="@(HelixWorkItem)"
-                  HelixProperties="@(HelixProperties)">
+                  HelixProperties="@(HelixProperties)"
+                  UsingDownloadResultsFeature="$(_usingDownloadResultsFeature)">
       <Output TaskParameter="JobCorrelationId" PropertyName="HelixJobId"/>
       <Output TaskParameter="ResultsContainerUri" PropertyName="HelixResultsContainer"/>
+      <Output TaskParameter="ResultsContainerReadSAS" PropertyName="HelixResultsContainerReadSAS"/>
     </SendHelixJob>
     <ItemGroup>
       <SentJob Include="$(HelixJobId)">
         <WorkItemCount>@(HelixWorkItem->Count())</WorkItemCount>
         <HelixTargetQueue>$(HelixTargetQueue)</HelixTargetQueue>
         <ResultsContainerUri>$(HelixResultsContainer)</ResultsContainerUri>
+        <ResultsContainerReadSAS>$(HelixResultsContainerReadSAS)</ResultsContainerReadSAS>
       </SentJob>
     </ItemGroup>
     <Message Text="Sent Helix Job $(HelixJobId)" Importance="High" />

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
@@ -59,10 +59,13 @@
                   WorkItems="@(HelixWorkItem)"
                   HelixProperties="@(HelixProperties)">
       <Output TaskParameter="JobCorrelationId" PropertyName="HelixJobId"/>
+      <Output TaskParameter="ResultsContainerUri" PropertyName="HelixResultsContainer"/>
     </SendHelixJob>
     <ItemGroup>
       <SentJob Include="$(HelixJobId)">
         <WorkItemCount>@(HelixWorkItem->Count())</WorkItemCount>
+        <HelixTargetQueue>$(HelixTargetQueue)</HelixTargetQueue>
+        <ResultsContainerUri>$(HelixResultsContainer)</ResultsContainerUri>
       </SentJob>
     </ItemGroup>
     <Message Text="Sent Helix Job $(HelixJobId)" Importance="High" />

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.props
@@ -15,4 +15,5 @@
   <UsingTask TaskName="StartAzurePipelinesTestRun" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)"/>
   <UsingTask TaskName="StopAzurePipelinesTestRun" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)"/>
   <UsingTask TaskName="CheckAzurePipelinesTestRun" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)"/>
+  <UsingTask TaskName="DownloadFromResultsContainer" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)"/>
 </Project>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/download-results/DownloadFromResultsContainer.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/download-results/DownloadFromResultsContainer.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <_HelixMultiQueueTargets>$(_HelixMultiQueueTargets);$(MSBuildThisFileDirectory)DownloadFromResultsContainer.targets</_HelixMultiQueueTargets>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/download-results/DownloadFromResultsContainer.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/download-results/DownloadFromResultsContainer.targets
@@ -14,13 +14,15 @@
 
     <PropertyGroup>
       <HelixResultsDestinationDir Condition="'$(HelixResultsDestinationDir)' == '' AND '$(BUILD_SOURCESDIRECTORY)' != ''">$([MSBuild]::NormalizePath('$(BUILD_SOURCESDIRECTORY)', 'artifacts', helixresults'))</HelixResultsDestinationDir>
+
+      <_shouldDownloadResults>false</_shouldDownloadResults>
+      <_shouldDownloadResults Condition="'@(_workItemsWithDownloadMetadata)' != '' AND '$(HelixResultsDestinationDir)' != ''">true</_shouldDownloadResults>
     </PropertyGroup>
 
-    <Warning Text="DownloadFromResultsContainer will be skipped for job %(SentJob.Identity) becaue results container uri is empty" Condition="'%(SentJob.ResultsContainerUri)' == ''" />
-    <Warning Text="DownloadFromResultsContainer will be skipped because HelixResultsDestinationDir is empty" Condition="'$(HelixResultsDestinationDir)' == ''" />
+    <Warning Text="DownloadFromResultsContainer will be skipped for job %(SentJob.Identity) becaue results container uri is empty" Condition="'%(SentJob.ResultsContainerUri)' == '' AND $(_shouldDownloadResults)" />
 
     <DownloadFromResultsContainer
-        Condition="'@(_workItemsWithDownloadMetadata)' != '' AND '%(SentJob.ResultsContainerUri)' != '' AND '$(HelixResultsDestinationDir)' != ''"
+        Condition="$(_shouldDownloadResults) AND '%(SentJob.ResultsContainerUri)' != ''"
         WorkItems="@(_workItemsWithDownloadMetadata)"
         ResultsContainer="%(SentJob.ResultsContainerUri)"
         OutputDirectory="$(HelixResultsDestinationDir)"

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/download-results/DownloadFromResultsContainer.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/download-results/DownloadFromResultsContainer.targets
@@ -1,0 +1,30 @@
+<Project>
+  <Target Name="DownloadFromResultsContainer"
+  		  Condition="$(WaitForWorkItemCompletion)"
+  		  AfterTargets="CoreTest"
+  		  Inputs="unused"
+  		  Outputs="%(SentJob.HelixTargetQueue);%(SentJob.ResultsContainerUri)">
+    <ItemGroup>
+      <_workItemsWithDownloadMetadata Include="@(HelixWorkItem)" Condition="'%(HelixWorkItem.DownloadFilesFromResults)' != ''" />
+
+      <DownloadResultsMetadata Include="HelixQueue=%(SentJob.HelixTargetQueue)" />
+      <DownloadResultsMetadata Condition="'$(HelixConfiguration)' != ''" Include="Configuration=$(HelixConfiguration)" />
+      <DownloadResultsMetadata Condition="'$(HelixArchitecture)' != ''" Include="Architecture=$(HelixArchitecture)" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <ResultsDestinationPath Condition="'$(ResultsDestinationPath)' == '' AND '$(BUILD_SOURCESDIRECTORY)' != ''">$([MSBuild]::NormalizePath('$(BUILD_SOURCESDIRECTORY)', 'artifacts', helixresults'))</ResultsDestinationPath>
+      <ResultsDestinationPath Condition="'$(ResultsDestinationPath)' == ''">$([MSBuild]::NormalizePath('$(MSBuildStartupDirectory)', 'helixresults'))</ResultsDestinationPath>
+    </PropertyGroup>
+
+    <Warning Text="DownloadFromResultsContainer will be skipped for job %(SentJob.Identity) becaue results container uri is empty" Condition="'%(SentJob.ResultsContainerUri)' == ''" />
+
+    <DownloadFromResultsContainer
+    	Condition="'@(_workItemsWithDownloadMetadata)' != '' AND '%(SentJob.ResultsContainerUri)' != ''"
+    	WorkItems="@(_workItemsWithDownloadMetadata)"
+    	ResultsContainer="%(SentJob.ResultsContainerUri)"
+    	PathToDownload="$(ResultsDestinationPath)"
+    	MetadataToWrite="@(DownloadResultsMetadata)"
+    	JobId="%(SentJob.Identity)" />
+  </Target>
+</Project>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/download-results/DownloadFromResultsContainer.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/download-results/DownloadFromResultsContainer.targets
@@ -1,30 +1,31 @@
 <Project>
   <Target Name="DownloadFromResultsContainer"
-  		  Condition="$(WaitForWorkItemCompletion)"
-  		  AfterTargets="CoreTest"
-  		  Inputs="unused"
-  		  Outputs="%(SentJob.HelixTargetQueue);%(SentJob.ResultsContainerUri)">
+          Condition="$(WaitForWorkItemCompletion)"
+          AfterTargets="CoreTest"
+          Inputs="unused"
+          Outputs="%(SentJob.Identity)">
     <ItemGroup>
       <_workItemsWithDownloadMetadata Include="@(HelixWorkItem)" Condition="'%(HelixWorkItem.DownloadFilesFromResults)' != ''" />
 
-      <DownloadResultsMetadata Include="HelixQueue=%(SentJob.HelixTargetQueue)" />
-      <DownloadResultsMetadata Condition="'$(HelixConfiguration)' != ''" Include="Configuration=$(HelixConfiguration)" />
-      <DownloadResultsMetadata Condition="'$(HelixArchitecture)' != ''" Include="Architecture=$(HelixArchitecture)" />
+      <HelixDownloadResultsMetadata Include="HelixQueue=%(SentJob.HelixTargetQueue)" />
+      <HelixDownloadResultsMetadata Condition="'$(HelixConfiguration)' != ''" Include="Configuration=$(HelixConfiguration)" />
+      <HelixDownloadResultsMetadata Condition="'$(HelixArchitecture)' != ''" Include="Architecture=$(HelixArchitecture)" />
     </ItemGroup>
 
     <PropertyGroup>
-      <ResultsDestinationPath Condition="'$(ResultsDestinationPath)' == '' AND '$(BUILD_SOURCESDIRECTORY)' != ''">$([MSBuild]::NormalizePath('$(BUILD_SOURCESDIRECTORY)', 'artifacts', helixresults'))</ResultsDestinationPath>
-      <ResultsDestinationPath Condition="'$(ResultsDestinationPath)' == ''">$([MSBuild]::NormalizePath('$(MSBuildStartupDirectory)', 'helixresults'))</ResultsDestinationPath>
+      <HelixResultsDestinationDir Condition="'$(HelixResultsDestinationDir)' == '' AND '$(BUILD_SOURCESDIRECTORY)' != ''">$([MSBuild]::NormalizePath('$(BUILD_SOURCESDIRECTORY)', 'artifacts', helixresults'))</HelixResultsDestinationDir>
     </PropertyGroup>
 
     <Warning Text="DownloadFromResultsContainer will be skipped for job %(SentJob.Identity) becaue results container uri is empty" Condition="'%(SentJob.ResultsContainerUri)' == ''" />
+    <Warning Text="DownloadFromResultsContainer will be skipped because HelixResultsDestinationDir is empty" Condition="'$(HelixResultsDestinationDir)' == ''" />
 
     <DownloadFromResultsContainer
-    	Condition="'@(_workItemsWithDownloadMetadata)' != '' AND '%(SentJob.ResultsContainerUri)' != ''"
-    	WorkItems="@(_workItemsWithDownloadMetadata)"
-    	ResultsContainer="%(SentJob.ResultsContainerUri)"
-    	PathToDownload="$(ResultsDestinationPath)"
-    	MetadataToWrite="@(DownloadResultsMetadata)"
-    	JobId="%(SentJob.Identity)" />
+        Condition="'@(_workItemsWithDownloadMetadata)' != '' AND '%(SentJob.ResultsContainerUri)' != '' AND '$(HelixResultsDestinationDir)' != ''"
+        WorkItems="@(_workItemsWithDownloadMetadata)"
+        ResultsContainer="%(SentJob.ResultsContainerUri)"
+        OutputDirectory="$(HelixResultsDestinationDir)"
+        MetadataToWrite="@(HelixDownloadResultsMetadata)"
+        JobId="%(SentJob.Identity)"
+        ResultsContainerReadSAS="%(SentJob.ResultsContainerReadSAS)" />
   </Target>
 </Project>


### PR DESCRIPTION
Contributes to: #2076 

This pr adds a Task for helix jobs to be able to download a file from the results container after a helix run, i.e testResults.xml or coverage.xml. 

1. Every `HelixWorkItem` should include a metadata entry to specify which files it needs to download:
```xml
<HelixWorkItem Include="WorkItem">
   <DownloadFilesFromResults>testResults.xml</DownloadFilesFromResults>
</HelixWorkItem>
```
2. A destination directory in the host machine can be specified through an MSBuild property -- `$(HelixResultsDestinationDir)`.
    - If this property is not set and `BUILD_SOURCESDIRECTORY` property is available (predefined variable in Azure DevOps), it defaults to `$(BUILD_SOURCESDIRECTORY)/artifacts/helixresults`.
    - If `BUILD_SOURCESDIRECTORY` is empty, it would log a warning and will not execute the task.
3. A directory under this destination folder will be created per each Job created => each `HelixTargetQueue` for the same payload. This folder will be named with the JobId.
4. Under this Job directory, there will be a `metadata.txt` file, that will contain the following information:
```
HelixQueue=%(SentJob.HelixTargetQueue)
Configuration=$(HelixConfiguration)
Architecture=$(HelixArchitecture)
```
More metadata can be specified to be written into this file, through and ItemGroup => `HelixDownloadResultsMetadata`
5. Under the Job directory, there will be a directory for every `HelixWorkItem` that specified the `DownloadFilesFromResults` metadata, and under that folder it will contain the files that where available for download.
6. If a file is not found within the container, a Warning will be logged through MSBuild.

The structure of the directory will look as follows:
```
- HelixResultsDestinationDir \
  - JobId \
    - metadata.txt
    - HelixWorkItemName \
       - downloaded files.
```

cc: @ViktorHofer @danmosemsft @markwilkie @Chrisboh 
