### PR TITLE
Ensure MSBuild doesn't downgrade NuGet

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -34,7 +34,7 @@
     <McMasterExtensionsCommandLineUtils>2.3.0</McMasterExtensionsCommandLineUtils>
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
     <NuGetVersioningVersion>4.4.0</NuGetVersioningVersion>
-    <NuGetVersion>4.9.3</NuGetVersion>
+    <NuGetVersion>4.9.0-rtm.5658</NuGetVersion>
     <OctokitVersion>0.30.0</OctokitVersion>
     <DotNetSleetLibVersion>2.2.127</DotNetSleetLibVersion>
     <SwashbuckleAspNetCoreSwaggerVersion>3.0.0</SwashbuckleAspNetCoreSwaggerVersion>


### PR DESCRIPTION
MSBuild uses NuGet and lists it in its own deps file.
As a result CoreCLR will unify the version loaded by the task the version loaded in MSBuild.

If the version needed by the task is greater than the one in MSBuild
this results in a FileLoadException.

Workaround this by compiling against the first assembly that has the
LicenseMetadata API needed by e39764c1fcf0664db63aa63c44ea0aca5f9ad36c which is
equal to the version inbox in the SDK 2.1.500.