### PR TITLE
Remove obsolete TargetFrameworkMonikers from XUnitExtensions

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ActiveIssueDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ActiveIssueDiscoverer.cs
@@ -50,16 +50,15 @@ namespace Microsoft.DotNet.XUnitExtensions
                 (platforms.HasFlag(TestPlatforms.OSX) && RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) ||
                 (platforms.HasFlag(TestPlatforms.Windows) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)))
             {
-                if (frameworks.HasFlag(TargetFrameworkMonikers.NetFramework))
-                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetfxTest);
-                if (frameworks.HasFlag(TargetFrameworkMonikers.Mono))
-                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonMonoTest);
+                
                 if (frameworks.HasFlag(TargetFrameworkMonikers.Netcoreapp))
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreappTest);
-                if (frameworks.HasFlag(TargetFrameworkMonikers.UapNotUapAot))
+                if (frameworks.HasFlag(TargetFrameworkMonikers.NetFramework))
+                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetfxTest);
+                if (frameworks.HasFlag(TargetFrameworkMonikers.Uap))
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonUapTest);
-                if (frameworks.HasFlag(TargetFrameworkMonikers.UapAot))
-                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonUapAotTest);
+                if (frameworks.HasFlag(TargetFrameworkMonikers.Mono))
+                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonMonoTest);
                 if (frameworks == (TargetFrameworkMonikers)0)
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing);
 

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnTargetFrameworkDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnTargetFrameworkDiscoverer.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 using Xunit;
@@ -24,40 +24,14 @@ namespace Microsoft.DotNet.XUnitExtensions
         public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
         {
             TargetFrameworkMonikers frameworks = (TargetFrameworkMonikers)traitAttribute.GetConstructorArguments().First();
-            if (frameworks.HasFlag(TargetFrameworkMonikers.Net45))
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNet45Test);
-            if (frameworks.HasFlag(TargetFrameworkMonikers.Net451))
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNet451Test);
-            if (frameworks.HasFlag(TargetFrameworkMonikers.Net452))
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNet452Test);
-            if (frameworks.HasFlag(TargetFrameworkMonikers.Net46))
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNet46Test);
-            if (frameworks.HasFlag(TargetFrameworkMonikers.Net461))
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNet461Test);
-            if (frameworks.HasFlag(TargetFrameworkMonikers.Net472))
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNet472Test);
-            if (frameworks.HasFlag(TargetFrameworkMonikers.Net462))
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNet462Test);
-            if (frameworks.HasFlag(TargetFrameworkMonikers.Net463))
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNet463Test);
-            if (frameworks.HasFlag(TargetFrameworkMonikers.Netcore50))
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcore50Test);
-            if (frameworks.HasFlag(TargetFrameworkMonikers.Netcore50aot))
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcore50aotTest);
-            if (frameworks.HasFlag(TargetFrameworkMonikers.Netcoreapp1_0))
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreapp1_0Test);
-            if (frameworks.HasFlag(TargetFrameworkMonikers.Netcoreapp1_1))
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreapp1_1Test);
-            if (frameworks.HasFlag(TargetFrameworkMonikers.NetFramework))
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetfxTest);
-            if (frameworks.HasFlag(TargetFrameworkMonikers.Mono))
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonMonoTest);
             if (frameworks.HasFlag(TargetFrameworkMonikers.Netcoreapp))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreappTest);
-            if (frameworks.HasFlag(TargetFrameworkMonikers.UapNotUapAot))
+            if (frameworks.HasFlag(TargetFrameworkMonikers.NetFramework))
+                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetfxTest);
+            if (frameworks.HasFlag(TargetFrameworkMonikers.Uap))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonUapTest);
-            if (frameworks.HasFlag(TargetFrameworkMonikers.UapAot))
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonUapAotTest);
+            if (frameworks.HasFlag(TargetFrameworkMonikers.Mono))
+                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonMonoTest);
         }
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Microsoft.DotNet.XUnitExtensions.csproj
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Microsoft.DotNet.XUnitExtensions.csproj
@@ -2,11 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
-    <OutputType>Library</OutputType>
     <AssemblyName>Microsoft.DotNet.XUnitExtensions</AssemblyName>
-    <IsPackable>true</IsPackable>    
-    <VersionPrefix>2.4.1</VersionPrefix>
-    <Description>This package provides things like various traits and discovers like OuterLoop/ActiveIssue that are used by .NET Core framework test projects.</Description>
+    <IsPackable>true</IsPackable>
+    <Description>This package provides things like various traits and discovers like OuterLoop/ActiveIssue that are used by .NET test projects.</Description>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.XUnitExtensions/src/TargetFrameworkMonikers.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/TargetFrameworkMonikers.cs
@@ -9,24 +9,9 @@ namespace Xunit
     [Flags]
     public enum TargetFrameworkMonikers
     {
-        Net45 = 0x1,
-        Net451 = 0x2,
-        Net452 = 0x4,
-        Net46 = 0x8,
-        Net461 = 0x10,
-        Net462 = 0x20,
-        Net463 = 0x40,
-        Net472 = 0x60,
-        Netcore50 = 0x80,
-        Netcore50aot = 0x100,
-        Netcoreapp1_0 = 0x200,
-        Netcoreapp1_1 = 0x400,
-        NetFramework = 0x800,
-        Netcoreapp = 0x1000,
-        UapNotUapAot = 0x2000,
-        UapAot = 0x4000,
-        Uap = UapAot | UapNotUapAot,
-        // unused = 0x8000,
-        Mono = 0x10000
+        Netcoreapp = 0x1,
+        NetFramework = 0x2,
+        Uap = 0x4,
+        Mono = 0x8
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/XunitConstants.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/XunitConstants.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using Xunit.Sdk;
 
 namespace Microsoft.DotNet.XUnitExtensions
 {
@@ -15,25 +14,10 @@ namespace Microsoft.DotNet.XUnitExtensions
         internal const string NonOSXTest = "nonosxtests";
         internal const string NonWindowsTest = "nonwindowstests";
 
-        internal const string NonNet45Test = "nonnet45tests";
-        internal const string NonNet451Test = "nonnet451tests";
-        internal static string NonNet452Test = "nonnet452tests";
-        internal static string NonNet46Test = "nonnet46tests";
-        internal static string NonNet461Test = "nonnet461tests";
-        internal static string NonNet462Test = "nonnet462tests";
-        internal static string NonNet463Test = "nonnet463tests";
-        internal static string NonNet472Test = "nonnet472tests";
-        internal static string NonNetcore50Test = "nonnetcore50tests";
-        internal static string NonNetcore50aotTest = "nonnetcore50aottests";
-        internal static string NonNetcoreapp1_0Test = "nonnetcoreapp1.0tests";
-        internal static string NonNetcoreapp1_1Test = "nonnetcoreapp1.1tests";
-
-        //Non version framework constants
-        internal static string NonNetfxTest = "nonnetfxtests";
-        internal static string NonMonoTest = "nonmonotests";
-        internal static string NonUapTest = "nonuaptests";
-        internal static string NonUapAotTest = "nonuapaottests";
         internal static string NonNetcoreappTest = "nonnetcoreapptests";
+        internal static string NonNetfxTest = "nonnetfxtests";
+        internal static string NonUapTest = "nonuaptests";
+        internal static string NonMonoTest = "nonmonotests";
 
         internal const string Failing = "failing";
         internal const string ActiveIssue = "activeissue";


### PR DESCRIPTION
This is a code cleanup only change. Normalizing the ordering as well (netcoreapp, netfx, uap, mono).