### PR TITLE
Add support for opting out of xcopy-msbuild fallback behavior

### DIFF
--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -1,4 +1,4 @@
-# Arcade SDK
+﻿# Arcade SDK
 
 Arcade SDK is a set of msbuild props and targets files and packages that provide common build features used across multiple repos, such as CI integration, packaging, VSIX and VS setup authoring, testing, and signing via Microbuild.
 
@@ -342,6 +342,19 @@ The version of `RoslynTools.MSBuild` package can be specified in `global.json` f
 ```
 
 If it is not specified the build script attempts to find `RoslynTools.MSBuild` version `{VSMajor}.{VSMinor}.0-alpha` where `VSMajor.VSMinor` is the value of `tools.vs.version`.
+
+If the fallback behavior to use xcopy-deployable MSBuild package is not desirable, then a version of `none` should be indicated in `global.json`, like this: 
+
+```json
+{
+  "tools": {
+    "vs": {
+      "version": "16.4"
+    },
+    "xcopy-msbuild": "none"
+  }
+}
+```
 
 #### Example: Restoring multiple .NET Core Runtimes for running tests
 

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -293,8 +293,11 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
       $vsMajorVersion = $vsMinVersion.Major
       $xcopyMSBuildVersion = "$vsMajorVersion.$($vsMinVersion.Minor).0-alpha"
     }
-
-    $vsInstallDir = InitializeXCopyMSBuild $xcopyMSBuildVersion $install
+    
+    $vsInstallDir = $null
+    if ($xcopyMSBuildVersion.Trim() -ine "none") {
+        $vsInstallDir = InitializeXCopyMSBuild $xcopyMSBuildVersion $install
+    }
     if ($vsInstallDir -eq $null) {
       throw 'Unable to find Visual Studio that has required version and components installed'
     }


### PR DESCRIPTION
Fixes #4534 

When `xcopy-msbuild` version is set to `none` in `global.json`, fallback to teh xcopy-deployable version of MSBuild will be skipped. 

/cc @rladuca 