### PR TITLE
Ibc merge failure logging

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
@@ -100,10 +100,11 @@
       <_IbcFileByAssemblyName Include="@(_IbcFile->'%(AssemblyFileName)')"
                               IbcFiles="%(_IbcFile.Identity)"
                               PreviousAssemblyPath="%(_IbcFile.PreviousAssemblyDir)\%(_IbcFile.AssemblyFileName)"
-                              PreviousAssemblyCopyPath="$(ArtifactsTmpDir)OptimizedAssemblies\$([System.Guid]::NewGuid())"
+                              UniqueId="$([System.Guid]::NewGuid())"
+                              PreviousAssemblyCopyPath="$(ArtifactsTmpDir)OptimizedAssemblies\%(_IbcFileByAssemblyName.UniqueId)"
                               OptimizeAssemblyPath="%(_IbcFile.OptimizeAssemblyPath)"
                               TargetFramework="%(_IbcFile.TargetFramework)"
-                              XmlOutputPath="$(_IbcMergeXmlOutputDir)\%(_IbcFile.AssemblyFileName).$([System.Guid]::NewGuid()).temp.ibc.xml" />
+                              XmlOutputPath="$(_IbcMergeXmlOutputDir)\%(_IbcFile.AssemblyFileName).%(_IbcFileByAssemblyName.UniqueId).temp.ibc.xml" />
     </ItemGroup>
 
     <Error Text="No optimization data found for assemblies: @(_AssemblyWithoutRawIbcData, ', ')"
@@ -138,6 +139,10 @@
         <UnsignFile>%(_AssemblyWithRawIbcData.OptimizeAssemblyPath)</UnsignFile>
         <XmlOutputPath Condition="'$(EnableNgenOptimizationLogDetails)' == 'true'">%(_AssemblyWithRawIbcData.XmlOutputPath)</XmlOutputPath>
         <TargetFramework>%(_AssemblyWithRawIbcData.TargetFramework)</TargetFramework>
+
+        <!-- Files to copy to log dir if IbcMerge fails -->
+        <LogFilesOnFailure>%(_AssemblyWithRawIbcData.OptimizeAssemblyPath);%(_AssemblyWithRawIbcData.PreviousAssemblyCopyPath)</LogFilesOnFailure>
+        <LogFilesOnFailureDir>$(ArtifactsLogNgenDir)%(_AssemblyWithRawIbcData.UniqueId)\</LogFilesOnFailureDir>
       </_IbcMergeInvocation>
 
       <_IbcMergeInvocation>
@@ -166,14 +171,24 @@
           DestinationFiles="%(_IbcMergeInvocation.CopyFilesDestination)" 
           Condition="'%(_IbcMergeInvocation.CopyFilesSource)' != ''" />
 
-    <Exec Command='"$(DotNetTool)" exec "$(_IbcMergePath)" %(_IbcMergeInvocation.IbcMergeArgs)' ConsoleToMSBuild="true" Condition="'$(_RunIbcMerge)' == 'true'">
+    <Exec Command='"$(DotNetTool)" exec "$(_IbcMergePath)" %(_IbcMergeInvocation.IbcMergeArgs)' ConsoleToMSBuild="true" Condition="'$(_RunIbcMerge)' == 'true'" IgnoreExitCode="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="_IbcMergeOutput" />
+      <Output TaskParameter="ExitCode" PropertyName="_IbcMergeErrorCode" />
     </Exec>
 
     <Message Text="$(_IbcMergeOutput)" Importance="low" />
 
+    <!-- Copy IBCMerge input assembly to logs if the tool fails, to allow investigation -->
+    <Copy SourceFiles="%(_IbcMergeInvocation.LogFilesOnFailure)"
+          DestinationFolder="%(_IbcMergeInvocation.LogFilesOnFailureDir)"
+          Condition="'$(_IbcMergeErrorCode)' != '0' and '%(_IbcMergeInvocation.LogFilesOnFailure)' != ''" />
+
+    <Error Text="IBCMerge failed with exit code $(_IbcMergeErrorCode)."
+           Condition="'$(_IbcMergeErrorCode)' != '0'" />
+
     <!-- Remove Authenticode signing record if present. -->
     <Microsoft.DotNet.Arcade.Sdk.Unsign FilePath="%(_IbcMergeInvocation.UnsignFile)" Condition="'%(_IbcMergeInvocation.UnsignFile)' != ''" />
