### PR TITLE
Fix missing [] in MSBuild function call to calculate Version Prefix

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
@@ -52,7 +52,7 @@
     Note that .NET Core SDK sets VersionPrefix to 1.0.0 if not set by the project. Override it here if the project sets MajorVersion, MinorVersion, and optionally a PatchVersion.
   -->
   <PropertyGroup>
-    <VersionPrefix Condition="'$(MajorVersion)' != '' and '$(MinorVersion)' != ''">$(MajorVersion).$(MinorVersion).$(MSBuild::ValueOrDefault('$(PatchVersion)', '0'))</VersionPrefix>
+    <VersionPrefix Condition="'$(MajorVersion)' != '' and '$(MinorVersion)' != ''">$(MajorVersion).$(MinorVersion).$([MSBuild]::ValueOrDefault('$(PatchVersion)', '0'))</VersionPrefix>
     <_OriginalVersionPrefix>$(VersionPrefix)</_OriginalVersionPrefix>
   </PropertyGroup>
 


### PR DESCRIPTION
This was introduced here: https://github.com/dotnet/arcade/pull/3601 and since it is missing `[]` around the MSBuild reference it evaluates to empty property causing build errors: 
> packages/microsoft.dotnet.arcade.sdk/1.0.0-beta.19408.2/tools/Version.targets(17,5): error : 
 VersionPrefix is not a valid 3-part version: 5.0.

