### PR TITLE
Add generate shared framework manifest target, inverse xunit analyzer, reference Test SDK correctly

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/FileUtilities.cs
+++ b/src/Microsoft.DotNet.CoreFxTesting/FileUtilities.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Copied from https://raw.githubusercontent.com/dotnet/core-setup/master/tools-local/tasks/FileUtilities.cs
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    internal static partial class FileUtilities
+    {
+        private static readonly HashSet<string> s_assemblyExtensions = new HashSet<string>(
+            new[] { ".dll", ".exe", ".winmd" },
+            StringComparer.OrdinalIgnoreCase);
+
+        public static Version GetFileVersion(string sourcePath)
+        {
+            var fvi = FileVersionInfo.GetVersionInfo(sourcePath);
+
+            if (fvi != null)
+            {
+                return new Version(fvi.FileMajorPart, fvi.FileMinorPart, fvi.FileBuildPart, fvi.FilePrivatePart);
+            }
+
+            return null;
+        }
+
+        public static AssemblyName GetAssemblyName(string path)
+        {
+            if (!s_assemblyExtensions.Contains(Path.GetExtension(path)))
+            {
+                return null;
+            }
+
+            try
+            {
+                return AssemblyName.GetAssemblyName(path);
+            }
+            catch (BadImageFormatException)
+            {
+                // Not a valid assembly.
+                return null;
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.CoreFxTesting/FileUtilities.cs
+++ b/src/Microsoft.DotNet.CoreFxTesting/FileUtilities.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Copied from https://raw.githubusercontent.com/dotnet/core-setup/master/tools-local/tasks/FileUtilities.cs
+// Copied from https://github.com/dotnet/core-setup/blob/b73c0af268be449db317a7c0718012027cd8b173/tools-local/tasks/FileUtilities.cs
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.CoreFxTesting/GenerateFileVersionProps.cs
+++ b/src/Microsoft.DotNet.CoreFxTesting/GenerateFileVersionProps.cs
@@ -1,0 +1,210 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Copied and slightly modified from https://raw.githubusercontent.com/dotnet/core-setup/master/tools-local/tasks/GenerateFileVersionProps.cs
+
+using Microsoft.Build.Construction;
+using Microsoft.Build.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public partial class GenerateFileVersionProps : BuildTask
+    {
+        private const string PlatformManifestsItem = "PackageConflictPlatformManifests";
+        private const string PreferredPackagesProperty = "PackageConflictPreferredPackages";
+        private static readonly Version ZeroVersion = new Version(0, 0, 0, 0);
+
+        [Required]
+        public ITaskItem[] Files { get; set; }
+
+        [Required]
+        public string PackageId { get; set; }
+
+        [Required]
+        public string PackageVersion { get; set; }
+
+        [Required]
+        public string PlatformManifestFile { get; set; }
+
+        public string PropsFile { get; set; }
+
+        [Required]
+        public string PreferredPackages { get; set; }
+
+        /// <summary>
+        /// The task normally enforces that all DLL and EXE files have a non-0.0.0.0 FileVersion.
+        /// This flag disables the check.
+        /// </summary>
+        public bool PermitDllAndExeFilesLackingFileVersion { get; set; }
+
+        public override bool Execute()
+        {
+            var fileVersions = new Dictionary<string, FileVersionData>(StringComparer.OrdinalIgnoreCase);
+            foreach(var file in Files)
+            {
+                var targetPath = file.GetMetadata("TargetPath");
+
+                if (!targetPath.StartsWith("runtimes/"))
+                {
+                    continue;
+                }
+
+                if (file.GetMetadata("IsSymbolFile").Equals("true", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var fileName = Path.GetFileName(file.ItemSpec);
+
+                var current = GetFileVersionData(file);
+
+                FileVersionData existing;
+
+                if (fileVersions.TryGetValue(fileName, out existing))
+                {
+                    if (current.AssemblyVersion != null)
+                    {
+                        if (existing.AssemblyVersion == null)
+                        {
+                            fileVersions[fileName] = current;
+                            continue;
+                        }
+                        else if (current.AssemblyVersion != existing.AssemblyVersion)
+                        {
+                            if (current.AssemblyVersion > existing.AssemblyVersion)
+                            {
+                                fileVersions[fileName] = current;
+                            }
+                            continue;
+                        }
+                    }
+
+                    if (current.FileVersion != null && 
+                        existing.FileVersion != null)
+                    {
+                        if (current.FileVersion > existing.FileVersion)
+                        {
+                            fileVersions[fileName] = current;
+                        }
+                    }
+                }
+                else
+                {
+                    fileVersions[fileName] = current;
+                }
+            }
+
+            // Check for versionless files after all duplicate filenames are resolved, rather than
+            // logging errors immediately upon encountering a versionless file. There may be
+            // duplicate filenames where only one has a version, and this is ok. The highest version
+            // is used.
+            if (!PermitDllAndExeFilesLackingFileVersion)
+            {
+                var versionlessFiles = fileVersions
+                    .Where(p =>
+                        p.Key.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) ||
+                        p.Key.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                    .Where(p => (p.Value.FileVersion ?? ZeroVersion) == ZeroVersion)
+                    .Select(p => p.Value.File.ItemSpec)
+                    .ToArray();
+
+                if (versionlessFiles.Any())
+                {
+                    Log.LogError(
+                        $"Missing FileVersion in {versionlessFiles.Length} shared framework files:" +
+                        string.Concat(versionlessFiles.Select(f => Environment.NewLine + f)));
+                }
+            }
+
+            bool generatePropsFile = !string.IsNullOrWhiteSpace(PropsFile);
+            ProjectRootElement props = null;
+
+            if (generatePropsFile)
+            {
+                props = ProjectRootElement.Create();
+                var itemGroup = props.AddItemGroup();
+                // set the platform manifest when the platform is not being published as part of the app
+                itemGroup.Condition = "'$(RuntimeIdentifier)' == '' or '$(SelfContained)' != 'true'";
+
+                var manifestFileName = Path.GetFileName(PlatformManifestFile);
+                itemGroup.AddItem(PlatformManifestsItem, $"$(MSBuildThisFileDirectory){manifestFileName}");
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(PlatformManifestFile));
+            using (var manifestWriter = File.CreateText(PlatformManifestFile))
+            {
+                foreach (var fileData in fileVersions)
+                {
+                    var name = fileData.Key;
+                    var versions = fileData.Value;
+                    var assemblyVersion = versions.AssemblyVersion?.ToString() ?? String.Empty;
+                    var fileVersion = versions.FileVersion?.ToString() ?? String.Empty;
+
+                    manifestWriter.WriteLine($"{name}|{PackageId}|{assemblyVersion}|{fileVersion}");
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(PropsFile))
+            {
+                var propertyGroup = props.AddPropertyGroup();
+                propertyGroup.AddProperty(PreferredPackagesProperty, PreferredPackages);
+
+                var versionPropertyName = $"_{PackageId.Replace(".", "_")}_Version";
+                propertyGroup.AddProperty(versionPropertyName, PackageVersion);
+
+                props.Save(PropsFile);
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+
+        FileVersionData GetFileVersionData(ITaskItem file)
+        {
+            var filePath = file.GetMetadata("FullPath");
+
+            if (File.Exists(filePath))
+            {
+                return new FileVersionData()
+                {
+                    AssemblyVersion = FileUtilities.GetAssemblyName(filePath)?.Version,
+                    FileVersion = FileUtilities.GetFileVersion(filePath),
+                    File = file
+                };
+            }
+            else
+            {
+                // allow for the item to specify version directly
+                Version assemblyVersion, fileVersion;
+
+                Version.TryParse(file.GetMetadata("AssemblyVersion"), out assemblyVersion);
+                Version.TryParse(file.GetMetadata("FileVersion"), out fileVersion);
+
+                if (fileVersion == null)
+                {
+                    // FileVersionInfo will return 0.0.0.0 if a file doesn't have a version.
+                    // match that behavior
+                    fileVersion = ZeroVersion;
+                }
+
+                return new FileVersionData()
+                {
+                    AssemblyVersion = assemblyVersion,
+                    FileVersion = fileVersion,
+                    File = file
+                };
+            }
+        }
+
+        class FileVersionData
+        {
+            public Version AssemblyVersion { get; set; }
+            public Version FileVersion { get; set; }
+            public ITaskItem File { get; set; }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.CoreFxTesting/GenerateFileVersionProps.cs
+++ b/src/Microsoft.DotNet.CoreFxTesting/GenerateFileVersionProps.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Copied and slightly modified from https://raw.githubusercontent.com/dotnet/core-setup/master/tools-local/tasks/GenerateFileVersionProps.cs
+// Copied and slightly modified from https://github.com/dotnet/core-setup/blob/b73c0af268be449db317a7c0718012027cd8b173/tools-local/tasks/GenerateFileVersionProps.cs
 
 using Microsoft.Build.Construction;
 using Microsoft.Build.Framework;

--- a/src/Microsoft.DotNet.CoreFxTesting/Microsoft.DotNet.CoreFxTesting.csproj
+++ b/src/Microsoft.DotNet.CoreFxTesting/Microsoft.DotNet.CoreFxTesting.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" Condition="'$(TargetFramework)' == 'net472'" />

--- a/src/Microsoft.DotNet.CoreFxTesting/build/Microsoft.DotNet.CoreFxTesting.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/Microsoft.DotNet.CoreFxTesting.targets
@@ -77,16 +77,8 @@
 
   </Target>
 
-  <PropertyGroup>
-    <PlatformManifestFile>$(TestHostFrameworkPath)PlatformManifest.txt</PlatformManifestFile>
-  </PropertyGroup>
-
-  <ItemGroup Condition="Exists('$(PlatformManifestFile)')">
-    <PackageConflictPlatformManifests Include="$(PlatformManifestFile)" />
-  </ItemGroup>
-
   <UsingTask TaskName="GenerateFileVersionProps" AssemblyFile="$(CoreFxTestingAssemblyPath)"/>
-  <Target Name="GenerateFileVersionProps" Condition="'$(GenerateFileVersionProps)' == 'true'">
+  <Target Name="GenerateFileVersionProps">
     <GenerateFileVersionProps Files="@(SharedFrameworkRuntimeFiles)"
                               PackageId="Microsoft.NETCore.App"
                               PackageVersion="$(ProductVersion)"
@@ -101,7 +93,7 @@
     To use invoke target directly specifying NETCoreAppTestSharedFrameworkPath property.
   -->
   <UsingTask TaskName="GenerateTestSharedFrameworkDepsFile" AssemblyFile="$(CoreFxTestingAssemblyPath)"/>
-  <Target Name="GenerateTestSharedFrameworkDepsFile" Condition="'$(GenerateTestSharedFrameworkDepsFile)' == 'true'">
+  <Target Name="GenerateTestSharedFrameworkDepsFile">
     <GenerateTestSharedFrameworkDepsFile SharedFrameworkDirectory="$(NETCoreAppTestSharedFrameworkPath)" />
   </Target>
 

--- a/src/Microsoft.DotNet.CoreFxTesting/build/Microsoft.DotNet.CoreFxTesting.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/Microsoft.DotNet.CoreFxTesting.targets
@@ -77,6 +77,24 @@
 
   </Target>
 
+  <PropertyGroup>
+    <PlatformManifestFile>$(TestHostFrameworkPath)PlatformManifest.txt</PlatformManifestFile>
+  </PropertyGroup>
+
+  <ItemGroup Condition="Exists('$(PlatformManifestFile)')">
+    <PackageConflictPlatformManifests Include="$(PlatformManifestFile)" />
+  </ItemGroup>
+
+  <UsingTask TaskName="GenerateFileVersionProps" AssemblyFile="$(CoreFxTestingAssemblyPath)"/>
+  <Target Name="GenerateFileVersionProps" Condition="'$(GenerateFileVersionProps)' == 'true'">
+    <GenerateFileVersionProps Files="@(SharedFrameworkRuntimeFiles)"
+                              PackageId="Microsoft.NETCore.App"
+                              PackageVersion="$(ProductVersion)"
+                              PlatformManifestFile="$(PlatformManifestFile)"
+                              PreferredPackages="Microsoft.NetCore.App"
+                              PermitDllAndExeFilesLackingFileVersion="true" />
+  </Target>
+
   <!--
     Shared framework deps file generation.
     Produces a test shared-framework deps file.

--- a/src/Microsoft.DotNet.CoreFxTesting/build/Microsoft.DotNet.CoreFxTesting.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/Microsoft.DotNet.CoreFxTesting.targets
@@ -12,7 +12,7 @@
     <TestRuntimeTemplateConfigPath Condition="'$(TestRuntimeTemplateConfigPath)' == '' and '$(TargetFrameworkIdentifier)' == '.NETFramework'">$(TestAssetsDir)netfx.exe.config</TestRuntimeTemplateConfigPath>
 
     <!-- By default copy the test runtime config file for executable test projects (+ test support projects). -->
-    <GenerateRuntimeConfigurationFiles Condition="'$(IsTestProject)' == 'true' and ('$(IsTestSupportProject)' != 'true' or '$(OutputType.ToLower())' == 'exe')">true</GenerateRuntimeConfigurationFiles>
+    <GenerateRuntimeConfigurationFiles Condition="'$(IsTestProject)' == 'true' and ('$(IsTestSupportProject)' != 'true' or '$(OutputType.ToLower())' == 'exe') and '$(TargetFrameworkIdentifier)' != 'UAP'">true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(GenerateRuntimeConfigurationFiles)' == 'true'">

--- a/src/Microsoft.DotNet.CoreFxTesting/build/Resources.uap.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/Resources.uap.targets
@@ -21,8 +21,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <_AllRuntimeDllFiles Include="$(RuntimePath)\*.dll" Exclude="$(RuntimePath)\Microsoft.VisualStudio.TestPlatform.*dll;$(RuntimePath)\Microsoft.TestPlatform.*dll" />
-    <_ExternalReswFiles Include="$(_ExternalReswOutputPath)*.resw" Exclude="$(RuntimePath)\Microsoft.VisualStudio.TestPlatform.*resw;$(RuntimePath)\Microsoft.TestPlatform.*resw" />
+    <_AllRuntimeDllFiles Include="$(RuntimePath)*.dll" />
+    <_ExternalReswFiles Include="$(_ExternalReswOutputPath)*.resw" />
 
     <!-- The first time the CreateReswFilesForExternalDependencies target is executed the itemgroup _ExternalReswFiles will be empty
     and that will avoid the target from executing, so we add a dummy file if they are empty so that the target is executed the first time. -->

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
@@ -42,8 +42,7 @@
   </Target>
 
   <UsingTask TaskName="GenerateRunScript" AssemblyFile="$(CoreFxTestingAssemblyPath)"/>
-  <Target Name="GenerateRunScript"
-          DependsOnTargets="$(GenerateRunScriptDependsOn)">
+  <Target Name="GenerateRunScript">
 
     <PropertyGroup>
       <!-- RSP file support. -->

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.props
@@ -5,21 +5,21 @@
   <PropertyGroup>
     <TestRunnerConfigPath>$(TestAssetsDir)xunit.runner.json</TestRunnerConfigPath>
     <TestResultsName>testResults.xml</TestResultsName>
-    <GenerateRunScriptDependsOn>ValidateTargetOSTrait;$(GenerateRunScriptDependsOn);</GenerateRunScriptDependsOn>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Condition="'$(IncludeRemoteExecutor)' == 'true'" Include="Microsoft.DotNet.RemoteExecutor" Version="$(MicrosoftDotNetRemoteExecutorPackageVersion)" />
 
-    <!-- xunit -->
     <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsPackageVersion)" />
-    <!-- Excluding build as xunit.core enables deps file generation. -->
+    <!-- Excluding xunit.core/build as it enables deps file generation. -->
     <PackageReference Include="xunit" Version="$(XUnitPackageVersion)" ExcludeAssets="build" />
     <PackageReference Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" Include="Microsoft.DotNet.XUnitConsoleRunner" Version="$(MicrosoftDotNetXUnitConsoleRunnerPackageVersion)" />
     <PackageReference Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" Include="xunit.runner.console" Version="$(XUnitPackageVersion)" />
 
-    <PackageReference Condition="'$(ContinuousIntegrationBuild)' != 'true' and '$(OfficialBuildId)' == ''" Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" IncludeAssets="build" />
+    <!-- Microsoft.Net.Test.Sdk brings a lot of assemblies with it. To reduce helix payload submission size we disable it on CI. -->
+    <PackageReference Condition="'$(ArchiveTest)' != 'true'" Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
+    <PackageReference Condition="'$(ArchiveTest)' != 'true'" Include="xunit.runner.visualstudio" Version="$(XUnitPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -34,34 +34,10 @@
           CopyToOutputDirectory="PreserveNewest"
           Visible="false" />
     <None Include="$([System.IO.Path]::GetDirectoryName('$(XunitConsoleNetCore21AppPath)'))\*"
-          Exclude="$([System.IO.Path]::GetDirectoryName('$(XunitConsoleNetCore21AppPath)'))\xunit.console.deps.json"
+          Exclude="$([System.IO.Path]::GetDirectoryName('$(XunitConsoleNetCore21AppPath)'))\xunit.console.deps.json;$([System.IO.Path]::GetDirectoryName('$(XunitConsoleNetCore21AppPath)'))\xunit.console.runtimeconfig.json"
           Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(XunitConsoleNetCore21AppPath)' != ''"
           CopyToOutputDirectory="PreserveNewest"
           Visible="false" />
-  </ItemGroup>
-
-  <!--
-    Only add the Test SDK with assemblies when building locally for .NET Core.
-    Microsoft.NET.Test.Sdk brings framework assemblies with it: https://github.com/microsoft/vstest/issues/1764
-  -->
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(ContinuousIntegrationBuild)' != 'true' and '$(OfficialBuildId)' == ''">
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelPackageVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="$(MicrosoftNETTestSdkPackageVersion)" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftNETTestSdkPackageVersion)" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitPackageVersion)" PrivateAssets="all" IncludeAssets="build"/>
-
-    <Reference Include="$(PkgMicrosoft_TestPlatform_TestHost)\lib\netstandard1.5\Microsoft.TestPlatform.CommunicationUtilities.dll" />
-    <Reference Include="$(PkgMicrosoft_TestPlatform_TestHost)\lib\netstandard1.5\Microsoft.TestPlatform.CrossPlatEngine.dll" />
-    <Reference Include="$(PkgMicrosoft_TestPlatform_TestHost)\lib\netstandard1.5\Microsoft.VisualStudio.TestPlatform.Common.dll" />
-    <None Include="$(PkgMicrosoft_TestPlatform_TestHost)\lib\netstandard1.5\testhost.dll"
-          CopyToOutputDirectory="PreserveNewest"
-          Visible="false" />
-    <None Include="$(PkgMicrosoft_TestPlatform_TestHost)\lib\netstandard1.5\testhost.deps.json"
-          Condition="'$(GenerateDependencyFile)' == 'true'"
-          CopyToOutputDirectory="PreserveNewest"
-          Visible="false" />
-    <Reference Include="$(PkgMicrosoft_TestPlatform_ObjectModel)\lib\netstandard1.5\*.dll" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.props
@@ -20,6 +20,12 @@
     <!-- Microsoft.Net.Test.Sdk brings a lot of assemblies with it. To reduce helix payload submission size we disable it on CI. -->
     <PackageReference Condition="'$(ArchiveTest)' != 'true'" Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
     <PackageReference Condition="'$(ArchiveTest)' != 'true'" Include="xunit.runner.visualstudio" Version="$(XUnitPackageVersion)" />
+    <!--
+      Microsoft.Net.Test.Sdk has a dependency on Newtonsoft.Json v9.0.1. We upgrade the dependency version
+      with the one used in corefx to have a consistent set of dependency versions. Additionally this works
+      around a dupliate type between System.Runtime.Serialization.Formatters and Newtonsoft.Json.
+    -->
+    <PackageReference Condition="'$(ArchiveTest)' != 'true'" Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
@@ -39,7 +39,7 @@
     <TestScope Condition="'$(TestScope)' == '' and '$(Outerloop)' == 'true'">all</TestScope>
     
     <!-- Traits -->
-    <WithoutCategories Condition="'$(WithoutCategories)' == '' and '$(ContinuousIntegrationBuild)' == 'true' and '$(OfficialBuildId)' == ''">IgnoreForCI</WithoutCategories>
+    <WithoutCategories Condition="'$(ArchiveTest)' == 'true'">IgnoreForCI</WithoutCategories>
     <_withCategories Condition="'$(WithCategories)' != ''">;$(WithCategories.Trim(';'))</_withCategories>
     <_withoutCategories Condition="'$(WithoutCategories)' != ''">;$(WithoutCategories.Trim(';'))</_withoutCategories>
     <!-- Default categories -->
@@ -59,7 +59,8 @@
     <TestsSuccessfulSemaphoreName Condition="'$(WithoutCategories)' != ''">$(TestsSuccessfulSemaphoreName).without$(WithoutCategories.Replace(';', '.'))</TestsSuccessfulSemaphoreName>
   </PropertyGroup>
 
-  <Target Name="ValidateTargetOSTrait">
+  <Target Name="ValidateTargetOSTrait"
+          BeforeTargets="GenerateRunScript">
 
     <Error Condition="'$(TargetOSTrait)' == ''"
            Text="TargetOS [$(TargetOS)] is unknown so we don't know how to configure the test run for this project [$(TestProjectName)]" />
@@ -68,29 +69,21 @@
 
   <!-- Overwrite the runner config file with the app local one. -->
   <Target Name="OverwriteTestRunnerConfigFile"
-          Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' or '$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
+          Condition="'$(GenerateRuntimeConfigurationFiles)' == 'true'"
           AfterTargets="CopyFilesToOutputDirectory">
 
-    <PropertyGroup>
-      <TestRunnerNameWithoutExtension>$([System.IO.Path]::GetFileNameWithoutExtension('$(TestRunnerName)'))</TestRunnerNameWithoutExtension>
-    </PropertyGroup>
-
     <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-      <_testRunnerConfigSourceFile Include="$(TargetDir)$(TargetName).exe.config" Condition="'$(GenerateRuntimeConfigurationFiles)' == 'true'" />
+      <_testRunnerConfigSourceFile Include="$(TargetDir)$(TargetName).exe.config" />
       <_testRunnerConfigSourceFile Include="$(TargetDir)$(TargetName).exe.config" Condition="'$(IncludeRemoteExecutor)' == 'true'" />
-      <_testRunnerConfigDestFile Include="$(TargetDir)$(TestRunnerName).config" Condition="'$(GenerateRuntimeConfigurationFiles)' == 'true'" />
+      <_testRunnerConfigDestFile Include="$(TargetDir)$(TestRunnerName).config" />
       <_testRunnerConfigDestFile Include="$(TargetDir)Microsoft.DotNet.RemoteExecutorHost.exe.config" Condition="'$(IncludeRemoteExecutor)' == 'true'" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
-      <_testRunnerConfigSourceFile Include="$(ProjectRuntimeConfigFilePath)" Condition="Exists('$(ProjectRuntimeConfigFilePath)')" />
-      <_testRunnerConfigSourceFile Include="$(ProjectRuntimeConfigDevFilePath)" Condition="Exists('$(ProjectRuntimeConfigDevFilePath)')" />
-      <_testRunnerConfigSourceFile Include="$(ProjectRuntimeConfigFilePath)" Condition="Exists('$(ProjectRuntimeConfigFilePath)') and '$(IncludeRemoteExecutor)' == 'true'" />
-      <_testRunnerConfigSourceFile Include="$(ProjectRuntimeConfigDevFilePath)" Condition="Exists('$(ProjectRuntimeConfigDevFilePath)') and '$(IncludeRemoteExecutor)' == 'true'" />
-      <_testRunnerConfigDestFile Include="$(TargetDir)$(TestRunnerNameWithoutExtension).runtimeconfig.json" Condition="Exists('$(ProjectRuntimeConfigFilePath)')" />
-      <_testRunnerConfigDestFile Include="$(TargetDir)$(TestRunnerNameWithoutExtension).runtimeconfig.dev.json" Condition="Exists('$(ProjectRuntimeConfigDevFilePath)')" />
-      <_testRunnerConfigDestFile Include="$(TargetDir)Microsoft.DotNet.RemoteExecutorHost.runtimeconfig.json" Condition="Exists('$(ProjectRuntimeConfigFilePath)') and '$(IncludeRemoteExecutor)' == 'true'" />
-      <_testRunnerConfigDestFile Include="$(TargetDir)Microsoft.DotNet.RemoteExecutorHost.runtimeconfig.dev.json" Condition="Exists('$(ProjectRuntimeConfigDevFilePath)') and '$(IncludeRemoteExecutor)' == 'true'" />
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and Exists('$(ProjectRuntimeConfigFilePath)')">
+      <_testRunnerConfigSourceFile Include="$(ProjectRuntimeConfigFilePath)" />
+      <_testRunnerConfigSourceFile Include="$(ProjectRuntimeConfigFilePath)" Condition="'$(IncludeRemoteExecutor)' == 'true'" />
+      <_testRunnerConfigDestFile Include="$(TargetDir)$([System.IO.Path]::GetFileNameWithoutExtension('$(TestRunnerName)')).runtimeconfig.json" />
+      <_testRunnerConfigDestFile Include="$(TargetDir)Microsoft.DotNet.RemoteExecutorHost.runtimeconfig.json" Condition="'$(IncludeRemoteExecutor)' == 'true'" />
     </ItemGroup>
 
     <Copy SourceFiles="@(_testRunnerConfigSourceFile)"
@@ -102,7 +95,7 @@
 
   <!-- Work around https://github.com/dotnet/sdk/issues/968 -->
   <Target Name="RemoveXUnitAnalyzer"
-          Condition="'$(EnableXUnitAnalyzer)' != 'true'"
+          Condition="'$(DisableXUnitAnalyzer)' == 'true'"
           BeforeTargets="CoreCompile">
     <ItemGroup>
       <Analyzer Remove="@(Analyzer)"

--- a/src/Microsoft.DotNet.RemoteExecutor/src/Microsoft.DotNet.RemoteExecutor/build/Microsoft.DotNet.RemoteExecutor.targets
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/Microsoft.DotNet.RemoteExecutor/build/Microsoft.DotNet.RemoteExecutor.targets
@@ -2,7 +2,13 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
   <ItemGroup>
-    <Content Include="$(MSBuildThisFileDirectory)\..\tools\net472\*" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" CopyToOutputDirectory="PreserveNewest" />
-    <Content Include="$(MSBuildThisFileDirectory)\..\tools\netcoreapp2.1\*" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="$(MSBuildThisFileDirectory)\..\tools\net472\*" 
+             Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'"
+             CopyToOutputDirectory="PreserveNewest"
+             Visible="false" />
+    <Content Include="$(MSBuildThisFileDirectory)\..\tools\netcoreapp2.1\*"
+             Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
+             CopyToOutputDirectory="PreserveNewest"
+             Visible="false" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Changes:
- Add a generate shared framework manifest file target to handle conflict resolution.
- PackageReference `Microsoft.Net.Test.Sdk` correctly
- Simplify `GenerateRuntimeConfigurationFiles` and `OverwriteTestRunnerConfigFile` logic.
- Exclude xunit.console.runtimeconfig.json from the nuget package to avoid races and duplicate file writes.
- Remove `GenerateRunScriptDependsOn` as a sequenced extension point isn't needed for that target.
- Remove runtimeconfig.dev.json copying as this file isn't needed anymore on netcoreapp3.0.
- Change `RemoveXUnitAnalyzer` condition from an opt-in to an opt-out.
