### PR TITLE
Make Tasks.Feed copy artifacts to temporary folder before uploading them

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "2.1.401"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19155.12",
+    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19154.14",
     "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19154.14"
   }
 }

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "2.1.401"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19154.14",
+    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19155.12",
     "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19154.14"
   }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
@@ -77,10 +77,14 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                             var packagesTempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
                             Directory.CreateDirectory(packagesTempPath);
 
+                            Log.LogMessage($"Publishing artifacts from the temp directory ${packagesTempPath}");
+
                             foreach (var packagePath in packageItems)
                             {
                                 var destFile = $"{packagesTempPath}/{Path.GetFileName(packagePath.ItemSpec)}";
                                 File.Copy(packagePath.ItemSpec, destFile);
+
+                                Log.LogMessage($"Copying package file from {packagePath.ItemSpec} to {destFile}");
 
                                 Log.LogMessage(MessageImportance.High,
                                     $"##vso[artifact.upload containerfolder=PackageArtifacts;artifactname=PackageArtifacts]{destFile}");
@@ -95,11 +99,15 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                             // removed in the future.
                             var symbolsTempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
                             Directory.CreateDirectory(symbolsTempPath);
-                            
+
+                            Log.LogMessage($"Publishing artifacts from the temp directory ${symbolsTempPath}");
+
                             foreach (var symbolPath in symbolItems)
                             {
                                 var destFile = $"{symbolsTempPath}/{Path.GetFileName(symbolPath.ItemSpec)}";
                                 File.Copy(symbolPath.ItemSpec, destFile);
+
+                                Log.LogMessage($"Copying symbol file from {symbolPath.ItemSpec} to {destFile}");
 
                                 Log.LogMessage(MessageImportance.High, 
                                     $"##vso[artifact.upload containerfolder=BlobArtifacts;artifactname=BlobArtifacts]{destFile}");

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
@@ -86,8 +86,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                             var destFile = $"{AssetsTemporaryDirectory}/{Path.GetFileName(packagePath.ItemSpec)}";
                             File.Copy(packagePath.ItemSpec, destFile);
 
-                            Log.LogMessage(MessageImportance.High, $"Copying package file from {packagePath.ItemSpec} to {destFile}");
-
                             Log.LogMessage(MessageImportance.High,
                                 $"##vso[artifact.upload containerfolder=PackageArtifacts;artifactname=PackageArtifacts]{destFile}");
                         }
@@ -96,8 +94,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         {
                             var destFile = $"{AssetsTemporaryDirectory}/{Path.GetFileName(symbolPath.ItemSpec)}";
                             File.Copy(symbolPath.ItemSpec, destFile);
-
-                            Log.LogMessage(MessageImportance.High, $"Copying symbol file from {symbolPath.ItemSpec} to {destFile}");
 
                             Log.LogMessage(MessageImportance.High,
                                 $"##vso[artifact.upload containerfolder=BlobArtifacts;artifactname=BlobArtifacts]{destFile}");

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
@@ -81,32 +81,26 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                             Directory.CreateDirectory(AssetsTemporaryDirectory);
                         }
 
-                        if (packageItems.Length > 0)
+                        foreach (var packagePath in packageItems)
                         {
-                            foreach (var packagePath in packageItems)
-                            {
-                                var destFile = $"{AssetsTemporaryDirectory}/{Path.GetFileName(packagePath.ItemSpec)}";
-                                File.Copy(packagePath.ItemSpec, destFile);
+                            var destFile = $"{AssetsTemporaryDirectory}/{Path.GetFileName(packagePath.ItemSpec)}";
+                            File.Copy(packagePath.ItemSpec, destFile);
 
-                                Log.LogMessage(MessageImportance.High, $"Copying package file from {packagePath.ItemSpec} to {destFile}");
+                            Log.LogMessage(MessageImportance.High, $"Copying package file from {packagePath.ItemSpec} to {destFile}");
 
-                                Log.LogMessage(MessageImportance.High,
-                                    $"##vso[artifact.upload containerfolder=PackageArtifacts;artifactname=PackageArtifacts]{destFile}");
-                            }
+                            Log.LogMessage(MessageImportance.High,
+                                $"##vso[artifact.upload containerfolder=PackageArtifacts;artifactname=PackageArtifacts]{destFile}");
                         }
 
-                        if (symbolItems.Length > 0)
+                        foreach (var symbolPath in symbolItems)
                         {
-                            foreach (var symbolPath in symbolItems)
-                            {
-                                var destFile = $"{AssetsTemporaryDirectory}/{Path.GetFileName(symbolPath.ItemSpec)}";
-                                File.Copy(symbolPath.ItemSpec, destFile);
+                            var destFile = $"{AssetsTemporaryDirectory}/{Path.GetFileName(symbolPath.ItemSpec)}";
+                            File.Copy(symbolPath.ItemSpec, destFile);
 
-                                Log.LogMessage(MessageImportance.High, $"Copying symbol file from {symbolPath.ItemSpec} to {destFile}");
+                            Log.LogMessage(MessageImportance.High, $"Copying symbol file from {symbolPath.ItemSpec} to {destFile}");
 
-                                Log.LogMessage(MessageImportance.High,
-                                    $"##vso[artifact.upload containerfolder=BlobArtifacts;artifactname=BlobArtifacts]{destFile}");
-                            }
+                            Log.LogMessage(MessageImportance.High,
+                                $"##vso[artifact.upload containerfolder=BlobArtifacts;artifactname=BlobArtifacts]{destFile}");
                         }
 
                         packageArtifacts = packageItems.Select(BuildManifestUtil.CreatePackageArtifactModel);


### PR DESCRIPTION
Some builds were failing because validate-sdk.ps1 tries to rename the artifacts folder while there were still some AzDO artifacts uploads in flight. The current PR makes tasks.Feed copy the assets to a temporary folder prior to uploading them as AzDO artifacts.