### PR TITLE
More Functionality For Genfacades

### DIFF
--- a/src/Microsoft.DotNet.GenFacades/GenPartialFacadeSource.cs
+++ b/src/Microsoft.DotNet.GenFacades/GenPartialFacadeSource.cs
@@ -5,7 +5,6 @@
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System;
-using System.IO;
 using System.Linq;
 
 namespace Microsoft.DotNet.GenFacades
@@ -53,7 +52,6 @@ namespace Microsoft.DotNet.GenFacades
             catch (Exception e)
             {
                 Log.LogErrorFromException(e, showStackTrace: false);
-                File.Delete(OutputSourcePath);
             }
 
             return result && !Log.HasLoggedErrors;

--- a/src/Microsoft.DotNet.GenFacades/GenPartialFacadeSource.cs
+++ b/src/Microsoft.DotNet.GenFacades/GenPartialFacadeSource.cs
@@ -5,6 +5,7 @@
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System;
+using System.IO;
 using System.Linq;
 
 namespace Microsoft.DotNet.GenFacades
@@ -52,6 +53,7 @@ namespace Microsoft.DotNet.GenFacades
             catch (Exception e)
             {
                 Log.LogErrorFromException(e, showStackTrace: false);
+                File.Delete(OutputSourcePath);
             }
 
             return result && !Log.HasLoggedErrors;

--- a/src/Microsoft.DotNet.GenFacades/GenPartialFacadeSourceGenerator.cs
+++ b/src/Microsoft.DotNet.GenFacades/GenPartialFacadeSourceGenerator.cs
@@ -138,7 +138,7 @@ namespace Microsoft.DotNet.GenFacades
 
                 foreach (var type in assembly.GetAllTypes().OfType<INamedTypeDefinition>())
                 {         
-                    if ( internalsVisibleTo ? TypeHelper.IsVisibleToFriendAssemblies(type) : TypeHelper.IsVisibleOutsideAssembly(type))
+                    if (internalsVisibleTo ? TypeHelper.IsVisibleToFriendAssemblies(type) : TypeHelper.IsVisibleOutsideAssembly(type))
                         AddTypeAndNestedTypesToTable(typeTable, type);
                 }
             }

--- a/src/Microsoft.DotNet.GenFacades/GenPartialFacadeSourceGenerator.cs
+++ b/src/Microsoft.DotNet.GenFacades/GenPartialFacadeSourceGenerator.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.GenFacades
                     referenceTypes = referenceTypes.Where(type => !OmitTypes.Contains(type));
 
                 IAssembly[] seedAssemblies = LoadAssemblies(seedHost, seeds).ToArray();
-                var seedTypes = GenerateTypeTable(seedAssemblies);
+                var seedTypes = GenerateTypeTable(seedAssemblies, contractAssembly);
 
                 var sourceGenerator = new SourceGenerator(referenceTypes, seedTypes, seedTypePreferences, outputSourcePath, ignoreMissingTypesList, logger);
                 return sourceGenerator.GenerateSource(compileFiles, ParseDefineConstants(defineConstants), ignoreMissingTypes);
@@ -132,9 +132,7 @@ namespace Microsoft.DotNet.GenFacades
             var typeTable = new Dictionary<string, IReadOnlyList<INamedTypeDefinition>>();
             foreach (var assembly in seedAssemblies)
             {                
-                bool internalsVisibleTo = refAssembly != null
-                    ? UnitHelper.AssemblyOneAllowsAssemblyTwoToAccessItsInternals(assembly, refAssembly)
-                    : false;
+                bool internalsVisibleTo = refAssembly != null && UnitHelper.AssemblyOneAllowsAssemblyTwoToAccessItsInternals(assembly, refAssembly);
 
                 foreach (var type in assembly.GetAllTypes().OfType<INamedTypeDefinition>())
                 {         

--- a/src/Microsoft.DotNet.GenFacades/SourceGenerator.cs
+++ b/src/Microsoft.DotNet.GenFacades/SourceGenerator.cs
@@ -70,7 +70,7 @@ namespace Microsoft.DotNet.GenFacades
                 }
 
                 string alias = "";
-                if (seedTypes.Count > 2)
+                if (seedTypes.Count > 1)
                 {
                     _logger.LogError("The type '{0}' is defined in multiple seed assemblies. The multiple assemblies are {1}. If this is intentional, specify the alias for this type and project reference", type, string.Join(",", seedTypes.Select(t => t.Name.Value)));
                     result = false;
@@ -90,7 +90,9 @@ namespace Microsoft.DotNet.GenFacades
             }
 
             sb.AppendLine("#pragma warning restore CS0618");
-            File.WriteAllText(_outputSourcePath, BuildAliasDeclarations(externAliases) + sb.ToString());
+            if (result)
+                File.WriteAllText(_outputSourcePath, BuildAliasDeclarations(externAliases) + sb.ToString());
+
             return result;
         }
 

--- a/src/Microsoft.DotNet.GenFacades/SourceGenerator.cs
+++ b/src/Microsoft.DotNet.GenFacades/SourceGenerator.cs
@@ -70,19 +70,19 @@ namespace Microsoft.DotNet.GenFacades
                 }
 
                 string alias = "";
-                if (seedTypes.Count > 1)
+                if (seedTypes.Count > 2)
+                {
+                    _logger.LogError("The type '{0}' is defined in multiple seed assemblies. The multiple assemblies are {1}. If this is intentional, specify the alias for this type and project reference", type, string.Join(seedTypes.Select(t => t.Name)));
+                    result = false;
+                    continue;
+                }
+                else
                 {
                     if (_seedTypePreferences.Keys.Contains(type))
                     {
                         alias = _seedTypePreferences[type];
                         if (!externAliases.Contains(alias))
                             externAliases.Add(alias);
-                    }
-                    else
-                    {
-                        _logger.LogError("The type '{0}' is defined in multiple seed assemblies. If this is intentional, specify the alias for this type and project reference", type);
-                        result = false;
-                        continue;
                     }
                 }
                 

--- a/src/Microsoft.DotNet.GenFacades/SourceGenerator.cs
+++ b/src/Microsoft.DotNet.GenFacades/SourceGenerator.cs
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.GenFacades
                 string alias = "";
                 if (seedTypes.Count > 2)
                 {
-                    _logger.LogError("The type '{0}' is defined in multiple seed assemblies. The multiple assemblies are {1}. If this is intentional, specify the alias for this type and project reference", type, string.Join(seedTypes.Select(t => t.Name)));
+                    _logger.LogError("The type '{0}' is defined in multiple seed assemblies. The multiple assemblies are {1}. If this is intentional, specify the alias for this type and project reference", type, string.Join(",", seedTypes.Select(t => t.Name.Value)));
                     result = false;
                     continue;
                 }

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenPartialFacadeSource.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenPartialFacadeSource.targets
@@ -40,7 +40,7 @@
     />
 
     <ItemGroup>
-      <FileWrites Include="$(OutputSourcePath)"/>
+      <FileWrites Condition="Exists('$(OutputSourcePath)')" Include="$(OutputSourcePath)"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- Checks conflicts between internal and public types in case of "InternalsVisibleTo"
- Improves error message if type is present in 2 assembly
- use alias if provided even if the type is present in a single seed assembly
- Not producing the source file if an error is thrown 