### PR TITLE
Microsoft.DotNet.XUnitConsoleRunner fix pack content

### DIFF
--- a/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
@@ -6,11 +6,11 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Exe</OutputType>
     <RootNamespace>Xunit.ConsoleClient</RootNamespace>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>true</IsPackable>
     <VersionPrefix>2.5.1</VersionPrefix>
-    <LangVersion>latest</LangVersion>
     <DefaultItemExcludes Condition="'$(DefineConstants)' == 'WINDOWS_UWP'">common\AssemblyResolution\**;$(DefaultItemExcludes)</DefaultItemExcludes>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,5 +26,7 @@
     <PackageReference Include="xunit.abstractions" Version="$(XUnitAbstractionsVersion)" />
     <PackageReference Include="xunit.extensibility.core" Version="$(XUnitVersion)" />
   </ItemGroup>
+
+  <Import Project="$(RepoRoot)eng\BuildTask.targets" />
 
 </Project>

--- a/src/Microsoft.DotNet.XUnitConsoleRunner/src/build/Microsoft.DotNet.XUnitConsoleRunner.props
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/src/build/Microsoft.DotNet.XUnitConsoleRunner.props
@@ -1,0 +1,7 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <XunitConsoleNetCore21AppPath>$(MSBuildThisFileDirectory)..\tools\netcoreapp2.1\xunit.console.dll</XunitConsoleNetCore21AppPath>
+  </PropertyGroup>
+
+</Project>

--- a/src/Microsoft.DotNet.XUnitConsoleRunner/src/build/xunit.runner.console.props
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/src/build/xunit.runner.console.props
@@ -1,7 +1,0 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <PropertyGroup>
-    <XunitConsoleNetCore2AppPath>$(MSBuildThisFileDirectory)..\tools\netcoreapp2.0\xunit.console.dll</XunitConsoleNetCore2AppPath>
-  </PropertyGroup>
-
-</Project>


### PR DESCRIPTION
Import `BuildTask.targets` to use the tools directory instead of the lib directory for the runner package. Using the lib directory adds compiler references to the assemblies which is a misuse. Additionally fix the build props file name.