### PR TITLE
Revert remove launchSettings.json in CoreFxTesting

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/assets/launchSettings.json
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/assets/launchSettings.json
@@ -1,0 +1,19 @@
+{
+    "profiles": {
+        ".NET Core xUnit Console": {
+            "commandName": "Executable",
+            "executablePath": "$(TestHostRootPath)dotnet.exe",
+            "commandLineArgs": "$(RunArguments) -parallel none",
+            "workingDirectory": "$(TargetDir)"
+        },
+        ".NET Framework xUnit Console": {
+            "commandName": "Executable",
+            "executablePath": "$(TargetDir)xunit.console.exe",
+            "commandLineArgs": "$(RunArguments) -parallel none",
+            "workingDirectory": "$(TargetDir)",
+            "environmentVariables": {
+                "DEVPATH": "$(TestHostRootPath)"
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.CoreFxTesting/build/assets/launchSettings.json
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/assets/launchSettings.json
@@ -4,16 +4,7 @@
             "commandName": "Executable",
             "executablePath": "$(TestHostRootPath)dotnet.exe",
             "commandLineArgs": "$(RunArguments) -parallel none",
-            "workingDirectory": "$(TargetDir)"
-        },
-        ".NET Framework xUnit Console": {
-            "commandName": "Executable",
-            "executablePath": "$(TargetDir)xunit.console.exe",
-            "commandLineArgs": "$(RunArguments) -parallel none",
-            "workingDirectory": "$(TargetDir)",
-            "environmentVariables": {
-                "DEVPATH": "$(TestHostRootPath)"
-            }
+            "workingDirectory": "$(RunWorkingDirectory)"
         }
     }
 }

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.props
@@ -22,7 +22,7 @@
 
   <!--
     Code Coverage support.
-    Supported runners: coverlet.
+    Supported runners: OpenCover.
 
     Inputs:
       - Coverage: Intended to be passed in as a global property.

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.props
@@ -22,7 +22,7 @@
 
   <!--
     Code Coverage support.
-    Supported runners: OpenCover.
+    Supported runners: coverlet.
 
     Inputs:
       - Coverage: Intended to be passed in as a global property.

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
@@ -169,6 +169,15 @@
   <Import Condition="'$(TargetFrameworkIdentifier)' == 'UAP'" Project="$(MSBuildThisFileDirectory)Core.uap.targets" />
 
   <!--
+    LaunchSettings.json support.
+    Generates launchSettings.json files during compilation or on demand.
+
+    Inputs:
+      - EnableLaunchSettings: Intended to be passed in as a global property or being set.
+  -->
+  <Import Condition="'$(EnableLaunchSettings)' == 'true'" Project="$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', 'launchSettings', 'LaunchSettings.targets'))" />
+
+  <!--
     Unit/Functional/Integration test support.
     Supported runners: xunit.
   -->

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/launchSettings/LaunchSettings.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/launchSettings/LaunchSettings.targets
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project>
+
+  <!--
+    Generates the launch settings file in case it doesn't exist yet.
+    This supports scenarios when new projects are added or the file was deleted.
+  -->
+  <PropertyGroup>
+    <LaunchSettingsInputFileFullPath Condition="'$(LaunchSettingsInputFileFullPath)' == ''">$(TestAssetsDir)launchSettings.json</LaunchSettingsInputFileFullPath>
+    <LaunchSettingsOutputFileFullPath Condition="'$(LaunchSettingsOutputFileFullPath)' == ''">$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '$(AppDesignerFolder)', 'launchSettings.json'))</LaunchSettingsOutputFileFullPath>
+    <PrepareForRunDependsOn Condition="!Exists($(LaunchSettingsOutputFileFullPath))">GenerateLaunchSettingsFile;$(PrepareForRunDependsOn);</PrepareForRunDependsOn>
+  </PropertyGroup>
+
+  <!--
+    Target to generate the launch settings file.
+    Either called by PrepareForRunDependsOn if the file doesn't already exist when building
+    the test assembly or invoked manually from the build.proj when doing a full build.
+  -->
+  <Target Name="GenerateLaunchSettingsFile">
+
+    <Copy SourceFiles="$(LaunchSettingsInputFileFullPath)"
+          DestinationFiles="$(LaunchSettingsOutputFileFullPath)"
+          SkipUnchangedFiles="true" />
+
+  </Target>
+
+</Project>


### PR DESCRIPTION
CoreFx still requires the launchSettings.json support files. Reverting the commit that removed the feature.