### PR TITLE
Exclude NuGet assemblies from dotnet core Feed package

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -9,6 +9,7 @@
     <DevelopmentDependency>true</DevelopmentDependency>
     <PackageType>MSBuildSdk</PackageType>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <_ExcludeNuGetAssembliesTargetFramework>netcoreapp2.1</_ExcludeNuGetAssembliesTargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,6 +23,13 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.VersionTools\lib\Microsoft.DotNet.VersionTools.csproj" />
   </ItemGroup>
+
+  <!-- Exclude NuGet package assemblies per https://github.com/dotnet/arcade/issues/1965 -->
+  <Target Name="ExcludeNuGetPackagesFromNetCore" BeforeTargets="GenerateNuspec">
+    <ItemGroup>
+      <_PackageFilesToExclude Include="%(_PackageFiles.Identity)" Condition="$([System.String]::Copy('%(_PackageFiles.FileName)').StartsWith('NuGet')) and $([System.String]::Copy('%(_PackageFiles.Directory)').Contains('$(_ExcludeNuGetAssembliesTargetFramework)'))" />
+    </ItemGroup>
+  </Target>
 
   <Import Project="$(RepoRoot)eng\BuildTask.targets" />
 </Project>


### PR DESCRIPTION
This is a bit hacky.  Basically, we just check to see if a package file is a NuGet file.  The way we do it is, admittedly, fragile since it's possible for someone to construct a directory that contains `netcoreapp2.1` somewhere closer to the root and everything would get excluded.  This is a temporary "fix" to unblock repos which are encountering https://github.com/dotnet/arcade/issues/1965