### PR TITLE
Fix NGEN method logging

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/ExtractNgenMethodList.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/ExtractNgenMethodList.cs
@@ -7,13 +7,7 @@ using Microsoft.Build.Utilities;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
-using System.Linq;
 using System.Reflection.Metadata;
-using System.Reflection.PortableExecutable;
-using System.Runtime.Versioning;
-using System.Threading;
-using System.Xml;
 using System.Xml.Linq;
 
 namespace Microsoft.DotNet.Arcade.Sdk
@@ -69,17 +63,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
             items.Sort();
 
             Directory.CreateDirectory(OutputDirectory);
-            string outputFileName;
-            if (GetAssemblyMvid(AssemblyFilePath, out Guid mvid))
-            {
-                outputFileName = $"{Path.GetFileNameWithoutExtension(AssemblyFilePath)}-{AssemblyTargetFramework}-{mvid}.ngen.txt";
-            }
-            else
-            {
-                Log.LogWarning($"Unable to read MVID and TargetFramework from {AssemblyFilePath}");
-                outputFileName = $"{Guid.NewGuid()}.ngen.txt";
-            }
-
+            var outputFileName = $"{Path.GetFileNameWithoutExtension(AssemblyFilePath)}-{AssemblyTargetFramework}.ngen.txt";
             var outputFilePath = Path.Combine(OutputDirectory, outputFileName);
             using (var outputFileStream = new StreamWriter(outputFilePath, append: false))
             {
@@ -91,24 +75,5 @@ namespace Microsoft.DotNet.Arcade.Sdk
 
             return true;
         } 
-
-        private static bool GetAssemblyMvid(string assemblyFilePath, out Guid mvid)
-        {
-            mvid = default;
-
-            using (var stream = File.Open(assemblyFilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
-            using (var pereader = new PEReader(stream))
-            {
-                if (pereader.HasMetadata)
-                {
-                    var metadataReader = pereader.GetMetadataReader();
-                    var mvidHandle = metadataReader.GetModuleDefinition().Mvid;
-                    mvid = metadataReader.GetGuid(mvidHandle);
-                    return true;
-                }
-            }
-
-            return false;
-        }
     }
 }

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
@@ -54,7 +54,7 @@
 
   <Target Name="_InitializeAssemblyOptimizationWithTargetAssembly">
     <ItemGroup>
-      <OptimizeAssembly Include="@(IntermediateAssembly)" />
+      <OptimizeAssembly Include="@(IntermediateAssembly)" TargetFramework="$(TargetFramework)" />
     </ItemGroup>
   </Target>
 
@@ -93,7 +93,9 @@
         was a significant benefit in optimizing them separately.
         This would however require a more complicated setup authoring.
       -->
-      <_IbcFile Include="$(IbcOptimizationDataDir)**\%(OptimizeAssembly.FileName)%(OptimizeAssembly.Extension)\*.ibc" OptimizeAssemblyPath="%(OptimizeAssembly.Identity)"/>
+      <_IbcFile Include="$(IbcOptimizationDataDir)**\%(OptimizeAssembly.FileName)%(OptimizeAssembly.Extension)\*.ibc" 
+                OptimizeAssemblyPath="%(OptimizeAssembly.Identity)"
+                TargetFramework="%(OptimizeAssembly.TargetFramework)" />
 
       <_AssemblyWithoutRawIbcData Include="@(OptimizeAssembly)" Exclude="@(_IbcFile->'%(OptimizeAssemblyPath)')" />
 
@@ -107,6 +109,7 @@
                               PreviousAssemblyPath="%(_IbcFile.PreviousAssemblyDir)\%(_IbcFile.AssemblyFileName)"
                               PreviousAssemblyCopyPath="$(ArtifactsTmpDir)OptimizedAssemblies\$([System.Guid]::NewGuid())"
                               OptimizeAssemblyPath="%(_IbcFile.OptimizeAssemblyPath)"
