### PR TITLE
Fix exit codes

### DIFF
--- a/src/HelixPoolProvider/HelixPoolProvider/appsettings.dncenginternal-int.json
+++ b/src/HelixPoolProvider/HelixPoolProvider/appsettings.dncenginternal-int.json
@@ -11,7 +11,7 @@
     "BuildPool.Windows.10.Amd64.VS2019",
     "BuildPool.Windows.10.Amd64.VS2019.BT"
   ],
-  "HelixCreator": "helixpoolprovider-dncengpublic-int",
+  "HelixCreator": "helixpoolprovider-dncenginternal-int",
   "TimeoutInMinutes": 600,
   "HelixEndpoint": "https://helix.dot.net",
   "MaxParallelism": 1000,

--- a/src/HelixPoolProvider/HelixPoolProvider/wwwroot/startupscripts/startagent-linux.sh
+++ b/src/HelixPoolProvider/HelixPoolProvider/wwwroot/startupscripts/startagent-linux.sh
@@ -17,7 +17,7 @@ $workspace_path/run.sh
 
 # Expect an exit code of 2, which is what is given when the agent connection is revoked
 lastexitcode=$?
-if [[ $lastexitcode -ne 2 ]]; then
+if [[ $lastexitcode -ne 0 ]]; then
 	echo "Unexpected error returned from agent: $lastexitcode"
 	exit $lastexitcode
 else

--- a/src/HelixPoolProvider/HelixPoolProvider/wwwroot/startupscripts/startagent-mac.sh
+++ b/src/HelixPoolProvider/HelixPoolProvider/wwwroot/startupscripts/startagent-mac.sh
@@ -12,9 +12,8 @@ cp -f $HELIX_WORKITEM_PAYLOAD/.credentials $workspace_path
 
 $workspace_path/run.sh
 
-# Expect an exit code of 2, which is what is given when the agent connection is revoked
 lastexitcode=$?
-if [[ $lastexitcode -ne 2 ]]; then
+if [[ $lastexitcode -ne 0 ]]; then
 	echo "Unexpected error returned from agent: $lastexitcode"
 	exit $lastexitcode
 else

--- a/src/HelixPoolProvider/HelixPoolProvider/wwwroot/startupscripts/startagent-win.cmd
+++ b/src/HelixPoolProvider/HelixPoolProvider/wwwroot/startupscripts/startagent-win.cmd
@@ -6,11 +6,10 @@ mkdir %WORKSPACEPATH%
 xcopy /Y /S /I %HELIX_CORRELATION_PAYLOAD%\* %WORKSPACEPATH%
 copy /Y %HELIX_WORKITEM_PAYLOAD%\.agent %WORKSPACEPATH%
 copy /Y %HELIX_WORKITEM_PAYLOAD%\.credentials %WORKSPACEPATH%
-%WORKSPACEPATH%\run.cmd
+call %WORKSPACEPATH%\run.cmd
 
 set LASTEXITCODE=%errorlevel%
-REM Expect an exit code of 2, which is what is given when the agent connection is revoked
-if not "%LASTEXITCODE%" == "2" (
+if not "%LASTEXITCODE%" == "0" (
 	echo "Unexpected error returned from agent: %LASTEXITCODE%"
 	exit /b 1
 ) else (


### PR DESCRIPTION
It used to be that a return code of 2 was success (indicating the client was disconnected).  Now, 0 appears to be the correct return code.