### PR TITLE
Workaround symbol packages with native libgit2.so

### DIFF
--- a/eng/common/PublishToSymbolServers.proj
+++ b/eng/common/PublishToSymbolServers.proj
@@ -24,6 +24,14 @@
     <ItemGroup>
       <FilesToPublishToSymbolServer Include="$(PDBArtifactsDirectory)\*.pdb"/>
       <PackagesToPublishToSymbolServer Include="$(BlobBasePath)\*.symbols.nupkg"/>
+
+      <!--
+        These packages from Arcade-Services include some native libraries that
+        our current symbol uploader can't handle. Below is a workaround until
+        we get issue: https://github.com/dotnet/arcade/issues/2457 sorted.
+      -->
+      <PackagesToPublishToSymbolServer Remove="$(BlobBasePath)\Microsoft.DotNet.Darc.*" />
+      <PackagesToPublishToSymbolServer Remove="$(BlobBasePath)\Microsoft.DotNet.Maestro.Tasks.*" />
     </ItemGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
Workaround for this issue: https://github.com/dotnet/arcade/issues/2457