### PR TITLE
Declare `scriptroot` before its usage

### DIFF
--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -356,10 +356,10 @@ function MSBuild-Core {
   }
 }
 
-. "$scriptroot/pipeline-logging-functions.sh"
-
 ResolvePath "${BASH_SOURCE[0]}"
 _script_dir=`dirname "$_ResolvePath"`
+
+. "$_script_dir/pipeline-logging-functions.sh"
 
 eng_root=`cd -P "$_script_dir/.." && pwd`
 repo_root=`cd -P "$_script_dir/../.." && pwd`


### PR DESCRIPTION
Following error is reported (and ignored) when building CoreCLR:

```sh
...
...
Checking prerequisites...
/datadrive/projects/coreclr/eng/common/tools.sh: line 359: /pipeline-logging-functions.sh: No such file or directory
/datadrive/projects/coreclr/eng/common/tools.sh: line 359: /pipeline-logging-functions.sh: No such file or directory
Laying out dynamically generated EventSource classes
...
...
```