### PR TITLE
Update xunit versions to latest stable

### DIFF
--- a/Documentation/RepoToolset/MigrationToArcade.md
+++ b/Documentation/RepoToolset/MigrationToArcade.md
@@ -73,7 +73,7 @@ The following applies to CI build definition, not PR validation build definition
   - Set SemanticVersioningV1 property to true if you want to continue using SemVer1.
 
 ### XUnit updated
--	Arcade uses XUnit 2.4.1 preview by default, which introduces new diagnostics that might fail the build.
+-	Arcade uses XUnit 2.4.1 by default, which introduces new diagnostics that might fail the build.
 -	You can override the version in Version.props if absolutely necessary.
 
 ### Output directory layout change

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,9 +56,9 @@
     <SystemThreadingTasksExtensionVersion>4.5.1</SystemThreadingTasksExtensionVersion>
     <SystemValueTupleVersion>4.4.0</SystemValueTupleVersion>
     <WindowsAzureStorageVersion>8.5.0</WindowsAzureStorageVersion>
-    <XUnitVersion>2.4.1-pre.build.4059</XUnitVersion>
+    <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>
-    <XUnitVSRunnerVersion>2.4.1-pre.build.4059</XUnitVSRunnerVersion>
+    <XUnitVSRunnerVersion>2.4.1</XUnitVSRunnerVersion>
     <MicrosoftDotNetBuildTasksFeedVersion>2.2.0-beta.19327.39</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetSignToolVersion>1.0.0-beta.19327.39</MicrosoftDotNetSignToolVersion>
     <MicrosoftAzureDocumentDBVersion>1.22.0</MicrosoftAzureDocumentDBVersion>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -86,7 +86,7 @@
     <RoslynToolsNuGetRepackVersion Condition="'$(RoslynToolsNuGetRepackVersion)' == ''">1.0.0-beta3.18526.1</RoslynToolsNuGetRepackVersion>
     <MicrosoftDotNetSignToolVersion Condition="'$(MicrosoftDotNetSignToolVersion)' == ''">$(ArcadeSdkVersion)</MicrosoftDotNetSignToolVersion>
     <XliffTasksVersion Condition="'$(XliffTasksVersion)' == ''">1.0.0-beta.19252.1</XliffTasksVersion>
-    <XUnitVersion Condition="'$(XUnitVersion)' == ''">2.4.1-pre.build.4059</XUnitVersion>
+    <XUnitVersion Condition="'$(XUnitVersion)' == ''">2.4.1</XUnitVersion>
     <XUnitRunnerConsoleVersion Condition="'$(XUnitRunnerConsoleVersion)' == ''">$(XUnitVersion)</XUnitRunnerConsoleVersion>
     <XUnitRunnerVisualStudioVersion Condition="'$(XUnitRunnerVisualStudioVersion)' == ''">$(XUnitVersion)</XUnitRunnerVisualStudioVersion>
     <MicrosoftDotNetBuildTasksFeedVersion Condition="'$(MicrosoftDotNetBuildTasksFeedVersion)' == ''">2.2.0-beta.19321.41</MicrosoftDotNetBuildTasksFeedVersion>

--- a/src/Microsoft.DotNet.Uap.TestTools/Microsoft.DotNet.XUnitRunnerUap/Microsoft.DotNet.XUnitRunnerUap.csproj
+++ b/src/Microsoft.DotNet.Uap.TestTools/Microsoft.DotNet.XUnitRunnerUap/Microsoft.DotNet.XUnitRunnerUap.csproj
@@ -203,10 +203,10 @@
       <Version>6.2.0-preview1-26926-04</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.4.1-pre.build.4059</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.utility">
-      <Version>2.4.1-pre.build.4059</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
With https://github.com/dotnet/corefx/pull/38792, CoreFx will use conflict resolution as expected so that incoming runtime package assets won't be preferred over live built assets anymore. Therefore we can now reference packages with <= netstandard2.0.

cc @ericstj