### PR TITLE
Handle non-x86 in dotnet-install.sh on *nix

### DIFF
--- a/eng/common/dotnet-install.sh
+++ b/eng/common/dotnet-install.sh
@@ -47,8 +47,38 @@ while [[ $# > 0 ]]; do
   shift
 done
 
+# Use uname to determine what the CPU is.
+cpuname=$(uname -p)
+# Some Linux platforms report unknown for platform, but the arch for machine.
+if [[ "$cpuname" == "unknown" ]]; then
+  cpuname=$(uname -m)
+fi
+
+case $cpuname in
+  aarch64)
+    buildarch=arm64
+    ;;
+  amd64|x86_64)
+    buildarch=x64
+    ;;
+  armv7l)
+    buildarch=arm
+    ;;
+  i686)
+    buildarch=x86
+    ;;
+  *)
+    echo "Unknown CPU $cpuname detected, treating it as x64"
+    buildarch=x64
+    ;;
+esac
+
 . "$scriptroot/tools.sh"
 dotnetRoot="$repo_root/.dotnet"
+if [[ $architecture != "" ]] && [[ $architecture != $buildarch ]]; then
+  dotnetRoot="$dotnetRoot/$architecture"
+fi
+
 InstallDotNet $dotnetRoot $version "$architecture" $runtime true $runtimeSourceFeed $runtimeSourceFeedKey || {
   local exit_code=$?
   echo "dotnet-install.sh failed (exit code '$exit_code')." >&2


### PR DESCRIPTION
Here's the problem:

Tasks in arcade, such as `InstallDotNetCore` end up calling this script to install .NET Core for development (building and testing projects).

In certain configurations, such as how AspNetCore's `global.json` is setup, this `dotnet-install.sh` script is called multiple times to install multiple architectures of .NET Core.

This script ends up calling the CLI's `dotnet-install.sh` to do the heavy lifting. But it always tells it to use the same path (eg `.dotnet`), even for different architectures.

This works mostly okay if x64 (and x86) are the only architectures. Because x86 is ignored and only x64 gets installed on *nix. On Windows, x64 goes in `.dotnet` and x86 goes in `.dotnet/x86`.

But as soon as multiple incompatible architectures enter the picture, things start breaking down. For example, as soon as I try and add arm64 to a `global.json`, this is what can happen:

0. The main bootstrap processes (executed as part of ./build.sh) installs an arm64 SDK in ~/.dotnet to run msbuild.

1. The `InstallDotNetCore` tasks tries to install the versions listed in `global.json` in order of their appearance.

2. This `dotnet-install.sh` script installs x64 in `.dotnet/`.

3. `InstallDotNetCore` task skips x86 (because it's non-Windows platform)

4. This `dotnet-install.sh` scripts calls CLI's `dotnet-install.sh` to install arm64 in `.dotnet/`

5. CLI's `dotnet-install.sh` sees that the runtime and/or SDK versions are already installed in `.dotnet/` and doesn't do anything.

6. When it comes time to execute `dotnet` again, the `.dotnet` directory contains multiple versions (some from the bootstrap, some from the `InstallDotNetCore` task). If the version in global.json is newer than the version installed initially, the `dotnet` binary tries to load that latest (and incompatible) x64 hostfxr that was installed.

7. Build blows up because an arm64 process can't load up an x64 `libhostfxr.so`.

This change uses the approach that the Windows build takes for x86 and x64: .NET Core for the current architecture of the machine is installed at `.dotnet/`. Other SDKs/Runtimes are installed at `.dotnet/$OTHER_ARCH/`.

This change doesn't address a larger question: does it make sense to install mutliple SDKs for different architectures? It makes sense to install x64 and x86 on x64 machines for testing. Does it make any sense to install x86 (or even x64) on arm64?

Perhaps it might better if the list in `global.json` was filtered by Arcade so only the architecture of the build machine and any architectures known to be compatible with it were installed.

For more background, see https://github.com/aspnet/AspNetCore/pull/14790 and https://github.com/dotnet/arcade/pull/2815

cc @dougbu @dagood @markwilkie @vatsan-madhavan @chcosta @tmat 