### PR TITLE
Pass down TreatWarningsAsErrors=false when -warnAsError 0

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -518,6 +518,9 @@ function MSBuild-Core() {
   if ($warnAsError) {
     $cmdArgs += " /warnaserror /p:TreatWarningsAsErrors=true"
   }
+  else {
+    $cmdArgs += " /p:TreatWarningsAsErrors=false"
+  }
 
   foreach ($arg in $args) {
     if ($arg -ne $null -and $arg.Trim() -ne "") {


### PR DESCRIPTION
Currently in windows we don't pass TreatWarningsAsErrors=false when -warnAsError 0 is used as a parameter, so when repos enable TreatWarningsAsErrors in their props in order to have that as the default behavior when building an individual project, we don't override that globally, and so -warnAsError 0 has no effect.

In Unix we do override it by passing down false, when `-warnAsError false` is passed down:

https://github.com/dotnet/arcade/blob/2359dc4184133defa27c8f3072622270b71b4ecf/eng/common/tools.sh#L352

cc: @stephentoub 