### PR TITLE
Signing.md doc note: FileSignInfo works during recursive signing

### DIFF
--- a/Documentation/CorePackages/Signing.md
+++ b/Documentation/CorePackages/Signing.md
@@ -54,9 +54,9 @@ This field requires the following metadata: `DualSigningAllowed` (boolean) and `
 
 **FileSignInfo** - Optional parameter
 
-This field accepts the following metadata: `PublicKeyToken` (*optional*), `CertificateName`, `TargetFramework` (*optional*) and the `Include` field is assumed to hold a file name (*including extension; not a full path*). The `CertificateName` attribute accept the value "*None*" to flag a file that should not be signed.
+This field accepts the following metadata: `PublicKeyToken` (*optional*), `CertificateName`, `TargetFramework` (*optional*) and the `Include` field is assumed to hold a file name (*including extension; not a full path*). The `CertificateName` attribute accepts the value "*None*" to flag a file that should not be signed.
 
-All files that match the combination informed will use the Signing information informed.
+All files that match the combination informed will use the Signing information informed. This applies to files discovered during recursive signing.
 
 **ItemsToSign** - Required parameter
 


### PR DESCRIPTION
Add "This applies to files discovered during recursive signing." to the `FileSignInfo` documentation.

It isn't strictly necessary--reading the examples in the doc in depth, I can tell that it will apply. It's also possible to guess it based on context and a little optimism. In my case, I was in a rush and reading things near search results for "recursive", and didn't put this together. This statement would have been a nice shortcut.