### PR TITLE
Don't add online sources when DotNetBuildOffline is set.

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Versions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Versions.props
@@ -12,8 +12,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <RestoreSources Condition="'$(DotNetBuildOffline)' == 'true'">$(DotNetRestoreSources)</RestoreSources>
-    <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
+    <RestoreSources>
       https://api.nuget.org/v3/index.json;
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
     </RestoreSources>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Versions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Versions.props
@@ -12,7 +12,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <RestoreSources>
+    <RestoreSources Condition="'$(DotNetBuildOffline)' == 'true'">$(DotNetRestoreSources)</RestoreSources>
+    <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
       https://api.nuget.org/v3/index.json;
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
     </RestoreSources>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -19,7 +19,7 @@
 
   <PropertyGroup>
     <RestoreSources>$(DotNetRestoreSources)</RestoreSources>
-    <RestoreSources>
+    <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
       $(RestoreSources);
       https://api.nuget.org/v3/index.json;
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;


### PR DESCRIPTION
`src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj` always adds online sources to `RestoreSources`, which can cause a build failure when source-build is building offline (depending on which source NuGet decides to hit first).  `src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Versions.props` has a similar construction, although I haven't actually seen that one cause problems yet I thought I would fix it too.