### PR TITLE
Remove usages of private CoreCLR and CoreFX packages from SharedFramework SDK.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.dependency.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.dependency.targets
@@ -214,8 +214,7 @@
   <Target Name="AddCrossgenToolPackageReferences"
           BeforeTargets="CollectPackageReferences">
     <ItemGroup>
-      <CrossgenToolPackageReference Include="Microsoft.Private.CoreFx.NETCoreApp" Version="$(MicrosoftPrivateCoreFxNETCoreAppVersion)" />
-      <CrossgenToolPackageReference Include="transport.Microsoft.NETCore.Runtime.CoreCLR" Version="$(MicrosoftNETCoreRuntimeCoreCLRVersion)" />
+      <CrossgenToolPackageReference Include="$(MicrosoftNETCoreAppRuntimePackage)" Version="$(MicrosoftNETCoreAppRuntimeVersion)" />
       <CrossgenToolPackageReference Include="$(MicrosoftTargetingPackPrivateWinRTPackage)" Version="$(MicrosoftTargetingPackPrivateWinRTVersion)" />
 
       <!-- This tool is a prebuilt not buildable from source. -->
@@ -241,12 +240,10 @@
   <Target Name="GetCorePackagePaths"
           DependsOnTargets="ResolveReferences">
     <PropertyGroup>
-      <_runtimePackageId>transport.runtime.$(PackageRID).$(MicrosoftNETCoreRuntimeCoreCLRPackage.ToLowerInvariant())</_runtimePackageId>
-      <_runtimePackageVersion>$(MicrosoftNETCoreRuntimeCoreCLRVersion)</_runtimePackageVersion>
+      <_runtimePackageId>$(MicrosoftNETCoreAppRuntimePackage.ToLowerInvariant()).$(PackageRID)</_runtimePackageId>
+      <_runtimePackageVersion>$(MicrosoftNETCoreAppRuntimeVersion)</_runtimePackageVersion>
 
       <_runtimePackageDir>$(NuGetPackageRoot)$(_runtimePackageId)/$(_runtimePackageVersion)/</_runtimePackageDir>
-      <_jitPackageDir>$(NuGetPackageRoot)transport.runtime.$(PackageRID).microsoft.netcore.jit/$(MicrosoftNETCoreRuntimeCoreCLRVersion)/</_jitPackageDir>
-      <_corefxPackageDir>$(NuGetPackageRoot)runtime.$(PackageRID).$(MicrosoftPrivateCoreFxNETCoreAppPackage.ToLowerInvariant())/$(MicrosoftPrivateCoreFxNETCoreAppVersion)/</_corefxPackageDir>
       <_winmdPackageDir>$(NuGetPackageRoot)$(MicrosoftTargetingPackPrivateWinRTPackage.ToLowerInvariant())/$(MicrosoftTargetingPackPrivateWinRTVersion)/</_winmdPackageDir>
       <_diaSymReaderPackageDir>$(NuGetPackageRoot)microsoft.diasymreader.native/$(MicrosoftDiaSymReaderNativeVersion)/</_diaSymReaderPackageDir>
     </PropertyGroup>
@@ -265,7 +262,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <_requiredProperty Include="_runtimePackageDir;_jitPackageDir;_corefxPackageDir;_winmdPackageDir" />
+      <_requiredProperty Include="_runtimePackageDir;_winmdPackageDir" />
     </ItemGroup>
 
     <Message Text="%(_requiredProperty.Identity): $(%(_requiredProperty.Identity))" />
@@ -279,7 +276,7 @@
       <!-- Find crossgen tool assets in package cache to allow ExcludeAssets=All. -->
       <_runtimeCLR Include="$(_runtimePackageDir)**/$(LibraryFilePrefix)coreclr$(LibraryFileExtension)" />
       <_runtimeCoreLib Include="$(_runtimePackageDir)**/native/System.Private.CoreLib.dll" />
-      <_fxSystemRuntime Include="$(_corefxPackageDir)**/System.Runtime.dll" />
+      <_fxSystemRuntime Include="$(_runtimePackageDir)**/System.Runtime.dll" />
       <_windowsWinMD Include="$(_winmdPackageDir)**/Windows.winmd" />
       <_diaSymReaderAssembly Include="$(_diaSymReaderPackageDir)**\Microsoft.DiaSymReader.Native.*.dll" />
     </ItemGroup>
