### PR TITLE
Disable ApiCompat on design time builds by default

### DIFF
--- a/src/Microsoft.DotNet.ApiCompat/build/Microsoft.DotNet.ApiCompat.targets
+++ b/src/Microsoft.DotNet.ApiCompat/build/Microsoft.DotNet.ApiCompat.targets
@@ -18,7 +18,7 @@
 
   <PropertyGroup>
     <!-- Default is to run API Compat if this package is referenced -->
-    <RunApiCompat Condition="'$(RunApiCompat)' == ''">true</RunApiCompat>
+    <RunApiCompat Condition="'$(RunApiCompat)' == '' and '$(DesignTimeBuild)' != 'true'">true</RunApiCompat>
   
     <RunApiCompatForSrc Condition="'$(RunApiCompatForSrc)' == ''">$(RunApiCompat)</RunApiCompatForSrc>
     <RunMatchingRefApiCompat Condition="'$(RunMatchingRefApiCompat)' == ''">false</RunMatchingRefApiCompat>


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/32157#discussion_r378331127

cc @Anipik