### PR TITLE
Add script for checking symbol availability

### DIFF
--- a/eng/common/CheckSymbols.ps1
+++ b/eng/common/CheckSymbols.ps1
@@ -1,0 +1,129 @@
+param(
+	[Parameter(Mandatory=$true)][string]$InputPath,             # Path to directory where NuGet packages to be checked are stored
+	[Parameter(Mandatory=$true)][string]$ExtractPath,           # Path to where the packages will be extracted during validation
+	[Parameter(Mandatory=$true)][string]$SymbolToolPath         # Path to where dotnet symbol-tool was installed
+)
+
+function ConfirmSymbolsAvailable {
+	param( 
+		[string]$PackagePath,               # Path to a NuGet package
+		[string]$OutputPath,                # Path to where symbols should be stored
+		[string]$SymbolToolDirectory        # Path to where symbol-tool was installed
+	)
+
+	# Ensure input file exist
+	if (!(Test-Path $PackagePath))
+	{
+		Write-Error "Input file not exist."
+	}
+	
+	# Extensions for which we'll look for symbols
+	$RelevantExtensions = @(".dll", ".exe", ".so", ".dylib")
+
+	# How many files are missing symbol information
+	$MissingSymbols = 0
+
+	$PackageId = [System.IO.Path]::GetFileNameWithoutExtension($PackagePath)
+	$ExtractPath = $OutputPath+$PackageId;
+	$SymbolsPath = $OutputPath+$PackageId+".Symbols";
+	
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($PackagePath, $ExtractPath)
+
+	# Makes easier to reference `symbol tool`
+	Push-Location $SymbolToolDirectory
+	Write-Host "Changing directory to $SymbolToolDirectory"
+
+	Get-ChildItem -Recurse $ExtractPath |
+		Where-Object {$RelevantExtensions -contains $_.Extension} |
+		ForEach-Object { 
+			$FullPath = $_.FullName
+			$FileName = [System.IO.Path]::GetFileName($FullPath)
+			$Extension = $_.Extension
+
+			# Those below are potential symbol files that the `dotnet symbol` might
+			# return. Which one will be returned depend on the type of file we are
+			# checking and which type of file was uploaded.
+
+			# The file itself is returned
+			$SymbolPath = $SymbolsPath+"\"+$FileName
+
+			# PDB file for the module
+			$PdbPath = $SymbolPath.Replace($Extension, ".pdb")
+
+			# PDB file for x-generated module
+			$NGenPdb = $SymbolPath.Replace($Extension, ".ni.pdb")
+
+			# DBG file for a .so library
+			$SODbg = $SymbolPath.Replace($Extension, ".so.dbg")
+
+			# DWARF file for a .dylib
+			$DylibDwarf = $SymbolPath.Replace($Extension, ".dylib.dwarf")
+
+			Write-Host -NoNewLine "`t Checking file $FullPath ... "
+			
+			.\dotnet-symbol.exe --symbols --modules $FullPath -o $SymbolsPath -d *>$null
+			
+			if (Test-Path $PdbPath)
+			{
+				$SymbolType = "PDB"
+			}
+			elseif (Test-Path $NGenPdb)
+			{
+				$SymbolType = "NGen PDB"
+			}
+			elseif (Test-Path $SODbg)
+			{
+				$SymbolType = "DBG for SO"
+			}	
+			elseif (Test-Path $DylibDwarf)
+			{
+				$SymbolType = "Dward for Dylib"
+			}			
+			elseif (Test-Path $SymbolPath)
+			{
+				$SymbolType = "Module"
+			}
+			else
+			{
+				$MissingSymbols++
+				Write-Host "No symbols found!"
+				return
+			}
+			
+			Write-Host "Symbols [$SymbolType] found."
+		}
+	
+	Pop-Location
+
+	return $MissingSymbols
+}
+
+function CheckSymbols {
+	param( 
+		# Path to a NuGet packages directory
+		[string]$PackagesPath, 
+		# Path to where packages will be extracted
+		[string]$OutputsPath,
+		# Path to symbol tool install dir
+		[string]$SymbolToolDir
+	)
+
+	if (Test-Path $OutputsPath)
+	{
+		Remove-Item -recurse $OutputsPath
+	}
+
+	Get-ChildItem "$PackagesPath\*.nupkg" |
+		ForEach-Object {
+			$FileName = $_.Name
+			Write-Host "Validating $FileName "
+			$Status = ConfirmSymbolsAvailable "$PackagesPath\$FileName" $OutputsPath $SymbolToolDir
+			
+			if ($Status -ne 0)
+			{
+				Write-Error "Missing symbols for $Status modules in the package $FileName"
+			}
+		}
+}
+
+CheckSymbols $InputPath $ExtractPath $SymbolToolPath

