### PR TITLE
Add support for junit results

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/AzureDevOpsTask.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/AzureDevOpsTask.cs
@@ -88,6 +88,16 @@ namespace Microsoft.DotNet.Helix.AzureDevOps
 
         }
 
+        protected Task<T> RetryAsync<T>(Func<Task<T>> function)
+        {
+            // Grab the retry logic from the helix api client
+            return ApiFactory.GetAnonymous()
+                .RetryAsync(
+                    async () => await function(),
+                    ex => Log.LogMessage(MessageImportance.Low, $"Azure Dev Ops Operation failed: {ex}\nRetrying..."));
+
+        }
+
         protected async Task LogFailedRequest(HttpRequestMessage req, HttpResponseMessage res)
         {
             Log.LogError($"Request to {req.RequestUri} returned failed status {(int)res.StatusCode} {res.ReasonPhrase}\n\n{(res.Content != null ? await res.Content.ReadAsStringAsync() : "")}");

--- a/src/Microsoft.DotNet.Helix/Sdk/CheckAzurePipelinesTestRun.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CheckAzurePipelinesTestRun.cs
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.Helix.AzureDevOps
                     }
                 });
 
-            var failedResults = (JArray) data["results"];
+            var failedResults = (JArray) data["value"];
             var expectedFailures = ExpectedTestFailures.Select(i => i.GetMetadata("Identity")).ToHashSet();
             foreach (var failedResult in failedResults)
             {

--- a/src/Microsoft.DotNet.Helix/Sdk/CheckAzurePipelinesTestRun.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CheckAzurePipelinesTestRun.cs
@@ -11,34 +11,79 @@ namespace Microsoft.DotNet.Helix.AzureDevOps
         [Required]
         public int TestRunId { get; set; }
 
+        public ITaskItem[] ExpectedTestFailures { get; set; }
+
         protected override async Task ExecuteCoreAsync(HttpClient client)
         {
-            await RetryAsync(
+            if (ExpectedTestFailures?.Length > 0)
+            {
+                await ValidateExpectedTestFailuresAsync(client);
+                return;
+            }
+            var data = await RetryAsync(
                 async () =>
                 {
                     using (var req = new HttpRequestMessage(
                         HttpMethod.Get,
-                        $"{CollectionUri}{TeamProject}/_apis/test/runs/{TestRunId}?api-version=5.0-preview.2"))
+                        $"{CollectionUri}{TeamProject}/_apis/test/runs/{TestRunId}?api-version=5.0"))
                     {
                         using (var res = await client.SendAsync(req))
                         {
-                            var data = await ParseResponseAsync(req, res);
-                            if (data != null && data["runStatistics"] is JArray runStatistics)
-                            {
-                                var failed = runStatistics.Children()
-                                    .FirstOrDefault(stat => stat["outcome"]?.ToString() == "Failed");
-                                if (failed != null)
-                                {
-                                    Log.LogError($"Test run {TestRunId} has one or more failing tests.");
-                                }
-                                else
-                                {
-                                    Log.LogMessage(MessageImportance.Low, $"Test run {TestRunId} has not failed.");
-                                }
-                            }
+                            return await ParseResponseAsync(req, res);
                         }
                     }
                 });
+            if (data != null && data["runStatistics"] is JArray runStatistics)
+            {
+                var failed = runStatistics.Children()
+                    .FirstOrDefault(stat => stat["outcome"]?.ToString() == "Failed");
+                if (failed != null)
+                {
+                    Log.LogError($"Test run {TestRunId} has one or more failing tests.");
+                }
+                else
+                {
+                    Log.LogMessage(MessageImportance.Low, $"Test run {TestRunId} has not failed.");
+                }
+            }
+        }
+
+        private async Task ValidateExpectedTestFailuresAsync(HttpClient client)
+        {
+            var data = await RetryAsync(
+                async () =>
+                {
+                    using (var req = new HttpRequestMessage(
+                        HttpMethod.Get,
+                        $"{CollectionUri}{TeamProject}/_apis/test/runs/{TestRunId}/results?api-version=5.0&outcomes=Failed"))
+                    {
+                        using (var res = await client.SendAsync(req))
+                        {
+                            return await ParseResponseAsync(req, res);
+                        }
+                    }
+                });
+
+            var failedResults = (JArray) data["results"];
+            var expectedFailures = ExpectedTestFailures.Select(i => i.GetMetadata("Identity")).ToHashSet();
+            foreach (var failedResult in failedResults)
+            {
+                var testName = (string) failedResult["automatedTestName"];
+                if (expectedFailures.Contains(testName))
+                {
+                    expectedFailures.Remove(testName);
+                    Log.LogMessage($"TestRun {TestRunId}: Test {testName} has failed and was expected to fail.");
+                }
+                else
+                {
+                    Log.LogError($"TestRun {TestRunId}: Test {testName} has failed and is not expected to fail.");
+                }
+            }
+
+            foreach (var expectedFailure in expectedFailures)
+            {
+                Log.LogError($"TestRun {TestRunId}: Test {expectedFailure} was expected to fail but did not fail.");
+            }
         }
     }
 }

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/AzurePipelines.MultiQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/AzurePipelines.MultiQueue.targets
@@ -36,6 +36,6 @@
           BeforeTargets="AfterTest"
           Condition="$(FailOnTestFailure)"
           Outputs="%(HelixTargetQueue.Identity)">
