### PR TITLE
Simplify SetupTargetFeeds.proj

### DIFF
--- a/eng/common/templates/post-build/channels/netcore-dev-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-30.yml
@@ -97,11 +97,6 @@ stages:
             /p:IsInternalBuild=$(IsInternalBuild)
             /p:RepositoryName=$(Build.Repository.Name)
             /p:CommitSha=$(Build.SourceVersion)
-            /p:StaticInternalFeed=$(StaticInternalFeed)
-            /p:InternalChecksumsTargetStaticFeed=$(InternalChecksumsBlobFeedUrl)
-            /p:InternalChecksumsTargetStaticFeedKey=$(InternalChecksumsBlobFeedKey)
-            /p:InternalInstallersTargetStaticFeed=$(InternalInstallersBlobFeedUrl)
-            /p:InternalInstallersTargetStaticFeedKey=$(InternalInstallersBlobFeedKey)
             /p:NugetPath=$(NuGetExeToolPath)
             /p:AzdoTargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)' 
             /p:TargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)' 
@@ -118,6 +113,11 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
+            /p:PublishToAzureDevOpsNuGetFeeds=true
+            /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3/nuget/v3/index.json'
+            /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
+            /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3-transport/nuget/v3/index.json'
+            /p:AzureDevOpsStaticTransportFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             ${{ parameters.artifactsPublishingAdditionalParameters }}
 
       - template: ../../steps/promote-build.yml

--- a/eng/common/templates/post-build/channels/netcore-dev-31.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-31.yml
@@ -97,11 +97,6 @@ stages:
             /p:IsInternalBuild=$(IsInternalBuild)
             /p:RepositoryName=$(Build.Repository.Name)
             /p:CommitSha=$(Build.SourceVersion)
-            /p:StaticInternalFeed=$(StaticInternalFeed)
-            /p:InternalChecksumsTargetStaticFeed=$(InternalChecksumsBlobFeedUrl)
-            /p:InternalChecksumsTargetStaticFeedKey=$(InternalChecksumsBlobFeedKey)
-            /p:InternalInstallersTargetStaticFeed=$(InternalInstallersBlobFeedUrl)
-            /p:InternalInstallersTargetStaticFeedKey=$(InternalInstallersBlobFeedKey)
             /p:NugetPath=$(NuGetExeToolPath)
             /p:AzdoTargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)'
             /p:TargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)'

--- a/eng/common/templates/post-build/channels/netcore-dev-5.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-5.yml
@@ -2,7 +2,6 @@ parameters:
   symbolPublishingAdditionalParameters: ''
   artifactsPublishingAdditionalParameters: ''
   publishInstallersAndChecksums: false
-  publishToAzureDevOpsFeeds: true
 
 stages:
 - stage: NetCore_Dev5_Publish
@@ -98,11 +97,6 @@ stages:
             /p:IsInternalBuild=$(IsInternalBuild)
             /p:RepositoryName=$(Build.Repository.Name)
             /p:CommitSha=$(Build.SourceVersion)
-            /p:StaticInternalFeed=$(StaticInternalFeed)
-            /p:InternalChecksumsTargetStaticFeed=$(InternalChecksumsBlobFeedUrl)
-            /p:InternalChecksumsTargetStaticFeedKey=$(InternalChecksumsBlobFeedKey)
-            /p:InternalInstallersTargetStaticFeed=$(InternalInstallersBlobFeedUrl)
-            /p:InternalInstallersTargetStaticFeedKey=$(InternalInstallersBlobFeedKey)
             /p:NugetPath=$(NuGetExeToolPath)
             /p:AzdoTargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)' 
             /p:TargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)' 
@@ -119,7 +113,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=${{ parameters.publishToAzureDevOpsFeeds }}
+            /p:PublishToAzureDevOpsNuGetFeeds=true
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-internal-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-internal-30.yml
@@ -90,27 +90,32 @@ stages:
           AZURE_DEVOPS_EXT_PAT: $(dn-bot-dnceng-universal-packages-rw)
         inputs:
           filePath: eng\common\sdk-task.ps1
-          arguments: -task PublishArtifactsInManifest -restore -msbuildEngine dotnet 
+          arguments: -task PublishArtifactsInManifest -restore -msbuildEngine dotnet
             /p:IsStableBuild=$(IsStableBuild)
             /p:IsInternalBuild=$(IsInternalBuild)
             /p:RepositoryName=$(Build.Repository.Name)
             /p:CommitSha=$(Build.SourceVersion)
