### PR TITLE
Enable defining test options

### DIFF
--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -38,7 +38,22 @@ parameters:
   enablePublishBuildAssets: false
 
   # Optional: Include PublishTestResults task
+  # Note: the publishTestResults parameter (below) can be used to provide more control over publishing test results.
+  #  You should use either "enablePublishTestResults" or "publishTestResults", not both.  If both are present and
+  #  either parameter is set to "enable=false", then publishing test results will be disabled
   enablePublishTestResults: false
+
+  # Optional:
+  # Schema:
+  #  publishTestResults:
+  #    enable: [bool] (optional: default 'true')
+  #    testResultsFormat: [string] (optional: default value defined below)
+  #    testResultsFiles: [string] (optional: default value defined below)
+  #    searchFolder: [string] (optional: default value defined below)
+  #    testRunTitle: [string] (optional: default Azure DevOps defined value)
+  # Note: You should use either "enablePublishTestResults" or "publishTestResults", not both.  If both are present and
+  #  either parameter is set to "enable=false", then publishing test results will be disabled
+  publishTestResults: {}
 
   # Optional: enable sending telemetry
   enableTelemetry: false
@@ -169,13 +184,24 @@ jobs:
       continueOnError: true
       condition: always()
 
-  - ${{ if eq(parameters.enablePublishTestResults, 'true') }}:
+  - ${{ if or(eq(parameters.enablePublishTestResults, 'true'), ne(parameters.publishTestResults.enable, 'false')) }}:
     - task: PublishTestResults@2
       displayName: Publish Test Results
       inputs:
-        testResultsFormat: 'xUnit'
-        testResultsFiles: '*.xml' 
-        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+        ${{ if eq(parameters.publishTestResults.testResultsFormat, '') }}:
+          testResultsFormat: 'xUnit'
+        ${{ if ne(parameters.publishTestResults.testResultsFormat, '') }}:
+          testResultsFormat: ${{ parameters.publishTestResults.testResultsFormat }}
+        ${{ if eq(parameters.publishTestResults.testResultsFiles, '') }}:
+          testResultsFiles: '*.xml' 
+        ${{ if ne(parameters.publishTestResults.testResultsFiles, '') }}:
+          testResultsFiles: ${{ parameters.publishTestResults.testResultsFiles }}
+        ${{ if eq(parameters.publishTestResults.searchFolder, '') }}:
+          searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+        ${{ if ne(parameters.publishTestResults.searchFolder, '') }}:
+          searchFolder: ${{ parameters.publishTestResults.searchFolder }}
+        ${{ if ne(parameters.publishTestResults.testRunTitle, '') }}:
+          testRunTitle: ${{ parameters.publishTestResults.testRunTitle }}
       continueOnError: true
       condition: always()
     


### PR DESCRIPTION
Validation job is [here](https://dev.azure.com/dnceng/public/_build/results?buildId=155900)

To use this feature, a repo would change their azure-pipelines.yml file from using the Boolean `enablePublishTestResults` parameter...

```yaml
jobs:
- template: /eng/common/templates/job/job.yml
  parameters:
    enablePublishTestResults: true
```

to specifying the `publishTestResults` object parameter...

```yaml
jobs:
- template: /eng/common/templates/job/job.yml
  parameters:
    publishTestResults:
      testRunTitle: My test results
```

@dsplaisted 