### PR TITLE
Fixing Version comparison for packaging tasks

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VersionUtility.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VersionUtility.cs
@@ -9,7 +9,7 @@ using System.Reflection.PortableExecutable;
 
 namespace Microsoft.DotNet.Build.Tasks.Packaging
 {
-    internal static class VersionUtility
+    public static class VersionUtility
     {
         public static readonly Version MaxVersion = new Version(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue);
 
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             return (referenceVersion.Major == definitionVersion.Major &&
                 referenceVersion.Minor == definitionVersion.Minor &&
                     (referenceVersion.Build < definitionVersion.Build || // If the Build number is greater, then we don't need to check revision
-                    (referenceVersion.Build == definitionVersion.Build && referenceVersion.Revision <= definitionVersion.Revision));
+                    (referenceVersion.Build == definitionVersion.Build && referenceVersion.Revision <= definitionVersion.Revision)));
         }
 
 

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VersionUtility.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VersionUtility.cs
@@ -17,8 +17,8 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         {
             return (referenceVersion.Major == definitionVersion.Major &&
                 referenceVersion.Minor == definitionVersion.Minor &&
-                referenceVersion.Build <= definitionVersion.Build &&
-                referenceVersion.Revision <= definitionVersion.Revision);
+                    (referenceVersion.Build < definitionVersion.Build || // If the Build number is greater, then we don't need to check revision
+                    (referenceVersion.Build == definitionVersion.Build && referenceVersion.Revision <= definitionVersion.Revision));
         }
 
 

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/VersionUtilityTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/VersionUtilityTests.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
+{
+    public class VersionUtilityTests
+    {
+        public static IEnumerable<object[]> IsCompatibleTestData()
+        {
+            yield return new object[] { new Version(4, 0, 0, 0), new Version(4, 0, 0, 0), true };
+            yield return new object[] { new Version(4, 0, 0, 0), new Version(5, 0, 0, 0), false };
+            yield return new object[] { new Version(4, 0, 0, 0), new Version(3, 0, 0, 0), false };
+            yield return new object[] { new Version(4, 0, 0, 0), new Version(4, 1, 0, 0), false };
+            yield return new object[] { new Version(3, 8, 0, 0), new Version(3, 7, 0, 0), false };
+            yield return new object[] { new Version(4, 0, 0, 0), new Version(4, 0, 1, 0), true };
+            yield return new object[] { new Version(4, 0, 1, 0), new Version(4, 0, 0, 0), false };
+            yield return new object[] { new Version(4, 0, 0, 0), new Version(4, 0, 0, 1), true };
+            yield return new object[] { new Version(4, 0, 0, 1), new Version(4, 0, 0, 0), false };
+            yield return new object[] { new Version(4, 0, 3, 2), new Version(4, 0, 4, 3), true };
+            yield return new object[] { new Version(4, 0, 3, 2), new Version(4, 0, 4, 0), true };
+        }
+
+        [Theory]
+        [MemberData(nameof(IsCompatibleTestData))]
+        public void IsCompatibleApiVersionTest(Version referenceVersion, Version candidateVersion, bool shouldBeCompatible)
+        {
+            bool isCompatible = VersionUtility.IsCompatibleApiVersion(referenceVersion, candidateVersion);
+            if (shouldBeCompatible)
+            {
+                Assert.True(isCompatible, $"Version {candidateVersion.ToString()} should be compatible with version {referenceVersion.ToString()}");
+            }
+            else
+            {
+                Assert.False(isCompatible, $"Version {candidateVersion.ToString()} should not be compatible with version {referenceVersion.ToString()}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
cc: @ericstj 

If the Major and Minor versions are the same, but the Build number is greater, then we don't have to check the revision. With the logic as it was, a version like 4.0.4.0 would be compatible with 4.0.3.0, but that wouldn't be true for 4.0.3.2 which is wrong, as it should be compatible as well. This change will fix that.