-            /p:StaticInternalFeed=$(StaticInternalFeed)
-            /p:InternalChecksumsTargetStaticFeed=$(InternalChecksumsBlobFeedUrl)
-            /p:InternalChecksumsTargetStaticFeedKey=$(InternalChecksumsBlobFeedKey)
-            /p:InternalInstallersTargetStaticFeed=$(InternalInstallersBlobFeedUrl)
-            /p:InternalInstallersTargetStaticFeedKey=$(InternalInstallersBlobFeedKey)
+            /p:PublishInstallersAndChecksums=true
+            /p:ChecksumsTargetStaticFeed=$(InternalChecksumsBlobFeedUrl)
+            /p:ChecksumsTargetStaticFeedKey=$(InternalChecksumsBlobFeedKey)
+            /p:InstallersTargetStaticFeed=$(InternalInstallersBlobFeedUrl)
+            /p:InstallersTargetStaticFeedKey=$(InternalInstallersBlobFeedKey)
             /p:NugetPath=$(NuGetExeToolPath)
-            /p:AzdoTargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)' 	
-            /p:TargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)' 
-            /p:AzureStorageTargetFeedPAT='$(dotnetfeed-storage-access-key-1)' 
-            /p:BARBuildId=$(BARBuildId) 
-            /p:MaestroApiEndpoint='$(MaestroApiEndPoint)' 
-            /p:BuildAssetRegistryToken='$(MaestroApiAccessToken)' 
-            /p:ManifestsBasePath='$(Build.ArtifactStagingDirectory)/AssetManifests/' 
-            /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/' 
-            /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts/' 
-            /p:Configuration=Release 
+            /p:AzdoTargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)'
+            /p:TargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)'
+            /p:AzureStorageTargetFeedPAT='$(dotnetfeed-storage-access-key-1)'
+            /p:BARBuildId=$(BARBuildId)
+            /p:MaestroApiEndpoint='$(MaestroApiEndPoint)'
+            /p:BuildAssetRegistryToken='$(MaestroApiAccessToken)'
+            /p:ManifestsBasePath='$(Build.ArtifactStagingDirectory)/AssetManifests/'
+            /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/'
+            /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts/'
+            /p:Configuration=Release
+            /p:PublishToAzureDevOpsNuGetFeeds=true
+            /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3-internal/nuget/v3/index.json'
+            /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
+            /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3-internal-transport/nuget/v3/index.json'
+            /p:AzureDevOpsStaticTransportFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             ${{ parameters.artifactsPublishingAdditionalParameters }}
 
       - template: ../../steps/promote-build.yml

--- a/eng/common/templates/post-build/channels/netcore-release-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-release-30.yml
@@ -97,11 +97,6 @@ stages:
             /p:IsInternalBuild=$(IsInternalBuild)
             /p:RepositoryName=$(Build.Repository.Name)
             /p:CommitSha=$(Build.SourceVersion)
-            /p:StaticInternalFeed=$(StaticInternalFeed)
-            /p:InternalChecksumsTargetStaticFeed=$(InternalChecksumsBlobFeedUrl)
-            /p:InternalChecksumsTargetStaticFeedKey=$(InternalChecksumsBlobFeedKey)
-            /p:InternalInstallersTargetStaticFeed=$(InternalInstallersBlobFeedUrl)
-            /p:InternalInstallersTargetStaticFeedKey=$(InternalInstallersBlobFeedKey)
             /p:NugetPath=$(NuGetExeToolPath)
             /p:AzdoTargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)'
             /p:TargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)' 
@@ -118,6 +113,11 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
+            /p:PublishToAzureDevOpsNuGetFeeds=true
+            /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3/nuget/v3/index.json'
+            /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
+            /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3-transport/nuget/v3/index.json'
+            /p:AzureDevOpsStaticTransportFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             ${{ parameters.artifactsPublishingAdditionalParameters }}
 
       - template: ../../steps/promote-build.yml

--- a/eng/common/templates/post-build/channels/netcore-release-31.yml
+++ b/eng/common/templates/post-build/channels/netcore-release-31.yml
@@ -97,11 +97,6 @@ stages:
             /p:IsInternalBuild=$(IsInternalBuild)
             /p:RepositoryName=$(Build.Repository.Name)
             /p:CommitSha=$(Build.SourceVersion)
