### PR TITLE
Change the location of the vswhere download

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -387,8 +387,6 @@ function InitializeXCopyMSBuild([string]$packageVersion, [bool]$install) {
 # or $null if no instance meeting the requirements is found on the machine.
 #
 function LocateVisualStudio([object]$vsRequirements = $null){
-  Import-Module -Name (Join-Path $PSScriptRoot 'native\CommonLibrary.psm1')
-
   if (Get-Member -InputObject $GlobalJson.tools -Name 'vswhere') {
     $vswhereVersion = $GlobalJson.tools.vswhere
   } else {
@@ -401,7 +399,7 @@ function LocateVisualStudio([object]$vsRequirements = $null){
   if (!(Test-Path $vsWhereExe)) {
     Create-Directory $vsWhereDir
     Write-Host 'Downloading vswhere'
-    CommonLibrary\Get-File -Uri "https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/vswhere/$vswhereVersion/vswhere.exe" -Path $vswhereExe
+    Invoke-WebRequest "https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/vswhere/$vswhereVersion/vswhere.exe" -OutFile $vswhereExe
   }
 
   if (!$vsRequirements) { $vsRequirements = $GlobalJson.tools.vs }

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -399,7 +399,7 @@ function LocateVisualStudio([object]$vsRequirements = $null){
   if (!(Test-Path $vsWhereExe)) {
     Create-Directory $vsWhereDir
     Write-Host 'Downloading vswhere'
-    Invoke-WebRequest "https://github.com/Microsoft/vswhere/releases/download/$vswhereVersion/vswhere.exe" -OutFile $vswhereExe
+    Invoke-WebRequest "https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/vswhere/$vswhereVersion/vswhere.exe" -OutFile $vswhereExe
   }
 
   if (!$vsRequirements) { $vsRequirements = $GlobalJson.tools.vs }

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -399,7 +399,12 @@ function LocateVisualStudio([object]$vsRequirements = $null){
   if (!(Test-Path $vsWhereExe)) {
     Create-Directory $vsWhereDir
     Write-Host 'Downloading vswhere'
-    Invoke-WebRequest "https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/vswhere/$vswhereVersion/vswhere.exe" -OutFile $vswhereExe
+    try {
+      Invoke-WebRequest "https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/vswhere/$vswhereVersion/vswhere.exe" -OutFile $vswhereExe
+    }
+    catch {
+      Write-PipelineTelemetryError -Category 'InitializeToolset' -Message $_
+    }
   }
 
   if (!$vsRequirements) { $vsRequirements = $GlobalJson.tools.vs }

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -387,6 +387,8 @@ function InitializeXCopyMSBuild([string]$packageVersion, [bool]$install) {
 # or $null if no instance meeting the requirements is found on the machine.
 #
 function LocateVisualStudio([object]$vsRequirements = $null){
+  Import-Module -Name (Join-Path $PSScriptRoot 'native\CommonLibrary.psm1')
+
   if (Get-Member -InputObject $GlobalJson.tools -Name 'vswhere') {
     $vswhereVersion = $GlobalJson.tools.vswhere
   } else {
@@ -399,7 +401,7 @@ function LocateVisualStudio([object]$vsRequirements = $null){
   if (!(Test-Path $vsWhereExe)) {
     Create-Directory $vsWhereDir
     Write-Host 'Downloading vswhere'
-    Invoke-WebRequest "https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/vswhere/$vswhereVersion/vswhere.exe" -OutFile $vswhereExe
+    CommonLibrary\Get-File -Uri "https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/vswhere/$vswhereVersion/vswhere.exe" -Path $vswhereExe
   }
 
   if (!$vsRequirements) { $vsRequirements = $GlobalJson.tools.vs }


### PR DESCRIPTION
This change changes where we look to download vswhere from the github releases page, which seems to have added flakiness to builds to azure blob storage.

Storage now contains 2.5.2 (the default version), and 2.2.7, which roslyn-analyzers appears to specify in their global.json.