### PR TITLE
Add `--test-env-file` option to corefx RunTests scripts

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/assets/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/assets/RunnerTemplate.Unix.txt
@@ -2,13 +2,14 @@
 
 usage()
 {
-  echo "Usage: RunTests.sh {-r|--runtime-path} <runtime-path> [{-d|--dotnet-root} <dotnet-root>] [{-g|--global-tools-dir} <global-tools-dir>] [{--rsp-file} <rsp-file>]"
+  echo "Usage: RunTests.sh {-r|--runtime-path} <runtime-path> [{-d|--dotnet-root} <dotnet-root>] [{-g|--global-tools-dir} <global-tools-dir>] [{--rsp-file} <rsp-file>] [{--test-env-file} <test-env-file>]"
   echo ""
   echo "Parameters:"
   echo "--runtime-path           (Mandatory) Testhost containing the test runtime used during test execution (short: -r)"
   echo "--dotnet-root            SDK directory for hosting shims and tools (short: -d)"
   echo "--global-tools-dir       Global tools directory (short: -g)"
-  echo "--rsp-file               RSP file to pass in additional arguments"
+  echo "--rsp-file               RSP file to pass in additional arguments to xunit"
+  echo "--test-env-file          Test environment batch file"
   echo "--help                   Print help and exit (short: -h)"
 }
 
@@ -16,6 +17,7 @@ EXECUTION_DIR=$(dirname "$0")
 RUNTIME_PATH=''
 GLOBAL_TOOLS_DIR=''
 RSP_FILE=''
+TEST_ENV_FILE=''
 
 while [[ $# > 0 ]]; do
   opt="$(echo "${1}" | awk '{print tolower($0)}')"
@@ -38,6 +40,10 @@ while [[ $# > 0 ]]; do
       ;;
     --rsp-file)
       RSP_FILE=\@$2
+      shift
+      ;;
+    --test-env-file)
+      TEST_ENV_FILE=$2
       shift
       ;;
     *)
@@ -167,10 +173,19 @@ fi
 # ========================= BEGIN Test Execution =============================
 echo ----- start $(date +"%T") ===============  To repro directly: ===================================================== 
 echo pushd $EXECUTION_DIR
+if [ "$TEST_ENV_FILE" != "" ]; then
+  echo source $TEST_ENV_FILE
+  echo ============ Test environment file:
+  cat $TEST_ENV_FILE
+  echo ============ End test environment file
+fi
 [[RunCommandsEcho]]
 echo popd
 echo ===========================================================================================================
 pushd $EXECUTION_DIR
+if [ "$TEST_ENV_FILE" != "" ]; then
+  source $TEST_ENV_FILE
+fi
 [[RunCommands]]
 test_exitcode=$?
 popd

--- a/src/Microsoft.DotNet.CoreFxTesting/build/assets/RunnerTemplate.Windows.txt
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/assets/RunnerTemplate.Windows.txt
@@ -1,6 +1,8 @@
 ﻿@echo off
 setlocal enabledelayedexpansion
 
+set RSP_FILE=
+set TEST_ENV_FILE=
 set EXECUTION_DIR=%~dp0
 
 :argparser_start
@@ -48,6 +50,12 @@ set EXECUTION_DIR=%~dp0
     goto argparser_break
   )
 
+  if /i "%argparser_currentarg%"=="--test-env-file" (
+    if "%~1" == "" ( goto argparser_invalid )
+    set "TEST_ENV_FILE=%~1"
+    goto argparser_break
+  )
+
 :argparser_invalid
   echo Invalid argument or value: %argparser_currentarg%
   call :usage
@@ -74,11 +82,18 @@ set DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX=2
 :: ========================= BEGIN Test Execution ============================= 
 echo ----- start %TIME% ===============  To repro directly: ===================================================== 
 echo pushd %EXECUTION_DIR%
+if not "%TEST_ENV_FILE%"=="" (
+  echo call %TEST_ENV_FILE%
+  echo ============ Test environment file:
+  type %TEST_ENV_FILE%
+  echo ============ End test environment file
+)
 [[RunCommandsEcho]]
 echo popd
 echo ===========================================================================================================
 pushd %EXECUTION_DIR%
 @echo on
+@if not "%TEST_ENV_FILE%"=="" call %TEST_ENV_FILE%
 [[RunCommands]]
 @echo off
 popd
@@ -87,11 +102,12 @@ exit /b %ERRORLEVEL%
 :: ========================= END Test Execution =================================
 
 :usage
-echo Usage: RunTests.cmd {-r^|--runtime-path} ^<runtime-path^> [{-d^|--dotnet-root} ^<dotnet-root^>] [{-g^|--global-tools-dir} ^<global-tools-dir^>] [{--rsp-file} ^<rsp-file^>]
+echo Usage: RunTests.cmd {-r^|--runtime-path} ^<runtime-path^> [{-d^|--dotnet-root} ^<dotnet-root^>] [{-g^|--global-tools-dir} ^<global-tools-dir^>] [{--rsp-file} ^<rsp-file^>] [{--test-env-file} ^<test-env-file^>]
 echo.
 echo Parameters:
 echo --runtime-path           (Mandatory) Testhost containing the test runtime used during test execution (short: -r)"
 echo --dotnet-root            SDK directory for hosting shims and tools (short: -d)
 echo --global-tools-dir       Global tools directory (short: -g)
-echo --rsp-file               RSP file to pass in additional arguments
+echo --rsp-file               RSP file to pass in additional arguments to xunit
+echo --test-env-file          Test environment batch file
 echo --help                   Print help and exit (short: -h)


### PR DESCRIPTION
This is needed so when running corefx tests in coreclr repro,
with various JIT and other stress modes, we can use the same
cached corefx test build with multiple stress variations.