### PR TITLE
source build prebuilts

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -22,5 +22,35 @@
       <Uri>https://github.com/dotnet/arcade-services</Uri>
       <Sha>e58ea0f91eef69affbb512c8d66fe18f0c9bcc68</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Build" Version="16.1.0-preview.21">
+      <SourceBuildId>5040</SourceBuildId>
+      <Uri>https://github.com/microsoft/msbuild</Uri>
+      <Sha>c36f772a8565538bbd215437b84885a6a677758c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Build.Tasks.Core" Version="16.1.0-preview.21">
+      <SourceBuildId>5040</SourceBuildId>
+      <Uri>https://github.com/microsoft/msbuild</Uri>
+      <Sha>c36f772a8565538bbd215437b84885a6a677758c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Build.Framework" Version="16.1.0-preview.21">
+      <SourceBuildId>5040</SourceBuildId>
+      <Uri>https://github.com/microsoft/msbuild</Uri>
+      <Sha>c36f772a8565538bbd215437b84885a6a677758c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Build.Utilities.Core" Version="16.1.0-preview.21">
+      <SourceBuildId>5040</SourceBuildId>
+      <Uri>https://github.com/microsoft/msbuild</Uri>
+      <Sha>c36f772a8565538bbd215437b84885a6a677758c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="3.1.0-beta1-19156-03">
+      <SourceBuildId>4741</SourceBuildId>
+      <Uri>https://github.com/dotnet/roslyn</Uri>
+      <Sha>8c2170cdec7fd91df55477f99fa8ebcdadadbf7c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.PlatformAbstractions" Version="3.0.0-preview4-27511-05">
+      <SourceBuildId>5236</SourceBuildId>
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>2befa32cec8cc3cb4b59b4272dfb36d2f14b9e58</Sha>
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,12 +15,12 @@
     <log4netVersion>2.0.8</log4netVersion>
     <SystemNetHttpVersion>4.3.3</SystemNetHttpVersion>
     <MicrosoftAzureKeyVaultVersion>3.0.0</MicrosoftAzureKeyVaultVersion>
-    <MicrosoftBuildVersion>15.7.179</MicrosoftBuildVersion>
-    <MicrosoftBuildFrameworkVersion>15.7.179</MicrosoftBuildFrameworkVersion>
-    <MicrosoftBuildTasksCoreVersion>15.7.179</MicrosoftBuildTasksCoreVersion>
-    <MicrosoftBuildUtilitiesCoreVersion>15.7.179</MicrosoftBuildUtilitiesCoreVersion>
-    <MicrosoftCodeAnalysisCSharpVersion>2.9.0</MicrosoftCodeAnalysisCSharpVersion>
-    <MicrosoftDotNetPlatformAbstractionsVersion>2.1.0</MicrosoftDotNetPlatformAbstractionsVersion>
+    <MicrosoftBuildVersion>16.1.0-preview.21</MicrosoftBuildVersion>
+    <MicrosoftBuildFrameworkVersion>16.1.0-preview.21</MicrosoftBuildFrameworkVersion>
+    <MicrosoftBuildTasksCoreVersion>16.1.0-preview.21</MicrosoftBuildTasksCoreVersion>
+    <MicrosoftBuildUtilitiesCoreVersion>16.1.0-preview.21</MicrosoftBuildUtilitiesCoreVersion>
+    <MicrosoftCodeAnalysisCSharpVersion>3.1.0-beta1-19156-03</MicrosoftCodeAnalysisCSharpVersion>
+    <MicrosoftDotNetPlatformAbstractionsVersion>3.0.0-preview4-27511-05</MicrosoftDotNetPlatformAbstractionsVersion>
     <MicrosoftDotNetVersionToolsVersion>2.2.0-preview1-02815-01</MicrosoftDotNetVersionToolsVersion>
     <MicrosoftIdentityModelClientsActiveDirectoryVersion>3.19.8</MicrosoftIdentityModelClientsActiveDirectoryVersion>
     <MicrosoftRestClientRuntimeVersion>2.3.13</MicrosoftRestClientRuntimeVersion>
@@ -33,17 +33,19 @@
     <MonoOptionsVersion>5.3.0.1</MonoOptionsVersion>
     <McMasterExtensionsCommandLineUtils>2.3.0</McMasterExtensionsCommandLineUtils>
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
+    <NuGetCommandsVersion>4.9.3</NuGetCommandsVersion>
+    <NuGetPackagingVersion>4.9.3</NuGetPackagingVersion>
+    <NuGetProjectModelVersion>4.9.3</NuGetProjectModelVersion>
     <NuGetVersioningVersion>4.4.0</NuGetVersioningVersion>
-    <NuGetVersion>4.9.3</NuGetVersion>
     <OctokitVersion>0.30.0</OctokitVersion>
     <DotNetSleetLibVersion>2.2.127</DotNetSleetLibVersion>
     <SwashbuckleAspNetCoreSwaggerVersion>3.0.0</SwashbuckleAspNetCoreSwaggerVersion>
-    <SystemCollectionsImmutableVersion>1.3.1</SystemCollectionsImmutableVersion>
+    <SystemCollectionsImmutableVersion>1.5.0</SystemCollectionsImmutableVersion>
     <SystemIOCompressionVersion>4.3.0</SystemIOCompressionVersion>
     <SystemIOPackagingVersion>4.5.0</SystemIOPackagingVersion>
     <SystemIOFileSystemPrimitivesVersion>4.3.0</SystemIOFileSystemPrimitivesVersion>
     <SystemMemoryVersion>4.5.1</SystemMemoryVersion>
