### PR TITLE
Harvest validation

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>
@@ -63,6 +63,7 @@
     <PackageReference Include="NuGet.Commands" Version="$(NuGetVersion)" />
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetVersion)" />
     <PackageReference Include="NuGet.ProjectModel" Version="$(NuGetVersion)" />
+    <PackageReference Include="System.Text.Json" Version="4.6.0-preview7.19362.9" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="$(MicrosoftNETCorePlatformsVersion)" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidateHarvestVersionIsLatestForEra.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidateHarvestVersionIsLatestForEra.cs
@@ -1,0 +1,190 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging
+{
+    /// <summary>
+    /// MSBuild Task that validates if a package is harvesting
+    /// the latest package version for a specific package era
+    /// </summary>
+    public class ValidateHarvestVersionIsLatestForEra : BuildTask
+    {
+        /// <summary>
+        /// Path to the package report to be analyzed.
+        /// </summary>
+        [Required]
+        public string PackageReportPath { get; set; }
+
+        /// <summary>
+        /// Version endpoints to be queried in order to get the latest stable patch
+        /// version for a package era.
+        /// </summary>
+        public ITaskItem[] NugetPackageVersionsEndpoints { get; set; }
+
+        private const string NuGetDotOrgVersionEndpoint = @"http://api.nuget.org/v3-flatcontainer/";
+
+        public override bool Execute()
+        {
+            var packageReport = PackageReport.Load(PackageReportPath);
+            bool isHarvestingAssetsFromPackage = TryGetHarvestVersionFromReport(packageReport, out string harvestVersion, out int harvestEraMajor, out int harvestEraMinor);
+
+            if (isHarvestingAssetsFromPackage)
+            {
+                // If no package versions endpoints were provided, then default to use NuGet.org version endpoint.
+                if (NugetPackageVersionsEndpoints == null || NugetPackageVersionsEndpoints.Length == 0)
+                {
+                    NugetPackageVersionsEndpoints = new TaskItem[]
+                    {
+                        new TaskItem(NuGetDotOrgVersionEndpoint)
+                    };
+                }
+
+                string latestPatchVersion = GetLatestStableVersionForEra(packageReport.Id, harvestEraMajor, harvestEraMinor);
+                if (latestPatchVersion.CompareTo(harvestVersion) != 0)
+                {
+                    Log.LogError($"Validation Failed: {packageReport.Id} is harvesting assets from package version {harvestVersion} which is not the latest for that package era. Latest package version from that era is {latestPatchVersion}. Update packageIndex.json in order to fix this.");
+                }
+                else
+                {
+                    Log.LogMessage(LogImportance.Normal, $"Validation Succeeded: {packageReport.Id} is harvesting assets from package version {harvestVersion} which is the latest for that package era.");
+                }
+            }
+            else
+            {
+                Log.LogMessage(LogImportance.Normal, $"Validation Succeeded: {packageReport.Id} is not harvesting any assets.");
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private bool TryGetHarvestVersionFromReport(PackageReport report, out string harvestVersion, out int harvestEraMajor, out int harvestEraMinor)
+        {
+            harvestVersion = string.Empty;
+            harvestEraMajor = harvestEraMinor = 0;
+            Regex regex = new Regex($"{report.Id}/(\\d*).(\\d*).(\\d*)/");
+
+            foreach (KeyValuePair<string, Target> packageTarget in report.Targets.NullAsEmpty())
+            {
+                foreach (PackageAsset compileAsset in packageTarget.Value.CompileAssets.NullAsEmpty())
+                {
+                    if (!string.IsNullOrEmpty(compileAsset.HarvestedFrom))
+                    {
+                        return MatchesHarvestVersionPattern(regex, compileAsset.HarvestedFrom, out harvestVersion, out harvestEraMajor, out harvestEraMinor);
+                    }
+                }
+
+                foreach (PackageAsset runtimeAsset in packageTarget.Value.RuntimeAssets.NullAsEmpty())
+                {
+                    if (!string.IsNullOrEmpty(runtimeAsset.HarvestedFrom))
+                    {
+                        return MatchesHarvestVersionPattern(regex, runtimeAsset.HarvestedFrom, out harvestVersion, out harvestEraMajor, out harvestEraMinor);
+                    }
+                }
+
+                foreach (PackageAsset nativeAsset in packageTarget.Value.NativeAssets.NullAsEmpty())
+                {
+                    if (!string.IsNullOrEmpty(nativeAsset.HarvestedFrom))
+                    {
+                        return MatchesHarvestVersionPattern(regex, nativeAsset.HarvestedFrom, out harvestVersion, out harvestEraMajor, out harvestEraMinor);
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private bool MatchesHarvestVersionPattern(Regex regex, string harvestedFrom, out string harvestVersion, out int harvestEraMajor, out int harvestEraMinor)
+        {
+            var match = regex.Match(harvestedFrom);
+            if (match.Success)
+            {
+                harvestEraMajor = int.Parse(match.Groups[1].Value);
+                harvestEraMinor = int.Parse(match.Groups[2].Value);
+                harvestVersion = $"{match.Groups[1].Value}.{match.Groups[2].Value}.{match.Groups[3].Value}";
+                return true;
+            }
+            else
+            {
+                harvestVersion = string.Empty;
+                harvestEraMajor = harvestEraMinor = 0;
+                Log.LogError($"Failed to get harvest version from string {harvestedFrom}");
+                return false;
+            }
+        }
+
+        private string GetLatestStableVersionForEra(string packageId, int eraMajorVersion, int eraMinorVersion)
+        {
+            string latestPatchVersion = string.Empty;
+            foreach (var versionEndpoint in NugetPackageVersionsEndpoints)
+            {
+
+                string allPackageVersionsUrl = string.Concat(versionEndpoint.ItemSpec, packageId, "/index.json");
+                string versionsJson = string.Empty;
+
+                HttpWebRequest request = (HttpWebRequest)WebRequest.Create(allPackageVersionsUrl);
+                using (HttpWebResponse response = (HttpWebResponse)request.GetResponse())
+                {
+                    if (response.StatusCode != HttpStatusCode.OK)
+                    {
+                        Log.LogError($"Unable to reach the package versions url at {allPackageVersionsUrl}. Recieved status code {response.StatusCode}.");
+                        return null;
+                    }
+                    using (var stream = response.GetResponseStream())
+                    using (var reader = new StreamReader(stream))
+                    {
+                        versionsJson = reader.ReadToEnd();
+                    }
+                }
+
+                PackageVersions packageVersions = JsonConvert.DeserializeObject<PackageVersions>(versionsJson);
+                string latestPatchFromFeed = packageVersions.GetLatestPatchStableVersionForEra(eraMajorVersion, eraMinorVersion, Log);
+                // CompareTo method will return 1 if latestPatchVersion is empty so no need to add check.
+                if (latestPatchFromFeed.CompareTo(latestPatchVersion) > 0)
+                {
+                    latestPatchVersion = latestPatchFromFeed;
+                }
+            }
+            return latestPatchVersion;
+        }
+
+        private class PackageVersions
+        {
+            [JsonProperty(PropertyName = "versions")]
+            public List<string> Versions { get; set; }
+
+            public string GetLatestPatchStableVersionForEra(int major, int minor, Log buildlog)
+            {
+                string result = string.Empty;
+
+                foreach (var version in Versions)
+                {
+                    if (IsStableVersion(version) && version.StartsWith($"{major}.{minor}"))
+                    {
+                        result = version;
+                    }
+                }
+
+                if (string.IsNullOrEmpty(result))
+                {
+                    buildlog.LogError($"There are no stable versions that match {major}.{minor}.* package version.");
+                }
+
+                return result;
+            }
+
+            private bool IsStableVersion(string version)
+            {
+                return version.IndexOf("-") == -1;
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidateHarvestVersionIsLatestForEra.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidateHarvestVersionIsLatestForEra.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
         public override bool Execute()
         {
-            var packageReport = PackageReport.Load(PackageReportPath);
+            PackageReport packageReport = GetPackageReportFromPath();
             bool isHarvestingAssetsFromPackage = TryGetHarvestVersionFromReport(packageReport, out string harvestVersion, out int harvestEraMajor, out int harvestEraMinor);
 
             if (isHarvestingAssetsFromPackage)
@@ -64,6 +64,12 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             }
 
             return !Log.HasLoggedErrors;
+        }
+
+        // Making this method protected virtual for tests.
+        protected virtual PackageReport GetPackageReportFromPath()
+        {
+            return PackageReport.Load(PackageReportPath);
         }
 
         private bool TryGetHarvestVersionFromReport(PackageReport report, out string harvestVersion, out int harvestEraMajor, out int harvestEraMinor)
@@ -121,7 +127,8 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             }
         }
 
-        private string GetLatestStableVersionForEra(string packageId, int eraMajorVersion, int eraMinorVersion)
+        // Making this method protected virtual for tests.
+        protected virtual string GetLatestStableVersionForEra(string packageId, int eraMajorVersion, int eraMinorVersion)
         {
             string latestPatchVersion = string.Empty;
             foreach (var versionEndpoint in NugetPackageVersionsEndpoints)

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidateHarvestVersionIsLatestForEra.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidateHarvestVersionIsLatestForEra.cs
@@ -39,6 +39,12 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
             if (isHarvestingAssetsFromPackage)
             {
+                if (packageReport.Version.StartsWith($"{harvestEraMajor}.{harvestEraMinor}."))
+                {
+                    Log.LogError($"Validation Failed: {packageReport.Id} is harvesting package version {harvestVersion} which belongs to the current package era: {packageReport.Version}");
+                    return false;
+                }
+
                 // If no package versions endpoints were provided, then default to use NuGet.org version endpoint.
                 if (NugetPackageVersionsEndpoints == null || NugetPackageVersionsEndpoints.Length == 0)
                 {

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidateHarvestVersionIsLatestForEra.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidateHarvestVersionIsLatestForEra.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         /// </summary>
         public ITaskItem[] NugetPackageVersionsEndpoints { get; set; }
 
-        private const string NuGetDotOrgVersionEndpoint = @"http://api.nuget.org/v3-flatcontainer/";
+        private const string NuGetDotOrgVersionEndpoint = @"https://api.nuget.org/v3-flatcontainer/";
 
         public override bool Execute()
         {
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 string latestPatchVersion = GetLatestStableVersionForEra(packageReport.Id, harvestEraMajor, harvestEraMinor);
                 if (latestPatchVersion.CompareTo(harvestVersion) != 0)
                 {
-                    Log.LogError($"Validation Failed: {packageReport.Id} is harvesting assets from package version {harvestVersion} which is not the latest for that package era. Latest package version from that era is {latestPatchVersion}. Update packageIndex.json in order to fix this.");
+                    Log.LogError($"Validation Failed: {packageReport.Id} is harvesting assets from package version {harvestVersion} which is not the latest for that package era. Latest package version from that era is {latestPatchVersion}.");
                 }
                 else
                 {

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidateHarvestVersionIsLatestForEra.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidateHarvestVersionIsLatestForEra.cs
@@ -160,15 +160,17 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 string allPackageVersionsUrl = string.Concat(versionEndpoint.ItemSpec, packageId, "/index.json");
                 string versionsJson = string.Empty;
 
-                using HttpClient httpClient = new HttpClient();
-                using (HttpResponseMessage httpResponseMessage = await httpClient.GetAsync(allPackageVersionsUrl))
+                using (HttpClient httpClient = new HttpClient())
                 {
-                    if (httpResponseMessage.StatusCode != HttpStatusCode.OK)
+                    using (HttpResponseMessage httpResponseMessage = await httpClient.GetAsync(allPackageVersionsUrl))
                     {
-                        Log.LogError($"Unable to reach the package versions url at {allPackageVersionsUrl}. Recieved status code {httpResponseMessage.StatusCode}.");
-                        return null;
+                        if (httpResponseMessage.StatusCode != HttpStatusCode.OK)
+                        {
+                            Log.LogError($"Unable to reach the package versions url at {allPackageVersionsUrl}. Recieved status code {httpResponseMessage.StatusCode}.");
+                            return null;
+                        }
+                        versionsJson = await httpResponseMessage.Content.ReadAsStringAsync();
                     }
-                    versionsJson = await httpResponseMessage.Content.ReadAsStringAsync();
                 }
 
                 PackageVersions packageVersions = JsonSerializer.Deserialize<PackageVersions>(versionsJson);

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/ValidateHarvestVersionIsLatestForEraTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/ValidateHarvestVersionIsLatestForEraTests.cs
@@ -1,0 +1,124 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
+{
+    public class ValidateHarvestVersionIsLatestForEraTests
+    {
+        private Log _log;
+        private TestBuildEngine _engine;
+        private const string TestReportPath = "dummyReport.json";
+        private PackageReport _testPackageReport = new PackageReport()
+        {
+            Id = "TestPackage",
+            Targets = new Dictionary<string, Target>
+            {
+                {
+                    "testTarget", new Target
+                    {
+                        CompileAssets = new PackageAsset[]
+                        {
+                            new PackageAsset{ HarvestedFrom = "TestPackage/4.6.2/ref/netstandard2.0/TestPackage.dll" }
+                        }
+                    }
+                }
+            }
+        };
+
+        public ValidateHarvestVersionIsLatestForEraTests(ITestOutputHelper output)
+        {
+            _log = new Log(output);
+            _engine = new TestBuildEngine(_log);
+        }
+
+        [Fact]
+        public void ValidationFailsWhenHarvestVersionIsNotLatestTest()
+        {
+            TestableValidateHarvestVersionTask task = new TestableValidateHarvestVersionTask(() => _testPackageReport, (packageId, eraMajor, eraMinor) =>
+            {
+                return $"{eraMajor}.{eraMinor}.3";
+            }) { BuildEngine = _engine, PackageReportPath = TestReportPath };
+
+            _log.Reset();
+            task.Execute();
+            Assert.Equal(1, _log.ErrorsLogged);
+            Assert.Equal(0, _log.WarningsLogged);
+        }
+
+        [Fact]
+        public void ValidationSucceedsWhenHarvestVersionIsLatestTest()
+        {
+            TestableValidateHarvestVersionTask task = new TestableValidateHarvestVersionTask(() => _testPackageReport, (packageId, eraMajor, eraMinor) =>
+            {
+                return $"{eraMajor}.{eraMinor}.2";
+            })
+            { BuildEngine = _engine, PackageReportPath = TestReportPath };
+
+            _log.Reset();
+            task.Execute();
+            Assert.Equal(0, _log.ErrorsLogged);
+            Assert.Equal(0, _log.WarningsLogged);
+        }
+
+        [Fact]
+        public void ValidationSucceedsWhenNoPackagesWhereHarvestedTest()
+        {
+            TestableValidateHarvestVersionTask task = new TestableValidateHarvestVersionTask(() =>
+            {
+                return new PackageReport()
+                {
+                    Id = "TestPackage",
+                    Targets = new Dictionary<string, Target>
+                    {
+                        {
+                            "testTarget", new Target
+                            {
+                                CompileAssets = new PackageAsset[]
+                                {
+                                    new PackageAsset{  }
+                                },
+                                RuntimeAssets = new PackageAsset[]
+                                {
+                                    new PackageAsset{  }
+                                },
+                                NativeAssets = new PackageAsset[]
+                                {
+                                    new PackageAsset{  }
+                                }
+                            }
+                        }
+                    }
+                };
+            }, (packageId, eraMajor, eraMinor) => string.Empty)
+            { BuildEngine = _engine, PackageReportPath = TestReportPath };
+
+            _log.Reset();
+            task.Execute();
+            Assert.Equal(0, _log.ErrorsLogged);
+            Assert.Equal(0, _log.WarningsLogged);
+        }
+
+        private class TestableValidateHarvestVersionTask : ValidateHarvestVersionIsLatestForEra
+        {
+            private Func<PackageReport> _packageReportFunc;
+            private Func<string, int, int, string> _getLatestStableVersionFunc;
+
+            public TestableValidateHarvestVersionTask(Func<PackageReport> packageReportFunc, Func<string, int, int, string> getLatestStableVersionFunc)
+            {
+                _packageReportFunc = packageReportFunc;
+                _getLatestStableVersionFunc = getLatestStableVersionFunc;
+            }
+
+            protected override PackageReport GetPackageReportFromPath() => _packageReportFunc();
+
+            protected override string GetLatestStableVersionForEra(string packageId, int eraMajorVersion, int eraMinorVersion) => _getLatestStableVersionFunc(packageId, eraMajorVersion, eraMinorVersion);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/ValidateHarvestVersionIsLatestForEraTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/ValidateHarvestVersionIsLatestForEraTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
         private PackageReport _testPackageReport = new PackageReport()
         {
             Id = "TestPackage",
+            Version = "4.7.0",
             Targets = new Dictionary<string, Target>
             {
                 {
@@ -102,6 +103,37 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
             _log.Reset();
             task.Execute();
             Assert.Equal(0, _log.ErrorsLogged);
+            Assert.Equal(0, _log.WarningsLogged);
+        }
+
+        [Fact]
+        public void ValidationFailsWhenHarvestingFromCurrentVersionTest()
+        {
+            TestableValidateHarvestVersionTask task = new TestableValidateHarvestVersionTask(() =>
+            {
+                return new PackageReport()
+                {
+                    Id = "TestPackage",
+                    Version = "4.6.3",
+                    Targets = new Dictionary<string, Target>
+                    {
+                        {
+                            "testTarget", new Target
+                            {
+                                CompileAssets = new PackageAsset[]
+                                {
+                                    new PackageAsset{ HarvestedFrom = "TestPackage/4.6.2/ref/netstandard2.0/TestPackage.dll" }
+                                }
+                            }
+                        }
+                    }
+                };
+            }, (packageId, eraMajor, eraMinor) => string.Empty)
+            { BuildEngine = _engine, PackageReportPath = TestReportPath };
+
+            _log.Reset();
+            task.Execute();
+            Assert.Equal(1, _log.ErrorsLogged);
             Assert.Equal(0, _log.WarningsLogged);
         }
 


### PR DESCRIPTION
cc: @ericstj @safern 

This msbuild task will take a package report as an input, then it will calculate what was the harvest packaged version (if assets were not harvested then validation will skip the rest of the steps and will just succeed), and then it will ensure that the harvest version being used is the latest one for that package era. The way we validate this, is by hitting nuget.org feed endpoint (which callers can override to provide different feeds) and getting all stable versions that have been pushed for that package to get a list of all packages. The endpoints will return all pushed packages (including packages that were de-listed).

This is progress towards: https://github.com/dotnet/corefx/issues/39537