### PR TITLE
Fix VS project load error and remove verticals

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/Microsoft.DotNet.CoreFxTesting.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/Microsoft.DotNet.CoreFxTesting.targets
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <!-- Copies the app.config file to the OutDir. -->
-    <TestRuntimeTemplateConfigPath Condition="'$(TestRuntimeTemplateConfigPath)' == '' and '$(BuildingNETFxVertical)' == 'true'">$(TestAssetsDir)netfx.exe.config</TestRuntimeTemplateConfigPath>
+    <TestRuntimeTemplateConfigPath Condition="'$(TestRuntimeTemplateConfigPath)' == '' and '$(TargetFrameworkIdentifier)' == '.NETFramework'">$(TestAssetsDir)netfx.exe.config</TestRuntimeTemplateConfigPath>
 
     <!-- By default copy the test runtime config file for executable test projects (+ test support projects). -->
     <GenerateRuntimeConfigurationFiles Condition="'$(IsTestProject)' == 'true' and ('$(IsTestSupportProject)' != 'true' or '$(OutputType.ToLower())' == 'exe')">true</GenerateRuntimeConfigurationFiles>
@@ -17,7 +17,7 @@
 
   <ItemGroup Condition="'$(GenerateRuntimeConfigurationFiles)' == 'true'">
     <None Include="$(TestRuntimeTemplateConfigPath)"
-          Condition="'$(BuildingNETFxVertical)' == 'true'"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'"
           Link="$(TargetName).exe.config"
           CopyToOutputDirectory="PreserveNewest"
           Visible="false" />
@@ -27,11 +27,11 @@
       Tracking issue: https://github.com/dotnet/sdk/issues/1675
     -->
     <ContentWithTargetPath Include="$(ProjectDepsFilePath)"
-                           Condition="'$(BuildingNETCoreAppVertical)' == 'true' and '$(GenerateDependencyFile)' == 'true'"
+                           Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(GenerateDependencyFile)' == 'true'"
                            CopyToOutputDirectory="PreserveNewest"
                            TargetPath="$(ProjectDepsFileName)" />
     <ContentWithTargetPath Include="$(ProjectRuntimeConfigFilePath)"
-                           Condition="'$(BuildingNETCoreAppVertical)' == 'true'"
+                           Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
                            CopyToOutputDirectory="PreserveNewest"
                            TargetPath="$(ProjectRuntimeConfigFileName)" />
   </ItemGroup>
@@ -88,7 +88,7 @@
   </Target>
 
   <!-- UAP resource generation needed by both source and test projects. -->
-  <Import Condition="'$(BuildingUAPVertical)' == 'true'" Project="$(MSBuildThisFileDirectory)Resources.uap.targets" />
+  <Import Condition="'$(TargetFrameworkIdentifier)' == 'UAP'" Project="$(MSBuildThisFileDirectory)Resources.uap.targets" />
 
   <!-- Full coverage report. -->
   <Import Condition="'$(EnableFullCoverageReportTarget)' == 'true' and '$(SkipCoverageReport)' != 'true' and '$(Coverage)' == 'true'" Project="$([MSBuild]::NormalizePath('$(TestCoreDir)', 'coverage', 'CoverageReport.targets'))" />

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.props
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <!-- Set env variable to use the local netfx assemblies instead of the ones in the GAC. -->
-  <ItemGroup Condition="'$(BuildingNETFxVertical)' == 'true'">
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <RunScriptCommands Include="set DEVPATH=%RUNTIME_PATH%" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
@@ -167,7 +167,7 @@
 
   </Target>
 
-  <Import Condition="'$(BuildingUAPVertical)' == 'true'" Project="$(MSBuildThisFileDirectory)Core.uap.targets" />
+  <Import Condition="'$(TargetFrameworkIdentifier)' == 'UAP'" Project="$(MSBuildThisFileDirectory)Core.uap.targets" />
 
   <!--
     LaunchSettings.json support.

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.props
@@ -16,8 +16,8 @@
     <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsPackageVersion)" />
     <!-- Excluding build as xunit.core enables deps file generation. -->
     <PackageReference Include="xunit" Version="$(XUnitPackageVersion)" ExcludeAssets="build" />
