### PR TITLE
Skip NuGetRepack tests until they can be stabilized

### DIFF
--- a/src/Microsoft.DotNet.NuGetRepack/tests/ReplacePackagePartsTests.cs
+++ b/src/Microsoft.DotNet.NuGetRepack/tests/ReplacePackagePartsTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Tools.Tests
 {
     public class ReplacePackagePartsTests
     {
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/arcade/issues/3794")]
         public static void ReplaceFile()
         {
             var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());

--- a/src/Microsoft.DotNet.NuGetRepack/tests/VersionUpdaterTests.cs
+++ b/src/Microsoft.DotNet.NuGetRepack/tests/VersionUpdaterTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Tools.Tests
         // the SemVer tests were built on Windows which makes these test only valid for Windows.
         //
         // This can be removed when https://github.com/dotnet/corefx/issues/39931 is fixed. 
-        [WindowsOnlyFact]
+        [WindowsOnlyFact(Skip = "https://github.com/dotnet/arcade/issues/3794")]
         public void TestPackagesSemVer1()
         {
             var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.Tools.Tests
             Directory.Delete(dir, recursive: true);
         }
 
-        [WindowsOnlyFact]
+        [WindowsOnlyFact(Skip = "https://github.com/dotnet/arcade/issues/3794")]
         public void TestPackagesSemVer2()
         {
             var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.Tools.Tests
             Directory.Delete(dir, recursive: true);
         }
 
-        [Fact]
+        [WindowsOnlyFact(Skip = "https://github.com/dotnet/arcade/issues/3794")]
         public void TestValidation()
         {
             var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
@@ -157,7 +157,7 @@ namespace Microsoft.DotNet.Tools.Tests
             Directory.Delete(dir, recursive: true);
         }
 
-        [Fact]
+        [WindowsOnlyFact(Skip = "https://github.com/dotnet/arcade/issues/3794")]
         public void TestDotnetToolValidation()
         {
             var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());


### PR DESCRIPTION
part of https://github.com/dotnet/arcade/issues/3794