### PR TITLE
Fix CopyRunnerToOutputDirectory execution order to run early enough

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
@@ -147,7 +147,8 @@
 
   </Choose>
 
-  <Target Name="CopyRunnerToOutputDirectory" BeforeTargets="CopyFilesToOutputDirectory">
+  <!-- ResolveAssemblyReferences is the target that populates ReferenceCopyLocalPaths which is what is copied to output directory. -->
+  <Target Name="CopyRunnerToOutputDirectory" BeforeTargets="ResolveAssemblyReferences">
     <ItemGroup>
       <!-- Add the runner configuration file -->
       <None Include="$(TestRunnerConfigPath)"


### PR DESCRIPTION
https://github.com/dotnet/arcade/pull/3616 broke corefx tests as the runner is not being copied to the output directory at all. The reason for that is because `ResolveAssemblyReferences` is the target that populates `ReferenceCopyLocalPaths` which is the item that `CopyToOutputDirectory` uses to copy the items to the output directory. So we need to run before `ResolveAssemblyReferences`

Test are failing with:
> The application to execute does not exist: 'xunit.console.dll'

cc: @joperezr who told me needed to consume arcade soon in corefx.