### PR TITLE
Let user set post-build dependencies.

### DIFF
--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -7,9 +7,12 @@ parameters:
     enable: false
     params: ''
 
+  # Which stages should finish execution before post-build stages start
+  depends: [build]
+
 stages:
 - stage: validate
-  dependsOn: build
+  dependsOn: ${{ parameters.depends }}
   displayName: Validate
   jobs:
   - ${{ if eq(parameters.enableNugetValidation, 'true') }}:

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -8,11 +8,11 @@ parameters:
     params: ''
 
   # Which stages should finish execution before post-build stages start
-  depends: [build]
+  dependsOn: [build]
 
 stages:
 - stage: validate
-  dependsOn: ${{ parameters.depends }}
+  dependsOn: ${{ parameters.dependsOn }}
   displayName: Validate
   jobs:
   - ${{ if eq(parameters.enableNugetValidation, 'true') }}:


### PR DESCRIPTION
Relates to #3188 

Let the user specify the names of the stage(s) which the post-build stages should be dependent on. Useful when the user have more than one build stage, for instance.

Tested here: https://dnceng.visualstudio.com/internal/_build/results?buildId=274892&view=results
and here: https://dnceng.visualstudio.com/internal/_build/results?buildId=275052&view=results
and here: https://dnceng.visualstudio.com/internal/_build/results?buildId=275143&view=results