### PR TITLE
Add support for signing validation in the publishing release pipelines.

### DIFF
--- a/eng/common/SigningValidation.proj
+++ b/eng/common/SigningValidation.proj
@@ -38,6 +38,7 @@
         https://github.com/dotnet/arcade/tree/master/src/SignCheck
       -->
       <SignCheckArgs Include="--recursive" />
+      <SignCheckArgs Include="--traverse-subfolders" />
       <SignCheckArgs Include="--file-status AllFiles" />
       <SignCheckArgs Include="--log-file $(SignCheckLog)" />
       <SignCheckArgs Include="--error-log-file $(SignCheckErrorLog)" />

--- a/eng/common/SigningValidation.proj
+++ b/eng/common/SigningValidation.proj
@@ -1,0 +1,78 @@
+<!--
+  This MSBuild file is intended to be used as the body of the default 
+  publishing release pipeline. The release pipeline will use this file
+  to invoke the the SignCheck tool to validate that packages about to
+  be published are correctly signed.
+  
+  Parameters:
+  
+    - PackageBasePath   : Directory containing all files that need to be validated.
+    - SignCheckVersion  : Version of SignCheck package to be used.
+    - SignValidationExclusionList   : ItemGroup containing exclusion list to be forwarded to SignCheck.
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <!--
+    From here we import $(SignValidationExclusionList)
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)Signing.props" Condition="Exists('$(MSBuildThisFileDirectory)Signing.props')" />
+
+  <Target Name="ValidateSigning">
+    <PropertyGroup>
+      <SignCheckToolPath>$(NuGetPackageRoot)Microsoft.DotNet.SignCheck\$(SignCheckVersion)\tools\Microsoft.DotNet.SignCheck.exe</SignCheckToolPath>
+
+      <SignCheckInputDir>$(PackageBasePath)</SignCheckInputDir>
+      <SignCheckLog>signcheck.log</SignCheckLog>
+      <SignCheckErrorLog>signcheck.errors.log</SignCheckErrorLog>
+      <SignCheckExclusionsFile>signcheck.exclusions.txt</SignCheckExclusionsFile>
+    </PropertyGroup>
+    
+    <ItemGroup>
+      <!--
+        Documentation for these arguments is available here:
+        https://github.com/dotnet/arcade/tree/master/src/SignCheck
+      -->
+      <SignCheckArgs Include="--recursive" />
+      <SignCheckArgs Include="--verbosity Detailed" />
+      <SignCheckArgs Include="--log-file $(SignCheckLog)" />
+      <SignCheckArgs Include="--error-log-file $(SignCheckErrorLog)" />
+      <SignCheckArgs Include="--input-files $(SignCheckInputDir)" />
+      
+      <SignCheckArgs Include="--exclusions-file $(SignCheckExclusionsFile)" Condition="'@(SignValidationExclusionList)' != ''" />
+      <SignCheckArgs Include="--verify-jar" Condition="'$(EnableJarSigningCheck)' == 'true'" />
+      <SignCheckArgs Include="--verify-strongname" Condition="'$(EnableStrongNameCheck)' == 'true'" />
+    </ItemGroup>
+   
+    <WriteLinesToFile 
+      File="$(SignCheckExclusionsFile)"
+      Lines="@(SignValidationExclusionList)"
+      Condition="'@(SignValidationExclusionList)' != ''"
+      Overwrite="true"
+      Encoding="Unicode"/>
+    
+    <!--
+      IgnoreExitCode='true' because the tool doesn't return '0' on success.
+    -->
+    <Exec 
+      Command="&quot;$(SignCheckToolPath)&quot; @(SignCheckArgs, ' ')"
+      IgnoreExitCode='true' 
+      ConsoleToMsBuild="false" 
+      StandardErrorImportance="high" />
+
+    <Error 
+      Text="Signing validation failed. Check $(SignCheckErrorLog) for more information." 
+      Condition="Exists($(SignCheckErrorLog)) and '$([System.IO.File]::ReadAllText($(SignCheckErrorLog)))' != ''" />
+
+    <Message
+      Text="##vso[artifact.upload containerfolder=LogFiles;artifactname=LogFiles]{SignCheckErrorLog}"
+      Condition="Exists($(SignCheckErrorLog)) and '$([System.IO.File]::ReadAllText($(SignCheckErrorLog)))' != ''" />
+    
+  </Target>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.SignCheck" Version="$(SignCheckVersion)" />
+  </ItemGroup>
+</Project>

--- a/eng/common/SigningValidation.proj
+++ b/eng/common/SigningValidation.proj
@@ -9,6 +9,8 @@
     - PackageBasePath   : Directory containing all files that need to be validated.
     - SignCheckVersion  : Version of SignCheck package to be used.
     - SignValidationExclusionList   : ItemGroup containing exclusion list to be forwarded to SignCheck.
+    - EnableJarSigningCheck    : Whether .jar files should be validated.
+    - EnableStrongNameCheck    : Whether strong name check should be performed.
 -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>

--- a/eng/common/SigningValidation.proj
+++ b/eng/common/SigningValidation.proj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <!--
-    From here we import $(SignValidationExclusionList)
+    From 'Signing.props' we import $(SignValidationExclusionList)
   -->
   <Import Project="$(MSBuildThisFileDirectory)Signing.props" Condition="Exists('$(MSBuildThisFileDirectory)Signing.props')" />
 
@@ -36,7 +36,7 @@
         https://github.com/dotnet/arcade/tree/master/src/SignCheck
       -->
       <SignCheckArgs Include="--recursive" />
-      <SignCheckArgs Include="--verbosity Detailed" />
+      <SignCheckArgs Include="--file-status AllFiles" />
       <SignCheckArgs Include="--log-file $(SignCheckLog)" />
       <SignCheckArgs Include="--error-log-file $(SignCheckErrorLog)" />
       <SignCheckArgs Include="--input-files $(SignCheckInputDir)" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -91,7 +91,22 @@
         MSBuildPath="$(_DesktopMSBuildPath)"
         SNBinaryPath="$(NuGetPackageRoot)sn\$(SNVersion)\sn.exe"
         MicroBuildCorePath="$(NuGetPackageRoot)microbuild.core\$(MicroBuildCoreVersion)"/>
+    
+    <!--
+      Signing.props can be used to include configurations used by signing validation during publishing.
+    -->
+    <Message
+      Text="##vso[artifact.upload containerfolder=ReleaseConfigs;artifactname=ReleaseConfigs]$(RepositoryEngineeringDir)Signing.props"
+      Condition="Exists('$(RepositoryEngineeringDir)Signing.props')"
+      Importance="high" />
 
+    <!--
+      SigningValidation.proj includes the logic to call SignCheck and will be used during release to validate signed packages.
+    -->
+    <Message
+      Text="##vso[artifact.upload containerfolder=ReleaseConfigs;artifactname=ReleaseConfigs]$(RepositoryEngineeringDir)common\SigningValidation.proj"
+      Importance="high" />
+    
   </Target>
 
 </Project>


### PR DESCRIPTION
Relates to: #1444 

Add MSBuild wrapper target to call SignCheck. This project file + task will be used by the publishing pipeline to validate package signatures.

Here are some example releases using this project file:

https://dnceng.visualstudio.com/internal/_releaseProgress?releaseId=3946&_a=release-pipeline-progress
https://dnceng.visualstudio.com/internal/_releaseProgress?_a=release-pipeline-progress&releaseId=3945
https://dnceng.visualstudio.com/internal/_releaseProgress?_a=release-pipeline-progress&releaseId=3944