-            /p:StaticInternalFeed=$(StaticInternalFeed)
-            /p:InternalChecksumsTargetStaticFeed=$(InternalChecksumsBlobFeedUrl)
-            /p:InternalChecksumsTargetStaticFeedKey=$(InternalChecksumsBlobFeedKey)
-            /p:InternalInstallersTargetStaticFeed=$(InternalInstallersBlobFeedUrl)
-            /p:InternalInstallersTargetStaticFeedKey=$(InternalInstallersBlobFeedKey)
             /p:NugetPath=$(NuGetExeToolPath)
             /p:AzdoTargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)'
             /p:TargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)'

--- a/eng/common/templates/post-build/channels/netcore-tools-latest.yml
+++ b/eng/common/templates/post-build/channels/netcore-tools-latest.yml
@@ -2,7 +2,6 @@ parameters:
   symbolPublishingAdditionalParameters: ''
   artifactsPublishingAdditionalParameters: ''
   publishInstallersAndChecksums: false
-  publishToAzureDevOpsFeeds: true
 
 stages:
 - stage: NetCore_Tools_Latest_Publish
@@ -92,40 +91,35 @@ stages:
           AZURE_DEVOPS_EXT_PAT: $(dn-bot-dnceng-universal-packages-rw)
         inputs:
           filePath: eng\common\sdk-task.ps1
-          arguments: -task PublishArtifactsInManifest -restore -msbuildEngine dotnet 
+          arguments: -task PublishArtifactsInManifest -restore -msbuildEngine dotnet
             /p:ArtifactsCategory=$(_DotNetArtifactsCategory)
             /p:IsStableBuild=$(IsStableBuild)
             /p:IsInternalBuild=$(IsInternalBuild)
             /p:RepositoryName=$(Build.Repository.Name)
             /p:CommitSha=$(Build.SourceVersion)
-            /p:StaticInternalFeed=$(StaticInternalFeed)
-            /p:InternalChecksumsTargetStaticFeed=$(InternalChecksumsBlobFeedUrl)
-            /p:InternalChecksumsTargetStaticFeedKey=$(InternalChecksumsBlobFeedKey)
-            /p:InternalInstallersTargetStaticFeed=$(InternalInstallersBlobFeedUrl)
-            /p:InternalInstallersTargetStaticFeedKey=$(InternalInstallersBlobFeedKey)
             /p:NugetPath=$(NuGetExeToolPath)
-            /p:AzdoTargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)' 
-            /p:TargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)' 
-            /p:AzureStorageTargetFeedPAT='$(dotnetfeed-storage-access-key-1)' 
-            /p:BARBuildId=$(BARBuildId) 
-            /p:MaestroApiEndpoint='$(MaestroApiEndPoint)' 
-            /p:BuildAssetRegistryToken='$(MaestroApiAccessToken)' 
-            /p:ManifestsBasePath='$(Build.ArtifactStagingDirectory)/AssetManifests/' 
-            /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/' 
-            /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts/' 
+            /p:AzdoTargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)'
+            /p:TargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)'
+            /p:AzureStorageTargetFeedPAT='$(dotnetfeed-storage-access-key-1)'
+            /p:BARBuildId=$(BARBuildId)
+            /p:MaestroApiEndpoint='$(MaestroApiEndPoint)'
+            /p:BuildAssetRegistryToken='$(MaestroApiAccessToken)'
+            /p:ManifestsBasePath='$(Build.ArtifactStagingDirectory)/AssetManifests/'
+            /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/'
+            /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts/'
             /p:Configuration=Release
             /p:PublishInstallersAndChecksums=${{ parameters.publishInstallersAndChecksums }}
             /p:InstallersTargetStaticFeed=$(InstallersBlobFeedUrl)
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=${{ parameters.publishToAzureDevOpsFeeds }}
+            /p:PublishToAzureDevOpsNuGetFeeds=true
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'
             /p:AzureDevOpsStaticTransportFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)
             ${{ parameters.artifactsPublishingAdditionalParameters }}
-              
+
       - template: ../../steps/promote-build.yml
         parameters:
           ChannelId: ${{ variables.NetCore_Tools_Latest_Channel_Id }}

