### PR TITLE
Emit attribute target as a keyword

### DIFF
--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Attributes.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Attributes.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Cci.Writers.CSharp
         {
             if (!string.IsNullOrEmpty(prefix))
             {
-                Write(prefix);
+                WriteKeyword(prefix);
                 WriteSymbol(":");
             }
             WriteTypeName(attribute.Constructor.ContainingType, noSpace: true); // Should we strip Attribute from name?


### PR DESCRIPTION
This ensure `return` is rendered as a keyword when emitting stuff like

```C#
[return: SomeAttribute]
```

/cc @safern @ericstj 