### PR TITLE
PublishArtifactsInManifest updates for GA + 3.1 + Servicing

### DIFF
--- a/eng/common/templates/post-build/channels/netcore-dev-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-30.yml
@@ -97,14 +97,8 @@ stages:
             /p:IsInternalBuild=$(IsInternalBuild)
             /p:RepositoryName=$(Build.Repository.Name)
             /p:CommitSha=$(Build.SourceVersion)
-            /p:StaticInternalFeed=$(StaticInternalFeed)
-            /p:InternalChecksumsTargetStaticFeed=$(InternalChecksumsBlobFeedUrl)
-            /p:InternalChecksumsTargetStaticFeedKey=$(InternalChecksumsBlobFeedKey)
-            /p:InternalInstallersTargetStaticFeed=$(InternalInstallersBlobFeedUrl)
-            /p:InternalInstallersTargetStaticFeedKey=$(InternalInstallersBlobFeedKey)
             /p:NugetPath=$(NuGetExeToolPath)
             /p:AzdoTargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)' 
-            /p:TargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)' 
             /p:AzureStorageTargetFeedPAT='$(dotnetfeed-storage-access-key-1)' 
             /p:BARBuildId=$(BARBuildId) 
             /p:MaestroApiEndpoint='$(MaestroApiEndPoint)' 
@@ -118,6 +112,13 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
+            /p:PublishToAzureDevOpsNuGetFeeds=true
+            /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3/nuget/v3/index.json'
+            /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
+            /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3-transport/nuget/v3/index.json'
+            /p:AzureDevOpsStaticTransportFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
+            /p:AzureDevOpsStaticSymbolsFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3-symbols/nuget/v3/index.json'
+            /p:AzureDevOpsStaticSymbolsFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             ${{ parameters.artifactsPublishingAdditionalParameters }}
 
       - template: ../../steps/promote-build.yml

--- a/eng/common/templates/post-build/channels/netcore-dev-31.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-31.yml
@@ -46,7 +46,7 @@ stages:
             /p:Configuration=Release
             ${{ parameters.symbolPublishingAdditionalParameters }}
 
-  - job:
+  - job: publish_assets
     displayName: Publish Assets
     dependsOn: setupMaestroVars
     variables:
@@ -97,14 +97,8 @@ stages:
             /p:IsInternalBuild=$(IsInternalBuild)
             /p:RepositoryName=$(Build.Repository.Name)
             /p:CommitSha=$(Build.SourceVersion)
-            /p:StaticInternalFeed=$(StaticInternalFeed)
-            /p:InternalChecksumsTargetStaticFeed=$(InternalChecksumsBlobFeedUrl)
-            /p:InternalChecksumsTargetStaticFeedKey=$(InternalChecksumsBlobFeedKey)
-            /p:InternalInstallersTargetStaticFeed=$(InternalInstallersBlobFeedUrl)
-            /p:InternalInstallersTargetStaticFeedKey=$(InternalInstallersBlobFeedKey)
             /p:NugetPath=$(NuGetExeToolPath)
             /p:AzdoTargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)'
-            /p:TargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)'
             /p:AzureStorageTargetFeedPAT='$(dotnetfeed-storage-access-key-1)'
             /p:BARBuildId=$(BARBuildId)
             /p:MaestroApiEndpoint='$(MaestroApiEndPoint)'
@@ -118,6 +112,13 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
+            /p:PublishToAzureDevOpsNuGetFeeds=true
+            /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1/nuget/v3/index.json'
+            /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
+            /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-transport/nuget/v3/index.json'
+            /p:AzureDevOpsStaticTransportFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
+            /p:AzureDevOpsStaticSymbolsFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-symbols/nuget/v3/index.json'
+            /p:AzureDevOpsStaticSymbolsFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             ${{ parameters.artifactsPublishingAdditionalParameters }}
 
       - template: ../../steps/promote-build.yml

--- a/eng/common/templates/post-build/channels/netcore-dev-5.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-5.yml
@@ -2,7 +2,6 @@ parameters:
   symbolPublishingAdditionalParameters: ''
   artifactsPublishingAdditionalParameters: ''
   publishInstallersAndChecksums: false
-  publishToAzureDevOpsFeeds: true
 
 stages:
 - stage: NetCore_Dev5_Publish
@@ -92,38 +91,34 @@ stages:
           AZURE_DEVOPS_EXT_PAT: $(dn-bot-dnceng-universal-packages-rw)
         inputs:
           filePath: eng\common\sdk-task.ps1
-          arguments: -task PublishArtifactsInManifest -restore -msbuildEngine dotnet 
+          arguments: -task PublishArtifactsInManifest -restore -msbuildEngine dotnet
             /p:ArtifactsCategory=$(_DotNetArtifactsCategory)
             /p:IsStableBuild=$(IsStableBuild)
             /p:IsInternalBuild=$(IsInternalBuild)
             /p:RepositoryName=$(Build.Repository.Name)
             /p:CommitSha=$(Build.SourceVersion)
-            /p:StaticInternalFeed=$(StaticInternalFeed)
-            /p:InternalChecksumsTargetStaticFeed=$(InternalChecksumsBlobFeedUrl)
-            /p:InternalChecksumsTargetStaticFeedKey=$(InternalChecksumsBlobFeedKey)
-            /p:InternalInstallersTargetStaticFeed=$(InternalInstallersBlobFeedUrl)
-            /p:InternalInstallersTargetStaticFeedKey=$(InternalInstallersBlobFeedKey)
             /p:NugetPath=$(NuGetExeToolPath)
-            /p:AzdoTargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)' 
-            /p:TargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)' 
-            /p:AzureStorageTargetFeedPAT='$(dotnetfeed-storage-access-key-1)' 
-            /p:BARBuildId=$(BARBuildId) 
-            /p:MaestroApiEndpoint='$(MaestroApiEndPoint)' 
-            /p:BuildAssetRegistryToken='$(MaestroApiAccessToken)' 
-            /p:ManifestsBasePath='$(Build.ArtifactStagingDirectory)/AssetManifests/' 
-            /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/' 
-            /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts/' 
+            /p:AzdoTargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)'
+            /p:AzureStorageTargetFeedPAT='$(dotnetfeed-storage-access-key-1)'
+            /p:BARBuildId=$(BARBuildId)
+            /p:MaestroApiEndpoint='$(MaestroApiEndPoint)'
+            /p:BuildAssetRegistryToken='$(MaestroApiAccessToken)'
+            /p:ManifestsBasePath='$(Build.ArtifactStagingDirectory)/AssetManifests/'
+            /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/'
+            /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts/'
             /p:Configuration=Release
             /p:PublishInstallersAndChecksums=${{ parameters.publishInstallersAndChecksums }}
             /p:InstallersTargetStaticFeed=$(InstallersBlobFeedUrl)
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=${{ parameters.publishToAzureDevOpsFeeds }}
+            /p:PublishToAzureDevOpsNuGetFeeds=true
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json'
             /p:AzureDevOpsStaticTransportFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
+            /p:AzureDevOpsStaticSymbolsFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-symbols/nuget/v3/index.json'
+            /p:AzureDevOpsStaticSymbolsFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             ${{ parameters.artifactsPublishingAdditionalParameters }}
 
       - template: ../../steps/promote-build.yml

--- a/eng/common/templates/post-build/channels/netcore-internal-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-internal-30.yml
@@ -90,27 +90,33 @@ stages:
           AZURE_DEVOPS_EXT_PAT: $(dn-bot-dnceng-universal-packages-rw)
         inputs:
           filePath: eng\common\sdk-task.ps1
-          arguments: -task PublishArtifactsInManifest -restore -msbuildEngine dotnet 
+          arguments: -task PublishArtifactsInManifest -restore -msbuildEngine dotnet
             /p:IsStableBuild=$(IsStableBuild)
             /p:IsInternalBuild=$(IsInternalBuild)
             /p:RepositoryName=$(Build.Repository.Name)
             /p:CommitSha=$(Build.SourceVersion)
-            /p:StaticInternalFeed=$(StaticInternalFeed)
-            /p:InternalChecksumsTargetStaticFeed=$(InternalChecksumsBlobFeedUrl)
-            /p:InternalChecksumsTargetStaticFeedKey=$(InternalChecksumsBlobFeedKey)
-            /p:InternalInstallersTargetStaticFeed=$(InternalInstallersBlobFeedUrl)
-            /p:InternalInstallersTargetStaticFeedKey=$(InternalInstallersBlobFeedKey)
             /p:NugetPath=$(NuGetExeToolPath)
