### PR TITLE
Add support for relative project-paths in build.ps1

### DIFF
--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -85,6 +85,12 @@ function Build {
     # Re-assign properties to a new variable because PowerShell doesn't let us append properties directly for unclear reasons.
     # Explicitly set the type as string[] because otherwise PowerShell would make this char[] if $properties is empty.
     [string[]] $msbuildArgs = $properties
+    
+    # Resolve relative project paths into full paths 
+    # Multiple projects can be specified by delimiting them with semi-colons - obtain the 
+    #   individual paths, resolve them, and splice them back into a single semi-colon delimited list. 
+    $projects = ($projects.Split(';').ForEach({Resolve-Path $_}) -join ';')
+    
     $msbuildArgs += "/p:Projects=$projects"
     $properties = $msbuildArgs
   }

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -87,8 +87,6 @@ function Build {
     [string[]] $msbuildArgs = $properties
     
     # Resolve relative project paths into full paths 
-    # Multiple projects can be specified by delimiting them with semi-colons - obtain the 
-    #   individual paths, resolve them, and splice them back into a single semi-colon delimited list. 
     $projects = ($projects.Split(';').ForEach({Resolve-Path $_}) -join ';')
     
     $msbuildArgs += "/p:Projects=$projects"


### PR DESCRIPTION
`eng\common\build.ps1`'s `-projects` argument requires full-path's to projects. 

This change adds support for relative paths to supported as well. 

Before: 
   `eng\common\build.ps1 -build -projects .\src\Project1.csproj` // error 
   `eng\common\build.ps1 -build -projects C:\repos\somerepo\src\Project1.csproj` // ok 

After:
   `eng\common\build.ps1 -build -projects .\src\Project1.csproj` // **new** - ok
   `eng\common\build.ps1 -build -projects C:\repos\somerepo\src\Project1.csproj` // ok 
