### PR TITLE
Set $scriptroot in tools.sh

### DIFF
--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
 
+source="${BASH_SOURCE[0]}"
+
+# resolve $source until the file is no longer a symlink
+while [[ -h "$source" ]]; do
+  scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+  source="$(readlink "$source")"
+  # if $source was a relative symlink, we need to resolve it relative to the path where the
+  # symlink file was located
+  [[ $source != /* ]] && source="$scriptroot/$source"
+done
+scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+
 # Initialize variables if they aren't already defined.
 
 # CI mode - set to true on CI server for PR validation build or official build.


### PR DESCRIPTION
The telemetry change started using $scriptroot in this file, but this file doesn't set $scriptroot so it may be the wrong directory or empty if the calling script doesn't set the environment variable