### PR TITLE
adding No Column for already trained model

### DIFF
--- a/src/Microsoft.DotNet.Github.IssueLabeler/Models/GithubIssue.cs
+++ b/src/Microsoft.DotNet.Github.IssueLabeler/Models/GithubIssue.cs
@@ -31,6 +31,7 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
         public int Number { get; set; }
 
         [JsonIgnore]
+        [NoColumn]
         public GithubObjectType IssueOrPr { get; set; }
     }
 


### PR DESCRIPTION
```C#
      Connection id "0HLONHGPEP30F", Request id "0HLONHGPEP30F:00000001": An unhandled exception was thrown by the application.
System.ArgumentOutOfRangeException: Could not determine an IDataView type for member IssueOrPr
Parameter name: rawType
   at Microsoft.ML.Data.InternalSchemaDefinition.GetVectorAndItemType(Type rawType, String name, Boolean& isVector, Type& itemType)
   at Microsoft.ML.Data.SchemaDefinition.Create(Type userType, Direction direction)
   at Microsoft.ML.Data.DataViewConstructionUtils.CreateInputRow[TRow](IHostEnvironment env, SchemaDefinition schemaDefinition)
   at Microsoft.ML.PredictionEngineBase`2..ctor(IHostEnvironment env, ITransformer transformer, Boolean ignoreMissingColumns, SchemaDefinition inputSchemaDefinition, SchemaDefinition outputSchemaDefinition)
   at Microsoft.DotNet.GitHub.IssueLabeler.Predictor.Predict(GitHubIssue issue, ILogger logger, Double threshold) in C:\git\arcade\src\Microsoft.DotNet.Github.IssueLabeler\Models\Predictor.cs:line 20
   at Microsoft.DotNet.GitHub.IssueLabeler.Labeler.<PredictAndApplyLabelAsync>d__9.MoveNext() in C:\git\arcade\src\Microsoft.DotNet.Github.IssueLabeler\Models\Labeler.cs:line 74
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
```

It solves this problem