### PR TITLE
Add Azure DevOps feed support to the Feed tasks

### DIFF
--- a/Arcade.sln
+++ b/Arcade.sln
@@ -93,6 +93,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.NuGetRepac
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.NuGetRepack.Tasks", "src\Microsoft.DotNet.NuGetRepack\tasks\Microsoft.DotNet.NuGetRepack.Tasks.csproj", "{0E7AB9DD-A1D5-4A49-9ED0-3C400A04C885}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Build.Tasks.Feed.Tests", "src\Microsoft.DotNet.Build.Tasks.Feed.Tests\Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj", "{6E19C6B6-4ADF-4DD6-86CC-6C1624BCDB71}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -579,6 +581,18 @@ Global
 		{0E7AB9DD-A1D5-4A49-9ED0-3C400A04C885}.Release|x64.Build.0 = Release|Any CPU
 		{0E7AB9DD-A1D5-4A49-9ED0-3C400A04C885}.Release|x86.ActiveCfg = Release|Any CPU
 		{0E7AB9DD-A1D5-4A49-9ED0-3C400A04C885}.Release|x86.Build.0 = Release|Any CPU
+		{6E19C6B6-4ADF-4DD6-86CC-6C1624BCDB71}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6E19C6B6-4ADF-4DD6-86CC-6C1624BCDB71}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6E19C6B6-4ADF-4DD6-86CC-6C1624BCDB71}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6E19C6B6-4ADF-4DD6-86CC-6C1624BCDB71}.Debug|x64.Build.0 = Debug|Any CPU
+		{6E19C6B6-4ADF-4DD6-86CC-6C1624BCDB71}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6E19C6B6-4ADF-4DD6-86CC-6C1624BCDB71}.Debug|x86.Build.0 = Debug|Any CPU
+		{6E19C6B6-4ADF-4DD6-86CC-6C1624BCDB71}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6E19C6B6-4ADF-4DD6-86CC-6C1624BCDB71}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6E19C6B6-4ADF-4DD6-86CC-6C1624BCDB71}.Release|x64.ActiveCfg = Release|Any CPU
+		{6E19C6B6-4ADF-4DD6-86CC-6C1624BCDB71}.Release|x64.Build.0 = Release|Any CPU
+		{6E19C6B6-4ADF-4DD6-86CC-6C1624BCDB71}.Release|x86.ActiveCfg = Release|Any CPU
+		{6E19C6B6-4ADF-4DD6-86CC-6C1624BCDB71}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -599,6 +613,7 @@ Global
 		{86D901E6-C054-445B-92EC-E267EBB16278} = {80888CDA-37DC-4061-AF5F-7237BF16A320}
 		{4626A7D1-7AC0-4E21-9FED-083EF2A8194C} = {C53DD924-C212-49EA-9BC4-1827421361EF}
 		{41F3EF12-6062-44CE-A1DB-1DCA76122AF8} = {C53DD924-C212-49EA-9BC4-1827421361EF}
