### PR TITLE
Make test libraries use the test's deps file.

### DIFF
--- a/src/Microsoft.DotNet.CoreFxTesting/Microsoft.DotNet.CoreFxTesting.csproj
+++ b/src/Microsoft.DotNet.CoreFxTesting/Microsoft.DotNet.CoreFxTesting.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" Condition="'$(TargetFramework)' == 'net472'" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
+    <PackageReference Include="NuGet.Packaging" Version="$(NuGetVersion)" />
   </ItemGroup>
 
   <Import Project="$(RepoRoot)eng\BuildTask.targets" />

--- a/src/Microsoft.DotNet.CoreFxTesting/build/Microsoft.DotNet.CoreFxTesting.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/Microsoft.DotNet.CoreFxTesting.targets
@@ -37,13 +37,14 @@
   </ItemGroup>
 
   <!--
-    As we disabled implicit framework references but want to populate the framework node in the runtimeconfig's
-    runtimeOptions node we manually set the RuntimeFramework.
+    We disabled implicit framework references but still want to be treated as framework dependent:
+    1. To have runtimeTargets in the deps file.
+    2. To populate the framework node in the runtimeconfig's runtimeOptions 
+    To do this we manually set the RuntimeFramework.
     At that point restore and conflict resolution already happened therefore setting the item here has no side effects.
    -->
-  <Target Name="SetRuntimeFrameworksBeforeGenerateConfigurationFiles"
-          Condition="'$(GenerateRuntimeConfigurationFiles)' == 'true'"
-          BeforeTargets="GenerateBuildRuntimeConfigurationFiles">
+  <Target Name="_SetRuntimeFrameworksForCoreFxTesting"
+          BeforeTargets="GenerateBuildDependencyFile;GenerateBuildRuntimeConfigurationFiles">
     <ItemGroup>
       <RuntimeFramework Include="Microsoft.NETCore.App" Version="$(ProductVersion)" />
     </ItemGroup>
@@ -98,7 +99,9 @@
   -->
   <UsingTask TaskName="GenerateTestSharedFrameworkDepsFile" AssemblyFile="$(CoreFxTestingAssemblyPath)"/>
   <Target Name="GenerateTestSharedFrameworkDepsFile">
-    <GenerateTestSharedFrameworkDepsFile SharedFrameworkDirectory="$(NETCoreAppTestSharedFrameworkPath)" />
+    <GenerateTestSharedFrameworkDepsFile SharedFrameworkDirectory="$(NETCoreAppTestSharedFrameworkPath)"
+                                         RuntimeGraphFiles="$(RuntimeIdGraphDefinitionFile)"
+                                         TargetRuntimeIdentifier="$(PackageRID)" />
   </Target>
 
   <!-- UAP resource generation needed by both source and test projects. -->

--- a/src/Microsoft.DotNet.CoreFxTesting/build/Microsoft.DotNet.CoreFxTesting.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/Microsoft.DotNet.CoreFxTesting.targets
@@ -44,7 +44,8 @@
     At that point restore and conflict resolution already happened therefore setting the item here has no side effects.
    -->
   <Target Name="_SetRuntimeFrameworksForCoreFxTesting"
-          BeforeTargets="GenerateBuildDependencyFile;GenerateBuildRuntimeConfigurationFiles">
+          Condition="'$(SelfContained)' != 'true'"
+          BeforeTargets="GenerateBuildDependencyFile">
     <ItemGroup>
       <RuntimeFramework Include="Microsoft.NETCore.App" Version="$(ProductVersion)" />
     </ItemGroup>

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
@@ -101,7 +101,8 @@
       <PropertyGroup>
         <TestRunnerName>xunit.console.dll</TestRunnerName>
         <RunCommand>"$(RunScriptHost)"</RunCommand>
-        <RunArguments>exec --runtimeconfig $(AssemblyName).runtimeconfig.json $(TestRunnerName) $(RunArguments)</RunArguments>
+        <_depsFileRunArgument Condition="'$(GenerateDependencyFile)' == 'true'">--depsfile $(AssemblyName).deps.json</_depsFileRunArgument>
+        <RunArguments>exec --runtimeconfig $(AssemblyName).runtimeconfig.json $(_depsFileRunArgument) $(TestRunnerName) $(RunArguments)</RunArguments>
       </PropertyGroup>
     </When>
 

--- a/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
+++ b/src/Microsoft.DotNet.CoreFxTesting/build/core/test/Test.targets
@@ -101,8 +101,8 @@
       <PropertyGroup>
         <TestRunnerName>xunit.console.dll</TestRunnerName>
         <RunCommand>"$(RunScriptHost)"</RunCommand>
-        <_depsFileRunArgument Condition="'$(GenerateDependencyFile)' == 'true'">--depsfile $(AssemblyName).deps.json</_depsFileRunArgument>
-        <RunArguments>exec --runtimeconfig $(AssemblyName).runtimeconfig.json $(_depsFileRunArgument) $(TestRunnerName) $(RunArguments)</RunArguments>
+        <_depsFileRunArgument Condition="'$(GenerateDependencyFile)' == 'true'">--depsfile $(ProjectDepsFileName)</_depsFileRunArgument>
+        <RunArguments>exec --runtimeconfig $(ProjectRuntimeConfigFileName) $(_depsFileRunArgument) $(TestRunnerName) $(RunArguments)</RunArguments>
       </PropertyGroup>
     </When>
 


### PR DESCRIPTION
This lets us reference packages with runtimeTargets in our tests and run using those (rather than stuffing them into the shared framework).  It will help us remove SQLClient SNI from the product build's runitme project.