### PR TITLE
Detect runtimeconfig in RemoteExecutor

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/TestProject.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/TestProject.props
@@ -2,14 +2,9 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
 
-  <PropertyGroup Condition="'$(IsUnitTestProject)' == ''">
-    <IsUnitTestProject>false</IsUnitTestProject>
-    <IsUnitTestProject Condition="$(MSBuildProjectName.EndsWith('.UnitTests')) or $(MSBuildProjectName.EndsWith('.Tests'))">true</IsUnitTestProject>
-  </PropertyGroup>
-
   <PropertyGroup>
     <IsTestProject>false</IsTestProject>
-    <IsTestProject Condition="'$(IsUnitTestProject)' == 'true'">true</IsTestProject>
+    <IsTestProject Condition="$(MSBuildProjectName.EndsWith('.UnitTests')) or $(MSBuildProjectName.EndsWith('.Tests'))">true</IsTestProject>
 
     <IsTestSupportProject>false</IsTestSupportProject>
     <IsTestSupportProject Condition="($(MSBuildProjectFullPath.Contains('\tests\')) OR $(MSBuildProjectFullPath.Contains('/tests/'))) AND '$(IsTestProject)' != 'true'">true</IsTestSupportProject>

--- a/src/Microsoft.DotNet.CoreFxTesting/build/assets/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/assets/RunnerTemplate.Unix.txt
@@ -48,9 +48,6 @@ fi
 # Don't use a globally installed SDK.
 export DOTNET_MULTILEVEL_LOOKUP=0
 
-# Roll forward on [major], [minor] and [patch].
-export DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX=2
-
 exitcode_list[0]="Exited Successfully"
 exitcode_list[130]="SIGINT  Ctrl-C occurred. Likely tests timed out."
 exitcode_list[131]="SIGQUIT Ctrl-\ occurred. Core dumped."

