### PR TITLE
Allow long paths in branch-merge script

### DIFF
--- a/scripts/GitHubMergeBranches.ps1
+++ b/scripts/GitHubMergeBranches.ps1
@@ -168,6 +168,8 @@ function GetOrCreateFork() {
 
 $workDir = "$PSScriptRoot/obj/$RepoOwner/$RepoName"
 New-Item "$PSScriptRoot/obj/" -ItemType Directory -ErrorAction Ignore | Out-Null
+            
+Invoke-Block { & git config --system core.longpaths true }
 
 $fetch = $true
 if (-not (Test-Path $workDir)) {


### PR DESCRIPTION
Resolves https://github.com/dotnet/core-setup/issues/6610

Allows for long paths in the branch-merge job - previously the job failed due to https://github.com/dotnet/core-setup/blob/master/src/test/Assets/TestProjects/AppWithSubDirs/Sentence/This%20is%20a%20really%2C%20really%2C%20really%2C%20really%2C%20really%2C%20really%2C%20really%2C%20really%2C%20really%2C%20really%2C%20really%2C%20really%2C%20really%2C%20really%20long%20file%20name%20for%20punctuation/word.

I ran a test job with this change & it succeeded.

CC @dagood @swaroop-sridhar 