### PR TITLE
Add retry loop around push to azdo feeds followed by 404

### DIFF
--- a/eng/common/templates/post-build/channels/generic-internal-channel.yml
+++ b/eng/common/templates/post-build/channels/generic-internal-channel.yml
@@ -84,6 +84,7 @@ stages:
   - job: publish_assets
     displayName: Publish Assets
     dependsOn: setupMaestroVars
+    timeoutInMinutes: 120
     variables:
       - name: BARBuildId
         value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]

--- a/eng/common/templates/post-build/channels/generic-public-channel.yml
+++ b/eng/common/templates/post-build/channels/generic-public-channel.yml
@@ -83,6 +83,7 @@ stages:
   - job: publish_assets
     displayName: Publish Assets
     dependsOn: setupMaestroVars
+    timeoutInMinutes: 120
     variables:
       - name: BARBuildId
         value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -9,7 +9,6 @@ using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.DotNet.VersionTools.BuildManifest.Model;
 using Microsoft.DotNet.VersionTools.Util;
 using NuGet.Packaging.Core;
-using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -49,7 +48,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         // Matches package feeds like
         // https://pkgs.dev.azure.com/dnceng/public/_packaging/public-feed-name/nuget/v3/index.json
         // or https://pkgs.dev.azure.com/dnceng/_packaging/internal-feed-name/nuget/v3/index.json
-        public const string AzDoNuGetFeedPattern = 
+        public const string AzDoNuGetFeedPattern =
             @"https://pkgs.dev.azure.com/(?<account>[a-zA-Z0-9]+)/(?<visibility>[a-zA-Z0-9-]+/)?_packaging/(?<feed>.+)/nuget/v3/index.json";
         private const string SymbolPackageSuffix = ".symbols.nupkg";
         private const string PackageSuffix = ".nupkg";
@@ -164,7 +163,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 Maestro.Client.Models.Build buildInformation = await client.Builds.GetBuildAsync(BARBuildId);
 
                 await ParseTargetFeedConfigAsync();
