### PR TITLE
Use PreReleaseVersionIteration in SemVer1

### DIFF
--- a/Documentation/CorePackages/Versioning.md
+++ b/Documentation/CorePackages/Versioning.md
@@ -100,7 +100,7 @@ The pre-release label is determined based on the following table:
 | Release official build           | ""                                                | "1.2.3"                    |   
 
 In official builds, the value of **PRERELEASE_LABELS** is derived as in the following way:
-- If `SemanticVersioningV1` is set to true, it will be `PreReleaseVersionLabel`
+- If `SemanticVersioningV1` is set to true, it will be `PreReleaseVersionLabel` with `PreReleaseVersionIteration` appended. `PreReleaseVersionIteration` may be empty
 - If `SemanticVersioningV1` is not set to true, and `PreReleaseVersionIteration` is empty, it will be `PreReleaseVersionLabel`
 - If `SemanticVersioningV1` is not set to true, and `PreReleaseVersionIteration` is non empty, it will be `PreReleaseVersionLabel`.`PreReleaseVersionIteration`
 
@@ -220,7 +220,7 @@ Below is a list of the main parameters that control the logic.
 | DotNetUseShippingVersions  | Arcade | Set to `true` to produce shipping version strings in non-official builds. I.e., instead of fixed values like `42.42.42.42` for `AssemblyVersion`. |
 | DotNetFinalVersionKind     | Arcade | Specify the kind of version being generated: `release`, `prerelease` or empty. |
 | PreReleaseVersionLabel     | Arcade | Pre-release label to be used on the string. E.g., `beta`, `prerelease`, etc. `ci` and `dev` are reserved for non-official CI builds and dev builds, respectively. |
-| PreReleaseVersionIteration | Arcade | Numeric pre-release iteration to be used on the pre-release suffix string. E.g., `1`, `2`, etc. If set, and SemVer2 is in use, appends to the prerelease version label, separated by a `.` |
+| PreReleaseVersionIteration | Arcade | Numeric pre-release iteration to be used on the pre-release suffix string. E.g., `1`, `2`, etc. If set, and SemVer2 is in use, appends to the prerelease version label, separated by a `.`. If SemVer1 is in use, then it is appended without a separator. |
 | VersionPrefix              | .NET   | Specify the leading part of the version string. If empty and both `MajorVersion` and `MinorVersion` are set, initialized to `$(MajorVersion).$(MinorVersion).0`. |
 | MajorVersion               | Arcade | Major version to use in `VersionPrefix`. |
 | MinorVersion               | Arcade | Minor version to use in `VersionPrefix`. |

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
@@ -109,6 +109,7 @@
     -->
     <_PreReleaseLabel>$(PreReleaseVersionLabel)</_PreReleaseLabel>
     <_PreReleaseLabel Condition="'$(SemanticVersioningV1)' != 'true' and '$(PreReleaseVersionIteration)' != ''">$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</_PreReleaseLabel>
+    <_PreReleaseLabel Condition="'$(SemanticVersioningV1)' == 'true'">$(PreReleaseVersionLabel)$(PreReleaseVersionIteration)</_PreReleaseLabel>
     <_PreReleaseLabel Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(OfficialBuild)' != 'true'">ci</_PreReleaseLabel>
     <_PreReleaseLabel Condition="'$(ContinuousIntegrationBuild)' != 'true'">dev</_PreReleaseLabel>
 


### PR DESCRIPTION
If using SemVer1, append the PreReleaseVersionIteration (which can still be empty) to the PreReleaseVersionLabel. This enables consistent branding properties across repos in the stack.