### PR TITLE
allow semi-colon delimited property value

### DIFF
--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -91,7 +91,7 @@ function Build {
     # Resolve relative project paths into full paths 
     $projects = ($projects.Split(';').ForEach({Resolve-Path $_}) -join ';')
     
-    $msbuildArgs += "/p:Projects=$projects"
+    $msbuildArgs += "/p:Projects=\""$projects\"""
     $properties = $msbuildArgs
   }
 

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -175,7 +175,7 @@ function Build {
   InitializeCustomToolset
 
   if [[ ! -z "$projects" ]]; then
-    properties="$properties /p:Projects=$projects"
+    properties="$properties /p:Projects=\\\"$projects\\\""
   fi
 
   local bl=""


### PR DESCRIPTION
When invoking `eng\common\build.ps1 -projects "a.sln;b.sln"` that gets expanded to `/p:Projects=C:\path\to\a.sln;C:\path\do\b.sln`.  MSBuild sees the semicolon and misinterprets that as separating two different properties along with their values, e.g., `/p:Prop1=Val1;Prop2=Val2`.  To force MSBuild to treat the semicolon as part of the value and not a separator, the value of the property needs to be escaped with escaped quotes which then need to be escaped for PowerShell.