### PR TITLE
Use DotNetTool for coverage invocation

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/coverage/Coverage.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/coverage/Coverage.targets
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <RunArguments>"$(TestAssembly)" --target "$(RunCommand)" --targetargs "$(RunArguments)" --format "$(CoverageFormat)" --output "$(CoverageOutputPath)" --threshold "$(CoverageThreshold)" --threshold-type "$(CoverageThresholdType)"</RunArguments>
     <RunArguments Condition="'$(CoverageSourceLink)' == 'true'">$(RunArguments) --use-source-link</RunArguments>
-    <RunCommand>"$(RunScriptHost)" tool run coverlet</RunCommand>
+    <RunCommand>"$(DotNetTool)" tool run coverlet</RunCommand>
   </PropertyGroup>
 
   <Target Name="SetupCoverageFilter">

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/coverage/CoverageReport.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/coverage/CoverageReport.targets
@@ -10,7 +10,7 @@
     <CoverageReportVerbosity Condition="'$(CoverageReportVerbosity)' == ''">Info</CoverageReportVerbosity>
     <CoverageReportResultsPath>$([MSBuild]::NormalizePath('$(CoverageReportDir)', 'index.htm'))</CoverageReportResultsPath>
 
-    <CoverageReportCommandLine>"$(RunScriptHost)" tool run reportgenerator "-reports:$(CoverageReportInputPath)" "-targetdir:$(CoverageReportDir)" "-reporttypes:$(CoverageReportTypes)" "-verbosity:$(CoverageReportVerbosity)"</CoverageReportCommandLine>
+    <CoverageReportCommandLine>"$(DotNetTool)" tool run reportgenerator "-reports:$(CoverageReportInputPath)" "-targetdir:$(CoverageReportDir)" "-reporttypes:$(CoverageReportTypes)" "-verbosity:$(CoverageReportVerbosity)"</CoverageReportCommandLine>
   </PropertyGroup>
 
   <!-- Skip generating individual reports if a full report is generated. -->


### PR DESCRIPTION
Fixes code coverage invocation failures in CoreFx.