--- a/eng/common/templates/post-build/channels/public-validation-release.yml
+++ b/eng/common/templates/post-build/channels/public-validation-release.yml
@@ -1,7 +1,6 @@
 parameters:
   artifactsPublishingAdditionalParameters: ''
   publishInstallersAndChecksums: false
-  publishToAzureDevOpsFeeds: true
 
 stages:
 - stage: PVR_Publish
@@ -79,7 +78,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=${{ parameters.publishToAzureDevOpsFeeds }}
+            /p:PublishToAzureDevOpsNuGetFeeds=true
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'

--- a/eng/common/templates/post-build/common-variables.yml
+++ b/eng/common/templates/post-build/common-variables.yml
@@ -55,10 +55,6 @@ variables:
   # Feed Configurations
   # These should include the suffix "/index.json"
 
-  # Configuration for the feed where packages from internal non-stable builds will be published to
-  - name: StaticInternalFeed
-    value: 'https://dnceng.pkgs.visualstudio.com/_packaging/dotnet-core-internal/nuget/v3/index.json'
-
   # Default locations for Installers and checksums
   # Public Locations
   - name: ChecksumsBlobFeedUrl

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -4,7 +4,6 @@ parameters:
   enableSymbolValidation: false
   enableNugetValidation: true
   publishInstallersAndChecksums: false
-  enableAzDONuGetFeeds: true
   SDLValidationParameters:
     enable: false
     continueOnError: false
@@ -101,7 +100,6 @@ stages:
     symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
     artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
     publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
-    enableAzDONuGetFeeds: ${{ parameters.enableAzDONuGetFeeds }}
 
 - template: \eng\common\templates\post-build\channels\netcore-dev-30.yml
   parameters:
@@ -120,13 +118,11 @@ stages:
     symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
     artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
     publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
-    enableAzDONuGetFeeds: ${{ parameters.enableAzDONuGetFeeds }}
 
 - template: \eng\common\templates\post-build\channels\public-validation-release.yml
   parameters:
     artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
     publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
-    enableAzDONuGetFeeds: ${{ parameters.enableAzDONuGetFeeds }}
 
 - template: \eng\common\templates\post-build\channels\netcore-release-30.yml
   parameters:

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
@@ -57,7 +57,7 @@
   -->
 
   <Target Name="SetupTargetFeeds">
-    Error
+    <Error
       Condition="'$(IsStableBuild)' == ''"
       Text="Parameter 'IsStableBuild' is empty. A boolean value is required." />
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
@@ -3,56 +3,52 @@
   <!--
     This file main target, namely `SetupTargetFeeds`, is used to create an ItemGroup with
     feed descriptors that will be used for publishing build assets.
-    
+
     Summary of the logic implemented here:
-      - A stable build is a non-preview build. Package versions are usually in 
+      - A stable build is a non-preview build. Package versions are usually in
         the format <Major.Minor.Patch>. To create stable builds the user have to
         set the `DotNetFinalVersionKind` build parameter to `release`.
-        
+
       - An internal build is a build from a branch that has `internal` on its name.
         The assets produced from this kind of build aren't meant for public usage.
-        
+
       - For business reasons package versions for stable builds don't increment
         automatically. That means that different stable builds may produce packages
         with different binary content but same version number.
-        
+
       - Since feeds don't permit overriding packages, the approach we followed
-        to publish assets from stable builds was to create a new _feed_ for every 
+        to publish assets from stable builds was to create a new _feed_ for every
         stable build. Therefore, whenever we are publishing packages from a stable
         build we create a new (public | internal) feed to publish packages to.
-        
+
       - Non stable builds are the usual ones. Package's version for such builds have
         a prerelease label, e.g., preview, beta, alpha, etc. Since packages for these
         builds have their version incremented automatically for every build we can
         publish the packages always to the same feed.
-        
+
       - Non-stable internal build's assets are published to a fixed internal feed.
-      
+
       - Non-stable public build's assets are published to various public feeds.
-    
+
     Parameters:
       - IsInternalBuild                       : true if the build is internal, i.e., created from an branch with internal on its name.
       - IsStableBuild                         : true if the build is stable, i.e., `DotNetFinalVersionKind` == `release`.
       - RepositoryName                        : Name of the source repo. Used when creating a stable internal feed.
       - CommitSha                             : Commit SHA for this build. Used when creating a stable internal feed.
