### PR TITLE
Add return install path to init-native-tools.ps1

### DIFF
--- a/eng/common/init-tools-native.ps1
+++ b/eng/common/init-tools-native.ps1
@@ -133,6 +133,7 @@ try {
   if (Test-Path $InstallBin) {
     Write-Host "Native tools are available from" (Convert-Path -Path $InstallBin)
     Write-Host "##vso[task.prependpath]$(Convert-Path -Path $InstallBin)"
+    return $InstallBin
   }
   else {
     Write-Error "Native tools install directory does not exist, installation failed"


### PR DESCRIPTION
Super simple change to return the native tool install path in `init-native-tools.ps1`. This makes it easier to call the tools if you're using the scripts locally.

Fixes #4019.