### PR TITLE
Include last modified time in package index cache key

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageIndex.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageIndex.cs
@@ -35,7 +35,8 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
         public static PackageIndex Load(IEnumerable<string> packageIndexFiles)
         {
-            string indexKey = String.Join("|", packageIndexFiles);
+            string indexKey = String.Join("|",
+                packageIndexFiles.Select(pif => $"{pif}:{File.GetLastWriteTimeUtc(pif).Ticks}"));
 
             PackageIndex result = null;
 

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageIndex.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageIndex.cs
@@ -36,7 +36,8 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         public static PackageIndex Load(IEnumerable<string> packageIndexFiles)
         {
             string indexKey = String.Join("|",
-                packageIndexFiles.Select(pif => $"{pif}:{File.GetLastWriteTimeUtc(pif).Ticks}"));
+                packageIndexFiles.Select(packageIndexFile => new FileInfo(packageIndexFile))
+                                 .Select(packageIndexFileInfo => $"{packageIndexFileInfo.FullName}:{packageIndexFileInfo.Length}:{packageIndexFileInfo.LastWriteTimeUtc.Ticks}"));
 
             PackageIndex result = null;
 

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/PackageIndexTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/PackageIndexTests.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using NuGet.Frameworks;
+using System;
+using System.IO;
+using System.Threading;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
+{
+    public class PackageIndexTests
+    {
+        [Fact]
+        public void IndexCacheConsidersModifiedTime()
+        {
+            string packageIndexFile = $"{nameof(IndexCacheConsidersModifiedTime)}.json";
+            
+            PackageIndex packageIndex = new PackageIndex();
+            packageIndex.Packages.Add("MyPackage", new PackageInfo());
+            Assert.Equal(1, packageIndex.Packages.Count);
+            Assert.True(packageIndex.Packages.ContainsKey("MyPackage"));
+            packageIndex.Save(packageIndexFile);
+
+            string[] packageIndexFiles = new[] { packageIndexFile };
+
+            packageIndex = PackageIndex.Load(packageIndexFiles);
+            Assert.Equal(1, packageIndex.Packages.Count);
+            Assert.True(packageIndex.Packages.ContainsKey("MyPackage"));
+            
+            packageIndex = new PackageIndex();
+            packageIndex.Packages.Add("MyPackage", new PackageInfo());
+            packageIndex.Packages.Add("MyPackage2", new PackageInfo());
+            Assert.Equal(2, packageIndex.Packages.Count);
+            Assert.True(packageIndex.Packages.ContainsKey("MyPackage"));
+            Assert.True(packageIndex.Packages.ContainsKey("MyPackage2"));
+            packageIndex.Save(packageIndexFile);
+
+            packageIndex = PackageIndex.Load(packageIndexFiles);
+            Assert.Equal(2, packageIndex.Packages.Count);
+            Assert.True(packageIndex.Packages.ContainsKey("MyPackage"));
+            Assert.True(packageIndex.Packages.ContainsKey("MyPackage2"));
+        }
+    }
+}


### PR DESCRIPTION
We were seeing cases when stabalizing packages that the index may have
already been cached in the MSBuild process, resulting in some projects
seeing the update and others not.  Avoid this by including modified time
in the cache key.  If the file is changed it will be a cache miss.