### PR TITLE
Properly support ARM64's 32-bit compatibility profile

### DIFF
--- a/eng/common/dotnet-install.sh
+++ b/eng/common/dotnet-install.sh
@@ -63,7 +63,7 @@ case $cpuname in
   amd64|x86_64)
     buildarch=x64
     ;;
-  armv7l)
+  armv*l)
     buildarch=arm
     ;;
   i686)


### PR DESCRIPTION
`uname -m` on ARM64 processors using 32-bit personality shows as `armv8l`, not `armv7l`. See https://github.com/torvalds/linux/blob/cef7298262e9af841fb70d8673af45caf55300a1/arch/arm64/include/asm/compat.h#L22

This allows building on 64-bit ARM machines in a 32-bit environment. Without this patch, the build system thinks 32-bit personality on ARM64 is linux-x64, and the build explodes accordingly.

32-bit personality allows building ARM32 code on modern ARM64 systems, which in this day and age are easier to obtain with decent performance characteristics.

```
builder@xam-softiron-1:~$ uname -a
Linux xam-softiron-1 4.17.0ilp32-31333-gb2d7ec3 #1 SMP Tue Oct 16 16:37:20 EDT 2018 aarch64 aarch64 aarch64 GNU/Linux
builder@xam-softiron-1:~$ linux32 uname -a
Linux xam-softiron-1 4.17.0ilp32-31333-gb2d7ec3 #1 SMP Tue Oct 16 16:37:20 EDT 2018 armv8l armv8l armv8l GNU/Linux
```

Closes: https://github.com/dotnet/cli/issues/11437

Whatever process pushes to https://dot.net/v1/dotnet-install.sh *really* needs this update