### PR TITLE
Fix for exception during shutdown

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.py
@@ -33,9 +33,9 @@ class UploadWorker(Thread):
 
     def run(self):
         self.__print("starting...")
-        while True:
-            item = self.queue.get()
+        while True:            
             try:
+                item = self.queue.get()
                 self.__process(item)
             except:
                 self.__print("got error: {}".format(traceback.format_exc()))


### PR DESCRIPTION
We are seeing an exception during python shutdown after run.py is done uploading results. This is likely happening because the queue object gets deleted during the shutdown and the threads try to use it. With this change we will catch this exception so we don't show it in the logs.

Call stack:
Exception in thread Thread-1 (most likely raised during interpreter shutdown):
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
  File "/ssd/dotnetbuild/work/8d46130c-722a-4222-8ceb-811690b03074/Payload/reporter/run.py", line 37, in run
  File "/usr/lib/python2.7/Queue.py", line 168, in get
  File "/usr/lib/python2.7/threading.py", line 332, in wait
<type 'exceptions.TypeError'>: 'NoneType' object is not callable