### PR TITLE
Fix License file handling with mono on case-sensitive filesystems

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GetLicenseFilePath.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GetLicenseFilePath.cs
@@ -39,8 +39,13 @@ namespace Microsoft.DotNet.Arcade.Sdk
             const string fileName = "license";
 
 #if NET472
-            IEnumerable<string> enumerateFiles(string extension) =>
-                System.IO.Directory.EnumerateFiles(Directory, fileName + extension, SearchOption.TopDirectoryOnly);
+            IEnumerable<string> enumerateFiles(string extension)
+            {
+                var fileNameWithExtension = fileName + extension;
+                return System.IO.Directory.EnumerateFiles(Directory, "*", SearchOption.TopDirectoryOnly)
+                        .Where(path => string.Equals(fileNameWithExtension, System.IO.Path.GetFileName(path), System.StringComparison.OrdinalIgnoreCase));
+            }
+
 #else
             var options = new EnumerationOptions
             {


### PR DESCRIPTION
Building mono/msbuild on linux (with case-sensitive filesystem) fails
with:

` /home/ankit/dev/msbuild/.packages/microsoft.dotnet.arcade.sdk/1.0.0-beta.19461.7/tools/RepositoryValidation.proj(29,5): error : No license file found in '/home/ankit/dev/msbuild/'`

Analysis:

- msbuild on mono is built against net472.
- The [repo](https://github.com/mono/msbuild/) has LICENSE file, which github [requires in upper case](https://help.github.com/en/articles/adding-a-license-to-a-repository).
- [GetLicenseFilePath.cs](https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Arcade.Sdk/src/GetLicenseFilePath.cs#L39) is looking for "license" but [here](https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Arcade.Sdk/src/GetLicenseFilePath.cs#L41-43) it does not ignore case, which causes it to fail on Linux.

Fix:
- Filter to match filenames, ignoring the case.

Fixes: https://github.com/dotnet/arcade/issues/4086