### PR TITLE
Fix merge instructions to force pull branch to remote

### DIFF
--- a/scripts/GitHubMergeBranches.ps1
+++ b/scripts/GitHubMergeBranches.ps1
@@ -396,8 +396,9 @@ git push
 Contributors to this repo have permission update this pull request by pushing to the branch '$mergeBranchName'. This can be done to resolve conflicts or make other changes to this pull request before it is merged.
 
 ``````
+git fetch
 git branch -D ${mergeBranchName}
-git checkout -b ${mergeBranchName} $BaseBranch
+git checkout -b ${mergeBranchName} origin/$BaseBranch
 git pull https://github.com/$prOwnerName/$prRepoName ${mergeBranchName}
 (make changes)
 git commit -m "Updated PR with my changes"

--- a/scripts/GitHubMergeBranches.ps1
+++ b/scripts/GitHubMergeBranches.ps1
@@ -396,22 +396,24 @@ git push
 Contributors to this repo have permission update this pull request by pushing to the branch '$mergeBranchName'. This can be done to resolve conflicts or make other changes to this pull request before it is merged.
 
 ``````
+git branch -D ${mergeBranchName}
 git checkout -b ${mergeBranchName} $BaseBranch
 git pull https://github.com/$prOwnerName/$prRepoName ${mergeBranchName}
 (make changes)
 git commit -m "Updated PR with my changes"
-git push https://github.com/$prOwnerName/$prRepoName ${mergeBranchName}
+git push -f https://github.com/$prOwnerName/$prRepoName ${mergeBranchName}
 ``````
 
 <details>
     <summary>or if you are using SSH</summary>
 
 ``````
+git branch -D ${mergeBranchName}
 git checkout -b ${mergeBranchName} $BaseBranch
 git pull git@github.com:$prOwnerName/$prRepoName ${mergeBranchName}
 (make changes)
 git commit -m "Updated PR with my changes"
-git push git@github.com:$prOwnerName/$prRepoName ${mergeBranchName}
+git push -f git@github.com:$prOwnerName/$prRepoName ${mergeBranchName}
 ``````
 
 </details>

--- a/scripts/GitHubMergeBranches.ps1
+++ b/scripts/GitHubMergeBranches.ps1
@@ -409,8 +409,9 @@ git push -f https://github.com/$prOwnerName/$prRepoName ${mergeBranchName}
     <summary>or if you are using SSH</summary>
 
 ``````
+git fetch
 git branch -D ${mergeBranchName}
-git checkout -b ${mergeBranchName} $BaseBranch
+git checkout -b ${mergeBranchName} origin/$BaseBranch
 git pull git@github.com:$prOwnerName/$prRepoName ${mergeBranchName}
 (make changes)
 git commit -m "Updated PR with my changes"


### PR DESCRIPTION
I was doing a merge from release/2.1 to release/2.2 and hit two separate issues. One was if you already have a branch created locally by the same name, you need to either delete the local branch or git reset --hard release/x.x. Next, if you don't force push to the pr branch, I saw extra commits from release/2.2 there that shouldn't be there. The best way I found to get around this was by force pushing to the bot PR.