### PR TITLE
YAML fixes to unblock Arcade builds

### DIFF
--- a/eng/common/templates/post-build/channels/netcore-3-eng.yml
+++ b/eng/common/templates/post-build/channels/netcore-3-eng.yml
@@ -147,7 +147,7 @@ stages:
       - template: ../../steps/publish-logs.yml
         parameters:
           StageLabel: 'Channel_Net_3_Tools'
-          JobLabel: 'SymbolPublishing'
+          JobLabel: 'AssetPublishing'
 
       - template: ../../steps/promote-build.yml
         parameters:

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -81,10 +81,10 @@ stages:
               /p:SignCheckExclusionsFile='$(Build.SourcesDirectory)/eng/SignCheckExclusionsFile.txt'
               ${{ parameters.signingValidationAdditionalParameters }}
 
-      - template: ../../steps/publish-logs.yml
-        parameters:
-          StageLabel: 'Validation'
-          JobLabel: 'Signing'
+        - template: ../steps/publish-logs.yml
+          parameters:
+            StageLabel: 'Validation'
+            JobLabel: 'Signing'
 
   - ${{ if eq(parameters.enableSourceLinkValidation, 'true') }}:
     - job:


### PR DESCRIPTION
Fixes `JobLabel` typo reported by @dougbu 
Fixes correct indentation for including publish-logs.yml in post-build.yml ; This broke Arcade official build. 