### PR TITLE
Add RuntimeConfiguration flags to have more flexibility on SkipOnCoreClrAttribute

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnCoreClrAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnCoreClrAttribute.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using Xunit.Sdk;
 
@@ -11,7 +15,11 @@ namespace Xunit
 
         public SkipOnCoreClrAttribute(string reason, TestPlatforms testPlatforms) { }
         public SkipOnCoreClrAttribute(string reason, RuntimeTestModes testMode) { }
+        public SkipOnCoreClrAttribute(string reason, RuntimeConfiguration runtimeConfigurations) { }
+        public SkipOnCoreClrAttribute(string reason, RuntimeConfiguration runtimeConfigurations, RuntimeTestModes testModes) { }
+        public SkipOnCoreClrAttribute(string reason, TestPlatforms testPlatforms, RuntimeConfiguration runtimeConfigurations) { }
         public SkipOnCoreClrAttribute(string reason, TestPlatforms testPlatforms, RuntimeTestModes testMode) { }
+        public SkipOnCoreClrAttribute(string reason, TestPlatforms testPlatforms, RuntimeConfiguration runtimeConfigurations, RuntimeTestModes testModes) { }
         public SkipOnCoreClrAttribute(string reason) { }
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnMonoAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnMonoAttribute.cs
@@ -1,5 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
-using Xunit;
 using Xunit.Sdk;
 
 namespace Xunit

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCoreClrDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCoreClrDiscoverer.cs
@@ -1,5 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -19,6 +22,7 @@ namespace Microsoft.DotNet.XUnitExtensions
         private static readonly Lazy<bool> s_isGCStress3 = new Lazy<bool>(() => CompareGCStressModeAsLower(GetEnvironmentVariableValue("COMPlus_GCStress"), "0x3", "3"));
         private static readonly Lazy<bool> s_isGCStressC = new Lazy<bool>(() => CompareGCStressModeAsLower(GetEnvironmentVariableValue("COMPlus_GCStress"), "0xC", "C"));
         private static readonly Lazy<bool> s_isCheckedRuntime = new Lazy<bool>(() => IsCheckedRuntime());
+        private static readonly Lazy<bool> s_isReleaseRuntime = new Lazy<bool>(() => IsReleaseRuntime());
 
         public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
         {
@@ -26,19 +30,24 @@ namespace Microsoft.DotNet.XUnitExtensions
             {
                 TestPlatforms testPlatforms = TestPlatforms.Any;
                 RuntimeTestModes stressMode = RuntimeTestModes.Any;
+                RuntimeConfiguration runtimeConfigurations = RuntimeConfiguration.Any;
                 foreach (object arg in traitAttribute.GetConstructorArguments().Skip(1)) // We skip the first one as it is the reason
                 {
                     if (arg is TestPlatforms tp)
                     {
                         testPlatforms = tp;
                     }
-                    else if (arg is RuntimeTestModes rstm)
+                    else if (arg is RuntimeTestModes rtm)
                     {
-                        stressMode = rstm;
+                        stressMode = rtm;
+                    }
+                    else if (arg is RuntimeConfiguration rc)
+                    {
+                        runtimeConfigurations = rc;
                     }
                 }
 
-                if (DiscovererHelpers.TestPlatformApplies(testPlatforms) && StressModeApplies(stressMode))
+                if (DiscovererHelpers.TestPlatformApplies(testPlatforms) && RuntimeConfigurationApplies(runtimeConfigurations) && StressModeApplies(stressMode))
                 {
                     return new[] { new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing) };
                 }
@@ -47,10 +56,13 @@ namespace Microsoft.DotNet.XUnitExtensions
             return Array.Empty<KeyValuePair<string, string>>();
         }
 
+        private static bool RuntimeConfigurationApplies(RuntimeConfiguration runtimeConfigurations) =>
+            (runtimeConfigurations.HasFlag(RuntimeConfiguration.Checked) && s_isCheckedRuntime.Value) ||
+            (runtimeConfigurations.HasFlag(RuntimeConfiguration.Release) && s_isReleaseRuntime.Value);
+
         // Order here matters as some env variables may appear in multiple modes
         private static bool StressModeApplies(RuntimeTestModes stressMode) =>
-            stressMode == RuntimeTestModes.Any ||
-            (stressMode.HasFlag(RuntimeTestModes.CheckedRuntime) && s_isCheckedRuntime.Value) ||
+            (stressMode.HasFlag(RuntimeTestModes.RegularRun) && !IsStressTest) ||
             (stressMode.HasFlag(RuntimeTestModes.GCStress3) && s_isGCStress3.Value) ||
             (stressMode.HasFlag(RuntimeTestModes.GCStressC) && s_isGCStressC.Value) ||
             (stressMode.HasFlag(RuntimeTestModes.ZapDisable) && s_isZapDisable.Value) ||
