### PR TITLE
Fix a few swagger generator bugs and use AsyncPageable for paging

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,7 @@
     <CommandLineParserVersion>2.2.1</CommandLineParserVersion>
     <CredentialManagementVersion>1.0.2</CredentialManagementVersion>
     <MicrosoftCciVersion>4.0.0-rc3-24214-00</MicrosoftCciVersion>
-    <HandlebarsNetVersion>1.9.5</HandlebarsNetVersion>
+    <HandlebarsNetVersion>1.10.1</HandlebarsNetVersion>
     <LibGit2SharpVersion>0.25.2</LibGit2SharpVersion>
     <log4netVersion>2.0.8</log4netVersion>
     <SystemNetHttpVersion>4.3.3</SystemNetHttpVersion>

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/Microsoft.DotNet.Helix.Client.csproj
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/Microsoft.DotNet.Helix.Client.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <Description>This package provides access to the Helix Api located at https://helix.dot.net/</Description>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8.0</LangVersion>
 
     <SwaggerDocumentUri>https://helix.dot.net/swagger/docs</SwaggerDocumentUri>
     <SwaggerClientName>HelixApi</SwaggerClientName>
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.0.1" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/PagedResponse.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/PagedResponse.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure;
@@ -16,46 +17,61 @@ namespace Microsoft.DotNet.Helix.Client
         public static async Task<List<T>> ToListAsync<T>(this IAsyncEnumerable<T> that, CancellationToken cancellationToken)
         {
             var results = new List<T>();
-            using (var enumerator = that.GetEnumerator())
+            await foreach (var value in that.WithCancellation(cancellationToken))
             {
-                while (await enumerator.MoveNextAsync(cancellationToken))
-                {
-                    results.Add(enumerator.Current);
-                }
+                results.Add(value);
             }
+
             return results;
         }
     }
 
-    public interface IAsyncEnumerable<out T>
+    public class AsyncPageable
     {
-        IAsyncEnumerator<T> GetEnumerator();
-    }
-
-    public interface IAsyncEnumerator<out T> : IDisposable
-    {
-        T Current { get; }
-        Task<bool> MoveNextAsync(CancellationToken cancellationToken);
-    }
-
-    public class PagedResponse<T> : IReadOnlyList<T>
-    {
-        private readonly Func<Request, Response, Task> _onFailure;
-
-        public PagedResponse(HelixApi client, Func<Request, Response, Task> onFailure, Response response, IImmutableList<T> values)
+        public static AsyncPageable<T> Create<T>(Func<string, int?, IAsyncEnumerable<Page<T>>> pageFunc)
         {
-            _onFailure = onFailure;
-            Client = client;
-            Values = values;
-            if (!response.Headers.TryGetValues("Link", out var linkHeader))
+            return new FuncAsyncPageable<T>(pageFunc);
+        }
+
+        public class FuncAsyncPageable<T> : AsyncPageable<T>
+        {
+            private readonly Func<string, int?, IAsyncEnumerable<Page<T>>> _pageFunc;
+
+            public FuncAsyncPageable(Func<string, int?, IAsyncEnumerable<Page<T>>> pageFunc)
             {
-                return;
+                _pageFunc = pageFunc;
             }
-            var links = ParseLinkHeader(linkHeader).ToList();
-            FirstPageLink = links.FirstOrDefault(t => t.rel == "first").href;
-            PrevPageLink = links.FirstOrDefault(t => t.rel == "prev").href;
-            NextPageLink = links.FirstOrDefault(t => t.rel == "next").href;
-            LastPageLink = links.FirstOrDefault(t => t.rel == "last").href;
+
+            public override IAsyncEnumerable<Page<T>> AsPages(string continuationToken = null, int? pageSizeHint = null)
+            {
+                return _pageFunc(continuationToken, pageSizeHint);
+            }
+        }
+    }
+
+    public class LinkHeader
+    {
+        private LinkHeader(string firstPageLink, string prevPageLink, string nextPageLink, string lastPageLink)
+        {
+            FirstPageLink = firstPageLink;
+            PrevPageLink = prevPageLink;
+            NextPageLink = nextPageLink;
+            LastPageLink = lastPageLink;
+        }
+
+        public string FirstPageLink { get; }
+        public string PrevPageLink { get; }
+        public string NextPageLink { get; }
+        public string LastPageLink { get; }
+
+        public static LinkHeader Parse(IEnumerable<string> header)
+        {
+            var links = ParseLinkHeader(header).ToList();
+            var first = links.FirstOrDefault(t => t.rel == "first").href;
+            var prev = links.FirstOrDefault(t => t.rel == "prev").href;
+            var next = links.FirstOrDefault(t => t.rel == "next").href;
+            var last = links.FirstOrDefault(t => t.rel == "last").href;
+            return new LinkHeader(first, prev, next, last);
         }
 
         private static IEnumerable<(string href, string rel)> ParseLinkHeader(IEnumerable<string> linkHeader)
@@ -118,108 +134,5 @@ namespace Microsoft.DotNet.Helix.Client
             result = (key, v);
             return true;
         }