-    <CheckAzurePipelinesTestRun TestRunId="%(HelixTargetQueue.TestRunId)"/>
+    <CheckAzurePipelinesTestRun TestRunId="%(HelixTargetQueue.TestRunId)" ExpectedTestFailures="@(AzurePipelinesExpectedTestFailure)"/>
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/formats/__init__.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/formats/__init__.py
@@ -1,8 +1,10 @@
 from typing import List
 from result_format import ResultFormat
 from xunit import XUnitFormat
+from junit import JUnitFormat
 
 
 all_formats = [
-    XUnitFormat()
+    XUnitFormat(),
+    JUnitFormat()
 ]  # type: List[ResultFormat]

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/formats/junit.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/formats/junit.py
@@ -1,0 +1,70 @@
+import xml.etree.ElementTree
+from result_format import ResultFormat
+from defs import TestResult, TestResultAttachment
+
+
+class JUnitFormat(ResultFormat):
+
+    def __init__(self):
+        super(JUnitFormat, self).__init__()
+        pass
+
+    @property
+    def name(self):
+        return 'junit'
+
+    @property
+    def acceptable_file_names(self):
+        yield 'junit-results.xml'
+        yield 'junitresults.xml'
+
+    def read_results(self, path):
+        for (_, element) in xml.etree.ElementTree.iterparse(path, events=['end']):
+            if element.tag == 'testcase':
+                test_name = element.get("name")
+                classname = element.get("classname")
+                name = classname + "." + test_name
+                type_name = classname
+                method = test_name
+                duration = float(element.get("time"))
+                result = "Pass"
+                exception_type = None
+                failure_message = None
+                stack_trace = None
+                skip_reason = None
+                attachments = []
+
+
+                failure_element = element.find("failure") or element.find("error")
+                if failure_element is not None:
+                    result = "Fail"
+                    exception_type = failure_element.get("type")
+                    failure_message = failure_element.get("message")
+                    stack_trace = failure_element.text
+
+                    stdout_element = element.find("system-out")
+                    if stdout_element is not None:
+                        attachments.append(TestResultAttachment(
+                            name=u"Console_Output.log",
+                            text=stdout_element.text,
+                        ))
+
+                    stderr_element = element.find("system-err")
+                    if stderr_element is not None:
+                        attachments.append(TestResultAttachment(
+                            name=u"Error_Output.log",
+                            text=stderr_element.text,
+                        ))
+
+                skipped_element = element.find("skipped")
+                if skipped_element is not None:
+                    result = "Skip"
+                    skip_reason = skipped_element.text
+
+
+                res = TestResult(name, u'junit', type_name, method, duration, result, exception_type, failure_message, stack_trace,
+                                 skip_reason, attachments)
+                yield res
+                # remove the element's content so we don't keep it around too long.
+                element.clear()
+

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/formats/junit.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/formats/junit.py
@@ -59,7 +59,7 @@ class JUnitFormat(ResultFormat):
                 skipped_element = element.find("skipped")
                 if skipped_element is not None:
                     result = "Skip"
