### PR TITLE
Implementation for channels 2 and 131

### DIFF
--- a/eng/common/templates/post-build/channels/netcore-dev-5.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-5.yml
@@ -1,0 +1,148 @@
+parameters:
+  enableSymbolValidation: true
+
+stages:
+- stage: Publish
+  dependsOn: validate
+  variables:
+    - template: ../common-variables.yml
+  displayName: .NET Core 5 Dev Channel
+  jobs:
+  - template: ../setup-maestro-vars.yml
+
+  - job:
+    displayName: Symbol Publishing
+    dependsOn: setupMaestroVars
+    condition: contains(dependencies.setupMaestroVars.outputs['setReleaseVars.InitialChannels'], format('[{0}]', variables.NetCore_5_Dev_Channel_Id))
+    variables:
+      - group: DotNet-Symbol-Server-Pats
+    pool:
+      vmImage: 'windows-2019'
+    steps:
+      - task: DownloadBuildArtifacts@0
+        displayName: Download Artifacts
+        inputs:
+          downloadType: specific files
+          matchingPattern: "*Artifacts*"
+
+      - task: PowerShell@2
+        displayName: Publish
+        inputs:
+          filePath: eng\common\sdk-task.ps1
+          arguments: -task PublishToSymbolServers -restore -msbuildEngine dotnet
+            /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat) 
+            /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat) 
+            /p:PDBArtifactsDirectory='$(Build.ArtifactStagingDirectory)/PDBArtifacts/'
+            /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/'
+            /p:Configuration=Release
+
+  - job:
+    displayName: Publish Assets
+    dependsOn: setupMaestroVars
+    variables:
+      - group: DotNet-Blob-Feed
+      - group: AzureDevOps-Artifact-Feeds-Pats
+      - name: BARBuildId
+        value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
+      - name: IsStableBuild
+        value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.IsStableBuild'] ]
+    condition: contains(dependencies.setupMaestroVars.outputs['setReleaseVars.InitialChannels'], format('[{0}]', variables.NetCore_5_Dev_Channel_Id))
+    pool:
+      vmImage: 'windows-2019'
+    steps:
+      - task: DownloadBuildArtifacts@0
+        displayName: Download Package Artifacts
+        inputs:
+          buildType: current
+          artifactName: PackageArtifacts
+
+      - task: DownloadBuildArtifacts@0
+        displayName: Download Blob Artifacts
+        inputs:
+          buildType: current
+          artifactName: BlobArtifacts
+
+      - task: DownloadBuildArtifacts@0
+        displayName: Download Asset Manifests
+        inputs:
+          buildType: current
+          artifactName: AssetManifests
+
+      - task: PowerShell@2
+        displayName: Add Assets Location
+        env:
+          AZURE_DEVOPS_EXT_PAT: $(dn-bot-dnceng-unviersal-packages-rw)
+        inputs:
+          filePath: eng\common\sdk-task.ps1
+          arguments: -task PublishArtifactsInManifest -restore -msbuildEngine dotnet 
+            /p:ChannelId=$(NetCore_5_Dev_Channel_Id)
+            /p:ArtifactsCategory=$(_DotNetArtifactsCategory)
+            /p:IsStableBuild=$(IsStableBuild)
+            /p:IsInternalBuild=$(IsInternalBuild)
+            /p:RepositoryName=$(Build.Repository.Name)
+            /p:CommitSha=$(Build.SourceVersion)
+            /p:NugetPath=$(Agent.BuildDirectory)\Nuget\NuGet.exe
+            /p:AzdoTargetFeedPAT='$(dn-bot-dnceng-unviersal-packages-rw)' 
+            /p:TargetFeedPAT='$(dn-bot-dnceng-unviersal-packages-rw)' 
+            /p:AzureStorageTargetFeedPAT='$(dotnetfeed-storage-access-key-1)' 
+            /p:BARBuildId=$(BARBuildId) 
+            /p:MaestroApiEndpoint='$(MaestroApiEndPoint)' 
+            /p:BuildAssetRegistryToken='$(MaestroApiAccessToken)' 
+            /p:ManifestsBasePath='$(Build.ArtifactStagingDirectory)/AssetManifests/' 
+            /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/' 
+            /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts/' 
+            /p:Configuration=Release 
+        
+      - task: NuGetCommand@2
+        displayName: Publish Packages to AzDO Feed
+        condition: contains(variables['TargetAzDOFeed'], 'pkgs.visualstudio.com')
+        inputs:
+          command: push
+          vstsFeed: $(AzDoFeedName)
+          packagesToPush: $(Build.ArtifactStagingDirectory)\PackageArtifacts\*.nupkg
+          publishVstsFeed: $(AzDoFeedName)
+
+      - task: PowerShell@2
+        displayName: Publish Blobs to AzDO Feed
+        inputs:
+          filePath: $(Build.SourcesDirectory)/eng/common/post-build/publish-blobs-to-azdo.ps1
+          arguments: -FeedName $(AzDoFeedName) 
+            -SourceFolderCollection $(Build.ArtifactStagingDirectory)/BlobArtifacts/
+            -PersonalAccessToken $(dn-bot-dnceng-unviersal-packages-rw)
+        enabled: false
+
+
+- stage: PublishValidation
+  displayName: Publish Validation
+  variables:
+    - template: ../common-variables.yml  
+  jobs:
+  - template: ../setup-maestro-vars.yml
+
+  - ${{ if eq(parameters.enableSymbolValidation, 'true') }}:
+    - job:
+      displayName: Symbol Availability
+      dependsOn: setupMaestroVars
+      condition: contains(dependencies.setupMaestroVars.outputs['setReleaseVars.InitialChannels'], format('[{0}]', variables.NetCore_5_Dev_Channel_Id))
+      pool:
+        vmImage: 'windows-2019'
+      steps:
+        - task: DownloadBuildArtifacts@0
+          displayName: Download Package Artifacts
+          inputs:
+            buildType: current
+            artifactName: PackageArtifacts
+
+        - task: PowerShell@2
+          displayName: Check Symbol Availability
+          inputs:
+            filePath: $(Build.SourcesDirectory)/eng/common/post-build/symbols-validation.ps1
+            arguments: -InputPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/ -ExtractPath $(Agent.BuildDirectory)/Temp/ -DotnetSymbolVersion $(SymbolToolVersion)
+
+  - template: ../darc-gather-drop.yml
+    parameters:
+      ChannelId: ${{ variables.NetCore_5_Dev_Channel_Id }}
+
+  - template: ../promote-build.yml	
+    parameters:	
+      ChannelId: ${{ variables.NetCore_5_Dev_Channel_Id }}