--- a/eng/common/CheckSymbols.ps1
+++ b/eng/common/CheckSymbols.ps1
@@ -1,129 +1,119 @@
 param(
-	[Parameter(Mandatory=$true)][string]$InputPath,             # Path to directory where NuGet packages to be checked are stored
-	[Parameter(Mandatory=$true)][string]$ExtractPath,           # Path to where the packages will be extracted during validation
-	[Parameter(Mandatory=$true)][string]$SymbolToolPath         # Path to where dotnet symbol-tool was installed
+  [Parameter(Mandatory=$true)][string] $InputPath,       # Full path to directory where NuGet packages to be checked are stored
+  [Parameter(Mandatory=$true)][string] $ExtractPath,     # Full path to directory where the packages will be extracted during validation
+  [Parameter(Mandatory=$true)][string] $SymbolToolPath   # Full path to directory where dotnet symbol-tool was installed
 )
 
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
 function ConfirmSymbolsAvailable {
-	param( 
-		[string]$PackagePath,               # Path to a NuGet package
-		[string]$OutputPath,                # Path to where symbols should be stored
-		[string]$SymbolToolDirectory        # Path to where symbol-tool was installed
-	)
+  param( 
+    [string] $PackagePath          # Path to a NuGet package
+  )
 
-	# Ensure input file exist
-	if (!(Test-Path $PackagePath))
-	{
-		Write-Error "Input file not exist."
-	}
-	
-	# Extensions for which we'll look for symbols
-	$RelevantExtensions = @(".dll", ".exe", ".so", ".dylib")
+  # Ensure input file exist
+  if (!(Test-Path $PackagePath))
+  {
+    throw "Input file does not exist: $PackagePath"
+  }
+  
+  # Extensions for which we'll look for symbols
+  $RelevantExtensions = @(".dll", ".exe", ".so", ".dylib")
 
-	# How many files are missing symbol information
-	$MissingSymbols = 0
+  # How many files are missing symbol information
+  $MissingSymbols = 0
 
-	$PackageId = [System.IO.Path]::GetFileNameWithoutExtension($PackagePath)
-	$ExtractPath = $OutputPath+$PackageId;
-	$SymbolsPath = $OutputPath+$PackageId+".Symbols";
-	
-    [System.IO.Compression.ZipFile]::ExtractToDirectory($PackagePath, $ExtractPath)
+  $PackageId = [System.IO.Path]::GetFileNameWithoutExtension($PackagePath)
+  $ExtractPath = $ExtractPath + $PackageId;
+  $SymbolsPath = $ExtractPath + $PackageId + ".Symbols";
+  
+  [System.IO.Compression.ZipFile]::ExtractToDirectory($PackagePath, $ExtractPath)
 
-	# Makes easier to reference `symbol tool`
-	Push-Location $SymbolToolDirectory
-	Write-Host "Changing directory to $SymbolToolDirectory"
+  # Makes easier to reference `symbol tool`
+  Push-Location $SymbolToolPath
 
-	Get-ChildItem -Recurse $ExtractPath |
-		Where-Object {$RelevantExtensions -contains $_.Extension} |
-		ForEach-Object { 
-			$FullPath = $_.FullName
-			$FileName = [System.IO.Path]::GetFileName($FullPath)
-			$Extension = $_.Extension
+  Get-ChildItem -Recurse $ExtractPath |
+    Where-Object {$RelevantExtensions -contains $_.Extension} |
+    ForEach-Object { 
+      $FullPath = $_.FullName
+      $FileName = [System.IO.Path]::GetFileName($FullPath)
+      $Extension = $_.Extension
 
-			# Those below are potential symbol files that the `dotnet symbol` might
-			# return. Which one will be returned depend on the type of file we are
-			# checking and which type of file was uploaded.
+      # Those below are potential symbol files that the `dotnet symbol` might
+      # return. Which one will be returned depend on the type of file we are
+      # checking and which type of file was uploaded.
 
-			# The file itself is returned
-			$SymbolPath = $SymbolsPath+"\"+$FileName
+      # The file itself is returned
+      $SymbolPath = $SymbolsPath + "\" + $FileName
 
-			# PDB file for the module
-			$PdbPath = $SymbolPath.Replace($Extension, ".pdb")
+      # PDB file for the module
+      $PdbPath = $SymbolPath.Replace($Extension, ".pdb")
 
-			# PDB file for x-generated module
-			$NGenPdb = $SymbolPath.Replace($Extension, ".ni.pdb")
+      # PDB file for R2R module (created by crossgen)
+      $NGenPdb = $SymbolPath.Replace($Extension, ".ni.pdb")
 
-			# DBG file for a .so library
-			$SODbg = $SymbolPath.Replace($Extension, ".so.dbg")
+      # DBG file for a .so library
+      $SODbg = $SymbolPath.Replace($Extension, ".so.dbg")
 
-			# DWARF file for a .dylib
-			$DylibDwarf = $SymbolPath.Replace($Extension, ".dylib.dwarf")
+      # DWARF file for a .dylib
+      $DylibDwarf = $SymbolPath.Replace($Extension, ".dylib.dwarf")
 
-			Write-Host -NoNewLine "`t Checking file $FullPath ... "
-			
-			.\dotnet-symbol.exe --symbols --modules $FullPath -o $SymbolsPath -d *>$null
-			
-			if (Test-Path $PdbPath)
-			{
-				$SymbolType = "PDB"
-			}
-			elseif (Test-Path $NGenPdb)
-			{
-				$SymbolType = "NGen PDB"
-			}
-			elseif (Test-Path $SODbg)
-			{
-				$SymbolType = "DBG for SO"
-			}	
-			elseif (Test-Path $DylibDwarf)
-			{
-				$SymbolType = "Dward for Dylib"
-			}			
-			elseif (Test-Path $SymbolPath)
-			{
-				$SymbolType = "Module"
-			}
-			else
-			{
-				$MissingSymbols++
-				Write-Host "No symbols found!"
-				return
-			}
-			
-			Write-Host "Symbols [$SymbolType] found."
-		}
-	
-	Pop-Location
+      Write-Host -NoNewLine "`t Checking file $FullPath ... "
+  
+      .\dotnet-symbol.exe --symbols --modules --microsoft-symbol-server --internal-server $FullPath -o $SymbolsPath -d *>$null
+  
+      if (Test-Path $PdbPath)
+      {
+        $SymbolType = "PDB"
+      }
+      elseif (Test-Path $NGenPdb)
+      {
+        $SymbolType = "NGen PDB"
+      }
+      elseif (Test-Path $SODbg)
+      {
+        $SymbolType = "DBG for SO"
+      }  
+      elseif (Test-Path $DylibDwarf)
+      {
+        $SymbolType = "Dward for Dylib"
+      }  
+      elseif (Test-Path $SymbolPath)
+      {
+        $SymbolType = "Module"
+      }
+      else
+      {
+        $MissingSymbols++
+        Write-Host "No symbols found!"
+        return
+      }
+  
+      Write-Host "Symbols [$SymbolType] found."
+    }
+  
+  Pop-Location
 
-	return $MissingSymbols
+  return $MissingSymbols
 }
 
 function CheckSymbols {
-	param( 
-		# Path to a NuGet packages directory
-		[string]$PackagesPath, 
-		# Path to where packages will be extracted
-		[string]$OutputsPath,
-		# Path to symbol tool install dir
-		[string]$SymbolToolDir
-	)
+  if (Test-Path $ExtractPath)
+  {
+    Remove-Item -recurse $ExtractPath
+  }
 
-	if (Test-Path $OutputsPath)
-	{
-		Remove-Item -recurse $OutputsPath
-	}
-
-	Get-ChildItem "$PackagesPath\*.nupkg" |
-		ForEach-Object {
-			$FileName = $_.Name
-			Write-Host "Validating $FileName "
-			$Status = ConfirmSymbolsAvailable "$PackagesPath\$FileName" $OutputsPath $SymbolToolDir
-			
-			if ($Status -ne 0)
-			{
-				Write-Error "Missing symbols for $Status modules in the package $FileName"
-			}
-		}
+  Get-ChildItem "$InputPath\*.nupkg" |
+    ForEach-Object {
+      $FileName = $_.Name
+      Write-Host "Validating $FileName "
+      $Status = ConfirmSymbolsAvailable "$InputPath\$FileName"
+  
+      if ($Status -ne 0)
+      {
+        Write-Error "Missing symbols for $Status modules in the package $FileName"
+      }
+    }
 }
 
-CheckSymbols $InputPath $ExtractPath $SymbolToolPath
+CheckSymbols

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -217,6 +217,10 @@
       Text="##vso[artifact.upload containerfolder=ReleaseConfigs;artifactname=ReleaseConfigs]$(RepositoryEngineeringDir)common\PublishToSymbolServers.proj"
       Importance="high" />
 
+    <Message
+      Text="##vso[artifact.upload containerfolder=ReleaseConfigs;artifactname=ReleaseConfigs]$(RepositoryEngineeringDir)common\CheckSymbols.ps1"
+      Importance="high" />
+
   </Target>
 
   <Target Name="PublishSymbols">


### PR DESCRIPTION
Closes: #1874 

It was decided by e-mail that we would use `dotnet symbol tool` to check availability & completeness of symbols for packages.

The tool however doesn't accept a package for checking availability, only individual modules. The script in this PR opens packages and check for availability of symbols for each contained module using `dotnet symbol tool`.

This script is a temporary solution. Once the maintainer of `dotnet symbol tool` (@mikem8361) returns from vacation we'll work on improving the tool to accept a package as input for validation.

It was also agreed that for now symbol completeness will be done as part of symbol availability. Again, until `dotnet symbol tool` can be patched to do the right thing for completeness.