### PR TITLE
Use sudo when installing VSTS reporting packages

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.sh
@@ -13,13 +13,13 @@ fi
 if $ENV_PATH/bin/python -c "import azure.devops"; then
   echo "azure-devops module already available"
 else
-  $ENV_PATH/bin/python -m pip install azure-devops==5.0.0b9
+  sudo $ENV_PATH/bin/python -m pip install azure-devops==5.0.0b9
 fi
 
 if $ENV_PATH/bin/python -c "import future"; then
   echo "future module already available"
 else
-  $ENV_PATH/bin/python -m pip install future==0.17.1
+  sudo $ENV_PATH/bin/python -m pip install future==0.17.1
 fi
 
 date -u +"%FT%TZ"


### PR DESCRIPTION
Fixes a variety of problems where the current user doesn't have permission to install virtualenv packages (typically seen in docker runs)  due to not owning the directory.
The fix for dockerfiles is easy, but flowing them everywhere will take a long time; this will be removable if and when everyone is on properly created docker files.