### PR TITLE
Add additional test references to output dir

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.props
@@ -14,6 +14,11 @@
   <ItemGroup>
     <!-- Test runner config file. -->
     <SupplementalTestData Condition="'$(SkipTestRunnerConfigCopying)' != 'true'" Include="$(TestRunnerConfigPath)" />
+    <SupplementalTestData Include="$(RuntimePath)Microsoft.DotNet.XUnitExtensions.dll" />
+    <SupplementalTestData Include="$(RuntimePath)xunit.assert.dll" />
+    <SupplementalTestData Include="$(RuntimePath)xunit.core.dll" />
+    <SupplementalTestData Include="$(RuntimePath)xunit.abstractions.dll" />
+    <SupplementalTestData Include="$(RuntimePath)CoreFx.Private.TestUtilities.dll" />
   </ItemGroup>
 
   <!-- Supplemental test data. -->
@@ -37,15 +42,6 @@
     <SupplementalTestData Include="$(RuntimePath)xunit.execution.desktop.dll" />
     <SupplementalTestData Include="$(RuntimePath)xunit.runner.reporters.net452.dll" />
     <SupplementalTestData Include="$(RuntimePath)xunit.runner.utility.net452.dll" />
-  </ItemGroup>
-
-  <!-- Helix dependencies -->
-  <ItemGroup Condition="'$(IncludeTestFrameworkReferences)' == 'true'">
-    <TestArchiveDependencies Include="$(RuntimePath)Microsoft.DotNet.XUnitExtensions.dll" />
-    <TestArchiveDependencies Include="$(RuntimePath)xunit.assert.dll" />
-    <TestArchiveDependencies Include="$(RuntimePath)xunit.core.dll" />
-    <TestArchiveDependencies Include="$(RuntimePath)xunit.abstractions.dll" />
-    <TestArchiveDependencies Include="$(RuntimePath)CoreFx.Private.TestUtilities.dll" />
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)References.props" />


### PR DESCRIPTION
Copy all test assembly references that are not runtime assemblies to the test directory.