### PR TITLE
Updates based on feedback from tactics

### DIFF
--- a/Documentation/Policy/ToolsetPolicy.md
+++ b/Documentation/Policy/ToolsetPolicy.md
@@ -16,6 +16,10 @@ For purposes of this document, 'Toolset' refers to tools which create and/or mod
 - As needed, dependencies can be taken on brand new, non-shipping versions of a toolset, and conversely, older versions too - so long as tactics approves.
 - Tools should be bootstrapped into the build where ever possible.  It is recognized that this is not always reasonable (or even the best approach), but is still desireable as we try and get as close as possible to 'clone and build'.  NOTE: There will still need to be provision for source-build to build "offline".
 
+### Servicing (LTS)
+- All toolsets should be the latest RTM (serviceable) version for LTS.
+- Toolsets should only change as needed, and with explicit consent of tactics.
+  
 ### VC toolset
 - VC tools are brought in via Visual Studio, preferably via the build sku.  Given the install limitations of VS and the Windows SDK, VC tools are provided via VM images which make up our build/test pools.   
 - Tools from the latest public preview of VS are available via a machine pool.  Private previews of VS are not widely available and are used for targeting testing only.
@@ -33,10 +37,6 @@ For purposes of this document, 'Toolset' refers to tools which create and/or mod
 
 ### Mac native toolsets
 - Mac tools are managed via O/S itself.  Here too we have both hosted and private machine pools.
-
-### Servicing (LTS)
-- All toolsets should be the latest RTM (serviceable) version for LTS.
-- Toolsets should only change as needed, and with explicit consent of tactics.
 
 ### Other
 - Any other tools not directly called out should be managed via Arcade, and preferably bootstrapped in as part of the build.

--- a/Documentation/Policy/ToolsetPolicy.md
+++ b/Documentation/Policy/ToolsetPolicy.md
@@ -4,7 +4,7 @@ For purposes of this document, 'Toolset' refers to tools which create and/or mod
 
 ## Principles
 
-- **Consistent across the stack:** The minimum number of tool versions should be used - with the ideal being one version per tool for the entire .NET Core product.  
+- **Consistent and serviceable across the stack:** The minimum number of tool versions should be used with the ideal being one (serviceable) version per tool for the entire .NET Core product.
 - **Visible:** It must be obvious which tool is being used in which situation.
 - **For tools MSFT owns, the latest shipping version is used to build .NET Core:** Our product/s should be built using the last shipping version of our toolsets.
 
@@ -33,6 +33,10 @@ For purposes of this document, 'Toolset' refers to tools which create and/or mod
 
 ### Mac native toolsets
 - Mac tools are managed via O/S itself.  Here too we have both hosted and private machine pools.
+
+### Servicing (LTS)
+- All toolsets should be the latest RTM (serviceable) version for LTS.
+- Toolsets should only change as needed, and with explicit consent of tactics.
 
 ### Other
 - Any other tools not directly called out should be managed via Arcade, and preferably bootstrapped in as part of the build.

--- a/Documentation/Policy/ToolsetPolicy.md
+++ b/Documentation/Policy/ToolsetPolicy.md
@@ -12,24 +12,23 @@ For purposes of this document, 'Toolset' refers to tools which create and/or mod
 
 ### General
 - Which tool version used across the stack should be determined in one place.  For more comments on this, see farther below.
-- After every shipment (previews included), all tools are brought forward to the latest appropriate release based on input from tactics.
-- As needed, dependencies can be taken on non-shipping versions of a toolset so long as tactics approves.
-- The latest shipping version of a tool should be used.  This implies ongoing diligence to update our toolset dependencies.
+- The latest shipped version of a tool should be used.  This implies ongoing diligence of the product teams to update toolset dependencies.
+- As needed, dependencies can be taken on brand new, non-shipping versions of a toolset, and conversely, older versions too - so long as tactics approves.
 - Tools should be bootstrapped into the build where ever possible.  It is recognized that this is not always reasonable (or even the best approach), but is still desireable as we try and get as close as possible to 'clone and build'.  NOTE: There will still need to be provision for source-build to build "offline".
 
 ### VC toolset
 - VC tools are brought in via Visual Studio, preferably via the build sku.  Given the install limitations of VS and the Windows SDK, VC tools are provided via VM images which make up our build/test pools.   
-- Tools from the latest public preview of VS are available via a machine pool.  Private previews of VS should not be widely available and used for targeting testing only.
-- The guidance is to do limited building and testing on the preview versions of VS, such that the upgrade to the latest tools can be done with confidence.  The distinction here comes from two competing business priorities: 1) Always be building and testing using the latest VC toolset, and 2) Keep our cost at a reasonable level. The RTM'd version of VS is on the hosted pools, while previews are on our private pools.
+- Tools from the latest public preview of VS are available via a machine pool.  Private previews of VS are not widely available and are used for targeting testing only.
+- The guidance is to build against the latest RTM'd version of VC, and do testing on the latest public preview versions of VS, such that upgrades can be done with confidence. 
 
 ### .NET SDK / Managed toolset
-- Arcade SDK (shared infra for .NET Core) must always reference the latest preview version of the .NET Core SDK at a minimum.  
+- Arcade SDK (shared infra for .NET Core) must always reference the latest preview version of the .NET Core SDK at a minimum. Immediately after shipping a preview, Arcade will update its .NET Core SDK reference.
 - In cases where a newer version of the .NET Core SDK is needed, a non-shipping (newer) version can be referenced by the Arcade SDK with approval from tactics.
-- Roslyn version is brought in as a dependency via the Arcade SDK.  It is not recommended for any build to take a direct dependency on Roslyn
 - In cases where an older version of .NET (and by implication Roslyn) is needed, exceptions are supported via Arcade, but should be approved by tactics and considered highly temporary.
+- Roslyn version is brought in as a dependency via the Arcade SDK.  It is not recommended for any build to take a direct dependency on Roslyn
 
 ### Linux native toolsets
-- The native \*nix build tools are managed via Docker containers.
+- The native \*nix build tools are mostly managed via Docker containers.
 - Where possible, the Docker containers should be shared across the teams.
 
 ### Mac native toolsets
@@ -38,5 +37,5 @@ For purposes of this document, 'Toolset' refers to tools which create and/or mod
 ### Other
 - Any other tools not directly called out should be managed via Arcade, and preferably bootstrapped in as part of the build.
 - All toolset updates will be communicated in advance by the engineering services team.
-- The implication here is that product teams should expect to deal with the toolsets updating on a higher cadence.  However, this in turn means that the delta will be much smaller each update.
+- The implication here is that product teams should expect to deal with the toolsets updating on a relatively high cadence.  However, this in turn means that the delta will be much smaller for each update.
 - The latest version principle does not apply to .net runtimes and refpacks when used for compat testing


### PR DESCRIPTION
Other than some minor cleanup, the main change here is to update the policy to say:
- Use last RTM version of VS
- Use last public preview of the SDK