### PR TITLE
Allow major version rollforward

### DIFF
--- a/src/Microsoft.DotNet.ApiCompat/runtimeconfig.template.json
+++ b/src/Microsoft.DotNet.ApiCompat/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+    "rollForwardOnNoCandidateFx": 2
+}

--- a/src/Microsoft.DotNet.GenAPI/runtimeconfig.template.json
+++ b/src/Microsoft.DotNet.GenAPI/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+    "rollForwardOnNoCandidateFx": 2
+}

--- a/src/Microsoft.DotNet.SourceRewriter/runtimeconfig.template.json
+++ b/src/Microsoft.DotNet.SourceRewriter/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+    "rollForwardOnNoCandidateFx": 2
+}


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/34498

Not sharing that file as a runtimeconfig is application specific.