### PR TITLE
Add support for downloading the Runtime from a private location

### DIFF
--- a/eng/common/dotnet-install.ps1
+++ b/eng/common/dotnet-install.ps1
@@ -17,7 +17,7 @@ try {
     if ($architecture -and $architecture.Trim() -eq "x86") {
         $installdir = Join-Path $installdir "x86"
     }
-    InstallDotNet $installdir $version $architecture $runtime $true -RuntimeSourceFeed $RuntimeSourceFeed -RuntimeSourceFeedKey $RuntimeSourceFeedKey
+   InstallDotNet $installdir $version $architecture $runtime $true -RuntimeSourceFeed $RuntimeSourceFeed -RuntimeSourceFeedKey $RuntimeSourceFeedKey
 } 
 catch {
   Write-Host $_

--- a/eng/common/dotnet-install.ps1
+++ b/eng/common/dotnet-install.ps1
@@ -3,7 +3,9 @@ Param(
   [string] $verbosity = "minimal",
   [string] $architecture = "",
   [string] $version = "Latest",
-  [string] $runtime = "dotnet"
+  [string] $runtime = "dotnet",
+  [string] $RuntimeSourceFeed = "",
+  [string] $RuntimeSourceFeedKey = ""
 )
 
 . $PSScriptRoot\tools.ps1
@@ -15,7 +17,7 @@ try {
     if ($architecture -and $architecture.Trim() -eq "x86") {
         $installdir = Join-Path $installdir "x86"
     }
-   InstallDotNet $installdir $version $architecture $runtime $true
+    InstallDotNet $installdir $version $architecture $runtime $true -RuntimeSourceFeed $RuntimeSourceFeed -RuntimeSourceFeedKey $RuntimeSourceFeedKey
 } 
 catch {
   Write-Host $_

--- a/eng/common/dotnet-install.sh
+++ b/eng/common/dotnet-install.sh
@@ -14,6 +14,8 @@ scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 version='Latest'
 architecture=''
 runtime='dotnet'
+runtimeSourceFeed=''
+runtimeSourceFeedKey=''
 while [[ $# > 0 ]]; do
   opt="$(echo "$1" | awk '{print tolower($0)}')"
   case "$opt" in
@@ -29,6 +31,14 @@ while [[ $# > 0 ]]; do
       shift
       runtime="$1"
       ;;
+    -runtimeSourceFeed)
+      shift
+      runtimeSourceFeed="$1"
+      ;;
+    -runtimeSourceFeedKey)
+      shift
+      runtimeSourceFeedKey="$1"
+      ;;
     *)
       echo "Invalid argument: $1"
       usage
@@ -40,7 +50,7 @@ done
 
 . "$scriptroot/tools.sh"
 dotnetRoot="$repo_root/.dotnet"
-InstallDotNet $dotnetRoot $version "$architecture" $runtime true || {
+InstallDotNet $dotnetRoot $version "$architecture" $runtime true $runtimeSourceFeed $runtimeSourceFeedKey || {
   local exit_code=$?
   echo "dotnet-install.sh failed (exit code '$exit_code')." >&2
   ExitWithExitCode $exit_code

--- a/eng/common/dotnet-install.sh
+++ b/eng/common/dotnet-install.sh
@@ -41,7 +41,6 @@ while [[ $# > 0 ]]; do
       ;;
     *)
       echo "Invalid argument: $1"
-      usage
       exit 1
       ;;
   esac

--- a/eng/common/dotnet-install.sh
+++ b/eng/common/dotnet-install.sh
@@ -31,11 +31,11 @@ while [[ $# > 0 ]]; do
       shift
       runtime="$1"
       ;;
-    -runtimeSourceFeed)
+    -runtimesourcefeed)
       shift
       runtimeSourceFeed="$1"
       ;;
-    -runtimeSourceFeedKey)
+    -runtimesourcefeedkey)
       shift
       runtimeSourceFeedKey="$1"
       ;;

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -175,7 +175,14 @@ function InstallDotNetSdk([string] $dotnetRoot, [string] $version, [string] $arc
   InstallDotNet $dotnetRoot $version $architecture
 }
 
-function InstallDotNet([string] $dotnetRoot, [string] $version, [string] $architecture = "", [string] $runtime = "", [bool] $skipNonVersionedFiles = $false, [string]$RuntimeSourceFeed = "", [string]$RuntimeSourceFeedKey = "") {
+function InstallDotNet([string] $dotnetRoot, 
+  [string] $version, 
+  [string] $architecture = "", 
+  [string] $runtime = "", 
+  [bool] $skipNonVersionedFiles = $false, 
+  [string] $runtimeSourceFeed = "", 
+  [string] $runtimeSourceFeedKey = "") {
+
   $installScript = GetDotNetInstallScript $dotnetRoot
   $installParameters = @{
     Version = $version
@@ -193,11 +200,11 @@ function InstallDotNet([string] $dotnetRoot, [string] $version, [string] $archit
     Write-PipelineTelemetryError -Category "InitializeToolset" -Message "Failed to install dotnet runtime '$runtime' from public location."
 
     # Only the runtime can be installed from a custom [private] location.
-    if ($runtime -and ($RuntimeSourceFeed -or $RuntimeSourceFeedKey)) {
-      if ($RuntimeSourceFeed) { $installParameters.AzureFeed = $RuntimeSourceFeed }
+    if ($runtime -and ($runtimeSourceFeed -or $runtimeSourceFeedKey)) {
+      if ($runtimeSourceFeed) { $installParameters.AzureFeed = $runtimeSourceFeed }
 
-      if ($RuntimeSourceFeedKey) {
-        $decodedBytes = [System.Convert]::FromBase64String($RuntimeSourceFeedKey)
+      if ($runtimeSourceFeedKey) {
+        $decodedBytes = [System.Convert]::FromBase64String($runtimeSourceFeedKey)
         $decodedString = [System.Text.Encoding]::UTF8.GetString($decodedBytes)
         $installParameters.FeedCredential = $decodedString
       }
@@ -206,7 +213,7 @@ function InstallDotNet([string] $dotnetRoot, [string] $version, [string] $archit
         & $installScript @installParameters
       }
       catch {
-        Write-PipelineTelemetryError -Category "InitializeToolset" -Message "Failed to install dotnet runtime '$runtime' from custom location '$RuntimeSourceFeed'."
+        Write-PipelineTelemetryError -Category "InitializeToolset" -Message "Failed to install dotnet runtime '$runtime' from custom location '$runtimeSourceFeed'."
       }
     }
   }

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -193,7 +193,7 @@ function InstallDotNet([string] $dotnetRoot, [string] $version, [string] $archit
     Write-PipelineTelemetryError -Category "InitializeToolset" -Message "Failed to install dotnet runtime '$runtime' from public location."
 
     # Only the runtime can be installed from a custom [private] location.
-	if ($runtime -and ($RuntimeSourceFeed -or $RuntimeSourceFeedKey)) {
+    if ($runtime -and ($RuntimeSourceFeed -or $RuntimeSourceFeedKey)) {
     if ($RuntimeSourceFeed) { $installParameters.AzureFeed = $RuntimeSourceFeed }
 
     if ($RuntimeSourceFeedKey) {

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -194,19 +194,20 @@ function InstallDotNet([string] $dotnetRoot, [string] $version, [string] $archit
 
     # Only the runtime can be installed from a custom [private] location.
     if ($runtime -and ($RuntimeSourceFeed -or $RuntimeSourceFeedKey)) {
-    if ($RuntimeSourceFeed) { $installParameters.AzureFeed = $RuntimeSourceFeed }
+      if ($RuntimeSourceFeed) { $installParameters.AzureFeed = $RuntimeSourceFeed }
 
-    if ($RuntimeSourceFeedKey) {
-      $decodedBytes = [System.Convert]::FromBase64String($RuntimeSourceFeedKey)
-      $decodedString = [System.Text.Encoding]::UTF8.GetString($decodedBytes)
-      $installParameters.FeedCredential = $decodedString
-    }
+      if ($RuntimeSourceFeedKey) {
+        $decodedBytes = [System.Convert]::FromBase64String($RuntimeSourceFeedKey)
+        $decodedString = [System.Text.Encoding]::UTF8.GetString($decodedBytes)
+        $installParameters.FeedCredential = $decodedString
+      }
 
-    try {
-      & $installScript @installParameters
-    }
-    catch {
-	  Write-PipelineTelemetryError -Category "InitializeToolset" -Message "Failed to install dotnet runtime '$runtime' from custom location '$RuntimeSourceFeed'."
+      try {
+        & $installScript @installParameters
+      }
+      catch {
+        Write-PipelineTelemetryError -Category "InitializeToolset" -Message "Failed to install dotnet runtime '$runtime' from custom location '$RuntimeSourceFeed'."
+      }
     }
   }
 }

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -193,7 +193,7 @@ function InstallDotNet {
     local exit_code=$?
     Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install dotnet SDK from public location (exit code '$exit_code')."
 
-    if [[ ! -z "$runtimeArg" ]]; then
+    if [[ -n "$runtimeArg" ]]; then
       local runtimeSourceFeed=''
       if [[ -n "${6:-}" ]]; then
         runtimeSourceFeed="--azure-feed $6"
@@ -205,7 +205,7 @@ function InstallDotNet {
         runtimeSourceFeedKey="--feed-credential $decodedFeedKey"
       fi
 
-      if [[ ! -z "$runtimeSourceFeed" || ! -z "$runtimeSourceFeedKey" ]]; then
+      if [[ -n "$runtimeSourceFeed" || -n "$runtimeSourceFeedKey" ]]; then
         bash "$install_script" --version $version --install-dir "$root" $archArg $runtimeArg $skipNonVersionedFilesArg $runtimeSourceFeed $runtimeSourceFeedKey || {
           local exit_code=$?
           Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install dotnet SDK from custom location '$runtimeSourceFeed' (exit code '$exit_code')."

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -193,7 +193,7 @@ function InstallDotNet {
     local exit_code=$?
     Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install dotnet SDK from public location (exit code '$exit_code')."
 
-    if [[ ! -z "$runtime" ]]; then
+    if [[ ! -z "$runtimeArg" ]]; then
       local runtimeSourceFeed=''
       if [[ -n "${6:-}" ]]; then
         runtimeSourceFeed="--azure-feed $6"
@@ -201,14 +201,11 @@ function InstallDotNet {
 
       local runtimeSourceFeedKey=''
       if [[ -n "${7:-}" ]]; then
-        runtimeSourceFeedKey="--feed-credential $7"
+        decodedFeedKey=`echo $7 | base64 --decode`
+        runtimeSourceFeedKey="--feed-credential $decodedFeedKey"
       fi
 
       if [[ ! -z "$runtimeSourceFeed" || ! -z "$runtimeSourceFeedKey" ]]; then
-        if [[ -z "$runtimeSourceFeedKey" ]]; then
-          runtimeSourceFeedKey=`echo $runtimeSourceFeedKey | base64 --decode`
-        fi
-
         bash "$install_script" --version $version --install-dir "$root" $archArg $runtimeArg $skipNonVersionedFilesArg $runtimeSourceFeed $runtimeSourceFeedKey || {
           local exit_code=$?
           Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install dotnet SDK from custom location '$runtimeSourceFeed' (exit code '$exit_code')."

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -191,8 +191,23 @@ function InstallDotNet {
   fi
   bash "$install_script" --version $version --install-dir "$root" $archArg $runtimeArg $skipNonVersionedFilesArg || {
     local exit_code=$?
-    Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install dotnet SDK (exit code '$exit_code')."
-    ExitWithExitCode $exit_code
+    Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install dotnet SDK from public location (exit code '$exit_code')."
+
+    local runtimeSourceFeed=''
+    if [[ -n "${6:-}" ]]; then
+      runtimeSourceFeed="--azure-feed $6"
+    fi
+
+    local runtimeSourceFeedKey=''
+    if [[ -n "${7:-}" ]]; then
+      runtimeSourceFeedKey="--feed-credential $7"
+    fi
+    
+    bash "$install_script" --version $version --install-dir "$root" $archArg $runtimeArg $skipNonVersionedFilesArg $runtimeSourceFeed $runtimeSourceFeedKey || {
+      local exit_code=$?
+      Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install dotnet SDK from custom location '$runtimeSourceFeed' (exit code '$exit_code')."
+      ExitWithExitCode $exit_code
+    }
   }
 }
 

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -193,7 +193,7 @@ function InstallDotNet {
     local exit_code=$?
     Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install dotnet SDK from public location (exit code '$exit_code')."
 
-    if ($runtime) {
+    if [[ ! -z "$runtime" ]]; then
       local runtimeSourceFeed=''
       if [[ -n "${6:-}" ]]; then
         runtimeSourceFeed="--azure-feed $6"
@@ -204,18 +204,18 @@ function InstallDotNet {
         runtimeSourceFeedKey="--feed-credential $7"
       fi
 
-      if ($runtimeSourceFeed -or $runtimeSourceFeedKey) {
-        if ($runtimeSourceFeedKey) {
+      if [[ ! -z "$runtimeSourceFeed" || ! -z "$runtimeSourceFeedKey" ]]; then
+        if [[ -z "$runtimeSourceFeedKey" ]]; then
           runtimeSourceFeedKey=`echo $runtimeSourceFeedKey | base64 --decode`
-        }
+        fi
 
         bash "$install_script" --version $version --install-dir "$root" $archArg $runtimeArg $skipNonVersionedFilesArg $runtimeSourceFeed $runtimeSourceFeedKey || {
           local exit_code=$?
           Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install dotnet SDK from custom location '$runtimeSourceFeed' (exit code '$exit_code')."
           ExitWithExitCode $exit_code
         }
-      }
-    }
+      fi
+    fi
   }
 }
 

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -193,20 +193,28 @@ function InstallDotNet {
     local exit_code=$?
     Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install dotnet SDK from public location (exit code '$exit_code')."
 
-    local runtimeSourceFeed=''
-    if [[ -n "${6:-}" ]]; then
-      runtimeSourceFeed="--azure-feed $6"
-    fi
+    if ($runtime) {
+      local runtimeSourceFeed=''
+      if [[ -n "${6:-}" ]]; then
+        runtimeSourceFeed="--azure-feed $6"
+      fi
 
-    local runtimeSourceFeedKey=''
-    if [[ -n "${7:-}" ]]; then
-      runtimeSourceFeedKey="--feed-credential $7"
-    fi
-    
-    bash "$install_script" --version $version --install-dir "$root" $archArg $runtimeArg $skipNonVersionedFilesArg $runtimeSourceFeed $runtimeSourceFeedKey || {
-      local exit_code=$?
-      Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install dotnet SDK from custom location '$runtimeSourceFeed' (exit code '$exit_code')."
-      ExitWithExitCode $exit_code
+      local runtimeSourceFeedKey=''
+      if [[ -n "${7:-}" ]]; then
+        runtimeSourceFeedKey="--feed-credential $7"
+      fi
+
+      if ($runtimeSourceFeed -or $runtimeSourceFeedKey) {
+        if ($runtimeSourceFeedKey) {
+          runtimeSourceFeedKey=`echo $runtimeSourceFeedKey | base64 --decode`
+        }
+
+        bash "$install_script" --version $version --install-dir "$root" $archArg $runtimeArg $skipNonVersionedFilesArg $runtimeSourceFeed $runtimeSourceFeedKey || {
+          local exit_code=$?
+          Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install dotnet SDK from custom location '$runtimeSourceFeed' (exit code '$exit_code')."
+          ExitWithExitCode $exit_code
+        }
+      }
     }
   }
 }

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
@@ -126,8 +126,9 @@ namespace Microsoft.DotNet.Arcade.Sdk
                                         {
                                             arguments += $" -RuntimeSourceFeed {RuntimeSourceFeed}";
                                         }
-                                        // The default NetRuntimeSourceFeed doesn't need a key
-                                        if (!string.IsNullOrWhiteSpace(RuntimeSourceFeed) && !String.IsNullOrWhiteSpace(RuntimeSourceFeedKey))
+
+                                        // The default RuntimeSourceFeed doesn't need a key
+                                        if (!string.IsNullOrWhiteSpace(RuntimeSourceFeed) && !string.IsNullOrWhiteSpace(RuntimeSourceFeedKey))
                                         {
                                             arguments += $" -RuntimeSourceFeedKey {RuntimeSourceFeedKey}";
                                         }

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
@@ -31,6 +31,10 @@ namespace Microsoft.DotNet.Arcade.Sdk
         [Required]
         public string Platform { get; set; }
 
+        public string NetRuntimeSourceFeed { get; set; }
+        
+        public string NetRuntimeSourceFeedKey { get; set; }
+
         public override bool Execute()
         {
             if (!File.Exists(GlobalJsonPath))
@@ -116,6 +120,16 @@ namespace Microsoft.DotNet.Arcade.Sdk
                                         if (!string.IsNullOrEmpty(architecture))
                                         {
                                             arguments += $" -architecture {architecture}";
+                                        }
+
+                                        if (!String.IsNullOrWhiteSpace(NetRuntimeSourceFeed))
+                                        {
+                                            arguments += $" -NetRuntimeSourceFeed {NetRuntimeSourceFeed}";
+                                        }
+                                        // The default NetRuntimeSourceFeed doesn't need a key
+                                        if (!String.IsNullOrWhiteSpace(NetRuntimeSourceFeed) && !String.IsNullOrWhiteSpace(NetRuntimeSourceFeedKey))
+                                        {
+                                            arguments += $" -NetRuntimeSourceFeedKey {NetRuntimeSourceFeedKey}";
                                         }
 
                                         Log.LogMessage(MessageImportance.Low, $"Executing: {DotNetInstallScript} {arguments}");

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
@@ -31,9 +31,9 @@ namespace Microsoft.DotNet.Arcade.Sdk
         [Required]
         public string Platform { get; set; }
 
-        public string NetRuntimeSourceFeed { get; set; }
+        public string RuntimeSourceFeed { get; set; }
         
-        public string NetRuntimeSourceFeedKey { get; set; }
+        public string RuntimeSourceFeedKey { get; set; }
 
         public override bool Execute()
         {
@@ -122,14 +122,14 @@ namespace Microsoft.DotNet.Arcade.Sdk
                                             arguments += $" -architecture {architecture}";
                                         }
 
-                                        if (!String.IsNullOrWhiteSpace(NetRuntimeSourceFeed))
+                                        if (!string.IsNullOrWhiteSpace(RuntimeSourceFeed))
                                         {
-                                            arguments += $" -NetRuntimeSourceFeed {NetRuntimeSourceFeed}";
+                                            arguments += $" -RuntimeSourceFeed {RuntimeSourceFeed}";
                                         }
                                         // The default NetRuntimeSourceFeed doesn't need a key
-                                        if (!String.IsNullOrWhiteSpace(NetRuntimeSourceFeed) && !String.IsNullOrWhiteSpace(NetRuntimeSourceFeedKey))
+                                        if (!string.IsNullOrWhiteSpace(RuntimeSourceFeed) && !String.IsNullOrWhiteSpace(RuntimeSourceFeedKey))
                                         {
-                                            arguments += $" -NetRuntimeSourceFeedKey {NetRuntimeSourceFeedKey}";
+                                            arguments += $" -RuntimeSourceFeedKey {RuntimeSourceFeedKey}";
                                         }
 
                                         Log.LogMessage(MessageImportance.Low, $"Executing: {DotNetInstallScript} {arguments}");

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
@@ -124,13 +124,13 @@ namespace Microsoft.DotNet.Arcade.Sdk
 
                                         if (!string.IsNullOrWhiteSpace(RuntimeSourceFeed))
                                         {
-                                            arguments += $" -RuntimeSourceFeed {RuntimeSourceFeed}";
+                                            arguments += $" -runtimeSourceFeed {RuntimeSourceFeed}";
                                         }
 
                                         // The default RuntimeSourceFeed doesn't need a key
                                         if (!string.IsNullOrWhiteSpace(RuntimeSourceFeed) && !string.IsNullOrWhiteSpace(RuntimeSourceFeedKey))
                                         {
-                                            arguments += $" -RuntimeSourceFeedKey {RuntimeSourceFeedKey}";
+                                            arguments += $" -runtimeSourceFeedKey {RuntimeSourceFeedKey}";
                                         }
 
                                         Log.LogMessage(MessageImportance.Low, $"Executing: {DotNetInstallScript} {arguments}");

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -20,6 +20,8 @@
     DotNetSymbolServerTokenSymWeb   Personal access token for SymWeb symbol server. Available from variable group DotNet-Symbol-Publish.
     DotNetSymbolExpirationInDays    Symbol expiration time in days (defaults to 10 years).
     DotNetSignType                  Specifies the signing type: 'real' (default), 'test'.
+    DotNetRuntimeSourceFeed         Storage account to lookup for the .Net runtime files
+    DotNetRuntimeSourceFeedKey      In case the storage account to fetch the .Net runtime files are private this should contain a SAS token.
 
     ContinuousIntegrationBuild      "true" when building on a CI server (PR build or official build)
     Restore                         "true" to restore toolset and solution
@@ -130,6 +132,15 @@
       <_RestoreToolsProps Include="ExcludeRestorePackageImports=true"/>
       <_RestoreToolsProps Include="PublishingToBlobStorage=$(DotNetPublishToBlobFeed)"/>
       <_RestoreToolsProps Include="_NuGetRestoreTargets=$(_NuGetRestoreTargets)"/>
+    </ItemGroup>
+
+    <!--
+      Private builds, i.e., those building from a branch that has '/internal/' in the name,
+      can install the private .net Runtime.
+    -->
+    <ItemGroup Condition="'$(Restore)' == 'true' and $(BUILD_SOURCEBRANCH.Contains('/internal/'))">
+      <_RestoreToolsProps Include="NetRuntimeSourceFeed=$(DotNetRuntimeSourceFeed)"/>
+      <_RestoreToolsProps Include="NetRuntimeSourceFeedKey=$(DotNetRuntimeSourceFeedKey)"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -135,12 +135,12 @@
     </ItemGroup>
 
     <!--
-      Private builds, i.e., those building from a branch that has '/internal/' in the name,
-      can install the private .net Runtime.
+      Builds from the 'internal' project, and only those, can download the .net Runtime 
+      from a private location.
     -->
-    <ItemGroup Condition="'$(Restore)' == 'true' and $(BUILD_SOURCEBRANCH.Contains('/internal/'))">
-      <_RestoreToolsProps Include="NetRuntimeSourceFeed=$(DotNetRuntimeSourceFeed)"/>
-      <_RestoreToolsProps Include="NetRuntimeSourceFeedKey=$(DotNetRuntimeSourceFeedKey)"/>
+    <ItemGroup Condition="'$(SYSTEM_TEAMPROJECT)' == 'internal'">
+      <_RestoreToolsProps Include="DotNetRuntimeSourceFeed=$(DotNetRuntimeSourceFeed)"/>
+      <_RestoreToolsProps Include="DotNetRuntimeSourceFeedKey=$(DotNetRuntimeSourceFeedKey)"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/InstallDotNetCore.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/InstallDotNetCore.targets
@@ -16,7 +16,9 @@
       VersionsPropsPath="$(RepoRoot)eng\Versions.props"
       GlobalJsonPath="$(RepoRoot)global.json"
       DotNetInstallScript="$(_DotNetInstallScript)"
-      Platform="$(Platform)"/>
+      Platform="$(Platform)"
+      NetRuntimeSourceFeed="$(NetRuntimeSourceFeed)"
+      NetRuntimeSourceFeedKey="$(NetRuntimeSourceFeedKey)"/>
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/InstallDotNetCore.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/InstallDotNetCore.targets
@@ -17,8 +17,8 @@
       GlobalJsonPath="$(RepoRoot)global.json"
       DotNetInstallScript="$(_DotNetInstallScript)"
       Platform="$(Platform)"
-      NetRuntimeSourceFeed="$(NetRuntimeSourceFeed)"
-      NetRuntimeSourceFeedKey="$(NetRuntimeSourceFeedKey)"/>
+      RuntimeSourceFeed="$(DotNetRuntimeSourceFeed)"
+      RuntimeSourceFeedKey="$(DotNetRuntimeSourceFeedKey)"/>
   </Target>
 
 </Project>


### PR DESCRIPTION
Closes: #4108 

Add two new parameters to the SDK build system that let the user specify a custom URL and a SAS token to be used while downloading the .net Runtime.

Changes tested [here](https://dnceng.visualstudio.com/internal/_build/results?buildId=388681&view=results) and [here](https://dnceng.visualstudio.com/internal/_build/results?buildId=388686&view=logs&s=6884a131-87da-5381-61f3-d7acc3b91d76&j=09811346-8274-5b72-2d96-1dd38f87c84b).