### PR TITLE
Set TEMP environment variable for the current process

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -655,6 +655,9 @@ Write-PipelineSetVariable -Name 'Artifacts.Log' -Value $LogDir
 Write-PipelineSetVariable -Name 'TEMP' -Value $TempDir
 Write-PipelineSetVariable -Name 'TMP' -Value $TempDir
 
+$env:TEMP=$TempDir
+$env:TMP=$TempDir
+
 # Import custom tools configuration, if present in the repo.
 # Note: Import in global scope so that the script set top-level variables without qualification.
 if (!$disableConfigureToolsetImport) {


### PR DESCRIPTION
The variable was only set via ADO, which only sets it for the next ADO task not the current script environment.