### PR TITLE
Add more extensions and categories to publish

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -511,6 +511,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 { ".SHA", "CHECKSUM" },
                 { ".POM", "MAVEN" },
                 { ".VSIX", "VSIX" },
+                { ".CAB", "BINARYLAYOUT" },
+                { ".TAR", "BINARYLAYOUT" },
+                { ".GZ", "BINARYLAYOUT" },
+                { ".TGZ", "BINARYLAYOUT" },
+                { ".EXE", "INSTALLER" },
+                { ".SVG", "BADGE"}
             };
 
             if (whichCategory.TryGetValue(extension, out var category))


### PR DESCRIPTION
Saw this while validating #3607

Some common extensions for repos that publish blobs are getting assigned the default category.