### PR TITLE
Pass license expression string to LicenseMetadata

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateNuSpec.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateNuSpec.cs
@@ -182,11 +182,11 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             if (!string.IsNullOrEmpty(PackageLicenseExpression))
             {
                 manifestMetadata.LicenseMetadata = new LicenseMetadata(
-                    LicenseType.Expression,
-                    license: "",
-                    NuGetLicenseExpression.Parse(PackageLicenseExpression),
-                    Array.Empty<string>(),
-                    LicenseMetadata.CurrentVersion);
+                    type: LicenseType.Expression,
+                    license: PackageLicenseExpression,
+                    expression: NuGetLicenseExpression.Parse(PackageLicenseExpression),
+                    warningsAndErrors: null,
+                    LicenseMetadata.EmptyVersion);
 
             }
             else if (!string.IsNullOrEmpty(LicenseUrl))


### PR DESCRIPTION
Pass the same parameters as NuGet implementation.