### PR TITLE
Replacing source repo with target repo

### DIFF
--- a/src/Microsoft.DotNet.GitSync/Program.cs
+++ b/src/Microsoft.DotNet.GitSync/Program.cs
@@ -28,6 +28,7 @@ namespace Microsoft.DotNet.GitSync
         private const string RepoTableName = "MirrorBranchRepos";
         private static CloudTable s_table;
         private static Dictionary<(string, string), List<string>> s_repos { get; set; } = new Dictionary<(string, string), List<string>>();
+        private static Dictionary<string, HashSet<string>> s_branchRepoPairs = new Dictionary<string, HashSet<string>>();
         private ConfigFile ConfigFile { get; }
         private static Lazy<GitHubClient> _lazyClient;
         private static EmailManager s_emailManager;
@@ -125,7 +126,7 @@ namespace Microsoft.DotNet.GitSync
 
                 foreach (RepositoryInfo repo in config.Repos)
                 {
-                    if (!s_repos.ContainsKey((repo.Name, prBranch)))
+                    if (!s_branchRepoPairs[prBranch].Contains(repo.Name))
                         break;
 
                     if (repo.LastSynchronizedCommits != null)
@@ -377,7 +378,7 @@ namespace Microsoft.DotNet.GitSync
         {
             foreach (var repo in repos)
             {
-                if (!s_repos.ContainsKey((repo.Name, branch)))
+                if (!s_branchRepoPairs[branch].Contains(repo.Name))
                     break;
 
                 s_logger.Debug($"Updating {repo}\\{branch} to latest version.");
@@ -550,7 +551,23 @@ namespace Microsoft.DotNet.GitSync
             var repos = RepoTable.ExecuteQuery(getAllMirrorPairs);
             foreach (var item in repos)
             {
-                s_repos.Add((item.PartitionKey, item["Branch"].StringValue), item["ReposToMirrorInto"].StringValue.Split(';').ToList());
+                string branchName = item["Branch"].StringValue;
+                string[] targetRepos = item["ReposToMirrorInto"].StringValue.Split(';');
+
+                s_repos.Add((item.PartitionKey, branchName), targetRepos.ToList());
+
+                if (s_branchRepoPairs.ContainsKey(branchName))
+                {
+                    foreach (var repoName in targetRepos)
+                    {
+                        s_branchRepoPairs[branchName].Add(repoName);
+                    }
+                }
+                else
+                {
+                    s_branchRepoPairs.Add(branchName, targetRepos.ToHashSet());
+                }
+
                 s_logger.Info($"The commits in  {item.PartitionKey} repo will be mirrored into {item["ReposToMirrorInto"].StringValue} Repos");
             }
 

--- a/src/Microsoft.DotNet.GitSync/Program.cs
+++ b/src/Microsoft.DotNet.GitSync/Program.cs
@@ -122,6 +122,9 @@ namespace Microsoft.DotNet.GitSync
 
             foreach (string prBranch in config.Branches)
             {
+                if (!s_branchRepoPairs.ContainsKey(prBranch))
+                    throw new ArgumentException($"None of the repos mirror {prBranch} branch.", nameof(prBranch));
+
                 UpdateRepository(config.Repos, prBranch);
 
                 foreach (RepositoryInfo repo in config.Repos)


### PR DESCRIPTION
s_repos match sourceRepo, Branch -> targetRepo 
where as we just need to check if target repo needs mirroring for that branch.

this was creating problems for uniDirectional mirror like mono as s_repos was reporting that no branch pair needs to be mirrored into this repo.
