### PR TITLE
Update ask-mode/tell-mode info

### DIFF
--- a/Documentation/Policy/ArcadeServicing.md
+++ b/Documentation/Policy/ArcadeServicing.md
@@ -21,9 +21,9 @@ of Arcade or services.**
 
 ### How do I get my servicing fix into master?
 - Fixes that apply to both master as well as servicing releases must be first checked into
-  master and then cherry picked into the appropriate servicing branches. Code flow happens from
-  servicing branches back into master for the purposes of completeness, but developers must
-  **not** rely on this to get fixes into master.
+  master and then cherry picked into the appropriate servicing branches.
+- Code flow happens from servicing branches back into master for the purposes of completeness,
+  but developers must **not** rely on this to get fixes into master.
 
 ### When do we branch?
 - Major releases of .NET Core, not minor

--- a/Documentation/Policy/ArcadeServicing.md
+++ b/Documentation/Policy/ArcadeServicing.md
@@ -20,8 +20,10 @@ of Arcade or services.**
 - `release/<NET Core Major Version Number>` for servicing
 
 ### How do I get my servicing fix into master?
-- By default, servicing branch updates will flow to master.
-- Because of the potential number of PRs, this flow is *not* automatic, but does happen periodically.
+- Fixes that apply to both master as well as servicing releases should be first checked into
+  master and then cherry picked into the appropriate servicing branches. Code flow happens from
+  servicing branches back into master for the purposes of completeness, but developers should
+  **not** rely on this to get fixes into master.
 
 ### When do we branch?
 - Major releases of .NET Core, not minor

--- a/Documentation/Policy/ArcadeServicing.md
+++ b/Documentation/Policy/ArcadeServicing.md
@@ -20,9 +20,9 @@ of Arcade or services.**
 - `release/<NET Core Major Version Number>` for servicing
 
 ### How do I get my servicing fix into master?
-- Fixes that apply to both master as well as servicing releases should be first checked into
+- Fixes that apply to both master as well as servicing releases must be first checked into
   master and then cherry picked into the appropriate servicing branches. Code flow happens from
-  servicing branches back into master for the purposes of completeness, but developers should
+  servicing branches back into master for the purposes of completeness, but developers must
   **not** rely on this to get fixes into master.
 
 ### When do we branch?

--- a/Documentation/Policy/AskModeTellModeTemplate.md
+++ b/Documentation/Policy/AskModeTellModeTemplate.md
@@ -1,3 +1,4 @@
+```
 ## Description
 
 Description of the change here.
@@ -17,3 +18,4 @@ How risky is this change?
 ## Workarounds
 
 Are there available workarounds for the bug?
+```

--- a/Documentation/Policy/AskModeTellModeTemplate.md
+++ b/Documentation/Policy/AskModeTellModeTemplate.md
@@ -1,0 +1,19 @@
+## Description
+
+Description of the change here.
+
+## Customer Impact
+
+Customer impact if this change is **not** made.
+
+## Regression
+
+Yes/No
+
+## Risk
+
+How risky is this change?
+
+## Workarounds
+
+Are there available workarounds for the bug?

--- a/Documentation/Policy/AskTellMode.md
+++ b/Documentation/Policy/AskTellMode.md
@@ -16,8 +16,8 @@ When multiple products share the same infrastructure, the most "strict" product 
 - "Branch Infra": Infrastructure changes in the product branch
 - "Product Infra": Infrastructure changes in shared infra like Arcade, Helix, etc.
 - "Tell Mode" for each product, teams will follow their own process
-- "Tell Mode" to Arcade means including the [PR template](AskModeTellModeTemplate.md) and add the 'tell-mode' label on your PR as an FYI that the change is being made. Review is required.
-- "Ask Mode" to Arcade means including the [PR template](AskModeTellModeTemplate.md)and add the 'servicing-consider' label on your PR. Your PR must be explicitly approved by a member of the dnceng LT prior to merge, who will replace 'servicing-consider' with 'servicing-approved' label. The approver may require additional approval from .NET Core tactics if the change is particularly impactful to the product.
+- "Tell Mode" to Arcade means including the [PR template](AskModeTellModeTemplate.md) and adding the 'tell-mode' label on your PR as an FYI that the change is being made. Review is required.
+- "Ask Mode" to Arcade means including the [PR template](AskModeTellModeTemplate.md) and adding the 'servicing-consider' label on your PR. Your PR must be explicitly approved by a member of the dnceng LT prior to merge, who will replace 'servicing-consider' with 'servicing-approved' label. The approver may require additional approval from .NET Core tactics if the change is particularly impactful to the product.
 - "Ask Mode" to tactics handled according the guidance managed by Lee Coward
 
 ## Things to keep in mind:

--- a/Documentation/Policy/AskTellMode.md
+++ b/Documentation/Policy/AskTellMode.md
@@ -16,7 +16,8 @@ When multiple products share the same infrastructure, the most "strict" product 
 - "Branch Infra": Infrastructure changes in the product branch
 - "Product Infra": Infrastructure changes in shared infra like Arcade, Helix, etc.
 - "Tell Mode" for each product, teams will follow their own process
-- "Tell Mode" to Arcade means emailing the Arcade Working Group at arcadewg@microsoft.com.  We'll keep this lightweight for now.
+- "Tell Mode" to Arcade means including the [PR template](AskModeTellModeTemplate.md) and add the 'tell-mode' label on your PR as an FYI that the change is being made. Review is required.
+- "Ask Mode" to Arcade means including the [PR template](AskModeTellModeTemplate.md)and add the 'servicing-consider' label on your PR. Your PR must be explicitly approved by a member of the dnceng LT prior to merge, who will replace 'servicing-consider' with 'servicing-approved' label. The approver may require additional approval from .NET Core tactics if the change is particularly impactful to the product.
 - "Ask Mode" to tactics handled according the guidance managed by Lee Coward
 
 ## Things to keep in mind:


### PR DESCRIPTION
Update the info with the following:
- Check into master first, then cherry pick fixes to servicing branches
- Instead of sending mail to arcadewg for ask mode/tell mode, tag PRs with "servicing-consider" and "tell-mode" to line up with the rest of the product.