### PR TITLE
Adding internal abstract methods to ref

### DIFF
--- a/src/Microsoft.Cci.Extensions/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.Cci.Extensions/Extensions/TypeExtensions.cs
@@ -710,5 +710,52 @@ namespace Microsoft.Cci.Extensions
                     return ApiKind.Method;
             }
         }
+
+        public static bool IsConstructorVisible(this ITypeDefinition type)
+        {
+            foreach (var item in type.GetAllMembers())
+            {
+                if (item is IMethodDefinition method &&
+                    method.IsConstructor &&
+                    method.IsVisibleOutsideAssembly())
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public static bool IsAbstract(this ITypeDefinitionMember member)
+        {
+            IMethodReference backingMethod;
+            if (member is IMethodDefinition method)
+            {
+                return method.IsAbstract;
+            }
+            else if (member is IPropertyDefinition property)
+            {
+                backingMethod = property.Getter;
+                if (backingMethod != null)
+                {
+                    return backingMethod.ResolvedMethod.IsAbstract;
+                }
+
+                backingMethod = property.Setter;
+                if (backingMethod != null)
+                {
+                    return backingMethod.ResolvedMethod.IsAbstract;
+                }
+            }
+            else if (member is IEventDefinition containedEvent)
+            {
+                backingMethod = containedEvent.Accessors.First();
+                if (backingMethod != null)
+                {
+                    return backingMethod.ResolvedMethod.IsAbstract;
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/src/Microsoft.Cci.Extensions/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.Cci.Extensions/Extensions/TypeExtensions.cs
@@ -724,38 +724,5 @@ namespace Microsoft.Cci.Extensions
             }
             return false;
         }
-
-        public static bool IsAbstract(this ITypeDefinitionMember member)
-        {
-            IMethodReference backingMethod;
-            if (member is IMethodDefinition method)
-            {
-                return method.IsAbstract;
-            }
-            else if (member is IPropertyDefinition property)
-            {
-                backingMethod = property.Getter;
-                if (backingMethod != null)
-                {
-                    return backingMethod.ResolvedMethod.IsAbstract;
-                }
-
-                backingMethod = property.Setter;
-                if (backingMethod != null)
-                {
-                    return backingMethod.ResolvedMethod.IsAbstract;
-                }
-            }
-            else if (member is IEventDefinition containedEvent)
-            {
-                backingMethod = containedEvent.Accessors.First();
-                if (backingMethod != null)
-                {
-                    return backingMethod.ResolvedMethod.IsAbstract;
-                }
-            }
-
-            return false;
-        }
     }
 }

--- a/src/Microsoft.Cci.Extensions/Filters/PublicOnlyCciFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/PublicOnlyCciFilter.cs
@@ -55,8 +55,9 @@ namespace Microsoft.Cci.Filters
             if (!member.IsVisibleOutsideAssembly())
             {
                 if (member.ContainingTypeDefinition.IsAbstract &&
-                    IsConstructorVisible(member.ContainingTypeDefinition) &&
-                    IsAbstract(member))
+                    member.IsAbstract() &&
+                    member.ContainingTypeDefinition.IsConstructorVisible()
+                    )
                 {
                     return true;
                 }
@@ -64,16 +65,6 @@ namespace Microsoft.Cci.Filters
             }
 
             return true;
-        }
-
-        private bool IsConstructorVisible(ITypeDefinition type)
-        {
-            foreach (var item in type.GetAllMembers().Where(t => t.Name.Value == ".ctor"))
-            {
-                if (item.IsVisibleOutsideAssembly())
-                    return true;
-            }
-            return false;
         }
 
         public virtual bool Include(ICustomAttribute attribute)
@@ -98,39 +89,6 @@ namespace Microsoft.Cci.Filters
             }
 
             return true;
