### PR TITLE
Include PlatformName in the SymStore output directory

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SymStore.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SymStore.targets
@@ -25,13 +25,16 @@
       <_BuildsPortablePdb>false</_BuildsPortablePdb>
       <_BuildsPortablePdb Condition="'$(DebugType)' == 'portable' or '$(DebugType)' == 'embedded'">true</_BuildsPortablePdb>
 
-      <_SymStoreTargetFramework>$(TargetFramework)</_SymStoreTargetFramework>
       <!--
         Support Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk TargetFrameworkSuffix property.
         TODO: Remove when https://github.com/dotnet/arcade/issues/4859 is fixed.
       -->
+      <_SymStoreTargetFramework>$(TargetFramework)</_SymStoreTargetFramework>
       <_SymStoreTargetFramework Condition="'$(TargetFrameworkSuffix)' != ''">$(_SymStoreTargetFramework)-$(TargetFrameworkSuffix)</_SymStoreTargetFramework>
+
       <_SymStoreOutputDir>$(ArtifactsSymStoreDirectory)$(MSBuildProjectName)\$(_SymStoreTargetFramework)\</_SymStoreOutputDir>
+      <_SymStoreOutputDir Condition="'$(PlatformName)' != 'AnyCPU'">$(_SymStoreOutputDir)$(PlatformName)\</_SymStoreOutputDir>
+
       <_SymStorePdbPath>$(_SymStoreOutputDir)$(TargetName).pdb</_SymStorePdbPath>
 
       <!-- By default publish Windows PDBs only for shipping components -->


### PR DESCRIPTION
Enables publishing converted PDBs for projects that target multiple platforms (x86/x64).