### PR TITLE
Update version of Maestro.Tasks & Tasks.Feed in SDK

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ variables:
   - name: _TeamName
     value: DotNetCore
   - name: _PublishUsingPipelines
-    value: false
+    value: true
   - name: _DotNetArtifactsCategory
     value: .NETCore
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ variables:
   - name: _TeamName
     value: DotNetCore
   - name: _PublishUsingPipelines
-    value: true
+    value: false
   - name: _DotNetArtifactsCategory
     value: .NETCore
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Versions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Versions.props
@@ -6,9 +6,9 @@
   <Import Project="..\DefaultVersions.Generated.props" Condition="Exists('..\DefaultVersions.Generated.props')"/>
 
   <PropertyGroup>
-    <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.19164.3</MicrosoftDotNetMaestroTasksVersion>
+    <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.19170.5</MicrosoftDotNetMaestroTasksVersion>
     <MicrosoftDotNetBuildTasksVisualStudioVersion>$(ArcadeSdkVersion)</MicrosoftDotNetBuildTasksVisualStudioVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>2.2.0-beta.19151.6</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>2.2.0-beta.19170.8</MicrosoftDotNetBuildTasksFeedVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Update Arcade SDK to use a version of Maestro.Tasks that [has this fix](https://github.com/dotnet/arcade-services/pull/257).

This PR was [tested in a private branch here](https://dnceng.visualstudio.com/internal/_build/results?buildId=129322). I'm testing the package produced on that build on a [Roslyn build here](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2516168). 