### PR TITLE
Update toolchain.cmake to match the version in CoreCLR.

### DIFF
--- a/eng/common/cross/toolchain.cmake
+++ b/eng/common/cross/toolchain.cmake
@@ -31,6 +31,10 @@ else()
   message(FATAL_ERROR "Arch is ${TARGET_ARCH_NAME}. Only armel, arm, arm64 and x86 are supported!")
 endif()
 
+if(DEFINED ENV{TOOLCHAIN})
+  set(TOOLCHAIN $ENV{TOOLCHAIN})
+endif()
+
 # Specify include paths
 if(TARGET_ARCH_NAME STREQUAL "armel")
   if(DEFINED TIZEN_TOOLCHAIN)
@@ -39,48 +43,25 @@ if(TARGET_ARCH_NAME STREQUAL "armel")
   endif()
 endif()
 
-# add_compile_param - adds only new options without duplicates.
-# arg0 - list with result options, arg1 - list with new options.
-# arg2 - optional argument, quick summary string for optional using CACHE FORCE mode.
-macro(add_compile_param)
-  if(NOT ${ARGC} MATCHES "^(2|3)$")
-    message(FATAL_ERROR "Wrong using add_compile_param! Two or three parameters must be given! See add_compile_param description.")
-  endif()
-  foreach(OPTION ${ARGV1})
-    if(NOT ${ARGV0} MATCHES "${OPTION}($| )")
-      set(${ARGV0} "${${ARGV0}} ${OPTION}")
-      if(${ARGC} EQUAL "3") # CACHE FORCE mode
-        set(${ARGV0} "${${ARGV0}}" CACHE STRING "${ARGV2}" FORCE)
-      endif()
-    endif()
-  endforeach()
-endmacro()
+set(CMAKE_SYSROOT "${CROSS_ROOTFS}")
+set(CMAKE_C_COMPILER_EXTERNAL_TOOLCHAIN "${CROSS_ROOTFS}/usr")
+set(CMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN "${CROSS_ROOTFS}/usr")
+set(CMAKE_ASM_COMPILER_EXTERNAL_TOOLCHAIN "${CROSS_ROOTFS}/usr")
 
 # Specify link flags
-add_compile_param(CROSS_LINK_FLAGS "--sysroot=${CROSS_ROOTFS}")
-add_compile_param(CROSS_LINK_FLAGS "--gcc-toolchain=${CROSS_ROOTFS}/usr")
-add_compile_param(CROSS_LINK_FLAGS "--target=${TOOLCHAIN}")
-add_compile_param(CROSS_LINK_FLAGS "-fuse-ld=gold")
 
 if(TARGET_ARCH_NAME STREQUAL "armel")
   if(DEFINED TIZEN_TOOLCHAIN) # For Tizen only
-    add_compile_param(CROSS_LINK_FLAGS "-B${CROSS_ROOTFS}/usr/lib/gcc/${TIZEN_TOOLCHAIN}")
-    add_compile_param(CROSS_LINK_FLAGS "-L${CROSS_ROOTFS}/lib")
-    add_compile_param(CROSS_LINK_FLAGS "-L${CROSS_ROOTFS}/usr/lib")
-    add_compile_param(CROSS_LINK_FLAGS "-L${CROSS_ROOTFS}/usr/lib/gcc/${TIZEN_TOOLCHAIN}")
+    add_link_options("-B${CROSS_ROOTFS}/usr/lib/gcc/${TIZEN_TOOLCHAIN}")
+    add_link_options("-L${CROSS_ROOTFS}/lib")
+    add_link_options("-L${CROSS_ROOTFS}/usr/lib")
+    add_link_options("-L${CROSS_ROOTFS}/usr/lib/gcc/${TIZEN_TOOLCHAIN}")
   endif()
 elseif(TARGET_ARCH_NAME STREQUAL "x86")
-  add_compile_param(CROSS_LINK_FLAGS "-m32")
+  add_link_options(-m32)
 endif()
 
-add_compile_param(CMAKE_EXE_LINKER_FLAGS "${CROSS_LINK_FLAGS}" "TOOLCHAIN_EXE_LINKER_FLAGS")
-add_compile_param(CMAKE_SHARED_LINKER_FLAGS "${CROSS_LINK_FLAGS}" "TOOLCHAIN_EXE_LINKER_FLAGS")
-add_compile_param(CMAKE_MODULE_LINKER_FLAGS "${CROSS_LINK_FLAGS}" "TOOLCHAIN_EXE_LINKER_FLAGS")
-
 # Specify compile options
-add_compile_options("--sysroot=${CROSS_ROOTFS}")
-add_compile_options("--target=${TOOLCHAIN}")
-add_compile_options("--gcc-toolchain=${CROSS_ROOTFS}/usr")
 
 if(TARGET_ARCH_NAME MATCHES "^(arm|armel|arm64)$")
   set(CMAKE_C_COMPILER_TARGET ${TOOLCHAIN})
@@ -103,7 +84,7 @@ elseif(TARGET_ARCH_NAME STREQUAL "x86")
   add_compile_options(-Wno-error=unused-command-line-argument)
 endif()
 
-# Set LLDB include and library paths
+# Set LLDB include and library paths for builds that need lldb.
 if(TARGET_ARCH_NAME MATCHES "^(arm|armel|x86)$")
   if(TARGET_ARCH_NAME STREQUAL "x86")
     set(LLVM_CROSS_DIR "$ENV{LLVM_CROSS_HOME}")
@@ -131,7 +112,7 @@ if(TARGET_ARCH_NAME MATCHES "^(arm|armel|x86)$")
   endif()
 endif()
 
-set(CMAKE_FIND_ROOT_PATH "${CROSS_ROOTFS}")
+
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)


### PR DESCRIPTION
As part of repo consolidation, we want to move CoreCLR, CoreFX, and Core-Setup to use the eng/common/cross folder when possible. This PR updates the `eng/common/cross/toolchain.cmake` file to the current CoreCLR version. It has some changes needed to support Clang and GCC. It also uses newer CMake features to heavily simplify the implementation.

Related: https://github.com/dotnet/diagnostics/pull/597
