### PR TITLE
Conditional theory data row support (theory pre-enumeration support)

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ConditionalFactAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ConditionalFactAttribute.cs
@@ -11,7 +11,7 @@ namespace Xunit
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
     public sealed class ConditionalFactAttribute : FactAttribute
     {
-        public Type     CalleeType { get; private set; }
+        public Type CalleeType { get; private set; }
         public string[] ConditionMemberNames { get; private set; }
 
         public ConditionalFactAttribute(Type calleeType, params string[] conditionMemberNames)

--- a/src/Microsoft.DotNet.XUnitExtensions/src/ConditionalDiscovererException.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/ConditionalDiscovererException.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.DotNet.XUnitExtensions
+{
+    internal class ConditionalDiscovererException : Exception
+    {
+        public ConditionalDiscovererException(string message) : base(message) { }
+    }
+}

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ConditionalTestDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ConditionalTestDiscoverer.cs
@@ -101,7 +101,7 @@ namespace Microsoft.DotNet.XUnitExtensions
             if (falseConditions.Count > 0)
             {
                 string skippedReason = string.Format("Condition(s) not met: \"{0}\"", string.Join("\", \"", falseConditions));
-                return testCases.Select(tc => new SkippedTestCase(tc, skippedReason));
+                return testCases.Select(tc => new SkippedTestCase(skippedReason, diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, tc.TestMethod, tc.TestMethodArguments));
             }
 
             // No conditions returned false (including the absence of any conditions).

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ConditionalTestDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ConditionalTestDiscoverer.cs
@@ -13,28 +13,21 @@ namespace Microsoft.DotNet.XUnitExtensions
 {
     // Internal helper class for code common to conditional test discovery through
     // [ConditionalFact] and [ConditionalTheory]
-    internal class ConditionalTestDiscoverer
+    internal static class ConditionalTestDiscoverer
     {
         // This helper method evaluates the given condition member names for a given set of test cases.
         // If any condition member evaluates to 'false', the test cases are marked to be skipped.
         // The skip reason is the collection of all the condition members that evaluated to 'false'.
-        internal static IEnumerable<IXunitTestCase> Discover(
-                                                        ITestFrameworkDiscoveryOptions discoveryOptions,
-                                                        IMessageSink diagnosticMessageSink,
-                                                        ITestMethod testMethod,
-                                                        IEnumerable<IXunitTestCase> testCases,
-                                                        object[] conditionArguments)
+        internal static string EvaluateSkipConditions(ITestMethod testMethod, object[] conditionArguments)
         {
             Type calleeType = null;
             string[] conditionMemberNames = null;
 
-            if (CheckInputToSkipExecution(conditionArguments, ref calleeType, ref conditionMemberNames, testMethod)) return testCases;
+            if (CheckInputToSkipExecution(conditionArguments, ref calleeType, ref conditionMemberNames, testMethod)) return null;
 
             MethodInfo testMethodInfo = testMethod.Method.ToRuntimeMethod();
             Type testMethodDeclaringType = testMethodInfo.DeclaringType;
             List<string> falseConditions = new List<string>(conditionMemberNames.Count());
-            TestMethodDisplay defaultMethodDisplay = discoveryOptions.MethodDisplayOrDefault();
-            TestMethodDisplayOptions defaultMethodDisplayOptions = discoveryOptions.MethodDisplayOptionsOrDefault();
 
             foreach (string entry in conditionMemberNames)
             {
@@ -71,15 +64,7 @@ namespace Microsoft.DotNet.XUnitExtensions
                 MethodInfo conditionMethodInfo;
                 if ((conditionMethodInfo = LookupConditionalMethod(declaringType, conditionMemberName)) == null)
                 {
-                    return new[] 
-                    {
-                        new ExecutionErrorTestCase(
-                            diagnosticMessageSink,
-                            defaultMethodDisplay,
-                            defaultMethodDisplayOptions,
-                            testMethod,
-                            GetFailedLookupString(conditionMemberName, declaringType))
-                    };
+                    throw new ConditionalDiscovererException(GetFailedLookupString(conditionMemberName, declaringType));
                 }
 
                 // In the case of multiple conditions, collect the results of all
@@ -100,12 +85,32 @@ namespace Microsoft.DotNet.XUnitExtensions
             // Compose a summary of all conditions that returned false.
             if (falseConditions.Count > 0)
             {
-                string skippedReason = string.Format("Condition(s) not met: \"{0}\"", string.Join("\", \"", falseConditions));
-                return testCases.Select(tc => new SkippedTestCase(skippedReason, diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, tc.TestMethod, tc.TestMethodArguments));
+                return string.Format("Condition(s) not met: \"{0}\"", string.Join("\", \"", falseConditions));
             }
 
             // No conditions returned false (including the absence of any conditions).
-            return testCases;
+            return null;
+        }
+
+        internal static bool TryEvaluateSkipConditions(ITestFrameworkDiscoveryOptions discoveryOptions, IMessageSink diagnosticMessageSink, ITestMethod testMethod, object[] conditionArguments, out string skipReason, out ExecutionErrorTestCase errorTestCase)
+        {
+            skipReason = null;
+            errorTestCase = null;
+            try
+            {
+                skipReason = EvaluateSkipConditions(testMethod, conditionArguments);
+                return true;
+            }
+            catch (ConditionalDiscovererException e)
+            {
+                errorTestCase = new ExecutionErrorTestCase(
+                    diagnosticMessageSink,
+                    discoveryOptions.MethodDisplayOrDefault(),
+                    discoveryOptions.MethodDisplayOptionsOrDefault(),
+                    testMethod,
+                    e.Message);
+                return false;
+            }
         }
 
         internal static string GetFailedLookupString(string name, Type type)

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ConditionalTheoryDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ConditionalTheoryDiscoverer.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit.Abstractions;
@@ -12,19 +11,42 @@ namespace Microsoft.DotNet.XUnitExtensions
 {
     public class ConditionalTheoryDiscoverer : TheoryDiscoverer
     {
-        private readonly IMessageSink _diagnosticMessageSink;
+        private readonly Dictionary<IMethodInfo, string> _conditionCache;
 
         public ConditionalTheoryDiscoverer(IMessageSink diagnosticMessageSink) : base(diagnosticMessageSink)
         {
-            _diagnosticMessageSink = diagnosticMessageSink;
+            _conditionCache = new Dictionary<IMethodInfo, string>();
         }
 
-        public override IEnumerable<IXunitTestCase> Discover(
-            ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
+        protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
         {
-            IEnumerable<IXunitTestCase> testCases = base.Discover(discoveryOptions, testMethod, theoryAttribute).Select(tc => new SkippedTheoryTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod));
+            if (ConditionalTestDiscoverer.TryEvaluateSkipConditions(discoveryOptions, DiagnosticMessageSink, testMethod, theoryAttribute.GetConstructorArguments().ToArray(), out string skipReason, out ExecutionErrorTestCase errorTestCase))
+            {
+                return skipReason != null
+                   ? new[] { new SkippedTestCase(skipReason, DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod) }
+                   : new IXunitTestCase[] { new SkippedTheoryTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod) }; // Theory skippable at runtime.
+            }
 
-            return ConditionalTestDiscoverer.Discover(discoveryOptions, _diagnosticMessageSink, testMethod, testCases, theoryAttribute.GetConstructorArguments().ToArray());
+            return new IXunitTestCase[] { errorTestCase };
+        }
+
+        protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow)
+        {
+            IMethodInfo methodInfo = testMethod.Method;
+
+            if (!_conditionCache.TryGetValue(methodInfo, out string skipReason))
+            {
+                if (!ConditionalTestDiscoverer.TryEvaluateSkipConditions(discoveryOptions, DiagnosticMessageSink, testMethod, theoryAttribute.GetConstructorArguments().ToArray(), out skipReason, out ExecutionErrorTestCase errorTestCase))
+                {
+                    return new IXunitTestCase[] { errorTestCase };
+                }
+
+                _conditionCache.Add(methodInfo, skipReason);
+            }
+
+            return skipReason != null ?
+                        base.CreateTestCasesForSkippedDataRow(discoveryOptions, testMethod, theoryAttribute, dataRow, skipReason)
+                        : new IXunitTestCase[] { new SkippedFactTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, dataRow) }; // Test case skippable at runtime.
         }
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Microsoft.DotNet.XUnitExtensions.csproj
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Microsoft.DotNet.XUnitExtensions.csproj
@@ -16,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="$(RepoRoot)LICENSE.txt" PackagePath="LICENSE.txt" Pack="true"/>
-    <None Include="$(RepoRoot)THIRD-PARTY-NOTICES.txt" PackagePath="THIRD-PARTY-NOTICES.txt" Pack="true"/>
+    <None Include="$(RepoRoot)LICENSE.txt" PackagePath="LICENSE.txt" Pack="true" />
+    <None Include="$(RepoRoot)THIRD-PARTY-NOTICES.txt" PackagePath="THIRD-PARTY-NOTICES.txt" Pack="true" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This change updates ConditionalTheoryDiscoverer and ConditionalFactDiscoverer to use the correct overrides that xunit discoverer's call.

In order to support pre-enumeration of theories, we needed to override `CreateTestCasesForTheory` and `CreateTestCasesForDataRow` in order to support enumeration of theories.

`CreateTestCasesForTheory` is the one that is used when enumeration is disabled (current state with using xunit), however when switching to `VSTest`, enumeration of theories is enabled, and so, this override is used if the test data is non-serializable, so then it treats it as a single test case.

However, if test data is serializable, it treats it as a test cases with `TestMethodArguments`, which is created through `CreateTestCasesForDataRow`.

While doing this work I found there are still a lot of duplicate test data that the static analysis in the xunit analyzer can't figure out, because they're different when static, but the same at runtime, similar to `0.0` and `-0.0` but the other way around 😄 -- I'm starting to look at some of this guys in System.Runtime.Tests already.

cc: @stephentoub @ViktorHofer 