### PR TITLE
Provide an option to suppress Native tools installation warnings

### DIFF
--- a/eng/common/init-tools-native.ps1
+++ b/eng/common/init-tools-native.ps1
@@ -103,7 +103,14 @@ try {
       if ($LASTEXITCODE -Ne "0") {
         $errMsg = "$ToolName installation failed"
         if ((Get-Variable 'DoNotAbortNativeToolsInstallationOnFailure' -ErrorAction 'SilentlyContinue') -and $DoNotAbortNativeToolsInstallationOnFailure) {
-            Write-Warning $errMsg
+            $showNativeToolsWarning = $true
+            if ((Get-Variable 'DoNotDisplayNativeToolsInstallationWarnings' -ErrorAction 'SilentlyContinue') -and $DoNotDisplayNativeToolsInstallationWarnings) {
+                $showNativeToolsWarning = $false
+            }
+            
+            if ($showNativeToolsWarning) {
+                Write-Warning $errMsg
+            }
             $toolInstallationFailure = $true
         } else {
             Write-Error $errMsg

--- a/eng/common/init-tools-native.ps1
+++ b/eng/common/init-tools-native.ps1
@@ -107,7 +107,6 @@ try {
             if ((Get-Variable 'DoNotDisplayNativeToolsInstallationWarnings' -ErrorAction 'SilentlyContinue') -and $DoNotDisplayNativeToolsInstallationWarnings) {
                 $showNativeToolsWarning = $false
             }
-            
             if ($showNativeToolsWarning) {
                 Write-Warning $errMsg
             }


### PR DESCRIPTION
Provides an option to suppress native tools installation related warnings for repos (like WPF, WinForms) that use the native-tools section in `global.json` for onboarding tools like perl and other tools that not contain typical managed assemblies. These tools always result in in error messages or warnings with text **"$ToolName installation failed"**. 

Interested repos can set `$DoNotDisplayNativeToolsInstallationWarnings = $true` in `eng\configure-toolset.ps1` to opt-in. 

/cc @AdamYoblick 