--- a/eng/common/templates/post-build/channels/netcore-dev-5.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-5.yml
@@ -2,7 +2,7 @@ parameters:
   enableSymbolValidation: true
 
 stages:
-- stage: Publish
+- stage: NetCore_Dev5_Publish
   dependsOn: validate
   variables:
     - template: ../common-variables.yml
@@ -112,7 +112,7 @@ stages:
         enabled: false
 
 
-- stage: PublishValidation
+- stage: NetCore_Dev5_PublishValidation
   displayName: Publish Validation
   variables:
     - template: ../common-variables.yml  

--- a/eng/common/templates/post-build/channels/netcore-tools-latest.yml
+++ b/eng/common/templates/post-build/channels/netcore-tools-latest.yml
@@ -2,7 +2,7 @@ parameters:
   enableSymbolValidation: true
 
 stages:
-- stage: Publish
+- stage: NetCore_Tools_Latest_Publish
   dependsOn: validate
   variables:
     - template: ../common-variables.yml
@@ -112,7 +112,7 @@ stages:
         enabled: false
 
 
-- stage: PublishValidation
+- stage: NetCore_Tools_Latest_PublishValidation
   displayName: Publish Validation
   variables:
     - template: ../common-variables.yml  

--- a/eng/common/templates/post-build/channels/netcore-tools-latest.yml
+++ b/eng/common/templates/post-build/channels/netcore-tools-latest.yml
@@ -1,0 +1,148 @@
+parameters:
+  enableSymbolValidation: true
+
+stages:
+- stage: Publish
+  dependsOn: validate
+  variables:
+    - template: ../common-variables.yml
+  displayName: .NET Tools - Latest
+  jobs:
+  - template: ../setup-maestro-vars.yml
+
+  - job:
+    displayName: Symbol Publishing
+    dependsOn: setupMaestroVars
+    condition: contains(dependencies.setupMaestroVars.outputs['setReleaseVars.InitialChannels'], format('[{0}]', variables.NetCore_Tools_Latest_Channel_Id))
+    variables:
+      - group: DotNet-Symbol-Server-Pats
+    pool:
+      vmImage: 'windows-2019'
+    steps:
+      - task: DownloadBuildArtifacts@0
+        displayName: Download Artifacts
+        inputs:
+          downloadType: specific files
+          matchingPattern: "*Artifacts*"
+
+      - task: PowerShell@2
+        displayName: Publish
+        inputs:
+          filePath: eng\common\sdk-task.ps1
+          arguments: -task PublishToSymbolServers -restore -msbuildEngine dotnet
+            /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat) 
+            /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat) 
+            /p:PDBArtifactsDirectory='$(Build.ArtifactStagingDirectory)/PDBArtifacts/'
+            /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/'
+            /p:Configuration=Release
+
+  - job:
+    displayName: Publish Assets
+    dependsOn: setupMaestroVars
+    variables:
+      - group: DotNet-Blob-Feed
+      - group: AzureDevOps-Artifact-Feeds-Pats
+      - name: BARBuildId
+        value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
+      - name: IsStableBuild
+        value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.IsStableBuild'] ]
+    condition: contains(dependencies.setupMaestroVars.outputs['setReleaseVars.InitialChannels'], format('[{0}]', variables.NetCore_Tools_Latest_Channel_Id))
+    pool:
+      vmImage: 'windows-2019'
+    steps:
+      - task: DownloadBuildArtifacts@0
+        displayName: Download Package Artifacts
+        inputs:
+          buildType: current
+          artifactName: PackageArtifacts
+
+      - task: DownloadBuildArtifacts@0
+        displayName: Download Blob Artifacts
+        inputs:
+          buildType: current
+          artifactName: BlobArtifacts
+
+      - task: DownloadBuildArtifacts@0
+        displayName: Download Asset Manifests
+        inputs:
+          buildType: current
+          artifactName: AssetManifests
+
+      - task: PowerShell@2
+        displayName: Add Assets Location
+        env:
+          AZURE_DEVOPS_EXT_PAT: $(dn-bot-dnceng-unviersal-packages-rw)
+        inputs:
+          filePath: eng\common\sdk-task.ps1
+          arguments: -task PublishArtifactsInManifest -restore -msbuildEngine dotnet 
+            /p:ChannelId=$(NetCore_Tools_Latest_Channel_Id)
+            /p:ArtifactsCategory=$(_DotNetArtifactsCategory)
+            /p:IsStableBuild=$(IsStableBuild)
+            /p:IsInternalBuild=$(IsInternalBuild)
+            /p:RepositoryName=$(Build.Repository.Name)
+            /p:CommitSha=$(Build.SourceVersion)
+            /p:NugetPath=$(Agent.BuildDirectory)\Nuget\NuGet.exe
+            /p:AzdoTargetFeedPAT='$(dn-bot-dnceng-unviersal-packages-rw)' 
+            /p:TargetFeedPAT='$(dn-bot-dnceng-unviersal-packages-rw)' 
+            /p:AzureStorageTargetFeedPAT='$(dotnetfeed-storage-access-key-1)' 
+            /p:BARBuildId=$(BARBuildId) 
+            /p:MaestroApiEndpoint='$(MaestroApiEndPoint)' 
+            /p:BuildAssetRegistryToken='$(MaestroApiAccessToken)' 
+            /p:ManifestsBasePath='$(Build.ArtifactStagingDirectory)/AssetManifests/' 
+            /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/' 
+            /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts/' 
+            /p:Configuration=Release 
+        
+      - task: NuGetCommand@2
+        displayName: Publish Packages to AzDO Feed
+        condition: contains(variables['TargetAzDOFeed'], 'pkgs.visualstudio.com')
+        inputs:
+          command: push
+          vstsFeed: $(AzDoFeedName)
+          packagesToPush: $(Build.ArtifactStagingDirectory)\PackageArtifacts\*.nupkg
+          publishVstsFeed: $(AzDoFeedName)
+
+      - task: PowerShell@2
+        displayName: Publish Blobs to AzDO Feed
+        inputs:
+          filePath: $(Build.SourcesDirectory)/eng/common/post-build/publish-blobs-to-azdo.ps1
+          arguments: -FeedName $(AzDoFeedName) 
+            -SourceFolderCollection $(Build.ArtifactStagingDirectory)/BlobArtifacts/
+            -PersonalAccessToken $(dn-bot-dnceng-unviersal-packages-rw)
+        enabled: false
+
+
+- stage: PublishValidation
+  displayName: Publish Validation
+  variables:
+    - template: ../common-variables.yml  
+  jobs:
+  - template: ../setup-maestro-vars.yml
+
+  - ${{ if eq(parameters.enableSymbolValidation, 'true') }}:
+    - job:
+      displayName: Symbol Availability
+      dependsOn: setupMaestroVars
+      condition: contains(dependencies.setupMaestroVars.outputs['setReleaseVars.InitialChannels'], format('[{0}]', variables.NetCore_Tools_Latest_Channel_Id))
+      pool:
+        vmImage: 'windows-2019'
+      steps:
+        - task: DownloadBuildArtifacts@0
+          displayName: Download Package Artifacts
+          inputs:
+            buildType: current
+            artifactName: PackageArtifacts
+
+        - task: PowerShell@2
+          displayName: Check Symbol Availability
+          inputs:
+            filePath: $(Build.SourcesDirectory)/eng/common/post-build/symbols-validation.ps1
+            arguments: -InputPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/ -ExtractPath $(Agent.BuildDirectory)/Temp/ -DotnetSymbolVersion $(SymbolToolVersion)
+
+  - template: ../darc-gather-drop.yml
+    parameters:
+      ChannelId: ${{ variables.NetCore_Tools_Latest_Channel_Id }}
+
+  - template: ../promote-build.yml	
+    parameters:	
+      ChannelId: ${{ variables.NetCore_Tools_Latest_Channel_Id }}

