### PR TITLE
`ParseResponseAsync` failures should trigger retry

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/AzureDevOpsTask.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/AzureDevOpsTask.cs
@@ -96,12 +96,12 @@ namespace Microsoft.DotNet.Helix.AzureDevOps
             }
         }
 
-        protected Task<T> RetryAsync<T>(Func<Task<T>> function)
+        protected async Task<T> RetryAsync<T>(Func<Task<T>> function)
         {
             // Grab the retry logic from the helix api client
             try
             {
-                return ApiFactory.GetAnonymous().RetryAsync(
+                return await ApiFactory.GetAnonymous().RetryAsync(
                         async () => await function(),
                         ex => Log.LogMessage(MessageImportance.Low, $"Azure Dev Ops Operation failed: {ex}\nRetrying..."),
                         CancellationToken.None);
@@ -109,7 +109,7 @@ namespace Microsoft.DotNet.Helix.AzureDevOps
             catch (HttpRequestException ex)
             {
                 Log.LogError(FailureCategory.Helix, ex.ToString());
-                return null;
+                return default;
             }
         }
 

--- a/src/Microsoft.DotNet.Helix/Sdk/AzureDevOpsTask.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/AzureDevOpsTask.cs
@@ -76,43 +76,65 @@ namespace Microsoft.DotNet.Helix.AzureDevOps
             return !Log.HasLoggedErrors;
         }
 
-        protected Task RetryAsync(Func<Task> function)
+        protected async Task RetryAsync(Func<Task> function)
         {
-            // Grab the retry logic from the helix api client
-            return ApiFactory.GetAnonymous().RetryAsync(
-                    async () =>
-                    {
-                        await function();
-                        return false; // the retry function requires a return, give it one
-                    },
-                    ex => Log.LogMessage(MessageImportance.Low, $"Azure Dev Ops Operation failed: {ex}\nRetrying..."),
-                    CancellationToken.None);
-
+            try
+            {
+                // Grab the retry logic from the helix api client
+                await ApiFactory.GetAnonymous().RetryAsync(
+                        async () =>
+                        {
+                            await function();
+                            return false; // the retry function requires a return, give it one
+                        },
+                        ex => Log.LogMessage(MessageImportance.Low, $"Azure Dev Ops Operation failed: {ex}\nRetrying..."),
+                        CancellationToken.None);
+            }
+            catch (HttpRequestException ex)
+            {
+                Log.LogError(FailureCategory.Helix, ex.ToString());
+            }
         }
 
         protected Task<T> RetryAsync<T>(Func<Task<T>> function)
         {
             // Grab the retry logic from the helix api client
-            return ApiFactory.GetAnonymous().RetryAsync(
-                    async () => await function(),
-                    ex => Log.LogMessage(MessageImportance.Low, $"Azure Dev Ops Operation failed: {ex}\nRetrying..."),
-                    CancellationToken.None);
-
+            try
+            {
+                return ApiFactory.GetAnonymous().RetryAsync(
+                        async () => await function(),
+                        ex => Log.LogMessage(MessageImportance.Low, $"Azure Dev Ops Operation failed: {ex}\nRetrying..."),
+                        CancellationToken.None);
+            }
+            catch (HttpRequestException ex)
+            {
+                Log.LogError(FailureCategory.Helix, ex.ToString());
+                return null;
+            }
         }
 
-        protected async Task LogFailedRequest(HttpRequestMessage req, HttpResponseMessage res)
+        protected async Task HandleFailedRequest(HttpRequestMessage req, HttpResponseMessage res)
         {
-            int statusCodeValue = (int) res.StatusCode;
-            FailureCategory category = statusCodeValue >= 400 && statusCodeValue < 500
-                ? FailureCategory.Build
-                : FailureCategory.Helix;
-
-            Log.LogError(category, $"Request to {req.RequestUri} returned failed status {statusCodeValue} {res.ReasonPhrase}\n\n{(res.Content != null ? await res.Content.ReadAsStringAsync() : "")}");
             if (res.StatusCode == HttpStatusCode.Found)
             {
                 Log.LogError(
                     FailureCategory.Build,
                     "A call to an Azure DevOps api returned 302 Indicating a bad 'System.AccessToken' value.\n\nPlease Check the 'Make secrets available to builds of forks' in the pipeline pull request validation trigger settings.\nWe have evaluated the security considerations of this setting and have determined that it is fine to use for our public PR validation builds.");
+                return;
+            }
+
+            var statusCodeValue = (int)res.StatusCode;
+            var message = $"Request to {req.RequestUri} returned failed status {statusCodeValue} {res.ReasonPhrase}\n\n{(res.Content != null ? await res.Content.ReadAsStringAsync() : "")}";
+
+            if (statusCodeValue >= 400 && statusCodeValue < 500)
+            {
+                Log.LogError(FailureCategory.Build, message);
+            }
+            else
+            {
+                // we want to engage retry logic from HelixApi.RetryAsync in this case
+                Log.LogMessage(MessageImportance.Normal, message);
+                throw new HttpRequestException(message);
             }
         }
 
@@ -120,7 +142,7 @@ namespace Microsoft.DotNet.Helix.AzureDevOps
         {
             if (!res.IsSuccessStatusCode)
             {
-                await LogFailedRequest(req, res);
+                await HandleFailedRequest(req, res);
                 return null;
             }
 


### PR DESCRIPTION
Fixes #4220 

There is a discrepancy between `null`-based error signalization of `ParseResponseAsync` and exception-based convention that `RetryAsync` expects. Failures of `ParseResponseAsync` therefore currently don't translate into retries properly. So we need to translate.

I wondered a little bit about changing the contracts. I could have made `ParseResponseAsync` throw instead of returning `null`, or rewrite it to Try-pattern, or made RetryAsync to take `null` as a failure... Given the upcoming changes to C# that is going to make the `null` contract tracked by type system (+ will enforce pattern matching on it) and given the weirdness of `Try_Async`, I choose just to fix usages for now. It makes exception handling plausibly local. But still, feel free to advise on this.

In the nullability-tracking-enabled future, we can add `T RetryAsync(Func<T?>)` overload with the obvious semantics and remove the `?? throw new` construct.