### PR TITLE
[release/3.x] Update maestro.tasks version (#4547)

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Versions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Versions.props
@@ -6,7 +6,7 @@
   <Import Project="..\DefaultVersions.Generated.props" Condition="Exists('..\DefaultVersions.Generated.props')"/>
 
   <PropertyGroup>
-    <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.19530.2</MicrosoftDotNetMaestroTasksVersion>
+    <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.19616.1</MicrosoftDotNetMaestroTasksVersion>
     <MicrosoftDotNetBuildTasksVisualStudioVersion>$(ArcadeSdkVersion)</MicrosoftDotNetBuildTasksVisualStudioVersion>
     <MicrosoftDotNetBuildTasksFeedVersion>2.2.0-beta.19514.1</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetSignCheckVersion Condition="'$(MicrosoftDotNetSignCheckVersion)' == ''">1.0.0-beta.19509.6</MicrosoftDotNetSignCheckVersion>


### PR DESCRIPTION
## Description

Cherry-picking 4ec1c99a0a8b3dca4526c4d2c6acb5fb5f8f5829

This updates the maestro tasks version used by Arcade so that we take into account default channels for AzDO and GitHub separately during publishing.


## Customer Impact

The default channel setup for a servicing build becomes difficult if the tip of the internal servicing branch is up to date with GitHub.

## Regression

No.

## Risk

Low.

## Workarounds

You can push empty commits to the internal repo, or set up the default channel for the GitHub repo instead to unblock this, but it's usually hard to diagnose why expected publishing didn't happen.