### PR TITLE
Add NuGet metadata validation job/script

### DIFF
--- a/eng/common/post-build/nuget-validation.ps1
+++ b/eng/common/post-build/nuget-validation.ps1
@@ -1,0 +1,26 @@
+# This script validates NuGet package metadata information using this 
+# tool: https://github.com/NuGet/NuGetGallery/tree/jver-verify/src/VerifyMicrosoftPackage
+
+param(
+  [Parameter(Mandatory=$true)][string] $PackagesPath,           # Path to where the packages to be validated are
+  [Parameter(Mandatory=$true)][string] $ToolDestinationPath     # Where the validation tool should be downloaded to
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version 2.0
+
+. $PSScriptRoot\..\tools.ps1
+
+try {
+  $url = "https://raw.githubusercontent.com/NuGet/NuGetGallery/jver-verify/src/VerifyMicrosoftPackage/verify.ps1" 
+
+  Invoke-WebRequest $url -OutFile ${ToolDestinationPath}\verify.ps1 
+
+  & ${ToolDestinationPath}\verify.ps1 ${PackagesPath}\*.nupkg
+} 
+catch {
+  Write-PipelineTaskError "NuGet package validation failed. Please check error logs."
+  Write-Host $_
+  Write-Host $_.ScriptStackTrace
+  ExitWithExitCode 1
+}

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -2,6 +2,7 @@ parameters:
   enableSourceLinkValidation: true
   enableSigningValidation: true
   enableSymbolValidation: true
+  enableNugetValidation: true
   SDLValidationParameters:
     enable: false
     params: ''
@@ -11,6 +12,25 @@ stages:
   dependsOn: build
   displayName: Validate
   jobs:
+  - ${{ if eq(parameters.enableNugetValidation, 'true') }}:
+    - job:
+      displayName: NuGet Validation
+      pool:
+        vmImage: 'windows-2019'
+      steps:
+        - task: DownloadBuildArtifacts@0
+          displayName: Download Package Artifacts
+          inputs:
+            buildType: current
+            artifactName: PackageArtifacts
+
+        - task: PowerShell@2
+          displayName: Validate
+          inputs:
+            filePath: $(Build.SourcesDirectory)/eng/common/post-build/nuget-validation.ps1
+            arguments: -PackagesPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/ 
+              -ToolDestinationPath $(Agent.BuildDirectory)/Extract/ 
+
   - ${{ if eq(parameters.enableSigningValidation, 'true') }}:
     - job:
       displayName: Signing Validation


### PR DESCRIPTION
Closes: https://github.com/dotnet/arcade/issues/2945

Add a PS script to do NuGet package metadata validation using this tool: https://github.com/dotnet/arcade/issues/2945

Add a new job in the validation stage to call the validation script.

I tested this with Arcade-* and they're all passing the validation.