### PR TITLE
Set default for DotNetArtifactsCategory

### DIFF
--- a/eng/common/templates/post-build/channels/generic-public-channel.yml
+++ b/eng/common/templates/post-build/channels/generic-public-channel.yml
@@ -94,6 +94,8 @@ stages:
         value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOPipelineId'] ]
       - name: AzDOBuildId
         value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOBuildId'] ]
+      - name: ArtifactsCategory
+        value: ${{ coalesce(variables._DotNetArtifactsCategory, '.NETCore') }}
     condition: or(contains(dependencies.setupMaestroVars.outputs['setReleaseVars.InitialChannels'], format('[{0}]', ${{ parameters.channelId }} )), eq(dependencies.setupMaestroVars.outputs['setReleaseVars.PromoteToMaestroChannelId'], ${{ parameters.channelId }}))
     pool:
       vmImage: 'windows-2019'
@@ -132,7 +134,7 @@ stages:
         inputs:
           filePath: eng\common\sdk-task.ps1
           arguments: -task PublishArtifactsInManifest -restore -msbuildEngine dotnet
-            /p:ArtifactsCategory=$(_DotNetArtifactsCategory)
+            /p:ArtifactsCategory=$(ArtifactsCategory)
             /p:IsStableBuild=$(IsStableBuild)
             /p:IsInternalBuild=$(IsInternalBuild)
             /p:RepositoryName=$(Build.Repository.Name)


### PR DESCRIPTION
Closes: #3661 

Use `.NETCore` by default if no global ArtifactCategory variable was set. 

I understand that we'll move away from Sleet feeds soon and we probably won't need ArtifactCategory at all anymore. However, we are not there yet and since I'll update the publishing documentation with the list of [deprecated properties introduced by this PR](https://github.com/dotnet/arcade/pull/4626) I thought would be good to also tell people that they don't need to set DotNetArtifactsCategory anymore if they don't need to.

Tested it here: https://dnceng.visualstudio.com/internal/_build/results?buildId=521874&view=results the publishing .binlogs shows the correct value for the property even though I removed the global declaration.