### PR TITLE
Fix use of default for null comparisons

### DIFF
--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/CSharp.cs
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/CSharp.cs
@@ -114,35 +114,8 @@ namespace Microsoft.DotNet.SwaggerGenerator.Languages
                 throw new NotSupportedException(reference.ToString());
             }
 
-            /// <summary>
-            ///     When doing a null/default check, get the value that
-            ///     the given type reference should be compared against.
-            /// </summary>
-            /// <param name="reference">Type reference. May not be 'string'</param>
-            /// <returns>Value that a null/default comparison should be done against</returns>
-            private static string GetNullComparisonValue(TypeReference reference)
-            {
-                if (reference == TypeReference.String)
-                {
-                    throw new ArgumentException("Type reference should not be a string");
-                }
-
-                if ((reference is TypeReference.TypeModelReference typeModelRef && !typeModelRef.Model.IsEnum) ||
-                    reference is TypeReference.ArrayTypeReference ||
-                    reference is TypeReference.DictionaryTypeReference ||
-                    reference == TypeReference.Any ||
-                    reference == TypeReference.File)
-                {
-                    return "null";
-                }
-                else
-                {
-                    return "default";
-                }
-            }
-
             [BlockHelperMethod]
-            public static void NullCheck(TextWriter output, object context, Action<TextWriter, object> template, TypeReference reference)
+            public void NullCheck(TextWriter output, object context, Action<TextWriter, object> template, TypeReference reference)
             {
                 if (reference == TypeReference.String)
                 {
@@ -153,12 +126,12 @@ namespace Microsoft.DotNet.SwaggerGenerator.Languages
                 else
                 {
                     template(output, context);
-                    output.Write($" == {GetNullComparisonValue(reference)}");
+                    output.WriteSafeString($" == default({ResolveReference(reference, null)})");
                 }
             }
 
             [BlockHelperMethod]
-            public static void NotNullCheck(TextWriter output, object context, Action<TextWriter, object> template, TypeReference reference)
+            public void NotNullCheck(TextWriter output, object context, Action<TextWriter, object> template, TypeReference reference)
             {
                 if (reference == TypeReference.String)
                 {
@@ -169,7 +142,7 @@ namespace Microsoft.DotNet.SwaggerGenerator.Languages
                 else
                 {
                     template(output, context);
-                    output.Write($" != {GetNullComparisonValue(reference)}");
+                    output.WriteSafeString($" != default({ResolveReference(reference, null)})");
                 }
             }
 

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/CSharp.cs
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/CSharp.cs
@@ -2,6 +2,7 @@ using HandlebarsDotNet;
 using Microsoft.DotNet.SwaggerGenerator.Modeler;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -113,6 +114,33 @@ namespace Microsoft.DotNet.SwaggerGenerator.Languages
                 throw new NotSupportedException(reference.ToString());
             }
 
+            /// <summary>
+            ///     When doing a null/default check, get the value that
+            ///     the given type reference should be compared against.
+            /// </summary>
+            /// <param name="reference">Type reference. May not be 'string'</param>
+            /// <returns>Value that a null/default comparison should be done against</returns>
+            private static string GetNullComparisonValue(TypeReference reference)
+            {
+                if (reference == TypeReference.String)
+                {
+                    throw new ArgumentException("Type reference should not be a string");
+                }
+
+                if ((reference is TypeReference.TypeModelReference typeModelRef && !typeModelRef.Model.IsEnum) ||
+                    reference is TypeReference.ArrayTypeReference ||
+                    reference is TypeReference.DictionaryTypeReference ||
+                    reference == TypeReference.Any ||
+                    reference == TypeReference.File)
+                {
+                    return "null";
+                }
+                else
+                {
+                    return "default";
+                }
+            }
+
             [BlockHelperMethod]
             public static void NullCheck(TextWriter output, object context, Action<TextWriter, object> template, TypeReference reference)
             {
@@ -125,7 +153,7 @@ namespace Microsoft.DotNet.SwaggerGenerator.Languages
                 else
                 {
                     template(output, context);
-                    output.Write(" == default");
+                    output.Write($" == {GetNullComparisonValue(reference)}");
                 }
             }
 
@@ -141,7 +169,7 @@ namespace Microsoft.DotNet.SwaggerGenerator.Languages
                 else
                 {
                     template(output, context);
-                    output.Write(" != default");
+                    output.Write($" != {GetNullComparisonValue(reference)}");
                 }
             }
 


### PR DESCRIPTION
(refType == default) is not a valid comparison for refTyp == null as of 16.4. 'default' was interpreted as null but this was a side-effect of implementation and this has been removed. Fix the code generator to use null for ref types.