### PR TITLE
[Release/3.x] Fix error reporting when failing to install runtime in tools.ps1/sh

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -223,7 +223,10 @@ function InstallDotNet([string] $dotnetRoot,
       }
       catch {
         Write-PipelineTelemetryError -Category "InitializeToolset" -Message "Failed to install dotnet runtime '$runtime' from custom location '$runtimeSourceFeed'."
+        ExitWithExitCode 1
       }
+    } else {
+      ExitWithExitCode 1
     }
   }
 }

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -220,6 +220,8 @@ function InstallDotNet {
           Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install dotnet SDK from custom location '$runtimeSourceFeed' (exit code '$exit_code')."
           ExitWithExitCode $exit_code
         }
+      else
+        ExitWithExitCode $exit_code
       fi
     fi
   }


### PR DESCRIPTION
## Description

Release/3.x version of https://github.com/dotnet/arcade/pull/4505 
The changes to the scripts stopped reporting failure when downloading the runtime and instead only report telemetry failures.

## Customer Impact

The build doesn't fail early enough when installing the runtime, and will instead fail when trying to use it.

## Regression

Yes

## Risk

Low.

## Workarounds

No