### PR TITLE
Addressing issues with the new GenfacadesSourceTask

### DIFF
--- a/src/Microsoft.DotNet.GenAPI/build/Microsoft.DotNet.GenAPI.targets
+++ b/src/Microsoft.DotNet.GenAPI/build/Microsoft.DotNet.GenAPI.targets
@@ -58,7 +58,7 @@
     <!-- Tell ResolveMatchingContract to run and resolve contract to project reference -->
     <ResolveMatchingContract>true</ResolveMatchingContract>
     <NotSupportedSourceFile>$(IntermediateOutputPath)$(TargetName).notsupported.cs</NotSupportedSourceFile>
-    <CoreCompileDependsOn>$(CoreCompileDependsOn);GenerateNotSupportedSource</CoreCompileDependsOn>
+    <CoreCompileDependsOn>GenerateNotSupportedSource;$(CoreCompileDependsOn)</CoreCompileDependsOn>
     <!-- Not supported sources are created from the ref assembly, we currently don't produce finalizers in dummmy assemblies, so we disable ApiCompat to not fail. -->
     <RunApiCompat>false</RunApiCompat>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.targets
@@ -1,10 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     <_MicrosoftDotNetGenFacadesTaskDir Condition="'$(MSBuildRuntimeType)' == 'core'">$(MSBuildThisFileDirectory)../tools/netcoreapp2.1/</_MicrosoftDotNetGenFacadesTaskDir>
     <_MicrosoftDotNetGenFacadesTaskDir Condition="'$(MSBuildRuntimeType)' != 'core'">$(MSBuildThisFileDirectory)../tools/net472/</_MicrosoftDotNetGenFacadesTaskDir>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <GenFacadesTargetAssemblyPath Condition="'$(GenFacadesTargetAssemblyPath)' == ''">$(_MicrosoftDotNetGenFacadesTaskDir)Microsoft.DotNet.GenFacades.dll</GenFacadesTargetAssemblyPath>
+  </PropertyGroup>
+
+  <UsingTask TaskName="GenFacadesTask" AssemblyFile="$(GenFacadesTargetAssemblyPath)" />
 
   <Import Condition="'$(IsPartialFacadeAssembly)' == 'true' AND '$(IsReferenceAssembly)' != 'true'" Project="Microsoft.DotNet.GenPartialFacadeSource.targets" />
   <Import Condition="'$(IsPartialFacadeAssembly)' == 'true' AND '$(IsReferenceAssembly)' == 'true'" Project="Microsoft.DotNet.GenFacadesILRewriter.targets" />

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacadesILRewriter.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacadesILRewriter.targets
@@ -1,3 +1,4 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
   <PropertyGroup>
     <!-- reference facades will always have overlapping types so suppress compiler warnings -->
@@ -14,8 +15,6 @@
     <GenFacadesOutputPath>$(IntermediateOutputPath)</GenFacadesOutputPath>
     <GenFacadesResponseFile>$(GenFacadesInputPath)genfacades.rsp</GenFacadesResponseFile>
   </PropertyGroup>
-
-  <UsingTask TaskName="GenFacadesTask" AssemblyFile="$(_MicrosoftDotNetGenFacadesTaskDir)Microsoft.DotNet.GenFacades.dll" />
 
   <!-- Hook both partial-facade-related targets into TargetsTriggeredByCompilation. This will cause them
           to only be invoked upon a successful compilation; they can conceptualized as an extension
@@ -43,7 +42,7 @@
       <GenFacadesSeeds Include="@(ReferencePath)" />
     </ItemGroup>
 
-    <Error Text="No single matching contract found." Condition="'$(IsReferenceAssembly)' != 'true' AND '@(ResolvedMatchingContract->Count())' != '1'" />
+    <Error Text="No single matching contract found." Condition="'$(IsReferenceAssembly)' != 'true' and '@(ResolvedMatchingContract->Count())' != '1'" />
 
     <MakeDir Directories="$(GenFacadesInputPath)" />
 
@@ -55,7 +54,7 @@
     <PropertyGroup>
       <ProducePdb>true</ProducePdb>
       <!-- Partial facade PDB generation only functions on Windows -->
-      <ProducePdb Condition="'$(DebugSymbols)' == 'false' OR '$(OS)' != 'Windows_NT'">false</ProducePdb>
+      <ProducePdb Condition="'$(DebugSymbols)' == 'false' or '$(OS)' != 'Windows_NT'">false</ProducePdb>
       <GenFacadesIgnoreMissingTypes Condition="'$(GenFacadesIgnoreMissingTypes)' == ''">false</GenFacadesIgnoreMissingTypes>
       <GenFacadesIgnoreBuildAndRevisionMismatch Condition="'$(GenFacadesIgnoreBuildAndRevisionMismatch)' == ''">false</GenFacadesIgnoreBuildAndRevisionMismatch>
     </PropertyGroup>

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenPartialFacadeSource.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenPartialFacadeSource.targets
@@ -7,11 +7,6 @@
       $(GeneratePartialFacadeSourceDependsOn);ResolveMatchingContract
     </GeneratePartialFacadeSourceDependsOn>
 
