### PR TITLE
Revert "Set TEMP environment variable for the current process (#4687)"

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -655,9 +655,6 @@ Write-PipelineSetVariable -Name 'Artifacts.Log' -Value $LogDir
 Write-PipelineSetVariable -Name 'TEMP' -Value $TempDir
 Write-PipelineSetVariable -Name 'TMP' -Value $TempDir
 
-$env:TEMP=$TempDir
-$env:TMP=$TempDir
-
 # Import custom tools configuration, if present in the repo.
 # Note: Import in global scope so that the script set top-level variables without qualification.
 if (!$disableConfigureToolsetImport) {


### PR DESCRIPTION
- broke at least dotnet/aspnetcore and can be done locally in dotnet/roslyn

This reverts commit cc8fe69635c7c6e791c87540851aea75946945fa.