### PR TITLE
Internal feed AzDO artifact feeds operations

### DIFF
--- a/eng/common/internal-feed-operations.ps1
+++ b/eng/common/internal-feed-operations.ps1
@@ -1,4 +1,4 @@
-﻿param(
+param(
   [Parameter(Mandatory=$true)][string] $Operation,
   [string] $AuthToken,
   [string] $CommitSha,
@@ -54,7 +54,7 @@ function SetupCredProvider {
   }
   
   $endpoints = New-Object System.Collections.ArrayList
-  $nugetConfigPackageSources = Select-Xml -Path $nugetConfigPath -XPath "//packageSources/add[contains(@key, 'darc-')]/@value" | foreach{$_.Node.Value}
+  $nugetConfigPackageSources = Select-Xml -Path $nugetConfigPath -XPath "//packageSources/add[contains(@key, 'darc-int-')]/@value" | foreach{$_.Node.Value}
   
   if (($nugetConfigPackageSources | Measure-Object).Count -gt 0 ) {
     foreach ($stableRestoreResource in $nugetConfigPackageSources) {
@@ -67,11 +67,17 @@ function SetupCredProvider {
       # Create the JSON object. It should look like '{"endpointCredentials": [{"endpoint":"http://example.index.json", "username":"optional", "password":"accesstoken"}]}'
       $endpointCredentials = @{endpointCredentials=$endpoints} | ConvertTo-Json -Compress
 
-      # Create the environment variables the AzDo way
-      Write-PipelineSetVariable -Name 'VSS_NUGET_EXTERNAL_FEED_ENDPOINTS' -Value $endpointCredentials
+     # Create the environment variables the AzDo way
+      Write-LoggingCommand -Area 'task' -Event 'setvariable' -Data $endpointCredentials -Properties @{
+        'variable' = 'VSS_NUGET_EXTERNAL_FEED_ENDPOINTS'
+        'issecret' = 'false'
+      } 
 
       # We don't want sessions cached since we will be updating the endpoints quite frequently
-      Write-PipelineSetVariable -Name 'NUGET_CREDENTIALPROVIDER_SESSIONTOKENCACHE_ENABLED' -Value 'False'
+      Write-LoggingCommand -Area 'task' -Event 'setvariable' -Data 'False' -Properties @{
+        'variable' = 'NUGET_CREDENTIALPROVIDER_SESSIONTOKENCACHE_ENABLED'
+        'issecret' = 'false'
+      } 
   }
   else
   {

--- a/eng/common/internal-feed-operations.ps1
+++ b/eng/common/internal-feed-operations.ps1
@@ -11,6 +11,10 @@ Set-StrictMode -Version 2.0
 
 . $PSScriptRoot\tools.ps1
 
+# Sets VSS_NUGET_EXTERNAL_FEED_ENDPOINTS based on the "darc-int-*" feeds defined in NuGet.config. This is needed by
+# in build agents by CredProvider to authenticate the restore requests to internal feeds as specified in
+# https://github.com/microsoft/artifacts-credprovider#environment-variables. This should ONLY be called from identified
+# internal builds
 function SetupCredProvider{
   param(
     [string] $AuthToken

--- a/eng/common/internal-feed-operations.ps1
+++ b/eng/common/internal-feed-operations.ps1
@@ -1,0 +1,129 @@
+param(
+  [Parameter(Mandatory=$true)][string] $Operation,
+  [string] $AuthToken,
+  [string] $CommitSha,
+  [string] $RepoName,
+  [switch] $IsFeedPrivate
+)
+
+. $PSScriptRoot\tools.ps1
+
+function SetupCredProvider{
+  param(
+    [string] $AuthToken
+  )    
+
+  # Install the Cred Provider NuGet plugin
+  Write-Host "Setting up Cred Provider NuGet plugin in the agent..."...
+  Write-Host "Getting 'installcredprovider.ps1' from 'https://github.com/microsoft/artifacts-credprovider'..."
+
+  $url = 'https://raw.githubusercontent.com/microsoft/artifacts-credprovider/master/helpers/installcredprovider.ps1'
+  
+  Write-Host "Writing the contents of 'installcredprovider.ps1' locally..."
+  Invoke-WebRequest $url -OutFile installcredprovider.ps1
+  
+  Write-Host "Installing plugin..."
+  .\installcredprovider.ps1 -Force
+  
+  Write-Host "Deleting local copy of 'installcredprovider.ps1'..."
+  Remove-Item .\installcredprovider.ps1
+
+  if (-Not("$env:USERPROFILE\.nuget\plugins\netcore")) {
+    Write-Host "CredProvider plugin was not installed correctly!"
+    ExitWithExitCode 1  
+  } 
+  else {
+    Write-Host "CredProvider plugin was installed correctly!"
+  }
+
+  # Then, we set the 'VSS_NUGET_EXTERNAL_FEED_ENDPOINTS' environment variable to restore from the stable 
+  # feeds successfully
+
+  $nugetConfigPath = "$RepoRoot\NuGet.config"
+
+  if (-Not (Test-Path -Path $nugetConfigPath)) {
+    Write-Host "NuGet.config file not found in repo's root!"
+    ExitWithExitCode 1  
+  }
+  
+  $endpoints = New-Object System.Collections.ArrayList
+  $nugetConfigPackageSources = Select-Xml -Path $nugetConfigPath -XPath "//packageSources/add[contains(@key, 'darc-')]/@value" | foreach{$_.Node.Value}
+  
+  if (($nugetConfigPackageSources | Measure-Object).Count -gt 0 ) {
+    foreach ($stableRestoreResource in $nugetConfigPackageSources) {
+      $trimmedResource = ([string]$stableRestoreResource).Trim()
+      [void]$endpoints.Add(@{endpoint="$trimmedResource"; password="$AuthToken"}) 
+    }
+  }
+
+  if (($endpoints | Measure-Object).Count -gt 0) {
+      # Create the JSON object. It should look like '{"endpointCredentials": [{"endpoint":"http://example.index.json", "username":"optional", "password":"accesstoken"}]}'
+      $endpointCredentials = @{endpointCredentials=$endpoints} | ConvertTo-Json -Compress
+      $restoreProjPath = "$PSScriptRoot\restore.proj"
+
+      # Create the environment variables de AzDo way
+      Write-LoggingCommand -Area 'task' -Event 'setvariable' -Data $endpointCredentials -Properties @{
+        'variable' = 'VSS_NUGET_EXTERNAL_FEED_ENDPOINTS'
+        'issecret' = 'false'
+      } 
+
+      # We don't want sessions cached since we will be updating the endpoints quite frequently
+      Write-LoggingCommand -Area 'task' -Event 'setvariable' -Data 'False' -Properties @{
+        'variable' = 'NUGET_CREDENTIALPROVIDER_SESSIONTOKENCACHE_ENABLED'
+        'issecret' = 'false'
+      } 
+
+      '<Project Sdk="Microsoft.DotNet.Arcade.Sdk"/>' | Out-File "$restoreProjPath"
+  }
+  else
+  {
+    Write-Host "No internal endpoints found in NuGet.config"
+  }
+}
+
+#Workaround for https://github.com/microsoft/msbuild/issues/4430
+function InstallDotNetSdkAndRestoreArcade {
+  $dotnetTempDir = "$RepoRoot\dotnet"
+  $dotnetSdkVersion="2.1.507"
+  $dotnet = "$dotnetTempDir\dotnet.exe"
+  $restoreProjPath = "$PSScriptRoot\restore.proj"
+  
+  Write-Host "Installing dotnet SDK version $dotnetSdkVersion to restore Arcade SDK..."
+  InstallDotNetSdk "$dotnetTempDir" "$dotnetSdkVersion"
+
+  & $dotnet restore $restoreProjPath
+
+  Write-Host "Arcade SDK restored!"
+
+  if (Test-Path -Path $restoreProjPath) {
+    Remove-Item $restoreProjPath
+  }
+
+  if (Test-Path -Path $dotnetTempDir) {
+    Remove-Item $dotnetTempDir -Recurse
+  }
+}
+
+try {
+  Push-Location $PSScriptRoot
+
+  if ($Operation -like "setup") {
+    SetupCredProvider $AuthToken
+  } 
+  elseif ($Operation -like "install-restore") {
+    InstallDotNetSdkAndRestoreArcade
+  }
+  else {
+    Write-Host "Unknown operation '$Operation'!"
+    ExitWithExitCode 1  
+  }
+} 
+catch {
+  Write-Host $_
+  Write-Host $_.Exception
+  Write-Host $_.ScriptStackTrace
+  ExitWithExitCode 1
+} 
+finally {
+    Pop-Location
+}

--- a/eng/common/internal-feed-operations.ps1
+++ b/eng/common/internal-feed-operations.ps1
@@ -1,4 +1,4 @@
-param(
+﻿param(
   [Parameter(Mandatory=$true)][string] $Operation,
   [string] $AuthToken,
   [string] $CommitSha,
@@ -47,7 +47,7 @@ function SetupCredProvider{
   }
   
   $endpoints = New-Object System.Collections.ArrayList
-  $nugetConfigPackageSources = Select-Xml -Path $nugetConfigPath -XPath "//packageSources/add[contains(@key, 'darc-')]/@value" | foreach{$_.Node.Value}
+  $nugetConfigPackageSources = Select-Xml -Path $nugetConfigPath -XPath "//packageSources/add[contains(@key, 'darc-int-')]/@value" | foreach{$_.Node.Value}
   
   if (($nugetConfigPackageSources | Measure-Object).Count -gt 0 ) {
     foreach ($stableRestoreResource in $nugetConfigPackageSources) {
@@ -59,8 +59,9 @@ function SetupCredProvider{
   if (($endpoints | Measure-Object).Count -gt 0) {
       # Create the JSON object. It should look like '{"endpointCredentials": [{"endpoint":"http://example.index.json", "username":"optional", "password":"accesstoken"}]}'
       $endpointCredentials = @{endpointCredentials=$endpoints} | ConvertTo-Json -Compress
+      $restoreProjPath = "$PSScriptRoot\restore.proj"
 
-      # Create the environment variables the AzDo way
+      # Create the environment variables de AzDo way
       Write-LoggingCommand -Area 'task' -Event 'setvariable' -Data $endpointCredentials -Properties @{
         'variable' = 'VSS_NUGET_EXTERNAL_FEED_ENDPOINTS'
         'issecret' = 'false'
@@ -71,6 +72,28 @@ function SetupCredProvider{
         'variable' = 'NUGET_CREDENTIALPROVIDER_SESSIONTOKENCACHE_ENABLED'
         'issecret' = 'false'
       } 
+
+      '<Project Sdk="Microsoft.DotNet.Arcade.Sdk"/>' | Out-File "$restoreProjPath"
+
+      #Workaround for https://github.com/microsoft/msbuild/issues/4430
+      $dotnetTempDir = "$RepoRoot\dotnet"
+      $dotnetSdkVersion="2.1.507"
+      $dotnet = "$dotnetTempDir\dotnet.exe"
+
+      Write-Host "Installing dotnet SDK version $dotnetSdkVersion to restore Arcade SDK..."
+      InstallDotNetSdk "$dotnetTempDir" "$dotnetSdkVersion"
+
+      & $dotnet restore $restoreProjPath
+
+      Write-Host "Arcade SDK restored!"
+
+      if (Test-Path -Path $restoreProjPath) {
+        Remove-Item $restoreProjPath
+      }
+
+      if (Test-Path -Path $dotnetTempDir) {
+        Remove-Item $dotnetTempDir -Recurse
+      }
   }
   else
   {
@@ -78,27 +101,39 @@ function SetupCredProvider{
   }
 }
 
-#Workaround for https://github.com/microsoft/msbuild/issues/4430
-function InstallDotNetSdkAndRestoreArcade {
-  $dotnetTempDir = "$RepoRoot\dotnet"
-  $dotnetSdkVersion="2.1.507" # After experimentation we know this version works when restoring the SDK (compared to 3.0.*)
-  $dotnet = "$dotnetTempDir\dotnet.exe"
-  $restoreProjPath = "$PSScriptRoot\restore.proj"
+function CreateNewFeed {
+  param(
+    [switch] $IsFeedPrivate,
+    [string] $AuthToken,
+    [string] $RepoName,
+    [string] $CommitSha
+  )  
+
+  Write-Host $IsFeedPrivate
+  if ($IsFeedPrivate) {
+    $feedsUrl = 'https://feeds.dev.azure.com/dnceng/_apis/packaging/feeds'
+    $feedName = "darc-int-$RepoName-$CommitSha"
+
+    Write-Host "Creating new feed '$feedName' in '$feedsUrl'"
   
-  Write-Host "Installing dotnet SDK version $dotnetSdkVersion to restore Arcade SDK..."
-  InstallDotNetSdk "$dotnetTempDir" "$dotnetSdkVersion"
-  '<Project Sdk="Microsoft.DotNet.Arcade.Sdk"/>' | Out-File "$restoreProjPath"
+    # Mimic the permissions added to a feed when created in the browser
+    $permissions = New-Object System.Collections.ArrayList
+    [void]$permissions.Add(@{identityDescriptor="Microsoft.TeamFoundation.ServiceIdentity;116cce53-b859-4624-9a95-934af41eccef:Build:b55de4ed-4b5a-4215-a8e4-0a0a5f71e7d8"; role=3});
+    [void]$permissions.Add(@{identityDescriptor="Microsoft.TeamFoundation.ServiceIdentity;116cce53-b859-4624-9a95-934af41eccef:Build:7ea9116e-9fac-403d-b258-b31fcf1bb293"; role=3});
+    [void]$permissions.Add(@{identityDescriptor="Microsoft.TeamFoundation.Identity;S-1-9-1551374245-1349140002-2196814402-2899064621-3782482097-0-0-0-0-1"; role=4});
+    [void]$permissions.Add(@{identityDescriptor="Microsoft.TeamFoundation.Identity;S-1-9-1551374245-1846651262-2896117056-2992157471-3474698899-1-2052915359-1158038602-2757432096-2854636005"; role=4});
 
-  & $dotnet restore $restoreProjPath
+    $body = @{name=$feedName;permissions=$permissions} | ConvertTo-Json -Compress
 
-  Write-Host "Arcade SDK restored!"
-
-  if (Test-Path -Path $restoreProjPath) {
-    Remove-Item $restoreProjPath
+    $bytes = [System.Text.Encoding]::ASCII.GetBytes(":$AuthToken")
+    $encodedToken = [Convert]::ToBase64String($bytes)
+    $headers = @{"Accept"="application/json; api-version=5.0-preview.1"; "Content-type"="application/json"; "Authorization"="Basic $encodedToken"}
+    
+    Invoke-WebRequest $feedsUrl -Body $body -Headers $headers -Method 'POST'
   }
-
-  if (Test-Path -Path $dotnetTempDir) {
-    Remove-Item $dotnetTempDir -Recurse
+  else {
+  #Write-Host $IsFeedPrivate
+   # Public feeds haven't GA'ed yet and we don't know yet how they work. 
   }
 }
 
@@ -108,9 +143,19 @@ try {
   if ($Operation -like "setup") {
     SetupCredProvider $AuthToken
   } 
-  elseif ($Operation -like "install-restore") {
-    InstallDotNetSdkAndRestoreArcade
-  }
+  elseif ($Operation -like "create-feed") {
+    if ($RepoName -eq "" -or $CommitSha -eq "") {
+      Write-Host "-RepoName and -CommitSha are required for a 'create-feed' operation!"
+      ExitWithExitCode 1  
+    }
+
+    if ($IsFeedPrivate -and $AuthToken -eq "") {
+      Write-Host "-AuthToken is required for a private feed creation!"
+      ExitWithExitCode 1  
+    }
+
+    CreateNewFeed -IsFeedPrivate $IsFeedPrivate -AuthToken $AuthToken -RepoName $RepoName -CommitSha $CommitSha
+  } 
   else {
     Write-Host "Unknown operation '$Operation'!"
     ExitWithExitCode 1  

--- a/eng/common/internal-feed-operations.ps1
+++ b/eng/common/internal-feed-operations.ps1
@@ -6,6 +6,9 @@
   [switch] $IsFeedPrivate
 )
 
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version 2.0
+
 . $PSScriptRoot\tools.ps1
 
 function SetupCredProvider{
@@ -14,7 +17,7 @@ function SetupCredProvider{
   )    
 
   # Install the Cred Provider NuGet plugin
-  Write-Host "Setting up Cred Provider NuGet plugin in the agent..."...
+  Write-Host "Setting up Cred Provider NuGet plugin in the agent..."
   Write-Host "Getting 'installcredprovider.ps1' from 'https://github.com/microsoft/artifacts-credprovider'..."
 
   $url = 'https://raw.githubusercontent.com/microsoft/artifacts-credprovider/master/helpers/installcredprovider.ps1'
@@ -47,7 +50,7 @@ function SetupCredProvider{
   }
   
   $endpoints = New-Object System.Collections.ArrayList
-  $nugetConfigPackageSources = Select-Xml -Path $nugetConfigPath -XPath "//packageSources/add[contains(@key, 'darc-int-')]/@value" | foreach{$_.Node.Value}
+  $nugetConfigPackageSources = Select-Xml -Path $nugetConfigPath -XPath "//packageSources/add[contains(@key, 'darc-')]/@value" | foreach{$_.Node.Value}
   
   if (($nugetConfigPackageSources | Measure-Object).Count -gt 0 ) {
     foreach ($stableRestoreResource in $nugetConfigPackageSources) {
@@ -59,9 +62,8 @@ function SetupCredProvider{
   if (($endpoints | Measure-Object).Count -gt 0) {
       # Create the JSON object. It should look like '{"endpointCredentials": [{"endpoint":"http://example.index.json", "username":"optional", "password":"accesstoken"}]}'
       $endpointCredentials = @{endpointCredentials=$endpoints} | ConvertTo-Json -Compress
-      $restoreProjPath = "$PSScriptRoot\restore.proj"
 
-      # Create the environment variables de AzDo way
+      # Create the environment variables the AzDo way
       Write-LoggingCommand -Area 'task' -Event 'setvariable' -Data $endpointCredentials -Properties @{
         'variable' = 'VSS_NUGET_EXTERNAL_FEED_ENDPOINTS'
         'issecret' = 'false'
@@ -72,28 +74,6 @@ function SetupCredProvider{
         'variable' = 'NUGET_CREDENTIALPROVIDER_SESSIONTOKENCACHE_ENABLED'
         'issecret' = 'false'
       } 
-
-      '<Project Sdk="Microsoft.DotNet.Arcade.Sdk"/>' | Out-File "$restoreProjPath"
-
-      #Workaround for https://github.com/microsoft/msbuild/issues/4430
-      $dotnetTempDir = "$RepoRoot\dotnet"
-      $dotnetSdkVersion="2.1.507"
-      $dotnet = "$dotnetTempDir\dotnet.exe"
-
-      Write-Host "Installing dotnet SDK version $dotnetSdkVersion to restore Arcade SDK..."
-      InstallDotNetSdk "$dotnetTempDir" "$dotnetSdkVersion"
-
-      & $dotnet restore $restoreProjPath
-
-      Write-Host "Arcade SDK restored!"
-
-      if (Test-Path -Path $restoreProjPath) {
-        Remove-Item $restoreProjPath
-      }
-
-      if (Test-Path -Path $dotnetTempDir) {
-        Remove-Item $dotnetTempDir -Recurse
-      }
   }
   else
   {
@@ -101,39 +81,28 @@ function SetupCredProvider{
   }
 }
 
-function CreateNewFeed {
-  param(
-    [switch] $IsFeedPrivate,
-    [string] $AuthToken,
-    [string] $RepoName,
-    [string] $CommitSha
-  )  
-
-  Write-Host $IsFeedPrivate
-  if ($IsFeedPrivate) {
-    $feedsUrl = 'https://feeds.dev.azure.com/dnceng/_apis/packaging/feeds'
-    $feedName = "darc-int-$RepoName-$CommitSha"
-
-    Write-Host "Creating new feed '$feedName' in '$feedsUrl'"
+#Workaround for https://github.com/microsoft/msbuild/issues/4430
+function InstallDotNetSdkAndRestoreArcade {
+  $dotnetTempDir = "$RepoRoot\dotnet"
+  $dotnetSdkVersion="2.1.507" # After experimentation we know this version works when restoring the SDK (compared to 3.0.*)
+  $dotnet = "$dotnetTempDir\dotnet.exe"
+  $restoreProjPath = "$PSScriptRoot\restore.proj"
   
-    # Mimic the permissions added to a feed when created in the browser
-    $permissions = New-Object System.Collections.ArrayList
-    [void]$permissions.Add(@{identityDescriptor="Microsoft.TeamFoundation.ServiceIdentity;116cce53-b859-4624-9a95-934af41eccef:Build:b55de4ed-4b5a-4215-a8e4-0a0a5f71e7d8"; role=3});
-    [void]$permissions.Add(@{identityDescriptor="Microsoft.TeamFoundation.ServiceIdentity;116cce53-b859-4624-9a95-934af41eccef:Build:7ea9116e-9fac-403d-b258-b31fcf1bb293"; role=3});
-    [void]$permissions.Add(@{identityDescriptor="Microsoft.TeamFoundation.Identity;S-1-9-1551374245-1349140002-2196814402-2899064621-3782482097-0-0-0-0-1"; role=4});
-    [void]$permissions.Add(@{identityDescriptor="Microsoft.TeamFoundation.Identity;S-1-9-1551374245-1846651262-2896117056-2992157471-3474698899-1-2052915359-1158038602-2757432096-2854636005"; role=4});
+  Write-Host "Installing dotnet SDK version $dotnetSdkVersion to restore Arcade SDK..."
+  InstallDotNetSdk "$dotnetTempDir" "$dotnetSdkVersion"
+  
+  '<Project Sdk="Microsoft.DotNet.Arcade.Sdk"/>' | Out-File "$restoreProjPath"
 
-    $body = @{name=$feedName;permissions=$permissions} | ConvertTo-Json -Compress
+  & $dotnet restore $restoreProjPath
 
-    $bytes = [System.Text.Encoding]::ASCII.GetBytes(":$AuthToken")
-    $encodedToken = [Convert]::ToBase64String($bytes)
-    $headers = @{"Accept"="application/json; api-version=5.0-preview.1"; "Content-type"="application/json"; "Authorization"="Basic $encodedToken"}
-    
-    Invoke-WebRequest $feedsUrl -Body $body -Headers $headers -Method 'POST'
+  Write-Host "Arcade SDK restored!"
+
+  if (Test-Path -Path $restoreProjPath) {
+    Remove-Item $restoreProjPath
   }
-  else {
-  #Write-Host $IsFeedPrivate
-   # Public feeds haven't GA'ed yet and we don't know yet how they work. 
+
+  if (Test-Path -Path $dotnetTempDir) {
+    Remove-Item $dotnetTempDir -Recurse
   }
 }
 
@@ -143,19 +112,9 @@ try {
   if ($Operation -like "setup") {
     SetupCredProvider $AuthToken
   } 
-  elseif ($Operation -like "create-feed") {
-    if ($RepoName -eq "" -or $CommitSha -eq "") {
-      Write-Host "-RepoName and -CommitSha are required for a 'create-feed' operation!"
-      ExitWithExitCode 1  
-    }
-
-    if ($IsFeedPrivate -and $AuthToken -eq "") {
-      Write-Host "-AuthToken is required for a private feed creation!"
-      ExitWithExitCode 1  
-    }
-
-    CreateNewFeed -IsFeedPrivate $IsFeedPrivate -AuthToken $AuthToken -RepoName $RepoName -CommitSha $CommitSha
-  } 
+  elseif ($Operation -like "install-restore") {
+    InstallDotNetSdkAndRestoreArcade
+  }
   else {
     Write-Host "Unknown operation '$Operation'!"
     ExitWithExitCode 1  

--- a/eng/common/internal-feed-operations.ps1
+++ b/eng/common/internal-feed-operations.ps1
@@ -11,11 +11,11 @@ Set-StrictMode -Version 2.0
 
 . $PSScriptRoot\tools.ps1
 
-# Sets VSS_NUGET_EXTERNAL_FEED_ENDPOINTS based on the "darc-int-*" feeds defined in NuGet.config. This is needed by
+# Sets VSS_NUGET_EXTERNAL_FEED_ENDPOINTS based on the "darc-int-*" feeds defined in NuGet.config. This is needed
 # in build agents by CredProvider to authenticate the restore requests to internal feeds as specified in
-# https://github.com/microsoft/artifacts-credprovider#environment-variables. This should ONLY be called from identified
+# https://github.com/microsoft/artifacts-credprovider/blob/0f53327cd12fd893d8627d7b08a2171bf5852a41/README.md#environment-variables. This should ONLY be called from identified
 # internal builds
-function SetupCredProvider{
+function SetupCredProvider {
   param(
     [string] $AuthToken
   )    

--- a/eng/common/internal-feed-operations.ps1
+++ b/eng/common/internal-feed-operations.ps1
@@ -68,16 +68,10 @@ function SetupCredProvider {
       $endpointCredentials = @{endpointCredentials=$endpoints} | ConvertTo-Json -Compress
 
       # Create the environment variables the AzDo way
-      Write-LoggingCommand -Area 'task' -Event 'setvariable' -Data $endpointCredentials -Properties @{
-        'variable' = 'VSS_NUGET_EXTERNAL_FEED_ENDPOINTS'
-        'issecret' = 'false'
-      } 
+      Write-PipelineSetVariable -Name 'VSS_NUGET_EXTERNAL_FEED_ENDPOINTS' -Value $endpointCredentials
 
       # We don't want sessions cached since we will be updating the endpoints quite frequently
-      Write-LoggingCommand -Area 'task' -Event 'setvariable' -Data 'False' -Properties @{
-        'variable' = 'NUGET_CREDENTIALPROVIDER_SESSIONTOKENCACHE_ENABLED'
-        'issecret' = 'false'
-      } 
+      Write-PipelineSetVariable -Name 'NUGET_CREDENTIALPROVIDER_SESSIONTOKENCACHE_ENABLED' -Value 'False'
   }
   else
   {

--- a/eng/common/internal-feed-operations.ps1
+++ b/eng/common/internal-feed-operations.ps1
@@ -59,9 +59,8 @@ function SetupCredProvider{
   if (($endpoints | Measure-Object).Count -gt 0) {
       # Create the JSON object. It should look like '{"endpointCredentials": [{"endpoint":"http://example.index.json", "username":"optional", "password":"accesstoken"}]}'
       $endpointCredentials = @{endpointCredentials=$endpoints} | ConvertTo-Json -Compress
-      $restoreProjPath = "$PSScriptRoot\restore.proj"
 
-      # Create the environment variables de AzDo way
+      # Create the environment variables the AzDo way
       Write-LoggingCommand -Area 'task' -Event 'setvariable' -Data $endpointCredentials -Properties @{
         'variable' = 'VSS_NUGET_EXTERNAL_FEED_ENDPOINTS'
         'issecret' = 'false'
@@ -72,8 +71,6 @@ function SetupCredProvider{
         'variable' = 'NUGET_CREDENTIALPROVIDER_SESSIONTOKENCACHE_ENABLED'
         'issecret' = 'false'
       } 
-
-      '<Project Sdk="Microsoft.DotNet.Arcade.Sdk"/>' | Out-File "$restoreProjPath"
   }
   else
   {
@@ -84,12 +81,13 @@ function SetupCredProvider{
 #Workaround for https://github.com/microsoft/msbuild/issues/4430
 function InstallDotNetSdkAndRestoreArcade {
   $dotnetTempDir = "$RepoRoot\dotnet"
-  $dotnetSdkVersion="2.1.507"
+  $dotnetSdkVersion="2.1.507" # After experimentation we know this version works when restoring the SDK (compared to 3.0.*)
   $dotnet = "$dotnetTempDir\dotnet.exe"
   $restoreProjPath = "$PSScriptRoot\restore.proj"
   
   Write-Host "Installing dotnet SDK version $dotnetSdkVersion to restore Arcade SDK..."
   InstallDotNetSdk "$dotnetTempDir" "$dotnetSdkVersion"
+  '<Project Sdk="Microsoft.DotNet.Arcade.Sdk"/>' | Out-File "$restoreProjPath"
 
   & $dotnet restore $restoreProjPath
 

--- a/eng/common/internal-feed-operations.sh
+++ b/eng/common/internal-feed-operations.sh
@@ -58,12 +58,9 @@ function SetupCredProvider {
   if [ ${#endpoints} -gt 2 ]; then 
       # Create the JSON object. It should look like '{"endpointCredentials": [{"endpoint":"http://example.index.json", "username":"optional", "password":"accesstoken"}]}'
       local endpointCredentials="{\"endpointCredentials\": "$endpoints"}"
-      local restoreProjPath="$repo_root/eng/common/restore.proj"
 
       echo "##vso[task.setvariable variable=VSS_NUGET_EXTERNAL_FEED_ENDPOINTS]$endpointCredentials"
       echo "##vso[task.setvariable variable=NUGET_CREDENTIALPROVIDER_SESSIONTOKENCACHE_ENABLED]False"
-
-      echo "<Project Sdk=\"Microsoft.DotNet.Arcade.Sdk\"/>" > "$restoreProjPath"
   else
     echo "No internal endpoints found in NuGet.config"
   fi
@@ -72,8 +69,12 @@ function SetupCredProvider {
 # Workaround for https://github.com/microsoft/msbuild/issues/4430
 function InstallDotNetSdkAndRestoreArcade {
   local dotnetTempDir="$repo_root/dotnet"
-  local dotnetSdkVersion="2.1.507"
+  local dotnetSdkVersion="2.1.507" # After experimentation we know this version works when restoring the SDK (compared to 3.0.*)
+  local restoreProjPath="$repo_root/eng/common/restore.proj"
+  
   echo "Installing dotnet SDK version $dotnetSdkVersion to restore Arcade SDK..."
+  echo "<Project Sdk=\"Microsoft.DotNet.Arcade.Sdk\"/>" > "$restoreProjPath"
+  
   InstallDotNetSdk "$dotnetTempDir" "$dotnetSdkVersion"
 
   local res=`$dotnetTempDir/dotnet restore $restoreProjPath`

--- a/eng/common/internal-feed-operations.sh
+++ b/eng/common/internal-feed-operations.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+function SetupCredProvider {
+  local authToken=$1
+  
+  # Install the Cred Provider NuGet plugin
+  echo "Setting up Cred Provider NuGet plugin in the agent..."...
+  echo "Getting 'installcredprovider.ps1' from 'https://github.com/microsoft/artifacts-credprovider'..."
+
+  local url="https://raw.githubusercontent.com/microsoft/artifacts-credprovider/master/helpers/installcredprovider.sh"  
+  
+  echo "Writing the contents of 'installcredprovider.ps1' locally..."
+  local installcredproviderPath="installcredprovider.sh"
+  if command -v curl > /dev/null; then
+    curl $url > "$installcredproviderPath"
+  else   
+    wget -q -O "$installcredproviderPath" "$url"
+  fi
+  
+  echo "Installing plugin..."
+  . "$installcredproviderPath"
+  
+  echo "Deleting local copy of 'installcredprovider.sh'..."
+  rm installcredprovider.sh
+
+  if [ ! -d "$HOME/.nuget/plugins" ]; then
+    echo "CredProvider plugin was not installed correctly!"
+    ExitWithExitCode 1  
+  else 
+    echo "CredProvider plugin was installed correctly!"
+  fi
+
+  # Then, we set the 'VSS_NUGET_EXTERNAL_FEED_ENDPOINTS' environment variable to restore from the stable 
+  # feeds successfully
+
+  local nugetConfigPath="$repo_root/NuGet.config"
+
+  if [ ! "$nugetConfigPath" ]; then
+    echo "NuGet.config file not found in repo's root!"
+    ExitWithExitCode 1  
+  fi
+  
+  local endpoints='['
+  local nugetConfigPackageValues=`cat "$nugetConfigPath" | grep "key=\"darc-"`
+  local pattern="value=\"(.*)\""
+
+  for value in $nugetConfigPackageValues 
+  do
+    if [[ $value =~ $pattern ]]; then
+      local endpoint="${BASH_REMATCH[1]}"  
+      endpoints+="{\"endpoint\": \"$endpoint\", \"password\": \"$authToken\"},"
+    fi
+  done
+  
+  endpoints=${endpoints%?}
+  endpoints+=']'
+
+  if [ ${#endpoints} -gt 2 ]; then 
+      # Create the JSON object. It should look like '{"endpointCredentials": [{"endpoint":"http://example.index.json", "username":"optional", "password":"accesstoken"}]}'
+      local endpointCredentials="{\"endpointCredentials\": "$endpoints"}"
+      local restoreProjPath="$repo_root/eng/common/restore.proj"
+
+      echo "##vso[task.setvariable variable=VSS_NUGET_EXTERNAL_FEED_ENDPOINTS]$endpointCredentials"
+      echo "##vso[task.setvariable variable=NUGET_CREDENTIALPROVIDER_SESSIONTOKENCACHE_ENABLED]False"
+
+      echo "<Project Sdk=\"Microsoft.DotNet.Arcade.Sdk\"/>" > "$restoreProjPath"
+  else
+    echo "No internal endpoints found in NuGet.config"
+  fi
+} 
+
+# Workaround for https://github.com/microsoft/msbuild/issues/4430
+function InstallDotNetSdkAndRestoreArcade {
+  local dotnetTempDir="$repo_root/dotnet"
+  local dotnetSdkVersion="2.1.507" # After experimentation we know this version works when restoring the SDK (compared to 3.0.*)
+  echo "Installing dotnet SDK version $dotnetSdkVersion to restore Arcade SDK..."
+  InstallDotNetSdk "$dotnetTempDir" "$dotnetSdkVersion"
+
+  local res=`$dotnetTempDir/dotnet restore $restoreProjPath`
+  echo "Arcade SDK restored!"
+
+  # Cleanup
+  if [ "$restoreProjPath" ]; then
+    rm "$restoreProjPath"
+  fi
+
+  if [ "$dotnetTempDir" ]; then
+    rm -r $dotnetTempDir
+  fi
+}
+
+source="${BASH_SOURCE[0]}"
+operation=''
+authToken=''
+repoName=''
+
+while [[ $# > 0 ]]; do
+  opt="$(echo "$1" | awk '{print tolower($0)}')"
+  case "$opt" in
+    --operation)
+      operation=$2
+      shift
+      ;;
+    --authtoken)
+      authToken=$2
+      shift
+      ;;
+    *)
+      echo "Invalid argument: $1"
+      usage
+      exit 1
+      ;;
+  esac
+
+  shift
+done
+
+while [[ -h "$source" ]]; do
+  scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+  source="$(readlink "$source")"
+  # if $source was a relative symlink, we need to resolve it relative to the path where the
+  # symlink file was located
+  [[ $source != /* ]] && source="$scriptroot/$source"
+done
+scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+
+. "$scriptroot/tools.sh"
+
+if [ "$operation" = "setup" ]; then
+  SetupCredProvider $authToken
+elif [ "$operation" = "install-restore" ]; then
+  InstallDotNetSdkAndRestoreArcade
+else
+  echo "Unknown operation '$operation'!"
+fi

--- a/eng/common/internal-feed-operations.sh
+++ b/eng/common/internal-feed-operations.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
-# Sets VSS_NUGET_EXTERNAL_FEED_ENDPOINTS based on the "darc-int-*" feeds defined in NuGet.config. This is needed by
+set -e
+
+# Sets VSS_NUGET_EXTERNAL_FEED_ENDPOINTS based on the "darc-int-*" feeds defined in NuGet.config. This is needed
 # in build agents by CredProvider to authenticate the restore requests to internal feeds as specified in
-# https://github.com/microsoft/artifacts-credprovider#environment-variables. This should ONLY be called from identified
-# internal builds
+# https://github.com/microsoft/artifacts-credprovider/blob/0f53327cd12fd893d8627d7b08a2171bf5852a41/README.md#environment-variables. 
+# This should ONLY be called from identified internal builds
 function SetupCredProvider {
   local authToken=$1
   

--- a/eng/common/internal-feed-operations.sh
+++ b/eng/common/internal-feed-operations.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Sets VSS_NUGET_EXTERNAL_FEED_ENDPOINTS based on the "darc-int-*" feeds defined in NuGet.config. This is needed by
+# in build agents by CredProvider to authenticate the restore requests to internal feeds as specified in
+# https://github.com/microsoft/artifacts-credprovider#environment-variables. This should ONLY be called from identified
+# internal builds
 function SetupCredProvider {
   local authToken=$1
   

--- a/eng/common/internal-feed-operations.sh
+++ b/eng/common/internal-feed-operations.sh
@@ -72,7 +72,7 @@ function SetupCredProvider {
 # Workaround for https://github.com/microsoft/msbuild/issues/4430
 function InstallDotNetSdkAndRestoreArcade {
   local dotnetTempDir="$repo_root/dotnet"
-  local dotnetSdkVersion="2.1.507" # After experimentation we know this version works when restoring the SDK (compared to 3.0.*)
+  local dotnetSdkVersion="2.1.507"
   echo "Installing dotnet SDK version $dotnetSdkVersion to restore Arcade SDK..."
   InstallDotNetSdk "$dotnetTempDir" "$dotnetSdkVersion"
 


### PR DESCRIPTION
These scripts expose a way to add the internal AzDO artifact feed operations specified in NuGet,config to the envvar the CredProvider checks to get the required tokens as defined [here](https://github.com/dotnet/arcade/issues/2954).

These also exposes a way to install dotnet SDK 2.1.507 since in order to restore the Arcade SDK since for 3.0.* versions this breaks. Currently tracked by https://github.com/microsoft/msbuild/issues/4430.

Final test build here: https://dnceng.visualstudio.com/internal/_build/results?buildId=227495

Failure in Publish to Build Asset Registry is known since I'm not including any YAML files. Also, it fails since there is an internal feed in NuGet.config, something which there won't be soon.