### PR TITLE
Fix Alpine rootfs build

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -25,8 +25,9 @@ __UbuntuPackages="build-essential"
 __AlpinePackages="alpine-base"
 __AlpinePackages+=" build-base"
 __AlpinePackages+=" linux-headers"
-__AlpinePackages+=" lldb-dev"
-__AlpinePackages+=" llvm-dev"
+__AlpinePackagesEdgeTesting=" lldb-dev"
+__AlpinePackagesEdgeMain=" llvm9-libs"
+__AlpinePackagesEdgeMain+=" python3"
 
 # symlinks fixer
 __UbuntuPackages+=" symlinks"
@@ -199,13 +200,23 @@ if [[ "$__LinuxCodeName" == "alpine" ]]; then
     tar -xf $__ApkToolsDir/apk-tools-$__ApkToolsVersion-x86_64-linux.tar.gz -C $__ApkToolsDir
     mkdir -p $__RootfsDir/usr/bin
     cp -v /usr/bin/qemu-$__QEMUArch-static $__RootfsDir/usr/bin
+
     $__ApkToolsDir/apk-tools-$__ApkToolsVersion/apk \
       -X http://dl-cdn.alpinelinux.org/alpine/v$__AlpineVersion/main \
       -X http://dl-cdn.alpinelinux.org/alpine/v$__AlpineVersion/community \
-      -X http://dl-cdn.alpinelinux.org/alpine/edge/testing \
-      -X http://dl-cdn.alpinelinux.org/alpine/edge/main \
       -U --allow-untrusted --root $__RootfsDir --arch $__AlpineArch --initdb \
       add $__AlpinePackages
+
+    $__ApkToolsDir/apk-tools-$__ApkToolsVersion/apk \
+      -X http://dl-cdn.alpinelinux.org/alpine/edge/main \
+      -U --allow-untrusted --root $__RootfsDir --arch $__AlpineArch --initdb \
+      add $__AlpinePackagesEdgeMain
+
+    $__ApkToolsDir/apk-tools-$__ApkToolsVersion/apk \
+      -X http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+      -U --allow-untrusted --root $__RootfsDir --arch $__AlpineArch --initdb \
+      add $__AlpinePackagesEdgeTesting
+
     rm -r $__ApkToolsDir
 elif [[ -n $__LinuxCodeName ]]; then
     qemu-debootstrap --arch $__UbuntuArch $__LinuxCodeName $__RootfsDir $__UbuntuRepo


### PR DESCRIPTION
Specifying the edge/main and edge/testing repos for all the
packages lead to an unintended installation of libstdc++.so.6.0.27.
The libstdc++.so.6.0.25 from 3.9/main should be installed instead, 
otherwise the binaries we build have unresolved dependency to
`std::__cxx11::basic_stringstream<char, std::char_traits<char>, std::allocator<char> >::basic_stringstream()`
that got apparently added in the latest version of the library.

This change fixes it by separating installations of packages from
the edge/testing and edge/main.