### PR TITLE
Xunit runner: Treat response file names case-sensitively

### DIFF
--- a/src/Microsoft.DotNet.XUnitConsoleRunner/src/CommandLine.cs
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/src/CommandLine.cs
@@ -243,7 +243,7 @@ namespace Xunit.ConsoleClient
 
                 if (optionName.StartsWith("@", StringComparison.Ordinal))
                 {
-                    ParseRspFile(optionName.Substring(1));
+                    ParseRspFile(option.Key.Substring(1));
                     continue;
                 }
 


### PR DESCRIPTION
In Mono we use response files that are named like `excludes-System.Runtime.Tests.xsp`. While the Xunit runner supports .rsp files now it always lower-cases the file names. On case-sensitive file systems it fails to find the files.