### PR TITLE
Publish PDBs in nested folders

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -212,8 +212,13 @@
       <FilesToPublishToSymbolServer Include="$(ArtifactsSymStoreDirectory)**\*.pdb"/>
     </ItemGroup>
 
+    <!--
+       Publishes the whole folder of symbols as an artifact container. Unfortunately,
+       AzDO logging commands don't let us add subfolders by executing different `##vso` commands:
+       https://github.com/microsoft/azure-pipelines-tasks/issues/11689
+    -->
     <Message
-      Text="##vso[artifact.upload containerfolder=PdbArtifacts;artifactname=PdbArtifacts]%(FilesToPublishToSymbolServer.Identity)"
+      Text="##vso[artifact.upload containerfolder=PdbArtifacts;artifactname=PdbArtifacts]$(ArtifactsSymStoreDirectory)"
       Importance="high" 
       Condition="'@(FilesToPublishToSymbolServer)' != ''"/>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishToSymbolServers.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishToSymbolServers.proj
@@ -30,7 +30,7 @@
 
   <Target Name="Execute">
     <ItemGroup>
-      <FilesToPublishToSymbolServer Include="$(PDBArtifactsDirectory)\*.pdb"/>
+      <FilesToPublishToSymbolServer Include="$(PDBArtifactsDirectory)\**\*.pdb"/>
       <PackagesToPublishToSymbolServer Include="$(BlobBasePath)\*.symbols.nupkg"/>
 
       <!--


### PR DESCRIPTION
Closes: https://github.com/dotnet/arcade/issues/4247

Upload the PDBs in their nested folders as an AzDO artifact container. This keeps the original structure of file directory to prevent overriding files when publishing them to an AzDO container.