### PR TITLE
Support split-out of symbols and other feed changes

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
@@ -40,7 +40,6 @@
       - AzureDevOpsFeedsBaseUrl
       - ArtifactsCategory                     : Used to let user override target feed of public channels.
       - AzureStorageTargetFeedPAT
-      - StaticInternalFeed                    : URL of the feed to publish internal non-stable packages
       - PublishInstallersAndChecksums         : Whether to publish installers and checksums to a secondary location for Dev channels
       - InstallersTargetStaticFeed
       - InstallersAzureAccountKey
@@ -48,9 +47,11 @@
       - ChecksumsAzureAccountKey
       - PublishToAzureDevOpsNuGetFeeds        : If true, publish NuGet packages to Azure DevOps feeds.
       - AzureDevOpsStaticShippingFeed         : URL of the Azure DevOps NuGet feed to publish non-stable shipping packages to.
-      - AzureDevOpsStaticShippingFeedKey      : Key of the feed Azure DevOps NuGet feed to publish non-stable shipping packages to.
-      - AzureDevOpsStaticTransportFeed        : URL of the feed Azure DevOps NuGet feed to publish transport packages to.
-      - AzureDevOpsStaticTransportFeedKey     : Key of the feed Azure DevOps NuGet feed to publish to transport packages to.
+      - AzureDevOpsStaticShippingFeedKey      : Key of the Azure DevOps NuGet feed to publish non-stable shipping packages to.
+      - AzureDevOpsStaticTransportFeed        : URL of the Azure DevOps NuGet feed to publish transport packages to.
+      - AzureDevOpsStaticTransportFeedKey     : Key of the Azure DevOps NuGet feed to publish transport packages to.
+      - AzureDevOpsStaticSymbolsFeed          : URL of the Azure DevOps NuGet feed to publish symbol packages to. Only non-stabilized assets are published here.
+      - AzureDevOpsStaticSymbolsFeedKey       : Key of the Azure DevOps NuGet feed to publish symbol packages to.
 
       - CreateTestConfig                      : If set to true the user will be able to test a TargetFeedConfig 
                                                 constructed using parameters below:
@@ -99,24 +100,24 @@
     </ItemGroup>
 
     <!--
-      When a build is stable we ask `CreateAzureDevOpsFeed` in Tasks.Feed to create a new AzDO feed.
+      When a build is stable we ask `CreateAzureDevOpsFeed` in Tasks.Feed to create a new AzDO feed for packages
+      and an azure storage blob feed for symbols. We do not use 
     -->
     <CreateAzureDevOpsFeed
         Condition="'@(TargetFeedConfig)' == '' AND '$(IsStableBuild)' == 'true'"
         IsInternal="$(IsInternalBuild)"
         AzureDevOpsPersonalAccessToken="$(AzdoTargetFeedPAT)"
         RepositoryName="$(RepositoryName)"
-        CommitSha="$(CommitSha)">
+        CommitSha="$(CommitSha)" >
       <Output TaskParameter="TargetFeedURL" PropertyName="NewAzDoFeedURL"/>
     </CreateAzureDevOpsFeed>
-
     <ItemGroup Condition="'@(TargetFeedConfig)' == '' AND '$(IsStableBuild)' == 'true'">
       <!--
         Configs below are for STABLE INTERNAL builds.
       -->
       <TargetFeedConfig
         Condition="'$(IsInternalBuild)' == 'true'"
-        Include="NetCore"
+        Include="Package;Other"
         TargetURL="$(NewAzDoFeedURL)"
         Internal="true"
         Isolated="true"
@@ -148,7 +149,7 @@
       <TargetFeedConfig
         Condition="'$(IsInternalBuild)' == 'false'"
         AssetSelection="ShippingOnly"
-        Include="NetCore"
+        Include="Package"
         TargetURL="$(NewAzDoFeedURL)"
         Internal="false"
         Isolated="true"
@@ -158,7 +159,7 @@
       <TargetFeedConfig
         Condition="'$(IsInternalBuild)' == 'false'"
         AssetSelection="NonShippingOnly"
