### PR TITLE
Define sentinel file to opt out of native tool installation

### DIFF
--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -130,8 +130,8 @@ try {
   # This is currently tracked by https://github.com/dotnet/arcade/issues/2673
   # Don't take a dependency on this as this is expected to be temporary unless the work
   # to revert this is being actively tracked along the mentioned issue.
-  $nativeToolsOptOutFile = Join-Path $EngRoot "disable-nativetool-install.workaround"
-  if (($restore) -and ($null -eq $env:DisableNativeToolsetInstalls) -and (-not Test-Path $nativeToolsOptOutFile)) {
+  $nativeToolsetOptOutFile = Join-Path $EngRoot "disable-native-toolset-installs-woraround"
+  if (($restore) -and ($null -eq $env:DisableNativeToolsetInstalls) -and (-not (Test-Path $nativeToolsetOptOutFile))) {
     InitializeNativeTools
   }
 

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -126,6 +126,10 @@ try {
     . $configureToolsetScript
   }
 
+  # This is a sentinel file to work around hangs caused by native tool installation.
+  # This is currently tracked by https://github.com/dotnet/arcade/issues/2673
+  # Don't take a dependency on this as this is expected to be temporary unless the work
+  # to revert this is being actively tracked along the mentioned issue.
   $nativeToolsOptOutFile = Join-Path $EngRoot "disable-nativetool-install.workaround"
   if (($restore) -and ($null -eq $env:DisableNativeToolsetInstalls) -and (-not Test-Path $nativeToolsOptOutFile)) {
     InitializeNativeTools

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -126,7 +126,8 @@ try {
     . $configureToolsetScript
   }
 
-  if (($restore) -and ($null -eq $env:DisableNativeToolsetInstalls)) {
+  $nativeToolsOptOutFile = Join-Path $EngRoot "disable-nativetool-install.workaround"
+  if (($restore) -and ($null -eq $env:DisableNativeToolsetInstalls) -and (-not Test-Path $nativeToolsOptOutFile)) {
     InitializeNativeTools
   }
 

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -209,6 +209,10 @@ if [[ -n "${useInstalledDotNetCli:-}" ]]; then
   use_installed_dotnet_cli="$useInstalledDotNetCli"
 fi
 
+# This is a sentinel file to work around hangs caused by native tool installation.
+# This is currently tracked by https://github.com/dotnet/arcade/issues/2673
+# Don't take a dependency on this as this is expected to be temporary unless the work
+# to revert this is being actively tracked along the mentioned issue.
 native_tools_opt_out_file="$eng_root/disable-nativetool-install.workaround"
 if [[ "$restore" == true && -z ${DisableNativeToolsetInstalls:-} && ! -f "$native_tools_opt_out_file" ]]; then
   InitializeNativeTools

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -209,7 +209,8 @@ if [[ -n "${useInstalledDotNetCli:-}" ]]; then
   use_installed_dotnet_cli="$useInstalledDotNetCli"
 fi
 
-if [[ "$restore" == true && -z ${DisableNativeToolsetInstalls:-} ]]; then
+native_tools_opt_out_file="$eng_root/disable-nativetool-install.workaround"
+if [[ "$restore" == true && -z ${DisableNativeToolsetInstalls:-} && ! -f "$native_tools_opt_out_file" ]]; then
   InitializeNativeTools
 fi
 

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -213,8 +213,8 @@ fi
 # This is currently tracked by https://github.com/dotnet/arcade/issues/2673
 # Don't take a dependency on this as this is expected to be temporary unless the work
 # to revert this is being actively tracked along the mentioned issue.
-native_tools_opt_out_file="$eng_root/disable-nativetool-install.workaround"
-if [[ "$restore" == true && -z ${DisableNativeToolsetInstalls:-} && ! -f "$native_tools_opt_out_file" ]]; then
+native_toolset_opt_out_file="$eng_root/disable-native-toolset-installs-workaround"
+if [[ "$restore" == true && -z ${DisableNativeToolsetInstalls:-} && ! -f "$native_toolset_opt_out_file" ]]; then
   InitializeNativeTools
 fi
 


### PR DESCRIPTION
In CoreCLR we are manually change scripts under `eng/common` on every update to remove native tool installation as it indefinitely hangs our CI for Linux and OSX legs. Then env variable work around exists, but we use the script in many different places and it is currently affecting dev loops as well. This **workaround** allows to drop a file named  `disable-nativetool-install.workaround` under the `eng` folder to skip the automatic acquisition of native tools until #2673 gets resolved.

Are we ok with these names and logic?

@RussKeldorph @jkotas 