### PR TITLE
[WIP] Use dotnet vstest runner instead of xunit.console

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/Microsoft.DotNet.CoreFxTesting.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/Microsoft.DotNet.CoreFxTesting.targets
@@ -54,8 +54,6 @@
           Condition="'$(IncludeDefaultReferences)' == 'true' and '$(IncludeDefaultTestReferences)' == 'true'"
           BeforeTargets="SetupDefaultReferences">
     <ItemGroup>
-      <!-- Harmless, but causes PRI targets to run -->
-      <DefaultReferenceExclusions Include="System.Runtime.WindowsRuntime.UI.Xaml" />
       <DefaultReferenceExclusions Include="@(ReferenceFromRuntime)"/>
 
       <!-- Reference everything in the targeting pack directory -->

--- a/src/Microsoft.DotNet.CoreFxTesting/build/assets/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/assets/RunnerTemplate.Unix.txt
@@ -48,6 +48,9 @@ fi
 # Don't use a globally installed SDK.
 export DOTNET_MULTILEVEL_LOOKUP=0
 
+# Roll forward on [major], [minor] and [patch].
+export DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX=2
+
 exitcode_list[0]="Exited Successfully"
 exitcode_list[130]="SIGINT  Ctrl-C occurred. Likely tests timed out."
 exitcode_list[131]="SIGQUIT Ctrl-\ occurred. Core dumped."

