### PR TITLE
Move BuildAssetManifest to temporary location

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,8 @@ variables:
   # Cannot use key:value syntax in root defined variables
   - name: _TeamName
     value: DotNetCore
+  - name: _PublishUsingPipelines
+    value: false
 
 resources:
   containers:
@@ -48,6 +50,7 @@ jobs:
             /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
             /p:DotNetPublishBlobFeedUrl=$(_PublishBlobFeedUrl)
             /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
+            /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
             /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
 
       strategy:

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -161,7 +161,7 @@
       ManifestCommit="$(BUILD_SOURCEVERSION)"
       PublishFlatContainer="false"
       AssetManifestPath="$(AssetManifestFilePath)"
-      AssetsTemporaryDirectory="$(ArtifactsDir)\..\AssetsTmpDir\$([System.Guid]::NewGuid())" />
+      AssetsTemporaryDirectory="$(TempWorkingDirectory)" />
 
     <!--
       The publishing pipeline (implemented by PublishToPackageFeed.proj) will use the Tasks.Feed package

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -24,7 +24,9 @@
     
     <PublishToSymbolServer>false</PublishToSymbolServer>
     <PublishToSymbolServer Condition="'$(UsingToolSymbolUploader)' == 'true' and '$(AzureFeedUrl)' == '' and '$(ContinuousIntegrationBuild)' == 'true'">true</PublishToSymbolServer>
-    <AssetManifestFilePath>$(ArtifactsLogDir)AssetManifest\$(OS)-$(PlatformName).xml</AssetManifestFilePath>
+
+    <AssetManifestFileName>$(OS)-$(PlatformName).xml</AssetManifestFileName>
+    <AssetManifestFilePath>$(ArtifactsLogDir)AssetManifest\$(AssetManifestFileName)</AssetManifestFilePath>
 
     <SymbolPackagesDir>$(ArtifactsTmpDir)SymbolPackages\</SymbolPackagesDir>
 
@@ -125,6 +127,8 @@
 		
 			<!-- When we have <account>.visualstudio.com -->
       <AzureDevOpsAccount Condition="$(CollectionUri.IndexOf('visualstudio.com')) >= 0">$(CollectionUri.Split('.')[0].Split('/')[2])</AzureDevOpsAccount>
+
+      <TempWorkingDirectory>$(ArtifactsDir)\..\AssetsTmpDir\$([System.Guid]::NewGuid())</TempWorkingDirectory>
     </PropertyGroup>
 
     <!--
@@ -142,6 +146,12 @@
       <NewManifestBuildData Include="AzureDevOpsBranch=$(BUILD_SOURCEBRANCH)" />
     </ItemGroup>
 
+    <!-- 
+      Due to interferences with validate-sdk.ps1 we need to copy a 
+      few files to some temporary location until they are published as AzDO artifacts. 
+    -->
+    <MakeDir Directories="$(TempWorkingDirectory)"/>
+    
     <PushToAzureDevOpsArtifacts 
       ItemsToPush="@(ItemsToPushToBlobFeed)"
       ManifestBuildData="@(NewManifestBuildData)"
@@ -173,8 +183,12 @@
       Condition="Exists('$(RepositoryEngineeringDir)Versions.props')"
       Importance="high" />
 
+    <Copy 
+      SourceFiles="$(AssetManifestFilePath)" 
+      DestinationFolder="$(TempWorkingDirectory)\$(AssetManifestFileName)" />
+    
     <Message
-      Text="##vso[artifact.upload containerfolder=AssetManifests;artifactname=AssetManifests]$(AssetManifestFilePath)"
+      Text="##vso[artifact.upload containerfolder=AssetManifests;artifactname=AssetManifests]$(TempWorkingDirectory)\$(AssetManifestFileName)"
       Importance="high" />
 
     <!-- 


### PR DESCRIPTION
The build manifest also is under `artifacts` folder.. so it's also conflicting with the change made by validate-sdk.ps1.