### PR TITLE
Fix typo in trigger-subscription.yml

### DIFF
--- a/eng/common/templates/post-build/trigger-subscription.yml
+++ b/eng/common/templates/post-build/trigger-subscription.yml
@@ -8,4 +8,4 @@ steps:
     filePath: $(Build.SourcesDirectory)/eng/common/post-build/trigger-subscriptions.ps1
     arguments: -SourceRepo $(Build.Repository.Uri)
       -ChannelId ${{ parameters.ChannelId }}
-      -BarToken $(MaestroAccessTokenInt)
+      -BarToken $(MaestroAccessToken)


### PR DESCRIPTION
Code is accessing (incorrectly) INT instead of PROD.