### PR TITLE
Update MicrosoftNetCompilersToolsetVersion to 3.2.0-beta1-19253-08

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,7 +28,7 @@
     <MicrosoftExtensionsDependencyModelVersion>2.1.0</MicrosoftExtensionsDependencyModelVersion>
     <MicrosoftExtensionsFileSystemGlobbingVersion>2.0.0</MicrosoftExtensionsFileSystemGlobbingVersion>
     <MicrosoftNETCorePlatformsVersion>2.1.0</MicrosoftNETCorePlatformsVersion>
-    <MicrosoftNetCompilersToolsetVersion>3.2.0-beta1-19229-02</MicrosoftNetCompilersToolsetVersion>
+    <MicrosoftNetCompilersToolsetVersion>3.2.0-beta1-19253-08</MicrosoftNetCompilersToolsetVersion>
     <MicrosoftNetTestSdkVersion>15.7.2</MicrosoftNetTestSdkVersion>
     <MoqVersion>4.8.3</MoqVersion>
     <MonoOptionsVersion>5.3.0.1</MonoOptionsVersion>


### PR DESCRIPTION
FYI @stephentoub @ViktorHofer @jaredpar @agocke 

Relates to https://github.com/dotnet/roslyn/issues/35290 (compiler race condition breaks corefx build on Linux/MacOS)

Note: this build (3.2.0-beta1-19253-08) should include the fix (https://github.com/dotnet/roslyn/pull/35373) based on my investigation of the commit SHA it is based on (https://github.com/dotnet/roslyn/commit/6a87a933050706e75aadd74ed689d98a40fdda8f).
