### PR TITLE
Set IgnoreProfileNotGeneratedExceptions to true

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/VisualStudio.IbcTraining.runsettings
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/VisualStudio.IbcTraining.runsettings
@@ -47,6 +47,7 @@
         <Configuration>
           <WorkingDirectory>C:\OptProf</WorkingDirectory>
           <ProfilesDirectory>C:\Profiles</ProfilesDirectory>
+          <IgnoreProfileNotGeneratedExceptions>true</IgnoreProfileNotGeneratedExceptions>
           <Deployment PackageName="Microsoft.DevDiv.TestExtensions.OptProfDataCollector" />
         </Configuration>
       </InProcDataCollector>


### PR DESCRIPTION
This will enable IBC training to report errors for all issues except for when module isn't covered by training scenario