### PR TITLE
Log IBC XML and NGEN list

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/ExtractNgenMethodList.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/ExtractNgenMethodList.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Reflection.PortableExecutable;
+using System.Threading;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.Arcade.Sdk
+{
+    /// <summary>
+    /// Used to convert a raw XML dump from IBCMerge into the set of methods which will be NGEN'd when 
+    /// partial NGEN is enabled
+    /// </summary>
+    public sealed class ExtractNgenMethodList : Task
+    {
+        /// <summary>
+        /// Resources (resx) file.
+        /// </summary>
+        [Required]
+        public string IbcXmlFilePath { get; set; }
+
+        [Required]
+        public string OutputPath { get; set; }
+
+        public override bool Execute()
+        {
+            var document = XDocument.Load(IbcXmlFilePath);
+            var items = new List<string>();
+            var parentElement = document.Root.Element("MethodProfilingData");
+            if (parentElement != null)
+            {
+                foreach (var child in parentElement.Elements("Item"))
+                {
+                    var flags = child.Attribute("flags");
+                    var name = child.Attribute("name");
+                    if (flags?.Value.Contains("ReadMethodCode") == true && name != null)
+                    {
+                        items.Add(name.Value);
+                    }
+                }
+            }
+
+            items.Sort();
+            var outputFilePath = Path.ChangeExtension(IbcXmlFilePath, ".ngen.txt");
+            using (var outputFileStream = new StreamWriter(outputFilePath, append: false))
+            {
+                foreach (var item in items)
+                {
+                    outputFileStream.WriteLine(item);
+                }
+            }
+
+            return true;
+        } 
+    }
+}

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/ExtractNgenMethodList.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/ExtractNgenMethodList.cs
@@ -23,13 +23,17 @@ namespace Microsoft.DotNet.Arcade.Sdk
     public sealed class ExtractNgenMethodList : Task
     {
         /// <summary>
-        /// Resources (resx) file.
+        /// This is the XML file produced by passing -dxml to ibcmerge. It will be transformed into the set of
+        /// methods marked for NGEN in the assembly
         /// </summary>
         [Required]
         public string IbcXmlFilePath { get; set; }
 
+        /// <summary>
+        /// This is the directory the NGEN list should be output to
+        /// </summary>
         [Required]
-        public string OutputPath { get; set; }
+        public string OutputDirectory { get; set; }
 
         public override bool Execute()
         {
@@ -50,7 +54,8 @@ namespace Microsoft.DotNet.Arcade.Sdk
             }
 
             items.Sort();
-            var outputFilePath = Path.ChangeExtension(IbcXmlFilePath, ".ngen.txt");
+            var outputFileName = Path.ChangeExtension(Path.GetFileName(IbcXmlFilePath), ".ngen.txt");
+            var outputFilePath = Path.Combine(OutputDirectory, outputFileName);
             using (var outputFileStream = new StreamWriter(outputFilePath, append: false))
             {
                 foreach (var item in items)

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/ExtractNgenMethodList.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/ExtractNgenMethodList.cs
@@ -54,6 +54,8 @@ namespace Microsoft.DotNet.Arcade.Sdk
             }
 
             items.Sort();
+
+            Directory.CreateDirectory(OutputDirectory);
             var outputFileName = Path.ChangeExtension(Path.GetFileName(IbcXmlFilePath), ".ngen.txt");
             var outputFilePath = Path.Combine(OutputDirectory, outputFileName);
             using (var outputFileStream = new StreamWriter(outputFilePath, append: false))

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
@@ -28,8 +28,7 @@
 
     <EnableNgenOptimization Condition="'$(EnableNgenOptimization)' == ''">$(EnablePartialNgenOptimization)</EnableNgenOptimization>
     <ApplyNgenOptimization Condition="'$(ApplyPartialNgenOptimization)' == 'true'">partial</ApplyNgenOptimization>
-    <ArtifactsIbcDirXml>$(ArtifactsIbcDir)\xml</ArtifactsIbcDirXml>
-    <ArtifactsIbcDirNgen>$(ArtifactsIbcDir)\ngen</ArtifactsIbcDirNgen>
+    <_IbcMergeXmlOutputDir>$(ArtifactsTmpDir)ibcxml</_IbcMergeXmlOutputDir>
   </PropertyGroup>
 
   <!--
@@ -106,8 +105,7 @@
                               PreviousAssemblyPath="%(_IbcFile.PreviousAssemblyDir)\%(_IbcFile.AssemblyFileName)"
                               PreviousAssemblyCopyPath="$(ArtifactsTmpDir)OptimizedAssemblies\$([System.Guid]::NewGuid())"
                               OptimizeAssemblyPath="%(_IbcFile.OptimizeAssemblyPath)"
-                              XmlOutputPath="$(ArtifactsIbcDirXml)\%(_IbcFile.AssemblyFileName).ibc.xml"
-                              />
+                              XmlOutputPath="$(_IbcMergeXmlOutputDir)\%(_IbcFile.AssemblyFileName).ibc.xml" />
     </ItemGroup>
 
     <Error Text="No optimization data found for assemblies: @(_AssemblyWithoutRawIbcData, ', ')"
@@ -160,8 +158,8 @@
              Condition="'$(_RunIbcMerge)' != 'true'" 
              Importance="normal"/>
 
-    <MakeDir Directories="$(ArtifactsIbcDirXml)" />
-    <MakeDir Directories="$(ArtifactsIbcDirNgen)" />
+    <MakeDir Directories="$(_IbcMergeXmlOutputDir)" />
+    <MakeDir Directories="$(ArtifactsLogNgenDir)" />
 
     <Copy SourceFiles="%(_IbcMergeInvocation.CopyFilesSource)" 
           DestinationFiles="%(_IbcMergeInvocation.CopyFilesDestination)" 
@@ -175,7 +173,7 @@
 
     <!-- Remove Authenticode signing record if present. -->
     <Microsoft.DotNet.Arcade.Sdk.Unsign FilePath="%(_IbcMergeInvocation.UnsignFile)" Condition="'%(_IbcMergeInvocation.UnsignFile)' != ''" />
-    <Microsoft.DotNet.Arcade.Sdk.ExtractNgenMethodList IbcXmlFilePath="%(_IbcMergeInvocation.IbcXmlDocFilePath)" OutputDirectory="$(ArtifactsIbcDirNgen)" Condition="'%(_IbcMergeInvocation.IbcXmlDocFilePath)' != ''"/>
+    <Microsoft.DotNet.Arcade.Sdk.ExtractNgenMethodList IbcXmlFilePath="%(_IbcMergeInvocation.IbcXmlDocFilePath)" OutputDirectory="$(ArtifactsLogNgenDir)" Condition="'%(_IbcMergeInvocation.IbcXmlDocFilePath)' != ''"/>
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
@@ -28,6 +28,8 @@
 
     <EnableNgenOptimization Condition="'$(EnableNgenOptimization)' == ''">$(EnablePartialNgenOptimization)</EnableNgenOptimization>
     <ApplyNgenOptimization Condition="'$(ApplyPartialNgenOptimization)' == 'true'">partial</ApplyNgenOptimization>
+    <ArtifactsIbcDirXml>$(ArtifactsIbcDir)\xml</ArtifactsIbcDirXml>
+    <ArtifactsIbcDirNgen>$(ArtifactsIbcDir)\ngen</ArtifactsIbcDirNgen>
   </PropertyGroup>
 
   <!--
@@ -103,7 +105,9 @@
                               IbcFiles="%(_IbcFile.Identity)"
                               PreviousAssemblyPath="%(_IbcFile.PreviousAssemblyDir)\%(_IbcFile.AssemblyFileName)"
                               PreviousAssemblyCopyPath="$(ArtifactsTmpDir)OptimizedAssemblies\$([System.Guid]::NewGuid())"
-                              OptimizeAssemblyPath="%(_IbcFile.OptimizeAssemblyPath)" />
+                              OptimizeAssemblyPath="%(_IbcFile.OptimizeAssemblyPath)"
+                              XmlOutputPath="$(ArtifactsIbcDirXml)\%(_IbcFile.AssemblyFileName).ibc.xml"
+                              />
     </ItemGroup>
 
     <Error Text="No optimization data found for assemblies: @(_AssemblyWithoutRawIbcData, ', ')"
@@ -134,8 +138,8 @@
           -delete to delete data previously embedded in the binary. This is a no-op for binaries produced by this build, but is needed for dependencies such as System.Reflection.Metadata.
           -incremental to map data stored in the optimized binary, which comes from a previous build, to the new build of the binary.
         -->
-        <IbcXmlDocFilePath>$(ArtifactsIbcDir)\%(_AssemblyWithRawIbcData.AssemblyFileName).ibc.xml</IbcXmlDocFilePath>
-        <IbcMergeArgs>-q -f $(_PartialNgenArg) -minify -delete -mo "%(_AssemblyWithRawIbcData.OptimizeAssemblyPath)" -incremental "%(_AssemblyWithRawIbcData.PreviousAssemblyCopyPath)" -dxml "$(ArtifactsIbcDir)\%(_AssemblyWithRawIbcData.AssemblyFileName).ibc.xml"</IbcMergeArgs>
+        <IbcXmlDocFilePath>%(_AssemblyWithRawIbcData.XmlOutputPath)</IbcXmlDocFilePath>
+        <IbcMergeArgs>-q -f $(_PartialNgenArg) -minify -delete -mo "%(_AssemblyWithRawIbcData.OptimizeAssemblyPath)" -incremental "%(_AssemblyWithRawIbcData.PreviousAssemblyCopyPath)" -dxml "%(_AssemblyWithRawIbcData.XmlOutputPath)"</IbcMergeArgs>
 
         <UnsignFile>%(_AssemblyWithRawIbcData.OptimizeAssemblyPath)</UnsignFile>
       </_IbcMergeInvocation>
@@ -156,7 +160,9 @@
              Condition="'$(_RunIbcMerge)' != 'true'" 
              Importance="normal"/>
 
-    <MakeDir Directories="$(ArtifactsIbcDir)" />
+    <MakeDir Directories="$(ArtifactsIbcDirXml)" />
+    <MakeDir Directories="$(ArtifactsIbcDirNgen)" />
+
     <Copy SourceFiles="%(_IbcMergeInvocation.CopyFilesSource)" 
           DestinationFiles="%(_IbcMergeInvocation.CopyFilesDestination)" 
           Condition="'%(_IbcMergeInvocation.CopyFilesSource)' != ''" />
@@ -169,7 +175,7 @@
 
     <!-- Remove Authenticode signing record if present. -->
     <Microsoft.DotNet.Arcade.Sdk.Unsign FilePath="%(_IbcMergeInvocation.UnsignFile)" Condition="'%(_IbcMergeInvocation.UnsignFile)' != ''" />
-    <Microsoft.DotNet.Arcade.Sdk.ExtractNgenMethodList IbcXmlFilePath="%(_IbcMergeInvocation.IbcXmlDocFilePath)" OutputPath="'$(ArtifactsIbcDir)'" Condition="'%(_IbcMergeInvocation.IbcXmlDocFilePath)' != ''"/>
+    <Microsoft.DotNet.Arcade.Sdk.ExtractNgenMethodList IbcXmlFilePath="%(_IbcMergeInvocation.IbcXmlDocFilePath)" OutputDirectory="$(ArtifactsIbcDirNgen)" Condition="'%(_IbcMergeInvocation.IbcXmlDocFilePath)' != ''"/>
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
@@ -6,6 +6,7 @@
     Properties:
       IbcOptimizationDataDir             The directory containing IBC optimization data. Optimization data are not applied if unset.
       EnableNgenOptimization             Set to true to enable NGEN optimization (partial or full).
+      EnableNgenOptimizationLogDetails   Set to true to enable NGEN method logging output
       ApplyNgenOptimization              Set to 'partial' or 'full' in a project to embed partial/full NGEN optimization data to the built binary.
 
     Obsolete (https://github.com/dotnet/arcade/issues/2092):
@@ -130,7 +131,6 @@
           -delete to delete data previously embedded in the binary. 
         -->
         <IbcMergeArgs>-q -f $(_PartialNgenArg) -minify -delete -mo "%(_AssemblyWithRawIbcData.PreviousAssemblyCopyPath)" "$([MSBuild]::ValueOrDefault('%(_AssemblyWithRawIbcData.IbcFiles)', '').Replace(';', '" "'))"</IbcMergeArgs>
-        <XmlOutputPath>%(_AssemblyWithRawIbcData.XmlOutputPath)</XmlOutputPath>
       </_IbcMergeInvocation>
 
       <_IbcMergeInvocation Include="%(_AssemblyWithRawIbcData.AssemblyFileName) [MergePreviousToCurrent]">
@@ -144,7 +144,7 @@
       </_IbcMergeInvocation>
 
       <_IbcMergeInvocation Condition="'$(EnableNgenOptimizationLogDetails)' == 'true'">
-        <IbcMergeArgs>%(_IbcMergeInvocation.IbcMergeArgs) -dxml "%(_IbcMergeInvocation.XmlOutputPath)"</IbcMergeArgs>
+        <IbcMergeArgs Condition="'%(_IbcMergeInvocation.XmlOutputPath)' != ''">%(_IbcMergeInvocation.IbcMergeArgs) -dxml "%(_IbcMergeInvocation.XmlOutputPath)"</IbcMergeArgs>
       </_IbcMergeInvocation>
     </ItemGroup>
   </Target>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
@@ -18,6 +18,7 @@
 
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.Unsign" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GroupItemsBy" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.ExtractNgenMethodList" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
 
   <PropertyGroup>
     <PostCompileBinaryModificationSentinelFile>$(IntermediateOutputPath)$(TargetFileName).pcbm</PostCompileBinaryModificationSentinelFile>
@@ -133,6 +134,7 @@
           -delete to delete data previously embedded in the binary. This is a no-op for binaries produced by this build, but is needed for dependencies such as System.Reflection.Metadata.
           -incremental to map data stored in the optimized binary, which comes from a previous build, to the new build of the binary.
         -->
+        <IbcXmlDocFilePath>$(ArtifactsIbcDir)\%(_AssemblyWithRawIbcData.AssemblyFileName).ibc.xml</IbcXmlDocFilePath>
         <IbcMergeArgs>-q -f $(_PartialNgenArg) -minify -delete -mo "%(_AssemblyWithRawIbcData.OptimizeAssemblyPath)" -incremental "%(_AssemblyWithRawIbcData.PreviousAssemblyCopyPath)" -dxml "$(ArtifactsIbcDir)\%(_AssemblyWithRawIbcData.AssemblyFileName).ibc.xml"</IbcMergeArgs>
 
         <UnsignFile>%(_AssemblyWithRawIbcData.OptimizeAssemblyPath)</UnsignFile>
@@ -167,6 +169,7 @@
 
     <!-- Remove Authenticode signing record if present. -->
     <Microsoft.DotNet.Arcade.Sdk.Unsign FilePath="%(_IbcMergeInvocation.UnsignFile)" Condition="'%(_IbcMergeInvocation.UnsignFile)' != ''" />
+    <Microsoft.DotNet.Arcade.Sdk.ExtractNgenMethodList IbcXmlFilePath="%(_IbcMergeInvocation.IbcXmlDocFilePath)" OutputPath="'$(ArtifactsIbcDir)'" Condition="'%(_IbcMergeInvocation.IbcXmlDocFilePath)' != ''"/>
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
@@ -27,6 +27,7 @@
     <EnablePartialNgenOptimization Condition="'$(EnablePartialNgenOptimization)' == '' and '$(Configuration)' == 'Release' and '$(OfficialBuild)' == 'true'">true</EnablePartialNgenOptimization>
 
     <EnableNgenOptimization Condition="'$(EnableNgenOptimization)' == ''">$(EnablePartialNgenOptimization)</EnableNgenOptimization>
+    <EnableNgenOptimizationLogDetails Condition="'$(EnableNgenOptimizationLogDetails)' == ''">$(UsingToolVisualStudioIbcTraining)</EnableNgenOptimizationLogDetails>
     <ApplyNgenOptimization Condition="'$(ApplyPartialNgenOptimization)' == 'true'">partial</ApplyNgenOptimization>
     <_IbcMergeXmlOutputDir>$(ArtifactsTmpDir)ibcxml</_IbcMergeXmlOutputDir>
   </PropertyGroup>
@@ -129,6 +130,7 @@
           -delete to delete data previously embedded in the binary. 
         -->
         <IbcMergeArgs>-q -f $(_PartialNgenArg) -minify -delete -mo "%(_AssemblyWithRawIbcData.PreviousAssemblyCopyPath)" "$([MSBuild]::ValueOrDefault('%(_AssemblyWithRawIbcData.IbcFiles)', '').Replace(';', '" "'))"</IbcMergeArgs>
+        <XmlOutputPath>%(_AssemblyWithRawIbcData.XmlOutputPath)</XmlOutputPath>
       </_IbcMergeInvocation>
 
       <_IbcMergeInvocation Include="%(_AssemblyWithRawIbcData.AssemblyFileName) [MergePreviousToCurrent]">
@@ -136,10 +138,13 @@
           -delete to delete data previously embedded in the binary. This is a no-op for binaries produced by this build, but is needed for dependencies such as System.Reflection.Metadata.
           -incremental to map data stored in the optimized binary, which comes from a previous build, to the new build of the binary.
         -->
-        <IbcXmlDocFilePath>%(_AssemblyWithRawIbcData.XmlOutputPath)</IbcXmlDocFilePath>
-        <IbcMergeArgs>-q -f $(_PartialNgenArg) -minify -delete -mo "%(_AssemblyWithRawIbcData.OptimizeAssemblyPath)" -incremental "%(_AssemblyWithRawIbcData.PreviousAssemblyCopyPath)" -dxml "%(_AssemblyWithRawIbcData.XmlOutputPath)"</IbcMergeArgs>
-
+        <IbcMergeArgs>-q -f $(_PartialNgenArg) -minify -delete -mo "%(_AssemblyWithRawIbcData.OptimizeAssemblyPath)" -incremental "%(_AssemblyWithRawIbcData.PreviousAssemblyCopyPath)"</IbcMergeArgs>
         <UnsignFile>%(_AssemblyWithRawIbcData.OptimizeAssemblyPath)</UnsignFile>
+        <XmlOutputPath>%(_AssemblyWithRawIbcData.XmlOutputPath)</XmlOutputPath>
+      </_IbcMergeInvocation>
+
+      <_IbcMergeInvocation Condition="'$(EnableNgenOptimizationLogDetails)' == 'true'">
+        <IbcMergeArgs>%(_IbcMergeInvocation.IbcMergeArgs) -dxml "%(_IbcMergeInvocation.XmlOutputPath)"</IbcMergeArgs>
       </_IbcMergeInvocation>
     </ItemGroup>
   </Target>
@@ -159,7 +164,6 @@
              Importance="normal"/>
 
     <MakeDir Directories="$(_IbcMergeXmlOutputDir)" />
-    <MakeDir Directories="$(ArtifactsLogNgenDir)" />
 
     <Copy SourceFiles="%(_IbcMergeInvocation.CopyFilesSource)" 
           DestinationFiles="%(_IbcMergeInvocation.CopyFilesDestination)" 
@@ -173,7 +177,7 @@
 
     <!-- Remove Authenticode signing record if present. -->
     <Microsoft.DotNet.Arcade.Sdk.Unsign FilePath="%(_IbcMergeInvocation.UnsignFile)" Condition="'%(_IbcMergeInvocation.UnsignFile)' != ''" />
-    <Microsoft.DotNet.Arcade.Sdk.ExtractNgenMethodList IbcXmlFilePath="%(_IbcMergeInvocation.IbcXmlDocFilePath)" OutputDirectory="$(ArtifactsLogNgenDir)" Condition="'%(_IbcMergeInvocation.IbcXmlDocFilePath)' != ''"/>
+    <Microsoft.DotNet.Arcade.Sdk.ExtractNgenMethodList IbcXmlFilePath="%(_IbcMergeInvocation.XmlOutputPath)" OutputDirectory="$(ArtifactsLogNgenDir)" Condition="'%(_IbcMergeInvocation.XmlOutputPath)' != ''"/>
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
@@ -27,6 +27,7 @@
 
     <EnableNgenOptimization Condition="'$(EnableNgenOptimization)' == ''">$(EnablePartialNgenOptimization)</EnableNgenOptimization>
     <ApplyNgenOptimization Condition="'$(ApplyPartialNgenOptimization)' == 'true'">partial</ApplyNgenOptimization>
+    <EnableNgenOptimizationLogging Condition="'$(EnableNgenOptimizationLogging)' == ''">true</EnableNgenOptimizationLogging>
   </PropertyGroup>
 
   <!--
@@ -134,6 +135,7 @@
           -incremental to map data stored in the optimized binary, which comes from a previous build, to the new build of the binary.
         -->
         <IbcMergeArgs>-q -f $(_PartialNgenArg) -minify -delete -mo "%(_AssemblyWithRawIbcData.OptimizeAssemblyPath)" -incremental "%(_AssemblyWithRawIbcData.PreviousAssemblyCopyPath)"</IbcMergeArgs>
+        <IbcMergeArgs Condition="'$(EnableNgenOptimizationLogging)' == 'true'">$(IbcMergeArgs) "$(ArtifactsIbcDir)\%(_AssemblyWithRawIbcData.AssemblyFileName).ibc.xml"</IbcMergeArgs>
 
         <UnsignFile>%(_AssemblyWithRawIbcData.OptimizeAssemblyPath)</UnsignFile>
       </_IbcMergeInvocation>
@@ -154,6 +156,7 @@
              Condition="'$(_RunIbcMerge)' != 'true'" 
              Importance="normal"/>
 
+    <MakDir Directories="$(ArtifactsIbcDir)" />
     <Copy SourceFiles="%(_IbcMergeInvocation.CopyFilesSource)" 
           DestinationFiles="%(_IbcMergeInvocation.CopyFilesDestination)" 
           Condition="'%(_IbcMergeInvocation.CopyFilesSource)' != ''" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
@@ -27,7 +27,6 @@
 
     <EnableNgenOptimization Condition="'$(EnableNgenOptimization)' == ''">$(EnablePartialNgenOptimization)</EnableNgenOptimization>
     <ApplyNgenOptimization Condition="'$(ApplyPartialNgenOptimization)' == 'true'">partial</ApplyNgenOptimization>
-    <EnableNgenOptimizationLogging Condition="'$(EnableNgenOptimizationLogging)' == ''">true</EnableNgenOptimizationLogging>
   </PropertyGroup>
 
   <!--
@@ -134,8 +133,7 @@
           -delete to delete data previously embedded in the binary. This is a no-op for binaries produced by this build, but is needed for dependencies such as System.Reflection.Metadata.
           -incremental to map data stored in the optimized binary, which comes from a previous build, to the new build of the binary.
         -->
-        <IbcMergeArgs>-q -f $(_PartialNgenArg) -minify -delete -mo "%(_AssemblyWithRawIbcData.OptimizeAssemblyPath)" -incremental "%(_AssemblyWithRawIbcData.PreviousAssemblyCopyPath)"</IbcMergeArgs>
-        <IbcMergeArgs Condition="'$(EnableNgenOptimizationLogging)' == 'true'">$(IbcMergeArgs) "$(ArtifactsIbcDir)\%(_AssemblyWithRawIbcData.AssemblyFileName).ibc.xml"</IbcMergeArgs>
+        <IbcMergeArgs>-q -f $(_PartialNgenArg) -minify -delete -mo "%(_AssemblyWithRawIbcData.OptimizeAssemblyPath)" -incremental "%(_AssemblyWithRawIbcData.PreviousAssemblyCopyPath)" -dxml "$(ArtifactsIbcDir)\%(_AssemblyWithRawIbcData.AssemblyFileName).ibc.xml"</IbcMergeArgs>
 
         <UnsignFile>%(_AssemblyWithRawIbcData.OptimizeAssemblyPath)</UnsignFile>
       </_IbcMergeInvocation>
@@ -156,7 +154,7 @@
              Condition="'$(_RunIbcMerge)' != 'true'" 
              Importance="normal"/>
 
-    <MakDir Directories="$(ArtifactsIbcDir)" />
+    <MakeDir Directories="$(ArtifactsIbcDir)" />
     <Copy SourceFiles="%(_IbcMergeInvocation.CopyFilesSource)" 
           DestinationFiles="%(_IbcMergeInvocation.CopyFilesDestination)" 
           Condition="'%(_IbcMergeInvocation.CopyFilesSource)' != ''" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props
@@ -56,6 +56,7 @@
     <ArtifactsPackagesDir>$(ArtifactsDir)packages\$(Configuration)\</ArtifactsPackagesDir>
     <ArtifactsShippingPackagesDir>$(ArtifactsPackagesDir)Shipping\</ArtifactsShippingPackagesDir>
     <ArtifactsNonShippingPackagesDir>$(ArtifactsPackagesDir)NonShipping\</ArtifactsNonShippingPackagesDir>
+    <ArtifactsIbcDir>$(ArtifactsDir)\ibc\</ArtifactsIbcDir>
     <VisualStudioSetupOutputPath>$(ArtifactsDir)VSSetup\$(Configuration)\</VisualStudioSetupOutputPath>
     <VisualStudioSetupInsertionPath>$(VisualStudioSetupOutputPath)Insertion\</VisualStudioSetupInsertionPath>
     <VisualStudioSetupIntermediateOutputPath>$(ArtifactsDir)VSSetup.obj\$(Configuration)\</VisualStudioSetupIntermediateOutputPath>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props
@@ -50,7 +50,7 @@
     <ArtifactsObjDir>$(ArtifactsDir)obj\</ArtifactsObjDir>
     <ArtifactsBinDir>$(ArtifactsDir)bin\</ArtifactsBinDir>
     <ArtifactsLogDir>$(ArtifactsDir)log\$(Configuration)\</ArtifactsLogDir>
-    <ArtifactsLogNgenDir>$(ArtifactsLogDir)ngen</ArtifactsLogNgenDir>
+    <ArtifactsLogNgenDir>$(ArtifactsLogDir)ngen\</ArtifactsLogNgenDir>
     <ArtifactsTmpDir>$(ArtifactsDir)tmp\$(Configuration)\</ArtifactsTmpDir>
     <ArtifactsTestResultsDir>$(ArtifactsDir)TestResults\$(Configuration)\</ArtifactsTestResultsDir>
     <ArtifactsSymStoreDirectory>$(ArtifactsDir)SymStore\$(Configuration)\</ArtifactsSymStoreDirectory>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props
@@ -50,13 +50,13 @@
     <ArtifactsObjDir>$(ArtifactsDir)obj\</ArtifactsObjDir>
     <ArtifactsBinDir>$(ArtifactsDir)bin\</ArtifactsBinDir>
     <ArtifactsLogDir>$(ArtifactsDir)log\$(Configuration)\</ArtifactsLogDir>
+    <ArtifactsLogNgenDir>$(ArtifactsLogDir)ngen</ArtifactsLogNgenDir>
     <ArtifactsTmpDir>$(ArtifactsDir)tmp\$(Configuration)\</ArtifactsTmpDir>
     <ArtifactsTestResultsDir>$(ArtifactsDir)TestResults\$(Configuration)\</ArtifactsTestResultsDir>
     <ArtifactsSymStoreDirectory>$(ArtifactsDir)SymStore\$(Configuration)\</ArtifactsSymStoreDirectory>
     <ArtifactsPackagesDir>$(ArtifactsDir)packages\$(Configuration)\</ArtifactsPackagesDir>
     <ArtifactsShippingPackagesDir>$(ArtifactsPackagesDir)Shipping\</ArtifactsShippingPackagesDir>
     <ArtifactsNonShippingPackagesDir>$(ArtifactsPackagesDir)NonShipping\</ArtifactsNonShippingPackagesDir>
-    <ArtifactsIbcDir>$(ArtifactsDir)\ibc\</ArtifactsIbcDir>
     <VisualStudioSetupOutputPath>$(ArtifactsDir)VSSetup\$(Configuration)\</VisualStudioSetupOutputPath>
     <VisualStudioSetupInsertionPath>$(VisualStudioSetupOutputPath)Insertion\</VisualStudioSetupInsertionPath>
     <VisualStudioSetupIntermediateOutputPath>$(ArtifactsDir)VSSetup.obj\$(Configuration)\</VisualStudioSetupIntermediateOutputPath>


### PR DESCRIPTION
This changes the IBCMerge task to document the set of methods marked for NGEN. This will be documented in the folder `artifacts\log\<Configuration>\ngen`. 

Example of the NGEN file list:

```
!0 Microsoft.CodeAnalysis.PooledObjects.ObjectPool`1<System.__Canon>.Allocate()
!0 Microsoft.CodeAnalysis.PooledObjects.ObjectPool`1<System.__Canon>.AllocateSlow()
!0 Microsoft.CodeAnalysis.PooledObjects.ObjectPool`1<System.__Canon>.CreateInstance()
bool Microsoft.CodeAnalysis.ExpressionEvaluator.DkmEvaluationResultFlagsExtensions::Includes(value class [Microsoft.VisualStudio.Debugger.Engine]Microsoft.VisualStudio.Debugger.Evaluation.DkmEvaluationResultFlags,value class [Microsoft.VisualStudio.Debugger.Engine]Microsoft.VisualStudio.Debugger.Evaluation.DkmEvaluationResultFlags)
instance bool Microsoft.CodeAnalysis.ExpressionEvaluator.Formatter::NeedsParentheses(System.String)
instance Microsoft.CodeAnalysis.PooledObjects.PooledStringBuilder Microsoft.CodeAnalysis.PooledObjects.PooledStringBuilder.<>c__DisplayClass10_0::<CreatePool>b__0()
instance void Microsoft.CodeAnalysis.ExpressionEvaluator.ResultProvider.<>c__DisplayClass7_0::<Microsoft.VisualStudio.Debugger.ComponentInterfaces.IDkmClrResultProvider.GetResult>b__2([Microsoft.VisualStudio.Debugger.Engine]Microsoft.VisualStudio.Debugger.Evaluation.DkmEvaluationResult)
instance void Microsoft.CodeAnalysis.ExpressionEvaluator.ResultProvider.WorkList::Execute()
instance void Microsoft.CodeAnalysis.PooledObjects.PooledStringBuilder::Free()
Microsoft.CodeAnalysis.ArrayBuilder`1<!0> Microsoft.CodeAnalysis.ArrayBuilder`1.<>c<System.__Canon>.<.cctor>b__23_0()
Microsoft.CodeAnalysis.PooledObjects.ObjectPool`1<Microsoft.CodeAnalysis.PooledObjects.PooledStringBuilder> Microsoft.CodeAnalysis.PooledObjects.PooledStringBuilder::CreatePool(int32)
void Microsoft.CodeAnalysis.ArrayBuilder`1.<>c<System.__Canon>..cctor()
void Microsoft.CodeAnalysis.ArrayBuilder`1<System.__Canon>..cctor()
void Microsoft.CodeAnalysis.ArrayBuilder`1<System.__Canon>..ctor()
void Microsoft.CodeAnalysis.ErrorReporting.FatalError::.cctor()
void Microsoft.CodeAnalysis.ExpressionEvaluator.CustomTypeInfoTypeArgumentMap::.cctor()
void Microsoft.CodeAnalysis.PooledObjects.ObjectPool`1<System.__Canon>..ctor(Microsoft.CodeAnalysis.PooledObjects.ObjectPool`1.Factory<!0>,int32)
void Microsoft.CodeAnalysis.PooledObjects.ObjectPool`1<System.__Canon>.Free(!0)
void Microsoft.CodeAnalysis.PooledObjects.ObjectPool`1<System.__Canon>.FreeSlow(!0)
void Microsoft.CodeAnalysis.PooledObjects.PooledStringBuilder::.cctor()
```