### PR TITLE
Persist blobs info to BAR

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -381,8 +381,10 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             Maestro.Client.Models.Build buildInformation,
             FeedConfig feedConfig)
         {
-            BlobAssetsBasePath = BlobAssetsBasePath.TrimEnd(Path.DirectorySeparatorChar,
-                Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+            BlobAssetsBasePath = BlobAssetsBasePath.TrimEnd(
+                Path.DirectorySeparatorChar,
+                Path.AltDirectorySeparatorChar) 
+                + Path.DirectorySeparatorChar;
 
             var blobs = blobsToPublish
                 .Select(blob =>
@@ -452,7 +454,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             }
             else
             {
-                return "NetCore";
+                return "NETCORE";
             }
         }
     }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -434,7 +434,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
             var whichCategory = new Dictionary<string, string>()
             {
-                { ".NUPKG", "NetCore" },
+                { ".NUPKG", "NETCORE" },
                 { ".PKG", "OSX" },
                 { ".DEB", "DEB" },
                 { ".RPM", "RPM" },


### PR DESCRIPTION
As talked with @jcagme, this code, for now, when publishing to an AzDO target feed will only save the assets information to BAR. The actual publishing will be performed through YAML tasks.