### PR TITLE
Fix bug in SkipOnCoreClrDiscoverer

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCoreClrDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCoreClrDiscoverer.cs
@@ -74,7 +74,6 @@ namespace Microsoft.DotNet.XUnitExtensions
             (stressMode.HasFlag(RuntimeTestModes.JitMinOpts) && s_isJitMinOpts.Value);
 
         private static bool IsStressTest =>
-            s_isCheckedRuntime.Value ||
             s_isGCStress3.Value ||
             s_isGCStressC.Value ||
             s_isZapDisable.Value ||


### PR DESCRIPTION
Accidentally included IsCheckedRuntime check to IsStressTest so when RuntimeTestModes.Any, is not skipped when in a Checked runtime.

cc: @ViktorHofer 