### PR TITLE
Update post-build.yml to pass path to SignCheckExclusionsFile

### DIFF
--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -52,7 +52,7 @@ stages:
             filePath: eng\common\sdk-task.ps1
             arguments: -task SigningValidation -restore -msbuildEngine dotnet
               /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts'
-              /p:SignCheckExclusionsFile='$(Build.SourcesDirectory)/eng/SignCheckExclusionsFile.props'
+              /p:SignCheckExclusionsFile='$(Build.SourcesDirectory)/eng/SignCheckExclusionsFile.txt'
               /p:Configuration=Release
 
   - ${{ if eq(parameters.enableSourceLinkValidation, 'true') }}:

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -52,6 +52,7 @@ stages:
             filePath: eng\common\sdk-task.ps1
             arguments: -task SigningValidation -restore -msbuildEngine dotnet
               /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts'
+              /p:SignCheckExclusionsFile='$(Build.SourcesDirectory)/eng/SignCheckExclusionsFile.props'
               /p:Configuration=Release
 
   - ${{ if eq(parameters.enableSourceLinkValidation, 'true') }}:


### PR DESCRIPTION
Need to add this to pass the parameter to the signing validation step so that users can inform files that should be excluded from signing validation.

Test build is running here: https://dnceng.visualstudio.com/internal/_build/results?buildId=295740&view=results