### PR TITLE
Remove workarounds in publishing templates

### DIFF
--- a/eng/common/templates/post-build/setup-maestro-vars.yml
+++ b/eng/common/templates/post-build/setup-maestro-vars.yml
@@ -21,28 +21,15 @@ jobs:
 
           . "$(Build.SourcesDirectory)/eng/common/tools.ps1"
 
-          # This check is just temporary while we transition from having separate files
-          # for each variable to a single file for all variables.
-          if (Test-Path -Path "$(Build.StagingDirectory)/ReleaseConfigs/ReleaseConfigs.txt") {
-            $Content = Get-Content "$(Build.StagingDirectory)/ReleaseConfigs/ReleaseConfigs.txt"
+          $Content = Get-Content "$(Build.StagingDirectory)/ReleaseConfigs/ReleaseConfigs.txt"
 
-            $BarId = $Content | Select -Index 0
+          $BarId = $Content | Select -Index 0
+
+          $Channels = ""            
+          $Content | Select -Index 1 | ForEach-Object { $Channels += "$_ ," }
             
-            $Channels = ""
-            $Channels = $Content | Select -Index 1 | ForEach-Object { $Channels += "$_ ," }
-            
-            $IsInternalBuild = $Content | Select -Index 2
-            $IsStableBuild = $Content | Select -Index 3
-          }
-          else {
-            $BarId = Get-Content "$(Build.StagingDirectory)/ReleaseConfigs/BARBuildId.txt" 
-
-            $Channels = ""
-            Get-Content "$(Build.StagingDirectory)/ReleaseConfigs/Channels.txt" | ForEach-Object { $Channels += "$_ ," }        
-
-            $IsInternalBuild = "false"
-            $IsStableBuild = "false"
-          }
+          $IsInternalBuild = $Content | Select -Index 2
+          $IsStableBuild = $Content | Select -Index 3
 
           Write-PipelineSetVariable -Name 'BARBuildId' -Value $BarId
           Write-PipelineSetVariable -Name 'InitialChannels' -Value "$Channels"


### PR DESCRIPTION
We don't need this check anymore. Furthermore, the current implementation is failing.

Here is the build where I tested this: https://dnceng.visualstudio.com/internal/_build/results?buildId=234158&view=results