### PR TITLE
Fix error reporting when failing to install runtime in tools.ps1/sh

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -216,7 +216,10 @@ function InstallDotNet([string] $dotnetRoot,
       }
       catch {
         Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "Failed to install dotnet runtime '$runtime' from custom location '$runtimeSourceFeed'."
+        ExitWithExitCode 1
       }
+    } else {
+      ExitWithExitCode 1
     }
   }
 }

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -211,6 +211,8 @@ function InstallDotNet {
           Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install dotnet SDK from custom location '$runtimeSourceFeed' (exit code '$exit_code')."
           ExitWithExitCode $exit_code
         }
+      else
+        ExitWithExitCode $exit_code
       fi
     fi
   }


### PR DESCRIPTION
Related to  https://github.com/dotnet/arcade/issues/4503

As of https://github.com/dotnet/arcade/pull/4122 we only report telemetry but don't actually fail the scripts.