### PR TITLE
Compute IsShipping* before version strings are computed

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.targets
@@ -13,23 +13,6 @@
 
   <PropertyGroup>
     <!--
-      Unless specified otherwise project is assumed to produce artifacts (assembly, package, vsix, etc.) that ship.
-      Test projects automatically set IsShipping to false.
-
-      Some projects may produce packages that contain shipping assemblies but the packages themselves do not ship.
-      Thes projects shall specify IsShippingPackage=false and leave IsShipping unset (will default to true).
-
-      Targets that need to determine whether an artifact is shipping shall use the artifact specific IsShippingXxx property,
-      if available for the kind of artifact they operate on.
-    -->
-    <IsShipping Condition="'$(IsShipping)' == ''">true</IsShipping>
-
-    <IsShippingAssembly Condition="'$(IsShippingAssembly)' == ''">$(IsShipping)</IsShippingAssembly>
-    <IsShippingPackage Condition="'$(IsVisualStudioBuildPackage)' == 'true'">false</IsShippingPackage>
-    <IsShippingPackage Condition="'$(IsShippingPackage)' == ''">$(IsShipping)</IsShippingPackage>
-    <IsShippingVsix Condition="'$(IsShippingVsix)' == ''">$(IsShipping)</IsShippingVsix>
-
-    <!--
       Set PackageOutputPath based on the IsShippingPackage flag set by projects.
       This distinction allows publishing tools to determine which assets to publish to official channels.
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
@@ -3,6 +3,27 @@
 <Project>
 
   <!--
+    Compute the IsShipping* properties
+
+    Unless specified otherwise project is assumed to produce artifacts (assembly, package, vsix, etc.) that ship.
+      Test projects automatically set IsShipping to false.
+
+      Some projects may produce packages that contain shipping assemblies but the packages themselves do not ship.
+      Thes projects shall specify IsShippingPackage=false and leave IsShipping unset (will default to true).
+
+      Targets that need to determine whether an artifact is shipping shall use the artifact specific IsShippingXxx property,
+      if available for the kind of artifact they operate on.
+  -->
+  <PropertyGroup>
+    <IsShipping Condition="'$(IsShipping)' == ''">true</IsShipping>
+
+    <IsShippingAssembly Condition="'$(IsShippingAssembly)' == ''">$(IsShipping)</IsShippingAssembly>
+    <IsShippingPackage Condition="'$(IsVisualStudioBuildPackage)' == 'true'">false</IsShippingPackage>
+    <IsShippingPackage Condition="'$(IsShippingPackage)' == ''">$(IsShipping)</IsShippingPackage>
+    <IsShippingVsix Condition="'$(IsShippingVsix)' == ''">$(IsShipping)</IsShippingVsix>
+  </PropertyGroup>
+
+  <!--
     Specification: https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md
 
     Workaround for https://github.com/dotnet/sdk/issues/3173:


### PR DESCRIPTION
The IsShipping properties were previously computed in ProjectDefaults.targets, which is imported after Version.BeforeCommonTargets.targets.  This means you can't use IsShippingPackage to determine how to version. Move this computation to Version.BeforeCommonTargets.targets.