+		{6E19C6B6-4ADF-4DD6-86CC-6C1624BCDB71} = {C53DD924-C212-49EA-9BC4-1827421361EF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {32B9C883-432E-4FC8-A1BF-090EB033DD5B}

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj
@@ -8,10 +8,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
+	<!-- This is here so that we agree with the feed tasks project's transitive reference to NewtonSoft.Json -->
+	<PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.Build.Tasks.Feed\Microsoft.DotNet.Build.Tasks.Feed.csproj" />
   </ItemGroup>
 
+  <Import Project="$(RepoRoot)eng\BuildTask.targets" />
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
 	<!-- This is here so that we agree with the feed tasks project's transitive reference to NewtonSoft.Json -->
-	<PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
+	<PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj
@@ -2,9 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>
-    <VersionPrefix>2.2.0</VersionPrefix>
-
-    <IsPackable>false</IsPackable>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>
+    <VersionPrefix>2.2.0</VersionPrefix>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.DotNet.Build.Tasks.Feed\Microsoft.DotNet.Build.Tasks.Feed.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/MockBuildEngine.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/MockBuildEngine.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
+{
+    public class MockBuildEngine : IBuildEngine
+    {
+        public bool ContinueOnError => throw new NotImplementedException();
+
+        public int LineNumberOfTaskNode => 0;
+
+        public int ColumnNumberOfTaskNode => 0;
+
+        public string ProjectFileOfTaskNode => "Fake File";
+
+        public List<CustomBuildEventArgs> CustomBuildEvents = new List<CustomBuildEventArgs>();
+        public List<BuildErrorEventArgs> BuildErrorEvents = new List<BuildErrorEventArgs>();
+        public List<BuildMessageEventArgs> BuildMessageEvents = new List<BuildMessageEventArgs>();
+        public List<BuildWarningEventArgs> BuildWarningEvents = new List<BuildWarningEventArgs>();
+
+        public bool BuildProjectFile(string projectFileName, string[] targetNames, IDictionary globalProperties, IDictionary targetOutputs)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void LogCustomEvent(CustomBuildEventArgs e)
+        {
+            CustomBuildEvents.Add(e);
+        }
+
+        public void LogErrorEvent(BuildErrorEventArgs e)
+        {
+            BuildErrorEvents.Add(e);
+        }
+
+        public void LogMessageEvent(BuildMessageEventArgs e)
+        {
+            BuildMessageEvents.Add(e);
+        }
+
+        public void LogWarningEvent(BuildWarningEventArgs e)
+        {
+            BuildWarningEvents.Add(e);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
@@ -1,0 +1,249 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using Xunit;
+
+namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
+{
+    public class PublishArtifactsInManifestTests
+    {
+        const string RandomToken = "abcd";
+        const string BlobFeedUrl = "https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json";
+
+        [Fact]
+        public void FeedConfigParserTests1()
+        {
+            var buildEngine = new MockBuildEngine();
+            var task = new PublishArtifactsInManifest
+            {
+                // Create a single ITaskItem for a simple feed config, then parse to FeedConfigs and
+                // check the expected values.
+                TargetFeedConfig = new TaskItem[]
+                {
+                    new TaskItem("FOOPACKAGES", new Dictionary<string, string> {
+                        { "TargetUrl", BlobFeedUrl },
+                        { "Token", RandomToken },
+                        { "Type", "AzDoNugetFeed" }}),
+                },
+                BuildEngine = buildEngine
+            };
+
+            task.ParseTargetFeedConfig();
+            Assert.False(task.Log.HasLoggedErrors);
+
+            // This will have set the feed configs.
+            Assert.Collection(task.FeedConfigs,
+                configList =>
+                {
+                    Assert.Equal("FOOPACKAGES", configList.Key);
+                    Assert.Collection(configList.Value, config =>
+                    {
+                        Assert.Equal(RandomToken, config.FeedKey);
+                        Assert.Equal(BlobFeedUrl, config.TargetFeedURL);
+                        Assert.Equal(FeedType.AzDoNugetFeed, config.Type);
+                        Assert.Equal(AssetSelection.All, config.AssetSelection);
+                    });
+                });
+        }
+
+        [Fact]
+        public void FeedConfigParserTests2()
+        {
+            var buildEngine = new MockBuildEngine();
+            var task = new PublishArtifactsInManifest
+            {
+                TargetFeedConfig = new TaskItem[]
+                {
+                    new TaskItem("FOOPACKAGES", new Dictionary<string, string> {
+                        { "TargetUrl", BlobFeedUrl },
+                        { "Token", RandomToken },
+                        { "Type", "MyUnknownFeedType" } }),
+                },
+                BuildEngine = buildEngine
+            };
+
+            task.ParseTargetFeedConfig();
+            Assert.True(task.Log.HasLoggedErrors);
+            Assert.Contains(buildEngine.BuildErrorEvents, e => e.Message.Equals("Invalid feed config type 'MyUnknownFeedType'. Possible values are: AzDoNugetFeed, AzureStorageFeed"));
+        }
+
+        [Fact]
+        public void FeedConfigParserTests3()
+        {
+            var buildEngine = new MockBuildEngine();
+            var task = new PublishArtifactsInManifest
+            {
+                TargetFeedConfig = new TaskItem[]
+                {
+                    new TaskItem("FOOPACKAGES", new Dictionary<string, string> {
+                        { "TargetUrl", string.Empty },
+                        { "Token", string.Empty },
+                        { "Type", string.Empty } }),
+                },
+                BuildEngine = buildEngine
+            };
+
+            task.ParseTargetFeedConfig();
+            Assert.True(task.Log.HasLoggedErrors);
+            Assert.Contains(buildEngine.BuildErrorEvents, e => e.Message.Equals("Invalid FeedConfig entry. TargetURL='' Type='' Token=''"));
+        }
+
+        /// <summary>
+        ///     Valid feed config with an asset selection set.
+        /// </summary>
+        [Fact]
+        public void FeedConfigParserTests4()
+        {
+            var buildEngine = new MockBuildEngine();
+            var task = new PublishArtifactsInManifest
+            {
+                TargetFeedConfig = new TaskItem[]
+                {
+                    new TaskItem("FOOPACKAGES", new Dictionary<string, string> {
+                        { "TargetUrl", BlobFeedUrl },
+                        { "Token", RandomToken },
+                        { "Type", "AZURESTORAGEFEED" },
+                        { "AssetSelection", "SHIPPINGONLY" }}),
+                },
+                BuildEngine = buildEngine
+            };
+
+            task.ParseTargetFeedConfig();
+
+            // This will have set the feed configs.
+            Assert.Collection(task.FeedConfigs,
+                configList =>
+                {
+                    Assert.Equal("FOOPACKAGES", configList.Key);
+                    Assert.Collection(configList.Value, config =>
+                    {
+                        Assert.Equal(RandomToken, config.FeedKey);
+                        Assert.Equal(BlobFeedUrl, config.TargetFeedURL);
+                        Assert.Equal(FeedType.AzureStorageFeed, config.Type);
+                        Assert.Equal(AssetSelection.ShippingOnly, config.AssetSelection);
+                    });
+                });
+        }
+
+        [Theory]
+        [InlineData("https://pkgs.dev.azure.com/dnceng/public/_packaging/mmitche-test-transport/nuget/v3/index.json", "dnceng", "public", "mmitche-test-transport")]
+        [InlineData("https://pkgs.dev.azure.com/DevDiv/public/_packaging/1234.5/nuget/v3/index.json", "DevDiv", "public", "1234.5")]
+        public void NugetFeedParseTests(string uri, string account, string project, string feed)
+        {
+            var matches = Regex.Match(uri, PublishArtifactsInManifest.AzDoNuGetFeedPattern);
+            Assert.Equal(account, matches.Groups["account"]?.Value);
+            Assert.Equal(project, matches.Groups["project"]?.Value);
+            Assert.Equal(feed, matches.Groups["feed"]?.Value);
+        }
+
+        [Theory]
+        // Simple case where we fill the whole buffer on each stream call and the streams match
+        [InlineData("QXJjYWRl", "QXJjYWRl", new int[] { int.MaxValue }, new int[] { int.MaxValue }, 1024)]
+        // Simple case where we fill the whole buffer on each stream call and the streams don't match
+        [InlineData("QXJjYWRl", "QXJjYWRm", new int[] { int.MaxValue }, new int[] { int.MaxValue }, 1024)]
+        // Case where the first stream returns everything initially, but the second returns one byte at a time.
+        [InlineData("QXJjYWRl", "QXJjYWRl", new int[] { int.MaxValue }, new int[] { 1, 1, 1, 1, 1 }, 1024)]
+        // Case where the first stream returns everything initially, but the second returns one byte at a time and they are not equal
+        [InlineData("QXJjYWRl", "QXJjYWRm", new int[] { int.MaxValue }, new int[] { 1, 1, 1, 1, 1 }, 1024)]
+        // Case where both streams return one byte at a time
+        [InlineData("QXJjYWRl", "QXJjYWRl", new int[] { 1, 1, 1, 1, 1 }, new int[] { 1, 1, 1, 1, 1 }, 1024)]
+        // Case where both streams return one byte at a time
+        [InlineData("QXJjYWRl", "QXJjYWQ=", new int[] { 1, 1, 1, 1, 1 }, new int[] { 1, 1, 1, 1, 1 }, 1024)]
+        // Case where the buffer must wrap around and one stream returns faster than the other, equal streams
+        [InlineData("VGhlIHF1aWNrIGJyb3JuIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5aXNoIGRvZ2dv", "VGhlIHF1aWNrIGJyb3JuIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5aXNoIGRvZ2dv", new int[] { 16, 16, 16, 16, 16, 16 }, new int[] { 1, 1, 1, 1, 1 }, 8)]
+        // Case where the buffer must wrap around and one stream returns faster than the other, unequal streams
+        [InlineData("VGhpcyBpcyBhIHNlbnRlbmNlIHRoYXQgaXMgYSBsaXR0bGUgbG9uZ2Vy", "VGhpcyBpcyBhIHNlbnRlbmNlIHRoYXQgaXMgYSBsb25nZXI=", new int[] { 7, 3, 5, 16, 16, 16 }, new int[] { 1, 1, 1, 1, 1 }, 8)]
+        public async void StreamComparisonTests(string streamA, string streamB, int[] maxStreamABytesReturnedEachCall, int[] maxStreamBBytesReturnedEachCall, int bufferSize)
+        {
+            byte[] streamABytes = Convert.FromBase64String(streamA);
+            byte[] streamBBytes = Convert.FromBase64String(streamB);
+
+            FakeStream fakeStreamA = new FakeStream(streamABytes, maxStreamABytesReturnedEachCall);
+            FakeStream fakeStreamB = new FakeStream(streamBBytes, maxStreamBBytesReturnedEachCall);
+
+            Assert.Equal(streamA == streamB, await PublishArtifactsInManifest.CompareStreamsAsync(fakeStreamA, fakeStreamB, bufferSize));
+        }
+
+        class FakeStream : Stream
+        {
+            public FakeStream(byte[] streamBytes, int[] maxStreamBytesReturned)
+            {
+                _streamBytes = streamBytes;
+                _maxStreamBytesReturned = maxStreamBytesReturned;
+            }
+
+            byte[] _streamBytes;
+            int[] _maxStreamBytesReturned;
+            int _callIndex = 0;
+            int _position = 0;
+
+            public override System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                Assert.True(count > 0);
+
+                // If we reach the end of the _maxStreamBytesReturned array, just use max int.
+                int maxStreamBytesThisCall = int.MaxValue;
+                if (_callIndex < _maxStreamBytesReturned.Length)
+                {
+                    maxStreamBytesThisCall = _maxStreamBytesReturned[_callIndex];
+                    _callIndex++;
+                }
+                int bytesToWrite = Math.Min(Math.Min(_streamBytes.Length - _position, count), maxStreamBytesThisCall);
+
+                for (int i = 0; i < bytesToWrite; i++)
+                {
+                    buffer[offset + i] = _streamBytes[_position + i];
+                }
+                _position += bytesToWrite;
+
+                return System.Threading.Tasks.Task.FromResult(bytesToWrite);
+            }
+
+            #region Unused
+
+            public override bool CanRead => throw new NotImplementedException();
+
+            public override bool CanSeek => throw new NotImplementedException();
+
+            public override bool CanWrite => throw new NotImplementedException();
+
+            public override long Length => throw new NotImplementedException();
+
+            public override long Position { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+            public override void Flush()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                throw new NotImplementedException();
+            }
+            #endregion
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -23,6 +23,4 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.VersionTools\lib\Microsoft.DotNet.VersionTools.csproj" />
   </ItemGroup>
-
-  <Import Project="$(RepoRoot)eng\BuildTask.targets" />
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
+using Microsoft.DotNet.Build.CloudTestTasks;
 using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.DotNet.VersionTools.BuildManifest.Model;
@@ -11,7 +12,11 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using MSBuild = Microsoft.Build.Utilities;
 
@@ -23,6 +28,26 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
     /// </summary>
     public class PublishArtifactsInManifest : MSBuild.Task
     {
+        // Matches package feeds like
+        // https://dotnet-feed-internal.azurewebsites.net/container/dotnet-core-internal/sig/dsdfasdfasdf234234s/se/2020-02-02/darc-int-dotnet-arcade-services-babababababe-08/index.json
+        const string AzureStorageProxyFeedPattern =
+            @"(?<feedURL>https://([a-z-]+).azurewebsites.net/container/(?<container>[^/]+)/sig/\w+/se/([0-9]{4}-[0-9]{2}-[0-9]{2})/(?<baseFeedName>darc-(?<type>int|pub)-(?<repository>.+?)-(?<sha>[A-Fa-f0-9]{7,40})-?(?<subversion>\d*)/))index.json";
+
+        // Matches package feeds like the one below. Special case for static internal proxy-backed feed
+        // https://dotnet-feed-internal.azurewebsites.net/container/dotnet-core-internal/sig/dsdfasdfasdf234234s/se/2020-02-02/darc-int-dotnet-arcade-services-babababababe-08/index.json
+        const string AzureStorageProxyFeedStaticPattern =
+            @"(?<feedURL>https://([a-z-]+).azurewebsites.net/container/(?<container>[^/]+)/sig/\w+/se/([0-9]{4}-[0-9]{2}-[0-9]{2})/(?<baseFeedName>[^/]+/))index.json";
+
+        // Matches package feeds like
+        // https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+        const string AzureStorageStaticBlobFeedPattern =
+            @"https://([a-z-]+).blob.core.windows.net/[^/]+/index.json";
+
+        // Matches package feeds like
+        // https://pkgs.dev.azure.com/dnceng/public/_packaging/mmitche-test-transport/nuget/v3/index.json
+        public const string AzDoNuGetFeedPattern =
+            @"https://pkgs.dev.azure.com/(?<account>[a-zA-Z0-9]+)/(?<project>[a-zA-Z0-9-]+)/_packaging/(?<feed>.+)/nuget/v3/index.json";
+
         /// <summary>
         /// Configuration telling which target feed to use for each artifact category.
         /// ItemSpec: ArtifactCategory
@@ -71,12 +96,17 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public string BuildAssetRegistryToken { get; set; }
 
         /// <summary>
+        /// Maximum number of parallel uploads for the upload tasks
+        /// </summary>
+        public int MaxClients { get; set; } = 8;
+
+        /// <summary>
         /// Directory where "nuget.exe" is installed. This will be used to publish packages.
         /// </summary>
         [Required]
         public string NugetPath { get; set; }
 
-        private readonly Dictionary<string, List<FeedConfig>> FeedConfigs = new Dictionary<string, List<FeedConfig>>();
+        public readonly Dictionary<string, List<FeedConfig>> FeedConfigs = new Dictionary<string, List<FeedConfig>>();
 
         private readonly Dictionary<string, List<PackageArtifactModel>> PackagesByCategory = new Dictionary<string, List<PackageArtifactModel>>();
 
@@ -122,29 +152,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 IMaestroApi client = ApiFactory.GetAuthenticated(MaestroApiEndpoint, BuildAssetRegistryToken);
                 Maestro.Client.Models.Build buildInformation = await client.Builds.GetBuildAsync(BARBuildId);
 
-                foreach (var fc in TargetFeedConfig)
-                {
-                    var feedConfig = new FeedConfig()
-                    {
-                        TargetFeedURL = fc.GetMetadata("TargetURL"),
-                        Type = fc.GetMetadata("Type"),
-                        FeedKey = fc.GetMetadata("Token")
-                    };
-
-                    if (string.IsNullOrEmpty(feedConfig.TargetFeedURL) ||
-                        string.IsNullOrEmpty(feedConfig.Type) ||
-                        string.IsNullOrEmpty(feedConfig.FeedKey))
-                    {
-                        Log.LogError($"Invalid FeedConfig entry. TargetURL='{feedConfig.TargetFeedURL}' Type='{feedConfig.Type}' Token='{feedConfig.FeedKey}'");
-                    }
-
-                    string categoryKey = fc.ItemSpec.Trim().ToUpper();
-                    if (!FeedConfigs.TryGetValue(categoryKey, out var feedsList))
-                    {
-                        FeedConfigs[categoryKey] = new List<FeedConfig>();
-                    }
-                    FeedConfigs[categoryKey].Add(feedConfig);
-                }
+                ParseTargetFeedConfig();
 
                 // Return errors from parsing FeedConfig
                 if (Log.HasLoggedErrors)
@@ -166,6 +174,58 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             return !Log.HasLoggedErrors;
         }
 
+        /// <summary>
+        ///     Parse out the input TargetFeedConfig into a dictionary of FeedConfig types
+        /// </summary>
+        public void ParseTargetFeedConfig()
+        {
+            foreach (var fc in TargetFeedConfig)
+            {
+                string targetFeedUrl = fc.GetMetadata("TargetURL");
+                string feedKey = fc.GetMetadata("Token");
+                string type = fc.GetMetadata("Type");
+
+                if (string.IsNullOrEmpty(targetFeedUrl) ||
+                    string.IsNullOrEmpty(feedKey) ||
+                    string.IsNullOrEmpty(type))
+                {
+                    Log.LogError($"Invalid FeedConfig entry. TargetURL='{targetFeedUrl}' Type='{type}' Token='{feedKey}'");
+                    continue;
+                }
+
+                if (!Enum.TryParse<FeedType>(type, true, out FeedType feedType))
+                {
+                    Log.LogError($"Invalid feed config type '{type}'. Possible values are: {string.Join(", ", Enum.GetNames(typeof(FeedType)))}");
+                    continue;
+                }
+
+                var feedConfig = new FeedConfig()
+                {
+                    TargetFeedURL = targetFeedUrl,
+                    Type = feedType,
+                    FeedKey = feedKey
+                };
+
+                string assetSelection = fc.GetMetadata("AssetSelection");
+                if (!string.IsNullOrEmpty(assetSelection))
+                {
+                    if (!Enum.TryParse<AssetSelection>(assetSelection, true, out AssetSelection selection))
+                    {
+                        Log.LogError($"Invalid feed config asset selection '{type}'. Possible values are: {string.Join(", ", Enum.GetNames(typeof(AssetSelection)))}");
+                        continue;
+                    }
+                    feedConfig.AssetSelection = selection;
+                }
+
+                string categoryKey = fc.ItemSpec.Trim().ToUpper();
+                if (!FeedConfigs.TryGetValue(categoryKey, out var feedsList))
+                {
+                    FeedConfigs[categoryKey] = new List<FeedConfig>();
+                }
+                FeedConfigs[categoryKey].Add(feedConfig);
+            }
+        }
+
         private async Task HandlePackagePublishingAsync(IMaestroApi client, Maestro.Client.Models.Build buildInformation)
         {
             foreach (var packagesPerCategory in PackagesByCategory)
@@ -177,19 +237,19 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 {
                     foreach (var feedConfig in feedConfigsForCategory)
                     {
-                        var feedType = feedConfig.Type.ToUpper();
+                        List<PackageArtifactModel> filteredPackages = FilterPackages(packages, feedConfig);
 
-                        if (feedType.Equals("AZDONUGETFEED"))
+                        switch (feedConfig.Type)
                         {
-                            await PublishPackagesToAzDoNugetFeedAsync(packages, client, buildInformation, feedConfig);
-                        }
-                        else if (feedType.Equals("AZURESTORAGEFEED"))
-                        {
-                            await PublishPackagesToAzureStorageNugetFeedAsync(packages, client, buildInformation, feedConfig);
-                        }
-                        else
-                        {
-                            Log.LogError($"Unknown target feed type for category '{category}': '{feedType}'.");
+                            case FeedType.AzDoNugetFeed:
+                                await PublishPackagesToAzDoNugetFeedAsync(filteredPackages, client, buildInformation, feedConfig);
+                                break;
+                            case FeedType.AzureStorageFeed:
+                                await PublishPackagesToAzureStorageNugetFeedAsync(filteredPackages, client, buildInformation, feedConfig);
+                                break;
+                            default:
+                                Log.LogError($"Unknown target feed type for category '{category}': '{feedConfig.Type}'.");
+                                break;
                         }
                     }
                 }
@@ -198,6 +258,31 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     Log.LogError($"No target feed configuration found for artifact category: '{category}'.");
                 }
             }
+        }
+
+        private List<PackageArtifactModel> FilterPackages(List<PackageArtifactModel> packages, FeedConfig feedConfig)
+        {
+            // If the feed config wants further filtering, do that now.
+            List<PackageArtifactModel> filteredPackages = null;
+            switch (feedConfig.AssetSelection)
+            {
+                case AssetSelection.All:
+                    // No filtering needed
+                    filteredPackages = packages;
+                    break;
+                case AssetSelection.NonShippingOnly:
+                    filteredPackages = packages.Where(p => p.NonShipping).ToList();
+                    break;
+                case AssetSelection.ShippingOnly:
+                    filteredPackages = packages.Where(p => !p.NonShipping).ToList();
+                    break;
+                default:
+                    // Throw NYI here instead of logging an error because error would have already been logged in the
+                    // parser for the user.
+                    throw new NotImplementedException("Unknown asset selection type '{feedConfig.AssetSelection}'");
+            }
+
+            return filteredPackages;
         }
 
         private async Task HandleBlobPublishingAsync(IMaestroApi client, Maestro.Client.Models.Build buildInformation)
@@ -211,19 +296,19 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 {
                     foreach (var feedConfig in feedConfigsForCategory)
                     {
-                        var feedType = feedConfig.Type.ToUpper();
+                        List<BlobArtifactModel> filteredBlobs = FilterBlobs(blobs, feedConfig);
 
-                        if (feedType.Equals("AZDONUGETFEED"))
+                        switch (feedConfig.Type)
                         {
-                            await PublishBlobsToAzDoNugetFeedAsync(blobs, client, buildInformation, feedConfig);
-                        }
-                        else if (feedType.Equals("AZURESTORAGEFEED"))
-                        {
-                            await PublishBlobsToAzureStorageNugetFeedAsync(blobs, client, buildInformation, feedConfig);
-                        }
-                        else
-                        {
-                            Log.LogError($"Unknown target feed type for category '{category}': '{feedType}'.");
+                            case FeedType.AzDoNugetFeed:
+                                await PublishBlobsToAzDoNugetFeedAsync(filteredBlobs, client, buildInformation, feedConfig);
+                                break;
+                            case FeedType.AzureStorageFeed:
+                                await PublishBlobsToAzureStorageNugetFeedAsync(filteredBlobs, client, buildInformation, feedConfig);
+                                break;
+                            default:
+                                Log.LogError($"Unknown target feed type for category '{category}': '{feedConfig.Type}'.");
+                                break;
                         }
                     }
                 }
@@ -234,6 +319,44 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             }
         }
 
+        /// <summary>
+        ///     Filter the blobs by the feed config information
+        /// </summary>
+        /// <param name="blobs"></param>
+        /// <param name="feedConfig"></param>
+        /// <returns></returns>
+        private List<BlobArtifactModel> FilterBlobs(List<BlobArtifactModel> blobs, FeedConfig feedConfig)
+        {
+            // If the feed config wants further filtering, do that now.
+            List<BlobArtifactModel> filteredBlobs = null;
+            switch (feedConfig.AssetSelection)
+            {
+                case AssetSelection.All:
+                    // No filtering needed
+                    filteredBlobs = blobs;
+                    break;
+                case AssetSelection.NonShippingOnly:
+                    filteredBlobs = blobs.Where(p => p.NonShipping).ToList();
+                    break;
+                case AssetSelection.ShippingOnly:
+                    filteredBlobs = blobs.Where(p => !p.NonShipping).ToList();
+                    break;
+                default:
+                    // Throw NYI here instead of logging an error because error would have already been logged in the
+                    // parser for the user.
+                    throw new NotImplementedException("Unknown asset selection type '{feedConfig.AssetSelection}'");
+            }
+
+            return filteredBlobs;
+        }
+
+        /// <summary>
+        ///     Split the artifacts into categories.
+        ///     
+        ///     Categories are either specified explicitly when publishing (with the asset attribute "Category", separated by ';'),
+        ///     or they are inferred based on the extension of the asset.
+        /// </summary>
+        /// <param name="buildModel"></param>
         private void SplitArtifactsInCategories(BuildModel buildModel)
         {
             foreach (var packageAsset in buildModel.Artifacts.Packages)
@@ -289,6 +412,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         {
             foreach (var package in packagesToPublish)
             {
+
                 var assetRecord = buildInformation.Assets
                     .Where(a => a.Name.Equals(package.Id) && a.Version.Equals(package.Version))
                     .FirstOrDefault();
@@ -309,6 +433,286 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                 await client.Assets.AddAssetLocationToAssetAsync(assetRecord.Id, AddAssetLocationToAssetAssetLocationType.NugetFeed, feedConfig.TargetFeedURL);
             }
+
+            await PushNugetPackagesAsync(packagesToPublish, feedConfig, maxClients: MaxClients);
+        }
+
+        public Task<int> StartProcessAsync(string path, string arguments)
+        {
+            ProcessStartInfo info = new ProcessStartInfo(path, arguments)
+            {
+                UseShellExecute = false,
+                RedirectStandardError = true,
+            };
+
+            Process process = new Process
+            {
+                StartInfo = info,
+                EnableRaisingEvents = true
+            };
+
+            var completionSource = new TaskCompletionSource<int>();
+
+            process.Exited += (obj, args) =>
+            {
+                completionSource.SetResult(((Process)obj).ExitCode);
+                process.Dispose();
+            };
+
+            process.Start();
+
+            return completionSource.Task;
+        }
+
+        /// <summary>
+        ///     Push nuget packages to the azure devops feed.
+        /// </summary>
+        /// <param name="packagesToPublish">List of packages to publish</param>
+        /// <param name="feedConfig">Information about feed to publish ot</param>
+        /// <returns>Async task.</returns>
+        public async Task PushNugetPackagesAsync(List<PackageArtifactModel> packagesToPublish, FeedConfig feedConfig, int maxClients)
+        {
+            var parsedUri = Regex.Match(feedConfig.TargetFeedURL, PublishArtifactsInManifest.AzDoNuGetFeedPattern);
+            if (!parsedUri.Success)
+            {
+                Log.LogError($"Azure DevOps NuGetFeed was not in the expected format '{PublishArtifactsInManifest.AzDoNuGetFeedPattern}'");
+                return;
+            }
+            string feedAccount = parsedUri.Groups["account"].Value;
+            string feedProject = parsedUri.Groups["project"].Value;
+            string feedName = parsedUri.Groups["feed"].Value;
+
+            using (var clientThrottle = new SemaphoreSlim(maxClients, maxClients))
+            {
+                using (HttpClient httpClient = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true }))
+                {
+                    httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+                        "Basic",
+                        Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Format("{0}:{1}", "", feedConfig.FeedKey))));
+
+                    Log.LogMessage(MessageImportance.High, $"Pushing {packagesToPublish.Count()} packages.");
+                    await System.Threading.Tasks.Task.WhenAll(packagesToPublish.Select(async packageToPublish =>
+                    {
+                        try
+                        {
+                            // Wait to avoid starting too many processes.
+                            await clientThrottle.WaitAsync();
+                            await PushNugetPackageAsync(feedConfig, httpClient, packageToPublish, feedAccount, feedProject, feedName);
+                        }
+                        finally
+                        {
+                            clientThrottle.Release();
+                        }
+                    }));
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Push a single package to the azure devops nuget feed.
+        /// </summary>
+        /// <param name="feedConfig">Feed</param>
+        /// <param name="packageToPublish">Package to push</param>
+        /// <returns>Task</returns>
+        /// <remarks>
+        ///     This method attempts to take the most efficient path to push the package.
+        ///     There are two cases:
+        ///         - The package does not exist, and is pushed normally
+        ///         - The package exists, and its contents may or may not be equivalent.
+        ///     The second case is is by far the most common. So, we first attempt to push the package normally using nuget.exe.
+        ///     If this fails, this could mean any number of things (like failed auth). But in normal circumstances, this might
+        ///     mean the package already exists. This either means that we are attempting to push the same package, or attemtping to push
+        ///     a different package with the same id and version. The second case is an error, as azure devops feeds are immutable, the former
+        ///     is simply a case where we should continue onward.
+        /// </remarks>
+        private async Task PushNugetPackageAsync(FeedConfig feedConfig, HttpClient client, PackageArtifactModel packageToPublish,
+            string feedAccount, string feedProject, string feedName)
+        {
+            Log.LogMessage(MessageImportance.High, $"Pushing package '{packageToPublish.Id}' to feed {feedConfig.TargetFeedURL}");
+
+            string localPackageLocation = $"{PackageAssetsBasePath}{packageToPublish.Id}.{packageToPublish.Version}.nupkg";
+            if (!File.Exists(localPackageLocation))
+            {
+                Log.LogError($"Could not locate '{packageToPublish.Id}.{packageToPublish.Version}' at '{localPackageLocation}'");
+                return;
+            }
+
+            // The feed key when pushing to AzDo feeds is "AzureDevOps" (works with the credential helper).
+            int result = await StartProcessAsync(NugetPath, $"push \"{localPackageLocation}\" -Source \"{feedConfig.TargetFeedURL}\" -NonInteractive -ApiKey AzureDevOps");
+            if (result != 0)
+            {
+                Log.LogMessage(MessageImportance.Low, $"Failed to push {localPackageLocation}, attempting to determine whether the package already exists on the feed with the same content.");
+
+                try
+                {
+                    string packageContentUrl = $"https://pkgs.dev.azure.com/{feedAccount}/{feedProject}/_apis/packaging/feeds/{feedName}/nuget/packages/{packageToPublish.Id}/versions/{packageToPublish.Version}/content";
+
+                    if (await IsLocalPackageIdenticalToFeedPackage(localPackageLocation, packageContentUrl, client))
+                    {
+                        Log.LogMessage(MessageImportance.Normal, $"Package '{packageToPublish.Id}@{packageToPublish.Version}' already exists on '{feedConfig.TargetFeedURL}' but has the same content. Skipping.");
+                    }
+                    else
+                    {
+                        Log.LogError($"Package '{packageToPublish.Id}@{packageToPublish.Version}' already exists on '{feedConfig.TargetFeedURL}' with different content.");
+                    }
+
+                    return;
+                }
+                catch (Exception e)
+                {
+                    // This is an error. It means we were unable to push using nuget, and then could not access to the package otherwise.
+                    Log.LogWarning($"Failed to determine whether an existing package on the feed has the same content: {e.Message}");
+                }
+
+                Log.LogError($"Failed to push '{packageToPublish.Id}@{packageToPublish.Version}'. Result code '{result}'.");
+            }
+        }
+
+        /// <summary>
+        ///     Determine whether a local package is the same as a package on an AzDO feed.
+        /// </summary>
+        /// <param name="localPackageFullPath"></param>
+        /// <param name="packageContentUrl"></param>
+        /// <param name="client"></param>
+        /// <returns></returns>
+        /// <remarks>
+        ///     Open a stream to the local file and an http request to the package. There are a couple possibilities:
+        ///     - The returned headers includes a content MD5 header, in which case we can
+        ///       hash the local file and just compare those.
+        ///     - No content MD5 hash, and the streams must be compared in blocks. This is a bit trickier to do efficiently,
+        ///       since we do not necessarily want to read all bytes if we can help it. Thus, we should compare in blocks.  However,
+        ///       the streams make no gaurantee that they will return a full block each time when read operations are performed, so we
+        ///       must be sure to only compare the minimum number of bytes returned.
+        /// </remarks>
+        private async Task<bool> IsLocalPackageIdenticalToFeedPackage(string localPackageFullPath, string packageContentUrl, HttpClient client)
+        {
+            Log.LogMessage($"Getting package content from {packageContentUrl} and comparing to {localPackageFullPath}");
+
+            try
+            {
+                using (Stream localFileStream = File.OpenRead(localPackageFullPath))
+                using (HttpResponseMessage response = await client.GetAsync(packageContentUrl))
+                {
+                    response.EnsureSuccessStatusCode();
+
+                    // Check the headers for content length and md5
+                    bool md5HeaderAvailable = response.Headers.TryGetValues("Content-MD5", out var md5);
+                    bool lengthHeaderAvailable = response.Headers.TryGetValues("Content-Length", out var contentLength);
+
+                    if (lengthHeaderAvailable && long.Parse(contentLength.Single()) != localFileStream.Length)
+                    {
+                        Log.LogMessage(MessageImportance.Low, $"Package '{localPackageFullPath}' has different length than remote package '{packageContentUrl}'.");
+                        return false;
+                    }
+
+                    if (md5HeaderAvailable)
+                    {
+                        var localMD5 = AzureStorageUtils.CalculateMD5(localPackageFullPath);
+                        if (!localMD5.Equals(md5.Single(), StringComparison.OrdinalIgnoreCase))
+                        {
+                            Log.LogMessage(MessageImportance.Low, $"Package '{localPackageFullPath}' has different MD5 hash than remote package '{packageContentUrl}'.");
+                        }
+
+                        return true;
+                    }
+
+                    const int BufferSize = 64 * 1024;
+
+                    // Otherwise, compare the streams
+                    var remoteStream = await response.Content.ReadAsStreamAsync();
+                    return await CompareStreamsAsync(localFileStream, remoteStream, BufferSize);
+                }
+            }
+            catch (Exception e)
+            {
+                // This is an error. It means we were unable to push using nuget, and then could not access to the package otherwise.
+                Log.LogWarning($"Failed to determine whether an existing package on the feed has the same content: {e.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        ///     Compare a local stream and a remote stream for quality
+        /// </summary>
+        /// <param name="localFileStream">Local stream</param>
+        /// <param name="remoteStream">Remote stream</param>
+        /// <param name="bufferSize">Buffer to keep around</param>
+        /// <returns>True if the streams are equal, false otherwise.</returns>
+        public static async Task<bool> CompareStreamsAsync(Stream localFileStream, Stream remoteStream, int bufferSize)
+        {
+            byte[] localBuffer = new byte[bufferSize];
+            byte[] remoteBuffer = new byte[bufferSize];
+            int localBufferWriteOffset = 0;
+            int remoteBufferWriteOffset = 0;
+            int localBufferReadOffset = 0;
+            int remoteBufferReadOffset = 0;
+
+            do
+            {
+                int localBytesToRead = bufferSize - localBufferWriteOffset;
+                int remoteBytesToRead = bufferSize - remoteBufferWriteOffset;
+
+                int bytesRemoteFile = 0;
+                int bytesLocalFile = 0;
+                if (remoteBytesToRead > 0)
+                {
+                    bytesRemoteFile = await remoteStream.ReadAsync(remoteBuffer, remoteBufferWriteOffset, remoteBytesToRead);
+                }
+
+                if (localBytesToRead > 0)
+                {
+                    bytesLocalFile = await localFileStream.ReadAsync(localBuffer, localBufferWriteOffset, localBytesToRead);
+                }
+
+                int bytesLocalAvailable = bytesLocalFile + (localBufferWriteOffset - localBufferReadOffset);
+                int bytesRemoteAvailable = bytesRemoteFile + (remoteBufferWriteOffset - remoteBufferReadOffset);
+                int minBytesAvailable = Math.Min(bytesLocalAvailable, bytesRemoteAvailable);
+
+                if (minBytesAvailable == 0)
+                {
+                    // If there is nothing left to compare (EOS), then good to go.
+                    if (bytesLocalFile == bytesRemoteFile)
+                    {
+                        return true;
+                    }
+                    // One stream reached EOS before the other.
+                    else
+                    {
+                        return false;
+                    }
+                }
+
+                // Compare the minimum number of bytes between the two streams, starting at the offset,
+                // then advance the offsets for the next pass
+                for (int i = 0; i < minBytesAvailable; i++)
+                {
+                    if (remoteBuffer[remoteBufferReadOffset + i] != localBuffer[localBufferReadOffset + i])
+                    {
+                        return false;
+                    }
+                }
+
+                // Advance the offsets. The read offset gets advanced by the amount that we actually compared,
+                // While the write offset gets advanced by the amount each of the streams returned.
+                localBufferReadOffset += minBytesAvailable;
+                remoteBufferReadOffset += minBytesAvailable;
+
+                localBufferWriteOffset += bytesLocalFile;
+                remoteBufferWriteOffset += bytesRemoteFile;
+
+                if (localBufferReadOffset == bufferSize)
+                {
+                    localBufferReadOffset = 0;
+                    localBufferWriteOffset = 0;
+                }
+
+                if (remoteBufferReadOffset == bufferSize)
+                {
+                    remoteBufferReadOffset = 0;
+                    remoteBufferWriteOffset = 0;
+                }
+            }
+            while (true);
         }
 
         private async Task PublishBlobsToAzDoNugetFeedAsync(
@@ -439,29 +843,14 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 await client.Assets.AddAssetLocationToAssetAsync(assetRecord.Id, AddAssetLocationToAssetAssetLocationType.Container, feedConfig.TargetFeedURL);
             }
 
-            await blobFeedAction.PublishToFlatContainerAsync(blobs, maxClients: 8, pushOptions);
+            await blobFeedAction.PublishToFlatContainerAsync(blobs, maxClients: MaxClients, pushOptions);
         }
 
         private BlobFeedAction CreateBlobFeedAction(FeedConfig feedConfig)
         {
-            // Matches package feeds like
-            // https://dotnet-feed-internal.azurewebsites.net/container/dotnet-core-internal/sig/dsdfasdfasdf234234s/se/2020-02-02/darc-int-dotnet-arcade-services-babababababe-08/index.json
-            const string azureStorageProxyFeedPattern =
-                @"(?<feedURL>https://([a-z-]+).azurewebsites.net/container/(?<container>[^/]+)/sig/\w+/se/([0-9]{4}-[0-9]{2}-[0-9]{2})/(?<baseFeedName>darc-(?<type>int|pub)-(?<repository>.+?)-(?<sha>[A-Fa-f0-9]{7,40})-?(?<subversion>\d*)/))index.json";
-
-            // Matches package feeds like the one below. Special case for static internal proxy-backed feed
-            // https://dotnet-feed-internal.azurewebsites.net/container/dotnet-core-internal/sig/dsdfasdfasdf234234s/se/2020-02-02/darc-int-dotnet-arcade-services-babababababe-08/index.json
-            const string azureStorageProxyFeedStaticPattern =
-                @"(?<feedURL>https://([a-z-]+).azurewebsites.net/container/(?<container>[^/]+)/sig/\w+/se/([0-9]{4}-[0-9]{2}-[0-9]{2})/(?<baseFeedName>[^/]+/))index.json";
-
-            // Matches package feeds like
-            // https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-            const string azureStorageStaticBlobFeedPattern =
-                @"https://([a-z-]+).blob.core.windows.net/[^/]+/index.json";
-
-            var proxyBackedFeedMatch = Regex.Match(feedConfig.TargetFeedURL, azureStorageProxyFeedPattern);
-            var proxyBackedStaticFeedMatch = Regex.Match(feedConfig.TargetFeedURL, azureStorageProxyFeedStaticPattern);
-            var azureStorageStaticBlobFeedMatch = Regex.Match(feedConfig.TargetFeedURL, azureStorageStaticBlobFeedPattern);
+            var proxyBackedFeedMatch = Regex.Match(feedConfig.TargetFeedURL, AzureStorageProxyFeedPattern);
+            var proxyBackedStaticFeedMatch = Regex.Match(feedConfig.TargetFeedURL, AzureStorageProxyFeedStaticPattern);
+            var azureStorageStaticBlobFeedMatch = Regex.Match(feedConfig.TargetFeedURL, AzureStorageStaticBlobFeedPattern);
 
             if (proxyBackedFeedMatch.Success || proxyBackedStaticFeedMatch.Success)
             {
@@ -495,6 +884,14 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 return null;
             }
         }
+
+        /// <summary>
+        ///     Infers the category based on the extension of the particular asset
+        ///     
+        ///     If no category can be inferred, then "NETCORE" is used.
+        /// </summary>
+        /// <param name="assetId">ID of asset</param>
+        /// <returns>Asset cateogry</returns>
         private string InferCategory(string assetId)
         {
             var extension = Path.GetExtension(assetId).ToUpper();
@@ -524,13 +921,31 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         }
     }
 
+    public enum FeedType
+    {
+        AzDoNugetFeed,
+        AzureStorageFeed
+    }
+
+    /// <summary>
+    ///     Which assets from the category should be
+    ///     added to the feed.
+    /// </summary>
+    public enum AssetSelection
+    {
+        All,
+        ShippingOnly,
+        NonShippingOnly
+    }
+
     /// <summary>
     /// Hold properties of a target feed endpoint.
     /// </summary>
-    internal class FeedConfig
+    public class FeedConfig
     {
         public string TargetFeedURL { get; set; }
-        public string Type { get; set; }
+        public FeedType Type { get; set; }
         public string FeedKey { get; set; }
+        public AssetSelection AssetSelection { get; set; } = AssetSelection.All;
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -569,7 +569,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             }
             catch (Exception e)
             {
-                Log.LogError($"Unexpected exception pushing package '{packageToPublish.Id}@{packageToPublish.Version}'.");
+                Log.LogError($"Unexpected exception pushing package '{packageToPublish.Id}@{packageToPublish.Version}': {e.Message}");
             }
         }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -676,15 +676,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 if (minBytesAvailable == 0)
                 {
                     // If there is nothing left to compare (EOS), then good to go.
-                    if (bytesLocalFile == bytesRemoteFile)
-                    {
-                        return true;
-                    }
-                    // One stream reached EOS before the other.
-                    else
-                    {
-                        return false;
-                    }
+                    // Otherwise, one stream reached EOS before the other.
+                    return bytesLocalFile == bytesRemoteFile;
                 }
 
                 // Compare the minimum number of bytes between the two streams, starting at the offset,

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/BlobArtifactModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/BlobArtifactModel.cs
@@ -23,6 +23,20 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
             set { Attributes[nameof(Id)] = value; }
         }
 
