### PR TITLE
[Pool Provider] Prod, more logging, and correlation script

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,10 +47,10 @@ jobs:
         # For public or PR jobs, use the hosted pool.  For internal jobs use the internal pool.
         # Will eventually change this to two BYOC pools.
         ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-          name: NetCorePublic-Int-Pool
+          name: NetCorePublic-Pool
           queue: BuildPool.Windows.10.Amd64.VS2017.Open
         ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-          name: NetCoreInternal-Int-Pool
+          name: NetCoreInternal-Pool
           queue: BuildPool.Windows.10.Amd64.VS2017
       variables:
       - _Script: eng\common\cibuild.cmd
@@ -122,10 +122,10 @@ jobs:
         container: LinuxContainer
         pool:
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-            name:  NetCorePublic-Int-Pool
+            name:  NetCorePublic-Pool
             queue: BuildPool.Ubuntu.1604.Amd64.Open
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            name:  NetCoreInternal-Int-Pool
+            name:  NetCoreInternal-Pool
             queue: BuildPool.Ubuntu.1604.Amd64
         variables:
         - HelixApiAccessToken: ''

--- a/src/HelixPoolProvider/HelixPoolProvider/FixedApplicationInsightsLogger.cs
+++ b/src/HelixPoolProvider/HelixPoolProvider/FixedApplicationInsightsLogger.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.HelixPoolProvider
+{
+    public class FixedApplicationInsightsLogger : ILogger
+    {
+        private readonly ILogger _inner;
+        private readonly TelemetryClient _telemetryClient;
+
+        public FixedApplicationInsightsLogger(ILogger inner, TelemetryClient telemetryClient)
+        {
+            _inner = inner;
+            _telemetryClient = telemetryClient;
+        }
+
+        private static Dictionary<string, string> EmptyLogDict { get; } = new Dictionary<string, string>();
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception exception,
+            Func<TState, Exception, string> formatter)
+        {
+            _inner.Log(logLevel, eventId, state, exception, formatter);
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return _inner.IsEnabled(logLevel);
+        }
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            string logString = state.ToString();
+            var op = new Activity(logString);
+            Dictionary<string, string> logDict;
+
+            if (state is IEnumerable<KeyValuePair<string, object>> enumerable)
+            {
+                logDict = enumerable.ToDictionary(p => p.Key, p => Convert.ToString(p.Value));
+            }
+            else
+            {
+                logDict = EmptyLogDict;
+            }
+
+            foreach ((string key, string value) in logDict)
+            {
+                if (key == "{OriginalFormat}")
+                {
+                    continue;
+                }
+
+                // Fix up the format of key and value to not cause issues until
+                // https://github.com/dotnet/corefx/issues/31687 is fixed
+                string keyP = Regex.Replace(key, "[^a-zA-Z0-9]", "");
+                string valueP = JsonConvert.SerializeObject(value);
+                op.AddBaggage(keyP, valueP);
+            }
+
+            op.Start();
+            _telemetryClient.TrackTrace($"Begin Scope: {logString}", SeverityLevel.Verbose, logDict);
+            return new Scope(op, _telemetryClient);
+        }
+
+        private class Scope : IDisposable
+        {
+            private readonly Activity _op;
+            private readonly TelemetryClient _telemetryClient;
+
+            public Scope(Activity op, TelemetryClient telemetryClient)
+            {
+                _op = op;
+                _telemetryClient = telemetryClient;
+            }
+
+            public void Dispose()
+            {
+                _telemetryClient.TrackTrace($"End Scope: {_op.OperationName}");
+                _op.Stop();
+            }
+        }
+    }
+}

