### PR TITLE
Support importing Version.props directly

### DIFF
--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -983,3 +983,22 @@ If set to true calls to GetResourceString receive a default resource string valu
 
 #### `GenerateResxSourceOmitGetResourceString` (bool)
 If set to true the GetResourceString method is not included in the generated class and must be specified in a separate source file.
+
+
+### `ArcadeVersionProps` (string)
+
+This contains a file path to Arcade's properties file which is used to determine the versioning properties. It can be used in a project
+file when the values for `Version`, `PackageVersion` or `VersionSuffix` need to be used for other derived project properties.
+
+Example:
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="$(ArcadeVersionProps)" />
+
+  <PropertyGroup>
+    <PackageDescription>This is package v$(PackageVersion)</PackageDescription>
+  </PropertyGroup>
+
+</Project>
+```

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/BeforeCommonTargets.CrossTargeting.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/BeforeCommonTargets.CrossTargeting.targets
@@ -3,5 +3,5 @@
 <Project>
   <Import Project="$(_ArcadeOverriddenCustomBeforeMicrosoftCommonCrossTargetingTargets)" Condition="Exists('$(_ArcadeOverriddenCustomBeforeMicrosoftCommonCrossTargetingTargets)')"/>
 
-  <Import Project="Version.BeforeCommonTargets.targets"/>
+  <Import Project="Version.props" Condition="'$(_ArcadeVersionPropsImported)' != 'true'"/>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/BeforeCommonTargets.targets
@@ -7,5 +7,5 @@
     <_ArcadeBeforeCommonTargetsImported>true</_ArcadeBeforeCommonTargetsImported>
   </PropertyGroup>
 
-  <Import Project="Version.BeforeCommonTargets.targets"/>
+  <Import Project="Version.props" Condition="'$(_ArcadeVersionPropsImported)' != 'true'"/>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Settings.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Settings.props
@@ -6,6 +6,13 @@
     <_ArcadeOverriddenCustomBeforeMicrosoftCommonCrossTargetingTargets>$(CustomBeforeMicrosoftCommonCrossTargetingTargets)</_ArcadeOverriddenCustomBeforeMicrosoftCommonCrossTargetingTargets>
     <CustomBeforeMicrosoftCommonTargets>$(MSBuildThisFileDirectory)BeforeCommonTargets.targets</CustomBeforeMicrosoftCommonTargets>
     <CustomBeforeMicrosoftCommonCrossTargetingTargets>$(MSBuildThisFileDirectory)BeforeCommonTargets.CrossTargeting.targets</CustomBeforeMicrosoftCommonCrossTargetingTargets>
+
+    <!-- 
+      Version.props by default is imported after the project is evaluated and before Microsoft.Common.targets.
+      In cases where the computed version properties are needed within a project file, projects can add an
+      import to $(ArcadeVersionProps).
+    -->
+    <ArcadeVersionProps>$(MSBuildThisFileDirectory)Version.props</ArcadeVersionProps>
   </PropertyGroup>
 
   <Import Project="BuildTasks.props" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.props
@@ -2,6 +2,10 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
 
+  <PropertyGroup>
+    <_ArcadeVersionPropsImported>true</_ArcadeVersionPropsImported>
+  </PropertyGroup>
+
   <!--
     Specification: https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md
     
@@ -121,5 +125,13 @@
     <VersionPrefix Condition="'$(VersionPrefix)' == ''">1.0.0</VersionPrefix>
     <Version>$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(Version)-$(VersionSuffix)</Version>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- 
+      This is a commonly used property. Normally this is set by NuGet.Build.Tasks.Pack.targets,
+      but in some projects, it is useful to use this value before NuGet's targets are evaluated.
+    -->
+    <PackageVersion Condition=" '$(PackageVersion)' == '' ">$(Version)</PackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Normally, projects should not use this import. This should only be used when its necessary for a project to derive other properties from computed version properties.

Resolves #2984 

This unblocks https://github.com/aspnet/AspNetCore/pull/10674/