### PR TITLE
Passing new attribute to tell the publishing pipeline which target feed to use

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,8 @@ variables:
     value: DotNetCore
   - name: _PublishUsingPipelines
     value: true
+  - name: _DotNetPackagesType
+    value: ".NET Core"
 
 resources:
   containers:
@@ -69,6 +71,7 @@ jobs:
             /p:DotNetPublishBlobFeedUrl=$(_PublishBlobFeedUrl)
             /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
             /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+            /p:DotNetPackagesType=$(_DotNetPackagesType)
             /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
 
       strategy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ variables:
     value: DotNetCore
   - name: _PublishUsingPipelines
     value: true
-  - name: _DotNetPackagesType
+  - name: _DotNetArtifactsCategory
     value: ".NET Core"
 
 resources:
@@ -71,7 +71,7 @@ jobs:
             /p:DotNetPublishBlobFeedUrl=$(_PublishBlobFeedUrl)
             /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
             /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
-            /p:DotNetPackagesType=$(_DotNetPackagesType)
+            /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
             /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
 
       strategy:

--- a/eng/common/PublishToPackageFeed.proj
+++ b/eng/common/PublishToPackageFeed.proj
@@ -15,7 +15,7 @@
   <Import Project="$(NuGetPackageRoot)microsoft.dotnet.build.tasks.feed\$(MicrosoftDotNetBuildTasksFeedVersion)\build\Microsoft.DotNet.Build.Tasks.Feed.targets" />
 
   <Target Name="PublishToFeed">
-    <Error Condition="'$(TargetStaticFeed)' == ''" Text="TargetStaticFeed: Target feed for publishing assets wasn't provided." />
+    <Error Condition="'$(PackagesType)' == ''" Text="PackagesType: The type of packages produced by the build wasn't provided." />
     <Error Condition="'$(AccountKeyToStaticFeed)' == ''" Text="AccountKeyToStaticFeed: Account key for target feed wasn't provided." />
     <Error Condition="'$(ManifestsBasePath)' == ''" Text="Full path to asset manifests directory wasn't provided." />
     <Error Condition="'$(BlobBasePath)' == '' AND '$(PackageBasePath)' == ''" Text="A valid full path to BlobBasePath of PackageBasePath is required." />
@@ -26,7 +26,21 @@
     </ItemGroup>
 
     <Error Condition="'@(ManifestFiles)' == ''" Text="No manifest file was found in the provided path: $(ManifestsBasePath)" />
-	
+
+    <!--
+      For now the type of packages being published will be informed for the whole build.
+      Eventually this will be specified on a per package basis:
+      TODO: https://github.com/dotnet/arcade/issues/2266
+    -->
+    <PropertyGroup>
+      <TargetStaticFeed Condition="'$(PackagesType.ToUpper())' == '.NET CORE'">https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</TargetStaticFeed>
+      <TargetStaticFeed Condition="'$(PackagesType.ToUpper())' == '.NET CORE VALIDATION'">https://dotnetfeed.blob.core.windows.net/arcade-validation/index.json</TargetStaticFeed>
+    </PropertyGroup>
+
+    <Error 
+      Condition="'@(TargetStaticFeed)' == ''" 
+      Text="'$(PackagesType)' wasn't recognized as a valid package type. Valid types are: '.Net Core' and '.Net Core Validation'" />
+
     <!-- Iterate publishing assets from each manifest file. -->
     <PushArtifactsInManifestToFeed
       ExpectedFeedUrl="$(TargetStaticFeed)"

--- a/eng/common/PublishToPackageFeed.proj
+++ b/eng/common/PublishToPackageFeed.proj
@@ -15,7 +15,7 @@
   <Import Project="$(NuGetPackageRoot)microsoft.dotnet.build.tasks.feed\$(MicrosoftDotNetBuildTasksFeedVersion)\build\Microsoft.DotNet.Build.Tasks.Feed.targets" />
 
   <Target Name="PublishToFeed">
-    <Error Condition="'$(PackagesType)' == ''" Text="PackagesType: The type of packages produced by the build wasn't provided." />
+    <Error Condition="'$(ArtifactsCategory)' == ''" Text="ArtifactsCategory: The artifacts' category produced by the build wasn't provided." />
     <Error Condition="'$(AccountKeyToStaticFeed)' == ''" Text="AccountKeyToStaticFeed: Account key for target feed wasn't provided." />
     <Error Condition="'$(ManifestsBasePath)' == ''" Text="Full path to asset manifests directory wasn't provided." />
     <Error Condition="'$(BlobBasePath)' == '' AND '$(PackageBasePath)' == ''" Text="A valid full path to BlobBasePath of PackageBasePath is required." />
