### PR TITLE
Add missing key to public release channel YAML

### DIFF
--- a/eng/common/templates/post-build/channels/public-release.yml
+++ b/eng/common/templates/post-build/channels/public-release.yml
@@ -90,6 +90,7 @@ stages:
             /p:IsInternalBuild=$(IsInternalBuild)
             /p:RepositoryName=$(Build.Repository.Name)
             /p:CommitSha=$(Build.SourceVersion)
+            /p:AzureStorageTargetFeedPAT='$(dotnetfeed-storage-access-key-1)' 
             /p:AzureStorageAccountName=$(ProxyBackedFeedsAccountName)
             /p:AzureStorageAccountKey=$(dotnetfeed-storage-access-key-1)
             /p:AzureDevOpsFeedsBaseUrl=$(dotnetfeed-internal-private-feed-url)


### PR DESCRIPTION
Closes: #3719

The missing key caused this build to fail: https://dnceng.visualstudio.com/internal/_build/results?buildId=316876&view=results

After recent refactoring in SetupTargetFeeds.proj this key is now needed in the Public Release channel YAML.