-    <GeneratePartialFacadeSourceDependsOn Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' or '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">
-      $(GeneratePartialFacadeSourceDependsOn);GenerateNotSupportedSource
-    </GeneratePartialFacadeSourceDependsOn>
-  </PropertyGroup>
-
   <PropertyGroup>
     <OutputSourcePath>$(IntermediateOutputPath)\$(AssemblyTitle).Forwards.cs</OutputSourcePath>
     <CoreCompileDependsOn Condition="'$(DesignTimeBuild)' != 'true'">

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenPartialFacadeSource.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenPartialFacadeSource.targets
@@ -6,27 +6,31 @@
     <GeneratePartialFacadeSourceDependsOn>
       $(GeneratePartialFacadeSourceDependsOn);ResolveMatchingContract
     </GeneratePartialFacadeSourceDependsOn>
+
+    <GeneratePartialFacadeSourceDependsOn Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' or '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">
+      $(GeneratePartialFacadeSourceDependsOn);GenerateNotSupportedSource
+    </GeneratePartialFacadeSourceDependsOn>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <OutputSourcePath>$(IntermediateOutputPath)\$(AssemblyTitle).Forwards.cs</OutputSourcePath>
-    <CompileDependsOn Condition="'$(DesignTimeBuild)' != 'true'">
-      GeneratePartialFacadeSource;$(CompileDependsOn)
-    </CompileDependsOn>
+    <CoreCompileDependsOn Condition="'$(DesignTimeBuild)' != 'true'">
+      $(CoreCompileDependsOn);GeneratePartialFacadeSource
+    </CoreCompileDependsOn>
   </PropertyGroup>
 
   <UsingTask TaskName="GenPartialFacadeSource" AssemblyFile="$(GenFacadesTargetAssemblyPath)" />
-  
+
   <Target Name="GeneratePartialFacadeSource"
           Inputs="$(MSBuildAllProjects);@(ResolvedMatchingContract);@(ReferencePath);@(Compile)"
           Outputs="$(OutputSourcePath)"
-          DependsOnTargets="$(GeneratePartialFacadeSourceDependsOn)">  
+          DependsOnTargets="$(GeneratePartialFacadeSourceDependsOn)">
 
     <PropertyGroup>
       <OutputSourcePath>$(IntermediateOutputPath)\$(AssemblyTitle).Forwards.cs</OutputSourcePath>
       <ReferenceAssembly>%(ResolvedMatchingContract.Identity)</ReferenceAssembly>
     </PropertyGroup>
-    
+
     <GenPartialFacadeSource
       ReferencePaths="@(ReferencePath)"
       ReferenceAssembly="$(ReferenceAssembly)"
@@ -42,7 +46,7 @@
     <ItemGroup>
       <FileWrites Include="$(OutputSourcePath)"/>
     </ItemGroup>
-  
+
     <ItemGroup>
       <Compile Condition="Exists('$(OutputSourcePath)')" Include="$(OutputSourcePath)"/>
     </ItemGroup>

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenPartialFacadeSource.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenPartialFacadeSource.targets
@@ -1,3 +1,4 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
   <PropertyGroup>
     <!-- Tell ResolveMatchingContract to run and resolve contract to project reference -->
@@ -14,8 +15,8 @@
     </CompileDependsOn>
   </PropertyGroup>
 
-  <UsingTask TaskName="GenPartialFacadeSource" AssemblyFile="$(_MicrosoftDotNetGenFacadesTaskDir)Microsoft.DotNet.GenFacades.dll" />
-
+  <UsingTask TaskName="GenPartialFacadeSource" AssemblyFile="$(GenFacadesTargetAssemblyPath)" />
+  
   <Target Name="GeneratePartialFacadeSource"
           Inputs="$(MSBuildAllProjects);@(ResolvedMatchingContract);@(ReferencePath);@(Compile)"
           Outputs="$(OutputSourcePath)"
@@ -43,7 +44,7 @@
     </ItemGroup>
   
     <ItemGroup>
-      <Compile Condition="Exists($(OutputSourcePath))" Include="$(OutputSourcePath)"/>
+      <Compile Condition="Exists('$(OutputSourcePath)')" Include="$(OutputSourcePath)"/>
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
- moving using task to main file so that shims can use this task
- adding license header
- exposing genfacades assembly path variable if we manually want to set the path
- Added single quotes for generated file path