### PR TITLE
Fix issue with CertificatesSignInfo

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -83,7 +83,7 @@
         TestSign="$(_TestSign)"
         DoStrongNameCheck="$(DoStrongNameCheck)"
         AllowEmptySignList="$(AllowEmptySignList)"
-        CertificatesSignInfo="$(CertificatesSignInfo)"
+        CertificatesSignInfo="@(CertificatesSignInfo)"
         ItemsToSign="@(ItemsToSign)"
         StrongNameSignInfo="@(StrongNameSignInfo)"
         FileSignInfo="@(FileSignInfo)"


### PR DESCRIPTION
As written, CertificatesSignInfo is always empty unless someone sneaks in a way to translate the ItemGroup into a property.  Change $ to @ so the defaults get honored.