### PR TITLE
Pass new parameter to PushMetadataToBuildAssetRegistry

### DIFF
--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -52,6 +52,7 @@ jobs:
           /p:ManifestsPath='$(Build.StagingDirectory)/Download/AssetManifests'
           /p:BuildAssetRegistryToken=$(MaestroAccessToken)
           /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
+          /p:PublishUsingPipelines=$(_PublishUsingPipelines)
           /p:Configuration=$(_BuildConfig)
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishBuildAssets.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishBuildAssets.proj
@@ -29,6 +29,7 @@
     
     <PushMetadataToBuildAssetRegistry ManifestsPath="$(ManifestsPath)"
                                       BuildAssetRegistryToken="$(BuildAssetRegistryToken)"
-                                      MaestroApiEndpoint="$(MaestroApiEndpoint)" />
+                                      MaestroApiEndpoint="$(MaestroApiEndpoint)"
+                                      PublishUsingPipelines="$(PublishUsingPipelines)"/>
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Versions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Versions.props
@@ -6,7 +6,7 @@
   <Import Project="..\DefaultVersions.Generated.props" Condition="Exists('..\DefaultVersions.Generated.props')"/>
 
   <PropertyGroup>
-    <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.19162.5</MicrosoftDotNetMaestroTasksVersion>
+    <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.19164.3</MicrosoftDotNetMaestroTasksVersion>
     <MicrosoftDotNetBuildTasksVisualStudioVersion>$(ArcadeSdkVersion)</MicrosoftDotNetBuildTasksVisualStudioVersion>
     <MicrosoftDotNetBuildTasksFeedVersion>2.2.0-beta.19151.6</MicrosoftDotNetBuildTasksFeedVersion>
   </PropertyGroup>


### PR DESCRIPTION
Closes: https://github.com/dotnet/arcade/issues/2255

- Make Arcade use latest published Maestro.Tasks
- Make Arcade build inform Maestro -> BAR the choice of the repo+build for PublishingUsingPipelines