### PR TITLE
Update GenerateTrainingInputFiles task:

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests/OptProf/GenerateTrainingInputFilesTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests/OptProf/GenerateTrainingInputFilesTests.cs
@@ -21,10 +21,27 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio.UnitTests
       ""tests"": [
         {
           ""container"": ""DDRIT.RPS.CSharp"",
-          ""testCases"": [
-            ""DDRIT.RPS.CSharp.CSharpTest.EditingAndDesigner""
-          ]
-    }
+          ""filteredTestCases"" : [
+            {
+                ""filename"" : ""/x/y/z/Microsoft.CodeAnalysis.CSharp.dll"",
+                ""testCases"": [
+                    ""DDRIT.RPS.CSharp.CSharpTest.EditingAndDesigner""
+                 ]
+            },
+            {
+                ""filename"" : ""/x/y/z/Microsoft.CodeAnalysis.dll"",
+                ""testCases"": [
+                    ""DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging""
+                 ]
+            }
+           ]
+        },
+        {
+          ""container"": ""TeamEng"",
+          ""testCases"" : [
+            ""TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble""
+           ]
+        }
       ]
     }
   ],
@@ -80,6 +97,20 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio.UnitTests
       ""ngenArchitecture"": ""All"",
       ""ngenApplication"": """",
       ""ngenPriority"": 3
+    },
+    {
+      ""fileName"": ""/x/y/z/Microsoft.CodeAnalysis.dll"",
+      ""ngen"": true,
+      ""ngenArchitecture"": ""All"",
+      ""ngenApplication"": """",
+      ""ngenPriority"": 3
+    },
+    {
+      ""fileName"": ""/x/y/z/Microsoft.CodeAnalysis.VisualBasic.dll"",
+      ""ngen"": true,
+      ""ngenArchitecture"": ""All"",
+      ""ngenApplication"": """",
+      ""ngenPriority"": 3
     }
   ]
 }
@@ -129,12 +160,19 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio.UnitTests
             AssertEx.SetEqual(new[] 
             {
                 Path.Combine(outputDir, @"DDRIT.RPS.CSharp"),
+                Path.Combine(outputDir, @"TeamEng"),
                 Path.Combine(outputDir, @"DDRIT.RPS.CSharp\Configurations"),
                 Path.Combine(outputDir, @"DDRIT.RPS.CSharp\Configurations\DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging"),
                 Path.Combine(outputDir, @"DDRIT.RPS.CSharp\Configurations\DDRIT.RPS.CSharp.CSharpTest.EditingAndDesigner"),
                 Path.Combine(outputDir, @"DDRIT.RPS.CSharp\Configurations\DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging\System.Collections.Immutable.0.IBC.json"),
                 Path.Combine(outputDir, @"DDRIT.RPS.CSharp\Configurations\DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging\System.Collections.Immutable.1.IBC.json"),
-                Path.Combine(outputDir, @"DDRIT.RPS.CSharp\Configurations\DDRIT.RPS.CSharp.CSharpTest.EditingAndDesigner\xyzMicrosoft.CodeAnalysis.CSharp.0.IBC.json")
+                Path.Combine(outputDir, @"DDRIT.RPS.CSharp\Configurations\DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging\xyzMicrosoft.CodeAnalysis.0.IBC.json"),
+                Path.Combine(outputDir, @"DDRIT.RPS.CSharp\Configurations\DDRIT.RPS.CSharp.CSharpTest.EditingAndDesigner\xyzMicrosoft.CodeAnalysis.CSharp.0.IBC.json"),
+                Path.Combine(outputDir, @"TeamEng\Configurations"),
+                Path.Combine(outputDir, @"TeamEng\Configurations\TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble"),
+                Path.Combine(outputDir, @"TeamEng\Configurations\TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble\xyzMicrosoft.CodeAnalysis.0.IBC.json"),
+                Path.Combine(outputDir, @"TeamEng\Configurations\TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble\xyzMicrosoft.CodeAnalysis.CSharp.0.IBC.json"),
+                Path.Combine(outputDir, @"TeamEng\Configurations\TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble\xyzMicrosoft.CodeAnalysis.VisualBasic.0.IBC.json")
             }, entries);
 
 
@@ -165,6 +203,16 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio.UnitTests
 @"{
   ""Technology"": ""IBC"",
   ""RelativeInstallationPath"": ""Common7\\IDE\\CommonExtensions\\Microsoft\\ManagedLanguages\\VBCSharp\\LanguageServices\\x\\y\\z\\Microsoft.CodeAnalysis.CSharp.dll"",
+  ""InstrumentationArguments"": ""/ExeConfig:\""%VisualStudio.InstallationUnderTest.Path%\\Common7\\IDE\\vsn.exe\""""
+}
+", json);
+            JObject.Parse(json);
+
+            json = File.ReadAllText(Path.Combine(outputDir, @"TeamEng\Configurations\TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble\xyzMicrosoft.CodeAnalysis.VisualBasic.0.IBC.json"));
+            Assert.Equal(
+@"{
+  ""Technology"": ""IBC"",
+  ""RelativeInstallationPath"": ""Common7\\IDE\\CommonExtensions\\Microsoft\\ManagedLanguages\\VBCSharp\\LanguageServices\\x\\y\\z\\Microsoft.CodeAnalysis.VisualBasic.dll"",
   ""InstrumentationArguments"": ""/ExeConfig:\""%VisualStudio.InstallationUnderTest.Path%\\Common7\\IDE\\vsn.exe\""""
 }
 ", json);

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests/OptProf/GetRunSettingsSessionConfigurationTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests/OptProf/GetRunSettingsSessionConfigurationTests.cs
@@ -265,6 +265,135 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio.UnitTests
 }
 ";
 
+        private const string filtered_products_and_assemblies_expectedContainerString = "  <TestContainer FileName=\"DDRIT.RPS.CSharp.dll\" />\r\n  <TestContainer FileName=\"VSPE.dll\" />";
+        private const string filtered_products_and_assemblies_expectedTestCaseFilterString = "FullyQualifiedName=DDRIT.RPS.CSharp.CSharpTest.EditingAndDesigner|FullyQualifiedName=VSPE.OptProfTests.vs_perf_designtime_ide_searchtest|FullyQualifiedName=VSPE.OptProfTests.vs_perf_designtime_editor_intellisense_globalcompletionlist_cs|FullyQualifiedName=VSPE.OptProfTests.vs_asl_cs_scenario|FullyQualifiedName=VSPE.OptProfTests.vs_ddbvtqa_vbwi|FullyQualifiedName=VSPE.OptProfTests.vs_asl_vb_scenario|FullyQualifiedName=VSPE.OptProfTests.vs_env_solution_createnewproject_vb_winformsapp|FullyQualifiedName=DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging";
+        private const string filtered_products_and_assemblies = @"
+{
+  ""products"": [
+    {
+      ""name"": ""Roslyn.VisualStudio.Setup.vsix"",
+      ""tests"": [
+        {
+          ""container"": ""DDRIT.RPS.CSharp"",
+          ""testCases"": [
+            ""DDRIT.RPS.CSharp.CSharpTest.EditingAndDesigner""
+          ]
+        },
+        {
+          ""container"": ""VSPE"",
+          ""filteredTestCases"": [
+            {
+              ""fileName"": ""Microsoft.CodeAnalysis.CSharp.dll"",
+              ""testCases"": [
+                ""VSPE.OptProfTests.vs_perf_designtime_ide_searchtest"",
+                ""VSPE.OptProfTests.vs_perf_designtime_editor_intellisense_globalcompletionlist_cs"",
+                ""VSPE.OptProfTests.vs_asl_cs_scenario"",
+                ""VSPE.OptProfTests.vs_ddbvtqa_vbwi"",
+                ""VSPE.OptProfTests.vs_asl_vb_scenario"",
+                ""VSPE.OptProfTests.vs_env_solution_createnewproject_vb_winformsapp""
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      ""name"": ""ExpressionEvaluatorPackage.vsix"",
+      ""tests"": [
+        {
+          ""container"": ""DDRIT.RPS.CSharp"",
+          ""testCases"": [
+            ""DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging""
+          ]
+        }
+      ]
+    },
+    {
+      ""name"": ""Microsoft.CodeAnalysis.Compilers.vsix"",
+      ""tests"": [
+        {
+          ""container"": ""DDRIT.RPS.CSharp"",
+          ""testCases"": [
+            ""DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging""
+          ]
+        }
+      ]
+    },
+    {
+      ""name"": ""Roslyn.VisualStudio.InteractiveComponents.vsix"",
+      ""tests"": [
+        {
+          ""container"": ""DDRIT.RPS.CSharp"",
+          ""testCases"": [
+            ""DDRIT.RPS.CSharp.CSharpTest.EditingAndDesigner""
+          ]
+        }
+      ]
+    }
+  ],
+  ""assemblies"" : [
+    {
+      ""assembly"": ""System.Collections.Immutable.dll"",
+      ""instrumentationArguments"": [
+        {
+          ""relativeInstallationFolder"": ""Common7/IDE/PrivateAssemblies"",
+          ""instrumentationExecutable"" : ""Common7/IDE/vsn.exe""
+        },
+        {
+          ""relativeInstallationFolder"": ""MSBuild/15.0/Bin/Roslyn"",
+          ""instrumentationExecutable"" : ""Common7/IDE/vsn.exe""
+        },
+        {
+          ""relativeInstallationFolder"": ""MSBuild/Current/Bin"",
+          ""instrumentationExecutable"" : ""Common7/IDE/vsn.exe""
+        },
+        {
+          ""relativeInstallationFolder"": ""MSBuild/Current/Bin/amd64"",
+          ""instrumentationExecutable"" : ""Common7/IDE/vsn.exe""
+        },
+        {
+          ""relativeInstallationFolder"": ""Common7/IDE/Extensions/TestPlatform"",
+          ""instrumentationExecutable"" : ""Common7/IDE/vsn.exe""
+        }
+      ],
+      ""tests"": [
+        {
+          ""container"": ""DDRIT.RPS.CSharp"",
+          ""testCases"": [
+            ""DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging""
+          ]
+        }
+      ]
+    },
+    {
+      ""assembly"": ""System.Reflection.Metadata.dll"",
+      ""instrumentationArguments"": [
+        {
+          ""relativeInstallationFolder"": ""Common7/IDE/PrivateAssemblies"",
+          ""instrumentationExecutable"" : ""Common7/IDE/vsn.exe""
+        },
+        {
+          ""relativeInstallationFolder"": ""MSBuild/15.0/Bin/Roslyn"",
+          ""instrumentationExecutable"" : ""Common7/IDE/vsn.exe""
+        },
+        {
+          ""relativeInstallationFolder"": ""Common7/IDE/Extensions/TestPlatform"",
+          ""instrumentationExecutable"" : ""Common7/IDE/vsn.exe""
+        }
+      ],
+      ""tests"": [
+        {
+          ""container"": ""DDRIT.RPS.CSharp"",
+          ""testCases"": [
+            ""DDRIT.RPS.CSharp.CSharpTest.BuildAndDebugging""
+          ]
+        }
+      ]
+    }
+  ]
+}
+";
+
         [Theory]
         [InlineData(@"[{""BuildDrop"": ""https://vsdrop.corp.microsoft.com/file/v1/Products/42.42.42.42/42.42.42.42""}]", "Tests/42.42.42.42/42.42.42.42")]
         public static void TestsCorrectJsonFiles(string jsonString, string expectedUrl)
@@ -322,6 +451,7 @@ $@"<TestStores>
         [InlineData(products_only, products_only_expectedContainerString, products_only_expectedTestCaseFilterString)]
         [InlineData(assemblies_only, assemblies_only_expectedContainerString, assemblies_only_expectedTestCaseFilterString)]
         [InlineData(products_and_assemblies, products_and_assemblies_expectedContainerString, products_and_assemblies_expectedTestCaseFilterString)]
+        [InlineData(filtered_products_and_assemblies, filtered_products_and_assemblies_expectedContainerString, filtered_products_and_assemblies_expectedTestCaseFilterString)]
         public void TestProductsOnly(string configJson, string expectedContainerString, string expectedTestCaseFilterString)
         {
             var (actualContainerString, actualTestCaseFilterString) = GetRunSettingsSessionConfiguration.GetTestContainersAndFilters(configJson, "config.json");

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GenerateTrainingInputFiles.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GenerateTrainingInputFiles.cs
@@ -117,9 +117,23 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio
             foreach (var test in tests)
             {
                 var configurationsDir = Path.Combine(OutputDirectory, test.Container, "Configurations");
-                foreach (var fullyQualifiedName in test.TestCases)
+                if (test.TestCases is object)
                 {
-                    WriteEntries(ibcEntries, Path.Combine(configurationsDir, fullyQualifiedName));
+                    foreach (var fullyQualifiedName in test.TestCases)
+                    {
+                        WriteEntries(ibcEntries, Path.Combine(configurationsDir, fullyQualifiedName));
+                    }
+                }
+                else if (test.FilteredTestCases is object)
+                {
+                    foreach(var filteredTestCase in test.FilteredTestCases)
+                    {
+                        var filteredIbcEntries = ibcEntries.Where(ibc => ibc.EntryName == filteredTestCase.FileName).ToArray();
+                        foreach (var fullyQualifiedName in filteredTestCase.TestCases)
+                        {
+                            WriteEntries(filteredIbcEntries, Path.Combine(configurationsDir, fullyQualifiedName));
+                        }
+                    }
                 }
             }
         }

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GetRunSettingsSessionConfiguration.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GetRunSettingsSessionConfiguration.cs
@@ -141,7 +141,7 @@ $@"<TestStores>
         private static string GetTestFilters(OptProfTrainingConfiguration config)
         {
             var productTests = config.Products?.Any() == true
-                ? config.Products.SelectMany(x => x.Tests.SelectMany(y => y.TestCases))
+                ? config.Products.SelectMany(x => x.Tests.SelectMany(y => y.TestCases ?? y.FilteredTestCases.SelectMany(z => z.TestCases)))
                 : Enumerable.Empty<string>();
 
             var assemblyTests = config.Assemblies?.Any() == true

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/IbcEntry.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/IbcEntry.cs
@@ -16,14 +16,16 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio
         private const string VSInstallationRootVar = "%VisualStudio.InstallationUnderTest.Path%";
         private const string DefaultNgenApplication = VSInstallationRootVar + "\\Common7\\IDE\\vsn.exe";
 
+        public readonly string EntryName;
         public readonly string RelativeInstallationPath;
         public readonly string InstrumentationArguments;
         public readonly string RelativeDirectoryPath;
 
-        public IbcEntry(string relativeInstallationPath, string relativeDirectoryPath, string ngenApplicationPath)
+        public IbcEntry(string entryName, string relativeInstallationPath, string relativeDirectoryPath, string ngenApplicationPath)
         {
             string commandLineArg(string name, string value) => $"/{name}:\"{value}\"";
 
+            EntryName = entryName;
             RelativeInstallationPath = relativeInstallationPath;
             RelativeDirectoryPath = relativeDirectoryPath;
             InstrumentationArguments = commandLineArg("ExeConfig", ngenApplicationPath);
@@ -41,6 +43,7 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio
             foreach (var args in assembly.InstrumentationArguments)
             {
                 yield return new IbcEntry(
+                    assembly.Assembly,
                     relativeInstallationPath: args.RelativeInstallationFolder.Replace("/", "\\") + $"\\{assembly.Assembly}",
                     relativeDirectoryPath: "",
                     ngenApplicationPath: Path.Combine(VSInstallationRootVar, args.InstrumentationExecutable.Replace("/", "\\")));
@@ -75,7 +78,7 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio
                        let fileName = (string)file["fileName"]
                        where includeInIbcTraining(file, fileName)
                        let filePath = $"{extensionDir}\\{fileName.TrimStart('/').Replace("/", "\\")}"
-                       select new IbcEntry(filePath, relativeDirectoryPath: Path.GetDirectoryName(fileName), DefaultNgenApplication);
+                       select new IbcEntry(fileName, filePath, relativeDirectoryPath: Path.GetDirectoryName(fileName), DefaultNgenApplication);
             }
             else
             {
@@ -85,6 +88,7 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio
                        where includeInIbcTraining(file, fileName)
                        let filePath = fileName.Replace("/Contents/", string.Empty).Replace("/", "\\")
                        select new IbcEntry(
+                           fileName,
                            filePath,
                            relativeDirectoryPath: "",
                            (ngenApplication != null) ? replacePrefix(ngenApplication, "[installdir]", VSInstallationRootVar) : DefaultNgenApplication);

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/OptProfFileFilteredTest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/OptProfFileFilteredTest.cs
@@ -6,15 +6,13 @@ using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.Build.Tasks.VisualStudio
 {
-    internal sealed class OptProfTrainingTest
+    internal sealed class OptProfFileFilteredTest
     {
-        [JsonProperty(PropertyName = "container", Order = 3)]
-        public string Container { get; set; }
+        [JsonProperty(PropertyName = "fileName")]
+        public string FileName { get; set; }
 
         [JsonProperty(PropertyName = "testCases", Order = 3)]
         public string[] TestCases { get; set; }
 
-        [JsonProperty(PropertyName = "filteredTestCases", Order = 3)]
-        public OptProfFileFilteredTest[] FilteredTestCases { get; set; }
     }
 }


### PR DESCRIPTION
- Allow a users OptProf.json to specify a filtered list of test cases, where only certain assemblies within in a product generate entries for a given test.
- Update tests to cover new options