### PR TITLE
[Release/3.x] Port azure pipelines reporter fixes 3.x

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.bat
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.bat
@@ -7,7 +7,7 @@ if NOT EXIST %ENV_PATH%\Scripts\python.exe (
   rmdir /Q /S %TMP_ENV_PATH%
   rmdir /Q /S %ENV_PATH%
   %HELIX_PYTHONPATH% -m virtualenv --no-site-packages %TMP_ENV_PATH%
-  rename %TMP_ENV_PATH% %ENV_PATH%
+  rename %TMP_ENV_PATH% .vsts-env
 )
 
 %ENV_PATH%\Scripts\python.exe -c "import azure.devops" || %ENV_PATH%\Scripts\python.exe -m pip install azure-devops==5.0.0b9

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.bat
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.bat
@@ -1,9 +1,13 @@
 
 set ENV_PATH=%USERPROFILE%\.vsts-env
+set TMP_ENV_PATH=%USERPROFILE%\.vsts-env-tmp
 echo  %date%-%time%
 
 if NOT EXIST %ENV_PATH%\Scripts\python.exe (
-  %HELIX_PYTHONPATH% -m virtualenv --no-site-packages %ENV_PATH%
+  rmdir /Q /S %TMP_ENV_PATH%
+  rmdir /Q /S %ENV_PATH%
+  %HELIX_PYTHONPATH% -m virtualenv --no-site-packages %TMP_ENV_PATH%
+  rename %TMP_ENV_PATH% %ENV_PATH%
 )
 
 %ENV_PATH%\Scripts\python.exe -c "import azure.devops" || %ENV_PATH%\Scripts\python.exe -m pip install azure-devops==5.0.0b9

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.sh
@@ -14,18 +14,18 @@ if [ ! -f $ENV_PATH/bin/python ]; then
   mv -T $TMP_ENV_PATH $ENV_PATH
 fi
 
-if $ENV_PATH/bin/python -c "import azure.devops"; then
+if sudo $ENV_PATH/bin/python -c "import azure.devops"; then
   echo "azure-devops module already available"
 else
   sudo $ENV_PATH/bin/python -m pip install azure-devops==5.0.0b9
 fi
 
-if $ENV_PATH/bin/python -c "import future"; then
+if sudo $ENV_PATH/bin/python -c "import future"; then
   echo "future module already available"
 else
   sudo $ENV_PATH/bin/python -m pip install future==0.17.1
 fi
 
 date -u +"%FT%TZ"
-$ENV_PATH/bin/python $script_path/run.py "$@"
+sudo -E $ENV_PATH/bin/python $script_path/run.py "$@"
 date -u +"%FT%TZ"

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.sh
@@ -4,10 +4,14 @@ set -x
 script_path=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 
 ENV_PATH=$HOME/.vsts-env
+TMP_ENV_PATH=$HOME/.vsts-env-tmp
 date -u +"%FT%TZ"
 
 if [ ! -f $ENV_PATH/bin/python ]; then
-  $HELIX_PYTHONPATH -m virtualenv --no-site-packages $ENV_PATH
+  rm -rf $ENV_PATH
+  rm -rf $TMP_ENV_PATH
+  $HELIX_PYTHONPATH -m virtualenv --no-site-packages $TMP_ENV_PATH
+  mv -T $TMP_ENV_PATH $ENV_PATH
 fi
 
 if $ENV_PATH/bin/python -c "import azure.devops"; then


### PR DESCRIPTION
## Description

Ports the latest fixes to the reporter. Should fix the errors we started seeing in https://github.com/dotnet/arcade/issues/4484. These need to be ported as we use the same helix machines in both master and 3.x branches.

## Customer Impact

We are not reporting some test failures, and even though Arcade has explicit checks to make sure that we report those failures, the reporting might be affecting other repos silently.

## Regression

No

## Risk

Low

## Workarounds

No