### PR TITLE
Fixed [:space:] to [[:space:]] to fix regex warnings.

### DIFF
--- a/eng/common/init-tools-native.sh
+++ b/eng/common/init-tools-native.sh
@@ -71,7 +71,7 @@ function ReadGlobalJsonNativeTools {
   local native_tools_list=$(echo $native_tools_section | awk -F"[{}]" '{print $2}')
   native_tools_list=${native_tools_list//[\" ]/}
   native_tools_list=${native_tools_list//,/$'\n'}
-  native_tools_list="$(echo -e "${native_tools_list}" | tr -d '[:space:]')"
+  native_tools_list="$(echo -e "${native_tools_list}" | tr -d '[[:space:]]')"
 
   local old_IFS=$IFS
   while read -r line; do


### PR DESCRIPTION
During build of "Coreclr", awk prints out the following warning:

> warning: regexp component [:space:]' should probably be [[:space:]]'

So I fixed the script and code to fix the warning, so that this issue could be resolved without any major workaround or code breakage.

@janvorli then noted that the scripts are actually copied from the arcade repository, and asked me to make the .sh change in the arcade repo, so I am doing just that here.