### PR TITLE
Fix newline in failed work item logging

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/CheckHelixJobStatus.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CheckHelixJobStatus.cs
@@ -37,7 +37,8 @@ namespace Microsoft.DotNet.Helix.Sdk
                     var workItemName = failedWorkItem.GetMetadata("WorkItemName");
                     var consoleUri = failedWorkItem.GetMetadata("ConsoleOutputUri");
 
-                    Log.LogError($"Work item {failedWorkItem} in job {jobName} has failed, logs available here:{Environment.NewLine}{consoleUri}{accessTokenSuffix}.");
+                    Log.LogError($"Work item {failedWorkItem} in job {jobName} has failed.");
+                    Log.LogError($"Failure log: {consoleUri}{accessTokenSuffix} .");
                 }
             }
 


### PR DESCRIPTION
I wanted the log link to show up  but the newline made LogError lose everything after the newline.  Just do two LogErrors instead.