### PR TITLE
Workaround for projects that do not import Common targets

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/BeforeCommonTargets.targets
@@ -3,5 +3,9 @@
 <Project>
   <Import Project="$(_ArcadeOverriddenCustomBeforeMicrosoftCommonTargets)" Condition="Exists('$(_ArcadeOverriddenCustomBeforeMicrosoftCommonTargets)')"/>
 
+  <PropertyGroup>
+    <_ArcadeBeforeCommonTargetsImported>true</_ArcadeBeforeCommonTargetsImported>
+  </PropertyGroup>
+
   <Import Project="Version.BeforeCommonTargets.targets"/>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets
@@ -5,7 +5,13 @@
     Import NuGet targets to WPF temp projects (workaround for https://github.com/dotnet/sourcelink/issues/91) 
   -->
   <Import Project="$(_WpfTempProjectNuGetFilePathNoExt).targets" Condition="'$(_WpfTempProjectNuGetFilePathNoExt)' != '' and Exists('$(_WpfTempProjectNuGetFilePathNoExt).targets')"/>
-  
+
+  <!-- 
+    Some projects do not import Common targets, so BeforeCommonTargets.targets doesn't get imported. 
+    (https://github.com/dotnet/arcade/issues/2676).
+  -->
+  <Import Project="BeforeCommonTargets.targets" Condition="'$(_ArcadeBeforeCommonTargetsImported)' != 'true'"/>
+
   <Import Project="ProjectDefaults.targets"/>
   <Import Project="StrongName.targets"/>
   <Import Project="GenerateInternalsVisibleTo.targets" />


### PR DESCRIPTION
Some projects do not import Common targets, so BeforeCommonTargets.targets doesn't get imported. 
Opened issue https://github.com/dotnet/arcade/issues/2676 to track removal of the workaround.