### PR TITLE
Add build task to generate a rsp file from the CoreFX test exclusion list.

### DIFF
--- a/Arcade.sln
+++ b/Arcade.sln
@@ -95,6 +95,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.RemoteExec
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.XUnitExtensions.Tests", "src\Microsoft.DotNet.XUnitExtensions\tests\Microsoft.DotNet.XUnitExtensions.Tests.csproj", "{036A1269-EA1B-457A-8447-D90AEF80BAF9}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.CoreClrTesting", "src\Microsoft.DotNet.CoreClrTesting\Microsoft.DotNet.CoreClrTesting.csproj", "{A30B2867-23A2-4D79-87C0-7969BCF88964}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -593,6 +595,18 @@ Global
 		{036A1269-EA1B-457A-8447-D90AEF80BAF9}.Release|x64.Build.0 = Release|Any CPU
 		{036A1269-EA1B-457A-8447-D90AEF80BAF9}.Release|x86.ActiveCfg = Release|Any CPU
 		{036A1269-EA1B-457A-8447-D90AEF80BAF9}.Release|x86.Build.0 = Release|Any CPU
+		{A30B2867-23A2-4D79-87C0-7969BCF88964}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A30B2867-23A2-4D79-87C0-7969BCF88964}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A30B2867-23A2-4D79-87C0-7969BCF88964}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A30B2867-23A2-4D79-87C0-7969BCF88964}.Debug|x64.Build.0 = Debug|Any CPU
+		{A30B2867-23A2-4D79-87C0-7969BCF88964}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A30B2867-23A2-4D79-87C0-7969BCF88964}.Debug|x86.Build.0 = Debug|Any CPU
+		{A30B2867-23A2-4D79-87C0-7969BCF88964}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A30B2867-23A2-4D79-87C0-7969BCF88964}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A30B2867-23A2-4D79-87C0-7969BCF88964}.Release|x64.ActiveCfg = Release|Any CPU
+		{A30B2867-23A2-4D79-87C0-7969BCF88964}.Release|x64.Build.0 = Release|Any CPU
+		{A30B2867-23A2-4D79-87C0-7969BCF88964}.Release|x86.ActiveCfg = Release|Any CPU
+		{A30B2867-23A2-4D79-87C0-7969BCF88964}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -15,6 +15,7 @@
     <FileSignInfo Include="Mono.Options.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Newtonsoft.Json.Bson.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Newtonsoft.Json.Schema.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="SevenZip.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="winterop.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="wix.dll" CertificateName="3PartySHA2" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -34,6 +34,7 @@
     <MonoOptionsVersion>5.3.0.1</MonoOptionsVersion>
     <McMasterExtensionsCommandLineUtils>2.3.0</McMasterExtensionsCommandLineUtils>
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
+    <NewtonsoftJsonSchemaVersion>2.0.4</NewtonsoftJsonSchemaVersion>
     <NuGetVersioningVersion>4.4.0</NuGetVersioningVersion>
     <NuGetVersion>4.9.0-rtm.5658</NuGetVersion>
     <OctokitVersion>0.32.0</OctokitVersion>