-      - AzureStorageAccountName
-      - AzureStorageAccountKey
-      - AzureDevOpsFeedsBaseUrl
       - ArtifactsCategory                     : Used to let user override target feed of public channels.
-      - AzureStorageTargetFeedPAT
-      - StaticInternalFeed                    : URL of the feed to publish internal non-stable packages
-      - PublishInstallersAndChecksums         : Whether to publish installers and checksums to a secondary location for Dev channels
-      - InstallersTargetStaticFeed
-      - InstallersAzureAccountKey
-      - ChecksumsTargetStaticFeed
-      - ChecksumsAzureAccountKey
+      - AzureStorageTargetFeedPAT             : Key for Azure storage feed used to publish for non-stable, non-internal builds
+      - PublishInstallersAndChecksums         : Whether to publish installers and checksums to a secondary locations
+      - InstallersTargetStaticFeed            : Where installers should be published
+      - InstallersAzureAccountKey             : Account key for installers location
+      - ChecksumsTargetStaticFeed             : Where checksums should be published
+      - ChecksumsAzureAccountKey              : Account key forchecksums location
       - PublishToAzureDevOpsNuGetFeeds        : If true, publish NuGet packages to Azure DevOps feeds.
       - AzureDevOpsStaticShippingFeed         : URL of the Azure DevOps NuGet feed to publish non-stable shipping packages to.
       - AzureDevOpsStaticShippingFeedKey      : Key of the feed Azure DevOps NuGet feed to publish non-stable shipping packages to.
       - AzureDevOpsStaticTransportFeed        : URL of the feed Azure DevOps NuGet feed to publish transport packages to.
       - AzureDevOpsStaticTransportFeedKey     : Key of the feed Azure DevOps NuGet feed to publish to transport packages to.
 
-      - CreateTestConfig                      : If set to true the user will be able to test a TargetFeedConfig 
+      - CreateTestConfig                      : If set to true the user will be able to test a TargetFeedConfig
                                                 constructed using parameters below:
         - TestFeedCategories
         - TestFeedURL
@@ -61,7 +57,7 @@
   -->
 
   <Target Name="SetupTargetFeeds">
-    <Error
+    Error
       Condition="'$(IsStableBuild)' == ''"
       Text="Parameter 'IsStableBuild' is empty. A boolean value is required." />
 
@@ -87,7 +83,7 @@
 
     <!--
       If the user wants to use a test configuration we'll create a TargetFeedConfig using
-      optional parameters passed as properties. This should prevent all the other 
+      optional parameters passed as properties. This should prevent all the other
       cases below from being activated.
     -->
     <ItemGroup Condition="'$(CreateTestConfig)' == 'true'">
@@ -99,127 +95,8 @@
     </ItemGroup>
 
     <!--
