### PR TITLE
Don't use powershell error / warning functions

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -107,11 +107,11 @@ function Write-PipelineTaskError {
 
     if(!$ci) {
       if($Type -eq 'error') {
-        Write-Error $Message
+        Write-Host $Message -ForegroundColor Red
         return
       }
       elseif ($Type -eq 'warning') {
-        Write-Warning $Message
+        Write-Host $Message -ForegroundColor Yellow
         return
       }
     }


### PR DESCRIPTION
Using powershell's write-error function immediately throws an exception and stops script execution.  Instead of throwing an exception, color code the message and let calling scripts handle error cases.

@AdamYoblick 