### PR TITLE
Categorize missing 'helixtargetqueue' as 'Build'

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MultiQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MultiQueue.targets
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <Target Name="ValidateTargetQueues">
+    <Telemetry EventName="NETCORE_ENGINEERING_TELEMETRY" EventData="Category=Build" />
     <Error Condition="'@(HelixTargetQueue)' == ''" Text="You must specify at least one target queue to send a job to helix. Use the HelixTargetQueues property or HelixTargetQueue items." />
   </Target>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/core-eng/issues/8710

Updated per documentation at https://github.com/dotnet/arcade/blob/master/Documentation/Projects/DevOps/CI/Telemetry-Guidance.md#arcade-msbuild-logger-support

Validated with local testing against the dotnet/runtime repo.