### PR TITLE
Adding target that wraps building a pkgproj and then updating package index

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidateHarvestVersionIsLatestForRelease.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidateHarvestVersionIsLatestForRelease.cs
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 string latestPatchVersion = GetLatestStableVersionForPackageRelease(packageReport.Id, harvestMajor, harvestMinor);
                 if (latestPatchVersion.CompareTo(harvestVersion) != 0)
                 {
-                    Log.LogError($"Validation Failed: {packageReport.Id} is harvesting assets from package version {harvestVersion} which is not the latest for that package release. Latest package version from that release is {latestPatchVersion}. In order to fix this, run `dotnet msbuild {packageReport.Id}.pkgproj /t:UpdatePackageIndex /p:UpdateStablePackageInfo=true`");
+                    Log.LogError($"Validation Failed: {packageReport.Id} is harvesting assets from package version {harvestVersion} which is not the latest for that package release. Latest package version from that release is {latestPatchVersion}. In order to fix this, run `dotnet msbuild {packageReport.Id}.pkgproj /t:UpdateHarvestVersionOnPackageIndex /p:UpdateStablePackageInfo=true`");
                 }
                 else
                 {

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
@@ -1293,6 +1293,10 @@
                         UpdateStablePackageInfo="$(UpdateStablePackageInfo)" />
   </Target>
 
+  <!-- When we want to update the package index with the harvest version, we require the package to already be built, which a default call
+  to UpdatePackageIndex won't do. This target will just wrap both targets to ensure the package is built, and then we can update the index. -->
+  <Target Name="UpdateHarvestVersionOnPackageIndex" DependsOnTargets="Build;UpdatePackageIndex" />
+
   <!-- Updates the packageIndex with information from the multiple sources for the entire repo -->
   <!-- Intentionally not sequenced, invoked directly through /t:UpdateRepoPackageIndex -->
   <Target Name="UpdateRepoPackageIndex">


### PR DESCRIPTION
cc: @safern @ericstj 

Whenever there is a failure in harvesting validation due to a new revision of a package getting shipped in a different release, our current task instructs in the failure to run UpdatePackageIndex task on the failing project with a property set in order to fix the issue. @safern recently hit this (https://github.com/dotnet/runtime/pull/1729) and saw the problem that in order for this instruction to work, the pkgproj has to be built first, and there could be the case where locally this hasn't happened yet, and there is no clear instruction saying that this is the problem. In order to fix this, @safern and I decided to add a Target that would wrap both the build of the package, and the Update of the package index such that the instructions on the error will still work in case the package isn't built yet.