### PR TITLE
Set content-type of blobs published by Tasks.Feed tasks

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
@@ -156,8 +156,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                 {".svg", "image/svg+xml"}
             };
 
-            if (string.IsNullOrEmpty(filePath) || 
-                string.IsNullOrEmpty(Path.GetExtension(filePath)))
+            if (string.IsNullOrEmpty(Path.GetExtension(filePath)))
             {
                 throw new ArgumentNullException($"Invalid path to file was informed: '{filePath}'");
             }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
@@ -6,6 +6,7 @@ using Microsoft.Azure.Storage;
 using Microsoft.Azure.Storage.Auth;
 using Microsoft.Azure.Storage.Blob;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -46,6 +47,8 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
         public async Task UploadBlockBlobAsync(string filePath, string blobPath)
         {
             CloudBlockBlob cloudBlockBlob = GetBlockBlob(blobPath.Replace("\\", "/"));
+
+            cloudBlockBlob.Properties.ContentType = GetMimeMapping(filePath);
 
             await cloudBlockBlob.UploadFromFileAsync(filePath);
         }
@@ -144,6 +147,23 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             var blob = GetBlockBlob(blobPath);
 
             return await blob.ExistsAsync();
+        }
+
+        private string GetMimeMapping(string filePath)
+        {
+            var mimeMappings = new Dictionary<string, string>()
+            {
+                {".svg", "image/svg+xml"}
+            };
+
+            if (string.IsNullOrEmpty(filePath))
+            {
+                return null;
+            }
+
+            return mimeMappings.TryGetValue(Path.GetExtension(filePath).ToLower(), out string mime) ?
+                mime :
+                "application/octet-stream";
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
@@ -156,9 +156,10 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                 {".svg", "image/svg+xml"}
             };
 
-            if (string.IsNullOrEmpty(filePath))
+            if (string.IsNullOrEmpty(filePath) || 
+                string.IsNullOrEmpty(Path.GetExtension(filePath)))
             {
-                return null;
+                throw new ArgumentNullException($"Invalid path to file was informed: '{filePath}'");
             }
 
             return mimeMappings.TryGetValue(Path.GetExtension(filePath).ToLower(), out string mime) ?


### PR DESCRIPTION
Closes: https://github.com/dotnet/arcade/issues/3226

For now set the content-type only of SVG files. Eventually might need to add other extensions as well.

Tested by uploading a SVG file to cesarfeed/blu container in HelixStaging sub.