### PR TITLE
Make Tasks.Feed receive IsStableBuild parameter

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
@@ -25,9 +25,19 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             string manifestBuildId,
             string manifestBranch,
             string manifestCommit,
-            string[] manifestBuildData)
+            string[] manifestBuildData,
+            bool isStableBuild)
         {
-            CreateModel(blobArtifacts, packageArtifacts, manifestBuildId, manifestBuildData, manifestRepoUri, manifestBranch, manifestCommit, log)
+            CreateModel(
+                blobArtifacts,
+                packageArtifacts,
+                manifestBuildId,
+                manifestBuildData,
+                manifestRepoUri,
+                manifestBranch,
+                manifestCommit,
+                isStableBuild,
+                log)
                 .WriteAsXml(assetManifestPath, log);
         }
 
@@ -40,8 +50,16 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
             File.WriteAllText(filePath, buildModel.ToXml().ToString());
         }
-               
-        public static BuildModel CreateModelFromItems(ITaskItem[] artifacts, string buildId, string[] BuildProperties, string repoUri, string repoBranch, string repoCommit, TaskLoggingHelper log)
+
+        public static BuildModel CreateModelFromItems(
+            ITaskItem[] artifacts,
+            string buildId,
+            string[] BuildProperties,
+            string repoUri,
+            string repoBranch,
+            string repoCommit,
+            bool isStableBuild,
+            TaskLoggingHelper log)
         {
             if (artifacts == null)
             {
@@ -85,6 +103,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 repoUri,
                 repoBranch,
                 repoCommit,
+                isStableBuild,
                 log);
             return buildModel;
         }
@@ -96,6 +115,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             string manifestRepoUri,
             string manifestBranch,
             string manifestCommit,
+            bool isStableBuild,
             TaskLoggingHelper log)
         {
             var attributes = MSBuildListSplitter.GetNamedProperties(manifestBuildData);
@@ -110,7 +130,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         Name = manifestRepoUri,
                         BuildId = manifestBuildId,
                         Branch = manifestBranch,
-                        Commit = manifestCommit
+                        Commit = manifestCommit,
+                        IsStable = isStableBuild.ToString()
                     });
 
             buildModel.Artifacts.Blobs.AddRange(blobArtifacts);

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/GenerateBuildManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/GenerateBuildManifest.cs
@@ -56,11 +56,24 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         /// </summary>
         public string RepoCommit { get; set; }
 
+        /// <summary>
+        /// Is this manifest for a stable build?
+        /// </summary>
+        public bool IsStableBuild { get; set; }
+
         public override bool Execute()
         {
             try
             {
-                var buildModel = BuildManifestUtil.CreateModelFromItems(Artifacts, BuildId, BuildData, RepoUri, RepoBranch, RepoCommit, Log);
+                var buildModel = BuildManifestUtil.CreateModelFromItems(
+                    Artifacts,
+                    BuildId,
+                    BuildData,
+                    RepoUri,
+                    RepoBranch,
+                    RepoCommit,
+                    IsStableBuild,
+                    Log);
 
                 buildModel.WriteAsXml(OutputPath, Log);
             }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
@@ -34,6 +34,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public string AssetManifestPath { get; set; }
 
+        public bool IsStableBuild { get; set; }
+
         public override bool Execute()
         {
             try
@@ -111,8 +113,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         ManifestRepoUri, 
                         ManifestBuildId,
                         ManifestBranch, 
-                        ManifestCommit, 
-                        ManifestBuildData);
+                        ManifestCommit,
+                        ManifestBuildData,
+                        IsStableBuild);
                 }
             }
             catch (Exception e)

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBlobFeed.cs
@@ -56,6 +56,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public string AssetManifestPath { get; set; }
 
+        public bool IsStableBuild { get; set; }
+
         public override bool Execute()
         {
             return ExecuteAsync().GetAwaiter().GetResult();
@@ -162,7 +164,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     ManifestBuildId,
                     ManifestBranch,
                     ManifestCommit,
-                    ManifestBuildData);
+                    ManifestBuildData,
+                    IsStableBuild);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Relates to #3476 

This is first of 3 PRs to change the way that post-build scripts identify a build as stable. The current PR receive as parameter the information of whether the build is stable or not (default) and record it in the build manifest.

  - PR built here: https://dnceng.visualstudio.com/7ea9116e-9fac-403d-b258-b31fcf1bb293/_build/index?buildId=287212
  - Package tested here: https://dnceng.visualstudio.com/internal/_build/results?buildId=287948		(Manifest for stage 1 -- IsStable == true)
  - Package tested here: https://dnceng.visualstudio.com/internal/_build/results?buildId=289266 (Manifest for stage 1 -- IsStable == false)