### PR TITLE
Refactor logic around IsStableBuild variable

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,8 @@ variables:
     value: .NETCore
   - name: _DotNetValidationArtifactsCategory
     value: .NETCoreValidation
+  - name: _DotNetFinalVersionKind
+    value: ''
 
 resources:
   containers:
@@ -78,6 +80,7 @@ stages:
               /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
               /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
               /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+              /p:DotNetFinalVersionKind=$(_DotNetFinalVersionKind)
 
         strategy:
           matrix:
@@ -184,12 +187,17 @@ stages:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng\common\templates\post-build\post-build.yml
     parameters:
+      # Which kind of build is happening: 'release', 'prerelease', ''
+      dotNetFinalVersionKind: ${{ variables._DotNetFinalVersionKind }}
+
       # Symbol validation isn't being very reliable lately. This should be enabled back
       # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871
       enableSymbolValidation: false
+      
       # Sourcelink validation isn't passing for Arcade due to some regressions. This should be
       # enabled back once this issue is resolved: https://github.com/dotnet/arcade/issues/2912
       enableSourceLinkValidation: false
+      
       # This is to enable SDL runs part of Post-Build Validation Stage
       SDLValidationParameters:
         enable: true

--- a/eng/common/post-build/setup-maestro-vars.ps1
+++ b/eng/common/post-build/setup-maestro-vars.ps1
@@ -11,12 +11,9 @@ try {
   
   $Channels = ""            
   $Content | Select -Index 1 | ForEach-Object { $Channels += "$_ ," }
-  
-  $IsStableBuild = $Content | Select -Index 2
 
   Write-PipelineSetVariable -Name 'BARBuildId' -Value $BarId
   Write-PipelineSetVariable -Name 'InitialChannels' -Value "$Channels"
-  Write-PipelineSetVariable -Name 'IsStableBuild' -Value $IsStableBuild
 }
 catch {
   Write-Host $_

--- a/eng/common/templates/post-build/channels/internal-servicing.yml
+++ b/eng/common/templates/post-build/channels/internal-servicing.yml
@@ -1,5 +1,6 @@
 parameters:
   enableSymbolValidation: true
+  dotNetFinalVersionKind: ''
 
 stages:
 - stage: IS_Publish
@@ -45,7 +46,7 @@ stages:
       - name: BARBuildId
         value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
       - name: IsStableBuild
-        value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.IsStableBuild'] ]
+        value: ${{ eq(parameters.dotNetFinalVersionKind, 'release') }}
     condition: contains(dependencies.setupMaestroVars.outputs['setReleaseVars.InitialChannels'], variables.InternalServicing_30_Channel_Id)
     pool:
       vmImage: 'windows-2019'

--- a/eng/common/templates/post-build/channels/public-dev-release.yml
+++ b/eng/common/templates/post-build/channels/public-dev-release.yml
@@ -1,5 +1,6 @@
 parameters:
   enableSymbolValidation: true
+  dotNetFinalVersionKind: ''
 
 stages:
 - stage: Publish
@@ -45,7 +46,7 @@ stages:
       - name: BARBuildId
         value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
       - name: IsStableBuild
-        value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.IsStableBuild'] ]
+        value: ${{ eq(parameters.dotNetFinalVersionKind, 'release') }}
     condition: contains(dependencies.setupMaestroVars.outputs['setReleaseVars.InitialChannels'], variables.PublicDevRelease_30_Channel_Id)
     pool:
       vmImage: 'windows-2019'

--- a/eng/common/templates/post-build/channels/public-release.yml
+++ b/eng/common/templates/post-build/channels/public-release.yml
@@ -1,6 +1,7 @@
 parameters:
   enableSymbolValidation: true
-
+  dotNetFinalVersionKind: ''
+  
 stages:
 - stage: PubRel_Publish
   dependsOn: validate
@@ -45,7 +46,7 @@ stages:
       - name: BARBuildId
         value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
       - name: IsStableBuild
-        value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.IsStableBuild'] ]
+        value: ${{ eq(parameters.dotNetFinalVersionKind, 'release') }}
     condition: contains(dependencies.setupMaestroVars.outputs['setReleaseVars.InitialChannels'], variables.PublicRelease_30_Channel_Id)
     pool:
       vmImage: 'windows-2019'

--- a/eng/common/templates/post-build/channels/public-validation-release.yml
+++ b/eng/common/templates/post-build/channels/public-validation-release.yml
@@ -1,3 +1,6 @@
+parameters:
+  dotNetFinalVersionKind: ''
+
 stages:
 - stage: PVR_Publish
   dependsOn: validate
@@ -16,7 +19,7 @@ stages:
       - name: BARBuildId
         value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
       - name: IsStableBuild
-        value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.IsStableBuild'] ]
+        value: ${{ eq(parameters.dotNetFinalVersionKind, 'release') }}
     condition: contains(dependencies.setupMaestroVars.outputs['setReleaseVars.InitialChannels'], variables.PublicValidationRelease_30_Channel_Id)
     pool:
       vmImage: 'windows-2019'

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -7,6 +7,9 @@ parameters:
     enable: false
     params: ''
 
+  # Which kind of build is happening: 'release', 'prerelease', ''
+  dotNetFinalVersionKind: ''
+
   # Which stages should finish execution before post-build stages start
   dependsOn: [build]
 
@@ -85,10 +88,17 @@ stages:
 
 - template: \eng\common\templates\post-build\channels\public-dev-release.yml
   parameters:
+    dotNetFinalVersionKind: ${{ parameters.dotNetFinalVersionKind }}
     enableSymbolValidation: ${{ parameters.enableSymbolValidation }}
 
 - template: \eng\common\templates\post-build\channels\public-validation-release.yml
+  parameters:
+    dotNetFinalVersionKind: ${{ parameters.dotNetFinalVersionKind }}
 
 - template: \eng\common\templates\post-build\channels\public-release.yml
+  parameters:
+    dotNetFinalVersionKind: ${{ parameters.dotNetFinalVersionKind }}
 
 - template: \eng\common\templates\post-build\channels\internal-servicing.yml
+  parameters:
+    dotNetFinalVersionKind: ${{ parameters.dotNetFinalVersionKind }}


### PR DESCRIPTION
Closes: https://github.com/dotnet/arcade/issues/3476

Add new ADO variable called `_DotNetFinalVersionKind' to be used to identify builds as stable or non-stable following the [documentation here](https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md#build-kind). This variable is then forwarded to post-build stages.

I'll update on-boarded repos accordingly before merging this PR and also [patch Maestro.Tasks](https://github.com/dotnet/arcade-services/blob/master/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs#L102) to not compute the "IsStable" variable anymore.

  - [Test build here](https://dnceng.visualstudio.com/internal/_build/results?buildId=285585&view=results) with variable set to ''.
  - [Test build here](https://dnceng.visualstudio.com/internal/_build/results?buildId=285522&view=results) with variable set to 'release'.