### PR TITLE
Allow VersionPrefix to include an optionally provided PatchVersion

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
@@ -52,7 +52,7 @@
     Note that .NET Core SDK sets VersionPrefix to 1.0.0 if not set by the project. Override it here if the project sets MajorVersion, MinorVersion, and optionally a PatchVersion.
   -->
   <PropertyGroup>
-    <VersionPrefix Condition="'$(MajorVersion)' != '' and '$(MinorVersion)' != ''">$(MajorVersion).$(MinorVersion).$(MSBuild::ValueOrDefault('$(PatchVersion)', '0'))<VersionPrefix/>
+    <VersionPrefix Condition="'$(MajorVersion)' != '' and '$(MinorVersion)' != ''">$(MajorVersion).$(MinorVersion).$(MSBuild::ValueOrDefault('$(PatchVersion)', '0'))</VersionPrefix>
     <_OriginalVersionPrefix>$(VersionPrefix)</_OriginalVersionPrefix>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
@@ -48,12 +48,11 @@
   -->
 
   <!--
-    The project can specify version either directly using the .NET SDK recognized property VersionPrefix, or using MajorVersion, MinorVersion, and PatchVersion properties.
+    The project can specify version either directly using the .NET SDK recognized property VersionPrefix, or using MajorVersion and MinorVersion properties.
     Note that .NET Core SDK sets VersionPrefix to 1.0.0 if not set by the project. Override it here if the project sets MajorVersion, MinorVersion, and optionally a PatchVersion.
   -->
   <PropertyGroup>
-    <VersionPrefix Condition="'$(MajorVersion)' != '' and '$(MinorVersion)' != ''" and '$(PatchVersion)' != ''>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
-    <VersionPrefix Condition="'$(MajorVersion)' != '' and '$(MinorVersion)' != ''" and '$(PatchVersion)' == ''>$(MajorVersion).$(MinorVersion).0</VersionPrefix>
+    <VersionPrefix Condition="'$(MajorVersion)' != '' and '$(MinorVersion)' != ''">$(MajorVersion).$(MinorVersion).$(MSBuild::ValueOrDefault('$(PatchVersion)', '0'))<VersionPrefix/>
     <_OriginalVersionPrefix>$(VersionPrefix)</_OriginalVersionPrefix>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
@@ -48,11 +48,12 @@
   -->
 
   <!--
-    The project can specify version either directly using the .NET SDK recognized property VersionPrefix, or using MajorVersion and MinorVersion properties.
-    Note that .NET Core SDK sets VersionPrefix to 1.0.0 if not set by the project. Override it here if the project sets MajorVersion and MinorVersion.
+    The project can specify version either directly using the .NET SDK recognized property VersionPrefix, or using MajorVersion, MinorVersion, and PatchVersion properties.
+    Note that .NET Core SDK sets VersionPrefix to 1.0.0 if not set by the project. Override it here if the project sets MajorVersion, MinorVersion, and optionally a PatchVersion.
   -->
   <PropertyGroup>
-    <VersionPrefix Condition="'$(MajorVersion)' != '' and '$(MinorVersion)' != ''">$(MajorVersion).$(MinorVersion).0</VersionPrefix>
+    <VersionPrefix Condition="'$(MajorVersion)' != '' and '$(MinorVersion)' != ''" and '$(PatchVersion)' != ''>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
+    <VersionPrefix Condition="'$(MajorVersion)' != '' and '$(MinorVersion)' != ''" and '$(PatchVersion)' == ''>$(MajorVersion).$(MinorVersion).0</VersionPrefix>
     <_OriginalVersionPrefix>$(VersionPrefix)</_OriginalVersionPrefix>
   </PropertyGroup>
 


### PR DESCRIPTION
Roslyn constructs a VersionPrefix from MajorVersion, MinorVersion and PrefixVersion properties. This was being overwritten with MajorVersion.MinorVersion.0 in the Version.BeforeCommonTargets. This change will construct the VersionPrefix with a PatchVersion if provided.