--- a/src/Microsoft.DotNet.CoreFxTesting/build/assets/RunnerTemplate.Windows.txt
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/assets/RunnerTemplate.Windows.txt
@@ -50,6 +50,9 @@ if not defined RUNTIME_PATH (
 :: Don't use a globally installed SDK.
 set DOTNET_MULTILEVEL_LOOKUP=0
 
+:: Roll forward on [major], [minor] and [patch].
+set DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX=2
+
 :: ========================= BEGIN Test Execution ============================= 
 echo ----- start %DATE% %TIME% ===============  To repro directly: ===================================================== 
 echo pushd %EXECUTION_DIR%

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.props
@@ -4,9 +4,6 @@
 
   <PropertyGroup>
     <TestProjectName Condition="'$(TestProjectName)' == ''">$(MSBuildProjectName)</TestProjectName>
-    <TestsSuccessfulSemaphoreName>tests.passed</TestsSuccessfulSemaphoreName>
-    <TestDependsOn>GenerateRunScript;RunTests;</TestDependsOn>
-    <RunTestsDependsOn>ValidateTestPlatform;DiscoverRunTestsInputs;DiscoverRunTestsOutputs;</RunTestsDependsOn>
   </PropertyGroup>
 
   <!-- Set env variable to use the local netfx assemblies instead of the ones in the GAC. -->

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/Core.targets
@@ -7,7 +7,6 @@
     <TestAssembly Condition="'$(TestAssembly)' == ''">$(TargetFileName)</TestAssembly>
     <TestAssemblyFullPath>$([MSBuild]::NormalizePath('$(TestPath)', '$(TestAssembly)'))</TestAssemblyFullPath>
     <RunWorkingDirectory>$(TestPath)</RunWorkingDirectory>
-    <ArchiveTest Condition="'$(ArchiveTest)' == '' AND ('$(ArchiveTests.ToLower())' == 'all' OR $(MSBuildProjectName.ToLower().EndsWith('.$(ArchiveTests.ToLower())')))">true</ArchiveTest>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -85,36 +84,6 @@
 
   </Target>
 
-  <Target Name="DiscoverRunTestsInputs"
-          DependsOnTargets="ResolveReferences;GetCopyToOutputDirectoryItems">
-
-    <ItemGroup>
-      <RunTestsInputs Include="@(ReferenceCopyLocalPaths)" />
-      <RunTestsInputs Include="@(Content)" />
-      <RunTestsInputs Include="@(IntermediateAssembly)" />
-      <RunTestsInputs Include="@(_DebugSymbolsIntermediatePath)" />
-      <RunTestsInputs Include="@(AllItemsFullPathWithTargetPath)" />
-    </ItemGroup>
-
-  </Target>
-
-  <Target Name="DiscoverRunTestsOutputs">
-
-    <PropertyGroup>
-      <TestsSuccessfulSemaphorePath>$([MSBuild]::NormalizePath('$(TestPath)', '$(TestsSuccessfulSemaphoreName)'))</TestsSuccessfulSemaphorePath>
-      <TestResultsPath Condition="'$(TestResultsName)' != ''">$([MSBuild]::NormalizePath('$(TestPath)', '$(TestResultsName)'))</TestResultsPath>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <RunTestsOutputs Include="$(TestsSuccessfulSemaphorePath)" />
-      <RunTestsOutputs Condition="'$(TestResultsPath)' != ''" Include="$(TestResultsPath)" />
-    </ItemGroup>
-
-    <Delete Files="$(TestsSuccessfulSemaphorePath)"
-            Condition="'$(ForceRunTests)' == 'true' AND Exists($(TestsSuccessfulSemaphorePath))" />
-
-  </Target>
-
   <Target Name="ValidateTestPlatform">
 
     <ItemGroup>
@@ -137,9 +106,7 @@
 
   <Target Name="RunTests"
           Condition="'$(TestDisabled)' != 'true'"
-          DependsOnTargets="$(RunTestsDependsOn)"
-          Inputs="@(RunTestsInputs)"
-          Outputs="@(RunTestsOutputs)">
+          DependsOnTargets="ValidateTestPlatform">
 
     <Error Condition="!Exists('$(TestAssemblyFullPath)')"
            Text="Test assembly couldn't be found. Make sure to build the test project first." />
@@ -162,8 +129,6 @@
     </PropertyGroup>
 
     <Error Condition="'$(TestRunExitCode)' != '0'" Text="$(TestRunErrorMessage)" />
-    <Touch Condition="'$(TestRunExitCode)' == '0'" Files="$(TestsSuccessfulSemaphorePath)" AlwaysCreate="true" />
-
   </Target>
 
   <!--

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.props
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.props
@@ -5,27 +5,31 @@
   <PropertyGroup>
     <TestRunnerConfigPath>$(TestAssetsDir)xunit.runner.json</TestRunnerConfigPath>
     <TestResultsName>testResults.xml</TestResultsName>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!-- Microsoft.Net.Test.Sdk brings a lot of satellite assemblies in. -->
+    <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Condition="'$(IncludeRemoteExecutor)' == 'true'" Include="Microsoft.DotNet.RemoteExecutor" Version="$(MicrosoftDotNetRemoteExecutorPackageVersion)" />
 
-    <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsPackageVersion)" />
-    <!-- Excluding xunit.core/build as it enables deps file generation. -->
-    <PackageReference Include="xunit" Version="$(XUnitPackageVersion)" ExcludeAssets="build" />
-    <PackageReference Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" Include="Microsoft.DotNet.XUnitConsoleRunner" Version="$(MicrosoftDotNetXUnitConsoleRunnerPackageVersion)" />
-    <PackageReference Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" Include="xunit.runner.console" Version="$(XUnitPackageVersion)" />
-
-    <!-- Microsoft.Net.Test.Sdk brings a lot of assemblies with it. To reduce helix payload submission size we disable it on CI. -->
-    <PackageReference Condition="'$(ArchiveTest)' != 'true'" Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Condition="'$(ArchiveTest)' != 'true'" Include="xunit.runner.visualstudio" Version="$(XUnitPackageVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
     <!--
       Microsoft.Net.Test.Sdk has a dependency on Newtonsoft.Json v9.0.1. We upgrade the dependency version
       with the one used in corefx to have a consistent set of dependency versions. Additionally this works
       around a dupliate type between System.Runtime.Serialization.Formatters and Newtonsoft.Json.
     -->
-    <PackageReference Condition="'$(ArchiveTest)' != 'true'" Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+
+    <PackageReference Include="xunit" Version="$(XUnitPackageVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitPackageVersion)" />
+    <PackageReference Include="XunitXml.TestLogger" Version="$(XUnitXmlTestLoggerPackageVersion)" />
+    <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="$(TestRunnerConfigPath)"
+          CopyToOutputDirectory="PreserveNewest"
+          Visible="false" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
@@ -1,123 +1,65 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
-  <!-- General xunit options -->
+
   <PropertyGroup>
