### PR TITLE
Support configuring a test feed on the fly

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
@@ -17,8 +17,13 @@
       - AzureStorageTargetFeedPAT
       - StaticInternalFeed          : URL of the feed to publish internal non-stable packages
       
-      - CreateTestConfig            : If set to true the user will be able to test a TargetFeedConfig constructed using:
-          - TestFeedCategories, TestFeedURL, TestFeedName, TestFeedType and TestFeedToken
+      - CreateTestConfig            : If set to true the user will be able to test a TargetFeedConfig 
+                                      constructed using parameters below:
+        - TestFeedCategories
+        - TestFeedURL
+        - TestFeedName
+        - TestFeedType
+        - TestFeedToken
   -->
 
   <Target Name="SetupTargetFeeds">
@@ -39,7 +44,7 @@
       Text="Parameters 'AzureStorageAccountName/Key' are empty." />
 
     <!--
-      If the wants to use a test configuration we'll create a TargetFeedConfig using
+      If the user wants to use a test configuration we'll create a TargetFeedConfig using
       optional parameters passed as properties. This should prevent all the other 
       cases below from being activated.
     -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
@@ -16,6 +16,9 @@
       - ArtifactsCategory
       - AzureStorageTargetFeedPAT
       - StaticInternalFeed          : URL of the feed to publish internal non-stable packages
+      
+      - CreateTestConfig            : If set to true the user will be able to test a TargetFeedConfig constructed using:
+          - TestFeedCategories, TestFeedURL, TestFeedName, TestFeedType and TestFeedToken
   -->
 
   <Target Name="SetupTargetFeeds">
@@ -36,13 +39,27 @@
       Text="Parameters 'AzureStorageAccountName/Key' are empty." />
 
     <!--
+      If the wants to use a test configuration we'll create a TargetFeedConfig using
+      optional parameters passed as properties. This should prevent all the other 
+      cases below from being activated.
+    -->
+    <ItemGroup Condition="'$(CreateTestConfig)' == 'true'">
+      <TargetFeedConfig
+        Include="$(TestFeedCategories)"
+        TargetURL="$(TestFeedURL)"
+        FeedName="$(TestFeedName)"
+        Type="$(TestFeedType)"
+        Token="$(TestFeedToken)" />
+    </ItemGroup>
+
+    <!--
       When a build is stable we ask `CreateInternalBlobFeed` in Tasks.Feed to create a new AzDO feed.
       That task will return an Azure Storage feed wrapped by an authenticated Azure function proxy,
       we use that to mimic an internal/authenticated feed. This will likely change in the future once
       we switch to using AzDO private feeds.
     -->
     <CreateInternalBlobFeed
-        Condition="'$(IsStableBuild)' == 'true'"
+        Condition="'@(TargetFeedConfig)' == '' AND '$(IsStableBuild)' == 'true'"
         RepositoryName="$(RepositoryName)"
         CommitSha="$(CommitSha)"
         AzureDevOpsFeedsBaseUrl="$(AzureDevOpsFeedsBaseUrl)"
@@ -52,7 +69,7 @@
       <Output TaskParameter="TargetFeedName" PropertyName="NewTargetFeedName"/>
     </CreateInternalBlobFeed>
 
-    <ItemGroup Condition="'$(IsStableBuild)' == 'true'">
+    <ItemGroup Condition="'@(TargetFeedConfig)' == '' AND '$(IsStableBuild)' == 'true'">
       <TargetFeedConfig
         Include="NetCore;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX"
         TargetURL="$(NewAzDoFeedURL)/index.json"


### PR DESCRIPTION
Let the user pass a configuration for a test feed. This is useful when we need to test things in INT before creating PRs, etc.

Built an SDK here: https://dnceng.visualstudio.com/internal/_build/results?buildId=273063&view=results
Tested the task here: https://dnceng.visualstudio.com/internal/_build/results?buildId=273392&view=results