### PR TITLE
Make mirror use build number to convey info for diagnosis

### DIFF
--- a/azure-pipelines-code-mirror.yml
+++ b/azure-pipelines-code-mirror.yml
@@ -54,6 +54,7 @@ jobs:
         inputs:
           scriptType: inlineScript
           arguments: '$(GithubRepo) $(BranchToMirror)'
+          workingDirectory: $(WorkingDirectoryName)
           inlineScript: |
             param([string]$repo, [string]$branch)
 

--- a/azure-pipelines-code-mirror.yml
+++ b/azure-pipelines-code-mirror.yml
@@ -58,7 +58,7 @@ jobs:
             param([string]$repo, [string]$branch)
 
             $commit = (git rev-parse HEAD).Substring(0, 7)
-            $message = "$repo/$branch@$commit"
+            $message = "$repo $branch $commit".Replace('/', ' ')
 
             Write-Host "##vso[build.updatebuildnumber]$message"
             Write-Host "##vso[build.addbuildtag]$message"

--- a/azure-pipelines-code-mirror.yml
+++ b/azure-pipelines-code-mirror.yml
@@ -59,7 +59,7 @@ jobs:
             param([string]$repo, [string]$branch)
 
             $commit = (git rev-parse HEAD).Substring(0, 7)
-            $message = "$repo $branch $commit".Replace('/', ' ')
+            $target = "$repo $branch".Replace('/', ' ')
 
-            Write-Host "##vso[build.updatebuildnumber]$message"
-            Write-Host "##vso[build.addbuildtag]$message"
+            Write-Host "##vso[build.updatebuildnumber]$target $commit"
+            Write-Host "##vso[build.addbuildtag]$target"

--- a/azure-pipelines-code-mirror.yml
+++ b/azure-pipelines-code-mirror.yml
@@ -46,3 +46,19 @@ jobs:
           git push azdo-mirror $(BranchToMirror) $(ExtraPushArgs)
         displayName: Push changes to Azure DevOps repo
         workingDirectory: $(WorkingDirectoryName)
+
+      - task: PowerShell@1
+        displayName: Broadcast target, branch, commit in metadata
+        continueOnError: true
+        condition: always()
+        inputs:
+          scriptType: inlineScript
+          arguments: '$(GithubRepo) $(BranchToMirror)'
+          inlineScript: |
+            param([string]$repo, [string]$branch)
+
+            $commit = (git rev-parse HEAD).Substring(0, 7)
+            $message = "$repo/$branch@$commit"
+
+            Write-Host "##vso[build.updatebuildnumber]$message"
+            Write-Host "##vso[build.addbuildtag]$message"

--- a/azure-pipelines-merge-mirror.yml
+++ b/azure-pipelines-merge-mirror.yml
@@ -57,3 +57,20 @@ jobs:
           git push azdo-mirror $(TargetBranchName) $(ExtraPushArgs)
         displayName: Push changes to Azure DevOps repo
         workingDirectory: $(WorkingDirectoryName)
+
+      - task: PowerShell@1
+        displayName: Broadcast target, branch, commit in metadata
+        continueOnError: true
+        condition: always()
+        inputs:
+          scriptType: inlineScript
+          arguments: '$(GithubRepo) $(BranchToMirror)'
+          workingDirectory: $(WorkingDirectoryName)
+          inlineScript: |
+            param([string]$repo, [string]$branch)
+
+            $commit = (git rev-parse HEAD).Substring(0, 7)
+            $target = "$repo $branch".Replace('/', ' ')
+
+            Write-Host "##vso[build.updatebuildnumber]$target $commit"
+            Write-Host "##vso[build.addbuildtag]$target"


### PR DESCRIPTION
For https://github.com/dotnet/arcade/issues/1817

It's really frustrating seeing a wall of builds at https://dnceng.visualstudio.com/internal/_build?definitionId=16&_a=summary with no distinguishing features. You have to guess based on info like timestamp which ones might be useful to look at.

I haven't tested this. I copied the `PowerShell@1` usage from earlier in the yaml and modified.

/cc @dotnet/runtime-infrastructure 