### PR TITLE
Remove Gather drop for now

### DIFF
--- a/eng/common/templates/post-build/channels/netcore-dev-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-30.yml
@@ -149,10 +149,6 @@ stages:
             filePath: $(Build.SourcesDirectory)/eng/common/post-build/symbols-validation.ps1
             arguments: -InputPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/ -ExtractPath $(Agent.BuildDirectory)/Temp/ -DotnetSymbolVersion $(SymbolToolVersion)
 
-  - template: ../darc-gather-drop.yml
-    parameters:
-      ChannelId: ${{ variables.PublicDevRelease_30_Channel_Id }}
-
-  - template: ../promote-build.yml
+   - template: ../promote-build.yml
     parameters:
       ChannelId: ${{ variables.PublicDevRelease_30_Channel_Id }}

--- a/eng/common/templates/post-build/channels/netcore-dev-31.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-31.yml
@@ -149,10 +149,6 @@ stages:
             filePath: $(Build.SourcesDirectory)/eng/common/post-build/symbols-validation.ps1
             arguments: -InputPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/ -ExtractPath $(Agent.BuildDirectory)/Temp/ -DotnetSymbolVersion $(SymbolToolVersion)
 
-  - template: ../darc-gather-drop.yml
-    parameters:
-      ChannelId: ${{ variables.PublicDevRelease_31_Channel_Id }}
-
   - template: ../promote-build.yml
     parameters:
       ChannelId: ${{ variables.PublicDevRelease_31_Channel_Id }}

--- a/eng/common/templates/post-build/channels/netcore-dev-5.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-5.yml
@@ -149,10 +149,6 @@ stages:
             filePath: $(Build.SourcesDirectory)/eng/common/post-build/symbols-validation.ps1
             arguments: -InputPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/ -ExtractPath $(Agent.BuildDirectory)/Temp/ -DotnetSymbolVersion $(SymbolToolVersion)
 
-  - template: ../darc-gather-drop.yml
-    parameters:
-      ChannelId: ${{ variables.NetCore_5_Dev_Channel_Id }}
-
   - template: ../promote-build.yml
     parameters:
       ChannelId: ${{ variables.NetCore_5_Dev_Channel_Id }}

--- a/eng/common/templates/post-build/channels/netcore-tools-latest.yml
+++ b/eng/common/templates/post-build/channels/netcore-tools-latest.yml
@@ -155,10 +155,6 @@ stages:
             filePath: $(Build.SourcesDirectory)/eng/common/post-build/symbols-validation.ps1
             arguments: -InputPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/ -ExtractPath $(Agent.BuildDirectory)/Temp/ -DotnetSymbolVersion $(SymbolToolVersion)
 
-  - template: ../darc-gather-drop.yml
-    parameters:
-      ChannelId: ${{ variables.NetCore_Tools_Latest_Channel_Id }}
-
   - template: ../promote-build.yml
     parameters:
       ChannelId: ${{ variables.NetCore_Tools_Latest_Channel_Id }}

--- a/eng/common/templates/post-build/channels/public-validation-release.yml
+++ b/eng/common/templates/post-build/channels/public-validation-release.yml
@@ -94,10 +94,6 @@ stages:
   jobs:
   - template: ../setup-maestro-vars.yml
 
-  - template: ../darc-gather-drop.yml
-    parameters:
-      ChannelId: ${{ variables.PublicValidationRelease_30_Channel_Id }}
-
   - template: ../promote-build.yml
     parameters:
       ChannelId: ${{ variables.PublicValidationRelease_30_Channel_Id }}


### PR DESCRIPTION
Disable `darc gather drop` for now because:

- It doesn't support yet downloading packages from AzDO feeds. PR is on the way the the fix but it'll require an Maestro roll out. PR to fix is here: https://github.com/dotnet/arcade-services/pull/622/files
- Not all branches were running it anyway.