### PR TITLE
Exclude xunit.core from package

### DIFF
--- a/eng/BuildTask.targets
+++ b/eng/BuildTask.targets
@@ -64,20 +64,16 @@
   
   <Target Name="_AddBuildOutputToPackageCore" DependsOnTargets="Publish" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <ItemGroup>
-      <FilteredPackageFiles Include="$(PublishDir)**"
-                            Exclude="$(PublishDir)%(PackageExcludeFile.Identity)" />
       <!-- Publish .NET Core assets and include them in the package under tools directory. -->
-      <TfmSpecificPackageFile Include="@(FilteredPackageFiles)"
+      <TfmSpecificPackageFile Include="$(PublishDir)**" 
                               PackagePath="tools/$(TargetFramework)/%(RecursiveDir)%(FileName)%(Extension)"/>
     </ItemGroup>
   </Target>
 
   <Target Name="_AddBuildOutputToPackageDesktop" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <ItemGroup>
-      <FilteredPackageFiles Include="$(OutputPath)**"
-                            Exclude="$(OutputPath)%(PackageExcludeFile.Identity)" />
       <!-- Include .NET Framework build outputs in the package under tools directory. -->
-      <TfmSpecificPackageFile Include="@(FilteredPackageFiles)" PackagePath="tools/$(TargetFramework)/%(RecursiveDir)%(FileName)%(Extension)"/>
+      <TfmSpecificPackageFile Include="$(OutputPath)**" PackagePath="tools/$(TargetFramework)/%(RecursiveDir)%(FileName)%(Extension)"/>
     </ItemGroup>
   </Target>
 </Project>

--- a/eng/BuildTask.targets
+++ b/eng/BuildTask.targets
@@ -64,16 +64,20 @@
   
   <Target Name="_AddBuildOutputToPackageCore" DependsOnTargets="Publish" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <ItemGroup>
+      <FilteredPackageFiles Include="$(PublishDir)**"
+                            Exclude="$(PublishDir)%(PackageExcludeFile.Identity)" />
       <!-- Publish .NET Core assets and include them in the package under tools directory. -->
-      <TfmSpecificPackageFile Include="$(PublishDir)**" 
+      <TfmSpecificPackageFile Include="@(FilteredPackageFiles)"
                               PackagePath="tools/$(TargetFramework)/%(RecursiveDir)%(FileName)%(Extension)"/>
     </ItemGroup>
   </Target>
 
   <Target Name="_AddBuildOutputToPackageDesktop" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <ItemGroup>
+      <FilteredPackageFiles Include="$(OutputPath)**"
+                            Exclude="$(OutputPath)%(PackageExcludeFile.Identity)" />
       <!-- Include .NET Framework build outputs in the package under tools directory. -->
-      <TfmSpecificPackageFile Include="$(OutputPath)**" PackagePath="tools/$(TargetFramework)/%(RecursiveDir)%(FileName)%(Extension)"/>
+      <TfmSpecificPackageFile Include="@(FilteredPackageFiles)" PackagePath="tools/$(TargetFramework)/%(RecursiveDir)%(FileName)%(Extension)"/>
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageExcludeFile Include="xunit.core.dll" />
+  </ItemGroup>
+
+  <ItemGroup>
     <EmbeddedResource Include="HTML.xslt" />
     <EmbeddedResource Include="NUnitXml.xslt" />
     <EmbeddedResource Include="xUnit1.xslt" />

--- a/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
@@ -14,10 +14,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageExcludeFile Include="xunit.core.dll" />
-  </ItemGroup>
-
-  <ItemGroup>
     <EmbeddedResource Include="HTML.xslt" />
     <EmbeddedResource Include="NUnitXml.xslt" />
     <EmbeddedResource Include="xUnit1.xslt" />
@@ -28,7 +24,6 @@
     <PackageReference Include="xunit.runner.reporters" Version="$(XUnitVersion)" />
     <PackageReference Include="xunit.runner.utility" Version="$(XUnitVersion)" />
     <PackageReference Include="xunit.abstractions" Version="$(XUnitAbstractionsVersion)" />
-    <PackageReference Include="xunit.extensibility.core" Version="$(XUnitVersion)" />
   </ItemGroup>
 
   <Import Project="$(RepoRoot)eng\BuildTask.targets" />


### PR DESCRIPTION
Contributes to https://github.com/dotnet/arcade/issues/2912

xunit.core.dll is expected to be plumbed in through the test assembly's references (usually through a PackageReference to xunit) and shouldn't be part of the console runner package.