### PR TITLE
Update SDK tasks with new version of Tasks.Feed

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
@@ -24,6 +24,7 @@
       - AzureStorageAccountKey
       - AzureDevOpsFeedsBaseUrl
       - ArtifactsCategory
+      - AzureStorageTargetFeedPAT
   -->
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
@@ -14,6 +14,7 @@
       - AzureStorageAccountKey
       - AzureDevOpsFeedsBaseUrl
       - ArtifactsCategory
+      - AzureStorageTargetFeedPAT
   -->
 
   <Target Name="SetupTargetFeeds">

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Versions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Versions.props
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.19320.2</MicrosoftDotNetMaestroTasksVersion>
     <MicrosoftDotNetBuildTasksVisualStudioVersion>$(ArcadeSdkVersion)</MicrosoftDotNetBuildTasksVisualStudioVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>2.2.0-beta.19358.3</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>2.2.0-beta.19360.3</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetSignCheckVersion Condition="'$(MicrosoftDotNetSignCheckVersion)' == ''">1.0.0-beta.19177.2</MicrosoftDotNetSignCheckVersion>
     <MicrosoftSymbolUploaderBuildTaskVersion Condition="'$(MicrosoftSymbolUploaderBuildTaskVersion)' == ''">1.0.0-beta-64131-01</MicrosoftSymbolUploaderBuildTaskVersion>
   </PropertyGroup>


### PR DESCRIPTION
This new parameter is needed to inform the PAT to the Azure Storage account.