### PR TITLE
Publish symbols using release pipelines

### DIFF
--- a/eng/common/PublishToPackageFeed.proj
+++ b/eng/common/PublishToPackageFeed.proj
@@ -1,11 +1,13 @@
-<!--
-  This MSBuild file is intended to be used as the body of the default 
-  publishing release pipeline. The release pipeline will use this file
-  to invoke the PushToStaticFeed task that will read the build asset
-  manifest and publish the assets described in the manifest to
-  informed target feeds.
--->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
+  <!--
+    This MSBuild file is intended to be used as the body of the default 
+    publishing release pipeline. The release pipeline will use this file
+    to invoke the PushToStaticFeed task that will read the build asset
+    manifest and publish the assets described in the manifest to
+    informed target feeds.
+  -->
+
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>

--- a/eng/common/PublishToSymbolServers.proj
+++ b/eng/common/PublishToSymbolServers.proj
@@ -18,6 +18,8 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
+  <Import Project="$(NuGetPackageRoot)microsoft.symboluploader.build.task\$(SymbolUploaderVersion)\build\PublishSymbols.targets" />
+    
   <Target Name="PublishSymbols">
     <ItemGroup>
       <FilesToPublishToSymbolServer Include="$(PDBArtifactsDirectory)\*.pdb"/>
@@ -26,6 +28,8 @@
 
     <PropertyGroup>
       <DotNetSymbolExpirationInDays Condition="'$(DotNetSymbolExpirationInDays)' == ''">3650</DotNetSymbolExpirationInDays>
+      
+      <PublishToSymbolServer>true</PublishToSymbolServer>
       <PublishToSymbolServer Condition="'@(FilesToPublishToSymbolServer)' == '' and '@(PackagesToPublishToSymbolServer)' == ''">false</PublishToSymbolServer>
     </PropertyGroup>
 

--- a/eng/common/PublishToSymbolServers.proj
+++ b/eng/common/PublishToSymbolServers.proj
@@ -64,4 +64,8 @@
                     PdbConversionTreatAsWarning=""
                     Condition="$(PublishToSymbolServer)"/>
   </Target>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SymbolUploader.Build.Task" Version="$(SymbolUploaderVersion)" />
+  </ItemGroup>
 </Project>

--- a/eng/common/PublishToSymbolServers.proj
+++ b/eng/common/PublishToSymbolServers.proj
@@ -28,7 +28,6 @@
 
     <PropertyGroup>
       <DotNetSymbolExpirationInDays Condition="'$(DotNetSymbolExpirationInDays)' == ''">3650</DotNetSymbolExpirationInDays>
-      
       <PublishToSymbolServer>true</PublishToSymbolServer>
       <PublishToSymbolServer Condition="'@(FilesToPublishToSymbolServer)' == '' and '@(PackagesToPublishToSymbolServer)' == ''">false</PublishToSymbolServer>
     </PropertyGroup>