-      When a build is stable we ask `CreateInternalBlobFeed` in Tasks.Feed to create a new AzDO feed.
-      That task will return an Azure Storage feed wrapped by an authenticated Azure function proxy,
-      we use that to mimic an internal/authenticated feed. This will likely change in the future once
-      we switch to using AzDO private feeds.
-    -->
-    <CreateAzureDevOpsFeed
-        Condition="'@(TargetFeedConfig)' == '' AND '$(IsStableBuild)' == 'true'"
-        IsInternal="$(IsInternalBuild)"
-        AzureDevOpsPersonalAccessToken="$(AzdoTargetFeedPAT)"
-        RepositoryName="$(RepositoryName)"
-        CommitSha="$(CommitSha)">
-      <Output TaskParameter="TargetFeedURL" PropertyName="NewAzDoFeedURL"/>
-    </CreateAzureDevOpsFeed>
-
-    <ItemGroup Condition="'@(TargetFeedConfig)' == '' AND '$(IsStableBuild)' == 'true'">
-      <!--
-        Configs below are for STABLE INTERNAL builds.
-      -->
-      <TargetFeedConfig
-        Condition="'$(IsInternalBuild)' == 'true'"
-        Include="NetCore"
-        TargetURL="$(NewAzDoFeedURL)"
-        Internal="true"
-        Isolated="true"
-        Type="AzDoNugetFeed"
-        Token="$(AzdoTargetFeedPAT)" />
-      
-      <TargetFeedConfig
-        Condition="'$(IsInternalBuild)' == 'true'"
-        Include="OSX;Deb;Rpm;Node;BinaryLayout;Installer;Maven;VSIX;Badge"
-        TargetURL="$(InternalInstallersTargetStaticFeed)"
-        Internal="true"
-        Isolated="true"
-        Type="AzureStorageFeed"
-        Token="$(InternalInstallersTargetStaticFeedKey)" />
-      
-      <TargetFeedConfig
-        Condition="'$(IsInternalBuild)' == 'true'"
-        Include="Checksum"
-        TargetURL="$(InternalChecksumsTargetStaticFeed)"
-        Internal="true"
-        Isolated="true"
-        Type="AzureStorageFeed"
-        Token="$(InternalChecksumsTargetStaticFeedKey)" />
-      
-      
-      <!--
-        Configs below are for STABLE PUBLIC builds.
-      -->
-      <TargetFeedConfig
-        Condition="'$(IsInternalBuild)' == 'false'"
-        AssetSelection="ShippingOnly"
-        Include="NetCore"
-        TargetURL="$(NewAzDoFeedURL)"
-        Internal="false"
-        Isolated="true"
-        Type="AzDoNugetFeed"
-        Token="$(AzdoTargetFeedPAT)" />
-
-      <TargetFeedConfig
-        Condition="'$(IsInternalBuild)' == 'false'"
-        AssetSelection="NonShippingOnly"
-        Include="NetCore"
-        TargetURL="$(AzureDevOpsStaticTransportFeed)"
-        Internal="false"
-        Isolated="false"
-        Type="AzDoNugetFeed"
-        Token="$(AzureDevOpsStaticTransportFeedKey)" />
-
-      <TargetFeedConfig
-        Condition="'$(IsInternalBuild)' == 'false'"
-        Include="OSX;Deb;Rpm;Node;BinaryLayout;Installer;Maven;VSIX;Badge"
-        TargetURL="$(InstallersTargetStaticFeed)"
-        Internal="false"
-        Isolated="true"
-        Type="AzureStorageFeed"
-        Token="$(InstallersAzureAccountKey)" />
-      
-      <TargetFeedConfig
-        Condition="'$(IsInternalBuild)' == 'false'"
-        Include="Checksum"
-        TargetURL="$(ChecksumsTargetStaticFeed)"
-        Internal="false"
-        Isolated="true"
-        Type="AzureStorageFeed"
-        Token="$(ChecksumsAzureAccountKey)" />
-    </ItemGroup>
-
-    <!-- 
-      Feed configuration for non-stable AND Internal builds. 
-      The NuGet feed is a static feed in this case.
-    -->
-    <ItemGroup Condition="'@(TargetFeedConfig)' == '' AND '$(IsStableBuild)' == 'false' AND '$(IsInternalBuild)' == 'true'">
-      <TargetFeedConfig
-        Include="NetCore;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX"
-        TargetURL="$(StaticInternalFeed)"
-        Internal="true"
-        Isolated="false"
-        Type="AzDoNugetFeed"
-        Token="$(AzdoTargetFeedPAT)" />
-      
-      <TargetFeedConfig
-        Include="OSX;Deb;Rpm;Node;BinaryLayout;Installer;Maven;VSIX;Badge"
-        TargetURL="$(InternalInstallersTargetStaticFeed)"
-        Internal="true"
-        Isolated="true"
-        Type="AzureStorageFeed"
-        Token="$(InternalInstallersTargetStaticFeedKey)" />
-      
-      <TargetFeedConfig
-        Include="Checksum"
-        TargetURL="$(InternalChecksumsTargetStaticFeed)"
-        Internal="true"
-        Isolated="true"
-        Type="AzureStorageFeed"
-        Token="$(InternalChecksumsTargetStaticFeedKey)" />
-    </ItemGroup>
-
-    <!--
       - Adding this to let repos that want to override the TargetFeed be able to do so.
-      - I'm reusing the parameter that was introduced by RM pipelines so that no further 
+      - I'm reusing the parameter that was introduced by RM pipelines so that no further
         changes are needed in customer repos.
       - Eventually this will be deprecated or at least modified so that the build TargetFeed
         is selected based on build intent ('channel').
@@ -243,45 +120,169 @@
       <TargetStaticFeed Condition="'$(TargetStaticFeed)' == ''">https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</TargetStaticFeed>
     </PropertyGroup>
 
