### PR TITLE
Enable force repack for binaries that were signed externally

### DIFF
--- a/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
+++ b/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
@@ -277,7 +277,11 @@ namespace Microsoft.DotNet.SignTool
                 {
                     if (!_signTool.VerifySignedPEFile(stream))
                     {
-                        _log.LogError($"Assembly {file.FullPath} is not signed properly");
+                        _log.LogError($"Assembly {file.FullPath} is NOT signed properly");
+                    }
+                    else
+                    {
+                        _log.LogMessage($"Assembly {file.FullPath} is signed properly");
                     }
                 }
             }
@@ -321,9 +325,16 @@ namespace Microsoft.DotNet.SignTool
                     }
                 }
 
-                if (!SkipZipContainerSignatureMarkerCheck && (file.IsNupkg() || file.IsVsix()) && !signedContainer)
+                if (!SkipZipContainerSignatureMarkerCheck)
                 {
-                    _log.LogError($"Container {file.FullPath} does not have signature marker.");
+                    if ((file.IsNupkg() || file.IsVsix()) && !signedContainer)
+                    {
+                        _log.LogError($"Container {file.FullPath} does not have signature marker.");
+                    }
+                    else
+                    {
+                        _log.LogMessage($"Container {file.FullPath} has a signature marker.");
+                    }
                 }
             }
         }
@@ -341,6 +352,10 @@ namespace Microsoft.DotNet.SignTool
                 if (file.IsManaged() && !file.IsCrossgened() && !_signTool.VerifyStrongNameSign(file.FullPath))
                 {
                     _log.LogError($"Assembly {file.FullPath} is not strong-name signed correctly.");
+                }
+                else
+                {
+                    _log.LogMessage($"Assembly {file.FullPath} strong-name signature is valid.");
                 }
             }
         }

--- a/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
+++ b/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
@@ -281,7 +281,7 @@ namespace Microsoft.DotNet.SignTool
                     }
                     else
                     {
-                        _log.LogMessage($"Assembly {file.FullPath} is signed properly");
+                        _log.LogMessage(MessageImportance.Low, $"Assembly {file.FullPath} is signed properly");
                     }
                 }
             }
@@ -333,7 +333,7 @@ namespace Microsoft.DotNet.SignTool
                     }
                     else
                     {
-                        _log.LogMessage($"Container {file.FullPath} has a signature marker.");
+                        _log.LogMessage(MessageImportance.Low, $"Container {file.FullPath} has a signature marker.");
                     }
                 }
             }
@@ -355,7 +355,7 @@ namespace Microsoft.DotNet.SignTool
                 }
                 else
                 {
-                    _log.LogMessage($"Assembly {file.FullPath} strong-name signature is valid.");
+                    _log.LogMessage(MessageImportance.Low, $"Assembly {file.FullPath} strong-name signature is valid.");
                 }
             }
         }

--- a/src/Microsoft.DotNet.SignTool/src/Configuration.cs
+++ b/src/Microsoft.DotNet.SignTool/src/Configuration.cs
@@ -13,6 +13,7 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Runtime.Versioning;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.SignTool
@@ -142,7 +143,7 @@ namespace Microsoft.DotNet.SignTool
                     continue;
                 }
 
-                // if the content has of the file doesn't match the hash in file path then the file has changed
+                // if the content of the file doesn't match the hash in file path than the file has changed
                 // which indicates that it was signed so we need to ensure we repack the binary with the signed version
                 string actualFileHash = ContentUtil.HashToString(ContentUtil.GetContentHash(file));
                 bool forceRepack = stringHash != actualFileHash;
@@ -226,7 +227,7 @@ namespace Microsoft.DotNet.SignTool
                 }
             }
 
-            _log.LogMessage($"Caching file {key.FileName} {key.StringHash}");
+            _log.LogMessage(MessageImportance.Low, $"Caching file {key.FileName} {key.StringHash}");
             _filesByContentKey.Add(key, fileSignInfo);
 
             if (fileSignInfo.SignInfo.ShouldSign || fileSignInfo.ForceRepack || fileSignInfo.IsZipContainer())
