### PR TITLE
Add support for relative paths in --projects for eng/common/build.sh

### DIFF
--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -170,6 +170,16 @@ function Build {
   InitializeCustomToolset
 
   if [[ ! -z "$projects" ]]; then
+    # Split project paths by semi-colon, find full-paths using readlink, 
+    # finally and splice back as a semi-colon separated list
+    IFS=';' read -r -a projs <<< "$projects"
+    len=${#projs[@]}
+    for ((i=0; i<$len; i++)); 
+    do 
+        projs[$i]=$(readlink -f "${projs[$i]}");
+    done 
+    projects=$(IFS=\; ; echo "${projs[*]}")
+    echo Updated projects: $projects
     properties="$properties /p:Projects=$projects"
   fi
 


### PR DESCRIPTION
PR in response to @tmat's comment at https://github.com/dotnet/arcade/pull/3885#issuecomment-529050915. 

I don't use OS X or Ubuntu regularly since WPF doesn't build on those ;-) I'm hoping that reviewers would take care to think about this submission very carefully before approving. 

In practice, I don't think supplying multiple projects for `--projects` really works in `build.sh`. 

/cc @chcosta 