### PR TITLE
Add support for source packages

### DIFF
--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -442,7 +442,7 @@ Set `IsSourcePackage` to `true` to indicate that the project produces a source p
 If the project does not have an explicitly provided `.nuspec` file (`NuspecFile` property is empty) setting `IsSourcePackage` to `true` will trigger a target that 
 puts sources contained in the project directory to the `contentFiles` directory of the source package produced by the project.
 
-In addition to source files a `build/$(PackageId).targets` file will be auto-generated that links the sources contained in the package to the source server via a Source Link target.
+In addition a `build/$(PackageId).targets` file will be auto-generated that links the sources contained in the package to the source server via a Source Link target.
 If your package already has a `build/$(PackageId).targets` file set `SourcePackageSourceLinkTargetsFileName` property to a different file name (e.g. `SourceLink.targets`)
 and import the file from `build/$(PackageId).targets`. 
 

--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -433,6 +433,22 @@ Projects shall use `Microsoft.NET.Sdk` SDK like so:
 
 It might be useful to create other top-level directories containing projects that are not standard C#/VB/F# projects. For example, projects that aggregate outputs of multiple projects into a single NuGet package or Willow component. These projects should also be included in the main solution so that the build driver includes them in build process, but their `Directory.Build.*` may be different from source projects. Hence the different root directory.
 
+## Building source packages
+
+Arcade SDK provides targets for building source packages.
+
+Set `IsSourcePackage` to `true` to indicate that the project produces a source package (along with `IsPackable`, `PackageDescription` and other package properties).
+
+If the project does not have an explicitly provided `.nuspec` file (`NuspecFile` property is empty) setting `IsSourcePackage` to `true` will trigger a target that 
+puts sources contained in the project directory to the `contentFiles` directory of the source package produced by the project.
+
+In addition to source files a `build/$(PackageId).targets` file will be auto-generated that links the sources contained in the package to the source server via a Source Link target.
+If your package already has a `build/$(PackageId).targets` file set `SourcePackageSourceLinkTargetsFileName` property to a different file name (e.g. `SourceLink.targets`)
+and import the file from `build/$(PackageId).targets`. 
+
+If the project is packaged using a custom `.nuspec` file then the source and targets files must be listed in the `.nuspec` file. The path to the generated Source Link 
+targets file will be available within the `.nuspec` file via variable `$SourceLinkTargetsFilePath$`.
+
 ## Building VSIX packages (optional)
 
 Building Visual Studio components is an opt-in feature of the Arcade SDK. Property `UsingToolVSSDK` needs to be set to `true` in the `Versions.props` file.

