### PR TITLE
Add diagnostic information when RemoteExecutor.Invoke times out

### DIFF
--- a/src/Microsoft.DotNet.RemoteExecutor/src/Microsoft.DotNet.RemoteExecutor/Microsoft.DotNet.RemoteExecutor.csproj
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/Microsoft.DotNet.RemoteExecutor/Microsoft.DotNet.RemoteExecutor.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="xunit.assert" Version="$(XUnitVersion)" />
+    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="1.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.RemoteExecutor/src/Microsoft.DotNet.RemoteExecutor/RemoteInvokeHandle.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/Microsoft.DotNet.RemoteExecutor/RemoteInvokeHandle.cs
@@ -2,11 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Runtime;
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Microsoft.DotNet.RemoteExecutor
 {
@@ -49,6 +54,15 @@ namespace Microsoft.DotNet.RemoteExecutor
             Dispose(disposing: true);
         }
 
+        /// <summary>
+        /// Lock access to working with CLRMD.
+        /// </summary>
+        /// <remarks>
+        /// ClrMD doesn't like attaching to multiple processes concurrently.  If we happen to
+        /// hit multiple remote failures concurrently, only dump out one of them.
+        /// </remarks>
+        private static int s_clrMdLock = 0;
+
         private void Dispose(bool disposing)
         {
             Assert.True(disposing, $"A test {AssemblyName}!{ClassName}.{MethodName} forgot to Dispose() the result of RemoteInvoke()");
@@ -59,8 +73,63 @@ namespace Microsoft.DotNet.RemoteExecutor
                 // needing to do this in every derived test and keep each test much simpler.
                 try
                 {
-                    Assert.True(Process.WaitForExit(Options.TimeOut),
-                        $"Timed out after {Options.TimeOut}ms waiting for remote process {Process.Id}");
+                    if (!Process.WaitForExit(Options.TimeOut))
+                    {
+                        var description = new StringBuilder();
+                        description.AppendLine($"Timed out after {Options.TimeOut}ms waiting for remote process.");
+                        try
+                        {
+                            description.AppendLine($"\tProcess ID: {Process.Id}");
+                            description.AppendLine($"\tHandle: {Process.Handle}");
+                            description.AppendLine($"\tName: {Process.ProcessName}");
+                            description.AppendLine($"\tMainModule: {Process.MainModule?.FileName}");
+                            description.AppendLine($"\tStartTime: {Process.StartTime}");
+                            description.AppendLine($"\tTotalProcessorTime: {Process.TotalProcessorTime}");
+
+                            // Attach ClrMD to gather some additional details.
+                            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && // As of Microsoft.Diagnostics.Runtime v1.0.5, process attach only works on Windows.
+                                Interlocked.CompareExchange(ref s_clrMdLock, 1, 0) == 0) // Make sure we only attach to one process at a time.
+                            {
+                                try
+                                {
+                                    using (DataTarget dt = DataTarget.AttachToProcess(Process.Id, msecTimeout: 20_000)) // arbitrary timeout
+                                    {
+                                        ClrRuntime runtime = dt.ClrVersions.FirstOrDefault()?.CreateRuntime();
+                                        if (runtime != null)
+                                        {
+                                            // Dump the threads in the remote process.
+                                            description.AppendLine("\tThreads:");
+                                            foreach (ClrThread thread in runtime.Threads.Where(t => t.IsAlive))
+                                            {
+                                                string threadKind =
+                                                    thread.IsThreadpoolCompletionPort ? "[Thread pool completion port]" :
+                                                    thread.IsThreadpoolGate ? "[Thread pool gate]" :
+                                                    thread.IsThreadpoolTimer ? "[Thread pool timer]" :
+                                                    thread.IsThreadpoolWait ? "[Thread pool wait]" :
+                                                    thread.IsThreadpoolWorker ? "[Thread pool worker]" :
+                                                    thread.IsFinalizer ? "[Finalizer]" :
+                                                    thread.IsGC ? "[GC]" :
+                                                    "";
+
+                                                description.AppendLine($"\t\tThread #{thread.ManagedThreadId} (OS 0x{thread.OSThreadId:X}) {threadKind}");
+                                                foreach (ClrStackFrame frame in thread.StackTrace)
+                                                {
+                                                    description.AppendLine($"\t\t\t{frame}");
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                finally
+                                {
+                                    Interlocked.Exchange(ref s_clrMdLock, 0);
+                                }
+                            }
+                        }
+                        catch { }
+
+                        throw new XunitException(description.ToString());
+                    }
 
                     FileInfo exceptionFileInfo = new FileInfo(Options.ExceptionFile);
                     if (exceptionFileInfo.Exists && exceptionFileInfo.Length != 0)


### PR DESCRIPTION
When a RemoteExecute.Invoke times out, we get very little detail about what the remote process was doing at the time.  This commit adds details from the Process object, but more importantly, when available attaches ClrMD to the remote process in order to dump out details like threads and stacks.

Note:
- This currently only outputs threads information on Windows, because ClrMD currently only supports attaching to a live process on Windows, not on Linux or macOS.
- I initially wrote this to also dump details on all of the async state machines in the heap, but ClrMD reports the type of the StateMachine as System.__Canon instead of reporting the actual concrete generic instantiation, which is where all the important details are.  So for now at least I left that part out.
- I wanted to include file names and line numbers, but ClrMD doesn't work well with portable PDBs right now.
- ClrMD doesn't like to be used to debug multiple processes concurrently, so if multiple tests running RemoteExecutor concurrently time out, we may only get details from one of them.  I chose to just skip the others rather than taking a lock around all of the debugger work and potentially causing more problems.

cc: @ViktorHofer, @danmosemsft, @leculver 

Example for a (made-up) test that sleeps for too long inside a LINQ query:
```
    Discovering: System.Runtime.Extensions.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.Runtime.Extensions.Tests (found 1 of 888 test case)
    Starting:    System.Runtime.Extensions.Tests (parallel test collections = on, max threads = 8)
      System.Tests.EnvironmentTests.Example [FAIL]
        Timed out after 3000ms waiting for remote process.
                Process ID: 375136
                Handle: 2004
                Name: dotnet
                MainModule: D:\repos\corefx\artifacts\bin\testhost\netcoreapp-Windows_NT-Debug-x64\dotnet.exe
                StartTime: 5/29/2019 9:32:26 PM
                TotalProcessorTime: 00:00:00.1406250
                Threads:
                        Thread #1 (OS 0x5A09C)
                                [HelperMethodFrame] (System.Threading.Thread.SleepInternal)
                                System.Threading.Thread.Sleep(Int32)
                                System.Tests.EnvironmentTests+<>c.<Example>b__4_1(Int32)
                                System.Linq.Enumerable+SelectRangeIterator`1[[System.Int32, System.Private.CoreLib]].ToArray()
                                System.Linq.Enumerable.ToArray[[System.Int32, System.Private.CoreLib]](System.Collections.Generic.IEnumerable`1<Int32>)
                                System.Tests.EnvironmentTests+<>c.<Example>b__4_0()
                                [DebuggerU2MCatchHandlerFrame]
                                [HelperMethodFrame_PROTECTOBJ] (System.RuntimeMethodHandle.InvokeMethod)
                                System.Reflection.RuntimeMethodInfo.Invoke(System.Object, System.Reflection.BindingFlags, System.Reflection.Binder, System.Object[], System.Globalization.CultureInfo)
                                System.Reflection.MethodBase.Invoke(System.Object, System.Object[])
                                Microsoft.DotNet.RemoteExecutorHost.Program.Main(System.String[])
                                [GCFrame]
                                [GCFrame]
                        Thread #2 (OS 0x5B1B4) [Finalizer]
                                [DebuggerU2MCatchHandlerFrame]
                        Thread #3 (OS 0x5D33C) [Thread pool worker]
                        Thread #4 (OS 0x5B578) [Thread pool worker]

        Stack Trace:
          D:\repos\arcade\src\Microsoft.DotNet.RemoteExecutor\src\Microsoft.DotNet.RemoteExecutor\RemoteInvokeHandle.cs(134,0): at Microsoft.DotNet.RemoteExecutor.RemoteInvokeHandle.Dispose(Boolean disposing)
          D:\repos\arcade\src\Microsoft.DotNet.RemoteExecutor\src\Microsoft.DotNet.RemoteExecutor\RemoteInvokeHandle.cs(54,0): at Microsoft.DotNet.RemoteExecutor.RemoteInvokeHandle.Dispose()
          D:\repos\corefx\src\System.Runtime.Extensions\tests\System\EnvironmentTests.cs(64,0): at System.Tests.EnvironmentTests.Example()
    Finished:    System.Runtime.Extensions.Tests
  === TEST EXECUTION SUMMARY ===
     System.Runtime.Extensions.Tests  Total: 1, Errors: 0, Failed: 1, Skipped: 0, Time: 3.448s
```