### PR TITLE
Don't call WriteMetadataConstant from WriteEnumValue

### DIFF
--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Enums.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Enums.cs
@@ -116,13 +116,30 @@ namespace Microsoft.Cci.Writers.CSharp
                 }
             }
 
-            // couldn't find a symbol for enum, just cast it
-            WriteSymbol("(");
-            WriteTypeName(enumType, noSpace: true);
-            WriteSymbol(")");
-            WriteMetadataConstant(constant);
+            if (constant.Value == null)
+            {
+                if (enumType.IsValueType)
+                {
+                    // Write default(T) for value types
+                    WriteDefaultOf(enumType);
+                }
+                else
+                {
+                    WriteKeyword("null", noSpace: true);
+                }
+            }
+            else
+            {
+                // couldn't find a symbol for enum, just cast it
+                WriteSymbol("(");
+                WriteTypeName(enumType, noSpace: true);
+                WriteSymbol(")");
+                WriteSymbol("("); // Wrap value in parens to avoid issues with negative values
+                Write(constant.Value.ToString());
+                WriteSymbol(")");
+            }
         }
-        
+
         private static ulong ToULongUnchecked(object value)
         {
             if (value == null)


### PR DESCRIPTION
This was resulting in infinite recursion when the enum typedef could not be resolved.

I was trying to reuse some of the constant formatting in WriteMetadataConstant but this
was bad since WriteMetadataConstant would call WriteEnumValue.

Fixes #2122 