-
-        public string FirstPageLink { get; }
-        public string PrevPageLink { get; }
-        public string NextPageLink { get; }
-        public string LastPageLink { get; }
-        public HelixApi Client { get; }
-
-        public IImmutableList<T> Values { get; }
-
-        public async Task<PagedResponse<T>> GetPageAsync(string link, CancellationToken cancellationToken)
-        {
-            using (var req = Client.Pipeline.CreateRequest())
-            {
-                req.Uri.Reset(new Uri(link));
-
-                using (var res = await Client.SendAsync(req, cancellationToken).ConfigureAwait(false))
-                {
-                    if (res.Status < 200 || res.Status >= 300 || res.ContentStream == null)
-                    {
-                        await _onFailure(req, res).ConfigureAwait(false);
-                        throw new InvalidOperationException("Can't get here");
-                    }
-
-                    using (var reader = new StreamReader(res.ContentStream))
-                    {
-                        var content = await reader.ReadToEndAsync().ConfigureAwait(false);
-                        return new PagedResponse<T>(Client, _onFailure, res, Client.Deserialize<IImmutableList<T>>(content));
-                    }
-                }
-            }
-        }
-
-        public IAsyncEnumerable<T> EnumerateAll()
-        {
-            return new Enumerable(this);
-        }
-
-        private class Enumerable : IAsyncEnumerable<T>
-        {
-            private readonly PagedResponse<T> _that;
-
-            public Enumerable(PagedResponse<T> that)
-            {
-                _that = that;
-            }
-
-            public IAsyncEnumerator<T> GetEnumerator()
-            {
-                return new Enumerator(_that);
-            }
-        }
-
-        private class Enumerator : IAsyncEnumerator<T>
-        {
-            private PagedResponse<T> _currentPage;
-            private IEnumerator<T> _currentPageEnumerator;
-
-            public Enumerator(PagedResponse<T> that)
-            {
-                _currentPage = that;
-                _currentPageEnumerator = _currentPage.GetEnumerator();
-            }
-
-            public void Dispose()
-            {
-                _currentPageEnumerator?.Dispose();
-            }
-
-            public T Current => _currentPageEnumerator.Current;
-
-            public async Task<bool> MoveNextAsync(CancellationToken cancellationToken)
-            {
-                if (_currentPageEnumerator.MoveNext())
-                {
-                    return true;
-                }
-
-                if (string.IsNullOrEmpty(_currentPage.NextPageLink))
-                {
-                    return false;
-                }
-
-                _currentPageEnumerator.Dispose();
-                _currentPage = await _currentPage.GetPageAsync(_currentPage.NextPageLink, cancellationToken).ConfigureAwait(false);
-                _currentPageEnumerator = _currentPage.GetEnumerator();
-                return _currentPageEnumerator.MoveNext();
-            }
-        }
-
-        public IEnumerator<T> GetEnumerator()
-        {
-            return Values.GetEnumerator();
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return ((IEnumerable) Values).GetEnumerator();
-        }
-
-        public int Count => Values.Count;
-
-        public T this[int index] => Values[index];
     }
