### PR TITLE
Use full path for dotnet call inside the tools.sh script.

### DIFF
--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -332,7 +332,7 @@ function MSBuild {
     # Work around issues with Azure Artifacts credential provider
     # https://github.com/dotnet/arcade/issues/3932
     if [[ "$ci" == true ]]; then
-      dotnet nuget locals http-cache -c
+      "$_InitializeBuildTool" nuget locals http-cache -c
 
       export NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS=20
       export NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS=20


### PR DESCRIPTION
Changing the path earlier does not affect the currently running script, so this can error out if dotnet is not already on the path.