### PR TITLE
Fix typos in ApiCompat project

### DIFF
--- a/src/Microsoft.DotNet.ApiCompat/NamespaceRemappingComparer.cs
+++ b/src/Microsoft.DotNet.ApiCompat/NamespaceRemappingComparer.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -114,7 +114,7 @@ namespace Microsoft.Cci.Comparers
 
                 if (split.Length != 2)
                 {
-                    Debug.WriteLine("ApiCompat NamespaceRemappingComparer: Unparsible line found in file {0}.  Line: \"{1}\"", mappingFile, mapping);
+                    Debug.WriteLine("ApiCompat NamespaceRemappingComparer: unparseable line found in file {0}.  Line: \"{1}\"", mappingFile, mapping);
                     continue;
                 }
 

--- a/src/Microsoft.DotNet.ApiCompat/Program.cs
+++ b/src/Microsoft.DotNet.ApiCompat/Program.cs
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.ApiCompat
             CommandOption contractCoreAssembly = app.Option("--contract-core-assembly", "Simple name for the core assembly to use.", CommandOptionType.SingleValue);
             CommandOption ignoreDesignTimeFacades = app.Option("--ignore-design-time-facades", "Ignore design time facades in the contract set while analyzing.", CommandOptionType.NoValue);
             CommandOption warnOnIncorrectVersion = app.Option("--warn-on-incorrect-version", "Warn if the contract version number doesn't match the found implementation version number.", CommandOptionType.NoValue);
-            CommandOption warnOnMissingAssemblies = app.Option("--warn-on-missing-assemblies", "Warn if the contract assembly cannot be found in the implementation directories. Default is to error and not do anlysis.", CommandOptionType.NoValue);
+            CommandOption warnOnMissingAssemblies = app.Option("--warn-on-missing-assemblies", "Warn if the contract assembly cannot be found in the implementation directories. Default is to error and not do analysis.", CommandOptionType.NoValue);
             CommandOption excludeNonBrowsable = app.Option("--exclude-non-browsable", "When MDIL servicing rules are not being enforced, exclude validation on types that are marked with EditorBrowsable(EditorBrowsableState.Never).", CommandOptionType.NoValue);
             CommandOption excludeAttributes = app.Option("--exclude-attributes", "Specify a api list in the DocId format of which attributes to exclude.", CommandOptionType.SingleValue);
             CommandOption enforceOptionalRules = app.Option("--enforce-optional-rules", "Enforce optional rules, in addition to the mandatory set of rules.", CommandOptionType.NoValue);

--- a/src/Microsoft.DotNet.ApiCompat/Rules/Compat/CannotMakeMoreVisible.cs
+++ b/src/Microsoft.DotNet.ApiCompat/Rules/Compat/CannotMakeMoreVisible.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,7 +7,7 @@ using Microsoft.Cci.Writers.CSharp;
 
 namespace Microsoft.Cci.Differs.Rules
 {
-    // Removed because it appears the *MustExist rules already supercede these.
+    // Removed because it appears the *MustExist rules already supersede these.
     [ExportDifferenceRule]
     internal class CannotMakeMoreVisible : CompatDifferenceRule
     {

--- a/src/Microsoft.DotNet.ApiCompat/Rules/Compat/CannotRemoveGenerics.cs
+++ b/src/Microsoft.DotNet.ApiCompat/Rules/Compat/CannotRemoveGenerics.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -40,7 +40,7 @@ namespace Microsoft.Cci.Differs.Rules
             IGenericParameter[] implParams = implGenericParams.ToArray();
             IGenericParameter[] contractParams = contractGenericParams.ToArray();
 
-            // We shoudn't hit this because the types/members shouldn't be matched up if they have different generic argument lists
+            // We shouldn't hit this because the types/members shouldn't be matched up if they have different generic argument lists
             if (implParams.Length != contractParams.Length)
                 return DifferenceType.Changed;
 
@@ -87,7 +87,7 @@ namespace Microsoft.Cci.Differs.Rules
 
             foreach (var constraint in parameter.Constraints)
             {
-                // Skip valuetype becaue we should get it above.
+                // Skip valuetype because we should get it above.
                 if (TypeHelper.TypesAreEquivalent(constraint, constraint.PlatformType.SystemValueType) && parameter.MustBeValueType)
                     continue;
 

--- a/src/Microsoft.DotNet.ApiCompat/Rules/Compat/IDifferenceOperands.cs
+++ b/src/Microsoft.DotNet.ApiCompat/Rules/Compat/IDifferenceOperands.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -16,7 +16,7 @@ namespace Microsoft.Cci.Differs
         /// </summary>
         string Contract { get; }
         /// <summary>
-        /// Name of right operand of a difference operation.  Typically called an implemenation.
+        /// Name of right operand of a difference operation.  Typically called an implementation.
         /// </summary>
         string Implementation { get; }
     }

--- a/src/Microsoft.DotNet.ApiCompat/Rules/Compat/MembersMustExist.cs
+++ b/src/Microsoft.DotNet.ApiCompat/Rules/Compat/MembersMustExist.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -46,7 +46,7 @@ namespace Microsoft.Cci.Differs.Rules
                 IMethodDefinition contractMethod = contractMember as IMethodDefinition;
                 if (contractMethod != null)
                 {
-                    // If the contract is a Explicit Interface method, we don't need to check if the method is in implementation since that will be catched by different rule.
+                    // If the contract is a Explicit Interface method, we don't need to check if the method is in implementation since that will be caught by different rule.
                     if (contractMethod.IsExplicitInterfaceMethod())
                         return DifferenceType.Unknown;
 


### PR DESCRIPTION
This PR fixes a couple of small typos that I have found in the code of ApiCompat
- Replace `anlysis` with `analysis` in [Program.cs](https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.ApiCompat/Program.cs#L56)
- Replace `Unparsible` with `unparseable ` in [NamespaceRemappingComparer.cs](https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.ApiCompat/NamespaceRemappingComparer.cs#L117)
- Replace `supercede` with `supersede` in [CannotMakeMoreVisible.cs](https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.ApiCompat/Rules/Compat/CannotMakeMoreVisible.cs#L10)
- Replace `shoudn't` with `shouldn't` in [CannotRemoveGenerics.cs](https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.ApiCompat/Rules/Compat/CannotRemoveGenerics.cs#L43)
- Replace `becaue` with `because` in [CannotRemoveGenerics.cs](https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.ApiCompat/Rules/Compat/CannotRemoveGenerics.cs#L90)
- Replace `implemenation` with `implementation` in [IDifferenceOperands.cs](https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.ApiCompat/Rules/Compat/IDifferenceOperands.cs#L19)
- Replace `catched` with `caught` in [MembersMustExist.cs](https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.ApiCompat/Rules/Compat/MembersMustExist.cs#L49)