### PR TITLE
Add code to handle enums with default value but no value with zero explicitly defined

### DIFF
--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Enums.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Enums.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Cci.Writers.CSharp
                     }
 
                     // we found a valid combination of flags
-                    if (value == satisfiedValue)
+                    if (value == satisfiedValue && candidateFlagFields.Count > 0)
                     {
                         for (int i = 0; i < candidateFlagFields.Count; i++)
                         {
@@ -116,7 +116,7 @@ namespace Microsoft.Cci.Writers.CSharp
                 }
             }
 
-            if (constant.Value == null)
+            if (constant.Value == null || ToULongUnchecked(constant.Value) == 0) // default(T) on an enum is 0
             {
                 if (enumType.IsValueType)
                 {


### PR DESCRIPTION
This PR is blocked: https://github.com/dotnet/runtime/pull/112

There is a new method in the ref file whose last parameter is an optional enum:

```cs
    public static class NamedPipeServerStreamAcl
    {
        public static System.IO.Pipes.NamedPipeServerStream Create(
          ...
           System.IO.Pipes.PipeAccessRights additionalAccessRights = default) { throw null; }
    }
```

Credit to @safern for helping debug this and finding the code that needed the fix.