### PR TITLE
Replace CoreCompile target with Build

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SymStore.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SymStore.targets
@@ -19,7 +19,7 @@
     </MSBuild>
   </Target>
 
-  <Target Name="_InnerDeployToSymStore" DependsOnTargets="CoreCompile;_InnerDeployToSymStoreSetProperties;_DeployPortableSymbolsToSymStore;_DeployWindowsSymbolsToSymStore" />
+  <Target Name="_InnerDeployToSymStore" DependsOnTargets="Build;_InnerDeployToSymStoreSetProperties;_DeployPortableSymbolsToSymStore;_DeployWindowsSymbolsToSymStore" />
     
   <Target Name="_InnerDeployToSymStoreSetProperties">
     <PropertyGroup>


### PR DESCRIPTION
CoreCompile is not available in native projects.