### PR TITLE
Enable xunit analyzers on condition and fix test sdk

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.props
@@ -14,10 +14,12 @@
 
     <!-- xunit -->
     <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsPackageVersion)" />
-    <PackageReference Include="xunit.core" Version="$(XUnitPackageVersion)" ExcludeAssets="build" />
-    <PackageReference Include="xunit.assert" Version="$(XUnitPackageVersion)" />
+    <!-- Excluding build as xunit.core enables deps file generation. -->
+    <PackageReference Include="xunit" Version="$(XUnitPackageVersion)" ExcludeAssets="build" />
     <PackageReference Condition="'$(BuildingNetCoreAppVertical)' == 'true'" Include="Microsoft.DotNet.XUnitConsoleRunner" Version="$(MicrosoftDotNetXUnitConsoleRunnerPackageVersion)" />
     <PackageReference Condition="'$(BuildingNetFxVertical)' == 'true'" Include="xunit.runner.console" Version="$(XUnitPackageVersion)" />
+
+    <PackageReference Condition="'$(ContinuousIntegrationBuild)' != 'true' and '$(OfficialBuildId)' == ''" Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" IncludeAssets="build" />
   </ItemGroup>
 
   <ItemGroup>
@@ -43,7 +45,6 @@
     Microsoft.NET.Test.Sdk brings framework assemblies with it: https://github.com/microsoft/vstest/issues/1764
   -->
   <ItemGroup Condition="'$(BuildingNetCoreAppVertical)' == 'true' and '$(ContinuousIntegrationBuild)' != 'true' and '$(OfficialBuildId)' == ''">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" IncludeAssets="build" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
     <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="$(MicrosoftNETTestSdkPackageVersion)" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
@@ -100,6 +100,16 @@
 
   </Target>
 
+  <!-- Work around https://github.com/dotnet/sdk/issues/968 -->
+  <Target Name="RemoveXUnitAnalyzer"
+          Condition="'$(EnableXUnitAnalyzer)' != 'true'"
+          BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <Analyzer Remove="@(Analyzer)"
+                Condition="'%(Analyzer.NuGetPackageId)' == 'xunit.analyzers'" />
+    </ItemGroup>
+  </Target>
+
   <!-- Setup run commands. -->
   <Choose>
 


### PR DESCRIPTION
This allows us to turn on the xunit.analyzers package by setting `EnableXUnitAnalyzer` to true. Additionally this now references the xunit meta-package instead of the individual ones and adds a target to remove the xunit.analyzers as ExcludeAssets="anylzers" is not propagating correctly to transitives. Also I'm moving the Microsoft.Net.Test.Sdk package reference out of the netcoreapp condition to make it work again with netfx and uap.