### PR TITLE
move default location of rootfs to artifacts/rootfs instead of eng/common/cross

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -181,7 +181,7 @@ if [ -z "$__RootfsDir" ] && [ ! -z "$ROOTFS_DIR" ]; then
 fi
 
 if [ -z "$__RootfsDir" ]; then
-    __RootfsDir="$__CrossDir/rootfs/$__BuildArch"
+    __RootfsDir="$__CrossDir/../../../artifacts/rootfs/$__BuildArch"
 fi
 
 if [ -d "$__RootfsDir" ]; then

--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -181,7 +181,7 @@ if [ -z "$__RootfsDir" ] && [ ! -z "$ROOTFS_DIR" ]; then
 fi
 
 if [ -z "$__RootfsDir" ]; then
-    __RootfsDir="$__CrossDir/../../../artifacts/rootfs/$__BuildArch"
+    __RootfsDir="$__CrossDir/../../../.tools/rootfs/$__BuildArch"
 fi
 
 if [ -d "$__RootfsDir" ]; then


### PR DESCRIPTION
This is follow up on https://github.com/dotnet/corefx/pull/37678.
originally, build-rootfs lived in cross at arch repo and by default rootfs was created where script lives. After moving to Arcade, it makes more sense to follow Arcade standards and create everything under artifacts.
That makes cleaner separation between code and produced binaries. 

One can still crate rootfs elsewhere via passed argument or environmental variable. 