### PR TITLE
Changes in Sdk-tasks related to publishing to proxy-backed feeds

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
@@ -18,7 +18,11 @@
       - IsInternalBuild
       - IsStableBuild
       - ChannelId
-      - TargetFeedPAT
+      - RepositoryName
+      - CommitSha
+      - AzureStorageAccountName
+      - AzureStorageAccountKey
+      - AzureDevOpsFeedsBaseUrl
   -->
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
@@ -23,6 +23,7 @@
       - AzureStorageAccountName
       - AzureStorageAccountKey
       - AzureDevOpsFeedsBaseUrl
+      - ArtifactsCategory
   -->
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
@@ -10,7 +10,10 @@
       - RepositoryName
       - ChannelId
       - CommitSha
-      - AzdoTargetFeedPAT
+      - AzureStorageAccountName
+      - AzureStorageAccountKey
+      - AzureDevOpsFeedsBaseUrl
+      - ArtifactsCategory
   -->
 
   <Target Name="SetupTargetFeeds">
@@ -27,39 +30,31 @@
       Text="Parameter 'ChannelId' is empty. The ID of the target channel id BAR is required." />
 
     <Error
-      Condition="'$(AzdoTargetFeedPAT)' == '' and '$(IsStableBuild)' == 'true'"
-      Text="Parameter 'AzdoTargetFeedPAT' is empty. The PAT used for creating AzDO feeds is required for publishing stable builds." />
+      Condition="('$(AzureStorageAccountName)' == '' or '$(AzureStorageAccountKey)' == '') and '$(IsStableBuild)' == 'true'"
+      Text="Parameters 'AzureStorageAccountName/Key' are empty." />
 
     <!--
       When a build is stable we ask `CreateAzureDevOpsFeed` in Tasks.Feed to create a new AzDO feed.
       That feed will be public/internal depending on whether the build is public/internal.
     -->
-    <CreateAzureDevOpsFeed
+    <CreateInternalBlobFeed
         Condition="'$(IsStableBuild)' == 'true'"
-        IsInternal="$(IsInternalBuild)"
         RepositoryName="$(RepositoryName)"
         CommitSha="$(CommitSha)"
-        AzureDevOpsPersonalAccessToken="$(AzdoTargetFeedPAT)">
+        AzureDevOpsFeedsBaseUrl="$(AzureDevOpsFeedsBaseUrl)"
+        AzureStorageAccountName="$(AzureStorageAccountName)"
+        AzureStorageAccountKey="$(AzureStorageAccountKey)">
       <Output TaskParameter="TargetFeedURL" PropertyName="NewAzDoFeedURL"/>
       <Output TaskParameter="TargetFeedName" PropertyName="NewTargetFeedName"/>
-    </CreateAzureDevOpsFeed>
+    </CreateInternalBlobFeed>
 
     <ItemGroup Condition="'$(IsStableBuild)' == 'true'">
       <TargetFeedConfig
-        Condition="'$(IsInternalBuild)' == 'true'"
         Include="NetCore;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX"
-        TargetURL="$(NewAzDoFeedURL)/nuget/v3/index.json"
+        TargetURL="$(NewAzDoFeedURL)/index.json"
         FeedName="$(NewTargetFeedName)"
-        Type="AzDoNugetFeed"
-        Token="$(AzdoTargetFeedPAT)" />
-
-      <TargetFeedConfig
-        Condition="'$(IsInternalBuild)' == 'false'"
-        Include="NetCore;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX"
-        TargetURL="$(NewAzDoFeedURL)/nuget/v3/index.json"
-        FeedName="public/$(NewTargetFeedName)"
-        Type="AzDoNugetFeed"
-        Token="$(AzdoTargetFeedPAT)" />
+        Type="AzureStorageFeed"
+        Token="$(AzureStorageAccountKey)" />
     </ItemGroup>
 
     <!-- Assets for non-stable AND Internal builds are published to a static feed for now. -->
@@ -69,14 +64,39 @@
         TargetURL="https://dnceng.pkgs.visualstudio.com/_packaging/dotnet-core-internal/nuget/v3/index.json"
         FeedName="dotnet-core-internal"
         Type="AzDoNugetFeed"
-        Token="$(AzdoTargetFeedPAT)" />
+        Token="$(AzureStorageAccountKey)" />
     </ItemGroup>
