### PR TITLE
Post build) Reorg linking of variable groups & adjust cross org feed auth. to symbol publishing

### DIFF
--- a/eng/common/templates/post-build/channels/netcore-3-tools-validation.yml
+++ b/eng/common/templates/post-build/channels/netcore-3-tools-validation.yml
@@ -17,8 +17,6 @@ stages:
     displayName: Publish Assets
     dependsOn: setupMaestroVars
     variables:
-      - group: DotNet-Blob-Feed
-      - group: AzureDevOps-Artifact-Feeds-Pats
       - name: BARBuildId
         value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
       - name: IsStableBuild

--- a/eng/common/templates/post-build/channels/netcore-3-tools.yml
+++ b/eng/common/templates/post-build/channels/netcore-3-tools.yml
@@ -35,6 +35,18 @@ stages:
           artifactName: 'PDBArtifacts'
         continueOnError: true
 
+      # This is necessary whenever we want to publish/restore to an AzDO private feed
+      # Since sdk-task.ps1 tries to restore packages we need to do this authentication here
+      # otherwise it'll complain about accessing a private feed.
+      - task: NuGetAuthenticate@0
+        displayName: 'Authenticate to AzDO Feeds'
+
+      - task: PowerShell@2
+        displayName: Enable cross-org publishing
+        inputs:
+          filePath: eng\common\enable-cross-org-publishing.ps1
+          arguments: -token $(dn-bot-dnceng-artifact-feeds-rw)
+
       - task: PowerShell@2
         displayName: Publish
         inputs:
@@ -52,8 +64,6 @@ stages:
     displayName: Publish Assets
     dependsOn: setupMaestroVars
     variables:
-      - group: DotNet-Blob-Feed
-      - group: AzureDevOps-Artifact-Feeds-Pats
       - name: BARBuildId
         value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
       - name: IsStableBuild

--- a/eng/common/templates/post-build/channels/netcore-3-tools.yml
+++ b/eng/common/templates/post-build/channels/netcore-3-tools.yml
@@ -37,7 +37,7 @@ stages:
 
       # This is necessary whenever we want to publish/restore to an AzDO private feed
       # Since sdk-task.ps1 tries to restore packages we need to do this authentication here
-      # otherwise it'll complain about accessing a private feed.
+      # otherwise there will be authentication failures when accessing a private feed hosted in a different org.
       - task: NuGetAuthenticate@0
         displayName: 'Authenticate to AzDO Feeds'
 

--- a/eng/common/templates/post-build/channels/netcore-dev-31.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-31.yml
@@ -35,6 +35,18 @@ stages:
           artifactName: 'PDBArtifacts'
         continueOnError: true
 
+      # This is necessary whenever we want to publish/restore to an AzDO private feed
+      # Since sdk-task.ps1 tries to restore packages we need to do this authentication here
+      # otherwise it'll complain about accessing a private feed.
+      - task: NuGetAuthenticate@0
+        displayName: 'Authenticate to AzDO Feeds'
+
+      - task: PowerShell@2
+        displayName: Enable cross-org publishing
+        inputs:
+          filePath: eng\common\enable-cross-org-publishing.ps1
+          arguments: -token $(dn-bot-dnceng-artifact-feeds-rw)
+
       - task: PowerShell@2
         displayName: Publish
         inputs:
@@ -52,8 +64,6 @@ stages:
     displayName: Publish Assets
     dependsOn: setupMaestroVars
     variables:
-      - group: DotNet-Blob-Feed
-      - group: AzureDevOps-Artifact-Feeds-Pats
       - name: BARBuildId
         value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
       - name: IsStableBuild

--- a/eng/common/templates/post-build/channels/netcore-dev-5.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-5.yml
@@ -35,6 +35,18 @@ stages:
           artifactName: 'PDBArtifacts'
         continueOnError: true
 
+      # This is necessary whenever we want to publish/restore to an AzDO private feed
+      # Since sdk-task.ps1 tries to restore packages we need to do this authentication here
+      # otherwise it'll complain about accessing a private feed.
+      - task: NuGetAuthenticate@0
+        displayName: 'Authenticate to AzDO Feeds'
+
+      - task: PowerShell@2
+        displayName: Enable cross-org publishing
+        inputs:
+          filePath: eng\common\enable-cross-org-publishing.ps1
+          arguments: -token $(dn-bot-dnceng-artifact-feeds-rw)
+
       - task: PowerShell@2
         displayName: Publish
         inputs:
@@ -52,8 +64,6 @@ stages:
     displayName: Publish Assets
     dependsOn: setupMaestroVars
     variables:
-      - group: DotNet-Blob-Feed
-      - group: AzureDevOps-Artifact-Feeds-Pats
       - name: BARBuildId
         value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
       - name: IsStableBuild

--- a/eng/common/templates/post-build/channels/netcore-internal-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-internal-30.yml
@@ -64,8 +64,6 @@ stages:
     displayName: Publish Assets
     dependsOn: setupMaestroVars
     variables:
-      - group: DotNet-Blob-Feed
-      - group: AzureDevOps-Artifact-Feeds-Pats
       - name: BARBuildId
         value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
       - name: IsStableBuild

--- a/eng/common/templates/post-build/channels/netcore-release-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-release-30.yml
@@ -35,6 +35,18 @@ stages:
           artifactName: 'PDBArtifacts'
         continueOnError: true
 
