### PR TITLE
Make SDK pass to Tasks.Feed value of IsStableBuild parameter

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -59,7 +59,7 @@
     <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>
     <XUnitVSRunnerVersion>2.4.1</XUnitVSRunnerVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>2.2.0-beta.19380.3</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>2.2.0-beta.19380.4</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetSignToolVersion>1.0.0-beta.19380.3</MicrosoftDotNetSignToolVersion>
     <MicrosoftAzureDocumentDBVersion>1.22.0</MicrosoftAzureDocumentDBVersion>
     <MicrosoftAzureCosmosDBTableVersion>1.1.2</MicrosoftAzureCosmosDBTableVersion>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -4,6 +4,7 @@
     Optional variables:
       AzureFeedUrl                      Target Azure feed URL.
       AzureAccountKey                   Azure account key.
+      DotNetFinalVersionKind            Global property that stores the type of the current build: https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md#build-kind
       DotNetOutputBlobFeedDir           Source Build publishing directory
       DotNetSymbolServerTokenMsdl       Personal access token for MSDL symbol server. Available from variable group DotNet-Symbol-Publish.
       DotNetSymbolServerTokenSymWeb     Personal access token for SymWeb symbol server. Available from variable group DotNet-Symbol-Publish.
@@ -24,6 +25,10 @@
     
     <PublishToSymbolServer>false</PublishToSymbolServer>
     <PublishToSymbolServer Condition="'$(UsingToolSymbolUploader)' == 'true' and '$(AzureFeedUrl)' == '' and '$(ContinuousIntegrationBuild)' == 'true'">true</PublishToSymbolServer>
+
+    <!-- Globally set property. -->
+    <IsStableBuild>false</IsStableBuild>
+    <IsStableBuild Condition="'$(DotNetFinalVersionKind)' == 'release'">true</IsStableBuild>
 
     <AssetManifestFileName>$(OS)-$(PlatformName).xml</AssetManifestFileName>
     <AssetManifestFilePath>$(ArtifactsLogDir)AssetManifest\$(AssetManifestFileName)</AssetManifestFilePath>
@@ -159,6 +164,7 @@
       ManifestBranch="$(BUILD_SOURCEBRANCH)"
       ManifestBuildId="$(BUILD_BUILDNUMBER)"
       ManifestCommit="$(BUILD_SOURCEVERSION)"
+      IsStableBuild="$(IsStableBuild)"
       PublishFlatContainer="false"
       AssetManifestPath="$(AssetManifestFilePath)"
       AssetsTemporaryDirectory="$(TempWorkingDirectory)" />


### PR DESCRIPTION
Relates to #3476 

This is second of 3 PRs to change the way that post-build scripts identify a build as stable. The current PR change Arcade.SDK `Publish.proj` to pass (a form of) the parameter `DotNetFinalVersionKind` to Tasks.Feed tasks to inform it whether the build is stable or not.

  - PR built here: https://dnceng.visualstudio.com/internal/_build/results?buildId=287852
  - Package tested here: https://dnceng.visualstudio.com/internal/_build/results?buildId=287948		(Manifest for stage 1 -- IsStable == true)
  - Package tested here: https://dnceng.visualstudio.com/internal/_build/results?buildId=289266 (Manifest for stage 1 -- IsStable == false)