### PR TITLE
Support timeout for (non-Helix) test assembly execution 

### DIFF
--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -951,6 +951,10 @@ Additional command line arguments passed to the test runtime (i.e. `dotnet` or `
 For example, to invoke Mono with debug flags `--debug` (to get stack traces with line number information), set `TestRuntimeAdditionalArguments` to `--debug`.
 To override the default Shared Framework version that is selected based on the test project TFM, set `TestRuntimeAdditionalArguments` to `--fx-version x.y.z`.
 
+### `TestTimeout` (int)
+
+Timeout to apply to an individual invocation of the test runner (e.g. `xunit.console.exe`) for a single configuration. Integer number of milliseconds.
+
 ### `GenerateResxSource` (bool)
 
 When set to true, Arcade will generate a class source for all embedded .resx files.

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.targets
@@ -44,6 +44,7 @@
         <TargetFramework>$(TargetFramework)</TargetFramework>
         <TargetFrameworkIdentifier>$(TargetFrameworkIdentifier)</TargetFrameworkIdentifier>
         <TestRuntime>$(TestRuntime)</TestRuntime>
+        <TestTimeout>$(TestTimeout)</TestTimeout>
         <Architecture>$(_TestArchitecture)</Architecture>
         <EnvironmentDisplay>$(TargetFramework)|$(_TestArchitecture)</EnvironmentDisplay>
         <ResultsFilePathWithoutExtension>$(_ResultFileNameNoExt)</ResultsFilePathWithoutExtension>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
@@ -34,6 +34,7 @@
       <_TestEnvironment>%(TestToRun.EnvironmentDisplay)</_TestEnvironment>
       <_TestAssembly>%(TestToRun.Identity)</_TestAssembly>
       <_TestRuntime>%(TestToRun.TestRuntime)</_TestRuntime>
+      <_TestTimeout>%(TestToRun.TestTimeout)</_TestTimeout>
       <_TestRunnerAdditionalArguments>%(TestToRun.TestRunnerAdditionalArguments)</_TestRunnerAdditionalArguments>
 
       <!-- Always use net472 for desktop to enable displaying source location from Portable PDBs in stack traces -->
@@ -86,7 +87,12 @@
     <Delete Files="@(_OutputFiles)" />
 
     <Message Text="Running tests: $(_TestAssembly) [$(_TestEnvironment)]" Importance="high"/>
-    <Exec Command='$(_TestRunnerCommand)' LogStandardErrorAsError="false" WorkingDirectory="$(_TargetDir)" IgnoreExitCode="true">
+    <Exec Command='$(_TestRunnerCommand)'
+          LogStandardErrorAsError="false"
+          WorkingDirectory="$(_TargetDir)"
+          IgnoreExitCode="true"
+          Timeout="$(_TestTimeout)"
+          ContinueOnError="WarnAndContinue">
       <Output TaskParameter="ExitCode" PropertyName="_TestErrorCode" />
     </Exec>
 


### PR DESCRIPTION
Introduces $(TestTimeout), applied at the assembly/single-invocation-of-the-test-runner level.

Would this be interesting to y'all? We've been fighting mysterious timed-out builds that appear to be test hangs in MSBuild, but they're intermittent and happen only in Azure Pipelines, so I don't have any idea what is hanging. This would cause the build to kill the test process after a project-configurable time, so that it could complete before Pipelines kills the job for being over time, and the logging would be nicely collected.