### PR TITLE
Add functionality to supply artifact patterns in execute-sdl.yml 

### DIFF
--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -19,7 +19,7 @@ jobs:
   steps:
   - checkout: self
     clean: true
-  - ${{ if ne(parameters.artifactPatterns, '') }}:
+  - ${{ if ne(parameters.artifactPatterns, []) }}:
     - ${{ each artifactPattern in parameters.artifactPatterns }}:
       - task: DownloadBuildArtifacts@0
         displayName: Download Build Artifacts
@@ -27,7 +27,7 @@ jobs:
           buildType: current
           itemPattern: ${{ coalesce(artifactPattern, '**') }}
           downloadPath: $(Build.ArtifactStagingDirectory)\artifacts
-  - ${{ if eq(parameters.artifactPatterns, '') }}:
+  - ${{ if eq(parameters.artifactPatterns, []) }}:
     - task: DownloadBuildArtifacts@0
       displayName: Download Build Artifacts
       inputs:

--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -6,6 +6,7 @@ parameters:
   # This can also be remedied by the caller (post-build.yml) if it does not use a nested parameter
   sdlContinueOnError: false                                    # optional: determines whether to continue the build if the step errors;
   dependsOn: ''                                                # Optional: dependencies of the job
+  artifactPatterns: []                                     # Optional: patterns supplied to DownloadBuildArtifacts
 
 jobs:
 - job: Run_SDL
@@ -18,13 +19,22 @@ jobs:
   steps:
   - checkout: self
     clean: true
