### PR TITLE
Change BeforeTargets of _GenerateResxSource to BeforeCompile;CoreCompile

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateResxSource.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateResxSource.targets
@@ -22,7 +22,7 @@
     Note: Targets that generate Compile items are expected to run before BeforeCompile targets (common targets convention).
   -->
   <Target Name="_GenerateResxSource"
-          BeforeTargets="BeforeCompile"
+          BeforeTargets="BeforeCompile;CoreCompile"
           DependsOnTargets="PrepareResourceNames;
                             _GetEmbeddedResourcesWithSourceGeneration;
                             _BatchGenerateResxSource">


### PR DESCRIPTION
`CoreCompile` target is required for WPF temp projects.
`BeforeCompile` target is required for Source Link to work.