-        Include="NetCore"
+        Include="Package"
         TargetURL="$(AzureDevOpsStaticTransportFeed)"
         Internal="false"
         Isolated="false"
@@ -190,7 +191,7 @@
     -->
     <ItemGroup Condition="'@(TargetFeedConfig)' == '' AND '$(IsStableBuild)' == 'false' AND '$(IsInternalBuild)' == 'true'">
       <TargetFeedConfig
-        Include="NetCore;Symbols;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX"
+        Include="Package;Other;Symbols;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX"
         TargetURL="$(StaticInternalFeed)"
         Internal="true"
         Isolated="false"
@@ -243,7 +244,7 @@
     <!-- Configuration for public non-stable feeds -->
     <ItemGroup Condition="'@(TargetFeedConfig)' == ''">
       <TargetFeedConfig
-        Include="NetCore;Symbols;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX;Badge"
+        Include="Package;Other;Symbols;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX;Badge"
         TargetURL="$(TargetStaticFeed)"
         Internal="false"
         Isolated="false"
@@ -271,22 +272,22 @@
         shipping and non-shipping (transport) and push them to separate feeds.
       -->
       <TargetFeedConfig Condition="'$(PublishToAzureDevOpsNuGetFeeds)' == 'true' AND '$(IsStableBuild)' != 'true'"
-        Include="NetCore"
+        Include="Package"
         TargetURL="$(AzureDevOpsStaticShippingFeed)"
         Internal="false"
         Isolated="false"
         Type="AzDoNugetFeed"
         Token="$(AzureDevOpsStaticShippingFeedKey)"
         AssetSelection="ShippingOnly" />
-      
-      <TargetFeedConfig Condition="'$(PublishToAzureDevOpsNuGetFeeds)' == 'true'"
-        Include="NetCore;Symbols"
-        TargetURL="$(AzureDevOpsStaticTransportFeed)"
-        Internal="false"
-        Isolated="false"
-        Type="AzDoNugetFeed"
-        Token="$(AzureDevOpsStaticTransportFeedKey)"
-        AssetSelection="NonShippingOnly" />
+
+      <TargetFeedConfig Condition="'$(PublishToAzureDevOpsNuGetFeeds)' == 'true' AND '$(IsStableBuild)' != 'true'"
+          Include="Package"
+          TargetURL="$(AzureDevOpsStaticShippingFeed)"
+          Internal="false"
+          Isolated="false"
+          Type="AzDoNugetFeed"
+          Token="$(AzureDevOpsStaticShippingFeedKey)"
+          AssetSelection="ShippingOnly" />
     </ItemGroup>
 
     <Error

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
@@ -40,6 +40,7 @@
       - AzureDevOpsFeedsBaseUrl
       - ArtifactsCategory                     : Used to let user override target feed of public channels.
       - AzureStorageTargetFeedPAT
+      - StaticInternalFeed                    : URL of the feed to publish internal non-stable packages
       - PublishInstallersAndChecksums         : Whether to publish installers and checksums to a secondary location for Dev channels
       - InstallersTargetStaticFeed
       - InstallersAzureAccountKey
@@ -47,11 +48,9 @@
       - ChecksumsAzureAccountKey
       - PublishToAzureDevOpsNuGetFeeds        : If true, publish NuGet packages to Azure DevOps feeds.
       - AzureDevOpsStaticShippingFeed         : URL of the Azure DevOps NuGet feed to publish non-stable shipping packages to.
-      - AzureDevOpsStaticShippingFeedKey      : Key of the Azure DevOps NuGet feed to publish non-stable shipping packages to.
-      - AzureDevOpsStaticTransportFeed        : URL of the Azure DevOps NuGet feed to publish transport packages to.
-      - AzureDevOpsStaticTransportFeedKey     : Key of the Azure DevOps NuGet feed to publish transport packages to.
-      - AzureDevOpsStaticSymbolsFeed          : URL of the Azure DevOps NuGet feed to publish symbol packages to. Only non-stabilized assets are published here.
-      - AzureDevOpsStaticSymbolsFeedKey       : Key of the Azure DevOps NuGet feed to publish symbol packages to.
+      - AzureDevOpsStaticShippingFeedKey      : Key of the feed Azure DevOps NuGet feed to publish non-stable shipping packages to.
+      - AzureDevOpsStaticTransportFeed        : URL of the feed Azure DevOps NuGet feed to publish transport packages to.
+      - AzureDevOpsStaticTransportFeedKey     : Key of the feed Azure DevOps NuGet feed to publish to transport packages to.
 
       - CreateTestConfig                      : If set to true the user will be able to test a TargetFeedConfig 
                                                 constructed using parameters below:
