### PR TITLE
Add telemetry property for Helix tests

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.props
@@ -7,6 +7,10 @@
     <MicrosoftDotNetHelixSdkTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)net472/Microsoft.DotNet.Helix.Sdk.dll</MicrosoftDotNetHelixSdkTasksAssembly>
   </PropertyGroup>
 
+  <PropertyGroup>
+     <NETCORE_ENGINEERING_TELEMETRY>Test</NETCORE_ENGINEERING_TELEMETRY>
+  </PropertyGroup>
+
   <UsingTask TaskName="SendHelixJob" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)"/>
   <UsingTask TaskName="WaitForHelixJobCompletion" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)"/>
   <UsingTask TaskName="CheckHelixJobStatus" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)"/>


### PR DESCRIPTION
Helix runs are reporting telemetry that looks like...

```
.packages\microsoft.dotnet.helix.sdk\2.0.0-beta.19365.4\tools\Microsoft.DotNet.Helix.Sdk.MultiQueue.targets(67,5): error : (NETCORE_ENGINEERING_TELEMETRY=) Work item Microsoft.VisualBasic.Core.Tests in job 2ce7bf1e-d375-48a3-afd1-1ac8fcfb2a28 has failed, logs available here: https://helix.dot.net/api/2018-03-14/jobs/2ce7bf1e-d375-48a3-afd1-1ac8fcfb2a28/workitems/Microsoft.VisualBasic.Core.Tests/console.
```

This change adds the Test telemetry categorization to those failures.

Validated with https://dev.azure.com/dnceng/public/_build/results?buildId=289507&view=results