### PR TITLE
Run _GenerateResxSource target before BeforeCompile target.

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateResxSource.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateResxSource.targets
@@ -18,8 +18,11 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <!--
+    Note: Targets that generate Compile items are expected to run before BeforeCompile targets (common targets convention).
+  -->
   <Target Name="_GenerateResxSource"
-          BeforeTargets="CoreCompile"
+          BeforeTargets="BeforeCompile"
           DependsOnTargets="PrepareResourceNames;
                             _GetEmbeddedResourcesWithSourceGeneration;
                             _BatchGenerateResxSource">


### PR DESCRIPTION
The Common.targets convention is to hook code-generation targets to BeforeCompile.
Fixes https://github.com/dotnet/sourcelink/issues/392