-    <RunArguments>$(TestAssembly)</RunArguments>
-    <RunArguments>$(RunArguments) -xml $(TestResultsName)</RunArguments>
-    <RunArguments>$(RunArguments) -nologo</RunArguments>
-    <RunArguments Condition="'$(ArchiveTest)' == 'true'">$(RunArguments) -nocolor</RunArguments>
-    <RunArguments>$(RunArguments) -notrait category=non$(_bc_TargetGroup)tests</RunArguments>
+    <RunCommand>"$(RunScriptHost)"</RunCommand>
+    <RunArguments>test $(TestAssembly)</RunArguments>
 
-    <TargetOSTrait Condition="'$(TargetOS)' == 'Windows_NT'">nonwindowstests</TargetOSTrait>
-    <TargetOSTrait Condition="'$(TargetOS)' == 'Linux'">nonlinuxtests</TargetOSTrait>
-    <TargetOSTrait Condition="'$(TargetOS)' == 'OSX'">nonosxtests</TargetOSTrait>
-    <TargetOSTrait Condition="'$(TargetOS)' == 'FreeBSD'">nonfreebsdtests</TargetOSTrait>
-    <TargetOSTrait Condition="'$(TargetOS)' == 'NetBSD'">nonnetbsdtests</TargetOSTrait>
-    <RunArguments Condition="'$(TargetOSTrait)' != ''">$(RunArguments) -notrait category=$(TargetOSTrait)</RunArguments>
+    <RunArguments>$(RunArguments) --logger "xunit;LogFilePath=$(TestResultsName)"</RunArguments>
+    <RunArguments>$(RunArguments) --framework $(TargetFramework)</RunArguments>
+    <RunArguments>$(RunArguments) --platform $(ArchGroup)</RunArguments>
+    <RunArguments Condition="'$(TestDisableParallelization)' != 'true'">$(RunArguments) --parallel</RunArguments>
+    <RunArguments Condition="'$(TestBlame)' == 'true'">$(RunArguments) --blame</RunArguments>
 
-    <!-- Add local and global options to the argument stack. -->
-    <RunArguments Condition="'$(XUnitMaxThreads)' != ''">$(RunArguments) -maxthreads $(XUnitMaxThreads)</RunArguments>
-    <RunArguments Condition="'$(XUnitMethodName)' != ''">$(RunArguments) -method $(XUnitMethodName)</RunArguments>
-    <RunArguments Condition="'$(XUnitClassName)' != ''">$(RunArguments) -class $(XUnitClassName)</RunArguments>
-    <RunArguments Condition="'$(XUnitShowProgress)' == 'true'">$(RunArguments) -verbose</RunArguments>
-    <RunArguments Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(XUnitNoAppdomain)' == 'true'">$(RunArguments) -noappdomain</RunArguments>
+    <!-- Target OS category -->
+    <TargetOSCategory Condition="'$(TargetOS)' == 'Windows_NT'">nonwindowstests</TargetOSCategory>
+    <TargetOSCategory Condition="'$(TargetOS)' == 'Linux'">nonlinuxtests</TargetOSCategory>
+    <TargetOSCategory Condition="'$(TargetOS)' == 'OSX'">nonosxtests</TargetOSCategory>
+    <TargetOSCategory Condition="'$(TargetOS)' == 'FreeBSD'">nonfreebsdtests</TargetOSCategory>
+    <TargetOSCategory Condition="'$(TargetOS)' == 'NetBSD'">nonnetbsdtests</TargetOSCategory>
 
-    <!-- Legacy Outerloop switch -->
-    <TestScope Condition="'$(TestScope)' == '' and '$(Outerloop)' == 'true'">all</TestScope>
-    
-    <!-- Traits -->
-    <WithoutCategories Condition="'$(ArchiveTest)' == 'true'">IgnoreForCI</WithoutCategories>
+    <!-- Default and user defined categories -->
     <_withCategories Condition="'$(WithCategories)' != ''">;$(WithCategories.Trim(';'))</_withCategories>
     <_withoutCategories Condition="'$(WithoutCategories)' != ''">;$(WithoutCategories.Trim(';'))</_withoutCategories>
