### PR TITLE
making rebuild work in vs and command line incases of placeholder configs

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
@@ -10,8 +10,8 @@
   </PropertyGroup>
   
   <Target Name="RemovePlaceHolderConfigs"
-          Condition="'$(BuildAllConfigurations)' == 'true' and '$(MSBuildProjectExtension)' != '.pkgproj'"
-          BeforeTargets="DispatchToInnerBuilds">
+          Condition="'$(MSBuildProjectExtension)' != '.pkgproj'"
+          BeforeTargets="DispatchToInnerBuilds;Clean">
     <ItemGroup>
       <_InnerBuildProjects Remove="@(_InnerBuildProjects)" Condition="$([System.String]::Copy('%(_InnerBuildProjects.AdditionalProperties)').Contains('TargetFramework=_'))" />
     </ItemGroup>


### PR DESCRIPTION
Currently be default the clean runs for all the configs and when it try to clean _net472 config. so just running this target before clean to make sure it removes it from the inner project.
