### PR TITLE
Fix assert for empty assemblies

### DIFF
--- a/src/Microsoft.Cci.Extensions/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.Cci.Extensions/Extensions/TypeExtensions.cs
@@ -586,8 +586,10 @@ namespace Microsoft.Cci.Extensions
             if (assembly.GetAllTypes().Any(t => t.Name.Value != "<Module>"))
                 return false;
 
-            Contract.Assert(assembly.ExportedTypes.Any());
-            return true;
+            // Don't assert here -- turns out empty assemblies are a thing.
+            // Contract.Assert(assembly.ExportedTypes.Any());
+
+            return assembly.ExportedTypes.Any();
         }
 
         public static IEnumerable<T> OrderByIdentity<T>(this IEnumerable<T> assemblies)


### PR DESCRIPTION
This fixes a spurious assert that is triggered by empty assemblies.

/cc @ericstj @wtgodbe 

I've marked this as auto-merge because ~~API Reviewer is the only consumer of this extension method.~~ (actually [API Compat](https://github.com/dotnet/arcade/blob/ef139c7533e2e33c5e0946b80cb1aa95d84da868/src/Microsoft.DotNet.ApiCompat/Program.cs#L106) uses it too, but this still feels like goodness)