### PR TITLE
Fix Omnisharp init errors in CoreFx

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
@@ -147,26 +147,28 @@
 
   </Choose>
 
-  <ItemGroup>
-    <!-- Add the runner configuration file -->
-    <None Include="$(TestRunnerConfigPath)"
-          CopyToOutputDirectory="PreserveNewest"
-          Visible="false" />
+  <Target Name="CopyRunnerToOutputDirectory" BeforeTargets="CopyFilesToOutputDirectory">
+    <ItemGroup>
+      <!-- Add the runner configuration file -->
+      <None Include="$(TestRunnerConfigPath)"
+            CopyToOutputDirectory="PreserveNewest"
+            Visible="false" />
 
-    <!-- Copy test runner to output directory -->
-    <None Include="$([System.IO.Path]::GetDirectoryName('$(XunitConsole472Path)'))\*"
-          Exclude="$([System.IO.Path]::GetDirectoryName('$(XunitConsole472Path)'))\xunit.console.*exe.config;$([System.IO.Path]::GetDirectoryName('$(XunitConsole472Path)'))\xunit.console.x86.exe"
-          Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(XunitConsole472Path)' != ''"
-          CopyToOutputDirectory="PreserveNewest"
-          Visible="false" />
+      <!-- Copy test runner to output directory -->
+      <None Include="$([System.IO.Path]::GetDirectoryName('$(XunitConsole472Path)'))\*"
+            Exclude="$([System.IO.Path]::GetDirectoryName('$(XunitConsole472Path)'))\xunit.console.*exe.config;$([System.IO.Path]::GetDirectoryName('$(XunitConsole472Path)'))\xunit.console.x86.exe"
+            Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(XunitConsole472Path)' != ''"
+            CopyToOutputDirectory="PreserveNewest"
+            Visible="false" />
 
-    <_xunitConsoleNetCoreExclude Condition="'$(GenerateDependencyFile)' != 'true'" Include="$([System.IO.Path]::GetDirectoryName('$(XunitConsoleNetCore21AppPath)'))\xunit.console.deps.json" />
-    <None Include="$([System.IO.Path]::GetDirectoryName('$(XunitConsoleNetCore21AppPath)'))\*"
-          Exclude="@(_xunitConsoleNetCoreExclude)"
-          Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(XunitConsoleNetCore21AppPath)' != ''"
-          CopyToOutputDirectory="PreserveNewest"
-          Visible="false" />
-  </ItemGroup>
+      <_xunitConsoleNetCoreExclude Condition="'$(GenerateDependencyFile)' != 'true'" Include="$([System.IO.Path]::GetDirectoryName('$(XunitConsoleNetCore21AppPath)'))\xunit.console.deps.json" />
+      <None Include="$([System.IO.Path]::GetDirectoryName('$(XunitConsoleNetCore21AppPath)'))\*"
+            Exclude="@(_xunitConsoleNetCoreExclude)"
+            Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(XunitConsoleNetCore21AppPath)' != ''"
+            CopyToOutputDirectory="PreserveNewest"
+            Visible="false" />
+    </ItemGroup>
+  </Target>
 
   <!-- Main test targets -->
   <Target Name="Test" DependsOnTargets="$(TestDependsOn)" />


### PR DESCRIPTION
Omnisharp complained that during the design-time build `$([System.IO.Path]::GetDirectoryName('$(XunitConsoleNetCore21AppPath)'))` couldn't be resolved as `$(XunitConsoleNetCore21AppPath)` was resolved to ''. Putting the items inside a target which runs before files are copied to the output directory solves that and Intellisense is finally working in corefx in VSCode.

Hard to see but the diff simply wraps the ItemGroup inside a Target. This is temporary as we soon switch to dotnet vstest and don't need the runner copying anymore.