### PR TITLE
Add concept of VS build (CoreXT) packages

### DIFF
--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -800,6 +800,10 @@ By default, all _shipping_ libraries are localized.
 
 When `UsingToolNuGetRepack` is true _shipping_ packages are repackaged as release/pre-release packages to `artifacts\packages\$(Configuration)\Release` and `artifacts\packages\$(Configuration)\PreRelease` directories, respectively.
 
+### `IsVisualStudioBuildPackage` (bool)
+
+Set to `true` in projects that build Visual Studio Build (CoreXT) packages. These packages are non-shipping, but their content is shipping. They are inserted into and referenced from the internal DevDiv `VS` repository.
+
 ### `PublishWindowsPdb` (bool)
 
 `true` (default) if the PDBs produced by the project should be converted to Windows PDB and published to Microsoft symbol servers.

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.targets
@@ -32,7 +32,7 @@
     <!--
       Set PackageOutputPath based on the IsShippingPackage flag set by projects.
       This distinction allows publishing tools to determine which assets to publish to official channels.
-      
+
       Visual Studio Build (aka CoreXT) packages are non-shipping packages that are used to insert binaries into an internal 
       Visual Studio repository that builds the product from components. These packages are not standard NuGet packages.
     -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.targets
@@ -25,15 +25,20 @@
     <IsShipping Condition="'$(IsShipping)' == ''">true</IsShipping>
 
     <IsShippingAssembly Condition="'$(IsShippingAssembly)' == ''">$(IsShipping)</IsShippingAssembly>
+    <IsShippingPackage Condition="'$(IsVisualStudioBuildPackage)' == 'true'">false</IsShippingPackage>
     <IsShippingPackage Condition="'$(IsShippingPackage)' == ''">$(IsShipping)</IsShippingPackage>
     <IsShippingVsix Condition="'$(IsShippingVsix)' == ''">$(IsShipping)</IsShippingVsix>
 
     <!--
       Set PackageOutputPath based on the IsShippingPackage flag set by projects.
       This distinction allows publishing tools to determine which assets to publish to official channels.
+      
+      Visual Studio Build (aka CoreXT) packages are non-shipping packages that are used to insert binaries into an internal 
+      Visual Studio repository that builds the product from components. These packages are not standard NuGet packages.
     -->
     <PackageOutputPath Condition="'$(IsShippingPackage)' == 'true'">$(ArtifactsShippingPackagesDir)</PackageOutputPath>
     <PackageOutputPath Condition="'$(IsShippingPackage)' != 'true'">$(ArtifactsNonShippingPackagesDir)</PackageOutputPath>
+    <PackageOutputPath Condition="'$(IsVisualStudioBuildPackage)' == 'true'">$(VisualStudioBuildPackagesDir)</PackageOutputPath>
 
     <IsSwixProject>false</IsSwixProject>
     <IsSwixProject Condition="'$(VisualStudioInsertionComponent)' != '' and '$(IsVsixProject)' != 'true'">true</IsSwixProject>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props
@@ -60,5 +60,6 @@
     <VisualStudioSetupOutputPath>$(ArtifactsDir)VSSetup\$(Configuration)\</VisualStudioSetupOutputPath>
     <VisualStudioSetupInsertionPath>$(VisualStudioSetupOutputPath)Insertion\</VisualStudioSetupInsertionPath>
     <VisualStudioSetupIntermediateOutputPath>$(ArtifactsDir)VSSetup.obj\$(Configuration)\</VisualStudioSetupIntermediateOutputPath>
+    <VisualStudioBuildPackagesDir>$(VisualStudioSetupOutputPath)DevDivPackages\</VisualStudioBuildPackagesDir>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -16,6 +16,7 @@
     <!-- List of container files that will be opened and checked for files that need to be signed. -->
     <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.nupkg" />
     <ItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.vsix" />
+    <ItemsToSign Include="$(VisualStudioBuildPackagesDir)**\*.nupkg" />
 
     <!-- Default certificate/strong-name to be used for all files with PKT=="31bf3856ad364e35". -->
     <StrongNameSignInfo Include="MsSharedLib72" PublicKeyToken="31bf3856ad364e35" CertificateName="Microsoft400" />


### PR DESCRIPTION
Sets output dir for CoreXT packages to `artifacts\VSSetup\{config}\DevDivPackages\`. This is where the current tooling (Roslyn Insertion Tool) expects them, we can change that location if necessary if we update the tooling.