### PR TITLE
Package Microsoft.Cci.Extensions

### DIFF
--- a/src/Microsoft.Cci.Extensions/Microsoft.Cci.Extensions.csproj
+++ b/src/Microsoft.Cci.Extensions/Microsoft.Cci.Extensions.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssetTargetFallback>$(PackageTargetFallback)portable-net45+win8;</AssetTargetFallback>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
We still have a bunch of internal tools (CoreFxTools) that used to pick up CCI extensions from the old MyGet feed. This will unblock them.

Is this all that is needed to back CI deploy the package to the feed?