-        }
-
-        private static bool IsAbstract(ITypeDefinitionMember member)
-        {
-            IMethodReference backingMethod;
-            if (member is IMethodDefinition method)
-            {
-                return method.IsAbstract;
-            }
-            else if (member is IPropertyDefinition property)
-            {
-                backingMethod = property.Getter;
-                if (backingMethod != null)
-                {
-                    return backingMethod.ResolvedMethod.IsAbstract;
-                }
-
-                backingMethod = property.Setter;
-                if (backingMethod != null)
-                {
-                    return backingMethod.ResolvedMethod.IsAbstract;
-                }
-            }
-            else if (member is IEventDefinition containedEvent)
-            {
-                backingMethod = containedEvent.Accessors.First();
-                if (backingMethod != null)
-                {
-                    return backingMethod.ResolvedMethod.IsAbstract;
-                }
-            }
-
-            return false;
         }
     }
 }

--- a/src/Microsoft.Cci.Extensions/Filters/PublicOnlyCciFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/PublicOnlyCciFilter.cs
@@ -55,6 +55,8 @@ namespace Microsoft.Cci.Filters
 
             if (!member.IsVisibleOutsideAssembly())
             {
+                // If a type is public, abstract and has a public constructor,
+                // then it must expose all abstract members. 
                 if (member.ContainingTypeDefinition.IsAbstract &&
                     member.IsAbstract() &&
                     member.ContainingTypeDefinition.IsConstructorVisible()

--- a/src/Microsoft.Cci.Extensions/Filters/PublicOnlyCciFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/PublicOnlyCciFilter.cs
@@ -53,9 +53,27 @@ namespace Microsoft.Cci.Filters
             }
 
             if (!member.IsVisibleOutsideAssembly())
+            {
+                if (member.ContainingTypeDefinition.IsAbstract &&
+                    IsConstructorVisible(member.ContainingTypeDefinition) &&
+                    IsAbstract(member))
+                {
+                    return true;
+                }
                 return false;
+            }
 
             return true;
+        }
+
+        private bool IsConstructorVisible(ITypeDefinition type)
+        {
+            foreach (var item in type.GetAllMembers().Where(t => t.Name.Value == ".ctor"))
+            {
+                if (item.IsVisibleOutsideAssembly())
+                    return true;
+            }
+            return false;
         }
 
         public virtual bool Include(ICustomAttribute attribute)
@@ -80,6 +98,39 @@ namespace Microsoft.Cci.Filters
             }
 
             return true;
+        }
+
+        private static bool IsAbstract(ITypeDefinitionMember member)
+        {
+            IMethodReference backingMethod;
+            if (member is IMethodDefinition method)
+            {
+                return method.IsAbstract;
+            }
+            else if (member is IPropertyDefinition property)
+            {
+                backingMethod = property.Getter;
+                if (backingMethod != null)
+                {
+                    return backingMethod.ResolvedMethod.IsAbstract;
+                }
+
+                backingMethod = property.Setter;
+                if (backingMethod != null)
+                {
+                    return backingMethod.ResolvedMethod.IsAbstract;
+                }
+            }
+            else if (member is IEventDefinition containedEvent)
+            {
+                backingMethod = containedEvent.Accessors.First();
+                if (backingMethod != null)
+                {
+                    return backingMethod.ResolvedMethod.IsAbstract;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/Microsoft.Cci.Extensions/Filters/PublicOnlyCciFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/PublicOnlyCciFilter.cs
@@ -4,6 +4,7 @@
 
 using System.Linq;
 using Microsoft.Cci.Extensions;
+using Microsoft.Cci.Extensions.CSharp;
 
 namespace Microsoft.Cci.Filters
 {


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/2642

New Output
```C#
    public abstract partial class BaseNumberConverter : System.ComponentModel.TypeConverter
    {
        protected BaseNumberConverter() { }
        internal abstract System.Type TargetType { get; }
        public override bool CanConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Type sourceType) { throw null; }
        public override bool CanConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Type destinationType) { throw null; }
        public override object ConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value) { throw null; }
        public override object ConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, System.Type destinationType) { throw null; }
        internal abstract object FromString(string value, System.Globalization.NumberFormatInfo formatInfo);
        internal abstract object FromString(string value, int radix);
        internal abstract string ToString(object value, System.Globalization.NumberFormatInfo formatInfo);
    }

```