--- a/src/HelixPoolProvider/HelixPoolProvider/FixedApplicationInsightsLoggerFactoryExtensions.cs
+++ b/src/HelixPoolProvider/HelixPoolProvider/FixedApplicationInsightsLoggerFactoryExtensions.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.AspNetCore.Logging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.DotNet.HelixPoolProvider
+{
+    // Fix for app insights issue https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/491
+    public static class FixedApplicationInsightsLoggerFactoryExtensions
+    {
+        public static ILoggingBuilder AddFixedApplicationInsights(this ILoggingBuilder builder, LogLevel minLevel)
+        {
+            return builder.AddFixedApplicationInsights((category, logLevel) => logLevel >= minLevel);
+        }
+
+        public static ILoggingBuilder AddFixedApplicationInsights(
+            this ILoggingBuilder builder,
+            Func<string, LogLevel, bool> filter)
+        {
+            builder.Services.AddSingleton<ILoggerProvider>(
+                provider => new FixedApplicationInsightsLoggerProvider(
+                    provider.GetRequiredService<TelemetryClient>(),
+                    filter,
+                    provider.GetRequiredService<IOptions<ApplicationInsightsLoggerOptions>>()));
+            return builder;
+        }
+    }
+}

--- a/src/HelixPoolProvider/HelixPoolProvider/FixedApplicationInsightsLoggerProvider.cs
+++ b/src/HelixPoolProvider/HelixPoolProvider/FixedApplicationInsightsLoggerProvider.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.AspNetCore.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.DotNet.HelixPoolProvider
+{
+    [ProviderAlias("FixedApplicationInsights")]
+    public class FixedApplicationInsightsLoggerProvider : ILoggerProvider
+    {
+        private readonly ILoggerProvider _inner;
+        private readonly TelemetryClient _telemetryClient;
+
+        public FixedApplicationInsightsLoggerProvider(
+            TelemetryClient telemetryClient,
+            Func<string, LogLevel, bool> filter,
+            IOptions<ApplicationInsightsLoggerOptions> options)
+        {
+            _telemetryClient = telemetryClient;
+            // OFC the ApplicationInsights stuff is all internal so we can't inherit any of it
+
+            string appInsightsLoggerProviderTypeName =
+                $"Microsoft.ApplicationInsights.AspNetCore.Logging.ApplicationInsightsLoggerProvider, {typeof(ApplicationInsightsLoggerFactoryExtensions).Assembly.FullName}";
+            Type appInsightsLoggerProviderType = Type.GetType(appInsightsLoggerProviderTypeName);
+            if (appInsightsLoggerProviderType == null)
+            {
+                throw new TypeLoadException($"Could not load type {appInsightsLoggerProviderTypeName}");
+            }
+
+            _inner = (ILoggerProvider)Activator.CreateInstance(
+                appInsightsLoggerProviderType,
+                telemetryClient,
+                filter,
+                options);
+        }
+
+        public void Dispose()
+        {
+            _inner.Dispose();
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return new FixedApplicationInsightsLogger(_inner.CreateLogger(categoryName), _telemetryClient);
+        }
+    }
+}

--- a/src/HelixPoolProvider/HelixPoolProvider/HelixJobCreator.cs
+++ b/src/HelixPoolProvider/HelixPoolProvider/HelixJobCreator.cs
@@ -124,7 +124,7 @@ namespace Microsoft.DotNet.HelixPoolProvider
             }
             catch (HttpOperationException e)
             {
-                _logger.LogError(e, "Failed to submit new Helix job to queue {_queueInfo.QueueId} for agent id {_agentRequestItem.agentId}: {e.Response.Content}");
+                _logger.LogError(e, $"Failed to submit new Helix job to queue {_queueInfo.QueueId} for agent id {_agentRequestItem.agentId}: {e.Response.Content}");
 
                 return new AgentInfoItem() { accepted = false };
             }

