### PR TITLE
Handling Merge Commit properly

### DIFF
--- a/src/Microsoft.DotNet.GitSync/Program.cs
+++ b/src/Microsoft.DotNet.GitSync/Program.cs
@@ -184,9 +184,7 @@ namespace Microsoft.DotNet.GitSync
                     foreach (var change in newChanges.changes[sourceRepository.Name])
                     {
                         var commit = repo.Lookup<Commit>(change);
-                        if (!IsMirrorCommit(commit.Message, targetRepo.Configuration.MirrorSignatureUser)
-                            && commit.Parents.Count() == 1
-                            )
+                        if (!IsMirrorCommit(commit.Message, targetRepo.Configuration.MirrorSignatureUser))
                         {
                             s_logger.Info($"Applying {change}");
                             var patch = FormatPatch(sourceRepository, change);
@@ -213,6 +211,7 @@ namespace Microsoft.DotNet.GitSync
         }
 
         private static bool IsMirrorCommit(string message, string author) => message.Contains($"Signed-off-by: {author} <{author}@microsoft.com>");
+
         private static string FormatPatch(RepositoryInfo sourceRepository, string sha)
         {
             var result = Runner.RunCommand("git",


### PR DESCRIPTION
Earlier applying the merge commit was causing mergeConflicts because we already applied the individual commits present in the other branch. But now we are doing 3way merge which resolves these kind of conflicts automatically.

I tested it with an individual merge commit and it worked fine for this.
But for nullable branch it was still causing some problems, a little better than earlier but still has to resolve most of the conflicts. I tested it with the reverting the latest nullable PR in my corefx fork