### PR TITLE
Patch publish-logs.yml to always publish logs

### DIFF
--- a/eng/common/templates/steps/publish-logs.yml
+++ b/eng/common/templates/steps/publish-logs.yml
@@ -10,7 +10,9 @@ steps:
     script: |
       New-Item -ItemType Directory $(Build.SourcesDirectory)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
       Move-Item -Path $(Build.SourcesDirectory)/artifacts/log/Debug/* $(Build.SourcesDirectory)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
-
+  continueOnError: true
+  condition: always()
+  
 - task: PublishBuildArtifacts@1
   displayName: Publish Logs
   inputs:


### PR DESCRIPTION
Missed these conditions in the original PR.

Sample build where the logs where not uploaded: https://dnceng.visualstudio.com/internal/_build/results?buildId=426461&view=results