### PR TITLE
Set content-type of blobs

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -40,7 +40,7 @@
     <NuGetVersioningVersion>4.4.0</NuGetVersioningVersion>
     <NuGetVersion>4.9.0-rtm.5658</NuGetVersion>
     <OctokitVersion>0.32.0</OctokitVersion>
-    <DotNetSleetLibVersion>2.2.132</DotNetSleetLibVersion>
+    <DotNetSleetLibVersion>2.2.139</DotNetSleetLibVersion>
     <SwashbuckleAspNetCoreSwaggerVersion>3.0.0</SwashbuckleAspNetCoreSwaggerVersion>
     <SystemBuffersVersion>4.5.0</SystemBuffersVersion>
     <SystemCollectionsImmutableVersion>1.3.1</SystemCollectionsImmutableVersion>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/build/Microsoft.DotNet.Build.Tasks.Feed.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/build/Microsoft.DotNet.Build.Tasks.Feed.targets
@@ -55,6 +55,7 @@
   <UsingTask TaskName="PushArtifactsInManifestToFeed" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
   <UsingTask TaskName="PublishArtifactsInManifest" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
   <UsingTask TaskName="CreateAzureDevOpsFeed" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
+  <UsingTask TaskName="CreateInternalBlobFeed" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
   <UsingTask TaskName="ExecWithRetriesForNuGetPush" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
   <UsingTask TaskName="ParseBuildManifest" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
   

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BlobFeedAction.cs
@@ -75,7 +75,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         {
             ContainerName = sleetSource.Container;
             RelativePath = sleetSource.FeedSubPath;
-            AccountName = sleetSource.AccountName;
             AccountKey = accountKey;
             hasToken = true;
             Log = log;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BlobFeedAction.cs
@@ -5,7 +5,9 @@
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.CloudTestTasks;
 using Microsoft.WindowsAzure.Storage;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using Sleet;
@@ -67,6 +69,17 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             {
                 throw new Exception("Unable to parse expected feed. Please check ExpectedFeedUrl.");
             }
+        }
+
+        public BlobFeedAction(SleetSource sleetSource, string accountKey, MSBuild.TaskLoggingHelper log)
+        {
+            ContainerName = sleetSource.Container;
+            RelativePath = sleetSource.FeedSubPath;
+            AccountName = sleetSource.AccountName;
+            AccountKey = accountKey;
+            hasToken = true;
+            Log = log;
+            source = sleetSource;
         }
 
         public async Task<bool> PushToFeedAsync(
@@ -318,9 +331,16 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     }
             };
 
+            var jsonSerializer = JsonSerializer.Create(
+                new JsonSerializerSettings
+                {
+                    ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                    NullValueHandling = NullValueHandling.Ignore
+                });
+
             LocalSettings settings = new LocalSettings
             {
-                Json = JObject.FromObject(sleetSettings)
+                Json = JObject.FromObject(sleetSettings, jsonSerializer)
             };
 
             return settings;
@@ -425,12 +445,19 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             }
         }
 
