### PR TITLE
Add IsInternal and IsStable variable artifacts

### DIFF
--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -60,27 +60,18 @@ jobs:
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}
     - task: powershell@2
-      displayName: Create BARBuildId Artifact
+      displayName: Create ReleaseConfigs Artifact
       inputs:
         targetType: inline
         script: |
-          Add-Content -Path  "$(Build.StagingDirectory)/BARBuildId.txt" -Value $(BARBuildId)
-    - task: powershell@2
-      displayName: Create Channels Artifact
-      inputs:
-        targetType: inline
-        script: |
-          Add-Content -Path  "$(Build.StagingDirectory)/Channels.txt" -Value "$(DefaultChannels)"
+          Add-Content -Path "$(Build.StagingDirectory)/ReleaseConfigs.txt" -Value $(BARBuildId)
+          Add-Content -Path "$(Build.StagingDirectory)/ReleaseConfigs.txt" -Value "$(DefaultChannels)"
+          Add-Content -Path "$(Build.StagingDirectory)/ReleaseConfigs.txt" -Value $(IsInternalBuild)
+          Add-Content -Path "$(Build.StagingDirectory)/ReleaseConfigs.txt" -Value $(IsStableBuild)
     - task: PublishBuildArtifacts@1
-      displayName: Publish BAR BuildId to VSTS
+      displayName: Publish ReleaseConfigs Artifact
       inputs:
-        PathtoPublish: '$(Build.StagingDirectory)/BARBuildId.txt'
-        PublishLocation: Container
-        ArtifactName: ReleaseConfigs
-    - task: PublishBuildArtifacts@1
-      displayName: Publish Channels to VSTS
-      inputs:
-        PathtoPublish: '$(Build.StagingDirectory)/Channels.txt'
+        PathtoPublish: '$(Build.StagingDirectory)/ReleaseConfigs.txt'
         PublishLocation: Container
         ArtifactName: ReleaseConfigs
     - ${{ if eq(parameters.enablePublishBuildArtifacts, 'true') }}:

--- a/eng/common/templates/post-build/setup-maestro-vars.yml
+++ b/eng/common/templates/post-build/setup-maestro-vars.yml
@@ -17,22 +17,34 @@ jobs:
         targetType: inline
         script: |
           # This is needed to make Write-PipelineSetVariable works in this context
-          if ($env:BUILD_BUILDNUMBER -ne "" -and $env:BUILD_BUILDNUMBER -ne $null) {
-            $ci = $true
+          $ci = $true
 
-            . "$(Build.SourcesDirectory)/eng/common/tools.ps1"
-              
-            $BarId = Get-Content "$(Build.StagingDirectory)/ReleaseConfigs/BARBuildId.txt" 
-            Write-PipelineSetVariable -Name 'BARBuildId' -Value $BarId
+          . "$(Build.SourcesDirectory)/eng/common/tools.ps1"
 
-            Write-Host "Asked Write-PipelineSetVariable to create BARBuildId with value '$BarId'"
+          # This check is just temporary while we transition from having separate files
+          # for each variable to a single file for all variables.
+          if (Test-Path -Path "$(Build.StagingDirectory)/ReleaseConfigs/ReleaseConfigs.txt") {
+            $Content = Get-Content "$(Build.StagingDirectory)/ReleaseConfigs/ReleaseConfigs.txt"
 
+            $BarId = $Content | Select -Index 0
+            
             $Channels = ""
-            Get-Content "$(Build.StagingDirectory)/ReleaseConfigs/Channels.txt" | ForEach-Object { $Channels += "$_ ," }
-            Write-PipelineSetVariable -Name 'InitialChannels' -Value "$Channels"
-
-            Write-Host "Asked Write-PipelineSetVariable to create InitialChannels with value '$Channels'"
+            $Channels = $Content | Select -Index 1 | ForEach-Object { $Channels += "$_ ," }
+            
+            $IsInternalBuild = $Content | Select -Index 2
+            $IsStableBuild = $Content | Select -Index 3
           }
           else {
-            Write-Host "This step can only be run in an Azure DevOps CI environment."
+            $BarId = Get-Content "$(Build.StagingDirectory)/ReleaseConfigs/BARBuildId.txt" 
+
+            $Channels = ""
+            Get-Content "$(Build.StagingDirectory)/ReleaseConfigs/Channels.txt" | ForEach-Object { $Channels += "$_ ," }        
+
+            $IsInternalBuild = "false"
+            $IsStableBuild = "false"
           }
+
+          Write-PipelineSetVariable -Name 'BARBuildId' -Value $BarId
+          Write-PipelineSetVariable -Name 'InitialChannels' -Value "$Channels"
+          Write-PipelineSetVariable -Name 'IsInternalBuild' -Value $IsInternalBuild
+          Write-PipelineSetVariable -Name 'IsStableBuild' -Value $IsStableBuild


### PR DESCRIPTION
Relates to: https://github.com/dotnet/arcade/issues/1789

Since AzDO doesn't support communicating variables across stages we need to use artifacts to communicate values across stages.

This PR adds two new variables/artifacts: IsInternalBuild and IsStableBuild variable artifacts and do some refactoring to use just a single file to store the values instead of multiple files. 