### PR TITLE
Testing Granular Pack Stages to Avoid Use of AfterTargets.

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/AfterSigning.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/AfterSigning.proj
@@ -4,9 +4,33 @@
 
   <Target Name="Rebuild" DependsOnTargets="Clean;Build" />
   <Target Name="Clean" />
-  <Target Name="Build" />
+
+  <PropertyGroup>
+    <BuildDependsOn>
+      BeforeBuild;
+      CoreBuild;
+      AfterBuild
+    </BuildDependsOn>
+  </PropertyGroup>
+  <Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
+  <Target Name="BeforeBuild"/>
+  <Target Name="CoreBuild"/>
+  <Target Name="AfterBuild"/>
+  
   <Target Name="Test" />
-  <Target Name="Pack" />
+  
+  <PropertyGroup>
+    <PackDependsOn>
+      BeforePack;
+      CorePack;
+      AfterPack
+    </PackDependsOn>
+  </PropertyGroup>
+  <Target Name="Pack" DependsOnTargets="$(PackDependsOn)" />
+  <Target Name="BeforePack"/>
+  <Target Name="CorePack"/>
+  <Target Name="AfterPack"/>
+  
   <Target Name="IntegrationTest" />
   <Target Name="PerformanceTest" />
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.BuildIbcTrainingInputs.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.BuildIbcTrainingInputs.targets
@@ -14,7 +14,7 @@
   <UsingTask TaskName="Microsoft.DotNet.Build.Tasks.VisualStudio.GenerateTrainingInputFiles" AssemblyFile="$(_VisualStudioBuildTasksAssembly)" />
   <UsingTask TaskName="Microsoft.DotNet.Build.Tasks.VisualStudio.GenerateTrainingPropsFile" AssemblyFile="$(_VisualStudioBuildTasksAssembly)" />
 
-  <Target Name="_BuildTrainingInputs" AfterTargets="Build">
+  <Target Name="_BuildTrainingInputs" BeforeTargets="AfterBuild">
     <Error Condition="('$(VisualStudioDropName)' == '' or '$(RepositoryName)' == '') and '$(OfficialBuild)' == 'true'"
            Text="Properties VisualStudioDropName and RepositoryName must be specified in official build that produces Visual Studio insertion components." />
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.InsertionManifests.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.InsertionManifests.targets
@@ -10,7 +10,7 @@
     This is important since the manifest contain hashes of the VSIX files.
   -->
   <Target Name="GenerateVisualStudioInsertionManifests"
-          AfterTargets="Pack"
+          BeforeTargets="AfterPack"
           Outputs="%(_StubDirs.Identity)"
           Condition="'@(_StubDirs)' != ''">
     <PropertyGroup>


### PR DESCRIPTION
Implemented granular build and pack stages to avoid need for AfterTargets usage.  This approach aims to catch build errors in AfterSigning targets without causing issues like in https://github.com/dotnet/arcade/issues/4391.