### PR TITLE
Add Performance PR Support

### DIFF
--- a/Documentation/HowToAddPerfTestingToPipeline.md
+++ b/Documentation/HowToAddPerfTestingToPipeline.md
@@ -133,6 +133,7 @@ Performance testing has been fully tested in coreclr. Coreclr, corefx and other 
 The performance template also supplies support for running PRs on physical hardware to compare the current change against a baseline. The template has two parameters that will enable PR testing:
 
 | Name                       | Type    | Description                                  |
+| -------------------------- | ------- | -------------------------------------------- |
 | BaselineCoreRootDirectory  | string  | Path to the baseline core root directory. To be used when running PR testing to compare current work against a baseline |
 | Compare                    | switch  | Run comparison. To be used when running PR testing to compare against a baseline. Will tell the helix job to run a baseline run, the test run, and then run ResultsComparer to compare the two |
 

--- a/Documentation/HowToAddPerfTestingToPipeline.md
+++ b/Documentation/HowToAddPerfTestingToPipeline.md
@@ -1,6 +1,10 @@
 # Automate Performance testing run in AzDO Pipelines
 
-This document is meant to help repo owners onboard to performance testing. Currently, following these steps to add performance testing to your repo will allow you to run per-commit performance testing on physical hardware for internal builds. It is also set up to allow per-PR testing to run on virtual machines for functional testing of performance assets, with the ability to run PR performance testing on physical hardware to come in the near future. Performance testing run on internal builds will generate and upload performance data that will be able to be viewed in the performance visualization tool that is being developed by the perf team. 
+This document is meant to help repo owners onboard to performance testing. Currently, following these steps to add performance testing to your repo will allow you to run per-commit performance testing on physical hardware for internal builds. It is also set up to allow per-PR testing to run on virtual machines for functional testing of performance assets, in addition to the ability to run PR performance testing on physical hardware. Performance testing run on internal builds will generate and upload performance data that will be able to be viewed in the performance visualization tool that is being developed by the perf team.
+
+## Motivation
+
+The motivation for these scripts is to allow finer granularity in performance testing. While we test performance out of the dotnet/performance repo frequently, this testing is done at the full stack level. Running performance testing at each level of the stack (i.e. coreclr, corefx, etc.) can help us pinpoint where regressions or improvements originated, improving our ability to understand regressions and improvements.
 
 ## Performance scripts
 
@@ -28,22 +32,24 @@ Additional template parameters are:
 
 All parameters that have default values are based off of Azure Pipelines pre-defined variables should only be specified if there is a specific need.
 
-| Name                | Type    | Description                                  |
-| ------------------- | ------- | -------------------------------------------- |
-| SourceDirectory     | string  | The path to the root of the source directory. Default: $env:BUILD_SOURCESDIRECTORY |
-| CoreRootDirectory   | string  | Path to the core root directory. To be used when testing against a built corerun |
-| Architecture        | string  | Architecture of the build to be tested (i.e. x64, x86, arm64). Default: x64 |
-| Framework           | string  | Dotnet sdk framework to install. To be specified when testing against older frameworks. Default: netcoreapp3.0 |
-| CompilationMode     | string  | CompilationMode to use when jitting. Default: Tiered |
-| Repository          | string  | Repository that is running perf testing. Default: $env:BUILD_REPOSITORY_NAME |
-| Branch              | string  | Branch that is running perf testing. Default: $env:BUILD_SOURCEBRANCH |
-| CommitSha           | string  | Sha1 of the current branch. Default: $env:BUILD_SOURCEVERSION |
-| BuildNumber         | string  | Build number of the run in Azure Pipeline. Default: $env:BUILD_BUILDNUMBER |
-| RunCategories       | string  | Space separated list of test categories to run against. Should match the categories used by the csproj. Default: "coreclr corefx" |
-| Csproj              | string  | Relative path from the performance repository root to the csproj to run against. Default: src\benchmarks\micro\MicroBenchmarks.csproj |
-| Kind                | string  | Short identifier for the csproj. Should match csproj. Default: micro |
-| Internal            | switch  | If this is an official build |
-| Configurations      | string  | Space separated list of key=value pairs to describe the build (i.e. "OptimizationLevel=PGO CompilationMode=Tiered"). Default: CompilationMode=$CompilationMode |
+| Name                       | Type    | Description                                  |
+| -------------------------- | ------- | -------------------------------------------- |
+| SourceDirectory            | string  | The path to the root of the source directory. Default: $env:BUILD_SOURCESDIRECTORY |
+| CoreRootDirectory          | string  | Path to the core root directory. To be used when testing against a built corerun |
+| BaselineCoreRootDirectory  | string  | Path to the baseline core root directory. To be used when running PR testing to compare current work against a baseline |
+| Architecture               | string  | Architecture of the build to be tested (i.e. x64, x86, arm64). Default: x64 |
+| Framework                  | string  | Dotnet sdk framework to install. To be specified when testing against older frameworks. Default: netcoreapp3.0 |
+| CompilationMode            | string  | CompilationMode to use when jitting. Default: Tiered |
+| Repository                 | string  | Repository that is running perf testing. Default: $env:BUILD_REPOSITORY_NAME |
+| Branch                     | string  | Branch that is running perf testing. Default: $env:BUILD_SOURCEBRANCH |
+| CommitSha                  | string  | Sha1 of the current branch. Default: $env:BUILD_SOURCEVERSION |
+| BuildNumber                | string  | Build number of the run in Azure Pipeline. Default: $env:BUILD_BUILDNUMBER |
+| RunCategories              | string  | Space separated list of test categories to run against. Should match the categories used by the csproj. Default: "coreclr corefx" |
+| Csproj                     | string  | Relative path from the performance repository root to the csproj to run against. Default: src\benchmarks\micro\MicroBenchmarks.csproj |
+| Kind                       | string  | Short identifier for the csproj. Should match csproj. Default: micro |
+| Internal                   | switch  | If this is an official build |
+| Configurations             | string  | Space separated list of key=value pairs to describe the build (i.e. "OptimizationLevel=PGO CompilationMode=Tiered"). Default: CompilationMode=$CompilationMode |
+| Compare                    | switch  | Run comparison. To be used when running PR testing to compare against a baseline. Will tell the helix job to run a baseline run, the test run, and then run ResultsComparer to compare the two |
 
 Note: These parameters should be passed to the yml template in the extraSetupParameters parameter.
 