-            /p:AzdoTargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)' 	
-            /p:TargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)' 
-            /p:AzureStorageTargetFeedPAT='$(dotnetfeed-storage-access-key-1)' 
-            /p:BARBuildId=$(BARBuildId) 
-            /p:MaestroApiEndpoint='$(MaestroApiEndPoint)' 
-            /p:BuildAssetRegistryToken='$(MaestroApiAccessToken)' 
-            /p:ManifestsBasePath='$(Build.ArtifactStagingDirectory)/AssetManifests/' 
-            /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/' 
-            /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts/' 
-            /p:Configuration=Release 
+            /p:AzdoTargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)'
+            /p:AzureStorageTargetFeedPAT='$(dotnetfeed-storage-access-key-1)'
+            /p:BARBuildId=$(BARBuildId)
+            /p:MaestroApiEndpoint='$(MaestroApiEndPoint)'
+            /p:BuildAssetRegistryToken='$(MaestroApiAccessToken)'
+            /p:ManifestsBasePath='$(Build.ArtifactStagingDirectory)/AssetManifests/'
+            /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/'
+            /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts/'
+            /p:Configuration=Release
+            /p:PublishInstallersAndChecksums=true
+            /p:ChecksumsTargetStaticFeed=$(InternalChecksumsBlobFeedUrl)
+            /p:ChecksumsTargetStaticFeedKey=$(InternalChecksumsBlobFeedKey)
+            /p:InstallersTargetStaticFeed=$(InternalInstallersBlobFeedUrl)
+            /p:InstallersTargetStaticFeedKey=$(InternalInstallersBlobFeedKey)
+            /p:PublishToAzureDevOpsNuGetFeeds=true
+            /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3-internal/nuget/v3/index.json'
+            /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
+            /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3-internal-transport/nuget/v3/index.json'
+            /p:AzureDevOpsStaticTransportFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
+            /p:AzureDevOpsStaticSymbolsFeed='https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3-internal-symbols/nuget/v3/index.json'
+            /p:AzureDevOpsStaticSymbolsFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             ${{ parameters.artifactsPublishingAdditionalParameters }}
 
       - template: ../../steps/promote-build.yml

--- a/eng/common/templates/post-build/channels/netcore-release-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-release-30.yml
@@ -91,33 +91,34 @@ stages:
           AZURE_DEVOPS_EXT_PAT: $(dn-bot-dnceng-universal-packages-rw)
         inputs:
           filePath: eng\common\sdk-task.ps1
-          arguments: -task PublishArtifactsInManifest -restore -msbuildEngine dotnet 
+          arguments: -task PublishArtifactsInManifest -restore -msbuildEngine dotnet
             /p:ArtifactsCategory=$(_DotNetArtifactsCategory)
             /p:IsStableBuild=$(IsStableBuild)
             /p:IsInternalBuild=$(IsInternalBuild)
             /p:RepositoryName=$(Build.Repository.Name)
             /p:CommitSha=$(Build.SourceVersion)
-            /p:StaticInternalFeed=$(StaticInternalFeed)
-            /p:InternalChecksumsTargetStaticFeed=$(InternalChecksumsBlobFeedUrl)
-            /p:InternalChecksumsTargetStaticFeedKey=$(InternalChecksumsBlobFeedKey)
-            /p:InternalInstallersTargetStaticFeed=$(InternalInstallersBlobFeedUrl)
-            /p:InternalInstallersTargetStaticFeedKey=$(InternalInstallersBlobFeedKey)
             /p:NugetPath=$(NuGetExeToolPath)
             /p:AzdoTargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)'
-            /p:TargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)' 
-            /p:AzureStorageTargetFeedPAT='$(dotnetfeed-storage-access-key-1)' 
-            /p:BARBuildId=$(BARBuildId) 
-            /p:MaestroApiEndpoint='$(MaestroApiEndPoint)' 
-            /p:BuildAssetRegistryToken='$(MaestroApiAccessToken)' 
-            /p:ManifestsBasePath='$(Build.ArtifactStagingDirectory)/AssetManifests/' 
-            /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/' 
-            /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts/' 
+            /p:AzureStorageTargetFeedPAT='$(dotnetfeed-storage-access-key-1)'
+            /p:BARBuildId=$(BARBuildId)
+            /p:MaestroApiEndpoint='$(MaestroApiEndPoint)'
+            /p:BuildAssetRegistryToken='$(MaestroApiAccessToken)'
+            /p:ManifestsBasePath='$(Build.ArtifactStagingDirectory)/AssetManifests/'
+            /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/'
+            /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts/'
             /p:Configuration=Release
             /p:PublishInstallersAndChecksums=${{ parameters.publishInstallersAndChecksums }}
             /p:InstallersTargetStaticFeed=$(InstallersBlobFeedUrl)
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
+            /p:PublishToAzureDevOpsNuGetFeeds=true
+            /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3/nuget/v3/index.json'
+            /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
+            /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3-transport/nuget/v3/index.json'
+            /p:AzureDevOpsStaticTransportFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
+            /p:AzureDevOpsStaticSymbolsFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3-symbols/nuget/v3/index.json'
+            /p:AzureDevOpsStaticSymbolsFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             ${{ parameters.artifactsPublishingAdditionalParameters }}
 
       - template: ../../steps/promote-build.yml

--- a/eng/common/templates/post-build/channels/netcore-release-31.yml
+++ b/eng/common/templates/post-build/channels/netcore-release-31.yml
@@ -97,14 +97,8 @@ stages:
             /p:IsInternalBuild=$(IsInternalBuild)
             /p:RepositoryName=$(Build.Repository.Name)
             /p:CommitSha=$(Build.SourceVersion)
-            /p:StaticInternalFeed=$(StaticInternalFeed)
-            /p:InternalChecksumsTargetStaticFeed=$(InternalChecksumsBlobFeedUrl)
-            /p:InternalChecksumsTargetStaticFeedKey=$(InternalChecksumsBlobFeedKey)
-            /p:InternalInstallersTargetStaticFeed=$(InternalInstallersBlobFeedUrl)
-            /p:InternalInstallersTargetStaticFeedKey=$(InternalInstallersBlobFeedKey)
             /p:NugetPath=$(NuGetExeToolPath)
             /p:AzdoTargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)'
-            /p:TargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)'
             /p:AzureStorageTargetFeedPAT='$(dotnetfeed-storage-access-key-1)'
             /p:BARBuildId=$(BARBuildId)
             /p:MaestroApiEndpoint='$(MaestroApiEndPoint)'
@@ -118,6 +112,13 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
+            /p:PublishToAzureDevOpsNuGetFeeds=true
+            /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1/nuget/v3/index.json'
+            /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
+            /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-transport/nuget/v3/index.json'
+            /p:AzureDevOpsStaticTransportFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
+            /p:AzureDevOpsStaticSymbolsFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-symbols/nuget/v3/index.json'
+            /p:AzureDevOpsStaticSymbolsFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             ${{ parameters.artifactsPublishingAdditionalParameters }}
 
       - template: ../../steps/promote-build.yml

--- a/eng/common/templates/post-build/channels/netcore-tools-latest.yml
+++ b/eng/common/templates/post-build/channels/netcore-tools-latest.yml
@@ -2,7 +2,6 @@ parameters:
   symbolPublishingAdditionalParameters: ''
   artifactsPublishingAdditionalParameters: ''
   publishInstallersAndChecksums: false
-  publishToAzureDevOpsFeeds: true
 
 stages:
 - stage: NetCore_Tools_Latest_Publish
@@ -92,40 +91,36 @@ stages:
           AZURE_DEVOPS_EXT_PAT: $(dn-bot-dnceng-universal-packages-rw)
         inputs:
           filePath: eng\common\sdk-task.ps1
-          arguments: -task PublishArtifactsInManifest -restore -msbuildEngine dotnet 
+          arguments: -task PublishArtifactsInManifest -restore -msbuildEngine dotnet
             /p:ArtifactsCategory=$(_DotNetArtifactsCategory)
             /p:IsStableBuild=$(IsStableBuild)
             /p:IsInternalBuild=$(IsInternalBuild)
             /p:RepositoryName=$(Build.Repository.Name)
             /p:CommitSha=$(Build.SourceVersion)
-            /p:StaticInternalFeed=$(StaticInternalFeed)
-            /p:InternalChecksumsTargetStaticFeed=$(InternalChecksumsBlobFeedUrl)
-            /p:InternalChecksumsTargetStaticFeedKey=$(InternalChecksumsBlobFeedKey)
-            /p:InternalInstallersTargetStaticFeed=$(InternalInstallersBlobFeedUrl)
-            /p:InternalInstallersTargetStaticFeedKey=$(InternalInstallersBlobFeedKey)
             /p:NugetPath=$(NuGetExeToolPath)
