### PR TITLE
[release/3.x] Add msbuild hook for GenerateChecksums

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateChecksums.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateChecksums.cs
@@ -29,13 +29,13 @@ namespace Microsoft.DotNet.Arcade.Sdk
                     if (string.IsNullOrEmpty(destinationPath))
                     {
                         Log.LogError($"Metadata 'DestinationPath' is missing for item '{item.ItemSpec}'.");
-                        return;
+                        return false;
                     }
 
                     if (!File.Exists(item.ItemSpec))
                     {
                         Log.LogError($"The file '{item.ItemSpec}' does not exist.");
-                        return;
+                        return false;
                     }
 
                     Log.LogMessage(MessageImportance.High, $"Generating checksum for '{item.ItemSpec}' into '{destinationPath}'...");

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateChecksums.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateChecksums.cs
@@ -29,13 +29,13 @@ namespace Microsoft.DotNet.Arcade.Sdk
                     if (string.IsNullOrEmpty(destinationPath))
                     {
                         Log.LogError($"Metadata 'DestinationPath' is missing for item '{item.ItemSpec}'.");
-                        return false;
+                        return !Log.HasLoggedErrors;
                     }
 
                     if (!File.Exists(item.ItemSpec))
                     {
                         Log.LogError($"The file '{item.ItemSpec}' does not exist.");
-                        return false;
+                        return !Log.HasLoggedErrors;
                     }
 
                     Log.LogMessage(MessageImportance.High, $"Generating checksum for '{item.ItemSpec}' into '{destinationPath}'...");
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
                 catch (Exception e)
                 {
                     Log.LogErrorFromException(e);
-                    return false;
+                    return !Log.HasLoggedErrors;
                 }
             }
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateChecksums.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateChecksums.cs
@@ -28,14 +28,14 @@ namespace Microsoft.DotNet.Arcade.Sdk
                     string destinationPath = item.GetMetadata("DestinationPath");
                     if (string.IsNullOrEmpty(destinationPath))
                     {
-                        Log.LogMessage(MessageImportance.High, $"Metadata 'DestinationPath' is missing for item '{item.ItemSpec}'.");
-                        return false;
+                        Log.LogError($"Metadata 'DestinationPath' is missing for item '{item.ItemSpec}'.");
+                        return;
                     }
 
                     if (!File.Exists(item.ItemSpec))
                     {
-                        Log.LogMessage(MessageImportance.High, $"The file '{item.ItemSpec}' does not exist.");
-                        return false;
+                        Log.LogError($"The file '{item.ItemSpec}' does not exist.");
+                        return;
                     }
 
                     Log.LogMessage(MessageImportance.High, $"Generating checksum for '{item.ItemSpec}' into '{destinationPath}'...");

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateChecksums.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateChecksums.cs
@@ -28,12 +28,14 @@ namespace Microsoft.DotNet.Arcade.Sdk
                     string destinationPath = item.GetMetadata("DestinationPath");
                     if (string.IsNullOrEmpty(destinationPath))
                     {
-                        throw new Exception($"Metadata 'DestinationPath' is missing for item '{item.ItemSpec}'.");
+                        Log.LogMessage(MessageImportance.High, $"Metadata 'DestinationPath' is missing for item '{item.ItemSpec}'.");
+                        return false;
                     }
 
                     if (!File.Exists(item.ItemSpec))
                     {
-                        throw new Exception($"The file '{item.ItemSpec}' does not exist.");
+                        Log.LogMessage(MessageImportance.High, $"The file '{item.ItemSpec}' does not exist.");
+                        return false;
                     }
 
                     Log.LogMessage(MessageImportance.High, $"Generating checksum for '{item.ItemSpec}' into '{destinationPath}'...");
@@ -50,9 +52,6 @@ namespace Microsoft.DotNet.Arcade.Sdk
                 }
                 catch (Exception e)
                 {
-                    // We have 2 log calls because we want a nice error message but we also want to capture the
-                    // callstack in the log.
-                    Log.LogError("An exception occurred while trying to generate a checksum for '{0}'.", item.ItemSpec);
                     Log.LogErrorFromException(e);
                     return false;
                 }

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateChecksums.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateChecksums.cs
@@ -36,11 +36,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
                         throw new Exception($"The file '{item.ItemSpec}' does not exist.");
                     }
 