@@ -292,7 +293,7 @@ namespace Microsoft.DotNet.SignTool
             // If has overriding info, is it for ignoring the file?
             if (SignToolConstants.IgnoreFileCertificateSentinel.Equals(explicitCertificateName, StringComparison.OrdinalIgnoreCase))
             {
-                _log.LogMessage($"File configurated to not be signed: {fileName}{fileSpec}");
+                _log.LogMessage($"File configured to not be signed: {fileName}{fileSpec}");
                 return new FileSignInfo(fullPath, hash, SignInfo.Ignore, forceRepack:forceRepack);
             }
 

--- a/src/Microsoft.DotNet.SignTool/src/Configuration.cs
+++ b/src/Microsoft.DotNet.SignTool/src/Configuration.cs
@@ -131,17 +131,23 @@ namespace Microsoft.DotNet.SignTool
                 // might have changed the hash but we want to still use the same hash of the unsigned
                 // file that originally built the cache. 
                 string stringHash = cacheRelative.Substring(0, indexOfHash);
-
+                ImmutableArray<byte> contentHash;
                 try
                 {
-                    ImmutableArray<byte> contentHash = ContentUtil.StringToHash(stringHash);
+                    contentHash = ContentUtil.StringToHash(stringHash);
                 }
-                catch {
+                catch
+                {
                     _log.LogMessage($"Failed to parse the content hash from path '{file}' so skipping it.");
                     continue;
                 }
 
-                TrackFile(file, ContentUtil.StringToHash(stringHash), false);
+                // if the content has of the file doesn't match the hash in file path then the file has changed
+                // which indicates that it was signed so we need to ensure we repack the binary with the signed version
+                string actualFileHash = ContentUtil.HashToString(ContentUtil.GetContentHash(file));
+                bool forceRepack = stringHash != actualFileHash;
+
+                TrackFile(file, contentHash, false, forceRepack);
             }
             _log.LogMessage("Done loading existing files from cache");
         }
@@ -193,10 +199,10 @@ namespace Microsoft.DotNet.SignTool
             return new BatchSignInput(_filesToSign.ToImmutableArray(), _zipDataMap.ToImmutableDictionary(ByteSequenceComparer.Instance), _filesToCopy.ToImmutableArray());
         }
 
-        private FileSignInfo TrackFile(string fullPath, ImmutableArray<byte> contentHash, bool isNested)
+        private FileSignInfo TrackFile(string fullPath, ImmutableArray<byte> contentHash, bool isNested, bool forceRepack = false)
         {
             _log.LogMessage($"Tracking file '{fullPath}' isNested={isNested}");
-            var fileSignInfo = ExtractSignInfo(fullPath, contentHash);
+            var fileSignInfo = ExtractSignInfo(fullPath, contentHash, forceRepack);
 
             var key = new SignedFileContentKey(contentHash, Path.GetFileName(fullPath));
 
@@ -220,10 +226,10 @@ namespace Microsoft.DotNet.SignTool
                 }
             }
 
-            _log.LogMessage($"Caching file {key.FileName}");
+            _log.LogMessage($"Caching file {key.FileName} {key.StringHash}");
             _filesByContentKey.Add(key, fileSignInfo);
 
-            if (fileSignInfo.SignInfo.ShouldSign || fileSignInfo.IsZipContainer())
+            if (fileSignInfo.SignInfo.ShouldSign || fileSignInfo.ForceRepack || fileSignInfo.IsZipContainer())
             {
                 _filesToSign.Add(fileSignInfo);
             }
@@ -231,7 +237,7 @@ namespace Microsoft.DotNet.SignTool
             return fileSignInfo;
         }
 