@@ -121,6 +127,24 @@ Performance testing has been fully tested in coreclr. Coreclr, corefx and other 
     - script: build-test.cmd Release x64 skipmanaged skipnative
       displayName: Create Core_Root
 ```
+
+## PR Comparison Support
+
+The performance template also supplies support for running PRs on physical hardware to compare the current change against a baseline. The template has two parameters that will enable PR testing:
+
+| Name                       | Type    | Description                                  |
+| BaselineCoreRootDirectory  | string  | Path to the baseline core root directory. To be used when running PR testing to compare current work against a baseline |
+| Compare                    | switch  | Run comparison. To be used when running PR testing to compare against a baseline. Will tell the helix job to run a baseline run, the test run, and then run ResultsComparer to compare the two |
+
+For PR testing, the Compare switch is required. It does the following:
+
+* Changes the helix queue to be Windows.10.Amd64.19H1.Tiger.Perf.Open or Ubuntu.1804.Amd64.Tiger.Perf.Open (i.e. physical perf hardware).
+* Sets up all perf parameters to match a normal perf run
+* Sets FailOnTestFailure to false in the helix project, so that regressions do not fail the run
+* Tells helix to run the baseline as a precommand
+* Tells helix to run ResultsComparer to compare the baseline and diff
+
+The BaselineCoreRootDirectory is similar to the CoreRootDirectory. It causes the baseline CoreRun to be moved to the payload directory so it can be pushed to the Helix machine, and then adds the --corerun option to the baseline command. It is not required, though strongly recommended, to run a compare PR. If it is not supplied, the baseline will be the most recent dotnet sdk, which may be several commits behind the master of your repository, and could obfuscate actual performance regressions or improvements.
 
 ## Available parameter values
 

--- a/eng/common/performance/perfhelixpublish.proj
+++ b/eng/common/performance/perfhelixpublish.proj
@@ -5,8 +5,11 @@
     <CliArguments>--dotnet-versions %DOTNET_VERSION% --cli-source-info args --cli-branch %PERFLAB_BRANCH% --cli-commit-sha %PERFLAB_HASH% --cli-repository https://github.com/%PERFLAB_REPO% --cli-source-timestamp %PERFLAB_BUILDTIMESTAMP%</CliArguments>
     <Python>py -3</Python>
     <CoreRun>%HELIX_CORRELATION_PAYLOAD%\Core_Root\CoreRun.exe</CoreRun>
+    <BaselineCoreRun>%HELIX_CORRELATION_PAYLOAD%\Baseline_Core_Root\CoreRun.exe</BaselineCoreRun>
     <HelixPreCommands>$(HelixPreCommands);call %HELIX_CORRELATION_PAYLOAD%\performance\tools\machine-setup.cmd</HelixPreCommands>
     <ArtifactsDirectory>%HELIX_CORRELATION_PAYLOAD%\artifacts\BenchmarkDotNet.Artifacts</ArtifactsDirectory>
+    <BaselineArtifactsDirectory>%HELIX_CORRELATION_PAYLOAD%\artifacts\BenchmarkDotNet.Artifacts_Baseline</BaselineArtifactsDirectory>
+    <ResultsComparer>%HELIX_CORRELATION_PAYLOAD%\performance\src\tools\ResultsComparer\ResultsComparer.csproj</ResultsComparer>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(AGENT_OS)' != 'Windows_NT' and '$(RunFromPerfRepo)' == 'false'">
@@ -24,12 +27,19 @@
     <CliArguments>--dotnet-versions $DOTNET_VERSION --cli-source-info args --cli-branch $PERFLAB_BRANCH --cli-commit-sha $PERFLAB_HASH --cli-repository https://github.com/$PERFLAB_REPO --cli-source-timestamp $PERFLAB_BUILDTIMESTAMP</CliArguments>
     <Python>python3</Python>
     <CoreRun>$(BaseDirectory)/Core_Root/corerun</CoreRun>
+    <BaselineCoreRun>$(BaseDirectory)/Baseline_Core_Root/corerun</Baseline_CoreRun>
     <HelixPreCommands>$(HelixPreCommands);chmod +x $(PerformanceDirectory)/tools/machine-setup.sh;. $(PerformanceDirectory)/tools/machine-setup.sh</HelixPreCommands>
     <ArtifactsDirectory>$(BaseDirectory)/artifacts/BenchmarkDotNet.Artifacts</ArtifactsDirectory>
+    <BaselineArtifactsDirectory>$(BaseDirectory)/artifacts/BenchmarkDotNet.Artifacts_Baseline</BaselineArtifactsDirectory>
+    <ResultsComparer>$(PerformanceDirectory)/src/tools/ResultsComparer/ResultsComparer.csproj</ResultsComparer>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(UseCoreRun)' == 'true'">
     <CoreRunArgument>--corerun $(CoreRun)</CoreRunArgument>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(UseBaselineCoreRun)' == 'true'">
+    <BaselineCoreRunArgument>--corerun $(BaselineCoreRun)</BaselineCoreRunArgument>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(WorkItemCommand)' != ''">
@@ -63,14 +73,18 @@
   <ItemGroup Condition="$(TargetCsproj.Contains('MicroBenchmarks.csproj'))">
     <HelixWorkItem Include="@(Partition)">
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
+      <PreCommands Condition="'$(Compare)' == 'true'">$(WorkItemCommand) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(BaselineCoreRunArgument) --artifacts $(BaselineArtifactsDirectory) --partition-count $(PartitionCount) --partition-index %(HelixWorkItem.Index)"</PreCommands>
       <Command>$(WorkItemCommand) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(CoreRunArgument) --artifacts $(ArtifactsDirectory) --partition-count $(PartitionCount) --partition-index %(HelixWorkItem.Index)"</Command>
+      <PostCommands Condition="'$(Compare)' == 'true'">dotnet run -p $(ResultsComparer) --base $(BaselineArtifactsDirectory) --diff $(ArtifactsDirectory) --threshold 2%</PostCommands>
       <Timeout>4:00</Timeout>
     </HelixWorkItem>
   </ItemGroup>
   <ItemGroup Condition="!$(TargetCsproj.Contains('MicroBenchmarks.csproj'))">
     <HelixWorkItem Include="$(BuildConfig).WorkItem">
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
+      <PreCommands Condition="'$(Compare)' == 'true'">$(WorkItemCommand) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(BaselineCoreRunArgument) --artifacts $(ArtifactsDirectory)"</Command>
       <Command>$(WorkItemCommand) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(CoreRunArgument) --artifacts $(ArtifactsDirectory)"</Command>
+      <PostCommands Condition="'$(Compare)' == 'true'">dotnet run -p $(ResultsComparer) --base $(BaselineArtifactsDirectory) --diff $(ArtifactsDirectory) --threshold 2%</PostCommands>
       <Timeout>4:00</Timeout>
     </HelixWorkItem>
   </ItemGroup>

--- a/eng/common/performance/perfhelixpublish.proj
+++ b/eng/common/performance/perfhelixpublish.proj
@@ -12,8 +12,8 @@
     <ResultsComparer>%HELIX_CORRELATION_PAYLOAD%\performance\src\tools\ResultsComparer\ResultsComparer.csproj</ResultsComparer>
     <DotnetExe>%HELIX_CORRELATION_PAYLOAD%\performance\tools\dotnet\$(Architecture)\dotnet.exe</DotnetExe>
     <Dotnet21Install>$(Python) %HELIX_CORRELATION_PAYLOAD%\performance\scripts\dotnet.py install --channels 2.1 -v</Dotnet21Install>
-    <!-- Due to some msbuild & windows weirdness, we have to escape the percent sign twice on windows -->
     <Percent>%25%25</Percent>
+    <XMLResults>%HELIX_WORKITEM_ROOT%\testResults.xml</XMLResults>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(AGENT_OS)' != 'Windows_NT' and '$(RunFromPerfRepo)' == 'false'">
@@ -38,8 +38,8 @@
     <ResultsComparer>$(PerformanceDirectory)/src/tools/ResultsComparer/ResultsComparer.csproj</ResultsComparer>
     <DotnetExe>$(PerformanceDirectory)/tools/dotnet/$(Architecture)/dotnet</DotnetExe>
     <Dotnet21Install>$(Python) $(PerformanceDirectory)/scripts/dotnet.py install --channels 2.1 -v</Dotnet21Install>
-    <!-- Due to some msbuild weirdness, we have to escape the percent sign -->
     <Percent>%25</Percent>
+    <XMLResults>$HELIX_WORKITEM_ROOT/testResults.xml</XMLResults>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(UseCoreRun)' == 'true'">
@@ -75,6 +75,10 @@
     <Partition Include="$(BuildConfig).Partition4" Index="4" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(Compare)' == 'true'">
+    <FailOnTestFailure>false</FailOnTestFailure>
+  </PropertyGroup>
+
   <!-- 
     Partition the Microbenchmarks project, but nothing else
   -->
@@ -83,16 +87,17 @@
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
       <PreCommands Condition="'$(Compare)' == 'true'">$(WorkItemCommand) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(BaselineCoreRunArgument) --artifacts $(BaselineArtifactsDirectory) --partition-count $(PartitionCount) --partition-index %(HelixWorkItem.Index)"</PreCommands>
       <Command>$(WorkItemCommand) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(CoreRunArgument) --artifacts $(ArtifactsDirectory) --partition-count $(PartitionCount) --partition-index %(HelixWorkItem.Index)"</Command>
-      <PostCommands Condition="'$(Compare)' == 'true'">$(Dotnet21Install);$(DotnetExe) run -p $(ResultsComparer) --base $(BaselineArtifactsDirectory) --diff $(ArtifactsDirectory) --threshold 2$(Percent)</PostCommands>
+      <PostCommands Condition="'$(Compare)' == 'true'">$(Dotnet21Install);$(DotnetExe) run -p $(ResultsComparer) --base $(BaselineArtifactsDirectory) --diff $(ArtifactsDirectory) --threshold 2$(Percent) --xml $(XMLResults);$(FinalCommand)</PostCommands>
       <Timeout>4:00</Timeout>
     </HelixWorkItem>
   </ItemGroup>
+
   <ItemGroup Condition="!$(TargetCsproj.Contains('MicroBenchmarks.csproj'))">
     <HelixWorkItem Include="$(BuildConfig).WorkItem">
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
       <PreCommands Condition="'$(Compare)' == 'true'">$(WorkItemCommand) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(BaselineCoreRunArgument) --artifacts $(ArtifactsDirectory)"</PreCommands>
       <Command>$(WorkItemCommand) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(CoreRunArgument) --artifacts $(ArtifactsDirectory)"</Command>
-      <PostCommands Condition="'$(Compare)' == 'true'">$(Dotnet21Install);$(DotnetExe) run -p $(ResultsComparer) --base $(BaselineArtifactsDirectory) --diff $(ArtifactsDirectory) --threshold 2$(Percent)</PostCommands>
+      <PostCommands Condition="'$(Compare)' == 'true'">$(Dotnet21Install);$(DotnetExe) run -p $(ResultsComparer) --base $(BaselineArtifactsDirectory) --diff $(ArtifactsDirectory) --threshold 2$(Percent) --xml $(XMLResults)</PostCommands>
       <Timeout>4:00</Timeout>
     </HelixWorkItem>
   </ItemGroup>

--- a/eng/common/performance/perfhelixpublish.proj
+++ b/eng/common/performance/perfhelixpublish.proj
@@ -10,6 +10,10 @@
     <ArtifactsDirectory>%HELIX_CORRELATION_PAYLOAD%\artifacts\BenchmarkDotNet.Artifacts</ArtifactsDirectory>
     <BaselineArtifactsDirectory>%HELIX_CORRELATION_PAYLOAD%\artifacts\BenchmarkDotNet.Artifacts_Baseline</BaselineArtifactsDirectory>
     <ResultsComparer>%HELIX_CORRELATION_PAYLOAD%\performance\src\tools\ResultsComparer\ResultsComparer.csproj</ResultsComparer>
+    <DotnetExe>%HELIX_CORRELATION_PAYLOAD%\performance\tools\dotnet\$(Architecture)\dotnet.exe</DotnetExe>
+    <Dotnet21Install>$(Python) %HELIX_CORRELATION_PAYLOAD%\performance\scripts\dotnet.py install --channels 2.1 -v</Dotnet21Install>
+    <!-- Due to some msbuild & windows weirdness, we have to escape the percent sign twice on windows -->
+    <Percent>%25%25</Percent>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(AGENT_OS)' != 'Windows_NT' and '$(RunFromPerfRepo)' == 'false'">
@@ -27,11 +31,15 @@
     <CliArguments>--dotnet-versions $DOTNET_VERSION --cli-source-info args --cli-branch $PERFLAB_BRANCH --cli-commit-sha $PERFLAB_HASH --cli-repository https://github.com/$PERFLAB_REPO --cli-source-timestamp $PERFLAB_BUILDTIMESTAMP</CliArguments>
     <Python>python3</Python>
     <CoreRun>$(BaseDirectory)/Core_Root/corerun</CoreRun>
-    <BaselineCoreRun>$(BaseDirectory)/Baseline_Core_Root/corerun</Baseline_CoreRun>
+    <BaselineCoreRun>$(BaseDirectory)/Baseline_Core_Root/corerun</BaselineCoreRun>
     <HelixPreCommands>$(HelixPreCommands);chmod +x $(PerformanceDirectory)/tools/machine-setup.sh;. $(PerformanceDirectory)/tools/machine-setup.sh</HelixPreCommands>
     <ArtifactsDirectory>$(BaseDirectory)/artifacts/BenchmarkDotNet.Artifacts</ArtifactsDirectory>
     <BaselineArtifactsDirectory>$(BaseDirectory)/artifacts/BenchmarkDotNet.Artifacts_Baseline</BaselineArtifactsDirectory>
     <ResultsComparer>$(PerformanceDirectory)/src/tools/ResultsComparer/ResultsComparer.csproj</ResultsComparer>
+    <DotnetExe>$(PerformanceDirectory)/tools/dotnet/$(Architecture)/dotnet</DotnetExe>
+    <Dotnet21Install>$(Python) $(PerformanceDirectory)/scripts/dotnet.py install --channels 2.1 -v</Dotnet21Install>
+    <!-- Due to some msbuild weirdness, we have to escape the percent sign -->
+    <Percent>%25</Percent>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(UseCoreRun)' == 'true'">
@@ -75,16 +83,16 @@
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
       <PreCommands Condition="'$(Compare)' == 'true'">$(WorkItemCommand) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(BaselineCoreRunArgument) --artifacts $(BaselineArtifactsDirectory) --partition-count $(PartitionCount) --partition-index %(HelixWorkItem.Index)"</PreCommands>
       <Command>$(WorkItemCommand) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(CoreRunArgument) --artifacts $(ArtifactsDirectory) --partition-count $(PartitionCount) --partition-index %(HelixWorkItem.Index)"</Command>
-      <PostCommands Condition="'$(Compare)' == 'true'">dotnet run -p $(ResultsComparer) --base $(BaselineArtifactsDirectory) --diff $(ArtifactsDirectory) --threshold 2%</PostCommands>
+      <PostCommands Condition="'$(Compare)' == 'true'">$(Dotnet21Install);$(DotnetExe) run -p $(ResultsComparer) --base $(BaselineArtifactsDirectory) --diff $(ArtifactsDirectory) --threshold 2$(Percent)</PostCommands>
       <Timeout>4:00</Timeout>
     </HelixWorkItem>
   </ItemGroup>
   <ItemGroup Condition="!$(TargetCsproj.Contains('MicroBenchmarks.csproj'))">
     <HelixWorkItem Include="$(BuildConfig).WorkItem">
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
-      <PreCommands Condition="'$(Compare)' == 'true'">$(WorkItemCommand) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(BaselineCoreRunArgument) --artifacts $(ArtifactsDirectory)"</Command>
+      <PreCommands Condition="'$(Compare)' == 'true'">$(WorkItemCommand) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(BaselineCoreRunArgument) --artifacts $(ArtifactsDirectory)"</PreCommands>
       <Command>$(WorkItemCommand) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(CoreRunArgument) --artifacts $(ArtifactsDirectory)"</Command>
-      <PostCommands Condition="'$(Compare)' == 'true'">dotnet run -p $(ResultsComparer) --base $(BaselineArtifactsDirectory) --diff $(ArtifactsDirectory) --threshold 2%</PostCommands>
+      <PostCommands Condition="'$(Compare)' == 'true'">$(Dotnet21Install);$(DotnetExe) run -p $(ResultsComparer) --base $(BaselineArtifactsDirectory) --diff $(ArtifactsDirectory) --threshold 2$(Percent)</PostCommands>
       <Timeout>4:00</Timeout>
     </HelixWorkItem>
   </ItemGroup>

--- a/eng/common/performance/perfhelixpublish.proj
+++ b/eng/common/performance/perfhelixpublish.proj
@@ -11,7 +11,6 @@
     <BaselineArtifactsDirectory>%HELIX_CORRELATION_PAYLOAD%\artifacts\BenchmarkDotNet.Artifacts_Baseline</BaselineArtifactsDirectory>
     <ResultsComparer>%HELIX_CORRELATION_PAYLOAD%\performance\src\tools\ResultsComparer\ResultsComparer.csproj</ResultsComparer>
     <DotnetExe>%HELIX_CORRELATION_PAYLOAD%\performance\tools\dotnet\$(Architecture)\dotnet.exe</DotnetExe>
-    <Dotnet21Install>$(Python) %HELIX_CORRELATION_PAYLOAD%\performance\scripts\dotnet.py install --channels 2.1 -v</Dotnet21Install>
     <Percent>%25%25</Percent>
     <XMLResults>%HELIX_WORKITEM_ROOT%\testResults.xml</XMLResults>
   </PropertyGroup>
@@ -37,7 +36,6 @@
     <BaselineArtifactsDirectory>$(BaseDirectory)/artifacts/BenchmarkDotNet.Artifacts_Baseline</BaselineArtifactsDirectory>
     <ResultsComparer>$(PerformanceDirectory)/src/tools/ResultsComparer/ResultsComparer.csproj</ResultsComparer>
     <DotnetExe>$(PerformanceDirectory)/tools/dotnet/$(Architecture)/dotnet</DotnetExe>
-    <Dotnet21Install>$(Python) $(PerformanceDirectory)/scripts/dotnet.py install --channels 2.1 -v</Dotnet21Install>
     <Percent>%25</Percent>
     <XMLResults>$HELIX_WORKITEM_ROOT/testResults.xml</XMLResults>
   </PropertyGroup>
@@ -87,7 +85,7 @@
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
       <PreCommands Condition="'$(Compare)' == 'true'">$(WorkItemCommand) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(BaselineCoreRunArgument) --artifacts $(BaselineArtifactsDirectory) --partition-count $(PartitionCount) --partition-index %(HelixWorkItem.Index)"</PreCommands>
       <Command>$(WorkItemCommand) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(CoreRunArgument) --artifacts $(ArtifactsDirectory) --partition-count $(PartitionCount) --partition-index %(HelixWorkItem.Index)"</Command>
-      <PostCommands Condition="'$(Compare)' == 'true'">$(Dotnet21Install);$(DotnetExe) run -p $(ResultsComparer) --base $(BaselineArtifactsDirectory) --diff $(ArtifactsDirectory) --threshold 2$(Percent) --xml $(XMLResults);$(FinalCommand)</PostCommands>
+      <PostCommands Condition="'$(Compare)' == 'true'">$(DotnetExe) run -f $(_Framework) -p $(ResultsComparer) --base $(BaselineArtifactsDirectory) --diff $(ArtifactsDirectory) --threshold 2$(Percent) --xml $(XMLResults);$(FinalCommand)</PostCommands>
       <Timeout>4:00</Timeout>
     </HelixWorkItem>
   </ItemGroup>
@@ -97,7 +95,7 @@
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
       <PreCommands Condition="'$(Compare)' == 'true'">$(WorkItemCommand) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(BaselineCoreRunArgument) --artifacts $(ArtifactsDirectory)"</PreCommands>
       <Command>$(WorkItemCommand) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(CoreRunArgument) --artifacts $(ArtifactsDirectory)"</Command>
-      <PostCommands Condition="'$(Compare)' == 'true'">$(Dotnet21Install);$(DotnetExe) run -p $(ResultsComparer) --base $(BaselineArtifactsDirectory) --diff $(ArtifactsDirectory) --threshold 2$(Percent) --xml $(XMLResults)</PostCommands>
+      <PostCommands Condition="'$(Compare)' == 'true'">$(DotnetExe) run -f $(_Framework) -p $(ResultsComparer) --base $(BaselineArtifactsDirectory) --diff $(ArtifactsDirectory) --threshold 2$(Percent) --xml $(XMLResults)</PostCommands>
       <Timeout>4:00</Timeout>
     </HelixWorkItem>
   </ItemGroup>

--- a/eng/common/performance/performance-setup.ps1
+++ b/eng/common/performance/performance-setup.ps1
@@ -35,18 +35,18 @@ if ($Framework.StartsWith("netcoreapp")) {
     $Queue = "Windows.10.Amd64.ClientRS5.Open"
 }
 
+if ($Compare) {
+    $Queue = "Windows.10.Amd64.19H1.Tiger.Perf.Open"
+    $PerfLabArguments = ""
+    $ExtraBenchmarkDotNetArguments = ""
+}
+
 if ($Internal) {
     $Queue = "Windows.10.Amd64.19H1.Tiger.Perf"
     $PerfLabArguments = "--upload-to-perflab-container"
     $ExtraBenchmarkDotNetArguments = ""
     $Creator = ""
     $HelixSourcePrefix = "official"
-}
-
-if ($Compare) {
-    $Queue = "Windows.10.Amd64.19H1.Tiger.Perf.Open"
-    $PerfLabArguments = ""
-    $ExtraBenchmarkDotNetArguments = ""
 }
 
 $CommonSetupArguments="--frameworks $Framework --queue $Queue --build-number $BuildNumber --build-configs $Configurations"

--- a/eng/common/performance/performance-setup.ps1
+++ b/eng/common/performance/performance-setup.ps1
@@ -32,7 +32,7 @@ $HelixSourcePrefix = "pr"
 $Queue = "Windows.10.Amd64.ClientRS4.DevEx.15.8.Open"
 
 if ($Framework.StartsWith("netcoreapp")) {
-    $Queue = "Windows.10.Amd64.ClientRS4.Open"
+    $Queue = "Windows.10.Amd64.ClientRS5.Open"
 }
 
 if ($Internal) {
@@ -44,9 +44,9 @@ if ($Internal) {
 }
 
 if ($Compare) {
-    # $Queue = "Windows.10.Amd64.19H1.Tiger.Perf.Open"
-    # $PerfLabArguments = ""
-    # $ExtraBenchmarkDotNetArguments = ""
+    $Queue = "Windows.10.Amd64.19H1.Tiger.Perf.Open"
+    $PerfLabArguments = ""
+    $ExtraBenchmarkDotNetArguments = ""
 }
 
 $CommonSetupArguments="--frameworks $Framework --queue $Queue --build-number $BuildNumber --build-configs $Configurations"

--- a/eng/common/performance/performance-setup.ps1
+++ b/eng/common/performance/performance-setup.ps1
@@ -45,6 +45,7 @@ if ($Internal) {
 
 if ($Compare) {
     # $Queue = "Windows.10.Amd64.19H1.Tiger.Perf.Open"
+    # $PerfLabArguments = ""
     # $ExtraBenchmarkDotNetArguments = ""
 }
 

--- a/eng/common/performance/performance-setup.ps1
+++ b/eng/common/performance/performance-setup.ps1
@@ -1,6 +1,7 @@
 Param(
     [string] $SourceDirectory=$env:BUILD_SOURCESDIRECTORY,
     [string] $CoreRootDirectory,
+    [string] $BaselineCoreRootDirectory,
     [string] $Architecture="x64",
     [string] $Framework="netcoreapp5.0",
     [string] $CompilationMode="Tiered",
@@ -12,11 +13,13 @@ Param(
     [string] $Csproj="src\benchmarks\micro\MicroBenchmarks.csproj",
     [string] $Kind="micro",
     [switch] $Internal,
+    [switch] $Compare,
     [string] $Configurations="CompilationMode=$CompilationMode"
 )
 
 $RunFromPerformanceRepo = ($Repository -eq "dotnet/performance")
 $UseCoreRun = ($CoreRootDirectory -ne [string]::Empty)
+$UseBaselineCoreRun = ($BaselineCoreRootDirectory -ne [string]::Empty)
 
 $PayloadDirectory = (Join-Path $SourceDirectory "Payload")
 $PerformanceDirectory = (Join-Path $PayloadDirectory "performance")
@@ -40,6 +43,11 @@ if ($Internal) {
     $HelixSourcePrefix = "official"
 }
 
+if ($Compare) {
+    # $Queue = "Windows.10.Amd64.19H1.Tiger.Perf.Open"
+    # $ExtraBenchmarkDotNetArguments = ""
+}
+
 $CommonSetupArguments="--frameworks $Framework --queue $Queue --build-number $BuildNumber --build-configs $Configurations"
 $SetupArguments = "--repository https://github.com/$Repository --branch $Branch --get-perf-hash --commit-sha $CommitSha $CommonSetupArguments"
 
@@ -55,6 +63,10 @@ else {
 if ($UseCoreRun) {
     $NewCoreRoot = (Join-Path $PayloadDirectory "Core_Root")
     Move-Item -Path $CoreRootDirectory -Destination $NewCoreRoot
+}
+if ($UseBaselineCoreRun) {
+    $NewBaselineCoreRoot = (Join-Path $PayloadDirectory "Baseline_Core_Root")
+    Move-Item -Path $BaselineCoreRootDirectory -Destination $NewBaselineCoreRoot
 }
 
 $DocsDir = (Join-Path $PerformanceDirectory "docs")
@@ -80,7 +92,9 @@ Write-PipelineSetVariable -Name 'TargetCsproj' -Value "$Csproj" -IsMultiJobVaria
 Write-PipelineSetVariable -Name 'Kind' -Value "$Kind" -IsMultiJobVariable $false
 Write-PipelineSetVariable -Name 'Architecture' -Value "$Architecture" -IsMultiJobVariable $false
 Write-PipelineSetVariable -Name 'UseCoreRun' -Value "$UseCoreRun" -IsMultiJobVariable $false
+Write-PipelineSetVariable -Name 'UseBaselineCoreRun' -Value "$UseBaselineCoreRun" -IsMultiJobVariable $false
 Write-PipelineSetVariable -Name 'RunFromPerfRepo' -Value "$RunFromPerformanceRepo" -IsMultiJobVariable $false
+Write-PipelineSetVariable -Name 'Compare' -Value "$Compare" -IsMultiJobVariable $false
 
 # Helix Arguments
 Write-PipelineSetVariable -Name 'Creator' -Value "$Creator" -IsMultiJobVariable $false

--- a/eng/common/performance/performance-setup.sh
+++ b/eng/common/performance/performance-setup.sh
@@ -152,9 +152,9 @@ if [[ "$internal" == true ]]; then
 fi
 
 if [[ "$compare" == true ]]; then
-  # extra_benchmark_dotnet_arguments=
-  # perflab_arguments=
-  # queue=Ubuntu.1804.Amd64.Tiger.Perf.Open
+  extra_benchmark_dotnet_arguments=
+  perflab_arguments=
+  queue=Ubuntu.1804.Amd64.Tiger.Perf.Open
 fi
 
 common_setup_arguments="--frameworks $framework --queue $queue --build-number $build_number --build-configs $configurations"
@@ -177,7 +177,7 @@ if [[ "$use_core_run" = true ]]; then
     mv $core_root_directory $new_core_root
 fi
 
-if [[ "$use_baseline_core_run" = true]]; then
+if [[ "$use_baseline_core_run" = true ]]; then
   new_baseline_core_root=$payload_directory/Baseline_Core_Root
   mv $baseline_core_root_directory $new_baseline_core_root
 fi

--- a/eng/common/performance/performance-setup.sh
+++ b/eng/common/performance/performance-setup.sh
@@ -153,6 +153,7 @@ fi
 
 if [[ "$compare" == true ]]; then
   # extra_benchmark_dotnet_arguments=
+  # perflab_arguments=
   # queue=Ubuntu.1804.Amd64.Tiger.Perf.Open
 fi
 

--- a/eng/common/performance/performance-setup.sh
+++ b/eng/common/performance/performance-setup.sh
@@ -2,6 +2,7 @@
 
 source_directory=$BUILD_SOURCESDIRECTORY
 core_root_directory=
+baseline_core_root_directory=
 architecture=x64
 framework=netcoreapp5.0
 compilation_mode=tiered
@@ -10,12 +11,14 @@ branch=$BUILD_SOURCEBRANCH
 commit_sha=$BUILD_SOURCEVERSION
 build_number=$BUILD_BUILDNUMBER
 internal=false
+compare=false
 kind="micro"
 run_categories="coreclr corefx"
 csproj="src\benchmarks\micro\MicroBenchmarks.csproj"
 configurations=
 run_from_perf_repo=false
 use_core_run=true
+use_baseline_core_run=true
 
 while (($# > 0)); do
   lowerI="$(echo $1 | awk '{print tolower($0)}')"
@@ -26,6 +29,10 @@ while (($# > 0)); do
       ;;
     --corerootdirectory)
       core_root_directory=$2
+      shift 2
+      ;;
+    --baselinecorerootdirectory)
+      baseline_core_root_directory=$2
       shift 2
       ;;
     --architecture)
@@ -72,6 +79,10 @@ while (($# > 0)); do
       internal=true
       shift 1
       ;;
+    --compare)
+      compare=true
+      shift 1
+      ;;
     --configurations)
       configurations=$2
       shift 2
@@ -114,6 +125,10 @@ if [ -z "$core_root_directory" ]; then
     use_core_run=false
 fi
 
+if [ -z "$baseline_core_root_directory" ]; then
+    use_baseline_core_run=false
+fi
+
 payload_directory=$source_directory/Payload
 performance_directory=$payload_directory/performance
 workitem_directory=$source_directory/workitem
@@ -136,6 +151,11 @@ if [[ "$internal" == true ]]; then
     fi
 fi
 
+if [[ "$compare" == true ]]; then
+  # extra_benchmark_dotnet_arguments=
+  # queue=Ubuntu.1804.Amd64.Tiger.Perf.Open
+fi
+
 common_setup_arguments="--frameworks $framework --queue $queue --build-number $build_number --build-configs $configurations"
 setup_arguments="--repository https://github.com/$repository --branch $branch --get-perf-hash --commit-sha $commit_sha $common_setup_arguments"
 
@@ -156,6 +176,11 @@ if [[ "$use_core_run" = true ]]; then
     mv $core_root_directory $new_core_root
 fi
 
+if [[ "$use_baseline_core_run" = true]]; then
+  new_baseline_core_root=$payload_directory/Baseline_Core_Root
+  mv $baseline_core_root_directory $new_baseline_core_root
+fi
+
 ci=true
 
 _script_dir=$(pwd)/eng/common
@@ -163,6 +188,7 @@ _script_dir=$(pwd)/eng/common
 
 # Make sure all of our variables are available for future steps
 Write-PipelineSetVariable -name "UseCoreRun" -value "$use_core_run" -is_multi_job_variable false
+Write-PipelineSetVariable -name "UseBaselineCoreRun" -value "$use_baseline_core_run" -is_multi_job_variable false
 Write-PipelineSetVariable -name "Architecture" -value "$architecture" -is_multi_job_variable false
 Write-PipelineSetVariable -name "PayloadDirectory" -value "$payload_directory" -is_multi_job_variable false
 Write-PipelineSetVariable -name "PerformanceDirectory" -value "$performance_directory" -is_multi_job_variable false
@@ -179,3 +205,4 @@ Write-PipelineSetVariable -name "Creator" -value "$creator" -is_multi_job_variab
 Write-PipelineSetVariable -name "HelixSourcePrefix" -value "$helix_source_prefix" -is_multi_job_variable false
 Write-PipelineSetVariable -name "Kind" -value "$kind" -is_multi_job_variable false
 Write-PipelineSetVariable -name "_BuildConfig" -value "$architecture.$kind.$framework" -is_multi_job_variable false
+Write-PipelineSetVariable -name "Compare" -value "$compare" -is_multi_job_variable false

--- a/eng/common/performance/performance-setup.sh
+++ b/eng/common/performance/performance-setup.sh
@@ -138,6 +138,19 @@ queue=Ubuntu.1804.Amd64.Open
 creator=$BUILD_DEFINITIONNAME
 helix_source_prefix="pr"
 
+if [[ "$compare" == true ]]; then
+  extra_benchmark_dotnet_arguments=
+  perflab_arguments=
+
+  # No open queues for arm64
+  if [[ "$architecture" = "arm64" ]]; then
+    echo "Compare not available for arm64"
+    exit 1
+  fi
+
+  queue=Ubuntu.1804.Amd64.Tiger.Perf.Open
+fi
+
 if [[ "$internal" == true ]]; then
     perflab_arguments="--upload-to-perflab-container"
     helix_source_prefix="official"
@@ -149,12 +162,6 @@ if [[ "$internal" == true ]]; then
     else
         queue=Ubuntu.1804.Amd64.Tiger.Perf
     fi
-fi
-
-if [[ "$compare" == true ]]; then
-  extra_benchmark_dotnet_arguments=
-  perflab_arguments=
-  queue=Ubuntu.1804.Amd64.Tiger.Perf.Open
 fi
 
 common_setup_arguments="--frameworks $framework --queue $queue --build-number $build_number --build-configs $configurations"


### PR DESCRIPTION
This change adds support to perform A/B comparisons of performance testing. This change adds two new options to the performance-setup scripts:

* BaselineCoreRootDirectory - The directory where the baseline CoreRun.exe has been built
* Compare - a switch to tell the system that we want to compare a baseline to the PR that is being tested.

These two options are not mutually required. A user could supply a baseline, but not the compare switch, but then no comparison would be done. If the user supplies the compare flag, but no baseline, their job will compare against the latest dotnet sdk.

This change also adds the support to the proj file to perform the compare, which involves running the baseline as a precommand, then running the actual test run, then running ResultsComparer as a post command, which has been set up to write out an xml file that matches the xunit format that the xunit reporter expects. For compare runs, we will ignore failures, and pass the job, as deciding if a regression should fail the PR is at the code reviewer's discretion.

This change does not provide advice as to how to create the baseline Core_Root, which is up to the repo owners to decide.