### PR TITLE
Add SourceLink validation script - Considering only Portable PDBs

### DIFF
--- a/eng/common/SourceLinkValidation.ps1
+++ b/eng/common/SourceLinkValidation.ps1
@@ -32,86 +32,96 @@ $ValidatePackage = {
   $FailedFiles = 0
 
   Add-Type -AssemblyName System.IO.Compression.FileSystem
-  [System.IO.Compression.ZipFile]::ExtractToDirectory($PackagePath, $ExtractPath)
 
-  Get-ChildItem -Recurse $ExtractPath |
-    Where-Object { $RelevantExtensions -contains $_.Extension } |
-    ForEach-Object {
-      # We ignore resource DLLs
-      if ($_.FullName.EndsWith(".resources.dll")) {
-        return
-      }
-      
-      $ValidateFile = {
-        param( 
-          [string] $FullPath,                                # Full path to the module that has to be checked
-          [ref] $FailedFiles
-        )
+  $zip = [System.IO.Compression.ZipFile]::OpenRead($PackagePath)
 
-        # Makes easier to reference `sourcelink cli`
-        Push-Location $using:SourceLinkToolPath
+  $zip.Entries | 
+    Where-Object {$RelevantExtensions -contains [System.IO.Path]::GetExtension($_.Name)} |
+      ForEach-Object {
+        $FileName = $_.FullName
+        $TargetFile = "$ExtractPath\$FileName"
+        $TargetFolder = [System.IO.Directory]::GetParent($TargetFile)
 
-        $SourceLinkInfos = .\sourcelink.exe print-urls $FullPath | Out-String
+        # We ignore resource DLLs
+        if ($FileName.EndsWith(".resources.dll")) {
+          return
+        }
 
-        if ($LASTEXITCODE -eq 0 -and -not ([string]::IsNullOrEmpty($SourceLinkInfos))) {
-          $NumFailedLinks = 0
+        [System.IO.Directory]::CreateDirectory($TargetFolder);
+        [System.IO.Compression.ZipFileExtensions]::ExtractToFile($_, $TargetFile, $true)
 
-          # We only care about Http addresses
-          $Matches = (Select-String '(http[s]?)(:\/\/)([^\s,]+)' -Input $SourceLinkInfos -AllMatches).Matches
+        $ValidateFile = {
+          param( 
+            [string] $FullPath,                                # Full path to the module that has to be checked
+            [ref] $FailedFiles
+          )
 
-          if ($Matches.Count -ne 0) {
-            $Matches.Value |
-              ForEach-Object {
-                $Link = $_
-                $CommitUrl = -Join("https://raw.githubusercontent.com/", $using:GHRepoName, "/", $using:GHCommit, "/")
-                $FilePath = $Link.Replace($CommitUrl, "")
-                $Status = 200
-                $Cache = $using:RepoFiles
+          # Makes easier to reference `sourcelink cli`
+          Push-Location $using:SourceLinkToolPath
 
-                if ( !($Cache.ContainsKey($FilePath)) ) {
-                  try {
-                    $Uri = $Link -as [System.URI]
-                  
-                    # Only GitHub links are valid
-                    if ($Uri.AbsoluteURI -ne $null -and $Uri.Host -match "github") {
-                      $Status = (Invoke-WebRequest -Uri $Link -UseBasicParsing -Method HEAD -TimeoutSec 5).StatusCode
+          $SourceLinkInfos = .\sourcelink.exe print-urls $FullPath | Out-String
+
+          if ($LASTEXITCODE -eq 0 -and -not ([string]::IsNullOrEmpty($SourceLinkInfos))) {
+            $NumFailedLinks = 0
+
+            # We only care about Http addresses
+            $Matches = (Select-String '(http[s]?)(:\/\/)([^\s,]+)' -Input $SourceLinkInfos -AllMatches).Matches
+
+            if ($Matches.Count -ne 0) {
+              $Matches.Value |
+                ForEach-Object {
+                  $Link = $_
+                  $CommitUrl = -Join("https://raw.githubusercontent.com/", $using:GHRepoName, "/", $using:GHCommit, "/")
+                  $FilePath = $Link.Replace($CommitUrl, "")
+                  $Status = 200
+                  $Cache = $using:RepoFiles
+
+                  if ( !($Cache.ContainsKey($FilePath)) ) {
+                    try {
+                      $Uri = $Link -as [System.URI]
+                    
+                      # Only GitHub links are valid
+                      if ($Uri.AbsoluteURI -ne $null -and $Uri.Host -match "github") {
+                        $Status = (Invoke-WebRequest -Uri $Link -UseBasicParsing -Method HEAD -TimeoutSec 5).StatusCode
+                      }
+                      else {
+                        $Status = 0
+                      }
                     }
-                    else {
+                    catch {
                       $Status = 0
                     }
                   }
-                  catch {
-                    $Status = 0
-                  }
-                }
 
-                if ($Status -ne 200) {
-                  if ($NumFailedLinks -eq 0) {
-                    if ($FailedFiles.Value -eq 0) {
-                      Write-Host
+                  if ($Status -ne 200) {
+                    if ($NumFailedLinks -eq 0) {
+                      if ($FailedFiles.Value -eq 0) {
+                        Write-Host
+                      }
+
+                      Write-Host "`tFile $FullPath has broken links:"
                     }
 
-                    Write-Host "`tFile $FullPath has broken links:"
+                    Write-Host "`t`tFailed to retrieve $Link"
+
+                    $NumFailedLinks++
                   }
-
-                  Write-Host "`t`tFailed to retrieve $Link"
-
-                  $NumFailedLinks++
                 }
-              }
+            }
+
+            if ($NumFailedLinks -ne 0) {
+              $FailedFiles.value++
+              $global:LASTEXITCODE = 1
+            }
           }
 
-          if ($NumFailedLinks -ne 0) {
-            $FailedFiles.value++
-            $global:LASTEXITCODE = 1
-          }
+          Pop-Location
         }
-
-        Pop-Location
-      }
       
-      &$ValidateFile $_.FullName ([ref]$FailedFiles)
-    }
+        &$ValidateFile $TargetFile ([ref]$FailedFiles)
+      }
+
+  $zip.Dispose()
 
   if ($FailedFiles -eq 0) {
     Write-Host "Passed."

--- a/eng/common/SourceLinkValidation.ps1
+++ b/eng/common/SourceLinkValidation.ps1
@@ -45,7 +45,7 @@ $ValidatePackage = {
       $ValidateFile = {
         param( 
           [string] $FullPath,                                # Full path to the module that has to be checked
-          [string][ref] $FailedFiles
+          [ref] $FailedFiles
         )
 
         # Makes easier to reference `sourcelink cli`
@@ -53,7 +53,7 @@ $ValidatePackage = {
 
         $SourceLinkInfos = .\sourcelink.exe print-urls $FullPath | Out-String
 
-        if ($LastExitError -eq 0 -and -not ([string]::IsNullOrEmpty($SourceLinkInfos))) {
+        if ($LASTEXITCODE -eq 0 -and -not ([string]::IsNullOrEmpty($SourceLinkInfos))) {
           $NumFailedLinks = 0
 
           # We only care about Http addresses
@@ -70,7 +70,7 @@ $ValidatePackage = {
 
                 if ( !($Cache.ContainsKey($FilePath)) ) {
                   try {
-	                $Uri = $address -as [System.URI]
+	                $Uri = $Link -as [System.URI]
 	                
                     # Only GitHub links are valid
                     if ($Uri.AbsoluteURI -ne $null -and $Uri.Host -match "github") {
@@ -103,14 +103,14 @@ $ValidatePackage = {
 
           if ($NumFailedLinks -ne 0) {
             $FailedFiles.value++
-	        $global:LastExitError = 1
+	        $global:LASTEXITCODE = 1
           }
         }
 
         Pop-Location
       }
       
-      &$ValidateFile $_.FullName $using:SourceLinkToolPath ([ref]$FailedFiles)
+      &$ValidateFile $_.FullName ([ref]$FailedFiles)
     }
 
   if ($FailedFiles -eq 0) {

--- a/eng/common/SourceLinkValidation.ps1
+++ b/eng/common/SourceLinkValidation.ps1
@@ -1,0 +1,139 @@
+param(
+  [Parameter(Mandatory=$true)][string] $InputPath,           # Full path to directory where Symbols.NuGet packages to be checked are stored
+  [Parameter(Mandatory=$true)][string] $ExtractPath,         # Full path to directory where the packages will be extracted during validation
+  [Parameter(Mandatory=$true)][string] $SourceLinkToolPath   # Full path to directory where dotnet SourceLink CLI was installed
+)
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+function UrlStatusCode {
+  param(
+    [string] $Url		# URL to be checked
+  )
+
+  try {
+    (Invoke-WebRequest -Uri $Url -UseBasicParsing -DisableKeepAlive -Method HEAD).StatusCode
+  }
+  catch [Net.WebException] {
+    [int]$_.Exception.Response.StatusCode
+  }
+}
+
+function ExtractAndTestSourceLinkLinks {
+  param( 
+    [string] $FullPath					# Full path to the module that has to be checked
+  )
+
+  $FailedLinks = 0
+  $SourceLinkInfos = .\sourcelink.exe print-urls $FullPath
+
+  if ($LASTEXITCODE -eq 0) {
+	((Select-String '(http[s]?)(:\/\/)([^\s,]+)' -Input $SourceLinkInfos -AllMatches).Matches.Value) |
+	  ForEach-Object {
+	    $Link = $_
+
+		Write-Host -NoNewLine "| `t | `t | Checking link $Link ... "
+
+		$Status = UrlStatusCode $Link
+
+		if ($Status -ne "200") {
+		  Write-Host "Inacessible. Return status was $Status"
+		  $FailedLinks++
+		}
+		else {
+		  Write-Host "Passed. Return status was $Status"
+		}
+	  }
+  }
+  else {
+  	Write-Host "| `t | `t No SourceLink information found."
+  }
+
+  return $FailedLinks
+}
+
+function CheckSourceLinkLinks {
+  param( 
+    [string] $PackagePath		# Path to a Symbols.NuGet package
+  )
+
+  # Ensure input file exist
+  if (!(Test-Path $PackagePath)) {
+    throw "Input file does not exist: $PackagePath"
+  }
+
+  # Extensions for which we'll look for SourceLink information
+  # For now we'll only care about Portable & Embedded PDBs
+  $RelevantExtensions = @(".dll", ".exe", ".pdb")
+
+  # How many links were inacessible
+  $FailedFiles = 0
+  $PassedFiles = 0
+
+  $PackageId = [System.IO.Path]::GetFileNameWithoutExtension($PackagePath)
+  $ExtractPath = Join-Path -Path $ExtractPath -ChildPath $PackageId
+
+  [System.IO.Compression.ZipFile]::ExtractToDirectory($PackagePath, $ExtractPath)
+
+  # Makes easier to reference `sourcelink cli`
+  Push-Location $SourceLinkToolPath
+
+  Get-ChildItem -Recurse $ExtractPath |
+    Where-Object {$RelevantExtensions -contains $_.Extension} |
+    ForEach-Object {
+      $Copyright = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($_.FullName).LegalCopyright
+
+      # Skip files that aren't Microsoft or .Net Foundation
+      if (!($Copyright -Match "Microsoft" -or $Copyright -Match ".NET Foundation")) {
+        return
+      }
+
+      Write-Host "| `t Checking file" $_.FullName " [from $Copyright] "
+
+	  $Status = ExtractAndTestSourceLinkLinks $_.FullName
+
+	  if ($Status -ne 0) {
+	    $FailedFiles++
+	  }
+	  else {
+	    $PassedFiles++
+	  }
+    }
+  
+  Pop-Location
+
+  if ($PassedFiles -eq 0 -and $FailedFiles -eq 0) {
+	Write-Host "| `t No file to check in this package. "
+  }
+
+  return $FailedFiles
+}
+
+function CheckSourceLinkInformation {
+  if (Test-Path $ExtractPath) {
+    Remove-Item $ExtractPath -Force -Recurse -ErrorAction SilentlyContinue
+  }
+
+  $HasErrors = 0
+
+  Get-ChildItem "$InputPath\*.symbols.nupkg" |
+    ForEach-Object {
+      $FileName = $_.Name
+      Write-Host "Validating $InputPath\$FileName "
+      $Status = CheckSourceLinkLinks $_.FullName
+  
+      if ($Status -ne 0) {
+        Write-Error "| Result: Some links in $FileName were inacessible."
+		$HasErrors = 1
+      }
+	  else {
+	    Write-Host "| Result: Passed."
+	  }
+
+	  Write-Host
+    }
+
+	$global:LASTEXITCODE = $HasErrors
+}
+
+CheckSourceLinkInformation

--- a/eng/common/SourceLinkValidation.ps1
+++ b/eng/common/SourceLinkValidation.ps1
@@ -10,7 +10,7 @@ $script:SourceLinkInfoCache = @{}
 
 function UrlStatusCode {
   param(
-    [string] $Url		# URL to be checked
+    [string] $Url		                                     # URL to be checked
   )
 
   if ($SourceLinkInfoCache.ContainsKey($Url)) {
@@ -31,7 +31,7 @@ function UrlStatusCode {
 
 function ExtractAndTestSourceLinkLinks {
   param( 
-    [string] $FullPath					# Full path to the module that has to be checked
+    [string] $FullPath                                       # Full path to the module that has to be checked
   )
 
   $FailedLinks = 0
@@ -45,14 +45,14 @@ function ExtractAndTestSourceLinkLinks {
 		Write-Host -NoNewLine "| `t | `t | Checking link ($Link) ... "
 
 		$Status = UrlStatusCode $Link
+        $StatusMessage = "Passed."
 
 		if ($Status -ne "200") {
-		  Write-Host "Inaccessible. Return status was $Status"
+          $StatusMessage = "Inaccessible."
 		  $FailedLinks++
 		}
-		else {
-		  Write-Host "Passed. Return status was $Status"
-		}
+
+        Write-Host "$StatusMessage. Return status was $Status"
 	  }
   }
   else {
@@ -64,7 +64,7 @@ function ExtractAndTestSourceLinkLinks {
 
 function CheckSourceLinkLinks {
   param( 
-    [string] $PackagePath		# Path to a Symbols.NuGet package
+    [string] $PackagePath		                             # Path to a Symbols.NuGet package
   )
 
   # Ensure input file exist
@@ -106,7 +106,7 @@ function CheckSourceLinkLinks {
   Pop-Location
 
   if ($PassedFiles -eq 0 -and $FailedFiles -eq 0) {
-	Write-Host "| `t No file to check in this package. "
+	Write-Host "| `t No files to check in this package."
   }
 
   return $FailedFiles
@@ -126,7 +126,7 @@ function CheckSourceLinkInformation {
       $Status = CheckSourceLinkLinks $_.FullName
   
       if ($Status -ne 0) {
-        Write-Error "| Result: Some links in $FileName were inacessible."
+        Write-Error "| Result: Some links in $FileName were inaccessible."
 		$HasErrors = 1
       }
 	  else {


### PR DESCRIPTION
Relates to #2512 

This script will run as part of async publishing for validating sourcelink information.

Iterate over all *.symbols.nupkg and then over all contained DLL, EXE and PDB files. For each file that has a Microsoft or .Net foundation copyright it will try to extract the links to the source code. If links are found the script checks that the link is accessible.