### PR TITLE
Add safety checks for feeds to the feed tasks package

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
@@ -115,7 +115,7 @@
         TargetURL="$(StaticInternalFeed)/index.json"
         Type="AzureStorageFeed"
         Token="$(AzureStorageAccountKey)"
-        Internal="true" />
+        Internal="$(IsInternalBuild)" />
     </ItemGroup>
 
     <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
@@ -104,7 +104,8 @@
         Include="NetCore;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX"
         TargetURL="$(NewAzDoFeedURL)/index.json"
         Type="AzureStorageFeed"
-        Token="$(AzureStorageAccountKey)" />
+        Token="$(AzureStorageAccountKey)"
+        Isolated="true"/>
     </ItemGroup>
 
     <!-- Assets for non-stable AND Internal builds are published to a static feed for now. -->
@@ -113,7 +114,8 @@
         Include="NetCore;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX"
         TargetURL="$(StaticInternalFeed)/index.json"
         Type="AzureStorageFeed"
-        Token="$(AzureStorageAccountKey)" />
+        Token="$(AzureStorageAccountKey)"
+        Internal="true" />
     </ItemGroup>
 
     <!--

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj
@@ -14,5 +14,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.Build.Tasks.Feed\Microsoft.DotNet.Build.Tasks.Feed.csproj" />
+    <ProjectReference Include="..\Microsoft.DotNet.VersionTools\lib\Microsoft.DotNet.VersionTools.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
             var buildEngine = new MockBuildEngine();
             var task = new PublishArtifactsInManifest
             {
-                // Create a single IMicrosoft.Build.Utilities.TaskItem for a simple feed config, then parse to FeedConfigs and
+                // Create a single Microsoft.Build.Utilities.TaskItem for a simple feed config, then parse to FeedConfigs and
                 // check the expected values.
                 TargetFeedConfig = new Microsoft.Build.Utilities.TaskItem[]
                 {

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -254,7 +254,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         feedConfig.AssetSelection = selection;
                     }
 
-                    // To determine whether a feed is internal, we allow the user to either
+                    // To determine whether a feed is internal, we allow the user to
                     // specify the value explicitly. If that is unset, do an unauthenticated GET
                     // on the feed URL. If it succeeds, the feed is not public. If it fails with a 4* error,
                     // assume it is internal.


### PR DESCRIPTION
This adds some safety checks for feeds. There two types of checks:
- Is this build about to publish internal assets to a public feed. We determine whether a build is public via the IsInternal property passed to publishing, then the feed configs may specify whether feeds are internal or not. By default, they are treated as public. If the value of the internal property is not set on a feed, the code will attempt to do an HTTP get on the feed (all are currently index.json style feeds). If it succeeds, the feed is treated as public. If the error code is in the 400 range, it's treated as internal.
- Is this build about to publish stable (non-prerelease) assets to a non-isolated feed. This is currently only applicable to nuget packages. Determining whether an asset is stable is tough and pretty fuzzy. Some repos may produce "stable" assets with prerelease labels (like 3.0.0-final). The goal here is just to prevent accidental release of final assets early onto public feeds where the assets might need to be overwritten, which may not be possible. Since most (all?) of .NET Core either uses no prerelease label for final assets, or does not use suffix-less version numbers (meaning subsequent builds would have different versions), we simply check whether the version number has a prerelease label. If it does, we treat it as non-stable and allow publishing to non-isolated feeds.

Both checks can be overridden with SkipSafetyChecks