### PR TITLE
Change configure-toolset grep command to use flags supported on linux and osx

### DIFF
--- a/eng/configure-toolset.sh
+++ b/eng/configure-toolset.sh
@@ -13,7 +13,7 @@ function Test-FilesUseTelemetryOutput {
         'eng/common/performance/performance-setup.sh'
     )
 
-    local file_list=`grep --files-without-match --dereference-recursive --include=*.sh "Write-PipelineTelemetryError" $scriptroot`
+    local file_list=`grep --files-without-match --recursive --include=*.sh "Write-PipelineTelemetryError" $scriptroot`
     for file in $file_list; do
         for remove_file in ${require_telmetry_exclude_files[@]}; do
             if [[ $file =~ .*"$remove_file" ]]; then


### PR DESCRIPTION
Fixes #4634 

On Linux
 - `-r, --recursive, recursively search subdirectories listed`
  - `-R, --dereference-recursive, recursive search but follow all symlinks`

On Mac
 - `--dereference-recursive` is not supported
 - `-R, -r, --recursive, recursively search subdirectories listed`
 - `-S If -R is specified, all symbolic links are followed`

To get identical behavior (recursive symlink search), we'd have to do `-R` on Linux but `-R -S` on Mac.  If we just did `-R`, then we would do a symlink search on Linux but not Mac.  I think we should just simplify and go with `--recursive` which performs identical behavior on both.  I don't think symlink support is needed.  Could be wrong though...

@tmat, @riarenas PTAL