### PR TITLE
Revert NuGet.Versioning version to 4.4.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -33,7 +33,7 @@
     <MonoOptionsVersion>5.3.0.1</MonoOptionsVersion>
     <McMasterExtensionsCommandLineUtils>2.3.0</McMasterExtensionsCommandLineUtils>
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
-    <NuGetVersioningVersion>4.9.3</NuGetVersioningVersion>
+    <NuGetVersioningVersion>4.4.0</NuGetVersioningVersion>
     <NuGetVersion>4.9.3</NuGetVersion>
     <OctokitVersion>0.30.0</OctokitVersion>
     <DotNetSleetLibVersion>2.2.127</DotNetSleetLibVersion>


### PR DESCRIPTION
The newer version is causing build failures on .NET Core: https://dev.azure.com/dnceng/public/_build/results?buildId=116977
Need to investigate why, reverting meanwhile.