### PR TITLE
Fix darc-init.ps1 to use netcoreapp2.1

### DIFF
--- a/eng/common/darc-init.ps1
+++ b/eng/common/darc-init.ps1
@@ -27,7 +27,7 @@ function InstallDarcCli ($darcVersion) {
 
   Write-Host "Installing Darc CLI version $darcVersion..."
   Write-Host "You may need to restart your command window if this is the first dotnet tool you have installed."
-  & "$dotnet" tool install $darcCliPackageName --version $darcVersion --add-source "$arcadeServicesSource" -v $verbosity -g
+  & "$dotnet" tool install $darcCliPackageName --version $darcVersion --add-source "$arcadeServicesSource" -v $verbosity -g --framework netcoreapp2.1
 }
 
 InstallDarcCli $darcVersion


### PR DESCRIPTION
## Description

The release/3.x build doesn't work because darc is built for netcoreapp2.1 and netcoreapp3.0, and dotnet tool install picks netcoreapp3.0.

## Customer Impact

We can't ship arcade servicing.

## Regression

No

## Risk

Not risky.

## Workarounds

None.