### PR TITLE
Updating Microsoft.Cci.Extensions to include the "new" keyword for applicable nested types

### DIFF
--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Types.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Types.cs
@@ -146,6 +146,11 @@ namespace Microsoft.Cci.Writers.CSharp
 
         private void WriteTypeModifiers(ITypeDefinition type)
         {
+            if (type.GetHiddenBaseType(_filter) != Dummy.Type)
+            {
+                WriteKeyword("new");
+            }
+
             if (type.IsDelegate)
                 throw new NotSupportedException("This method doesn't support delegates!");
             else if (type.IsEnum)


### PR DESCRIPTION
CC. @ericstj, @Anipik

This should resolve https://github.com/dotnet/arcade/issues/1488