--- a/eng/common/templates/post-build/common-variables.yml
+++ b/eng/common/templates/post-build/common-variables.yml
@@ -5,9 +5,17 @@ variables:
   - name: PublicDevRelease_30_Channel_Id
     value: 3
 
+  # .NET Core 5 Dev
+  - name: NetCore_5_Dev_Channel_Id
+    value: 131
+
   # .NET Tools - Validation
   - name: PublicValidationRelease_30_Channel_Id
     value: 9
+
+  # .NET Tools - Latest
+  - name: NetCore_Tools_Latest_Channel_Id
+    value: 2
 
   # .NET Core 3.0 Internal Servicing
   - name: InternalServicing_30_Channel_Id

--- a/eng/common/templates/post-build/darc-gather-drop.yml
+++ b/eng/common/templates/post-build/darc-gather-drop.yml
@@ -5,7 +5,7 @@ jobs:
 - job: gatherDrop
   displayName: Gather Drop
   dependsOn: setupMaestroVars
-  condition: contains(dependencies.setupMaestroVars.outputs['setReleaseVars.InitialChannels'], ${{ parameters.ChannelId }})
+  condition: contains(dependencies.setupMaestroVars.outputs['setReleaseVars.InitialChannels'], format('[{0}]', ${{ parameters.ChannelId }}))
   variables:
     - name: BARBuildId
       value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -83,7 +83,15 @@ stages:
       parameters:
         additionalParameters: ${{ parameters.SDLValidationParameters.params }}
 