-
 }

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/Language.cs
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/Language.cs
@@ -13,10 +13,12 @@ namespace Microsoft.DotNet.SwaggerGenerator.Languages
     {
         private Templates() { }
 
+        public static string BasePath { get; set; } = Path.GetDirectoryName(typeof(Templates).Assembly.Location);
+
         public static Templates Load(string languageName, IHandlebars hb)
         {
             string templateDirectory = Path.GetFullPath(Path.Combine(
-                Path.GetDirectoryName(typeof(Templates).Assembly.Location),
+                BasePath,
                 "Languages",
                 languageName));
             var templates = new Templates();

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/CSharp.cs
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/CSharp.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.SwaggerGenerator.Languages
 
                 if (reference is TypeReference.TypeModelReference typeModelRef)
                 {
-                    return Helpers.PascalCase(typeModelRef.Model.Name.AsSpan());
+                    return "Models." + Helpers.PascalCase(typeModelRef.Model.Name.AsSpan());
                 }
 
                 if (reference is TypeReference.ArrayTypeReference arrayTypeRef)

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/PagedResponse.hb
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/PagedResponse.hb
@@ -1,13 +1,9 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure;
-using Azure.Core;
 
 namespace {{pascalCaseNs Namespace}}
 {
@@ -16,46 +12,61 @@ namespace {{pascalCaseNs Namespace}}
         public static async Task<List<T>> ToListAsync<T>(this IAsyncEnumerable<T> that, CancellationToken cancellationToken)
         {
             var results = new List<T>();
-            using (var enumerator = that.GetEnumerator())
+            await foreach (var value in that.WithCancellation(cancellationToken))
             {
-                while (await enumerator.MoveNextAsync(cancellationToken))
-                {
-                    results.Add(enumerator.Current);
-                }
+                results.Add(value);
             }
+
             return results;
         }
     }
 
-    public interface IAsyncEnumerable<out T>
+    public class AsyncPageable
     {
-        IAsyncEnumerator<T> GetEnumerator();
-    }
-
-    public interface IAsyncEnumerator<out T> : IDisposable
-    {
-        T Current { get; }
-        Task<bool> MoveNextAsync(CancellationToken cancellationToken);
-    }
-
-    public class PagedResponse<T> : IReadOnlyList<T>
-    {
-        private readonly Func<Request, Response, Task> _onFailure;
-
-        public PagedResponse({{pascalCase Name}} client, Func<Request, Response, Task> onFailure, Response response, IImmutableList<T> values)
+        public static AsyncPageable<T> Create<T>(Func<string, int?, IAsyncEnumerable<Page<T>>> pageFunc)
         {
-            _onFailure = onFailure;
-            Client = client;
-            Values = values;
-            if (!response.Headers.TryGetValues("Link", out var linkHeader))
+            return new FuncAsyncPageable<T>(pageFunc);
+        }
+
+        public class FuncAsyncPageable<T> : AsyncPageable<T>
+        {
+            private readonly Func<string, int?, IAsyncEnumerable<Page<T>>> _pageFunc;
+
+            public FuncAsyncPageable(Func<string, int?, IAsyncEnumerable<Page<T>>> pageFunc)
             {
-                return;
+                _pageFunc = pageFunc;
             }
-            var links = ParseLinkHeader(linkHeader).ToList();
-            FirstPageLink = links.FirstOrDefault(t => t.rel == "first").href;
-            PrevPageLink = links.FirstOrDefault(t => t.rel == "prev").href;
-            NextPageLink = links.FirstOrDefault(t => t.rel == "next").href;
-            LastPageLink = links.FirstOrDefault(t => t.rel == "last").href;
+
+            public override IAsyncEnumerable<Page<T>> AsPages(string continuationToken = null, int? pageSizeHint = null)
+            {
+                return _pageFunc(continuationToken, pageSizeHint);
+            }
+        }
+    }
+
+    public class LinkHeader
+    {
+        private LinkHeader(string firstPageLink, string prevPageLink, string nextPageLink, string lastPageLink)
+        {
+            FirstPageLink = firstPageLink;
+            PrevPageLink = prevPageLink;
+            NextPageLink = nextPageLink;
+            LastPageLink = lastPageLink;
+        }
+
+        public string FirstPageLink { get; }
+        public string PrevPageLink { get; }
+        public string NextPageLink { get; }
+        public string LastPageLink { get; }
+
+        public static LinkHeader Parse(IEnumerable<string> header)
+        {
+            var links = ParseLinkHeader(header).ToList();
+            var first = links.FirstOrDefault(t => t.rel == "first").href;
+            var prev = links.FirstOrDefault(t => t.rel == "prev").href;
+            var next = links.FirstOrDefault(t => t.rel == "next").href;
+            var last = links.FirstOrDefault(t => t.rel == "last").href;
+            return new LinkHeader(first, prev, next, last);
         }
 
         private static IEnumerable<(string href, string rel)> ParseLinkHeader(IEnumerable<string> linkHeader)
@@ -118,108 +129,5 @@ namespace {{pascalCaseNs Namespace}}
             result = (key, v);
             return true;
         }
-
-        public string FirstPageLink { get; }
-        public string PrevPageLink { get; }
-        public string NextPageLink { get; }
-        public string LastPageLink { get; }
-        public HelixApi Client { get; }
-
-        public IImmutableList<T> Values { get; }
-
-        public async Task<PagedResponse<T>> GetPageAsync(string link, CancellationToken cancellationToken)
-        {
-            using (var req = Client.Pipeline.CreateRequest())
-            {
-                req.Uri.Reset(new Uri(link));
-
-                using (var res = await Client.SendAsync(req, cancellationToken).ConfigureAwait(false))
-                {
-                    if (res.Status < 200 || res.Status >= 300 || res.ContentStream == null)
-                    {
-                        await _onFailure(req, res).ConfigureAwait(false);
-                        throw new InvalidOperationException("Can't get here");
-                    }
-
-                    using (var reader = new StreamReader(res.ContentStream))
-                    {
-                        var content = await reader.ReadToEndAsync().ConfigureAwait(false);
-                        return new PagedResponse<T>(Client, _onFailure, res, Client.Deserialize<IImmutableList<T>>(content));
-                    }
-                }
-            }
-        }
-
-        public IAsyncEnumerable<T> EnumerateAll()
-        {
-            return new Enumerable(this);
-        }
-
-        private class Enumerable : IAsyncEnumerable<T>
-        {
-            private readonly PagedResponse<T> _that;
-
-            public Enumerable(PagedResponse<T> that)
-            {
-                _that = that;
-            }
-
-            public IAsyncEnumerator<T> GetEnumerator()
-            {
-                return new Enumerator(_that);
-            }
-        }
-
-        private class Enumerator : IAsyncEnumerator<T>
-        {
-            private PagedResponse<T> _currentPage;
-            private IEnumerator<T> _currentPageEnumerator;
-
-            public Enumerator(PagedResponse<T> that)
-            {
-                _currentPage = that;
-                _currentPageEnumerator = _currentPage.GetEnumerator();
-            }
-
-            public void Dispose()
-            {
-                _currentPageEnumerator?.Dispose();
-            }
-
-            public T Current => _currentPageEnumerator.Current;
-
-            public async Task<bool> MoveNextAsync(CancellationToken cancellationToken)
-            {
-                if (_currentPageEnumerator.MoveNext())
-                {
-                    return true;
-                }
-
-                if (string.IsNullOrEmpty(_currentPage.NextPageLink))
-                {
-                    return false;
-                }
-
-                _currentPageEnumerator.Dispose();
-                _currentPage = await _currentPage.GetPageAsync(_currentPage.NextPageLink, cancellationToken).ConfigureAwait(false);
-                _currentPageEnumerator = _currentPage.GetEnumerator();
-                return _currentPageEnumerator.MoveNext();
-            }
-        }
-
-        public IEnumerator<T> GetEnumerator()
-        {
-            return Values.GetEnumerator();
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return ((IEnumerable) Values).GetEnumerator();
-        }
-
-        public int Count => Values.Count;
-
-        public T this[int index] => Values[index];
     }
-
 }

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/ServiceClient.hb
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/ServiceClient.hb
@@ -36,7 +36,7 @@ namespace {{pascalCaseNs Namespace}}
     public partial class {{pascalCase Name}}Options : ClientOptions
     {
         public {{pascalCase Name}}Options()
-            : this(new Uri("https://helix.dot.net"))
+            : this(new Uri("{{BaseUrl}}"))
         {
         }
 
@@ -46,7 +46,7 @@ namespace {{pascalCaseNs Namespace}}
         }
 
         public {{pascalCase Name}}Options(TokenCredential credentials)
