### PR TITLE
Source-build now runs some CoreFX tests, enable building CoreFxTesting.

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/Microsoft.DotNet.CoreFxTesting.csproj
+++ b/src/Microsoft.DotNet.CoreFxTesting/Microsoft.DotNet.CoreFxTesting.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>
     <Description>This package provides support for running tests inside CoreFx.</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
CoreFxTesting is source-buildable and used to run unit tests for source-build's copy of CoreFX.