### PR TITLE
Make variables consumable by subsequent jobs

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -139,6 +139,7 @@ function Write-PipelineSetVariable {
       Write-LoggingCommand -Area 'task' -Event 'setvariable' -Data $Value -Properties @{
         'variable' = $Name
         'issecret' = $Secret
+        'isoutput' = 'true'
       } -AsOutput:$AsOutput
     }
 }

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -138,8 +138,8 @@ function Write-PipelineSetVariable {
     if($ci) {
       Write-LoggingCommand -Area 'task' -Event 'setvariable' -Data $Value -Properties @{
         'variable' = $Name
-        'issecret' = $Secret
-        'isoutput' = 'true'
+        'isSecret' = $Secret
+        'isOutput' = 'true'
       } -AsOutput:$AsOutput
     }
 }


### PR DESCRIPTION
Had talked with @chcosta about this and he agreed. 

We need this change to make the variables created by this function consumable by subsequent jobs in the pipeline.