### PR TITLE
Support detecting VS BuildTools

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -378,7 +378,7 @@ function LocateVisualStudio([object]$vsRequirements = $null){
   }
 
   if (!$vsRequirements) { $vsRequirements = $GlobalJson.tools.vs }
-  $args = @("-latest", "-prerelease", "-format", "json", "-requires", "Microsoft.Component.MSBuild")
+  $args = @("-latest", "-prerelease", "-format", "json", "-requires", "Microsoft.Component.MSBuild", "-products", "*")
 
   if (Get-Member -InputObject $vsRequirements -Name "version") {
     $args += "-version"


### PR DESCRIPTION
Without this, Arcade tries to download RoslynTools.MSBuild 16.0.0-alpha when building AspNetCore, and RoslynTools.MSBuild does not appear to work correctly for C++ and VSIX projects.

Required to unblock https://github.com/aspnet/AspNetCore/pull/11122

cc @JunTaoLuo 