### PR TITLE
Exclude test projects from source-build by default.

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.props
@@ -30,6 +30,9 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" IsImplicitlyDefined="true" />
+
+    <!-- exclude test projects from source-build by default -->
+    <ExcludeFromSourceBuild Condition="'$(ExcludeFromSourceBuild)' == ''">true</ExcludeFromSourceBuild>
   </ItemGroup>
 
   <PropertyGroup Condition="'$(IsTestProject)' == 'true'">


### PR DESCRIPTION
Exclude test projects from source-build by default, but allow opting in to support future testing in source-build.