### PR TITLE
Native Bootstrapping stops and aborts when it encounters a tool without an executable

### DIFF
--- a/eng/common/init-tools-native.ps1
+++ b/eng/common/init-tools-native.ps1
@@ -98,9 +98,19 @@ try {
       Write-Verbose "Executing '$LocalInstallerCommand'"
       Invoke-Expression "$LocalInstallerCommand"
       if ($LASTEXITCODE -Ne "0") {
-        Write-Error "Execution failed"
-        exit 1
+        $errMsg = "$ToolName installation failed"
+        if ((Get-Variable 'DoNotAbortNativeToolsInstallationOnFailure' -ErrorAction 'SilentlyContinue') -and $DoNotAbortNativeToolsInstallationOnFailure) {
+            Write-Warning $errMsg
+            $toolInstallationFailure = $true
+        } else {
+            Write-Error $errMsg
+            exit 1
+        }
       }
+    }
+
+    if ((Get-Variable 'toolInstallationFailure' -ErrorAction 'SilentlyContinue') -and $toolInstallationFailure) {
+        exit 1
     }
   }
   else {


### PR DESCRIPTION
#2248 - Native Bootstrapping stops and aborts further processing when it encounters a tool without an executable

Allowing native bootstrapping to continue after showing a warning, and exiting after the foreach loop is done