### PR TITLE
Adjusting AzDO feed URL format

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
@@ -134,13 +134,14 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
         }
 
         [Theory]
-        [InlineData("https://pkgs.dev.azure.com/dnceng/public/_packaging/mmitche-test-transport/nuget/v3/index.json", "dnceng", "public", "mmitche-test-transport")]
-        [InlineData("https://pkgs.dev.azure.com/DevDiv/public/_packaging/1234.5/nuget/v3/index.json", "DevDiv", "public", "1234.5")]
-        public void NugetFeedParseTests(string uri, string account, string project, string feed)
+        [InlineData("https://pkgs.dev.azure.com/dnceng/public/_packaging/mmitche-test-transport/nuget/v3/index.json", "dnceng", "public/", "mmitche-test-transport")]
+        [InlineData("https://pkgs.dev.azure.com/DevDiv/public/_packaging/1234.5/nuget/v3/index.json", "DevDiv", "public/", "1234.5")]
+        [InlineData("https://pkgs.dev.azure.com/DevDiv/_packaging/1234.5/nuget/v3/index.json", "DevDiv", "", "1234.5")]
+        public void NugetFeedParseTests(string uri, string account, string visibility, string feed)
         {
             var matches = Regex.Match(uri, PublishArtifactsInManifest.AzDoNuGetFeedPattern);
             Assert.Equal(account, matches.Groups["account"]?.Value);
-            Assert.Equal(project, matches.Groups["project"]?.Value);
+            Assert.Equal(visibility, matches.Groups["visibility"]?.Value);
             Assert.Equal(feed, matches.Groups["feed"]?.Value);
         }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
@@ -135,7 +135,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     }
                 } while (needsUniqueName);
 
-                TargetFeedURL = $"https://{AzureDevOpsOrg}.pkgs.visualstudio.com/{publicSegment}_packaging/{baseFeedName}";
+                TargetFeedURL = $"https://pkgs.dev.azure.com/{AzureDevOpsOrg}/{publicSegment}_packaging/{baseFeedName}/nuget/v3/index.json";
                 TargetFeedName = baseFeedName;
 
                 Log.LogMessage(MessageImportance.High, $"Feed '{TargetFeedURL}' created successfully!");

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateInternalBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateInternalBlobFeed.cs
@@ -18,9 +18,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         [Output]
         public string TargetFeedURL { get; set; }
 
-        [Output]
-        public string TargetFeedName { get; set; }
-
         [Required]
         public string RepositoryName { get; set; }
 
@@ -111,7 +108,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 await bfAction.InitAsync();
 
                 TargetFeedURL = $"{AzureDevOpsFeedsBaseUrl}{baseFeedName}";
-                TargetFeedName = baseFeedName;
 
                 Log.LogMessage(MessageImportance.High, $"Feed '{TargetFeedURL}' created successfully!");
             }


### PR DESCRIPTION
Relates to: #3684 

- Turns out that the `public` word in the feed URL isn't really the name of the project, but a qualifier for the feed. 
- Returning the feed URL from CreateAzureDevOpsFeed in the format expected by PublishArtifactsInManifest
- Adding the suffix with "index.json" to the URL returned; to make the YAML code consistent with other cases (will be updated in another PR).
- Handle missing "/" in Publish Nuget Package

Tested this in a few builds, [including this one](https://dnceng.visualstudio.com/internal/_build/results?buildId=334121&view=results).