-                    skip_reason = skipped_element.text
+                    skip_reason = skipped_element.text or u""
 
 
                 res = TestResult(name, u'junit', type_name, method, duration, result, exception_type, failure_message, stack_trace,

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/formats/junit.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/formats/junit.py
@@ -35,7 +35,10 @@ class JUnitFormat(ResultFormat):
                 attachments = []
 
 
-                failure_element = element.find("failure") or element.find("error")
+                failure_element = element.find("failure")
+                if failure_element is None:
+                    failure_element = element.find("error")
+
                 if failure_element is not None:
                     result = "Fail"
                     exception_type = failure_element.get("type")

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/formats/result_format.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/formats/result_format.py
@@ -6,6 +6,9 @@ from typing import Iterable
 class ResultFormat:
     __metaclass__ = ABCMeta
 
+    def __init__(self):
+        pass
+
     @abstractproperty
     def name(self):
         pass

--- a/tests/Junit/junit-results.xml
+++ b/tests/Junit/junit-results.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+   <testsuite name="Pizza" errors="0" skipped="1" tests="3" failures="1" time="0.006" timestamp="2013-05-24T10:23:58">
+      <testcase classname="PizzaTests" name="cheese" time="0.006">
+         <failure message="test failure">Assertion failed</failure>
+      </testcase>
+      <testcase classname="PizzaTests" name="cheese" time="0.006">
+         <error message="test failure">Assertion failed</error>
+      </testcase>
+      <testcase classname="PizzaTests" name="pepperoni" time="0">
+         <skipped />
+      </testcase>
+      <testcase classname="PizzaTests" name="anchovy" time="0" />
+   </testsuite>
+</testsuites>

--- a/tests/Junit/junit-results.xml
+++ b/tests/Junit/junit-results.xml
@@ -4,7 +4,7 @@
       <testcase classname="PizzaTests" name="cheese" time="0.006">
          <failure message="test failure">Assertion failed</failure>
       </testcase>
-      <testcase classname="PizzaTests" name="cheese" time="0.006">
+      <testcase classname="PizzaTests" name="cheese2" time="0.006">
          <error message="test failure">Assertion failed</error>
       </testcase>
       <testcase classname="PizzaTests" name="pepperoni" time="0">

--- a/tests/UnitTests.proj
+++ b/tests/UnitTests.proj
@@ -20,6 +20,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <HelixWorkItem Include="JUnitTest">
+      <Command>echo 'done!'</Command>
+      <PayloadDirectory>$(MSBuildThisFileDirectory)Junit</PayloadDirectory>
+    </HelixWorkItem>
+  </ItemGroup>
+
+  <ItemGroup>
     <XUnitProject Include="..\src\**\*.Tests.csproj"/>
 
     <!-- Remove the arcade sdk tests project because it depends heavily on machine/repo state and doesn't work properly in helix yet -->

--- a/tests/UnitTests.proj
+++ b/tests/UnitTests.proj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <AzurePipelinesExpectedTestFailure Include="PizzaTests.cheese"/>
-    <AzurePipelinesExpectedTestFailure Include="PizzaTests.pepperoni"/>
+    <AzurePipelinesExpectedTestFailure Include="PizzaTests.cheese2"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/UnitTests.proj
+++ b/tests/UnitTests.proj
@@ -25,6 +25,10 @@
       <PayloadDirectory>$(MSBuildThisFileDirectory)Junit</PayloadDirectory>
     </HelixWorkItem>
   </ItemGroup>
+  <ItemGroup>
+    <AzurePipelinesExpectedTestFailure Include="PizzaTests.cheese"/>
+    <AzurePipelinesExpectedTestFailure Include="PizzaTests.pepperoni"/>
+  </ItemGroup>
 
   <ItemGroup>
     <XUnitProject Include="..\src\**\*.Tests.csproj"/>


### PR DESCRIPTION
Fixes #1485

This changes adds support to the helix sdk azure pipelines reporter to process junit xml results from junit-results.xml files.