--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/GenerateSourcePackageSourceLinkTargetsFileTests.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/GenerateSourcePackageSourceLinkTargetsFileTests.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Utilities;
+using System.Collections.Generic;
+using TestUtilities;
+using Xunit;
+
+namespace Microsoft.DotNet.Arcade.Sdk.Tests
+{
+    public sealed class GenerateSourcePackageSourceLinkTargetsFileTests 
+    {
+        [Fact]
+        public void GetOutputFileContent()
+        {
+            var task = new GenerateSourcePackageSourceLinkTargetsFile
+            {
+                ProjectDirectory = @"C:\temp\A\B\C\D\E\F",
+                PackageId = "My.Package",
+                SourceRoots = new TaskItem[] 
+                {
+                    new TaskItem(@"C:\temp\A\", new Dictionary<string, string> { { "SourceLinkUrl", "http://A-git/commitsha/*" } }),
+                    new TaskItem(@"C:\temp\A\B\"),
+                    new TaskItem(@"C:\temp\A\B\C\", new Dictionary<string, string> { { "SourceLinkUrl", "http://C-git/commitsha/*?var=value" } }),
+                    new TaskItem(@"C:\temp\A\B\C\D\"),
+                },
+                OutputPath = "xxx",
+            };
+
+            string content = task.GetOutputFileContent();
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(@"
+<?xml version=""1.0"" encoding=""utf-8""?>
+<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <Target Name=""_AddSourcePackageSourceRoot_CFB3FCB48DA6C1861F924045FCA162F513465D35"" BeforeTargets=""InitializeSourceControlInformation"">
+    <ItemGroup>
+      <_PackageCompileItems Remove=""@(_PackageCompileItems)""/>
+      <_PackageCompileItems Include=""%(Compile.RootDir)%(Compile.Directory)"" Condition=""'%(Compile.NuGetPackageId)' == 'My.Package'"" />
+    </ItemGroup>
+    <PropertyGroup>
+      <_PackageCompileItem>@(_PackageCompileItems)</_PackageCompileItem>
+      <_PackageCompileItem Condition=""'$(_PackageCompileItem)' != ''"">$(_PackageCompileItem.Split(';')[0])</_PackageCompileItem>
+    </PropertyGroup>
+    <ItemGroup>
+      <SourceRoot Include=""$([System.Text.RegularExpressions.Regex]::Match($(_PackageCompileItem), '^$([System.Text.RegularExpressions.Regex]::Escape($([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../contentFiles/'))))([^\\/]+[\\/][^\\/]+[\\/])'))"" 
+                  SourceLinkUrl=""http://C-git/commitsha/D/E/F/*?var=value""/>
+    </ItemGroup>
+  </Target>
+</Project>
+", content);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateSourcePackageSourceLinkTargetsFile.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateSourcePackageSourceLinkTargetsFile.cs
@@ -1,0 +1,137 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.Arcade.Sdk
+{
+    public sealed class GenerateSourcePackageSourceLinkTargetsFile : Task
+    {
+        [Required]
+        public string ProjectDirectory { get; set; }
+
+        [Required]
+        public string PackageId { get; set; }
+
+        [Required]
+        public ITaskItem[] SourceRoots { get; set; }
+
+        [Required]
+        public string OutputPath { get; set; }
+
+        public override bool Execute()
+        {
+            ExecuteImpl();
+            return !Log.HasLoggedErrors;
+        }
+
+        private void ExecuteImpl()
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(OutputPath));
+            File.WriteAllText(OutputPath, GetOutputFileContent(), Encoding.UTF8);
+        }
+
+        // for testing
+        internal string GetOutputFileContent()
+        {
+            var projectDir = EndWithSeparator(ProjectDirectory);
+
+            string innerMostRootItemSpec = null;
+            string innerMostRootSourceLinkUrl = null;
+            foreach (var sourceRoot in SourceRoots)
+            {
+                var itemSpec = sourceRoot.ItemSpec;
+                if (itemSpec.Length > projectDir.Length && itemSpec.StartsWith(projectDir, StringComparison.Ordinal))
+                {
+                    Log.LogError($"Directory '{ProjectDirectory}' contains source roots (e.g. git submodules), which is not supported.");
+                    return null;
+                }
+
+                if (!projectDir.StartsWith(itemSpec, StringComparison.Ordinal) ||
+                    innerMostRootItemSpec != null && itemSpec.Length <= innerMostRootItemSpec.Length)
+                {
+                    continue;
+                }
+
+                var url = sourceRoot.GetMetadata("SourceLinkUrl");
+                if (string.IsNullOrEmpty(url))
+                {
+                    continue;
+                }
+
+                innerMostRootItemSpec = itemSpec;
+                innerMostRootSourceLinkUrl = url;
+            }
+
+            if (innerMostRootSourceLinkUrl == null)
+            {
+                Log.LogError($"No SourceRoot with SourceLinkUrl contains directory '{ProjectDirectory}'.");
+                return null;
+            }
+
+            if (innerMostRootSourceLinkUrl.Count(c => c == '*') != 1)
+            {
+                Log.LogError($"SourceLinkUrl must contain exactly one '*': '{innerMostRootSourceLinkUrl}'");
+                return null;
+            }
+
+            if (!EndsWithSeparator(innerMostRootItemSpec))
+            {
+                Log.LogError($"SourceRoot must end with a directory separator: '{innerMostRootItemSpec}'");
+                return null;
+            }
+
+            var relativePathToSourceRoot = projectDir.Substring(innerMostRootItemSpec.Length);
+            var contentFilesSourceLinkUrl = innerMostRootSourceLinkUrl.Replace("*", Uri.EscapeUriString(relativePathToSourceRoot.Replace('\\', '/')) + "*");
+            return GetTargetsFileContent(PackageId, contentFilesSourceLinkUrl);
+        }
+
+        private static bool EndsWithSeparator(string path)
+        {
+            char last = path[path.Length - 1];
+            return last == Path.DirectorySeparatorChar || last == Path.AltDirectorySeparatorChar;
+        }
+
+        private static string EndWithSeparator(string path)
+            => EndsWithSeparator(path) ? path : path + Path.DirectorySeparatorChar;
+
+        private static string GetTargetsFileContent(string packageId, string sourceLinkUrl)
+        {
+            string hash;
+            using (var hashAlg = SHA256.Create())
+            {
+                hash = BitConverter.ToString(hashAlg.ComputeHash(Encoding.UTF8.GetBytes(packageId)), 0, 20).Replace("-", "");
+            }
+
+            return $@"
+<?xml version=""1.0"" encoding=""utf-8""?>
+<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <Target Name=""_AddSourcePackageSourceRoot_{hash}"" BeforeTargets=""InitializeSourceControlInformation"">
+    <ItemGroup>
+      <_PackageCompileItems Remove=""@(_PackageCompileItems)""/>
+      <_PackageCompileItems Include=""%(Compile.RootDir)%(Compile.Directory)"" Condition=""'%(Compile.NuGetPackageId)' == '{packageId}'"" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_PackageCompileItem>@(_PackageCompileItems)</_PackageCompileItem>
+      <_PackageCompileItem Condition=""'$(_PackageCompileItem)' != ''"">$(_PackageCompileItem.Split(';')[0])</_PackageCompileItem>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <SourceRoot Include=""$([System.Text.RegularExpressions.Regex]::Match($(_PackageCompileItem), '^$([System.Text.RegularExpressions.Regex]::Escape($([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../contentFiles/'))))([^\\/]+[\\/][^\\/]+[\\/])'))"" 
+                  SourceLinkUrl=""{sourceLinkUrl}""/>
+    </ItemGroup>
+  </Target>
+</Project>
+";
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
@@ -38,6 +38,49 @@
   </Target>
 
   <!--
+    Generates and adds {PackageId}.SourceLink.targets file to the build directory of the source package.
+  -->
+
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GenerateSourcePackageSourceLinkTargetsFile" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
+
+  <PropertyGroup Condition="'$(IsPackable)' == 'true' and '$(IsSourcePackage)' == 'true'">
+    <BeforePack>$(BeforePack);_AddSourcePackageSourceLinkFile</BeforePack>
+  </PropertyGroup>
+
+  <Target Name="_AddSourcePackageSourceLinkFile" DependsOnTargets="_GenerateSourcePackageSourceLinkFile">
+    <ItemGroup>
+      <!-- Add a packable item if the project builds the package with auto-generated .nuspec file -->
+      <None Include="$(_SourcePackageSourceLinkTargetsFilePath)" PackagePath="build" Pack="true" Condition="'$(NuspecFile)' == ''"/>
+
+      <!-- Include path in the nuspec properties if the project builds package using custom .nuspec -->
+      <NuspecProperty Include="SourceLinkTargetsFilePath=$(_SourcePackageSourceLinkTargetsFilePath)" Condition="'$(NuspecFile)' != ''"/>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_CalculateGenerateSourcePackageSourceLinkFileOutputs">
+    <PropertyGroup>
+      <_SourcePackageSourceLinkTargetsFileName>$([MSBuild]::ValueOrDefault($(SourcePackageSourceLinkTargetsFileName), '$(PackageId).targets'))</_SourcePackageSourceLinkTargetsFileName>
+      <_SourcePackageSourceLinkTargetsFilePath>$(IntermediateOutputPath)$(_SourcePackageSourceLinkTargetsFileName)</_SourcePackageSourceLinkTargetsFilePath>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="_GenerateSourcePackageSourceLinkFile"
+          DependsOnTargets="InitializeSourceControlInformation;$(SourceLinkUrlInitializerTargets);_CalculateGenerateSourcePackageSourceLinkFileOutputs"
+          Inputs="$(MSBuildAllProjects)"
+          Outputs="$(_SourcePackageSourceLinkTargetsFilePath)">
+
+    <Microsoft.DotNet.Arcade.Sdk.GenerateSourcePackageSourceLinkTargetsFile
+        ProjectDirectory="$(MSBuildProjectDirectory)"
+        PackageId="$(PackageId)"
+        SourceRoots="@(SourceRoot)"
+        OutputPath="$(_SourcePackageSourceLinkTargetsFilePath)"/>
+
+    <ItemGroup>
+      <FileWrites Include="$(_SourcePackageSourceLinkTargetsFilePath)"/>
+    </ItemGroup>
+  </Target>
+
+  <!--
     Validates repository-wide requirements.
     MSBuild only evaluates the target project once per each set of values of global properties and caches the results.
   -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -150,4 +150,26 @@
   <PropertyGroup Condition="'$(NuspecPackageId)' != ''">
     <PackageId>*$(MSBuildProjectName)*</PackageId>
   </PropertyGroup>
+
+  <!--
+    Source packaging helpers.
+  -->
+
+  <PropertyGroup Condition="'$(IsPackable)' == 'true' and '$(IsSourcePackage)' == 'true'">
+    <TargetsForTfmSpecificContentInPackage Condition="'$(NuspecFile)' == ''">$(TargetsForTfmSpecificContentInPackage);_AddSourceFilesToSourcePackage</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+  <Target Name="_AddSourceFilesToSourcePackage">
+    <PropertyGroup>
+      <!-- TODO: language to dir name mapping (https://github.com/Microsoft/msbuild/issues/2101) -->
+      <_LanguageDirName>$(DefaultLanguageSourceExtension.TrimStart('.'))</_LanguageDirName>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_File Remove="@(_File)"/>
+      <_File Include="$(MSBuildProjectDirectory)\**\*$(DefaultLanguageSourceExtension)" TargetDir="contentFiles/$(_LanguageDirName)/$(TargetFramework)" BuildAction="Compile" />
+
+      <TfmSpecificPackageFile Include="@(_File)" PackagePath="%(_File.TargetDir)/%(_File.RecursiveDir)%(_File.FileName)%(_File.Extension)"/>
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
When a source package is referenced from the project that has Source Link enabled the referenced project needs to add and item to `SourceRoot` item group that maps the root directory containing the sources (`{package root}\contentFiles\language\tfm`) to the source server URL of the source repo the package was built from.

This PR adds targets that insert such information to the source package.

**Docs**

 Set `IsSourcePackage` to `true` to indicate that the project produces a source package (along with `IsPackable`, `PackageDescription` and other package properties).

 If the project does not have an explicitly provided `.nuspec` file (`NuspecFile` property is empty) setting `IsSourcePackage` to `true` will trigger a target that 
puts sources contained in the project directory to the `contentFiles` directory of the source package produced by the project.

 In addition a `build/$(PackageId).targets` file will be auto-generated that links the sources contained in the package to the source server via a Source Link target.
If your package already has a `build/$(PackageId).targets` file set `SourcePackageSourceLinkTargetsFileName` property to a different file name (e.g. `SourceLink.targets`)
and import the file from `build/$(PackageId).targets`. 

 If the project is packaged using a custom `.nuspec` file then the source and targets files must be listed in the `.nuspec` file. The path to the generated Source Link 
targets file will be available within the `.nuspec` file via variable `$SourceLinkTargetsFilePath$`.