+
     <Microsoft.DotNet.Arcade.Sdk.ExtractNgenMethodList
       IbcXmlFilePath="%(_IbcMergeInvocation.XmlOutputPath)" 
       AssemblyFilePath="%(_IbcMergeInvocation.UnsignFile)"

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
@@ -9,10 +9,6 @@
       EnableNgenOptimizationLogDetails   Set to true to enable NGEN method logging output
       ApplyNgenOptimization              Set to 'partial' or 'full' in a project to embed partial/full NGEN optimization data to the built binary.
 
-    Obsolete (https://github.com/dotnet/arcade/issues/2092):
-      EnablePartialNgenOptimization      Set to true to enable Partial NGEN optimization data embedding.
-      ApplyPartialNgenOptimization       Set to true in a project to apply Partial NGEN optimization data to the built binary.
-
     Items:  
       OptimizeAssembly                   Set of assemblies to apply Partial NGEN optimization data to.
   -->
@@ -24,12 +20,9 @@
   <PropertyGroup>
     <PostCompileBinaryModificationSentinelFile>$(IntermediateOutputPath)$(TargetFileName).pcbm</PostCompileBinaryModificationSentinelFile>
 
-    <!-- TODO: remove (https://github.com/dotnet/arcade/issues/2092) -->
-    <EnablePartialNgenOptimization Condition="'$(EnablePartialNgenOptimization)' == '' and '$(Configuration)' == 'Release' and '$(OfficialBuild)' == 'true'">true</EnablePartialNgenOptimization>
-
-    <EnableNgenOptimization Condition="'$(EnableNgenOptimization)' == ''">$(EnablePartialNgenOptimization)</EnableNgenOptimization>
+    <EnableNgenOptimization Condition="'$(EnableNgenOptimization)' == '' and '$(Configuration)' == 'Release' and '$(OfficialBuild)' == 'true'">true</EnableNgenOptimization>
     <EnableNgenOptimizationLogDetails Condition="'$(EnableNgenOptimizationLogDetails)' == ''">$(UsingToolVisualStudioIbcTraining)</EnableNgenOptimizationLogDetails>
-    <ApplyNgenOptimization Condition="'$(ApplyPartialNgenOptimization)' == 'true'">partial</ApplyNgenOptimization>
+
     <_IbcMergeXmlOutputDir>$(ArtifactsTmpDir)ibcxml</_IbcMergeXmlOutputDir>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.AcquireOptimizationData.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.AcquireOptimizationData.targets
@@ -16,10 +16,7 @@
   <UsingTask AssemblyFile="$(_VisualStudioBuildTasksAssembly)" TaskName="Microsoft.DotNet.Build.Tasks.VisualStudio.FindLatestDrop"/>
 
   <PropertyGroup>
-    <!-- TODO: remove (https://github.com/dotnet/arcade/issues/2092) -->
-    <EnablePartialNgenOptimization Condition="'$(EnablePartialNgenOptimization)' == '' and '$(Configuration)' == 'Release' and '$(OfficialBuild)' == 'true'">true</EnablePartialNgenOptimization>
-
-    <EnableNgenOptimization Condition="'$(EnableNgenOptimization)' == ''">$(EnablePartialNgenOptimization)</EnableNgenOptimization>
+    <EnableNgenOptimization Condition="'$(EnableNgenOptimization)' == '' and '$(Configuration)' == 'Release' and '$(OfficialBuild)' == 'true'">true</EnableNgenOptimization>
   </PropertyGroup>
   
   <!--


### PR DESCRIPTION
We have seen some [intermittent failures](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3410702&view=results) recently in our signed builds. Unfortunately, the build does not currently publish build artifacts when such failure occurs, so it's hard to investigate the cause. This change adds logic to copy the input files of IBCMerge to log directory if IbcMerge fails.