-    <SystemReflectionMetadataVersion>1.4.2</SystemReflectionMetadataVersion>
+    <SystemReflectionMetadataVersion>1.6.0</SystemReflectionMetadataVersion>
     <SystemTextEncodingsWebVersion>4.5.0</SystemTextEncodingsWebVersion>
     <SystemValueTupleVersion>4.4.0</SystemValueTupleVersion>
     <WindowsAzureStorageVersion>8.5.0</WindowsAzureStorageVersion>

--- a/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
@@ -2,7 +2,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
 
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/BuildTasks.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/BuildTasks.props
@@ -3,6 +3,6 @@
 <Project>
   <PropertyGroup>
     <ArcadeSdkBuildTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)net472\Microsoft.DotNet.Arcade.Sdk.dll</ArcadeSdkBuildTasksAssembly>
-    <ArcadeSdkBuildTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)netcoreapp2.0\Microsoft.DotNet.Arcade.Sdk.dll</ArcadeSdkBuildTasksAssembly>
+    <ArcadeSdkBuildTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)netcoreapp2.1\Microsoft.DotNet.Arcade.Sdk.dll</ArcadeSdkBuildTasksAssembly>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
@@ -60,9 +60,9 @@
     <!--Need to reference version 2.8.2 of CodeAnalysis so that we don't have downgrade issues with System.Reflection.Metadata version-->
     <PackageReference Include="Microsoft.CodeAnalysis" Version="2.8.2" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="NuGet.Commands" Version="$(NuGetVersion)" />
-    <PackageReference Include="NuGet.Packaging" Version="$(NuGetVersion)" />
-    <PackageReference Include="NuGet.ProjectModel" Version="$(NuGetVersion)" />
+    <PackageReference Include="NuGet.Commands" Version="$(NuGetCommandsVersion)" />
+    <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagingVersion)" />
+    <PackageReference Include="NuGet.ProjectModel" Version="$(NuGetProjectModelVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="$(MicrosoftNETCorePlatformsVersion)" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/HarvestPackageTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/HarvestPackageTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
                 HarvestAssets = true,
                 IncludeAllPaths = true,
                 PackageId = "System.Collections.Immutable",
-                PackageVersion = "1.3.1",
+                PackageVersion = "1.5.0",
                 RuntimeFile = "runtime.json"
             };
 
@@ -102,10 +102,10 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
 
             Assert.Equal(0, _log.ErrorsLogged);
             Assert.Equal(0, _log.WarningsLogged);
-            Assert.Equal(4, task.HarvestedFiles.Length);
+            Assert.Equal(8, task.HarvestedFiles.Length);
             var ns10asset = task.HarvestedFiles.FirstOrDefault(f => f.GetMetadata("TargetFramework") == "netstandard1.0" );
             Assert.NotNull(ns10asset);
-            Assert.Equal("1.2.1.0", ns10asset.GetMetadata("AssemblyVersion"));
+            Assert.Equal("1.2.3.0", ns10asset.GetMetadata("AssemblyVersion"));
             Assert.Equal(_frameworks.Length, task.SupportedFrameworks.Length);
         }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/Microsoft.DotNet.Build.Tasks.Packaging.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/Microsoft.DotNet.Build.Tasks.Packaging.Tests.csproj
@@ -16,16 +16,16 @@
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)"/>
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)"/>
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="NuGet.Commands" Version="$(NuGetVersion)" />
-    <PackageReference Include="NuGet.Packaging" Version="$(NuGetVersion)" />
-    <PackageReference Include="NuGet.ProjectModel" Version="$(NuGetVersion)" />
+    <PackageReference Include="NuGet.Commands" Version="$(NuGetCommandsVersion)" />
+    <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagingVersion)" />
+    <PackageReference Include="NuGet.ProjectModel" Version="$(NuGetProjectModelVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
   </ItemGroup>
   
   <!-- test packages - these packages aren't needed for compilation but are copied
                        to the output and used for testing. -->
   <ItemGroup>
-    <TestPackage Include="System.Collections.Immutable" Version="1.3.1" />
+    <TestPackage Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <TestPackage Include="Microsoft.Win32.Registry" Version="4.3.0" />
     <TestPackage Include="System.Runtime" Version="4.3.0" />
     <TestPackage Include="runtime.any.System.Runtime" Version="4.3.0" />

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/Microsoft.DotNet.Build.Tasks.VisualStudio.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/Microsoft.DotNet.Build.Tasks.VisualStudio.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="System.IO.Compression" Version="$(SystemIOCompressionVersion)" />
 
     <Reference Include="WindowsBase" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.CodeAnalysis/Microsoft.DotNet.CodeAnalysis.csproj
+++ b/src/Microsoft.DotNet.CodeAnalysis/Microsoft.DotNet.CodeAnalysis.csproj
@@ -1,11 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- For analyzers we need to target netstandard1.3 to be able to build using full msbuild or dotnet msbuild.
-    We will be able to target netstandard2.0 once we only run in net472 and netstandard.dll 2.0.0 is inbox in
-    desktop. We can't multitarget analyzer packages as the nuget conventions don't include a TFM in the path.
-    This follows what roslyn is doing with their analyzers. -->
-    <TargetFrameworks>netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IsPackable>true</IsPackable>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodeAnalysis.ruleset</CodeAnalysisRuleSet>


### PR DESCRIPTION
Addresses https://github.com/dotnet/source-build/issues/970#issuecomment-471104736

Adds a daily Arcade subscription to consume MSBuild updates (NuGet dependencies are not yet available via dependency flow).

@safern is confirming that moving the TargetFramework for Microsoft.DotNet.CodeAnalysis to netstandard2.0 is now safe for CoreFx