### PR TITLE
Allow overriding of optprof drop name

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.AcquireOptimizationData.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.AcquireOptimizationData.targets
@@ -6,6 +6,7 @@
       VisualStudioIbcSourceBranchName  The name of the branch of the repository that was used to produce the IBC data to be acquired (e.g. 'master').
       VisualStudioIbcDropId            The id of the drop. If specified, drop named 'OptimizationData/$(RepositoryName)/$(VisualStudioIbcSourceBranchName)/$(VisualStudioIbcDropId)' is used.
                                        Otherwise, the most recent drop of name that matches 'OptimizationData/$(RepositoryName)/$(VisualStudioIbcSourceBranchName)/*' is used.
+      VisualStudioIbcDrop              The explicit drop to use. Overrides VisualStudioIbcSourceBranchName and VisualStudioIbcDropId
   -->
   
   <PropertyGroup>
@@ -49,8 +50,10 @@
 
   <Target Name="_DownloadVisualStudioOptimizationDataOpt" Condition="$(_DropToolExists)">
     <Error Text="VisualStudioDropAccessToken property has to be specified when EnableNgenOptimization and OfficialBuild is true" Condition="'$(VisualStudioDropAccessToken)' == '' and '$(OfficialBuild)' == 'true'"/>
-    <Error Text="RepositoryName property has to be specified when EnableNgenOptimization is true" Condition="'$(RepositoryName)' == ''"/>
-    <Error Text="VisualStudioIbcSourceBranchName property has to be specified when EnableNgenOptimization is true" Condition="'$(VisualStudioIbcSourceBranchName)' == ''"/>
+    <Error Text="RepositoryName property has to be specified when EnableNgenOptimization is true and VisualStudioIbcDrop is not set" Condition="'$(VisualStudioIbcDrop)' == '' and '$(RepositoryName)' == ''"/>
+    <Error Text="VisualStudioIbcSourceBranchName property has to be specified when EnableNgenOptimization is true and VisualStudioIbcDrop is not set" Condition="'$(VisualStudioIbcDrop)' == '' and '$(VisualStudioIbcSourceBranchName)' == ''"/>
+    <Error Text="VisualStudioIbcSourceBranchName property cannot be specified when using the VisualStudioIbcDrop property" Condition="'$(VisualStudioIbcDrop)' != '' and '$(VisualStudioIbcSourceBranchName)' != ''" />
+    <Error Text="VisualStudioIbcDropId property cannot be specified when using the VisualStudioIbcDrop property" Condition="'$(VisualStudioIbcDrop)' != '' and '$(VisualStudioIbcDropId)' != ''" />
 
     <PropertyGroup>
       <_DropServiceUrl>https://devdiv.artifacts.visualstudio.com</_DropServiceUrl>
@@ -60,14 +63,15 @@
       <_DropsLogPath>$(ArtifactsLogDir)OptimizationDataAcquisition.log</_DropsLogPath>
       <_DropNamePrefix>OptimizationData/$(RepositoryName)/$(VisualStudioIbcSourceBranchName)</_DropNamePrefix>
       <_DropName>$(_DropNamePrefix)/$(VisualStudioIbcDropId)</_DropName>
+      <_DropName Condition="'$(VisualStudioIbcDrop)' != ''">$(VisualStudioIbcDrop)</_DropName>
     </PropertyGroup>
 
     <Message Text="Acquiring optimization data" Importance="high"/>
 
     <Exec Command='"$(_DropToolPath)" list --dropservice "$(_DropServiceUrl)" $(_PatAuthArg) --pathPrefixFilter "$(_DropNamePrefix)" --toJsonFile "$(_DropsJsonPath)" --traceto "$(_DropsLogPath)"' 
-          Condition="'$(VisualStudioIbcDropId)' == ''"/>
+          Condition="'$(VisualStudioIbcDropId)' == '' and '$(VisualStudioIbcDrop)' == ''"/>
 
-    <FindLatestDrop DropListPath="$(_DropsJsonPath)" Condition="'$(VisualStudioIbcDropId)' == ''">
+    <FindLatestDrop DropListPath="$(_DropsJsonPath)" Condition="'$(VisualStudioIbcDropId)' == '' and '$(VisualStudioIbcDrop)' == ''">
       <Output TaskParameter="DropName" PropertyName="_DropName"/>
     </FindLatestDrop>
 


### PR DESCRIPTION
For central OptProf we need to use a drop with a name that differs from the arcade defaults (and is calculated in a different way). 

This change lets the build just provide the explicit drop name to use.