### PR TITLE
Set EmbedUntrackedSources to true by default

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
@@ -15,6 +15,7 @@
     <DevelopmentDependency>false</DevelopmentDependency>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
 
     <!-- Disable the message indicating we are using a preview SDK. That is understood and by design -->
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>


### PR DESCRIPTION
All repos will need this setting in order to pass Source Link validation for generated source files such as resource files.

See https://github.com/dotnet/sourcelink/tree/master/docs#embeduntrackedsources for details on the switch.
