### PR TITLE
Convert from Microsoft.Azure.Storage.Blob to new Azure.Storage.Blobs

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
     <LibGit2SharpVersion>0.25.2</LibGit2SharpVersion>
     <log4netVersion>2.0.8</log4netVersion>
     <SystemNetHttpVersion>4.3.3</SystemNetHttpVersion>
-    <MicrosoftAzureStorageBlobVersion>11.1.2</MicrosoftAzureStorageBlobVersion>
+    <AzureStorageBlobsVersion>12.2.0</AzureStorageBlobsVersion>
     <MicrosoftAzureKeyVaultVersion>3.0.0</MicrosoftAzureKeyVaultVersion>
     <MicrosoftAzureServicesAppAuthenticationVersion>1.3.1</MicrosoftAzureServicesAppAuthenticationVersion>
     <MicrosoftDataAnalysisVersion>0.1.0</MicrosoftDataAnalysisVersion>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="$(MicrosoftAzureStorageBlobVersion)" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="$(AzureStorageBlobsVersion)" />
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
     <PackageReference Include="Microsoft.DotNet.Maestro.Client" Version="$(MicrosoftDotNetMaestroClientVersion)" />

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureStorageBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureStorageBlobFeed.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Azure.Storage.Blob;
+using Azure.Storage.Blobs.Models;
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.CloudTestTasks;
 using Newtonsoft.Json;
@@ -72,11 +72,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 // Create container if it doesn't already exist
                 if (!await azUtils.CheckIfContainerExistsAsync())
                 {
-                    BlobContainerPermissions permissions = new BlobContainerPermissions
-                    {
-                        PublicAccess = IsInternal ? BlobContainerPublicAccessType.Off : BlobContainerPublicAccessType.Container
-                    };
-
+                    PublicAccessType permissions = IsInternal ? PublicAccessType.None : PublicAccessType.BlobContainer;
                     await azUtils.CreateContainerAsync(permissions);
                 }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/CreateAzureContainer.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/CreateAzureContainer.cs
@@ -3,9 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
-using Microsoft.Azure.Storage.Blob;
 using System.Threading.Tasks;
 using System;
+using Azure.Storage.Sas;
+using Azure.Storage.Blobs.Models;
 
 namespace Microsoft.DotNet.Build.CloudTestTasks
 {
@@ -21,7 +22,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
 
         /// <summary>
         /// When false, if the specified container already exists get a reference to it.
-        /// When true, if the specified container already exists the task will fail.
+        /// When true, if the specified container already exists, fail the task.
         /// </summary>
         public bool FailIfExists { get; set; }
 
@@ -43,7 +44,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
         public string StorageUri { get; set; }
 
         /// <summary>
-        /// The write-only SAS token create when WriteOnlyTokenDaysValid is greater than zero.
+        /// The write-only SAS token to create when the value of WriteOnlyTokenDaysValid is greater than zero.
         /// </summary>
         [Output]
         public string WriteOnlyToken { get; set; }
@@ -75,16 +76,12 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                     return false;
                 }
 
-                BlobContainerPermissions permissions = new BlobContainerPermissions
-                {
-                    PublicAccess = IsPublic ? BlobContainerPublicAccessType.Blob : BlobContainerPublicAccessType.Off
-                };
+                PublicAccessType permissions = IsPublic ? PublicAccessType.Blob : PublicAccessType.None;
 
                 StorageUri = await blobUtils.CreateContainerAsync(permissions);
 
-                ReadOnlyToken = blobUtils.CreateSASToken(ReadOnlyTokenDaysValid, SharedAccessBlobPermissions.Read);
-
-                WriteOnlyToken = blobUtils.CreateSASToken(WriteOnlyTokenDaysValid, SharedAccessBlobPermissions.Write);
+                ReadOnlyToken = blobUtils.CreateSASToken(ReadOnlyTokenDaysValid, BlobContainerSasPermissions.Read);
+                WriteOnlyToken = blobUtils.CreateSASToken(WriteOnlyTokenDaysValid, BlobContainerSasPermissions.Write);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Per the folks on the Azure storage SDK and server-side teams, this is an attempt to address https://github.com/dotnet/core-eng/issues/8582 as the new libraries are ostensibly more thread-safe.

I ran this build to validate it: https://dnceng.visualstudio.com/internal/_build/results?buildId=516665&view=logs&j=f7bb3748-e35d-53de-9dd7-460ecd2014d6&t=299a6d6d-a279-539e-b6e9-1576018947a8 but it's clear that this doesn't exercise the same call stack from the above issue, so I'm reaching out to some runtime folks to make sure I can try out their build(s). 

Relevant runtime build testing this package: https://dnceng.visualstudio.com/internal/_build/results?buildId=516821&view=results