### PR TITLE
Add extensions needed by aspnetcore

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -1113,7 +1113,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 { ".GZ", "BINARYLAYOUT" },
                 { ".TGZ", "BINARYLAYOUT" },
                 { ".EXE", "INSTALLER" },
-                { ".SVG", "BADGE"}
+                { ".SVG", "BADGE"},
+                { ".WIXLIB", "INSTALLER" },
+                { ".JAR", "INSTALLER" },
+                { ".VERSION", "INSTALLER"},
+                { ".SWR", "INSTALLER" }
             };
 
             if (whichCategory.TryGetValue(extension, out var category))


### PR DESCRIPTION
Another piece of https://github.com/dotnet/arcade/issues/3607

I believe this is the last set of file extensions we were missing.