-            /p:AzdoTargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)' 
-            /p:TargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)' 
-            /p:AzureStorageTargetFeedPAT='$(dotnetfeed-storage-access-key-1)' 
-            /p:BARBuildId=$(BARBuildId) 
-            /p:MaestroApiEndpoint='$(MaestroApiEndPoint)' 
-            /p:BuildAssetRegistryToken='$(MaestroApiAccessToken)' 
-            /p:ManifestsBasePath='$(Build.ArtifactStagingDirectory)/AssetManifests/' 
-            /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/' 
-            /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts/' 
+            /p:AzdoTargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)'
+            /p:AzureStorageTargetFeedPAT='$(dotnetfeed-storage-access-key-1)'
+            /p:BARBuildId=$(BARBuildId)
+            /p:MaestroApiEndpoint='$(MaestroApiEndPoint)'
+            /p:BuildAssetRegistryToken='$(MaestroApiAccessToken)'
+            /p:ManifestsBasePath='$(Build.ArtifactStagingDirectory)/AssetManifests/'
+            /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/'
+            /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts/'
             /p:Configuration=Release
             /p:PublishInstallersAndChecksums=${{ parameters.publishInstallersAndChecksums }}
             /p:InstallersTargetStaticFeed=$(InstallersBlobFeedUrl)
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=${{ parameters.publishToAzureDevOpsFeeds }}
+            /p:PublishToAzureDevOpsNuGetFeeds=true
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'
             /p:AzureDevOpsStaticTransportFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)
+            /p:AzureDevOpsStaticSymbolsFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools-symbols/nuget/v3/index.json'
+            /p:AzureDevOpsStaticSymbolsFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)
             ${{ parameters.artifactsPublishingAdditionalParameters }}
-              
+
       - template: ../../steps/promote-build.yml
         parameters:
           ChannelId: ${{ variables.NetCore_Tools_Latest_Channel_Id }}

--- a/eng/common/templates/post-build/channels/public-validation-release.yml
+++ b/eng/common/templates/post-build/channels/public-validation-release.yml
@@ -1,7 +1,6 @@
 parameters:
   artifactsPublishingAdditionalParameters: ''
   publishInstallersAndChecksums: false
-  publishToAzureDevOpsFeeds: true
 
 stages:
 - stage: PVR_Publish
@@ -57,35 +56,36 @@ stages:
           AZURE_DEVOPS_EXT_PAT: $(dn-bot-dnceng-universal-packages-rw)
         inputs:
           filePath: eng\common\sdk-task.ps1
-          arguments: -task PublishArtifactsInManifest -restore -msbuildEngine dotnet 
+          arguments: -task PublishArtifactsInManifest -restore -msbuildEngine dotnet
             /p:ArtifactsCategory=$(_DotNetValidationArtifactsCategory)
             /p:IsStableBuild=$(IsStableBuild)
             /p:IsInternalBuild=$(IsInternalBuild)
             /p:RepositoryName=$(Build.Repository.Name)
             /p:CommitSha=$(Build.SourceVersion)
             /p:NugetPath=$(NuGetExeToolPath)
-            /p:AzdoTargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)' 
-            /p:TargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)' 
-            /p:AzureStorageTargetFeedPAT='$(dotnetfeed-storage-access-key-1)' 
-            /p:BARBuildId=$(BARBuildId) 
-            /p:MaestroApiEndpoint='$(MaestroApiEndPoint)' 
-            /p:BuildAssetRegistryToken='$(MaestroApiAccessToken)' 
-            /p:ManifestsBasePath='$(Build.ArtifactStagingDirectory)/AssetManifests/' 
-            /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/' 
-            /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts/' 
+            /p:AzdoTargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)'
+            /p:AzureStorageTargetFeedPAT='$(dotnetfeed-storage-access-key-1)'
+            /p:BARBuildId=$(BARBuildId)
+            /p:MaestroApiEndpoint='$(MaestroApiEndPoint)'
+            /p:BuildAssetRegistryToken='$(MaestroApiAccessToken)'
+            /p:ManifestsBasePath='$(Build.ArtifactStagingDirectory)/AssetManifests/'
+            /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/'
+            /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts/'
             /p:Configuration=Release
             /p:PublishInstallersAndChecksums=${{ parameters.publishInstallersAndChecksums }}
             /p:InstallersTargetStaticFeed=$(InstallersBlobFeedUrl)
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=${{ parameters.publishToAzureDevOpsFeeds }}
+            /p:PublishToAzureDevOpsNuGetFeeds=true
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'
             /p:AzureDevOpsStaticTransportFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
+            /p:AzureDevOpsStaticSymbolsFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools-symbols/nuget/v3/index.json'
+            /p:AzureDevOpsStaticSymbolsFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)
             ${{ parameters.artifactsPublishingAdditionalParameters }}
-      
+
       - template: ../../steps/promote-build.yml
         parameters:
           ChannelId: ${{ variables.PublicValidationRelease_30_Channel_Id }}

--- a/eng/common/templates/post-build/common-variables.yml
+++ b/eng/common/templates/post-build/common-variables.yml
@@ -55,10 +55,6 @@ variables:
   # Feed Configurations
   # These should include the suffix "/index.json"
 
-  # Configuration for the feed where packages from internal non-stable builds will be published to
-  - name: StaticInternalFeed
-    value: 'https://dnceng.pkgs.visualstudio.com/_packaging/dotnet-core-internal/nuget/v3/index.json'
-
   # Default locations for Installers and checksums
   # Public Locations
   - name: ChecksumsBlobFeedUrl

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -4,7 +4,6 @@ parameters:
   enableSymbolValidation: false
   enableNugetValidation: true
   publishInstallersAndChecksums: false
-  enableAzDONuGetFeeds: true
   SDLValidationParameters:
     enable: false
     continueOnError: false
@@ -101,7 +100,6 @@ stages:
     symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
     artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
     publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
-    enableAzDONuGetFeeds: ${{ parameters.enableAzDONuGetFeeds }}
 
 - template: \eng\common\templates\post-build\channels\netcore-dev-30.yml
   parameters:
@@ -120,13 +118,11 @@ stages:
     symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
     artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
     publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
-    enableAzDONuGetFeeds: ${{ parameters.enableAzDONuGetFeeds }}
 
 - template: \eng\common\templates\post-build\channels\public-validation-release.yml
   parameters:
     artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
     publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
-    enableAzDONuGetFeeds: ${{ parameters.enableAzDONuGetFeeds }}
 
 - template: \eng\common\templates\post-build\channels\netcore-release-30.yml
   parameters:

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
@@ -3,56 +3,54 @@
   <!--
     This file main target, namely `SetupTargetFeeds`, is used to create an ItemGroup with
     feed descriptors that will be used for publishing build assets.
-    
+
     Summary of the logic implemented here:
-      - A stable build is a non-preview build. Package versions are usually in 
+      - A stable build is a non-preview build. Package versions are usually in
         the format <Major.Minor.Patch>. To create stable builds the user have to
         set the `DotNetFinalVersionKind` build parameter to `release`.
-        
+
       - An internal build is a build from a branch that has `internal` on its name.
         The assets produced from this kind of build aren't meant for public usage.
-        
+
       - For business reasons package versions for stable builds don't increment
         automatically. That means that different stable builds may produce packages
         with different binary content but same version number.
-        
+
       - Since feeds don't permit overriding packages, the approach we followed
-        to publish assets from stable builds was to create a new _feed_ for every 
+        to publish assets from stable builds was to create a new _feed_ for every
         stable build. Therefore, whenever we are publishing packages from a stable
         build we create a new (public | internal) feed to publish packages to.
-        
+
       - Non stable builds are the usual ones. Package's version for such builds have
         a prerelease label, e.g., preview, beta, alpha, etc. Since packages for these
         builds have their version incremented automatically for every build we can
         publish the packages always to the same feed.
-        
+
       - Non-stable internal build's assets are published to a fixed internal feed.
-      
+
       - Non-stable public build's assets are published to various public feeds.
-    
+
     Parameters:
       - IsInternalBuild                       : true if the build is internal, i.e., created from an branch with internal on its name.
       - IsStableBuild                         : true if the build is stable, i.e., `DotNetFinalVersionKind` == `release`.
       - RepositoryName                        : Name of the source repo. Used when creating a stable internal feed.
       - CommitSha                             : Commit SHA for this build. Used when creating a stable internal feed.
-      - AzureStorageAccountName
-      - AzureStorageAccountKey
-      - AzureDevOpsFeedsBaseUrl
       - ArtifactsCategory                     : Used to let user override target feed of public channels.
