### PR TITLE
Add support for pre-relese iterations

### DIFF
--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -221,8 +221,10 @@ The file is present in the repo and defines versions of all dependencies used in
   <PropertyGroup>
     <!-- Base three-part version used for all outputs of the repo (assemblies, packages, vsixes) -->
     <VersionPrefix>1.0.0</VersionPrefix>
-    <!-- Package pre-release suffix not including build number -->
-    <PreReleaseVersionLabel>rc2</PreReleaseVersionLabel>
+    <!-- Package pre-release label not including build number or the pre-release iteration-->
+    <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
+    <!-- Package pre-release version iteration. Combines with the label to produce a final pre-release suffix. -->
+    <PreReleaseVersionIteration>2</PreReleaseVersionIteration>
     <!-- Optional: base short date used for calculating version numbers of release-only packages (e.g. global tools) -->
     <VersionBaseShortDate>19000</VersionBaseShortDate>
 

--- a/Documentation/CorePackages/Versioning.md
+++ b/Documentation/CorePackages/Versioning.md
@@ -91,13 +91,15 @@ _Package Version_ comprises of a three-part version number (**PACKAGE_MAJOR**, *
 
 The pre-release label is determined based on the following table:
 
-| Build kind                      | Pre-release labels                                   | Package Version example   |
-|---------------------------------|------------------------------------------------------|---------------------------|
-| Local developer build default   | "dev"                                                | "1.2.3-dev"               |
-| PR validation build             | "ci"                                                 | "1.2.3-ci"                |
-| Daily official build            | `PreReleaseVersionLabel`.**SHORT_DATE**.**REVISION** | "1.2.3-preview1.12345.1"  |
-| Final pre-release official build | `PreReleaseVersionLabel`."final"                     | "1.2.3-beta.final"        |
-| Release official build          | ""                                                   | "1.2.3"                   |   
+| Build kind                                                     | Pre-release labels                                   | Package Version example    |
+|----------------------------------------------------------------|------------------------------------------------------|----------------------------|
+| Local developer build default                                  | "dev"                                                | "1.2.3-dev"                |
+| PR validation build                                            | "ci"                                                 | "1.2.3-ci"                 |
+| Daily official build with pre-release iteration                | `PreReleaseVersionLabel`.`PreReleaseVersionIteration`.**SHORT_DATE**.**REVISION** | "1.2.3-preview.1.12345.1" |
+| Daily official build with no pre-release iteration             | `PreReleaseVersionLabel`.**SHORT_DATE**.**REVISION** | "1.2.3-beta.12345.1"       |
+| Final pre-release official build with pre-release iteration    | `PreReleaseVersionLabel`.`PreReleaseVersionIteration`."final"                     | "1.2.3-beta.1.final" |
+| Final pre-release official build with no pre-release iteration | `PreReleaseVersionLabel`."final"                     | "1.2.3-beta.final"         |
+| Release official build                                         | ""                                                   | "1.2.3"                    |   
 
 In official builds the values of **SHORT_DATE** and **REVISION** are derived from build parameter `OfficialBuildId` with format `20yymmdd.r` like so:
 - **REVISION** is set to `r` component of `OfficialBuildId` build property.
@@ -212,6 +214,7 @@ Below is a list of the main parameters that control the logic.
 | DotNetUseShippingVersions  | Arcade | Set to `true` to produce shipping version strings in non-official builds. I.e., instead of fixed values like `42.42.42.42` for `AssemblyVersion`. |
 | DotNetFinalVersionKind     | Arcade | Specify the kind of version being generated: `release`, `prerelease` or empty. |
 | PreReleaseVersionLabel     | Arcade | Pre-release label to be used on the string. E.g., `beta`, `prerelease`, etc. `ci` and `dev` are reserved for non-official CI builds and dev builds, respectively. |
+| PreReleaseVersionIteration | Arcade | Numeric pre-release iteration to be used on the pre-release suffix string. E.g., `1`, `2`, etc. If set, and SemVer2 is in use, appends to the prerelease version label, separated by a `.` |
 | VersionPrefix              | .NET   | Specify the leading part of the version string. If empty and both `MajorVersion` and `MinorVersion` are set, initialized to `$(MajorVersion).$(MinorVersion).0`. |
 | MajorVersion               | Arcade | Major version to use in `VersionPrefix`. |
 | MinorVersion               | Arcade | Minor version to use in `VersionPrefix`. |

--- a/Documentation/CorePackages/Versioning.md
+++ b/Documentation/CorePackages/Versioning.md
@@ -91,15 +91,18 @@ _Package Version_ comprises of a three-part version number (**PACKAGE_MAJOR**, *
 
 The pre-release label is determined based on the following table:
 
-| Build kind                                                     | Pre-release labels                                   | Package Version example    |
-|----------------------------------------------------------------|------------------------------------------------------|----------------------------|
-| Local developer build default                                  | "dev"                                                | "1.2.3-dev"                |
-| PR validation build                                            | "ci"                                                 | "1.2.3-ci"                 |
-| Daily official build with pre-release iteration                | `PreReleaseVersionLabel`.`PreReleaseVersionIteration`.**SHORT_DATE**.**REVISION** | "1.2.3-preview.1.12345.1" |
-| Daily official build with no pre-release iteration             | `PreReleaseVersionLabel`.**SHORT_DATE**.**REVISION** | "1.2.3-beta.12345.1"       |
-| Final pre-release official build with pre-release iteration    | `PreReleaseVersionLabel`.`PreReleaseVersionIteration`."final"                     | "1.2.3-beta.1.final" |
-| Final pre-release official build with no pre-release iteration | `PreReleaseVersionLabel`."final"                     | "1.2.3-beta.final"         |
-| Release official build                                         | ""                                                   | "1.2.3"                    |   
+| Build kind                       | Pre-release labels                                | Package Version example    |
+|----------------------------------|---------------------------------------------------|----------------------------|
+| Local developer build default    | "dev"                                             | "1.2.3-dev"                |
+| PR validation build              | "ci"                                              | "1.2.3-ci"                 |
+| Daily official build             | **PRERELEASE_LABELS**.**SHORT_DATE**.**REVISION** | "1.2.3-preview.1.12345.1"  |
+| Final pre-release official build | **PRERELEASE_LABELS**."final"                     | "1.2.3-beta.1.final"       |
+| Release official build           | ""                                                | "1.2.3"                    |   
+
+In official builds, the value of **PRERELEASE_LABELS** is derived as in the following way:
+- If `SemanticVersioningV1` is set to true, it will be `PreReleaseVersionLabel`
+- If `SemanticVersioningV1` is not set to true, and `PreReleaseVersionIteration` is empty, it will be `PreReleaseVersionLabel`
+- If `SemanticVersioningV1` is not set to true, and `PreReleaseVersionIteration` is non empty, it will be `PreReleaseVersionLabel`.`PreReleaseVersionIteration`
 
 In official builds the values of **SHORT_DATE** and **REVISION** are derived from build parameter `OfficialBuildId` with format `20yymmdd.r` like so:
 - **REVISION** is set to `r` component of `OfficialBuildId` build property.

--- a/Documentation/RepoToolset/MigrationToArcade.md
+++ b/Documentation/RepoToolset/MigrationToArcade.md
@@ -66,10 +66,10 @@ The following applies to CI build definition, not PR validation build definition
 ### Versioning changes
 - Arcade has a new versioning scheme for packages
   - SHA is included in the package version
-  - The version number is calculated differently, which means you need to rev the pre-release label (or major/minor/revision number) to avoid version conflicts and keep correct ordering. For example, if your PreReleaseVersionLabel was beta before update it to beta2. 
+  - The version number is calculated differently, which means you need to rev the pre-release label (or major/minor/revision number) to avoid version conflicts and keep correct ordering. For example, if your PreReleaseVersionLabel was beta before and you wish to use SemVer2, set PreReleaseVersionIteration to '2'. If you are using SemVer1, set PreReleaseVersionLabel to beta2.
   - By default Arcade uses SemVer2. It allows for opting for SemVer1
 -	eng\Versions.props
-  - Update PreReleaseVersionLabel property to avoid version number collisions
+  - Update the PreReleaseVersionLabel and/or PreReleaseVersionIteration properties to avoid version number collisions
   - Set SemanticVersioningV1 property to true if you want to continue using SemVer1.
 
 ### XUnit updated

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
@@ -93,7 +93,22 @@
     Calculate VersionSuffix.
   -->
   <PropertyGroup Condition="'$(PreReleaseVersionLabel)' != '' or '$(VersionSuffixDateStamp)' == ''">
+  <!--
+      Traditionally, .NET Core has used prerelease labels like:
+      - preview1
+      - beta1,
+      - preview9
+
+      For previews, this presents a problem if we decide to release more than 9 previews, as preview10 sorts
+      after preview9. This could be dealt with by using preview01, preview02, etc. but this is harder to read.
+      Instead, repos should use preview.1, preview.2, etc. if using SemVer2. NuGet will properly preference preview.10
+      over preview.9.
+
+      If PreReleaseVersionIteration is set and SemanticVersioningV1 is not set to true, then the prerelease version
+      number is appended with a '.' to PreReleaseVersionLabel to create the final prerelease label.
+    -->
     <_PreReleaseLabel>$(PreReleaseVersionLabel)</_PreReleaseLabel>
+    <_PreReleaseLabel Condition="'$(SemanticVersioningV1)' != 'true' and '$(PreReleaseVersionIteration)' != ''">$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</_PreReleaseLabel>
     <_PreReleaseLabel Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(OfficialBuild)' != 'true'">ci</_PreReleaseLabel>
     <_PreReleaseLabel Condition="'$(ContinuousIntegrationBuild)' != 'true'">dev</_PreReleaseLabel>
 


### PR DESCRIPTION
In .NET 5, to avoid issues with preview sorting if there are more than 9 previews, we have decided to take advantage of SemVer2's ability to specify a pre-release iteration number after the prerelease tag.  For example: preview1 -> preview.1.
This commit adds support for this natively in Arcade. Repositories wishing to take part should set PreReleaseVersionIteration to the numeric value of the current iteration (e.g. 1).

Repositories that are not planning on any iteration should leave this property blank, for example:
    - The current label is servicing
    - The repo has alreeady shipped packages to nuget.org with a pre-release iteration built into the pre-release label at the current major.minor.patch (e.g. if they shipped a '5.0.0-beta4' package already)