### PR TITLE
Port GenerateChecksums task to Arcade

### DIFF
--- a/Documentation/CorePackages/Publishing.md
+++ b/Documentation/CorePackages/Publishing.md
@@ -183,13 +183,13 @@ Arcade also includes support for automatically generating checksum files. To opt
 
 Example:
 
-	```XML
+    ```XML
 	<ItemGroup>
 		<GenerateChecksumItems Include="@(OutputFile)">
 			<DestinationPath>%(FullPath).Sha512</OutputPath>
 		</GenerateChecksumItems>
 	</ItemGroup>
-	```
+    ```
 
 You will also need to pass `publishInstallersAndChecksums=true` to the `post-build.yml` template.
 

--- a/Documentation/CorePackages/Publishing.md
+++ b/Documentation/CorePackages/Publishing.md
@@ -144,7 +144,7 @@ In order to use the new publishing mechanism, the easiest way to start is by tur
     | symbolPublishingAdditionalParameters    | string   | Additional arguments for the PublishToSymbolServers sdk task.                                        | '' |
     | artifactsPublishingAdditionalParameters | string   | Additional arguments for the PublishArtifactsInManifest sdk task.                                    | '' |
     | signingValidationAdditionalParameters   | string  | Additional arguments for the SigningValidation sdk task.     | '' |
