### PR TITLE
Adjustments in Tasks.Feed for publishing to proxy-backed feeds

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BlobFeedAction.cs
@@ -75,6 +75,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         {
             ContainerName = sleetSource.Container;
             RelativePath = sleetSource.FeedSubPath;
+            AccountName = sleetSource.AccountName;
             AccountKey = accountKey;
             hasToken = true;
             Log = log;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BlobFeedAction.cs
@@ -178,7 +178,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 {
                     if (options.PassIfExistingItemIdentical)
                     {
-                        if (!await blobUtils.IsFileIdenticalToBlobAsync(item.ItemSpec, relativeBlobPath))
+                        if (!await blobUtils.IsFileIdenticalToBlobAsync(relativeBlobPath, item.ItemSpec))
                         {
                             Log.LogError(
                                 $"Item '{item}' already exists with different contents " +
@@ -346,11 +346,17 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             return settings;
         }
 
-        private AzureFileSystem GetAzureFileSystem(LocalCache fileCache)
+        private ISleetFileSystem GetAzureFileSystem(LocalCache fileCache)
         {
-            CloudStorageAccount storageAccount = CloudStorageAccount.Parse(source.ConnectionString);
-            AzureFileSystem fileSystem = new AzureFileSystem(fileCache, new Uri(source.Path), new Uri(source.Path), storageAccount, source.Name, source.FeedSubPath);
-            return fileSystem;
+            try
+            {
+                CloudStorageAccount storageAccount = CloudStorageAccount.Parse(source.ConnectionString);
+                return new AzureFileSystem(fileCache, new Uri(source.Path), new Uri(source.Path), storageAccount, source.Name, source.FeedSubPath);
+            }
+            catch (Exception)
+            {
+                return FileSystemFactory.CreateFileSystem(GetSettings(), fileCache, source.Name);
+            }
         }
 
         private async Task<bool> PushAsync(
@@ -368,7 +374,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             // normally performed inside the lock.
             using (var preLockCache = CreateFileCache())
             {
-                AzureFileSystem preLockFileSystem = GetAzureFileSystem(preLockCache);
+                var preLockFileSystem = GetAzureFileSystem(preLockCache);
 
                 if (!options.AllowOverwrite && options.PassIfExistingItemIdentical)
                 {

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BlobFeedAction.cs
@@ -353,7 +353,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 CloudStorageAccount storageAccount = CloudStorageAccount.Parse(source.ConnectionString);
                 return new AzureFileSystem(fileCache, new Uri(source.Path), new Uri(source.Path), storageAccount, source.Name, source.FeedSubPath);
             }
-            catch (Exception)
+            catch
             {
                 return FileSystemFactory.CreateFileSystem(GetSettings(), fileCache, source.Name);
             }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateInternalBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateInternalBlobFeed.cs
@@ -100,7 +100,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 {
                     Name = baseFeedName,
                     Type = "azure",
-                    BaseUri = $"{AzureDevOpsFeedsBaseUrl}/{baseFeedName}",
+                    BaseUri = $"{AzureDevOpsFeedsBaseUrl}{baseFeedName}",
                     AccountName = AzureStorageAccountName,
                     Container = containerName,
                     FeedSubPath = $"{baseFeedName}",
@@ -110,7 +110,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 BlobFeedAction bfAction = new BlobFeedAction(sleetSource, AzureStorageAccountKey, Log);
                 await bfAction.InitAsync();
 
-                TargetFeedURL = $"{AzureDevOpsFeedsBaseUrl}/{baseFeedName}";
+                TargetFeedURL = $"{AzureDevOpsFeedsBaseUrl}{baseFeedName}";
                 TargetFeedName = baseFeedName;
 
                 Log.LogMessage(MessageImportance.High, $"Feed '{TargetFeedURL}' created successfully!");


### PR DESCRIPTION
- A fix in BlobFeedAction
- Create a new method in PublishArtifactsInManifest that is able to parse proxy-backed feed URLs. I thought this better than changing BlobFeedAction to be able to parse this kind of URL because 1) this is a temporary while we figure out how to work with AzDO feeds; 2) I'm afraid to disrupt usage of Tasks.Feed.

Tested this changes locally and was able to publish artifacts to this feed: `dotnetfeed/dotnet-core-internal/darc-int-cesar-big-repo-name-caffeecaffee`. Later was able to successfully browse the packages via Visual Studio.