### PR TITLE
Use newer SleetLib version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -41,7 +41,7 @@
     <NuGetVersioningVersion>4.4.0</NuGetVersioningVersion>
     <NuGetVersion>5.3.0</NuGetVersion>
     <OctokitVersion>0.32.0</OctokitVersion>
-    <DotNetSleetLibVersion>2.2.139</DotNetSleetLibVersion>
+    <DotNetSleetLibVersion>2.2.143</DotNetSleetLibVersion>
     <SwashbuckleAspNetCoreSwaggerVersion>3.0.0</SwashbuckleAspNetCoreSwaggerVersion>
     <SystemBuffersVersion>4.5.0</SystemBuffersVersion>
     <SystemCollectionsImmutableVersion>1.3.1</SystemCollectionsImmutableVersion>


### PR DESCRIPTION
Relates to: https://github.com/dotnet/core-eng/issues/7551

Use newer version of SleetLib. This new version compares the content of the files in cases when we are attempting to publish a package that is already on the feed. If the contents are different the operation fails.