-    | publishInstallersAndChecksums           | bool     | Publish installers packages and checksums from the build artifacts to the dotnetcli storage account. | false |
+    | publishInstallersAndChecksums           | bool     | Publish installers packages and checksums from the build artifacts to the dotnetcli storage account. Documentation for opting in to automatic checksum generation can be found in the [Checksum section](https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Publishing.md#checksum-generation) of this document. | false |
     | SDLValidationParameters                 | object   | Parameters for the SDL job template, as documented in the [SDL template documentation](https://github.com/dotnet/arcade/blob/66175ebd3756697a3ca515e16cd5ffddc30582cd/Documentation/HowToAddSDLRunToPipeline.md) | -- |
     | validateDependsOn | [array] | Which stage(s) should the validation stage depend on. | build |
     | publishDependsOn | [array] | Which stage(s) should the publishing stage(s) depend on. | Validate |
@@ -176,6 +176,22 @@ Since the post-build stages will only trigger during builds that run in the inte
 
 1. Queue a build for your test branch
 1. Once the Build and Validate stages complete, the *General Testing* stage should execute and publish the packages to the feed during the `Publish Assets` job.
+
+### Checksum generation
+
+Arcade also includes support for automatically generating checksum files. To opt in to this feature, in each project that generates an asset for which you want to generate a checksum, add an Item named `GenerateChecksumItems` to the project file, which includes the output path of the original asset, and a metadata element named `DestinationPath` which represents the desired output path of the checksum file.
+
+Example:
+
+	```XML
+	<ItemGroup>
+		<GenerateChecksumItems Include="@(OutputFile)">
+			<DestinationPath>%(FullPath).Sha512</OutputPath>
+		</GenerateChecksumItems>
+	</ItemGroup>
+	```
+
+You will also need to pass `publishInstallersAndChecksums=true` to the `post-build.yml` template.
 
 ## More complex onboarding scenarios
 

--- a/Documentation/CorePackages/Publishing.md
+++ b/Documentation/CorePackages/Publishing.md
@@ -184,11 +184,11 @@ Arcade also includes support for automatically generating checksum files. To opt
 Example:
 
     ```XML
-	<ItemGroup>
-		<GenerateChecksumItems Include="@(OutputFile)">
-			<DestinationPath>%(FullPath).Sha512</OutputPath>
-		</GenerateChecksumItems>
-	</ItemGroup>
+    <ItemGroup>
+      <GenerateChecksumItems Include="@(OutputFile)">
+        <DestinationPath>%(FullPath).Sha512</OutputPath>
+      </GenerateChecksumItems>
+    </ItemGroup>
     ```
 
 You will also need to pass `publishInstallersAndChecksums=true` to the `post-build.yml` template.

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateChecksums.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateChecksums.cs
@@ -28,19 +28,17 @@ namespace Microsoft.DotNet.Arcade.Sdk
                     string destinationPath = item.GetMetadata("DestinationPath");
                     if (string.IsNullOrEmpty(destinationPath))
                     {
-                        throw new Exception($"Metadata 'DestinationPath' is missing for item '{item.ItemSpec}'.");
+                        Log.LogError($"Metadata 'DestinationPath' is missing for item '{item.ItemSpec}'.");
+                        return !Log.HasLoggedErrors;
                     }
 
                     if (!File.Exists(item.ItemSpec))
                     {
-                        throw new Exception($"The file '{item.ItemSpec}' does not exist.");
+                        Log.LogError($"The file '{item.ItemSpec}' does not exist.");
+                        return !Log.HasLoggedErrors;
                     }
 
-                    Log.LogMessage(
-                        MessageImportance.High,
-                        "Generating checksum for '{0}' into '{1}'...",
-                        item.ItemSpec,
-                        destinationPath);
+                    Log.LogMessage(MessageImportance.High, $"Generating checksum for '{item.ItemSpec}' into '{destinationPath}'...");
 
                     using (FileStream stream = File.OpenRead(item.ItemSpec))
                     {
@@ -54,15 +52,12 @@ namespace Microsoft.DotNet.Arcade.Sdk
                 }
                 catch (Exception e)
                 {
-                    // We have 2 log calls because we want a nice error message but we also want to capture the
-                    // callstack in the log.
-                    Log.LogError("An exception occurred while trying to generate a checksum for '{0}'.", item.ItemSpec);
-                    Log.LogMessage(MessageImportance.Low, e.ToString());
-                    return false;
+                    Log.LogErrorFromException(e);
+                    return !Log.HasLoggedErrors;
                 }
             }
 
-            return true;
+            return !Log.HasLoggedErrors;
         }
     }
 }

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateChecksums.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateChecksums.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.IO;
+using System.Security.Cryptography;
+
+namespace Microsoft.DotNet.Arcade.Sdk
+{
+    public class GenerateChecksums : Task
+    {
+        /// <summary>
+        /// An item collection of files for which to generate checksums.  Each item must have metadata
+        /// 'DestinationPath' that specifies the path of the checksum file to create.
+        /// </summary>
+        [Required]
+        public ITaskItem[] Items { get; set; }
+
+        public override bool Execute()
+        {
+            foreach (ITaskItem item in Items)
+            {
+                try
+                {
+                    string destinationPath = item.GetMetadata("DestinationPath");
+                    if (string.IsNullOrEmpty(destinationPath))
+                    {
+                        throw new Exception($"Metadata 'DestinationPath' is missing for item '{item.ItemSpec}'.");
+                    }
+
+                    if (!File.Exists(item.ItemSpec))
+                    {
+                        throw new Exception($"The file '{item.ItemSpec}' does not exist.");
+                    }
+
+                    Log.LogMessage(
+                        MessageImportance.High,
+                        "Generating checksum for '{0}' into '{1}'...",
+                        item.ItemSpec,
+                        destinationPath);
+
+                    using (FileStream stream = File.OpenRead(item.ItemSpec))
+                    {
+                        using(HashAlgorithm hashAlgorithm = SHA512.Create())
+                        {
+                            byte[] hash = hashAlgorithm.ComputeHash(stream);
+                            string checksum = BitConverter.ToString(hash).Replace("-", string.Empty);
+                            File.WriteAllText(destinationPath, checksum);
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    // We have 2 log calls because we want a nice error message but we also want to capture the
+                    // callstack in the log.
+                    Log.LogError("An exception occurred while trying to generate a checksum for '{0}'.", item.ItemSpec);
+                    Log.LogMessage(MessageImportance.Low, e.ToString());
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateChecksums.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateChecksums.targets
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GenerateChecksums" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
+
+  <!--
+    Generate Checksums for the specified assets. Runs after the build of a project.
+  -->
+  <Target Name="GenerateChecksums"
+          Condition="'@(GenerateChecksumItems)' != ''"
+          AfterTargets="Build">
+
+    <Error Condition="'%(GenerateChecksumItems.DestinationPath)' == ''"
+           Text="Item &quot;%(GenerateChecksumItems.Identity)&quot; does not define required metadata &quot;DestinationPath&quot;" />
+
+    <GenerateChecksums Items="@(GenerateChecksumItems)" />
+
+    <!-- Automatically include generated checksums in the asset manifest -->
+    <ItemGroup>
+      <ItemsToPushToBlobFeed Include="@(GenerateChecksumItems -> '%(DestinationPath)')" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets
@@ -14,6 +14,7 @@
 
   <Import Project="ProjectDefaults.targets"/>
   <Import Project="StrongName.targets"/>
+  <Import Project="GenerateChecksums.targets" />
   <Import Project="GenerateInternalsVisibleTo.targets" />
   <Import Project="GenerateResxSource.targets" />
   <Import Project="Workarounds.targets"/>


### PR DESCRIPTION
Ports https://github.com/dotnet/arcade/pull/4810 and https://github.com/dotnet/arcade/pull/4805 to master.

This task used to live in Buildtools, but now is checked directly in to dotnet/runtime & dotnet/core-sdk. dotnet/aspnetcore has (unintentionally) dropped this functionality entirely. We should centralize it in Arcade.

@mmitche @riarenas @markwilkie @JohnTortugo PTAL, especially at the added documentation.

CC @ViktorHofer @wli3 