### PR TITLE
Patch SwaggerGenerator 

### DIFF
--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/ServiceClient.hb
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/ServiceClient.hb
@@ -134,7 +134,14 @@ namespace {{pascalCaseNs Namespace}}
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string Serialize<T>(T value)
         {
-            return JsonConvert.SerializeObject(value, SerializerSettings);
+            string result = JsonConvert.SerializeObject(value, SerializerSettings);
+
+            if (value is Enum)
+            {
+                return result[1..result.Length-1];
+            }
+
+            return result;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/ServiceClient.hb
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/ServiceClient.hb
@@ -138,7 +138,7 @@ namespace {{pascalCaseNs Namespace}}
 
             if (value is Enum)
             {
-                return result[1..result.Length-1];
+                return result.Substring(1, result.Length-2);
             }
 
             return result;


### PR DESCRIPTION
Patch SwaggerGenerator to remove quotes from serialized values from Enums.

Without this change the serialized values for AssetLocationType are: "None", "NugetFeed", "Container"

With this change the serialized values for AssetLocationType are: None, NugetFeed, Container