### PR TITLE
Fix RemoteInvokeHandle timeout handling for infinite timeout

### DIFF
--- a/src/Microsoft.DotNet.RemoteExecutor/src/RemoteInvokeHandle.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/RemoteInvokeHandle.cs
@@ -99,9 +99,9 @@ namespace Microsoft.DotNet.RemoteExecutor
                 // needing to do this in every derived test and keep each test much simpler.
                 try
                 {
-                    int timeOut = Options.TimeOut;
+                    int halfTimeOut = Options.TimeOut == Timeout.Infinite ? Options.TimeOut : Options.TimeOut / 2;
 
-                    if (!Process.WaitForExit(timeOut / 2))
+                    if (!Process.WaitForExit(halfTimeOut))
                     {
                         var description = new StringBuilder();
                         description.AppendLine($"Half-way through waiting for remote process.");
@@ -119,7 +119,7 @@ namespace Microsoft.DotNet.RemoteExecutor
                             }
                         }
 
-                        if (!Process.WaitForExit(timeOut / 2))
+                        if (!Process.WaitForExit(halfTimeOut))
                         {
                             description.AppendLine($"Timed out at {DateTime.Now} after {Options.TimeOut}ms waiting for remote process.");
 


### PR DESCRIPTION
The recent tweak to dump memory load when half the timeout expired is causing problems for the rare case where an infinite timeout is used (generally during debugging), as an infinite timeout of -1 is a specially-recognized sentinel by WaitForExit.

cc: @jkotas, @ViktorHofer 