+- template: \eng\common\templates\post-build\channels\netcore-dev-5.yml
+  parameters:
+    enableSymbolValidation: ${{ parameters.enableSymbolValidation }}
+
 - template: \eng\common\templates\post-build\channels\public-dev-release.yml
+  parameters:
+    enableSymbolValidation: ${{ parameters.enableSymbolValidation }}
+
+- template: \eng\common\templates\post-build\channels\netcore-tools-latest.yml
   parameters:
     enableSymbolValidation: ${{ parameters.enableSymbolValidation }}
 

--- a/eng/common/templates/post-build/promote-build.yml
+++ b/eng/common/templates/post-build/promote-build.yml
@@ -5,7 +5,7 @@ jobs:
 - job:
   displayName: Promote Build
   dependsOn: setupMaestroVars
-  condition: contains(dependencies.setupMaestroVars.outputs['setReleaseVars.InitialChannels'], ${{ parameters.ChannelId }})
+  condition: contains(dependencies.setupMaestroVars.outputs['setReleaseVars.InitialChannels'], format('[{0}]', ${{ parameters.ChannelId }}))
   variables:
     - name: BARBuildId
       value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]


### PR DESCRIPTION
Closes: #3556

We need to add these implementations as there are people wanting to publish to these channels by default (i.e., websdk). I'd love to refactor these files in a template but don't have the cycles for that now.

Also included in the PR fixes for promote-build and gather-drop conditions.

Test build: https://dnceng.visualstudio.com/internal/_build/results?buildId=292815&view=results