### PR TITLE
Upgrading DotNet.Sleet and add PerfTracker

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -35,7 +35,7 @@
     <NuGetVersioningVersion>4.4.0</NuGetVersioningVersion>
     <NuGetVersion>4.4.0</NuGetVersion>
     <OctokitVersion>0.30.0</OctokitVersion>
-    <DotNetSleetLibVersion>2.2.94</DotNetSleetLibVersion>
+    <DotNetSleetLibVersion>2.2.127</DotNetSleetLibVersion>
     <SwashbuckleAspNetCoreSwaggerVersion>3.0.0</SwashbuckleAspNetCoreSwaggerVersion>
     <SystemCollectionsImmutableVersion>1.3.1</SystemCollectionsImmutableVersion>
     <SystemIOCompressionVersion>4.3.0</SystemIOCompressionVersion>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BlobFeedAction.cs
@@ -461,7 +461,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         {
             // By default a folder is created inside %temp% to store the cache, to 
             // change this location pass a folder path to the LocalCache constructor.
-            return new LocalCache();
+            // Passing PerfTracker in so a summary is logged at the end of publishing.
+            return new LocalCache(new PerfTracker());
         }
     }
 }


### PR DESCRIPTION
This new version of DotNet.Sleet contains several perf improvements and a summary of the time Sleet took executing a given task. i.e. 
```
Loaded package nuspecs in 32 ms
Updated VirtualCatalog in 40 ms
Updated AutoComplete in 88 ms
Updated PackageIndex in 109 ms
Updated FlatContainer in 278 ms
Updated Registrations in 580 ms
Updated Search in 330 ms
Updated all files locally. Total time: 1733 ms
Files committed: 108 Size: 69.92 MB Total upload time: 1486 ms
Total execution time: 3783 ms
```

The previous is logged in the [build task](https://dnceng.visualstudio.com/internal/_build/results?buildId=107584&view=logs&jobId=16ce49ee-8d0d-5a76-4958-88f78392b71f&taskId=206012c0-0eaa-56aa-8172-665f354177dc&lineStart=2441&lineEnd=2450&colStart=4&colEnd=34)

Also, when actually pushing the files (not accounting for the time spent in lock) this change improves the push times almost 3x. Currently the PushToBlobFeed task takes close to 9 secs and the test build showed it took 3.8 secs