--- a/eng/common/PublishToSymbolServers.proj
+++ b/eng/common/PublishToSymbolServers.proj
@@ -1,0 +1,67 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <!--
+    This MSBuild file is intended to be used as the body of the default 
+    publishing release pipeline. The release pipeline will use this file
+    to invoke the PublishSymbols tasks to publish symbols to MSDL and SymWeb.
+  
+    Parameters:
+  
+      - PDBArtifactsDirectory   : Full path to directory containing PDB files to be published.
+      - BlobBasePath            : Full path containing *.symbols.nupkg packages to be published.
+      - DotNetSymbolServerTokenMsdl   : PAT to access MSDL.
+      - DotNetSymbolServerTokenSymWeb : PAT to access SymWeb.
+      - DotNetSymbolExpirationInDays  : Expiration days for published packages. Default is 3650.
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name="PublishSymbols">
+    <ItemGroup>
+      <FilesToPublishToSymbolServer Include="$(PDBArtifactsDirectory)\*.pdb"/>
+      <PackagesToPublishToSymbolServer Include="$(BlobBasePath)\*.symbols.nupkg"/>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <DotNetSymbolExpirationInDays Condition="'$(DotNetSymbolExpirationInDays)' == ''">3650</DotNetSymbolExpirationInDays>
+      <PublishToSymbolServer Condition="'@(FilesToPublishToSymbolServer)' == '' and '@(PackagesToPublishToSymbolServer)' == ''">false</PublishToSymbolServer>
+    </PropertyGroup>
+
+    <Message
+      Importance="High"
+      Text="No symbol package(s) were found to publish." 
+      Condition="$(PublishToSymbolServer) == false" />
+    
+    <!-- Symbol Uploader: MSDL -->
+    <Message Importance="High" Text="Publishing symbol packages to MSDL ..." Condition="$(PublishToSymbolServer)" />
+    <PublishSymbols PackagesToPublish="@(PackagesToPublishToSymbolServer)"
+                    FilesToPublish="@(FilesToPublishToSymbolServer)"
+                    PersonalAccessToken="$(DotNetSymbolServerTokenMsdl)"
+                    SymbolServerPath="https://microsoftpublicsymbols.artifacts.visualstudio.com/DefaultCollection"
+                    ExpirationInDays="$(DotNetSymbolExpirationInDays)"
+                    VerboseLogging="true"
+                    DryRun="false"
+                    ConvertPortablePdbsToWindowsPdbs="false"
+                    PdbConversionTreatAsWarning=""
+                    Condition="$(PublishToSymbolServer)"/>
+
+    <!-- 
+      Symbol Uploader: SymWeb 
+      Watson, VS insertion testings and the typical internal dev usage require SymWeb.
+      Currently we need to call the task twice (https://github.com/dotnet/core-eng/issues/3489).
+    -->
+    <Message Importance="High" Text="Publishing symbol packages to SymWeb ..." Condition="$(PublishToSymbolServer)" />
+    <PublishSymbols PackagesToPublish="@(PackagesToPublishToSymbolServer)"
+                    FilesToPublish="@(FilesToPublishToSymbolServer)"
+                    PersonalAccessToken="$(DotNetSymbolServerTokenSymWeb)"
+                    SymbolServerPath="https://microsoft.artifacts.visualstudio.com/DefaultCollection"
+                    ExpirationInDays="$(DotNetSymbolExpirationInDays)"
+                    VerboseLogging="true"
+                    DryRun="false"
+                    ConvertPortablePdbsToWindowsPdbs="false"
+                    PdbConversionTreatAsWarning=""
+                    Condition="$(PublishToSymbolServer)"/>
+  </Target>
+</Project>

--- a/eng/common/SigningValidation.proj
+++ b/eng/common/SigningValidation.proj
@@ -1,18 +1,20 @@
-<!--
-  This MSBuild file is intended to be used as the body of the default 
-  publishing release pipeline. The release pipeline will use this file
-  to invoke the the SignCheck tool to validate that packages about to
-  be published are correctly signed.
-  
-  Parameters:
-  
-    - PackageBasePath   : Directory containing all files that need to be validated.
-    - SignCheckVersion  : Version of SignCheck package to be used.
-    - SignValidationExclusionList   : ItemGroup containing exclusion list to be forwarded to SignCheck.
-    - EnableJarSigningCheck    : Whether .jar files should be validated.
-    - EnableStrongNameCheck    : Whether strong name check should be performed.
--->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
+  <!--
+    This MSBuild file is intended to be used as the body of the default 
+    publishing release pipeline. The release pipeline will use this file
+    to invoke the the SignCheck tool to validate that packages about to
+    be published are correctly signed.
+  
+    Parameters:
+  
+      - PackageBasePath   : Directory containing all files that need to be validated.
+      - SignCheckVersion  : Version of SignCheck package to be used.
+      - SignValidationExclusionList   : ItemGroup containing exclusion list to be forwarded to SignCheck.
+      - EnableJarSigningCheck    : Whether .jar files should be validated.
+      - EnableStrongNameCheck    : Whether strong name check should be performed.
+  -->
+
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -204,7 +204,9 @@
         SymbolUploader doesn't support embedded PDBs yet, so let SymStore.targets do the conversion for now.
         https://github.com/dotnet/core-eng/issues/3645
       -->
-    <FilesToPublishToSymbolServer Include="$(ArtifactsSymStoreDirectory)**\*.pdb"/>
+    <ItemGroup>
+      <FilesToPublishToSymbolServer Include="$(ArtifactsSymStoreDirectory)**\*.pdb"/>
+    </ItemGroup>
 
     <Message
       Text="##vso[artifact.upload containerfolder=PdbArtifacts;artifactname=PdbArtifacts]%(FilesToPublishToSymbolServer.Identity)"

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -164,7 +164,7 @@
       AssetsTemporaryDirectory="$(TempWorkingDirectory)" />
 
     <Message
-      Text="##vso[artifact.upload containerfolder=PipelineArtifactsPublishingManifests;artifactname=PipelineArtifactsPublishingManifests]$(RepositoryEngineeringDir)common\PublishToPackageFeed.proj"
+      Text="##vso[artifact.upload containerfolder=ReleaseConfigs;artifactname=ReleaseConfigs]$(RepositoryEngineeringDir)common\PublishToPackageFeed.proj"
       Importance="high" />
 
     <!--
@@ -172,7 +172,7 @@
       to publish packages. The version of Tasks.Feed used will come from DefaultVersions.props
     -->
     <Message
-      Text="##vso[artifact.upload containerfolder=PipelineArtifactsPublishingManifests;artifactname=PipelineArtifactsPublishingManifests]$(MSBuildThisFileDirectory)DefaultVersions.props"
+      Text="##vso[artifact.upload containerfolder=ReleaseConfigs;artifactname=ReleaseConfigs]$(MSBuildThisFileDirectory)DefaultVersions.props"
       Condition="Exists('$(MSBuildThisFileDirectory)DefaultVersions.props')"
       Importance="high" />
 
@@ -195,9 +195,25 @@
       Encoding="Unicode" />
 
     <Message
-      Text="##vso[artifact.upload containerfolder=PipelineArtifactsPublishingManifests;artifactname=PipelineArtifactsPublishingManifests]$(MSBuildThisFileDirectory)ArtifactsCategory.props"
+      Text="##vso[artifact.upload containerfolder=ReleaseConfigs;artifactname=ReleaseConfigs]$(MSBuildThisFileDirectory)ArtifactsCategory.props"
       Importance="high" />
-    
+
+
+    <!-- 
+        Publish Windows PDBs produced by SymStore.targets (by default, only shipping PDBs are placed there).
+        SymbolUploader doesn't support embedded PDBs yet, so let SymStore.targets do the conversion for now.
+        https://github.com/dotnet/core-eng/issues/3645
+      -->
+    <FilesToPublishToSymbolServer Include="$(ArtifactsSymStoreDirectory)**\*.pdb"/>
+
+    <Message
+      Text="##vso[artifact.upload containerfolder=PdbArtifacts;artifactname=PdbArtifacts]%(FilesToPublishToSymbolServer.Identity)"
+      Importance="high" />
+
+    <Message
+      Text="##vso[artifact.upload containerfolder=ReleaseConfigs;artifactname=ReleaseConfigs]$(RepositoryEngineeringDir)common\PublishToSymbolServers.proj"
+      Importance="high" />
+
   </Target>
 
   <Target Name="PublishSymbols">

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -210,7 +210,8 @@
 
     <Message
       Text="##vso[artifact.upload containerfolder=PdbArtifacts;artifactname=PdbArtifacts]%(FilesToPublishToSymbolServer.Identity)"
-      Importance="high" />
+      Importance="high" 
+      Condition="'@(FilesToPublishToSymbolServer)' != ''"/>
 
     <Message
       Text="##vso[artifact.upload containerfolder=ReleaseConfigs;artifactname=ReleaseConfigs]$(RepositoryEngineeringDir)common\PublishToSymbolServers.proj"


### PR DESCRIPTION
Closes: https://github.com/dotnet/arcade/issues/1786

Bulk of the changes here is copying the `PublishSymbols` target from Publish.proj into a separate file that will be used by a release pipeline to publish symbols to MSDL & SymWeb.

I did other changes around formatting / commenting.