@@ -59,16 +71,36 @@ namespace Microsoft.DotNet.XUnitExtensions
             (stressMode.HasFlag(RuntimeTestModes.JitStress) && s_isJitStress.Value) ||
             (stressMode.HasFlag(RuntimeTestModes.JitMinOpts) && s_isJitMinOpts.Value);
 
+        private static bool IsStressTest =>
+            s_isCheckedRuntime.Value ||
+            s_isGCStress3.Value ||
+            s_isGCStressC.Value ||
+            s_isZapDisable.Value ||
+            s_isTailCallStress.Value ||
+            s_isJitStressRegs.Value ||
+            s_isJitStress.Value ||
+            s_isJitMinOpts.Value;
+
         private static string GetEnvironmentVariableValue(string name) => Environment.GetEnvironmentVariable(name) ?? "0";
 
         private static bool IsCheckedRuntime()
         {
-            Assembly assembly = typeof(string).Assembly;
-            AssemblyConfigurationAttribute assemblyConfigurationAttribute = assembly.GetCustomAttribute<AssemblyConfigurationAttribute>();
+            AssemblyConfigurationAttribute assemblyConfigurationAttribute = GetAssemblyConfigurationAttribute();
 
             return assemblyConfigurationAttribute != null &&
                 string.Equals(assemblyConfigurationAttribute.Configuration, "Checked", StringComparison.InvariantCulture);
         }
+
+        private static bool IsReleaseRuntime()
+        {
+            AssemblyConfigurationAttribute assemblyConfigurationAttribute = GetAssemblyConfigurationAttribute();
+
+            return assemblyConfigurationAttribute != null &&
+                string.Equals(assemblyConfigurationAttribute.Configuration, "Release", StringComparison.InvariantCulture);
+        }
+
+        private static AssemblyConfigurationAttribute GetAssemblyConfigurationAttribute() =>
+            typeof(string).Assembly.GetCustomAttribute<AssemblyConfigurationAttribute>();
 
         private static bool CompareGCStressModeAsLower(string value, string first, string second)
         {

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnMonoDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnMonoDiscoverer.cs
@@ -1,3 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeConfiguration.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeConfiguration.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Xunit
+{
+    [Flags]
+    public enum RuntimeConfiguration
+    {
+        Any = ~0,
+        Checked = 1,
+        Release = 1 << 1,
+    }
+}

--- a/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeTestModes.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeTestModes.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 
 namespace Xunit
@@ -8,26 +12,28 @@ namespace Xunit
         // Disable always when using coreclr runtime.
         Any = ~0,
 
+        // We're running regular tests with no runtime stress modes
+        RegularRun = 1,
+
         // JitStress, JitStressRegs, JitMinOpts and TailcallStress enable
         // various modes in the JIT that cause us to exercise more code paths,
         // and generate different kinds of code
-        JitStress = 1, // COMPlus_JitStress is set.
-        JitStressRegs = 1 << 1, // COMPlus_JitStressRegs is set.
-        JitMinOpts = 1 << 2, // COMPlus_JITMinOpts is set.
-        TailcallStress = 1 << 3, // COMPlus_TailcallStress is set.
+        JitStress = 1 << 1, // COMPlus_JitStress is set.
+        JitStressRegs = 1 << 2, // COMPlus_JitStressRegs is set.
+        JitMinOpts = 1 << 3, // COMPlus_JITMinOpts is set.
+        TailcallStress = 1 << 4, // COMPlus_TailcallStress is set.
 
         // ZapDisable says to not use NGEN or ReadyToRun images.
         // This means we JIT everything.
-        ZapDisable = 1 << 4, // COMPlus_ZapDisable is set.
+        ZapDisable = 1 << 5, // COMPlus_ZapDisable is set.
 
         // GCStress3 forces a GC at various locations, typically transitions
         // to/from the VM from managed code. 
-        GCStress3 = 1 << 5,  // COMPlus_GCStress includes mode 0x3.
+        GCStress3 = 1 << 6,  // COMPlus_GCStress includes mode 0x3.
 
         // GCStressC forces a GC at every JIT-generated code instruction,
         // including in NGEN/ReadyToRun code.
-        GCStressC = 1 << 6, // COMPlus_GCStress includes mode 0xC.
-        CheckedRuntime = 1 << 7, // Disable when running on a checked runtime
+        GCStressC = 1 << 7, // COMPlus_GCStress includes mode 0xC.
         AnyGCStress = GCStress3 | GCStressC // Disable when any GCStress is exercised.
     }
 }


### PR DESCRIPTION
This gives us the flexibility of disabling for a stress mode in a specific configuration or for disabling in any stress mode in any configuration, or to disable for just one configuration, etc. Before these where exclusive, it was either one or the other, now we can disable with more granularity.

Also added license files.