-      - AzureStorageTargetFeedPAT
-      - StaticInternalFeed                    : URL of the feed to publish internal non-stable packages
-      - PublishInstallersAndChecksums         : Whether to publish installers and checksums to a secondary location for Dev channels
-      - InstallersTargetStaticFeed
-      - InstallersAzureAccountKey
-      - ChecksumsTargetStaticFeed
-      - ChecksumsAzureAccountKey
+      - AzureStorageTargetFeedPAT             : Key for Azure storage feed used to publish for non-stable, non-internal builds
+      - PublishInstallersAndChecksums         : Whether to publish installers and checksums to a secondary locations
+      - InstallersTargetStaticFeed            : Where installers should be published
+      - InstallersAzureAccountKey             : Account key for installers location
+      - ChecksumsTargetStaticFeed             : Where checksums should be published
+      - ChecksumsAzureAccountKey              : Account key forchecksums location
       - PublishToAzureDevOpsNuGetFeeds        : If true, publish NuGet packages to Azure DevOps feeds.
       - AzureDevOpsStaticShippingFeed         : URL of the Azure DevOps NuGet feed to publish non-stable shipping packages to.
       - AzureDevOpsStaticShippingFeedKey      : Key of the feed Azure DevOps NuGet feed to publish non-stable shipping packages to.
       - AzureDevOpsStaticTransportFeed        : URL of the feed Azure DevOps NuGet feed to publish transport packages to.
       - AzureDevOpsStaticTransportFeedKey     : Key of the feed Azure DevOps NuGet feed to publish to transport packages to.
+      - AzureDevOpsStaticSymbolsFeed          : URL of the feed Azure DevOps NuGet feed to publish symbol packages to.
+      - AzureDevOpsStaticSymbolsFeedKey       : Key of the feed Azure DevOps NuGet feed to publish to symbol packages to.
 
-      - CreateTestConfig                      : If set to true the user will be able to test a TargetFeedConfig 
+      - CreateTestConfig                      : If set to true the user will be able to test a TargetFeedConfig
                                                 constructed using parameters below:
         - TestFeedCategories
         - TestFeedURL
@@ -85,9 +83,13 @@
       Condition="('$(AzureDevOpsStaticTransportFeed)' == '' or '$(AzureDevOpsStaticTransportFeedKey)' == '') and '$(PublishToAzureDevOpsNuGetFeeds)' == 'true'"
       Text="Parameters 'AzureDevOpsStaticTransportFeed/AzureDevOpsStaticTransportFeedKey' are empty." />
 
+    <Error
+      Condition="('$(AzureDevOpsStaticSymbolsFeed)' == '' or '$(AzureDevOpsStaticSymbolsFeedKey)' == '') and '$(PublishToAzureDevOpsNuGetFeeds)' == 'true'"
+      Text="Parameters 'AzureDevOpsStaticSymbolsFeed/AzureDevOpsStaticSymbolsFeedKey' are empty." />
+
     <!--
       If the user wants to use a test configuration we'll create a TargetFeedConfig using
-      optional parameters passed as properties. This should prevent all the other 
+      optional parameters passed as properties. This should prevent all the other
       cases below from being activated.
     -->
     <ItemGroup Condition="'$(CreateTestConfig)' == 'true'">
@@ -99,127 +101,8 @@
     </ItemGroup>
 
     <!--
-      When a build is stable we ask `CreateInternalBlobFeed` in Tasks.Feed to create a new AzDO feed.
-      That task will return an Azure Storage feed wrapped by an authenticated Azure function proxy,
-      we use that to mimic an internal/authenticated feed. This will likely change in the future once
-      we switch to using AzDO private feeds.
-    -->
-    <CreateAzureDevOpsFeed
-        Condition="'@(TargetFeedConfig)' == '' AND '$(IsStableBuild)' == 'true'"
-        IsInternal="$(IsInternalBuild)"
-        AzureDevOpsPersonalAccessToken="$(AzdoTargetFeedPAT)"
-        RepositoryName="$(RepositoryName)"
-        CommitSha="$(CommitSha)">
-      <Output TaskParameter="TargetFeedURL" PropertyName="NewAzDoFeedURL"/>
-    </CreateAzureDevOpsFeed>
-
-    <ItemGroup Condition="'@(TargetFeedConfig)' == '' AND '$(IsStableBuild)' == 'true'">
-      <!--
-        Configs below are for STABLE INTERNAL builds.
-      -->
-      <TargetFeedConfig
-        Condition="'$(IsInternalBuild)' == 'true'"
-        Include="NetCore"
-        TargetURL="$(NewAzDoFeedURL)"
-        Internal="true"
-        Isolated="true"
-        Type="AzDoNugetFeed"
-        Token="$(AzdoTargetFeedPAT)" />
-      
-      <TargetFeedConfig
-        Condition="'$(IsInternalBuild)' == 'true'"
-        Include="OSX;Deb;Rpm;Node;BinaryLayout;Installer;Maven;VSIX;Badge"
-        TargetURL="$(InternalInstallersTargetStaticFeed)"
-        Internal="true"
-        Isolated="true"
-        Type="AzureStorageFeed"
-        Token="$(InternalInstallersTargetStaticFeedKey)" />
-      
-      <TargetFeedConfig
-        Condition="'$(IsInternalBuild)' == 'true'"
-        Include="Checksum"
-        TargetURL="$(InternalChecksumsTargetStaticFeed)"
-        Internal="true"
-        Isolated="true"
-        Type="AzureStorageFeed"
-        Token="$(InternalChecksumsTargetStaticFeedKey)" />
-      
-      
-      <!--
-        Configs below are for STABLE PUBLIC builds.
-      -->
-      <TargetFeedConfig
-        Condition="'$(IsInternalBuild)' == 'false'"
-        AssetSelection="ShippingOnly"
-        Include="NetCore"
-        TargetURL="$(NewAzDoFeedURL)"
-        Internal="false"
-        Isolated="true"
-        Type="AzDoNugetFeed"
-        Token="$(AzdoTargetFeedPAT)" />
-
-      <TargetFeedConfig
-        Condition="'$(IsInternalBuild)' == 'false'"
-        AssetSelection="NonShippingOnly"
-        Include="NetCore"
-        TargetURL="$(AzureDevOpsStaticTransportFeed)"
-        Internal="false"
-        Isolated="false"
-        Type="AzDoNugetFeed"
-        Token="$(AzureDevOpsStaticTransportFeedKey)" />
-
-      <TargetFeedConfig
-        Condition="'$(IsInternalBuild)' == 'false'"
-        Include="OSX;Deb;Rpm;Node;BinaryLayout;Installer;Maven;VSIX;Badge"
-        TargetURL="$(InstallersTargetStaticFeed)"
-        Internal="false"
-        Isolated="true"
-        Type="AzureStorageFeed"
-        Token="$(InstallersAzureAccountKey)" />
-      
-      <TargetFeedConfig
-        Condition="'$(IsInternalBuild)' == 'false'"
-        Include="Checksum"
-        TargetURL="$(ChecksumsTargetStaticFeed)"
-        Internal="false"
-        Isolated="true"
-        Type="AzureStorageFeed"
-        Token="$(ChecksumsAzureAccountKey)" />
-    </ItemGroup>
-
-    <!-- 
-      Feed configuration for non-stable AND Internal builds. 
-      The NuGet feed is a static feed in this case.
-    -->
-    <ItemGroup Condition="'@(TargetFeedConfig)' == '' AND '$(IsStableBuild)' == 'false' AND '$(IsInternalBuild)' == 'true'">
-      <TargetFeedConfig
-        Include="NetCore;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX"
-        TargetURL="$(StaticInternalFeed)"
-        Internal="true"
-        Isolated="false"
-        Type="AzDoNugetFeed"
-        Token="$(AzdoTargetFeedPAT)" />
-      
-      <TargetFeedConfig
-        Include="OSX;Deb;Rpm;Node;BinaryLayout;Installer;Maven;VSIX;Badge"
-        TargetURL="$(InternalInstallersTargetStaticFeed)"
-        Internal="true"
-        Isolated="true"
-        Type="AzureStorageFeed"
-        Token="$(InternalInstallersTargetStaticFeedKey)" />
-      
-      <TargetFeedConfig
-        Include="Checksum"
-        TargetURL="$(InternalChecksumsTargetStaticFeed)"
-        Internal="true"
-        Isolated="true"
-        Type="AzureStorageFeed"
-        Token="$(InternalChecksumsTargetStaticFeedKey)" />
-    </ItemGroup>
-
-    <!--
       - Adding this to let repos that want to override the TargetFeed be able to do so.
-      - I'm reusing the parameter that was introduced by RM pipelines so that no further 
+      - I'm reusing the parameter that was introduced by RM pipelines so that no further
         changes are needed in customer repos.
       - Eventually this will be deprecated or at least modified so that the build TargetFeed
         is selected based on build intent ('channel').
@@ -243,53 +126,230 @@
       <TargetStaticFeed Condition="'$(TargetStaticFeed)' == ''">https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</TargetStaticFeed>
     </PropertyGroup>
 
