### PR TITLE
[release/3.x] Port GenerateChecksums Task to Arcade

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateChecksums.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateChecksums.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.IO;
+using System.Security.Cryptography;
+
+namespace Microsoft.DotNet.Arcade.Sdk
+{
+    public class GenerateChecksums : Task
+    {
+        /// <summary>
+        /// An item collection of files for which to generate checksums.  Each item must have metadata
+        /// 'DestinationPath' that specifies the path of the checksum file to create.
+        /// </summary>
+        [Required]
+        public ITaskItem[] Items { get; set; }
+
+        public override bool Execute()
+        {
+            foreach (ITaskItem item in Items)
+            {
+                try
+                {
+                    string destinationPath = item.GetMetadata("DestinationPath");
+                    if (string.IsNullOrEmpty(destinationPath))
+                    {
+                        throw new Exception($"Metadata 'DestinationPath' is missing for item '{item.ItemSpec}'.");
+                    }
+
+                    if (!File.Exists(item.ItemSpec))
+                    {
+                        throw new Exception($"The file '{item.ItemSpec}' does not exist.");
+                    }
+
+                    Log.LogMessage(
+                        MessageImportance.High,
+                        "Generating checksum for '{0}' into '{1}'...",
+                        item.ItemSpec,
+                        destinationPath);
+
+                    using (FileStream stream = File.OpenRead(item.ItemSpec))
+                    {
+                        using(HashAlgorithm hashAlgorithm = SHA512.Create())
+                        {
+                            byte[] hash = hashAlgorithm.ComputeHash(stream);
+                            string checksum = BitConverter.ToString(hash).Replace("-", string.Empty);
+                            File.WriteAllText(destinationPath, checksum);
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    // We have 2 log calls because we want a nice error message but we also want to capture the
+                    // callstack in the log.
+                    Log.LogError("An exception occurred while trying to generate a checksum for '{0}'.", item.ItemSpec);
+                    Log.LogMessage(MessageImportance.Low, e.ToString());
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
This task used to live in [Buildtools](https://github.com/dotnet/buildtools/blob/master/src/Microsoft.DotNet.Build.Tasks/GenerateChecksums.cs). Today, [dotnet/runtime](https://github.com/dotnet/runtime/blob/master/tools-local/tasks/installer.tasks/BuildTools.Publish/Tasks/GenerateChecksums.cs) & [dotnet/core-sdk](https://github.com/dotnet/core-sdk/blob/7464d9bca4a2f25d1f832f9ef51ed288d4b0201e/src/core-sdk-tasks/GenerateChecksums.cs) have this task checked in. Meanwhile, AspNetCore no longer generates checksums at all, since it [didn't port the task](https://github.com/dotnet/aspnetcore/issues/18792). We should centralize the task in Arcade in 3.x & master, and let those 3 repos migrate to the shared task in the 5.0 timeframe. AspNetCore needs this to get up-and-running in release/3.1.

@mmitche @dagood @tmat PTAL

CC @dougbu @Pilchie @mthalman  