+      # This is necessary whenever we want to publish/restore to an AzDO private feed
+      # Since sdk-task.ps1 tries to restore packages we need to do this authentication here
+      # otherwise it'll complain about accessing a private feed.
+      - task: NuGetAuthenticate@0
+        displayName: 'Authenticate to AzDO Feeds'
+
+      - task: PowerShell@2
+        displayName: Enable cross-org publishing
+        inputs:
+          filePath: eng\common\enable-cross-org-publishing.ps1
+          arguments: -token $(dn-bot-dnceng-artifact-feeds-rw)
+
       - task: PowerShell@2
         displayName: Publish
         inputs:
@@ -52,8 +64,6 @@ stages:
     displayName: Publish Assets
     dependsOn: setupMaestroVars
     variables:
-      - group: DotNet-Blob-Feed
-      - group: AzureDevOps-Artifact-Feeds-Pats
       - name: BARBuildId
         value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
       - name: IsStableBuild

--- a/eng/common/templates/post-build/channels/netcore-release-31.yml
+++ b/eng/common/templates/post-build/channels/netcore-release-31.yml
@@ -35,6 +35,18 @@ stages:
           artifactName: 'PDBArtifacts'
         continueOnError: true
 
+      # This is necessary whenever we want to publish/restore to an AzDO private feed
+      # Since sdk-task.ps1 tries to restore packages we need to do this authentication here
+      # otherwise it'll complain about accessing a private feed.
+      - task: NuGetAuthenticate@0
+        displayName: 'Authenticate to AzDO Feeds'
+
+      - task: PowerShell@2
+        displayName: Enable cross-org publishing
+        inputs:
+          filePath: eng\common\enable-cross-org-publishing.ps1
+          arguments: -token $(dn-bot-dnceng-artifact-feeds-rw)
+
       - task: PowerShell@2
         displayName: Publish
         inputs:
@@ -52,8 +64,6 @@ stages:
     displayName: Publish Assets
     dependsOn: setupMaestroVars
     variables:
-      - group: DotNet-Blob-Feed
-      - group: AzureDevOps-Artifact-Feeds-Pats
       - name: BARBuildId
         value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
       - name: IsStableBuild

--- a/eng/common/templates/post-build/channels/netcore-tools-latest.yml
+++ b/eng/common/templates/post-build/channels/netcore-tools-latest.yml
@@ -35,6 +35,18 @@ stages:
           artifactName: 'PDBArtifacts'
         continueOnError: true
 
+      # This is necessary whenever we want to publish/restore to an AzDO private feed
+      # Since sdk-task.ps1 tries to restore packages we need to do this authentication here
+      # otherwise it'll complain about accessing a private feed.
+      - task: NuGetAuthenticate@0
+        displayName: 'Authenticate to AzDO Feeds'
+
+      - task: PowerShell@2
+        displayName: Enable cross-org publishing
+        inputs:
+          filePath: eng\common\enable-cross-org-publishing.ps1
+          arguments: -token $(dn-bot-dnceng-artifact-feeds-rw)
+
       - task: PowerShell@2
         displayName: Publish
         inputs:
@@ -52,8 +64,6 @@ stages:
     displayName: Publish Assets
     dependsOn: setupMaestroVars
     variables:
-      - group: DotNet-Blob-Feed
-      - group: AzureDevOps-Artifact-Feeds-Pats
       - name: BARBuildId
         value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
       - name: IsStableBuild

--- a/eng/common/templates/post-build/channels/netcore-tools-validation.yml
+++ b/eng/common/templates/post-build/channels/netcore-tools-validation.yml
@@ -17,8 +17,6 @@ stages:
     displayName: Publish Assets
     dependsOn: setupMaestroVars
     variables:
-      - group: DotNet-Blob-Feed
-      - group: AzureDevOps-Artifact-Feeds-Pats
       - name: BARBuildId
         value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
       - name: IsStableBuild
@@ -51,6 +49,8 @@ stages:
         displayName: 'Install NuGet.exe'
 
       # This is necessary whenever we want to publish/restore to an AzDO private feed
+      # Since sdk-task.ps1 tries to restore packages we need to do this authentication here
+      # otherwise it'll complain about accessing a private feed.
       - task: NuGetAuthenticate@0
         displayName: 'Authenticate to AzDO Feeds'
 

--- a/eng/common/templates/post-build/common-variables.yml
+++ b/eng/common/templates/post-build/common-variables.yml
@@ -1,7 +1,9 @@
 variables:
-  - group: Publish-Build-Assets
+  - group: AzureDevOps-Artifact-Feeds-Pats
+  - group: DotNet-Blob-Feed
   - group: DotNet-DotNetCli-Storage
   - group: DotNet-MSRC-Storage
+  - group: Publish-Build-Assets
 
   # .NET Core 3.1 Dev
   - name: PublicDevRelease_31_Channel_Id

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -50,7 +50,7 @@ stages:
       displayName: Signing Validation
       variables:
         - template: common-variables.yml
-        pool:
+      pool:
         vmImage: 'windows-2019'
       steps:
         - task: DownloadBuildArtifacts@0

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -50,8 +50,7 @@ stages:
       displayName: Signing Validation
       variables:
         - template: common-variables.yml
-        - group: AzureDevOps-Artifact-Feeds-Pats
-      pool:
+        pool:
         vmImage: 'windows-2019'
       steps:
         - task: DownloadBuildArtifacts@0
@@ -64,7 +63,6 @@ stages:
         # Since sdk-task.ps1 tries to restore packages we need to do this authentication here
         # otherwise it'll complain about accessing a private feed.
         - task: NuGetAuthenticate@0
-          condition: eq(variables['IsInternalBuild'], 'true')
           displayName: 'Authenticate to AzDO Feeds'
 
         - task: PowerShell@2


### PR DESCRIPTION
Closes: #4257 

Continuing previous PR: https://github.com/dotnet/arcade/pull/4236