@@ -33,13 +33,13 @@
       TODO: https://github.com/dotnet/arcade/issues/2266
     -->
     <PropertyGroup>
-      <TargetStaticFeed Condition="'$(PackagesType.ToUpper())' == '.NET CORE'">https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</TargetStaticFeed>
-      <TargetStaticFeed Condition="'$(PackagesType.ToUpper())' == '.NET CORE VALIDATION'">https://dotnetfeed.blob.core.windows.net/arcade-validation/index.json</TargetStaticFeed>
+      <TargetStaticFeed Condition="'$(ArtifactsCategory.ToUpper())' == '.NET CORE'">https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</TargetStaticFeed>
+      <TargetStaticFeed Condition="'$(ArtifactsCategory.ToUpper())' == '.NET CORE VALIDATION'">https://dotnetfeed.blob.core.windows.net/arcade-validation/index.json</TargetStaticFeed>
     </PropertyGroup>
 
     <Error 
       Condition="'@(TargetStaticFeed)' == ''" 
-      Text="'$(PackagesType)' wasn't recognized as a valid package type. Valid types are: '.Net Core' and '.Net Core Validation'" />
+      Text="'$(ArtifactsCategory)' wasn't recognized as a valid artifact category. Valid categories are: '.Net Core' and '.Net Core Validation'" />
 
     <!-- Iterate publishing assets from each manifest file. -->
     <PushArtifactsInManifestToFeed

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -14,7 +14,7 @@
     DotNetBuildOffline              Building without access to NuGet servers.
     DotNetOutputBlobFeedDir         Directory to publish Source Build assets to (packages, symbol pacakges, installers, etc.).
     DotNetPublishUsingPipelines     Publish assets using Azure DevOps release pipelines.
-    DotNetPackagesType              Type of assets being produced by the build.
+    DotNetArtifactsCategory         Type of assets being produced by the build.
     DotNetPublishToBlobFeed         Publish assets to blob feed using DotNetPublishBlobFeedUrl and DotNetPublishBlobFeedKey.
     DotNetPublishBlobFeedUrl        Target feed URL, or empty if not publishing to Azure blob feed.
     DotNetPublishBlobFeedKey        Azure blob feed account key.
@@ -146,7 +146,7 @@
     <ItemGroup>
       <_PublishProps Include="@(_CommonProps)"/>
       <_PublishProps Include="PublishToAzureDevOpsArtifacts=$(DotNetPublishUsingPipelines)" />
-      <_PublishProps Include="PackagesType=$(DotNetPackagesType)" />
+      <_PublishProps Include="ArtifactsCategory=$(DotNetArtifactsCategory)" />
       <_PublishProps Include="AzureFeedUrl=$(DotNetPublishBlobFeedUrl)" Condition="'$(DotNetPublishToBlobFeed)' == 'true'" />
       <_PublishProps Include="AzureAccountKey=$(DotNetPublishBlobFeedKey)" Condition="'$(DotNetPublishToBlobFeed)' == 'true'" />
       <_PublishProps Include="DotNetOutputBlobFeedDir=$(_DotNetOutputBlobFeedDir)" Condition="'$(_DotNetOutputBlobFeedDir)' != ''" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -14,6 +14,7 @@
     DotNetBuildOffline              Building without access to NuGet servers.
     DotNetOutputBlobFeedDir         Directory to publish Source Build assets to (packages, symbol pacakges, installers, etc.).
     DotNetPublishUsingPipelines     Publish assets using Azure DevOps release pipelines.
+    DotNetPackagesType              Type of assets being produced by the build.
     DotNetPublishToBlobFeed         Publish assets to blob feed using DotNetPublishBlobFeedUrl and DotNetPublishBlobFeedKey.
     DotNetPublishBlobFeedUrl        Target feed URL, or empty if not publishing to Azure blob feed.
     DotNetPublishBlobFeedKey        Azure blob feed account key.
@@ -145,6 +146,7 @@
     <ItemGroup>
       <_PublishProps Include="@(_CommonProps)"/>
       <_PublishProps Include="PublishToAzureDevOpsArtifacts=$(DotNetPublishUsingPipelines)" />
+      <_PublishProps Include="PackagesType=$(DotNetPackagesType)" />
       <_PublishProps Include="AzureFeedUrl=$(DotNetPublishBlobFeedUrl)" Condition="'$(DotNetPublishToBlobFeed)' == 'true'" />
       <_PublishProps Include="AzureAccountKey=$(DotNetPublishBlobFeedKey)" Condition="'$(DotNetPublishToBlobFeed)' == 'true'" />
       <_PublishProps Include="DotNetOutputBlobFeedDir=$(_DotNetOutputBlobFeedDir)" Condition="'$(_DotNetOutputBlobFeedDir)' != ''" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -131,7 +131,7 @@
     -->
     <ItemGroup>
       <NewManifestBuildData Include="InitialAssetsLocation=$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)$(SYSTEM_TEAMPROJECT)/_apis/build/builds/$(BUILD_BUILDID)/artifacts" />
