### PR TITLE
Update YAML publishing guidance

### DIFF
--- a/Documentation/CorePackages/YamlStagesPublishing.md
+++ b/Documentation/CorePackages/YamlStagesPublishing.md
@@ -20,6 +20,8 @@ Using stages for publishing seeks to unify the Arcade SDK build artifact publish
 
 In order to use this new publishing mechanism, the easiest way to start is by making your existing build pipeline a single stage, and adding a second stage that is driven by a template distributed with Arcade.
 
+1. Update the repo's arcade version to `1.0.0-beta.19360.8` or newer.
+
 1. Disable package publishing during the build:
 
     Set the `enablePublishUsingPipelines` template parameter to `true` when calling the `/eng/common/templates/jobs/jobs.yml` template.

--- a/Documentation/YamlStagesRepoStatus.md
+++ b/Documentation/YamlStagesRepoStatus.md
@@ -13,9 +13,12 @@ Target completion date is 8/13/2019.
 | Arcade                     | mawilkie         | Complete | ✔️ | |
 | Arcade-Services            | mawilkie         | Complete | ✔️ | |
 | Arcade-Validation          | mawilkie         | Complete | ✔️ | |
+| aspnet-AspLabs             | dougbu/johluo    | On track | ➖ | |
 | aspnet-AspNetCore          | dougbu/johluo    | On track | ➖ | |
 | aspnet-AspNetCore-Tooling  | dougbu/johluo    | On track | ➖ | |
+| aspnet-EntityFramework6    | dougbu/johluo    | On track | ➖ | |
 | aspnet-EntityFrameworkCore | dougbu/johluo    | On track | ➖ | |
+| aspnet-Blazor              | dougbu/johluo    | On track | ➖ | |
 | aspnet-Extensions          | dougbu/johluo    | On track | ➖ | |
 | CLI                        | licavalc         | On track | ➖ | |
 | CLICommandLineParser       | licavalc         | On track | ➖ | |
@@ -26,6 +29,7 @@ Target completion date is 8/13/2019.
 | Core-Setup                 | dleeapho         | On track | ➖ | |
 | FSharp                     | brettfo          | On track | ➖ | |
 | MSBuild                    | licavalc         | On track | ➖ | |
+| nuget-NugetClient          | dtivel           | On track | ➖ | |
 | Roslyn                     | jaredpar         | On track | ➖ | |
 | SDK                        | licavalc         | On track | ➖ | |
 | Standard                   | danmose          | On track | ➖ | |


### PR DESCRIPTION
1.0.0-beta.19360.8 or newer is needed to use the Yaml publishing.