### PR TITLE
Disable publish test results

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,6 @@ jobs:
   parameters:
     enableMicrobuild: true
     enablePublishBuildArtifacts: true
-    enablePublishTestResults: true
     enablePublishBuildAssets: true
     enablePublishUsingPipelines: $(_PublishUsingPipelines)
     enableTelemetry: true


### PR DESCRIPTION
There are never any results to publish in Arcade builds so this always reports a warning.

@alexperovich PTAL