### PR TITLE
Adding a check before making a final query to update the issue

### DIFF
--- a/src/Microsoft.DotNet.Github.IssueLabeler/Controllers/WebhookIssueController.cs
+++ b/src/Microsoft.DotNet.Github.IssueLabeler/Controllers/WebhookIssueController.cs
@@ -32,9 +32,8 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
                 string title = issue.Title;
                 int number = issue.Number;
                 string body = issue.Description;
-                int? milestone = issue.Milestone?.Number;
 
-                await Issuelabeler.PredictAndApplyLabelAsync(number, title, body, milestone, Logger);
+                await Issuelabeler.PredictAndApplyLabelAsync(number, title, body, Logger);
                 Logger.LogInformation("! Labeling completed");
             }
             else

--- a/src/Microsoft.DotNet.Github.IssueLabeler/Models/Labeler.cs
+++ b/src/Microsoft.DotNet.Github.IssueLabeler/Models/Labeler.cs
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
             };
         }
 
-        public async Task PredictAndApplyLabelAsync(int number, string title, string body, int? milestone, ILogger logger)
+        public async Task PredictAndApplyLabelAsync(int number, string title, string body, ILogger logger)
         {
             if (_client == null)
             {
@@ -71,11 +71,14 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
             };
 
             string label = await Predictor.PredictAsync(corefxIssue, logger, _threshold);
-            if (label != null)
+
+            Issue issueGithubVersion = await _client.Issue.Get(_repoOwner, _repoName, number);
+
+            if (label != null && issueGithubVersion.Labels.Count == 0)
             {
                 var issueUpdate = new IssueUpdate();
                 issueUpdate.AddLabel(label);
-                issueUpdate.Milestone = milestone; // The number of milestone associated with the issue.
+                issueUpdate.Milestone = issueGithubVersion.Milestone.Number; // The number of milestone associated with the issue.
 
                 await _client.Issue.Update(_repoOwner, _repoName, number, issueUpdate);
             }


### PR DESCRIPTION
There is still possibility of someone applying the label between the get issue query and update query. 
But the probability of such a case is very less.

Thanks @ViktorHofer  for catching this bug