### PR TITLE
Fix Clean action build.ps1

### DIFF
--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -112,17 +112,18 @@ function Build {
     @properties
 }
 
-if ($clean) {
-  if(Test-Path $ArtifactsDir) {
-    Remove-Item -Recurse -Force $ArtifactsDir
-    Write-Host 'Artifacts directory deleted.'
-  }
-  exit 0
-}
-
 try {
   . $PSScriptRoot\tools.ps1
-  If ((Test-Path variable:LastExitCode) -And ($LastExitCode -ne 0)) {
+  
+  if ($clean) {
+    if (Test-Path $ArtifactsDir) {
+      Remove-Item -Recurse -Force $ArtifactsDir
+      Write-Host 'Artifacts directory deleted.'
+    }
+    exit 0
+  }
+  
+  if ((Test-Path variable:LastExitCode) -And ($LastExitCode -ne 0)) {
     Write-PipelineTelemetryError -Category 'InitializeToolset' -Message 'Eng/common/tools.ps1 returned a non-zero exit code.'
     ExitWithExitCode $LastExitCode
   }


### PR DESCRIPTION
The clean action broke with https://github.com/dotnet/arcade/commit/a68b528ad1d0305f55c4fbdc977ebb0c02cfcc19 as it relies on `ArtifactsDir` which is defined in `tools.ps1` which is now imported too late.

cc @chcosta 