-    <!-- Configuration for public non-stable feeds -->
-    <ItemGroup Condition="'@(TargetFeedConfig)' == ''">
+    <!--
+      When a build is stable we ask `CreateAzureDevOpsFeed` in Tasks.Feed to create a new AzDO feed.
+    -->
+    <CreateAzureDevOpsFeed
+        Condition="'@(TargetFeedConfig)' == '' AND '$(IsStableBuild)' == 'true'"
+        IsInternal="$(IsInternalBuild)"
+        AzureDevOpsPersonalAccessToken="$(AzdoTargetFeedPAT)"
+        RepositoryName="$(RepositoryName)"
+        CommitSha="$(CommitSha)">
+      <Output TaskParameter="TargetFeedURL" PropertyName="NewAzDoFeedURL"/>
+    </CreateAzureDevOpsFeed>
+
+    <Error
+      Condition="'@(TargetFeedConfig)' == '' AND '$(AzureStorageTargetFeedPAT)' == '' AND '$(IsInternalBuild)' == 'false'"
+      Text="Parameter 'AzureStorageTargetFeedPAT' is empty. A valid storage account key for $(TargetStaticFeed) is required." />
+
+    <!--
+        Config for:
+        - Stable = true
+        - Internal = true/false
+
+        Publish:
+          - Shipping (stable) assets to new azure devops feed url
+          - NonShipping (non-stable) assets to azure devops transport feed url
+          - NonShipping (non-stable) assets to legacy blob feed url
+          - Installers and checksums to desired storage accounts.
+
+        We leave the 'Internal' property off of these so that the
+        publish task will determine whether the feed is public or private by attempting to access
+        the URL anonymously.
+    -->
+    <ItemGroup Condition="'@(TargetFeedConfig)' == '' AND '$(IsStableBuild)' == 'true'">
       <TargetFeedConfig
-        Include="NetCore;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX;Badge"
+        AssetSelection="ShippingOnly"
+        Include="NetCore"
+        TargetURL="$(NewAzDoFeedURL)"
+        Isolated="true"
+        Type="AzDoNugetFeed"
+        Token="$(AzdoTargetFeedPAT)" />
+
+      <TargetFeedConfig
+        AssetSelection="NonShippingOnly"
+        Include="NetCore"
         TargetURL="$(TargetStaticFeed)"
-        Internal="false"
         Isolated="false"
         Type="AzureStorageFeed"
         Token="$(AzureStorageTargetFeedPAT)" />
