### PR TITLE
fix: remove a typo in /eng/common/tools.ps1

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -169,7 +169,7 @@ function InstallDotNetSdk([string] $dotnetRoot, [string] $version, [string] $arc
   InstallDotNet $dotnetRoot $version $architecture
 }
 
-function InstallDotNet([string] $dotnetRoot, [string] $version, [string] $architecture = "", [string] $runtime = "", [bool] $skipNonVersionedFiles = $false) {  $installScript = GetDotNetInstallScript $dotnetRoot
+function InstallDotNet([string] $dotnetRoot, [string] $version, [string] $architecture = "", [string] $runtime = "", [bool] $skipNonVersionedFiles = $false) {
   $installScript = GetDotNetInstallScript $dotnetRoot
   $installParameters = @{
     Version = $version


### PR DESCRIPTION
`GetDotNetInstallScript` was called twice

Summary of the changes (Less than 80 chars)
 - Removed the call to `GetDotNetInstallScript` that was on the `function` declaration

#### Addresses #3304