### PR TITLE
[release/3.x] Add opening <Project> tag to GenerateChecksums.targets

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateChecksums.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateChecksums.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
-
+<Project>
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GenerateChecksums" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
 
   <!--


### PR DESCRIPTION
This project was missing an opening `<Project>` tag, and was therefore failing to build. This broke ingestion PRs in upstream repos: https://github.com/dotnet/arcade-validation/pull/1250

Side note - I'm not sure how the Arcade CI didn't fail because of this.

@markwilkie @mmitche PTAL/merge if appropriate

CC @riarenas 