@@ -100,24 +99,27 @@
     </ItemGroup>
 
     <!--
-      When a build is stable we ask `CreateAzureDevOpsFeed` in Tasks.Feed to create a new AzDO feed for packages
-      and an azure storage blob feed for symbols. We do not use 
+      When a build is stable we ask `CreateInternalBlobFeed` in Tasks.Feed to create a new AzDO feed.
+      That task will return an Azure Storage feed wrapped by an authenticated Azure function proxy,
+      we use that to mimic an internal/authenticated feed. This will likely change in the future once
+      we switch to using AzDO private feeds.
     -->
     <CreateAzureDevOpsFeed
         Condition="'@(TargetFeedConfig)' == '' AND '$(IsStableBuild)' == 'true'"
         IsInternal="$(IsInternalBuild)"
         AzureDevOpsPersonalAccessToken="$(AzdoTargetFeedPAT)"
         RepositoryName="$(RepositoryName)"
-        CommitSha="$(CommitSha)" >
+        CommitSha="$(CommitSha)">
       <Output TaskParameter="TargetFeedURL" PropertyName="NewAzDoFeedURL"/>
     </CreateAzureDevOpsFeed>
+
     <ItemGroup Condition="'@(TargetFeedConfig)' == '' AND '$(IsStableBuild)' == 'true'">
       <!--
         Configs below are for STABLE INTERNAL builds.
       -->
       <TargetFeedConfig
         Condition="'$(IsInternalBuild)' == 'true'"
-        Include="Package;Other"
+        Include="NetCore"
         TargetURL="$(NewAzDoFeedURL)"
         Internal="true"
         Isolated="true"
@@ -149,7 +151,7 @@
       <TargetFeedConfig
         Condition="'$(IsInternalBuild)' == 'false'"
         AssetSelection="ShippingOnly"
-        Include="Package"
+        Include="NetCore"
         TargetURL="$(NewAzDoFeedURL)"
         Internal="false"
         Isolated="true"
@@ -159,7 +161,7 @@
       <TargetFeedConfig
         Condition="'$(IsInternalBuild)' == 'false'"
         AssetSelection="NonShippingOnly"
-        Include="Package"
+        Include="NetCore"
         TargetURL="$(AzureDevOpsStaticTransportFeed)"
         Internal="false"
         Isolated="false"
@@ -191,7 +193,7 @@
     -->
     <ItemGroup Condition="'@(TargetFeedConfig)' == '' AND '$(IsStableBuild)' == 'false' AND '$(IsInternalBuild)' == 'true'">
       <TargetFeedConfig
-        Include="Package;Other;Symbols;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX"
+        Include="NetCore;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX"
         TargetURL="$(StaticInternalFeed)"
         Internal="true"
         Isolated="false"
@@ -244,7 +246,7 @@
     <!-- Configuration for public non-stable feeds -->
     <ItemGroup Condition="'@(TargetFeedConfig)' == ''">
       <TargetFeedConfig
-        Include="Package;Other;Symbols;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX;Badge"
+        Include="NetCore;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX;Badge"
         TargetURL="$(TargetStaticFeed)"
         Internal="false"
         Isolated="false"
@@ -272,22 +274,22 @@
         shipping and non-shipping (transport) and push them to separate feeds.
       -->
       <TargetFeedConfig Condition="'$(PublishToAzureDevOpsNuGetFeeds)' == 'true' AND '$(IsStableBuild)' != 'true'"