--- a/src/Microsoft.DotNet.CoreClrTesting/GenerateRSPFile.cs
+++ b/src/Microsoft.DotNet.CoreClrTesting/GenerateRSPFile.cs
@@ -1,0 +1,214 @@
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Schema;
+using Newtonsoft.Json.Schema.Generation;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.DotNet.CoreFxTesting
+{
+    /// <summary>
+    /// A class representing a CoreFX test assembly to be run
+    /// </summary>
+    public class XUnitTestAssembly
+    {
+        [JsonRequired]
+        [JsonProperty("name")]
+        public string Name;
+
+        [JsonRequired]
+        [JsonProperty("enabled")]
+        public bool IsEnabled;
+
+        [JsonRequired]
+        [JsonProperty("exclusions")]
+        public Exclusions Exclusions;
+
+        // Used to assign a test url or to override it via the json file definition - mark it as optional in the test definition
+        [JsonIgnore]
+        [JsonProperty(Required = Required.Default)]
+        public string Url;
+
+    }
+    /// <summary>
+    /// Class representing a collection of test exclusions
+    /// </summary>
+    public class Exclusions
+    {
+        [JsonProperty("namespaces")]
+        public Exclusion[] Namespaces;
+
+        [JsonProperty("classes")]
+        public Exclusion[] Classes;
+
+        [JsonProperty("methods")]
+        public Exclusion[] Methods;
+    }
+
+    /// <summary>
+    /// Class representing a single test exclusion
+    /// </summary>
+    public class Exclusion
+    {
+        [JsonRequired]
+        [JsonProperty("name", Required = Required.DisallowNull)]
+        public string Name;
+
+        [JsonRequired]
+        [JsonProperty("reason", Required = Required.DisallowNull)]
+        public string Reason;
+    }
+
+    public class GenerateRSPFile : Task
+    {
+        [Required]
+        public string InputFile { get; set; }
+
+        [Required]
+        public string OutputFile { get; set; }
+
+        public override bool Execute()
+        {
+            Dictionary<string, XUnitTestAssembly> testAssemblyDefinitions = DeserializeTestJson(InputFile);
+
+            GenerateRSP(testAssemblyDefinitions, OutputFile);
+
+            return true;
+        }
+
+        /// <summary>
+        /// Deserialize a list of JSON objects defining test assemblies
+        /// </summary>
+        /// <param name="testDefinitionFilePath">The path on disk to the test list. The test list must conform to a schema generated from XUnitTestAssembly</param>
+        /// <returns></returns>
+        private Dictionary<string, XUnitTestAssembly> DeserializeTestJson(string testDefinitionFilePath)
+        {
+            JSchemaGenerator jsonGenerator = new JSchemaGenerator();
+
+            // Generate a JSON schema from the XUnitTestAssembly class against which to validate the test list
+            JSchema testDefinitionSchema = jsonGenerator.Generate(typeof(IList<XUnitTestAssembly>));
+            IList<XUnitTestAssembly> testAssemblies = new List<XUnitTestAssembly>();
+
+            IList<string> validationMessages = new List<string>();
+
+            using (var sr = new StreamReader(testDefinitionFilePath))
+            using (var jsonReader = new JsonTextReader(sr))
+            using (var jsonValidationReader = new JSchemaValidatingReader(jsonReader))
+            {
+                // Create schema validator
+                jsonValidationReader.Schema = testDefinitionSchema;
+                jsonValidationReader.ValidationEventHandler += (o, a) => validationMessages.Add(a.Message);
+
+                // Deserialize json test assembly definitions
+                JsonSerializer serializer = new JsonSerializer();
+                try
+                {
+                    testAssemblies = serializer.Deserialize<List<XUnitTestAssembly>>(jsonValidationReader);
+                }
+                catch (JsonSerializationException ex)
+                {
+                    // Invalid definition
+                    throw new AggregateException(ex);
+                }
+            }
+
+            if (validationMessages.Count != 0)
+            {
+                StringBuilder aggregateExceptionMessage = new StringBuilder();
+                foreach (string validationMessage in validationMessages)
+                {
+                    aggregateExceptionMessage.Append("JSON Validation Error: ");
+                    aggregateExceptionMessage.Append(validationMessage);
+                    aggregateExceptionMessage.AppendLine();
+                }
+
+                throw new AggregateException(new JSchemaValidationException(aggregateExceptionMessage.ToString()));
+
+            }
+            // Generate a map of test assembly names to their object representations - this is used to download and match them to their on-disk representations
+            var nameToTestAssemblyDef = new Dictionary<string, XUnitTestAssembly>();
+
+            // Map test names to their definitions
+            foreach (XUnitTestAssembly assembly in testAssemblies)
+            {
+                // Filter disabled tests
+                if (assembly.IsEnabled)
+                {
+                    nameToTestAssemblyDef.Add(assembly.Name, assembly);
+                }
+                // TODO: is this needed anywhere?
+                //else
+                //{
+                //    disabledTests.Add(assembly.Name);
+                //}
+            }
+
+            return nameToTestAssemblyDef;
+        }
+
+        /// <summary>
+        /// Generate an rsp file from an XUnitTestAssembly class
+        /// </summary>
+        /// <param name="testDefinition">The XUnitTestAssembly object parsed from a specified test list</param>
+        /// <param name="outputPath">Path to which to output a .rsp file</param>
+        private void GenerateRSP(Dictionary<string, XUnitTestAssembly> testAssemblyDefinitions, string rspFilePath)
+        {
+            if (File.Exists(rspFilePath))
+                File.Delete(rspFilePath);
+
+            // Write RSP file to disk
+            using (StreamWriter sr = File.CreateText(rspFilePath))
+            {
+                foreach (XUnitTestAssembly testDefinition in testAssemblyDefinitions.Values)
+                {
+                    // If no exclusions are defined, we don't need to generate an .rsp file
+                    if (testDefinition.Exclusions == null)
+                        return;
+
+                    // Method exclusions
+                    if (testDefinition.Exclusions.Methods != null)
+                    {
+                        foreach (Exclusion exclusion in testDefinition.Exclusions.Methods)
+                        {
+                            if (String.IsNullOrWhiteSpace(exclusion.Name))
+                                continue;
+                            sr.Write("-skipmethod ");
+                            sr.Write(exclusion.Name);
+                            sr.WriteLine();
+                        }
+                    }
+
+                    // Class exclusions
+                    if (testDefinition.Exclusions.Classes != null)
+                    {
+                        foreach (Exclusion exclusion in testDefinition.Exclusions.Classes)
+                        {
+                            if (String.IsNullOrWhiteSpace(exclusion.Name))
+                                continue;
+                            sr.Write("-skipclass ");
+                            sr.Write(exclusion.Name);
+                            sr.WriteLine();
+                        }
+
+                    }
+
+                    // Namespace exclusions
+                    if (testDefinition.Exclusions.Namespaces != null)
+                    {
+                        foreach (Exclusion exclusion in testDefinition.Exclusions.Namespaces)
+                        {
+                            if (String.IsNullOrWhiteSpace(exclusion.Name))
+                                continue;
+                            sr.Write("-skipnamespace ");
+                            sr.Write(exclusion.Name);
+                            sr.WriteLine();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.CoreClrTesting/GenerateRSPFile.cs
+++ b/src/Microsoft.DotNet.CoreClrTesting/GenerateRSPFile.cs
@@ -139,7 +139,8 @@ namespace Microsoft.DotNet.CoreFxTesting
                 {
                     nameToTestAssemblyDef.Add(assembly.Name, assembly);
                 }
-                // TODO: is this needed anywhere?
+                // TODO: Currently there is no way to specify excluding an entire test assembly, to work around
+                // exclude every namespace/class from the assembly instead.
                 //else
                 //{
                 //    disabledTests.Add(assembly.Name);

--- a/src/Microsoft.DotNet.CoreClrTesting/Microsoft.DotNet.CoreClrTesting.csproj
+++ b/src/Microsoft.DotNet.CoreClrTesting/Microsoft.DotNet.CoreClrTesting.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <Description>This package provides support for running tests inside CoreClr.</Description>
+    <PackageType>MSBuildSdk</PackageType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="Newtonsoft.Json.Schema" Version="$(NewtonsoftJsonSchemaVersion)" />
+  </ItemGroup>
+
+  <Import Project="$(RepoRoot)eng\BuildTask.targets" />
+
+  <ItemGroup>
+    <Compile Include="..\Common\BuildTask.cs" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <None Include="build\assets\**" Pack="True" PackagePath="build\assets\" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.DotNet.CoreClrTesting/build/Microsoft.DotNet.CoreClrTesting.targets
+++ b/src/Microsoft.DotNet.CoreClrTesting/build/Microsoft.DotNet.CoreClrTesting.targets
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project>
+  <PropertyGroup>
+    <CoreClrTestingTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)netcoreapp2.1\Microsoft.DotNet.Arcade.Sdk.dll</ArcadeSdkBuildTasksAssembly>
+  </PropertyGroup>
+
+  <UsingTask TaskName="Microsoft.DotNet.CoreFxTesting.GenerateRSPFile" AssemblyFile="$(CoreClrTestingTasksAssembly)" />
+
+  <Target Name="GenerateRSPFile">
+    <Microsoft.DotNet.CoreFxTesting.GenerateRSPFile
+      InputFile="$(CoreCLR_CoreFXTesting_JSONExclusionFile)"
+      OutputFile="$(CoreCLR_CoreFXTesting_RSPOutputFile)" />
+  </Target>
+</Project>


### PR DESCRIPTION
I didn't see a good place to stash this so I created a new assembly. There currently is the known limitation that whole test assemblies can't be excluded, to work around we will have to exclude every namespace/class from the assembly we don't want to run.

CC @mikem8361 @hoyosjs 