### PR TITLE
Retries for GetDotNetInstallScript in powershell+bash

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -205,7 +205,7 @@ function GetDotNetInstallScript([string] $dotnetRoot) {
         break
       }
       catch {
-        Write-Message "Failed to download '$uri'"
+        Write-Host "Failed to download '$uri'"
         Write-Error $_.Exception.Message -ErrorAction Continue
       }
 

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -155,12 +155,12 @@ function InitializeDotNetCli([bool]$install, [bool]$createSdkLocationFile) {
   # The following code block is protecting against concurrent access so that this function can
   # be called in parallel.
   if ($createSdkLocationFile) {
-    do { 
+    do {
       $sdkCacheFileTemp = Join-Path $ToolsetDir $([System.IO.Path]::GetRandomFileName())
-    } 
+    }
     until (!(Test-Path $sdkCacheFileTemp))
     Set-Content -Path $sdkCacheFileTemp -Value $dotnetRoot
-  
+
     try {
       Rename-Item -Force -Path $sdkCacheFileTemp 'sdk.txt'
     } catch {
@@ -188,7 +188,36 @@ function GetDotNetInstallScript([string] $dotnetRoot) {
   if (!(Test-Path $installScript)) {
     Create-Directory $dotnetRoot
     $ProgressPreference = 'SilentlyContinue' # Don't display the console progress UI - it's a huge perf hit
-    Invoke-WebRequest "https://dot.net/$dotnetInstallScriptVersion/dotnet-install.ps1" -OutFile $installScript
+
+    $maxRetries = 6
+    $retries = 1
+
+    $uri = "https://dot.net/$dotnetInstallScriptVersion/dotnet-install.ps1"
+
+    # MaximumRetryCount parameter will handle retries for cases when web server replies with codes 304,400-599.
+    # Connection failures, and lower-level errors should be handled by the retry loop.
+    while($true) {
+      try {
+        Write-Host "GET $uri"
+        $response = Invoke-WebRequest $uri -OutFile $installScript -MaximumRetryCount $maxRetries -RetryIntervalSec 2
+        Write-Host ('Status: {0} {1}' -f $response.StatusCode, $response.StatusDescription)
+        Write-Host ($response.Headers.Keys | ForEach-Object { "{0}: {1}" -f $_, [string]$response.Headers.$_ })
+        break
+      }
+      catch {
+        Write-Message "Failed to download '$uri'"
+        Write-Error $_.Exception.Message -ErrorAction Continue
+      }
+
+      if (++$retries -le $maxRetries) {
+        $delayInSeconds = [math]::Pow(2, $retries) - 1 # Exponential backoff
+        Write-Host "Retrying. Waiting for $delayInSeconds seconds before next attempt ($retries of $maxRetries)."
+      }
+      else {
+        throw "Unable to download file in $maxRetries attempts."
+      }
+
+    }
   }
 
   return $installScript
@@ -198,12 +227,12 @@ function InstallDotNetSdk([string] $dotnetRoot, [string] $version, [string] $arc
   InstallDotNet $dotnetRoot $version $architecture
 }
 
-function InstallDotNet([string] $dotnetRoot, 
-  [string] $version, 
-  [string] $architecture = '', 
-  [string] $runtime = '', 
-  [bool] $skipNonVersionedFiles = $false, 
-  [string] $runtimeSourceFeed = '', 
+function InstallDotNet([string] $dotnetRoot,
+  [string] $version,
+  [string] $architecture = '',
+  [string] $runtime = '',
+  [bool] $skipNonVersionedFiles = $false,
+  [string] $runtimeSourceFeed = '',
   [string] $runtimeSourceFeedKey = '') {
 
   $installScript = GetDotNetInstallScript $dotnetRoot
@@ -298,7 +327,7 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
       $vsMajorVersion = $vsMinVersion.Major
       $xcopyMSBuildVersion = "$vsMajorVersion.$($vsMinVersion.Minor).0-alpha"
     }
-    
+
     $vsInstallDir = $null
     if ($xcopyMSBuildVersion.Trim() -ine "none") {
         $vsInstallDir = InitializeXCopyMSBuild $xcopyMSBuildVersion $install

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -197,9 +197,7 @@ function GetDotNetInstallScript([string] $dotnetRoot) {
     while($true) {
       try {
         Write-Host "GET $uri"
-        $response = Invoke-WebRequest $uri -OutFile $installScript
-        Write-Host ('Status: {0} {1}' -f $response.StatusCode, $response.StatusDescription)
-        Write-Host ($response.Headers.Keys | ForEach-Object { "{0}: {1}" -f $_, [string]$response.Headers.$_ })
+        Invoke-WebRequest $uri -OutFile $installScript
         break
       }
       catch {

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -189,7 +189,7 @@ function GetDotNetInstallScript([string] $dotnetRoot) {
     Create-Directory $dotnetRoot
     $ProgressPreference = 'SilentlyContinue' # Don't display the console progress UI - it's a huge perf hit
 
-    $maxRetries = 6
+    $maxRetries = 5
     $retries = 1
 
     $uri = "https://dot.net/$dotnetInstallScriptVersion/dotnet-install.ps1"
@@ -208,6 +208,7 @@ function GetDotNetInstallScript([string] $dotnetRoot) {
       if (++$retries -le $maxRetries) {
         $delayInSeconds = [math]::Pow(2, $retries) - 1 # Exponential backoff
         Write-Host "Retrying. Waiting for $delayInSeconds seconds before next attempt ($retries of $maxRetries)."
+        Start-Sleep -Seconds $delayInSeconds
       }
       else {
         throw "Unable to download file in $maxRetries attempts."

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -194,12 +194,10 @@ function GetDotNetInstallScript([string] $dotnetRoot) {
 
     $uri = "https://dot.net/$dotnetInstallScriptVersion/dotnet-install.ps1"
 
-    # MaximumRetryCount parameter will handle retries for cases when web server replies with codes 304,400-599.
-    # Connection failures, and lower-level errors should be handled by the retry loop.
     while($true) {
       try {
         Write-Host "GET $uri"
-        $response = Invoke-WebRequest $uri -OutFile $installScript -MaximumRetryCount $maxRetries -RetryIntervalSec 2
+        $response = Invoke-WebRequest $uri -OutFile $installScript
         Write-Host ('Status: {0} {1}' -f $response.StatusCode, $response.StatusDescription)
         Write-Host ($response.Headers.Keys | ForEach-Object { "{0}: {1}" -f $_, [string]$response.Headers.$_ })
         break

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -219,7 +219,7 @@ function InstallDotNet {
 }
 
 function with_retries {
-  local maxRetries=${RETRIES-5}
+  local maxRetries=5
   local retries=1
   echo "Trying to run '$@' for maximum of $maxRetries attempts."
   while [[ $((retries++)) -le $maxRetries ]]; do
@@ -237,7 +237,7 @@ function with_retries {
 
   echo "Failed to execute '$@' for $maxRetries times." 1>&2
 
-  return -1
+  return 1
 }
 
 function GetDotNetInstallScript {

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -41,7 +41,7 @@ fi
 # Configures warning treatment in msbuild.
 warn_as_error=${warn_as_error:-true}
 
-# True to attempt using .NET Core already that meets requirements specified in global.json 
+# True to attempt using .NET Core already that meets requirements specified in global.json
 # installed on the machine instead of downloading one.
 use_installed_dotnet_cli=${use_installed_dotnet_cli:-true}
 
@@ -172,7 +172,7 @@ function InstallDotNetSdk {
 function InstallDotNet {
   local root=$1
   local version=$2
- 
+
   GetDotNetInstallScript "$root"
   local install_script=$_GetDotNetInstallScript
 
@@ -218,6 +218,28 @@ function InstallDotNet {
   }
 }
 
+function with_retries {
+  local maxRetries=${RETRIES-5}
+  local retries=1
+  echo "Executing '$@'."
+  while [[ $((retries++)) -le $maxRetries ]]; do
+    "$@" 1>&2
+
+    if [[ $? == 0 ]]; then
+      echo "Ran '$@' successfully."
+      return $?
+    fi
+
+    timeout=$((2**$retries-1))
+    echo "Failure! Retrying in $timeout seconds." 1>&2
+    sleep $timeout
+  done
+
+  echo "Failed to extute '$@' for $maxRetries times." 1>&2
+
+  return -1
+}
+
 function GetDotNetInstallScript {
   local root=$1
   local install_script="$root/dotnet-install.sh"
@@ -230,13 +252,13 @@ function GetDotNetInstallScript {
 
     # Use curl if available, otherwise use wget
     if command -v curl > /dev/null; then
-      curl "$install_script_url" -sSL --retry 10 --create-dirs -o "$install_script" || {
+      with_retries curl "$install_script_url" -isSLv --retry 10 --create-dirs -o "$install_script" || {
         local exit_code=$?
         Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to acquire dotnet install script (exit code '$exit_code')."
         ExitWithExitCode $exit_code
       }
-    else 
-      wget -q -O "$install_script" "$install_script_url" || {
+    else
+      with_retries wget -v -O "$install_script" "$install_script_url" || {
         local exit_code=$?
         Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to acquire dotnet install script (exit code '$exit_code')."
         ExitWithExitCode $exit_code
@@ -251,11 +273,11 @@ function InitializeBuildTool {
   if [[ -n "${_InitializeBuildTool:-}" ]]; then
     return
   fi
-  
+
   InitializeDotNetCli $restore
 
   # return values
-  _InitializeBuildTool="$_InitializeDotNetCli/dotnet"  
+  _InitializeBuildTool="$_InitializeDotNetCli/dotnet"
   _InitializeBuildToolCommand="msbuild"
   _InitializeBuildToolFramework="netcoreapp2.1"
 }
@@ -319,7 +341,7 @@ function InitializeToolset {
   if [[ "$binary_log" == true ]]; then
     bl="/bl:$log_dir/ToolsetRestore.binlog"
   fi
-  
+
   echo '<Project Sdk="Microsoft.DotNet.Arcade.Sdk"/>' > "$proj"
   MSBuild-Core "$proj" $bl /t:__WriteToolsetLocation /clp:ErrorsOnly\;NoSummary /p:__ToolsetLocationOutputFile="$toolset_location_file"
 

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -223,7 +223,7 @@ function with_retries {
   local retries=1
   echo "Executing '$@'."
   while [[ $((retries++)) -le $maxRetries ]]; do
-    "$@" 1>&2
+    "$@"
 
     if [[ $? == 0 ]]; then
       echo "Ran '$@' successfully."
@@ -231,11 +231,11 @@ function with_retries {
     fi
 
     timeout=$((2**$retries-1))
-    echo "Failure! Retrying in $timeout seconds." 1>&2
+    echo "Failed to execute '$@'. Waiting $timeout seconds before next attempt ($retries out of $maxRetries)." 1>&2
     sleep $timeout
   done
 
-  echo "Failed to extute '$@' for $maxRetries times." 1>&2
+  echo "Failed to execute '$@' for $maxRetries times." 1>&2
 
   return -1
 }

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -221,7 +221,7 @@ function InstallDotNet {
 function with_retries {
   local maxRetries=${RETRIES-5}
   local retries=1
-  echo "Executing '$@'."
+  echo "Trying to run '$@' for maximum of $maxRetries attempts."
   while [[ $((retries++)) -le $maxRetries ]]; do
     "$@"
 

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -227,7 +227,7 @@ function with_retries {
 
     if [[ $? == 0 ]]; then
       echo "Ran '$@' successfully."
-      return $?
+      return 0
     fi
 
     timeout=$((2**$retries-1))


### PR DESCRIPTION
Added retries with exponential backoff for any issues Invoke-WebRequest can potentially hit (PowerShell).
Added retries with exponential backoff for any issues curl and wget can potentially hit (bash).
Added response logging, headers, and status code (bash).
Added exception logging when retry happens (Powershell, bash).
Addresses #4740, and potentially workarounds any new instances of [#8687](https://github.com/dotnet/core-eng/issues/8687)