### PR TITLE
Remove VB test sdk exclusion

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/vstest/VSTest.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/vstest/VSTest.targets
@@ -2,8 +2,7 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
 
-  <!-- TODO: Fix VB test project reference to Test SDK. -->
-  <Import Condition="'$(Language)' != 'VB' AND ('$(BuildingNETCoreAppVertical)' == 'true' OR '$(BuildingNETFxVertical)' == 'true')" Project="$(RuntimePath)Microsoft.NET.Test.Sdk.targets" />
+  <Import Condition="'$(BuildingNETCoreAppVertical)' == 'true' OR '$(BuildingNETFxVertical)' == 'true'" Project="$(RuntimePath)Microsoft.NET.Test.Sdk.targets" />
 
   <Choose>
     <When Condition="'$(BuildingNETCoreAppVertical)' == 'true'">  


### PR DESCRIPTION
Fixed in VSTest with https://github.com/Microsoft/vstest/commit/1a2c1b254b764c03b78093f53010b4fa7bb45694