### PR TITLE
Enable pipeline logger for bash

### DIFF
--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -66,6 +66,7 @@ ci=false
 warn_as_error=true
 node_reuse=true
 binary_log=false
+pipelines_log=false
 
 projects=''
 configuration='Debug'
@@ -91,6 +92,9 @@ while [[ $# > 0 ]]; do
       ;;
     -binarylog|-bl)
       binary_log=true
+      ;;
+    -pipelineslog|-pl)
+      pipelines_log=true
       ;;
     -restore|-r)
       restore=true
@@ -146,6 +150,7 @@ while [[ $# > 0 ]]; do
 done
 
 if [[ "$ci" == true ]]; then
+  pipelines_log=true
   binary_log=true
   node_reuse=false
 fi

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -327,7 +327,6 @@ function MSBuild {
 }
 
 function MSBuild-Core {
-
   if [[ "$ci" == true ]]; then
     if [[ "$binary_log" != true ]]; then
       echo "Binary log must be enabled in CI build." >&2

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -3,6 +3,16 @@
 # CI mode - set to true on CI server for PR validation build or official build.
 ci=${ci:-false}
 
+# Set to true to use the pipelines logger which will enable Azure logging output.
+# https://github.com/Microsoft/azure-pipelines-tasks/blob/master/docs/authoring/commands.md
+# This flag is meant as a temporary opt-opt for the feature while validate it across
+# our consumers. It will be deleted in the future.
+if [[ "$ci" == true ]]; then
+  pipelines_log=${pipelines_log:-true}
+else
+  pipelines_log=${pipelines_log:-false}
+fi
+
 # Build configuration. Common values include 'Debug' and 'Release', but the repository may use other names.
 configuration=${configuration:-'Debug'}
 
@@ -216,6 +226,7 @@ function InitializeBuildTool {
   # return values
   _InitializeBuildTool="$_InitializeDotNetCli/dotnet"  
   _InitializeBuildToolCommand="msbuild"
+  _InitializeBuildToolFramework="netcoreapp2.1"
 }
 
 function GetNuGetPackageCachePath {
@@ -276,7 +287,7 @@ function InitializeToolset {
   fi
   
   echo '<Project Sdk="Microsoft.DotNet.Arcade.Sdk"/>' > "$proj"
-  MSBuild "$proj" $bl /t:__WriteToolsetLocation /clp:ErrorsOnly\;NoSummary /p:__ToolsetLocationOutputFile="$toolset_location_file"
+  MSBuild-Core "$proj" $bl /t:__WriteToolsetLocation /clp:ErrorsOnly\;NoSummary /p:__ToolsetLocationOutputFile="$toolset_location_file"
 
   local toolset_build_proj=`cat "$toolset_location_file"`
 
@@ -304,6 +315,19 @@ function StopProcesses {
 }
 
 function MSBuild {
+  args=$@
+  if [[ "$pipelines_log" == true ]]; then
+    InitializeBuildTool
+    InitializeToolset
+    _toolset_dir="${_InitializeToolset%/*}"
+    _loggerPath="$_toolset_dir/$_InitializeBuildToolFramework/Microsoft.DotNet.Arcade.Sdk.dll"
+    args=( "${args[@]}" "-logger:$_loggerPath" )
+  fi
+  MSBuild-Core ${args[@]}
+}
+
+function MSBuild-Core {
+
   if [[ "$ci" == true ]]; then
     if [[ "$binary_log" != true ]]; then
       echo "Binary log must be enabled in CI build." >&2


### PR DESCRIPTION
Fixes https://github.com/dotnet/core-eng/issues/6292

Validated in https://dev.azure.com/dnceng/public/_build/results?buildId=190473

Essentially, this change aligns the bash scripts with the way the pipeline logger for msbuild was enabled for the powershell scripts

FYI @Chrisboh 

