### PR TITLE
Add blname parameter to build scripts

### DIFF
--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -5,6 +5,7 @@ Param(
   [string] $projects,
   [string][Alias('v')]$verbosity = "minimal",
   [string] $msbuildEngine = $null,
+  [string] $blname = $null,
   [bool] $warnAsError = $true,
   [bool] $nodeReuse = $true,
   [switch][Alias('r')]$restore,
@@ -33,6 +34,7 @@ function Print-Usage() {
     Write-Host "  -platform <value>       Platform configuration: 'x86', 'x64' or any valid Platform value to pass to msbuild"
     Write-Host "  -verbosity <value>      Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
     Write-Host "  -binaryLog              Output binary log (short: -bl)"
+    Write-Host "  -blname <value>         Output binary log with the given name"
     Write-Host "  -help                   Print help and exit"
     Write-Host ""
 
@@ -78,7 +80,15 @@ function Build {
   $toolsetBuildProj = InitializeToolset
   InitializeCustomToolset
 
-  $bl = if ($binaryLog) { "/bl:" + (Join-Path $LogDir "Build.binlog") } else { "" }
+  $bl = if ($binaryLog) {
+    $name = "Build.binlog"
+    if ($blname)
+    {
+      $name = $blname
+    }
+    "/bl:" + (Join-Path $LogDir $name)
+  }
+  else { "" }
   $platformArg = if ($platform) { "/p:Platform=$platform" } else { "" }
 
   if ($projects) {
@@ -117,6 +127,11 @@ try {
   if ($ci) {
     $binaryLog = $true
     $nodeReuse = $false
+  }
+
+  if ($blname)
+  {
+    $binaryLog = $true
   }
 
   # Import custom tools configuration, if present in the repo.

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -13,6 +13,7 @@ usage()
   echo "  --configuration <value>    Build configuration: 'Debug' or 'Release' (short: -c)"
   echo "  --verbosity <value>        Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
   echo "  --binaryLog                Create MSBuild binary log (short: -bl)"
+  echo "  --blname <value>           Create MSBuild binary log with the given name"
   echo "  --help                     Print help and exit (short: -h)"
   echo ""
 
@@ -72,6 +73,7 @@ projects=''
 configuration='Debug'
 prepare_machine=false
 verbosity='minimal'
+binary_log_name=''
 
 properties=''
 
@@ -88,6 +90,11 @@ while [[ $# > 0 ]]; do
       ;;
     -verbosity|-v)
       verbosity=$2
+      shift
+      ;;
+    -blname)
+      binary_log_name=$2
+      binary_log=true
       shift
       ;;
     -binarylog|-bl)
@@ -175,7 +182,11 @@ function Build {
 
   local bl=""
   if [[ "$binary_log" == true ]]; then
-    bl="/bl:\"$log_dir/Build.binlog\""
+    local name="Build.binlog"
+    if [[ ! -z "$binary_log_name" ]]; then
+      name="$binary_log_name"
+    fi
+    bl="/bl:\"$log_dir/$name\""
   fi
 
   MSBuild $_InitializeToolset \


### PR DESCRIPTION
Currently, when the `-bl` flag or `-ci` flag is passed, there is no way to override the binary log name that is produced. The only way to do so, is to add an extra /bl:PathToBinlog, at the end of the script, where in the yaml files or elsewhere you need to hard code the path to the log dir, in order for arcade's step to publish logs to artifacts to be able to find it. 

With this change, if -blname is passed, a binlog is created in the log dir, with the given name.

cc: @ViktorHofer 