### PR TITLE
Use '-ag' instead of '-gg' in heat.exe command - enables stable GUIDs

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets
@@ -220,7 +220,7 @@
           -nologo ^
           -template fragment ^
           -sreg ^
-          -gg ^
+          -ag ^
           -var var.%(SubstituteVar) ^
           -cg %(ComponentGroupName) ^
           -srd ^


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/703

Simple change - verified that subsequent MSI builds produce the same GUIDs if product version doesn't change.