### PR TITLE
Fix publish to bar - fix publish using release pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,8 @@ variables:
   # Cannot use key:value syntax in root defined variables
   - name: _TeamName
     value: DotNetCore
+  - name: _PublishUsingPipelines
+    value: true
   - name: _DotNetArtifactsCategory
     value: .NETCore
 
@@ -32,6 +34,7 @@ jobs:
     enablePublishBuildArtifacts: true
     enablePublishTestResults: true
     enablePublishBuildAssets: true
+    enablePublishUsingPipelines: $(_PublishUsingPipelines)
     enableTelemetry: true
     graphFileGeneration:
       enabled: true
@@ -68,6 +71,7 @@ jobs:
             /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
             /p:DotNetPublishBlobFeedUrl=$(_PublishBlobFeedUrl)
             /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
+            /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
             /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
             /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,7 @@ jobs:
     enablePublishBuildArtifacts: true
     enablePublishTestResults: true
     enablePublishBuildAssets: true
+    enablePublishUsingPipelines: $(_PublishUsingPipelines)
     enableTelemetry: true
     graphFileGeneration:
       enabled: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,8 +17,6 @@ variables:
   # Cannot use key:value syntax in root defined variables
   - name: _TeamName
     value: DotNetCore
-  - name: _PublishUsingPipelines
-    value: true
   - name: _DotNetArtifactsCategory
     value: .NETCore
 
@@ -34,7 +32,6 @@ jobs:
     enablePublishBuildArtifacts: true
     enablePublishTestResults: true
     enablePublishBuildAssets: true
-    enablePublishUsingPipelines: $(_PublishUsingPipelines)
     enableTelemetry: true
     graphFileGeneration:
       enabled: true
@@ -71,7 +68,6 @@ jobs:
             /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
             /p:DotNetPublishBlobFeedUrl=$(_PublishBlobFeedUrl)
             /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
-            /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
             /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
             /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
 

--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -30,9 +30,15 @@ jobs:
   pool: ${{ parameters.pool }}
 
   variables:
-  - ${{ if ne(variables._PublishUsingPipelines, 'true') }}:
+  - ${{ if ne(variables['_PublishUsingPipelines'], 'true') }}:
     - name: _PublishUsingPipelines
-      value: false
+      value: 2
+  - ${{ if ne(variables['_PublishUsingPipelines'], true) }}:
+    - name: _PublishUsingPipelines
+      value: 3
+  - ${{ if ne(variables._PublishUsingPipelines, true) }}:
+    - name: _PublishUsingPipelines
+      value: 4
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - name: _BuildConfig
       value: ${{ parameters.configuration }}

--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -20,7 +20,7 @@ parameters:
   #           if 'true', the build won't run any of the internal only steps, even if it is running in non-public projects.
   runAsPublic: false
 
-  # Optional: whether this build was intended to publish artifacts using pipelines
+  # Optional: whether the build's artifacts will be published using release pipelines or direct feed publishing
   publishUsingPipelines: false
 
 jobs:

--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -20,6 +20,9 @@ parameters:
   #           if 'true', the build won't run any of the internal only steps, even if it is running in non-public projects.
   runAsPublic: false
 
+  # Optional: whether this build was intended to publish artifacts using pipelines
+  publishUsingPipelines: false
+
 jobs:
 - job: Asset_Registry_Publish
 
@@ -30,15 +33,6 @@ jobs:
   pool: ${{ parameters.pool }}
 
   variables:
-  - ${{ if ne(variables['_PublishUsingPipelines'], 'true') }}:
-    - name: _PublishUsingPipelines
-      value: 2
-  - ${{ if ne(variables['_PublishUsingPipelines'], true) }}:
-    - name: _PublishUsingPipelines
-      value: 3
-  - ${{ if ne(variables._PublishUsingPipelines, true) }}:
-    - name: _PublishUsingPipelines
-      value: 4
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - name: _BuildConfig
       value: ${{ parameters.configuration }}
@@ -61,7 +55,7 @@ jobs:
           /p:ManifestsPath='$(Build.StagingDirectory)/Download/AssetManifests'
           /p:BuildAssetRegistryToken=$(MaestroAccessToken)
           /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
-          /p:PublishUsingPipelines=$(_PublishUsingPipelines)
+          /p:PublishUsingPipelines=$(publishUsingPipelines)
           /p:Configuration=$(_BuildConfig)
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}

--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -55,7 +55,7 @@ jobs:
           /p:ManifestsPath='$(Build.StagingDirectory)/Download/AssetManifests'
           /p:BuildAssetRegistryToken=$(MaestroAccessToken)
           /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
-          /p:PublishUsingPipelines=$(publishUsingPipelines)
+          /p:PublishUsingPipelines=${{ parameters.publishUsingPipelines }}
           /p:Configuration=$(_BuildConfig)
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}

--- a/eng/common/templates/jobs/jobs.yml
+++ b/eng/common/templates/jobs/jobs.yml
@@ -14,7 +14,7 @@ parameters:
   # Optional: Enable publishing to the build asset registry
   enablePublishBuildAssets: false
 
-  # Optional: Enable publishing to the build asset registry
+  # Optional: Enable publishing using release pipelines
   enablePublishUsingPipelines: false
   
   graphFileGeneration:

--- a/eng/common/templates/jobs/jobs.yml
+++ b/eng/common/templates/jobs/jobs.yml
@@ -13,6 +13,9 @@ parameters:
 
   # Optional: Enable publishing to the build asset registry
   enablePublishBuildAssets: false
+
+  # Optional: Enable publishing to the build asset registry
+  enablePublishUsingPipelines: false
   
   graphFileGeneration:
     # Optional: Enable generating the graph files at the end of the build
@@ -73,6 +76,7 @@ jobs:
       pool:
         vmImage: vs2017-win2016
       runAsPublic: ${{ parameters.runAsPublic }}
+      publishUsingPipelines: ${{ parameters.enablePublishUsingPipelines }}
       enablePublishBuildArtifacts: ${{ parameters.enablePublishBuildArtifacts }}
       
 - ${{ if and(eq(parameters.graphFileGeneration.enabled, true), eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
Closes: #2279 

Add new parameter to `publish-build-assets.yml` that will be forwarded to Maestro++ flagging that the build is on-boarded with publishing using pipelines.

Test build where the parameter is not informed: https://dnceng.visualstudio.com/internal/_build/results?buildId=127948

Test build where the parameter is informed == true: https://dnceng.visualstudio.com/internal/_build/results?buildId=127754