### PR TITLE
Fix race with AssemblyLoadContext.ResolveUsingResolvingEvent

### DIFF
--- a/src/Microsoft.DotNet.XUnitConsoleRunner/README.md
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/README.md
@@ -7,3 +7,8 @@ the license for this code.
 
 ## Significant Changes
 * Added Response File parsing to `src/CommandLine.cs`
+* Fixed racing condition in `src/common/AssemblyResolution/DependencyContextAssemblyCache.cs` that manifests themself as
+```
+System.IO.FileLoadException: Could not load file or assembly 'Exceptions.Finalization.XUnitWrapper, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+An operation is not legal in the current state. (Exception from HRESULT: 0x80131509 (COR_E_INVALIDOPERATION))
+```

--- a/src/Microsoft.DotNet.XUnitConsoleRunner/README.md
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/README.md
@@ -7,7 +7,7 @@ the license for this code.
 
 ## Significant Changes
 * Added Response File parsing to `src/CommandLine.cs`
-* Fixed racing condition in `src/common/AssemblyResolution/DependencyContextAssemblyCache.cs` that manifests themself as
+* Fixed a race condition in `src/common/AssemblyResolution/DependencyContextAssemblyCache.cs` that manifests themself as
 ```
 System.IO.FileLoadException: Could not load file or assembly 'Exceptions.Finalization.XUnitWrapper, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
 An operation is not legal in the current state. (Exception from HRESULT: 0x80131509 (COR_E_INVALIDOPERATION))

--- a/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Xunit.ConsoleClient</RootNamespace>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <IsPackable>true</IsPackable>
-    <VersionPrefix>2.5.0</VersionPrefix>
+    <VersionPrefix>2.5.1</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <DefaultItemExcludes Condition="'$(DefineConstants)' == 'WINDOWS_UWP'">common\AssemblyResolution\**;$(DefaultItemExcludes)</DefaultItemExcludes>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.XUnitConsoleRunner/src/common/AssemblyResolution/DependencyContextAssemblyCache.cs
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/src/common/AssemblyResolution/DependencyContextAssemblyCache.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -25,11 +26,11 @@ namespace Xunit
         readonly Lazy<string> fallbackRuntimeIdentifier;
         readonly IFileSystem fileSystem;
         readonly IMessageSink internalDiagnosticsMessageSink;
-        readonly Dictionary<string, Assembly> managedAssemblyCache;
+        readonly ConcurrentDictionary<string, Assembly> managedAssemblyCache;
         readonly Dictionary<string, Tuple<RuntimeLibrary, RuntimeAssetGroup>> managedAssemblyMap;
         readonly Platform operatingSystemPlatform;
         readonly string[] unmanagedDllFormats;
-        readonly Dictionary<string, string> unmanagedAssemblyCache;
+        readonly ConcurrentDictionary<string, string> unmanagedAssemblyCache;
         readonly Dictionary<string, Tuple<RuntimeLibrary, RuntimeAssetGroup>> unmanagedAssemblyMap;
 
         public DependencyContextAssemblyCache(string assemblyFolder,
@@ -57,7 +58,7 @@ namespace Xunit
             if (internalDiagnosticsMessageSink != null)
                 internalDiagnosticsMessageSink.OnMessage(new _DiagnosticMessage($"[DependencyContextAssemblyCache..ctor] Compatible runtimes: [{string.Join(",", compatibleRuntimes.Select(x => $"'{x}'"))}]"));
 
-            managedAssemblyCache = new Dictionary<string, Assembly>(StringComparer.OrdinalIgnoreCase);
+            managedAssemblyCache = new ConcurrentDictionary<string, Assembly>(StringComparer.OrdinalIgnoreCase);
             managedAssemblyMap =
                 dependencyContext.RuntimeLibraries
                                  .Where(lib => lib.RuntimeAssemblyGroups?.Count > 0)
@@ -72,7 +73,7 @@ namespace Xunit
                 internalDiagnosticsMessageSink.OnMessage(new _DiagnosticMessage($"[DependencyContextAssemblyCache..ctor] Managed assembly map: [{string.Join(",", managedAssemblyMap.Keys.Select(k => $"'{k}'").OrderBy(k => k, StringComparer.OrdinalIgnoreCase))}]"));
 
             unmanagedDllFormats = GetUnmanagedDllFormats().ToArray();
-            unmanagedAssemblyCache = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            unmanagedAssemblyCache = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             unmanagedAssemblyMap =
                 dependencyContext.RuntimeLibraries
                                  .Select(lib => compatibleRuntimes.Select(runtime => Tuple.Create(lib, lib.NativeLibraryGroups.FirstOrDefault(libGroup => string.Equals(libGroup.Runtime, runtime))))


### PR DESCRIPTION
This ports the fix for https://github.com/dotnet/coreclr/issues/20594 - https://github.com/xunit/xunit/pull/1846 that was never accepted to official xUnit repo and required us to build our own version of xUnit with this fix and overwrite it during the test run in Jenkins.

@RussKeldorph This is required in order to unblock us for getting Helix balancing work https://github.com/dotnet/coreclr/pull/23476 merged in.

/cc @sbomer @BruceForstall @dotnet/jit-contrib 