### PR TITLE
Fix Arcade official build

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "3.0.100-preview5-011568"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19325.18",
+    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19325.28",
     "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19324.24"
   }
 }


### PR DESCRIPTION
Official build is broken because the referenced SDK refers to a nupkg that doesn't exist!

Test build with the new SDK is here: https://dnceng.visualstudio.com/internal/_build/results?buildId=238986&view=results