-        private FileSignInfo ExtractSignInfo(string fullPath, ImmutableArray<byte> hash)
+        private FileSignInfo ExtractSignInfo(string fullPath, ImmutableArray<byte> hash, bool forceRepack = false)
         {
             // Try to determine default certificate name by the extension of the file
             var hasSignInfo = _fileExtensionSignInfo.TryGetValue(Path.GetExtension(fullPath), out var signInfo);
@@ -287,7 +293,7 @@ namespace Microsoft.DotNet.SignTool
             if (SignToolConstants.IgnoreFileCertificateSentinel.Equals(explicitCertificateName, StringComparison.OrdinalIgnoreCase))
             {
                 _log.LogMessage($"File configurated to not be signed: {fileName}{fileSpec}");
-                return new FileSignInfo(fullPath, hash, SignInfo.Ignore);
+                return new FileSignInfo(fullPath, hash, SignInfo.Ignore, forceRepack:forceRepack);
             }
 
             // Do we have an explicit certificate after all?
@@ -301,7 +307,7 @@ namespace Microsoft.DotNet.SignTool
             {
                 if (isAlreadySigned && !_dualCertificates.Contains(signInfo.Certificate))
                 {
-                    return new FileSignInfo(fullPath, hash, SignInfo.AlreadySigned);
+                    return new FileSignInfo(fullPath, hash, SignInfo.AlreadySigned, forceRepack:forceRepack);
                 }
 
                 // TODO: implement this check for native PE files as well:
@@ -323,7 +329,7 @@ namespace Microsoft.DotNet.SignTool
                     }
                 }
 
-                return new FileSignInfo(fullPath, hash, signInfo, (peInfo != null && peInfo.TargetFramework != "") ? peInfo.TargetFramework : null);
+                return new FileSignInfo(fullPath, hash, signInfo, (peInfo != null && peInfo.TargetFramework != "") ? peInfo.TargetFramework : null, forceRepack:forceRepack);
             }
 
             if (SignToolConstants.SignableExtensions.Contains(extension) || SignToolConstants.SignableOSXExtensions.Contains(extension))
@@ -339,7 +345,7 @@ namespace Microsoft.DotNet.SignTool
                 _log.LogMessage($"Ignoring non-signable file: {fullPath}");
             }
 
-            return new FileSignInfo(fullPath, hash, SignInfo.Ignore);
+            return new FileSignInfo(fullPath, hash, SignInfo.Ignore, forceRepack: forceRepack);
         }
 
         private void LogWarning(SigningToolErrorCode code, string message)
@@ -519,7 +525,7 @@ namespace Microsoft.DotNet.SignTool
                             fileSignInfo = TrackFile(tempPath, contentHash, isNested: true);
                         }
 
-                        if (fileSignInfo.SignInfo.ShouldSign)
+                        if (fileSignInfo.SignInfo.ShouldSign || fileSignInfo.ForceRepack)
                         {
                             nestedParts.Add(new ZipPart(relativePath, fileSignInfo));
                         }

--- a/src/Microsoft.DotNet.SignTool/src/FileSignInfo.cs
+++ b/src/Microsoft.DotNet.SignTool/src/FileSignInfo.cs
@@ -20,6 +20,8 @@ namespace Microsoft.DotNet.SignTool
         // optional file information that allows to disambiguate among multiple files with the same name:
         internal readonly string TargetFramework;
 
+        internal readonly bool ForceRepack;
+
         internal static bool IsPEFile(string path)
             => Path.GetExtension(path) == ".exe" || Path.GetExtension(path) == ".dll";
 
@@ -64,7 +66,7 @@ namespace Microsoft.DotNet.SignTool
 
         internal bool IsPowerShellScript() => IsPowerShellScript(FileName);
 
-        internal FileSignInfo(string fullPath, ImmutableArray<byte> contentHash, SignInfo signInfo, string targetFramework = null)
+        internal FileSignInfo(string fullPath, ImmutableArray<byte> contentHash, SignInfo signInfo, string targetFramework = null, bool forceRepack = false)
         {
             Debug.Assert(fullPath != null);
             Debug.Assert(!contentHash.IsDefault && contentHash.Length == 256 / 8);
@@ -75,6 +77,7 @@ namespace Microsoft.DotNet.SignTool
             FullPath = fullPath;
             SignInfo = signInfo;
             TargetFramework = targetFramework;
+            ForceRepack = forceRepack;
         }
 
         public override string ToString()


### PR DESCRIPTION
Plumb options to force repack binaries that were signed externally
otherwise the repacking command will not pack the extracted signed
binaries and only repack the unsigned binaries which is not what we
want.

cc @JohnTortugo 