-                
+
                 // Return errors from parsing FeedConfig
                 if (Log.HasLoggedErrors)
                 {
@@ -707,34 +706,47 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
             try
             {
-                // The feed key when pushing to AzDo feeds is "AzureDevOps" (works with the credential helper).
-                int result = await StartProcessAsync(NugetPath, $"push \"{localPackageLocation}\" -Source \"{feedConfig.TargetURL}\" -NonInteractive -ApiKey AzureDevOps");
-                if (result != 0)
+                const int maxNuGetPushAttempts = 3;
+                const int delayInSecondsBetweenAttempts = 3;
+                bool? packageExist = null;
+                int attemptIndex = 0;
+
+                do
                 {
+                    // The feed key when pushing to AzDo feeds is "AzureDevOps" (works with the credential helper).
+                    int result = await StartProcessAsync(NugetPath, $"push \"{localPackageLocation}\" -Source \"{feedConfig.TargetURL}\" -NonInteractive -ApiKey AzureDevOps");
+
+                    if (result == 0)
+                    {
+                        break;
+                    }
+
                     Log.LogMessage(MessageImportance.Low, $"Failed to push {localPackageLocation}, attempting to determine whether the package already exists on the feed with the same content.");
 
-                    try
+                    string packageContentUrl = $"https://pkgs.dev.azure.com/{feedAccount}/{feedVisibility}_apis/packaging/feeds/{feedName}/nuget/packages/{id}/versions/{version}/content";
+                    packageExist = await IsLocalPackageIdenticalToFeedPackage(localPackageLocation, packageContentUrl, client);
+
+                    if (packageExist == true)
                     {
-                        string packageContentUrl = $"https://pkgs.dev.azure.com/{feedAccount}/{feedVisibility}_apis/packaging/feeds/{feedName}/nuget/packages/{id}/versions/{version}/content";
-
-                        if (await IsLocalPackageIdenticalToFeedPackage(localPackageLocation, packageContentUrl, client))
-                        {
-                            Log.LogMessage(MessageImportance.Normal, $"Package '{localPackageLocation}' already exists on '{feedConfig.TargetURL}' but has the same content. Skipping.");
-                        }
-                        else
-                        {
-                            Log.LogError($"Package '{localPackageLocation}' already exists on '{feedConfig.TargetURL}' with different content.");
-                        }
-
-                        return;
+                        Log.LogMessage(MessageImportance.Normal, $"Package '{localPackageLocation}' already exists on '{feedConfig.TargetURL}' but has the same content. Skipping.");
                     }
-                    catch (Exception e)
+                    else if (packageExist == false)
                     {
-                        // This is an error. It means we were unable to push using nuget, and then could not access to the package otherwise.
-                        Log.LogWarning($"Failed to determine whether an existing package on the feed has the same content as '{localPackageLocation}': {e.Message}");
+                        Log.LogError($"Package '{localPackageLocation}' already exists on '{feedConfig.TargetURL}' with different content.");
                     }
+                    else
+                    {
+                        // packageExist == null, which means we didn't find the package on the feed
+                        // will retry the push and check again
+                        await Task.Delay(TimeSpan.FromSeconds(delayInSecondsBetweenAttempts))
+                            .ConfigureAwait(false);
+                    }
+                }
+                while (packageExist == null && attemptIndex++ <= maxNuGetPushAttempts);
 
-                    Log.LogError($"Failed to push '{id}@{version}'. Result code '{result}'.");
+                if (attemptIndex > maxNuGetPushAttempts)
+                {
+                    Log.LogError($"Failed to publish package '{id}@{version}' after {maxNuGetPushAttempts} attempts.");
                 }
             }
             catch (Exception e)
@@ -759,41 +771,50 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         ///       the streams make no gaurantee that they will return a full block each time when read operations are performed, so we
         ///       must be sure to only compare the minimum number of bytes returned.
         /// </remarks>
-        private async Task<bool> IsLocalPackageIdenticalToFeedPackage(string localPackageFullPath, string packageContentUrl, HttpClient client)
+        private async Task<bool?> IsLocalPackageIdenticalToFeedPackage(string localPackageFullPath, string packageContentUrl, HttpClient client)
         {
             Log.LogMessage($"Getting package content from {packageContentUrl} and comparing to {localPackageFullPath}");
 
-            using (Stream localFileStream = File.OpenRead(localPackageFullPath))
-            using (HttpResponseMessage response = await client.GetAsync(packageContentUrl))
+            try
             {
-                response.EnsureSuccessStatusCode();
-
-                // Check the headers for content length and md5
-                bool md5HeaderAvailable = response.Headers.TryGetValues("Content-MD5", out var md5);
-                bool lengthHeaderAvailable = response.Headers.TryGetValues("Content-Length", out var contentLength);
-
-                if (lengthHeaderAvailable && long.Parse(contentLength.Single()) != localFileStream.Length)
+                using (Stream localFileStream = File.OpenRead(localPackageFullPath))
+                using (HttpResponseMessage response = await client.GetAsync(packageContentUrl))
                 {
-                    Log.LogMessage(MessageImportance.Low, $"Package '{localPackageFullPath}' has different length than remote package '{packageContentUrl}'.");
-                    return false;
-                }
+                    response.EnsureSuccessStatusCode();
 
-                if (md5HeaderAvailable)
-                {
-                    var localMD5 = AzureStorageUtils.CalculateMD5(localPackageFullPath);
-                    if (!localMD5.Equals(md5.Single(), StringComparison.OrdinalIgnoreCase))
+                    // Check the headers for content length and md5
+                    bool md5HeaderAvailable = response.Headers.TryGetValues("Content-MD5", out var md5);
+                    bool lengthHeaderAvailable = response.Headers.TryGetValues("Content-Length", out var contentLength);
+
+                    if (lengthHeaderAvailable && long.Parse(contentLength.Single()) != localFileStream.Length)
                     {
-                        Log.LogMessage(MessageImportance.Low, $"Package '{localPackageFullPath}' has different MD5 hash than remote package '{packageContentUrl}'.");
+                        Log.LogMessage(MessageImportance.Low, $"Package '{localPackageFullPath}' has different length than remote package '{packageContentUrl}'.");
+                        return false;
                     }
 
-                    return true;
+                    if (md5HeaderAvailable)
+                    {
+                        var localMD5 = AzureStorageUtils.CalculateMD5(localPackageFullPath);
+                        if (!localMD5.Equals(md5.Single(), StringComparison.OrdinalIgnoreCase))
+                        {
+                            Log.LogMessage(MessageImportance.Low, $"Package '{localPackageFullPath}' has different MD5 hash than remote package '{packageContentUrl}'.");
+                        }
+
+                        return true;
+                    }
+
+                    const int BufferSize = 64 * 1024;
+
+                    // Otherwise, compare the streams
+                    var remoteStream = await response.Content.ReadAsStreamAsync();
+                    return await CompareStreamsAsync(localFileStream, remoteStream, BufferSize);
                 }
-
-                const int BufferSize = 64 * 1024;
-
-                // Otherwise, compare the streams
-                var remoteStream = await response.Content.ReadAsStreamAsync();
-                return await CompareStreamsAsync(localFileStream, remoteStream, BufferSize);
+            }
+            // String based comparison because the status code isn't exposed in HttpRequestException
+            // see here: https://github.com/dotnet/runtime/issues/23648
+            catch (HttpRequestException e) when (e.Message.Contains("404 (Not Found)"))
+            {
+                return null;
             }
         }
 


### PR DESCRIPTION
Closes: #4746 

Add retry loop around publishing to AzDO feed if push failed and subsequent check for package existence returned 404. 

Successful publishing tested here: https://dnceng.visualstudio.com/internal/_build/results?buildId=520725&view=results
Failing + retry cases tested locally.