### PR TITLE
Make new PublishArtifactsInManifest recognize regular Azure storage feeds

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -438,13 +438,19 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             const string azureStorageProxyFeedPattern =
                 @"(?<feedURL>https://([a-z-]+).azurewebsites.net/container/(?<container>[^/]+)/sig/\w+/se/([0-9]{4}-[0-9]{2}-[0-9]{2})/(?<baseFeedName>darc-(?<type>int|pub)-(?<repository>.+?)-(?<sha>[A-Fa-f0-9]{7,40})-?(?<subversion>\d*)/))index.json";
 
-            var match = Regex.Match(feedConfig.TargetFeedURL, azureStorageProxyFeedPattern);
+            // Matches package feeds like
+            // https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+            const string classicalStaticFeedPattern =
+                @"https://([a-z-]+).blob.core.windows.net/[^/]+/index.json";
 
-            if (match.Success)
+            var proxyBackedFeedMatch = Regex.Match(feedConfig.TargetFeedURL, azureStorageProxyFeedPattern);
+            var classicalStaticFeedMatch = Regex.Match(feedConfig.TargetFeedURL, classicalStaticFeedPattern);
+
+            if (proxyBackedFeedMatch.Success)
             {
-                var containerName = match.Groups["container"].Value;
-                var baseFeedName = match.Groups["baseFeedName"].Value;
-                var feedURL = match.Groups["feedURL"].Value;
+                var containerName = proxyBackedFeedMatch.Groups["container"].Value;
+                var baseFeedName = proxyBackedFeedMatch.Groups["baseFeedName"].Value;
+                var feedURL = proxyBackedFeedMatch.Groups["feedURL"].Value;
                 var storageAccountName = "dotnetfeed";
 
                 // Initialize the feed using sleet
@@ -460,6 +466,10 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 };
 
                 return new BlobFeedAction(sleetSource, feedConfig.FeedKey, Log);
+            }
+            else if (classicalStaticFeedMatch.Success)
+            {
+                return new BlobFeedAction(feedConfig.TargetFeedURL, feedConfig.FeedKey, Log);
             }
             else
             {

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -440,11 +440,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
             // Matches package feeds like
             // https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-            const string classicalStaticFeedPattern =
+            const string azureStorageStaticBlobFeedPattern =
                 @"https://([a-z-]+).blob.core.windows.net/[^/]+/index.json";
 
             var proxyBackedFeedMatch = Regex.Match(feedConfig.TargetFeedURL, azureStorageProxyFeedPattern);
-            var classicalStaticFeedMatch = Regex.Match(feedConfig.TargetFeedURL, classicalStaticFeedPattern);
+            var azureStorageStaticBlobFeedMatch = Regex.Match(feedConfig.TargetFeedURL, azureStorageStaticBlobFeedPattern);
 
             if (proxyBackedFeedMatch.Success)
             {
@@ -467,7 +467,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                 return new BlobFeedAction(sleetSource, feedConfig.FeedKey, Log);
             }
-            else if (classicalStaticFeedMatch.Success)
+            else if (azureStorageStaticBlobFeedMatch.Success)
             {
                 return new BlobFeedAction(feedConfig.TargetFeedURL, feedConfig.FeedKey, Log);
             }


### PR DESCRIPTION
While refactoring the PublishArtifactsInManifest task I missed the scenario that this task should still recognize regular Azure Storage feeds. This PR add parsing for that kind of feed URLs.