### PR TITLE
Helix SDK Avoids Upload for Disabled Queues

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
@@ -122,9 +122,9 @@ namespace Microsoft.DotNet.Helix.Sdk
         public int MaxRetryCount { get; set; }
 
         /// <summary>
-        ///   Defaults to <see langword="false"/>, logging an error when a queue is disabled, if <see langword="true"/>, a warning will be logged instead.
+        ///   Defaults to <see langword="true"/>, logging an error when a queue is disabled, if <see langword="false"/>, a warning will be logged instead.
         /// </summary>
-        public bool NoErrorIfQueueDisabled { get; set; } = false;
+        public bool LogErrorIfQueueDisabled { get; set; } = true;
 
         private CommandPayload _commandPayload;
 
@@ -153,13 +153,13 @@ namespace Microsoft.DotNet.Helix.Sdk
                 QueueInfo qi = await currentHelixApi.Information.QueueInfoAsync(TargetQueue);
                 if (qi.IsAvailable == false)
                 {
-                    if (NoErrorIfQueueDisabled)
+                    if (LogErrorIfQueueDisabled)
                     {
-                        Log.LogWarning("Queue is not available");
+                        Log.LogError("Queue is not available");
                         return;
                     } else
                     {
-                        Log.LogError("Queue is not available");
+                        Log.LogWarning("Queue is not available");
                         return;
                     }
                 }

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
@@ -2,6 +2,7 @@
 <Project>
   <PropertyGroup>
     <EnableXUnitReporter Condition=" '$(EnableXUnitReporter)' != 'true' ">false</EnableXUnitReporter>
+    <ProceedIfDisabled Condition=" '$(ProceedIfDisabled)' != 'true' ">false</ProceedIfDisabled>
   </PropertyGroup>
 
   <Choose>
@@ -55,7 +56,8 @@
                   PostCommands="$(HelixPostCommands)"
                   CorrelationPayloads="@(HelixCorrelationPayload)"
                   WorkItems="@(HelixWorkItem)"
-                  HelixProperties="@(HelixProperties)">
+                  HelixProperties="@(HelixProperties)"
+                  ProceedIfQueueDisabled="$(ProceedIfDisabled)">
       <Output TaskParameter="JobCorrelationId" PropertyName="HelixJobId"/>
       <Output TaskParameter="ResultsContainerUri" PropertyName="HelixResultsContainer"/>
       <Output TaskParameter="ResultsContainerReadSAS" PropertyName="HelixResultsContainerReadSAS"/>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <EnableXUnitReporter Condition=" '$(EnableXUnitReporter)' != 'true' ">false</EnableXUnitReporter>
-    <ProceedIfDisabled Condition=" '$(ProceedIfDisabled)' != 'true' ">false</ProceedIfDisabled>
+    <LogErrorIfQueueDisabled Condition=" '$(LogErrorIfQueueDisabled)' != 'false' ">true</LogErrorIfQueueDisabled>
   </PropertyGroup>
 
   <Choose>
@@ -57,7 +57,7 @@
                   CorrelationPayloads="@(HelixCorrelationPayload)"
                   WorkItems="@(HelixWorkItem)"
                   HelixProperties="@(HelixProperties)"
-                  NoErrorIfQueueDisabled="$(ProceedIfDisabled)">
+                  LogErrorIfQueueDisabled="$(LogErrorIfQueueDisabled)">
       <Output TaskParameter="JobCorrelationId" PropertyName="HelixJobId"/>
       <Output TaskParameter="ResultsContainerUri" PropertyName="HelixResultsContainer"/>
       <Output TaskParameter="ResultsContainerReadSAS" PropertyName="HelixResultsContainerReadSAS"/>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
@@ -57,7 +57,7 @@
                   CorrelationPayloads="@(HelixCorrelationPayload)"
                   WorkItems="@(HelixWorkItem)"
                   HelixProperties="@(HelixProperties)"
-                  ProceedIfQueueDisabled="$(ProceedIfDisabled)">
+                  NoErrorIfQueueDisabled="$(ProceedIfDisabled)">
       <Output TaskParameter="JobCorrelationId" PropertyName="HelixJobId"/>
       <Output TaskParameter="ResultsContainerUri" PropertyName="HelixResultsContainer"/>
       <Output TaskParameter="ResultsContainerReadSAS" PropertyName="HelixResultsContainerReadSAS"/>

--- a/tests/UnitTests.proj
+++ b/tests/UnitTests.proj
@@ -73,6 +73,8 @@
     <HelixTargetQueue Include="Debian.9.Amd64.Open"/>
     <HelixTargetQueue Include="RedHat.7.Amd64.Open"/>
     <HelixTargetQueue Include="Windows.10.Amd64.Open"/>
+    <!--Used for testing behavior for unavailable queues-->
+    <!--<HelixTargetQueue Include="Alpine.36.Amd64"/>-->
   </ItemGroup>
 
   <PropertyGroup Condition="!$(HelixTargetQueue.StartsWith('Windows'))">


### PR DESCRIPTION
This fix detects if a specified target queue has IsAvailable = false, and if so, does not upload, and logs either an error or a warning (depending on whether ProceedIfQueueDisabled is true, or the default false)