### PR TITLE
Use official build of NuGet verification script

### DIFF
--- a/eng/common/post-build/nuget-validation.ps1
+++ b/eng/common/post-build/nuget-validation.ps1
@@ -9,7 +9,7 @@ param(
 try {
   . $PSScriptRoot\post-build-utils.ps1
 
-  $url = 'https://raw.githubusercontent.com/NuGet/NuGetGallery/jver-verify/src/VerifyMicrosoftPackage/verify.ps1'
+  $url = 'https://raw.githubusercontent.com/NuGet/NuGetGallery/3e25ad135146676bcab0050a516939d9958bfa5d/src/VerifyMicrosoftPackage/verify.ps1'
 
   New-Item -ItemType 'directory' -Path ${ToolDestinationPath} -Force
 


### PR DESCRIPTION
Per offline conversation with @jcagme.

Previously an official build of this tool was being used. The tool has since been merged to NuGet/NuGetGallery as of https://github.com/NuGet/NuGetGallery/pull/7834.

I picked `3e25ad135146676bcab0050a516939d9958bfa5d` in the raw GitHub URL since this is a commit in our default (protected) branch so this is a safer, stable reference. Referring to a branch is more susceptible to breaks in the future.