-      <NewManifestBuildData Include="PackagesType=$(PackagesType)" />
+      <NewManifestBuildData Include="ArtifactsCategory=$(ArtifactsCategory)" />
       <NewManifestBuildData Include="AzureDevOpsBuildId=$(BUILD_BUILDID)" />
       <NewManifestBuildData Include="AzureDevOpsBuildDefinitionId=$(SYSTEM_DEFINITIONID)" />
       <NewManifestBuildData Include="AzureDevOpsAccount=$(AzureDevOpsAccount)" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -131,7 +131,7 @@
     -->
     <ItemGroup>
       <NewManifestBuildData Include="InitialAssetsLocation=$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)$(SYSTEM_TEAMPROJECT)/_apis/build/builds/$(BUILD_BUILDID)/artifacts" />
-      <NewManifestBuildData Include="TargetStaticFeed=$(AzureFeedUrl)" />
+      <NewManifestBuildData Include="PackagesType=$(PackagesType)" />
       <NewManifestBuildData Include="AzureDevOpsBuildId=$(BUILD_BUILDID)" />
       <NewManifestBuildData Include="AzureDevOpsBuildDefinitionId=$(SYSTEM_DEFINITIONID)" />
       <NewManifestBuildData Include="AzureDevOpsAccount=$(AzureDevOpsAccount)" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -108,12 +108,6 @@
 
   <Target Name="PublishToAzureDevOpsArtifacts">
     <!-- 
-    Begin: 
-      Work in progress drop-in replacement for PushToBlobFeed task below. 
-      This is part of the work on https://github.com/dotnet/arcade/issues/1179 
-    --> 
-
-    <!-- 
       Sadly AzDO doesn't have a variable to tell the account name. Also
       the format of CollectionURI is not precise across different agent 
       configurations. Code below takes care of extracting the account 
@@ -137,6 +131,7 @@
     -->
     <ItemGroup>
       <NewManifestBuildData Include="InitialAssetsLocation=$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)$(SYSTEM_TEAMPROJECT)/_apis/build/builds/$(BUILD_BUILDID)/artifacts" />
+      <NewManifestBuildData Include="TargetStaticFeed=$(AzureFeedUrl)" />
       <NewManifestBuildData Include="AzureDevOpsBuildId=$(BUILD_BUILDID)" />
       <NewManifestBuildData Include="AzureDevOpsBuildDefinitionId=$(SYSTEM_DEFINITIONID)" />
       <NewManifestBuildData Include="AzureDevOpsAccount=$(AzureDevOpsAccount)" />
@@ -169,16 +164,14 @@
       AssetManifestPath="$(AssetManifestFilePath)"
       AssetsTemporaryDirectory="$(TempWorkingDirectory)" />
 
-    <!--
-      The publishing pipeline (implemented by PublishToPackageFeed.proj) will use the Tasks.Feed package
-      to publish packages. The version of Tasks.Feed used will come either from Version.props or from
-      DefaultVersions.props
-    -->
-
     <Message
       Text="##vso[artifact.upload containerfolder=PipelineArtifactsPublishingManifests;artifactname=PipelineArtifactsPublishingManifests]$(RepositoryEngineeringDir)common\PublishToPackageFeed.proj"
       Importance="high" />
 
+    <!--
+      The publishing pipeline (implemented by PublishToPackageFeed.proj) will use the Tasks.Feed package
+      to publish packages. The version of Tasks.Feed used will come from DefaultVersions.props
+    -->
     <Message
       Text="##vso[artifact.upload containerfolder=PipelineArtifactsPublishingManifests;artifactname=PipelineArtifactsPublishingManifests]$(MSBuildThisFileDirectory)DefaultVersions.props"
       Condition="Exists('$(MSBuildThisFileDirectory)DefaultVersions.props')"
@@ -191,12 +184,6 @@
     <Message
       Text="##vso[artifact.upload containerfolder=AssetManifests;artifactname=AssetManifests]$(TempWorkingDirectory)\$(AssetManifestFileName)"
       Importance="high" />
-
-    <!-- 
-    End: 
-      Work in progress drop-in replacement for PushToBlobFeed task below. 
-      This is part of the work on https://github.com/dotnet/arcade/issues/1179 
-    --> 
   </Target>
 
   <Target Name="PublishSymbols">


### PR DESCRIPTION
Relates to: #2258 

For now the target feed is fixed as dotnet-core, but we'll need to publish to other containers. 

I'll create another PR where I update Tasks.Feed to consume this parameter.