### PR TITLE
Specify the exact overload of string.Split to use

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -247,7 +247,7 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
     if ($msbuildCmd -ne $null) {
       # Workaround for https://github.com/dotnet/roslyn/issues/35793
       # Due to this issue $msbuildCmd.Version returns 0.0.0.0 for msbuild.exe 16.2+
-      $msbuildVersion = [Version]::new((Get-Item $msbuildCmd.Path).VersionInfo.ProductVersion.Split(@('-', '+'))[0])
+      $msbuildVersion = [Version]::new((Get-Item $msbuildCmd.Path).VersionInfo.ProductVersion.Split([char[]]@('-', '+'))[0])
 
       if ($msbuildVersion -ge $vsMinVersion) {
         return $global:_MSBuildExe = $msbuildCmd.Path


### PR DESCRIPTION
Running `build.ps1` using Powershell Core + vs toolset results in a build error:

```
(NETCORE_ENGINEERING_TELEMETRY=InitializeToolset) Exception calling ".ctor" with "1" argument(s): "Input string was not in a correct format."
```

Turns out this is a result of additional string overloads added to .NET Core: https://github.com/PowerShell/PowerShell/issues/7585#issuecomment-414805616. Specifying an exact overload helps.