### PR TITLE
Minimize events sent to Pipelines logger

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -483,7 +483,7 @@ function MSBuild() {
     $toolsetBuildProject = InitializeToolset
     $path = Split-Path -parent $toolsetBuildProject
     $path = Join-Path $path (Join-Path $buildTool.Framework "Microsoft.DotNet.Arcade.Sdk.dll")
-    $args += "/logger:$path"
+    $args += "-distributedLogger:$path*ConfigurableForwardingLogger,Microsoft.Build;ERROREVENT;WARNINGEVENT;PROJECTSTARTEDEVENT;PROJECTFINISHEDEVENT"
   }
 
   MSBuild-Core @args


### PR DESCRIPTION
Use the built-in `ConfigurableForwardingLogger` to send only events that
the Pipelines logger cares about to the Pipelines logger.

Fixes #2760.