@@ -294,8 +291,8 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <_jitPath Condition="'$(_crossDir)' == ''">$(_jitPackageDir)runtimes/$(PackageRID)/native/$(LibraryFilePrefix)clrjit$(LibraryFileExtension)</_jitPath>
-      <_jitPath Condition="'$(_crossDir)' != ''">$(_jitPackageDir)runtimes$(_crossDir)/native/$(LibraryFilePrefix)clrjit$(LibraryFileExtension)</_jitPath>
+      <_jitPath Condition="'$(_crossDir)' == ''">$(_runtimePackageDir)runtimes/$(PackageRID)/native/$(LibraryFilePrefix)clrjit$(LibraryFileExtension)</_jitPath>
+      <_jitPath Condition="'$(_crossDir)' != ''">$(_runtimePackageDir)runtimes$(_crossDir)/native/$(LibraryFilePrefix)clrjit$(LibraryFileExtension)</_jitPath>
     </PropertyGroup>
 
     <PropertyGroup Condition="'@(_fxSystemRuntime)' != ''">

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.dependency.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.dependency.targets
@@ -214,7 +214,7 @@
   <Target Name="AddCrossgenToolPackageReferences"
           BeforeTargets="CollectPackageReferences">
     <ItemGroup>
-      <CrossgenToolPackageReference Include="$(MicrosoftNETCoreAppRuntimePackage)" Version="$(MicrosoftNETCoreAppRuntimeVersion)" />
+      <CrossgenToolPackageReference Include="$(MicrosoftNETCoreAppInternalPackage)" Version="$(MicrosoftNETCoreAppInternalVersion)" />
       <CrossgenToolPackageReference Include="$(MicrosoftTargetingPackPrivateWinRTPackage)" Version="$(MicrosoftTargetingPackPrivateWinRTVersion)" />
 
       <!-- This tool is a prebuilt not buildable from source. -->
@@ -240,8 +240,8 @@
   <Target Name="GetCorePackagePaths"
           DependsOnTargets="ResolveReferences">
     <PropertyGroup>
-      <_runtimePackageId>$(MicrosoftNETCoreAppRuntimePackage.ToLowerInvariant()).$(PackageRID)</_runtimePackageId>
-      <_runtimePackageVersion>$(MicrosoftNETCoreAppRuntimeVersion)</_runtimePackageVersion>
+      <_runtimePackageId>runtime.$(PackageRID).$(MicrosoftNETCoreAppPackage.ToLowerInvariant())</_runtimePackageId>
+      <_runtimePackageVersion>$(MicrosoftNETCoreAppInternalVersion)</_runtimePackageVersion>
 
       <_runtimePackageDir>$(NuGetPackageRoot)$(_runtimePackageId)/$(_runtimePackageVersion)/</_runtimePackageDir>
       <_winmdPackageDir>$(NuGetPackageRoot)$(MicrosoftTargetingPackPrivateWinRTPackage.ToLowerInvariant())/$(MicrosoftTargetingPackPrivateWinRTVersion)/</_winmdPackageDir>

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.dependency.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.dependency.targets
@@ -214,7 +214,7 @@
   <Target Name="AddCrossgenToolPackageReferences"
           BeforeTargets="CollectPackageReferences">
     <ItemGroup>
-      <CrossgenToolPackageReference Include="$(MicrosoftNETCoreAppInternalPackage)" Version="$(MicrosoftNETCoreAppInternalVersion)" />
+      <CrossgenToolPackageReference Include="$(MicrosoftNETCoreAppRuntimePackage).$(PackageRID)" Version="$(MicrosoftNETCoreAppRuntimewinx64Version)" />
       <CrossgenToolPackageReference Include="$(MicrosoftTargetingPackPrivateWinRTPackage)" Version="$(MicrosoftTargetingPackPrivateWinRTVersion)" />
 
       <!-- This tool is a prebuilt not buildable from source. -->
@@ -240,10 +240,7 @@
   <Target Name="GetCorePackagePaths"
           DependsOnTargets="ResolveReferences">
     <PropertyGroup>
-      <_runtimePackageId>runtime.$(PackageRID).$(MicrosoftNETCoreAppPackage.ToLowerInvariant())</_runtimePackageId>
-      <_runtimePackageVersion>$(MicrosoftNETCoreAppInternalVersion)</_runtimePackageVersion>
-
-      <_runtimePackageDir>$(NuGetPackageRoot)$(_runtimePackageId)/$(_runtimePackageVersion)/</_runtimePackageDir>
+      <_runtimePackageDir>$(NuGetPackageRoot)$(MicrosoftNETCoreAppRuntimePackage).$(PackageRID)/$(MicrosoftNETCoreAppRuntimewinx64Version)/</_runtimePackageDir>
       <_winmdPackageDir>$(NuGetPackageRoot)$(MicrosoftTargetingPackPrivateWinRTPackage.ToLowerInvariant())/$(MicrosoftTargetingPackPrivateWinRTVersion)/</_winmdPackageDir>
       <_diaSymReaderPackageDir>$(NuGetPackageRoot)microsoft.diasymreader.native/$(MicrosoftDiaSymReaderNativeVersion)/</_diaSymReaderPackageDir>
     </PropertyGroup>


### PR DESCRIPTION
This moves us closer to being able to remove the old private transport packages from pre-consolidation from dotnet/runtime.

cc: @dagood 