### PR TITLE
Add Signing Telemetry Categorization

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -44,6 +44,10 @@
     <AllowEmptySignList>false</AllowEmptySignList>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <NETCORE_ENGINEERING_TELEMETRY>Signing</NETCORE_ENGINEERING_TELEMETRY>
+  </PropertyGroup>
+
   <!-- Allow repository to customize signing configuration -->
   <Import Project="$(RepositoryEngineeringDir)Signing.props" Condition="Exists('$(RepositoryEngineeringDir)Signing.props')" />
 


### PR DESCRIPTION
Adds the NETCORE_ENGINEERING_TELEMETRY property to Sign.proj