### PR TITLE
Add retry logic to AzureStorageUtils.UploadBlockBlobAsync

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
     <LibGit2SharpVersion>0.25.2</LibGit2SharpVersion>
     <log4netVersion>2.0.8</log4netVersion>
     <SystemNetHttpVersion>4.3.3</SystemNetHttpVersion>
-    <AzureStorageBlobsVersion>12.2.0</AzureStorageBlobsVersion>
+    <AzureStorageBlobsVersion>12.3.0</AzureStorageBlobsVersion>
     <MicrosoftAzureKeyVaultVersion>3.0.0</MicrosoftAzureKeyVaultVersion>
     <MicrosoftAzureServicesAppAuthenticationVersion>1.3.1</MicrosoftAzureServicesAppAuthenticationVersion>
     <MicrosoftDataAnalysisVersion>0.1.0</MicrosoftDataAnalysisVersion>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
@@ -69,7 +69,8 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
 
             // This function can sporadically throw 
             // "System.Net.Http.HttpRequestException: Error while copying content to a stream."
-            // Ideally it should retry for itself internally, but the existing retry seems for throttling only.
+            // Ideally it should retry for itself internally, but the existing retry seems 
+            // to be intended for throttling only.
             var retryHandler = new ExponentialRetry
             {
                 MaxAttempts = 5,

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
@@ -99,7 +99,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             // If retry failed print out a nice looking exception
             if (!success)
             {
-                throw new Exception($"Failed to upload local file '{filePath}' to '{blobPath} in  {retryHandler.MaxAttempts} attempts!");
+                throw new Exception($"Failed to upload local file '{filePath}' to '{blobPath} in {retryHandler.MaxAttempts} attempts!");
             }
         }
 


### PR DESCRIPTION
## Change contents
Continuing to address https://github.com/dotnet/core-eng/issues/8582.  The verbosity of logging the Azure storage SDK team needs would massively increase our console log size so instead I'm simply adding retry around the API call.

## Some notes:

- As used here BlobClient.UploadAsync doesn't care if the blob already exists; so even if it's partially there (should not be the case; the call must finish to 'commit' the blob) the call will not fail.
- Azure Storage SDK confirms
  - They have no existing retry logic for network flakiness (only Azure throttling)
  - They have no retry policy built in like the <= V11 SDKs had so I used ours.
- The ExponentialRetry logic IS indeed in a weird namespace but I'm not moving it.

**TL;DR: Add 5 ExponentialRetry attempts per blob upload, and upgrade minor version too for luck.**
