### PR TITLE
Promote builds for channels not using legacy RM

### DIFF
--- a/eng/common/templates/post-build/channels/public-dev-release.yml
+++ b/eng/common/templates/post-build/channels/public-dev-release.yml
@@ -160,7 +160,3 @@ stages:
           targetType: inline
           script: |
             darc gather-drop --non-shipping --continue-on-error --id $(BARBuildId) --output-dir $(Agent.BuildDirectory)/Temp/Drop/ --bar-uri https://maestro-prod.westus2.cloudapp.azure.com/ --password $(MaestroAccessToken) --latest-location
-
-  - template: ../promote-build.yml
-    parameters:
-      ChannelId: ${{ variables.PublicDevRelease_30_Channel_Id }}

--- a/eng/common/templates/post-build/channels/public-validation-release.yml
+++ b/eng/common/templates/post-build/channels/public-validation-release.yml
@@ -113,7 +113,3 @@ stages:
           targetType: inline
           script: |
             darc gather-drop --non-shipping --continue-on-error --id $(BARBuildId) --output-dir $(Agent.BuildDirectory)/Temp/Drop/ --bar-uri https://maestro-prod.westus2.cloudapp.azure.com --password $(MaestroAccessToken) --latest-location
-
-  - template: ../promote-build.yml
-    parameters:
-      ChannelId: ${{ variables.PublicValidationRelease_30_Channel_Id }}

--- a/eng/common/templates/post-build/promote-build.yml
+++ b/eng/common/templates/post-build/promote-build.yml
@@ -25,4 +25,3 @@ jobs:
             "Authorization" = "Bearer $(MaestroAccessToken)"
           }
           Invoke-RestMethod -Method Post -Headers $headers -Uri https://maestro-prod.westus2.cloudapp.azure.com/api/channels/$(ChannelId)/builds/$(BARBuildId)?api-version=2019-01-16
-      enabled: false


### PR DESCRIPTION
We need this because for the new channels we don't have a legacy release pipeline to promote the builds to a the default channel. For the old channels (validation and def channel) the release pipelines are responsible for promoting the build - for now.