### PR TITLE
Handle InternalsVisibleTo when there is neither PublicKey property.

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateInternalsVisibleTo.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateInternalsVisibleTo.targets
@@ -15,7 +15,8 @@
     <ItemGroup>
       <_InternalsVisibleToAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
         <_Parameter1 Condition="'%(InternalsVisibleTo.Key)' != ''">%(InternalsVisibleTo.Identity), PublicKey=%(InternalsVisibleTo.Key)</_Parameter1>
-        <_Parameter1 Condition="'%(InternalsVisibleTo.Key)' == ''">%(InternalsVisibleTo.Identity), PublicKey=$(PublicKey)</_Parameter1>
+        <_Parameter1 Condition="'%(InternalsVisibleTo.Key)' == '' and '$(PublicKey)' != ''">%(InternalsVisibleTo.Identity), PublicKey=$(PublicKey)</_Parameter1>
+        <_Parameter1 Condition="'%(InternalsVisibleTo.Key)' == '' and '$(PublicKey)' == ''">%(InternalsVisibleTo.Identity)</_Parameter1>
       </_InternalsVisibleToAttribute>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
This case occurs in source-build when we disable signing for some repositories.  Arcade emits an incorrectly-formed attribute: `Assembly, PublicKey=`.  This change makes it so the `, PublicKey=` portion is dropped if there is no public key.