### PR TITLE
Upgrade dotnet cli to 2.1.503

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "2.1.401"
+    "dotnet": "2.1.503"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19160.2",


### PR DESCRIPTION
This is needed to get new NuSpec licensing features. See https://github.com/dotnet/arcade/pull/2003 for details.