### PR TITLE
Adding IoT category in order to publish to the right feed for dev release

### DIFF
--- a/Documentation/YamlStagesRepoStatus.md
+++ b/Documentation/YamlStagesRepoStatus.md
@@ -24,6 +24,7 @@ Target completion date is 8/13/2019.
 | CLICommandLineParser       | licavalc         | On track | ➖ | |
 | CoreClr                    | russellk         | On track | ➖ | |
 | CoreFx                     | danmose          | On track | ➖ | |
+| IoT                        | joperezr         | Complete | ✔️ | |
 | Core-SDK                   | licavalc         | On track | ➖ | |
 | Core-Setup                 | dleeapho         | On track | ➖ | |
 | FSharp                     | brettfo          | On track | ➖ | |

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
@@ -115,6 +115,7 @@
       <TargetStaticFeed Condition="'$(ArtifactsCategory.ToUpper())' == 'NUGETCLIENT'">https://dotnetfeed.blob.core.windows.net/nuget-nugetclient/index.json</TargetStaticFeed>
       <TargetStaticFeed Condition="'$(ArtifactsCategory.ToUpper())' == 'ASPNETENTITYFRAMEWORK6'">https://dotnetfeed.blob.core.windows.net/aspnet-entityframework6/index.json</TargetStaticFeed>
       <TargetStaticFeed Condition="'$(ArtifactsCategory.ToUpper())' == 'ASPNETBLAZOR'">https://dotnetfeed.blob.core.windows.net/aspnet-blazor/index.json</TargetStaticFeed>
+      <TargetStaticFeed Condition="'$(ArtifactsCategory.ToUpper())' == 'IOT'">https://dotnetfeed.blob.core.windows.net/dotnet-iot/index.json</TargetStaticFeed>
       <TargetStaticFeed Condition="'$(TargetStaticFeed)' == ''">https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</TargetStaticFeed>
     </PropertyGroup>
 


### PR DESCRIPTION
dotnet/iot repo needs to publish to the dotnet-iot blob feed for dev release builds. I chatted offline with @riarenas and this was the way to do that once the new channels was onboarded.