### PR TITLE
Manual bump on Arcade SDK version

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -3,9 +3,9 @@
   <ProductDependencies>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.20118.1">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.20119.10">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b40d0c89c230189b4c6aeb32c0a43218b4bc3359</Sha>
+      <Sha>dd52b7c416619f650fb8e93fe4034818084b47d9</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="5.0.0-beta.20118.1">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "3.0.101"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20119.2",
+    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20119.10",
     "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20118.1"
   }
 }


### PR DESCRIPTION
Previous attempt to bump the version missed the change in eng\Version.Details.xml which is fundamental for fixing the build promotion pipeline. The reason is that Darc `add-build-to-channel` uses the SHA from the Arcade SDK entry in Version.Details.xml as the source for the build promotion pipeline. Consequently, the previous attempt to update the version was ineffectual.