### PR TITLE
Remove parallelization from these calls

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/CheckHelixJobStatus.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CheckHelixJobStatus.cs
@@ -46,7 +46,11 @@ namespace Microsoft.DotNet.Helix.Sdk
             if (FailOnWorkItemFailure)
             {
                 // determines whether any of the work items failed (fireballed)
-                await Task.WhenAll(workItems.Select(wi => CheckForWorkItemFailureAsync(wi.Name, jobName)));
+                // Doing these all in parallel overloads the Helix server
+                foreach (var wi in workItems)
+                {
+                    await CheckForWorkItemFailureAsync(wi.Name, jobName);
+                }
             }
 
             if (FailOnMissionControlTestFailure)


### PR DESCRIPTION
When multiple builds run this code in parallel, the server crashes because it openes
hundreds of tcp connections to our server, which causes it to attempt to open
hundreds of tcp connections to SQL and Kusto.

This always slows everything down, and often results in dropped connections.
We experienced over 1 million failed requests last week because of this.
And many requests that usually take a few seconds were taking almost 2 minutes.

Later we'll create a better API to get this data is one call, but right now we need
the Helix service to stop dying.