--- a/src/HelixPoolProvider/HelixPoolProvider/HelixLinuxOSJobCreator.cs
+++ b/src/HelixPoolProvider/HelixPoolProvider/HelixLinuxOSJobCreator.cs
@@ -15,8 +15,8 @@ namespace Microsoft.DotNet.HelixPoolProvider
     {
         public HelixLinuxOSJobCreator(AgentAcquireItem agentRequestItem, QueueInfo queueInfo, IHelixApi api,
             ILoggerFactory loggerFactory, IHostingEnvironment hostingEnvironment,
-            Config configuration)
-            : base(agentRequestItem, queueInfo, api, loggerFactory, hostingEnvironment, configuration) { }
+            Config configuration, string orchestrationId, string jobName)
+            : base(agentRequestItem, queueInfo, api, loggerFactory, hostingEnvironment, configuration, orchestrationId, jobName) { }
 
         private string AgentPayloadFileName => $"vsts-agent-linux-x64-{_agentRequestItem.agentConfiguration.agentVersion}.tar.gz";
 

--- a/src/HelixPoolProvider/HelixPoolProvider/HelixMacOSJobCreator.cs
+++ b/src/HelixPoolProvider/HelixPoolProvider/HelixMacOSJobCreator.cs
@@ -15,8 +15,8 @@ namespace Microsoft.DotNet.HelixPoolProvider
     {
         public HelixMacOSJobCreator(AgentAcquireItem agentRequestItem, QueueInfo queueInfo, IHelixApi api,
             ILoggerFactory loggerFactory, IHostingEnvironment hostingEnvironment,
-            Config configuration)
-            : base(agentRequestItem, queueInfo, api, loggerFactory, hostingEnvironment, configuration) { }
+            Config configuration, string orchestrationId, string jobName)
+            : base(agentRequestItem, queueInfo, api, loggerFactory, hostingEnvironment, configuration, orchestrationId, jobName) { }
 
         public override Uri AgentPayloadUri => new Uri($"https://vstsagentpackage.azureedge.net/agent/{_agentRequestItem.agentConfiguration.agentVersion}/{AgentPayloadFileName}");
 

--- a/src/HelixPoolProvider/HelixPoolProvider/HelixWindowsOSJobCreator.cs
+++ b/src/HelixPoolProvider/HelixPoolProvider/HelixWindowsOSJobCreator.cs
@@ -15,8 +15,8 @@ namespace Microsoft.DotNet.HelixPoolProvider
     {
         public HelixWindowsOSJobCreator(AgentAcquireItem agentRequestItem, QueueInfo queueInfo, IHelixApi api,
             ILoggerFactory loggerFactory, IHostingEnvironment hostingEnvironment,
-            Config configuration)
-            : base(agentRequestItem, queueInfo, api, loggerFactory, hostingEnvironment, configuration) { }
+            Config configuration, string orchestrationId, string jobName)
+            : base(agentRequestItem, queueInfo, api, loggerFactory, hostingEnvironment, configuration, orchestrationId, jobName) { }
 
         public override string ConstructCommand()
         {

--- a/src/HelixPoolProvider/HelixPoolProvider/Program.cs
+++ b/src/HelixPoolProvider/HelixPoolProvider/Program.cs
@@ -22,6 +22,7 @@ namespace Microsoft.DotNet.HelixPoolProvider
                 {
                     logging.AddConsole();
                     logging.AddDebug();
+                    logging.AddFixedApplicationInsights(LogLevel.Information);
                 })
                 .UseStartup<Startup>()
                 .Build();

