### PR TITLE
Add a verbosity switch to the darc install scripts

### DIFF
--- a/eng/common/darc-init.ps1
+++ b/eng/common/darc-init.ps1
@@ -1,9 +1,9 @@
 param (
     $darcVersion = $null,
-    $versionEndpoint = "https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16"
+    $versionEndpoint = "https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16",
+    $verbosity = "m"
 )
 
-$verbosity = "m"
 . $PSScriptRoot\tools.ps1
 
 function InstallDarcCli ($darcVersion) {

--- a/eng/common/darc-init.sh
+++ b/eng/common/darc-init.sh
@@ -3,6 +3,7 @@
 source="${BASH_SOURCE[0]}"
 darcVersion=''
 versionEndpoint="https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16"
+verbosity=m
 
 while [[ $# > 0 ]]; do
   opt="$(echo "$1" | awk '{print tolower($0)}')"
@@ -13,6 +14,10 @@ while [[ $# > 0 ]]; do
       ;;
     --versionendpoint)
       versionEndpoint=$2
+      shift
+      ;;
+    --verbosity)
+      verbosity=$2
       shift
       ;;
     *)
@@ -34,7 +39,6 @@ while [[ -h "$source" ]]; do
   [[ $source != /* ]] && source="$scriptroot/$source"
 done
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
-verbosity=m
 
 . "$scriptroot/tools.sh"
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/arcade/issues/3708

darc-init.ps1 should have a verbosity option.

NuGet.Client is not fully integrated with arcade, but we do use scripts such as darc-init.ps1 to do our insertions.

We're seeing some failures caused by ambient machine state, and investigating those would be quicker if the script itself had a verbosity switch rather than a hardcoded one.