### PR TITLE
Allow 'IsWpfTempProject' to be set to prevent duplicate imports when restoring packages in temporary projects

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.props
@@ -6,9 +6,9 @@
     Determine whether the project is WPF temp project.
     Since .NET Framework 4.7.2 WPF temp project name ends with _wpftmp suffix and keeps the language specific extension (e.g. csproj). 
   -->
-  <PropertyGroup>
-    <IsWpfTempProject Condition="'$(IsWpfTempProject)' == '' and $(MSBuildProjectName.EndsWith('_wpftmp'))">true</IsWpfTempProject>
-    <IsWpfTempProject Condition="'$(IsWpfTempProject)' == ''">false</IsWpfTempProject>
+  <PropertyGroup Condition="'$(IsWpfTempProject)' == ''">
+    <IsWpfTempProject >false</IsWpfTempProject>
+    <IsWpfTempProject Condition="$(MSBuildProjectName.EndsWith('_wpftmp'))">true</IsWpfTempProject>
   </PropertyGroup>
 
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.props
@@ -7,8 +7,8 @@
     Since .NET Framework 4.7.2 WPF temp project name ends with _wpftmp suffix and keeps the language specific extension (e.g. csproj). 
   -->
   <PropertyGroup>
-    <IsWpfTempProject>false</IsWpfTempProject>
-    <IsWpfTempProject Condition="$(MSBuildProjectName.EndsWith('_wpftmp'))">true</IsWpfTempProject>
+    <IsWpfTempProject Condition="'$(IsWpfTempProject)' == '' and $(MSBuildProjectName.EndsWith('_wpftmp'))">true</IsWpfTempProject>
+    <IsWpfTempProject Condition="'$(IsWpfTempProject)' == ''">false</IsWpfTempProject>
   </PropertyGroup>
 
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.props
@@ -7,7 +7,7 @@
     Since .NET Framework 4.7.2 WPF temp project name ends with _wpftmp suffix and keeps the language specific extension (e.g. csproj). 
   -->
   <PropertyGroup Condition="'$(IsWpfTempProject)' == ''">
-    <IsWpfTempProject >false</IsWpfTempProject>
+    <IsWpfTempProject>false</IsWpfTempProject>
     <IsWpfTempProject Condition="$(MSBuildProjectName.EndsWith('_wpftmp'))">true</IsWpfTempProject>
   </PropertyGroup>
 


### PR DESCRIPTION
WPF for .NET Core is adding a restore step to temporary project compilation for PackageReferences.  The existing Arcade workaround needs to be temporarily updated to prevent duplicate imports, then removed entirely after the next WPF Preview release.  