### PR TITLE
Allow defining build metadata on the command-line

### DIFF
--- a/Documentation/DependencyFlowOnboardingWithoutArcade.md
+++ b/Documentation/DependencyFlowOnboardingWithoutArcade.md
@@ -89,7 +89,9 @@ Generate a manifest
 
 If all of your packages are "shipping" packages, you can just specify the `PackagesToPublishPattern` on the command-line and you do not need to include the "GenerateBuildManifest.props" file mentioned above...
 
-> `powershell -ExecutionPolicy Bypass -Command "eng\common\sdk-task.ps1 -restore -task GenerateBuildManifest /p:PackagesToPublishPattern=e:\gh\chcosta\arcade\artifacts\packages\Debug\NonShipping\*.nupkg /p:AssetManifestFilePath=e:\gh\chcosta\feed2\manifest.xml"`
+> `powershell -ExecutionPolicy Bypass -Command "eng\common\sdk-task.ps1 -restore -task GenerateBuildManifest /p:PackagesToPublishPattern=e:\gh\chcosta\arcade\artifacts\packages\Debug\NonShipping\*.nupkg /p:AssetManifestFilePath=e:\gh\chcosta\feed2\manifest.xml" /p:ManifestBuildData="Location=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json"`
+
+`ManifestBuildData` is used to to provide the "location" metadata which identifies where the assets have been / will be published to (ie, the feed url).
 
 For more control over your assets, you can exclude the `PackagesToPublishPattern` option from the command-line but include "GenerateBuildManifest.props" in your repo.  This will allow you to specify packages that are shipping vs non-shipping (shipping is the default).  More details about shipping are included [here](https://github.com/dotnet/arcade/blob/b0c930c2b44acd03671552f52b925183db0fc8ea/Documentation/Darc.md#gathering-a-build-drop).
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/GenerateBuildManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/GenerateBuildManifest.proj
@@ -30,6 +30,7 @@
     <GenerateBuildManifest Artifacts="@(ItemsToPush)"
                            OutputPath="$(AssetManifestFilePath)"
                            BuildId="$(BUILD_BUILDNUMBER)"
+                           BuildData="$(ManifestBuildData)"
                            RepoUri="$(BUILD_REPOSITORY_URI)"
                            RepoBranch="$(BUILD_SOURCEBRANCH)"
                            RepoCommit="$(BUILD_SOURCEVERSION)" />


### PR DESCRIPTION
@singhsarab was encountering this error when trying to manually generate a manifest...

```
E:\gh\chcosta\arcade\.packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19311.2\tools\SdkTasks\GenerateBuildManifest.proj(30,5): error : Missing 'location' property from ManifestBuildData
```

There's no way to flow the location metadata explicitly, you can only define it via an MSBuild props file.  This change permits defining additional metadata on the command-line.