### PR TITLE
Regenerate helix client and update for new api version

### DIFF
--- a/src/Microsoft.DotNet.Helix/Client/CSharp/Microsoft.DotNet.Helix.Client.csproj
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/Microsoft.DotNet.Helix.Client.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
 
-    <!--<ProjectReference Include="..\..\..\Microsoft.DotNet.SwaggerGenerator\Microsoft.DotNet.SwaggerGenerator.MSBuild\Microsoft.DotNet.SwaggerGenerator.MSBuild.csproj" />-->
+    <PackageReference Include="Microsoft.DotNet.SwaggerGenerator.MSBuild" Version="$(MicrosoftDotNetSwaggerGeneratorMSBuildVersion)" PrivateAssets="all"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Aggregate.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Aggregate.cs
@@ -154,6 +154,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnAnalysisSummaryFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedAnalysisSummaryRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse<AggregateWorkItemSummary>> AnalysisSummaryInternalAsync(
             IImmutableList<string> groupBy,
             IImmutableList<string> otherProperties,
@@ -182,7 +194,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/aggregate/analysis";
+            var _path = "/api/2019-06-17/aggregate/analysis";
 
             var _query = new QueryBuilder();
             if (!string.IsNullOrEmpty(workitem))
@@ -241,19 +253,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedAnalysisSummaryRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnAnalysisSummaryFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<AggregateWorkItemSummary>
                 {
                     Request = _req,
@@ -287,6 +291,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnBuildHistoryFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedBuildHistoryRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse<IImmutableList<BuildHistoryItem>>> BuildHistoryInternalAsync(
             IImmutableList<string> source,
             IImmutableList<string> type,
@@ -304,7 +320,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/aggregate/build/history";
+            var _path = "/api/2019-06-17/aggregate/build/history";
 
             var _query = new QueryBuilder();
             if (source != default)
@@ -339,19 +355,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedBuildHistoryRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnBuildHistoryFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<IImmutableList<BuildHistoryItem>>
                 {
                     Request = _req,
@@ -387,6 +395,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnBuildFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedBuildRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse<BuildAggregation>> BuildInternalAsync(
             string buildNumber,
             IImmutableList<string> sources,
@@ -410,7 +430,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/aggregate/build";
+            var _path = "/api/2019-06-17/aggregate/build";
 
             var _query = new QueryBuilder();
             if (sources != default)
@@ -449,19 +469,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedBuildRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnBuildFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<BuildAggregation>
                 {
                     Request = _req,
@@ -505,6 +517,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnJobSummaryFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedJobSummaryRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse<IImmutableList<AggregatedWorkItemCounts>>> JobSummaryInternalAsync(
             IImmutableList<string> groupBy,
             int maxResultSets,
@@ -527,7 +551,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/aggregate/jobs";
+            var _path = "/api/2019-06-17/aggregate/jobs";
 
             var _query = new QueryBuilder();
             if (groupBy != default)
@@ -579,19 +603,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedJobSummaryRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnJobSummaryFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<IImmutableList<AggregatedWorkItemCounts>>
                 {
                     Request = _req,
@@ -633,6 +649,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnWorkItemSummaryFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedWorkItemSummaryRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse<IImmutableList<AggregatedWorkItemCounts>>> WorkItemSummaryInternalAsync(
             IImmutableList<string> groupBy,
             string filterBuild = default,
@@ -649,7 +677,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/aggregate/workitems";
+            var _path = "/api/2019-06-17/aggregate/workitems";
 
             var _query = new QueryBuilder();
             if (groupBy != default)
@@ -697,19 +725,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedWorkItemSummaryRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnWorkItemSummaryFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<IImmutableList<AggregatedWorkItemCounts>>
                 {
                     Request = _req,
@@ -751,6 +771,18 @@ namespace Microsoft.DotNet.Helix.Client
             {
                 return _res.Body;
             }
+        }
+
+        internal async Task OnAnalysisDetailFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedAnalysisDetailRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
         }
 
         internal async Task<HttpOperationResponse<IImmutableList<AggregateAnalysisDetail>>> AnalysisDetailInternalAsync(
@@ -800,7 +832,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/aggregate/analysisdetail";
+            var _path = "/api/2019-06-17/aggregate/analysisdetail";
 
             var _query = new QueryBuilder();
             if (!string.IsNullOrEmpty(source))
@@ -852,19 +884,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedAnalysisDetailRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnAnalysisDetailFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<IImmutableList<AggregateAnalysisDetail>>
                 {
                     Request = _req,
@@ -904,6 +928,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnPropertiesFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedPropertiesRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse<IImmutableDictionary<string, Newtonsoft.Json.Linq.JToken>>> PropertiesInternalAsync(
             string filterBuild = default,
             string filterCreator = default,
@@ -914,7 +950,7 @@ namespace Microsoft.DotNet.Helix.Client
         )
         {
 
-            var _path = "/api/2018-03-14/aggregate/properties";
+            var _path = "/api/2019-06-17/aggregate/properties";
 
             var _query = new QueryBuilder();
             if (!string.IsNullOrEmpty(filterCreator))
@@ -955,19 +991,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedPropertiesRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnPropertiesFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<IImmutableDictionary<string, Newtonsoft.Json.Linq.JToken>>
                 {
                     Request = _req,
@@ -999,6 +1027,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnInvestigation_ContinueFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedInvestigation_ContinueRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse<InvestigationResult>> Investigation_ContinueInternalAsync(
             string id,
             CancellationToken cancellationToken = default
@@ -1010,7 +1050,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/aggregate/investigation/continue/{id}";
+            var _path = "/api/2019-06-17/aggregate/investigation/continue/{id}";
             _path = _path.Replace("{id}", Client.Serialize(id));
 
             var _query = new QueryBuilder();
@@ -1032,19 +1072,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedInvestigation_ContinueRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnInvestigation_ContinueFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<InvestigationResult>
                 {
                     Request = _req,
@@ -1090,6 +1122,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnInvestigationFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedInvestigationRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse<InvestigationResult>> InvestigationInternalAsync(
             IImmutableList<string> groupBy,
             int maxGroups,
@@ -1118,7 +1162,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/aggregate/investigation";
+            var _path = "/api/2019-06-17/aggregate/investigation";
 
             var _query = new QueryBuilder();
             if (groupBy != default)
@@ -1174,19 +1218,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedInvestigationRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnInvestigationFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<InvestigationResult>
                 {
                     Request = _req,
@@ -1226,6 +1262,18 @@ namespace Microsoft.DotNet.Helix.Client
             {
                 return _res.Body;
             }
+        }
+
+        internal async Task OnHistoryFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedHistoryRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
         }
 
         internal async Task<HttpOperationResponse<IImmutableList<HistoricalAnalysisItem>>> HistoryInternalAsync(
@@ -1269,7 +1317,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/aggregate/history/{analysisType}";
+            var _path = "/api/2019-06-17/aggregate/history/{analysisType}";
             _path = _path.Replace("{analysisType}", Client.Serialize(analysisType));
 
             var _query = new QueryBuilder();
@@ -1311,19 +1359,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedHistoryRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnHistoryFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<IImmutableList<HistoricalAnalysisItem>>
                 {
                     Request = _req,
@@ -1355,6 +1395,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnMultiSourceFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, content),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedMultiSourceRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse<MultiSourceResponse>> MultiSourceInternalAsync(
             MultiSourceRequest body,
             CancellationToken cancellationToken = default
@@ -1366,7 +1418,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/aggregate/multi-source";
+            var _path = "/api/2019-06-17/aggregate/multi-source";
 
             var _query = new QueryBuilder();
 
@@ -1400,19 +1452,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, _requestContent),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedMultiSourceRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnMultiSourceFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<MultiSourceResponse>
                 {
                     Request = _req,

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Analysis.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Analysis.cs
@@ -67,6 +67,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnSetReasonFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, content),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedSetReasonRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse> SetReasonInternalAsync(
             string analysisName,
             string analysisType,
@@ -102,7 +114,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/analysis/{job}/{analysisType}/reason";
+            var _path = "/api/2019-06-17/analysis/{job}/{analysisType}/reason";
             _path = _path.Replace("{job}", Client.Serialize(job));
             _path = _path.Replace("{analysisType}", Client.Serialize(analysisType));
 
@@ -146,19 +158,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, _requestContent),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedSetReasonRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnSetReasonFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse
                 {
                     Request = _req,
@@ -195,6 +199,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnGetDetailsFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedGetDetailsRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse<Newtonsoft.Json.Linq.JToken>> GetDetailsInternalAsync(
             string analysisName,
             string analysisType,
@@ -224,7 +240,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/analysis/{job}/{analysisType}";
+            var _path = "/api/2019-06-17/analysis/{job}/{analysisType}";
             _path = _path.Replace("{job}", Client.Serialize(job));
             _path = _path.Replace("{analysisType}", Client.Serialize(analysisType));
 
@@ -255,19 +271,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedGetDetailsRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnGetDetailsFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<Newtonsoft.Json.Linq.JToken>
                 {
                     Request = _req,

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/HelixApi.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/HelixApi.cs
@@ -164,7 +164,14 @@ namespace Microsoft.DotNet.Helix.Client
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string Serialize<T>(T value)
         {
-            return JsonConvert.SerializeObject(value, SerializerSettings);
+            string result = JsonConvert.SerializeObject(value, SerializerSettings);
+
+            if (value is Enum)
+            {
+                return result.Substring(1, result.Length-2);
+            }
+
+            return result;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Information.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Information.cs
@@ -51,6 +51,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnQueueInfoFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedQueueInfoRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse<QueueInfo>> QueueInfoInternalAsync(
             string queueId,
             CancellationToken cancellationToken = default
@@ -62,7 +74,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/info/queues/{queueId}";
+            var _path = "/api/2019-06-17/info/queues/{queueId}";
             _path = _path.Replace("{queueId}", Client.Serialize(queueId));
 
             var _query = new QueryBuilder();
@@ -84,19 +96,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedQueueInfoRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnQueueInfoFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<QueueInfo>
                 {
                     Request = _req,
@@ -126,12 +130,24 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnQueueInfoListFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedQueueInfoListRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse<IImmutableList<QueueInfo>>> QueueInfoListInternalAsync(
             CancellationToken cancellationToken = default
         )
         {
 
-            var _path = "/api/2018-03-14/info/queues";
+            var _path = "/api/2019-06-17/info/queues";
 
             var _query = new QueryBuilder();
 
@@ -152,19 +168,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedQueueInfoListRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnQueueInfoListFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<IImmutableList<QueueInfo>>
                 {
                     Request = _req,

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Machine.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Machine.cs
@@ -57,6 +57,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnGetMachineStatusFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedGetMachineStatusRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse<MachineInformation>> GetMachineStatusInternalAsync(
             string machineName,
             string queueId,
@@ -74,7 +86,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/machines/{queueId}/{machineName}/state";
+            var _path = "/api/2019-06-17/machines/{queueId}/{machineName}/state";
             _path = _path.Replace("{queueId}", Client.Serialize(queueId));
             _path = _path.Replace("{machineName}", Client.Serialize(machineName));
 
@@ -97,19 +109,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedGetMachineStatusRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnGetMachineStatusFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<MachineInformation>
                 {
                     Request = _req,
@@ -145,6 +149,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnChangeStateFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, content),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedChangeStateRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse<Newtonsoft.Json.Linq.JToken>> ChangeStateInternalAsync(
             MachineStateChangeRequest body,
             string machineName,
@@ -168,7 +184,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/machines/{queueId}/{machineName}/state";
+            var _path = "/api/2019-06-17/machines/{queueId}/{machineName}/state";
             _path = _path.Replace("{queueId}", Client.Serialize(queueId));
             _path = _path.Replace("{machineName}", Client.Serialize(machineName));
 
@@ -204,19 +220,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, _requestContent),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedChangeStateRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnChangeStateFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<Newtonsoft.Json.Linq.JToken>
                 {
                     Request = _req,

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/ContainerCreationRequest.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/ContainerCreationRequest.cs
@@ -6,14 +6,37 @@ namespace Microsoft.DotNet.Helix.Client.Models
 {
     public partial class ContainerCreationRequest
     {
-        public ContainerCreationRequest()
+        public ContainerCreationRequest(double expirationInDays, string desiredName, string targetQueue)
         {
+            ExpirationInDays = expirationInDays;
+            DesiredName = desiredName;
+            TargetQueue = targetQueue;
         }
 
         [JsonProperty("ExpirationInDays")]
-        public double? ExpirationInDays { get; set; }
+        public double ExpirationInDays { get; set; }
 
         [JsonProperty("DesiredName")]
         public string DesiredName { get; set; }
+
+        [JsonProperty("TargetQueue")]
+        public string TargetQueue { get; set; }
+
+        [JsonIgnore]
+        public bool IsValid
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(DesiredName))
+                {
+                    return false;
+                }
+                if (string.IsNullOrEmpty(TargetQueue))
+                {
+                    return false;
+                }
+                return true;
+            }
+        }
     }
 }

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/ContainerExtensionRequest.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/ContainerExtensionRequest.cs
@@ -6,17 +6,49 @@ namespace Microsoft.DotNet.Helix.Client.Models
 {
     public partial class ContainerExtensionRequest
     {
-        public ContainerExtensionRequest()
+        public ContainerExtensionRequest(double extensionInDays, string containerName, string storageAccountName, Guid subscriptionId, string region)
         {
+            ExtensionInDays = extensionInDays;
+            ContainerName = containerName;
+            StorageAccountName = storageAccountName;
+            SubscriptionId = subscriptionId;
+            Region = region;
         }
 
         [JsonProperty("ExtensionInDays")]
-        public double? ExtensionInDays { get; set; }
+        public double ExtensionInDays { get; set; }
 
         [JsonProperty("ContainerName")]
         public string ContainerName { get; set; }
 
         [JsonProperty("StorageAccountName")]
         public string StorageAccountName { get; set; }
+
+        [JsonProperty("SubscriptionId")]
+        public Guid SubscriptionId { get; set; }
+
+        [JsonProperty("Region")]
+        public string Region { get; set; }
+
+        [JsonIgnore]
+        public bool IsValid
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(ContainerName))
+                {
+                    return false;
+                }
+                if (string.IsNullOrEmpty(StorageAccountName))
+                {
+                    return false;
+                }
+                if (string.IsNullOrEmpty(Region))
+                {
+                    return false;
+                }
+                return true;
+            }
+        }
     }
 }

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/ContainerInformation.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/ContainerInformation.cs
@@ -6,13 +6,15 @@ namespace Microsoft.DotNet.Helix.Client.Models
 {
     public partial class ContainerInformation
     {
-        public ContainerInformation(DateTimeOffset created, DateTimeOffset expiration, string creator, string containerName, string storageAccountName)
+        public ContainerInformation(DateTimeOffset created, DateTimeOffset expiration, string creator, string containerName, string storageAccountName, Guid subscriptionId, string region)
         {
             Created = created;
             Expiration = expiration;
             Creator = creator;
             ContainerName = containerName;
             StorageAccountName = storageAccountName;
+            SubscriptionId = subscriptionId;
+            Region = region;
         }
 
         [JsonProperty("Created")]
@@ -36,6 +38,12 @@ namespace Microsoft.DotNet.Helix.Client.Models
         [JsonProperty("StorageAccountName")]
         public string StorageAccountName { get; set; }
 
+        [JsonProperty("SubscriptionId")]
+        public Guid SubscriptionId { get; set; }
+
+        [JsonProperty("Region")]
+        public string Region { get; set; }
+
         [JsonIgnore]
         public bool IsValid
         {
@@ -50,6 +58,10 @@ namespace Microsoft.DotNet.Helix.Client.Models
                     return false;
                 }
                 if (string.IsNullOrEmpty(StorageAccountName))
+                {
+                    return false;
+                }
+                if (string.IsNullOrEmpty(Region))
                 {
                     return false;
                 }

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/JobCreationRequest.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/JobCreationRequest.cs
@@ -6,24 +6,34 @@ namespace Microsoft.DotNet.Helix.Client.Models
 {
     public partial class JobCreationRequest
     {
-        public JobCreationRequest(string source, string type, string build, IImmutableDictionary<string, string> properties, string listUri, string queueId)
+        public JobCreationRequest(string type, IImmutableDictionary<string, string> properties, string listUri, string queueId)
         {
-            Source = source;
             Type = type;
-            Build = build;
             Properties = properties;
             ListUri = listUri;
             QueueId = queueId;
         }
 
+        [JsonProperty("Creator")]
+        public string Creator { get; set; }
+
         [JsonProperty("Source")]
         public string Source { get; set; }
 
+        [JsonProperty("SourcePrefix")]
+        public string SourcePrefix { get; set; }
+
+        [JsonProperty("TeamProject")]
+        public string TeamProject { get; set; }
+
+        [JsonProperty("Repository")]
+        public string Repository { get; set; }
+
+        [JsonProperty("Branch")]
+        public string Branch { get; set; }
+
         [JsonProperty("Type")]
         public string Type { get; set; }
-
-        [JsonProperty("Build")]
-        public string Build { get; set; }
 
         [JsonProperty("Properties")]
         public IImmutableDictionary<string, string> Properties { get; set; }
@@ -34,29 +44,11 @@ namespace Microsoft.DotNet.Helix.Client.Models
         [JsonProperty("QueueId")]
         public string QueueId { get; set; }
 
-        [JsonProperty("ResultsUri")]
-        public string ResultsUri { get; set; }
+        [JsonProperty("QueueAlias")]
+        public string QueueAlias { get; set; }
 
-        [JsonProperty("ResultsUriRSAS")]
-        public string ResultsUriRSAS { get; set; }
-
-        [JsonProperty("ResultsUriWSAS")]
-        public string ResultsUriWSAS { get; set; }
-
-        [JsonProperty("Creator")]
-        public string Creator { get; set; }
-
-        [JsonProperty("PullRequestId")]
-        public string PullRequestId { get; set; }
-
-        [JsonProperty("MaxRetryCount")]
-        public int? MaxRetryCount { get; set; }
-
-        [JsonProperty("Attempt")]
-        public string Attempt { get; set; }
-
-        [JsonProperty("JobStartIdentifier")]
-        public string JobStartIdentifier { get; set; }
+        [JsonProperty("DockerTag")]
+        public string DockerTag { get; set; }
 
         [JsonProperty("ResultContainerPrefix")]
         public string ResultContainerPrefix { get; set; }
@@ -66,15 +58,7 @@ namespace Microsoft.DotNet.Helix.Client.Models
         {
             get
             {
-                if (string.IsNullOrEmpty(Source))
-                {
-                    return false;
-                }
                 if (string.IsNullOrEmpty(Type))
-                {
-                    return false;
-                }
-                if (string.IsNullOrEmpty(Build))
                 {
                     return false;
                 }

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/UploadedFile.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/UploadedFile.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Immutable;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.Helix.Client.Models
+{
+    public partial class UploadedFile
+    {
+        public UploadedFile(string name, string link)
+        {
+            Name = name;
+            Link = link;
+        }
+
+        [JsonProperty("Name")]
+        public string Name { get; }
+
+        [JsonProperty("Link")]
+        public string Link { get; }
+    }
+}

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/PagedResponse.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/PagedResponse.cs
@@ -1,0 +1,232 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Rest;
+
+namespace Microsoft.DotNet.Helix.Client
+{
+    public static class AsyncEnumerable
+    {
+        public static async Task<List<T>> ToListAsync<T>(this IAsyncEnumerable<T> that, CancellationToken cancellationToken)
+        {
+            var results = new List<T>();
+            using (var enumerator = that.GetEnumerator())
+            {
+                while (await enumerator.MoveNextAsync(cancellationToken))
+                {
+                    results.Add(enumerator.Current);
+                }
+            }
+            return results;
+        }
+    }
+
+    public interface IAsyncEnumerable<out T>
+    {
+        IAsyncEnumerator<T> GetEnumerator();
+    }
+
+    public interface IAsyncEnumerator<out T> : IDisposable
+    {
+        T Current { get; }
+        Task<bool> MoveNextAsync(CancellationToken cancellationToken);
+    }
+
+    public class PagedResponse<T> : IReadOnlyList<T>
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage, Task> _onFailure;
+
+        public PagedResponse(HelixApi client, Func<HttpRequestMessage, HttpResponseMessage, Task> onFailure, IHttpOperationResponse<IImmutableList<T>> response)
+        {
+            _onFailure = onFailure;
+            Client = client;
+            Values = response.Body;
+            if (!response.Response.Headers.TryGetValues("Link", out var linkHeader))
+            {
+                return;
+            }
+            var links = ParseLinkHeader(linkHeader).ToList();
+            FirstPageLink = links.FirstOrDefault(t => t.rel == "first").href;
+            PrevPageLink = links.FirstOrDefault(t => t.rel == "prev").href;
+            NextPageLink = links.FirstOrDefault(t => t.rel == "next").href;
+            LastPageLink = links.FirstOrDefault(t => t.rel == "last").href;
+        }
+
+        private static IEnumerable<(string href, string rel)> ParseLinkHeader(IEnumerable<string> linkHeader)
+        {
+            foreach (var header in linkHeader)
+            {
+                foreach (var link in ParseLinkHeader(header))
+                {
+                    yield return link;
+                }
+            }
+        }
+
+        private static IEnumerable<(string href, string rel)> ParseLinkHeader(string linkHeader)
+        {
+            foreach (var link in linkHeader.Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (ParseLink(link, out var result))
+                {
+                    yield return result;
+                }
+            }
+        }
+
+        private static bool ParseLink(string link, out (string href, string rel) result)
+        {
+            result = default;
+            var parts = link.Split(new[] {';'}, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length < 2)
+            {
+                return false;
+            }
+
+            var href = parts[0].Trim().TrimStart('<').TrimEnd('>');
+            var props = new Dictionary<string, string>();
+            foreach (var prop in parts.Skip(1))
+            {
+                if (TryParseProp(prop, out var p))
+                {
+                    props.Add(p.key, p.value);
+                }
+            }
+
+            var rel = props["rel"];
+            result = (href, rel);
+            return true;
+        }
+
+        private static bool TryParseProp(string value, out (string key, string value) result)
+        {
+            result = default;
+            var equalIdx = value.IndexOf('=');
+            if (equalIdx < 0)
+            {
+                return false;
+            }
+
+            var key = value.Substring(0, equalIdx).Trim();
+            var v = value.Substring(equalIdx + 1).Trim().Trim('"');
+            result = (key, v);
+            return true;
+        }
+
+        public string FirstPageLink { get; }
+        public string PrevPageLink { get; }
+        public string NextPageLink { get; }
+        public string LastPageLink { get; }
+        public HelixApi Client { get; }
+
+        public IImmutableList<T> Values { get; }
+
+        public async Task<PagedResponse<T>> GetPageAsync(string link, CancellationToken cancellationToken)
+        {
+            using (var req = new HttpRequestMessage(HttpMethod.Get, link))
+            {
+                if (Client.Credentials != null)
+                {
+                    await Client.Credentials.ProcessHttpRequestAsync(req, cancellationToken);
+                }
+
+                using (var res = await Client.SendAsync(req, cancellationToken))
+                {
+                    if (!res.IsSuccessStatusCode)
+                    {
+                        await _onFailure(req, res);
+                    }
+
+                    var content = await res.Content.ReadAsStringAsync();
+
+                    using (var response = new HttpOperationResponse<IImmutableList<T>>
+                    {
+                        Request = req,
+                        Response = res,
+                        Body = Client.Deserialize<IImmutableList<T>>(content),
+                    })
+                    {
+                        return new PagedResponse<T>(Client, _onFailure, response);
+                    }
+                }
+            }
+        }
+
+        public IAsyncEnumerable<T> EnumerateAll()
+        {
+            return new Enumerable(this);
+        }
+
+        private class Enumerable : IAsyncEnumerable<T>
+        {
+            private readonly PagedResponse<T> _that;
+
+            public Enumerable(PagedResponse<T> that)
+            {
+                _that = that;
+            }
+
+            public IAsyncEnumerator<T> GetEnumerator()
+            {
+                return new Enumerator(_that);
+            }
+        }
+
+        private class Enumerator : IAsyncEnumerator<T>
+        {
+            private PagedResponse<T> _currentPage;
+            private IEnumerator<T> _currentPageEnumerator;
+
+            public Enumerator(PagedResponse<T> that)
+            {
+                _currentPage = that;
+                _currentPageEnumerator = _currentPage.GetEnumerator();
+            }
+
+            public void Dispose()
+            {
+                _currentPageEnumerator?.Dispose();
+            }
+
+            public T Current => _currentPageEnumerator.Current;
+
+            public async Task<bool> MoveNextAsync(CancellationToken cancellationToken)
+            {
+                if (_currentPageEnumerator.MoveNext())
+                {
+                    return true;
+                }
+
+                if (string.IsNullOrEmpty(_currentPage.NextPageLink))
+                {
+                    return false;
+                }
+
+                _currentPageEnumerator.Dispose();
+                _currentPage = await _currentPage.GetPageAsync(_currentPage.NextPageLink, cancellationToken);
+                _currentPageEnumerator = _currentPage.GetEnumerator();
+                return _currentPageEnumerator.MoveNext();
+            }
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return Values.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable) Values).GetEnumerator();
+        }
+
+        public int Count => Values.Count;
+
+        public T this[int index] => Values[index];
+    }
+
+}

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/ScaleSets.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/ScaleSets.cs
@@ -55,6 +55,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnGetDetailedVMScalingHistoryFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedGetDetailedVMScalingHistoryRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse<IImmutableList<DetailedVMScalingHistory>>> GetDetailedVMScalingHistoryInternalAsync(
             DateTimeOffset date,
             string scaleSet = default,
@@ -67,7 +79,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/scalesets/detailedHistory";
+            var _path = "/api/2019-06-17/scalesets/detailedHistory";
 
             var _query = new QueryBuilder();
             if (date != default)
@@ -96,19 +108,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedGetDetailedVMScalingHistoryRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnGetDetailedVMScalingHistoryFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<IImmutableList<DetailedVMScalingHistory>>
                 {
                     Request = _req,
@@ -140,6 +144,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnGetAggregatedVMScalingHistoryFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedGetAggregatedVMScalingHistoryRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse<IImmutableList<AggregatedVMScalingHistory>>> GetAggregatedVMScalingHistoryInternalAsync(
             DateTimeOffset date,
             CancellationToken cancellationToken = default
@@ -151,7 +167,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/scalesets/aggregatedHistory";
+            var _path = "/api/2019-06-17/scalesets/aggregatedHistory";
 
             var _query = new QueryBuilder();
             if (date != default)
@@ -176,19 +192,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedGetAggregatedVMScalingHistoryRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnGetAggregatedVMScalingHistoryFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<IImmutableList<AggregatedVMScalingHistory>>
                 {
                     Request = _req,

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Storage.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Storage.cs
@@ -57,13 +57,25 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnListFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedListRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse<IImmutableList<ContainerInformation>>> ListInternalAsync(
             bool? getSasTokens = default,
             CancellationToken cancellationToken = default
         )
         {
 
-            var _path = "/api/2018-03-14/storage";
+            var _path = "/api/2019-06-17/storage";
 
             var _query = new QueryBuilder();
             if (getSasTokens != default)
@@ -88,19 +100,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedListRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnListFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<IImmutableList<ContainerInformation>>
                 {
                     Request = _req,
@@ -132,6 +136,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnNewFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, content),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedNewRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse<ContainerInformation>> NewInternalAsync(
             ContainerCreationRequest body,
             CancellationToken cancellationToken = default
@@ -142,8 +158,13 @@ namespace Microsoft.DotNet.Helix.Client
                 throw new ArgumentNullException(nameof(body));
             }
 
+            if (!body.IsValid)
+            {
+                throw new ArgumentException("The parameter is not valid", nameof(body));
+            }
 
-            var _path = "/api/2018-03-14/storage";
+
+            var _path = "/api/2019-06-17/storage";
 
             var _query = new QueryBuilder();
 
@@ -177,19 +198,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, _requestContent),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedNewRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnNewFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<ContainerInformation>
                 {
                     Request = _req,
@@ -221,6 +234,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnExtendExpirationFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, content),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedExtendExpirationRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse<ContainerInformation>> ExtendExpirationInternalAsync(
             ContainerExtensionRequest body,
             CancellationToken cancellationToken = default
@@ -231,8 +256,13 @@ namespace Microsoft.DotNet.Helix.Client
                 throw new ArgumentNullException(nameof(body));
             }
 
+            if (!body.IsValid)
+            {
+                throw new ArgumentException("The parameter is not valid", nameof(body));
+            }
 
-            var _path = "/api/2018-03-14/storage/renew";
+
+            var _path = "/api/2019-06-17/storage/renew";
 
             var _query = new QueryBuilder();
 
@@ -266,19 +296,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, _requestContent),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedExtendExpirationRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnExtendExpirationFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<ContainerInformation>
                 {
                     Request = _req,

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Telemetry.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Telemetry.cs
@@ -104,6 +104,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnStartJobFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, content),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedStartJobRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse<string>> StartJobInternalAsync(
             JobInfo body,
             CancellationToken cancellationToken = default
@@ -120,7 +132,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/telemetry/job";
+            var _path = "/api/2019-06-17/telemetry/job";
 
             var _query = new QueryBuilder();
 
@@ -154,19 +166,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, _requestContent),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedStartJobRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnStartJobFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<string>
                 {
                     Request = _req,
@@ -200,6 +204,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnStartBuildWorkItemFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedStartBuildWorkItemRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse<string>> StartBuildWorkItemInternalAsync(
             string buildUri,
             string xHelixJobToken,
@@ -217,7 +233,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/telemetry/job/build";
+            var _path = "/api/2019-06-17/telemetry/job/build";
 
             var _query = new QueryBuilder();
             if (!string.IsNullOrEmpty(buildUri))
@@ -247,19 +263,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedStartBuildWorkItemRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnStartBuildWorkItemFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<string>
                 {
                     Request = _req,
@@ -299,6 +307,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnFinishBuildWorkItemFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedFinishBuildWorkItemRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse> FinishBuildWorkItemInternalAsync(
             int errorCount,
             string id,
@@ -329,7 +349,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/telemetry/job/build/{id}/finish";
+            var _path = "/api/2019-06-17/telemetry/job/build/{id}/finish";
             _path = _path.Replace("{id}", Client.Serialize(id));
 
             var _query = new QueryBuilder();
@@ -368,19 +388,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedFinishBuildWorkItemRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnFinishBuildWorkItemFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse
                 {
                     Request = _req,
@@ -413,6 +425,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnStartXUnitWorkItemFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedStartXUnitWorkItemRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse<string>> StartXUnitWorkItemInternalAsync(
             string friendlyName,
             string xHelixJobToken,
@@ -430,7 +454,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/telemetry/job/xunit";
+            var _path = "/api/2019-06-17/telemetry/job/xunit";
 
             var _query = new QueryBuilder();
             if (!string.IsNullOrEmpty(friendlyName))
@@ -460,19 +484,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedStartXUnitWorkItemRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnStartXUnitWorkItemFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<string>
                 {
                     Request = _req,
@@ -512,6 +528,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnFinishXUnitWorkItemFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedFinishXUnitWorkItemRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse> FinishXUnitWorkItemInternalAsync(
             int exitCode,
             string id,
@@ -542,7 +570,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/telemetry/job/xunit/{id}/finish";
+            var _path = "/api/2019-06-17/telemetry/job/xunit/{id}/finish";
             _path = _path.Replace("{id}", Client.Serialize(id));
 
             var _query = new QueryBuilder();
@@ -581,19 +609,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedFinishXUnitWorkItemRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnFinishXUnitWorkItemFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse
                 {
                     Request = _req,
@@ -632,6 +652,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnWarningFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedWarningRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse> WarningInternalAsync(
             string eid,
             string id,
@@ -657,7 +689,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/telemetry/job/workitem/{id}/warning";
+            var _path = "/api/2019-06-17/telemetry/job/workitem/{id}/warning";
             _path = _path.Replace("{id}", Client.Serialize(id));
 
             var _query = new QueryBuilder();
@@ -696,19 +728,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedWarningRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnWarningFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse
                 {
                     Request = _req,
@@ -747,6 +771,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnErrorFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedErrorRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse> ErrorInternalAsync(
             string eid,
             string id,
@@ -772,7 +808,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/telemetry/job/workitem/{id}/error";
+            var _path = "/api/2019-06-17/telemetry/job/workitem/{id}/error";
             _path = _path.Replace("{id}", Client.Serialize(id));
 
             var _query = new QueryBuilder();
@@ -811,19 +847,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedErrorRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnErrorFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse
                 {
                     Request = _req,
@@ -862,6 +890,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnLogFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedLogRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse> LogInternalAsync(
             string id,
             string logUri,
@@ -887,7 +927,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/telemetry/job/workitem/{id}/log";
+            var _path = "/api/2019-06-17/telemetry/job/workitem/{id}/log";
             _path = _path.Replace("{id}", Client.Serialize(id));
 
             var _query = new QueryBuilder();
@@ -926,19 +966,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedLogRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnLogFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse
                 {
                     Request = _req,

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/WorkItem.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/WorkItem.cs
@@ -13,6 +13,19 @@ namespace Microsoft.DotNet.Helix.Client
 {
     public partial interface IWorkItem
     {
+        Task<System.IO.Stream> GetFileAsync(
+            string file,
+            string id,
+            string job,
+            CancellationToken cancellationToken = default
+        );
+
+        Task<IImmutableList<UploadedFile>> ListFilesAsync(
+            string id,
+            string job,
+            CancellationToken cancellationToken = default
+        );
+
         Task<System.IO.Stream> ConsoleLogAsync(
             string id,
             string job,
@@ -43,15 +56,17 @@ namespace Microsoft.DotNet.Helix.Client
 
         partial void HandleFailedRequest(RestApiException ex);
 
-        partial void HandleFailedConsoleLogRequest(RestApiException ex);
+        partial void HandleFailedGetFileRequest(RestApiException ex);
 
-        public async Task<System.IO.Stream> ConsoleLogAsync(
+        public async Task<System.IO.Stream> GetFileAsync(
+            string file,
             string id,
             string job,
             CancellationToken cancellationToken = default
         )
         {
-            var _res = await ConsoleLogInternalAsync(
+            var _res = await GetFileInternalAsync(
+                file,
                 id,
                 job,
                 cancellationToken
@@ -59,7 +74,116 @@ namespace Microsoft.DotNet.Helix.Client
             return new ResponseStream(_res.Body, _res);
         }
 
-        internal async Task<HttpOperationResponse<System.IO.Stream>> ConsoleLogInternalAsync(
+        internal async Task OnGetFileFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedGetFileRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
+        internal async Task<HttpOperationResponse<System.IO.Stream>> GetFileInternalAsync(
+            string file,
+            string id,
+            string job,
+            CancellationToken cancellationToken = default
+        )
+        {
+            if (string.IsNullOrEmpty(file))
+            {
+                throw new ArgumentNullException(nameof(file));
+            }
+
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+
+            if (string.IsNullOrEmpty(job))
+            {
+                throw new ArgumentNullException(nameof(job));
+            }
+
+
+            var _path = "/api/2019-06-17/jobs/{job}/workitems/{id}/files/{file}";
+            _path = _path.Replace("{job}", Client.Serialize(job));
+            _path = _path.Replace("{id}", Client.Serialize(id));
+            _path = _path.Replace("{file}", Client.Serialize(file));
+
+            var _query = new QueryBuilder();
+
+            var _uriBuilder = new UriBuilder(Client.BaseUri);
+            _uriBuilder.Path = _uriBuilder.Path.TrimEnd('/') + _path;
+            _uriBuilder.Query = _query.ToString();
+            var _url = _uriBuilder.Uri;
+
+            HttpRequestMessage _req = null;
+            HttpResponseMessage _res = null;
+            try
+            {
+                _req = new HttpRequestMessage(HttpMethod.Get, _url);
+
+                if (Client.Credentials != null)
+                {
+                    await Client.Credentials.ProcessHttpRequestAsync(_req, cancellationToken).ConfigureAwait(false);
+                }
+
+                _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
+                if (!_res.IsSuccessStatusCode)
+                {
+                    await OnGetFileFailed(_req, _res);
+                }
+                System.IO.Stream _responseStream = await _res.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                return new HttpOperationResponse<System.IO.Stream>
+                {
+                    Request = _req,
+                    Response = _res,
+                    Body = _responseStream
+                };
+            }
+            catch (Exception)
+            {
+                _req?.Dispose();
+                _res?.Dispose();
+                throw;
+            }
+        }
+
+        partial void HandleFailedListFilesRequest(RestApiException ex);
+
+        public async Task<IImmutableList<UploadedFile>> ListFilesAsync(
+            string id,
+            string job,
+            CancellationToken cancellationToken = default
+        )
+        {
+            using (var _res = await ListFilesInternalAsync(
+                id,
+                job,
+                cancellationToken
+            ).ConfigureAwait(false))
+            {
+                return _res.Body;
+            }
+        }
+
+        internal async Task OnListFilesFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedListFilesRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
+        internal async Task<HttpOperationResponse<IImmutableList<UploadedFile>>> ListFilesInternalAsync(
             string id,
             string job,
             CancellationToken cancellationToken = default
@@ -76,7 +200,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/jobs/{job}/workitems/{id}/console";
+            var _path = "/api/2019-06-17/jobs/{job}/workitems/{id}/files";
             _path = _path.Replace("{job}", Client.Serialize(job));
             _path = _path.Replace("{id}", Client.Serialize(id));
 
@@ -99,19 +223,99 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedConsoleLogRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnListFilesFailed(_req, _res);
                 }
-                var _responseStream = await _res.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return new HttpOperationResponse<IImmutableList<UploadedFile>>
+                {
+                    Request = _req,
+                    Response = _res,
+                    Body = Client.Deserialize<IImmutableList<UploadedFile>>(_responseContent),
+                };
+            }
+            catch (Exception)
+            {
+                _req?.Dispose();
+                _res?.Dispose();
+                throw;
+            }
+        }
+
+        partial void HandleFailedConsoleLogRequest(RestApiException ex);
+
+        public async Task<System.IO.Stream> ConsoleLogAsync(
+            string id,
+            string job,
+            CancellationToken cancellationToken = default
+        )
+        {
+            var _res = await ConsoleLogInternalAsync(
+                id,
+                job,
+                cancellationToken
+            ).ConfigureAwait(false);
+            return new ResponseStream(_res.Body, _res);
+        }
+
+        internal async Task OnConsoleLogFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedConsoleLogRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
+        internal async Task<HttpOperationResponse<System.IO.Stream>> ConsoleLogInternalAsync(
+            string id,
+            string job,
+            CancellationToken cancellationToken = default
+        )
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+
+            if (string.IsNullOrEmpty(job))
+            {
+                throw new ArgumentNullException(nameof(job));
+            }
+
+
+            var _path = "/api/2019-06-17/jobs/{job}/workitems/{id}/console";
+            _path = _path.Replace("{job}", Client.Serialize(job));
+            _path = _path.Replace("{id}", Client.Serialize(id));
+
+            var _query = new QueryBuilder();
+
+            var _uriBuilder = new UriBuilder(Client.BaseUri);
+            _uriBuilder.Path = _uriBuilder.Path.TrimEnd('/') + _path;
+            _uriBuilder.Query = _query.ToString();
+            var _url = _uriBuilder.Uri;
+
+            HttpRequestMessage _req = null;
+            HttpResponseMessage _res = null;
+            try
+            {
+                _req = new HttpRequestMessage(HttpMethod.Get, _url);
+
+                if (Client.Credentials != null)
+                {
+                    await Client.Credentials.ProcessHttpRequestAsync(_req, cancellationToken).ConfigureAwait(false);
+                }
+
+                _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
+                if (!_res.IsSuccessStatusCode)
+                {
+                    await OnConsoleLogFailed(_req, _res);
+                }
+                System.IO.Stream _responseStream = await _res.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<System.IO.Stream>
                 {
                     Request = _req,
@@ -143,6 +347,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnListFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedListRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse<IImmutableList<WorkItemSummary>>> ListInternalAsync(
             string job,
             CancellationToken cancellationToken = default
@@ -154,7 +370,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/jobs/{job}/workitems";
+            var _path = "/api/2019-06-17/jobs/{job}/workitems";
             _path = _path.Replace("{job}", Client.Serialize(job));
 
             var _query = new QueryBuilder();
@@ -176,19 +392,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedListRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnListFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<IImmutableList<WorkItemSummary>>
                 {
                     Request = _req,
@@ -222,6 +430,18 @@ namespace Microsoft.DotNet.Helix.Client
             }
         }
 
+        internal async Task OnDetailsFailed(HttpRequestMessage req, HttpResponseMessage res)
+        {
+            var content = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var ex = new RestApiException(
+                new HttpRequestMessageWrapper(req, null),
+                new HttpResponseMessageWrapper(res, content));
+            HandleFailedDetailsRequest(ex);
+            HandleFailedRequest(ex);
+            Client.OnFailedRequest(ex);
+            throw ex;
+        }
+
         internal async Task<HttpOperationResponse<WorkItemDetails>> DetailsInternalAsync(
             string id,
             string job,
@@ -239,7 +459,7 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
 
-            var _path = "/api/2018-03-14/jobs/{job}/workitems/{id}";
+            var _path = "/api/2019-06-17/jobs/{job}/workitems/{id}";
             _path = _path.Replace("{job}", Client.Serialize(job));
             _path = _path.Replace("{id}", Client.Serialize(id));
 
@@ -262,19 +482,11 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 _res = await Client.SendAsync(_req, cancellationToken).ConfigureAwait(false);
-                string _responseContent;
                 if (!_res.IsSuccessStatusCode)
                 {
-                    _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var ex = new RestApiException(
-                        new HttpRequestMessageWrapper(_req, null),
-                        new HttpResponseMessageWrapper(_res, _responseContent));
-                    HandleFailedDetailsRequest(ex);
-                    HandleFailedRequest(ex);
-                    Client.OnFailedRequest(ex);
-                    throw ex;
+                    await OnDetailsFailed(_req, _res);
                 }
-                _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string _responseContent = await _res.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<WorkItemDetails>
                 {
                     Request = _req,

--- a/src/Microsoft.DotNet.Helix/JobSender/HelixApiExtensions.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/HelixApiExtensions.cs
@@ -2,7 +2,7 @@ namespace Microsoft.DotNet.Helix.Client
 {
     public static class HelixApiExtensions
     {
-        public static IJobDefinitionWithSource Define(this IJob jobApi)
+        public static IJobDefinitionWithType Define(this IJob jobApi)
         {
             return new JobDefinition(jobApi);
         }

--- a/src/Microsoft.DotNet.Helix/JobSender/IJobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/IJobDefinition.cs
@@ -16,13 +16,12 @@ namespace Microsoft.DotNet.Helix.Client
         IJobDefinition WithCorrelationPayloadArchive(string archive, string destination = "");
         IJobDefinition WithCorrelationPayloadFiles(params string[] files);
         IJobDefinition WithCorrelationPayloadFiles(IList<string> files, string destination);
+        IJobDefinition WithSource(string source);
         IJobDefinition WithProperty(string key, string value);
         IJobDefinition WithCreator(string creator);
         IJobDefinition WithContainerName(string targetContainerName);
         IJobDefinition WithStorageAccountConnectionString(string accountConnectionString);
         IJobDefinition WithResultsContainerName(string resultsContainerName);
-        IJobDefinition WithResultsStorageAccountConnectionString(string resultsAccountConnectionString);
-        IJobDefinition WithDefaultResultsContainer();
         IJobDefinition WithMaxRetryCount(int? maxRetryCount);
         Task<ISentJob> SendAsync(Action<string> log = null);
     }

--- a/src/Microsoft.DotNet.Helix/JobSender/IJobDefinitionWithBuild.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/IJobDefinitionWithBuild.cs
@@ -1,7 +1,0 @@
-namespace Microsoft.DotNet.Helix.Client
-{
-    public interface IJobDefinitionWithBuild
-    {
-        IJobDefinitionWithTargetQueue WithBuild(string buildNumber);
-    }
-}

--- a/src/Microsoft.DotNet.Helix/JobSender/IJobDefinitionWithSource.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/IJobDefinitionWithSource.cs
@@ -1,7 +1,0 @@
-namespace Microsoft.DotNet.Helix.Client
-{
-    public interface IJobDefinitionWithSource
-    {
-        IJobDefinitionWithType WithSource(string source);
-    }
-}

--- a/src/Microsoft.DotNet.Helix/JobSender/IJobDefinitionWithType.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/IJobDefinitionWithType.cs
@@ -2,6 +2,6 @@ namespace Microsoft.DotNet.Helix.Client
 {
     public interface IJobDefinitionWithType
     {
-        IJobDefinitionWithBuild WithType(string type);
+        IJobDefinitionWithTargetQueue WithType(string type);
     }
 }

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -13,15 +13,12 @@ using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.Helix.Client
 {
-    internal class JobDefinition : IJobDefinitionWithSource,
-        IJobDefinitionWithType,
-        IJobDefinitionWithBuild,
+    internal class JobDefinition : IJobDefinitionWithType,
         IJobDefinitionWithTargetQueue,
         IJobDefinition
     {
         private readonly Dictionary<string, string> _properties;
         private readonly List<WorkItemDefinition> _workItems;
-        private bool _withDefaultResultsContainer;
 
         public JobDefinition(IJob jobApi)
         {
@@ -48,7 +45,6 @@ namespace Microsoft.DotNet.Helix.Client
         public int? MaxRetryCount { get; private set; }
         public string StorageAccountConnectionString { get; private set; }
         public string TargetContainerName { get; set; } = DefaultContainerName;
-        public string ResultsStorageAccountConnectionString { get; private set; }
         public string TargetResultsContainerName { get; set; } = DefaultContainerName;
         public static string DefaultContainerName => $"helix-job-{Guid.NewGuid()}";
 
@@ -144,18 +140,6 @@ namespace Microsoft.DotNet.Helix.Client
             return this;
         }
 
-        public IJobDefinition WithResultsStorageAccountConnectionString(string resultsAccountConnectionString)
-        {
-            ResultsStorageAccountConnectionString = resultsAccountConnectionString;
-            return this;
-        }
-
-        public IJobDefinition WithDefaultResultsContainer()
-        {
-            _withDefaultResultsContainer = true;
-            return this;
-        }
-
         public async Task<ISentJob> SendAsync(Action<string> log = null)
         {
             IBlobHelper storage;
@@ -168,20 +152,10 @@ namespace Microsoft.DotNet.Helix.Client
                 storage = new ConnectionStringBlobHelper(StorageAccountConnectionString);
             }
 
-            IBlobContainer storageContainer = await storage.GetContainerAsync(TargetContainerName);
+            var (queueId, dockerTag, queueAlias) = ParseQueueId(TargetQueueId);
+
+            IBlobContainer storageContainer = await storage.GetContainerAsync(TargetContainerName, queueId);
             var jobList = new List<JobListEntry>();
-
-            IBlobContainer resultsStorageContainer = null;
-            if (!string.IsNullOrEmpty(ResultsStorageAccountConnectionString))
-            {
-
-                IBlobHelper resultsStorage = new ConnectionStringBlobHelper(ResultsStorageAccountConnectionString);
-                resultsStorageContainer = await resultsStorage.GetContainerAsync(TargetResultsContainerName);
-            }
-            else if (_withDefaultResultsContainer)
-            {
-                resultsStorageContainer = await storage.GetContainerAsync(TargetResultsContainerName);
-            }
 
             Dictionary<string, string> correlationPayloadUris =
                 (await Task.WhenAll(CorrelationPayloads.Select(async p => (uri: await p.Key.UploadAsync(storageContainer, log), destination: p.Value)))).ToDictionary(x => x.uri, x => x.destination);
@@ -220,31 +194,95 @@ namespace Microsoft.DotNet.Helix.Client
                 ResultContainerPrefix  = multipleDashes.Replace(illegalCharacters.Replace(ResultContainerPrefix, ""), "-");
             }
 
+            var creationRequest = new JobCreationRequest(Type, _properties.ToImmutableDictionary(), jobListUri.ToString(), queueId)
+            {
+                Creator = Creator,
+                ResultContainerPrefix = ResultContainerPrefix,
+                Branch = GetBranch(),
+                DockerTag = dockerTag,
+                QueueAlias = queueAlias,
+            };
+
+            if (string.IsNullOrEmpty(Source))
+            {
+                InitializeSourceParameters(creationRequest);
+            }
+            else
+            {
+                creationRequest.Source = Source;
+            }
+
             string jobStartIdentifier = Guid.NewGuid().ToString("N");
             JobCreationResult newJob = await HelixApi.RetryAsync(
-                () => JobApi.NewAsync(
-                    new JobCreationRequest(
-                        Source,
-                        Type,
-                        Build,
-                        _properties.ToImmutableDictionary(),
-                        jobListUri.ToString(),
-                        TargetQueueId)
-                    {
-                        Creator = Creator,
-                        MaxRetryCount = MaxRetryCount ?? 0,
-                        JobStartIdentifier = jobStartIdentifier,
-                        ResultsUri = resultsStorageContainer?.Uri,
-                        ResultsUriRSAS = resultsStorageContainer?.ReadSas,
-                        ResultsUriWSAS = resultsStorageContainer?.WriteSas,
-                        ResultContainerPrefix = ResultContainerPrefix,
-                    }),
+                () => JobApi.NewAsync(creationRequest, jobStartIdentifier),
                 ex => log?.Invoke($"Starting job failed with {ex}\nRetrying..."),
                 IsRetryableJobListUriHttpError,
                 CancellationToken.None);
 
+            return new SentJob(JobApi, newJob, newJob.ResultsUri, newJob.ResultsUriRSAS);
+        }
 
-            return new SentJob(JobApi, newJob, resultsStorageContainer?.Uri, string.IsNullOrEmpty(Creator) ? resultsStorageContainer?.ReadSas : string.Empty);
+        private (string queueId, string dockerTag, string queueAlias) ParseQueueId(string value)
+        {
+            var @index = value.IndexOf('@');
+            if (@index < 0)
+            {
+                return (value, string.Empty, value);
+            }
+
+            string queueInfo = value.Substring(0, @index);
+            string dockerTag = value.Substring(@index + 1);
+
+            string queueAlias;
+            string queueId;
+
+            Match queueInfoSplit = new Regex(@"\((.+?)\)(.*)").Match(queueInfo);
+            if (queueInfoSplit.Success && queueInfoSplit.Groups.Count == 3)
+            {
+                queueAlias = queueInfoSplit.Groups[1].Value;
+                queueId = queueInfoSplit.Groups[2].Value;
+            }
+            else
+            {
+                queueId = queueAlias = queueInfo;
+            }
+
+            return (queueId, dockerTag, queueAlias);
+        }
+
+        private string GetRequiredEnvironmentVariable(string name)
+        {
+            return Environment.GetEnvironmentVariable(name) ?? throw new ArgumentException("Missing required environment variable", name);
+        }
+
+        private void InitializeSourceParameters(JobCreationRequest creationRequest)
+        {
+            creationRequest.Branch = GetRequiredEnvironmentVariable("BUILD_SOURCEBRANCH");
+            creationRequest.Repository = GetRequiredEnvironmentVariable("BUILD_REPOSITORY_NAME");
+            creationRequest.TeamProject = GetRequiredEnvironmentVariable("SYSTEM_TEAMPROJECT");
+            creationRequest.SourcePrefix = GetSourcePrefix();
+        }
+
+        private string GetSourcePrefix()
+        {
+            var reason = GetRequiredEnvironmentVariable("BUILD_REASON");
+            if (string.Equals(reason, "PullRequest", StringComparison.OrdinalIgnoreCase))
+            {
+                return "pr";
+            }
+
+            var teamProject = GetRequiredEnvironmentVariable("SYSTEM_TEAMPROJECT");
+            if (string.Equals(teamProject, "internal", StringComparison.OrdinalIgnoreCase))
+            {
+                return "official";
+            }
+
+            return "ci";
+        }
+
+        private string GetBranch()
+        {
+            return Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH") ?? "~adhoc~";
         }
 
         public bool IsRetryableJobListUriHttpError(Exception ex)
@@ -263,7 +301,7 @@ namespace Microsoft.DotNet.Helix.Client
             return this;
         }
 
-        public IJobDefinitionWithType WithSource(string source)
+        public IJobDefinition WithSource(string source)
         {
             Source = source;
             return this;
@@ -275,7 +313,7 @@ namespace Microsoft.DotNet.Helix.Client
             return this;
         }
 
-        public IJobDefinitionWithBuild WithType(string type)
+        public IJobDefinitionWithTargetQueue WithType(string type)
         {
             Type = type;
             return this;

--- a/src/Microsoft.DotNet.Helix/JobSender/StorageHelpers/ApiBlobHelper.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/StorageHelpers/ApiBlobHelper.cs
@@ -24,11 +24,11 @@ namespace Microsoft.DotNet.Helix.Client
             _helixApi = ((IServiceOperations<HelixApi>) helixApiStorage).Client;
         }
 
-        public async Task<IBlobContainer> GetContainerAsync(string requestedName)
+        public async Task<IBlobContainer> GetContainerAsync(string requestedName, string targetQueue)
         {
             ContainerInformation info = await _helixApi.RetryAsync(
                 () => _helixApiStorage.NewAsync(
-                    new ContainerCreationRequest{DesiredName = requestedName, ExpirationInDays = 30}),
+                    new ContainerCreationRequest(30, requestedName, targetQueue)),
                 ex => { },
                 CancellationToken.None);
             var client = new CloudBlobClient(new Uri($"https://{info.StorageAccountName}.blob.core.windows.net/"), new StorageCredentials(info.WriteToken));

--- a/src/Microsoft.DotNet.Helix/JobSender/StorageHelpers/ConnectionStringBlobHelper.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/StorageHelpers/ConnectionStringBlobHelper.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Helix.Client
             _connectionString = connectionString;
         }
 
-        public async Task<IBlobContainer> GetContainerAsync(string requestedName)
+        public async Task<IBlobContainer> GetContainerAsync(string requestedName, string targetQueue)
         {
             CloudStorageAccount account = CloudStorageAccount.Parse(_connectionString);
             CloudBlobClient client = account.CreateCloudBlobClient();

--- a/src/Microsoft.DotNet.Helix/JobSender/StorageHelpers/IBlobHelper.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/StorageHelpers/IBlobHelper.cs
@@ -12,6 +12,6 @@ namespace Microsoft.DotNet.Helix.Client
 {
     internal interface IBlobHelper
     {
-        Task<IBlobContainer> GetContainerAsync(string requestedName);
+        Task<IBlobContainer> GetContainerAsync(string requestedName, string targetQueue);
     }
 }

--- a/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
@@ -20,15 +20,6 @@ namespace Microsoft.DotNet.Helix.Sdk
     public class SendHelixJob : HelixTask
     {
         /// <summary>
-        ///   The 'source' value reported to Helix
-        /// </summary>
-        /// <remarks>
-        ///   This value is used to filter and sort jobs on Mission Control
-        /// </remarks>
-        [Required]
-        public string Source { get; set; }
-
-        /// <summary>
         ///   The 'type' value reported to Helix
         /// </summary>
         /// <remarks>
@@ -36,15 +27,6 @@ namespace Microsoft.DotNet.Helix.Sdk
         /// </remarks>
         [Required]
         public string Type { get; set; }
-
-        /// <summary>
-        ///   The 'build' value reported to Helix
-        /// </summary>
-        /// <remarks>
-        ///   This value is used to filter and sort jobs on Mission Control
-        /// </remarks>
-        [Required]
-        public string Build { get; set; }
 
         /// <summary>
         ///   The Helix queue this job should run on
@@ -143,11 +125,6 @@ namespace Microsoft.DotNet.Helix.Sdk
         /// </summary>
         public int MaxRetryCount { get; set; }
 
-        /// <summary>
-        /// Currently, if we're using the download results feature, we need to return the results container back to know where to download results from. Currently, the Helix API is the one that provides this container and we have no way to get it back. If this property is set to true, we will create the container before sending the job and tell the API to use this container.
-        /// </summary>
-        public bool UsingDownloadResultsFeature { get; set; }
-
         private CommandPayload _commandPayload;
 
         protected override async Task ExecuteCore(CancellationToken cancellationToken)
@@ -164,9 +141,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                 return;
             }
 
-            Source = Source.ToLowerInvariant();
             Type = Type.ToLowerInvariant();
-            Build = Build.ToLowerInvariant();
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -175,12 +150,10 @@ namespace Microsoft.DotNet.Helix.Sdk
                 var currentHelixApi = HelixApi;
 
                 IJobDefinition def = currentHelixApi.Job.Define()
-                    .WithSource(Source)
                     .WithType(Type)
-                    .WithBuild(Build)
                     .WithTargetQueue(TargetQueue)
                     .WithMaxRetryCount(MaxRetryCount);
-                Log.LogMessage($"Initialized job definition with source '{Source}', type '{Type}', build number '{Build}', and target queue '{TargetQueue}'");
+                Log.LogMessage($"Initialized job definition with type '{Type}', and target queue '{TargetQueue}'");
 
                 if (!string.IsNullOrEmpty(Creator))
                 {
@@ -221,11 +194,6 @@ namespace Microsoft.DotNet.Helix.Sdk
                     }
                 }
 
-                if (UsingDownloadResultsFeature)
-                {
-                    def = def.WithDefaultResultsContainer();
-                }
-
                 // don't send the job if we have errors
                 if (Log.HasLoggedErrors)
                 {
@@ -242,9 +210,6 @@ namespace Microsoft.DotNet.Helix.Sdk
                 cancellationToken.ThrowIfCancellationRequested();
             }
 
-            string mcUri = await GetMissionControlResultUri();
-
-            Log.LogMessage(MessageImportance.High, $"Results will be available from {mcUri}");
             cancellationToken.ThrowIfCancellationRequested();
         }
 
@@ -476,46 +441,6 @@ namespace Microsoft.DotNet.Helix.Sdk
 
             Log.LogError($"Correlation Payload '{path}' not found.");
             return def;
-        }
-
-        private async Task<string> GetMissionControlResultUri()
-        {
-            var creator = Creator;
-            if (string.IsNullOrEmpty(creator))
-            {
-                using (var client = new HttpClient
-                {
-                    DefaultRequestHeaders =
-                    {
-                        UserAgent = { Helpers.UserAgentHeaderValue },
-                    },
-                })
-                {
-                    try
-                    {
-                        string githubJson =
-                            await client.GetStringAsync($"https://api.github.com/user?access_token={AccessToken}");
-                        var data = JObject.Parse(githubJson);
-                        if (data["login"] == null)
-                        {
-                            throw new Exception("Github user has no login");
-                        }
-
-                        creator = data["login"].ToString();
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.LogMessage(MessageImportance.High, "Failed to retrieve username from GitHub -- {0}", ex.ToString());
-                        return $"Mission Control (generation of MC link failed -- {ex.Message})";
-                    }
-                }
-            }
-
-            var build = UrlEncoder.Default.Encode(Build).Replace('%', '~');
-            var type = UrlEncoder.Default.Encode(Type).Replace('%', '~');
-            var source = UrlEncoder.Default.Encode(Source).Replace('%', '~');
-            var encodedCreator = UrlEncoder.Default.Encode(creator).Replace('%', '~');
-            return $"https://mc.dot.net/#/user/{encodedCreator}/{source}/{type}/{build}";
         }
     }
 }

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
@@ -44,13 +44,7 @@
     <PropertyGroup Condition="$(IsPosixShell)">
       <HelixPreCommands>set -x;$(HelixPreCommands)</HelixPreCommands>
     </PropertyGroup>
-    <PropertyGroup>
-      <_usingDownloadResultsFeature>false</_usingDownloadResultsFeature>
-      <_usingDownloadResultsFeature Condition="'@(HelixWorkItem -> HasMetadata('DownloadFilesFromResults'))' != ''">true</_usingDownloadResultsFeature>
-    </PropertyGroup>
-    <SendHelixJob Source="$(HelixSource)"
-                  Type="$(HelixType)"
-                  Build="$(HelixBuild)"
+    <SendHelixJob Type="$(HelixType)"
                   TargetQueue="$(HelixTargetQueue)"
                   IsPosixShell="$(IsPosixShell)"
                   Creator="$(Creator)"
@@ -61,8 +55,7 @@
                   PostCommands="$(HelixPostCommands)"
                   CorrelationPayloads="@(HelixCorrelationPayload)"
                   WorkItems="@(HelixWorkItem)"
-                  HelixProperties="@(HelixProperties)"
-                  UsingDownloadResultsFeature="$(_usingDownloadResultsFeature)">
+                  HelixProperties="@(HelixProperties)">
       <Output TaskParameter="JobCorrelationId" PropertyName="HelixJobId"/>
       <Output TaskParameter="ResultsContainerUri" PropertyName="HelixResultsContainer"/>
       <Output TaskParameter="ResultsContainerReadSAS" PropertyName="HelixResultsContainerReadSAS"/>

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/MethodGroup.hb
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/MethodGroup.hb
@@ -216,7 +216,7 @@ namespace {{pascalCaseNs Namespace}}
                     {{/unless}}
                 };
                 {{else}}
-                Stream _responseStream = await _res.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                System.IO.Stream _responseStream = await _res.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 return new HttpOperationResponse<System.IO.Stream>
                 {
                     Request = _req,


### PR DESCRIPTION
This change generates code for the new helix api version and updates the JobSender and MSBuild SDK to work with the new apis.