### PR TITLE
Fix installdotnet linux arg parsing

### DIFF
--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -165,11 +165,11 @@ function InstallDotNet {
   local install_script=$_GetDotNetInstallScript
 
   local archArg=''
-  if [[ "$#" -ge "3" ]]; then
+  if [[ "$#" -ge 3 && "$3" != '' ]]; then
     archArg="--architecture $3"
   fi
   local runtimeArg=''
-  if [[ "$#" -ge "4" ]]; then
+  if [[ "$#" -ge 4 && "$4" != '' ]]; then
     runtimeArg="--runtime $4"
   fi
 
@@ -177,6 +177,7 @@ function InstallDotNet {
   if [[ "$#" -ge "5" ]]; then
     skipNonVersionedFilesArg="--skip-non-versioned-files"
   fi
+
   bash "$install_script" --version $version --install-dir "$root" $archArg $runtimeArg $skipNonVersionedFilesArg || {
     local exit_code=$?
     echo "Failed to install dotnet SDK (exit code '$exit_code')." >&2

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -165,11 +165,11 @@ function InstallDotNet {
   local install_script=$_GetDotNetInstallScript
 
   local archArg=''
-  if [[ "$#" -ge 3 && "$3" != '' ]]; then
+  if [[ -n "${3:-}"]]; then
     archArg="--architecture $3"
   fi
   local runtimeArg=''
-  if [[ "$#" -ge 4 && "$4" != '' ]]; then
+  if [[ -n "${4:-}"]]; then
     runtimeArg="--runtime $4"
   fi
 

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -177,7 +177,6 @@ function InstallDotNet {
   if [[ "$#" -ge "5" ]]; then
     skipNonVersionedFilesArg="--skip-non-versioned-files"
   fi
-
   bash "$install_script" --version $version --install-dir "$root" $archArg $runtimeArg $skipNonVersionedFilesArg || {
     local exit_code=$?
     echo "Failed to install dotnet SDK (exit code '$exit_code')." >&2


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/2730

My validation job on Linux was parsing `"dotnet": "blah"` and not `"dotnet/x64": "blah"`.  Thanks for catching this failure Nate. 