### PR TITLE
Add a helixType parameter to job.yml

### DIFF
--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -43,8 +43,11 @@ parameters:
   # Optional: enable sending telemetry
   enableTelemetry: false
 
-  # Optional: define the helix repo for telemeetry (example: 'dotnet/arcade')
+  # Optional: define the helix repo for telemetry (example: 'dotnet/arcade')
   helixRepo: ''
+
+  # Optional: define the helix type for telemetry (example: 'build/product/')
+  helixType: ''
 
   # Required: name of the job
   name: ''
@@ -122,6 +125,8 @@ jobs:
       displayName: 'Send Helix Start Telemetry'
       inputs:
         helixRepo: ${{ parameters.helixRepo }}
+        ${{ if ne(parameters.helixType, '') }}:
+          helixType: ${{ parameters.helixType }}
         buildConfig: $(_BuildConfig)
         runAsPublic: ${{ parameters.runAsPublic }}
       continueOnError: ${{ parameters.continueOnError }}


### PR DESCRIPTION
This is parameter is passed through to the StartTelemetry task that already supports it.