-            : this(new Uri("https://helix.dot.net"), credentials)
+            : this(new Uri("{{BaseUrl}}"), credentials)
         {
         }
 

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator.csproj
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Microsoft.DotNet.SwaggerGenerator</RootNamespace>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,6 +22,7 @@
   <ItemGroup>
     <None Update="Languages\**\*.hb">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Pack>true</Pack>
     </None>
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Modeler/MethodModel.cs
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Modeler/MethodModel.cs
@@ -47,8 +47,13 @@ namespace Microsoft.DotNet.SwaggerGenerator.Modeler
         public IEnumerable<ParameterModel> NonConstantParameters =>
             Parameters.Where(p => !(p.Type is TypeReference.ConstantTypeReference)).OrderBy(p => p.Name);
 
-        public IEnumerable<ParameterModel> FormalParameters =>
-            NonConstantParameters.OrderBy(p => p.Required ? 0 : 1).ThenBy(p => p.Name);
+        public IEnumerable<ParameterModel> FormalParameters => NonConstantParameters.OrderBy(p => p.Required ? 0 : 1).ThenBy(p => p.Name);
+
+        public IEnumerable<ParameterModel> FormalParametersNoPaging => NonConstantParameters.OrderBy(p => p.Required ? 0 : 1).ThenBy(p => p.Name).Where(p => Paginated == null || (p.Name != Paginated.PageParameterName && p.Name != Paginated.PageSizeParameterName));
+
+        public ParameterModel PageParameter => Paginated == null ? null : NonConstantParameters.Single(p => p.Name == Paginated.PageParameterName);
+
+        public ParameterModel PageSizeParameter => Paginated == null ? null : NonConstantParameters.Single(p => p.Name == Paginated.PageSizeParameterName);
 
         public IEnumerable<ParameterModel> PathParameters =>
             Parameters.Where(p => p.Location == ParameterLocation.Path);


### PR DESCRIPTION
This change removes the custom paging implementation and switches to the AsyncPageable construct from Azure.Core.

I also fixed 2 bugs found from the Maestro++ client: the BaseUri wasn't templated properly, and the model types will conflict with Api category names.