-  - task: DownloadBuildArtifacts@0
-    displayName: Download Build Artifacts
-    inputs:
-      buildType: current
-      downloadType: specific files
-      matchingPattern: "**"
-      downloadPath: $(Build.ArtifactStagingDirectory)\artifacts
+  - ${{ if ne(parameters.artifactPatterns, '') }}:
+    - ${{ each artifactPattern in parameters.artifactPatterns }}:
+      - task: DownloadBuildArtifacts@0
+        displayName: Download Build Artifacts
+        inputs:
+          buildType: current
+          itemPattern: ${{ coalesce(artifactPattern, '**'') }}
+          downloadPath: $(Build.ArtifactStagingDirectory)\artifacts
+  - ${{ if eq (paramteters.artifactsPatterns, '') }}:
+    - task: DownloadBuildArtifacts@0
+        displayName: Download Build Artifacts
+        inputs:
+          buildType: current
+          downloadType: single item
+          itemPattern: "**"
+          downloadPath: $(Build.ArtifactStagingDirectory)\artifacts
   - powershell: eng/common/sdl/extract-artifact-packages.ps1
       -InputPath $(Build.ArtifactStagingDirectory)\artifacts\BlobArtifacts
       -ExtractPath $(Build.ArtifactStagingDirectory)\artifacts\BlobArtifacts

--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -29,12 +29,12 @@ jobs:
           downloadPath: $(Build.ArtifactStagingDirectory)\artifacts
   - ${{ if eq(paramteters.artifactPatterns, '') }}:
     - task: DownloadBuildArtifacts@0
-        displayName: Download Build Artifacts
-        inputs:
-          buildType: current
-          downloadType: single item
-          itemPattern: "**"
-          downloadPath: $(Build.ArtifactStagingDirectory)\artifacts
+      displayName: Download Build Artifacts
+      inputs:
+        buildType: current
+        downloadType: single item
+        itemPattern: "**"
+        downloadPath: $(Build.ArtifactStagingDirectory)\artifacts
   - powershell: eng/common/sdl/extract-artifact-packages.ps1
       -InputPath $(Build.ArtifactStagingDirectory)\artifacts\BlobArtifacts
       -ExtractPath $(Build.ArtifactStagingDirectory)\artifacts\BlobArtifacts

--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -27,7 +27,7 @@ jobs:
           buildType: current
           itemPattern: ${{ coalesce(artifactPattern, '**') }}
           downloadPath: $(Build.ArtifactStagingDirectory)\artifacts
-  - ${{ if eq (paramteters.artifactsPatterns, '') }}:
+  - ${{ if eq(paramteters.artifactPatterns, '') }}:
     - task: DownloadBuildArtifacts@0
         displayName: Download Build Artifacts
         inputs:

--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -6,7 +6,7 @@ parameters:
   # This can also be remedied by the caller (post-build.yml) if it does not use a nested parameter
   sdlContinueOnError: false                                    # optional: determines whether to continue the build if the step errors;
   dependsOn: ''                                                # Optional: dependencies of the job
-  artifactPatterns: []                                     # Optional: patterns supplied to DownloadBuildArtifacts
+  artifactPatterns: ''                                         # Optional: patterns supplied to DownloadBuildArtifacts
 
 jobs:
 - job: Run_SDL
@@ -19,7 +19,7 @@ jobs:
   steps:
   - checkout: self
     clean: true
-  - ${{ if ne(parameters.artifactPatterns, []) }}:
+  - ${{ if ne(parameters.artifactPatterns, '') }}:
     - ${{ each artifactPattern in parameters.artifactPatterns }}:
       - task: DownloadBuildArtifacts@0
         displayName: Download Build Artifacts
@@ -27,7 +27,7 @@ jobs:
           buildType: current
           itemPattern: ${{ coalesce(artifactPattern, '**') }}
           downloadPath: $(Build.ArtifactStagingDirectory)\artifacts
-  - ${{ if eq(parameters.artifactPatterns, []) }}:
+  - ${{ if eq(parameters.artifactPatterns, '') }}:
     - task: DownloadBuildArtifacts@0
       displayName: Download Build Artifacts
       inputs:

--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -6,7 +6,7 @@ parameters:
   # This can also be remedied by the caller (post-build.yml) if it does not use a nested parameter
   sdlContinueOnError: false                                    # optional: determines whether to continue the build if the step errors;
   dependsOn: ''                                                # Optional: dependencies of the job
-  artifactPatterns: ''                                         # Optional: patterns supplied to DownloadBuildArtifacts
+  artifactNames: ''                                         # Optional: patterns supplied to DownloadBuildArtifacts
 
 jobs:
 - job: Run_SDL
@@ -19,15 +19,15 @@ jobs:
   steps:
   - checkout: self
     clean: true
-  - ${{ if ne(parameters.artifactPatterns, '') }}:
-    - ${{ each artifactPattern in parameters.artifactPatterns }}:
+  - ${{ if ne(parameters.artifactNames, '') }}:
+    - ${{ each artifactName in parameters.artifactNames }}:
       - task: DownloadBuildArtifacts@0
         displayName: Download Build Artifacts
         inputs:
           buildType: current
-          itemPattern: ${{ coalesce(artifactPattern, '**') }}
+          artifactName: ${{ artifactName }}
           downloadPath: $(Build.ArtifactStagingDirectory)\artifacts
-  - ${{ if eq(parameters.artifactPatterns, '') }}:
+  - ${{ if eq(parameters.artifactNames, '') }}:
     - task: DownloadBuildArtifacts@0
       displayName: Download Build Artifacts
       inputs:

--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -6,7 +6,11 @@ parameters:
   # This can also be remedied by the caller (post-build.yml) if it does not use a nested parameter
   sdlContinueOnError: false                                    # optional: determines whether to continue the build if the step errors;
   dependsOn: ''                                                # Optional: dependencies of the job
-  artifactNames: ''                                         # Optional: patterns supplied to DownloadBuildArtifacts
+  artifactNames: ''                                            # Optional: patterns supplied to DownloadBuildArtifacts
+                                                               # Usage:
+                                                               #  artifactNames:
+                                                               #    - 'BlobArtifacts'
+                                                               #    - 'Artifacts_Windows_NT_Release'
 
 jobs:
 - job: Run_SDL
@@ -32,7 +36,7 @@ jobs:
       displayName: Download Build Artifacts
       inputs:
         buildType: current
-        downloadType: single item
+        downloadType: specific files
         itemPattern: "**"
         downloadPath: $(Build.ArtifactStagingDirectory)\artifacts
   - powershell: eng/common/sdl/extract-artifact-packages.ps1

--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -27,7 +27,7 @@ jobs:
           buildType: current
           itemPattern: ${{ coalesce(artifactPattern, '**') }}
           downloadPath: $(Build.ArtifactStagingDirectory)\artifacts
-  - ${{ if eq(paramteters.artifactPatterns, '') }}:
+  - ${{ if eq(parameters.artifactPatterns, '') }}:
     - task: DownloadBuildArtifacts@0
       displayName: Download Build Artifacts
       inputs:

--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -25,7 +25,7 @@ jobs:
         displayName: Download Build Artifacts
         inputs:
           buildType: current
-          itemPattern: ${{ coalesce(artifactPattern, '**'') }}
+          itemPattern: ${{ coalesce(artifactPattern, '**') }}
           downloadPath: $(Build.ArtifactStagingDirectory)\artifacts
   - ${{ if eq (paramteters.artifactsPatterns, '') }}:
     - task: DownloadBuildArtifacts@0

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -111,7 +111,7 @@ stages:
       parameters:
         additionalParameters: ${{ parameters.SDLValidationParameters.params }}
         continueOnError: ${{ parameters.SDLValidationParameters.continueOnError }}
-        artifactPatterns:
+        artifactNames:
           - 'BlobArtifacts'
           - 'Artifacts_Windows_NT_Release'
 

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -111,6 +111,9 @@ stages:
       parameters:
         additionalParameters: ${{ parameters.SDLValidationParameters.params }}
         continueOnError: ${{ parameters.SDLValidationParameters.continueOnError }}
+        artifactPatterns:
+          - 'BlobArtifacts'
+          - 'Artifacts_Windows_NT_Release'
 
 - template: \eng\common\templates\post-build\channels\netcore-dev-5.yml
   parameters:

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -111,9 +111,6 @@ stages:
       parameters:
         additionalParameters: ${{ parameters.SDLValidationParameters.params }}
         continueOnError: ${{ parameters.SDLValidationParameters.continueOnError }}
-        artifactNames:
-          - 'BlobArtifacts'
-          - 'Artifacts_Windows_NT_Release'
 
 - template: \eng\common\templates\post-build\channels\netcore-dev-5.yml
   parameters:

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -8,6 +8,7 @@ parameters:
     enable: false
     continueOnError: false
     params: ''
+    artifactNames: ''
 
   # These parameters let the user customize the call to sdk-task.ps1 for publishing
   # symbols & general artifacts as well as for signing validation
@@ -111,6 +112,7 @@ stages:
       parameters:
         additionalParameters: ${{ parameters.SDLValidationParameters.params }}
         continueOnError: ${{ parameters.SDLValidationParameters.continueOnError }}
+        artifactNames: ${{ paramters.SLDValidationParameters.artifactNames }}
 
 - template: \eng\common\templates\post-build\channels\netcore-dev-5.yml
   parameters:

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -112,7 +112,7 @@ stages:
       parameters:
         additionalParameters: ${{ parameters.SDLValidationParameters.params }}
         continueOnError: ${{ parameters.SDLValidationParameters.continueOnError }}
-        artifactNames: ${{ paramters.SLDValidationParameters.artifactNames }}
+        artifactNames: ${{ parameters.SDLValidationParameters.artifactNames }}
 
 - template: \eng\common\templates\post-build\channels\netcore-dev-5.yml
   parameters:


### PR DESCRIPTION
This change adds the functionality to execute-sdl.yml to allow the user to supply a list of artifact folders to download.

```
Usage:
- template: /eng/common/templates/job/execute-sdl.yml
      parameters:
        artifactNames: 
          - 'Folder1'
          - 'Folder2'
```
