### PR TITLE
Remove xunit.console.deps.json from output dir

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.props
@@ -18,7 +18,6 @@
   <!-- Supplemental test data. -->
   <ItemGroup Condition="'$(BuildingNETCoreAppVertical)' == 'true'">
     <SupplementalTestData Include="$(RuntimePath)$(TestRunnerName)" />
-    <SupplementalTestData Include="$(RuntimePath)xunit.console.deps.json" />
     <SupplementalTestData Include="$(TestRuntimeConfigPath)" DestinationName="$(TestRunnerNameWithoutExtension).runtimeconfig.json" />
     <SupplementalTestData Include="$(RuntimePath)xunit.execution.dotnet.dll" />
     <SupplementalTestData Include="$(RuntimePath)xunit.runner.reporters.netcoreapp10.dll" />
@@ -37,6 +36,7 @@
   <ItemGroup Condition="'$(IncludeTestFrameworkReferences)' == 'true'">
     <TestArchiveDependencies Include="$(RuntimePath)Microsoft.DotNet.XUnitExtensions.dll" />
     <TestArchiveDependencies Include="$(RuntimePath)xunit.assert.dll" />
+    <TestArchiveDependencies Include="$(RuntimePath)xunit.console.deps.json" />
     <TestArchiveDependencies Include="$(RuntimePath)xunit.core.dll" />
     <TestArchiveDependencies Include="$(RuntimePath)xunit.abstractions.dll" />
     <TestArchiveDependencies Include="$(RuntimePath)CoreFx.Private.TestUtilities.dll" />


### PR DESCRIPTION
Having that file in our test output causes assembly load errors. Removing it and only bundling it into the test archive folder.