### PR TITLE
Enable projects to be optionally built sequentially in addition to restored sequentially.

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -46,6 +46,7 @@
   <ItemDefinitionGroup>
     <ProjectToBuild>
       <RestoreInParallel>true</RestoreInParallel>
+      <BuildInParallel>true</BuildInParallel>
     </ProjectToBuild>
   </ItemDefinitionGroup>
 
@@ -229,7 +230,7 @@
              Properties="@(_SolutionBuildProps);__BuildPhase=SolutionBuild;_NETCORE_ENGINEERING_TELEMETRY=Build"
              RemoveProperties="$(_RemoveProps)"
              Targets="@(_SolutionBuildTargets)"
-             BuildInParallel="true"
+             BuildInParallel="%(ProjectToBuild.BuildInParallel)"
              Condition="'@(_SolutionBuildTargets)' != ''" />
 
     <MSBuild Projects="AfterSolutionBuild.proj"


### PR DESCRIPTION
For the consolidated runtime repository, we want to be able to build some projects sequentially (for example CoreCLR and the libraries build) since the process/thread contention will slow down our builds.

I've designed this to be opt-in similar to the design of the `RestoreInParallel` feature.