-        private async Task<bool> InitAsync()
+        public async Task<bool> InitAsync()
         {
+            AzureStorageUtils blobUtils = new AzureStorageUtils(AccountName, AccountKey, ContainerName);
+
+            if (!await blobUtils.CheckIfContainerExistsAsync())
+            {
+                throw new Exception($"The informed container for the feed '{ContainerName}' doesn't exist!");
+            }
+
             using (var fileCache = CreateFileCache())
             {
                 LocalSettings settings = GetSettings();
-                AzureFileSystem fileSystem = GetAzureFileSystem(fileCache);
+                var fileSystem = FileSystemFactory.CreateFileSystem(settings, fileCache, source.Name);
                 bool result = await InitCommand.RunAsync(settings, fileSystem, enableCatalog: false, enableSymbols: false, log: new SleetLogger(Log, NuGet.Common.LogLevel.Verbose), token: CancellationToken);
                 return result;
             }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateInternalBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateInternalBlobFeed.cs
@@ -1,0 +1,126 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Azure.Storage.Blob;
+using Microsoft.Build.Framework;
+using Microsoft.DotNet.Build.CloudTestTasks;
+using Newtonsoft.Json;
+using System;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using MSBuild = Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.Build.Tasks.Feed
+{
+    public class CreateInternalBlobFeed : MSBuild.Task
+    {
+        [Output]
+        public string TargetFeedURL { get; set; }
+
+        [Output]
+        public string TargetFeedName { get; set; }
+
+        [Required]
+        public string RepositoryName { get; set; }
+
+        [Required]
+        public string CommitSha { get; set; }
+
+        [Required]
+        public string AzureDevOpsFeedsBaseUrl { get; set; }
+
+        [Required]
+        public string AzureStorageAccountName { get; set; }
+
+        [Required]
+        public string AzureStorageAccountKey { get; set; }
+
+        private const string baseUrlRegex = @"https:\/\/(?<containername>[^\.]+).*";
+
+        public override bool Execute()
+        {
+            return ExecuteAsync().GetAwaiter().GetResult();
+        }
+
+        private async Task<bool> ExecuteAsync()
+        {
+            try
+            {
+                string baseFeedName = $"darc-int-{RepositoryName}-{CommitSha}";
+                string versionedFeedName = baseFeedName;
+                bool needsUniqueName = false;
+                int subVersion = 0;
+                var containerName = string.Empty;
+
+                Log.LogMessage(MessageImportance.High, $"Creating a new Azure Storage internal feed ...");
+
+                Match m = Regex.Match(AzureDevOpsFeedsBaseUrl, baseUrlRegex);
+                if (m.Success)
+                {
+                    containerName = m.Groups["containername"].Value;
+                }
+                else
+                {
+                    Log.LogError($"Could not parse the {nameof(AzureDevOpsFeedsBaseUrl)} to extract the container name: '{AzureDevOpsFeedsBaseUrl}'");
+                    return false;
+                }
+
+                AzureStorageUtils azUtils = new AzureStorageUtils(AzureStorageAccountName, AzureStorageAccountKey, containerName);
+
+                // Create container if it doesn't already exist
+                if (!await azUtils.CheckIfContainerExistsAsync())
+                {
+                    BlobContainerPermissions permissions = new BlobContainerPermissions
+                    {
+                        PublicAccess = BlobContainerPublicAccessType.Off
+                    };
+
+                    await azUtils.CreateContainerAsync(permissions);
+                }
+
+                // Create folder inside the container. Note that AzureStorage requires a folder
+                // to have at least one file.
+                do
+                {
+                    if (await azUtils.CheckIfBlobExistsAsync($"{versionedFeedName}/index.json"))
+                    {
+                        versionedFeedName = $"{baseFeedName}-{++subVersion}";
+                        needsUniqueName = true;
+                    }
+                    else
+                    {
+                        baseFeedName = versionedFeedName;
+                        needsUniqueName = false;
+                    }
+                } while (needsUniqueName);
+
+                // Initialize the feed using sleet
+                SleetSource sleetSource = new SleetSource()
+                {
+                    Name = baseFeedName,
+                    Type = "azure",
+                    BaseUri = $"{AzureDevOpsFeedsBaseUrl}/{containerName}/{baseFeedName}",
+                    AccountName = AzureStorageAccountName,
+                    Container = containerName,
+                    FeedSubPath = $"{baseFeedName}",
+                    ConnectionString = $"DefaultEndpointsProtocol=https;AccountName={AzureStorageAccountName};AccountKey={AzureStorageAccountKey};EndpointSuffix=core.windows.net"
+                };
+
+                BlobFeedAction bfAction = new BlobFeedAction(sleetSource, AzureStorageAccountKey, Log);
+                await bfAction.InitAsync();
+
+                TargetFeedURL = $"{AzureDevOpsFeedsBaseUrl}/{baseFeedName}";
+                TargetFeedName = baseFeedName;
+
+                Log.LogMessage(MessageImportance.High, $"Feed '{TargetFeedURL}' created successfully!");
+            }
+            catch (Exception e)
+            {
+                Log.LogErrorFromException(e, true);
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateInternalBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateInternalBlobFeed.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         [Required]
         public string AzureStorageAccountKey { get; set; }
 
-        private const string baseUrlRegex = @"https:\/\/(?<containername>[^\.]+).*";
+        private const string baseUrlRegex = @"https:\/\/[^/]+/container/(?<containername>[^/]+).*";
 
         public override bool Execute()
         {
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 }
                 else
                 {
-                    Log.LogError($"Could not parse the {nameof(AzureDevOpsFeedsBaseUrl)} to extract the container name: '{AzureDevOpsFeedsBaseUrl}'");
+                    Log.LogError($"Could not parse {nameof(AzureDevOpsFeedsBaseUrl)} to extract the container name: '{AzureDevOpsFeedsBaseUrl}'");
                     return false;
                 }
 
@@ -100,7 +100,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 {
                     Name = baseFeedName,
                     Type = "azure",
-                    BaseUri = $"{AzureDevOpsFeedsBaseUrl}/{containerName}/{baseFeedName}",
+                    BaseUri = $"{AzureDevOpsFeedsBaseUrl}/{baseFeedName}",
                     AccountName = AzureStorageAccountName,
                     Container = containerName,
                     FeedSubPath = $"{baseFeedName}",

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/SleetSource.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/SleetSource.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -9,8 +9,10 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public string Name { get; set; }
         public string Type { get; set; }
         public string Path { get; set; }
+        public string BaseUri { get; set; }
         public string Container { get; set; }
         public string ConnectionString { get; set; }
         public string FeedSubPath { get; set; }
+        public string AccountName { get; internal set; }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
@@ -134,9 +134,9 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             return Container.GetSharedAccessSignature(sasConstraints);
         }
 
-        public Task<bool> CheckIfContainerExistsAsync()
+        public async Task<bool> CheckIfContainerExistsAsync()
         {
-            return Container.ExistsAsync();
+            return await Container.ExistsAsync();
         }
 
         public async Task<bool> CheckIfBlobExistsAsync(string blobPath)

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
@@ -6,6 +6,7 @@ using Microsoft.Azure.Storage;
 using Microsoft.Azure.Storage.Auth;
 using Microsoft.Azure.Storage.Blob;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -46,6 +47,8 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
         public async Task UploadBlockBlobAsync(string filePath, string blobPath)
         {
             CloudBlockBlob cloudBlockBlob = GetBlockBlob(blobPath.Replace("\\", "/"));
+
+            cloudBlockBlob.Properties.ContentType = GetMimeMapping(filePath);
 
             await cloudBlockBlob.UploadFromFileAsync(filePath);
         }
@@ -144,6 +147,23 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             var blob = GetBlockBlob(blobPath);
 
             return await blob.ExistsAsync();
+        }
+
+        private string GetMimeMapping(string filePath)
+        {
+            var mimeMappings = new Dictionary<string, string>()
+            {
+                {".svg", "image/svg+xml"}
+            };
+
+            if (string.IsNullOrEmpty(filePath))
+            {
+                return null;
+            }
+
+            return mimeMappings.TryGetValue(Path.GetExtension(filePath).ToLower(), out string mime) ? 
+                mime : 
+                "application/octet-stream";
         }
     }
 }


### PR DESCRIPTION
Closes: https://github.com/dotnet/arcade/issues/3226

For now set the content-type only of SVG files. Eventually might need to add other extensions as well.

Tested by uploading a SVG file to cesarfeed/blu container in HelixStaging sub.