### PR TITLE
Fix swagger generation for nullable types.

### DIFF
--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/CSharp.cs
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/CSharp.cs
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.SwaggerGenerator.Languages
             }
 
             [BlockHelperMethod]
-            public void NullCheck(TextWriter output, object context, Action<TextWriter, object> template, TypeReference reference)
+            public void NullCheck(TextWriter output, object context, Action<TextWriter, object> template, TypeReference reference, bool required)
             {
                 if (reference == TypeReference.String)
                 {
@@ -124,12 +124,12 @@ namespace Microsoft.DotNet.SwaggerGenerator.Languages
                 else
                 {
                     template(output, context);
-                    output.WriteSafeString($" == default({ResolveReference(reference, null)})");
+                    output.WriteSafeString($" == {GetDefaultExpression(reference, required)}");
                 }
             }
 
             [BlockHelperMethod]
-            public void NotNullCheck(TextWriter output, object context, Action<TextWriter, object> template, TypeReference reference)
+            public void NotNullCheck(TextWriter output, object context, Action<TextWriter, object> template, TypeReference reference, bool required)
             {
                 if (reference == TypeReference.String)
                 {
@@ -140,8 +140,19 @@ namespace Microsoft.DotNet.SwaggerGenerator.Languages
                 else
                 {
                     template(output, context);
-                    output.WriteSafeString($" != default({ResolveReference(reference, null)})");
+                    output.WriteSafeString($" != {GetDefaultExpression(reference, required)}");
                 }
+            }
+
+            public string GetDefaultExpression(TypeReference reference, bool required)
+            {
+                string typeElement = ResolveReference(reference, null);
+                string nullableElement = "";
+                if (!required && !IsNullable(reference))
+                {
+                    nullableElement = "?";
+                }
+                return $"default({typeElement}{nullableElement})";
             }
 
             [HelperMethod]

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/MethodGroup.hb
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/MethodGroup.hb
@@ -116,7 +116,7 @@ namespace {{pascalCaseNs Namespace}}
         {
             {{#each NonConstantParameters}}
             {{#if Required}}
-            if ({{#nullCheck Type}}{{camelCase Name}}{{/nullCheck}})
+            if ({{#nullCheck Type Required}}{{camelCase Name}}{{/nullCheck}})
             {
                 throw new ArgumentNullException(nameof({{camelCase Name}}));
             }
@@ -144,7 +144,7 @@ namespace {{pascalCaseNs Namespace}}
             {{#if IsConstant}}
             _query.Add("{{Name}}", Client.Serialize({{camelCase Name}}));
             {{else}}
-            if ({{#notNullCheck Type}}{{camelCase Name}}{{/notNullCheck}})
+            if ({{#notNullCheck Type Required}}{{camelCase Name}}{{/notNullCheck}})
             {
                 {{#if IsArray}}
                 foreach (var _item in {{camelCase Name}})
@@ -170,7 +170,7 @@ namespace {{pascalCaseNs Namespace}}
                 _req = new HttpRequestMessage({{method HttpMethod}}, _url);
                 {{#each HeaderParameters}}
 
-                if ({{#notNullCheck Type}}{{camelCase Name}}{{/notNullCheck}})
+                if ({{#notNullCheck Type Required}}{{camelCase Name}}{{/notNullCheck}})
                 {
                     _req.Headers.Add("{{Name}}", {{camelCase Name}});
                 }
@@ -178,7 +178,7 @@ namespace {{pascalCaseNs Namespace}}
                 {{#with BodyParameter}}
 
                 string _requestContent = null;
-                if ({{#notNullCheck Type}}{{camelCase Name}}{{/notNullCheck}})
+                if ({{#notNullCheck Type Required}}{{camelCase Name}}{{/notNullCheck}})
                 {
                     _requestContent = Client.Serialize({{camelCase Name}});
                     _req.Content = new StringContent(_requestContent, Encoding.UTF8)

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/Model.hb
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/Model.hb
@@ -36,7 +36,7 @@ namespace {{pascalCaseNs Namespace}}.Models
             {
                 {{#each Properties}}
                 {{#if (and Required (isNullable Type))}}
-                if ({{#nullCheck Type}}{{pascalCase Name}}{{/nullCheck}})
+                if ({{#nullCheck Type Required}}{{pascalCase Name}}{{/nullCheck}})
                 {
                     return false;
                 }


### PR DESCRIPTION
On non-nullable, non-required parameter types, the handlebars code will automatically append a ? to the type reference, making it nullable. This logic needs to be duplicated in the null check code, otherwise we end up with:

```
int foo(int? p)
{
    if (p == default(int)) {...}
}
```

This will compile fine but will not have the intended behavior (default(int) is 0 while default(int?) is null).