### PR TITLE
Remove one more GitHub project from source-build.

### DIFF
--- a/src/Microsoft.DotNet.Git.IssueManager/src/Microsoft.DotNet.Git.IssueManager.csproj
+++ b/src/Microsoft.DotNet.Git.IssueManager/src/Microsoft.DotNet.Git.IssueManager.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
     <SignAssembly>false</SignAssembly>
     <IsPackable>true</IsPackable>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#2990 missed one GitHub project that we see bringing in Octokit in prebuilts.