### PR TITLE
don't try to upload SendToHelix.binlog when sending a job to Helix

### DIFF
--- a/src/Microsoft.DotNet.Helix/JobSender/Payloads/DirectoryPayload.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/Payloads/DirectoryPayload.cs
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.Helix.Client
             {
                 using (var zip = new ZipArchive(stream, ZipArchiveMode.Create, true))
                 {
-                    foreach (FileInfo file in DirectoryInfo.EnumerateFiles("*", SearchOption.AllDirectories))
+                    foreach (FileInfo file in DirectoryInfo.EnumerateFiles("*", SearchOption.AllDirectories).Where(IsNotHelixBinLog))
                     {
                         string relativePath =
                             file.FullName.Substring(basePath.Length + 1); // +1 prevents it from including the leading backslash
@@ -109,5 +109,9 @@ namespace Microsoft.DotNet.Helix.Client
                 .Max();
             return alreadyUploadedFile.LastWriteTimeUtc >= newestFileWriteTime;
         }
+
+        // the binary log file for sending jobs to helix is written to $SourcesDirectory\artifacts\log\$BuildConfig\SendToHelix.binlog
+        // if the user wants to send entire repo to Helix, on Windows it fails with file in use exception
+        private bool IsNotHelixBinLog(FileInfo file) => !file.Name.Equals("SendToHelix.binlog", StringComparison.InvariantCultureIgnoreCase);
     }
 }


### PR DESCRIPTION
In the `dotnet/performance` repo we don't run xunit unit tests, but some custom scripts that run the benchmarks etc. To be able to do that we use `WorkItemDirectory` and `WorkItemCommand`.

The problem is that when we point `WorkItemDirectory` to `$(Build.SourcesDirectory)` the SendToHelix task fails with file in use exception because it's writing at the same time to `$SourcesDirectory\artifacts\log\$BuildConfig\SendToHelix.binlog`:

