### PR TITLE
Add 'no-cache' property to blob properties

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
@@ -170,7 +170,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                 throw new ArgumentException("An attempt to get the MIME mapping of an empty path was made.");
             }
 
-            string contentType = mimeMappings.TryGetValue(Path.GetExtension(filePath).ToLower(), out string cttType) ?
+            string contentType = mimeMappings.TryGetValue(Path.GetExtension(filePath).ToLowerInvariant(), out string cttType) ?
                 cttType :
                 "application/octet-stream";
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
@@ -178,9 +178,10 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                 cttType :
                 "application/octet-stream";
 
-            blob.Properties.CacheControl = CacheMappings.TryGetValue(fileExtension, out string cacheCtrl) ?
-                cacheCtrl :
-                blob.Properties.CacheControl;
+            if (CacheMappings.TryGetValue(fileExtension, out string cacheCtrl))
+            {
+                blob.Properties.CacheControl = cacheCtrl;
+            }
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
@@ -172,12 +172,14 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                 throw new ArgumentException($"Trying to set properties for a null blob or property field based on file: '{filePath}'");
             }
 
-            blob.Properties.ContentType = MimeMappings.TryGetValue(Path.GetExtension(filePath).ToLowerInvariant(), out string cttType) ?
+            var fileExtension = Path.GetExtension(filePath).ToLowerInvariant();
+
+            blob.Properties.ContentType = MimeMappings.TryGetValue(fileExtension, out string cttType) ?
                 cttType :
                 "application/octet-stream";
 
-            blob.Properties.CacheControl = CacheMappings.TryGetValue(Path.GetExtension(filePath).ToLowerInvariant(), out string cache) ?
-                cache :
+            blob.Properties.CacheControl = CacheMappings.TryGetValue(fileExtension, out string cacheCtrl) ?
+                cacheCtrl :
                 blob.Properties.CacheControl;
         }
     }


### PR DESCRIPTION
Closes: https://github.com/dotnet/arcade/issues/3948

Set CacheControl property to 'no-cache' for .svg blobs.