### PR TITLE
Fix ExtractNgenMethodList:

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/ExtractNgenMethodList.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/ExtractNgenMethodList.cs
@@ -6,6 +6,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
@@ -43,6 +44,11 @@ namespace Microsoft.DotNet.Arcade.Sdk
         [Required]
         public string OutputDirectory { get; set; }
 
+        /// <summary>
+        /// From IBCMerge.MethodProfilingDataFlags
+        /// </summary>
+        private const int ReadMethodCode = 0x1;
+
         public override bool Execute()
         {
             var document = XDocument.Load(IbcXmlFilePath);
@@ -52,9 +58,10 @@ namespace Microsoft.DotNet.Arcade.Sdk
             {
                 foreach (var child in parentElement.Elements("Item"))
                 {
-                    var flags = child.Attribute("flags");
+                    var flagsInt = child.Attribute("flagsInt");
                     var name = child.Attribute("name");
-                    if (flags?.Value.Contains("ReadMethodCode") == true && name != null)
+                    if (int.TryParse(flagsInt?.Value.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out int parsedFlagsInt) 
+                        && (parsedFlagsInt & ReadMethodCode) == 1)
                     {
                         items.Add(name.Value);
                     }


### PR DESCRIPTION
Fix ExtractNgenMethodList task:
- Don't rely on the text output of the flags attribute, core ibcmerge doesn't contain the complete enum so it won't always print out the correct string
- Check for the ReadMethodCode bit instead

---

Turns out we aren't reading the full list of methods that will be NGEN'd due to the core version of ibcmerge having obsolete attributes removed (see: https://devdiv.visualstudio.com/DevDiv/_git/DotNet-IbcMerge?path=%2Fsrc%2FIbcMerge%2Fibcmerge.cs&version=GBmaster&line=449&lineStyle=plain&lineEnd=450&lineStartColumn=1&lineEndColumn=1)

This means that the dumped xml from IBCMerge will incorrectly print out the flags field attribute as the raw value, not the printed enum string:

Framework version: 
```xml
<Item token="0x06000b3e" scenarios="" scenariosInt="0x0001" flagsInt="0xe0001883"
flags="ReadMethodCode, ReadMethodDesc, ReadGCInfo, ReadMethodPrecode, WriteMethodPrecode, RidMap, CommonMetaData, MetaData"
name="instance bool Microsoft.CodeAnalysis.Compilation::SerializeToPeStream(Microsoft.CodeAnalysis.Emit.CommonPEModuleBuilder,Microsoft.CodeAnalysis.Compilation.EmitStreamProvider,Microsoft.CodeAnalysis.Compilation.EmitStreamProvider,Microsoft.CodeAnalysis.Compilation.EmitStreamProvider,[netstandard]System.Func`2&lt;Microsoft.DiaSymReader.ISymWriterMetadataProvider,Microsoft.DiaSymReader.SymUnmanagedWriter&gt;,Microsoft.CodeAnalysis.DiagnosticBag,bool,bool,bool,System.String,value class [netstandard]System.Nullable`1&lt;value class [netstandard]System.Security.Cryptography.RSAParameters&gt;,value class [netstandard]System.Threading.CancellationToken)" />

```

Core version:
```xml
<Item token="0x06000b3e" scenarios="" scenariosInt="0x0001" flagsInt="0xe0001883"
flags="3758102659" 
name="bool Microsoft.CodeAnalysis.Compilation::SerializeToPeStream(Microsoft.CodeAnalysis.Emit.CommonPEModuleBuilder,Microsoft.CodeAnalysis.Compilation.EmitStreamProvider,Microsoft.CodeAnalysis.Compilation.EmitStreamProvider,Microsoft.CodeAnalysis.Compilation.EmitStreamProvider,[netstandard]System.Func`2&lt;Microsoft.DiaSymReader.ISymWriterMetadataProvider,Microsoft.DiaSymReader.SymUnmanagedWriter&gt;,Microsoft.CodeAnalysis.DiagnosticBag,bool,bool,bool,System.String,value class [netstandard]System.Nullable`1&lt;value class [netstandard]System.Security.Cryptography.RSAParameters&gt;,value class [netstandard]System.Threading.CancellationToken)" />
```

This change checks the `flagsInt` field for the `ReadMethodDesc` value instead, meaning we'll always correctly extract the method list, regardless of if the tool is printing the values correctly.
