### PR TITLE
GenAPI: Suppress null checks when generating base calls to constructors during notsupported.cs generation in GenAPI.

### DIFF
--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.cs
@@ -17,11 +17,10 @@ namespace Microsoft.Cci.Writers.CSharp
     public partial class CSDeclarationWriter : ICciDeclarationWriter, IDisposable
     {
         public static readonly Version LangVersion7_0 = new Version(7, 0);
-        public static readonly Version LangVersion7_3 = new Version(7, 3);
         public static readonly Version LangVersion8_0 = new Version(8, 0);
 
         public static readonly Version LangVersionDefault = LangVersion7_0;
-        public static readonly Version LangVersionLatest = LangVersion7_3;
+        public static readonly Version LangVersionLatest = LangVersion8_0;
         public static readonly Version LangVersionPreview = LangVersion8_0;
 
         private readonly SRMetadataPEReaderCache _metadataReaderCache;


### PR DESCRIPTION
When generating .notsupported.cs files where the base class has nullable annotations already applied, and we are calling a base constructor that doesn't allow `null` to be passed in, you get a compiler error. This is because we are always generating `default(T)` to pass to the base type.

Ideally, we could check if the base type doesn't support `null` and only add the `!` suppression then. However, since we are currently using CCI to inspect the code, this is deemed not worth the work. We can always add a suppression, even if the base type accepts `null`.

Also, bump the `latest` version to `8.0` now that 8.0 has shipped. That way, when `latest` is passed into GenAPI, it generates code for `8.0`.