### PR TITLE
Add X.509 certificate revocation checking

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
 
             Log.LogMessage($"Downloading '{Uri}' to '{DestinationPath}'");
 
-            using (var httpClient = new HttpClient())
+            using (var httpClient = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true }))
             {
                 try
                 {

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinkBase.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinkBase.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links
             ClientCredential credential = new ClientCredential(ClientId, ClientSecret);
             AuthenticationResult token = authContext.AcquireTokenAsync(Endpoint, credential).Result;
 
-            HttpClient httpClient = new HttpClient();
+            HttpClient httpClient = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true });
             httpClient.DefaultRequestHeaders.Add("Authorization", token.CreateAuthorizationHeader());
 
             return httpClient;

--- a/src/Microsoft.DotNet.Git.IssueManager/src/Clients/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Git.IssueManager/src/Clients/AzureDevOpsClient.cs
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.Git.IssueManager.Clients
 
         private static HttpClient GetHttpClient(string accountName, string projectName, string personalAccessToken)
         {
-            HttpClient client = new HttpClient
+            HttpClient client = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true })
             {
                 BaseAddress = new Uri($"https://dev.azure.com/{accountName}/{projectName}/")
             };

--- a/src/Microsoft.DotNet.Helix/Sdk/AzureDevOpsTask.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/AzureDevOpsTask.cs
@@ -50,6 +50,7 @@ namespace Microsoft.DotNet.Helix.AzureDevOps
                     using (var client = new HttpClient(new HttpClientHandler
                     {
                         AllowAutoRedirect = false,
+                        CheckCertificateRevocationList = true,
                     })
                     {
                         DefaultRequestHeaders =

--- a/src/Microsoft.DotNet.Helix/Sdk/FindDotNetCliPackage.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/FindDotNetCliPackage.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.Helix.Sdk
 {
     public class FindDotNetCliPackage : BaseTask
     {
-        private static readonly HttpClient _client = new HttpClient();
+        private static readonly HttpClient _client = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true });
         private const string DotNetCliAzureFeed = "https://dotnetcli.azureedge.net/dotnet";
 
         /// <summary>

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CmdLine/Program.cs
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CmdLine/Program.cs
@@ -112,7 +112,7 @@ namespace Microsoft.DotNet.SwaggerGenerator.CmdLine
 
         private static async Task<(OpenApiDiagnostic, OpenApiDocument)> GetSwaggerDocument(string input)
         {
-            using (var client = new HttpClient())
+            using (var client = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true }))
             {
                 using (Stream docStream = await client.GetStreamAsync(input))
                 {

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.MSBuild/GenerateSwaggerCode.cs
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.MSBuild/GenerateSwaggerCode.cs
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.SwaggerGenerator.MSBuild
 
         private static async Task<(OpenApiDiagnostic, OpenApiDocument)> GetSwaggerDocument(string input)
         {
-            using (var client = new HttpClient())
+            using (var client = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true }))
             {
                 using (Stream docStream = await client.GetStreamAsync(input))
                 {

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/GitHubApi/GitHubClient.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/GitHubApi/GitHubClient.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.DotNet.VersionTools.src.Util;
 
 namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
 {
@@ -53,7 +54,7 @@ namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
         {
             Auth = auth;
 
-            _httpClient = new HttpClient();
+            _httpClient = X509Helper.GetHttpClientWithCertRevocation();
             _httpClient.DefaultRequestHeaders.Add("Accept", "application/vnd.github.v3+json");
             _httpClient.DefaultRequestHeaders.Add("User-Agent", auth?.User ?? DefaultUserAgent);
             if (auth?.AuthToken != null)

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/VstsApi/VstsAdapterClient.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/VstsApi/VstsAdapterClient.cs
@@ -15,7 +15,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.DotNet.VersionTools.src.Util
+using Microsoft.DotNet.VersionTools.src.Util;
 
 namespace Microsoft.DotNet.VersionTools.Automation.VstsApi
 {

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/VstsApi/VstsAdapterClient.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/VstsApi/VstsAdapterClient.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -15,6 +15,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.DotNet.VersionTools.src.Util
 
 namespace Microsoft.DotNet.VersionTools.Automation.VstsApi
 {
@@ -50,7 +51,7 @@ namespace Microsoft.DotNet.VersionTools.Automation.VstsApi
             Auth = auth;
             VstsInstanceName = vstsInstanceName;
 
-            _httpClient = new HttpClient();
+            _httpClient = X509Helper.GetHttpClientWithCertRevocation();
 
             _httpClient.DefaultRequestHeaders.Add(
                 "Accept",

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildInfo.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildInfo.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,6 +11,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.DotNet.VersionTools.src.Util;
 
 namespace Microsoft.DotNet.VersionTools
 {
@@ -31,7 +32,7 @@ namespace Microsoft.DotNet.VersionTools
             string rawBuildInfoBaseUrl,
             bool fetchLatestReleaseFile = true)
         {
-            using (var client = new HttpClient())
+            using (var client = X509Helper.GetHttpClientWithCertRevocation())
             {
                 return GetAsync(
                     client,

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Util/X509Helper.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Util/X509Helper.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Net.Http;
+
+namespace Microsoft.DotNet.VersionTools.src.Util
+{
+    class X509Helper
+    {
+        public static HttpClient GetHttpClientWithCertRevocation()
+        {
+            return new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true });
+        }
+    }
+}


### PR DESCRIPTION
Adds X.509 cert revocation checking to all created HttpClients in Arcade. Solves [#181 in dnceng](https://dev.azure.com/dnceng/internal/_workitems/edit/181).