-    <PackageReference Condition="'$(BuildingNetCoreAppVertical)' == 'true'" Include="Microsoft.DotNet.XUnitConsoleRunner" Version="$(MicrosoftDotNetXUnitConsoleRunnerPackageVersion)" />
-    <PackageReference Condition="'$(BuildingNetFxVertical)' == 'true'" Include="xunit.runner.console" Version="$(XUnitPackageVersion)" />
+    <PackageReference Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" Include="Microsoft.DotNet.XUnitConsoleRunner" Version="$(MicrosoftDotNetXUnitConsoleRunnerPackageVersion)" />
+    <PackageReference Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" Include="xunit.runner.console" Version="$(XUnitPackageVersion)" />
 
     <PackageReference Condition="'$(ContinuousIntegrationBuild)' != 'true' and '$(OfficialBuildId)' == ''" Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" IncludeAssets="build" />
   </ItemGroup>
@@ -30,12 +30,12 @@
     <!-- Copy test runner to output directory -->
     <None Include="$([System.IO.Path]::GetDirectoryName('$(XunitConsole472Path)'))\*"
           Exclude="$([System.IO.Path]::GetDirectoryName('$(XunitConsole472Path)'))\xunit.console.*exe.config;$([System.IO.Path]::GetDirectoryName('$(XunitConsole472Path)'))\xunit.console.x86.exe"
-          Condition="'$(BuildingNetFxVertical)' == 'true'"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(XunitConsole472Path)' != ''"
           CopyToOutputDirectory="PreserveNewest"
           Visible="false" />
     <None Include="$([System.IO.Path]::GetDirectoryName('$(XunitConsoleNetCore21AppPath)'))\*"
           Exclude="$([System.IO.Path]::GetDirectoryName('$(XunitConsoleNetCore21AppPath)'))\xunit.console.deps.json"
-          Condition="'$(BuildingNetCoreAppVertical)' == 'true'"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(XunitConsoleNetCore21AppPath)' != ''"
           CopyToOutputDirectory="PreserveNewest"
           Visible="false" />
   </ItemGroup>
@@ -44,7 +44,7 @@
     Only add the Test SDK with assemblies when building locally for .NET Core.
     Microsoft.NET.Test.Sdk brings framework assemblies with it: https://github.com/microsoft/vstest/issues/1764
   -->
-  <ItemGroup Condition="'$(BuildingNetCoreAppVertical)' == 'true' and '$(ContinuousIntegrationBuild)' != 'true' and '$(OfficialBuildId)' == ''">
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(ContinuousIntegrationBuild)' != 'true' and '$(OfficialBuildId)' == ''">
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
     <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="$(MicrosoftNETTestSdkPackageVersion)" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
@@ -2,7 +2,7 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
 
-  <PropertyGroup Condition="'$(BuildingUAPVertical)' == 'true'">
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == 'UAP'">
     <!--
       Inside an AppContainer we can't write into the WorkingDirectory. As System.IO is used
       to write the results file we can't use the documents folder either. Therefore we write
@@ -14,8 +14,8 @@
   <!-- General xunit options -->
   <PropertyGroup>
     <RunArguments>$(TestAssembly)</RunArguments>
-    <RunArguments Condition="'$(BuildingUAPVertical)' != 'true'">$(RunArguments) -xml $(TestResultsName)</RunArguments>
-    <RunArguments Condition="'$(BuildingUAPVertical)' == 'true'">$(RunArguments) -xml $(UAPResultsPathCmd)</RunArguments>
+    <RunArguments Condition="'$(TargetFrameworkIdentifier)' != 'UAP'">$(RunArguments) -xml $(TestResultsName)</RunArguments>
+    <RunArguments Condition="'$(TargetFrameworkIdentifier)' == 'UAP'">$(RunArguments) -xml $(UAPResultsPathCmd)</RunArguments>
     <RunArguments>$(RunArguments) -nologo</RunArguments>
     <RunArguments Condition="'$(ArchiveTest)' == 'true'">$(RunArguments) -nocolor</RunArguments>
     <RunArguments>$(RunArguments) -notrait category=non$(_bc_TargetGroup)tests</RunArguments>
@@ -32,8 +32,8 @@
     <RunArguments Condition="'$(XUnitMethodName)' != ''">$(RunArguments) -method $(XUnitMethodName)</RunArguments>
     <RunArguments Condition="'$(XUnitClassName)' != ''">$(RunArguments) -class $(XUnitClassName)</RunArguments>
     <!-- There's no verbose switch in the XUnitRunnerUap. -->
