### PR TITLE
Add result container prefix

### DIFF
--- a/src/Microsoft.DotNet.Helix/Client/CSharp/Microsoft.DotNet.Helix.Client.csproj
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/Microsoft.DotNet.Helix.Client.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
 
-    <!-- <PackageReference Include="Microsoft.DotNet.SwaggerGenerator.MSBuild" Version="$(MicrosoftDotNetSwaggerGeneratorMSBuildVersion)" PrivateAssets="all"/> -->
+    <PackageReference Include="Microsoft.DotNet.SwaggerGenerator.MSBuild" Version="$(MicrosoftDotNetSwaggerGeneratorMSBuildVersion)" PrivateAssets="all"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/Artifact.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/Artifact.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Immutable;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.Helix.Client.Models
+{
+    public partial class Artifact
+    {
+        public Artifact()
+        {
+        }
+
+        [JsonProperty("Id")]
+        public string Id { get; set; }
+
+        [JsonProperty("Parameters")]
+        public IImmutableDictionary<string, Newtonsoft.Json.Linq.JToken> Parameters { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/CustomImagePreInstalled.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/CustomImagePreInstalled.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Immutable;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.Helix.Client.Models
+{
+    public partial class CustomImagePreInstalled
+    {
+        public CustomImagePreInstalled()
+        {
+        }
+
+        [JsonProperty("System")]
+        public string System { get; set; }
+
+        [JsonProperty("Processor")]
+        public string Processor { get; set; }
+
+        [JsonProperty("Version")]
+        public string Version { get; set; }
+
+        [JsonProperty("Distro")]
+        public string Distro { get; set; }
+
+        [JsonProperty("DistroVersion")]
+        public string DistroVersion { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/CustomImagePrepared.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/CustomImagePrepared.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Immutable;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.Helix.Client.Models
+{
+    public partial class CustomImagePrepared
+    {
+        public CustomImagePrepared()
+        {
+        }
+
+        [JsonProperty("Name")]
+        public string Name { get; set; }
+
+        [JsonProperty("System")]
+        public string System { get; set; }
+
+        [JsonProperty("Version")]
+        public string Version { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/ImageInfo.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/ImageInfo.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Immutable;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.Helix.Client.Models
+{
+    public partial class ImageInfo
+    {
+        public ImageInfo()
+        {
+        }
+
+        [JsonProperty("Publisher")]
+        public string Publisher { get; set; }
+
+        [JsonProperty("Offer")]
+        public string Offer { get; set; }
+
+        [JsonProperty("Sku")]
+        public string Sku { get; set; }
+
+        [JsonProperty("Version")]
+        public string Version { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/JobCreationRequest.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/JobCreationRequest.cs
@@ -46,6 +46,9 @@ namespace Microsoft.DotNet.Helix.Client.Models
         [JsonProperty("Creator")]
         public string Creator { get; set; }
 
+        [JsonProperty("ResultContainerPrefix")]
+        public string ResultContainerPrefix { get; set; }
+
         [JsonProperty("PullRequestId")]
         public string PullRequestId { get; set; }
 

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/JobCreationRequest.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/JobCreationRequest.cs
@@ -46,9 +46,6 @@ namespace Microsoft.DotNet.Helix.Client.Models
         [JsonProperty("Creator")]
         public string Creator { get; set; }
 
-        [JsonProperty("ResultContainerPrefix")]
-        public string ResultContainerPrefix { get; set; }
-
         [JsonProperty("PullRequestId")]
         public string PullRequestId { get; set; }
 
@@ -60,6 +57,9 @@ namespace Microsoft.DotNet.Helix.Client.Models
 
         [JsonProperty("JobStartIdentifier")]
         public string JobStartIdentifier { get; set; }
+
+        [JsonProperty("ResultContainerPrefix")]
+        public string ResultContainerPrefix { get; set; }
 
         [JsonIgnore]
         public bool IsValid

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/QueueInfo.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/QueueInfo.cs
@@ -10,8 +10,20 @@ namespace Microsoft.DotNet.Helix.Client.Models
         {
         }
 
+        [JsonProperty("Artifacts")]
+        public IImmutableList<Artifact> Artifacts { get; set; }
+
         [JsonProperty("Description")]
         public string Description { get; set; }
+
+        [JsonProperty("GalleryImage")]
+        public ImageInfo GalleryImage { get; set; }
+
+        [JsonProperty("Purpose")]
+        public string Purpose { get; set; }
+
+        [JsonProperty("Architecture")]
+        public string Architecture { get; set; }
 
         [JsonProperty("IsAvailable")]
         public bool? IsAvailable { get; set; }
@@ -25,11 +37,23 @@ namespace Microsoft.DotNet.Helix.Client.Models
         [JsonProperty("OperatingSystemGroup")]
         public string OperatingSystemGroup { get; set; }
 
+        [JsonProperty("PreInstalledImage")]
+        public CustomImagePreInstalled PreInstalledImage { get; set; }
+
+        [JsonProperty("PreparedImage")]
+        public CustomImagePrepared PreparedImage { get; set; }
+
         [JsonProperty("QueueId")]
         public string QueueId { get; set; }
 
         [JsonProperty("QueueDepth")]
         public long? QueueDepth { get; set; }
+
+        [JsonProperty("ScaleMin")]
+        public int? ScaleMin { get; set; }
+
+        [JsonProperty("ScaleMax")]
+        public int? ScaleMax { get; set; }
 
         [JsonProperty("UserList")]
         public string UserList { get; set; }

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -208,10 +208,13 @@ namespace Microsoft.DotNet.Helix.Client
             {
                 // Remove all slashes from repository name and branch name. Also remove refs/, heads/, and pulls/ from branch name.
                 // ResultContainerPrefix will be <Repository Name>-<BranchName>
-                string repoName = Environment.GetEnvironmentVariable("BUILD_REPOSITORY_NAME").Replace("/", "-");
+                string repoName = Environment.GetEnvironmentVariable("BUILD_REPOSITORY_NAME")
+                    .Replace("/", "-")
+                    .Replace(".","");
                 string branchName = Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH")
-                    .Replace("/","-");
-                ResultContainerPrefix = $"{repoName}.{branchName}-";
+                    .Replace("/","-")
+                    .Replace(".","");
+                ResultContainerPrefix = $"{repoName}-{branchName}-";
             }
 
             string jobStartIdentifier = Guid.NewGuid().ToString("N");

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -43,6 +43,7 @@ namespace Microsoft.DotNet.Helix.Client
         public string Build { get; private set; }
         public string TargetQueueId { get; private set; }
         public string Creator { get; private set; }
+        public string ResultContainerPrefix { get; private set; }
         public IDictionary<IPayload, string> CorrelationPayloads { get; } = new Dictionary<IPayload, string>();
         public int? MaxRetryCount { get; private set; }
         public string StorageAccountConnectionString { get; private set; }
@@ -202,6 +203,14 @@ namespace Microsoft.DotNet.Helix.Client
             string jobListUriForLogging = jobListUri.ToString().Replace(jobListUri.Query, "");
             log?.Invoke($"Created job list at {jobListUriForLogging}");
 
+            // Only specify the ResultContainerPrefix if both repository name and source branch are available.
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("BUILD_REPOSITORY_NAME")) && !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH")))
+            {
+                // Remove all slashes from repository name and branch name. Also remove refs/heads/ and /merge from branch name.
+                // ResultContainerPrefix will be <Repository Name><BranchName>
+                ResultContainerPrefix = $"{Environment.GetEnvironmentVariable("BUILD_REPOSITORY_NAME").Replace("/", "")}{Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH").Replace("refs/heads/","").Replace("/merge","")}";
+            }
+
             string jobStartIdentifier = Guid.NewGuid().ToString("N");
             JobCreationResult newJob = await HelixApi.RetryAsync(
                 () => JobApi.NewAsync(
@@ -214,6 +223,7 @@ namespace Microsoft.DotNet.Helix.Client
                         TargetQueueId)
                     {
                         Creator = Creator,
+                        ResultContainerPrefix = ResultContainerPrefix,
                         MaxRetryCount = MaxRetryCount ?? 0,
                         JobStartIdentifier = jobStartIdentifier,
                         ResultsUri = resultsStorageContainer?.Uri,

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -210,11 +210,8 @@ namespace Microsoft.DotNet.Helix.Client
                 // ResultContainerPrefix will be <Repository Name>-<BranchName>
                 string repoName = Environment.GetEnvironmentVariable("BUILD_REPOSITORY_NAME").Replace("/", "-");
                 string branchName = Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH")
-                    .Replace("refs/","")
-                    .Replace("heads/","")
-                    .Replace("/merge","")
                     .Replace("/","-");
-                ResultContainerPrefix = $"{repoName}-{branchName}-";
+                ResultContainerPrefix = $"{repoName}.{branchName}-";
             }
 
             string jobStartIdentifier = Guid.NewGuid().ToString("N");

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -214,7 +214,7 @@ namespace Microsoft.DotNet.Helix.Client
                     .Replace("heads/","")
                     .Replace("pulls/","")
                     .Replace("/","-");
-                ResultContainerPrefix = $"{repoName}-{branchName}";
+                ResultContainerPrefix = $"{repoName}-{branchName}-";
             }
 
             string jobStartIdentifier = Guid.NewGuid().ToString("N");

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -212,7 +212,7 @@ namespace Microsoft.DotNet.Helix.Client
                 string branchName = Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH")
                     .Replace("refs/","")
                     .Replace("heads/","")
-                    .Replace("pulls/","")
+                    .Replace("/merge","")
                     .Replace("/","-");
                 ResultContainerPrefix = $"{repoName}-{branchName}-";
             }

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Helix.Client.Models;
 using Microsoft.Rest;
@@ -206,14 +207,18 @@ namespace Microsoft.DotNet.Helix.Client
             // Only specify the ResultContainerPrefix if both repository name and source branch are available.
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("BUILD_REPOSITORY_NAME")) && !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH")))
             {
-                // Remove all slashes from repository name and branch name. Also remove refs/, heads/, and pulls/ from branch name.
+                // Replace / with -. Remove all characters not allowed in container names. Make it lowercase.
                 // ResultContainerPrefix will be <Repository Name>-<BranchName>
+                Regex illegalCharacters = new Regex("[^a-z0-9-]");
+
                 string repoName = Environment.GetEnvironmentVariable("BUILD_REPOSITORY_NAME")
-                    .Replace("/", "-")
-                    .Replace(".","");
+                    .Replace("/", "-").ToLower();
+                repoName = illegalCharacters.Replace(repoName, "");
+
                 string branchName = Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH")
-                    .Replace("/","-")
-                    .Replace(".","");
+                    .Replace("/","-").ToLower();
+                branchName = illegalCharacters.Replace(branchName, "");
+
                 ResultContainerPrefix = $"{repoName}-{branchName}-";
             }
 

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -213,17 +213,12 @@ namespace Microsoft.DotNet.Helix.Client
                 Regex illegalCharacters = new Regex("[^a-z0-9-]");
                 Regex multipleDashes = new Regex("--+");
 
-                string repoName = Environment.GetEnvironmentVariable("BUILD_REPOSITORY_NAME")
-                    .Replace("/", "-").ToLower();
-                repoName = multipleDashes.Replace(illegalCharacters.Replace(repoName, ""), "-");
-
-
-                string branchName = Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH")
-                    .Replace("/","-").ToLower();
-                branchName = multipleDashes.Replace(illegalCharacters.Replace(branchName, ""), "-");
+                string repoName = Environment.GetEnvironmentVariable("BUILD_REPOSITORY_NAME");
+                string branchName = Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH");
 
                 // ResultContainerPrefix will be <Repository Name>-<BranchName>
-                ResultContainerPrefix = $"{repoName}-{branchName}-";
+                ResultContainerPrefix = $"{repoName}-{branchName}-".Replace("/", "-").ToLower();
+                ResultContainerPrefix  = multipleDashes.Replace(illegalCharacters.Replace(ResultContainerPrefix, ""), "-");
             }
 
             string jobStartIdentifier = Guid.NewGuid().ToString("N");

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -223,12 +223,12 @@ namespace Microsoft.DotNet.Helix.Client
                         TargetQueueId)
                     {
                         Creator = Creator,
-                        ResultContainerPrefix = ResultContainerPrefix,
                         MaxRetryCount = MaxRetryCount ?? 0,
                         JobStartIdentifier = jobStartIdentifier,
                         ResultsUri = resultsStorageContainer?.Uri,
                         ResultsUriRSAS = resultsStorageContainer?.ReadSas,
                         ResultsUriWSAS = resultsStorageContainer?.WriteSas,
+                        ResultContainerPrefix = ResultContainerPrefix,
                     }),
                 ex => log?.Invoke($"Starting job failed with {ex}\nRetrying..."));
 

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -211,7 +211,7 @@ namespace Microsoft.DotNet.Helix.Client
                 // Replace / with -, make all branch and repository names lowercase, remove any characters not
                 // allowed in container names, and replace any string of dashes with a single dash.
                 Regex illegalCharacters = new Regex("[^a-z0-9-]");
-                Regex multipleDashes = new Regex("--+");
+                Regex multipleDashes = new Regex("-{2,}");
 
                 string repoName = Environment.GetEnvironmentVariable("BUILD_REPOSITORY_NAME");
                 string branchName = Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH");

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -207,8 +207,9 @@ namespace Microsoft.DotNet.Helix.Client
             // Only specify the ResultContainerPrefix if both repository name and source branch are available.
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("BUILD_REPOSITORY_NAME")) && !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH")))
             {
-                // Replace / with -. Remove all characters not allowed in container names. Make it lowercase.
-                // ResultContainerPrefix will be <Repository Name>-<BranchName>
+                // Container names can only be alphanumeric (plus dashes) lowercase names, with no consecutive dashes.
+                // Replace / with -, make all branch and repository names lowercase, remove any characters not
+                // allowed in container names, and replace any string of dashes with a single dash.
                 Regex illegalCharacters = new Regex("[^a-z0-9-]");
                 Regex multipleDashes = new Regex("--+");
 
@@ -221,6 +222,7 @@ namespace Microsoft.DotNet.Helix.Client
                     .Replace("/","-").ToLower();
                 branchName = multipleDashes.Replace(illegalCharacters.Replace(branchName, ""), "-");
 
+                // ResultContainerPrefix will be <Repository Name>-<BranchName>
                 ResultContainerPrefix = $"{repoName}-{branchName}-";
             }
 

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -210,14 +210,16 @@ namespace Microsoft.DotNet.Helix.Client
                 // Replace / with -. Remove all characters not allowed in container names. Make it lowercase.
                 // ResultContainerPrefix will be <Repository Name>-<BranchName>
                 Regex illegalCharacters = new Regex("[^a-z0-9-]");
+                Regex multipleDashes = new Regex("--+");
 
                 string repoName = Environment.GetEnvironmentVariable("BUILD_REPOSITORY_NAME")
                     .Replace("/", "-").ToLower();
-                repoName = illegalCharacters.Replace(repoName, "");
+                repoName = multipleDashes.Replace(illegalCharacters.Replace(repoName, ""), "-");
+
 
                 string branchName = Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH")
                     .Replace("/","-").ToLower();
-                branchName = illegalCharacters.Replace(branchName, "");
+                branchName = multipleDashes.Replace(illegalCharacters.Replace(branchName, ""), "-");
 
                 ResultContainerPrefix = $"{repoName}-{branchName}-";
             }

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -208,7 +208,7 @@ namespace Microsoft.DotNet.Helix.Client
             {
                 // Remove all slashes from repository name and branch name. Also remove refs/heads/ and /merge from branch name.
                 // ResultContainerPrefix will be <Repository Name><BranchName>
-                ResultContainerPrefix = $"{Environment.GetEnvironmentVariable("BUILD_REPOSITORY_NAME").Replace("/", "")}{Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH").Replace("refs/heads/","").Replace("/merge","")}";
+                ResultContainerPrefix = $"{Environment.GetEnvironmentVariable("BUILD_REPOSITORY_NAME").Replace("/", "-")}{Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH").Replace("refs/heads/","").Replace("/","-")}";
             }
 
             string jobStartIdentifier = Guid.NewGuid().ToString("N");

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -206,9 +206,15 @@ namespace Microsoft.DotNet.Helix.Client
             // Only specify the ResultContainerPrefix if both repository name and source branch are available.
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("BUILD_REPOSITORY_NAME")) && !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH")))
             {
-                // Remove all slashes from repository name and branch name. Also remove refs/heads/ and /merge from branch name.
-                // ResultContainerPrefix will be <Repository Name><BranchName>
-                ResultContainerPrefix = $"{Environment.GetEnvironmentVariable("BUILD_REPOSITORY_NAME").Replace("/", "-")}{Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH").Replace("refs/heads/","").Replace("/","-")}";
+                // Remove all slashes from repository name and branch name. Also remove refs/, heads/, and pulls/ from branch name.
+                // ResultContainerPrefix will be <Repository Name>-<BranchName>
+                string repoName = Environment.GetEnvironmentVariable("BUILD_REPOSITORY_NAME").Replace("/", "-");
+                string branchName = Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH")
+                    .Replace("refs/","")
+                    .Replace("heads/","")
+                    .Replace("pulls/","")
+                    .Replace("/","-");
+                ResultContainerPrefix = $"{repoName}-{branchName}";
             }
 
             string jobStartIdentifier = Guid.NewGuid().ToString("N");


### PR DESCRIPTION
Specify the ResultsContainerPrefix to be used when we send jobs to helix so that the results containers are more easily discoverable.

For PRs, we will get containers that have the prefix `<repo-name>-pull-<pr number>-` and for non prs, we will have the prefix `<repo-name>-<branch-name>-` with all slashes (/) replaced with dashes (-). For example, the container for this pr has the prefix `dotnet-arcade-pull-2367-` and the container for the master branch of dotnet\arcade will be prefixed with `dotnet-arcade-master-`. The end of the container name is the first 18 characters of the correlation id of the job.