--- a/src/Microsoft.DotNet.CoreFxTesting/build/assets/RunnerTemplate.Windows.txt
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/assets/RunnerTemplate.Windows.txt
@@ -50,9 +50,6 @@ if not defined RUNTIME_PATH (
 :: Don't use a globally installed SDK.
 set DOTNET_MULTILEVEL_LOOKUP=0
 
-:: Roll forward on [major], [minor] and [patch].
-set DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX=2
-
 :: ========================= BEGIN Test Execution ============================= 
 echo ----- start %DATE% %TIME% ===============  To repro directly: ===================================================== 
 echo pushd %EXECUTION_DIR%

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.props
@@ -18,7 +18,7 @@
     Unit/Functional/Integration test support.
     Supported runners: xunit.
   -->
-  <Import Condition="'$(IsUnitTestProject)' == 'true'" Project="$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', 'test', 'Test.props'))" />
+  <Import Project="$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', 'test', 'Test.props'))" />
 
   <!--
     Code Coverage support.

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
@@ -172,7 +172,7 @@
     Unit/Functional/Integration test support.
     Supported runners: xunit.
   -->
-  <Import Condition="'$(IsUnitTestProject)' == 'true'" Project="$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', 'test', 'Test.targets'))" />
+  <Import Project="$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', 'test', 'Test.targets'))" />
 
   <!--
     Code Coverage support.

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
@@ -169,8 +169,8 @@
   </ItemGroup>
 
   <!-- Main test targets -->
-  <Target Name="Test" DependsOnTargets="$(TestDependsOn)" Condition="'$(IsUnitTestProject)' == 'true'" />
-  <Target Name="BuildAndTest" DependsOnTargets="Build;Test" Condition="'$(IsUnitTestProject)' == 'true'" />
-  <Target Name="RebuildAndTest" DependsOnTargets="Rebuild;Test" Condition="'$(IsUnitTestProject)' == 'true'" />
+  <Target Name="Test" DependsOnTargets="$(TestDependsOn)" />
+  <Target Name="BuildAndTest" DependsOnTargets="Build;Test" />
+  <Target Name="RebuildAndTest" DependsOnTargets="Rebuild;Test" />
 
 </Project>

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
@@ -14,6 +14,7 @@
   <!-- General xunit options -->
   <PropertyGroup>
     <RunArguments>$(TestAssembly)</RunArguments>
+    <RunArguments Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">$(RunArguments) --runtimeconfig $(ProjectRuntimeConfigFileName)</RunArguments>
     <RunArguments Condition="'$(TargetFrameworkIdentifier)' != 'UAP'">$(RunArguments) -xml $(TestResultsName)</RunArguments>
     <RunArguments Condition="'$(TargetFrameworkIdentifier)' == 'UAP'">$(RunArguments) -xml $(UAPResultsPathCmd)</RunArguments>
     <RunArguments>$(RunArguments) -nologo</RunArguments>
@@ -69,21 +70,14 @@
 
   <!-- Overwrite the runner config file with the app local one. -->
   <Target Name="OverwriteTestRunnerConfigFile"
-          Condition="'$(GenerateRuntimeConfigurationFiles)' == 'true'"
+          Condition="'$(GenerateRuntimeConfigurationFiles)' == 'true' and '$(TargetFrameworkIdentifier)' == '.NETFramework'"
           AfterTargets="CopyFilesToOutputDirectory">
 
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <ItemGroup>
       <_testRunnerConfigSourceFile Include="$(TargetDir)$(TargetName).exe.config" />
       <_testRunnerConfigSourceFile Include="$(TargetDir)$(TargetName).exe.config" Condition="'$(IncludeRemoteExecutor)' == 'true'" />
       <_testRunnerConfigDestFile Include="$(TargetDir)$(TestRunnerName).config" />
       <_testRunnerConfigDestFile Include="$(TargetDir)Microsoft.DotNet.RemoteExecutorHost.exe.config" Condition="'$(IncludeRemoteExecutor)' == 'true'" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and Exists('$(ProjectRuntimeConfigFilePath)')">
-      <_testRunnerConfigSourceFile Include="$(ProjectRuntimeConfigFilePath)" />
-      <_testRunnerConfigSourceFile Include="$(ProjectRuntimeConfigFilePath)" Condition="'$(IncludeRemoteExecutor)' == 'true'" />
-      <_testRunnerConfigDestFile Include="$(TargetDir)$([System.IO.Path]::GetFileNameWithoutExtension('$(TestRunnerName)')).runtimeconfig.json" />
-      <_testRunnerConfigDestFile Include="$(TargetDir)Microsoft.DotNet.RemoteExecutorHost.runtimeconfig.json" Condition="'$(IncludeRemoteExecutor)' == 'true'" />
     </ItemGroup>
 
     <Copy SourceFiles="@(_testRunnerConfigSourceFile)"
@@ -167,7 +161,6 @@
           CopyToOutputDirectory="PreserveNewest"
           Visible="false" />
 
-    <_xunitConsoleNetCoreExclude Include="$([System.IO.Path]::GetDirectoryName('$(XunitConsoleNetCore21AppPath)'))\xunit.console.runtimeconfig.json" />
     <_xunitConsoleNetCoreExclude Condition="'$(GenerateDependencyFile)' != 'true'" Include="$([System.IO.Path]::GetDirectoryName('$(XunitConsoleNetCore21AppPath)'))\xunit.console.deps.json" />
     <None Include="$([System.IO.Path]::GetDirectoryName('$(XunitConsoleNetCore21AppPath)'))\*"
           Exclude="@(_xunitConsoleNetCoreExclude)"

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
@@ -14,7 +14,6 @@
   <!-- General xunit options -->
   <PropertyGroup>
     <RunArguments>$(TestAssembly)</RunArguments>
-    <RunArguments Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">$(RunArguments) --runtimeconfig $(ProjectRuntimeConfigFileName)</RunArguments>
     <RunArguments Condition="'$(TargetFrameworkIdentifier)' != 'UAP'">$(RunArguments) -xml $(TestResultsName)</RunArguments>
     <RunArguments Condition="'$(TargetFrameworkIdentifier)' == 'UAP'">$(RunArguments) -xml $(UAPResultsPathCmd)</RunArguments>
     <RunArguments>$(RunArguments) -nologo</RunArguments>
@@ -104,7 +103,7 @@
       <PropertyGroup>
         <TestRunnerName>xunit.console.dll</TestRunnerName>
         <RunCommand>"$(RunScriptHost)"</RunCommand>
-        <RunArguments>$(TestRunnerName) $(RunArguments)</RunArguments>
+        <RunArguments>exec --runtimeconfig $(AssemblyName).runtimeconfig.json $(TestRunnerName) $(RunArguments)</RunArguments>
       </PropertyGroup>
     </When>
 

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
@@ -69,7 +69,7 @@
   </Target>
 
   <!-- Overwrite the runner config file with the app local one. -->
-  <Target Name="OverwriteTestRunnerConfigFile"
+  <Target Name="OverwriteDesktopTestRunnerConfigs"
           Condition="'$(GenerateRuntimeConfigurationFiles)' == 'true' and '$(TargetFrameworkIdentifier)' == '.NETFramework'"
           AfterTargets="CopyFilesToOutputDirectory">
 

--- a/src/Microsoft.DotNet.RemoteExecutor/src/Microsoft.DotNet.RemoteExecutor/RemoteExecutor.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/Microsoft.DotNet.RemoteExecutor/RemoteExecutor.cs
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.RemoteExecutor
                 string runtimeConfigPath = GetInnerRuntimeConfig();
                 if (runtimeConfigPath != null)
                 {
-                    s_extraParameter = $"--runtimeconfig {runtimeConfigPath} {s_extraParameter}";
+                    s_extraParameter = $"exec --runtimeconfig \"{runtimeConfigPath}\" \"{s_extraParameter}\"";
                 }
             }
             else if (RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase))

