### PR TITLE
Remove the channel validation stage

### DIFF
--- a/eng/common/templates/post-build/channels/netcore-dev-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-30.yml
@@ -120,14 +120,6 @@ stages:
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
             ${{ parameters.artifactsPublishingAdditionalParameters }}
 
-
-- stage: NetCore_Dev30_Publish_Validation
-  displayName: .NET Core 3.0 Dev Publish Validation
-  variables:
-    - template: ../common-variables.yml
-  jobs:
-  - template: ../setup-maestro-vars.yml
-
-  - template: ../promote-build.yml
-    parameters:
-      ChannelId: ${{ variables.PublicDevRelease_30_Channel_Id }}
+      - template: ../../steps/promote-build.yml
+        parameters:
+          ChannelId: ${{ variables.PublicDevRelease_30_Channel_Id }}

--- a/eng/common/templates/post-build/channels/netcore-dev-31.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-31.yml
@@ -120,14 +120,6 @@ stages:
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
             ${{ parameters.artifactsPublishingAdditionalParameters }}
 
-
-- stage: NetCore_Dev31_Publish_Validation
-  displayName: .NET Core 3.1 Dev Publish Validation
-  variables:
-    - template: ../common-variables.yml
-  jobs:
-  - template: ../setup-maestro-vars.yml
-
-  - template: ../promote-build.yml
-    parameters:
-      ChannelId: ${{ variables.PublicDevRelease_31_Channel_Id }}
+      - template: ../../steps/promote-build.yml
+        parameters:
+          ChannelId: ${{ variables.PublicDevRelease_31_Channel_Id }}

--- a/eng/common/templates/post-build/channels/netcore-dev-5.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-5.yml
@@ -126,14 +126,6 @@ stages:
             /p:AzureDevOpsStaticTransportFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             ${{ parameters.artifactsPublishingAdditionalParameters }}
 
-
-- stage: NetCore_Dev5_Publish_Validation
-  displayName: .NET Core 5 Dev Publish Validation
-  variables:
-    - template: ../common-variables.yml
-  jobs:
-  - template: ../setup-maestro-vars.yml
-
-  - template: ../promote-build.yml
-    parameters:
-      ChannelId: ${{ variables.NetCore_5_Dev_Channel_Id }}
+      - template: ../../steps/promote-build.yml
+        parameters:
+          ChannelId: ${{ variables.NetCore_5_Dev_Channel_Id }}

--- a/eng/common/templates/post-build/channels/netcore-internal-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-internal-30.yml
@@ -113,17 +113,6 @@ stages:
             /p:Configuration=Release 
             ${{ parameters.artifactsPublishingAdditionalParameters }}
 
-      - template: ../trigger-subscription.yml
+      - template: ../../steps/promote-build.yml
         parameters:
           ChannelId: ${{ variables.InternalServicing_30_Channel_Id }}
-
-- stage: NetCore_30_Internal_Servicing_Publish_Validation
-  displayName: .NET Core 3.0 Internal Servicing Publish Validation
-  variables:
-    - template: ../common-variables.yml
-  jobs:
-  - template: ../setup-maestro-vars.yml
-
-  - template: ../promote-build.yml
-    parameters:
-      ChannelId: ${{ variables.InternalServicing_30_Channel_Id }}

--- a/eng/common/templates/post-build/channels/netcore-release-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-release-30.yml
@@ -113,17 +113,6 @@ stages:
             /p:Configuration=Release 
             ${{ parameters.artifactsPublishingAdditionalParameters }}
 
-      - template: ../trigger-subscription.yml
+      - template: ../../steps/promote-build.yml
         parameters:
           ChannelId: ${{ variables.PublicRelease_30_Channel_Id }}
-
-- stage: NetCore_Release30_Publish_Validation
-  displayName: .NET Core 3.0 Release Publish Validation
-  variables:
-    - template: ../common-variables.yml
-  jobs:
-  - template: ../setup-maestro-vars.yml
-
-  - template: ../promote-build.yml
-    parameters:
-      ChannelId: ${{ variables.PublicRelease_30_Channel_Id }}

--- a/eng/common/templates/post-build/channels/netcore-release-31.yml
+++ b/eng/common/templates/post-build/channels/netcore-release-31.yml
@@ -119,17 +119,6 @@ stages:
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
             ${{ parameters.artifactsPublishingAdditionalParameters }}
 
-      - template: ../trigger-subscription.yml
+      - template: ../../steps/promote-build.yml
         parameters:
           ChannelId: ${{ variables.PublicRelease_31_Channel_Id }}
-
-- stage: NetCore_Release31_Publish_Validation
-  displayName: .NET Core 3.1 Release Publish Validation
-  variables:
-    - template: ../common-variables.yml
-  jobs:
-  - template: ../setup-maestro-vars.yml
-
-  - template: ../promote-build.yml
-    parameters:
-      ChannelId: ${{ variables.PublicRelease_31_Channel_Id }}

--- a/eng/common/templates/post-build/channels/netcore-tools-latest.yml
+++ b/eng/common/templates/post-build/channels/netcore-tools-latest.yml
@@ -125,15 +125,7 @@ stages:
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'
             /p:AzureDevOpsStaticTransportFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)
             ${{ parameters.artifactsPublishingAdditionalParameters }}
-        
-
-- stage: NetCore_Tools_Latest_PublishValidation
-  displayName: .NET Tools - Latest Publish Validation
-  variables:
-    - template: ../common-variables.yml
-  jobs:
-  - template: ../setup-maestro-vars.yml
-
-  - template: ../promote-build.yml
-    parameters:
-      ChannelId: ${{ variables.NetCore_Tools_Latest_Channel_Id }}
+              
+      - template: ../../steps/promote-build.yml
+        parameters:
+          ChannelId: ${{ variables.NetCore_Tools_Latest_Channel_Id }}

--- a/eng/common/templates/post-build/channels/public-validation-release.yml
+++ b/eng/common/templates/post-build/channels/public-validation-release.yml
@@ -85,15 +85,7 @@ stages:
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'
             /p:AzureDevOpsStaticTransportFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             ${{ parameters.artifactsPublishingAdditionalParameters }}
-
-
-- stage: PVR_PublishValidation
-  displayName: .NET Tools - Validation Publish Validation
-  variables:
-    - template: ../common-variables.yml
-  jobs:
-  - template: ../setup-maestro-vars.yml
-
-  - template: ../promote-build.yml
-    parameters:
-      ChannelId: ${{ variables.PublicValidationRelease_30_Channel_Id }}
+      
+      - template: ../../steps/promote-build.yml
+        parameters:
+          ChannelId: ${{ variables.PublicValidationRelease_30_Channel_Id }}

--- a/eng/common/templates/steps/promote-build.yml
+++ b/eng/common/templates/steps/promote-build.yml
@@ -1,0 +1,13 @@
+parameters:
+  ChannelId: 0
+
+steps:
+- task: PowerShell@2
+  displayName: Add Build to Channel
+  inputs:
+    filePath: $(Build.SourcesDirectory)/eng/common/post-build/promote-build.ps1
+    arguments: -BuildId $(BARBuildId) 
+      -ChannelId $(ChannelId) 
+      -MaestroApiAccessToken $(MaestroApiAccessToken)
+      -MaestroApiEndPoint $(MaestroApiEndPoint)
+      -MaestroApiVersion $(MaestroApiVersion)


### PR DESCRIPTION
Move the promotion into publish. This is just wasted time (checkout, machine allocation, etc.) and the validation stage doesn't do anything for any channel any longer