### PR TITLE
Fix test project source-build exclusion to be a property instead of an item.

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.props
@@ -30,9 +30,6 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" IsImplicitlyDefined="true" />
-
-    <!-- exclude test projects from source-build by default -->
-    <ExcludeFromSourceBuild Condition="'$(ExcludeFromSourceBuild)' == ''">true</ExcludeFromSourceBuild>
   </ItemGroup>
 
   <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
@@ -41,6 +38,9 @@
 
     <!-- Default test runner -->
     <TestRunnerName Condition="'$(UsingToolXUnit)' == 'true'">XUnit</TestRunnerName>
+
+    <!-- exclude test projects from source-build by default -->
+    <ExcludeFromSourceBuild Condition="'$(ExcludeFromSourceBuild)' == ''">true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <!-- Import specialized props files of supported test runners -->


### PR DESCRIPTION
Fixes issue introduced in #3034 where I put the property in an ItemGroup instead of a PropertyGroup.