### PR TITLE
Authenticate for restoring from private feeds

### DIFF
--- a/eng/common/templates/post-build/channels/netcore-internal-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-internal-30.yml
@@ -32,6 +32,12 @@ stages:
           artifactName: 'PDBArtifacts'
         continueOnError: true
 
+      # This is necessary whenever we want to publish/restore to an AzDO private feed
+      # Since sdk-task.ps1 tries to restore packages we need to do this authentication here
+      # otherwise it'll complain about accessing a private feed.
+      - task: NuGetAuthenticate@0
+        displayName: 'Authenticate to AzDO Feeds'
+
       - task: PowerShell@2
         displayName: Publish
         inputs:

--- a/eng/common/templates/post-build/channels/netcore-internal-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-internal-30.yml
@@ -39,6 +39,12 @@ stages:
         displayName: 'Authenticate to AzDO Feeds'
 
       - task: PowerShell@2
+        displayName: Enable cross-org publishing
+        inputs:
+          filePath: eng\common\enable-cross-org-publishing.ps1
+          arguments: -token $(dn-bot-dnceng-artifact-feeds-rw)
+
+      - task: PowerShell@2
         displayName: Publish
         inputs:
           filePath: eng\common\sdk-task.ps1

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -45,6 +45,8 @@ stages:
   - ${{ if eq(parameters.enableSigningValidation, 'true') }}:
     - job:
       displayName: Signing Validation
+      variables:
+        - template: common-variables.yml
       pool:
         vmImage: 'windows-2019'
       steps:
@@ -53,6 +55,13 @@ stages:
           inputs:
             buildType: current
             artifactName: PackageArtifacts
+
+        # This is necessary whenever we want to publish/restore to an AzDO private feed
+        # Since sdk-task.ps1 tries to restore packages we need to do this authentication here
+        # otherwise it'll complain about accessing a private feed.
+        - task: NuGetAuthenticate@0
+          condition: eq(variables['IsInternalBuild'], 'true')
+          displayName: 'Authenticate to AzDO Feeds'
 
         - task: PowerShell@2
           displayName: Validate

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -64,6 +64,12 @@ stages:
           displayName: 'Authenticate to AzDO Feeds'
 
         - task: PowerShell@2
+          displayName: Enable cross-org publishing
+          inputs:
+            filePath: eng\common\enable-cross-org-publishing.ps1
+            arguments: -token $(dn-bot-dnceng-artifact-feeds-rw)
+
+        - task: PowerShell@2
           displayName: Validate
           inputs:
             filePath: eng\common\sdk-task.ps1


### PR DESCRIPTION
Closes: #3956

Make these jobs authenticate with AzDO when the build is running from an internal branch. Otherwise the job might fail when trying to restore a package from a private feed.