### PR TITLE
[release/3.x] Enable auth for post build tasks

### DIFF
--- a/eng/common/templates/post-build/channels/generic-internal-channel.yml
+++ b/eng/common/templates/post-build/channels/generic-internal-channel.yml
@@ -26,6 +26,10 @@ stages:
     pool:
       vmImage: 'windows-2019'
     steps:
+      # This is necessary whenever we want to publish/restore to an AzDO private feed
+      - task: NuGetAuthenticate@0
+        displayName: 'Authenticate to AzDO Feeds'
+
       - task: DownloadBuildArtifacts@0
         displayName: Download Blob Artifacts
         inputs:

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -49,6 +49,12 @@ stages:
       pool:
         vmImage: 'windows-2019'
       steps:
+        # This is necessary whenever we want to publish/restore to an AzDO private feed
+        # Since sdk-task.ps1 tries to restore packages we need to do this authentication here
+        # otherwise it'll complain about accessing a private feed.
+        - task: NuGetAuthenticate@0
+          displayName: 'Authenticate to AzDO Feeds'
+
         - task: DownloadBuildArtifacts@0
           displayName: Download Package Artifacts
           inputs:


### PR DESCRIPTION
Feed auth was missing for a few places that were running post-build tasks.

Resolves https://github.com/dotnet/arcade/issues/4507

