### PR TITLE
Use the right channel ID for the 3.1 dev channel

### DIFF
--- a/eng/common/templates/post-build/common-variables.yml
+++ b/eng/common/templates/post-build/common-variables.yml
@@ -8,7 +8,7 @@ variables:
 
   # .NET Core 3.1 Dev
   - name: PublicDevRelease_31_Channel_Id
-    value: 260
+    value: 128
 
   # .NET Core 5 Dev
   - name: NetCore_5_Dev_Channel_Id


### PR DESCRIPTION
Made a mistake in https://github.com/dotnet/arcade/pull/3832 and used the wrong channel ID.