### PR TITLE
Remove duplicated "assets/" in blob paths

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushArtifactsInManifestToFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushArtifactsInManifestToFeed.cs
@@ -200,7 +200,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                             var fileName = Path.GetFileName(blob.Id);
                             return new MSBuild.TaskItem($"{BlobAssetsBasePath}{fileName}", new Dictionary<string, string>
                             {
-                                {"RelativeBlobPath", $"{BuildManifestUtil.AssetsVirtualDir}{blob.Id}"}
+                                {"RelativeBlobPath", blob.Id}
                             });
                         })
                         .ToArray();


### PR DESCRIPTION
This is what's causing the additional "assets/" prefix in blob paths. The "Id" property of a blob in our Build Manifests already contain the "assets/" prefix.