### PR TITLE
Add nologo to crossgen

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.dependency.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.dependency.targets
@@ -416,6 +416,7 @@
       <_crossGenResponseFile>$(_crossGenIntermediatePath)%(_filesToCrossGen.FileName).rsp</_crossGenResponseFile>
     </PropertyGroup>
     <ItemGroup>
+      <_crossGenArgs Include="-nologo" />
       <_crossGenArgs Include="-readytorun" />
       <_crossGenArgs Include="-in %(_filesToCrossGen.FullPath)" />
       <_crossGenArgs Include="-out %(_filesToCrossGen.CrossGenedPath)" />

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.dependency.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.dependency.targets
@@ -464,6 +464,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <_crossGenSymbolsArgs Include="-nologo" />
       <_crossGenSymbolsArgs Include="-readytorun" />
       <_crossGenSymbolsArgs Include="-platform_assemblies_paths %(_filesToCrossGen.CrossGenedDirectory)$(_pathSeparatorEscaped)$(_coreLibDirectory)$(_pathSeparatorEscaped)$(_fxLibDirectory)" />
       <_crossGenSymbolsArgs Include="-Platform_Winmd_Paths $(_windowsWinMDDirectory)" Condition="'$(OS)'=='Windows_NT'"/>


### PR DESCRIPTION
Turns this output in the runtime build
```
  Microsoft (R) CoreCLR Native Image Generator - Version 4.5.30319.0
  Copyright (c) Microsoft Corporation.  All rights reserved.

  Successfully generated perfmap for native assembly '/runtime/artifacts/bin/linux-x64.Debug/crossgen/netcoreapp/runtimes/linux-x64/lib/netcoreapp5.0/System.Xml.XPath.dll'.
  Microsoft (R) CoreCLR Native Image Generator - Version 4.5.30319.0
  Copyright (c) Microsoft Corporation.  All rights reserved.

  Successfully generated perfmap for native assembly '/runtime/artifacts/bin/linux-x64.Debug/crossgen/netcoreapp/runtimes/linux-x64/lib/netcoreapp5.0/System.Xml.XPath.XDocument.dll'.
  Microsoft (R) CoreCLR Native Image Generator - Version 4.5.30319.0
  Copyright (c) Microsoft Corporation.  All rights reserved.

  Successfully generated perfmap for native assembly '/runtime/artifacts/bin/linux-x64.Debug/crossgen/netcoreapp/runtimes/linux-x64/lib/netcoreapp5.0/WindowsBase.dll'.
```
x100 ..  into
```
  Native image /runtime/artifacts/bin/linux-x64.Debug/crossgen/netcoreapp/runtimes/linux-x64/lib/netcoreapp5.0/System.IO.Compression.Brotli.dll generated successfully.
  Native image /runtime/artifacts/bin/linux-x64.Debug/crossgen/netcoreapp/runtimes/linux-x64/lib/netcoreapp5.0/System.IO.Compression.dll generated successfully.
  Native image /runtime/artifacts/bin/linux-x64.Debug/crossgen/netcoreapp/runtimes/linux-x64/lib/netcoreapp5.0/System.IO.Compression.FileSystem.dll generated successfully.
  Native image /runtime/artifacts/bin/linux-x64.Debug/crossgen/netcoreapp/runtimes/linux-x64/lib/netcoreapp5.0/System.IO.Compression.ZipFile.dll generated successfully.
  Native image /runtime/artifacts/bin/linux-x64.Debug/crossgen/netcoreapp/runtimes/linux-x64/lib/netcoreapp5.0/System.IO.dll generated successfully.
```
ahhhh