-    <!-- Configuration for public non-stable feeds -->
-    <ItemGroup Condition="'@(TargetFeedConfig)' == ''">
+    <!--
+      When a build is stable we ask `CreateAzureDevOpsFeed` in Tasks.Feed to
+      create two new AzDo feeds.  One for symbols and one for packages. Package
+      IDs overlap with symbol package IDs, so they cannot be published to the
+      same azure devops feed.
+    -->
+    <CreateAzureDevOpsFeed
+        Condition="'@(TargetFeedConfig)' == '' AND '$(IsStableBuild)' == 'true'"
+        IsInternal="$(IsInternalBuild)"
+        AzureDevOpsPersonalAccessToken="$(AzdoTargetFeedPAT)"
+        RepositoryName="$(RepositoryName)"
+        CommitSha="$(CommitSha)">
+      <Output TaskParameter="TargetFeedURL" PropertyName="NewAzDoIsolatedPackageFeedURL"/>
+    </CreateAzureDevOpsFeed>
+
+    <CreateAzureDevOpsFeed
+        Condition="'@(TargetFeedConfig)' == '' AND '$(IsStableBuild)' == 'true'"
+        IsInternal="$(IsInternalBuild)"
+        AzureDevOpsPersonalAccessToken="$(AzdoTargetFeedPAT)"
+        RepositoryName="$(RepositoryName)"
+        CommitSha="$(CommitSha)"
+        ContentIdentifier="sym">
+      <Output TaskParameter="TargetFeedURL" PropertyName="NewAzDoIsolatedSymbolsFeedURL"/>
+    </CreateAzureDevOpsFeed>
+
+    <Error
+      Condition="'@(TargetFeedConfig)' == '' AND '$(AzureStorageTargetFeedPAT)' == '' AND '$(IsInternalBuild)' == 'false'"
+      Text="Parameter 'AzureStorageTargetFeedPAT' is empty. A valid storage account key for $(TargetStaticFeed) is required." />
+
+    <!--
+        Config for:
+        - Stable = true
+        - Internal = true/false
+
+        Publish:
+          - Shipping (stable) packages to new azure devops package feed url
+          - Shipping (stable) symbol packages to new azure devops symbol feed url
+          - NonShipping (non-stable) packages to azure devops transport feed url
+          - NonShipping (non-stable) symbol packages to azure devops symbol feed url
+          - NonShipping (non-stable) assets to legacy blob feed url
+          - Installers and checksums to desired storage accounts.
+
+        We leave the 'Internal' property off of these so that the
+        publish task will determine whether the feed is public or private by attempting to access
+        the URL anonymously.
+    -->
+    <ItemGroup Condition="'@(TargetFeedConfig)' == '' AND '$(IsStableBuild)' == 'true'">
+
       <TargetFeedConfig
-        Include="NetCore;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX;Badge"
+        AssetSelection="ShippingOnly"
+        Include="Package"
+        TargetURL="$(NewAzDoIsolatedPackageFeedURL)"
+        Isolated="true"
+        Type="AzDoNugetFeed"
+        Token="$(AzdoTargetFeedPAT)" />
+
+      <TargetFeedConfig
+        AssetSelection="ShippingOnly"
+        Include="Symbols"
+        TargetURL="$(NewAzDoIsolatedSymbolsFeedURL)"
+        Isolated="true"
+        Type="AzDoNugetFeed"
+        Token="$(AzdoTargetFeedPAT)" />
+
+      <!-- Legacy blob feed. Legacy feed is non-internal so we skip it for this. -->
+      <TargetFeedConfig
+        Condition="'$(IsInternalBuild)' == 'false'"
+        AssetSelection="NonShippingOnly"
+        Include="PACKAGE;SYMBOLS"
         TargetURL="$(TargetStaticFeed)"
-        Internal="false"
         Isolated="false"
         Type="AzureStorageFeed"
         Token="$(AzureStorageTargetFeedPAT)" />
-      
-      <TargetFeedConfig Condition="'$(PublishInstallersAndChecksums)' == 'true'"
-        Include="OSX;Deb;Rpm;Node;BinaryLayout;Installer;Maven;VSIX;Badge"
+
+      <TargetFeedConfig
+        Condition="'$(PublishToAzureDevOpsNuGetFeeds)' == 'true'"
+        AssetSelection="NonShippingOnly"
+        Include="Package"
+        TargetURL="$(AzureDevOpsStaticTransportFeed)"
+        Isolated="false"
+        Type="AzDoNugetFeed"
+        Token="$(AzureDevOpsStaticTransportFeedKey)" />
+
+      <TargetFeedConfig
+        Condition="'$(PublishToAzureDevOpsNuGetFeeds)' == 'true'"
+        AssetSelection="NonShippingOnly"
+        Include="Symbols"
+        TargetURL="$(AzureDevOpsStaticSymbolsFeed)"
+        Isolated="false"
+        Type="AzDoNugetFeed"
+        Token="$(AzureDevOpsStaticSymbolsFeedKey)" />
+
+      <!-- These feeds are marked as isolated even though they are not. We allow overwrite
+           the old data with the new. -->
+      <TargetFeedConfig
+        Condition="'$(PublishInstallersAndChecksums)' == 'true'"
+        Include="OSX;Deb;Rpm;Node;BinaryLayout;Installer;Maven;VSIX;Badge;Other"
         TargetURL="$(InstallersTargetStaticFeed)"
-        Internal="false"
+        Isolated="true"
+        AllowOverwrite="true"
+        Type="AzureStorageFeed"
+        Token="$(InstallersAzureAccountKey)" />
+
+      <TargetFeedConfig
+        Condition="'$(PublishInstallersAndChecksums)' == 'true'"
+        Include="Checksum"
+        TargetURL="$(ChecksumsTargetStaticFeed)"
+        Isolated="true"
+        AllowOverwrite="true"
+        Type="AzureStorageFeed"
+        Token="$(ChecksumsAzureAccountKey)" />
+    </ItemGroup>
+
+    <!--
+      Config for:
+        - Stable = false
+        - Internal = true
+
+        Publish:
+          - Shipping (non-stable) assets to azure devops shipping feed url
+          - NonShipping (non-stable) assets to azure devops transport feed url
+          - Symbol assets to azure devops symbol feed url
+          - Installers and checksums to desired storage accounts.
+    -->
+    <ItemGroup Condition="'@(TargetFeedConfig)' == '' AND '$(IsStableBuild)' == 'false' AND '$(IsInternalBuild)' == 'true'">
+      <TargetFeedConfig
+        Condition="'$(PublishToAzureDevOpsNuGetFeeds)' == 'true'"
+        AssetSelection="ShippingOnly"
+        Include="Package"
+        TargetURL="$(AzureDevOpsStaticShippingFeed)"
+        Isolated="false"
+        Type="AzDoNugetFeed"
+        Token="$(AzureDevOpsStaticShippingFeedKey)" />
+
+      <TargetFeedConfig
+        Condition="'$(PublishToAzureDevOpsNuGetFeeds)' == 'true'"
+        AssetSelection="NonShippingOnly"
+        Include="Package"
+        TargetURL="$(AzureDevOpsStaticTransportFeed)"
+        Isolated="false"
+        Type="AzDoNugetFeed"
+        Token="$(AzureDevOpsStaticTransportFeedKey)" />
+
+      <TargetFeedConfig
+        Condition="'$(PublishToAzureDevOpsNuGetFeeds)' == 'true'"
+        Include="Symbols"
+        TargetURL="$(AzureDevOpsStaticSymbolsFeed)"
+        Isolated="false"
+        Type="AzDoNugetFeed"
+        Token="$(AzureDevOpsStaticSymbolsFeedKey)" />
+
+      <TargetFeedConfig
+        Condition="'$(PublishInstallersAndChecksums)' == 'true'"
+        Include="OSX;Deb;Rpm;Node;BinaryLayout;Installer;Maven;VSIX;Badge;Other"
+        TargetURL="$(InstallersTargetStaticFeed)"
         Isolated="false"
         Type="AzureStorageFeed"
         Token="$(InstallersAzureAccountKey)" />
-      
+
+      <TargetFeedConfig
+        Condition="'$(PublishInstallersAndChecksums)' == 'true'"
+        Include="Checksum"
+        TargetURL="$(ChecksumsTargetStaticFeed)"
+        Isolated="false"
+        Type="AzureStorageFeed"
+        Token="$(ChecksumsAzureAccountKey)" />
+    </ItemGroup>
+
+    <!--
+      Config for:
+        - Stable = false
+        - Internal = false
+
+        Publish:
+          - Shipping (non-stable) package assets to azure devops shipping feed url
+          - NonShipping (non-stable) package assets to azure devops transport feed url
+          - Shipping and NonShipping symbol package assets to azure devops symbol feed url
+          - All assets to legacy blob feed url
+          - Installers and checksums to desired storage accounts.
+    -->
+    <ItemGroup Condition="'@(TargetFeedConfig)' == '' AND '$(IsStableBuild)' == 'false' AND '$(IsInternalBuild)' == 'false'">
+      <TargetFeedConfig
+        Include="Package;Symbols;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX;Badge;Other"
+        TargetURL="$(TargetStaticFeed)"
+        Isolated="false"
+        Type="AzureStorageFeed"
+        Token="$(AzureStorageTargetFeedPAT)" />
+
+      <TargetFeedConfig Condition="'$(PublishInstallersAndChecksums)' == 'true'"
+        Include="OSX;Deb;Rpm;Node;BinaryLayout;Installer;Maven;VSIX;Badge;Other"
+        TargetURL="$(InstallersTargetStaticFeed)"
+        Isolated="false"
+        Type="AzureStorageFeed"
+        Token="$(InstallersAzureAccountKey)" />
+
       <TargetFeedConfig Condition="'$(PublishInstallersAndChecksums)' == 'true'"
         Include="Checksum"
         TargetURL="$(ChecksumsTargetStaticFeed)"
