### PR TITLE
Capture list of assemblies before finding core Assembly

### DIFF
--- a/src/Microsoft.Cci.Extensions/HostEnvironment.cs
+++ b/src/Microsoft.Cci.Extensions/HostEnvironment.cs
@@ -224,7 +224,9 @@ namespace Microsoft.Cci.Extensions
             if (_coreAssemblyIdentity != null)
                 return _coreAssemblyIdentity;
 
-            foreach (var assembly in this.LoadedUnits.OfType<IAssembly>())
+            IAssembly[] loadedAssemblies = this.LoadedUnits.OfType<IAssembly>().ToArray();
+
+            foreach (var assembly in loadedAssemblies)
             {
                 AssemblyIdentity coreIdentity = ResolveCoreAssemblyIdentity(assembly);
 


### PR DESCRIPTION
If the first assembly loaded does not have a core assembly in any of
the probing paths its possible we will load a new assembly and not locate
the core assembly for the first.  This will result in enumeration after loading
an assembly and thus an InvalidOperationException.

/cc @ViktorHofer @Anipik 