### PR TITLE
Add functionality to supply artifact patterns in execute-sdl.yml (#4306)

### DIFF
--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -6,6 +6,11 @@ parameters:
   # This can also be remedied by the caller (post-build.yml) if it does not use a nested parameter
   sdlContinueOnError: false                                    # optional: determines whether to continue the build if the step errors;
   dependsOn: ''                                                # Optional: dependencies of the job
+  artifactNames: ''                                            # Optional: patterns supplied to DownloadBuildArtifacts
+                                                               # Usage:
+                                                               #  artifactNames:
+                                                               #    - 'BlobArtifacts'
+                                                               #    - 'Artifacts_Windows_NT_Release'
 
 jobs:
 - job: Run_SDL
@@ -18,13 +23,22 @@ jobs:
   steps:
   - checkout: self
     clean: true
-  - task: DownloadBuildArtifacts@0
-    displayName: Download Build Artifacts
-    inputs:
-      buildType: current
-      downloadType: specific files
-      matchingPattern: "**"
-      downloadPath: $(Build.SourcesDirectory)\artifacts
+  - ${{ if ne(parameters.artifactNames, '') }}:
+    - ${{ each artifactName in parameters.artifactNames }}:
+      - task: DownloadBuildArtifacts@0
+        displayName: Download Build Artifacts
+        inputs:
+          buildType: current
+          artifactName: ${{ artifactName }}
+          downloadPath: $(Build.ArtifactStagingDirectory)\artifacts
+  - ${{ if eq(parameters.artifactNames, '') }}:
+    - task: DownloadBuildArtifacts@0
+      displayName: Download Build Artifacts
+      inputs:
+        buildType: current
+        downloadType: specific files
+        itemPattern: "**"
+        downloadPath: $(Build.ArtifactStagingDirectory)\artifacts
   - powershell: eng/common/sdl/extract-artifact-packages.ps1
       -InputPath $(Build.SourcesDirectory)\artifacts\BlobArtifacts
       -ExtractPath $(Build.SourcesDirectory)\artifacts\BlobArtifacts

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -8,6 +8,7 @@ parameters:
     enable: false
     continueOnError: false
     params: ''
+    artifactNames: ''
 
   # These parameters let the user customize the call to sdk-task.ps1 for publishing
   # symbols & general artifacts as well as for signing validation
@@ -94,6 +95,7 @@ stages:
       parameters:
         additionalParameters: ${{ parameters.SDLValidationParameters.params }}
         continueOnError: ${{ parameters.SDLValidationParameters.continueOnError }}
+        artifactNames: ${{ parameters.SDLValidationParameters.artifactNames }}
 
 - template: \eng\common\templates\post-build\channels\netcore-dev-5.yml
   parameters:


### PR DESCRIPTION
Some repos upload a large number of artifacts that are not needed for sdl validation. This change allows users to specify various patterns for artifacts to download. If none are supplied, we default to downloading all artifacts.

This change adds the functionality to execute-sdl.yml to allow the user to supply a list of artifact folders to download.

Usage:
- template: /eng/common/templates/job/execute-sdl.yml
      parameters:
        artifactNames:
          - 'Folder1'
          - 'Folder2'