### PR TITLE
Remove trailing parenthesis from GenerateResxSource

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateResxSource.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateResxSource.cs
@@ -139,7 +139,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
                     case Lang.CSharp:
                         if (AsConstants)
                         {
-                            strings.AppendLine($"{memberIndent}internal const string @{identifier} = \"{name}\");");
+                            strings.AppendLine($"{memberIndent}internal const string @{identifier} = \"{name}\";");
                         }
                         else
                         {


### PR DESCRIPTION
Fixes regression from https://github.com/dotnet/arcade/pull/2208