### PR TITLE
[release/3.x] Port #4617 `sudo -E` the whole reporter script

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -x
 
+# relaunch as root
+[ `whoami` = root ] || exec sudo -E "$0" "$@"
+
 script_path=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 
 ENV_PATH=$HOME/.vsts-env
@@ -14,18 +17,18 @@ if [ ! -f $ENV_PATH/bin/python ]; then
   mv -T $TMP_ENV_PATH $ENV_PATH
 fi
 
-if sudo $ENV_PATH/bin/python -c "import azure.devops"; then
+if $ENV_PATH/bin/python -c "import azure.devops"; then
   echo "azure-devops module already available"
 else
-  sudo $ENV_PATH/bin/python -m pip install azure-devops==5.0.0b9
+  $ENV_PATH/bin/python -m pip install azure-devops==5.0.0b9
 fi
 
-if sudo $ENV_PATH/bin/python -c "import future"; then
+if $ENV_PATH/bin/python -c "import future"; then
   echo "future module already available"
 else
-  sudo $ENV_PATH/bin/python -m pip install future==0.17.1
+  $ENV_PATH/bin/python -m pip install future==0.17.1
 fi
 
 date -u +"%FT%TZ"
-sudo -E $ENV_PATH/bin/python $script_path/run.py "$@"
+$ENV_PATH/bin/python $script_path/run.py "$@"
 date -u +"%FT%TZ"


### PR DESCRIPTION
## Description

Update the helix AzDev reporter script to use sudo -E for everything.

## Customer Impact

Helix test runs will somewhat randomly fail to upload results with permissions issues. See https://github.com/dotnet/core-eng/issues/8615

## Regression

No

## Risk

Minimal risk. The change is to a single python script used to report test results.

## Workarounds

There are no workarounds.