-      
+
+      <TargetFeedConfig
+        Condition="'$(PublishToAzureDevOpsNuGetFeeds)' == 'true'"
+        AssetSelection="NonShippingOnly"
+        Include="NetCore"
+        TargetURL="$(AzureDevOpsStaticTransportFeed)"
+        Isolated="false"
+        Type="AzDoNugetFeed"
+        Token="$(AzureDevOpsStaticTransportFeedKey)" />
+
+      <!-- These feeds are marked as isolated even though they are not. We simply overwrite
+           the old data with the new -->
+      <TargetFeedConfig
+        Condition="'$(PublishInstallersAndChecksums)' == 'true'"
+        Include="OSX;Deb;Rpm;Node;BinaryLayout;Installer;Maven;VSIX;Badge"
+        TargetURL="$(InstallersTargetStaticFeed)"
+        Isolated="true"
+        Type="AzureStorageFeed"
+        Token="$(InstallersTargetStaticFeedKey)" />
+
+      <TargetFeedConfig
+        Condition="'$(PublishInstallersAndChecksums)' == 'true'"
+        Include="Checksum"
+        TargetURL="$(ChecksumsTargetStaticFeed)"
+        Isolated="true"
+        Type="AzureStorageFeed"
+        Token="$(ChecksumsTargetStaticFeedKey)" />
+    </ItemGroup>
+
+    <!--
+      Config for:
+        - Stable = false
+        - Internal = true
+
+        Publish:
+          - Shipping (non-stable) assets to azure devops shipping feed url
+          - NonShipping (non-stable) assets to azure devops transport feed url
+          - Installers and checksums to desired storage accounts.
+    -->
+    <ItemGroup Condition="'@(TargetFeedConfig)' == '' AND '$(IsStableBuild)' == 'false' AND '$(IsInternalBuild)' == 'true'">
+      <TargetFeedConfig
+        Condition="'$(PublishToAzureDevOpsNuGetFeeds)' == 'true'"
+        AssetSelection="ShippingOnly"
+        Include="NetCore"
+        TargetURL="$(AzureDevOpsStaticShippingFeed)"
+        Isolated="false"
+        Type="AzDoNugetFeed"
+        Token="$(AzureDevOpsStaticShippingFeedKey)" />
+
+      <TargetFeedConfig
+        Condition="'$(PublishToAzureDevOpsNuGetFeeds)' == 'true'"
+        AssetSelection="NonShippingOnly"
+        Include="NetCore"
+        TargetURL="$(AzureDevOpsStaticTransportFeed)"
+        Isolated="false"
+        Type="AzDoNugetFeed"
+        Token="$(AzureDevOpsStaticTransportFeedKey)" />
+
+      <TargetFeedConfig
+        Condition="'$(PublishInstallersAndChecksums)' == 'true'"
+        Include="OSX;Deb;Rpm;Node;BinaryLayout;Installer;Maven;VSIX;Badge"
+        TargetURL="$(InstallersTargetStaticFeed)"
+        Isolated="false"
+        Type="AzureStorageFeed"
+        Token="$(InstallersTargetStaticFeedKey)" />
+
+      <TargetFeedConfig
+        Condition="'$(PublishInstallersAndChecksums)' == 'true'"
+        Include="Checksum"
+        TargetURL="$(ChecksumsTargetStaticFeed)"
+        Isolated="false"
+        Type="AzureStorageFeed"
+        Token="$(ChecksumsTargetStaticFeedKey)" />
+    </ItemGroup>
+
+    <!--
+      Config for:
+        - Stable = false
+        - Internal = false
+
+        Publish:
+          - Shipping (non-stable) assets to azure devops shipping feed url
+          - NonShipping (non-stable) assets to azure devops transport feed url
+          - All assets to legacy blob feed url
+          - Installers and checksums to desired storage accounts.
+    -->
+    <ItemGroup Condition="'@(TargetFeedConfig)' == '' AND '$(IsStableBuild)' == 'false' AND '$(IsInternalBuild)' == 'false'">
+      <TargetFeedConfig
+        Include="NetCore;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX;Badge"
+        TargetURL="$(TargetStaticFeed)"
+        Isolated="false"
+        Type="AzureStorageFeed"
+        Token="$(AzureStorageTargetFeedPAT)" />
+
       <TargetFeedConfig Condition="'$(PublishInstallersAndChecksums)' == 'true'"
         Include="OSX;Deb;Rpm;Node;BinaryLayout;Installer;Maven;VSIX;Badge"
         TargetURL="$(InstallersTargetStaticFeed)"
-        Internal="false"
         Isolated="false"
         Type="AzureStorageFeed"
         Token="$(InstallersAzureAccountKey)" />
-      
+
       <TargetFeedConfig Condition="'$(PublishInstallersAndChecksums)' == 'true'"
         Include="Checksum"
         TargetURL="$(ChecksumsTargetStaticFeed)"
-        Internal="false"
         Isolated="false"
         Type="AzureStorageFeed"
         Token="$(ChecksumsAzureAccountKey)" />
 
-      <!--
-        If there is a request to also publish to NuGet feeds, we will divide the packages into
-        shipping and non-shipping (transport) and push them to separate feeds.
-      -->
-      <TargetFeedConfig Condition="'$(PublishToAzureDevOpsNuGetFeeds)' == 'true' AND '$(IsStableBuild)' != 'true'"
+      <TargetFeedConfig Condition="'$(PublishToAzureDevOpsNuGetFeeds)' == 'true'"
         Include="NetCore"
         TargetURL="$(AzureDevOpsStaticShippingFeed)"
-        Internal="false"
         Isolated="false"
         Type="AzDoNugetFeed"
         Token="$(AzureDevOpsStaticShippingFeedKey)"
         AssetSelection="ShippingOnly" />
-      
+
       <TargetFeedConfig Condition="'$(PublishToAzureDevOpsNuGetFeeds)' == 'true'"
         Include="NetCore"
         TargetURL="$(AzureDevOpsStaticTransportFeed)"


### PR DESCRIPTION
- Eliminate the Internal* parameters. Multi-plex from the channel yaml files instead
- Eliminate a bunch of duplicated config after eliminating parameters
- Improve the comments
- Make azdo publishing the default for all except 3.1.  Avoided changing for 3.1 because we are in shutdown mode.  For 3.0 I am less worried because most repos will require some level of AzDO publishing anyway for stable builds.