### PR TITLE
Optprof download diagnosability

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.AcquireOptimizationData.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.AcquireOptimizationData.targets
@@ -62,7 +62,7 @@
       <_DropName>$(_DropNamePrefix)/$(VisualStudioIbcDropId)</_DropName>
     </PropertyGroup>
 
-    <Message Text="Acquiring optimization data" Importance="high"/>
+    <Message Text="Listing optimization data from service $(_DropServiceUrl), prefix $(_DropNamePrefix)" Importance="high"/>
 
     <Exec Command='"$(_DropToolPath)" list --dropservice "$(_DropServiceUrl)" $(_PatAuthArg) --pathPrefixFilter "$(_DropNamePrefix)" --toJsonFile "$(_DropsJsonPath)" --traceto "$(_DropsLogPath)"' 
           Condition="'$(VisualStudioIbcDropId)' == ''"/>

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/FindLatestDrop.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/FindLatestDrop.cs
@@ -52,7 +52,15 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio
         {
             JObject candidate = null;
             DateTime latest = default;
-            foreach (JObject item in JArray.Parse(json))
+
+            JArray drops = JArray.Parse(json);
+
+            if (drops.Count == 0)
+            {
+                throw new ApplicationException("No drops matching the specified prefix were returned");
+            }
+
+            foreach (JObject item in drops)
             {
                 if (!DateTime.TryParse((string)item["CreatedDateUtc"], out var timestamp))
                 {
@@ -73,7 +81,7 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio
 
             if (candidate == null)
             {
-                throw new ApplicationException($"No drop name found");
+                throw new ApplicationException($"No complete, undeleted drops found");
             }
 
             return (string)candidate["Name"];


### PR DESCRIPTION
The MSBuild build broke as a result of the `Microsoft` organization moving to `microsoft`, which caused references to repo/branchname in OptProf artifact paths to change case, which resulted in empty query results on OptProf data (because it was published to, say, `OptimizationData/Microsoft/msbuild/vs16.3` instead of `OptimizationData/microsoft/msbuild/vs16.3`, so the latter was empty).

I think it would have taken us less time to figure out what was going on if things were logged this way rather than the existing way. I had to dig into binlogs each time to figure out what was being queried. 