### PR TITLE
revert validateDependsOn to dependsOn

### DIFF
--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -16,14 +16,14 @@ parameters:
   signingValidationAdditionalParameters: ''
 
   # Which stages should finish execution before post-build stages start
-  validateDependsOn:
+  dependsOn:
   - build
   publishDependsOn: 
   - Validate
 
 stages:
 - stage: Validate
-  dependsOn: ${{ parameters.validateDependsOn }}
+  dependsOn: ${{ parameters.dependsOn }}
   displayName: Validate
   jobs:
   - ${{ if eq(parameters.enableNugetValidation, 'true') }}:

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -16,14 +16,20 @@ parameters:
   signingValidationAdditionalParameters: ''
 
   # Which stages should finish execution before post-build stages start
-  dependsOn:
+  validateDependsOn:
   - build
   publishDependsOn: 
   - Validate
 
 stages:
 - stage: Validate
-  dependsOn: ${{ parameters.dependsOn }}
+
+  ${{ if eq(parameters.dependsOn, '') }}:
+    dependsOn: ${{ parameters.validateDependsOn }}
+  # for backwards compatibility
+  ${{ if ne(parameters.dependsOn, '') }}:
+    dependsOn: ${{ parameters.dependsOn }}
+
   displayName: Validate
   jobs:
   - ${{ if eq(parameters.enableNugetValidation, 'true') }}:


### PR DESCRIPTION
Didn't realize anybody was taking a direct dependency on this parameter (Arcade and Arcade-Validation repos don't).  Reverting the parameter name to unblock WCF.

Arcade validation build - https://dev.azure.com/dnceng/internal/_build/results?buildId=369251&view=results

WCF validation build (sort of) - https://dev.azure.com/dnceng/internal/_build/results?buildId=369240&view=results

FYI @StephenBonikowsky 