### PR TITLE
Fix incorrectly including HTTP headers in output and then executing them as shell commands

### DIFF
--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -252,7 +252,7 @@ function GetDotNetInstallScript {
 
     # Use curl if available, otherwise use wget
     if command -v curl > /dev/null; then
-      with_retries curl "$install_script_url" -isSLv --retry 10 --create-dirs -o "$install_script" || {
+      with_retries curl "$install_script_url" -sSL --retry 10 --create-dirs -o "$install_script" || {
         local exit_code=$?
         Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to acquire dotnet install script (exit code '$exit_code')."
         ExitWithExitCode $exit_code


### PR DESCRIPTION
Introduced in https://github.com/dotnet/arcade/pull/4766. Should resolve issue https://github.com/dotnet/runtime/issues/32100.