+        public bool NonShipping
+        {
+            get
+            {
+                string val = Attributes.GetOrDefault(nameof(NonShipping));
+                if (!string.IsNullOrEmpty(val))
+                {
+                    return bool.Parse(val);
+                }
+                return false;
+            }
+            set { Attributes[nameof(NonShipping)] = value.ToString(); }
+        }
+
         public override string ToString() => $"Blob {Id}";
 
         public XElement ToXml() => new XElement(

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/BlobArtifactModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/BlobArtifactModel.cs
@@ -34,7 +34,6 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
                 }
                 return false;
             }
-            set { Attributes[nameof(NonShipping)] = value.ToString(); }
         }
 
         public override string ToString() => $"Blob {Id}";

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/PackageArtifactModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/PackageArtifactModel.cs
@@ -42,6 +42,20 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
             set { Attributes[nameof(OriginBuildName)] = value; }
         }
 
+        public bool NonShipping
+        {
+            get
+            {
+                string val = Attributes.GetOrDefault(nameof(NonShipping));
+                if (!string.IsNullOrEmpty(val))
+                {
+                    return bool.Parse(val);
+                }
+                return false;
+            }
+            set { Attributes[nameof(NonShipping)] = value.ToString(); }
+        }
+
         public override string ToString() => $"Package {Id} {Version}";
 
         public XElement ToXml() => new XElement(

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/PackageArtifactModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/PackageArtifactModel.cs
@@ -53,7 +53,6 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
                 }
                 return false;
             }
-            set { Attributes[nameof(NonShipping)] = value.ToString(); }
         }
 
         public override string ToString() => $"Package {Id} {Version}";


### PR DESCRIPTION
Adds support for Azure DevOps feeds in the feed tasks package. This includes:
- A set of tests for various bits of functionality in the feed tasks package.
- An implementation of stream equality checks in case the package being pushed already exists.
- Various refactorings of the class to make it more robust (e.g. use enums vs. strings)
- Add ability for a feed config to have an "Asset Selection" which can be shipping or non-shipping.