-    <!-- Default categories -->
+
+    <TestScope Condition="'$(TestScope)' == '' and '$(Outerloop)' == 'true'">all</TestScope>
     <_withCategories Condition="'$(TestScope)' == 'outerloop'">$(_withCategories);OuterLoop</_withCategories>
+    <_withoutCategories Condition="'$(ArchiveTest)' == 'true'">$(_withoutCategories);IgnoreForCI</_withoutCategories>
     <_withoutCategories Condition="'$(TestScope)' == '' or '$(TestScope)' == 'innerloop'">$(_withoutCategories);OuterLoop</_withoutCategories>
     <_withoutCategories Condition="!$(_withCategories.Contains('failing'))">$(_withoutCategories);failing</_withoutCategories>
-    <!-- Add to run argument string -->
-    <RunArguments>$(RunArguments)$(_withCategories.Replace(';', ' -trait category='))</RunArguments>
-    <RunArguments>$(RunArguments)$(_withoutCategories.Replace(';', ' -notrait category='))</RunArguments>
+
+    <_withoutCategories>$(_withoutCategories);non$(_bc_TargetGroup)tests</_withoutCategories>
+    <_withoutCategories Condition="'$(TargetOSCategory)' != ''">$(_withoutCategories);$(TargetOSCategory)</_withoutCategories>
+
+    <_testFilter Condition="'$(_withCategories)' != ''">$(_withCategories.Replace(';', '&amp;category='))</_testFilter>
+    <_testFilter Condition="'$(_withoutCategories)' != ''">$(_testFilter)$(_withoutCategories.Replace(';', '&amp;category!='))</_testFilter>
+    <!-- On Windows in bat scripts with delayed expansion enabled we need to escape the bang operator. -->
+    <_testFilter Condition="'$(TargetOS)' == 'Windows_NT'">$(_testFilter.Replace('!=', '^!='))</_testFilter>
+    <_testFilter>$(_testFilter.Trim('&amp;'))</_testFilter>
+    <!-- On Windows in bat scripts with delayed expansion enabled we need to escape the bang operator. -->
+    <_testFilter Condition="'$(TestFilter)' != ''">$(_testFilter)&amp;$(TestFilter.Replace('!=', '^!='))</_testFilter>
+
+    <RunArguments>$(RunArguments) --filter "($(_testFilter))"</RunArguments>
 
     <!-- User passed in options. -->
-    <RunArguments Condition="'$(XUnitOptions)' != ''">$(RunArguments) $(XUnitOptions)</RunArguments>
+    <RunArguments Condition="'$(TestOptions)' != ''">$(RunArguments) $(TestOptions)</RunArguments>
+
+    <RunSettingsOptions Condition="'$(TestDisableParallelization)' == 'true'">$(RunSettingsOptions) RunConfiguration.DisableParallelization=true</RunSettingsOptions>
+    <RunSettingsOptions Condition="'$(TestDisableAppDomain)' == 'true'">$(RunSettingsOptions) RunConfiguration.DisableAppDomain=true</RunSettingsOptions>
+    <RunArguments Condition="'$(RunSettingsOptions)' != ''">$(RunArguments)  --(RunSettingsOptions)</RunArguments>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <TestsSuccessfulSemaphoreName Condition="'$(WithCategories)' != ''">$(TestsSuccessfulSemaphoreName).with$(WithCategories.Replace(';', '.'))</TestsSuccessfulSemaphoreName>
-    <TestsSuccessfulSemaphoreName Condition="'$(WithoutCategories)' != ''">$(TestsSuccessfulSemaphoreName).without$(WithoutCategories.Replace(';', '.'))</TestsSuccessfulSemaphoreName>
-  </PropertyGroup>
-
-  <Target Name="ValidateTargetOSTrait"
+  <Target Name="ValidateTargetOSCategory"
           BeforeTargets="GenerateRunScript">
 
-    <Error Condition="'$(TargetOSTrait)' == ''"
+    <Error Condition="'$(TargetOSCategory)' == ''"
            Text="TargetOS [$(TargetOS)] is unknown so we don't know how to configure the test run for this project [$(TestProjectName)]" />
 
   </Target>
 
