### PR TITLE
Use the ChannelID parameter during promote-build.yml

### DIFF
--- a/eng/common/templates/steps/promote-build.yml
+++ b/eng/common/templates/steps/promote-build.yml
@@ -7,7 +7,7 @@ steps:
   inputs:
     filePath: $(Build.SourcesDirectory)/eng/common/post-build/promote-build.ps1
     arguments: -BuildId $(BARBuildId) 
-      -ChannelId $(ChannelId) 
+      -ChannelId ${{ parameters.ChannelId }}
       -MaestroApiAccessToken $(MaestroApiAccessToken)
       -MaestroApiEndPoint $(MaestroApiEndPoint)
       -MaestroApiVersion $(MaestroApiVersion)


### PR DESCRIPTION
Fixes the errors seen in: https://dev.azure.com/dnceng/internal/_build/results?buildId=345466&view=logs&s=f65cc152-4f9d-5670-c98b-f8f01fd59748&j=15f1bd09-65e8-5b3d-7b2c-af6cf3549f5d