-        Include="Package"
+        Include="NetCore"
         TargetURL="$(AzureDevOpsStaticShippingFeed)"
         Internal="false"
         Isolated="false"
         Type="AzDoNugetFeed"
         Token="$(AzureDevOpsStaticShippingFeedKey)"
         AssetSelection="ShippingOnly" />
-
-      <TargetFeedConfig Condition="'$(PublishToAzureDevOpsNuGetFeeds)' == 'true' AND '$(IsStableBuild)' != 'true'"
-          Include="Package"
-          TargetURL="$(AzureDevOpsStaticShippingFeed)"
-          Internal="false"
-          Isolated="false"
-          Type="AzDoNugetFeed"
-          Token="$(AzureDevOpsStaticShippingFeedKey)"
-          AssetSelection="ShippingOnly" />
+      
+      <TargetFeedConfig Condition="'$(PublishToAzureDevOpsNuGetFeeds)' == 'true'"
+        Include="NetCore"
+        TargetURL="$(AzureDevOpsStaticTransportFeed)"
+        Internal="false"
+        Isolated="false"
+        Type="AzDoNugetFeed"
+        Token="$(AzureDevOpsStaticTransportFeedKey)"
+        AssetSelection="NonShippingOnly" />
     </ItemGroup>
 
     <Error

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
@@ -99,10 +99,7 @@
     </ItemGroup>
 
     <!--
-      When a build is stable we ask `CreateInternalBlobFeed` in Tasks.Feed to create a new AzDO feed.
-      That task will return an Azure Storage feed wrapped by an authenticated Azure function proxy,
-      we use that to mimic an internal/authenticated feed. This will likely change in the future once
-      we switch to using AzDO private feeds.
+      When a build is stable we ask `CreateAzureDevOpsFeed` in Tasks.Feed to create a new AzDO feed.
     -->
     <CreateAzureDevOpsFeed
         Condition="'@(TargetFeedConfig)' == '' AND '$(IsStableBuild)' == 'true'"
@@ -193,7 +190,7 @@
     -->
     <ItemGroup Condition="'@(TargetFeedConfig)' == '' AND '$(IsStableBuild)' == 'false' AND '$(IsInternalBuild)' == 'true'">
       <TargetFeedConfig
-        Include="NetCore;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX"
+        Include="NetCore;Symbols;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX"
         TargetURL="$(StaticInternalFeed)"
         Internal="true"
         Isolated="false"
@@ -246,7 +243,7 @@
     <!-- Configuration for public non-stable feeds -->
     <ItemGroup Condition="'@(TargetFeedConfig)' == ''">
       <TargetFeedConfig
-        Include="NetCore;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX;Badge"
+        Include="NetCore;Symbols;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX;Badge"
         TargetURL="$(TargetStaticFeed)"
         Internal="false"
         Isolated="false"
@@ -283,7 +280,7 @@
         AssetSelection="ShippingOnly" />
       
       <TargetFeedConfig Condition="'$(PublishToAzureDevOpsNuGetFeeds)' == 'true'"
