### PR TITLE
Fix namespace for SkipOnMono attribute

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnMonoAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnMonoAttribute.cs
@@ -2,7 +2,7 @@ using System;
 using Xunit;
 using Xunit.Sdk;
 
-namespace Microsoft.DotNet.XUnitExtensions.Attributes
+namespace Xunit
 {
     [TraitDiscoverer("Microsoft.DotNet.XUnitExtensions.SkipOnMonoDiscoverer", "Microsoft.DotNet.XUnitExtensions")]
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]


### PR DESCRIPTION
The old one was a mistake from the default of using VS to add the class to the project.

Fixes https://github.com/dotnet/arcade/issues/4710