### PR TITLE
Shorten the length of AzDO feeds to 8 chars.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                 if (baseFeedName.Length > MaxLengthForAzDoFeedNames)
                 {
-                    Log.LogError($"The name of the new feed ({baseFeedName}) exceed the maximum feed name size of {MaxLengthForAzDoFeedNames} chars. Aborting feed creation.");
+                    Log.LogError($"The name of the new feed ({baseFeedName}) exceeds the maximum feed name size of 64 chars. Aborting feed creation.");
                     return false;
                 }
 
@@ -124,7 +124,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                             if (versionedFeedName.Length > MaxLengthForAzDoFeedNames)
                             {
-                                Log.LogError($"The name of the new feed ({baseFeedName}) exceed the maximum feed name size of {MaxLengthForAzDoFeedNames} chars. Aborting feed creation.");
+                                Log.LogError($"The name of the new feed ({baseFeedName}) exceeds the maximum feed name size of 64 chars. Aborting feed creation.");
                                 return false;
                             }
                         }


### PR DESCRIPTION
Relates to : #3684 

The maximum allowed size for AzDO feed names is 64 chars. This change makes the AzDO feed creation task to pick up only the first 8 characters from the Commit SHA for the feed name, instead of all 40 characters.