### PR TITLE
SignCheck: Ensure container content is checked

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/Verification/FileVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/FileVerifier.cs
@@ -165,24 +165,16 @@ namespace Microsoft.SignCheck.Verification
         {
             Log.WriteMessage(LogVerbosity.Detailed, String.Format(SignCheckResources.ProcessingFile, Path.GetFileName(path), String.IsNullOrEmpty(parent) ? SignCheckResources.NA : parent));
 
-            SignatureVerificationResult svr;
-
-            if (Exclusions.IsExcluded(path, parent, containerPath))
-            {
-                svr = SignatureVerificationResult.ExcludedFileResult(path, parent);
-            }
-            else
-            {
-                FileVerifier fileVerifier = GetFileVerifier(path);
-                svr = fileVerifier.VerifySignature(path, parent);
-            }
+            FileVerifier fileVerifier = GetFileVerifier(path);
+            SignatureVerificationResult svr = fileVerifier.VerifySignature(path, parent);
+            svr.IsExcluded = Exclusions.IsExcluded(path, parent, containerPath);
 
             if (GenerateExclusion)
             {
                 svr.ExclusionEntry = String.Join(";", String.Join("|", path, containerPath), parent, String.Empty);
                 Log.WriteMessage(LogVerbosity.Diagnostic, SignCheckResources.DiagGenerateExclusion, svr.Filename, svr.ExclusionEntry);
             }
-
+            
             // Include the full path for top-level files
             if (String.IsNullOrEmpty(parent))
             {

--- a/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationManager.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationManager.cs
@@ -115,25 +115,18 @@ namespace Microsoft.SignCheck.Verification
         {
             foreach (string file in files)
             {
-                // If the file is excluded add a default result
-                if (Exclusions.IsExcluded(file, parent: null, containerPath: null))
-                {
-                    var result = SignatureVerificationResult.ExcludedFileResult(file, parent: null);
-                    Results.Add(result);
-                }
-                else
-                {
-                    FileVerifier fileVerifier = GetFileVerifier(file);
-                    SignatureVerificationResult result = fileVerifier.VerifySignature(file, parent: null);
+                FileVerifier fileVerifier = GetFileVerifier(file);
+                SignatureVerificationResult result;
+                result = fileVerifier.VerifySignature(file, parent: null);
 
-                    if ((Options & SignatureVerificationOptions.GenerateExclusion) == SignatureVerificationOptions.GenerateExclusion)
-                    {
-                        result.ExclusionEntry = String.Join(";", String.Join("|", file, String.Empty), String.Empty, String.Empty);
-                        Log.WriteMessage(LogVerbosity.Diagnostic, SignCheckResources.DiagGenerateExclusion, result.Filename, result.ExclusionEntry);
-                    }
-
-                    Results.Add(result);
+                if ((Options & SignatureVerificationOptions.GenerateExclusion) == SignatureVerificationOptions.GenerateExclusion)
+                {
+                    result.ExclusionEntry = String.Join(";", String.Join("|", file, String.Empty), String.Empty, String.Empty);
+                    Log.WriteMessage(LogVerbosity.Diagnostic, SignCheckResources.DiagGenerateExclusion, result.Filename, result.ExclusionEntry);
                 }
+
+                result.IsExcluded = Exclusions.IsExcluded(file, parent: null, containerPath: null);
+                Results.Add(result);
             }
 
             return Results;

--- a/src/SignCheck/SignCheck/SignCheck.cs
+++ b/src/SignCheck/SignCheck/SignCheck.cs
@@ -303,7 +303,7 @@ namespace SignCheck
             {
                 TotalFiles++;
 
-                if (result.IsSigned)
+                if (result.IsSigned && !result.IsExcluded)
                 {
                     TotalSignedFiles++;
                 }


### PR DESCRIPTION
Scan files in containers when the container is excluded and -r is specified. Previously, if you had an exclusion, e.g.

`*.nupkg;;`

and ran with -r, the contents of any nupkg would be skipped because the nupkg was excluded. This is actually not correct since -r specifies scanning recursive content. A typical use case for this is building a nupkg that's internally consumed, but contains files like EXEs, DLLs, etc. that should be verified