### PR TITLE
Add new sdk-task that is able to handle different target feed types

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
@@ -28,7 +28,7 @@
   <Import Project="SetupTargetFeeds.proj" />
 
   <Target Name="Execute" DependsOnTargets="SetupTargetFeeds">
-    <Error Condition="'$(ManifestsBasePath)' == ''" Text="ManifestsBasePath is empty. Please inform full path to asset manifest(s) directory." />
+    <Error Condition="'$(ManifestsBasePath)' == ''" Text="ManifestsBasePath is empty. Please provide the full path to asset manifest(s) directory." />
     <Error Condition="'$(BlobBasePath)' == '' OR '$(PackageBasePath)' == ''" Text="A valid full path to BlobBasePath and PackageBasePath is required." />
 
     <ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
@@ -1,0 +1,59 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Execute">
+  <!--
+    The target in this file initially calls `SetupTargetFeeds.proj` to create the list of
+    target feed descriptors for the artifacts and then calls the `PublishArtifactsInManifest` 
+    task (from Tasks.Feed) to publish the artifacts described in the informed build manifest.
+    
+    Parameters:
+      - ManifestsBasePath
+      - BlobBasePath
+      - PackageBasePath
+      - BARBuildId
+      - MaestroApiEndpoint
+      - BuildAssetRegistryToken
+      - NugetPath
+
+    Parameters required by SetupTargetFeeds.proj:
+      - IsInternalBuild
+      - IsStableBuild
+      - ChannelId
+      - TargetFeedPAT
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <Import Project="SetupTargetFeeds.proj" />
+
+  <Target Name="Execute" DependsOnTargets="SetupTargetFeeds">
+    <Error Condition="'$(ManifestsBasePath)' == ''" Text="ManifestsBasePath is empty. Please inform full path to asset manifest(s) directory." />
+    <Error Condition="'$(BlobBasePath)' == '' OR '$(PackageBasePath)' == ''" Text="A valid full path to BlobBasePath and PackageBasePath is required." />
+
+    <ItemGroup>
+      <ManifestFiles Include="$(ManifestsBasePath)\*.xml" />
+    </ItemGroup>
+
+    <Error
+      Condition="'@(ManifestFiles)' == ''"
+      Text="No manifest file was found in the provided path: $(ManifestsBasePath)" />
+
+    <!-- 
+      **Iterate** publishing assets from each manifest file. 
+    -->
+    <PublishArtifactsInManifest
+      TargetFeedConfig="@(TargetFeedConfig)"
+      BARBuildId="$(BARBuildId)"
+      MaestroApiEndpoint="$(MaestroApiEndpoint)"
+      BuildAssetRegistryToken="$(BuildAssetRegistryToken)"
+      AssetManifestPath="%(ManifestFiles.Identity)"
+      BlobAssetsBasePath="$(BlobBasePath)"
+      PackageAssetsBasePath="$(PackageBasePath)"
+      NugetPath="$(NugetPath)"/>
+  </Target>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="$(MicrosoftDotNetBuildTasksFeedVersion)" />
+  </ItemGroup>
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
@@ -1,0 +1,87 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project>
+  <!--
+    This file main target `SetupTargetFeeds` is used to create an ItemGroup with
+    feed descriptors that will be used for publishing build assets.
+    
+    Parameters:
+      - IsInternalBuild
+      - IsStableBuild
+      - ChannelId
+      - TargetFeedPAT
+  -->
+
+  <Target Name="SetupTargetFeeds">
+    <Error
+      Condition="'$(IsStableBuild)' == ''"
+      Text="Parameter 'IsStableBuild' is empty. A boolean value is required." />
+
+    <Error
+      Condition="'$(IsInternalBuild)' == ''"
+      Text="Parameter 'IsInternalBuild' is empty. A boolean value is required." />
+
+    <Error
+      Condition="'$(ChannelId)' == ''"
+      Text="Parameter 'ChannelId' is empty. The ID of the target channel id BAR is required." />
+
+    <Error
+      Condition="'$(TargetFeedPAT)' == '' and '$(IsStableBuild)' == 'true'"
+      Text="Parameter 'TargetFeedPAT' is empty. The PAT used for creating AzDO feeds is required for publishing stable builds." />
+
+    <!--
+      When a build is stable we ask `CreateAzureDevOpsFeed` in Tasks.Feed to create a new AzDO feed.
+      That feed will be public/internal depending on whether the build is public/internal.
+    -->
+    <CreateAzureDevOpsFeed
+        Condition="'$(IsStableBuild)' == 'true'"
+        IsInternal="$(IsInternalBuild)"
+        RepositoryName="$(RepositoryName)"
+        CommitSha="$(CommitSha)"
+        PersonalAccessToken="$(TargetFeedPAT)">
+      <Output TaskParameter="TargetFeedURL" PropertyName="NewAzDoFeedURL"/>
+    </CreateAzureDevOpsFeed>
+
+    <ItemGroup Condition="'$(IsStableBuild)' == 'true'">
+      <TargetFeedConfig
+        Include="NetCore;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX"
+        TargetURL="$(NewAzDoFeedURL)"
+        Type="AzDoNugetFeed"
+        Token="$(TargetFeedPAT)" />
+    </ItemGroup>
+
+    <!-- Assets for non-stable AND Internal builds are published to a static feed for now. -->
+    <ItemGroup Condition="'@(TargetFeedConfig)' == '' AND '$(IsInternalBuild)' == 'true'">
+      <TargetFeedConfig
+        Include="NetCore;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX"
+        TargetURL="https://dnceng.pkgs.visualstudio.com/_packaging/dotnet-core-internal/nuget/v3/index.json"
+        Type="AzDoNugetFeed"
+        Token="$(TargetFeedPAT)" />
+    </ItemGroup>
+
+    <!-- Public non-stable feed used by `Validation` Channel. -->
+    <ItemGroup Condition="'@(TargetFeedConfig)' == '' AND '$(ChannelId)' == '9'">
+      <TargetFeedConfig
+        Include="NetCore;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX"
+        TargetURL="https://dnceng.pkgs.visualstudio.com/_packaging/dotnet-core-validation-public/nuget/v3/index.json"
+        Type="AzDoNugetFeed"
+        Token="$(TargetFeedPAT)" />
+    </ItemGroup>
+
+    <!-- Public non-stable feed used by `.NET Core 3 Dev` Channel. -->
+    <ItemGroup Condition="'@(TargetFeedConfig)' == '' AND '$(ChannelId)' == '3'">
+      <TargetFeedConfig
+        Include="NetCore;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX"
+        TargetURL="https://dnceng.pkgs.visualstudio.com/_packaging/dotnet-core-public/nuget/v3/index.json"
+        Type="AzDoNugetFeed"
+        Token="$(TargetFeedPAT)" />
+    </ItemGroup>
+
+    <Error
+      Condition="'@(TargetFeedConfig)' == ''"
+      Text="It wasn't possible to determine which target feed configuration to use." />
+
+    <Message
+      Text="Artifact with category '%(TargetFeedConfig.Identity)' should go to %(TargetFeedConfig.Type) -> '%(TargetFeedConfig.TargetURL)'"
+      Importance="high" />
+  </Target>
+</Project>


### PR DESCRIPTION
Relates to: https://github.com/dotnet/arcade/issues/1789

This is a new Arcade.SDK task that will replace the current `PublishToBlobFeed.proj`. The interface of the sdk task changed considerably from the current version... so to prevent problems during the transition from one implementation to the other I decided to create a new one.

The new task support targeting targeting different feeds based on artifact category. The task relies on a new file called `SetupTargetFeeds` to identify which target feed should be used for each different artifact category. `SetupTargetFeeds` in turn relies on a new task in Tasks.Feed to create AzDO feeds for stable builds.

