### PR TITLE
Publish installers and checksums for stable build to alternate locations

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
@@ -194,10 +194,23 @@
       <TargetFeedConfig
         Condition="'$(IsInternalBuild)' == 'false'"
         AssetSelection="NonShippingOnly"
-        Include="PACKAGE;SYMBOLS"
+        Include="Package;Symbols"
         TargetURL="$(TargetStaticFeed)"
         Isolated="false"
         Type="AzureStorageFeed"
+        Token="$(AzureStorageTargetFeedPAT)" />
+
+      <!-- Backup locations for the non package artifacts for those repositories that
+           have not yet moved to allowing Arcade to publish their own installers and checksums.
+           Core-setup, for instance, publishes its own installers and checksums and sets up their
+           locations. -->
+      <TargetFeedConfig
+        Condition="'$(IsInternalBuild)' == 'false' AND '$(PublishInstallersAndChecksums)' == 'false'"
+        Include="Symbols;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX;Badge;Other"
+        TargetURL="$(TargetStaticFeed)"
+        Isolated="false"
+        Type="AzureStorageFeed"
+        AllowOverwrite="true"
         Token="$(AzureStorageTargetFeedPAT)" />
 
       <TargetFeedConfig


### PR DESCRIPTION
Add a config to publish the installers and checksums to alternate locations in case of a stable build.
This will eventually be removed once all the repos move to having arcade publish their installers and checksums OR publish their own installers and checksums and correctly set the locations.