### PR TITLE
Produce a non-stable version if package is non-shipping

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
@@ -4,15 +4,15 @@
 
   <!--
     Specification: https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md
-    
+
     Workaround for https://github.com/dotnet/sdk/issues/3173:
     The following must be evaluated after the project file is imported but before Microsoft.NET.DefaultAssemblyInfo.targets from .NET Core SDK is imported.
     The project may set VersionPrefix, MajorVersion, MinorVersion, or AutoGenerateAssemblyVersion properties, which are consumed below.
     Microsoft.NET.DefaultAssemblyInfo.targets consumes VersionPrefix property, which may be set below.
   -->
 
-  <!-- 
-    Version numbers calculated here are date-based. In official builds this is given by OfficialBuildId parameter, 
+  <!--
+    Version numbers calculated here are date-based. In official builds this is given by OfficialBuildId parameter,
     but other builds do not have such input and would therefore be non-deterministic.
   -->
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true' or '$(DotNetUseShippingVersions)' == 'true'">
@@ -38,7 +38,7 @@
     <!-- REVISION := r -->
     <VersionSuffixBuildOfTheDay>$(_BuildNumberR)</VersionSuffixBuildOfTheDay>
     <VersionSuffixBuildOfTheDayPadded>$(VersionSuffixBuildOfTheDay.PadLeft(2, $([System.Convert]::ToChar(`0`))))</VersionSuffixBuildOfTheDayPadded>
-  
+
     <!-- PATCH_NUMBER := (SHORT_DATE - VersionBaseShortDate) * 100 + r -->
     <_PatchNumber>$([MSBuild]::Add($([MSBuild]::Multiply($([MSBuild]::Subtract($(VersionSuffixDateStamp), $([MSBuild]::ValueOrDefault($(VersionBaseShortDate), 19000)))), 100)), $(_BuildNumberR)))</_PatchNumber>
   </PropertyGroup>
@@ -57,8 +57,8 @@
   </PropertyGroup>
 
   <!--
-    If a package is designated to be a release-only package (PreReleaseVersionLabel is empty) its package version does 
-    not include any pre-release labels in official build. The 3rd component of the version prefix is overwritten either 
+    If a package is designated to be a release-only package (PreReleaseVersionLabel is empty) its package version does
+    not include any pre-release labels in official build. The 3rd component of the version prefix is overwritten either
     by PATCH_NUMBER or '0' in non-official builds.
   -->
   <PropertyGroup Condition="'$(PreReleaseVersionLabel)' == ''">
@@ -78,7 +78,7 @@
 
     <_BuildNumberLabels Condition="'$(VersionSuffixDateStamp)' != '' and '$(SemanticVersioningV1)' != 'true'">.$(VersionSuffixDateStamp).$(VersionSuffixBuildOfTheDay)</_BuildNumberLabels>
     <_BuildNumberLabels Condition="'$(VersionSuffixDateStamp)' != '' and '$(SemanticVersioningV1)' == 'true'">-$(VersionSuffixDateStamp)-$(VersionSuffixBuildOfTheDayPadded)</_BuildNumberLabels>
-    
+
     <!--
       If DotNetFinalVersionKind is specified, overrides the package version produced by the build like so:
         ""           1.2.3-beta.12345.67
@@ -93,10 +93,15 @@
     <!--
       Some projects want to remain producing prerelease packages even if we are doing a final stable build because
       they don't ship or aren't ready to ship stable. Those projects can set SuppressFinalPackageVersion property to true.
-      
+
       TODO: BlockStable is obsolete. Remove once repos update. https://github.com/dotnet/arcade/issues/1213
     -->
     <VersionSuffix Condition="'$(BlockStable)' == 'true' or '$(SuppressFinalPackageVersion)' == 'true'">$(_PreReleaseLabel)$(_BuildNumberLabels)</VersionSuffix>
+
+    <!--
+      If a project produces non-shipping packages, these packages should always include the build number label
+    -->
+    <VersionSuffix Condition="'$(IsShipping)' == 'false'">$(_PreReleaseLabel)$(_BuildNumberLabels)</VersionSuffix>
 
     <!--
       Disable NuGet Pack warning that the version is SemVer 2.0.
@@ -113,7 +118,7 @@
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
-  <!-- 
+  <!--
     Workaround for https://github.com/dotnet/sdk/issues/3173.
     Overwrite the value of Version set in Microsoft.NET.DefaultAssemblyInfo.targets.
   -->


### PR DESCRIPTION
If a package is non-shipping (IsShipping=false). We should always produce a non-stabilized version. This was missed in the current versioning implementation