### PR TITLE
Add location as attribute of the manifest 

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -144,6 +144,12 @@
       <NewManifestBuildData Include="AzureDevOpsBuildNumber=$(BUILD_BUILDNUMBER)" />
       <NewManifestBuildData Include="AzureDevOpsRepository=$(BUILD_REPOSITORY_URI)" />
       <NewManifestBuildData Include="AzureDevOpsBranch=$(BUILD_SOURCEBRANCH)" />
+
+      <!-- 
+        Adding this just to not fail the validation when creating the manifest. 
+        TODO: Should be removed once PublishingUsingPipelines is the default.
+      -->
+      <NewManifestBuildData Include="Location=$(AzureFeedUrl)" />
     </ItemGroup>
 
     <!-- 


### PR DESCRIPTION
Add location as attribute to the manifest file so that we don't fail on the manifest validation in Tasks.Feed.

This will be reverted eventually when PublishingUsingPipelines is the default option.