### PR TITLE
Changing GetLastStablePackage logic in order to allow excluding same era packages

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VersionUtility.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VersionUtility.cs
@@ -73,6 +73,16 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             return new Version(version.Major, version.Minor, build);
         }
 
+        public static Version As2PartVersion(Version version)
+        {
+            if (version.Build == -1)
+            {
+                // we already have a 2-part version
+                return version;
+            }
+            return new Version(version.Major, version.Minor);
+        }
+
         public static Version As4PartVersion(Version version)
         {
             int build = version.Build, revision = version.Revision;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VersionUtility.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VersionUtility.cs
@@ -57,6 +57,9 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
         public static Version As3PartVersion(Version version)
         {
+            if (version == null)
+                return null;
+
             int build = version.Build;
 
             if (build == -1)
@@ -75,6 +78,9 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
         public static Version As2PartVersion(Version version)
         {
+            if (version == null)
+                return null;
+
             if (version.Build == -1)
             {
                 // we already have a 2-part version
@@ -85,6 +91,9 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
         public static Version As4PartVersion(Version version)
         {
+            if (version == null)
+                return null;
+
             int build = version.Build, revision = version.Revision;
 
             if (build == -1)

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
@@ -381,7 +381,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <DoNotAllowVersionsFromSameEra Condition="'$(DoNotAllowVersionsFromSameEra)' == ''">true</DoNotAllowVersionsFromSameEra>
+      <DoNotAllowVersionsFromSameRelease Condition="'$(DoNotAllowVersionsFromSameRelease)' == ''">true</DoNotAllowVersionsFromSameRelease>
     </PropertyGroup>
 
     <!-- Calculate the package version to harvest -->
@@ -389,7 +389,7 @@
                           LatestPackages="@(_latestPackage)"
                           StablePackages="@(StablePackage)"
                           PackageIndexes="@(PackageIndex)"
-                          DoNotAllowVersionsFromSameEra="$(DoNotAllowVersionsFromSameEra)">
+                          DoNotAllowVersionsFromSameRelease="$(DoNotAllowVersionsFromSameRelease)">
       <Output  TaskParameter="LastStablePackages" ItemName="_lastStablePackage"/>
     </GetLastStablePackage>
 
@@ -402,7 +402,7 @@
                           LatestPackages="@(_latestRuntimePackages)"
                           StablePackages="@(StablePackage)"
                           PackageIndexes="@(PackageIndex)"
-                          DoNotAllowVersionsFromSameEra="$(DoNotAllowVersionsFromSameEra)">
+                          DoNotAllowVersionsFromSameRelease="$(DoNotAllowVersionsFromSameRelease)">
       <Output  TaskParameter="LastStablePackages" ItemName="HarvestRuntimePackages"/>
     </GetLastStablePackage>
 
@@ -410,7 +410,7 @@
                           LatestPackages="@(HarvestAdditionalPackageIds)"
                           StablePackages="@(StablePackage)"
                           PackageIndexes="@(PackageIndex)"
-                          DoNotAllowVersionsFromSameEra="$(DoNotAllowVersionsFromSameEra)">
+                          DoNotAllowVersionsFromSameRelease="$(DoNotAllowVersionsFromSameRelease)">
       <Output  TaskParameter="LastStablePackages" ItemName="HarvestAdditionalPackages"/>
     </GetLastStablePackage>
 

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
@@ -380,11 +380,16 @@
       <_latestRuntimePackages Include="@(PkgProjDependency)" Condition="'%(PkgProjDependency.TargetRuntime)' != ''" KeepDuplicates="false" />
     </ItemGroup>
 
+    <PropertyGroup>
+      <DoNotAllowVersionsFromSameEra Condition="'$(DoNotAllowVersionsFromSameEra)' == ''">true</DoNotAllowVersionsFromSameEra>
+    </PropertyGroup>
+
     <!-- Calculate the package version to harvest -->
     <GetLastStablePackage Condition="'$(HarvestVersion)' == ''"
                           LatestPackages="@(_latestPackage)"
                           StablePackages="@(StablePackage)"
-                          PackageIndexes="@(PackageIndex)">
+                          PackageIndexes="@(PackageIndex)"
+                          DoNotAllowVersionsFromSameEra="$(DoNotAllowVersionsFromSameEra)">
       <Output  TaskParameter="LastStablePackages" ItemName="_lastStablePackage"/>
     </GetLastStablePackage>
 
@@ -396,14 +401,16 @@
     <GetLastStablePackage Condition="'@(HarvestRuntimePackages)' == ''"
                           LatestPackages="@(_latestRuntimePackages)"
                           StablePackages="@(StablePackage)"
-                          PackageIndexes="@(PackageIndex)">
+                          PackageIndexes="@(PackageIndex)"
+                          DoNotAllowVersionsFromSameEra="$(DoNotAllowVersionsFromSameEra)">
       <Output  TaskParameter="LastStablePackages" ItemName="HarvestRuntimePackages"/>
     </GetLastStablePackage>
 
     <GetLastStablePackage Condition="'@(HarvestAdditionalPackageIds)' != ''"
                           LatestPackages="@(HarvestAdditionalPackageIds)"
                           StablePackages="@(StablePackage)"
-                          PackageIndexes="@(PackageIndex)">
+                          PackageIndexes="@(PackageIndex)"
+                          DoNotAllowVersionsFromSameEra="$(DoNotAllowVersionsFromSameEra)">
       <Output  TaskParameter="LastStablePackages" ItemName="HarvestAdditionalPackages"/>
     </GetLastStablePackage>
 

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/GetLastStablePackageTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/GetLastStablePackageTests.cs
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
         }
 
         [Fact]
-        public void DoNotAllowSameEraPackageVersions()
+        public void DoNotAllowSameReleasePackageVersions()
         {
             ITaskItem[] latestPackages = new[]
             {
@@ -143,7 +143,32 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
         }
 
         [Fact]
-        public void AllowSameEraPackageVersions()
+        public void NullVersionShouldUseLatestStableVersion()
+        {
+            ITaskItem[] latestPackages = new[]
+            {
+                CreateItem("StableVersionTest", null)
+            };
+
+            GetLastStablePackage task = new GetLastStablePackage()
+            {
+                BuildEngine = _engine,
+                PackageIndexes = _packageIndexes,
+                LatestPackages = latestPackages,
+                DoNotAllowVersionsFromSameRelease = true
+            };
+
+            _log.Reset();
+            task.Execute();
+            Assert.Equal(0, _log.ErrorsLogged);
+            Assert.Equal(0, _log.WarningsLogged);
+            Assert.Equal(task.LatestPackages.Length, task.LastStablePackages.Length);
+            Assert.Equal("StableVersionTest", task.LastStablePackages[0].ItemSpec);
+            Assert.Equal("1.1.0", task.LastStablePackages[0].GetMetadata("Version"));
+        }
+
+        [Fact]
+        public void AllowSameReleasePackageVersions()
         {
             ITaskItem[] latestPackages = new[]
             {

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/GetLastStablePackageTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/GetLastStablePackageTests.cs
@@ -117,6 +117,55 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
             Assert.Equal(0, task.LastStablePackages.Length);
         }
 
+        [Fact]
+        public void DoNotAllowSameEraPackageVersions()
+        {
+            ITaskItem[] latestPackages = new[]
+            {
+                CreateItem("StableVersionTest", "1.1.1-pre")
+            };
+
+            GetLastStablePackage task = new GetLastStablePackage()
+            {
+                BuildEngine = _engine,
+                PackageIndexes = _packageIndexes,
+                LatestPackages = latestPackages,
+                DoNotAllowVersionsFromSameEra = true
+            };
+
+            _log.Reset();
+            task.Execute();
+            Assert.Equal(0, _log.ErrorsLogged);
+            Assert.Equal(0, _log.WarningsLogged);
+            Assert.Equal(task.LatestPackages.Length, task.LastStablePackages.Length);
+            Assert.Equal("StableVersionTest", task.LastStablePackages[0].ItemSpec);
+            Assert.Equal("1.0.0", task.LastStablePackages[0].GetMetadata("Version"));
+        }
+
+        [Fact]
+        public void AllowSameEraPackageVersions()
+        {
+            ITaskItem[] latestPackages = new[]
+            {
+                CreateItem("StableVersionTest", "1.1.1-pre")
+            };
+
+            GetLastStablePackage task = new GetLastStablePackage()
+            {
+                BuildEngine = _engine,
+                PackageIndexes = _packageIndexes,
+                LatestPackages = latestPackages
+            };
+
+            _log.Reset();
+            task.Execute();
+            Assert.Equal(0, _log.ErrorsLogged);
+            Assert.Equal(0, _log.WarningsLogged);
+            Assert.Equal(task.LatestPackages.Length, task.LastStablePackages.Length);
+            Assert.Equal("StableVersionTest", task.LastStablePackages[0].ItemSpec);
+            Assert.Equal("1.1.0", task.LastStablePackages[0].GetMetadata("Version"));
+        }
+
         private static ITaskItem CreateItem(string name, string version)
         {
             TaskItem item = new TaskItem(name);

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/GetLastStablePackageTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/GetLastStablePackageTests.cs
@@ -130,7 +130,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
                 BuildEngine = _engine,
                 PackageIndexes = _packageIndexes,
                 LatestPackages = latestPackages,
-                DoNotAllowVersionsFromSameEra = true
+                DoNotAllowVersionsFromSameRelease = true
             };
 
             _log.Reset();


### PR DESCRIPTION
cc: @ericstj 

Contributes to https://github.com/dotnet/corefx/issues/39537

These changes will ensure that we always harvest from the last stable package version which is not from the same era.