### PR TITLE
Change Single to FirstOrDefault

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushArtifactsInManifestToFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushArtifactsInManifestToFeed.cs
@@ -163,7 +163,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     {
                         var assetRecord = buildInformation.Assets
                             .Where(a => a.Name.Equals(package.Id) && a.Version.Equals(package.Version))
-                            .Single();
+                            .FirstOrDefault();
 
                         if (assetRecord == null)
                         {


### PR DESCRIPTION
If the query didn't return any hits calling `Single` would throw `Sequence contains no elements` as seen in https://dnceng.visualstudio.com/internal/_releaseProgress?_a=release-environment-logs&releaseId=7880&environmentId=21701

I checked each element in the manifest and those in BAR and all matched so at least this change will allow the process to log what asset was not found.