### PR TITLE
Do not validate queues unless Test target is called

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MultiQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MultiQueue.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project InitialTargets="ValidateTargetQueues">
+<Project>
   <PropertyGroup>
     <!-- Split up HelixTargetQueues list
          In order to support all delimiters (commas, plus and semicolons).
@@ -66,7 +66,7 @@
   </Target>
 
   <Target Name="Test"
-    DependsOnTargets="$(TestDependsOn)"
+    DependsOnTargets="$(TestDependsOn);ValidateTargetQueues"
     Returns="@(SentJob)">
   </Target>
 


### PR DESCRIPTION
This allows us running different test projects on different queues in IoT repo (i.e. hardware dependent tests on ARM32 and hardware independent on AMD64 which are faster)