### PR TITLE
Mistakenly removed the BuildTask.targets import from Feed.Tasks

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj
@@ -15,6 +15,4 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.Build.Tasks.Feed\Microsoft.DotNet.Build.Tasks.Feed.csproj" />
   </ItemGroup>
-
-  <Import Project="$(RepoRoot)eng\BuildTask.targets" />
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -23,4 +23,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.VersionTools\lib\Microsoft.DotNet.VersionTools.csproj" />
   </ItemGroup>
+
+  <Import Project="$(RepoRoot)eng\BuildTask.targets" />
 </Project>


### PR DESCRIPTION
Mistakenly removed the BuildTask.targets import from Feed.Tasks instead of Feed.Tasks.Tests