### PR TITLE
Core-Setup stages-based publishing complete

### DIFF
--- a/Documentation/YamlStagesRepoStatus.md
+++ b/Documentation/YamlStagesRepoStatus.md
@@ -25,7 +25,7 @@ Target completion date is 8/13/2019.
 | CoreFx                     | danmose/safern   | Complete | ✔️ | SourceLink validation disabled: https://github.com/dotnet/arcade/issues/3603 |
 | IoT                        | joperezr         | Complete | ✔️ | |
 | Core-SDK                   | licavalc         | In progress | ➖ |  Working in parallel.Will need https://github.com/dotnet/arcade/issues/3607 to be done before completing. |
-| Core-Setup                 | dleeapho         | In progress | ➖ |  Expected completion 8/19 |
+| Core-Setup                 | dleeapho         | Complete | ✔️ | Uses workarounds and skips most validation. Uses custom publish steps. |
 | FSharp                     | brettfo          | Complete | ✔️ | |
 | MSBuild                    | licavalc         | Complete | ✔️ | |
 | Roslyn                     | jaredpar         | Complete | ✔️ |  Complete with source link validation disabled |


### PR DESCRIPTION
Completed by https://github.com/dotnet/core-setup/pull/7725 (master) and https://github.com/dotnet/core-setup/pull/7735 (release/3.0).

Here's a 3.0 build with the changes: https://dev.azure.com/dnceng/internal/_build/results?buildId=315618&view=results.

🎉 

/cc @dleeapho @markwilkie 