### PR TITLE
Work around issues with the azure devops credential provider

### DIFF
--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -134,6 +134,13 @@ try {
     InitializeNativeTools
   }
 
+  # Work around issues with Azure Artifacts credential provider
+  if ($ci) {
+    dotnet nuget locals http-cache -c
+    $env:NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS=20
+    $env:NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS=20
+  }
+
   Build
 }
 catch {

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -213,4 +213,11 @@ if [[ "$restore" == true && -z ${DisableNativeToolsetInstalls:-} ]]; then
   InitializeNativeTools
 fi
 
+# Work around issues with Azure Artifacts Credential Provider
+if [[ "$ci" == true ]]; then
+  dotnet nuget locals http-cache -c
+  export NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS=20
+  export NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS=20
+fi
+
 Build


### PR DESCRIPTION
These environment variables and clearing the http-cache are required to get any sort of reliability when restoring packages from private feeds. 