### PR TITLE
Fix Perf template for internal runs

### DIFF
--- a/eng/common/performance/performance-setup.ps1
+++ b/eng/common/performance/performance-setup.ps1
@@ -17,7 +17,7 @@ Param(
     [string] $Configurations="CompilationMode=$CompilationMode"
 )
 
-$RunFromPerformanceRepo = ($Repository -eq "dotnet/performance")
+$RunFromPerformanceRepo = ($Repository -eq "dotnet/performance") -or ($Repository -eq "dotnet-performance")
 $UseCoreRun = ($CoreRootDirectory -ne [string]::Empty)
 $UseBaselineCoreRun = ($BaselineCoreRootDirectory -ne [string]::Empty)
 

--- a/eng/common/performance/performance-setup.sh
+++ b/eng/common/performance/performance-setup.sh
@@ -113,7 +113,7 @@ while (($# > 0)); do
   esac
 done
 
-if [[ "$repository" == "dotnet/performance" ]]; then
+if [ "$repository" == "dotnet/performance" ] || [ "$repository" == "dotnet-performance" ]; then
     run_from_perf_repo=true
 fi
 

--- a/eng/common/templates/job/performance.yml
+++ b/eng/common/templates/job/performance.yml
@@ -5,6 +5,7 @@ parameters:
   displayName: ''                 # optional -- display name for the job. Will use jobName if not passed
   pool: ''                        # required -- name of the Build pool
   container: ''                   # required -- name of the container
+  osGroup: ''                     # required -- operating system for the job
   extraSetupParameters: ''        # optional -- extra arguments to pass to the setup script
   frameworks: ['netcoreapp3.0']   # optional -- list of frameworks to run against
   continueOnError: 'false'        # optional -- determines whether to continue the build if the step errors
@@ -44,12 +45,13 @@ jobs:
         - HelixPreCommand: ''
 
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-          - ${{ if eq(variables['Agent.Os'], 'Windows_NT') }}:
+          - ${{ if eq( parameters.osGroup, 'Windows_NT') }}:
             - HelixPreCommand: 'set "PERFLAB_UPLOAD_TOKEN=$(PerfCommandUploadToken)"'
             - IsInternal: -Internal
-          - ${{ if ne(variables['Agent.Os'], 'Windows_NT') }}:
+          - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
             - HelixPreCommand: 'export PERFLAB_UPLOAD_TOKEN="$(PerfCommandUploadTokenLinux)"'
             - IsInternal: --internal
+            
           - group: DotNet-HelixApi-Access
           - group: dotnet-benchview
 


### PR DESCRIPTION
We shouldn't use Agent.Os to determine if we are running on windows or linux, and the name of the performance repo on internal jobs is dotnet-performance, so fix those two things to fix internal builds.