### PR TITLE
[release/3.x] Make SDL validation to not fail if no artifacts are published

### DIFF
--- a/eng/common/sdl/extract-artifact-packages.ps1
+++ b/eng/common/sdl/extract-artifact-packages.ps1
@@ -5,6 +5,13 @@ param(
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version 2.0
+
+# `tools.ps1` checks $ci to perform some actions. Since the post-build
+# scripts don't necessarily execute in the same agent that run the
+# build.ps1/sh script this variable isn't automatically set.
+$ci = $true
+. $PSScriptRoot\..\tools.ps1
+
 $ExtractPackage = {
   param( 
     [string] $PackagePath                                 # Full path to a NuGet package


### PR DESCRIPTION
Import eng\common\tools.ps1 to get ExitWithExitCode working in sdl extract-artifact-packages.ps1 in order for SDL validation to ignore if the artifacts download path is empty. 

