### PR TITLE
PR generator: handle commits created by dotnet-maestro

### DIFF
--- a/scripts/GitHubMergeBranches.ps1
+++ b/scripts/GitHubMergeBranches.ps1
@@ -85,6 +85,10 @@ function GetCommiterGitHubName($sha) {
     $email = & git show -s --format='%ce' $sha
     $key = 'committer'
 
+    if ($email -eq '@dotnet-maestro') {
+        return 'dotnet-maestro'
+    }
+
     # Exclude noreply@github.com - these map to https://github.com/web-flow, which is the user account
     # added as the 'committer' when users commit via the GitHub web UI on their own PRs
     if ((-not $email) -or ($email -eq 'noreply@github.com')) {
@@ -93,7 +97,8 @@ function GetCommiterGitHubName($sha) {
     }
 
     if ($email -like '*@users.noreply.github.com') {
-        return $email -replace '@users.noreply.github.com', ''
+        [string[]] $userNames = ($email -replace '@users.noreply.github.com', '') -split '\+'
+        return $userNames | select -last 1
     }
     elseif ($script:emails[$email]) {
         return $script:emails[$email]
@@ -205,8 +210,8 @@ try {
         | ? { $_ -ne $null } `
         | select -Unique
 
-    if (-not $AllowAutomatedCommits -and (($authors | measure).Count -eq 1) -and ($authors | select -first 1) -eq 'aspnetci') {
-        Write-Host -ForegroundColor Yellow 'Skipping PR generation because it appears this PR would only contain automated commits by aspnetci'
+    if (-not $AllowAutomatedCommits -and (($authors | measure).Count -eq 1) -and ($authors | select -first 1) -eq 'dotnet-maestro') {
+        Write-Host -ForegroundColor Yellow 'Skipping PR generation because it appears this PR would only contain automated commits by @dotnet-maestro'
         exit 0
     }
 


### PR DESCRIPTION
Fixes the description in generated PRs which include commits created by @dotnet-maestro

Incorrect
![image](https://user-images.githubusercontent.com/2696087/58975063-e471cf80-8778-11e9-933a-06fba775d881.png)

Correct
![image](https://user-images.githubusercontent.com/2696087/58975107-01a69e00-8779-11e9-8ac3-da4b8cda18c2.png)
