### PR TITLE
Fix feed url to match expected regex

### DIFF
--- a/eng/common/templates/post-build/common-variables.yml
+++ b/eng/common/templates/post-build/common-variables.yml
@@ -57,7 +57,7 @@ variables:
 
   # Configuration for the feed where packages from internal non-stable builds will be published to
   - name: StaticInternalFeed
-    value: 'https://dnceng.pkgs.visualstudio.com/_packaging/dotnet-core-internal/nuget/v3/index.json'
+    value: https://pkgs.dev.azure.com/dnceng/_packaging/dotnet-core-internal/nuget/v3/index.json
 
   # Default locations for Installers and checksums
   # Public Locations


### PR DESCRIPTION
Bug found during the testing for https://github.com/dotnet/arcade/issues/3868

The previous feed URL didn't match the regex. This URL points to the same feed and conforms to what we expect.

Test build that has this change and was able to publish to the feed: https://dev.azure.com/dnceng/internal/_build/results?buildId=341374&view=results