### PR TITLE
Add missing variable groups for servicing channels

### DIFF
--- a/eng/common/templates/post-build/common-variables.yml
+++ b/eng/common/templates/post-build/common-variables.yml
@@ -1,7 +1,9 @@
 variables:
-  - group: Publish-Build-Assets
+  - group: AzureDevOps-Artifact-Feeds-Pats
+  - group: DotNet-Blob-Feed
   - group: DotNet-DotNetCli-Storage
   - group: DotNet-MSRC-Storage
+  - group: Publish-Build-Assets
 
   # .NET Core 3.1 Dev
   - name: PublicDevRelease_31_Channel_Id
@@ -44,7 +46,7 @@ variables:
     value: 529
 
   # .NET Core 3.1 Blazor Features
-  - name: NetCore_31_Blazor_Features
+  - name: NetCore_31_Blazor_Features_Channel_Id
     value: 531
 
   # Whether the build is internal or not


### PR DESCRIPTION
## Description

Add missing variable groups for servicing channel

## Customer Impact

Need to manually add these variable groups to build pipelines

## Regression

No

## Risk

Very low

## Workarounds

Add variable groups to each build pipeline in servicing build.