### PR TITLE
Make SLN generation work when passed a file name

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Configuration/src/build/Microsoft.DotNet.Build.Tasks.Configuration.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Configuration/src/build/Microsoft.DotNet.Build.Tasks.Configuration.targets
@@ -255,10 +255,14 @@
   <!-- intentionally not sequenced, expected to be called directly-->
   <Target Name="UpdateVSConfigurations">
     <Message Importance="High" Text="Updating configurations for projects ..." />
+    <PropertyGroup>
+      <_solutionPath>$([MSBuild]::GetPathOfFileAbove('$(MSBuildProjectName).sln'))</_solutionPath>
+      <_solutionPath Condition="'$(_solutionPath)' == ''">..\$(MSBuildProjectName).sln</_solutionPath>
+    </PropertyGroup>
     <ItemGroup Condition="'@(ProjectsToUpdate)' == '' AND '@(SolutionsToUpdate)' == ''">
       <!-- if not specified, then use the current project and try to find a solution. -->
       <ProjectsToUpdate Include="$(MSBuildProjectFullPath)" />
-      <SolutionsToUpdate Exists="..\$(MSBuildProjectName).sln" Include="..\$(MSBuildProjectName).sln" />
+      <SolutionsToUpdate Include="$(_solutionPath)" />
     </ItemGroup>
     <UpdateVSConfigurations ProjectsToUpdate="@(ProjectsToUpdate)" SolutionsToUpdate="@(SolutionsToUpdate)" />
   </Target>


### PR DESCRIPTION
Previously SLN generation was broken because we were passing a file path
but it expected a root folder.

This meant you couldn't use this target to generate an initial SLN for a single
library.