### PR TITLE
add support for '-' args and '/dl' in build.sh

### DIFF
--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -137,13 +137,16 @@ while [[ $# > 0 ]]; do
       node_reuse=$2
       shift
       ;;
-    /p:*)
+    -p:*|/p:*)
       properties="$properties $1"
       ;;
-    /m:*)
+    -m:*|/m:*)
       properties="$properties $1"
       ;;
-    /bl:*)
+    -bl:*|/bl:*)
+      properties="$properties $1"
+      ;;
+    -dl:*|/dl:*)
       properties="$properties $1"
       ;;
     *)


### PR DESCRIPTION
We made this change in aspnet/Extensions in order to support passing the Azure Pipelines MSBuild logger through `build.sh` (see https://github.com/aspnet/Extensions/pull/1226). I'm presuming we should update the "central" copy so we don't drive apart. Let me know if this is the wrong place to do this :).

I also added support for `-` args since MSBuild supports them and they're more common in POSIX environments.