-        Internal="false"
         Isolated="false"
         Type="AzureStorageFeed"
         Token="$(ChecksumsAzureAccountKey)" />
 
-      <!--
-        If there is a request to also publish to NuGet feeds, we will divide the packages into
-        shipping and non-shipping (transport) and push them to separate feeds.
-      -->
-      <TargetFeedConfig Condition="'$(PublishToAzureDevOpsNuGetFeeds)' == 'true' AND '$(IsStableBuild)' != 'true'"
-        Include="NetCore"
+      <TargetFeedConfig Condition="'$(PublishToAzureDevOpsNuGetFeeds)' == 'true'"
+        Include="Package"
         TargetURL="$(AzureDevOpsStaticShippingFeed)"
-        Internal="false"
         Isolated="false"
         Type="AzDoNugetFeed"
         Token="$(AzureDevOpsStaticShippingFeedKey)"
         AssetSelection="ShippingOnly" />
-      
+
       <TargetFeedConfig Condition="'$(PublishToAzureDevOpsNuGetFeeds)' == 'true'"
-        Include="NetCore"
+        Include="Package"
         TargetURL="$(AzureDevOpsStaticTransportFeed)"
-        Internal="false"
         Isolated="false"
         Type="AzDoNugetFeed"
         Token="$(AzureDevOpsStaticTransportFeedKey)"
         AssetSelection="NonShippingOnly" />
+
+      <TargetFeedConfig Condition="'$(PublishToAzureDevOpsNuGetFeeds)' == 'true'"
+        Include="Symbols"
+        TargetURL="$(AzureDevOpsStaticSymbolsFeed)"
+        Isolated="false"
+        Type="AzDoNugetFeed"
+        Token="$(AzureDevOpsStaticSymbolsFeedKey)" />
     </ItemGroup>
 
     <Error
@@ -297,7 +357,7 @@
       Text="It wasn't possible to determine which target feed configuration to use." />
 
     <Message
-      Text="Artifact with category '%(TargetFeedConfig.Identity)', Isolated='%(TargetFeedConfig.Isolated)', Internal='%(TargetFeedConfig.Internal)', AssetSelection='%(TargetFeedConfig.AssetSelection)' should go to %(TargetFeedConfig.Type) -> '%(TargetFeedConfig.TargetURL)'"
+      Text="Artifacts with category '%(TargetFeedConfig.Identity)', Isolated='%(TargetFeedConfig.Isolated)', Internal='%(TargetFeedConfig.Internal)', AssetSelection='%(TargetFeedConfig.AssetSelection)' should go to %(TargetFeedConfig.Type) -> '%(TargetFeedConfig.TargetURL)'"
       Importance="high" />
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
@@ -44,11 +44,11 @@
       - ChecksumsAzureAccountKey              : Account key forchecksums location
       - PublishToAzureDevOpsNuGetFeeds        : If true, publish NuGet packages to Azure DevOps feeds.
       - AzureDevOpsStaticShippingFeed         : URL of the Azure DevOps NuGet feed to publish non-stable shipping packages to.
