### PR TITLE
Fix build break: Remove telemetry task declartion

### DIFF
--- a/Documentation/Projects/DevOps/CI/Telemetry-Guidance.md
+++ b/Documentation/Projects/DevOps/CI/Telemetry-Guidance.md
@@ -49,10 +49,6 @@ Project properties are useful to set a generic categorization for a project.  Th
 If we add...
 
 ```XML
-<UsingTask
-  TaskName="Telemetry"
-  AssemblyFile="Microsoft.Build.Tasks.Core.dll" />
-
 <PropertyGroup>
   <NETCORE_ENGINEERING_TELEMETRY>Build</NETCORE_ENGINEERING_TELEMETRY>
 </PropertyGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
@@ -22,10 +22,6 @@
           Condition="'$(XUnitCoreSettingsFile)' != '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
   </ItemGroup>
 
-  <UsingTask
-    TaskName="Telemetry"
-    AssemblyFile="Microsoft.Build.Tasks.Core.dll" />
-
   <!-- 
     Include '*' target to force running tests even if the input assemblies haven't changed and the outputs are present.
     This matches the common expectations that test command always runs all tests in scope.


### PR DESCRIPTION
https://github.com/dotnet/arcade/pull/3008#discussion_r293834259

Local testing confirms Rainer's assertion.

Working on getting an Azure DevOps build validated now.

@rainersigwald PTAL