```log
C:\Program Files\dotnet\sdk\2.2.103\MSBuild.dll /nologo -distributedlogger:Microsoft.DotNet.Tools.MSBuild.MSBuildLogger,C:\Program Files\dotnet\sdk\2.2.103\dotnet.dll*Microsoft.DotNet.Tools.MSBuild.MSBuildForwardingLogger,C:\Program Files\dotnet\sdk\2.2.103\dotnet.dll -maxcpucount /m -verbosity:m /v:minimal /bl:D:\a\1\s\artifacts\log\x64_coreclr_netcoreapp3.0\SendToHelix.binlog /clp:Summary /nr:True /p:ContinuousIntegrationBuild=False /p:TreatWarningsAsErrors=true /restore /t:Test /warnaserror D:\a\1\s\eng\common\helixpublish.proj
Restoring packages for D:\a\1\s\eng\common\helixpublish.proj...
Installing Microsoft.DotNet.Helix.Sdk 2.0.0-beta.19122.3.
Restoring packages for D:\a\1\s\eng\common\helixpublish.proj...
Installing Microsoft.DotNet.Arcade.Sdk 1.0.0-beta.19122.3.
  Restoring packages for D:\a\1\s\eng\common\helixpublish.proj...
  Installing Microsoft.Build.Tasks.Git 1.0.0-beta2-18618-05.
  Installing Microsoft.SourceLink.Common 1.0.0-beta2-18618-05.
  Installing Microsoft.SourceLink.Vsts.Git 1.0.0-beta2-18618-05.
  Installing Microsoft.SourceLink.GitHub 1.0.0-beta2-18618-05.
  Installing XliffTasks 0.2.0-beta-63004-01.
  Generating MSBuild file D:\a\1\s\artifacts\obj\helixpublish\helixpublish.proj.nuget.g.props.
  Generating MSBuild file D:\a\1\s\artifacts\obj\helixpublish\helixpublish.proj.nuget.g.targets.
  Restore completed in 5.22 sec for D:\a\1\s\eng\common\helixpublish.proj.
  Restore completed in 1.04 ms for D:\a\1\s\eng\common\helixpublish.proj.
C:\Users\VssAdministrator\.nuget\packages\microsoft.dotnet.helix.sdk\2.0.0-beta.19122.3\tools\Microsoft.DotNet.Helix.Sdk.MonoQueue.targets(47,5): error : IOException:   'D:\a\1\s\artifacts\log\x64_coreclr_netcoreapp3.0\SendToHelix.binlog' because it is being used by another process. [D:\a\1\s\eng\common\helixpublish.proj]
C:\Users\VssAdministrator\.nuget\packages\microsoft.dotnet.helix.sdk\2.0.0-beta.19122.3\tools\Microsoft.DotNet.Helix.Sdk.MonoQueue.targets(47,5): error :    at System.IO.FileStream.ValidateFileHandle(SafeFileHandle fileHandle) [D:\a\1\s\eng\common\helixpublish.proj]
C:\Users\VssAdministrator\.nuget\packages\microsoft.dotnet.helix.sdk\2.0.0-beta.19122.3\tools\Microsoft.DotNet.Helix.Sdk.MonoQueue.targets(47,5): error :    at System.IO.FileStream.CreateFileOpenHandle(FileMode mode, FileShare share, FileOptions options) [D:\a\1\s\eng\common\helixpublish.proj]
C:\Users\VssAdministrator\.nuget\packages\microsoft.dotnet.helix.sdk\2.0.0-beta.19122.3\tools\Microsoft.DotNet.Helix.Sdk.MonoQueue.targets(47,5): error :    at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options) [D:\a\1\s\eng\common\helixpublish.proj]
C:\Users\VssAdministrator\.nuget\packages\microsoft.dotnet.helix.sdk\2.0.0-beta.19122.3\tools\Microsoft.DotNet.Helix.Sdk.MonoQueue.targets(47,5): error :    at System.IO.Compression.ZipFileExtensions.DoCreateEntryFromFile(ZipArchive destination, String sourceFileName, String entryName, Nullable`1 compressionLevel) [D:\a\1\s\eng\common\helixpublish.proj]
C:\Users\VssAdministrator\.nuget\packages\microsoft.dotnet.helix.sdk\2.0.0-beta.19122.3\tools\Microsoft.DotNet.Helix.Sdk.MonoQueue.targets(47,5): error :    at Microsoft.DotNet.Helix.Client.DirectoryPayload.DoUploadAsync(IBlobContainer payloadContainer, Action`1 log) in /_/src/Microsoft.DotNet.Helix/JobSender/Payloads/DirectoryPayload.cs:line 83 [D:\a\1\s\eng\common\helixpublish.proj]
C:\Users\VssAdministrator\.nuget\packages\microsoft.dotnet.helix.sdk\2.0.0-beta.19122.3\tools\Microsoft.DotNet.Helix.Sdk.MonoQueue.targets(47,5): error :    at Microsoft.DotNet.Helix.Client.DirectoryPayload.UploadAsync(IBlobContainer payloadContainer, Action`1 log) in /_/src/Microsoft.DotNet.Helix/JobSender/Payloads/DirectoryPayload.cs:line 54 [D:\a\1\s\eng\common\helixpublish.proj]
C:\Users\VssAdministrator\.nuget\packages\microsoft.dotnet.helix.sdk\2.0.0-beta.19122.3\tools\Microsoft.DotNet.Helix.Sdk.MonoQueue.targets(47,5): error :    at System.Linq.Enumerable.SelectListIterator`2.MoveNext() [D:\a\1\s\eng\common\helixpublish.proj]
C:\Users\VssAdministrator\.nuget\packages\microsoft.dotnet.helix.sdk\2.0.0-beta.19122.3\tools\Microsoft.DotNet.Helix.Sdk.MonoQueue.targets(47,5): error :    at System.Threading.Tasks.Task.WhenAll[TResult](IEnumerable`1 tasks) [D:\a\1\s\eng\common\helixpublish.proj]
C:\Users\VssAdministrator\.nuget\packages\microsoft.dotnet.helix.sdk\2.0.0-beta.19122.3\tools\Microsoft.DotNet.Helix.Sdk.MonoQueue.targets(47,5): error :    at Microsoft.DotNet.Helix.Client.JobDefinition.SendAsync(Action`1 log) in /_/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs:line 159 [D:\a\1\s\eng\common\helixpublish.proj]
C:\Users\VssAdministrator\.nuget\packages\microsoft.dotnet.helix.sdk\2.0.0-beta.19122.3\tools\Microsoft.DotNet.Helix.Sdk.MonoQueue.targets(47,5): error :    at Microsoft.DotNet.Helix.Sdk.SendHelixJob.ExecuteCore() in /_/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs:line 210 [D:\a\1\s\eng\common\helixpublish.proj]
C:\Users\VssAdministrator\.nuget\packages\microsoft.dotnet.helix.sdk\2.0.0-beta.19122.3\tools\Microsoft.DotNet.Helix.Sdk.MonoQueue.targets(47,5): error :    at Microsoft.DotNet.Helix.Sdk.HelixTask.Execute() in /_/src/Microsoft.DotNet.Helix/Sdk/HelixTask.cs:line 43 [D:\a\1\s\eng\common\helixpublish.proj]
C:\Users\VssAdministrator\.nuget\packages\microsoft.dotnet.helix.sdk\2.0.0-beta.19122.3\tools\Microsoft.DotNet.Helix.Sdk.MonoQueue.targets(47,5): error :  [D:\a\1\s\eng\common\helixpublish.proj]
```

This PR excludes `SendToHelix.binlog` from the uploaded files. 

We want to be able to send the entire repo (2MB) to Helix and we don't want to introduce any workarounds on our side.

@adiaaida @alexperovich PTAL

/cc @jorive