### PR TITLE
Builds failing due to restore failure of recently published packages #2327

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -28,6 +28,14 @@
     <RestoreConfigFile>$(RepoRoot)NuGet.config</RestoreConfigFile>
   </PropertyGroup>
   
+  <!-- 
+    Prevent NuGet from using cached packages 
+    Workaround for https://github.com/NuGet/Home/issues/3116
+  -->
+  <PropertyGroup>
+    <RestoreNoCache Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</RestoreNoCache>
+  </PropertyGroup>
+  
   <!--
     Arcade SDK features.
   -->


### PR DESCRIPTION
Builds failing due to restore failure of recently published packages #2327

    Prevents NuGet from using cached packages in CI builds