### PR TITLE
Make SkipOnCoreClr skip always when running in CoreCLR if no flags specified and cache values

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnCoreClrAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnCoreClrAttribute.cs
@@ -10,8 +10,8 @@ namespace Xunit
         internal SkipOnCoreClrAttribute() { }
 
         public SkipOnCoreClrAttribute(string reason, TestPlatforms testPlatforms) { }
-        public SkipOnCoreClrAttribute(string reason, RuntimeStressTestModes testMode) { }
-        public SkipOnCoreClrAttribute(string reason, TestPlatforms testPlatforms, RuntimeStressTestModes testMode) { }
+        public SkipOnCoreClrAttribute(string reason, RuntimeTestModes testMode) { }
+        public SkipOnCoreClrAttribute(string reason, TestPlatforms testPlatforms, RuntimeTestModes testMode) { }
         public SkipOnCoreClrAttribute(string reason) { }
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCoreClrDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCoreClrDiscoverer.cs
@@ -25,14 +25,14 @@ namespace Microsoft.DotNet.XUnitExtensions
             if (!SkipOnMonoDiscoverer.IsMonoRuntime)
             {
                 TestPlatforms testPlatforms = TestPlatforms.Any;
-                RuntimeStressTestModes stressMode = RuntimeStressTestModes.Any;
+                RuntimeTestModes stressMode = RuntimeTestModes.Any;
                 foreach (object arg in traitAttribute.GetConstructorArguments().Skip(1)) // We skip the first one as it is the reason
                 {
                     if (arg is TestPlatforms tp)
                     {
                         testPlatforms = tp;
                     }
-                    else if (arg is RuntimeStressTestModes rstm)
+                    else if (arg is RuntimeTestModes rstm)
                     {
                         stressMode = rstm;
                     }
@@ -48,16 +48,16 @@ namespace Microsoft.DotNet.XUnitExtensions
         }
 
         // Order here matters as some env variables may appear in multiple modes
-        private static bool StressModeApplies(RuntimeStressTestModes stressMode) =>
-            stressMode == RuntimeStressTestModes.Any ||
-            (stressMode.HasFlag(RuntimeStressTestModes.CheckedRuntime) && s_isCheckedRuntime.Value) ||
-            (stressMode.HasFlag(RuntimeStressTestModes.GCStress3) && s_isGCStress3.Value) ||
-            (stressMode.HasFlag(RuntimeStressTestModes.GCStressC) && s_isGCStressC.Value) ||
-            (stressMode.HasFlag(RuntimeStressTestModes.ZapDisable) && s_isZapDisable.Value) ||
-            (stressMode.HasFlag(RuntimeStressTestModes.TailcallStress) && s_isTailCallStress.Value) ||
-            (stressMode.HasFlag(RuntimeStressTestModes.JitStressRegs) && s_isJitStressRegs.Value) ||
-            (stressMode.HasFlag(RuntimeStressTestModes.JitStress) && s_isJitStress.Value) ||
-            (stressMode.HasFlag(RuntimeStressTestModes.JitMinOpts) && s_isJitMinOpts.Value);
+        private static bool StressModeApplies(RuntimeTestModes stressMode) =>
+            stressMode == RuntimeTestModes.Any ||
+            (stressMode.HasFlag(RuntimeTestModes.CheckedRuntime) && s_isCheckedRuntime.Value) ||
+            (stressMode.HasFlag(RuntimeTestModes.GCStress3) && s_isGCStress3.Value) ||
+            (stressMode.HasFlag(RuntimeTestModes.GCStressC) && s_isGCStressC.Value) ||
+            (stressMode.HasFlag(RuntimeTestModes.ZapDisable) && s_isZapDisable.Value) ||
+            (stressMode.HasFlag(RuntimeTestModes.TailcallStress) && s_isTailCallStress.Value) ||
+            (stressMode.HasFlag(RuntimeTestModes.JitStressRegs) && s_isJitStressRegs.Value) ||
+            (stressMode.HasFlag(RuntimeTestModes.JitStress) && s_isJitStress.Value) ||
+            (stressMode.HasFlag(RuntimeTestModes.JitMinOpts) && s_isJitMinOpts.Value);
 
         private static string GetEnvironmentVariableValue(string name) => Environment.GetEnvironmentVariable(name) ?? "0";
 

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnMonoDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnMonoDiscoverer.cs
@@ -9,6 +9,8 @@ namespace Microsoft.DotNet.XUnitExtensions
 {
     public class SkipOnMonoDiscoverer : ITraitDiscoverer
     {
+        private static readonly Lazy<bool> s_isMonoRuntime = new Lazy<bool>(() => Type.GetType("Mono.RuntimeStructs") != null);
+
         public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
         {
             if (IsMonoRuntime)
@@ -30,6 +32,6 @@ namespace Microsoft.DotNet.XUnitExtensions
             return Array.Empty<KeyValuePair<string, string>>();
         }
 
-        public static bool IsMonoRuntime => Type.GetType("Mono.RuntimeStructs") != null;
+        public static bool IsMonoRuntime => s_isMonoRuntime.Value;
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeStressTestModes.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeStressTestModes.cs
@@ -5,10 +5,8 @@ namespace Xunit
     [Flags]
     public enum RuntimeStressTestModes
     {
-        // Disable on any stress test mode or on checked runtime.
-        // Can't be ~0 as that would include CheckedRuntime flag, which would break the case
-        // where you want to disable in all (including release stress test).
-        Any = 0,
+        // Disable always when using coreclr runtime.
+        Any = ~0,
 
         // JitStress, JitStressRegs, JitMinOpts and TailcallStress enable
         // various modes in the JIT that cause us to exercise more code paths,
@@ -29,7 +27,7 @@ namespace Xunit
         // GCStressC forces a GC at every JIT-generated code instruction,
         // including in NGEN/ReadyToRun code.
         GCStressC = 1 << 6, // COMPlus_GCStress includes mode 0xC.
-        CheckedRuntime = 1 << 7, // Disable only when running on checked runtime.
+        CheckedRuntime = 1 << 7, // Disable when running on a checked runtime
         AnyGCStress = GCStress3 | GCStressC // Disable when any GCStress is exercised.
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeTestModes.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeTestModes.cs
@@ -3,7 +3,7 @@ using System;
 namespace Xunit
 {
     [Flags]
-    public enum RuntimeStressTestModes
+    public enum RuntimeTestModes
     {
         // Disable always when using coreclr runtime.
         Any = ~0,


### PR DESCRIPTION
Based on: https://github.com/dotnet/runtime/pull/118#discussion_r350408817 -- I'm changing `SkipOnCoreClrAttribute` to only skip on checked runtime if `RuntimeStressTestModes.CheckedRuntime` is passed down.

Default usage will skip in all versions of coreclr.

Also fixes: https://github.com/dotnet/arcade/issues/4392 

cc: @stephentoub @akoeplinger @jkotas 