-      - AzureDevOpsStaticShippingFeedKey      : Key of the feed Azure DevOps NuGet feed to publish non-stable shipping packages to.
-      - AzureDevOpsStaticTransportFeed        : URL of the feed Azure DevOps NuGet feed to publish transport packages to.
-      - AzureDevOpsStaticTransportFeedKey     : Key of the feed Azure DevOps NuGet feed to publish to transport packages to.
-      - AzureDevOpsStaticSymbolsFeed          : URL of the feed Azure DevOps NuGet feed to publish symbol packages to.
-      - AzureDevOpsStaticSymbolsFeedKey       : Key of the feed Azure DevOps NuGet feed to publish to symbol packages to.
+      - AzureDevOpsStaticShippingFeedKey      : Key of the Azure DevOps NuGet feed to publish non-stable shipping packages to.
+      - AzureDevOpsStaticTransportFeed        : URL of the Azure DevOps NuGet feed to publish transport packages to.
+      - AzureDevOpsStaticTransportFeedKey     : Key of the Azure DevOps NuGet feed to publish to transport packages to.
+      - AzureDevOpsStaticSymbolsFeed          : URL of the Azure DevOps NuGet feed to publish symbol packages to.
+      - AzureDevOpsStaticSymbolsFeedKey       : Key of the Azure DevOps NuGet feed to publish to symbol packages to.
 
       - CreateTestConfig                      : If set to true the user will be able to test a TargetFeedConfig
                                                 constructed using parameters below:

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
@@ -230,7 +230,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                 SkipSafetyChecks = skipChecks,
                 TargetFeedConfig = new Microsoft.Build.Utilities.TaskItem[]
                 {
-                    new Microsoft.Build.Utilities.TaskItem("NETCORE", new Dictionary<string, string> {
+                    new Microsoft.Build.Utilities.TaskItem("PACKAGE", new Dictionary<string, string> {
                         { "TargetUrl", BlobFeedUrl },
                         { "Token", RandomToken },
                         { "Type", "AZURESTORAGEFEED" },

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/build/Microsoft.DotNet.Build.Tasks.Feed.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/build/Microsoft.DotNet.Build.Tasks.Feed.targets
@@ -55,7 +55,7 @@
   <UsingTask TaskName="PushArtifactsInManifestToFeed" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
   <UsingTask TaskName="PublishArtifactsInManifest" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
   <UsingTask TaskName="CreateAzureDevOpsFeed" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
-  <UsingTask TaskName="CreateInternalBlobFeed" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
+  <UsingTask TaskName="CreateAzureStorageBlobFeed" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
   <UsingTask TaskName="ExecWithRetriesForNuGetPush" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
   <UsingTask TaskName="ParseBuildManifest" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
   

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
@@ -33,6 +33,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         [Required]
         public string CommitSha { get; set; }
 
+        /// <summary>
+        /// Additional info to include in the feed name (for example "sym")
+        /// </summary>
+        public string ContentIdentifier { get; set; }
+
         [Required]
         public string AzureDevOpsPersonalAccessToken { get; set; }
 
@@ -76,7 +81,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 string accessType = IsInternal ? "internal" : "public";
                 string publicSegment = IsInternal ? string.Empty : "public/";
                 string accessId = IsInternal ? "int" : "pub";
-                string baseFeedName = $"darc-{accessId}-{RepositoryName}-{CommitSha.Substring(0, ShaUsableLength)}";
+                string extraContentInfo = !string.IsNullOrEmpty(ContentIdentifier) ? $"-{ContentIdentifier}" : "";
+                string baseFeedName = $"darc-{accessId}{extraContentInfo}-{RepositoryName}-{CommitSha.Substring(0, ShaUsableLength)}";
                 string versionedFeedName = baseFeedName;
                 bool needsUniqueName = false;
                 int subVersion = 0;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -7,6 +7,9 @@ using Microsoft.DotNet.Build.CloudTestTasks;
 using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.DotNet.VersionTools.BuildManifest.Model;
+using Microsoft.DotNet.VersionTools.Util;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -18,10 +21,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using NuGet.Versioning;
 using MSBuild = Microsoft.Build.Utilities;
-using Microsoft.DiaSymReader.PortablePdb;
-using Microsoft.DotNet.VersionTools.Util;
 
 namespace Microsoft.DotNet.Build.Tasks.Feed
 {
@@ -51,6 +51,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         // or https://pkgs.dev.azure.com/dnceng/_packaging/internal-feed-name/nuget/v3/index.json
         public const string AzDoNuGetFeedPattern = 
             @"https://pkgs.dev.azure.com/(?<account>[a-zA-Z0-9]+)/(?<visibility>[a-zA-Z0-9-]+/)?_packaging/(?<feed>.+)/nuget/v3/index.json";
+        private const string SymbolPackageSuffix = ".symbols.nupkg";
+        private const string PackagesCategory = "PACKAGE";
 
         /// <summary>
         /// Configuration telling which target feed to use for each artifact category.
@@ -288,6 +290,17 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         feedConfig.Isolated = feedSetting;
                     }
 
+                    string allowOverwriteOnFeed = fc.GetMetadata(nameof(FeedConfig.AllowOverwrite));
+                    if (!string.IsNullOrEmpty(allowOverwriteOnFeed))
+                    {
+                        if (!bool.TryParse(allowOverwriteOnFeed, out bool feedSetting))
+                        {
+                            Log.LogError($"Invalid feed config '{nameof(FeedConfig.AllowOverwrite)}' setting.  Must be 'true' or 'false'.");
+                            continue;
+                        }
+                        feedConfig.AllowOverwrite = feedSetting;
+                    }
+
                     string categoryKey = fc.ItemSpec.Trim().ToUpper();
                     if (!FeedConfigs.TryGetValue(categoryKey, out var feedsList))
                     {
@@ -436,6 +449,14 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     {
                         List<PackageArtifactModel> filteredPackages = FilterPackages(packages, feedConfig);
 
+                        foreach (var package in filteredPackages)
+                        {
+                            string isolatedString = feedConfig.Isolated ? "Isolated" : "Non-Isolated";
+                            string internalString = feedConfig.Internal ? $", Internal" : ", Public";
+                            string shippingString = package.NonShipping ? "NonShipping" : "Shipping";
+                            Log.LogMessage(MessageImportance.High, $"{package.Id}@{package.Version} ({shippingString}) -> {feedConfig.TargetURL} ({isolatedString}{internalString})");
+                        }
+
                         switch (feedConfig.Type)
                         {
                             case FeedType.AzDoNugetFeed:
@@ -487,6 +508,14 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     foreach (var feedConfig in feedConfigsForCategory)
                     {
                         List<BlobArtifactModel> filteredBlobs = FilterBlobs(blobs, feedConfig);
+
+                        foreach (var blob in filteredBlobs)
+                        {
+                            string isolatedString = feedConfig.Isolated ? "Isolated" : "Non-Isolated";
+                            string internalString = feedConfig.Internal ? $", Internal" : ", Public";
+                            string shippingString = blob.NonShipping ? "NonShipping" : "Shipping";
+                            Log.LogMessage(MessageImportance.High, $"{blob.Id} ({shippingString}) -> {feedConfig.TargetURL} ({isolatedString}{internalString})");
+                        }
 
                         switch (feedConfig.Type)
                         {
@@ -555,7 +584,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                 if (!packageAsset.Attributes.TryGetValue("Category", out categories))
                 {
-                    categories = InferCategory(packageAsset.Id);
+                    // Package artifacts don't have extensions. They are always nupkgs.
+                    // Set the category explicitly to "PACKAGE"
+                    categories = PackagesCategory;
                 }
 
                 foreach (var category in categories.Split(';').Select(c => c.ToUpper()))
@@ -623,7 +654,18 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 await client.Assets.AddAssetLocationToAssetAsync(assetRecord.Id, AddAssetLocationToAssetAssetLocationType.NugetFeed, feedConfig.TargetURL);
             }
 
-            await PushNugetPackagesAsync(packagesToPublish, feedConfig, maxClients: MaxClients);
+            await PushNugetPackagesAsync(packagesToPublish, feedConfig, maxClients: MaxClients,
+                async (feed, httpClient, package, feedAccount, feedVisibility, feedName) =>
+                {
+                    string localPackagePath = Path.Combine(PackageAssetsBasePath, $"{package.Id}.{package.Version}.nupkg");
+                    if (!File.Exists(localPackagePath))
+                    {
+                        Log.LogError($"Could not locate '{package.Id}.{package.Version}' at '{localPackagePath}'");
+                        return;
+                    }
+
+                    await PushNugetPackageAsync(feed, httpClient, localPackagePath, package.Id, package.Version, feedAccount, feedVisibility, feedName);
+                });
         }
 
         /// <summary>
@@ -665,8 +707,14 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         /// <param name="packagesToPublish">List of packages to publish</param>
         /// <param name="feedConfig">Information about feed to publish ot</param>
         /// <returns>Async task.</returns>
-        public async Task PushNugetPackagesAsync(List<PackageArtifactModel> packagesToPublish, FeedConfig feedConfig, int maxClients)
+        public async Task PushNugetPackagesAsync<T>(List<T> packagesToPublish, FeedConfig feedConfig, int maxClients,
+            Func<FeedConfig, HttpClient, T, string, string, string, Task> packagePublishAction)
         {
+            if (!packagesToPublish.Any())
+            {
+                return;
+            }
+
             var parsedUri = Regex.Match(feedConfig.TargetURL, PublishArtifactsInManifest.AzDoNuGetFeedPattern);
             if (!parsedUri.Success)
             {
@@ -692,7 +740,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         {
                             // Wait to avoid starting too many processes.
                             await clientThrottle.WaitAsync();
-                            await PushNugetPackageAsync(feedConfig, httpClient, packageToPublish, feedAccount, feedVisibility, feedName);
+                            await packagePublishAction(feedConfig, httpClient, packageToPublish, feedAccount, feedVisibility, feedName);
                         }
                         finally
                         {
@@ -720,17 +768,10 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         ///     a different package with the same id and version. The second case is an error, as azure devops feeds are immutable, the former
         ///     is simply a case where we should continue onward.
         /// </remarks>
-        private async Task PushNugetPackageAsync(FeedConfig feedConfig, HttpClient client, PackageArtifactModel packageToPublish,
+        private async Task PushNugetPackageAsync(FeedConfig feedConfig, HttpClient client, string localPackageLocation, string id, string version,
             string feedAccount, string feedVisibility, string feedName)
         {
-            Log.LogMessage(MessageImportance.High, $"Pushing package '{packageToPublish.Id}' to feed {feedConfig.TargetURL}");
-
-            string localPackageLocation = Path.Combine(PackageAssetsBasePath, $"{packageToPublish.Id}.{packageToPublish.Version}.nupkg");
-            if (!File.Exists(localPackageLocation))
-            {
-                Log.LogError($"Could not locate '{packageToPublish.Id}.{packageToPublish.Version}' at '{localPackageLocation}'");
-                return;
-            }
+            Log.LogMessage(MessageImportance.High, $"Pushing package '{localPackageLocation}' to feed {feedConfig.TargetURL}");
 
             try
             {
@@ -742,15 +783,15 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                     try
                     {
-                        string packageContentUrl = $"https://pkgs.dev.azure.com/{feedAccount}/{feedVisibility}_apis/packaging/feeds/{feedName}/nuget/packages/{packageToPublish.Id}/versions/{packageToPublish.Version}/content";
+                        string packageContentUrl = $"https://pkgs.dev.azure.com/{feedAccount}/{feedVisibility}_apis/packaging/feeds/{feedName}/nuget/packages/{id}/versions/{version}/content";
 
                         if (await IsLocalPackageIdenticalToFeedPackage(localPackageLocation, packageContentUrl, client))
                         {
-                            Log.LogMessage(MessageImportance.Normal, $"Package '{packageToPublish.Id}@{packageToPublish.Version}' already exists on '{feedConfig.TargetURL}' but has the same content. Skipping.");
+                            Log.LogMessage(MessageImportance.Normal, $"Package '{localPackageLocation}' already exists on '{feedConfig.TargetURL}' but has the same content. Skipping.");
                         }
                         else
                         {
-                            Log.LogError($"Package '{packageToPublish.Id}@{packageToPublish.Version}' already exists on '{feedConfig.TargetURL}' with different content.");
+                            Log.LogError($"Package '{localPackageLocation}' already exists on '{feedConfig.TargetURL}' with different content.");
                         }
 
                         return;
@@ -761,12 +802,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         Log.LogWarning($"Failed to determine whether an existing package on the feed has the same content as '{localPackageLocation}': {e.Message}");
                     }
 
-                    Log.LogError($"Failed to push '{packageToPublish.Id}@{packageToPublish.Version}'. Result code '{result}'.");
+                    Log.LogError($"Failed to push '{id}@{version}'. Result code '{result}'.");
                 }
             }
             catch (Exception e)
             {
-                Log.LogError($"Unexpected exception pushing package '{packageToPublish.Id}@{packageToPublish.Version}': {e.Message}");
+                Log.LogError($"Unexpected exception pushing package '{id}@{version}': {e.Message}");
             }
         }
 
@@ -790,46 +831,37 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         {
             Log.LogMessage($"Getting package content from {packageContentUrl} and comparing to {localPackageFullPath}");
 
-            try
+            using (Stream localFileStream = File.OpenRead(localPackageFullPath))
+            using (HttpResponseMessage response = await client.GetAsync(packageContentUrl))
             {
-                using (Stream localFileStream = File.OpenRead(localPackageFullPath))
-                using (HttpResponseMessage response = await client.GetAsync(packageContentUrl))
+                response.EnsureSuccessStatusCode();
+
+                // Check the headers for content length and md5
+                bool md5HeaderAvailable = response.Headers.TryGetValues("Content-MD5", out var md5);
+                bool lengthHeaderAvailable = response.Headers.TryGetValues("Content-Length", out var contentLength);
+
+                if (lengthHeaderAvailable && long.Parse(contentLength.Single()) != localFileStream.Length)
                 {
-                    response.EnsureSuccessStatusCode();
-
-                    // Check the headers for content length and md5
-                    bool md5HeaderAvailable = response.Headers.TryGetValues("Content-MD5", out var md5);
-                    bool lengthHeaderAvailable = response.Headers.TryGetValues("Content-Length", out var contentLength);
-
-                    if (lengthHeaderAvailable && long.Parse(contentLength.Single()) != localFileStream.Length)
-                    {
-                        Log.LogMessage(MessageImportance.Low, $"Package '{localPackageFullPath}' has different length than remote package '{packageContentUrl}'.");
-                        return false;
-                    }
-
-                    if (md5HeaderAvailable)
-                    {
-                        var localMD5 = AzureStorageUtils.CalculateMD5(localPackageFullPath);
-                        if (!localMD5.Equals(md5.Single(), StringComparison.OrdinalIgnoreCase))
-                        {
-                            Log.LogMessage(MessageImportance.Low, $"Package '{localPackageFullPath}' has different MD5 hash than remote package '{packageContentUrl}'.");
-                        }
-
-                        return true;
-                    }
-
-                    const int BufferSize = 64 * 1024;
-
-                    // Otherwise, compare the streams
-                    var remoteStream = await response.Content.ReadAsStreamAsync();
-                    return await CompareStreamsAsync(localFileStream, remoteStream, BufferSize);
+                    Log.LogMessage(MessageImportance.Low, $"Package '{localPackageFullPath}' has different length than remote package '{packageContentUrl}'.");
+                    return false;
                 }
-            }
-            catch (Exception e)
-            {
-                // This is an error. It means we were unable to push using nuget, and then could not access to the package otherwise.
-                Log.LogWarning($"Failed to determine whether an existing package on the feed has the same content: {e.Message}");
-                return false;
+
+                if (md5HeaderAvailable)
+                {
+                    var localMD5 = AzureStorageUtils.CalculateMD5(localPackageFullPath);
+                    if (!localMD5.Equals(md5.Single(), StringComparison.OrdinalIgnoreCase))
+                    {
+                        Log.LogMessage(MessageImportance.Low, $"Package '{localPackageFullPath}' has different MD5 hash than remote package '{packageContentUrl}'.");
+                    }
+
+                    return true;
+                }
+
+                const int BufferSize = 64 * 1024;
+
+                // Otherwise, compare the streams
+                var remoteStream = await response.Content.ReadAsStreamAsync();
+                return await CompareStreamsAsync(localFileStream, remoteStream, BufferSize);
             }
         }
 
@@ -916,6 +948,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             Maestro.Client.Models.Build buildInformation,
             FeedConfig feedConfig)
         {
+            List<BlobArtifactModel> symbolPackagesToPublish = new List<BlobArtifactModel>();
+
             foreach (var blob in blobsToPublish)
             {
                 var assetRecord = buildInformation.Assets
@@ -937,7 +971,41 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 }
 
                 await client.Assets.AddAssetLocationToAssetAsync(assetRecord.Id, AddAssetLocationToAssetAssetLocationType.Container, feedConfig.TargetURL);
+
+                if (blob.Id.EndsWith(SymbolPackageSuffix, StringComparison.OrdinalIgnoreCase))
+                {
+                    symbolPackagesToPublish.Add(blob);
+                }
+                else
+                {
+                    Log.LogWarning($"AzDO feed publishing not available for blobs. Blob '{blob.Id}' was not published.");
+                }
             }
+
+            await PushNugetPackagesAsync<BlobArtifactModel>(symbolPackagesToPublish, feedConfig, maxClients: MaxClients,
+                async (feed, httpClient, blob, feedAccount, feedVisibility, feedName) =>
+                {
+                    // Determine the local path to the blob
+                    string fileName = Path.GetFileName(blob.Id);
+                    string localBlobPath = Path.Combine(BlobAssetsBasePath, fileName);
+                    if (!File.Exists(localBlobPath))
+                    {
+                        Log.LogError($"Could not locate '{blob.Id} at '{localBlobPath}'");
+                        return;
+                    }
+
+                    string id;
+                    string version;
+                    // Determine package ID and version by asking the nuget libraries
+                    using (var packageReader = new NuGet.Packaging.PackageArchiveReader(localBlobPath))
+                    {
+                        PackageIdentity packageIdentity = packageReader.GetIdentity();
+                        id = packageIdentity.Id;
+                        version = packageIdentity.Version.ToString();
+                    }
+
+                    await PushNugetPackageAsync(feed, httpClient, localBlobPath, id, version, feedAccount, feedVisibility, feedName);
+                });
         }
 
         private async Task PublishPackagesToAzureStorageNugetFeedAsync(
@@ -951,7 +1019,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
             var pushOptions = new PushOptions
             {
-                AllowOverwrite = false,
+                AllowOverwrite = feedConfig.AllowOverwrite,
                 PassIfExistingItemIdentical = true
             };
 
@@ -987,16 +1055,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             Maestro.Client.Models.Build buildInformation,
             FeedConfig feedConfig)
         {
-            BlobAssetsBasePath = BlobAssetsBasePath.TrimEnd(
-                Path.DirectorySeparatorChar,
-                Path.AltDirectorySeparatorChar) 
-                + Path.DirectorySeparatorChar;
-
             var blobs = blobsToPublish
                 .Select(blob =>
                 {
                     var fileName = Path.GetFileName(blob.Id);
-                    return new MSBuild.TaskItem($"{BlobAssetsBasePath}{fileName}", new Dictionary<string, string>
+                    return new MSBuild.TaskItem(Path.Combine(BlobAssetsBasePath, fileName), new Dictionary<string, string>
                     {
                         {"RelativeBlobPath", blob.Id}
                     });
@@ -1006,7 +1069,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             var blobFeedAction = CreateBlobFeedAction(feedConfig);
             var pushOptions = new PushOptions
             {
-                AllowOverwrite = false,
+                AllowOverwrite = feedConfig.AllowOverwrite,
                 PassIfExistingItemIdentical = true
             };
 
@@ -1078,7 +1141,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         /// <summary>
         ///     Infers the category based on the extension of the particular asset
         ///     
-        ///     If no category can be inferred, then "NETCORE" is used.
+        ///     If no category can be inferred, then "OTHER" is used.
         /// </summary>
         /// <param name="assetId">ID of asset</param>
         /// <returns>Asset cateogry</returns>
@@ -1088,7 +1151,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
             var whichCategory = new Dictionary<string, string>()
             {
-                { ".NUPKG", "NETCORE" },
+                { ".NUPKG", PackagesCategory },
                 { ".PKG", "OSX" },
                 { ".DEB", "DEB" },
                 { ".RPM", "RPM" },
@@ -1112,11 +1175,22 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
             if (whichCategory.TryGetValue(extension, out var category))
             {
+                // Special handling for symbols.nupkg. There are typically plenty of
+                // periods in package names. We get the extension to identify nupkg
+                // assets. But symbol packages have the extension '.symbols.nupkg'.
+                // We want to divide these into a separate category because for stabilized builds,
+                // they should go to an isolated location. In a non-stabilized build, they can go straight
+                // to blob feeds because the blob feed push tasks will automatically push them to the assets.
+                if (assetId.EndsWith(SymbolPackageSuffix, StringComparison.OrdinalIgnoreCase))
+                {
+                    return "SYMBOLS";
+                }
                 return category;
             }
             else
             {
-                return "NETCORE";
+                Log.LogMessage(MessageImportance.High, $"Defaulting to category 'OTHER' for asset {assetId}");
+                return "OTHER";
             }
         }
     }
@@ -1157,5 +1231,10 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         /// can be published here.
         /// </summary>
         public bool Internal { get; set; } = false;
+        /// <summary>
+        /// If true, the items on the feed can be overwritten. This is only
+        /// valid for azure blob storage feeds.
+        /// </summary>
+        public bool AllowOverwrite { get; set; } = false;
     }
 }


### PR DESCRIPTION
- Change NETCORE -> PACKAGE and anything not in PACKAGE to OTHER
- Fix bug where package artifacts could accidentally have gotten the wrong category
- Simplify SetupTargetFeeds
- Remove all Internal* feed inputs and just multiplex with the channel yaml instead
- Remove all manual setting of the Internal properties and rely on the automatic detection
- Classify symbol blob artifacts as SYMBOLS
- Push symbol blob artifacts as packages
- Change the create blob feed task to be able to create public feeds.  Not used currently but this is a backup plan.
- Introduce a symbol feed for 3, 3.1, and 5.
- Remove a bunch of unused parameters from the channel yaml files
- Improve comments in SetupTargetFeeds.proj