### PR TITLE
Switch to `$(RestoreAdditionalProjectSources)`

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Versions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Versions.props
@@ -14,10 +14,12 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <RestoreSources>
+    <RestoreAdditionalProjectSources>
+      $(RestoreAdditionalProjectSources);
       https://api.nuget.org/v3/index.json;
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
-    </RestoreSources>
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json;
+    </RestoreAdditionalProjectSources>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
- include `dotnet-tools` feed to be sure it's available