### PR TITLE
Adding Branch Key checks For updateRepository and Sanity check

### DIFF
--- a/src/Microsoft.DotNet.GitSync/Program.cs
+++ b/src/Microsoft.DotNet.GitSync/Program.cs
@@ -125,6 +125,9 @@ namespace Microsoft.DotNet.GitSync
 
                 foreach (RepositoryInfo repo in config.Repos)
                 {
+                    if (!s_repos.ContainsKey((repo.Name, prBranch)))
+                        break;
+
                     if (repo.LastSynchronizedCommits != null)
                         SanityCheck(repo, prBranch);
 
@@ -374,6 +377,9 @@ namespace Microsoft.DotNet.GitSync
         {
             foreach (var repo in repos)
             {
+                if (!s_repos.ContainsKey((repo.Name, branch)))
+                    break;
+
                 s_logger.Debug($"Updating {repo}\\{branch} to latest version.");
                 using (var repository = new Repository(repo.Path))
                 {


### PR DESCRIPTION
This is done to check if a branch exists in a particular repo during the update repository and sanity check operations.