### PR TITLE
Workaround NuGet breaking change

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateNuSpec.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateNuSpec.cs
@@ -111,7 +111,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
             using (var file = File.Create(OutputFileName))
             {
-                manifest.Save(file, false);
+                manifest.Save(file);
             }
         }
 


### PR DESCRIPTION
NuGet removed Manifest.Save(Stream, bool) in the latest version.
Since NuGet is part of MSBuild our task is forcibly upgraded to the
latest version when running in the latest SDK.  This results in a
missing method exception.

Workaround it by calling an API that NuGet didn't remove.  This can
potentially cause failures in GenerateNuSpec because it will now run
Validation, however anyone using the Pack task in our package should
already be passing validation since NuGet runs the same validation
when reading the Manifest.

Replaces https://github.com/dotnet/arcade/pull/2004.