### PR TITLE
Using azure key vault more efficiently and safely

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,6 +17,7 @@
     <SystemNetHttpVersion>4.3.3</SystemNetHttpVersion>
     <MicrosoftAzureStorageBlobVersion>10.0.2</MicrosoftAzureStorageBlobVersion>
     <MicrosoftAzureKeyVaultVersion>3.0.0</MicrosoftAzureKeyVaultVersion>
+    <MicrosoftAzureServicesAppAuthenticationVersion>1.3.1</MicrosoftAzureServicesAppAuthenticationVersion>
     <MicrosoftBuildVersion>15.7.179</MicrosoftBuildVersion>
     <MicrosoftBuildFrameworkVersion>15.7.179</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildTasksCoreVersion>15.7.179</MicrosoftBuildTasksCoreVersion>

--- a/src/Microsoft.DotNet.Github.IssueLabeler/Microsoft.DotNet.Github.IssueLabeler.csproj
+++ b/src/Microsoft.DotNet.Github.IssueLabeler/Microsoft.DotNet.Github.IssueLabeler.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="$(CommandLineParserVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="$(MicrosoftAspNetCoreAllVersion)" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="$(MicrosoftAzureServicesAppAuthenticationVersion)" />
     <PackageReference Include="Microsoft.ML" Version="$(MicrosoftMLVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="$(MicrosoftVisualStudioWebCodeGenerationDesignVersion)" />
     <PackageReference Include="Octokit" Version="$(OctokitVersion)" />

--- a/src/Microsoft.DotNet.Github.IssueLabeler/Models/Labeler.cs
+++ b/src/Microsoft.DotNet.Github.IssueLabeler/Models/Labeler.cs
@@ -4,8 +4,8 @@
 
 using Microsoft.Azure.KeyVault;
 using Microsoft.Azure.KeyVault.Models;
+using Microsoft.Azure.Services.AppAuthentication;
 using Microsoft.Extensions.Logging;
-using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Octokit;
 using System;
 using System.Collections.Generic;
@@ -20,36 +20,21 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
         private readonly string _repoOwner;
         private readonly string _repoName;
         private readonly double _threshold;
-        private readonly string _clientId;
-        private readonly string _clientSecret;
         private readonly string _secretUri;
 
-        public Labeler(string repoOwner, string repoName, string clientId, string clientSecret, string secretUri, double threshold)
+        public Labeler(string repoOwner, string repoName, string secretUri, double threshold)
         {
             _repoOwner = repoOwner;
             _repoName = repoName;
             _threshold = threshold;
-            _clientId = clientId;
-            _clientSecret = clientSecret;
             _secretUri = secretUri;
         }
 
         private async Task GitSetupAsync()
         {
-            var kvc = new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(
-                async (authority, resource, scope) =>
-                {
-                    var authContext = new AuthenticationContext(authority);
-                    var clientCred = new ClientCredential(_clientId, _clientSecret);
-                    var result = await authContext.AcquireTokenAsync(resource, clientCred);
-
-                    if (result == null)
-                        throw new InvalidOperationException("Failed to obtain the github token");
-
-                    return result.AccessToken;
-                }));
-
-            SecretBundle secretBundle = await kvc.GetSecretAsync(_secretUri);
+            AzureServiceTokenProvider azureServiceTokenProvider = new AzureServiceTokenProvider();
+            KeyVaultClient keyVaultClient = new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(azureServiceTokenProvider.KeyVaultTokenCallback));
+            SecretBundle secretBundle = await keyVaultClient.GetSecretAsync(_secretUri).ConfigureAwait(false);
 
             var productInformation = new ProductHeaderValue("MLGitHubLabeler");
             _client = new GitHubClient(productInformation)

--- a/src/Microsoft.DotNet.Github.IssueLabeler/Startup.cs
+++ b/src/Microsoft.DotNet.Github.IssueLabeler/Startup.cs
@@ -25,8 +25,6 @@ namespace Microsoft.DotNet.GitHub.IssueLabeler
                 new Labeler(
                     Configuration["GitHubRepoOwner"],
                     Configuration["GitHubRepoName"],
-                    Configuration["ClientId"],
-                    Configuration["ClientSecret"],
                     Configuration["SecretUri"],
                     double.Parse(Configuration["Threshold"])));
         }

--- a/src/Microsoft.DotNet.Github.IssueLabeler/appsettings.json
+++ b/src/Microsoft.DotNet.Github.IssueLabeler/appsettings.json
@@ -2,8 +2,6 @@
   "GitHubRepoOwner": "dotnet",
   "GitHubRepoName": "corefx",
   "Threshold": "0.4",
-  "ClientId": "",
-  "ClientSecret": "",
   "SecretUri": "",
   "Logging": {
     "IncludeScopes": false,


### PR DESCRIPTION
Accessing key vault directly from the labeler and not through sprecifying the app id and and secret.
This is done through giving appropiate permisions to the labeler to read the secret.