### PR TITLE
make GenerateNativeVersionFile check for differences

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
@@ -125,7 +125,8 @@ static char sccsid[] __attribute__((used)) = "@(#)Version $(FileVersion)$(_Sourc
     <WriteLinesToFile
       File="$(NativeVersionFile)"
       Lines="$(_NativeVersionFileContents.Replace(';', '%3B'))"
-      Overwrite="true" />
+      Overwrite="true"
+      WriteOnlyWhenDifferent="true" />
 
     <ItemGroup>
       <FileWrites Include="$(NativeVersionFile)" />


### PR DESCRIPTION
projects that use `GenerateNativeVersionFile `as a dependency for a build task force msbuild to rebuild the code because the timestamp of the generated file changes every time it is invoked, even if the content is the same. This was reported on #2968 and I'm seeing it happen on corefx (during the native 
code build stage), as examples.
`WriteOnlyWhenDifferent `was introduced a while back so it should be present on every supported version.