### PR TITLE
Make SignTool not fail when a cross generated file doesn't have PKT

### DIFF
--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -1221,7 +1221,7 @@ $@"
         }
 
         [Fact]
-        public void CrossGenneratedLibraryWithoutPKT()
+        public void CrossGeneratedLibraryWithoutPKT()
         {
             var itemsToSign = new[]
             {

--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -1219,5 +1219,18 @@ $@"
 
             Assert.False(task.Log.HasLoggedErrors);
         }
+
+        [Fact]
+        public void CrossGenneratedLibraryWithoutPKT()
+        {
+            var itemsToSign = new[]
+            {
+                GetResourcePath("SPCNoPKT.dll")
+            };
+
+            ValidateFileSignInfos(itemsToSign, new Dictionary<string, SignInfo>(), new Dictionary<ExplicitCertificateKey, string>(), s_fileExtensionSignInfo, new string[0]);
+
+            ValidateGeneratedProject(itemsToSign, new Dictionary<string, SignInfo>(), new Dictionary<ExplicitCertificateKey, string>(), s_fileExtensionSignInfo, new string[0]);
+        }
     }
 }

--- a/src/Microsoft.DotNet.SignTool/src/Configuration.cs
+++ b/src/Microsoft.DotNet.SignTool/src/Configuration.cs
@@ -373,11 +373,8 @@ namespace Microsoft.DotNet.SignTool
             }
 
             bool isCrossgened = ContentUtil.IsCrossgened(fullPath);
+            string publicKeyToken = ContentUtil.GetPublicKeyToken(fullPath);
 
-            AssemblyName assemblyName = AssemblyName.GetAssemblyName(fullPath);
-            var pktBytes = assemblyName.GetPublicKeyToken();
-
-            string publicKeyToken = (pktBytes == null || pktBytes.Length == 0) ? string.Empty : string.Join("", pktBytes.Select(b => b.ToString("x2")));
             GetTargetFrameworkAndCopyright(fullPath, out string targetFramework, out string copyright);
             return new PEInfo(isManaged, isCrossgened, copyright, publicKeyToken, targetFramework);
         }

--- a/src/Microsoft.DotNet.SignTool/src/ContentUtil.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ContentUtil.cs
@@ -104,5 +104,22 @@ namespace Microsoft.DotNet.SignTool
                 return entry.Size > 0;
             }
         }
+
+        public static string GetPublicKeyToken(string fullPath)
+        {
+            try
+            {
+                AssemblyName assemblyName = AssemblyName.GetAssemblyName(fullPath);
+                byte[] pktBytes = assemblyName.GetPublicKeyToken();
+
+                return (pktBytes == null || pktBytes.Length == 0) ? 
+                    string.Empty : 
+                    string.Join("", pktBytes.Select(b => b.ToString("x2")));
+            }
+            catch (BadImageFormatException)
+            {
+                return string.Empty;
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes: #2159 

SignTool currently fails with _"Could not load file or assembly 'xyz.dll' or one of its dependencies. An attempt was made to load a program with an incorrect format."_ when a cross generated file doesn't have PKT. See sample build here.

This PR make SN not fail in such scenario and also add a new test case to check that.