### PR TITLE
Update Core-Setup stages publish ETA

### DIFF
--- a/Documentation/YamlStagesRepoStatus.md
+++ b/Documentation/YamlStagesRepoStatus.md
@@ -25,7 +25,7 @@ Target completion date is 8/13/2019.
 | CoreFx                     | danmose/safern   | Complete | ✔️ | SourceLink validation disabled: https://github.com/dotnet/arcade/issues/3603 |
 | IoT                        | joperezr         | Complete | ✔️ | |
 | Core-SDK                   | licavalc         | At risk | ❌ |  We need clarity on how to do the blob storage publishing with YAML stages: https://github.com/dotnet/arcade/issues/3607|
-| Core-Setup                 | dleeapho         | In progress | ➖ |  Expected completion 8/21 |
+| Core-Setup                 | dleeapho         | In progress | ➖ |  Expected completion 8/19 |
 | FSharp                     | brettfo          | Complete | ✔️ | |
 | MSBuild                    | licavalc         | At risk | ❌ |  No ETA yet. Investigation under way. |
 | Roslyn                     | jaredpar         | Complete | ✔️ |  Complete with source link validation disabled |


### PR DESCRIPTION
I expect to merge the stages publish PR today (8/15), give it a few days to work out issues that only occur in `master`, making sure assets flow downstream (8/16 - 8/18), then merge to `release/3.0` (8/19).

(I don't know what the bar is for "At risk" vs. "In progress", changed by https://github.com/dotnet/arcade/pull/3664.)

/cc @dleeapho @markwilkie 