### PR TITLE
change msbuild arg variable name

### DIFF
--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -389,16 +389,16 @@ function StopProcesses {
 }
 
 function MSBuild {
-  _msbuild_args=$@
+  local args=$@
   if [[ "$pipelines_log" == true ]]; then
     InitializeBuildTool
     InitializeToolset
-    _toolset_dir="${_InitializeToolset%/*}"
-    _loggerPath="$_toolset_dir/$_InitializeBuildToolFramework/Microsoft.DotNet.Arcade.Sdk.dll"
-    _msbuild_args=( "${_msbuild_args[@]}" "-logger:$_loggerPath" )
+    local toolset_dir="${_InitializeToolset%/*}"
+    local logger_path="$toolset_dir/$_InitializeBuildToolFramework/Microsoft.DotNet.Arcade.Sdk.dll"
+    args=( "${args[@]}" "-logger:$logger_path" )
   fi
 
-  MSBuild-Core ${_msbuild_args[@]}
+  MSBuild-Core ${args[@]}
 }
 
 function MSBuild-Core {

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -389,15 +389,16 @@ function StopProcesses {
 }
 
 function MSBuild {
-  args=$@
+  _msbuild_args=$@
   if [[ "$pipelines_log" == true ]]; then
     InitializeBuildTool
     InitializeToolset
     _toolset_dir="${_InitializeToolset%/*}"
     _loggerPath="$_toolset_dir/$_InitializeBuildToolFramework/Microsoft.DotNet.Arcade.Sdk.dll"
-    args=( "${args[@]}" "-logger:$_loggerPath" )
+    _msbuild_args=( "${_msbuild_args[@]}" "-logger:$_loggerPath" )
   fi
-  MSBuild-Core ${args[@]}
+
+  MSBuild-Core ${_msbuild_args[@]}
 }
 
 function MSBuild-Core {


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/2864

dotnet/toolset repo is broken by https://github.com/dotnet/arcade/pull/2766 because dotnet/toolset does custom argument parsing in `run-build.sh` which creates an argument array named `args`.  The same object is being used in the MSBuild function as a temporary array to parse args and the result is that the object contains both the arguments parsed in `run-build.sh` and `tools.sh`

`args` is too generic of a name, disambiguating.

FYI @livarcocc 