--- a/src/HelixPoolProvider/HelixPoolProvider/Properties/PublishProfiles/helixpoolprovider-dncenginternal-prod - Web Deploy.pubxml
+++ b/src/HelixPoolProvider/HelixPoolProvider/Properties/PublishProfiles/helixpoolprovider-dncenginternal-prod - Web Deploy.pubxml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+This file is used by the publish/package process of your Web project. You can customize the behavior of this process
+by editing this MSBuild file. In order to learn more about this please visit https://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <WebPublishMethod>MSDeploy</WebPublishMethod>
+    <ResourceId>/subscriptions/68672ab8-de0c-40f1-8d1b-ffb20bd62c0f/resourcegroups/helixpoolprovider-dncenginternal-prod/providers/Microsoft.Web/sites/helixpoolprovider-dncenginternal-prod</ResourceId>
+    <ResourceGroup>helixpoolprovider-dncenginternal-prod</ResourceGroup>
+    <PublishProvider>AzureWebSite</PublishProvider>
+    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <SiteUrlToLaunchAfterPublish>https://helixpoolprovider-dncenginternal-prod.azurewebsites.net</SiteUrlToLaunchAfterPublish>
+    <LaunchSiteAfterPublish>True</LaunchSiteAfterPublish>
+    <ExcludeApp_Data>False</ExcludeApp_Data>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <ProjectGuid>5ed29e38-a65d-4123-bfed-799ada885f08</ProjectGuid>
+    <SelfContained>false</SelfContained>
+    <_IsPortable>true</_IsPortable>
+    <MSDeployServiceURL>helixpoolprovider-dncenginternal-prod.scm.azurewebsites.net:443</MSDeployServiceURL>
+    <DeployIisAppPath>helixpoolprovider-dncenginternal-prod</DeployIisAppPath>
+    <RemoteSitePhysicalPath />
+    <SkipExtraFilesOnServer>False</SkipExtraFilesOnServer>
+    <MSDeployPublishMethod>WMSVC</MSDeployPublishMethod>
+    <EnableMSDeployBackup>True</EnableMSDeployBackup>
+    <UserName>$helixpoolprovider-dncenginternal-prod</UserName>
+    <_SavePWD>True</_SavePWD>
+    <_DestinationType>AzureWebSite</_DestinationType>
+    <InstallAspNetCoreSiteExtension>False</InstallAspNetCoreSiteExtension>
+  </PropertyGroup>
+</Project>

--- a/src/HelixPoolProvider/HelixPoolProvider/Properties/PublishProfiles/helixpoolprovider-dncengpublic-prod - Web Deploy.pubxml
+++ b/src/HelixPoolProvider/HelixPoolProvider/Properties/PublishProfiles/helixpoolprovider-dncengpublic-prod - Web Deploy.pubxml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+This file is used by the publish/package process of your Web project. You can customize the behavior of this process
+by editing this MSBuild file. In order to learn more about this please visit https://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <WebPublishMethod>MSDeploy</WebPublishMethod>
+    <ResourceId>/subscriptions/68672ab8-de0c-40f1-8d1b-ffb20bd62c0f/resourcegroups/helixpoolprovider-dncengpublic-prod/providers/Microsoft.Web/sites/helixpoolprovider-dncengpublic-prod</ResourceId>
+    <ResourceGroup>helixpoolprovider-dncengpublic-prod</ResourceGroup>
+    <PublishProvider>AzureWebSite</PublishProvider>
+    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <SiteUrlToLaunchAfterPublish>https://helixpoolprovider-dncengpublic-prod.azurewebsites.net</SiteUrlToLaunchAfterPublish>
+    <LaunchSiteAfterPublish>True</LaunchSiteAfterPublish>
+    <ExcludeApp_Data>False</ExcludeApp_Data>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <ProjectGuid>5ed29e38-a65d-4123-bfed-799ada885f08</ProjectGuid>
+    <SelfContained>false</SelfContained>
+    <_IsPortable>true</_IsPortable>
+    <MSDeployServiceURL>helixpoolprovider-dncengpublic-prod.scm.azurewebsites.net:443</MSDeployServiceURL>
+    <DeployIisAppPath>helixpoolprovider-dncengpublic-prod</DeployIisAppPath>
+    <RemoteSitePhysicalPath />
+    <SkipExtraFilesOnServer>False</SkipExtraFilesOnServer>
+    <MSDeployPublishMethod>WMSVC</MSDeployPublishMethod>
+    <EnableMSDeployBackup>True</EnableMSDeployBackup>
+    <UserName>$helixpoolprovider-dncengpublic-prod</UserName>
+    <_SavePWD>True</_SavePWD>
+    <_DestinationType>AzureWebSite</_DestinationType>
+    <InstallAspNetCoreSiteExtension>False</InstallAspNetCoreSiteExtension>
+  </PropertyGroup>
+</Project>

