### PR TITLE
Fix manifest validation in Tasks.Feed

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
@@ -119,10 +119,15 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             TaskLoggingHelper log)
         {
             var attributes = MSBuildListSplitter.GetNamedProperties(manifestBuildData);
-            if(!ManifestBuildDataHasLocationProperty(attributes))
+            if(!ValidateManifestBuildData(attributes, out List<string> errors))
             {
-                log.LogError($"Missing 'location' property from ManifestBuildData");
+                log.LogError("Missing properties in ManifestBuildData:");
+                foreach (var error in errors)
+                {
+                    log.LogError($"\t{error}");
+                }
             }
+
             BuildModel buildModel = new BuildModel(
                     new BuildIdentity
                     {
@@ -147,6 +152,18 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         internal static bool ManifestBuildDataHasLocationProperty(IDictionary<string, string> attributes)
         {
             return attributes.ContainsKey("Location");
+        }
+
+        internal static bool ValidateManifestBuildData(IDictionary<string, string> attributes, out List<string> errors)
+        {
+            errors = new List<string>();
+
+            if (!attributes.ContainsKey("InitialAssetsLocation"))
+            {
+                errors.Add("Missing required property InitialAssetsLocation.");
+            }
+
+            return errors.Count == 0;
         }
 
         public static BuildModel ManifestFileToModel(string assetManifestPath, TaskLoggingHelper log)

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
@@ -17,6 +17,17 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
     {
         public const string AssetsVirtualDir = "assets/";
 
+        private static readonly string[] RequiredBuildAttributes = { 
+            "InitialAssetsLocation",
+            "AzureDevOpsBuildId",
+            "AzureDevOpsBuildDefinitionId",
+            "AzureDevOpsAccount",
+            "AzureDevOpsProject",
+            "AzureDevOpsBuildNumber",
+            "AzureDevOpsRepository",
+            "AzureDevOpsBranch",
+        };
+
         public static void CreateBuildManifest(TaskLoggingHelper log,
             IEnumerable<BlobArtifactModel> blobArtifacts,
             IEnumerable<PackageArtifactModel> packageArtifacts,
@@ -158,9 +169,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         {
             errors = new List<string>();
 
-            if (!attributes.ContainsKey("InitialAssetsLocation"))
+            foreach (var requiredAttribute in RequiredBuildAttributes)
             {
-                errors.Add("Missing required property InitialAssetsLocation.");
+                if (!attributes.ContainsKey(requiredAttribute))
+                {
+                    errors.Add($"Missing required property {requiredAttribute}.");
+                }
             }
 
             return errors.Count == 0;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
@@ -37,7 +37,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             string manifestBranch,
             string manifestCommit,
             string[] manifestBuildData,
-            bool isStableBuild)
+            bool isStableBuild,
+            bool validateManifest = false)
         {
             CreateModel(
                 blobArtifacts,
@@ -48,7 +49,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 manifestBranch,
                 manifestCommit,
                 isStableBuild,
-                log)
+                log,
+                validateManifest)
                 .WriteAsXml(assetManifestPath, log);
         }
 
@@ -70,7 +72,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             string repoBranch,
             string repoCommit,
             bool isStableBuild,
-            TaskLoggingHelper log)
+            TaskLoggingHelper log,
+            bool validateManifest)
         {
             if (artifacts == null)
             {
@@ -115,7 +118,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 repoBranch,
                 repoCommit,
                 isStableBuild,
-                log);
+                log,
+                validateManifest);
             return buildModel;
         }
 
@@ -127,10 +131,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             string manifestBranch,
             string manifestCommit,
             bool isStableBuild,
-            TaskLoggingHelper log)
+            TaskLoggingHelper log,
+            bool validateManifest)
         {
             var attributes = MSBuildListSplitter.GetNamedProperties(manifestBuildData);
-            if(!ValidateManifestBuildData(attributes, out List<string> errors))
+            if(validateManifest && !ValidateManifestBuildData(attributes, out List<string> errors))
             {
                 log.LogError("Missing properties in ManifestBuildData:");
                 foreach (var error in errors)
@@ -157,11 +162,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         internal static bool ManifestBuildDataHasLocationProperty(string [] manifestBuildData)
         {
-            return ManifestBuildDataHasLocationProperty(MSBuildListSplitter.GetNamedProperties(manifestBuildData));
-        }
+            IDictionary<string, string> attributes = MSBuildListSplitter.GetNamedProperties(manifestBuildData);
 
-        internal static bool ManifestBuildDataHasLocationProperty(IDictionary<string, string> attributes)
-        {
             return attributes.ContainsKey("Location");
         }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/GenerateBuildManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/GenerateBuildManifest.cs
@@ -73,7 +73,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     RepoBranch,
                     RepoCommit,
                     IsStableBuild,
-                    Log);
+                    Log,
+                    validateManifest: false);
 
                 buildModel.WriteAsXml(OutputPath, Log);
             }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
@@ -144,7 +144,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         ManifestBranch,
                         ManifestCommit,
                         ManifestBuildData,
-                        IsStableBuild);
+                        IsStableBuild,
+                        validateManifest: true);
 
                     Log.LogMessage(MessageImportance.High,
                         $"##vso[artifact.upload containerfolder=AssetManifests;artifactname=AssetManifests]{AssetManifestPath}");


### PR DESCRIPTION
Closes: https://github.com/dotnet/arcade/issues/2201

The `Location` attribute is something from the old format of the Build Manifest. Moving forward we don't need that attribute. 