### PR TITLE
Catch Build Errors in Insertion Manifests

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/AfterSigning.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/AfterSigning.proj
@@ -6,7 +6,10 @@
   <Target Name="Clean" />
   <Target Name="Build" />
   <Target Name="Test" />
-  <Target Name="Pack" />
+  <Target Name="Pack" >
+    <MSBuild Projects="VisualStudio.InsertionManifests.targets"
+             Targets="GenerateVisualStudioInsertionManifests" />
+  </Target>
   <Target Name="IntegrationTest" />
   <Target Name="PerformanceTest" />
 
@@ -18,7 +21,7 @@
     These need to be calculated using signed VSIXes.
     Hence we need to run this task after signing.
   -->
-  <Import Project="VisualStudio.InsertionManifests.targets" Condition="'$(UsingToolVSSDK)' == 'true' and '$(MSBuildRuntimeType)' != 'Core'" />
+  <Import Project="VisualStudio.InsertionManifests.targets"  Condition="'$(UsingToolVSSDK)' == 'true' and '$(MSBuildRuntimeType)' != 'Core'" />
 
   <!-- 
     Generate IBC training inputs for VS insertion components.

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/AfterSigning.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/AfterSigning.proj
@@ -21,7 +21,7 @@
     These need to be calculated using signed VSIXes.
     Hence we need to run this task after signing.
   -->
-  <Import Project="VisualStudio.InsertionManifests.targets"  Condition="'$(UsingToolVSSDK)' == 'true' and '$(MSBuildRuntimeType)' != 'Core'" />
+  <Import Project="VisualStudio.InsertionManifests.targets" Condition="'$(UsingToolVSSDK)' == 'true' and '$(MSBuildRuntimeType)' != 'Core'" />
 
   <!-- 
     Generate IBC training inputs for VS insertion components.

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.InsertionManifests.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.InsertionManifests.targets
@@ -10,7 +10,6 @@
     This is important since the manifest contain hashes of the VSIX files.
   -->
   <Target Name="GenerateVisualStudioInsertionManifests"
-          AfterTargets="Pack"
           Outputs="%(_StubDirs.Identity)"
           Condition="'@(_StubDirs)' != ''">
     <PropertyGroup>


### PR DESCRIPTION
Use of the AfterTargets parameter was causing errors in Insertion Manifests to not trigger a build failure like they should.