### PR TITLE
Correcting seed names and if condition

### DIFF
--- a/src/Microsoft.DotNet.GenFacades/SourceGenerator.cs
+++ b/src/Microsoft.DotNet.GenFacades/SourceGenerator.cs
@@ -6,8 +6,10 @@ using Microsoft.Build.Utilities;
 using Microsoft.Cci;
 using System.Collections.Generic;
 using System.IO;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using Microsoft.Cci.Extensions;
 
 namespace Microsoft.DotNet.GenFacades
 {
@@ -70,22 +72,20 @@ namespace Microsoft.DotNet.GenFacades
                 }
 
                 string alias = "";
-                if (seedTypes.Count > 1)
+
+                if (_seedTypePreferences.Keys.Contains(type))
                 {
-                    _logger.LogError("The type '{0}' is defined in multiple seed assemblies. The multiple assemblies are {1}. If this is intentional, specify the alias for this type and project reference", type, string.Join(",", seedTypes.Select(t => t.Name.Value)));
+                    alias = _seedTypePreferences[type];
+                    if (!externAliases.Contains(alias))
+                        externAliases.Add(alias);
+                }
+                else if (seedTypes.Count > 1)
+                {
+                    _logger.LogError("The type '{0}' is defined in multiple seed assemblies. The multiple assemblies are {1}. If this is intentional, specify the alias for this type and project reference", type, string.Join(", ", seedTypes.Select(t => t.GetAssembly().Name.Value)));
                     result = false;
                     continue;
                 }
-                else
-                {
-                    if (_seedTypePreferences.Keys.Contains(type))
-                    {
-                        alias = _seedTypePreferences[type];
-                        if (!externAliases.Contains(alias))
-                            externAliases.Add(alias);
-                    }
-                }
-                
+
                 sb.AppendLine(GetTypeForwardsToString(type, alias));
             }
 


### PR DESCRIPTION
The error will look like 
```
error : The type 'System.Reflection.Emit.AssemblyBuilder' is defined in multiple seed assemblies. The multiple assemblies are System.Private.CoreLib, System.Reflection.Emit. If this is intentional, specify the alias for this type and project reference [c:\git\corefx\src\shims\manual\mscorlib.csproj]
```

I introduced the bug in my last PR. I missed the testing with uapaot case. However, this time i tested it with all 4 configuration uap, uapaot, netcoreapp and netfx

There is still a bug with uap build as ```TargetsAot``` property is not getting set to true when we target uap framework. but that seems more related to the corefx. I tested against uapaot by using ```_bc_TargetGroup``` variable as the condition variable for seedTypePreferences

sry for trouble @ericstj 
