### PR TITLE
Use RepoTools syntax in CoreFxTesting & add arcade repo tools restore step

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -55,7 +55,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <_RepoToolManifest>$([MSBuild]::NormalizePath('$(RepositoryEngineeringDir), '.config' 'dotnet-tools.json'))</_RepoToolManifest>
+    <_RepoToolManifest>$([MSBuild]::NormalizePath('$(RepoRoot), '.config' 'dotnet-tools.json'))</_RepoToolManifest>
   </PropertyGroup>
 
   <Target Name="RestoreRepoTools"

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -55,7 +55,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <_RepoToolManifest>$([MSBuild]::NormalizePath('$(RepoRoot), '.config' 'dotnet-tools.json'))</_RepoToolManifest>
+    <_RepoToolManifest>$([MSBuild]::NormalizePath('$(RepoRoot)', '.config', 'dotnet-tools.json'))</_RepoToolManifest>
   </PropertyGroup>
 
   <Target Name="RestoreRepoTools"

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -54,6 +54,24 @@
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.VisualStudio" Version="$(MicrosoftDotNetBuildTasksVisualStudioVersion)" Condition="'$(UsingToolVSSDK)' == 'true'" IsImplicitlyDefined="true" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <RepoToolManifest>$([MSBuild]::NormalizePath('$(RepositoryEngineeringDir), 'dotnet-tools.json'))</RepoToolManifest>
+  </PropertyGroup>
+
+  <Target Name="RestoreRepoTools"
+          Condition="'$(DotNetBuildFromSource)' != 'true' and Exists('$(RepoToolManifest)')"
+          AfterTargets="Restore">
+
+    <PropertyGroup>
+      <RestoreRepoToolsCommmand>"$(DotNetTool)" tool restore --tool-manifest "$(RepoToolManifest)"</RestoreRepoToolsCommmand>
+      <RestoreRepoToolsSources Condition="'@(RestoreSources)' != ''"> --add-source @(RestoreSources -> '"%(Identity)"', ' --add-source ')</RestoreRepoToolsSources>
+    </PropertyGroup>
+
+    <Exec Command="$(RestoreRepoToolsCommmand)"
+          WorkingDirectory="$(RepoRoot)" />
+
+  </Target>
+
   <!-- Repository extensibility point -->
   <Import Project="$(RepositoryEngineeringDir)Tools.props" Condition="Exists('$(RepositoryEngineeringDir)Tools.props')" />
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -55,15 +55,15 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <RepoToolManifest>$([MSBuild]::NormalizePath('$(RepositoryEngineeringDir), 'dotnet-tools.json'))</RepoToolManifest>
+    <_RepoToolManifest>$([MSBuild]::NormalizePath('$(RepositoryEngineeringDir), '.config' 'dotnet-tools.json'))</_RepoToolManifest>
   </PropertyGroup>
 
   <Target Name="RestoreRepoTools"
-          Condition="'$(DotNetBuildFromSource)' != 'true' and Exists('$(RepoToolManifest)')"
+          Condition="'$(DotNetBuildFromSource)' != 'true' and Exists('$(_RepoToolManifest)')"
           AfterTargets="Restore">
 
     <PropertyGroup>
-      <RestoreRepoToolsCommmand>"$(DotNetTool)" tool restore --tool-manifest "$(RepoToolManifest)"</RestoreRepoToolsCommmand>
+      <RestoreRepoToolsCommmand>"$(DotNetTool)" tool restore</RestoreRepoToolsCommmand>
       <RestoreRepoToolsSources Condition="'@(RestoreSources)' != ''"> --add-source @(RestoreSources -> '"%(Identity)"', ' --add-source ')</RestoreRepoToolsSources>
     </PropertyGroup>
 

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
@@ -94,7 +94,7 @@
       <!-- Escape arguments with user inputs. -->
       <RunArguments>$([MSBuild]::Escape('$(RunArguments)'))</RunArguments>
 
-      <RunScriptCommand Condition="'$(RunScriptCommand)' == ''">"$(RunCommand)" $(RunArguments)</RunScriptCommand>
+      <RunScriptCommand Condition="'$(RunScriptCommand)' == ''">$(RunCommand) $(RunArguments)</RunScriptCommand>
     </PropertyGroup>
 
     <!-- Set $(TestDebugger) to eg c:\debuggers\windbg.exe to run tests under a debugger. -->

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/coverage/Coverage.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/coverage/Coverage.targets
@@ -4,11 +4,9 @@
 
   <!-- Wrap RunCommand and RunArguments inside code coverage invocation. -->
   <PropertyGroup>
-    <CoverageExecutablePath Condition="'$(CoverageExecutablePath)' == '' AND '$(TargetOS)' == 'Windows_NT'">$(RunScriptGlobalToolsDir)coverlet.exe</CoverageExecutablePath>
-    <CoverageExecutablePath Condition="'$(CoverageExecutablePath)' == '' AND '$(TargetOS)' != 'Windows_NT'">$(RunScriptGlobalToolsDir)coverlet</CoverageExecutablePath>
     <RunArguments>"$(TestAssembly)" --target "$(RunCommand)" --targetargs "$(RunArguments)" --format "$(CoverageFormat)" --output "$(CoverageOutputPath)" --threshold "$(CoverageThreshold)" --threshold-type "$(CoverageThresholdType)"</RunArguments>
     <RunArguments Condition="'$(CoverageSourceLink)' == 'true'">$(RunArguments) --use-source-link</RunArguments>
-    <RunCommand>$(CoverageExecutablePath)</RunCommand>
+    <RunCommand>"$(RunScriptHost)" tool run coverlet</RunCommand>
   </PropertyGroup>
 
   <Target Name="SetupCoverageFilter">

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/coverage/CoverageReport.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/coverage/CoverageReport.targets
@@ -3,9 +3,6 @@
 <Project>
 
   <PropertyGroup>
-    <CoverageReportExecutablePath Condition="'$(CoverageReportExecutablePath)' == '' AND '$(TargetOS)' == 'Windows_NT'">$(RunScriptGlobalToolsDir)reportgenerator.exe</CoverageReportExecutablePath>
-    <CoverageReportExecutablePath Condition="'$(CoverageReportExecutablePath)' == '' AND '$(TargetOS)' != 'Windows_NT'">$(RunScriptGlobalToolsDir)reportgenerator</CoverageReportExecutablePath>
-
     <CoverageReportInputPath Condition="'$(CoverageReportInputPath)' == ''">$(CoverageOutputPath)</CoverageReportInputPath>
     <!-- We use NormalizePath as ReportGenerator's command line argument syntax doesn't work well with trailing slashes. -->
     <CoverageReportDir Condition="'$(CoverageReportDir)' == ''">$([MSBuild]::NormalizePath('$(TestPath)', 'report'))</CoverageReportDir>
@@ -13,8 +10,7 @@
     <CoverageReportVerbosity Condition="'$(CoverageReportVerbosity)' == ''">Info</CoverageReportVerbosity>
     <CoverageReportResultsPath>$([MSBuild]::NormalizePath('$(CoverageReportDir)', 'index.htm'))</CoverageReportResultsPath>
 
-    <CoverageReportCommandLine>"$(CoverageReportExecutablePath)" "-reports:$(CoverageReportInputPath)" "-targetdir:$(CoverageReportDir)" "-reporttypes:$(CoverageReportTypes)" "-verbosity:$(CoverageReportVerbosity)"</CoverageReportCommandLine>
-    <CoverageReportOpenCommandLine Condition="'$(PopCoverageReport)' == 'true' AND '$(TargetOS)' == 'Windows_NT'">start $(CoverageReportResultsPath)</CoverageReportOpenCommandLine>
+    <CoverageReportCommandLine>"$(RunScriptHost)" tool run reportgenerator "-reports:$(CoverageReportInputPath)" "-targetdir:$(CoverageReportDir)" "-reporttypes:$(CoverageReportTypes)" "-verbosity:$(CoverageReportVerbosity)"</CoverageReportCommandLine>
   </PropertyGroup>
 
   <!-- Skip generating individual reports if a full report is generated. -->

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
@@ -70,7 +70,7 @@
         <TestRunnerName>xunit.console.dll</TestRunnerName>
         <TestRunnerNameWithoutExtension>$([System.IO.Path]::GetFileNameWithoutExtension('$(TestRunnerName)'))</TestRunnerNameWithoutExtension>
 
-        <RunCommand>$(RunScriptHost)</RunCommand>
+        <RunCommand>"$(RunScriptHost)"</RunCommand>
         <RunArguments>$(TestRunnerName) $(RunArguments)</RunArguments>
       </PropertyGroup>
     </When>


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/1906

- Use repo tools instead of global tools in CoreFxTesting
- Add an arcade extension point to restore repo tools if a manifest exists.