### PR TITLE
Reenable native tools bootstrapping

### DIFF
--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -122,6 +122,10 @@ try {
     . $configureToolsetScript
   }
 
+  if ($restore) {
+    InitializeNativeTools
+  }
+
   Build
 }
 catch {

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -218,4 +218,8 @@ if [[ -n "${useInstalledDotNetCli:-}" ]]; then
   use_installed_dotnet_cli="$useInstalledDotNetCli"
 fi
 
+if [[ "$restore" == true ]]; then
+  InitializeNativeTools
+fi
+
 Build

--- a/eng/common/init-tools-native.ps1
+++ b/eng/common/init-tools-native.ps1
@@ -45,7 +45,7 @@ Param (
 )
 
 if (!$GlobalJsonFile) {
-  $GlobalJsonFile = Join-Path (get-item $PSScriptRoot).parent.parent.FullName "global.json"
+  $GlobalJsonFile = Join-Path (Get-Item $PSScriptRoot).Parent.Parent.FullName "global.json"
 }
 
 Set-StrictMode -version 2.0

--- a/eng/common/init-tools-native.ps1
+++ b/eng/common/init-tools-native.ps1
@@ -41,8 +41,12 @@ Param (
   [switch] $Force = $False,
   [int] $DownloadRetries = 5,
   [int] $RetryWaitTimeInSeconds = 30,
-  [string] $GlobalJsonFile = "$PSScriptRoot\..\..\global.json"
+  [string] $GlobalJsonFile
 )
+
+if (!$GlobalJsonFile) {
+  $GlobalJsonFile = Join-Path (get-item $PSScriptRoot).parent.parent.FullName "global.json"
+}
 
 Set-StrictMode -version 2.0
 $ErrorActionPreference="Stop"

--- a/eng/common/init-tools-native.sh
+++ b/eng/common/init-tools-native.sh
@@ -117,8 +117,6 @@ else
       installer_command+=" --clean"
     fi
 
-    # echo "Installing $tool version $tool_version"
-    # echo "Executing '$installer_command'"
     $installer_command
 
     if [[ $? != 0 ]]; then

--- a/eng/common/init-tools-native.sh
+++ b/eng/common/init-tools-native.sh
@@ -9,7 +9,7 @@ clean=false
 force=false
 download_retries=5
 retry_wait_time_seconds=30
-global_json_file="${scriptroot}/../../global.json"
+global_json_file="$(dirname "$(dirname "${scriptroot}")")/global.json"
 declare -A native_assets
 
 . $scriptroot/native/common-library.sh
@@ -71,6 +71,7 @@ function ReadGlobalJsonNativeTools {
   local native_tools_list=$(echo $native_tools_section | awk -F"[{}]" '{print $2}')
   native_tools_list=${native_tools_list//[\" ]/}
   native_tools_list=${native_tools_list//,/$'\n'}
+  native_tools_list="$(echo -e "${native_tools_list}" | tr -d '[:space:]')"
 
   local old_IFS=$IFS
   while read -r line; do
@@ -116,8 +117,8 @@ else
       installer_command+=" --clean"
     fi
 
-    echo "Installing $tool version $tool_version"
-    echo "Executing '$installer_command'"
+    # echo "Installing $tool version $tool_version"
+    # echo "Executing '$installer_command'"
     $installer_command
 
     if [[ $? != 0 ]]; then
@@ -127,19 +128,16 @@ else
   done
 fi
 
-if [[ ! -z $clean ]]; then
+if [[ $clean = true ]]; then
   exit 0
 fi
 
 if [[ -d $install_bin ]]; then
   echo "Native tools are available from $install_bin"
-  if [[ !-z BUILD_BUILDNUMBER ]]; then
-    echo "##vso[task.prependpath]$install_bin"
-  fi
+  echo "##vso[task.prependpath]$install_bin"
 else
   echo "Native tools install directory does not exist, installation failed" >&2
   exit 1
 fi
 
 exit 0
-

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -391,6 +391,17 @@ function GetSdkTaskProject([string]$taskName) {
   return Join-Path (Split-Path (InitializeToolset) -Parent) "SdkTasks\$taskName.proj"
 }
 
+function InitializeNativeTools() {
+  $nativeTools = $GlobalJson | Select-Object -Expand "native-tools" -ErrorAction SilentlyContinue
+  if ($nativeTools) {
+    $nativeArgs=""
+    if ($ci) {
+      $nativeArgs = "-InstallDirectory " + (Join-Path $ToolsDir "native")
+    }
+    Invoke-Expression "& `"$PSScriptRoot/init-tools-native.ps1`" $nativeArgs"
+  }
+}
+
 function InitializeToolset() {
   if (Test-Path variable:global:_ToolsetBuildProj) {
     return $global:_ToolsetBuildProj

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -392,11 +392,10 @@ function GetSdkTaskProject([string]$taskName) {
 }
 
 function InitializeNativeTools() {
-  $nativeTools = $GlobalJson | Select-Object -Expand "native-tools" -ErrorAction SilentlyContinue
-  if ($nativeTools) {
+  if (Get-Member -InputObject $GlobalJson -Name "native-tools") {
     $nativeArgs=""
     if ($ci) {
-      $nativeArgs = "-InstallDirectory " + (Join-Path $ToolsDir "native")
+      $nativeArgs = "-InstallDirectory $ToolsDir"
     }
     Invoke-Expression "& `"$PSScriptRoot/init-tools-native.ps1`" $nativeArgs"
   }

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -212,6 +212,17 @@ function GetNuGetPackageCachePath {
   _GetNuGetPackageCachePath=$NUGET_PACKAGES
 }
 
+function InitializeNativeTools() {
+  if grep -Fq "native-tools" $global_json_file
+  then
+    local nativeArgs=""
+    if [[ "$ci" == true ]]; then
+      nativeArgs="-InstallDirectory $tools_dir/native"
+    fi
+    "$_script_dir/init-tools-native.sh" $nativeArgs
+  fi
+}
+
 function InitializeToolset {
   if [[ -n "${_InitializeToolset:-}" ]]; then
     return
@@ -307,6 +318,7 @@ eng_root=`cd -P "$_script_dir/.." && pwd`
 repo_root=`cd -P "$_script_dir/../.." && pwd`
 artifacts_dir="$repo_root/artifacts"
 toolset_dir="$artifacts_dir/toolset"
+tools_dir="$repo_root/.tools"
 log_dir="$artifacts_dir/log/$configuration"
 temp_dir="$artifacts_dir/tmp/$configuration"
 

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -217,7 +217,7 @@ function InitializeNativeTools() {
   then
     local nativeArgs=""
     if [[ "$ci" == true ]]; then
-      nativeArgs="-InstallDirectory $tools_dir/native"
+      nativeArgs="-InstallDirectory $tools_dir"
     fi
     "$_script_dir/init-tools-native.sh" $nativeArgs
   fi


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/2533

After reenabling the bootstrapping I hit serveral issues which I also fixed as part of this PR:
- global.json path was wrong in some situations
- `native_tools_list` variable in the shell script contained zero-width whitespace characters which overwrote the first few characters in a path.
- Wrong condition in the shell script when using the clean option
- Inconsistent console outputs between Unix and Windows

Changes:
- When using with CI the bin directory now defaults to `$(RepoRoot)/.tools/native/`

Tested on both Ubuntu 18.04 and Windows 10 1903.

cc @ericstj 