### PR TITLE
Quote all usages of ApiCompatBaseline at callsite instead of declaration

### DIFF
--- a/src/Microsoft.DotNet.ApiCompat/build/Microsoft.DotNet.ApiCompat.targets
+++ b/src/Microsoft.DotNet.ApiCompat/build/Microsoft.DotNet.ApiCompat.targets
@@ -28,8 +28,8 @@
     <_apiCompatTargetSuffix>$(TargetGroup)</_apiCompatTargetSuffix>
     <_apiCompatTargetSuffix Condition="'$(_apiCompatTargetSuffix)' == ''">$(TargetFramework)</_apiCompatTargetSuffix>
 
-    <ApiCompatBaseline Condition="!Exists('$(ApiCompatBaseline)')">"$(MSBuildProjectDirectory)\ApiCompatBaseline.$(_apiCompatTargetSuffix).txt"</ApiCompatBaseline>
-    <ApiCompatBaseline Condition="!Exists('$(ApiCompatBaseline)')">"$(MSBuildProjectDirectory)\ApiCompatBaseline.txt"</ApiCompatBaseline>
+    <ApiCompatBaseline Condition="!Exists('$(ApiCompatBaseline)')">$(MSBuildProjectDirectory)\ApiCompatBaseline.$(_apiCompatTargetSuffix).txt</ApiCompatBaseline>
+    <ApiCompatBaseline Condition="!Exists('$(ApiCompatBaseline)')">$(MSBuildProjectDirectory)\ApiCompatBaseline.txt</ApiCompatBaseline>
 
     <MatchingRefApiCompatBaseline Condition="!Exists('$(MatchingRefApiCompatBaseline)')">$(MSBuildProjectDirectory)\MatchingRefApiCompatBaseline.$(_apiCompatTargetSuffix).txt</MatchingRefApiCompatBaseline>
     <MatchingRefApiCompatBaseline Condition="'$(BaselineAllMatchingRefApiCompatError)' != 'true' and !Exists('$(MatchingRefApiCompatBaseline)')">$(MSBuildProjectDirectory)\MatchingRefApiCompatBaseline.txt</MatchingRefApiCompatBaseline>
@@ -70,7 +70,7 @@
       <ApiCompatArgs Condition="'$(BaselineAllAPICompatError)' != 'true' and Exists('$(ApiCompatBaseline)')">$(ApiCompatArgs) --baseline "$(ApiCompatBaseline)"</ApiCompatArgs>
       <!-- Must be last option. -->
       <ApiCompatArgs>$(ApiCompatArgs) --impl-dirs "$(IntermediateOutputPath),@(_DependencyDirectories, ','),"</ApiCompatArgs>
-      <ApiCompatBaselineAll Condition="'$(BaselineAllAPICompatError)' == 'true'">&gt; $(ApiCompatBaseline)</ApiCompatBaselineAll>
+      <ApiCompatBaselineAll Condition="'$(BaselineAllAPICompatError)' == 'true'">&gt; "$(ApiCompatBaseline)"</ApiCompatBaselineAll>
       <ApiCompatExitCode>0</ApiCompatExitCode>
 
       <ApiCompatResponseFile>$(IntermediateOutputPath)apicompat.rsp</ApiCompatResponseFile>
@@ -130,7 +130,7 @@
       <MatchingRefApiCompatArgs Condition="'$(BaselineAllMatchingRefApiCompatError)' != 'true' and Exists('$(MatchingRefApiCompatBaseline)')">$(MatchingRefApiCompatArgs) --baseline "$(MatchingRefApiCompatBaseline)"</MatchingRefApiCompatArgs>
       <!-- Must be last option. -->
       <MatchingRefApiCompatArgs>$(MatchingRefApiCompatArgs) --impl-dirs "@(_ImplementationDependencyDirectories, ','),"</MatchingRefApiCompatArgs>
-      <MatchingRefApiCompatBaselineAll Condition="'$(BaselineAllMatchingRefApiCompatError)' == 'true'">&gt; $(MatchingRefApiCompatBaseline)</MatchingRefApiCompatBaselineAll>
+      <MatchingRefApiCompatBaselineAll Condition="'$(BaselineAllMatchingRefApiCompatError)' == 'true'">&gt; "$(MatchingRefApiCompatBaseline)"</MatchingRefApiCompatBaselineAll>
 
       <MatchingRefApiCompatExitCode>0</MatchingRefApiCompatExitCode>
 


### PR DESCRIPTION
https://github.com/dotnet/arcade/pull/3835 was trying to fix paths with spaces in it, but actually the issue is that we were missing a couple of usages to be quoted, however when adding quotes to the declaration of the file, the usages that were actually quoted were passed down with double quotes, breaking APICompat: https://dev.azure.com/dnceng/public/_build/results?buildId=392091

cc: @BogdanCodreanu @ericstj @wtgodbe 