### PR TITLE
Don't add dummy dependencies to partial packages

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
@@ -590,13 +590,6 @@
       <_harvestFile Include="@(File)" Condition="'%(File.HarvestDependencies)' == 'true' and '%(File.Extension)' == '.dll'" />
       <_missingHarvestFile Include="@(_harvestFile)" Condition="!Exists('%(FullPath)')" />
       <_harvestFile Remove="@(_missingHarvestFile)" Condition="'$(AllowPartialPackages)' == 'true'" />
-
-      <!-- add a fake dependency to represent the dependencies of any missing file
-           this will prevent the package from installing on that platform. -->
-      <FilePackageDependency Include="Unavailable" Condition="'$(AllowPartialPackages)' == 'true' AND '@(_missingHarvestFile)' != '' AND '$(_TargetFramework)' != ''">
-        <TargetFramework>$(_TargetFramework)</TargetFramework>
-        <Version>0.0.0</Version>
-      </FilePackageDependency>
     </ItemGroup>
 
     <!-- Generate package references based on assembly dependencies -->


### PR DESCRIPTION
These dependencies were causing issues because they get copied to
newer/compatible frameworks when we live build the newer/more-specific
thing but are missing the other.

We could better plumb exclusions for these dummy dependencies to maintain
the "fail to install" characteristics, but I don't think it's particularly
interesting to try to force the packages to fail install.  If we're missing
the actual DLL the project will fail to compile.