### PR TITLE
Add Crossgen pack support to shared framework tooling

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.packaging.targets
@@ -23,6 +23,16 @@
     </PropertyGroup>
   </Target>
 
+  <Target Name="GetCrossgenPackInstallerProperties"
+          Condition="'$(FrameworkPackType)' == 'crossgen'"
+          BeforeTargets="GetInstallerProperties">
+    <PropertyGroup>
+      <InstallerName>$(ShortFrameworkName)-crossgen-pack</InstallerName>
+      <WixProductMoniker>$(CrossgenPackBrandName)</WixProductMoniker>
+      <VSInsertionShortComponentName>CrossgenPack</VSInsertionShortComponentName>
+    </PropertyGroup>
+  </Target>
+
   <Target Name="GetRuntimePackInstallerProperties"
           Condition="'$(FrameworkPackType)' == 'runtime'"
           BeforeTargets="GetInstallerGenerationFlags">

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/packaging-tools.props
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/packaging-tools.props
@@ -53,6 +53,11 @@
     <BuildRidSpecificPacks>true</BuildRidSpecificPacks>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$(MSBuildProjectName.EndsWith('.Crossgen'))">
+    <FrameworkPackType>crossgen</FrameworkPackType>
+    <BuildRidSpecificPacks>true</BuildRidSpecificPacks>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(BuildRidSpecificPacks)' == 'true'">
     <!-- RID-specific packs don't have a lineup package. -->
     <BuildLineupPackage>false</BuildLineupPackage>


### PR DESCRIPTION
In theory this code can be added to the crossgen pack project itself, however it requires a specific placement due to MSBuild evaluation order. I used that to test out the change in an official build, but to keep things simple let's add support here.

For https://github.com/dotnet/runtime/issues/906.

Supports PR https://github.com/dotnet/runtime/pull/1859.