### PR TITLE
Add publishUsingPipelines parameter to publish-build-assets phase template

### DIFF
--- a/eng/common/templates/phases/publish-build-assets.yml
+++ b/eng/common/templates/phases/publish-build-assets.yml
@@ -5,6 +5,7 @@ parameters:
   condition: succeeded()
   continueOnError: false
   runAsPublic: false
+  publishUsingPipelines: false
 phases:
   - phase: Asset_Registry_Publish
     displayName: Publish to Build Asset Registry
@@ -36,6 +37,7 @@ phases:
               /p:ManifestsPath='$(Build.StagingDirectory)/Download/AssetManifests'
               /p:BuildAssetRegistryToken=$(MaestroAccessToken)
               /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
+              /p:PublishUsingPipelines=${{ parameters.publishUsingPipelines }}
               /p:Configuration=$(_BuildConfig)
           condition: ${{ parameters.condition }}
           continueOnError: ${{ parameters.continueOnError }}


### PR DESCRIPTION
Add publishUsingPipelines parameter to `eng\common\templates\phases\publish-build-asets.yml` similarly to what we have for `eng\common\templates\job\publish-build-assets.yml' . This let the build communicate to BAR+Maestro that the build will publish using pipelines.

Change tested here: https://dnceng.visualstudio.com/internal/_build/results?buildId=145394