### PR TITLE
Manually update SDK version

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "3.0.101"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20118.1",
+    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20119.2",
     "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20118.1"
   }
 }


### PR DESCRIPTION
Build promotion pipeline is stuck because current Arcade SDK is using a buggy version of Tasks.Feed. Because of that we aren't able to use the promotion pipeline to promote Arcade builds and therefore no dependency flow is happening out of Arcade.

Manually updating the Arcade SDK version in global.json will unblock the promotion pipeline because it uses the same version of Tasks.Feed as the current version of SDK in Arcade@master.

Test build is here: https://dnceng.visualstudio.com/internal/_build/results?buildId=528669&view=results