### PR TITLE
Fix missing referenced mscorlib in VS

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -32,8 +32,12 @@
     <OutDir/>
   </PropertyGroup>
 
+  <!--
+    Workaround to fix that Visual Studio sometimes uses a special MSBuild evaluation
+    mode where all common conditions (e.g., inside ItemGroup) are ignored.
+  -->
   <Choose>
-    <When Condition=" '$(IsWpfTempProject)' == 'true' AND '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
+    <When Condition=" '$(IsWpfTempProject)' == 'true' and '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
       <ItemGroup>
         <Reference Include="mscorlib" Pack="false" />
       </ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -32,9 +32,13 @@
     <OutDir/>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(IsWpfTempProject)' == 'true' and '$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <Reference Include="mscorlib" Pack="false" />
-  </ItemGroup>
+  <Choose>
+    <When Condition=" '$(IsWpfTempProject)' == 'true' AND '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
+      <ItemGroup>
+        <Reference Include="mscorlib" Pack="false" />
+      </ItemGroup>
+    </When>
+  </Choose>
 
   <!--
     Workaround for a race condition https://github.com/Microsoft/msbuild/issues/1479.
@@ -44,7 +48,7 @@
     <TargetFrameworkMonikerAssemblyAttributesFileClean>true</TargetFrameworkMonikerAssemblyAttributesFileClean>
   </PropertyGroup>
 
-  <!-- 
+  <!--
      Portable PDBs are not included in .nupkg by default. Include them unless the project produces symbol packages.
      Remove this once we migrate to .snupkg. See https://github.com/dotnet/arcade/issues/1959.
    -->
@@ -143,7 +147,7 @@
 
   <!--
     NuGet Restore uses PackageId and project name in the same namespace, so that project reference can be interchanged with a package reference.
-    This causes issues however for leaf packages that are not to be referenced (such as analyzer or tools packages) when we want to name the package 
+    This causes issues however for leaf packages that are not to be referenced (such as analyzer or tools packages) when we want to name the package
     the same as an existing project in the solution. In that case we set PackageId to an invalid but unique value for Restore and override it for Pack
     with the desired name stored in $(NuspecPackageId).
   -->


### PR DESCRIPTION
Without this `Choose/When` statement inside VS we hit this missing reference in legacy projects:
![image](https://user-images.githubusercontent.com/1489133/61184173-f2a1ee00-a64a-11e9-9324-50542fb48718.png)
