### PR TITLE
Make DiffingService public

### DIFF
--- a/src/Microsoft.Cci.Extensions/Differs/Rules/TokenListDiffer.cs
+++ b/src/Microsoft.Cci.Extensions/Differs/Rules/TokenListDiffer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Cci.Differs.Rules
     public class TokenListDiffer : DifferenceRule
     {
         [Import(AllowDefault = true)]
-        private IDiffingService DiffingService { get; set; }
+        public IDiffingService DiffingService { get; set; }
 
         private CSDeclarationHelper _declHelper = null;
 


### PR DESCRIPTION
In MEF v1, imports on private properties are fulfilled as well. However, in MEF v2 this isn't the case. Sadly, the code handles not having a diffing service by creating a default one. However, the default one doesn't diff attributes.

This resulted in API Reviewer/AsmDiff not reporting differences when they only occurred in attributes. It seems we haven't noticed this for quite a while...