### PR TITLE
Import configure-toolset from tools.ps1/sh

### DIFF
--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -123,13 +123,6 @@ try {
     $nodeReuse = $false
   }
 
-  # Import custom tools configuration, if present in the repo.
-  # Note: Import in global scope so that the script set top-level variables without qualification.
-  $configureToolsetScript = Join-Path $EngRoot "configure-toolset.ps1"
-  if (Test-Path $configureToolsetScript) {
-    . $configureToolsetScript
-  }
-
   if (($restore) -and ($null -eq $env:DisableNativeToolsetInstalls)) {
     InitializeNativeTools
   }

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -196,12 +196,6 @@ function Build {
   ExitWithExitCode 0
 }
 
-# Import custom tools configuration, if present in the repo.
-configure_toolset_script="$eng_root/configure-toolset.sh"
-if [[ -a "$configure_toolset_script" ]]; then
-  . "$configure_toolset_script"
-fi
-
 # TODO: https://github.com/dotnet/arcade/issues/1468
 # Temporary workaround to avoid breaking change.
 # Remove once repos are updated.

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -196,13 +196,6 @@ function Build {
   ExitWithExitCode 0
 }
 
-# TODO: https://github.com/dotnet/arcade/issues/1468
-# Temporary workaround to avoid breaking change.
-# Remove once repos are updated.
-if [[ -n "${useInstalledDotNetCli:-}" ]]; then
-  use_installed_dotnet_cli="$useInstalledDotNetCli"
-fi
-
 if [[ "$restore" == true && -z ${DisableNativeToolsetInstalls:-} ]]; then
   InitializeNativeTools
 fi

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -603,3 +603,10 @@ Write-PipelineSetVariable -Name 'Artifacts.Toolset' -Value $ToolsetDir
 Write-PipelineSetVariable -Name 'Artifacts.Log' -Value $LogDir
 Write-PipelineSetVariable -Name 'TEMP' -Value $TempDir
 Write-PipelineSetVariable -Name 'TMP' -Value $TempDir
+
+# Import custom tools configuration, if present in the repo.
+# Note: Import in global scope so that the script set top-level variables without qualification.
+$configureToolsetScript = Join-Path $EngRoot "configure-toolset.ps1"
+if (Test-Path $configureToolsetScript) {
+    . $configureToolsetScript
+}

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -415,3 +415,9 @@ Write-PipelineSetVariable -name "Artifacts.Toolset" -value "$toolset_dir"
 Write-PipelineSetVariable -name "Artifacts.Log" -value "$log_dir"
 Write-PipelineSetVariable -name "Temp" -value "$temp_dir"
 Write-PipelineSetVariable -name "TMP" -value "$temp_dir"
+
+# Import custom tools configuration, if present in the repo.
+configure_toolset_script="$eng_root/configure-toolset.sh"
+if [[ -a "$configure_toolset_script" ]]; then
+  . "$configure_toolset_script"
+fi

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -421,3 +421,10 @@ configure_toolset_script="$eng_root/configure-toolset.sh"
 if [[ -a "$configure_toolset_script" ]]; then
   . "$configure_toolset_script"
 fi
+
+# TODO: https://github.com/dotnet/arcade/issues/1468
+# Temporary workaround to avoid breaking change.
+# Remove once repos are updated.
+if [[ -n "${useInstalledDotNetCli:-}" ]]; then
+  use_installed_dotnet_cli="$useInstalledDotNetCli"
+fi


### PR DESCRIPTION
This is a fix for https://github.com/dotnet/arcade/issues/3763, tested on OSX. I know that it solves the issue I was hitting, but I don't know how other folks expect configure-toolset to work. Does this seem reasonable to you @chcosta?

I noticed that there's another extension point, `restore-toolset` - I wonder if that should also be done in tools.sh intstead of `build.sh`, for the same reason?