### PR TITLE
Remove TargetFrameworkMonikers.Mono and replace with runtime detection

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ActiveIssueAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ActiveIssueAttribute.cs
@@ -18,7 +18,9 @@ namespace Xunit
         public ActiveIssueAttribute(string issue, TestPlatforms platforms) { }
         public ActiveIssueAttribute(int issueNumber, TargetFrameworkMonikers framework) { }
         public ActiveIssueAttribute(string issue, TargetFrameworkMonikers framework) { }
-        public ActiveIssueAttribute(int issueNumber, TestPlatforms platforms = TestPlatforms.Any, TargetFrameworkMonikers framework = (TargetFrameworkMonikers)0) { }
-        public ActiveIssueAttribute(string issue, TestPlatforms platforms = TestPlatforms.Any, TargetFrameworkMonikers framework = (TargetFrameworkMonikers)0) { }
+        public ActiveIssueAttribute(int issueNumber, TestRuntimes runtimes) { }
+        public ActiveIssueAttribute(string issue, TestRuntimes runtimes) { }
+        public ActiveIssueAttribute(int issueNumber, TestPlatforms platforms = TestPlatforms.Any, TargetFrameworkMonikers framework = (TargetFrameworkMonikers)0, TestRuntimes runtimes = TestRuntimes.Any) { }
+        public ActiveIssueAttribute(string issue, TestPlatforms platforms = TestPlatforms.Any, TargetFrameworkMonikers framework = (TargetFrameworkMonikers)0, TestRuntimes runtimes = TestRuntimes.Any) { }
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/ConditionalDiscovererException.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/ConditionalDiscovererException.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.DotNet.XUnitExtensions
 {

--- a/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
@@ -11,5 +11,10 @@ namespace Microsoft.DotNet.XUnitExtensions
                 (platforms.HasFlag(TestPlatforms.NetBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"))) ||
                 (platforms.HasFlag(TestPlatforms.OSX) && RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) ||
                 (platforms.HasFlag(TestPlatforms.Windows) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+        
+        internal static bool TestRuntimeApplies(TestRuntimes runtimes) =>
+                (runtimes.HasFlag(TestRuntimes.Mono) && SkipOnMonoDiscoverer.IsMonoRuntime) ||
+                (runtimes.HasFlag(TestRuntimes.CoreCLR) && !SkipOnMonoDiscoverer.IsMonoRuntime); // assume CoreCLR if it's not Mono
+
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ActiveIssueDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ActiveIssueDiscoverer.cs
@@ -55,8 +55,6 @@ namespace Microsoft.DotNet.XUnitExtensions
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreappTest);
                 if (frameworks.HasFlag(TargetFrameworkMonikers.NetFramework))
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetfxTest);
-                if (frameworks.HasFlag(TargetFrameworkMonikers.Uap))
-                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonUapTest);
                 if (frameworks == (TargetFrameworkMonikers)0)
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing);
             }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ActiveIssueDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ActiveIssueDiscoverer.cs
@@ -31,6 +31,7 @@ namespace Microsoft.DotNet.XUnitExtensions
             string issue = ctorArgs.First().ToString();
             TestPlatforms platforms = TestPlatforms.Any;
             TargetFrameworkMonikers frameworks = (TargetFrameworkMonikers)0;
+            TestRuntimes runtimes = TestRuntimes.Any;
             
             foreach (object arg in ctorArgs.Skip(1)) // First argument is the issue number.
             {
@@ -42,9 +43,13 @@ namespace Microsoft.DotNet.XUnitExtensions
                 {
                     frameworks = (TargetFrameworkMonikers)arg;
                 }
+                else if (arg is TestRuntimes)
+                {
+                    runtimes = (TestRuntimes)arg;
+                }
             }
         
