### PR TITLE
Adds Retries For Connection Failures When Validating Harvest Version

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetUtility.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetUtility.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                                 logger.Log(LogLevel.Error, "Encountered Connection Issue: " + e.ToString() + ", retries exhausted");
                                 throw e;
                             }
-                            logger.Log(LogLevel.Warning, "Encountered Connection Issue: " + e.ToString() + ", retrying...");
+                            logger.Log(LogLevel.Information, "Encountered Connection Issue: " + e.ToString() + ", retrying...");
                             // returns to start of while loop to retry after a delay
                             Thread.Sleep(5000);
                         }

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetUtility.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetUtility.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                             }
                             logger.Log(LogLevel.Warning, "Encountered Connection Issue: " + e.ToString() + ", retrying...");
                             // returns to start of while loop to retry after a delay
-                            Task.Delay(5000);
+                            Thread.Sleep(5000);
                         }
                     }
 


### PR DESCRIPTION
In response to issue 8022:
https://app.zenhub.com/workspaces/net-core-engineering-services-5c1012cd9291d617e98ef69e/issues/dotnet/core-eng/8022

This PR currently just attempts to retry twice if attempts to get resources or metadata trigger an exception (a SocketException in the issue).  I'm considering adding a test to verify this functionality works, but unsure how the test could properly call that part of the code or cause GetResourceAsync or GetMetadataAsync to throw an exception.