### PR TITLE
Condition IBCMerge error handling on IBC run

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
@@ -176,15 +176,17 @@
       <Output TaskParameter="ExitCode" PropertyName="_IbcMergeErrorCode" />
     </Exec>
 
-    <Message Text="$(_IbcMergeOutput)" Importance="low" />
+    <Message Text="$(_IbcMergeOutput)"
+             Importance="low"
+             Condition="'$(_RunIbcMerge)' == 'true'" />
 
     <!-- Copy IBCMerge input assembly to logs if the tool fails, to allow investigation -->
     <Copy SourceFiles="%(_IbcMergeInvocation.LogFilesOnFailure)"
           DestinationFolder="%(_IbcMergeInvocation.LogFilesOnFailureDir)"
-          Condition="'$(_IbcMergeErrorCode)' != '0' and '%(_IbcMergeInvocation.LogFilesOnFailure)' != ''" />
+          Condition="'$(_RunIbcMerge)' == 'true' and '$(_IbcMergeErrorCode)' != '0' and '%(_IbcMergeInvocation.LogFilesOnFailure)' != ''" />
 
     <Error Text="IBCMerge failed with exit code $(_IbcMergeErrorCode)."
-           Condition="'$(_IbcMergeErrorCode)' != '0'" />
+           Condition="'$(_RunIbcMerge)' == 'true' and '$(_IbcMergeErrorCode)' != '0'" />
 
     <!-- Remove Authenticode signing record if present. -->
     <Microsoft.DotNet.Arcade.Sdk.Unsign FilePath="%(_IbcMergeInvocation.UnsignFile)" Condition="'%(_IbcMergeInvocation.UnsignFile)' != ''" />


### PR DESCRIPTION
Currently an IBCMerge error is thrown even though the tool doesn't even
run. Adding a condition to only do error handling if IBC ran. As I
already was there, I also conditioned the Message task.

Fixes build breaks in dotnet/runtime repo when IBCMerge isn't run: https://github.com/dotnet/arcade/commit/668181c7f8e4e6b6ee764173bfb876ebe6748b84#r37027947.

https://github.com/dotnet/runtime/pull/2074