### PR TITLE
Tweak spacing in `throw new PNSE();}`

### DIFF
--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
@@ -241,7 +241,7 @@ namespace Microsoft.Cci.Writers.CSharp
                 else if (_platformNotSupportedExceptionMessage.Length > 0)
                     Write($"\"{_platformNotSupportedExceptionMessage}\"");
 
-                 Write(");");
+                 Write("); ");
             }
             else if (NeedsMethodBodyForCompilation(method))
             {


### PR DESCRIPTION
To generate:
```C#
{ throw new PlatformNotSupportedException(); }
```
instead of:
```C#
{ throw new PlatformNotSupportedException();}
```