--- a/src/Microsoft.DotNet.RemoteExecutor/src/Microsoft.DotNet.RemoteExecutorHost/Program.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/Microsoft.DotNet.RemoteExecutorHost/Program.cs
@@ -96,20 +96,17 @@ namespace Microsoft.DotNet.RemoteExecutorHost
                 (instance as IDisposable)?.Dispose();
             }
 
-            // Environment.Exit not supported on .Net Native - don't even call it to avoid the nuisance exception.
-            if (!RuntimeInformation.FrameworkDescription.StartsWith(".NET Native", StringComparison.OrdinalIgnoreCase))
+            // Use Exit rather than simply returning the exit code so that we forcibly shut down
+            // the process even if there are foreground threads created by the operation that would
+            // end up keeping the process alive potentially indefinitely.
+            try
             {
-                // Use Exit rather than simply returning the exit code so that we forcibly shut down
-                // the process even if there are foreground threads created by the operation that would
-                // end up keeping the process alive potentially indefinitely.
-                try
-                {
-                    Environment.Exit(exitCode);
-                }
-                catch (PlatformNotSupportedException)
-                {
-                }
+                Environment.Exit(exitCode);
             }
+            catch (PlatformNotSupportedException)
+            {
+            }
+            
             return exitCode;
         }
 

--- a/src/Microsoft.DotNet.RemoteExecutor/src/Microsoft.DotNet.RemoteExecutorHost/runtimeconfig.template.json
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/Microsoft.DotNet.RemoteExecutorHost/runtimeconfig.template.json
@@ -1,3 +1,0 @@
-{
-  "rollForwardOnNoCandidateFx": 2
-}


### PR DESCRIPTION
Removes the necessity of a roll-forward policy and the manual
runtimeconfig copying in corefx.

I saw this option being used by dotnet test and noticed it not being documented: https://github.com/dotnet/docs/issues/12543.