### PR TITLE
Add missing corefx test files for mono

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.props
@@ -18,6 +18,7 @@
   <!-- Supplemental test data. -->
   <ItemGroup Condition="'$(BuildingNETCoreAppVertical)' == 'true'">
     <SupplementalTestData Include="$(RuntimePath)$(TestRunnerName)" />
+    <SupplementalTestData Include="$(RuntimePath)xunit.console.deps.json" />
     <SupplementalTestData Include="$(TestRuntimeConfigPath)" DestinationName="$(TestRunnerNameWithoutExtension).runtimeconfig.json" />
     <SupplementalTestData Include="$(RuntimePath)xunit.execution.dotnet.dll" />
     <SupplementalTestData Include="$(RuntimePath)xunit.runner.reporters.netcoreapp10.dll" />
@@ -38,6 +39,7 @@
     <TestArchiveDependencies Include="$(RuntimePath)xunit.assert.dll" />
     <TestArchiveDependencies Include="$(RuntimePath)xunit.core.dll" />
     <TestArchiveDependencies Include="$(RuntimePath)xunit.abstractions.dll" />
+    <TestArchiveDependencies Include="$(RuntimePath)CoreFx.Private.TestUtilities.dll" />
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)References.props" />


### PR DESCRIPTION
Adding xunit.console.deps.json and CoreFx.Private.TestUtilities.dll. The first one actuals should be in the test directory not just for archiving. The second one is in our runtimepath which means we only want to add it for archiving.