### PR TITLE
Move away from ServerRS4 queue for helix tests

### DIFF
--- a/tests/UnitTests.proj
+++ b/tests/UnitTests.proj
@@ -72,7 +72,7 @@
   <ItemGroup Condition=" '$(HelixAccessToken)' == '' ">
     <HelixTargetQueue Include="Debian.9.Amd64.Open"/>
     <HelixTargetQueue Include="RedHat.7.Amd64.Open"/>
-    <HelixTargetQueue Include="Windows.10.Amd64.ServerRS4.Open"/>
+    <HelixTargetQueue Include="Windows.10.Amd64.Open"/>
   </ItemGroup>
 
   <PropertyGroup Condition="!$(HelixTargetQueue.StartsWith('Windows'))">


### PR DESCRIPTION
The Windows.10.Amd64.ServerRS4.Open queue sees very heavy usage, with less machines than the normal windows 10 queue. We don't require anything specific to the server RS4 queue.

Windows.10.Amd64.ServerRS4.Open = 60 max scale
Windows.10.Amd64.Open = 300 max scale