### PR TITLE
Add new feed URL

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -21,9 +21,9 @@
     <RestoreSources>$(DotNetRestoreSources)</RestoreSources>
     <RestoreSources>
       $(RestoreSources);
-      https://dotnetfeed.blob.core.windows.net/arcade-validation/index.json;
       https://api.nuget.org/v3/index.json;
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
+      https://dotnetfeed.blob.core.windows.net/arcade-validation/index.json;
       https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json
     </RestoreSources>
     <RestoreSources Condition="'$(UsingToolSymbolUploader)' == 'true'">

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -21,6 +21,7 @@
     <RestoreSources>$(DotNetRestoreSources)</RestoreSources>
     <RestoreSources>
       $(RestoreSources);
+      https://dotnetfeed.blob.core.windows.net/arcade-validation/index.json;
       https://api.nuget.org/v3/index.json;
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
       https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json


### PR DESCRIPTION
Relates to: #2085

Arcade will now publish to this new feed using release pipelines. This PR add the feed as a source of packages for the SDK to use.