### PR TITLE
Limit number of parallel jobs in SourceLink validation

### DIFF
--- a/eng/common/post-build/sourcelink-validation.ps1
+++ b/eng/common/post-build/sourcelink-validation.ps1
@@ -17,7 +17,7 @@ $global:RepoFiles = @{}
 $MaxParallelJobs = 6
 
 # Wait time between check for system load
-$MinutesBetweenLoadChecks = 10
+$SecondsBetweenLoadChecks = 10
 
 $ValidatePackage = {
   param( 
@@ -198,18 +198,19 @@ function ValidateSourceLinkLinks {
       $NumJobs = @(Get-Job -State 'Running').Count
       
       while ($NumJobs -ge $MaxParallelJobs) {
-        Write-Host "There are $NumJobs at the moment. Waiting 10 seconds."
-        sleep $MinutesBetweenLoadChecks
+        Write-Host "There are $NumJobs validation jobs running right now. Waiting $SecondsBetweenLoadChecks seconds to check again."
+        sleep $SecondsBetweenLoadChecks
         $NumJobs = @(Get-Job -State 'Running').Count
       }
 
       foreach ($Job in @(Get-Job -State 'Completed')) {
+        Receive-Job -Id $Job.Id
         Remove-Job -Id $Job.Id
       }
     }
 
   foreach ($Job in @(Get-Job)) {
-    Wait-Job -Id $Job.Id | Remove-Job
+    Wait-Job -Id $Job.Id | Receive-Job
   }
 }
 

--- a/eng/common/post-build/sourcelink-validation.ps1
+++ b/eng/common/post-build/sourcelink-validation.ps1
@@ -1,8 +1,8 @@
 param(
   [Parameter(Mandatory=$true)][string] $InputPath,              # Full path to directory where Symbols.NuGet packages to be checked are stored
   [Parameter(Mandatory=$true)][string] $ExtractPath,            # Full path to directory where the packages will be extracted during validation
-  [Parameter(Mandatory=$false)][string] $GHRepoName,             # GitHub name of the repo including the Org. E.g., dotnet/arcade
-  [Parameter(Mandatory=$false)][string] $GHCommit,               # GitHub commit SHA used to build the packages
+  [Parameter(Mandatory=$true)][string] $GHRepoName,             # GitHub name of the repo including the Org. E.g., dotnet/arcade
+  [Parameter(Mandatory=$true)][string] $GHCommit,               # GitHub commit SHA used to build the packages
   [Parameter(Mandatory=$true)][string] $SourcelinkCliVersion    # Version of SourceLink CLI to use
 )
 
@@ -151,7 +151,7 @@ $ValidatePackage = {
 }
 
 function ValidateSourceLinkLinks {
-    if (!($GHRepoName -Match "^[^\s\/]+/[^\s\/]+$")) {
+  if (!($GHRepoName -Match "^[^\s\/]+/[^\s\/]+$")) {
     if (!($GHRepoName -Match "^[^\s-]+-[^\s]+$")) {
       Write-PipelineTaskError "GHRepoName should be in the format <org>/<repo> or <org>-<repo>"
       ExitWithExitCode 1


### PR DESCRIPTION
Closes: https://github.com/dotnet/arcade/issues/3603

Keep the number of parallel validation jobs below a threshold to limit memory usage.