+                              TargetFramework="%(_IbcFile.TargetFramework)"
                               XmlOutputPath="$(_IbcMergeXmlOutputDir)\%(_IbcFile.AssemblyFileName).$([System.Guid]::NewGuid()).temp.ibc.xml" />
     </ItemGroup>
 
@@ -141,6 +144,7 @@
         <IbcMergeArgs>-q -f $(_PartialNgenArg) -minify -delete -mo "%(_AssemblyWithRawIbcData.OptimizeAssemblyPath)" -incremental "%(_AssemblyWithRawIbcData.PreviousAssemblyCopyPath)"</IbcMergeArgs>
         <UnsignFile>%(_AssemblyWithRawIbcData.OptimizeAssemblyPath)</UnsignFile>
         <XmlOutputPath Condition="'$(EnableNgenOptimizationLogDetails)' == 'true'">%(_AssemblyWithRawIbcData.XmlOutputPath)</XmlOutputPath>
+        <TargetFramework>%(_AssemblyWithRawIbcData.TargetFramework)</TargetFramework>
       </_IbcMergeInvocation>
 
       <_IbcMergeInvocation>
@@ -180,7 +184,7 @@
     <Microsoft.DotNet.Arcade.Sdk.ExtractNgenMethodList
       IbcXmlFilePath="%(_IbcMergeInvocation.XmlOutputPath)" 
       AssemblyFilePath="%(_IbcMergeInvocation.UnsignFile)"
-      AssemblyTargetFramework="$(TargetFramework)"
+      AssemblyTargetFramework="%(_IbcMergeInvocation.TargetFramework)"
       OutputDirectory="$(ArtifactsLogNgenDir)" 
       Condition="'%(_IbcMergeInvocation.XmlOutputPath)' != ''"/>
   </Target>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
@@ -107,7 +107,7 @@
                               PreviousAssemblyPath="%(_IbcFile.PreviousAssemblyDir)\%(_IbcFile.AssemblyFileName)"
                               PreviousAssemblyCopyPath="$(ArtifactsTmpDir)OptimizedAssemblies\$([System.Guid]::NewGuid())"
                               OptimizeAssemblyPath="%(_IbcFile.OptimizeAssemblyPath)"
-                              XmlOutputPath="$(_IbcMergeXmlOutputDir)\%(_IbcFile.AssemblyFileName).ibc.xml" />
+                              XmlOutputPath="$(_IbcMergeXmlOutputDir)\%(_IbcFile.AssemblyFileName).$([System.Guid]::NewGuid()).temp.ibc.xml" />
     </ItemGroup>
 
     <Error Text="No optimization data found for assemblies: @(_AssemblyWithoutRawIbcData, ', ')"
@@ -177,7 +177,12 @@
 
     <!-- Remove Authenticode signing record if present. -->
     <Microsoft.DotNet.Arcade.Sdk.Unsign FilePath="%(_IbcMergeInvocation.UnsignFile)" Condition="'%(_IbcMergeInvocation.UnsignFile)' != ''" />
-    <Microsoft.DotNet.Arcade.Sdk.ExtractNgenMethodList IbcXmlFilePath="%(_IbcMergeInvocation.XmlOutputPath)" OutputDirectory="$(ArtifactsLogNgenDir)" Condition="'%(_IbcMergeInvocation.XmlOutputPath)' != ''"/>
+    <Microsoft.DotNet.Arcade.Sdk.ExtractNgenMethodList
+      IbcXmlFilePath="%(_IbcMergeInvocation.XmlOutputPath)" 
+      AssemblyFilePath="%(_IbcMergeInvocation.UnsignFile)"
+      AssemblyTargetFramework="$(TargetFramework)"
+      OutputDirectory="$(ArtifactsLogNgenDir)" 
+      Condition="'%(_IbcMergeInvocation.XmlOutputPath)' != ''"/>
   </Target>
 
 </Project>


### PR DESCRIPTION
The NGEN method logging code didn't account for the fact that we run
IBCMerge for the same assembly multiple times when the project uses
multi-targeting. This created race conditions on both writing the temp
XML file and the NGEN method list.

This PR fixes this by properly writing out separate files for each
target framework of an assembly.

closes #2309