### PR TITLE
Support ProjectServicingConfiguration build skips in sharedfx tooling

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.packaging.targets
@@ -35,6 +35,17 @@
     </PropertyGroup>
   </Target>
 
+  <Target Name="SkipBuildInstallerProperties"
+          DependsOnTargets="GetSkipBuildProps"
+          BeforeTargets="GetInstallerGenerationFlags">
+    <PropertyGroup Condition="'$(SkipBuild)' == 'true'">
+      <GenerateDeb>false</GenerateDeb>
+      <GenerateRpm>false</GenerateRpm>
+      <GeneratePkg>false</GeneratePkg>
+      <GenerateMSI>false</GenerateMSI>
+    </PropertyGroup>
+  </Target>
+
   <!--
     This targets file is imported for all pkgproj files, but some (like DotNetHostPolicy) don't need
     installers and just use the normal packaging tooling.

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/packaging-tools.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/packaging-tools.targets
@@ -115,7 +115,54 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="GetSkipBuildProps">
+  <Target Name="GetCurrentProjectServicingConfiguration">
+    <ItemGroup>
+      <CurrentProjectServicingConfiguration
+        Include="@(ProjectServicingConfiguration)"
+        Condition="'%(Identity)' == '$(MSBuildProjectName)'" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    The Microsoft build's per-package servicing policy conflicts with the source-build restrictions.
+    Targeting packs, for example, are only built/published when there's a known change to release.
+    This is in contrast to runtime packs and the shared framework, which are always built and
+    published. This means it's common in the Microsoft build for downstream repos to depend on two
+    builds' outputs: the current build's runtime assets, and some old build's targeting pack.
+
+    The Microsoft build can simply download the old targeting pack from NuGet.org. Source-build
+    can't do this because the bits on NuGet.org are not built locally. Instead, source-build assumes
+    it's possible to use current sources to build a package with the old version. This target
+    applies the old build's patch version to make that happen.
+
+    This solution has pitfalls. More info at https://github.com/dotnet/core-setup/issues/8735. The
+    target supports SkipSetLastReleasedVersionForSourceBuild (unused as of writing) to allow
+    disabling this workaround if a better way forward is implemented.
+  -->
+  <Target Name="SetLastReleasedVersionForSourceBuild"
+          Condition="
+            '$(DotNetBuildFromSource)' == 'true' and
+            '$(SkipSetLastReleasedVersionForSourceBuild)' != 'true'"
+          BeforeTargets="GetProductVersions"
+          DependsOnTargets="GetCurrentProjectServicingConfiguration">
+    <PropertyGroup>
+      <MostRecentProducedServicingPatchVersion>%(CurrentProjectServicingConfiguration.PatchVersion)</MostRecentProducedServicingPatchVersion>
+      <PatchVersion Condition="'$(MostRecentProducedServicingPatchVersion)' != ''">$(MostRecentProducedServicingPatchVersion)</PatchVersion>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="GetSkipBuildProps"
+          DependsOnTargets="
+            GetCurrentProjectServicingConfiguration;
+            GetProductVersions">
+    <!--
+      Skip the build if there is an applicable servicing configuration, and the servicing
+      configuration indicates this project shouldn't build for this patch version.
+    -->
+    <PropertyGroup Condition="'@(CurrentProjectServicingConfiguration)' != ''">
+      <SkipBuild Condition="'%(CurrentProjectServicingConfiguration.PatchVersion)' != '$(PatchVersion)'">true</SkipBuild>
+    </PropertyGroup>
+
     <PropertyGroup>
       <!-- Avoid building a project when none of the possible BuildRIDs is the current RID. -->
       <_packageRIDInBuildRIDList Condition="'%(BuildRID.Identity)' == '$(PackageRID)'">true</_packageRIDInBuildRIDList>


### PR DESCRIPTION
Support configuring which projects build for a certain release via `ProjectServicingConfiguration` items in `eng/Versions.props`:

```xml
  <!--
    Servicing build settings.
    * To enable a package build for the current patch release, set PatchVersion to match the current
      patch version of that package. (major.minor.patch)
    * Do not delete these lines to disable the package build. When PatchVersion is incremented at
      the beginning of the next servicing release, the package automatically stops building because
      the version no longer matches.
    * These items also keep track of the last time each package was patched, enabling source-build
      to produce the correct old version number using current sources.
  -->
  <ItemGroup Condition="'$(StabilizePackageVersion)' == 'true'">
    <ProjectServicingConfiguration Include="Microsoft.NETCore.App.Ref" PatchVersion="0" />
    <ProjectServicingConfiguration Include="NETStandard.Library.Ref" PatchVersion="0" />
  </ItemGroup>
```

Full context of the repo-side config: https://github.com/dotnet/core-setup/compare/master...dagood:servicing-skips

This adds support for https://github.com/dotnet/core-setup/issues/8735 and https://github.com/dotnet/core-setup/issues/8507 to the shared tooling.

Behavior (did a few stabilized local builds with the values tweaked):

NETCoreApp Runtime | NETCoreApp Ref | NETStandard Ref
-- | -- | --
5.0.0 | 5.0.0 | N/A
5.0.1 | N/A | N/A
5.0.0 (source-build) | 5.0.0 | 2.1.0
5.0.1 (source-build) | 5.0.0 | 2.1.0

I ported the changes to Core-Setup `release/3.0`, and the results are the same there (and they include WindowsDesktop with the same pattern as NETCoreApp).

/cc @nguerrera @mmitche @Anipik 