### PR TITLE
fix for darc-init.ps1 in build machines

### DIFF
--- a/eng/common/darc-init.ps1
+++ b/eng/common/darc-init.ps1
@@ -20,7 +20,7 @@ function InstallDarcCli ($darcVersion) {
   # If the user didn't explicitly specify the darc version,
   # query the Maestro API for the correct version of darc to install.
   if (-not $darcVersion) {
-    $darcVersion = $(Invoke-WebRequest $versionEndpoint).Content
+    $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
   }
   
   $arcadeServicesSource = 'https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json'


### PR DESCRIPTION
I believe this should fix this error in the Arcade official build:

```
The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete. Specify the UseBasicParsing parameter and try again. 
System.NotSupportedException: The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete. Specify the UseBasicParsing parameter and try again. 
   at Microsoft.PowerShell.Commands.WebRequestPSCmdlet.VerifyInternetExplorerAvailable(Boolean checkComObject)
   at Microsoft.PowerShell.Commands.InvokeWebRequestCommand.ProcessResponse(WebResponse response)
   at Microsoft.PowerShell.Commands.WebRequestPSCmdlet.ProcessRecord()
at InstallDarcCli, F:\workspace\_work\1\s\eng\common\darc-init.ps1: line 23
at <ScriptBlock>, F:\workspace\_work\1\s\eng\common\darc-init.ps1: line 33
at <ScriptBlock>, F:\workspace\_work\1\s\eng\validate-sdk.ps1: line 95
at <ScriptBlock>, <No file>: line 1
```

running https://dnceng.visualstudio.com/internal/_build/results?buildId=188952 to validate