### PR TITLE
Remove STAThread attribute from Xunit.Console.dll

### DIFF
--- a/src/Microsoft.DotNet.XUnitConsoleRunner/src/Program.cs
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/src/Program.cs
@@ -5,7 +5,6 @@ namespace Xunit.ConsoleClient
 {
     public class Program
     {
-        [STAThread]
         public static int Main(string[] args)
         {
             // This code must not contain any references to code in any external assembly (or any code that references any code in any


### PR DESCRIPTION
Windows 10 Nano Server does not support using the STA threading apartment. CoreCLR has been recently updated to handle this case and notify the user via an exception (instead of an assert that is ignored in release builds). Because xunit.console.dll has been requiring the STA thread, this has caused our test runs on Windows 10 Nano Server to fail recently.

Since both CoreCLR and CoreFX have been running without issue on xunit.console.dll for a while without having an issue related to failing to initalize the STA thread, I believe that we can remove the STAThread attribute and allow the main thread of xunit.console.dll to run in the MTA.

This will fix all of the Windows 10 Nano Server runs on CoreCLR (debug, checked, and release).

cc: @RussKeldorph  @echesakovMSFT