### PR TITLE
Remove the dotnet-core blob feed from arcade build

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -6,10 +6,7 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
-    <add key="symreader-converter" value="https://dotnet.myget.org/F/symreader-converter/api/v3/index.json" />
-    <add key="symreader" value="https://dotnet.myget.org/F/symreader/api/v3/index.json" />
-    <add key="dotnet-tools-internal" value="https://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json" />
+    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />


### PR DESCRIPTION
- Pushed legacy tools packages necessary to build to the dotnet-tools azdo feed

This does not cover the feeds required to restore some packages. Will be covered in a separate PR