### PR TITLE
[Build break fix] Add pats variable group for cross-org publishing during signing validation job

### DIFF
--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -50,6 +50,7 @@ stages:
       displayName: Signing Validation
       variables:
         - template: common-variables.yml
+        - group: AzureDevOps-Artifact-Feeds-Pats
       pool:
         vmImage: 'windows-2019'
       steps:


### PR DESCRIPTION
fixes https://github.com/dotnet/arcade/issues/3993

Test build currently running to validate: https://dev.azure.com/dnceng/internal/_build/results?buildId=361497