### PR TITLE
Add error code to AppContainer detection

### DIFF
--- a/src/Microsoft.DotNet.RemoteExecutor/src/Microsoft.DotNet.RemoteExecutor/PlatformDetection.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/Microsoft.DotNet.RemoteExecutor/PlatformDetection.cs
@@ -37,6 +37,9 @@ namespace Microsoft.DotNet.RemoteExecutor
                     switch (result)
                     {
                         case 15703: // APPMODEL_ERROR_NO_APPLICATION
+                        case 120:   // ERROR_CALL_NOT_IMPLEMENTED
+                                    // This function is not supported on this system.
+                                    // In example on Windows Nano Server
                             s_isInAppContainer = 0;
                             break;
                         case 0:     // ERROR_SUCCESS


### PR DESCRIPTION
On Windows Nano Server 1809+ GetCurrentApplicationUserModelId returns ERROR_CALL_NOT_IMPLEMENTED which means that feature isn't available.