### PR TITLE
Add missing constructor to SkipOnCoreclrAttribute

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnCoreClrAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnCoreClrAttribute.cs
@@ -11,6 +11,7 @@ namespace Xunit
 
         public SkipOnCoreClrAttribute(string reason, TestPlatforms testPlatforms) { }
         public SkipOnCoreClrAttribute(string reason, RuntimeStressTestModes testMode) { }
+        public SkipOnCoreClrAttribute(string reason, TestPlatforms testPlatforms, RuntimeStressTestModes testMode) { }
         public SkipOnCoreClrAttribute(string reason) { }
     }
 }


### PR DESCRIPTION
Somehow in my previous PR I missed to push a local commit that added this constructor. When using my local package it of course worked but now that I moved to the arcade package it failed.

cc: @ViktorHofer 