### PR TITLE
Fix annotation target order and dependencies

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Configuration/src/build/Microsoft.DotNet.Build.Tasks.Configuration.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Configuration/src/build/Microsoft.DotNet.Build.Tasks.Configuration.targets
@@ -163,7 +163,8 @@
     Make sure to run late enough for transitive dependencies which runs before AssignProjectConfiguration.
   -->
   <Target Name="AnnotateProjectReference"
-          AfterTargets="ResolvePackageDependenciesForBuild"
+          BeforeTargets="AssignProjectConfiguration"
+          DependsOnTargets="ResolvePackageDependenciesForBuild"
           Condition="'@(ProjectReference)' != ''"
           Inputs="%(ProjectReference.Identity)"
           Outputs="unused">


### PR DESCRIPTION
`AnnotateProjectReference` needs to run before `AssignProjectConfiguration`. Setting it to run after `ResolvePackageDependenciesForBuild` will create misses when that target doesn't run.