### PR TITLE
Fix merge mistake in sourcelink-validation.ps1

### DIFF
--- a/eng/common/post-build/sourcelink-validation.ps1
+++ b/eng/common/post-build/sourcelink-validation.ps1
@@ -215,7 +215,7 @@ function ValidateSourceLinkLinks {
     }
 
   $ValidationFailures = 0
-  foreach ($Job in $Jobs) {
+  foreach ($Job in @(Get-Job)) {
     $jobResult = Wait-Job -Id $Job.Id | Receive-Job
     if ($jobResult -ne "0") {
       $ValidationFailures++


### PR DESCRIPTION
Closes: #3750 

I made a mistake while solving a merge conflict in a previous PR and ended referencing a removed variable `@Jobs`. This PR fixes it.