--- a/src/HelixPoolProvider/HelixPoolProvider/appsettings.dncenginternal-prod.json
+++ b/src/HelixPoolProvider/HelixPoolProvider/appsettings.dncenginternal-prod.json
@@ -1,0 +1,31 @@
+{
+  "ContainerName": "internal-workitemstorage",
+  "ConnectionString-Key": "https://helixprodkv.vault.azure.net/secrets/helixpoolprovider-dnceng-PayloadConnectionString",
+  "ApiAuthorizationPat-Key": "https://buildagents.vault.azure.net/secrets/BotAccount-helix-buildagent-bot-helix-token",
+  "SharedSecret-Key": "https://helixprodkv.vault.azure.net/secrets/helixpoolprovider-dncenginternal-SharedSecret",
+  "AllowedTargetQueues": "Specific",
+  "AllowedTargetQueueNames": [
+    "BuildPool.FreeBSD.12.Amd64",
+    "BuildPool.Ubuntu.1604.Amd64",
+    "BuildPool.Windows.10.Amd64.VS2017",
+    "BuildPool.Windows.10.Amd64.VS2019",
+    "BuildPool.Windows.10.Amd64.VS2019.BT"
+  ],
+  "HelixCreator": "helixpoolprovider-dncenginternal-prod",
+  "TimeoutInMinutes": 600,
+  "HelixEndpoint": "https://helix.dot.net",
+  "MaxParallelism": 1000,
+  "Logging": {
+    "IncludeScopes": false,
+    "Debug": {
+      "LogLevel": {
+        "Default": "Warning"
+      }
+    },
+    "Console": {
+      "LogLevel": {
+        "Default": "Warning"
+      }
+    }
+  }
+}

--- a/src/HelixPoolProvider/HelixPoolProvider/appsettings.dncengpublic-prod.json
+++ b/src/HelixPoolProvider/HelixPoolProvider/appsettings.dncengpublic-prod.json
@@ -1,0 +1,32 @@
+{
+  "ContainerName": "public-workitemstorage",
+  "ConnectionString-Key": "https://helixprodkv.vault.azure.net/secrets/helixpoolprovider-dnceng-PayloadConnectionString",
+  "ApiAuthorizationPat-Key": "https://buildagents.vault.azure.net/secrets/BotAccount-helix-buildagent-bot-helix-token",
+  "SharedSecret-Key": "https://helixprodkv.vault.azure.net/secrets/helixpoolprovider-dncengpublic-SharedSecret",
+  "AllowedTargetQueues": "Specific",
+  "AllowedTargetQueueNames": [
+    "BuildPool.FreeBSD.12.Amd64.Open",
+    "BuildPool.Ubuntu.1604.Amd64.Open",
+    "BuildPool.Windows.10.Amd64.ES.VS2017.Open",
+    "BuildPool.Windows.10.Amd64.VS2017.Open",
+    "BuildPool.Windows.10.Amd64.VS2019.Open",
+    "BuildPool.Windows.10.Amd64.VS2019.BT.Open"
+  ],
+  "HelixCreator": "helixpoolprovider-dncengpublic-prod",
+  "TimeoutInMinutes": 600,
+  "HelixEndpoint": "https://helix.dot.net",
+  "MaxParallelism": 1000,
+  "Logging": {
+    "IncludeScopes": false,
+    "Debug": {
+      "LogLevel": {
+        "Default": "Warning"
+      }
+    },
+    "Console": {
+      "LogLevel": {
+        "Default": "Warning"
+      }
+    }
+  }
+}

--- a/src/HelixPoolProvider/HelixPoolProvider/configure-pool.ps1
+++ b/src/HelixPoolProvider/HelixPoolProvider/configure-pool.ps1
@@ -52,19 +52,3 @@ if (-not $skipCreatePool) {
 } else {
 	$poolProviderId = $existingAgentPoolId
 }
