### PR TITLE
Don't fail automatically on no artifacts

### DIFF
--- a/eng/common/templates/post-build/channels/netcore-3-tools-validation.yml
+++ b/eng/common/templates/post-build/channels/netcore-3-tools-validation.yml
@@ -32,12 +32,14 @@ stages:
         inputs:
           buildType: current
           artifactName: PackageArtifacts
+        continueOnError: true
 
       - task: DownloadBuildArtifacts@0
         displayName: Download Blob Artifacts
         inputs:
           buildType: current
           artifactName: BlobArtifacts
+        continueOnError: true
 
       - task: DownloadBuildArtifacts@0
         displayName: Download Asset Manifests

--- a/eng/common/templates/post-build/channels/netcore-3-tools.yml
+++ b/eng/common/templates/post-build/channels/netcore-3-tools.yml
@@ -67,12 +67,14 @@ stages:
         inputs:
           buildType: current
           artifactName: PackageArtifacts
+        continueOnError: true
 
       - task: DownloadBuildArtifacts@0
         displayName: Download Blob Artifacts
         inputs:
           buildType: current
           artifactName: BlobArtifacts
+        continueOnError: true
 
       - task: DownloadBuildArtifacts@0
         displayName: Download Asset Manifests

--- a/eng/common/templates/post-build/channels/netcore-dev-31.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-31.yml
@@ -67,12 +67,14 @@ stages:
         inputs:
           buildType: current
           artifactName: PackageArtifacts
+        continueOnError: true
 
       - task: DownloadBuildArtifacts@0
         displayName: Download Blob Artifacts
         inputs:
           buildType: current
           artifactName: BlobArtifacts
+        continueOnError: true
 
       - task: DownloadBuildArtifacts@0
         displayName: Download Asset Manifests

--- a/eng/common/templates/post-build/channels/netcore-dev-5.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-5.yml
@@ -67,12 +67,14 @@ stages:
         inputs:
           buildType: current
           artifactName: PackageArtifacts
+        continueOnError: true
 
       - task: DownloadBuildArtifacts@0
         displayName: Download Blob Artifacts
         inputs:
           buildType: current
           artifactName: BlobArtifacts
+        continueOnError: true
 
       - task: DownloadBuildArtifacts@0
         displayName: Download Asset Manifests

--- a/eng/common/templates/post-build/channels/netcore-internal-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-internal-30.yml
@@ -78,12 +78,14 @@ stages:
         inputs:
           buildType: current
           artifactName: PackageArtifacts
+        continueOnError: true
 
       - task: DownloadBuildArtifacts@0
         displayName: Download Blob Artifacts
         inputs:
           buildType: current
           artifactName: BlobArtifacts
+        continueOnError: true
 
       - task: DownloadBuildArtifacts@0
         displayName: Download Asset Manifests

--- a/eng/common/templates/post-build/channels/netcore-release-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-release-30.yml
@@ -67,12 +67,14 @@ stages:
         inputs:
           buildType: current
           artifactName: PackageArtifacts
+        continueOnError: true
 
       - task: DownloadBuildArtifacts@0
         displayName: Download Blob Artifacts
         inputs:
           buildType: current
           artifactName: BlobArtifacts
+        continueOnError: true
 
       - task: DownloadBuildArtifacts@0
         displayName: Download Asset Manifests

--- a/eng/common/templates/post-build/channels/netcore-release-31.yml
+++ b/eng/common/templates/post-build/channels/netcore-release-31.yml
@@ -67,12 +67,14 @@ stages:
         inputs:
           buildType: current
           artifactName: PackageArtifacts
+        continueOnError: true
 
       - task: DownloadBuildArtifacts@0
         displayName: Download Blob Artifacts
         inputs:
           buildType: current
           artifactName: BlobArtifacts
+        continueOnError: true
 
       - task: DownloadBuildArtifacts@0
         displayName: Download Asset Manifests

--- a/eng/common/templates/post-build/channels/netcore-tools-latest.yml
+++ b/eng/common/templates/post-build/channels/netcore-tools-latest.yml
@@ -67,12 +67,14 @@ stages:
         inputs:
           buildType: current
           artifactName: PackageArtifacts
+        continueOnError: true
 
       - task: DownloadBuildArtifacts@0
         displayName: Download Blob Artifacts
         inputs:
           buildType: current
           artifactName: BlobArtifacts
+        continueOnError: true
 
       - task: DownloadBuildArtifacts@0
         displayName: Download Asset Manifests

--- a/eng/common/templates/post-build/channels/netcore-tools-validation.yml
+++ b/eng/common/templates/post-build/channels/netcore-tools-validation.yml
@@ -32,12 +32,14 @@ stages:
         inputs:
           buildType: current
           artifactName: PackageArtifacts
+        continueOnError: true
 
       - task: DownloadBuildArtifacts@0
         displayName: Download Blob Artifacts
         inputs:
           buildType: current
           artifactName: BlobArtifacts
+        continueOnError: true
 
       - task: DownloadBuildArtifacts@0
         displayName: Download Asset Manifests


### PR DESCRIPTION
Some repos don't publish packages and blobs (or both) but may want to particpate in publishing for other reasons (symbols for instance). This is prevented by two things:
- The artifact download steps fail if the the artifacts don't exist
- The publishing logic checks that the directories exists.

Instead, pass continue on error to the artifact download steps, and then error out in publishing only if files mentioned in the manifest are missing.