### PR TITLE
Remove outdated comment in Publish.proj

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -184,10 +184,6 @@
       Text="##vso[artifact.upload containerfolder=AssetManifests;artifactname=AssetManifests]$(TempWorkingDirectory)/$(AssetManifestFileName)"
       Importance="high" />
 
-    <!--
-      This won't be necessary once we solve this issue:
-      https://github.com/dotnet/arcade/issues/2266
-    -->
     <WriteLinesToFile
       File="$(MSBuildThisFileDirectory)ArtifactsCategory.props"
       Lines="&lt;Project>&lt;PropertyGroup>&lt;ArtifactsCategory>$(ArtifactsCategory)&lt;/ArtifactsCategory>&lt;/PropertyGroup>&lt;/Project>"


### PR DESCRIPTION
- The infra around publishing using RM pipelines still rely on that section of code.

Just for context: I'm updating this after a comment @tmat send to me in pvt.