### PR TITLE
Create NuGet tool validation directory if it doesn't exist

### DIFF
--- a/eng/common/post-build/nuget-validation.ps1
+++ b/eng/common/post-build/nuget-validation.ps1
@@ -14,6 +14,8 @@ Set-StrictMode -Version 2.0
 try {
   $url = "https://raw.githubusercontent.com/NuGet/NuGetGallery/jver-verify/src/VerifyMicrosoftPackage/verify.ps1" 
 
+  New-Item -ItemType "directory" -Path ${ToolDestinationPath} -Force
+
   Invoke-WebRequest $url -OutFile ${ToolDestinationPath}\verify.ps1 
 
   & ${ToolDestinationPath}\verify.ps1 ${PackagesPath}\*.nupkg


### PR DESCRIPTION
The validation currently fails because the download of `verify.ps1` doesn't create the output directory when it doesn't exist.