### PR TITLE
Fix Publish.proj PDB publishing

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -130,6 +130,9 @@
       <AzureDevOpsAccount Condition="$(CollectionUri.IndexOf('visualstudio.com')) >= 0">$(CollectionUri.Split('.')[0].Split('/')[2])</AzureDevOpsAccount>
 
       <TempWorkingDirectory>$(ArtifactsDir)\..\AssetsTmpDir\$([System.Guid]::NewGuid())</TempWorkingDirectory>
+      
+      <!-- Directory where pdbs pointed in `FilesToPublishToSymbolServer` are copied before publishing to AzDO artifacts. -->
+      <PDBsToPublishTempLocation>$(ArtifactsTmpDir)PDBsToPublish/</PDBsToPublishTempLocation>
     </PropertyGroup>
 
     <!--
@@ -227,11 +230,11 @@
     -->
 		<Copy
 			SourceFiles="@(FilesToPublishToSymbolServer)"
-			DestinationFiles="@(FilesToPublishToSymbolServer->'$(ArtifactsTmpDir)PDBsToPublish/%(RecursiveDir)%(Filename)%(Extension)')"
+			DestinationFiles="@(FilesToPublishToSymbolServer->'$(PDBsToPublishTempLocation)%(RecursiveDir)%(Filename)%(Extension)')"
 		/>
 
     <Message
-      Text="##vso[artifact.upload containerfolder=PdbArtifacts;artifactname=PdbArtifacts]$(ArtifactsTmpDir)PDBsToPublish/"
+      Text="##vso[artifact.upload containerfolder=PdbArtifacts;artifactname=PdbArtifacts]$(PDBsToPublishTempLocation)"
       Importance="high" 
       Condition="'@(FilesToPublishToSymbolServer)' != ''"/>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -206,19 +206,32 @@
     <!-- 
         Publish Windows PDBs produced by SymStore.targets (by default, only shipping PDBs are placed there).
         SymbolUploader doesn't support embedded PDBs yet, so let SymStore.targets do the conversion for now.
-        https://github.com/dotnet/core-eng/issues/3645
+        https://github.com/dotnet/symstore/issues/143
       -->
     <ItemGroup>
       <FilesToPublishToSymbolServer Include="$(ArtifactsSymStoreDirectory)**\*.pdb"/>
     </ItemGroup>
 
     <!--
-       Publishes the whole folder of symbols as an artifact container. Unfortunately,
-       AzDO logging commands don't let us add subfolders by executing different `##vso` commands:
-       https://github.com/microsoft/azure-pipelines-tasks/issues/11689
+      The below lines comprise workarounds for two issues:
+        - AzDO logging commands don't let us add subfolders by executing different `##vso` commands:
+          https://github.com/microsoft/azure-pipelines-tasks/issues/11689 . Therefore a parent folder
+          containing all desired subfolders is published. The primary goal of these artifacts isn't
+          to be browsable by humans. The target that publish the symbols will filter and publish only
+          the PDB files.
+
+        - It's possible that the user have PDBs outside the Arcade.SDK standard folder 
+           (artifacts/SymStore/$Configuration) and we need to maintain that support. For that reason,
+           and the one mentioned above, we copy all files in `FilesToPublishToSymbolServer` to a temporary
+           folder before adding them to the AzDO artifact container.
     -->
+		<Copy
+			SourceFiles="@(FilesToPublishToSymbolServer)"
+			DestinationFiles="@(FilesToPublishToSymbolServer->'$(ArtifactsTmpDir)PDBsToPublish/%(RecursiveDir)%(Filename)%(Extension)')"
+		/>
+
     <Message
-      Text="##vso[artifact.upload containerfolder=PdbArtifacts;artifactname=PdbArtifacts]$(ArtifactsSymStoreDirectory)"
+      Text="##vso[artifact.upload containerfolder=PdbArtifacts;artifactname=PdbArtifacts]$(ArtifactsTmpDir)PDBsToPublish/"
       Importance="high" 
       Condition="'@(FilesToPublishToSymbolServer)' != ''"/>
 


### PR DESCRIPTION
Relates to: #4324

Included fixes:

- Maintain PDB directory structure to prevent overriding files in the AzDO conatiner.
- Keep publishing PDBs that are outside the default Arcade folder.
- Don't fail if the default path to PDBs doesn't exist.

Tested in these builds:

- https://dnceng.visualstudio.com/internal/_build/results?buildId=424789&view=results
- https://dnceng.visualstudio.com/internal/_build/results?buildId=424826&view=results
- https://dnceng.visualstudio.com/internal/_build/results?buildId=424827&view=results