### PR TITLE
Fix xunit session never completes in Visual Studio F5

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/assets/launchSettings.json
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/assets/launchSettings.json
@@ -3,13 +3,13 @@
         ".NET Core xUnit Console": {
             "commandName": "Executable",
             "executablePath": "$(TestHostRootPath)dotnet.exe",
-            "commandLineArgs": "$(RunArguments) -wait -parallel none",
+            "commandLineArgs": "$(RunArguments) -parallel none",
             "workingDirectory": "$(TargetDir)"
         },
         ".NET Framework xUnit Console": {
             "commandName": "Executable",
             "executablePath": "$(TargetDir)xunit.console.exe",
-            "commandLineArgs": "$(RunArguments) -wait -parallel none",
+            "commandLineArgs": "$(RunArguments) -parallel none",
             "workingDirectory": "$(TargetDir)",
             "environmentVariables": {
                 "DEVPATH": "$(TestHostRootPath)"


### PR DESCRIPTION
This was reported in the Gitter channel by the community. The -wait switch isn't needed anymore with the newer VS and causes xunit to never report results.