### PR TITLE
Allow NETCoreApp runtimeconfig version override in sharedfx tooling

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.sharedfx.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.sharedfx.targets
@@ -74,6 +74,9 @@
     <MakeDir Directories="$(PublishDir)" />
 
     <PropertyGroup>
+      <!-- Allow the repo to specify a version of Microsoft.NETCore.App to depend on. -->
+      <MicrosoftNETCoreAppRuntimeConfigVersion Condition="'$(MicrosoftNETCoreAppRuntimeConfigVersion)' == ''">$(SharedFrameworkNugetVersion)</MicrosoftNETCoreAppRuntimeConfigVersion>
+
       <_runtimeConfigContent>
       <![CDATA[
 {
@@ -81,7 +84,7 @@
     "tfm": "$(TargetFramework)",
     "framework": {
       "name": "Microsoft.NETCore.App",
-      "version": "$(SharedFrameworkNugetVersion)",
+      "version": "$(MicrosoftNETCoreAppRuntimeConfigVersion)",
       "rollForward": "LatestPatch"
     }
   }


### PR DESCRIPTION
Support changing `MicrosoftNETCoreAppRuntimeConfigVersion` from the default `SharedFrameworkNugetVersion`, for https://github.com/dotnet/windowsdesktop/issues/368.

It worked previously because WindowsDesktop was built alongside NETCoreApp. Now that's no longer the case, and it needs to be specified to match the actual dependency.