-            if (DiscovererHelpers.TestPlatformApplies(platforms))
+            if (DiscovererHelpers.TestPlatformApplies(platforms) && DiscovererHelpers.TestRuntimeApplies(runtimes))
             {
                 if (frameworks.HasFlag(TargetFrameworkMonikers.Netcoreapp))
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreappTest);
@@ -52,8 +57,6 @@ namespace Microsoft.DotNet.XUnitExtensions
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetfxTest);
                 if (frameworks.HasFlag(TargetFrameworkMonikers.Uap))
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonUapTest);
-                if (frameworks.HasFlag(TargetFrameworkMonikers.Mono))
-                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonMonoTest);
                 if (frameworks == (TargetFrameworkMonikers)0)
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing);
 

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ActiveIssueDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ActiveIssueDiscoverer.cs
@@ -59,8 +59,6 @@ namespace Microsoft.DotNet.XUnitExtensions
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonUapTest);
                 if (frameworks == (TargetFrameworkMonikers)0)
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing);
-
-                yield return new KeyValuePair<string, string>(XunitConstants.ActiveIssue, issue);
             }
         }
     }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnTargetFrameworkDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnTargetFrameworkDiscoverer.cs
@@ -30,8 +30,6 @@ namespace Microsoft.DotNet.XUnitExtensions
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetfxTest);
             if (frameworks.HasFlag(TargetFrameworkMonikers.Uap))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonUapTest);
-            if (frameworks.HasFlag(TargetFrameworkMonikers.Mono))
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonMonoTest);
         }
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnTargetFrameworkDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnTargetFrameworkDiscoverer.cs
@@ -28,8 +28,6 @@ namespace Microsoft.DotNet.XUnitExtensions
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreappTest);
             if (frameworks.HasFlag(TargetFrameworkMonikers.NetFramework))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetfxTest);
-            if (frameworks.HasFlag(TargetFrameworkMonikers.Uap))
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonUapTest);
         }
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/TestCategoryDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/TestCategoryDiscoverer.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit.Abstractions;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Extensions/TheoryExtensions.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Extensions/TheoryExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/TargetFrameworkMonikers.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/TargetFrameworkMonikers.cs
@@ -10,7 +10,6 @@ namespace Xunit
     public enum TargetFrameworkMonikers
     {
         Netcoreapp = 0x1,
-        NetFramework = 0x2,
-        Uap = 0x4
+        NetFramework = 0x2
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/TestRuntimes.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/TestRuntimes.cs
@@ -7,10 +7,10 @@ using System;
 namespace Xunit
 {
     [Flags]
-    public enum TargetFrameworkMonikers
+    public enum TestRuntimes
     {
-        Netcoreapp = 0x1,
-        NetFramework = 0x2,
-        Uap = 0x4
+        CoreCLR = 1,
+        Mono = 2,
+        Any = ~0
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/XunitConstants.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/XunitConstants.cs
@@ -19,7 +19,6 @@ namespace Microsoft.DotNet.XUnitExtensions
         internal static string NonUapTest = "nonuaptests";
 
         internal const string Failing = "failing";
-        internal const string ActiveIssue = "activeissue";
         internal const string OuterLoop = "outerloop";
 
         public const string Category = "category";

--- a/src/Microsoft.DotNet.XUnitExtensions/src/XunitConstants.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/XunitConstants.cs
@@ -17,7 +17,6 @@ namespace Microsoft.DotNet.XUnitExtensions
         internal static string NonNetcoreappTest = "nonnetcoreapptests";
         internal static string NonNetfxTest = "nonnetfxtests";
         internal static string NonUapTest = "nonuaptests";
-        internal static string NonMonoTest = "nonmonotests";
 
         internal const string Failing = "failing";
         internal const string ActiveIssue = "activeissue";

--- a/src/Microsoft.DotNet.XUnitExtensions/src/XunitConstants.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/XunitConstants.cs
@@ -16,7 +16,6 @@ namespace Microsoft.DotNet.XUnitExtensions
 
         internal static string NonNetcoreappTest = "nonnetcoreapptests";
         internal static string NonNetfxTest = "nonnetfxtests";
-        internal static string NonUapTest = "nonuaptests";
 
         internal const string Failing = "failing";
         internal const string OuterLoop = "outerloop";


### PR DESCRIPTION
The Mono TFM is a leftover from some earlier plans and doesn't apply anymore with .NET 5.
It just creates confusion so remove it and replace with runtime detection.

Noticed this while looking at https://github.com/dotnet/runtime/pull/31920.