### PR TITLE
Quite value that contains spaces

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,7 +71,7 @@ jobs:
             /p:DotNetPublishBlobFeedUrl=$(_PublishBlobFeedUrl)
             /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
             /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
-            /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
+            /p:DotNetArtifactsCategory="$(_DotNetArtifactsCategory)"
             /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
 
       strategy:


### PR DESCRIPTION
Fixes build break introduced by dotnet/arcade#2259.

This change broke CI:

```
MSBUILD : error MSB1008: Only one project can be specified.
Switch: Core
```

The value of _DotNetArtifactsCategory can't contain spaces (or it needs to be quoted).