-
-if (-not $skipCreateAgents) {
-	for ($i=0; $i -lt 100; $i++) {
-		try {
-			echo "Creating agent $byocProviderName-Agent${i} for pool"
-			$result = Invoke-WebRequest -Headers $allHeaders -Method POST "$accountUrl/_apis/DistributedTask/pools/$poolProviderId/agents?api-version=5.0-preview" -Body "{`"name`":`"$byocProviderName-Agent${i}`",`"version`":`"2.138.6`",`"provisioningState`":`"Deallocated`"}"
-			if ($result.StatusCode -ne 200) {
-				echo $result.Content
-				throw "Failed to create agent"
-			}
-		}
-		catch {
-			throw "Failed to create agent: $_"
-		}
-	}
-}

--- a/src/HelixPoolProvider/HelixPoolProvider/job-to-helix-info.ps1
+++ b/src/HelixPoolProvider/HelixPoolProvider/job-to-helix-info.ps1
@@ -1,0 +1,59 @@
+﻿param (
+    $buildUrl,
+    $azdoPat,
+    $appInsightsAppId,
+    $appInsightsKey
+)
+
+$base64authinfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(":$azdoPat"))
+$vstsAuthHeader = @{"Authorization"="Basic $base64authinfo"}
+$allHeaders = $vstsAuthHeader + @{"Content-Type"="application/json"; "Accept"="application/json"}
+
+# Find the plan info
+
+$buildUri = [System.Uri]$buildUrl
+$buildId = $null
+$account = $null
+$project = $null
+
+if ($buildUri.Host -eq "dev.azure.com") {
+    $account = $buildUri.Segments[1].Replace("/", "")
+    $project = $buildUri.Segments[2].Replace("/", "")
+}
+
+if ($buildUri.Query -match "buildId=(?<buildId>\d+)") {
+    $buildId = [int]$Matches.buildId
+} else {
+    throw "Could not parse build url $buildUrl"
+}
+
+Write-Verbose "Looking up plan info for build $buildId in project $project on account $account"
+
+$buildInfo = Invoke-WebRequest -Method Get -Headers $allHeaders -Uri "https://dev.azure.com/$account/$project/_apis/build/builds/$buildId" | ConvertFrom-Json
+$planId = $buildInfo.orchestrationPlan.planId
+
+Write-Verbose "Found plan id $planId, looking up in appinsights"
+
+$appInsightsHeaders = @{ “X-Api-Key” = $appInsightsKey; “Content-Type” = “application/json” }
+$appInsightsOperation = "query"
+$appInsightsQuery = [uri]::EscapeUriString("?query=traces|where message contains `"Successfully submitted new Helix job`" | where customDimensions.orchestrationId contains `"$planId`"")
+$fullUri = “https://api.applicationinsights.io/v1/apps/$appInsightsAppId/$appInsightsOperation$appInsightsQuery”
+$appInsightsData = Invoke-WebRequest -Method Get -Uri $fullUri -Headers $appInsightsHeaders | ConvertFrom-Json
+
+Write-Host ""
+$firstRow = $true
+foreach ($row in $appInsightsData.tables.rows) {
+    $customDims = ConvertFrom-Json $row[4]
+    if ($firstRow) {
+        $firstRow = $false
+        Write-Host "Pool: $($customDims.agentPool)"
+        Write-Host "Plan Id: $($customDims.orchestrationId)"
+        Write-Host ""
+    }
+    Write-Host "Agent Id:                      $($customDims.agentId)"
+    Write-Host "Job Name:                      $($customDims.jobName)"
+    Write-Host "Queue:                         $($customDims.queueId)"
+    Write-Host "Helix Correlation Id:          $($customDims.helixJob)"
+    Write-Host "Helix Work Item Friendly Name: $($customDims.workItemName)"
+    Write-Host ""
+}


### PR DESCRIPTION
- Add a prod deployment (which is really ahead of int at this point).
- Add a additional logging in based on the Maestro logging setup
- Add a rough script that can map from a build onto the helix work items (and other info) that was submitted for that build