### PR TITLE
Allow ActiveIssue attribute on the assembly level

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ActiveIssueAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ActiveIssueAttribute.cs
@@ -11,7 +11,7 @@ namespace Xunit
     /// Apply this attribute to your test method to specify an active issue.
     /// </summary>
     [TraitDiscoverer("Microsoft.DotNet.XUnitExtensions.ActiveIssueDiscoverer", "Microsoft.DotNet.XUnitExtensions")]
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = true)]
     public class ActiveIssueAttribute : Attribute, ITraitAttribute
     {
         public ActiveIssueAttribute(string issue, TestPlatforms platforms) { }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ActiveIssueDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ActiveIssueDiscoverer.cs
@@ -13,7 +13,7 @@ using Xunit.Sdk;
 namespace Microsoft.DotNet.XUnitExtensions
 {
     /// <summary>
-    /// This class discovers all of the tests and test classes that have
+    /// This class discovers all of the tests, test classes and test assemblies that have
     /// applied the ActiveIssue attribute
     /// </summary>
     public class ActiveIssueDiscoverer : ITraitDiscoverer


### PR DESCRIPTION
For example when a whole test assembly is flaky and should be disabled.