### PR TITLE
Remove deps from test archive

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.props
@@ -43,7 +43,6 @@
   <ItemGroup Condition="'$(IncludeTestFrameworkReferences)' == 'true'">
     <TestArchiveDependencies Include="$(RuntimePath)Microsoft.DotNet.XUnitExtensions.dll" />
     <TestArchiveDependencies Include="$(RuntimePath)xunit.assert.dll" />
-    <TestArchiveDependencies Condition="'$(BuildingNETCoreAppVertical)' == 'true'" Include="$(RuntimePath)xunit.console.deps.json" />
     <TestArchiveDependencies Include="$(RuntimePath)xunit.core.dll" />
     <TestArchiveDependencies Include="$(RuntimePath)xunit.abstractions.dll" />
     <TestArchiveDependencies Include="$(RuntimePath)CoreFx.Private.TestUtilities.dll" />


### PR DESCRIPTION
If we add the deps.json our tests start to fail. Removing it as Mono shouldn't need it either: https://mc.dot.net/#/user/dotnet-bot/pr~2Fdotnet~2Fcorefx~2Frefs~2Fpull~2F36487~2Fmerge/test~2Ffunctional~2Fcli~2F/20190402.3/workItem/Microsoft.XmlSerializer.Generator.Tests/wilogs