### PR TITLE
Do CredProvider setup when an 'internal' branch is built

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,7 +106,8 @@ stages:
             $(_ValidateSdkArgs)
             /p:Test=false
           displayName: Windows Build / Publish
-
+          env:
+            InternalFeedPAT: $(InternalFeedAccessToken)
         - powershell: eng\common\build.ps1
             -configuration $(_BuildConfig) 
             -prepareMachine
@@ -167,6 +168,8 @@ stages:
               --prepareMachine
               /p:Test=false
             displayName: Unix Build / Publish
+            env:
+              InternalFeedPAT: $(InternalFeedAccessToken)
           - script: eng/common/build.sh
               --configuration $(_BuildConfig)
               --prepareMachine

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -116,8 +116,8 @@ try {
   
   if ("$env:InternalFeedPAT" -ne "") {
     Write-Host "Building from an internal branch. Setting up CredProvider..."
-    . $PSScriptRoot\internal-feed-operations.ps1 -Operation 'setup' -AuthToken "$env:InternalFeedPAT"
-    . $PSScriptRoot\internal-feed-operations.ps1 -Operation 'install-restore'
+    & $PSScriptRoot\internal-feed-operations.ps1 -Operation 'setup' -AuthToken "$env:InternalFeedPAT"
+    & $PSScriptRoot\internal-feed-operations.ps1 -Operation 'install-restore'
   }
 
   if ($ci) {

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -113,6 +113,12 @@ try {
     Print-Usage
     exit 0
   }
+  
+  if ("$env:InternalFeedPAT" -ne "") {
+    Write-Host "Building from an internal branch. Setting up CredProvider..."
+    . $PSScriptRoot\internal-feed-operations.ps1 -Operation 'setup' -AuthToken "$env:InternalFeedPAT"
+    . $PSScriptRoot\internal-feed-operations.ps1 -Operation 'install-restore'
+  }
 
   if ($ci) {
     $binaryLog = $true

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -149,9 +149,9 @@ while [[ $# > 0 ]]; do
   shift
 done
 
-if [[ ! -z ${InternalFeedPAT} ]]; then
+if [[ ! -z "${InternalFeedPAT:-}" ]]; then
   echo "Building from an internal branch. Setting up CredProvider..."
-  . "$scriptroot/internal-feed-operations.sh" --operation 'setup' --authToken "${InternalFeedPAT}"
+  . "$scriptroot/internal-feed-operations.sh" --operation 'setup' --authToken "${InternalFeedPAT:-}"
   . "$scriptroot/internal-feed-operations.sh" --operation 'install-restore'
 fi
 

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -149,6 +149,12 @@ while [[ $# > 0 ]]; do
   shift
 done
 
+if [[ ! -z ${InternalFeedPAT:-}]]; then
+  echo "Building from an internal branch. Setting up CredProvider..."
+  . "$scriptroot/internal-feed-operations.sh" --operation 'setup' --authToken "${InternalFeedPAT:-}"
+  . "$scriptroot/internal-feed-operations.sh" --operation 'install-restore'
+fi
+
 if [[ "$ci" == true ]]; then
   pipelines_log=true
   binary_log=true

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -149,9 +149,9 @@ while [[ $# > 0 ]]; do
   shift
 done
 
-if [[ ! -z ${InternalFeedPAT:-}]]; then
+if [[ ! -z ${InternalFeedPAT} ]]; then
   echo "Building from an internal branch. Setting up CredProvider..."
-  . "$scriptroot/internal-feed-operations.sh" --operation 'setup' --authToken "${InternalFeedPAT:-}"
+  . "$scriptroot/internal-feed-operations.sh" --operation 'setup' --authToken "${InternalFeedPAT}"
   . "$scriptroot/internal-feed-operations.sh" --operation 'install-restore'
 fi
 

--- a/eng/common/internal-feed-operations.ps1
+++ b/eng/common/internal-feed-operations.ps1
@@ -1,9 +1,7 @@
 param(
   [Parameter(Mandatory=$true)][string] $Operation,
   [string] $AuthToken,
-  [string] $CommitSha,
-  [string] $RepoName,
-  [switch] $IsFeedPrivate
+  [string] $CommitSha
 )
 
 $ErrorActionPreference = "Stop"

--- a/eng/common/internal-feed-operations.ps1
+++ b/eng/common/internal-feed-operations.ps1
@@ -62,20 +62,22 @@ function SetupCredProvider {
   }
 
   if (($endpoints | Measure-Object).Count -gt 0) {
-      # Create the JSON object. It should look like '{"endpointCredentials": [{"endpoint":"http://example.index.json", "username":"optional", "password":"accesstoken"}]}'
-      $endpointCredentials = @{endpointCredentials=$endpoints} | ConvertTo-Json -Compress
+    # Create the JSON object. It should look like '{"endpointCredentials": [{"endpoint":"http://example.index.json", "username":"optional", "password":"accesstoken"}]}'
+    $endpointCredentials = @{endpointCredentials=$endpoints} | ConvertTo-Json -Compress
 
-     # Create the environment variables the AzDo way
-      Write-LoggingCommand -Area 'task' -Event 'setvariable' -Data $endpointCredentials -Properties @{
-        'variable' = 'VSS_NUGET_EXTERNAL_FEED_ENDPOINTS'
-        'issecret' = 'false'
-      } 
+    # Create the environment variables the AzDo way
+    Write-LoggingCommand -Area 'task' -Event 'setvariable' -Data $endpointCredentials -Properties @{
+      'variable' = 'VSS_NUGET_EXTERNAL_FEED_ENDPOINTS'
+      'issecret' = 'false'
+    } 
+      
+    $env:VSS_NUGET_EXTERNAL_FEED_ENDPOINTS = $endpointCredentials
 
-      # We don't want sessions cached since we will be updating the endpoints quite frequently
-      Write-LoggingCommand -Area 'task' -Event 'setvariable' -Data 'False' -Properties @{
-        'variable' = 'NUGET_CREDENTIALPROVIDER_SESSIONTOKENCACHE_ENABLED'
-        'issecret' = 'false'
-      } 
+    # We don't want sessions cached since we will be updating the endpoints quite frequently
+    Write-LoggingCommand -Area 'task' -Event 'setvariable' -Data 'False' -Properties @{
+      'variable' = 'NUGET_CREDENTIALPROVIDER_SESSIONTOKENCACHE_ENABLED'
+      'issecret' = 'false'
+    } 
   }
   else
   {

--- a/eng/common/internal-feed-operations.sh
+++ b/eng/common/internal-feed-operations.sh
@@ -15,7 +15,7 @@ function SetupCredProvider {
 
   local url="https://raw.githubusercontent.com/microsoft/artifacts-credprovider/master/helpers/installcredprovider.sh"  
   
-  echo "Writing the contents of 'installcredprovider.ps1' locally..."
+  echo "Writing the contents of 'installcredprovider.sh' locally..."
   local installcredproviderPath="installcredprovider.sh"
   if command -v curl > /dev/null; then
     curl $url > "$installcredproviderPath"
@@ -62,11 +62,16 @@ function SetupCredProvider {
   endpoints+=']'
 
   if [ ${#endpoints} -gt 2 ]; then 
-      # Create the JSON object. It should look like '{"endpointCredentials": [{"endpoint":"http://example.index.json", "username":"optional", "password":"accesstoken"}]}'
-      local endpointCredentials="{\"endpointCredentials\": "$endpoints"}"
+    # Create the JSON object. It should look like '{"endpointCredentials": [{"endpoint":"http://example.index.json", "username":"optional", "password":"accesstoken"}]}'
+    local endpointCredentials="{\"endpointCredentials\": "$endpoints"}"
 
-      echo "##vso[task.setvariable variable=VSS_NUGET_EXTERNAL_FEED_ENDPOINTS]$endpointCredentials"
-      echo "##vso[task.setvariable variable=NUGET_CREDENTIALPROVIDER_SESSIONTOKENCACHE_ENABLED]False"
+    # Create the environment variables the AzDo way
+    echo "##vso[task.setvariable variable=VSS_NUGET_EXTERNAL_FEED_ENDPOINTS]$endpointCredentials"
+      
+    export VSS_NUGET_EXTERNAL_FEED_ENDPOINTS="$endpointCredentials"
+    
+    # We don't want sessions cached since we will be updating the endpoints quite frequently
+    echo "##vso[task.setvariable variable=NUGET_CREDENTIALPROVIDER_SESSIONTOKENCACHE_ENABLED]False"
   else
     echo "No internal endpoints found in NuGet.config"
   fi

--- a/eng/common/internal-feed-operations.sh
+++ b/eng/common/internal-feed-operations.sh
@@ -99,7 +99,6 @@ function InstallDotNetSdkAndRestoreArcade {
 source="${BASH_SOURCE[0]}"
 operation=''
 authToken=''
-repoName=''
 
 while [[ $# > 0 ]]; do
   opt="$(echo "$1" | awk '{print tolower($0)}')"

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -90,6 +90,12 @@ jobs:
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
 
   variables:
+  - name: InternalFeedAccessToken
+    value: ''
+  - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), contains(variables['Build.SourceBranch'], 'internal')) }}:
+    - group: AzureDevOps-Artifact-Feeds-Pats
+    - name: InternalFeedAccessToken
+      value: $(dn-bot-dnceng-artifact-feeds-rw)
   - ${{ if eq(parameters.enableTelemetry, 'true') }}:
     - name: DOTNET_CLI_TELEMETRY_PROFILE
       value: '$(Build.Repository.Uri)'


### PR DESCRIPTION
When it is detected that an "internal" branch is been built we setup the CredProvider required env variables in case the repo which is building has internal feeds in its NuGet.config. The environment variables are required to restore packages from internal feeds as described in https://github.com/microsoft/artifacts-credprovider#environment-variables