+
+    <!--
+      - Adding this to let repos that want to override the TargetFeed be able to do so.
+      - I'm reusing the parameter that was introduced by RM pipelines so that no further 
+        changes are needed in customer repos.
+      - Eventually this will be deprecated or at least modified so that the build TargetFeed
+        is selected based on build intent ('channel').
+    -->
+    <PropertyGroup>
+      <TargetStaticFeed Condition="'$(ArtifactsCategory.ToUpper())' == '.NETCORE'">https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</TargetStaticFeed>
+      <TargetStaticFeed Condition="'$(ArtifactsCategory.ToUpper())' == '.NETCOREVALIDATION'">https://dotnetfeed.blob.core.windows.net/arcade-validation/index.json</TargetStaticFeed>
+      <TargetStaticFeed Condition="'$(ArtifactsCategory.ToUpper())' == 'ASPNETCORE'">https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json</TargetStaticFeed>
+      <TargetStaticFeed Condition="'$(ArtifactsCategory.ToUpper())' == 'ASPNETCORETOOLING'">https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore-tooling/index.json</TargetStaticFeed>
+      <TargetStaticFeed Condition="'$(ArtifactsCategory.ToUpper())' == 'ENTITYFRAMEWORKCORE'">https://dotnetfeed.blob.core.windows.net/aspnet-entityframeworkcore/index.json</TargetStaticFeed>
+      <TargetStaticFeed Condition="'$(ArtifactsCategory.ToUpper())' == 'ASPNETEXTENSIONS'">https://dotnetfeed.blob.core.windows.net/aspnet-extensions/index.json</TargetStaticFeed>
+      <TargetStaticFeed Condition="'$(ArtifactsCategory.ToUpper())' == 'CORECLR'">https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json</TargetStaticFeed>
+      <TargetStaticFeed Condition="'$(ArtifactsCategory.ToUpper())' == 'CORESDK'">https://dotnetfeed.blob.core.windows.net/dotnet-sdk/index.json</TargetStaticFeed>
+      <TargetStaticFeed Condition="'$(ArtifactsCategory.ToUpper())' == 'TOOLSINTERNAL'">https://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json</TargetStaticFeed>
+      <TargetStaticFeed Condition="'$(ArtifactsCategory.ToUpper())' == 'TOOLSET'">https://dotnetfeed.blob.core.windows.net/dotnet-toolset/index.json</TargetStaticFeed>
+      <TargetStaticFeed Condition="'$(ArtifactsCategory.ToUpper())' == 'WINDOWSDESKTOP'">https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json</TargetStaticFeed>
+      <TargetStaticFeed Condition="'$(ArtifactsCategory.ToUpper())' == 'NUGETCLIENT'">https://dotnetfeed.blob.core.windows.net/nuget-nugetclient/index.json</TargetStaticFeed>
+      <TargetStaticFeed Condition="'$(ArtifactsCategory.ToUpper())' == 'ASPNETENTITYFRAMEWORK6'">https://dotnetfeed.blob.core.windows.net/aspnet-entityframework6/index.json</TargetStaticFeed>
+      <TargetStaticFeed Condition="'$(ArtifactsCategory.ToUpper())' == 'ASPNETBLAZOR'">https://dotnetfeed.blob.core.windows.net/aspnet-blazor/index.json</TargetStaticFeed>
+      <TargetStaticFeed Condition="'$(TargetStaticFeed)' == ''">https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</TargetStaticFeed>
+    </PropertyGroup>
 
     <!-- Public non-stable feed used by `Validation` Channel. -->
     <ItemGroup Condition="'@(TargetFeedConfig)' == '' AND '$(ChannelId)' == '9'">
       <TargetFeedConfig
         Include="NetCore;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX"
-        TargetURL="https://dotnetfeed.blob.core.windows.net/arcade-validation/index.json"
+        TargetURL="$(TargetStaticFeed)"
         FeedName="public/dotnet-core-validation-public"
         Type="AzureStorageFeed"
         Token="$(AzureStorageTargetFeedPAT)" />
@@ -86,7 +106,7 @@
     <ItemGroup Condition="'@(TargetFeedConfig)' == '' AND '$(ChannelId)' == '3'">
       <TargetFeedConfig
         Include="NetCore;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX"
-        TargetURL="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json"
+        TargetURL="$(TargetStaticFeed)"
         FeedName="public/dotnet-core-public"
         Type="AzureStorageFeed"
         Token="$(AzureStorageTargetFeedPAT)" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
@@ -34,8 +34,10 @@
       Text="Parameters 'AzureStorageAccountName/Key' are empty." />
 
     <!--
-      When a build is stable we ask `CreateAzureDevOpsFeed` in Tasks.Feed to create a new AzDO feed.
-      That feed will be public/internal depending on whether the build is public/internal.
+      When a build is stable we ask `CreateInternalBlobFeed` in Tasks.Feed to create a new AzDO feed.
+      That task will return an Azure Storage feed wrapped by an authenticated Azure function proxy,
+      we use that to mimic an internal/authenticated feed. This will likely change in the future once
+      we switch to using AzDO private feeds.
     -->
     <CreateInternalBlobFeed
         Condition="'$(IsStableBuild)' == 'true'"

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Versions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Versions.props
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.19320.2</MicrosoftDotNetMaestroTasksVersion>
     <MicrosoftDotNetBuildTasksVisualStudioVersion>$(ArcadeSdkVersion)</MicrosoftDotNetBuildTasksVisualStudioVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>2.2.0-beta.19325.6</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>2.2.0-beta.19358.3</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetSignCheckVersion Condition="'$(MicrosoftDotNetSignCheckVersion)' == ''">1.0.0-beta.19177.2</MicrosoftDotNetSignCheckVersion>
     <MicrosoftSymbolUploaderBuildTaskVersion Condition="'$(MicrosoftSymbolUploaderBuildTaskVersion)' == ''">1.0.0-beta-64131-01</MicrosoftSymbolUploaderBuildTaskVersion>
   </PropertyGroup>


### PR DESCRIPTION
Changes in Arcade SDK-Tasks required by this other PR: https://github.com/dotnet/arcade/pull/3249

This PR changes the feed selection logic to use the new task `CreateInternalBlobFeed` and also add support for customer repos overriding the default feeds in .Net Core and .Core Validation channels. This is needed when repos publish to their own feeds.

The other PR was tested with an SDK that I produced with these changes. This PR needs to be merged before that other one.