### PR TITLE
Fix RemoteExecutor netfx app.config detection

### DIFF
--- a/src/Microsoft.DotNet.RemoteExecutor/src/build/Microsoft.DotNet.RemoteExecutor.targets
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/build/Microsoft.DotNet.RemoteExecutor.targets
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <RemoteClientAppConfigFile>$(OutDir)$(TargetFileName).config</RemoteClientAppConfigFile>
+    <RemoteClientAppConfigFile Condition="'$(RemoteClientAppConfigFile)' == ''">$(OutDir)$(TargetName).exe.config</RemoteClientAppConfigFile>
     <RemoteHostAppConfigFile>$(OutDir)$(RemoteExecutorName).exe.config</RemoteHostAppConfigFile>
   </PropertyGroup>
 


### PR DESCRIPTION
The right way to do this would involve much more work. Instead of searching for an .exe.config file and copying it over for the RemoteExecutor during build time, the RemoteExecutor (host) would search for the app's config file during runtime and load it into a new AppDomain. That's what vstest is doing as well. But given that this is good enough for corefx and we don't have many other consumers of this package yet and that only a small percentage would need the custom app.config file, I'm fine with approach for now. Additionally I added the option to overwrite the `RemoteClientAppConfigFile` property to point to a different config file.

I'm going to merge this when CI is green to unblock corefx.