### PR TITLE
Support TargetFramework.Sdk in SymStore.targets

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SymStore.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SymStore.targets
@@ -26,7 +26,10 @@
       <_BuildsPortablePdb Condition="'$(DebugType)' == 'portable' or '$(DebugType)' == 'embedded'">true</_BuildsPortablePdb>
 
       <_SymStoreTargetFramework>$(TargetFramework)</_SymStoreTargetFramework>
-      <!-- Support Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk TargetFrameworkSuffix property. -->
+      <!--
+        Support Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk TargetFrameworkSuffix property.
+        TODO: Remove when https://github.com/dotnet/arcade/issues/4859 is fixed.
+      -->
       <_SymStoreTargetFramework Condition="'$(TargetFrameworkSuffix)' != ''">$(_SymStoreTargetFramework)-$(TargetFrameworkSuffix)</_SymStoreTargetFramework>
       <_SymStoreOutputDir>$(ArtifactsSymStoreDirectory)$(MSBuildProjectName)\$(_SymStoreTargetFramework)\</_SymStoreOutputDir>
       <_SymStorePdbPath>$(_SymStoreOutputDir)$(TargetName).pdb</_SymStorePdbPath>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SymStore.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SymStore.targets
@@ -25,7 +25,10 @@
       <_BuildsPortablePdb>false</_BuildsPortablePdb>
       <_BuildsPortablePdb Condition="'$(DebugType)' == 'portable' or '$(DebugType)' == 'embedded'">true</_BuildsPortablePdb>
 
-      <_SymStoreOutputDir>$(ArtifactsSymStoreDirectory)$(MSBuildProjectName)\$(TargetFramework)\</_SymStoreOutputDir>
+      <_SymStoreTargetFramework>$(TargetFramework)</_SymStoreTargetFramework>
+      <!-- Support Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk TargetFrameworkSuffix property. -->
+      <_SymStoreTargetFramework Condition="'$(TargetFrameworkSuffix)' != ''">$(_SymStoreTargetFramework)-$(TargetFrameworkSuffix)</_SymStoreTargetFramework>
+      <_SymStoreOutputDir>$(ArtifactsSymStoreDirectory)$(MSBuildProjectName)\$(_SymStoreTargetFramework)\</_SymStoreOutputDir>
       <_SymStorePdbPath>$(_SymStoreOutputDir)$(TargetName).pdb</_SymStorePdbPath>
 
       <!-- By default publish Windows PDBs only for shipping components -->


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/32300

This fixes the frequent failures where multiple inner builds try to write to the same location in combination with SymStore.targets. As discussed in the linked issue, we should investigate if we can change the TargetFramework.Sdk to not depend on such hacks.

cc @Anipik @ericstj 