### PR TITLE
Load `Signing.props` from the correct directory.

### DIFF
--- a/eng/common/SigningValidation.proj
+++ b/eng/common/SigningValidation.proj
@@ -22,7 +22,7 @@
   <!--
     From 'Signing.props' we import $(SignValidationExclusionList)
   -->
-  <Import Project="$(MSBuildThisFileDirectory)Signing.props" Condition="Exists('$(MSBuildThisFileDirectory)Signing.props')" />
+  <Import Project="$(RepositoryEngineeringDir)Signing.props" Condition="Exists('$(RepositoryEngineeringDir)Signing.props')" />
 
   <Target Name="ValidateSigning">
     <PropertyGroup>


### PR DESCRIPTION
Currently, adding to the item group `@(SignValidationExclusionList)` has no effect because `Signing.props` is mistakenly (not) imported from `$(MSBuildThisFileDirectory)` (e.g., `arcade/eng/common`) instead of the correct location `$(RepositoryEngineeringDir)`.