### PR TITLE
Add SkipOnCoreclr and SkipOnMono attributes

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnCoreClrAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnCoreClrAttribute.cs
@@ -1,0 +1,16 @@
+using System;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+    [TraitDiscoverer("Microsoft.DotNet.XUnitExtensions.SkipOnCoreClrDiscoverer", "Microsoft.DotNet.XUnitExtensions")]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    public class SkipOnCoreClrAttribute : Attribute, ITraitAttribute
+    {
+        internal SkipOnCoreClrAttribute() { }
+
+        public SkipOnCoreClrAttribute(string reason, TestPlatforms testPlatforms) { }
+        public SkipOnCoreClrAttribute(string reason, RuntimeStressTestModes testMode) { }
+        public SkipOnCoreClrAttribute(string reason) { }
+    }
+}

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnMonoAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnMonoAttribute.cs
@@ -6,7 +6,7 @@ namespace Microsoft.DotNet.XUnitExtensions.Attributes
 {
     [TraitDiscoverer("Microsoft.DotNet.XUnitExtensions.SkipOnMonoDiscoverer", "Microsoft.DotNet.XUnitExtensions")]
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
-    public class SkipOnMonoAttribute : Attribute
+    public class SkipOnMonoAttribute : Attribute, ITraitAttribute
     {
         internal SkipOnMonoAttribute() { }
         public SkipOnMonoAttribute(string reason, TestPlatforms testPlatforms = TestPlatforms.Any) { }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnMonoAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnMonoAttribute.cs
@@ -1,0 +1,14 @@
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Microsoft.DotNet.XUnitExtensions.Attributes
+{
+    [TraitDiscoverer("Microsoft.DotNet.XUnitExtensions.SkipOnMonoDiscoverer", "Microsoft.DotNet.XUnitExtensions")]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    public class SkipOnMonoAttribute : Attribute
+    {
+        internal SkipOnMonoAttribute() { }
+        public SkipOnMonoAttribute(string reason, TestPlatforms testPlatforms = TestPlatforms.Any) { }
+    }
+}

--- a/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
@@ -1,0 +1,15 @@
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Microsoft.DotNet.XUnitExtensions
+{
+    internal static class DiscovererHelpers
+    {
+        internal static bool TestPlatformApplies(TestPlatforms platforms) =>
+                (platforms.HasFlag(TestPlatforms.FreeBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"))) ||
+                (platforms.HasFlag(TestPlatforms.Linux) && RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) ||
+                (platforms.HasFlag(TestPlatforms.NetBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"))) ||
+                (platforms.HasFlag(TestPlatforms.OSX) && RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) ||
+                (platforms.HasFlag(TestPlatforms.Windows) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+    }
+}

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ActiveIssueDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ActiveIssueDiscoverer.cs
@@ -44,13 +44,8 @@ namespace Microsoft.DotNet.XUnitExtensions
                 }
             }
         
-            if ((platforms.HasFlag(TestPlatforms.FreeBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"))) ||
-                (platforms.HasFlag(TestPlatforms.Linux) && RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) ||
-                (platforms.HasFlag(TestPlatforms.NetBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"))) ||
-                (platforms.HasFlag(TestPlatforms.OSX) && RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) ||
-                (platforms.HasFlag(TestPlatforms.Windows) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)))
+            if (DiscovererHelpers.TestPlatformApplies(platforms))
             {
-                
                 if (frameworks.HasFlag(TargetFrameworkMonikers.Netcoreapp))
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreappTest);
                 if (frameworks.HasFlag(TargetFrameworkMonikers.NetFramework))

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCoreClrDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCoreClrDiscoverer.cs
@@ -41,16 +41,19 @@ namespace Microsoft.DotNet.XUnitExtensions
             return Array.Empty<KeyValuePair<string, string>>();
         }
 
+        // Order here matters as some env variables may appear in multiple modes
         private static bool StressModeApplies(RuntimeStressTestModes stressMode) =>
-            stressMode == 0 ||
+            stressMode == RuntimeStressTestModes.Any ||
             (stressMode.HasFlag(RuntimeStressTestModes.GCStress3) && IsGCStress3) ||
             (stressMode.HasFlag(RuntimeStressTestModes.GCStressC) && IsGCStressC) ||
             (stressMode.HasFlag(RuntimeStressTestModes.ZapDisable) && IsZapDisable) ||
             (stressMode.HasFlag(RuntimeStressTestModes.TailcallStress) && IsTailCallStress) ||
             (stressMode.HasFlag(RuntimeStressTestModes.JitStressRegs) && IsJitStressRegs) ||
             (stressMode.HasFlag(RuntimeStressTestModes.JitStress) && IsJitStress) ||
-            (stressMode.HasFlag(RuntimeStressTestModes.JitMinOpts) && IsJitMinOpts);
+            (stressMode.HasFlag(RuntimeStressTestModes.JitMinOpts) && IsJitMinOpts) ||
+            stressMode == RuntimeStressTestModes.CheckedRuntime; // if checked runtime is the only flag, all stress modes apply.
 
+        // Order here matters as some env variables may appear in multiple modes
         private static bool IsRuntimeStressTesting =>
             IsGCStress3 ||
             IsGCStressC ||
@@ -88,8 +91,8 @@ namespace Microsoft.DotNet.XUnitExtensions
         private static bool CompareGCStressModeAsLower(string value, string first, string second)
         {
             value = value.ToLowerInvariant();
-            return string.Equals(value, first.ToLower(), StringComparison.InvariantCulture) ||
-                string.Equals(value, second.ToLower(), StringComparison.InvariantCulture) ||
+            return string.Equals(value, first.ToLowerInvariant(), StringComparison.InvariantCulture) ||
+                string.Equals(value, second.ToLowerInvariant(), StringComparison.InvariantCulture) ||
                 string.Equals(value, "0xf", StringComparison.InvariantCulture) ||
                 string.Equals(value, "f", StringComparison.InvariantCulture);
         }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCoreClrDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCoreClrDiscoverer.cs
@@ -72,9 +72,9 @@ namespace Microsoft.DotNet.XUnitExtensions
 
         private static bool IsZapDisable => string.Equals(GetEnvironmentVariableValue("COMPlus_ZapDisable"), "1", StringComparison.InvariantCulture);
 
-        private static bool IsGCStress3 => CompareMultipleValues(GetEnvironmentVariableValue("COMPlus_GCStress"), "0x3", "3");
+        private static bool IsGCStress3 => CompareAsNumber(GetEnvironmentVariableValue("COMPlus_GCStress"), 0x3, 0xF);
 
-        private static bool IsGCStressC => CompareMultipleValues(GetEnvironmentVariableValue("COMPlus_GCStress"), "0xC", "C");
+        private static bool IsGCStressC => CompareAsNumber(GetEnvironmentVariableValue("COMPlus_GCStress"), 0xC, 0xF);
 
         private static bool IsCheckedRuntime()
         {
@@ -85,8 +85,7 @@ namespace Microsoft.DotNet.XUnitExtensions
                 string.Equals(assemblyConfigurationAttribute.Configuration, "Checked", StringComparison.InvariantCulture);
         }
 
-        private static bool CompareMultipleValues(string value, string firstOption, string secondOption) =>
-            string.Equals(value, firstOption, StringComparison.InvariantCulture) ||
-            string.Equals(value, secondOption, StringComparison.InvariantCulture);
+        private static bool CompareAsNumber(string value, int first, int second) =>
+            int.TryParse(value, out int result) && result == first || result == second;
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCoreClrDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCoreClrDiscoverer.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.DotNet.XUnitExtensions
+{
+    public class SkipOnCoreClrDiscoverer : ITraitDiscoverer
+    {
+        public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
+        {
+            if (IsCheckedRuntime())
+            {
+                TestPlatforms testPlatforms = TestPlatforms.Any;
+                RuntimeStressTestModes stressMode = 0;
+
+                foreach (object arg in traitAttribute.GetConstructorArguments().Skip(1)) // We skip the first one as it is the reason
+                {
+                    if (arg is TestPlatforms tp)
+                    {
+                        testPlatforms = tp;
+                    }
+                    else if (arg is RuntimeStressTestModes rstm)
+                    {
+                        stressMode = rstm;
+                    }
+                }
+
+                if (DiscovererHelpers.TestPlatformApplies(testPlatforms))
+                {
+                    if (StressModeApplies(stressMode))
+                    {
+                        return new[] { new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing) };
+                    }
+                }
+            }
+
+            return Array.Empty<KeyValuePair<string, string>>();
+        }
+
+        private bool StressModeApplies(RuntimeStressTestModes stressMode)
+        {
+            if (stressMode == 0)
+            {
+                return true;
+            }
+
+            if (stressMode.HasFlag(RuntimeStressTestModes.ZapDisable) && string.Equals(GetEnvironmentVariableValue("COMPlus_ZapDisable"), "1", StringComparison.InvariantCulture))
+            {
+                return true;
+            }
+
+            if (stressMode.HasFlag(RuntimeStressTestModes.TailcallStress) && string.Equals(GetEnvironmentVariableValue("COMPlus_TailcallStress"), "1", StringComparison.InvariantCulture))
+            {
+                return true;
+            }
+
+            if (stressMode.HasFlag(RuntimeStressTestModes.JitStressRegs) && !string.Equals(GetEnvironmentVariableValue("COMPlus_JitStressRegs"), "0", StringComparison.InvariantCulture))
+            {
+                return true;
+            }
+
+            if (stressMode.HasFlag(RuntimeStressTestModes.JitStress) && !string.Equals(GetEnvironmentVariableValue("COMPlus_JitStress"), "0", StringComparison.InvariantCulture))
+            {
+                return true;
+            }
+
+            if (stressMode.HasFlag(RuntimeStressTestModes.JitMinOpts) && string.Equals(GetEnvironmentVariableValue("COMPlus_JitMinOpts"), "1", StringComparison.InvariantCulture))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private string GetEnvironmentVariableValue(string name) => Environment.GetEnvironmentVariable(name) ?? "0";
+
+        private bool IsCheckedRuntime()
+        {
+            if (!SkipOnMonoDiscoverer.IsMonoRuntime)
+            {
+                Assembly assembly = typeof(string).Assembly;
+                AssemblyConfigurationAttribute assemblyConfigurationAttribute = assembly.GetCustomAttribute<AssemblyConfigurationAttribute>();
+                if (assemblyConfigurationAttribute != null)
+                {
+                    if (string.Equals(assemblyConfigurationAttribute.Configuration, "Checked", StringComparison.InvariantCulture))
+                        return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCoreClrDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCoreClrDiscoverer.cs
@@ -72,9 +72,9 @@ namespace Microsoft.DotNet.XUnitExtensions
 
         private static bool IsZapDisable => string.Equals(GetEnvironmentVariableValue("COMPlus_ZapDisable"), "1", StringComparison.InvariantCulture);
 
-        private static bool IsGCStress3 => CompareAsNumber(GetEnvironmentVariableValue("COMPlus_GCStress"), 0x3, 0xF);
+        private static bool IsGCStress3 => CompareGCStressModeAsLower(GetEnvironmentVariableValue("COMPlus_GCStress"), "0x3", "3");
 
-        private static bool IsGCStressC => CompareAsNumber(GetEnvironmentVariableValue("COMPlus_GCStress"), 0xC, 0xF);
+        private static bool IsGCStressC => CompareGCStressModeAsLower(GetEnvironmentVariableValue("COMPlus_GCStress"), "0xC", "C");
 
         private static bool IsCheckedRuntime()
         {
@@ -85,7 +85,13 @@ namespace Microsoft.DotNet.XUnitExtensions
                 string.Equals(assemblyConfigurationAttribute.Configuration, "Checked", StringComparison.InvariantCulture);
         }
 
-        private static bool CompareAsNumber(string value, int first, int second) =>
-            int.TryParse(value, out int result) && result == first || result == second;
+        private static bool CompareGCStressModeAsLower(string value, string first, string second)
+        {
+            value = value.ToLowerInvariant();
+            return string.Equals(value, first.ToLower(), StringComparison.InvariantCulture) ||
+                string.Equals(value, second.ToLower(), StringComparison.InvariantCulture) ||
+                string.Equals(value, "0xf", StringComparison.InvariantCulture) ||
+                string.Equals(value, "f", StringComparison.InvariantCulture);
+        }
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCoreClrDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCoreClrDiscoverer.cs
@@ -66,15 +66,15 @@ namespace Microsoft.DotNet.XUnitExtensions
 
         private static bool IsJitStressRegs => !string.Equals(GetEnvironmentVariableValue("COMPlus_JitStressRegs"), "0", StringComparison.InvariantCulture);
 
-        private static bool IsJitMinOpts => string.Equals(GetEnvironmentVariableValue("COMPlus_JitMinOpts"), "1", StringComparison.InvariantCulture);
+        private static bool IsJitMinOpts => string.Equals(GetEnvironmentVariableValue("COMPlus_JITMinOpts"), "1", StringComparison.InvariantCulture);
 
         private static bool IsTailCallStress => string.Equals(GetEnvironmentVariableValue("COMPlus_TailcallStress"), "1", StringComparison.InvariantCulture);
 
         private static bool IsZapDisable => string.Equals(GetEnvironmentVariableValue("COMPlus_ZapDisable"), "1", StringComparison.InvariantCulture);
 
-        private static bool IsGCStress3 => string.Equals(GetEnvironmentVariableValue("COMPlus_GCStress"), "0x3", StringComparison.InvariantCulture);
+        private static bool IsGCStress3 => CompareMultipleValues(GetEnvironmentVariableValue("COMPlus_GCStress"), "0x3", "3");
 
-        private static bool IsGCStressC => string.Equals(GetEnvironmentVariableValue("COMPlus_GCStress"), "0xC", StringComparison.InvariantCulture);
+        private static bool IsGCStressC => CompareMultipleValues(GetEnvironmentVariableValue("COMPlus_GCStress"), "0xC", "C");
 
         private static bool IsCheckedRuntime()
         {
@@ -84,5 +84,9 @@ namespace Microsoft.DotNet.XUnitExtensions
             return assemblyConfigurationAttribute != null &&
                 string.Equals(assemblyConfigurationAttribute.Configuration, "Checked", StringComparison.InvariantCulture);
         }
+
+        private static bool CompareMultipleValues(string value, string firstOption, string secondOption) =>
+            string.Equals(value, firstOption, StringComparison.InvariantCulture) ||
+            string.Equals(value, secondOption, StringComparison.InvariantCulture);
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnMonoDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnMonoDiscoverer.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.DotNet.XUnitExtensions
+{
+    public class SkipOnMonoDiscoverer : ITraitDiscoverer
+    {
+        public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
+        {
+            if (IsMonoRuntime)
+            {
+                TestPlatforms testPlatforms = TestPlatforms.Any;
+
+                // Last argument is either the TestPlatform or the test platform to skip the test on.
+                if (traitAttribute.GetConstructorArguments().LastOrDefault() is TestPlatforms tp)
+                {
+                    testPlatforms = tp;
+                }
+
+                if (DiscovererHelpers.TestPlatformApplies(testPlatforms))
+                {
+                    return new[] { new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing) };
+                }
+            }
+
+            return Array.Empty<KeyValuePair<string, string>>();
+        }
+
+        public static bool IsMonoRuntime => Type.GetType("Mono.RuntimeStructs") != null;
+    }
+}

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Microsoft.DotNet.XUnitExtensions.csproj
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Microsoft.DotNet.XUnitExtensions.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <AssemblyName>Microsoft.DotNet.XUnitExtensions</AssemblyName>
@@ -17,5 +16,4 @@
     <None Include="$(RepoRoot)LICENSE.txt" PackagePath="LICENSE.txt" Pack="true" />
     <None Include="$(RepoRoot)THIRD-PARTY-NOTICES.txt" PackagePath="THIRD-PARTY-NOTICES.txt" Pack="true" />
   </ItemGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeStressTestModes.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeStressTestModes.cs
@@ -9,6 +9,10 @@ namespace Xunit
         JitStressRegs = 1 << 1,
         JitMinOpts = 1 << 2,
         TailcallStress = 1 << 3,
-        ZapDisable = 1 << 4
+        ZapDisable = 1 << 4,
+        GCStress3 = 1 << 5,
+        GCStressC = 1 << 6,
+        AnyGCStress = GCStress3 | GCStressC,
+        Any = ~0
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeStressTestModes.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeStressTestModes.cs
@@ -5,6 +5,11 @@ namespace Xunit
     [Flags]
     public enum RuntimeStressTestModes
     {
+        // Disable on any stress test mode or on checked runtime.
+        // Can't be ~0 as that would include CheckedRuntime flag, which would break the case
+        // where you want to disable in all (including release stress test).
+        Any = 0,
+
         // JitStress, JitStressRegs, JitMinOpts and TailcallStress enable
         // various modes in the JIT that cause us to exercise more code paths,
         // and generate different kinds of code
@@ -25,7 +30,6 @@ namespace Xunit
         // including in NGEN/ReadyToRun code.
         GCStressC = 1 << 6, // COMPlus_GCStress includes mode 0xC.
         CheckedRuntime = 1 << 7, // Disable only when running on checked runtime.
-        AnyGCStress = GCStress3 | GCStressC, // Disable when any GCStress is exercised.
-        Any = ~0 // Disable on any stress test mode.
+        AnyGCStress = GCStress3 | GCStressC // Disable when any GCStress is exercised.
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeStressTestModes.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeStressTestModes.cs
@@ -12,6 +12,7 @@ namespace Xunit
         ZapDisable = 1 << 4,
         GCStress3 = 1 << 5,
         GCStressC = 1 << 6,
+        CheckedRuntime = 1 << 7,
         AnyGCStress = GCStress3 | GCStressC,
         Any = ~0
     }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeStressTestModes.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeStressTestModes.cs
@@ -5,15 +5,27 @@ namespace Xunit
     [Flags]
     public enum RuntimeStressTestModes
     {
-        JitStress = 1,
-        JitStressRegs = 1 << 1,
-        JitMinOpts = 1 << 2,
-        TailcallStress = 1 << 3,
-        ZapDisable = 1 << 4,
-        GCStress3 = 1 << 5,
-        GCStressC = 1 << 6,
-        CheckedRuntime = 1 << 7,
-        AnyGCStress = GCStress3 | GCStressC,
-        Any = ~0
+        // JitStress, JitStressRegs, JitMinOpts and TailcallStress enable
+        // various modes in the JIT that cause us to exercise more code paths,
+        // and generate different kinds of code
+        JitStress = 1, // COMPlus_JitStress is set.
+        JitStressRegs = 1 << 1, // COMPlus_JitStressRegs is set.
+        JitMinOpts = 1 << 2, // COMPlus_JITMinOpts is set.
+        TailcallStress = 1 << 3, // COMPlus_TailcallStress is set.
+
+        // ZapDisable says to not use NGEN or ReadyToRun images.
+        // This means we JIT everything.
+        ZapDisable = 1 << 4, // COMPlus_ZapDisable is set.
+
+        // GCStress3 forces a GC at various locations, typically transitions
+        // to/from the VM from managed code. 
+        GCStress3 = 1 << 5,  // COMPlus_GCStress includes mode 0x3.
+
+        // GCStressC forces a GC at every JIT-generated code instruction,
+        // including in NGEN/ReadyToRun code.
+        GCStressC = 1 << 6, // COMPlus_GCStress includes mode 0xC.
+        CheckedRuntime = 1 << 7, // Disable only when running on checked runtime.
+        AnyGCStress = GCStress3 | GCStressC, // Disable when any GCStress is exercised.
+        Any = ~0 // Disable on any stress test mode.
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeStressTestModes.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeStressTestModes.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Xunit
+{
+    [Flags]
+    public enum RuntimeStressTestModes
+    {
+        JitStress = 1,
+        JitStressRegs = 1 << 1,
+        JitMinOpts = 1 << 2,
+        TailcallStress = 1 << 3,
+        ZapDisable = 1 << 4
+    }
+}


### PR DESCRIPTION
This contributes toward unifying the way we disable tests in between CoreFX/CoreCLR and Mono testing for corefx tests. 

The way it works is as follows:

### SkipOnCoreClrAttribute
We can use this attribute in different ways:

1. Disable always when running on a checked System.Private.CoreLib runtime.
```cs
[SkipOnCoreClr("The reason to disable it")]
```
2. Disable it only when running on a specific test platform (Windows, AnyUnix, Linux, OSX, etc).
```cs
[SkipOnCoreClr("The reason to disable it", TestPlatform.Windows)]
```
3. Disable it only when running in a specific runtime stress mode:
```cs
[SkipOnCoreClr("The reason to disable it", RuntimeStressTestModes.JitStress)]
```
4. A combination of both
```cs
[SkipOnCoreClr("The reason to disable it", TestPlatform.Linux, RuntimeStressTestModes.JitStress)]
```

### SkipOnMonoAttribute
We can use this attribute in different ways:

1. Disable always when running on the mono runtime
```cs
[SkipOnMono("The reason to disable it")]
```
2. Disable it only when running on a specific test platform (Windows, AnyUnix, Linux, OSX, etc).
```cs
[SkipOnMono("The reason to disable it", TestPlatform.Windows)]
```

The way these attributes work, if the attribute is added and the conditions are met, we will add a trait to the member which it was added (assembly, class or method) `Category=failing`. Then when calling XUnit as we already do today, we need to pass an argument, `-notrait Category=failing`.

I'm still testing this locally but wanted to start gathering feedback on the proposal.

cc: @jkotas @BruceForstall @stephentoub @jaredpar @ViktorHofer @danmosemsft