### PR TITLE
Refactor gather-drop validation into separate template

### DIFF
--- a/eng/common/post-build/darc-gather-drop.ps1
+++ b/eng/common/post-build/darc-gather-drop.ps1
@@ -1,0 +1,36 @@
+param(
+  [Parameter(Mandatory=$true)][string] $BarBuildId,             # ID of the build which assets should be downloaded
+  [Parameter(Mandatory=$true)][string] $MaestroAccessToken,     # Token used to access Maestro API
+  [Parameter(Mandatory=$true)][string] $DropLocation            # Where the assets should be downloaded to
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version 2.0
+
+. $PSScriptRoot\..\tools.ps1
+
+try {
+  Write-Host "Installing DARC ..."
+
+  . $PSScriptRoot\..\darc-init.ps1
+  $exitCode = $LASTEXITCODE
+
+  if ($exitCode -ne 0) {
+    Write-PipelineTaskError "Something failed while running 'darc-init.ps1'. Check for errors above. Exiting now..."
+    ExitWithExitCode $exitCode
+  }
+
+  darc gather-drop --non-shipping `
+    --continue-on-error `
+    --id $BarBuildId `
+    --output-dir $DropLocation `
+    --bar-uri https://maestro-prod.westus2.cloudapp.azure.com/ `
+    --password $MaestroAccessToken `
+    --latest-location
+}
+catch {
+  Write-Host $_
+  Write-Host $_.Exception
+  Write-Host $_.ScriptStackTrace
+  ExitWithExitCode 1
+}

--- a/eng/common/templates/post-build/channels/internal-servicing.yml
+++ b/eng/common/templates/post-build/channels/internal-servicing.yml
@@ -143,29 +143,6 @@ stages:
             filePath: $(Build.SourcesDirectory)/eng/common/post-build/symbols-validation.ps1
             arguments: -InputPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/ -ExtractPath $(Agent.BuildDirectory)/Temp/ -DotnetSymbolVersion $(SymbolToolVersion)
 
-  - job:
-    displayName: Gather Drop
-    dependsOn: setupMaestroVars
-    variables:
-      BARBuildId: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
-    condition: contains(dependencies.setupMaestroVars.outputs['setReleaseVars.InitialChannels'], variables.InternalServicing_30_Channel_Id)
-    pool:
-      vmImage: 'windows-2019'
-    steps:
-      - task: PowerShell@2
-        displayName: Setup Darc CLI
-        inputs:
-          targetType: filePath
-          filePath: '$(Build.SourcesDirectory)/eng/common/darc-init.ps1'
-
-      - task: PowerShell@2
-        displayName: Run Darc gather-drop
-        inputs:
-          targetType: inline
-          script: |
-            darc gather-drop --non-shipping --continue-on-error --id $(BARBuildId) --output-dir $(Agent.BuildDirectory)/Temp/Drop/ --bar-uri https://maestro-prod.westus2.cloudapp.azure.com/ --password $(MaestroAccessToken) --latest-location
-        enabled: false
-
   - template: ../promote-build.yml
     parameters:
       ChannelId: ${{ variables.InternalServicing_30_Channel_Id }}

--- a/eng/common/templates/post-build/channels/public-dev-release.yml
+++ b/eng/common/templates/post-build/channels/public-dev-release.yml
@@ -140,27 +140,9 @@ stages:
             filePath: $(Build.SourcesDirectory)/eng/common/post-build/symbols-validation.ps1
             arguments: -InputPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/ -ExtractPath $(Agent.BuildDirectory)/Temp/ -DotnetSymbolVersion $(SymbolToolVersion)
 
-  - job:
-    displayName: Gather Drop
-    dependsOn: setupMaestroVars
-    variables:
-      BARBuildId: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
-    condition: contains(dependencies.setupMaestroVars.outputs['setReleaseVars.InitialChannels'], variables.PublicDevRelease_30_Channel_Id)
-    pool:
-      vmImage: 'windows-2019'
-    steps:
-      - task: PowerShell@2
-        displayName: Setup Darc CLI
-        inputs:
-          targetType: filePath
-          filePath: '$(Build.SourcesDirectory)/eng/common/darc-init.ps1'
-
-      - task: PowerShell@2
-        displayName: Run Darc gather-drop
-        inputs:
-          targetType: inline
-          script: |
-            darc gather-drop --non-shipping --continue-on-error --id $(BARBuildId) --output-dir $(Agent.BuildDirectory)/Temp/Drop/ --bar-uri https://maestro-prod.westus2.cloudapp.azure.com/ --password $(MaestroAccessToken) --latest-location
+  - template: ../darc-gather-drop.yml
+    parameters:
+      ChannelId: ${{ variables.PublicDevRelease_30_Channel_Id }}
 
   - template: ../promote-build.yml	
     parameters:	

--- a/eng/common/templates/post-build/channels/public-release.yml
+++ b/eng/common/templates/post-build/channels/public-release.yml
@@ -143,29 +143,6 @@ stages:
             filePath: $(Build.SourcesDirectory)/eng/common/post-build/symbols-validation.ps1
             arguments: -InputPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/ -ExtractPath $(Agent.BuildDirectory)/Temp/ -DotnetSymbolVersion $(SymbolToolVersion)
 
-  - job:
-    displayName: Gather Drop
-    dependsOn: setupMaestroVars
-    variables:
-      BARBuildId: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
-    condition: contains(dependencies.setupMaestroVars.outputs['setReleaseVars.InitialChannels'], variables.PublicRelease_30_Channel_Id)
-    pool:
-      vmImage: 'windows-2019'
-    steps:
-      - task: PowerShell@2
-        displayName: Setup Darc CLI
-        inputs:
-          targetType: filePath
-          filePath: '$(Build.SourcesDirectory)/eng/common/darc-init.ps1'
-
-      - task: PowerShell@2
-        displayName: Run Darc gather-drop
-        inputs:
-          targetType: inline
-          script: |
-            darc gather-drop --non-shipping --continue-on-error --id $(BARBuildId) --output-dir $(Agent.BuildDirectory)/Temp/Drop/ --bar-uri https://maestro-prod.westus2.cloudapp.azure.com/ --password $(MaestroAccessToken) --latest-location
-        enabled: false
-
   - template: ../promote-build.yml
     parameters:
       ChannelId: ${{ variables.PublicRelease_30_Channel_Id }}

--- a/eng/common/templates/post-build/channels/public-validation-release.yml
+++ b/eng/common/templates/post-build/channels/public-validation-release.yml
@@ -91,29 +91,9 @@ stages:
   jobs:
   - template: ../setup-maestro-vars.yml
 
-  - job:
-    displayName: Gather Drop
-    dependsOn: setupMaestroVars
-    condition: contains(dependencies.setupMaestroVars.outputs['setReleaseVars.InitialChannels'], variables.PublicValidationRelease_30_Channel_Id)
-    variables:
-      - name: BARBuildId
-        value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
-      - group: Publish-Build-Assets
-    pool:
-      vmImage: 'windows-2019'
-    steps:
-      - task: PowerShell@2
-        displayName: Setup Darc CLI
-        inputs:
-          targetType: filePath
-          filePath: '$(Build.SourcesDirectory)/eng/common/darc-init.ps1'
-
-      - task: PowerShell@2
-        displayName: Run Darc gather-drop
-        inputs:
-          targetType: inline
-          script: |
-            darc gather-drop --non-shipping --continue-on-error --id $(BARBuildId) --output-dir $(Agent.BuildDirectory)/Temp/Drop/ --bar-uri https://maestro-prod.westus2.cloudapp.azure.com --password $(MaestroAccessToken) --latest-location
+  - template: ../darc-gather-drop.yml
+    parameters:
+      ChannelId: ${{ variables.PublicValidationRelease_30_Channel_Id }}
 
   - template: ../promote-build.yml	
     parameters:	

--- a/eng/common/templates/post-build/darc-gather-drop.yml
+++ b/eng/common/templates/post-build/darc-gather-drop.yml
@@ -19,4 +19,4 @@ jobs:
         filePath: $(Build.SourcesDirectory)/eng/common/post-build/darc-gather-drop.ps1
         arguments: -BarBuildId $(BARBuildId) 
           -DropLocation $(Agent.BuildDirectory)/Temp/Drop/ 
-          -MaestroAccessToken $(MaestroAccessTokenInt)
+          -MaestroAccessToken $(MaestroAccessToken)

--- a/eng/common/templates/post-build/darc-gather-drop.yml
+++ b/eng/common/templates/post-build/darc-gather-drop.yml
@@ -1,0 +1,22 @@
+parameters:
+  ChannelId: 0
+
+jobs:
+- job: gatherDrop
+  displayName: Gather Drop
+  dependsOn: setupMaestroVars
+  condition: contains(dependencies.setupMaestroVars.outputs['setReleaseVars.InitialChannels'], ${{ parameters.ChannelId }})
+  variables:
+    - group: Publish-Build-Assets
+    - name: BARBuildId
+      value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
+  pool:
+    vmImage: 'windows-2019'
+  steps:
+    - task: PowerShell@2
+      displayName: Darc gather-drop
+      inputs:
+        filePath: $(Build.SourcesDirectory)/eng/common/post-build/darc-gather-drop.ps1
+        arguments: -BarBuildId $(BARBuildId) 
+          -DropLocation $(Agent.BuildDirectory)/Temp/Drop/ 
+          -MaestroAccessToken $(MaestroAccessTokenInt)


### PR DESCRIPTION
Related to #3188 

Move job `darc gather-drop validation` to its own template and PS script. 

I'm still looking whether this will remain as a job or if we'll change it to just a step, but these change if it happens will be in a different PR.

Tested here: https://dnceng.visualstudio.com/internal/_build/results?buildId=273429&view=results - the error in one of the channel is because in this test all channels are using the same target feed.