### PR TITLE
Remove copy of non-PDBs to SymStore directory

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SymStore.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SymStore.targets
@@ -87,21 +87,4 @@
       <FileWrites Include="$(_SymStorePdbPath)"/>
     </ItemGroup>
   </Target>
-
-  <Target Name="_DeployAssembliesToSymStore"
-          AfterTargets="_InnerDeployToSymStore"
-          Condition="'$(PublishWindowsPdb)' == 'true' and '$(UsingToolSymbolUploader)' != 'true'"
-          Inputs="$(TargetPath)"
-          Outputs="$(_SymStoreAssemblyPath)">
-
-    <MakeDir Directories="$(_SymStoreOutputDir)"/>
-   
-    <Copy SourceFiles="$(TargetPath)"
-          DestinationFiles="$(_SymStoreAssemblyPath)"
-          UseHardlinksIfPossible="true"/>
-
-    <ItemGroup>
-      <FileWrites Include="$(_SymStoreAssemblyPath)"/>
-    </ItemGroup>
-  </Target>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SymStore.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SymStore.targets
@@ -26,7 +26,6 @@
 
       <_SymStoreOutputDir>$(ArtifactsSymStoreDirectory)$(MSBuildProjectName)\$(TargetFramework)\</_SymStoreOutputDir>
       <_SymStorePdbPath>$(_SymStoreOutputDir)$(TargetName).pdb</_SymStorePdbPath>
-      <_SymStoreAssemblyPath>$(_SymStoreOutputDir)$(TargetName)$(TargetExt)</_SymStoreAssemblyPath>
 
       <!-- By default publish Windows PDBs only for shipping components -->
       <PublishWindowsPdb Condition="'$(PublishWindowsPdb)' == '' and '$(IsShippingAssembly)' == 'true' and Exists('$(TargetPath)') and ('$(DebugType)' == 'embedded' or Exists('$(_TargetPdbPath)'))">true</PublishWindowsPdb>


### PR DESCRIPTION
Closes: #4295

As @tmat [explained here](https://github.com/dotnet/arcade/pull/4284#issuecomment-550134655), we don't need this feature anymore. I've tested an SDK created after this change, in an Arcade build, and everything was still working fine.