### PR TITLE
[release/3.x] Add support for downloading the Runtime from a private location (#4122)

### DIFF
--- a/eng/common/dotnet-install.ps1
+++ b/eng/common/dotnet-install.ps1
@@ -3,7 +3,9 @@ Param(
   [string] $verbosity = "minimal",
   [string] $architecture = "",
   [string] $version = "Latest",
-  [string] $runtime = "dotnet"
+  [string] $runtime = "dotnet",
+  [string] $RuntimeSourceFeed = "",
+  [string] $RuntimeSourceFeedKey = ""
 )
 
 . $PSScriptRoot\tools.ps1
@@ -15,7 +17,7 @@ try {
     if ($architecture -and $architecture.Trim() -eq "x86") {
         $installdir = Join-Path $installdir "x86"
     }
-   InstallDotNet $installdir $version $architecture $runtime $true
+   InstallDotNet $installdir $version $architecture $runtime $true -RuntimeSourceFeed $RuntimeSourceFeed -RuntimeSourceFeedKey $RuntimeSourceFeedKey
 } 
 catch {
   Write-Host $_

--- a/eng/common/dotnet-install.sh
+++ b/eng/common/dotnet-install.sh
@@ -14,6 +14,8 @@ scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 version='Latest'
 architecture=''
 runtime='dotnet'
+runtimeSourceFeed=''
+runtimeSourceFeedKey=''
 while [[ $# > 0 ]]; do
   opt="$(echo "$1" | awk '{print tolower($0)}')"
   case "$opt" in
@@ -29,9 +31,16 @@ while [[ $# > 0 ]]; do
       shift
       runtime="$1"
       ;;
+    -runtimesourcefeed)
+      shift
+      runtimeSourceFeed="$1"
+      ;;
+    -runtimesourcefeedkey)
+      shift
+      runtimeSourceFeedKey="$1"
+      ;;
     *)
       echo "Invalid argument: $1"
-      usage
       exit 1
       ;;
   esac
@@ -40,7 +49,7 @@ done
 
 . "$scriptroot/tools.sh"
 dotnetRoot="$repo_root/.dotnet"
-InstallDotNet $dotnetRoot $version "$architecture" $runtime true || {
+InstallDotNet $dotnetRoot $version "$architecture" $runtime true $runtimeSourceFeed $runtimeSourceFeedKey || {
   local exit_code=$?
   echo "dotnet-install.sh failed (exit code '$exit_code')." >&2
   ExitWithExitCode $exit_code

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -184,7 +184,14 @@ function InstallDotNetSdk([string] $dotnetRoot, [string] $version, [string] $arc
   InstallDotNet $dotnetRoot $version $architecture
 }
 
-function InstallDotNet([string] $dotnetRoot, [string] $version, [string] $architecture = "", [string] $runtime = "", [bool] $skipNonVersionedFiles = $false) {
+function InstallDotNet([string] $dotnetRoot, 
+  [string] $version, 
+  [string] $architecture = "", 
+  [string] $runtime = "", 
+  [bool] $skipNonVersionedFiles = $false, 
+  [string] $runtimeSourceFeed = "", 
+  [string] $runtimeSourceFeedKey = "") {
+
   $installScript = GetDotNetInstallScript $dotnetRoot
   $installParameters = @{
     Version = $version
@@ -195,10 +202,29 @@ function InstallDotNet([string] $dotnetRoot, [string] $version, [string] $archit
   if ($runtime) { $installParameters.Runtime = $runtime }
   if ($skipNonVersionedFiles) { $installParameters.SkipNonVersionedFiles = $skipNonVersionedFiles }
 
-  & $installScript @installParameters
-  if ($lastExitCode -ne 0) {
-    Write-PipelineTelemetryError -Category "InitializeToolset" -Message "Failed to install dotnet cli (exit code '$lastExitCode')."
-    ExitWithExitCode $lastExitCode
+  try {
+    & $installScript @installParameters
+  }
+  catch {
+    Write-PipelineTelemetryError -Category "InitializeToolset" -Message "Failed to install dotnet runtime '$runtime' from public location."
+
+    # Only the runtime can be installed from a custom [private] location.
+    if ($runtime -and ($runtimeSourceFeed -or $runtimeSourceFeedKey)) {
+      if ($runtimeSourceFeed) { $installParameters.AzureFeed = $runtimeSourceFeed }
+
+      if ($runtimeSourceFeedKey) {
+        $decodedBytes = [System.Convert]::FromBase64String($runtimeSourceFeedKey)
+        $decodedString = [System.Text.Encoding]::UTF8.GetString($decodedBytes)
+        $installParameters.FeedCredential = $decodedString
+      }
+
+      try {
+        & $installScript @installParameters
+      }
+      catch {
+        Write-PipelineTelemetryError -Category "InitializeToolset" -Message "Failed to install dotnet runtime '$runtime' from custom location '$runtimeSourceFeed'."
+      }
+    }
   }
 }
 

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -200,8 +200,28 @@ function InstallDotNet {
   fi
   bash "$install_script" --version $version --install-dir "$root" $archArg $runtimeArg $skipNonVersionedFilesArg || {
     local exit_code=$?
-    Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install dotnet SDK (exit code '$exit_code')."
-    ExitWithExitCode $exit_code
+    Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install dotnet SDK from public location (exit code '$exit_code')."
+
+    if [[ -n "$runtimeArg" ]]; then
+      local runtimeSourceFeed=''
+      if [[ -n "${6:-}" ]]; then
+        runtimeSourceFeed="--azure-feed $6"
+      fi
+
+      local runtimeSourceFeedKey=''
+      if [[ -n "${7:-}" ]]; then
+        decodedFeedKey=`echo $7 | base64 --decode`
+        runtimeSourceFeedKey="--feed-credential $decodedFeedKey"
+      fi
+
+      if [[ -n "$runtimeSourceFeed" || -n "$runtimeSourceFeedKey" ]]; then
+        bash "$install_script" --version $version --install-dir "$root" $archArg $runtimeArg $skipNonVersionedFilesArg $runtimeSourceFeed $runtimeSourceFeedKey || {
+          local exit_code=$?
+          Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install dotnet SDK from custom location '$runtimeSourceFeed' (exit code '$exit_code')."
+          ExitWithExitCode $exit_code
+        }
+      fi
+    fi
   }
 }
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
@@ -31,6 +31,10 @@ namespace Microsoft.DotNet.Arcade.Sdk
         [Required]
         public string Platform { get; set; }
 
+        public string RuntimeSourceFeed { get; set; }
+        
+        public string RuntimeSourceFeedKey { get; set; }
+
         public override bool Execute()
         {
             if (!File.Exists(GlobalJsonPath))
@@ -116,6 +120,17 @@ namespace Microsoft.DotNet.Arcade.Sdk
                                         if (!string.IsNullOrEmpty(architecture))
                                         {
                                             arguments += $" -architecture {architecture}";
+                                        }
+
+                                        if (!string.IsNullOrWhiteSpace(RuntimeSourceFeed))
+                                        {
+                                            arguments += $" -runtimeSourceFeed {RuntimeSourceFeed}";
+                                        }
+
+                                        // The default RuntimeSourceFeed doesn't need a key
+                                        if (!string.IsNullOrWhiteSpace(RuntimeSourceFeed) && !string.IsNullOrWhiteSpace(RuntimeSourceFeedKey))
+                                        {
+                                            arguments += $" -runtimeSourceFeedKey {RuntimeSourceFeedKey}";
                                         }
 
                                         Log.LogMessage(MessageImportance.Low, $"Executing: {DotNetInstallScript} {arguments}");

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -20,6 +20,8 @@
     DotNetSymbolServerTokenSymWeb   Personal access token for SymWeb symbol server. Available from variable group DotNet-Symbol-Publish.
     DotNetSymbolExpirationInDays    Symbol expiration time in days (defaults to 10 years).
     DotNetSignType                  Specifies the signing type: 'real' (default), 'test'.
+    DotNetRuntimeSourceFeed         Storage account to lookup for the .Net runtime files
+    DotNetRuntimeSourceFeedKey      In case the storage account to fetch the .Net runtime files are private this should contain a SAS token.
 
     ContinuousIntegrationBuild      "true" when building on a CI server (PR build or official build)
     Restore                         "true" to restore toolset and solution
@@ -123,6 +125,15 @@
       <_RestoreToolsProps Include="BaseIntermediateOutputPath=$(ArtifactsToolsetDir)Common"/>
       <_RestoreToolsProps Include="ExcludeRestorePackageImports=true"/>
       <_RestoreToolsProps Include="PublishingToBlobStorage=$(DotNetPublishToBlobFeed)"/>
+    </ItemGroup>
+
+    <!--
+      Builds from the 'internal' project, and only those, can download the .net Runtime 
+      from a private location.
+    -->
+    <ItemGroup Condition="'$(SYSTEM_TEAMPROJECT)' == 'internal'">
+      <_RestoreToolsProps Include="DotNetRuntimeSourceFeed=$(DotNetRuntimeSourceFeed)"/>
+      <_RestoreToolsProps Include="DotNetRuntimeSourceFeedKey=$(DotNetRuntimeSourceFeedKey)"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/InstallDotNetCore.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/InstallDotNetCore.targets
@@ -16,7 +16,9 @@
       VersionsPropsPath="$(RepoRoot)eng\Versions.props"
       GlobalJsonPath="$(RepoRoot)global.json"
       DotNetInstallScript="$(_DotNetInstallScript)"
-      Platform="$(Platform)"/>
+      Platform="$(Platform)"
+      RuntimeSourceFeed="$(DotNetRuntimeSourceFeed)"
+      RuntimeSourceFeedKey="$(DotNetRuntimeSourceFeedKey)"/>
   </Target>
 
 </Project>


### PR DESCRIPTION
## Description

Port functionality for downloading internal runtimes

## Customer Impact

Can't perform internal servicing from the .NET 3 channels.
The change was missing from the release/3.x branch when we forked.

## Regression

No

## Risk

Low.  No functionality is changed unless the new feed / key are passed.

## Workarounds

No