### PR TITLE
Workaround some bug in AzDO templates

### DIFF
--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -1,7 +1,10 @@
 parameters:
   overrideParameters: ''                                       # Optional: to override values for parameters.
   additionalParameters: ''                                     # Optional: parameters that need user specific values eg: '-SourceToolsList @("abc","def") -ArtifactToolsList @("ghi","jkl")'
-  continueOnError: false                                       # optional: determines whether to continue the build if the step errors;
+  # There is some sort of bug (has been reported) in Azure DevOps where if this parameter is named
+  # 'continueOnError', the parameter value is not correctly picked up.
+  # This can also be remedied by the caller (post-build.yml) if it does not use a nested parameter
+  sdlContinueOnError: false                                    # optional: determines whether to continue the build if the step errors;
   dependsOn: ''                                                # Optional: dependencies of the job
 
 jobs:
@@ -26,12 +29,12 @@ jobs:
       -InputPath $(Build.SourcesDirectory)\artifacts\BlobArtifacts
       -ExtractPath $(Build.SourcesDirectory)\artifacts\BlobArtifacts
     displayName: Extract Blob Artifacts
-    continueOnError: ${{ parameters.continueOnError }}
+    continueOnError: ${{ parameters.sdlContinueOnError }}
   - powershell: eng/common/sdl/extract-artifact-packages.ps1
       -InputPath $(Build.SourcesDirectory)\artifacts\PackageArtifacts
       -ExtractPath $(Build.SourcesDirectory)\artifacts\PackageArtifacts
     displayName: Extract Package Artifacts
-    continueOnError: ${{ parameters.continueOnError }}
+    continueOnError: ${{ parameters.sdlContinueOnError }}
   - task: NuGetToolInstaller@1
     displayName: 'Install NuGet.exe'
   - task: NuGetCommand@2
@@ -45,7 +48,7 @@ jobs:
   - ${{ if ne(parameters.overrideParameters, '') }}:
     - powershell: eng/common/sdl/execute-all-sdl-tools.ps1 ${{ parameters.overrideParameters }}
       displayName: Execute SDL
-      continueOnError: ${{ parameters.continueOnError }}
+      continueOnError: ${{ parameters.sdlContinueOnError }}
   - ${{ if eq(parameters.overrideParameters, '') }}:
     - powershell: eng/common/sdl/execute-all-sdl-tools.ps1
         -GuardianPackageName Microsoft.Guardian.Cli.0.7.1
@@ -53,4 +56,4 @@ jobs:
         -AzureDevOpsAccessToken $(dn-bot-dotnet-build-rw-code-rw)
         ${{ parameters.additionalParameters }}
       displayName: Execute SDL
-      continueOnError: ${{ parameters.continueOnError }}
+      continueOnError: ${{ parameters.sdlContinueOnError }}


### PR DESCRIPTION
The parameter value for continueOnError was not being properly passed through (ending up as an empty value). After some experimentation, this appears to be a bug that can be worked around in two ways:
- Change the caller (post-build.yml) to not have the 'continueOnError' parameter as a nested parameter
- Chnaging the template itself to not call the parameter name 'continueOnError'.
Note that the "params" nested parameter seems to work just fine. My hunch is that this is becuase the matching template parameter is named different than the caller's parameter.