### PR TITLE
Make sdk-tasks.ps1 upload binlog

### DIFF
--- a/eng/common/pipeline-logging-functions.ps1
+++ b/eng/common/pipeline-logging-functions.ps1
@@ -89,6 +89,22 @@ function Write-PipelineTaskError {
       }
   }
   
+  function Write-PipelinePublishArtifact {
+    [CmdletBinding()]
+    param(
+      [Parameter(Mandatory = $true)]
+      [string]$ArtifactSourcePath,
+      [Parameter(Mandatory = $true)]
+      [string]$TargetArtifactName,
+      [switch]$AsOutput
+    )
+    if($ci) {
+      Write-LoggingCommand -Area 'artifact' -Event 'upload' -Data $ArtifactSourcePath -Properties @{
+        'artifactName' = $TargetArtifactName
+      } -AsOutput:$AsOutput  
+    }
+  }
+
   function Write-PipelinePrependPath {
     [CmdletBinding()]
     param(

--- a/eng/common/pipeline-logging-functions.ps1
+++ b/eng/common/pipeline-logging-functions.ps1
@@ -13,238 +13,238 @@ $script:loggingCommandEscapeMappings = @( # TODO: WHAT ABOUT "="? WHAT ABOUT "%"
 # TODO: Add test to verify don't need to escape "=".
 
 function Write-PipelineTelemetryError {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$Category,
-        [Parameter(Mandatory = $true)]
-        [string]$Message,
-        [Parameter(Mandatory = $false)]
-        [string]$Type = 'error',
-        [string]$ErrCode,
-        [string]$SourcePath,
-        [string]$LineNumber,
-        [string]$ColumnNumber,
-        [switch]$AsOutput)
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Category,
+    [Parameter(Mandatory = $true)]
+    [string]$Message,
+    [Parameter(Mandatory = $false)]
+    [string]$Type = 'error',
+    [string]$ErrCode,
+    [string]$SourcePath,
+    [string]$LineNumber,
+    [string]$ColumnNumber,
+    [switch]$AsOutput)
 
-        $PSBoundParameters.Remove("Category") | Out-Null
+  $PSBoundParameters.Remove("Category") | Out-Null
 
-        $Message = "(NETCORE_ENGINEERING_TELEMETRY=$Category) $Message"
-        $PSBoundParameters.Remove("Message") | Out-Null
-        $PSBoundParameters.Add("Message", $Message)
+  $Message = "(NETCORE_ENGINEERING_TELEMETRY=$Category) $Message"
+  $PSBoundParameters.Remove("Message") | Out-Null
+  $PSBoundParameters.Add("Message", $Message)
 
-        Write-PipelineTaskError @PSBoundParameters
+  Write-PipelineTaskError @PSBoundParameters
 }
 
 function Write-PipelineTaskError {
-    [CmdletBinding()]
-    param(
-      [Parameter(Mandatory = $true)]
-      [string]$Message,
-      [Parameter(Mandatory = $false)]
-      [string]$Type = 'error',
-      [string]$ErrCode,
-      [string]$SourcePath,
-      [string]$LineNumber,
-      [string]$ColumnNumber,
-      [switch]$AsOutput)
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Message,
+    [Parameter(Mandatory = $false)]
+    [string]$Type = 'error',
+    [string]$ErrCode,
+    [string]$SourcePath,
+    [string]$LineNumber,
+    [string]$ColumnNumber,
+    [switch]$AsOutput)
   
-      if(!$ci) {
-        if($Type -eq 'error') {
-          Write-Host $Message -ForegroundColor Red
-          return
-        }
-        elseif ($Type -eq 'warning') {
-          Write-Host $Message -ForegroundColor Yellow
-          return
-        }
-      }
-  
-      if(($Type -ne 'error') -and ($Type -ne 'warning')) {
-        Write-Host $Message
-        return
-      }
-      if(-not $PSBoundParameters.ContainsKey('Type')) {
-        $PSBoundParameters.Add('Type', 'error')
-      }
-      Write-LogIssue @PSBoundParameters
-  }
-  
-  function Write-PipelineSetVariable {
-    [CmdletBinding()]
-    param(
-      [Parameter(Mandatory = $true)]
-      [string]$Name,
-      [string]$Value,
-      [switch]$Secret,
-      [switch]$AsOutput,
-      [bool]$IsMultiJobVariable=$true)
-
-      if($ci) {
-        Write-LoggingCommand -Area 'task' -Event 'setvariable' -Data $Value -Properties @{
-          'variable' = $Name
-          'isSecret' = $Secret
-          'isOutput' = $IsMultiJobVariable
-        } -AsOutput:$AsOutput
-      }
-  }
-  
-  function Write-PipelinePublishArtifact {
-    [CmdletBinding()]
-    param(
-      [Parameter(Mandatory = $true)]
-      [string]$ArtifactSourcePath,
-      [Parameter(Mandatory = $true)]
-      [string]$TargetArtifactName,
-      [switch]$AsOutput
-    )
-    if($ci) {
-      Write-LoggingCommand -Area 'artifact' -Event 'upload' -Data $ArtifactSourcePath -Properties @{
-        'artifactName' = $TargetArtifactName
-      } -AsOutput:$AsOutput  
+  if(!$ci) {
+    if($Type -eq 'error') {
+      Write-Host $Message -ForegroundColor Red
+      return
+    }
+    elseif ($Type -eq 'warning') {
+      Write-Host $Message -ForegroundColor Yellow
+      return
     }
   }
-
-  function Write-PipelinePrependPath {
-    [CmdletBinding()]
-    param(
-      [Parameter(Mandatory=$true)]
-      [string]$Path,
-      [switch]$AsOutput)
-      if($ci) {
-        Write-LoggingCommand -Area 'task' -Event 'prependpath' -Data $Path -AsOutput:$AsOutput
-      }
+  
+  if(($Type -ne 'error') -and ($Type -ne 'warning')) {
+    Write-Host $Message
+    return
   }
+  if(-not $PSBoundParameters.ContainsKey('Type')) {
+    $PSBoundParameters.Add('Type', 'error')
+  }
+  Write-LogIssue @PSBoundParameters
+}
+  
+function Write-PipelineSetVariable {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name,
+    [string]$Value,
+    [switch]$Secret,
+    [switch]$AsOutput,
+    [bool]$IsMultiJobVariable=$true)
+
+  if($ci) {
+    Write-LoggingCommand -Area 'task' -Event 'setvariable' -Data $Value -Properties @{
+      'variable' = $Name
+      'isSecret' = $Secret
+      'isOutput' = $IsMultiJobVariable
+    } -AsOutput:$AsOutput
+  }
+}
+  
+function Write-PipelineArtifactUpload {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$SourcePath,
+    [Parameter(Mandatory = $true)]
+    [string]$TargetName,
+    [switch]$AsOutput
+  )
+  if($ci) {
+    Write-LoggingCommand -Area 'artifact' -Event 'upload' -Data $SourcePath -Properties @{
+      'artifactName' = $TargetName
+    } -AsOutput:$AsOutput  
+  }
+}
+
+function Write-PipelinePrependPath {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory=$true)]
+    [string]$Path,
+    [switch]$AsOutput)
+  if($ci) {
+    Write-LoggingCommand -Area 'task' -Event 'prependpath' -Data $Path -AsOutput:$AsOutput
+  }
+}
 
 <########################################
 # Private functions.
 ########################################>
 function Format-LoggingCommandData {
-    [CmdletBinding()]
-    param([string]$Value, [switch]$Reverse)
+  [CmdletBinding()]
+  param([string]$Value, [switch]$Reverse)
 
-    if (!$Value) {
-        return ''
+  if (!$Value) {
+    return ''
+  }
+
+  if (!$Reverse) {
+    foreach ($mapping in $script:loggingCommandEscapeMappings) {
+      $Value = $Value.Replace($mapping.Token, $mapping.Replacement)
     }
-
-    if (!$Reverse) {
-        foreach ($mapping in $script:loggingCommandEscapeMappings) {
-            $Value = $Value.Replace($mapping.Token, $mapping.Replacement)
-        }
-    } else {
-        for ($i = $script:loggingCommandEscapeMappings.Length - 1 ; $i -ge 0 ; $i--) {
-            $mapping = $script:loggingCommandEscapeMappings[$i]
-            $Value = $Value.Replace($mapping.Replacement, $mapping.Token)
-        }
+  } else {
+    for ($i = $script:loggingCommandEscapeMappings.Length - 1 ; $i -ge 0 ; $i--) {
+     $mapping = $script:loggingCommandEscapeMappings[$i]
+     $Value = $Value.Replace($mapping.Replacement, $mapping.Token)
     }
+  }
 
-    return $Value
+  return $Value
 }
 
 function Format-LoggingCommand {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$Area,
-        [Parameter(Mandatory = $true)]
-        [string]$Event,
-        [string]$Data,
-        [hashtable]$Properties)
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Area,
+    [Parameter(Mandatory = $true)]
+    [string]$Event,
+    [string]$Data,
+    [hashtable]$Properties)
 
-    # Append the preamble.
-    [System.Text.StringBuilder]$sb = New-Object -TypeName System.Text.StringBuilder
-    $null = $sb.Append($script:loggingCommandPrefix).Append($Area).Append('.').Append($Event)
+  # Append the preamble.
+  [System.Text.StringBuilder]$sb = New-Object -TypeName System.Text.StringBuilder
+  $null = $sb.Append($script:loggingCommandPrefix).Append($Area).Append('.').Append($Event)
 
-    # Append the properties.
-    if ($Properties) {
-        $first = $true
-        foreach ($key in $Properties.Keys) {
-            [string]$value = Format-LoggingCommandData $Properties[$key]
-            if ($value) {
-                if ($first) {
-                    $null = $sb.Append(' ')
-                    $first = $false
-                } else {
-                    $null = $sb.Append(';')
-                }
-
-                $null = $sb.Append("$key=$value")
-            }
+  # Append the properties.
+  if ($Properties) {
+    $first = $true
+    foreach ($key in $Properties.Keys) {
+      [string]$value = Format-LoggingCommandData $Properties[$key]
+      if ($value) {
+        if ($first) {
+          $null = $sb.Append(' ')
+          $first = $false
+        } else {
+          $null = $sb.Append(';')
         }
-    }
 
-    # Append the tail and output the value.
-    $Data = Format-LoggingCommandData $Data
-    $sb.Append(']').Append($Data).ToString()
+        $null = $sb.Append("$key=$value")
+      }
+    }
+  }
+
+  # Append the tail and output the value.
+  $Data = Format-LoggingCommandData $Data
+  $sb.Append(']').Append($Data).ToString()
 }
 
 function Write-LoggingCommand {
-    [CmdletBinding(DefaultParameterSetName = 'Parameters')]
-    param(
-        [Parameter(Mandatory = $true, ParameterSetName = 'Parameters')]
-        [string]$Area,
-        [Parameter(Mandatory = $true, ParameterSetName = 'Parameters')]
-        [string]$Event,
-        [Parameter(ParameterSetName = 'Parameters')]
-        [string]$Data,
-        [Parameter(ParameterSetName = 'Parameters')]
-        [hashtable]$Properties,
-        [Parameter(Mandatory = $true, ParameterSetName = 'Object')]
-        $Command,
-        [switch]$AsOutput)
+  [CmdletBinding(DefaultParameterSetName = 'Parameters')]
+  param(
+    [Parameter(Mandatory = $true, ParameterSetName = 'Parameters')]
+    [string]$Area,
+    [Parameter(Mandatory = $true, ParameterSetName = 'Parameters')]
+    [string]$Event,
+    [Parameter(ParameterSetName = 'Parameters')]
+    [string]$Data,
+    [Parameter(ParameterSetName = 'Parameters')]
+    [hashtable]$Properties,
+    [Parameter(Mandatory = $true, ParameterSetName = 'Object')]
+    $Command,
+    [switch]$AsOutput)
 
-    if ($PSCmdlet.ParameterSetName -eq 'Object') {
-        Write-LoggingCommand -Area $Command.Area -Event $Command.Event -Data $Command.Data -Properties $Command.Properties -AsOutput:$AsOutput
-        return
-    }
+  if ($PSCmdlet.ParameterSetName -eq 'Object') {
+    Write-LoggingCommand -Area $Command.Area -Event $Command.Event -Data $Command.Data -Properties $Command.Properties -AsOutput:$AsOutput
+    return
+  }
 
-    $command = Format-LoggingCommand -Area $Area -Event $Event -Data $Data -Properties $Properties
-    if ($AsOutput) {
-        $command
-    } else {
-        Write-Host $command
-    }
+  $command = Format-LoggingCommand -Area $Area -Event $Event -Data $Data -Properties $Properties
+  if ($AsOutput) {
+    $command
+  } else {
+    Write-Host $command
+  }
 }
 
 function Write-LogIssue {
-    [CmdletBinding()]
-    param(
-        [ValidateSet('warning', 'error')]
-        [Parameter(Mandatory = $true)]
-        [string]$Type,
-        [string]$Message,
-        [string]$ErrCode,
-        [string]$SourcePath,
-        [string]$LineNumber,
-        [string]$ColumnNumber,
-        [switch]$AsOutput)
+  [CmdletBinding()]
+  param(
+    [ValidateSet('warning', 'error')]
+    [Parameter(Mandatory = $true)]
+    [string]$Type,
+    [string]$Message,
+    [string]$ErrCode,
+    [string]$SourcePath,
+    [string]$LineNumber,
+    [string]$ColumnNumber,
+    [switch]$AsOutput)
 
-    $command = Format-LoggingCommand -Area 'task' -Event 'logissue' -Data $Message -Properties @{
-            'type' = $Type
-            'code' = $ErrCode
-            'sourcepath' = $SourcePath
-            'linenumber' = $LineNumber
-            'columnnumber' = $ColumnNumber
-        }
-    if ($AsOutput) {
-        return $command
+  $command = Format-LoggingCommand -Area 'task' -Event 'logissue' -Data $Message -Properties @{
+    'type' = $Type
+    'code' = $ErrCode
+    'sourcepath' = $SourcePath
+    'linenumber' = $LineNumber
+    'columnnumber' = $ColumnNumber
+  }
+  if ($AsOutput) {
+    return $command
+  }
+
+  if ($Type -eq 'error') {
+    $foregroundColor = $host.PrivateData.ErrorForegroundColor
+    $backgroundColor = $host.PrivateData.ErrorBackgroundColor
+    if ($foregroundColor -isnot [System.ConsoleColor] -or $backgroundColor -isnot [System.ConsoleColor]) {
+      $foregroundColor = [System.ConsoleColor]::Red
+      $backgroundColor = [System.ConsoleColor]::Black
     }
-
-    if ($Type -eq 'error') {
-        $foregroundColor = $host.PrivateData.ErrorForegroundColor
-        $backgroundColor = $host.PrivateData.ErrorBackgroundColor
-        if ($foregroundColor -isnot [System.ConsoleColor] -or $backgroundColor -isnot [System.ConsoleColor]) {
-            $foregroundColor = [System.ConsoleColor]::Red
-            $backgroundColor = [System.ConsoleColor]::Black
-        }
-    } else {
-        $foregroundColor = $host.PrivateData.WarningForegroundColor
-        $backgroundColor = $host.PrivateData.WarningBackgroundColor
-        if ($foregroundColor -isnot [System.ConsoleColor] -or $backgroundColor -isnot [System.ConsoleColor]) {
-            $foregroundColor = [System.ConsoleColor]::Yellow
-            $backgroundColor = [System.ConsoleColor]::Black
-        }
+  } else {
+    $foregroundColor = $host.PrivateData.WarningForegroundColor
+    $backgroundColor = $host.PrivateData.WarningBackgroundColor
+    if ($foregroundColor -isnot [System.ConsoleColor] -or $backgroundColor -isnot [System.ConsoleColor]) {
+      $foregroundColor = [System.ConsoleColor]::Yellow
+      $backgroundColor = [System.ConsoleColor]::Black
     }
+  }
 
-    Write-Host $command -ForegroundColor $foregroundColor -BackgroundColor $backgroundColor
+  Write-Host $command -ForegroundColor $foregroundColor -BackgroundColor $backgroundColor
 }

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -49,7 +49,7 @@ function Build([string]$target, [string]$binlogSuffix, [string]$logFolder) {
       @properties
   }
   finally {
-    Write-PipelinePublishArtifact -ArtifactSourcePath $log -TargetArtifactName $logFolder
+    Write-PipelineArtifactUpload -ArtifactSourcePath $log -TargetArtifactName $logFolder
   }
 }
 


### PR DESCRIPTION
Closes: https://github.com/dotnet/arcade/issues/3687

Make sdk-task.ps1 optionally upload the produced binlog to an specific azdo artifact folder.

Tested this in a few builds. Take a look here for an example: https://dnceng.visualstudio.com/internal/_build/results?buildId=339907&view=results . See the 'artifact folder' CesarLogsFolder