### PR TITLE
Use parameter instead of global var in `job.yml`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ stages:
       enableMicrobuild: true
       enablePublishBuildArtifacts: true
       enablePublishBuildAssets: true
-      enablePublishUsingPipelines: $(_PublishUsingPipelines)
+      enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
       enableTelemetry: true
       graphFileGeneration:
         enabled: true

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -37,6 +37,9 @@ parameters:
   # Optional: Enable publishing to the build asset registry
   enablePublishBuildAssets: false
 
+  # Optional: Prevent gather/push manifest from executing when using publishing pipelines
+  enablePublishUsingPipelines: false
+
   # Optional: Include PublishTestResults task
   enablePublishTestResults: false
 
@@ -187,7 +190,7 @@ jobs:
       continueOnError: true
       condition: always()
     
-  - ${{ if and(eq(parameters.enablePublishBuildAssets, true), ne(variables['_PublishUsingPipelines'], 'true'), eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - ${{ if and(eq(parameters.enablePublishBuildAssets, true), ne(parameters.enablePublishUsingPipelines, 'true'), eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - task: CopyFiles@2
       displayName: Gather Asset Manifests
       inputs:
@@ -195,6 +198,7 @@ jobs:
         TargetFolder: '$(Build.StagingDirectory)/AssetManifests'
       continueOnError: ${{ parameters.continueOnError }}
       condition: and(succeeded(), eq(variables['_DotNetPublishToBlobFeed'], 'true'))
+
     - task: PublishBuildArtifacts@1
       displayName: Push Asset Manifests
       inputs:


### PR DESCRIPTION
Closes: https://github.com/dotnet/arcade/issues/3412

Replace the use of a global variable by a parameter. However, there is a catch: since that parameter is used in a template(?) expression we need to make sure the parameter is set using a value available at the moment of YAML template evaluation. 

- Test build where parameter is set using variable: https://dnceng.visualstudio.com/internal/_build/results?buildId=285274&view=logs&j=83516c17-6666-5250-abde-63983ce72a49
- Test build where parameter is set using a value at template expansion time: https://dnceng.visualstudio.com/internal/_build/results?buildId=285268&view=logs&j=83516c17-6666-5250-abde-63983ce72a49

Before merging I'll update on-boarded repos to make sure they are setting the parameter appropriately.