### PR TITLE
Make SourceLink script fail the build

### DIFF
--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -85,6 +85,7 @@ stages:
               -GHRepoName $(Build.Repository.Name) 
               -GHCommit $(Build.SourceVersion)
               -SourcelinkCliVersion $(SourceLinkCLIVersion)
+          continueOnError: true
 
   - ${{ if eq(parameters.SDLValidationParameters.enable, 'true') }}:
     - template: /eng/common/templates/job/execute-sdl.yml


### PR DESCRIPTION
Closes: https://github.com/dotnet/core-eng/issues/7353
Closes: https://github.com/dotnet/arcade/issues/3604
Test build: https://dnceng.visualstudio.com/internal/_build/results?buildId=313923&view=results

Patch the source link validation script to:

1. Actually fail the build if the validation fails
2. Don't stop validation if the commit for the build isn't found in GitHub