-    <RunArguments Condition="'$(XUnitShowProgress)' == 'true' AND '$(BuildingUAPVertical)' != 'true'">$(RunArguments) -verbose</RunArguments>
-    <RunArguments Condition="'$(BuildingNETFxVertical)' == 'true' and '$(XUnitNoAppdomain)' == 'true'">$(RunArguments) -noappdomain</RunArguments>
+    <RunArguments Condition="'$(XUnitShowProgress)' == 'true' AND '$(TargetFrameworkIdentifier)' != 'UAP'">$(RunArguments) -verbose</RunArguments>
+    <RunArguments Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(XUnitNoAppdomain)' == 'true'">$(RunArguments) -noappdomain</RunArguments>
 
     <!-- Legacy Outerloop switch -->
     <TestScope Condition="'$(TestScope)' == '' and '$(Outerloop)' == 'true'">all</TestScope>
@@ -68,21 +68,21 @@
 
   <!-- Overwrite the runner config file with the app local one. -->
   <Target Name="OverwriteTestRunnerConfigFile"
-          Condition="'$(BuildingNETFxVertical)' == 'true' or '$(BuildingNetCoreAppVertical)' == 'true'"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' or '$(TargetFrameworkIdentifier)' == '.NETCore'"
           AfterTargets="CopyFilesToOutputDirectory">
 
     <PropertyGroup>
       <TestRunnerNameWithoutExtension>$([System.IO.Path]::GetFileNameWithoutExtension('$(TestRunnerName)'))</TestRunnerNameWithoutExtension>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(BuildingNETFxVertical)' == 'true'">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
       <_testRunnerConfigSourceFile Include="$(TargetDir)$(TargetName).exe.config" Condition="'$(GenerateRuntimeConfigurationFiles)' == 'true'" />
       <_testRunnerConfigSourceFile Include="$(TargetDir)$(TargetName).exe.config" Condition="'$(IncludeRemoteExecutor)' == 'true'" />
       <_testRunnerConfigDestFile Include="$(TargetDir)$(TestRunnerName).config" Condition="'$(GenerateRuntimeConfigurationFiles)' == 'true'" />
       <_testRunnerConfigDestFile Include="$(TargetDir)Microsoft.DotNet.RemoteExecutorHost.exe.config" Condition="'$(IncludeRemoteExecutor)' == 'true'" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(BuildingNetCoreAppVertical)' == 'true'">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
       <_testRunnerConfigSourceFile Include="$(ProjectRuntimeConfigFilePath)" Condition="Exists('$(ProjectRuntimeConfigFilePath)')" />
       <_testRunnerConfigSourceFile Include="$(ProjectRuntimeConfigDevFilePath)" Condition="Exists('$(ProjectRuntimeConfigDevFilePath)')" />
       <_testRunnerConfigSourceFile Include="$(ProjectRuntimeConfigFilePath)" Condition="Exists('$(ProjectRuntimeConfigFilePath)') and '$(IncludeRemoteExecutor)' == 'true'" />
@@ -113,7 +113,7 @@
   <!-- Setup run commands. -->
   <Choose>
 
-    <When Condition="'$(BuildingNETCoreAppVertical)' == 'true'">
+    <When Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
       <PropertyGroup>
         <TestRunnerName>xunit.console.dll</TestRunnerName>
         <RunCommand>"$(RunScriptHost)"</RunCommand>
@@ -121,14 +121,14 @@
       </PropertyGroup>
     </When>
 
-    <When Condition="'$(BuildingNETFxVertical)' == 'true'">
+    <When Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
       <PropertyGroup>
         <TestRunnerName>xunit.console.exe</TestRunnerName>
         <RunCommand>$(TestRunnerName)</RunCommand>
       </PropertyGroup>
     </When>
 
-    <When Condition="'$(BuildingUAPVertical)' == 'true'">
+    <When Condition="'$(TargetFrameworkIdentifier)' == 'UAP'">
       <PropertyGroup>
         <!-- Globally registered UWP console app. -->
         <TestRunnerName>XUnitRunnerUap</TestRunnerName>


### PR DESCRIPTION
@stephentoub this fixes the VS load error as it seems VS doesn't load the generated props and target files from package references correctly.

Additionally replacing the verticals with `TargetFrameworkIdentifier` properties.