### PR TITLE
Add telemetry categorization

### DIFF
--- a/eng/common/SetupNugetSources.ps1
+++ b/eng/common/SetupNugetSources.ps1
@@ -95,7 +95,7 @@ function InsertMaestroPrivateFeedCredentials($Sources, $Creds, $Password) {
 }
 
 if (!(Test-Path $ConfigFile -PathType Leaf)) {
-  Write-Host "Couldn't find the file NuGet config file: $ConfigFile"
+  Write-PipelineTelemetryError -Category 'Build' -Message "Couldn't find the file NuGet config file: $ConfigFile"
   ExitWithExitCode 1
 }
 

--- a/eng/common/SetupNugetSources.ps1
+++ b/eng/common/SetupNugetSources.ps1
@@ -94,34 +94,41 @@ function InsertMaestroPrivateFeedCredentials($Sources, $Creds, $Password) {
     }
 }
 
-if (!(Test-Path $ConfigFile -PathType Leaf)) {
-  Write-PipelineTelemetryError -Category 'Build' -Message "Couldn't find the file NuGet config file: $ConfigFile"
-  ExitWithExitCode 1
+try {
+    if (!(Test-Path $ConfigFile -PathType Leaf)) {
+    Write-PipelineTelemetryError -Category 'Build' -Message "Couldn't find the file NuGet config file: $ConfigFile"
+    ExitWithExitCode 1
+    }
+
+    # Load NuGet.config
+    $doc = New-Object System.Xml.XmlDocument
+    $filename = (Get-Item $ConfigFile).FullName
+    $doc.Load($filename)
+
+    # Get reference to <PackageSources> or create one if none exist already
+    $sources = $doc.DocumentElement.SelectSingleNode("packageSources")
+    if ($sources -eq $null) {
+        $sources = $doc.CreateElement("packageSources")
+        $doc.DocumentElement.AppendChild($sources) | Out-Null
+    }
+
+    # Looks for a <PackageSourceCredentials> node. Create it if none is found.
+    $creds = $doc.DocumentElement.SelectSingleNode("packageSourceCredentials")
+    if ($creds -eq $null) {
+        $creds = $doc.CreateElement("packageSourceCredentials")
+        $doc.DocumentElement.AppendChild($creds) | Out-Null
+    }
+
+    # Insert credential nodes for Maestro's private feeds
+    InsertMaestroPrivateFeedCredentials -Sources $sources -Creds $creds -Password $Password
+
+    AddPackageSource -Sources $sources -SourceName "dotnet3-internal" -SourceEndPoint "https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3-internal/nuget/v2" -Creds $creds -Username "dn-bot" -Password $Password
+    AddPackageSource -Sources $sources -SourceName "dotnet3-internal-transport" -SourceEndPoint "https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3-internal-transport/nuget/v2" -Creds $creds -Username "dn-bot" -Password $Password
+
+    $doc.Save($filename)
 }
-
-# Load NuGet.config
-$doc = New-Object System.Xml.XmlDocument
-$filename = (Get-Item $ConfigFile).FullName
-$doc.Load($filename)
-
-# Get reference to <PackageSources> or create one if none exist already
-$sources = $doc.DocumentElement.SelectSingleNode("packageSources")
-if ($sources -eq $null) {
-    $sources = $doc.CreateElement("packageSources")
-    $doc.DocumentElement.AppendChild($sources) | Out-Null
+catch {
+    Write-Host $_.ScriptStackTrace
+    Write-PipelineTelemetryError -Category 'InitializeToolset' -Message $_
+    ExitWithExitCode 1
 }
-
-# Looks for a <PackageSourceCredentials> node. Create it if none is found.
-$creds = $doc.DocumentElement.SelectSingleNode("packageSourceCredentials")
-if ($creds -eq $null) {
-    $creds = $doc.CreateElement("packageSourceCredentials")
-    $doc.DocumentElement.AppendChild($creds) | Out-Null
-}
-
-# Insert credential nodes for Maestro's private feeds
-InsertMaestroPrivateFeedCredentials -Sources $sources -Creds $creds -Password $Password
-
-AddPackageSource -Sources $sources -SourceName "dotnet3-internal" -SourceEndPoint "https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3-internal/nuget/v2" -Creds $creds -Username "dn-bot" -Password $Password
-AddPackageSource -Sources $sources -SourceName "dotnet3-internal-transport" -SourceEndPoint "https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3-internal-transport/nuget/v2" -Creds $creds -Username "dn-bot" -Password $Password
-
-$doc.Save($filename)

--- a/eng/common/SetupNugetSources.sh
+++ b/eng/common/SetupNugetSources.sh
@@ -42,7 +42,7 @@ scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 . "$scriptroot/tools.sh"
 
 if [ ! -f "$ConfigFile" ]; then
-    echo "Couldn't find the file NuGet config file: $ConfigFile"
+    Write-PipelineTelemetryError -Category 'Build' -Message "Couldn't find the file NuGet config file: $ConfigFile"
     ExitWithExitCode 1
 fi
 

--- a/eng/common/SourceLinkValidation.ps1
+++ b/eng/common/SourceLinkValidation.ps1
@@ -6,140 +6,15 @@ param(
   [Parameter(Mandatory=$true)][string] $GHCommit             # GitHub commit SHA used to build the packages
 )
 
-# Cache/HashMap (File -> Exist flag) used to consult whether a file exist 
-# in the repository at a specific commit point. This is populated by inserting
-# all files present in the repo at a specific commit point.
-$global:RepoFiles = @{}
-
-$ValidatePackage = {
-  param( 
-    [string] $PackagePath                                 # Full path to a Symbols.NuGet package
-  )
-
-  # Ensure input file exist
-  if (!(Test-Path $PackagePath)) {
-    throw "Input file does not exist: $PackagePath"
-  }
-
-  # Extensions for which we'll look for SourceLink information
-  # For now we'll only care about Portable & Embedded PDBs
-  $RelevantExtensions = @(".dll", ".exe", ".pdb")
- 
-  Write-Host -NoNewLine "Validating" ([System.IO.Path]::GetFileName($PackagePath)) "... "
-
-  $PackageId = [System.IO.Path]::GetFileNameWithoutExtension($PackagePath)
-  $ExtractPath = Join-Path -Path $using:ExtractPath -ChildPath $PackageId
-  $FailedFiles = 0
-
-  Add-Type -AssemblyName System.IO.Compression.FileSystem
-
-  [System.IO.Directory]::CreateDirectory($ExtractPath);
-
-  $zip = [System.IO.Compression.ZipFile]::OpenRead($PackagePath)
-
-  $zip.Entries | 
-    Where-Object {$RelevantExtensions -contains [System.IO.Path]::GetExtension($_.Name)} |
-      ForEach-Object {
-        $FileName = $_.FullName
-        $Extension = [System.IO.Path]::GetExtension($_.Name)
-        $FakeName = -Join((New-Guid), $Extension)
-        $TargetFile = Join-Path -Path $ExtractPath -ChildPath $FakeName 
-
-        # We ignore resource DLLs
-        if ($FileName.EndsWith(".resources.dll")) {
-          return
-        }
-
-        [System.IO.Compression.ZipFileExtensions]::ExtractToFile($_, $TargetFile, $true)
-
-        $ValidateFile = {
-          param( 
-            [string] $FullPath,                                # Full path to the module that has to be checked
-            [string] $RealPath,
-            [ref] $FailedFiles
-          )
-
-          # Makes easier to reference `sourcelink cli`
-          Push-Location $using:SourceLinkToolPath
-
-          $SourceLinkInfos = .\sourcelink.exe print-urls $FullPath | Out-String
-
-          if ($LASTEXITCODE -eq 0 -and -not ([string]::IsNullOrEmpty($SourceLinkInfos))) {
-            $NumFailedLinks = 0
-
-            # We only care about Http addresses
-            $Matches = (Select-String '(http[s]?)(:\/\/)([^\s,]+)' -Input $SourceLinkInfos -AllMatches).Matches
-
-            if ($Matches.Count -ne 0) {
-              $Matches.Value |
-                ForEach-Object {
-                  $Link = $_
-                  $CommitUrl = -Join("https://raw.githubusercontent.com/", $using:GHRepoName, "/", $using:GHCommit, "/")
-                  $FilePath = $Link.Replace($CommitUrl, "")
-                  $Status = 200
-                  $Cache = $using:RepoFiles
-
-                  if ( !($Cache.ContainsKey($FilePath)) ) {
-                    try {
-                      $Uri = $Link -as [System.URI]
-                    
-                      # Only GitHub links are valid
-                      if ($Uri.AbsoluteURI -ne $null -and $Uri.Host -match "github") {
-                        $Status = (Invoke-WebRequest -Uri $Link -UseBasicParsing -Method HEAD -TimeoutSec 5).StatusCode
-                      }
-                      else {
-                        $Status = 0
-                      }
-                    }
-                    catch {
-                      $Status = 0
-                    }
-                  }
-
-                  if ($Status -ne 200) {
-                    if ($NumFailedLinks -eq 0) {
-                      if ($FailedFiles.Value -eq 0) {
-                        Write-Host
-                      }
-
-                      Write-Host "`tFile $RealPath has broken links:"
-                    }
-
-                    Write-Host "`t`tFailed to retrieve $Link"
-
-                    $NumFailedLinks++
-                  }
-                }
-            }
-
-            if ($NumFailedLinks -ne 0) {
-              $FailedFiles.value++
-              $global:LASTEXITCODE = 1
-            }
-          }
-
-          Pop-Location
-        }
-      
-        &$ValidateFile $TargetFile $FileName ([ref]$FailedFiles)
-      }
-
-  $zip.Dispose()
-
-  if ($FailedFiles -eq 0) {
-    Write-Host "Passed."
-  }
-}
-
 function ValidateSourceLinkLinks {
   if (!($GHRepoName -Match "^[^\s\/]+/[^\s\/]+$")) {
-    Write-Host "GHRepoName should be in the format <org>/<repo>"
+    Write-PipelineTelemetryError -Category "Build" -Message "GHRepoName should be in the format <org>/<repo>"
     $global:LASTEXITCODE = 1
     return
   }
 
   if (!($GHCommit -Match "^[0-9a-fA-F]{40}$")) {
-    Write-Host "GHCommit should be a 40 chars hexadecimal string"
+    Write-PipelineTelemetryError -Category "Build" -Message "GHCommit should be a 40 chars hexadecimal string"
     $global:LASTEXITCODE = 1
     return
   }
@@ -160,7 +35,7 @@ function ValidateSourceLinkLinks {
     }
   }
   catch {
-    Write-Host "Problems downloading the list of files from the repo. Url used: $RepoTreeURL"
+    Write-PipelineTelemetryError -Category "Build" -Message "Problems downloading the list of files from the repo. Url used: $RepoTreeURL"
     $global:LASTEXITCODE = 1
     return
   }
@@ -181,4 +56,140 @@ function ValidateSourceLinkLinks {
   }
 }
 
-Measure-Command { ValidateSourceLinkLinks }
+try {
+  . $PSScriptRoot\pipeline-logging-functions.ps1
+
+  # Cache/HashMap (File -> Exist flag) used to consult whether a file exist 
+  # in the repository at a specific commit point. This is populated by inserting
+  # all files present in the repo at a specific commit point.
+  $global:RepoFiles = @{}
+
+  $ValidatePackage = {
+    param( 
+      [string] $PackagePath                                 # Full path to a Symbols.NuGet package
+    )
+
+    # Ensure input file exist
+    if (!(Test-Path $PackagePath)) {
+      throw "Input file does not exist: $PackagePath"
+    }
+
+    # Extensions for which we'll look for SourceLink information
+    # For now we'll only care about Portable & Embedded PDBs
+    $RelevantExtensions = @(".dll", ".exe", ".pdb")
+  
+    Write-Host -NoNewLine "Validating" ([System.IO.Path]::GetFileName($PackagePath)) "... "
+
+    $PackageId = [System.IO.Path]::GetFileNameWithoutExtension($PackagePath)
+    $ExtractPath = Join-Path -Path $using:ExtractPath -ChildPath $PackageId
+    $FailedFiles = 0
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+    [System.IO.Directory]::CreateDirectory($ExtractPath);
+
+    $zip = [System.IO.Compression.ZipFile]::OpenRead($PackagePath)
+
+    $zip.Entries | 
+      Where-Object {$RelevantExtensions -contains [System.IO.Path]::GetExtension($_.Name)} |
+        ForEach-Object {
+          $FileName = $_.FullName
+          $Extension = [System.IO.Path]::GetExtension($_.Name)
+          $FakeName = -Join((New-Guid), $Extension)
+          $TargetFile = Join-Path -Path $ExtractPath -ChildPath $FakeName 
+
+          # We ignore resource DLLs
+          if ($FileName.EndsWith(".resources.dll")) {
+            return
+          }
+
+          [System.IO.Compression.ZipFileExtensions]::ExtractToFile($_, $TargetFile, $true)
+
+          $ValidateFile = {
+            param( 
+              [string] $FullPath,                                # Full path to the module that has to be checked
+              [string] $RealPath,
+              [ref] $FailedFiles
+            )
+
+            # Makes easier to reference `sourcelink cli`
+            Push-Location $using:SourceLinkToolPath
+
+            $SourceLinkInfos = .\sourcelink.exe print-urls $FullPath | Out-String
+
+            if ($LASTEXITCODE -eq 0 -and -not ([string]::IsNullOrEmpty($SourceLinkInfos))) {
+              $NumFailedLinks = 0
+
+              # We only care about Http addresses
+              $Matches = (Select-String '(http[s]?)(:\/\/)([^\s,]+)' -Input $SourceLinkInfos -AllMatches).Matches
+
+              if ($Matches.Count -ne 0) {
+                $Matches.Value |
+                  ForEach-Object {
+                    $Link = $_
+                    $CommitUrl = -Join("https://raw.githubusercontent.com/", $using:GHRepoName, "/", $using:GHCommit, "/")
+                    $FilePath = $Link.Replace($CommitUrl, "")
+                    $Status = 200
+                    $Cache = $using:RepoFiles
+
+                    if ( !($Cache.ContainsKey($FilePath)) ) {
+                      try {
+                        $Uri = $Link -as [System.URI]
+                      
+                        # Only GitHub links are valid
+                        if ($Uri.AbsoluteURI -ne $null -and $Uri.Host -match "github") {
+                          $Status = (Invoke-WebRequest -Uri $Link -UseBasicParsing -Method HEAD -TimeoutSec 5).StatusCode
+                        }
+                        else {
+                          $Status = 0
+                        }
+                      }
+                      catch {
+                        $Status = 0
+                      }
+                    }
+
+                    if ($Status -ne 200) {
+                      if ($NumFailedLinks -eq 0) {
+                        if ($FailedFiles.Value -eq 0) {
+                          Write-Host
+                        }
+
+                        Write-Host "`tFile $RealPath has broken links:"
+                      }
+
+                      Write-Host "`t`tFailed to retrieve $Link"
+
+                      $NumFailedLinks++
+                    }
+                  }
+              }
+
+              if ($NumFailedLinks -ne 0) {
+                $FailedFiles.value++
+                $global:LASTEXITCODE = 1
+              }
+            }
+
+            Pop-Location
+          }
+        
+          &$ValidateFile $TargetFile $FileName ([ref]$FailedFiles)
+        }
+
+    $zip.Dispose()
+
+    if ($FailedFiles -eq 0) {
+      Write-Host "Passed."
+    }
+  }
+
+  Measure-Command { ValidateSourceLinkLinks }
+}
+catch {
+  Write-Host $_.ScriptStackTrace
+  Write-PipelineTelemetryError -Category 'SourceLink' -Message $_
+  ExitWithExitCode 1
+}
+
+

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -26,42 +26,40 @@ Param(
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 
-. $PSScriptRoot\tools.ps1
-
 function Print-Usage() {
-    Write-Host "Common settings:"
-    Write-Host "  -configuration <value>  Build configuration: 'Debug' or 'Release' (short: -c)"
-    Write-Host "  -platform <value>       Platform configuration: 'x86', 'x64' or any valid Platform value to pass to msbuild"
-    Write-Host "  -verbosity <value>      Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
-    Write-Host "  -binaryLog              Output binary log (short: -bl)"
-    Write-Host "  -help                   Print help and exit"
-    Write-Host ""
+  Write-Host "Common settings:"
+  Write-Host "  -configuration <value>  Build configuration: 'Debug' or 'Release' (short: -c)"
+  Write-Host "  -platform <value>       Platform configuration: 'x86', 'x64' or any valid Platform value to pass to msbuild"
+  Write-Host "  -verbosity <value>      Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
+  Write-Host "  -binaryLog              Output binary log (short: -bl)"
+  Write-Host "  -help                   Print help and exit"
+  Write-Host ""
 
-    Write-Host "Actions:"
-    Write-Host "  -restore                Restore dependencies (short: -r)"
-    Write-Host "  -build                  Build solution (short: -b)"
-    Write-Host "  -rebuild                Rebuild solution"
-    Write-Host "  -deploy                 Deploy built VSIXes"
-    Write-Host "  -deployDeps             Deploy dependencies (e.g. VSIXes for integration tests)"
-    Write-Host "  -test                   Run all unit tests in the solution (short: -t)"
-    Write-Host "  -integrationTest        Run all integration tests in the solution"
-    Write-Host "  -performanceTest        Run all performance tests in the solution"
-    Write-Host "  -pack                   Package build outputs into NuGet packages and Willow components"
-    Write-Host "  -sign                   Sign build outputs"
-    Write-Host "  -publish                Publish artifacts (e.g. symbols)"
-    Write-Host "  -clean                  Clean the solution"
-    Write-Host ""
+  Write-Host "Actions:"
+  Write-Host "  -restore                Restore dependencies (short: -r)"
+  Write-Host "  -build                  Build solution (short: -b)"
+  Write-Host "  -rebuild                Rebuild solution"
+  Write-Host "  -deploy                 Deploy built VSIXes"
+  Write-Host "  -deployDeps             Deploy dependencies (e.g. VSIXes for integration tests)"
+  Write-Host "  -test                   Run all unit tests in the solution (short: -t)"
+  Write-Host "  -integrationTest        Run all integration tests in the solution"
+  Write-Host "  -performanceTest        Run all performance tests in the solution"
+  Write-Host "  -pack                   Package build outputs into NuGet packages and Willow components"
+  Write-Host "  -sign                   Sign build outputs"
+  Write-Host "  -publish                Publish artifacts (e.g. symbols)"
+  Write-Host "  -clean                  Clean the solution"
+  Write-Host ""
 
-    Write-Host "Advanced settings:"
-    Write-Host "  -projects <value>       Semi-colon delimited list of sln/proj's to build. Globbing is supported (*.sln)"
-    Write-Host "  -ci                     Set when running on CI server"
-    Write-Host "  -prepareMachine         Prepare machine for CI run, clean up processes after build"
-    Write-Host "  -warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
-    Write-Host "  -msbuildEngine <value>  Msbuild engine to use to run build ('dotnet', 'vs', or unspecified)."
-    Write-Host ""
+  Write-Host "Advanced settings:"
+  Write-Host "  -projects <value>       Semi-colon delimited list of sln/proj's to build. Globbing is supported (*.sln)"
+  Write-Host "  -ci                     Set when running on CI server"
+  Write-Host "  -prepareMachine         Prepare machine for CI run, clean up processes after build"
+  Write-Host "  -warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
+  Write-Host "  -msbuildEngine <value>  Msbuild engine to use to run build ('dotnet', 'vs', or unspecified)."
+  Write-Host ""
 
-    Write-Host "Command line arguments not listed above are passed thru to msbuild."
-    Write-Host "The above arguments can be shortened as much as to be unambiguous (e.g. -co for configuration, -t for test, etc.)."
+  Write-Host "Command line arguments not listed above are passed thru to msbuild."
+  Write-Host "The above arguments can be shortened as much as to be unambiguous (e.g. -co for configuration, -t for test, etc.)."
 }
 
 function InitializeCustomToolset {
@@ -69,7 +67,7 @@ function InitializeCustomToolset {
     return
   }
 
-  $script = Join-Path $EngRoot "restore-toolset.ps1"
+  $script = Join-Path $EngRoot 'restore-toolset.ps1'
 
   if (Test-Path $script) {
     . $script
@@ -80,8 +78,8 @@ function Build {
   $toolsetBuildProj = InitializeToolset
   InitializeCustomToolset
 
-  $bl = if ($binaryLog) { "/bl:" + (Join-Path $LogDir "Build.binlog") } else { "" }
-  $platformArg = if ($platform) { "/p:Platform=$platform" } else { "" }
+  $bl = if ($binaryLog) { '/bl:' + (Join-Path $LogDir 'Build.binlog') } else { '' }
+  $platformArg = if ($platform) { "/p:Platform=$platform" } else { '' }
 
   if ($projects) {
     # Re-assign properties to a new variable because PowerShell doesn't let us append properties directly for unclear reasons.
@@ -117,13 +115,19 @@ function Build {
 if ($clean) {
   if(Test-Path $ArtifactsDir) {
     Remove-Item -Recurse -Force $ArtifactsDir
-    Write-Host "Artifacts directory deleted."
+    Write-Host 'Artifacts directory deleted.'
   }
   exit 0
 }
 
 try {
-  if ($help -or (($null -ne $properties) -and ($properties.Contains("/help") -or $properties.Contains("/?")))) {
+  . $PSScriptRoot\tools.ps1
+  If ((Test-Path variable:LastExitCode) -And ($LastExitCode -ne 0)) {
+    Write-PipelineTelemetryError -Category 'InitializeToolset' -Message 'Eng/common/tools.ps1 returned a non-zero exit code.'
+    ExitWithExitCode $LastExitCode
+  }
+  
+  if ($help -or (($null -ne $properties) -and ($properties.Contains('/help') -or $properties.Contains('/?')))) {
     Print-Usage
     exit 0
   }
@@ -141,7 +145,7 @@ try {
 }
 catch {
   Write-Host $_.ScriptStackTrace
-  Write-PipelineTelemetryError -Category "InitializeToolset" -Message $_
+  Write-PipelineTelemetryError -Category 'InitializeToolset' -Message $_
   ExitWithExitCode 1
 }
 

--- a/eng/common/darc-init.ps1
+++ b/eng/common/darc-init.ps1
@@ -1,14 +1,14 @@
 param (
     $darcVersion = $null,
-    $versionEndpoint = "https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16",
-    $verbosity = "m",
+    $versionEndpoint = 'https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16',
+    $verbosity = 'minimal',
     $toolpath = $null
 )
 
 . $PSScriptRoot\tools.ps1
 
 function InstallDarcCli ($darcVersion) {
-  $darcCliPackageName = "microsoft.dotnet.darc"
+  $darcCliPackageName = 'microsoft.dotnet.darc'
 
   $dotnetRoot = InitializeDotNetCli -install:$true
   $dotnet = "$dotnetRoot\dotnet.exe"
@@ -27,12 +27,19 @@ function InstallDarcCli ($darcVersion) {
   $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'
 
   Write-Host "Installing Darc CLI version $darcVersion..."
-  Write-Host "You may need to restart your command window if this is the first dotnet tool you have installed."
+  Write-Host 'You may need to restart your command window if this is the first dotnet tool you have installed.'
   if (-not $toolpath) {
     & "$dotnet" tool install $darcCliPackageName --version $darcVersion --add-source "$arcadeServicesSource" -v $verbosity -g
   }else {
-    & "$dotnet" tool install $darcCliPackageName --version $darcVersion --add-source "$arcadeServicesSource" -v $verbosity --tool-path "$toolpath"    
+    & "$dotnet" tool install $darcCliPackageName --version $darcVersion --add-source "$arcadeServicesSource" -v $verbosity --tool-path "$toolpath"
   }
 }
 
-InstallDarcCli $darcVersion
+try {
+  InstallDarcCli $darcVersion
+}
+catch {
+  Write-Host $_.ScriptStackTrace
+  Write-PipelineTelemetryError -Category 'Darc' -Message $_
+  ExitWithExitCode 1
+}

--- a/eng/common/darc-init.sh
+++ b/eng/common/darc-init.sh
@@ -2,8 +2,8 @@
 
 source="${BASH_SOURCE[0]}"
 darcVersion=''
-versionEndpoint="https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16"
-verbosity=m
+versionEndpoint='https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16'
+verbosity='minimal'
 
 while [[ $# > 0 ]]; do
   opt="$(echo "$1" | awk '{print tolower($0)}')"

--- a/eng/common/dotnet-install.ps1
+++ b/eng/common/dotnet-install.ps1
@@ -1,28 +1,27 @@
 [CmdletBinding(PositionalBinding=$false)]
 Param(
-  [string] $verbosity = "minimal",
-  [string] $architecture = "",
-  [string] $version = "Latest",
-  [string] $runtime = "dotnet",
-  [string] $RuntimeSourceFeed = "",
-  [string] $RuntimeSourceFeedKey = ""
+  [string] $verbosity = 'minimal',
+  [string] $architecture = '',
+  [string] $version = 'Latest',
+  [string] $runtime = 'dotnet',
+  [string] $RuntimeSourceFeed = '',
+  [string] $RuntimeSourceFeedKey = ''
 )
 
 . $PSScriptRoot\tools.ps1
 
-$dotnetRoot = Join-Path $RepoRoot ".dotnet"
+$dotnetRoot = Join-Path $RepoRoot '.dotnet'
 
 $installdir = $dotnetRoot
 try {
-    if ($architecture -and $architecture.Trim() -eq "x86") {
-        $installdir = Join-Path $installdir "x86"
+    if ($architecture -and $architecture.Trim() -eq 'x86') {
+        $installdir = Join-Path $installdir 'x86'
     }
-   InstallDotNet $installdir $version $architecture $runtime $true -RuntimeSourceFeed $RuntimeSourceFeed -RuntimeSourceFeedKey $RuntimeSourceFeedKey
-} 
+    InstallDotNet $installdir $version $architecture $runtime $true -RuntimeSourceFeed $RuntimeSourceFeed -RuntimeSourceFeedKey $RuntimeSourceFeedKey
+}
 catch {
-  Write-Host $_
-  Write-Host $_.Exception
   Write-Host $_.ScriptStackTrace
+  Write-PipelineTelemetryError -Category 'InitializeToolset' -Message $_
   ExitWithExitCode 1
 }
 

--- a/eng/common/dotnet-install.sh
+++ b/eng/common/dotnet-install.sh
@@ -42,7 +42,7 @@ while [[ $# > 0 ]]; do
       runtimeSourceFeedKey="$1"
       ;;
     *)
-      Write-PipelineTelemetryError -Category "Build" -Message "Invalid argument: $1"
+      Write-PipelineTelemetryError -Category 'Build' -Message "Invalid argument: $1"
       exit 1
       ;;
   esac
@@ -82,7 +82,7 @@ fi
 
 InstallDotNet $dotnetRoot $version "$architecture" $runtime true $runtimeSourceFeed $runtimeSourceFeedKey || {
   local exit_code=$?
-  Write-PipelineTelemetryError -Category "InitializeToolset" -Message "dotnet-install.sh failed (exit code '$exit_code')." >&2
+  Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "dotnet-install.sh failed (exit code '$exit_code')." >&2
   ExitWithExitCode $exit_code
 }
 

--- a/eng/common/dotnet-install.sh
+++ b/eng/common/dotnet-install.sh
@@ -11,6 +11,8 @@ while [[ -h "$source" ]]; do
 done
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 
+. "$scriptroot/tools.sh"
+
 version='Latest'
 architecture=''
 runtime='dotnet'
@@ -40,7 +42,7 @@ while [[ $# > 0 ]]; do
       runtimeSourceFeedKey="$1"
       ;;
     *)
-      echo "Invalid argument: $1"
+      Write-PipelineTelemetryError -Category "Build" -Message "Invalid argument: $1"
       exit 1
       ;;
   esac
@@ -73,7 +75,6 @@ case $cpuname in
     ;;
 esac
 
-. "$scriptroot/tools.sh"
 dotnetRoot="$repo_root/.dotnet"
 if [[ $architecture != "" ]] && [[ $architecture != $buildarch ]]; then
   dotnetRoot="$dotnetRoot/$architecture"
@@ -81,7 +82,7 @@ fi
 
 InstallDotNet $dotnetRoot $version "$architecture" $runtime true $runtimeSourceFeed $runtimeSourceFeedKey || {
   local exit_code=$?
-  echo "dotnet-install.sh failed (exit code '$exit_code')." >&2
+  Write-PipelineTelemetryError -Category "InitializeToolset" -Message "dotnet-install.sh failed (exit code '$exit_code')." >&2
   ExitWithExitCode $exit_code
 }
 

--- a/eng/common/enable-cross-org-publishing.ps1
+++ b/eng/common/enable-cross-org-publishing.ps1
@@ -2,5 +2,7 @@ param(
   [string] $token
 )
 
-Write-Host "##vso[task.setvariable variable=VSS_NUGET_ACCESSTOKEN]$token"
-Write-Host "##vso[task.setvariable variable=VSS_NUGET_URI_PREFIXES]https://dnceng.pkgs.visualstudio.com/;https://pkgs.dev.azure.com/dnceng/;https://devdiv.pkgs.visualstudio.com/;https://pkgs.dev.azure.com/devdiv/"
+. $PSScriptRoot\pipeline-logging-functions.ps1
+
+Write-PipelineSetVariable -Name 'VSS_NUGET_ACCESSTOKEN' -Value $token
+Write-PipelineSetVariable -Name 'VSS_NUGET_URI_PREFIXES' -Value 'https://dnceng.pkgs.visualstudio.com/;https://pkgs.dev.azure.com/dnceng/;https://devdiv.pkgs.visualstudio.com/;https://pkgs.dev.azure.com/devdiv/'

--- a/eng/common/generate-graph-files.ps1
+++ b/eng/common/generate-graph-files.ps1
@@ -9,33 +9,33 @@ Param(
                                                         # toolset dependencies see https://github.com/dotnet/arcade/blob/master/Documentation/Darc.md#toolset-vs-product-dependencies
 )
 
-$ErrorActionPreference = "Stop"
-. $PSScriptRoot\tools.ps1
-
-Import-Module -Name (Join-Path $PSScriptRoot "native\CommonLibrary.psm1")
-
 function CheckExitCode ([string]$stage)
 {
   $exitCode = $LASTEXITCODE
   if ($exitCode  -ne 0) {
-    Write-Host "Something failed in stage: '$stage'. Check for errors above. Exiting now..."
+    Write-PipelineTelemetryError -Category 'Arcade' -Message "Something failed in stage: '$stage'. Check for errors above. Exiting now..."
     ExitWithExitCode $exitCode
   }
 }
 
 try {
+  $ErrorActionPreference = 'Stop'
+  . $PSScriptRoot\tools.ps1
+  
+  Import-Module -Name (Join-Path $PSScriptRoot 'native\CommonLibrary.psm1')
+
   Push-Location $PSScriptRoot
 
-  Write-Host "Installing darc..."
+  Write-Host 'Installing darc...'
   . .\darc-init.ps1 -darcVersion $darcVersion
-  CheckExitCode "Running darc-init"
+  CheckExitCode 'Running darc-init'
 
-  $engCommonBaseDir = Join-Path $PSScriptRoot "native\"
+  $engCommonBaseDir = Join-Path $PSScriptRoot 'native\'
   $graphvizInstallDir = CommonLibrary\Get-NativeInstallDirectory
-  $nativeToolBaseUri = "https://netcorenativeassets.blob.core.windows.net/resource-packages/external"
-  $installBin = Join-Path $graphvizInstallDir "bin"
+  $nativeToolBaseUri = 'https://netcorenativeassets.blob.core.windows.net/resource-packages/external'
+  $installBin = Join-Path $graphvizInstallDir 'bin'
 
-  Write-Host "Installing dot..."
+  Write-Host 'Installing dot...'
   .\native\install-tool.ps1 -ToolName graphviz -InstallPath $installBin -BaseUri $nativeToolBaseUri -CommonLibraryDirectory $engCommonBaseDir -Version $graphvizVersion -Verbose
 
   $darcExe = "$env:USERPROFILE\.dotnet\tools"
@@ -51,37 +51,36 @@ try {
   $graphVizImageFilePath = "$outputFolder\graph.png"
   $normalGraphFilePath = "$outputFolder\graph-full.txt"
   $flatGraphFilePath = "$outputFolder\graph-flat.txt"
-  $baseOptions = @( "--github-pat", "$gitHubPat", "--azdev-pat", "$azdoPat", "--password", "$barToken" )
+  $baseOptions = @( '--github-pat', "$gitHubPat", '--azdev-pat', "$azdoPat", '--password', "$barToken" )
 
   if ($includeToolset) {
-    Write-Host "Toolsets will be included in the graph..."
-    $baseOptions += @( "--include-toolset" )
+    Write-Host 'Toolsets will be included in the graph...'
+    $baseOptions += @( '--include-toolset' )
   }
 
-  Write-Host "Generating standard dependency graph..."
+  Write-Host 'Generating standard dependency graph...'
   & "$darcExe" get-dependency-graph @baseOptions --output-file $normalGraphFilePath
-  CheckExitCode "Generating normal dependency graph"
+  CheckExitCode 'Generating normal dependency graph'
 
-  Write-Host "Generating flat dependency graph and graphviz file..."
+  Write-Host 'Generating flat dependency graph and graphviz file...'
   & "$darcExe" get-dependency-graph @baseOptions --flat --coherency --graphviz $graphVizFilePath --output-file $flatGraphFilePath
-  CheckExitCode "Generating flat and graphviz dependency graph"
+  CheckExitCode 'Generating flat and graphviz dependency graph'
 
   Write-Host "Generating graph image $graphVizFilePath"
   $dotFilePath = Join-Path $installBin "graphviz\$graphvizVersion\release\bin\dot.exe"
   & "$dotFilePath" -Tpng -o"$graphVizImageFilePath" "$graphVizFilePath"
-  CheckExitCode "Generating graphviz image"
+  CheckExitCode 'Generating graphviz image'
 
   Write-Host "'$graphVizFilePath', '$flatGraphFilePath', '$normalGraphFilePath' and '$graphVizImageFilePath' created!"
 }
 catch {
   if (!$includeToolset) {
-    Write-Host "This might be a toolset repo which includes only toolset dependencies. " -NoNewline -ForegroundColor Yellow
-    Write-Host "Since -includeToolset is not set there is no graph to create. Include -includeToolset and try again..." -ForegroundColor Yellow
+    Write-Host 'This might be a toolset repo which includes only toolset dependencies. ' -NoNewline -ForegroundColor Yellow
+    Write-Host 'Since -includeToolset is not set there is no graph to create. Include -includeToolset and try again...' -ForegroundColor Yellow
   }
-  Write-Host $_
-  Write-Host $_.Exception
   Write-Host $_.ScriptStackTrace
+  Write-PipelineTelemetryError -Category 'Arcade' -Message $_
   ExitWithExitCode 1
 } finally {
-    Pop-Location
+  Pop-Location
 }

--- a/eng/common/init-tools-native.sh
+++ b/eng/common/init-tools-native.sh
@@ -12,6 +12,7 @@ retry_wait_time_seconds=30
 global_json_file="$(dirname "$(dirname "${scriptroot}")")/global.json"
 declare -A native_assets
 
+. $scriptroot/pipeline-logging-functions.sh
 . $scriptroot/native/common-library.sh
 
 while (($# > 0)); do
@@ -120,7 +121,7 @@ else
     $installer_command
 
     if [[ $? != 0 ]]; then
-      echo "Execution Failed" >&2
+      Write-PipelineTelemetryError -category 'NativeToolsBootstrap' "Execution Failed"
       exit 1
     fi
   done
@@ -134,7 +135,7 @@ if [[ -d $install_bin ]]; then
   echo "Native tools are available from $install_bin"
   echo "##vso[task.prependpath]$install_bin"
 else
-  echo "Native tools install directory does not exist, installation failed" >&2
+  Write-PipelineTelemetryError -category 'NativeToolsBootstrap' "Native tools install directory does not exist, installation failed"
   exit 1
 fi
 

--- a/eng/common/internal-feed-operations.sh
+++ b/eng/common/internal-feed-operations.sh
@@ -30,7 +30,7 @@ function SetupCredProvider {
   rm installcredprovider.sh
 
   if [ ! -d "$HOME/.nuget/plugins" ]; then
-    echo "CredProvider plugin was not installed correctly!"
+    Write-PipelineTelemetryError -category 'Build' 'CredProvider plugin was not installed correctly!'
     ExitWithExitCode 1  
   else 
     echo "CredProvider plugin was installed correctly!"
@@ -42,7 +42,7 @@ function SetupCredProvider {
   local nugetConfigPath="$repo_root/NuGet.config"
 
   if [ ! "$nugetConfigPath" ]; then
-    echo "NuGet.config file not found in repo's root!"
+    Write-PipelineTelemetryError -category 'Build' "NuGet.config file not found in repo's root!"
     ExitWithExitCode 1  
   fi
   

--- a/eng/common/msbuild.ps1
+++ b/eng/common/msbuild.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding(PositionalBinding=$false)]
 Param(
-  [string] $verbosity = "minimal",
+  [string] $verbosity = 'minimal',
   [bool] $warnAsError = $true,
   [bool] $nodeReuse = $true,
   [switch] $ci,
@@ -18,9 +18,8 @@ try {
   MSBuild @extraArgs
 } 
 catch {
-  Write-Host $_
-  Write-Host $_.Exception
   Write-Host $_.ScriptStackTrace
+  Write-PipelineTelemetryError -Category 'Build' -Message $_
   ExitWithExitCode 1
 }
 

--- a/eng/common/native/common-library.sh
+++ b/eng/common/native/common-library.sh
@@ -34,7 +34,7 @@ function ExpandZip {
     echo "'Force flag enabled, but '$output_directory' exists. Removing directory"
     rm -rf $output_directory
     if [[ $? != 0 ]]; then
-      echo Unable to remove '$output_directory'>&2
+      Write-PipelineTelemetryError -category 'NativeToolsBootstrap' "Unable to remove '$output_directory'"
       return 1
     fi
   fi
@@ -45,7 +45,7 @@ function ExpandZip {
   echo "Extracting archive"
   tar -xf $zip_path -C $output_directory
   if [[ $? != 0 ]]; then
-    echo "Unable to extract '$zip_path'" >&2
+    Write-PipelineTelemetryError -category 'NativeToolsBootstrap' "Unable to extract '$zip_path'"
     return 1
   fi
 
@@ -117,7 +117,7 @@ function DownloadAndExtract {
   # Download file
   GetFile "$uri" "$temp_tool_path" $force $download_retries $retry_wait_time_seconds
   if [[ $? != 0 ]]; then
-    echo "Failed to download '$uri' to '$temp_tool_path'." >&2
+    Write-PipelineTelemetryError -category 'NativeToolsBootstrap' "Failed to download '$uri' to '$temp_tool_path'."
     return 1
   fi
 
@@ -125,7 +125,7 @@ function DownloadAndExtract {
   echo "extracting from  $temp_tool_path to $installDir"
   ExpandZip "$temp_tool_path" "$installDir" $force $download_retries $retry_wait_time_seconds
   if [[ $? != 0 ]]; then
-    echo "Failed to extract '$temp_tool_path' to '$installDir'." >&2
+    Write-PipelineTelemetryError -category 'NativeToolsBootstrap' "Failed to extract '$temp_tool_path' to '$installDir'."
     return 1
   fi
 
@@ -148,7 +148,7 @@ function NewScriptShim {
   fi
   
   if [[ ! -f $tool_file_path ]]; then
-    echo "Specified tool file path:'$tool_file_path' does not exist" >&2
+    Write-PipelineTelemetryError -category 'NativeToolsBootstrap' "Specified tool file path:'$tool_file_path' does not exist"
     return 1
   fi
 

--- a/eng/common/native/install-cmake-test.sh
+++ b/eng/common/native/install-cmake-test.sh
@@ -101,7 +101,7 @@ fi
 DownloadAndExtract $uri $tool_install_directory $force $download_retries $retry_wait_time_seconds
 
 if [[ $? != 0 ]]; then
-  echo "Installation failed" >&2
+  Write-PipelineTelemetryError -category 'NativeToolsBootstrap' 'Installation failed'
   exit 1
 fi
 
@@ -110,7 +110,7 @@ fi
 NewScriptShim $shim_path $tool_file_path true
 
 if [[ $? != 0 ]]; then
-  echo "Shim generation failed" >&2
+  Write-PipelineTelemetryError -category 'NativeToolsBootstrap' 'Shim generation failed'
   exit 1
 fi
 

--- a/eng/common/native/install-cmake.sh
+++ b/eng/common/native/install-cmake.sh
@@ -101,7 +101,7 @@ fi
 DownloadAndExtract $uri $tool_install_directory $force $download_retries $retry_wait_time_seconds
 
 if [[ $? != 0 ]]; then
-  echo "Installation failed" >&2
+  Write-PipelineTelemetryError -category 'NativeToolsBootstrap' 'Installation failed'
   exit 1
 fi
 
@@ -110,7 +110,7 @@ fi
 NewScriptShim $shim_path $tool_file_path true
 
 if [[ $? != 0 ]]; then
-  echo "Shim generation failed" >&2
+  Write-PipelineTelemetryError -category 'NativeToolsBootstrap' 'Shim generation failed'
   exit 1
 fi
 

--- a/eng/common/native/install-tool.ps1
+++ b/eng/common/native/install-tool.ps1
@@ -46,6 +46,8 @@ Param (
   [int] $RetryWaitTimeInSeconds = 30
 )
 
+. $PSScriptRoot\..\pipeline-logging-functions.ps1
+
 # Import common library modules
 Import-Module -Name (Join-Path $CommonLibraryDirectory "CommonLibrary.psm1")
 
@@ -93,7 +95,7 @@ try {
                                                       -Verbose:$Verbose
 
     if ($InstallStatus -Eq $False) {
-      Write-Error "Installation failed"
+      Write-PipelineTelemetryError "Installation failed" -Category "NativeToolsetBootstrapping"
       exit 1
     }
   }
@@ -117,14 +119,14 @@ try {
                                                      -Verbose:$Verbose
 
   if ($GenerateShimStatus -Eq $False) {
-    Write-Error "Generate shim failed"
+    Write-PipelineTelemetryError "Generate shim failed" -Category "NativeToolsetBootstrapping"
     return 1
   }
 
   exit 0
 }
 catch {
-  Write-Host $_
-  Write-Host $_.Exception
+  Write-Host $_.ScriptStackTrace
+  Write-PipelineTelemetryError -Category "NativeToolsetBootstrapping" -Message $_
   exit 1
 }

--- a/eng/common/pipeline-logging-functions.ps1
+++ b/eng/common/pipeline-logging-functions.ps1
@@ -12,6 +12,7 @@ $script:loggingCommandEscapeMappings = @( # TODO: WHAT ABOUT "="? WHAT ABOUT "%"
 # TODO: BUG: Escape % ???
 # TODO: Add test to verify don't need to escape "=".
 
+# Specify "-Force" to force pipeline formatted output even if "$ci" is false or not set
 function Write-PipelineTelemetryError {
     [CmdletBinding()]
     param(
@@ -25,49 +26,53 @@ function Write-PipelineTelemetryError {
         [string]$SourcePath,
         [string]$LineNumber,
         [string]$ColumnNumber,
-        [switch]$AsOutput)
+        [switch]$AsOutput,
+        [switch]$Force)
 
-        $PSBoundParameters.Remove("Category") | Out-Null
+        $PSBoundParameters.Remove('Category') | Out-Null
 
         $Message = "(NETCORE_ENGINEERING_TELEMETRY=$Category) $Message"
-        $PSBoundParameters.Remove("Message") | Out-Null
-        $PSBoundParameters.Add("Message", $Message)
-
+        $PSBoundParameters.Remove('Message') | Out-Null
+        $PSBoundParameters.Add('Message', $Message)
         Write-PipelineTaskError @PSBoundParameters
 }
 
+# Specify "-Force" to force pipeline formatted output even if "$ci" is false or not set
 function Write-PipelineTaskError {
     [CmdletBinding()]
     param(
-      [Parameter(Mandatory = $true)]
-      [string]$Message,
-      [Parameter(Mandatory = $false)]
-      [string]$Type = 'error',
-      [string]$ErrCode,
-      [string]$SourcePath,
-      [string]$LineNumber,
-      [string]$ColumnNumber,
-      [switch]$AsOutput)
-  
-      if(!$ci) {
+        [Parameter(Mandatory = $true)]
+        [string]$Message,
+        [Parameter(Mandatory = $false)]
+        [string]$Type = 'error',
+        [string]$ErrCode,
+        [string]$SourcePath,
+        [string]$LineNumber,
+        [string]$ColumnNumber,
+        [switch]$AsOutput,
+        [switch]$Force
+    )
+
+    if(!$Force -And (-Not (Test-Path variable:ci) -Or !$ci)) {
         if($Type -eq 'error') {
-          Write-Host $Message -ForegroundColor Red
-          return
+            Write-Host $Message -ForegroundColor Red
+            return
         }
         elseif ($Type -eq 'warning') {
-          Write-Host $Message -ForegroundColor Yellow
-          return
+            Write-Host $Message -ForegroundColor Yellow
+            return
         }
-      }
-  
-      if(($Type -ne 'error') -and ($Type -ne 'warning')) {
-        Write-Host $Message
-        return
-      }
-      if(-not $PSBoundParameters.ContainsKey('Type')) {
-        $PSBoundParameters.Add('Type', 'error')
-      }
-      Write-LogIssue @PSBoundParameters
+    }
+
+    if(($Type -ne 'error') -and ($Type -ne 'warning')) {
+    Write-Host $Message
+    return
+    }
+    $PSBoundParameters.Remove('Force') | Out-Null      
+    if(-not $PSBoundParameters.ContainsKey('Type')) {
+    $PSBoundParameters.Add('Type', 'error')
+    }
+    Write-LogIssue @PSBoundParameters
   }
   
   function Write-PipelineSetVariable {
@@ -80,7 +85,7 @@ function Write-PipelineTaskError {
       [switch]$AsOutput,
       [bool]$IsMultiJobVariable=$true)
 
-      if($ci) {
+      if(-Not (Test-Path variable:ci) -Or !$ci) {
         Write-LoggingCommand -Area 'task' -Event 'setvariable' -Data $Value -Properties @{
           'variable' = $Name
           'isSecret' = $Secret
@@ -95,7 +100,8 @@ function Write-PipelineTaskError {
       [Parameter(Mandatory=$true)]
       [string]$Path,
       [switch]$AsOutput)
-      if($ci) {
+
+      if(-Not (Test-Path variable:ci) -Or !$ci) {
         Write-LoggingCommand -Area 'task' -Event 'prependpath' -Data $Path -AsOutput:$AsOutput
       }
   }

--- a/eng/common/pipeline-logging-functions.sh
+++ b/eng/common/pipeline-logging-functions.sh
@@ -2,6 +2,7 @@
 
 function Write-PipelineTelemetryError {
   local telemetry_category=''
+  local force=false
   local function_args=()
   local message=''
   while [[ $# -gt 0 ]]; do
@@ -10,6 +11,9 @@ function Write-PipelineTelemetryError {
       -category|-c)
         telemetry_category=$2
         shift
+        ;;
+      -force|-f)
+        force=true
         ;;
       -*)
         function_args+=("$1 $2")
@@ -22,19 +26,22 @@ function Write-PipelineTelemetryError {
     shift
   done
 
-  if [[ "$ci" != true ]]; then
+  if [[ $force != true ]] && [[ "$ci" != true ]]; then
     echo "$message" >&2
     return
   fi
 
   message="(NETCORE_ENGINEERING_TELEMETRY=$telemetry_category) $message"
   function_args+=("$message")
+  if [[ $force == true ]]; then
+    function_args+=("-force")
+  fi
 
   Write-PipelineTaskError $function_args
 }
 
 function Write-PipelineTaskError {
-  if [[ "$ci" != true ]]; then
+  if [[ $force != true ]] && [[ "$ci" != true ]]; then
     echo "$@" >&2
     return
   fi

--- a/eng/common/post-build/darc-gather-drop.ps1
+++ b/eng/common/post-build/darc-gather-drop.ps1
@@ -2,20 +2,20 @@ param(
   [Parameter(Mandatory=$true)][int] $BarBuildId,                # ID of the build which assets should be downloaded
   [Parameter(Mandatory=$true)][string] $DropLocation,           # Where the assets should be downloaded to
   [Parameter(Mandatory=$true)][string] $MaestroApiAccessToken,  # Token used to access Maestro API
-  [Parameter(Mandatory=$false)][string] $MaestroApiEndPoint = "https://maestro-prod.westus2.cloudapp.azure.com",     # Maestro API URL
-  [Parameter(Mandatory=$false)][string] $MaestroApiVersion = "2019-01-16"                                            # Version of Maestro API to use
+  [Parameter(Mandatory=$false)][string] $MaestroApiEndPoint = 'https://maestro-prod.westus2.cloudapp.azure.com',     # Maestro API URL
+  [Parameter(Mandatory=$false)][string] $MaestroApiVersion = '2019-01-16'                                            # Version of Maestro API to use
 )
 
-. $PSScriptRoot\post-build-utils.ps1
-
 try {
-  Write-Host "Installing DARC ..."
+  . $PSScriptRoot\post-build-utils.ps1
+
+  Write-Host 'Installing DARC ...'
 
   . $PSScriptRoot\..\darc-init.ps1
   $exitCode = $LASTEXITCODE
 
   if ($exitCode -ne 0) {
-    Write-PipelineTaskError "Something failed while running 'darc-init.ps1'. Check for errors above. Exiting now..."
+    Write-PipelineTelemetryError -Category "Darc" -Message "Something failed while running 'darc-init.ps1'. Check for errors above. Exiting now..."
     ExitWithExitCode $exitCode
   }
 
@@ -38,8 +38,7 @@ try {
     --latest-location
 }
 catch {
-  Write-Host $_
-  Write-Host $_.Exception
   Write-Host $_.ScriptStackTrace
+  Write-PipelineTelemetryError -Category "Darc" -Message $_
   ExitWithExitCode 1
 }

--- a/eng/common/post-build/nuget-validation.ps1
+++ b/eng/common/post-build/nuget-validation.ps1
@@ -6,20 +6,19 @@ param(
   [Parameter(Mandatory=$true)][string] $ToolDestinationPath     # Where the validation tool should be downloaded to
 )
 
-. $PSScriptRoot\post-build-utils.ps1
-
 try {
-  $url = "https://raw.githubusercontent.com/NuGet/NuGetGallery/jver-verify/src/VerifyMicrosoftPackage/verify.ps1" 
+  . $PSScriptRoot\post-build-utils.ps1
 
-  New-Item -ItemType "directory" -Path ${ToolDestinationPath} -Force
+  $url = 'https://raw.githubusercontent.com/NuGet/NuGetGallery/jver-verify/src/VerifyMicrosoftPackage/verify.ps1'
+
+  New-Item -ItemType 'directory' -Path ${ToolDestinationPath} -Force
 
   Invoke-WebRequest $url -OutFile ${ToolDestinationPath}\verify.ps1 
 
   & ${ToolDestinationPath}\verify.ps1 ${PackagesPath}\*.nupkg
 } 
 catch {
-  Write-PipelineTaskError "NuGet package validation failed. Please check error logs."
-  Write-Host $_
   Write-Host $_.ScriptStackTrace
+  Write-PipelineTelemetryError -Category 'NuGetValidation' -Message $_
   ExitWithExitCode 1
 }

--- a/eng/common/post-build/post-build-utils.ps1
+++ b/eng/common/post-build/post-build-utils.ps1
@@ -1,17 +1,17 @@
 # Most of the functions in this file require the variables `MaestroApiEndPoint`, 
 # `MaestroApiVersion` and `MaestroApiAccessToken` to be globally available.
 
-$ErrorActionPreference = "Stop"
+$ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
 
 # `tools.ps1` checks $ci to perform some actions. Since the post-build
 # scripts don't necessarily execute in the same agent that run the
 # build.ps1/sh script this variable isn't automatically set.
 $ci = $true
-$disableConfigureToolsetImport = "true"
+$disableConfigureToolsetImport = $true
 . $PSScriptRoot\..\tools.ps1
 
-function Create-MaestroApiRequestHeaders([string]$ContentType = "application/json") {
+function Create-MaestroApiRequestHeaders([string]$ContentType = 'application/json') {
   Validate-MaestroVars
 
   $headers = New-Object 'System.Collections.Generic.Dictionary[[String],[String]]'
@@ -51,14 +51,6 @@ function Get-MaestroSubscriptions([string]$SourceRepository, [int]$ChannelId) {
   return $result
 }
 
-function Trigger-Subscription([string]$SubscriptionId) {
-  Validate-MaestroVars
-
-  $apiHeaders = Create-MaestroApiRequestHeaders -AuthToken $MaestroApiAccessToken
-  $apiEndpoint = "$MaestroApiEndPoint/api/subscriptions/$SubscriptionId/trigger?api-version=$MaestroApiVersion"
-  Invoke-WebRequest -Uri $apiEndpoint -Headers $apiHeaders -Method Post | Out-Null
-}
-
 function Assign-BuildToChannel([int]$BuildId, [int]$ChannelId) {
   Validate-MaestroVars
 
@@ -67,24 +59,32 @@ function Assign-BuildToChannel([int]$BuildId, [int]$ChannelId) {
   Invoke-WebRequest -Method Post -Uri $apiEndpoint -Headers $apiHeaders | Out-Null
 }
 
+function Trigger-Subscription([string]$SubscriptionId) {
+  Validate-MaestroVars
+
+  $apiHeaders = Create-MaestroApiRequestHeaders -AuthToken $MaestroApiAccessToken
+  $apiEndpoint = "$MaestroApiEndPoint/api/subscriptions/$SubscriptionId/trigger?api-version=$MaestroApiVersion"
+  Invoke-WebRequest -Uri $apiEndpoint -Headers $apiHeaders -Method Post | Out-Null
+}
+
 function Validate-MaestroVars {
   try {
     Get-Variable MaestroApiEndPoint -Scope Global | Out-Null
     Get-Variable MaestroApiVersion -Scope Global | Out-Null
     Get-Variable MaestroApiAccessToken -Scope Global | Out-Null
 
-    if (!($MaestroApiEndPoint -Match "^http[s]?://maestro-(int|prod).westus2.cloudapp.azure.com$")) {
-      Write-PipelineTaskError "MaestroApiEndPoint is not a valid Maestro URL. '$MaestroApiEndPoint'"
+    if (!($MaestroApiEndPoint -Match '^http[s]?://maestro-(int|prod).westus2.cloudapp.azure.com$')) {
+      Write-PipelineTelemetryError -Category 'MaestroVars' -Message "MaestroApiEndPoint is not a valid Maestro URL. '$MaestroApiEndPoint'"
       ExitWithExitCode 1  
     }
 
-    if (!($MaestroApiVersion -Match "^[0-9]{4}-[0-9]{2}-[0-9]{2}$")) {
-      Write-PipelineTaskError "MaestroApiVersion does not match a version string in the format yyyy-MM-DD. '$MaestroApiVersion'"
+    if (!($MaestroApiVersion -Match '^[0-9]{4}-[0-9]{2}-[0-9]{2}$')) {
+      Write-PipelineTelemetryError -Category 'MaestroVars' -Message "MaestroApiVersion does not match a version string in the format yyyy-MM-DD. '$MaestroApiVersion'"
       ExitWithExitCode 1
     }
   }
   catch {
-    Write-PipelineTaskError "Error: Variables `MaestroApiEndPoint`, `MaestroApiVersion` and `MaestroApiAccessToken` are required while using this script."
+    Write-PipelineTelemetryError -Category 'MaestroVars' -Message 'Error: Variables `MaestroApiEndPoint`, `MaestroApiVersion` and `MaestroApiAccessToken` are required while using this script.'
     Write-Host $_
     ExitWithExitCode 1
   }

--- a/eng/common/post-build/promote-build.ps1
+++ b/eng/common/post-build/promote-build.ps1
@@ -2,18 +2,18 @@ param(
   [Parameter(Mandatory=$true)][int] $BuildId,
   [Parameter(Mandatory=$true)][int] $ChannelId,
   [Parameter(Mandatory=$true)][string] $MaestroApiAccessToken,
-  [Parameter(Mandatory=$false)][string] $MaestroApiEndPoint = "https://maestro-prod.westus2.cloudapp.azure.com",
-  [Parameter(Mandatory=$false)][string] $MaestroApiVersion = "2019-01-16"
+  [Parameter(Mandatory=$false)][string] $MaestroApiEndPoint = 'https://maestro-prod.westus2.cloudapp.azure.com',
+  [Parameter(Mandatory=$false)][string] $MaestroApiVersion = '2019-01-16'
 )
 
-. $PSScriptRoot\post-build-utils.ps1
-
 try {
+  . $PSScriptRoot\post-build-utils.ps1
+
   # Check that the channel we are going to promote the build to exist
   $channelInfo = Get-MaestroChannel -ChannelId $ChannelId
 
   if (!$channelInfo) {
-    Write-Host "Channel with BAR ID $ChannelId was not found in BAR!"
+    Write-PipelineTelemetryCategory -Category 'PromoteBuild' -Message "Channel with BAR ID $ChannelId was not found in BAR!"
     ExitWithExitCode 1
   }
 
@@ -21,7 +21,7 @@ try {
   $buildInfo = Get-MaestroBuild -BuildId $BuildId
   
   if (!$buildInfo) {
-    Write-Host "Build with BAR ID $BuildId was not found in BAR!"
+    Write-PipelineTelemetryError -Category 'PromoteBuild' -Message "Build with BAR ID $BuildId was not found in BAR!"
     ExitWithExitCode 1
   }
 
@@ -39,10 +39,10 @@ try {
 
   Assign-BuildToChannel -BuildId $BuildId -ChannelId $ChannelId
 
-  Write-Host "done."
+  Write-Host 'done.'
 } 
 catch {
-  Write-Host "There was an error while trying to promote build '$BuildId' to channel '$ChannelId'"
   Write-Host $_
-  Write-Host $_.ScriptStackTrace
+  Write-PipelineTelemetryError -Category 'PromoteBuild' -Message "There was an error while trying to promote build '$BuildId' to channel '$ChannelId'"
+  ExitWithExitCode 1
 }

--- a/eng/common/post-build/symbols-validation.ps1
+++ b/eng/common/post-build/symbols-validation.ps1
@@ -4,10 +4,6 @@ param(
   [Parameter(Mandatory=$true)][string] $DotnetSymbolVersion     # Version of dotnet symbol to use
 )
 
-. $PSScriptRoot\post-build-utils.ps1
-
-Add-Type -AssemblyName System.IO.Compression.FileSystem
-
 function FirstMatchingSymbolDescriptionOrDefault {
   param( 
     [string] $FullPath,                  # Full path to the module that has to be checked
@@ -23,19 +19,19 @@ function FirstMatchingSymbolDescriptionOrDefault {
   # checking and which type of file was uploaded.
 
   # The file itself is returned
-  $SymbolPath = $SymbolsPath + "\" + $FileName
+  $SymbolPath = $SymbolsPath + '\' + $FileName
 
   # PDB file for the module
-  $PdbPath = $SymbolPath.Replace($Extension, ".pdb")
+  $PdbPath = $SymbolPath.Replace($Extension, '.pdb')
 
   # PDB file for R2R module (created by crossgen)
-  $NGenPdb = $SymbolPath.Replace($Extension, ".ni.pdb")
+  $NGenPdb = $SymbolPath.Replace($Extension, '.ni.pdb')
 
   # DBG file for a .so library
-  $SODbg = $SymbolPath.Replace($Extension, ".so.dbg")
+  $SODbg = $SymbolPath.Replace($Extension, '.so.dbg')
 
   # DWARF file for a .dylib
-  $DylibDwarf = $SymbolPath.Replace($Extension, ".dylib.dwarf")
+  $DylibDwarf = $SymbolPath.Replace($Extension, '.dylib.dwarf')
  
   $dotnetSymbolExe = "$env:USERPROFILE\.dotnet\tools"
   $dotnetSymbolExe = Resolve-Path "$dotnetSymbolExe\dotnet-symbol.exe"
@@ -43,19 +39,19 @@ function FirstMatchingSymbolDescriptionOrDefault {
   & $dotnetSymbolExe --symbols --modules --windows-pdbs $TargetServerParam $FullPath -o $SymbolsPath | Out-Null
 
   if (Test-Path $PdbPath) {
-    return "PDB"
+    return 'PDB'
   }
   elseif (Test-Path $NGenPdb) {
-    return "NGen PDB"
+    return 'NGen PDB'
   }
   elseif (Test-Path $SODbg) {
-    return "DBG for SO"
+    return 'DBG for SO'
   }  
   elseif (Test-Path $DylibDwarf) {
-    return "Dwarf for Dylib"
+    return 'Dwarf for Dylib'
   }  
   elseif (Test-Path $SymbolPath) {
-    return "Module"
+    return 'Module'
   }
   else {
     return $null
@@ -74,7 +70,7 @@ function CountMissingSymbols {
   }
   
   # Extensions for which we'll look for symbols
-  $RelevantExtensions = @(".dll", ".exe", ".so", ".dylib")
+  $RelevantExtensions = @('.dll', '.exe', '.so', '.dylib')
 
   # How many files are missing symbol information
   $MissingSymbols = 0
@@ -82,38 +78,38 @@ function CountMissingSymbols {
   $PackageId = [System.IO.Path]::GetFileNameWithoutExtension($PackagePath)
   $PackageGuid = New-Guid
   $ExtractPath = Join-Path -Path $ExtractPath -ChildPath $PackageGuid
-  $SymbolsPath = Join-Path -Path $ExtractPath -ChildPath "Symbols"
+  $SymbolsPath = Join-Path -Path $ExtractPath -ChildPath 'Symbols'
   
   [System.IO.Compression.ZipFile]::ExtractToDirectory($PackagePath, $ExtractPath)
 
   Get-ChildItem -Recurse $ExtractPath |
     Where-Object {$RelevantExtensions -contains $_.Extension} |
     ForEach-Object {
-      if ($_.FullName -Match "\\ref\\") {
-        Write-Host "`t Ignoring reference assembly file" $_.FullName
+      if ($_.FullName -Match '\\ref\\') {
+        Write-Host "`t Ignoring reference assembly file " $_.FullName
         return
       }
 
-      $SymbolsOnMSDL = FirstMatchingSymbolDescriptionOrDefault $_.FullName "--microsoft-symbol-server" $SymbolsPath
-      $SymbolsOnSymWeb = FirstMatchingSymbolDescriptionOrDefault $_.FullName "--internal-server" $SymbolsPath
+      $SymbolsOnMSDL = FirstMatchingSymbolDescriptionOrDefault $_.FullName '--microsoft-symbol-server' $SymbolsPath
+      $SymbolsOnSymWeb = FirstMatchingSymbolDescriptionOrDefault $_.FullName '--internal-server' $SymbolsPath
 
-      Write-Host -NoNewLine "`t Checking file" $_.FullName "... "
+      Write-Host -NoNewLine "`t Checking file " $_.FullName "... "
   
       if ($SymbolsOnMSDL -ne $null -and $SymbolsOnSymWeb -ne $null) {
-        Write-Host "Symbols found on MSDL (" $SymbolsOnMSDL ") and SymWeb (" $SymbolsOnSymWeb ")"
+        Write-Host "Symbols found on MSDL ($SymbolsOnMSDL) and SymWeb ($SymbolsOnSymWeb)"
       }
       else {
         $MissingSymbols++
 
         if ($SymbolsOnMSDL -eq $null -and $SymbolsOnSymWeb -eq $null) {
-          Write-Host "No symbols found on MSDL or SymWeb!"
+          Write-Host 'No symbols found on MSDL or SymWeb!'
         }
         else {
           if ($SymbolsOnMSDL -eq $null) {
-            Write-Host "No symbols found on MSDL!"
+            Write-Host 'No symbols found on MSDL!'
           }
           else {
-            Write-Host "No symbols found on SymWeb!"
+            Write-Host 'No symbols found on SymWeb!'
           }
         }
       }
@@ -132,27 +128,27 @@ function CheckSymbolsAvailable {
   Get-ChildItem "$InputPath\*.nupkg" |
     ForEach-Object {
       $FileName = $_.Name
-	  
+
       # These packages from Arcade-Services include some native libraries that
       # our current symbol uploader can't handle. Below is a workaround until
       # we get issue: https://github.com/dotnet/arcade/issues/2457 sorted.
-      if ($FileName -Match "Microsoft\.DotNet\.Darc\.") {
+      if ($FileName -Match 'Microsoft\.DotNet\.Darc\.') {
         Write-Host "Ignoring Arcade-services file: $FileName"
         Write-Host
         return
       }
-      elseif ($FileName -Match "Microsoft\.DotNet\.Maestro\.Tasks\.") {
+      elseif ($FileName -Match 'Microsoft\.DotNet\.Maestro\.Tasks\.') {
         Write-Host "Ignoring Arcade-services file: $FileName"
         Write-Host
         return
       }
-	  
+
       Write-Host "Validating $FileName "
       $Status = CountMissingSymbols "$InputPath\$FileName"
-  
+
       if ($Status -ne 0) {
-	    Write-PipelineTaskError "Missing symbols for $Status modules in the package $FileName"
-		ExitWithExitCode $exitCode
+        Write-PipelineTelemetryError -Category 'CheckSymbols' -Message "Missing symbols for $Status modules in the package $FileName"
+        ExitWithExitCode $exitCode
       }
 
       Write-Host
@@ -160,7 +156,7 @@ function CheckSymbolsAvailable {
 }
 
 function InstallDotnetSymbol {
-  $dotnetSymbolPackageName = "dotnet-symbol"
+  $dotnetSymbolPackageName = 'dotnet-symbol'
 
   $dotnetRoot = InitializeDotNetCli -install:$true
   $dotnet = "$dotnetRoot\dotnet.exe"
@@ -171,19 +167,22 @@ function InstallDotnetSymbol {
   }
   else {
     Write-Host "Installing dotnet-symbol version $dotnetSymbolVersion..."
-    Write-Host "You may need to restart your command window if this is the first dotnet tool you have installed."
+    Write-Host 'You may need to restart your command window if this is the first dotnet tool you have installed.'
     & "$dotnet" tool install $dotnetSymbolPackageName --version $dotnetSymbolVersion --verbosity "minimal" --global
   }
 }
 
 try {
+  . $PSScriptRoot\post-build-utils.ps1
+
+  Add-Type -AssemblyName System.IO.Compression.FileSystem
+  
   InstallDotnetSymbol
 
   CheckSymbolsAvailable
 }
 catch {
-  Write-Host $_
-  Write-Host $_.Exception
   Write-Host $_.ScriptStackTrace
+  Write-PipelineTelemetryError -Category 'CheckSymbols' -Message $_
   ExitWithExitCode 1
 }

--- a/eng/common/post-build/trigger-subscriptions.ps1
+++ b/eng/common/post-build/trigger-subscriptions.ps1
@@ -2,56 +2,63 @@ param(
   [Parameter(Mandatory=$true)][string] $SourceRepo,
   [Parameter(Mandatory=$true)][int] $ChannelId,
   [Parameter(Mandatory=$true)][string] $MaestroApiAccessToken,
-  [Parameter(Mandatory=$false)][string] $MaestroApiEndPoint = "https://maestro-prod.westus2.cloudapp.azure.com",
-  [Parameter(Mandatory=$false)][string] $MaestroApiVersion = "2019-01-16"
+  [Parameter(Mandatory=$false)][string] $MaestroApiEndPoint = 'https://maestro-prod.westus2.cloudapp.azure.com',
+  [Parameter(Mandatory=$false)][string] $MaestroApiVersion = '2019-01-16'
 )
 
-. $PSScriptRoot\post-build-utils.ps1
+try {
+  . $PSScriptRoot\post-build-utils.ps1
 
-# Get all the $SourceRepo subscriptions
-$normalizedSourceRepo = $SourceRepo.Replace('dnceng@', '')
-$subscriptions = Get-MaestroSubscriptions -SourceRepository $normalizedSourceRepo -ChannelId $ChannelId
+  # Get all the $SourceRepo subscriptions
+  $normalizedSourceRepo = $SourceRepo.Replace('dnceng@', '')
+  $subscriptions = Get-MaestroSubscriptions -SourceRepository $normalizedSourceRepo -ChannelId $ChannelId
 
-if (!$subscriptions) {
-  Write-Host "No subscriptions found for source repo '$normalizedSourceRepo' in channel '$ChannelId'"
-  ExitWithExitCode 0
-}
+  if (!$subscriptions) {
+    Write-PipelineTelemetryError -Category 'TriggerSubscriptions' -Message "No subscriptions found for source repo '$normalizedSourceRepo' in channel '$ChannelId'"
+    ExitWithExitCode 0
+  }
 
-$subscriptionsToTrigger = New-Object System.Collections.Generic.List[string]
-$failedTriggeredSubscription = $false
+  $subscriptionsToTrigger = New-Object System.Collections.Generic.List[string]
+  $failedTriggeredSubscription = $false
 
-# Get all enabled subscriptions that need dependency flow on 'everyBuild'
-foreach ($subscription in $subscriptions) {
-  if ($subscription.enabled -and $subscription.policy.updateFrequency -like 'everyBuild' -and $subscription.channel.id -eq $ChannelId) {
-    Write-Host "Should trigger this subscription: $subscription.id"
-    [void]$subscriptionsToTrigger.Add($subscription.id)
+  # Get all enabled subscriptions that need dependency flow on 'everyBuild'
+  foreach ($subscription in $subscriptions) {
+    if ($subscription.enabled -and $subscription.policy.updateFrequency -like 'everyBuild' -and $subscription.channel.id -eq $ChannelId) {
+      Write-Host "Should trigger this subscription: ${$subscription.id}"
+      [void]$subscriptionsToTrigger.Add($subscription.id)
+    }
+  }
+
+  foreach ($subscriptionToTrigger in $subscriptionsToTrigger) {
+    try {
+      Write-Host "Triggering subscription '$subscriptionToTrigger'."
+
+      Trigger-Subscription -SubscriptionId $subscriptionToTrigger
+    
+      Write-Host 'done.'
+    } 
+    catch
+    {
+      Write-Host "There was an error while triggering subscription '$subscriptionToTrigger'"
+      Write-Host $_
+      Write-Host $_.ScriptStackTrace
+      $failedTriggeredSubscription = $true
+    }
+  }
+
+  if ($subscriptionsToTrigger.Count -eq 0) {
+    Write-Host "No subscription matched source repo '$normalizedSourceRepo' and channel ID '$ChannelId'."
+  }
+  elseif ($failedTriggeredSubscription) {
+    Write-PipelineTelemetryError -Category 'TriggerSubscriptions' -Message 'At least one subscription failed to be triggered...'
+    ExitWithExitCode 1
+  }
+  else {
+    Write-Host 'All subscriptions were triggered successfully!'
   }
 }
-
-foreach ($subscriptionToTrigger in $subscriptionsToTrigger) {
-  try {
-    Write-Host "Triggering subscription '$subscriptionToTrigger'."
-
-    Trigger-Subscription -SubscriptionId $subscriptionToTrigger
-  
-    Write-Host "done."
-  } 
-  catch
-  {
-    Write-Host "There was an error while triggering subscription '$subscriptionToTrigger'"
-    Write-Host $_
-    Write-Host $_.ScriptStackTrace
-    $failedTriggeredSubscription = $true
-  }
-}
-
-if ($subscriptionsToTrigger.Count -eq 0) {
-  Write-Host "No subscription matched source repo '$normalizedSourceRepo' and channel ID '$ChannelId'."
-}
-elseif ($failedTriggeredSubscription) {
-  Write-Host "At least one subscription failed to be triggered..."
+catch {
+  Write-Host $_.ScriptStackTrace
+  Write-PipelineTelemetryError -Category 'TriggerSubscriptions' -Message $_
   ExitWithExitCode 1
-}
-else {
-  Write-Host "All subscriptions were triggered successfully!"
 }

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -1,8 +1,8 @@
 [CmdletBinding(PositionalBinding=$false)]
 Param(
-  [string] $configuration = "Debug",
+  [string] $configuration = 'Debug',
   [string] $task,
-  [string] $verbosity = "minimal",
+  [string] $verbosity = 'minimal',
   [string] $msbuildEngine = $null,
   [switch] $restore,
   [switch] $prepareMachine,
@@ -32,7 +32,7 @@ function Print-Usage() {
 }
 
 function Build([string]$target) {
-  $logSuffix = if ($target -eq "Execute") { "" } else { ".$target" }
+  $logSuffix = if ($target -eq 'Execute') { '' } else { ".$target" }
   $log = Join-Path $LogDir "$task$logSuffix.binlog"
   $outputPath = Join-Path $ToolsetDir "$task\\"
 
@@ -46,33 +46,32 @@ function Build([string]$target) {
 }
 
 try {
-  if ($help -or (($null -ne $properties) -and ($properties.Contains("/help") -or $properties.Contains("/?")))) {
+  if ($help -or (($null -ne $properties) -and ($properties.Contains('/help') -or $properties.Contains('/?')))) {
     Print-Usage
     exit 0
   }
 
   if ($task -eq "") {
-    Write-Host "Missing required parameter '-task <value>'" -ForegroundColor Red
+    Write-PipelineTelemetryError -Category 'Build' -Message "Missing required parameter '-task <value>'" -ForegroundColor Red
     Print-Usage
     ExitWithExitCode 1
   }
 
   $taskProject = GetSdkTaskProject $task
   if (!(Test-Path $taskProject)) {
-    Write-Host "Unknown task: $task" -ForegroundColor Red
+    Write-PipelineTelemetryError -Category 'Build' -Message "Unknown task: $task" -ForegroundColor Red
     ExitWithExitCode 1
   }
 
   if ($restore) {
-    Build "Restore"
+    Build 'Restore'
   }
 
-  Build "Execute"
+  Build 'Execute'
 }
 catch {
-  Write-Host $_
-  Write-Host $_.Exception
   Write-Host $_.ScriptStackTrace
+  Write-PipelineTelemetryError -Category 'Build' -Message $_
   ExitWithExitCode 1
 }
 

--- a/eng/common/sdl/execute-all-sdl-tools.ps1
+++ b/eng/common/sdl/execute-all-sdl-tools.ps1
@@ -5,7 +5,7 @@ Param(
   [string] $Repository=$env:BUILD_REPOSITORY_NAME,                                               # Required: the name of the repository (e.g. dotnet/arcade)
   [string] $BranchName=$env:BUILD_SOURCEBRANCH,                                                  # Optional: name of branch or version of gdn settings; defaults to master
   [string] $SourceDirectory=$env:BUILD_SOURCESDIRECTORY,                                         # Required: the directory where source files are located
-  [string] $ArtifactsDirectory = (Join-Path $env:BUILD_ARTIFACTSTAGINGDIRECTORY ("artifacts")),  # Required: the directory where build artifacts are located
+  [string] $ArtifactsDirectory = (Join-Path $env:BUILD_ARTIFACTSTAGINGDIRECTORY ('artifacts')),  # Required: the directory where build artifacts are located
   [string] $AzureDevOpsAccessToken,                                                              # Required: access token for dnceng; should be provided via KeyVault
   [string[]] $SourceToolsList,                                                                   # Optional: list of SDL tools to run on source code
   [string[]] $ArtifactToolsList,                                                                 # Optional: list of SDL tools to run on built artifacts
@@ -22,79 +22,89 @@ Param(
   [string] $TsaCodebaseAdmin,                                                                    # Optional: only needed if TsaOnboard is true; the aliases which are admins of the TSA codebase (e.g. DOMAIN\alias); TSA is the automated framework used to upload test results as bugs.
   [string] $TsaBugAreaPath,                                                                      # Optional: only needed if TsaOnboard is true; the area path where TSA will file bugs in AzDO; TSA is the automated framework used to upload test results as bugs.
   [string] $TsaIterationPath,                                                                    # Optional: only needed if TsaOnboard is true; the iteration path where TSA will file bugs in AzDO; TSA is the automated framework used to upload test results as bugs.
-  [string] $GuardianLoggerLevel="Standard",                                                      # Optional: the logger level for the Guardian CLI; options are Trace, Verbose, Standard, Warning, and Error
+  [string] $GuardianLoggerLevel='Standard',                                                      # Optional: the logger level for the Guardian CLI; options are Trace, Verbose, Standard, Warning, and Error
   [string[]] $CrScanAdditionalRunConfigParams,                                                   # Optional: Additional Params to custom build a CredScan run config in the format @("xyz:abc","sdf:1")
   [string[]] $PoliCheckAdditionalRunConfigParams                                                 # Optional: Additional Params to custom build a Policheck run config in the format @("xyz:abc","sdf:1")
 )
 
-$ErrorActionPreference = "Stop"
-Set-StrictMode -Version 2.0
-$LASTEXITCODE = 0
+try {
+  $ErrorActionPreference = 'Stop'
+  Set-StrictMode -Version 2.0
+  $disableConfigureToolsetImport = $true
+  $LASTEXITCODE = 0
 
-#Replace repo names to the format of org/repo
-if (!($Repository.contains('/'))) {
-  $RepoName = $Repository -replace '(.*?)-(.*)', '$1/$2';
+  . $PSScriptRoot\..\tools.ps1
+
+  #Replace repo names to the format of org/repo
+  if (!($Repository.contains('/'))) {
+    $RepoName = $Repository -replace '(.*?)-(.*)', '$1/$2';
+  }
+  else{
+    $RepoName = $Repository;
+  }
+
+  if ($GuardianPackageName) {
+    $guardianCliLocation = Join-Path $NugetPackageDirectory (Join-Path $GuardianPackageName (Join-Path 'tools' 'guardian.cmd'))
+  } else {
+    $guardianCliLocation = $GuardianCliLocation
+  }
+
+  $workingDirectory = (Split-Path $SourceDirectory -Parent)
+  $ValidPath = Test-Path $guardianCliLocation
+
+  if ($ValidPath -eq $False)
+  {
+    Write-PipelineTelemetryError -Force -Category 'Sdl' -Message 'Invalid Guardian CLI Location.'
+    ExitWithExitCode 1
+  }
+
+  & $(Join-Path $PSScriptRoot 'init-sdl.ps1') -GuardianCliLocation $guardianCliLocation -Repository $RepoName -BranchName $BranchName -WorkingDirectory $workingDirectory -AzureDevOpsAccessToken $AzureDevOpsAccessToken -GuardianLoggerLevel $GuardianLoggerLevel
+  $gdnFolder = Join-Path $workingDirectory '.gdn'
+
+  if ($TsaOnboard) {
+    if ($TsaCodebaseName -and $TsaNotificationEmail -and $TsaCodebaseAdmin -and $TsaBugAreaPath) {
+      Write-Host "$guardianCliLocation tsa-onboard --codebase-name `"$TsaCodebaseName`" --notification-alias `"$TsaNotificationEmail`" --codebase-admin `"$TsaCodebaseAdmin`" --instance-url `"$TsaInstanceUrl`" --project-name `"$TsaProjectName`" --area-path `"$TsaBugAreaPath`" --iteration-path `"$TsaIterationPath`" --working-directory $workingDirectory --logger-level $GuardianLoggerLevel"
+      & $guardianCliLocation tsa-onboard --codebase-name "$TsaCodebaseName" --notification-alias "$TsaNotificationEmail" --codebase-admin "$TsaCodebaseAdmin" --instance-url "$TsaInstanceUrl" --project-name "$TsaProjectName" --area-path "$TsaBugAreaPath" --iteration-path "$TsaIterationPath" --working-directory $workingDirectory --logger-level $GuardianLoggerLevel
+      if ($LASTEXITCODE -ne 0) {
+        Write-PipelineTelemetryError -Force -Category 'Sdl' -Message "Guardian tsa-onboard failed with exit code $LASTEXITCODE."
+        ExitWithExitCode $LASTEXITCODE
+      }
+    } else {
+      Write-PipelineTelemetryError -Force -Category 'Sdl' -Message 'Could not onboard to TSA -- not all required values ($TsaCodebaseName, $TsaNotificationEmail, $TsaCodebaseAdmin, $TsaBugAreaPath) were specified.'
+      ExitWithExitCode 1
+    }
+  }
+
+  if ($ArtifactToolsList -and $ArtifactToolsList.Count -gt 0) {
+    & $(Join-Path $PSScriptRoot 'run-sdl.ps1') -GuardianCliLocation $guardianCliLocation -WorkingDirectory $workingDirectory -TargetDirectory $ArtifactsDirectory -GdnFolder $gdnFolder -ToolsList $ArtifactToolsList -AzureDevOpsAccessToken $AzureDevOpsAccessToken -UpdateBaseline $UpdateBaseline -GuardianLoggerLevel $GuardianLoggerLevel -CrScanAdditionalRunConfigParams $CrScanAdditionalRunConfigParams -PoliCheckAdditionalRunConfigParams $PoliCheckAdditionalRunConfigParams
+  }
+  if ($SourceToolsList -and $SourceToolsList.Count -gt 0) {
+    & $(Join-Path $PSScriptRoot 'run-sdl.ps1') -GuardianCliLocation $guardianCliLocation -WorkingDirectory $workingDirectory -TargetDirectory $SourceDirectory -GdnFolder $gdnFolder -ToolsList $SourceToolsList -AzureDevOpsAccessToken $AzureDevOpsAccessToken -UpdateBaseline $UpdateBaseline -GuardianLoggerLevel $GuardianLoggerLevel -CrScanAdditionalRunConfigParams $CrScanAdditionalRunConfigParams -PoliCheckAdditionalRunConfigParams $PoliCheckAdditionalRunConfigParams
+  }
+
+  if ($UpdateBaseline) {
+    & (Join-Path $PSScriptRoot 'push-gdn.ps1') -Repository $RepoName -BranchName $BranchName -GdnFolder $GdnFolder -AzureDevOpsAccessToken $AzureDevOpsAccessToken -PushReason 'Update baseline'
+  }
+
+  if ($TsaPublish) {
+    if ($TsaBranchName -and $BuildNumber) {
+      if (-not $TsaRepositoryName) {
+        $TsaRepositoryName = "$($Repository)-$($BranchName)"
+      }
+      Write-Host "$guardianCliLocation tsa-publish --all-tools --repository-name `"$TsaRepositoryName`" --branch-name `"$TsaBranchName`" --build-number `"$BuildNumber`" --codebase-name `"$TsaCodebaseName`" --notification-alias `"$TsaNotificationEmail`" --codebase-admin `"$TsaCodebaseAdmin`" --instance-url `"$TsaInstanceUrl`" --project-name `"$TsaProjectName`" --area-path `"$TsaBugAreaPath`" --iteration-path `"$TsaIterationPath`" --working-directory $workingDirectory --logger-level $GuardianLoggerLevel"
+      & $guardianCliLocation tsa-publish --all-tools --repository-name "$TsaRepositoryName" --branch-name "$TsaBranchName" --build-number "$BuildNumber" --onboard $True --codebase-name "$TsaCodebaseName" --notification-alias "$TsaNotificationEmail" --codebase-admin "$TsaCodebaseAdmin" --instance-url "$TsaInstanceUrl" --project-name "$TsaProjectName" --area-path "$TsaBugAreaPath" --iteration-path "$TsaIterationPath" --working-directory $workingDirectory  --logger-level $GuardianLoggerLevel
+      if ($LASTEXITCODE -ne 0) {
+        Write-PipelineTelemetryError -Force -Category 'Sdl' -Message "Guardian tsa-publish failed with exit code $LASTEXITCODE."
+        ExitWithExitCode $LASTEXITCODE
+      }
+    } else {
+      Write-PipelineTelemetryError -Force -Category 'Sdl' -Message 'Could not publish to TSA -- not all required values ($TsaBranchName, $BuildNumber) were specified.'
+      ExitWithExitCode 1
+    }
+  }
 }
-else{
-  $RepoName = $Repository;
-}
-
-if ($GuardianPackageName) {
-  $guardianCliLocation = Join-Path $NugetPackageDirectory (Join-Path $GuardianPackageName (Join-Path "tools" "guardian.cmd"))
-} else {
-  $guardianCliLocation = $GuardianCliLocation
-}
-
-$workingDirectory = (Split-Path $SourceDirectory -Parent)
-$ValidPath = Test-Path $guardianCliLocation
-
-if ($ValidPath -eq $False)
-{
-  Write-Host "Invalid Guardian CLI Location."
+catch {
+  Write-Host $_.ScriptStackTrace
+  Write-PipelineTelemetryError -Force -Category 'Sdl' -Message $_
   exit 1
-}
-
-& $(Join-Path $PSScriptRoot "init-sdl.ps1") -GuardianCliLocation $guardianCliLocation -Repository $RepoName -BranchName $BranchName -WorkingDirectory $workingDirectory -AzureDevOpsAccessToken $AzureDevOpsAccessToken -GuardianLoggerLevel $GuardianLoggerLevel
-$gdnFolder = Join-Path $workingDirectory ".gdn"
-
-if ($TsaOnboard) {
-  if ($TsaCodebaseName -and $TsaNotificationEmail -and $TsaCodebaseAdmin -and $TsaBugAreaPath) {
-    Write-Host "$guardianCliLocation tsa-onboard --codebase-name `"$TsaCodebaseName`" --notification-alias `"$TsaNotificationEmail`" --codebase-admin `"$TsaCodebaseAdmin`" --instance-url `"$TsaInstanceUrl`" --project-name `"$TsaProjectName`" --area-path `"$TsaBugAreaPath`" --iteration-path `"$TsaIterationPath`" --working-directory $workingDirectory --logger-level $GuardianLoggerLevel"
-    & $guardianCliLocation tsa-onboard --codebase-name "$TsaCodebaseName" --notification-alias "$TsaNotificationEmail" --codebase-admin "$TsaCodebaseAdmin" --instance-url "$TsaInstanceUrl" --project-name "$TsaProjectName" --area-path "$TsaBugAreaPath" --iteration-path "$TsaIterationPath" --working-directory $workingDirectory --logger-level $GuardianLoggerLevel
-    if ($LASTEXITCODE -ne 0) {
-      Write-Host "Guardian tsa-onboard failed with exit code $LASTEXITCODE."
-      exit $LASTEXITCODE
-    }
-  } else {
-    Write-Host "Could not onboard to TSA -- not all required values ($$TsaCodebaseName, $$TsaNotificationEmail, $$TsaCodebaseAdmin, $$TsaBugAreaPath) were specified."
-    exit 1
-  }
-}
-
-if ($ArtifactToolsList -and $ArtifactToolsList.Count -gt 0) {
-  & $(Join-Path $PSScriptRoot "run-sdl.ps1") -GuardianCliLocation $guardianCliLocation -WorkingDirectory $workingDirectory -TargetDirectory $ArtifactsDirectory -GdnFolder $gdnFolder -ToolsList $ArtifactToolsList -AzureDevOpsAccessToken $AzureDevOpsAccessToken -UpdateBaseline $UpdateBaseline -GuardianLoggerLevel $GuardianLoggerLevel -CrScanAdditionalRunConfigParams $CrScanAdditionalRunConfigParams -PoliCheckAdditionalRunConfigParams $PoliCheckAdditionalRunConfigParams
-}
-if ($SourceToolsList -and $SourceToolsList.Count -gt 0) {
-  & $(Join-Path $PSScriptRoot "run-sdl.ps1") -GuardianCliLocation $guardianCliLocation -WorkingDirectory $workingDirectory -TargetDirectory $SourceDirectory -GdnFolder $gdnFolder -ToolsList $SourceToolsList -AzureDevOpsAccessToken $AzureDevOpsAccessToken -UpdateBaseline $UpdateBaseline -GuardianLoggerLevel $GuardianLoggerLevel -CrScanAdditionalRunConfigParams $CrScanAdditionalRunConfigParams -PoliCheckAdditionalRunConfigParams $PoliCheckAdditionalRunConfigParams
-}
-
-if ($UpdateBaseline) {
-  & (Join-Path $PSScriptRoot "push-gdn.ps1") -Repository $RepoName -BranchName $BranchName -GdnFolder $GdnFolder -AzureDevOpsAccessToken $AzureDevOpsAccessToken -PushReason "Update baseline"
-}
-
-if ($TsaPublish) {
-  if ($TsaBranchName -and $BuildNumber) {
-    if (-not $TsaRepositoryName) {
-      $TsaRepositoryName = "$($Repository)-$($BranchName)"
-    }
-    Write-Host "$guardianCliLocation tsa-publish --all-tools --repository-name `"$TsaRepositoryName`" --branch-name `"$TsaBranchName`" --build-number `"$BuildNumber`" --codebase-name `"$TsaCodebaseName`" --notification-alias `"$TsaNotificationEmail`" --codebase-admin `"$TsaCodebaseAdmin`" --instance-url `"$TsaInstanceUrl`" --project-name `"$TsaProjectName`" --area-path `"$TsaBugAreaPath`" --iteration-path `"$TsaIterationPath`" --working-directory $workingDirectory --logger-level $GuardianLoggerLevel"
-    & $guardianCliLocation tsa-publish --all-tools --repository-name "$TsaRepositoryName" --branch-name "$TsaBranchName" --build-number "$BuildNumber" --onboard $True --codebase-name "$TsaCodebaseName" --notification-alias "$TsaNotificationEmail" --codebase-admin "$TsaCodebaseAdmin" --instance-url "$TsaInstanceUrl" --project-name "$TsaProjectName" --area-path "$TsaBugAreaPath" --iteration-path "$TsaIterationPath" --working-directory $workingDirectory  --logger-level $GuardianLoggerLevel
-    if ($LASTEXITCODE -ne 0) {
-      Write-Host "Guardian tsa-publish failed with exit code $LASTEXITCODE."
-      exit $LASTEXITCODE
-    }
-  } else {
-    Write-Host "Could not publish to TSA -- not all required values ($$TsaBranchName, $$BuildNumber) were specified."
-    exit 1
-  }
 }

--- a/eng/common/sdl/extract-artifact-packages.ps1
+++ b/eng/common/sdl/extract-artifact-packages.ps1
@@ -3,55 +3,16 @@ param(
   [Parameter(Mandatory=$true)][string] $ExtractPath            # Full path to directory where the packages will be extracted
 )
 
-$ErrorActionPreference = "Stop"
+$ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
 
 # `tools.ps1` checks $ci to perform some actions. Since the post-build
 # scripts don't necessarily execute in the same agent that run the
 # build.ps1/sh script this variable isn't automatically set.
 $ci = $true
-$disableConfigureToolsetImport = "true"
-. $PSScriptRoot\..\tools.ps1
+$disableConfigureToolsetImport = $true
 
-$ExtractPackage = {
-  param( 
-    [string] $PackagePath                                 # Full path to a NuGet package
-  )
-  
-  if (!(Test-Path $PackagePath)) {
-    Write-PipelineTaskError "Input file does not exist: $PackagePath"
-    ExitWithExitCode 1
-  }
-  
-  $RelevantExtensions = @(".dll", ".exe", ".pdb")
-  Write-Host -NoNewLine "Extracting" ([System.IO.Path]::GetFileName($PackagePath)) "... "
-
-  $PackageId = [System.IO.Path]::GetFileNameWithoutExtension($PackagePath)
-  $ExtractPath = Join-Path -Path $using:ExtractPath -ChildPath $PackageId
-
-  Add-Type -AssemblyName System.IO.Compression.FileSystem
-
-  [System.IO.Directory]::CreateDirectory($ExtractPath);
-
-  try {
-    $zip = [System.IO.Compression.ZipFile]::OpenRead($PackagePath)
-
-    $zip.Entries | 
-    Where-Object {$RelevantExtensions -contains [System.IO.Path]::GetExtension($_.Name)} |
-      ForEach-Object {
-          $TargetFile = Join-Path -Path $ExtractPath -ChildPath $_.Name
-
-          [System.IO.Compression.ZipFileExtensions]::ExtractToFile($_, $TargetFile, $true)
-        }
-  }
-  catch {
-  
-  }
-  finally {
-    $zip.Dispose() 
-  }
- }
- function ExtractArtifacts {
+function ExtractArtifacts {
   if (!(Test-Path $InputPath)) {
     Write-Host "Input Path does not exist: $InputPath"
     ExitWithExitCode 0
@@ -68,11 +29,52 @@ $ExtractPackage = {
 }
 
 try {
+  . $PSScriptRoot\..\tools.ps1
+
+  $ExtractPackage = {
+    param( 
+      [string] $PackagePath                                 # Full path to a NuGet package
+    )
+    
+    if (!(Test-Path $PackagePath)) {
+      Write-PipelineTelemetryError -Category 'Build' -Message "Input file does not exist: $PackagePath"
+      ExitWithExitCode 1
+    }
+    
+    $RelevantExtensions = @('.dll', '.exe', '.pdb')
+    Write-Host -NoNewLine 'Extracting ' ([System.IO.Path]::GetFileName($PackagePath)) '...'
+  
+    $PackageId = [System.IO.Path]::GetFileNameWithoutExtension($PackagePath)
+    $ExtractPath = Join-Path -Path $using:ExtractPath -ChildPath $PackageId
+  
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+  
+    [System.IO.Directory]::CreateDirectory($ExtractPath);
+  
+    try {
+      $zip = [System.IO.Compression.ZipFile]::OpenRead($PackagePath)
+  
+      $zip.Entries | 
+      Where-Object {$RelevantExtensions -contains [System.IO.Path]::GetExtension($_.Name)} |
+        ForEach-Object {
+            $TargetFile = Join-Path -Path $ExtractPath -ChildPath $_.Name
+  
+            [System.IO.Compression.ZipFileExtensions]::ExtractToFile($_, $TargetFile, $true)
+          }
+    }
+    catch {
+      Write-Host $_.ScriptStackTrace
+      Write-PipelineTelemetryError -Force -Category 'Sdl' -Message $_
+      ExitWithExitCode 1
+    }
+    finally {
+      $zip.Dispose() 
+    }
+  }
   Measure-Command { ExtractArtifacts }
 }
 catch {
-  Write-Host $_
-  Write-Host $_.Exception
   Write-Host $_.ScriptStackTrace
+  Write-PipelineTelemetryError -Force -Category 'Sdl' -Message $_
   ExitWithExitCode 1
 }

--- a/eng/common/sdl/init-sdl.ps1
+++ b/eng/common/sdl/init-sdl.ps1
@@ -1,15 +1,18 @@
 Param(
   [string] $GuardianCliLocation,
   [string] $Repository,
-  [string] $BranchName="master",
+  [string] $BranchName='master',
   [string] $WorkingDirectory,
   [string] $AzureDevOpsAccessToken,
-  [string] $GuardianLoggerLevel="Standard"
+  [string] $GuardianLoggerLevel='Standard'
 )
 
-$ErrorActionPreference = "Stop"
+$ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
+$disableConfigureToolsetImport = $true
 $LASTEXITCODE = 0
+
+. $PSScriptRoot\..\tools.ps1
 
 # Don't display the console progress UI - it's a huge perf hit
 $ProgressPreference = 'SilentlyContinue'
@@ -21,11 +24,10 @@ $uri = "https://dev.azure.com/dnceng/internal/_apis/git/repositories/sdl-tool-cf
 $zipFile = "$WorkingDirectory/gdn.zip"
 
 Add-Type -AssemblyName System.IO.Compression.FileSystem
-$gdnFolder = (Join-Path $WorkingDirectory ".gdn")
-Try
-{
+$gdnFolder = (Join-Path $WorkingDirectory '.gdn')
+try {
   # We try to download the zip; if the request fails (e.g. the file doesn't exist), we catch it and init guardian instead
-  Write-Host "Downloading gdn folder from internal config repostiory..."
+  Write-Host 'Downloading gdn folder from internal config repostiory...'
   Invoke-WebRequest -Headers @{ "Accept"="application/zip"; "Authorization"="Basic $encodedPat" } -Uri $uri -OutFile $zipFile
   if (Test-Path $gdnFolder) {
     # Remove the gdn folder if it exists (it shouldn't unless there's too much caching; this is just in case)
@@ -33,19 +35,29 @@ Try
   }
   [System.IO.Compression.ZipFile]::ExtractToDirectory($zipFile, $WorkingDirectory)
   Write-Host $gdnFolder
-} Catch [System.Net.WebException] {
+  ExitWithExitCode 0
+} catch [System.Net.WebException] { } # Catch and ignore webexception
+try {
   # if the folder does not exist, we'll do a guardian init and push it to the remote repository
-  Write-Host "Initializing Guardian..."
+  Write-Host 'Initializing Guardian...'
   Write-Host "$GuardianCliLocation init --working-directory $WorkingDirectory --logger-level $GuardianLoggerLevel"
   & $GuardianCliLocation init --working-directory $WorkingDirectory --logger-level $GuardianLoggerLevel
   if ($LASTEXITCODE -ne 0) {
-    Write-Error "Guardian init failed with exit code $LASTEXITCODE."
+    Write-PipelineTelemetryError -Force -Category 'Build' -Message "Guardian init failed with exit code $LASTEXITCODE."
+    ExitWithExitCode $LASTEXITCODE
   }
   # We create the mainbaseline so it can be edited later
   Write-Host "$GuardianCliLocation baseline --working-directory $WorkingDirectory --name mainbaseline"
   & $GuardianCliLocation baseline --working-directory $WorkingDirectory --name mainbaseline
   if ($LASTEXITCODE -ne 0) {
-    Write-Error "Guardian baseline failed with exit code $LASTEXITCODE."
+    Write-PipelineTelemetryError -Force -Category 'Build' -Message "Guardian baseline failed with exit code $LASTEXITCODE."
+    ExitWithExitCode $LASTEXITCODE
   }
-  & $(Join-Path $PSScriptRoot "push-gdn.ps1") -Repository $Repository -BranchName $BranchName -GdnFolder $gdnFolder -AzureDevOpsAccessToken $AzureDevOpsAccessToken -PushReason "Initialize gdn folder"
+  & $(Join-Path $PSScriptRoot 'push-gdn.ps1') -Repository $Repository -BranchName $BranchName -GdnFolder $gdnFolder -AzureDevOpsAccessToken $AzureDevOpsAccessToken -PushReason 'Initialize gdn folder'
+  ExitWithExitCode 0
+}
+catch {
+  Write-Host $_.ScriptStackTrace
+  Write-PipelineTelemetryError -Category 'Sdl' -Message $_
+  ExitWithExitCode 1
 }

--- a/eng/common/sdl/push-gdn.ps1
+++ b/eng/common/sdl/push-gdn.ps1
@@ -1,51 +1,65 @@
 Param(
   [string] $Repository,
-  [string] $BranchName="master",
+  [string] $BranchName='master',
   [string] $GdnFolder,
   [string] $AzureDevOpsAccessToken,
   [string] $PushReason
 )
 
-$ErrorActionPreference = "Stop"
+$ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
+$disableConfigureToolsetImport = $true
 $LASTEXITCODE = 0
 
-# We create the temp directory where we'll store the sdl-config repository
-$sdlDir = Join-Path $env:TEMP "sdl"
-if (Test-Path $sdlDir) {
-  Remove-Item -Force -Recurse $sdlDir
-}
+try {
+  . $PSScriptRoot\..\tools.ps1
 
-Write-Host "git clone https://dnceng:`$AzureDevOpsAccessToken@dev.azure.com/dnceng/internal/_git/sdl-tool-cfg $sdlDir"
-git clone https://dnceng:$AzureDevOpsAccessToken@dev.azure.com/dnceng/internal/_git/sdl-tool-cfg $sdlDir
-if ($LASTEXITCODE -ne 0) {
-  Write-Error "Git clone failed with exit code $LASTEXITCODE."
-}
-# We copy the .gdn folder from our local run into the git repository so it can be committed
-$sdlRepositoryFolder = Join-Path (Join-Path (Join-Path $sdlDir $Repository) $BranchName) ".gdn"
-if (Get-Command Robocopy) {
-  Robocopy /S $GdnFolder $sdlRepositoryFolder
-} else {
-  rsync -r $GdnFolder $sdlRepositoryFolder
-}
-# cd to the sdl-config directory so we can run git there
-Push-Location $sdlDir
-# git add . --> git commit --> git push
-Write-Host "git add ."
-git add .
-if ($LASTEXITCODE -ne 0) {
-  Write-Error "Git add failed with exit code $LASTEXITCODE."
-}
-Write-Host "git -c user.email=`"dn-bot@microsoft.com`" -c user.name=`"Dotnet Bot`" commit -m `"$PushReason for $Repository/$BranchName`""
-git -c user.email="dn-bot@microsoft.com" -c user.name="Dotnet Bot" commit -m "$PushReason for $Repository/$BranchName"
-if ($LASTEXITCODE -ne 0) {
-  Write-Error "Git commit failed with exit code $LASTEXITCODE."
-}
-Write-Host "git push"
-git push
-if ($LASTEXITCODE -ne 0) {
-  Write-Error "Git push failed with exit code $LASTEXITCODE."
-}
+  # We create the temp directory where we'll store the sdl-config repository
+  $sdlDir = Join-Path $env:TEMP 'sdl'
+  if (Test-Path $sdlDir) {
+    Remove-Item -Force -Recurse $sdlDir
+  }
 
-# Return to the original directory
-Pop-Location
+  Write-Host "git clone https://dnceng:`$AzureDevOpsAccessToken@dev.azure.com/dnceng/internal/_git/sdl-tool-cfg $sdlDir"
+  git clone https://dnceng:$AzureDevOpsAccessToken@dev.azure.com/dnceng/internal/_git/sdl-tool-cfg $sdlDir
+  if ($LASTEXITCODE -ne 0) {
+    Write-PipelineTelemetryError -Force -Category 'Sdl' -Message "Git clone failed with exit code $LASTEXITCODE."
+    ExitWithExitCode $LASTEXITCODE
+  }
+  # We copy the .gdn folder from our local run into the git repository so it can be committed
+  $sdlRepositoryFolder = Join-Path (Join-Path (Join-Path $sdlDir $Repository) $BranchName) '.gdn'
+  if (Get-Command Robocopy) {
+    Robocopy /S $GdnFolder $sdlRepositoryFolder
+  } else {
+    rsync -r $GdnFolder $sdlRepositoryFolder
+  }
+  # cd to the sdl-config directory so we can run git there
+  Push-Location $sdlDir
+  # git add . --> git commit --> git push
+  Write-Host 'git add .'
+  git add .
+  if ($LASTEXITCODE -ne 0) {
+    Write-PipelineTelemetryError -Force -Category 'Sdl' -Message "Git add failed with exit code $LASTEXITCODE."
+    ExitWithExitCode $LASTEXITCODE
+  }
+  Write-Host "git -c user.email=`"dn-bot@microsoft.com`" -c user.name=`"Dotnet Bot`" commit -m `"$PushReason for $Repository/$BranchName`""
+  git -c user.email="dn-bot@microsoft.com" -c user.name="Dotnet Bot" commit -m "$PushReason for $Repository/$BranchName"
+  if ($LASTEXITCODE -ne 0) {
+    Write-PipelineTelemetryError -Force -Category 'Sdl' -Message "Git commit failed with exit code $LASTEXITCODE."
+    ExitWithExitCode $LASTEXITCODE
+  }
+  Write-Host 'git push'
+  git push
+  if ($LASTEXITCODE -ne 0) {
+    Write-PipelineTelemetryError -Force -Category 'Sdl' -Message "Git push failed with exit code $LASTEXITCODE."
+    ExitWithExitCode $LASTEXITCODE
+  }
+
+  # Return to the original directory
+  Pop-Location
+}
+catch {
+  Write-Host $_.ScriptStackTrace
+  Write-PipelineTelemetryError -Category 'Sdl' -Message $_
+  ExitWithExitCode 1
+}

--- a/eng/common/sdl/run-sdl.ps1
+++ b/eng/common/sdl/run-sdl.ps1
@@ -5,55 +5,65 @@ Param(
   [string] $GdnFolder,
   [string[]] $ToolsList,
   [string] $UpdateBaseline,
-  [string] $GuardianLoggerLevel="Standard",
+  [string] $GuardianLoggerLevel='Standard',
   [string[]] $CrScanAdditionalRunConfigParams,
   [string[]] $PoliCheckAdditionalRunConfigParams
 )
 
-$ErrorActionPreference = "Stop"
+$ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
+$disableConfigureToolsetImport = $true
 $LASTEXITCODE = 0
 
-# We store config files in the r directory of .gdn
-Write-Host $ToolsList
-$gdnConfigPath = Join-Path $GdnFolder "r"
-$ValidPath = Test-Path $GuardianCliLocation
+try {
+  . $PSScriptRoot\..\tools.ps1
 
-if ($ValidPath -eq $False)
-{
-  Write-Host "Invalid Guardian CLI Location."
-  exit 1
-}
+  # We store config files in the r directory of .gdn
+  Write-Host $ToolsList
+  $gdnConfigPath = Join-Path $GdnFolder 'r'
+  $ValidPath = Test-Path $GuardianCliLocation
 
-$configParam = @("--config")
-
-foreach ($tool in $ToolsList) {
-  $gdnConfigFile = Join-Path $gdnConfigPath "$tool-configure.gdnconfig"
-  Write-Host $tool
-  # We have to manually configure tools that run on source to look at the source directory only
-  if ($tool -eq "credscan") {
-    Write-Host "$GuardianCliLocation configure --working-directory $WorkingDirectory --tool $tool --output-path $gdnConfigFile --logger-level $GuardianLoggerLevel --noninteractive --force --args `" TargetDirectory < $TargetDirectory `" `" OutputType < pre `" $(If ($CrScanAdditionalRunConfigParams) {$CrScanAdditionalRunConfigParams})"
-    & $GuardianCliLocation configure --working-directory $WorkingDirectory --tool $tool --output-path $gdnConfigFile --logger-level $GuardianLoggerLevel --noninteractive --force --args " TargetDirectory < $TargetDirectory " "OutputType < pre" $(If ($CrScanAdditionalRunConfigParams) {$CrScanAdditionalRunConfigParams})
-    if ($LASTEXITCODE -ne 0) {
-      Write-Host "Guardian configure for $tool failed with exit code $LASTEXITCODE."
-      exit $LASTEXITCODE
-    }
-  }
-  if ($tool -eq "policheck") {
-    Write-Host "$GuardianCliLocation configure --working-directory $WorkingDirectory --tool $tool --output-path $gdnConfigFile --logger-level $GuardianLoggerLevel --noninteractive --force --args `" Target < $TargetDirectory `" $(If ($PoliCheckAdditionalRunConfigParams) {$PoliCheckAdditionalRunConfigParams})"
-    & $GuardianCliLocation configure --working-directory $WorkingDirectory --tool $tool --output-path $gdnConfigFile --logger-level $GuardianLoggerLevel --noninteractive --force --args " Target < $TargetDirectory " $(If ($PoliCheckAdditionalRunConfigParams) {$PoliCheckAdditionalRunConfigParams})
-    if ($LASTEXITCODE -ne 0) {
-      Write-Host "Guardian configure for $tool failed with exit code $LASTEXITCODE."
-      exit $LASTEXITCODE
-    }
+  if ($ValidPath -eq $False)
+  {
+    Write-PipelineTelemetryError -Force -Category 'Sdl' -Message "Invalid Guardian CLI Location."
+    ExitWithExitCode 1
   }
 
-  $configParam+=$gdnConfigFile
-}
+  $configParam = @('--config')
 
-Write-Host "$GuardianCliLocation run --working-directory $WorkingDirectory --baseline mainbaseline --update-baseline $UpdateBaseline --logger-level $GuardianLoggerLevel $configParam"
-& $GuardianCliLocation run --working-directory $WorkingDirectory --tool $tool --baseline mainbaseline --update-baseline $UpdateBaseline --logger-level $GuardianLoggerLevel $configParam
-if ($LASTEXITCODE -ne 0) {
-  Write-Host "Guardian run for $ToolsList using $configParam failed with exit code $LASTEXITCODE."
-  exit $LASTEXITCODE
+  foreach ($tool in $ToolsList) {
+    $gdnConfigFile = Join-Path $gdnConfigPath "$tool-configure.gdnconfig"
+    Write-Host $tool
+    # We have to manually configure tools that run on source to look at the source directory only
+    if ($tool -eq 'credscan') {
+      Write-Host "$GuardianCliLocation configure --working-directory $WorkingDirectory --tool $tool --output-path $gdnConfigFile --logger-level $GuardianLoggerLevel --noninteractive --force --args `" TargetDirectory < $TargetDirectory `" `" OutputType < pre `" $(If ($CrScanAdditionalRunConfigParams) {$CrScanAdditionalRunConfigParams})"
+      & $GuardianCliLocation configure --working-directory $WorkingDirectory --tool $tool --output-path $gdnConfigFile --logger-level $GuardianLoggerLevel --noninteractive --force --args " TargetDirectory < $TargetDirectory " "OutputType < pre" $(If ($CrScanAdditionalRunConfigParams) {$CrScanAdditionalRunConfigParams})
+      if ($LASTEXITCODE -ne 0) {
+        Write-PipelineTelemetryError -Force -Category 'Sdl' -Message "Guardian configure for $tool failed with exit code $LASTEXITCODE."
+        ExitWithExitCode $LASTEXITCODE
+      }
+    }
+    if ($tool -eq 'policheck') {
+      Write-Host "$GuardianCliLocation configure --working-directory $WorkingDirectory --tool $tool --output-path $gdnConfigFile --logger-level $GuardianLoggerLevel --noninteractive --force --args `" Target < $TargetDirectory `" $(If ($PoliCheckAdditionalRunConfigParams) {$PoliCheckAdditionalRunConfigParams})"
+      & $GuardianCliLocation configure --working-directory $WorkingDirectory --tool $tool --output-path $gdnConfigFile --logger-level $GuardianLoggerLevel --noninteractive --force --args " Target < $TargetDirectory " $(If ($PoliCheckAdditionalRunConfigParams) {$PoliCheckAdditionalRunConfigParams})
+      if ($LASTEXITCODE -ne 0) {
+        Write-PipelineTelemetryError -Force -Category 'Sdl' -Message "Guardian configure for $tool failed with exit code $LASTEXITCODE."
+        ExitWithExitCode $LASTEXITCODE
+      }
+    }
+
+    $configParam+=$gdnConfigFile
+  }
+
+  Write-Host "$GuardianCliLocation run --working-directory $WorkingDirectory --baseline mainbaseline --update-baseline $UpdateBaseline --logger-level $GuardianLoggerLevel $configParam"
+  & $GuardianCliLocation run --working-directory $WorkingDirectory --tool $tool --baseline mainbaseline --update-baseline $UpdateBaseline --logger-level $GuardianLoggerLevel $configParam
+  if ($LASTEXITCODE -ne 0) {
+    Write-PipelineTelemetryError -Force -Category 'Sdl' -Message "Guardian run for $ToolsList using $configParam failed with exit code $LASTEXITCODE."
+    ExitWithExitCode $LASTEXITCODE
+  }
+}
+catch {
+  Write-Host $_.ScriptStackTrace
+  Write-PipelineTelemetryError -Category 'Sdl' -Message $_
+  ExitWithExitCode 1
 }

--- a/eng/common/templates/post-build/common-variables.yml
+++ b/eng/common/templates/post-build/common-variables.yml
@@ -1,9 +1,7 @@
 variables:
-  - group: AzureDevOps-Artifact-Feeds-Pats
-  - group: DotNet-Blob-Feed
+  - group: Publish-Build-Assets
   - group: DotNet-DotNetCli-Storage
   - group: DotNet-MSRC-Storage
-  - group: Publish-Build-Assets
 
   # .NET Core 3.1 Dev
   - name: PublicDevRelease_31_Channel_Id

--- a/eng/configure-toolset.ps1
+++ b/eng/configure-toolset.ps1
@@ -1,13 +1,15 @@
+. $PSScriptRoot\common\pipeline-logging-functions.ps1
 function Test-FilesUseTelemetryOutput {
     $requireTelemetryExcludeFiles = @(
         "enable-cross-org-publishing.ps1",
         "performance-setup.ps1" )
 
-    $filesMissingTelemetry = Get-ChildItem -File -Recurse -Path $engCommonRoot -Include "*.ps1" -Exclude $requireTelemetryExcludeFiles |
+    $filesMissingTelemetry = Get-ChildItem -File -Recurse -Path "$PSScriptRoot\common" -Include "*.ps1" -Exclude $requireTelemetryExcludeFiles |
         Where-Object { -Not( $_ | Select-String -Pattern "Write-PipelineTelemetryError" )}
 
     If($filesMissingTelemetry) {
-        Write-PipelineTelemetryError -category 'Build' 'One or more eng/common scripts do not use telemetry categorization.'        Write-Host "See https://github.com/dotnet/arcade/blob/master/eng/common/pipeline-logging-functions.ps1"
+        Write-PipelineTelemetryError -category 'Build' 'One or more eng/common scripts do not use telemetry categorization.'
+        Write-Host "See https://github.com/dotnet/arcade/blob/master/Documentation/Projects/DevOps/CI/Telemetry-Guidance.md"
         Write-Host "The following ps1 files do not include telemetry categorization output:"
         ForEach($file In $filesMissingTelemetry) {
             Write-Host $file
@@ -17,7 +19,6 @@ function Test-FilesUseTelemetryOutput {
     }
 }
 
-$engCommonRoot = Join-Path $PSScriptRoot "common"
 $failOnConfigureToolsetError = $true
 $exitCode = Test-FilesUseTelemetryOutput
-return $exitCode
+exit $exitCode

--- a/eng/configure-toolset.ps1
+++ b/eng/configure-toolset.ps1
@@ -1,0 +1,23 @@
+function Test-FilesUseTelemetryOutput {
+    $requireTelemetryExcludeFiles = @(
+        "enable-cross-org-publishing.ps1",
+        "performance-setup.ps1" )
+
+    $filesMissingTelemetry = Get-ChildItem -File -Recurse -Path $engCommonRoot -Include "*.ps1" -Exclude $requireTelemetryExcludeFiles |
+        Where-Object { -Not( $_ | Select-String -Pattern "Write-PipelineTelemetryError" )}
+
+    If($filesMissingTelemetry) {
+        Write-PipelineTelemetryError -category 'Build' 'One or more eng/common scripts do not use telemetry categorization.'        Write-Host "See https://github.com/dotnet/arcade/blob/master/eng/common/pipeline-logging-functions.ps1"
+        Write-Host "The following ps1 files do not include telemetry categorization output:"
+        ForEach($file In $filesMissingTelemetry) {
+            Write-Host $file
+        }
+
+        return 1
+    }
+}
+
+$engCommonRoot = Join-Path $PSScriptRoot "common"
+$failOnConfigureToolsetError = $true
+$exitCode = Test-FilesUseTelemetryOutput
+return $exitCode

--- a/eng/configure-toolset.sh
+++ b/eng/configure-toolset.sh
@@ -23,7 +23,8 @@ function Test-FilesUseTelemetryOutput {
     done
 
     if [[ -n "${file_list//[[:space:]]/}" ]]; then 
-        Write-PipelineTelemetryError -force -category 'Build' 'One or more eng/common scripts do not use telemetry categorization.'        echo "See https://github.com/dotnet/arcade/blob/master/eng/common/pipeline-logging-functions.sh"
+        Write-PipelineTelemetryError -force -category 'Build' 'One or more eng/common scripts do not use telemetry categorization.'
+        echo "https://github.com/dotnet/arcade/blob/master/Documentation/Projects/DevOps/CI/Telemetry-Guidance.md"
         echo "The following bash files do not include telemetry categorization output:"
         for file in $file_list
             do echo "'$file'"

--- a/eng/configure-toolset.sh
+++ b/eng/configure-toolset.sh
@@ -1,0 +1,44 @@
+function Test-FilesUseTelemetryOutput {
+    _files_use_telemetry_result=0
+    declare -a require_telmetry_exclude_files
+    require_telmetry_exclude_files=(
+        'eng/common/build.sh'
+        'eng/common/cibuild.sh'
+        'eng/common/cross/armel/tizen-build-rootfs.sh'
+        'eng/common/cross/armel/tizen-fetch.sh'
+        'eng/common/cross/build-android-rootfs.sh'
+        'eng/common/cross/build-rootfs.sh'
+        'eng/common/darc-init.sh'
+        'eng/common/msbuild.sh'
+        'eng/common/performance/performance-setup.sh'
+    )
+
+    local file_list=`grep --files-without-match --dereference-recursive --include=*.sh "Write-PipelineTelemetryError" $scriptroot`
+    for file in $file_list; do
+        for remove_file in ${require_telmetry_exclude_files[@]}; do
+            if [[ $file =~ .*"$remove_file" ]]; then
+            file_list=( "${file_list[@]/$file}" )
+            fi
+        done
+    done
+
+    if [[ -n "${file_list//[[:space:]]/}" ]]; then 
+        Write-PipelineTelemetryError -force -category 'Build' 'One or more eng/common scripts do not use telemetry categorization.'        echo "See https://github.com/dotnet/arcade/blob/master/eng/common/pipeline-logging-functions.sh"
+        echo "The following bash files do not include telemetry categorization output:"
+        for file in $file_list
+            do echo "'$file'"
+        done
+
+        _files_use_telemetry_result=1
+        return
+    fi
+}
+
+ResolvePath "${BASH_SOURCE[0]}"
+scriptroot=`dirname "$_ResolvePath"`
+
+Test-FilesUseTelemetryOutput
+
+if [[ $_files_use_telemetry_result != 0 ]]; then
+  exit $_files_use_telemetry_result
+fi

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SigningValidation.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SigningValidation.proj
@@ -16,6 +16,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <NETCORE_ENGINEERING_TELEMETRY>Build</NETCORE_ENGINEERING_TELEMETRY>
   </PropertyGroup>
 
   <Target Name="Execute">


### PR DESCRIPTION
Add telemetry categorization to all Arcade scripts (eng/common).
Add checks (in configure-toolset.ps1 and configure-toolset.sh) to ensure that all ps1 and sh files under eng/common are using some level of telemetry categorization.  
Misc fixes / formatting changes to be more consistent across all of our scripts.

internal build validation
- Arcade - https://dev.azure.com/dnceng/internal/_build/results?buildId=411438&view=results
- Arcade-validation - https://dev.azure.com/dnceng/internal/_build/results?buildId=412063&view=results
- coreclr-validation

public build validation
- Arcade - this
- coreclr - https://github.com/dotnet/coreclr/pull/27616