### PR TITLE
Adding destinationsubdirectory to targetpath when binplacing files

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Configuration/src/build/BinPlace.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Configuration/src/build/BinPlace.targets
@@ -29,7 +29,7 @@
       <_BinPlaceItems Include="@($(_BinPlaceItemName))" />
       <BinPlaceItemsWithFullTargetPath Include="@(_BinPlaceItems)">
         <TargetPath Condition="'%(_BinPlaceItems.TargetPath)' != ''">%(_BinPlaceItems.TargetPath)</TargetPath>
-        <TargetPath Condition="'%(_BinPlaceItems.TargetPath)' == ''">%(Filename)%(Extension)</TargetPath>
+        <TargetPath Condition="'%(_BinPlaceItems.TargetPath)' == ''">%(_BinPlaceItems.DestinationSubDirectory)%(Filename)%(Extension)</TargetPath>
       </BinPlaceItemsWithFullTargetPath>
     </ItemGroup>
 


### PR DESCRIPTION
cc: @safern @ericstj 

FYI: @tarekgh 

This will fix the issue @tarekgh was hitting when trying to test using satellite assemblies. MSBuild does use the DestinationSubDirectory when copying to output path and setting TargetPath so we should be doing the same.