### PR TITLE
Set EmbedUntrackedSources=false to prevent generated WPF files from being gathered during SourceLink

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.props
@@ -25,6 +25,7 @@
     <_WpfTempProjectNuGetFilePathNoExt>$(ArtifactsObjDir)$(_TargetAssemblyProjectName)\$(_TargetAssemblyProjectName)$(MSBuildProjectExtension).nuget.g</_WpfTempProjectNuGetFilePathNoExt>
 
     <EnableSourceLink>false</EnableSourceLink>
+    <EmbedUntrackedSources>false</EmbedUntrackedSources>
     <DeterministicSourcePaths>false</DeterministicSourcePaths>
     <EnableXlfLocalization>false</EnableXlfLocalization>
   </PropertyGroup>


### PR DESCRIPTION
Set EmbedUntrackedSources=false in Workarounds.props since Microsoft.SourceLink.Common.targets gathers these files for embedding in _SetEmbeddedFilesFromSourceControlManagerUntrackedFiles otherwise

/cc @rladuca 
/cc @chcosta, @tmat 