### PR TITLE
2286: Return passing test result for exit code 0 when no result files are found

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
@@ -366,7 +366,7 @@ namespace Microsoft.DotNet.Helix.Sdk
 
             // Capture helix command exit code, in case work item command (i.e xunit call) exited with a failure,
             // this way we can exit the process honoring that exit code, needed for retry.
-            yield return IsPosixShell ? $"{exitCodeVariableName}=$?" : $"set {exitCodeVariableName}=%ERRORLEVEL%";
+            yield return IsPosixShell ? $"export {exitCodeVariableName}=$?" : $"set {exitCodeVariableName}=%ERRORLEVEL%";
 
             if (workItem.TryGetMetadata("PostCommands", out string workItemPostCommandsString))
             {

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/test_results_reader/__init__.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/test_results_reader/__init__.py
@@ -6,16 +6,25 @@ from helpers import get_env
 
 
 def __no_results_result():
+    exitCode = get_env("_commandExitCode")
     work_item_name = get_env("HELIX_WORKITEM_FRIENDLYNAME")
+    
+    if exitCode != "0":
+        result = 'Fail'
+        failure_message = 'The work item failed to produce any test results.'
+    else:
+        result = 'Pass'
+        failure_message = None
+
     yield TestResult(
         name=u'{}.WorkItemExecution'.format(work_item_name),
         kind=u'unknown',
         type_name=u'{}'.format(work_item_name),
         method=u'WorkItemExecution',
         duration=1,
-        result=u'Fail',
+        result=u'{}'.format(result),
         exception_type=None,
-        failure_message=u'The work item failed to produce any test results.',
+        failure_message=u'{}'.format(failure_message),
         stack_trace=None,
         skip_reason=None,
         attachments=None,


### PR DESCRIPTION
When a test returns an exit code of 0 and no results files are available, we'll return a passing test result. 

Verified by creating two tests: one that set the exit code as 0 and another that set the exit code as -1. Verified that the test with the -1 exit code continued to return a failing test results, and the test with the 0 exit code would return a passing test result. 