### PR TITLE
Remove Pdb2Pdb dependency on packages

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SymStore.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SymStore.targets
@@ -4,7 +4,7 @@
   <!-- This file is only imported in CI build. The conversion thus does not affect dev build. -->
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.DiaSymReader.Pdb2Pdb" Version="$(MicrosoftDiaSymReaderPdb2PdbVersion)" Condition="'$(UsingToolPdbConverter)' == 'true'" IsImplicitlyDefined="true" />
+    <PackageReference Include="Microsoft.DiaSymReader.Pdb2Pdb" Version="$(MicrosoftDiaSymReaderPdb2PdbVersion)" Condition="'$(UsingToolPdbConverter)' == 'true'" IsImplicitlyDefined="true" PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Moving the Pdb2Pdb PackageReference to SymStore.targets without specifying PrivateAssets="all" adds an unnecessary dependency which shows up in the produce package dependency graph.

Example package:
![image](https://user-images.githubusercontent.com/7412651/70389285-90f96c00-19bd-11ea-91b7-0379eab62633.png)


