### PR TITLE
Revert "Helix SDK Avoids Upload for Disabled Queues (#4011)"

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
@@ -3,13 +3,17 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Text;
+using System.Text.Encodings.Web;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Helix.Client;
-using Microsoft.DotNet.Helix.Client.Models;
+using Microsoft.WindowsAzure.Storage;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.DotNet.Helix.Sdk
 {
@@ -121,11 +125,6 @@ namespace Microsoft.DotNet.Helix.Sdk
         /// </summary>
         public int MaxRetryCount { get; set; }
 
-        /// <summary>
-        ///   Defaults to <see langword="true"/>, logging an error when a queue is disabled, if <see langword="false"/>, a warning will be logged instead.
-        /// </summary>
-        public bool LogErrorIfQueueDisabled { get; set; } = true;
-
         private CommandPayload _commandPayload;
 
         protected override async Task ExecuteCore(CancellationToken cancellationToken)
@@ -149,20 +148,6 @@ namespace Microsoft.DotNet.Helix.Sdk
             using (_commandPayload = new CommandPayload(this))
             {
                 var currentHelixApi = HelixApi;
-
-                QueueInfo qi = await currentHelixApi.Information.QueueInfoAsync(TargetQueue);
-                if (qi.IsAvailable == false)
-                {
-                    if (LogErrorIfQueueDisabled)
-                    {
-                        Log.LogError("Queue is not available");
-                        return;
-                    } else
-                    {
-                        Log.LogWarning("Queue is not available");
-                        return;
-                    }
-                }
 
                 IJobDefinition def = currentHelixApi.Job.Define()
                     .WithType(Type)

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
@@ -2,7 +2,6 @@
 <Project>
   <PropertyGroup>
     <EnableXUnitReporter Condition=" '$(EnableXUnitReporter)' != 'true' ">false</EnableXUnitReporter>
-    <LogErrorIfQueueDisabled Condition=" '$(LogErrorIfQueueDisabled)' != 'false' ">true</LogErrorIfQueueDisabled>
   </PropertyGroup>
 
   <Choose>
@@ -56,8 +55,7 @@
                   PostCommands="$(HelixPostCommands)"
                   CorrelationPayloads="@(HelixCorrelationPayload)"
                   WorkItems="@(HelixWorkItem)"
-                  HelixProperties="@(HelixProperties)"
-                  LogErrorIfQueueDisabled="$(LogErrorIfQueueDisabled)">
+                  HelixProperties="@(HelixProperties)">
       <Output TaskParameter="JobCorrelationId" PropertyName="HelixJobId"/>
       <Output TaskParameter="ResultsContainerUri" PropertyName="HelixResultsContainer"/>
       <Output TaskParameter="ResultsContainerReadSAS" PropertyName="HelixResultsContainerReadSAS"/>

--- a/tests/UnitTests.proj
+++ b/tests/UnitTests.proj
@@ -73,8 +73,6 @@
     <HelixTargetQueue Include="Debian.9.Amd64.Open"/>
     <HelixTargetQueue Include="RedHat.7.Amd64.Open"/>
     <HelixTargetQueue Include="Windows.10.Amd64.Open"/>
-    <!--Used for testing behavior for unavailable queues-->
-    <!--<HelixTargetQueue Include="Alpine.36.Amd64"/>-->
   </ItemGroup>
 
   <PropertyGroup Condition="!$(HelixTargetQueue.StartsWith('Windows'))">


### PR DESCRIPTION
This reverts commit 663f5c6784b20b4c95ce92f0e4777af35b5eb771.

This is failing a lot of builds and sort of defeats the purpose of deadlettering things in the first place (which is to not fail builds when we do it... if we want the builds to fail, we can just delete the queue information)