-        Include="NetCore"
+        Include="NetCore;Symbols"
         TargetURL="$(AzureDevOpsStaticTransportFeed)"
         Internal="false"
         Isolated="false"

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
@@ -230,7 +230,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                 SkipSafetyChecks = skipChecks,
                 TargetFeedConfig = new Microsoft.Build.Utilities.TaskItem[]
                 {
-                    new Microsoft.Build.Utilities.TaskItem("NETCORE", new Dictionary<string, string> {
+                    new Microsoft.Build.Utilities.TaskItem("PACKAGE", new Dictionary<string, string> {
                         { "TargetUrl", BlobFeedUrl },
                         { "Token", RandomToken },
                         { "Type", "AZURESTORAGEFEED" },

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/build/Microsoft.DotNet.Build.Tasks.Feed.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/build/Microsoft.DotNet.Build.Tasks.Feed.targets
@@ -55,7 +55,7 @@
   <UsingTask TaskName="PushArtifactsInManifestToFeed" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
   <UsingTask TaskName="PublishArtifactsInManifest" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
   <UsingTask TaskName="CreateAzureDevOpsFeed" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
-  <UsingTask TaskName="CreateInternalBlobFeed" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
+  <UsingTask TaskName="CreateAzureStorageBlobFeed" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
   <UsingTask TaskName="ExecWithRetriesForNuGetPush" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
   <UsingTask TaskName="ParseBuildManifest" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
   

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
@@ -33,8 +33,10 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         [Required]
         public string CommitSha { get; set; }
 
-        [Required]
-        public string Bool { get; set; }
+        /// <summary>
+        /// Additional info to include in the feed name (for example "-sym-")
+        /// </summary>
+        public string ContentIdentifier { get; set; }
 
         [Required]
         public string AzureDevOpsPersonalAccessToken { get; set; }
@@ -79,7 +81,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 string accessType = IsInternal ? "internal" : "public";
                 string publicSegment = IsInternal ? string.Empty : "public/";
                 string accessId = IsInternal ? "int" : "pub";
-                string baseFeedName = $"darc-{accessId}-{RepositoryName}-{CommitSha.Substring(0, ShaUsableLength)}";
+                string extraContentInfo = !string.IsNullOrEmpty(ContentIdentifier) ? $"-{ContentIdentifier}" : "";
+                string baseFeedName = $"darc-{accessId}{extraContentInfo}-{RepositoryName}-{CommitSha.Substring(0, ShaUsableLength)}";
                 string versionedFeedName = baseFeedName;
                 bool needsUniqueName = false;
                 int subVersion = 0;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
@@ -34,6 +34,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public string CommitSha { get; set; }
 
         [Required]
+        public string Bool { get; set; }
+
+        [Required]
         public string AzureDevOpsPersonalAccessToken { get; set; }
 
         public string AzureDevOpsFeedsApiVersion { get; set; } = "5.0-preview.1";

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -625,7 +625,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             }
 
             await PushNugetPackagesAsync(packagesToPublish, feedConfig, maxClients: MaxClients,
-                async (feedConfig, httpClient, package, feedAccount, feedVisibility, feedName) =>
+                async (feed, httpClient, package, feedAccount, feedVisibility, feedName) =>
                 {
                     string localPackagePath = Path.Combine(PackageAssetsBasePath, $"{package.Id}.{package.Version}.nupkg");
                     if (!File.Exists(localPackagePath))
@@ -634,7 +634,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         return;
                     }
 
-                    await PushNugetPackageAsync(feedConfig, httpClient, localPackagePath, package.Id, package.Version, feedAccount, feedVisibility, feedName);
+                    await PushNugetPackageAsync(feed, httpClient, localPackagePath, package.Id, package.Version, feedAccount, feedVisibility, feedName);
                 });
         }
 
@@ -957,7 +957,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             }
 
             await PushNugetPackagesAsync<BlobArtifactModel>(symbolPackagesToPublish, feedConfig, maxClients: MaxClients,
-                async (feedConfig, httpClient, blob, feedAccount, feedVisibility, feedName) =>
+                async (feed, httpClient, blob, feedAccount, feedVisibility, feedName) =>
                 {
                     // Determine the local path to the blob
                     string fileName = Path.GetFileName(blob.Id);
@@ -978,7 +978,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         version = packageIdentity.Version.ToString();
                     }
 
-                    await PushNugetPackageAsync(feedConfig, httpClient, localBlobPath, id, version, feedAccount, feedVisibility, feedName);
+                    await PushNugetPackageAsync(feed, httpClient, localBlobPath, id, version, feedAccount, feedVisibility, feedName);
                 });
         }
 


### PR DESCRIPTION
- For stabilized builds, we can't publish the symbols to the same azdo feed because their package IDs overlap with the implementation package. Implement splitting of these into a symbols category
- Allow for additional content info to be placed into the azdo feed name.
- Change CreateInternalBlobFeed to CreateAzureStorageBlobFeed and add an IsInternal property.  May need to use these for symbols.
- Change the "NETCORE" category,which is not descriptive, to PACKAGE and OTHER (default).
- Implement pushing of symbol nupkg blobs to azdo feeds.