-                    Log.LogMessage(
-                        MessageImportance.High,
-                        "Generating checksum for '{0}' into '{1}'...",
-                        item.ItemSpec,
-                        destinationPath);
+                    Log.LogMessage(MessageImportance.High, $"Generating checksum for '{item.ItemSpec}' into '{destinationPath}'...");
 
                     using (FileStream stream = File.OpenRead(item.ItemSpec))
                     {
@@ -57,12 +53,12 @@ namespace Microsoft.DotNet.Arcade.Sdk
                     // We have 2 log calls because we want a nice error message but we also want to capture the
                     // callstack in the log.
                     Log.LogError("An exception occurred while trying to generate a checksum for '{0}'.", item.ItemSpec);
-                    Log.LogMessage(MessageImportance.Low, e.ToString());
+                    Log.LogErrorFromException(e);
                     return false;
                 }
             }
 
-            return true;
+            return !Log.HasLoggedErrors;
         }
     }
 }

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateChecksums.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateChecksums.targets
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GenerateChecksums" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
+
+  <!--
+    Generate Checksums for the specified assets. Runs after the build of a project.
+  -->
+  <Target Name="GenerateChecksums"
+          Condition="'@(GenerateChecksumItems)' != ''"
+          AfterTargets="Build"
+          Inputs="@(GenerateChecksumItems)"
+          Outputs="%(GenerateChecksumItems.DestinationPath)">
+
+    <GenerateChecksums Items="@(GenerateChecksumItems)" />
+
+    <!-- Automatically include generated checksums in the asset manifest -->
+    <ItemGroup>
+      <ItemsToPushToBlobFeed Include="@(GenerateChecksumItems -> '%(DestinationPath)')" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateChecksums.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateChecksums.targets
@@ -8,9 +8,7 @@
   -->
   <Target Name="GenerateChecksums"
           Condition="'@(GenerateChecksumItems)' != ''"
-          AfterTargets="Build"
-          Inputs="@(GenerateChecksumItems)"
-          Outputs="%(GenerateChecksumItems.DestinationPath)">
+          AfterTargets="Build">
 
     <Error Condition="'%(GenerateChecksumItems.DestinationPath)' == ''"
            Text="Item &quot;%(GenerateChecksumItems.Identity)&quot; does not define required metadata &quot;DestinationPath&quot;" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateChecksums.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateChecksums.targets
@@ -12,6 +12,9 @@
           Inputs="@(GenerateChecksumItems)"
           Outputs="%(GenerateChecksumItems.DestinationPath)">
 
+    <Error Condition="'%(GenerateChecksumItems.DestinationPath)' == ''"
+           Text="Item &quot;%(GenerateChecksumItems.Identity)&quot; does not define required metadata &quot;DestinationPath&quot;" />
+
     <GenerateChecksums Items="@(GenerateChecksumItems)" />
 
     <!-- Automatically include generated checksums in the asset manifest -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets
@@ -14,6 +14,7 @@
 
   <Import Project="ProjectDefaults.targets"/>
   <Import Project="StrongName.targets"/>
+  <Import Project="GenerateChecksums.targets" />
   <Import Project="GenerateInternalsVisibleTo.targets" />
   <Import Project="GenerateResxSource.targets" />
   <Import Project="Workarounds.targets"/>


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/arcade/pull/4805. Addresses feedback in the task, and adds a target that runs post-build to generate the checksums & insert them in the manifest file (which will cause Arcade to publish them). I don't believe this will be sufficient for AspNetCore, since we don't generate our manifests in the same build step that we generate the assets for which we'll generate checksums - we'll need to modify `Publishing.props` to include the checksums in our manifest.

@dagood @mmitche @riarenas @tmat PTAL

CC @dougbu @mthalman 

Is there a markdown file somewhere where I should document what repos need to do to opt in to this feature?