### PR TITLE
Disable PInvokeUWPAnalyzer by default

### DIFF
--- a/src/Microsoft.DotNet.CodeAnalysis/build/Microsoft.DotNet.CodeAnalysis.targets
+++ b/src/Microsoft.DotNet.CodeAnalysis/build/Microsoft.DotNet.CodeAnalysis.targets
@@ -3,7 +3,7 @@
 
   <!-- PInvokeChecker data files-->
   <PropertyGroup Condition="'$(OSGroup)'=='Windows_NT'">
-    <EnablePinvokeUWPAnalyzer Condition="'$(EnablePinvokeUWPAnalyzer)' == ''">true</EnablePinvokeUWPAnalyzer>
+    <!-- Opt-in feature -->
     <UseUWPPinvokeAnalyzer Condition="'$(UWPCompatible)'=='true' AND '$(EnablePinvokeUWPAnalyzer)' == 'true'">true</UseUWPPinvokeAnalyzer>
 
     <!-- Just validate for OneCore: default -->


### PR DESCRIPTION
Spoke with @ericstj about this some time ago. He agrees that we should flip this.