-  <!-- Overwrite the runner config file with the app local one. -->
-  <Target Name="OverwriteDesktopTestRunnerConfigs"
-          Condition="'$(GenerateRuntimeConfigurationFiles)' == 'true' and '$(TargetFrameworkIdentifier)' == '.NETFramework'"
-          AfterTargets="CopyFilesToOutputDirectory">
-
-    <ItemGroup>
-      <_testRunnerConfigSourceFile Include="$(TargetDir)$(TargetName).exe.config" />
-      <_testRunnerConfigDestFile Include="$(TargetDir)$(TestRunnerName).config" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(_testRunnerConfigSourceFile)"
-          Condition="'@(_testRunnerConfigSourceFile)' != ''"
-          DestinationFiles="@(_testRunnerConfigDestFile)"
-          SkipUnchangedFiles="true" />
-
-  </Target>
-
-  <!-- Setup run commands. -->
-  <Choose>
-
-    <When Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
-      <PropertyGroup>
-        <TestRunnerName>xunit.console.dll</TestRunnerName>
-        <RunCommand>"$(RunScriptHost)"</RunCommand>
-        <RunArguments>exec --runtimeconfig $(AssemblyName).runtimeconfig.json $(TestRunnerName) $(RunArguments)</RunArguments>
-      </PropertyGroup>
-    </When>
-
-    <When Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-      <PropertyGroup>
-        <TestRunnerName>xunit.console.exe</TestRunnerName>
-        <RunCommand>$(TestRunnerName)</RunCommand>
-      </PropertyGroup>
-    </When>
-
-  </Choose>
-
-  <!-- ResolveAssemblyReferences is the target that populates ReferenceCopyLocalPaths which is what is copied to output directory. -->
-  <Target Name="CopyRunnerToOutputDirectory" BeforeTargets="ResolveAssemblyReferences">
-    <ItemGroup>
-      <!-- Add the runner configuration file -->
-      <None Include="$(TestRunnerConfigPath)"
-            CopyToOutputDirectory="PreserveNewest"
-            Visible="false" />
-
-      <!-- Copy test runner to output directory -->
-      <None Include="$([System.IO.Path]::GetDirectoryName('$(XunitConsole472Path)'))\*"
-            Exclude="$([System.IO.Path]::GetDirectoryName('$(XunitConsole472Path)'))\xunit.console.*exe.config;$([System.IO.Path]::GetDirectoryName('$(XunitConsole472Path)'))\xunit.console.x86.exe"
-            Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(XunitConsole472Path)' != ''"
-            CopyToOutputDirectory="PreserveNewest"
-            Visible="false" />
-
-      <_xunitConsoleNetCoreExclude Condition="'$(GenerateDependencyFile)' != 'true'" Include="$([System.IO.Path]::GetDirectoryName('$(XunitConsoleNetCore21AppPath)'))\xunit.console.deps.json" />
-      <None Include="$([System.IO.Path]::GetDirectoryName('$(XunitConsoleNetCore21AppPath)'))\*"
-            Exclude="@(_xunitConsoleNetCoreExclude)"
-            Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(XunitConsoleNetCore21AppPath)' != ''"
-            CopyToOutputDirectory="PreserveNewest"
-            Visible="false" />
-    </ItemGroup>
-  </Target>
-
   <!-- Main test targets -->
-  <Target Name="Test" DependsOnTargets="$(TestDependsOn)" />
+  <Target Name="Test" DependsOnTargets="GenerateRunScript;RunTests" />
   <Target Name="BuildAndTest" DependsOnTargets="Build;Test" />
   <Target Name="RebuildAndTest" DependsOnTargets="Rebuild;Test" />
 


### PR DESCRIPTION
Switching from the unsupported xunit.console to dotnet test.

I had to bring the major version roll-forward policy back as the 3.0 SDK expects a 3.0 runtime to be present in the testhost folder. I don't know how to work around that until we have a 5.0 SDK and how to prevent that in future when we again switch the major version. Maybe we should coordinate the SDK branching with corefx/coreclr/core-setup more closely going forward.

Keeping the WIP marker until I validated all verticals and configurations in corefx. The consuming corefx branch to be cloned locally can be found here: https://github.com/ViktorHofer/corefx/tree/DotNetTest

cc @ericstj @safern @danmosemsft