### PR TITLE
[release/3.x] Update dotnet sdk to 3.0.101

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.100"
+    "dotnet": "3.0.101"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19459.10",


### PR DESCRIPTION
## Description

Update the sdk to 3.0.101

## Customer Impact

Nuget issues will make internal builds more difficult

## Regression

No

## Risk

Low-ish. The 3.0.100 sdk has flowed everywhere, and this is a relatively small delta on top of that.

## Workarounds

None