### PR TITLE
Report skip reason for trx test result files

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/formats/trx.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/formats/trx.py
@@ -62,7 +62,12 @@ class TRXFormat(ResultFormat):
 
                 if outcome == "NotExecuted":
                     result = "Skip"
-                    skip_reason = u""
+                    output_element = element.find("vstest:Output", ns)
+                    if output_element is not None:
+                        stdout_element = output_element.find("vstest:StdOut", ns)
+                        if stdout_element is not None:
+                            skip_reason = stdout_element.text
+
                 elif outcome == "Failed":
                     result = "Fail"
                     output_element = element.find("vstest:Output", ns)


### PR DESCRIPTION
xunit reports skip reason as "stdout" in a trx file. This updates the trx parser to find this element and its contents if they exist.

Example:
```xml
    <UnitTestResult executionId="5340c07a-fd86-4e42-b838-5a88fbb46ddc" testId="290cc923-dea6-1440-6ea5-ac34eedbd5e7" testName="Microsoft.Net.Http.Headers.DateParserTest.ToString_UseDifferentValues_MatchExpectation" computerName="EMPIRE-Z" duration="00:00:00.0010000" startTime="2019-05-08T18:04:29.7611736-07:00" endTime="2019-05-08T18:04:29.7611744-07:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="5340c07a-fd86-4e42-b838-5a88fbb46ddc">
      <Output>
        <StdOut>Testing skip reason messages</StdOut>
      </Output>
    </UnitTestResult>
```

![image](https://user-images.githubusercontent.com/2696087/57420338-eec19d80-71bb-11e9-863d-b2436d7b4471.png)
