### PR TITLE
Suppress nuspec dependencies for Microsoft.DotNet.CodeAnalysis

### DIFF
--- a/src/Microsoft.DotNet.CodeAnalysis/Microsoft.DotNet.CodeAnalysis.csproj
+++ b/src/Microsoft.DotNet.CodeAnalysis/Microsoft.DotNet.CodeAnalysis.csproj
@@ -9,6 +9,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IsPackable>true</IsPackable>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodeAnalysis.ruleset</CodeAnalysisRuleSet>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This package currently has this in its generated nuspec:
```
    <dependencies>
      <group targetFramework=".NETStandard1.3">
        <dependency id="Microsoft.CodeAnalysis.CSharp" version="2.9.0" exclude="Build,Analyzers" />
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
      </group>
    </dependencies>
```
This is incorrect for packages that bundle analyzers and build targets/content. The dependency Microsoft.CodeAnalysis.CSharp is a build-time only dependency for this project and shouldn't leak into projects consuming this analyzer package.