### PR TITLE
Try trigger file update on Arcade-validation

### DIFF
--- a/eng/common/post-build/add-build-to-channel.ps1
+++ b/eng/common/post-build/add-build-to-channel.ps1
@@ -17,7 +17,7 @@ try {
     ExitWithExitCode 1
   }
 
-  # Get info about which channels the build has already been promoted to
+  # Get info about which channel(s) the build has already been promoted to
   $buildInfo = Get-MaestroBuild -BuildId $BuildId
   
   if (!$buildInfo) {

--- a/eng/common/templates/steps/add-build-to-channel.yml
+++ b/eng/common/templates/steps/add-build-to-channel.yml
@@ -5,7 +5,7 @@ steps:
 - task: PowerShell@2
   displayName: Add Build to Channel
   inputs:
-    filePath: $(Build.SourcesDirectory)/eng/common/post-build/promote-build.ps1
+    filePath: $(Build.SourcesDirectory)/eng/common/post-build/add-build-to-channel.ps1
     arguments: -BuildId $(BARBuildId) 
       -ChannelId ${{ parameters.ChannelId }}
       -MaestroApiAccessToken $(MaestroApiAccessToken)

--- a/eng/common/templates/steps/add-build-to-channel.yml
+++ b/eng/common/templates/steps/add-build-to-channel.yml
@@ -10,4 +10,4 @@ steps:
       -ChannelId ${{ parameters.ChannelId }}
       -MaestroApiAccessToken $(MaestroApiAccessToken)
       -MaestroApiEndPoint $(MaestroApiEndPoint)
-      -MaestroApiVersion $(MaestroApiVersion)
+      -MaestroApiVersion $(MaestroApiVersion) 


### PR DESCRIPTION
Arcade validation builds are failing because the branch is missing `eng/common/templates/step/add-build-to-channel.yml`. I'm doing this change to the file to test whether the change will be propagated and the file created in Arcade Validation.