### PR TITLE
RemoveOSGroup from the arcade

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/PackageLibs.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/PackageLibs.targets
@@ -9,7 +9,7 @@
         <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
         <Targets>GetPackageAssets</Targets>
         <OutputItemType>PkgProjAsset</OutputItemType>
-        <UndefineProperties>%(ProjectReference.UndefineProperties);OSGroup;TargetGroup</UndefineProperties>
+        <UndefineProperties>%(ProjectReference.UndefineProperties)</UndefineProperties>
       </ProjectReference>
     </ItemGroup>
   </Target>

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.dependency.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.dependency.targets
@@ -188,7 +188,7 @@
       Workaround: zero-versioned Microsoft.VisualBasic.dll in non-Windows CoreFX transport package.
       See https://github.com/dotnet/corefx/issues/36630
     -->
-    <PropertyGroup Condition="'$(OSGroup)' != 'Windows_NT'">
+    <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
       <PermitDllAndExeFilesLackingFileVersion>true</PermitDllAndExeFilesLackingFileVersion>
     </PropertyGroup>
 
@@ -386,11 +386,11 @@
 
   <!-- Ensure crossgen is executable. See https://github.com/NuGet/Home/issues/4424 -->
   <Target Name="EnsureCrossGenIsExecutable"
-          Condition="'$(OSGroup)' != 'Windows_NT'"
+          Condition="'$(OS)' != 'Windows_NT'"
           DependsOnTargets="GetCrossgenToolPaths">
     <Exec
       Command="chmod u+x $(_crossGenPath)"
-      Condition="'$(OSGroup)' != 'Windows_NT' AND Exists('$(_crossGenPath)')" />
+      Condition="'$(OS)' != 'Windows_NT' AND Exists('$(_crossGenPath)')" />
   </Target>
 
   <Target Name="CrossGen"
@@ -424,7 +424,7 @@
     </PropertyGroup>
 
     <!-- Measurements show that doing partial crossgen on these assemblies captures a lot of the potential size saving. -->
-    <PropertyGroup Condition="'$(OSGroup)' == 'Linux'">
+    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('linux'))">
       <_partialCrossgenFlag Condition="'%(_filesToCrossGen.FileName)' == 'System.ComponentModel.TypeConverter'">1</_partialCrossgenFlag>
       <_partialCrossgenFlag Condition="'%(_filesToCrossGen.FileName)' == 'System.Linq.Expressions'">1</_partialCrossgenFlag>
       <_partialCrossgenFlag Condition="'%(_filesToCrossGen.FileName)' == 'System.Private.Xml'">1</_partialCrossgenFlag>

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.sharedfx.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.sharedfx.targets
@@ -146,7 +146,7 @@
 
     <!-- Ensure the host is executable. See https://github.com/NuGet/Home/issues/4424 -->
     <Exec Command="chmod u+x $(SharedFrameworkLayoutDir)dotnet$(ExeSuffix)"
-          Condition="'$(OSGroup)' != 'Windows_NT'" />
+          Condition="'$(OS)' != 'Windows_NT'" />
   </Target>
 
   <!-- Clean up artifacts that dotnet-publish generates which we don't need -->
@@ -216,9 +216,9 @@
           DependsOnTargets="FixDepsJsonFileName"
           AfterTargets="Publish">
     <PropertyGroup>
-      <RuntimeGraphGeneratorRuntime Condition="'$(OSGroup)'=='Windows_NT'">win</RuntimeGraphGeneratorRuntime>
-      <RuntimeGraphGeneratorRuntime Condition="'$(OSGroup)'=='OSX'">osx</RuntimeGraphGeneratorRuntime>
-      <RuntimeGraphGeneratorRuntime Condition="'$(OSGroup)'=='FreeBSD'">freebsd</RuntimeGraphGeneratorRuntime>
+      <RuntimeGraphGeneratorRuntime Condition="$([MSBuild]::IsOSPlatform('windows'))">win</RuntimeGraphGeneratorRuntime>
+      <RuntimeGraphGeneratorRuntime Condition="$([MSBuild]::IsOSPlatform('osx'))">osx</RuntimeGraphGeneratorRuntime>
+      <RuntimeGraphGeneratorRuntime Condition="$([MSBuild]::IsOSPlatform('freebsd'))">freebsd</RuntimeGraphGeneratorRuntime>
       <RuntimeGraphGeneratorRuntime Condition="'$(RuntimeGraphGeneratorRuntime)'==''">linux</RuntimeGraphGeneratorRuntime>
     </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/installer.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/installer.targets
@@ -187,7 +187,7 @@
             GenerateZip"/>
 
   <Target Name="GenerateZip"
-          Condition="'$(OSGroup)' == 'Windows_NT'">
+          Condition="'$(OS)' == 'Windows_NT'">
     <ZipFileCreateFromDirectory
       SourceDirectory="$(SharedFrameworkArchiveSourceDir)"
       DestinationArchive="$(CompressedArchiveFile)"
@@ -261,7 +261,7 @@
   </Target>
 
   <Target Name="FixLayoutPermissions"
-          Condition="'$(OSGroup)' != 'Windows_NT'">
+          Condition="'$(OS)' != 'Windows_NT'">
     <Error Text="Layout '$(PackLayoutDir)' does not exist." Condition="!Exists('$(PackLayoutDir)')" />
 
     <!-- Fix file permissions in the layout dir. -->

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/packaging-tools.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/packaging-tools.targets
@@ -19,7 +19,7 @@
     <!-- Filter the installer generation/build flags for the current build machine. -->
     <PropertyGroup>
       <_osSupportsWixBasedInstallers>true</_osSupportsWixBasedInstallers>
-      <_osSupportsWixBasedInstallers Condition="'$(OSGroup)' != 'Windows_NT'">false</_osSupportsWixBasedInstallers>
+      <_osSupportsWixBasedInstallers Condition="'$(OS)' != 'Windows_NT'">false</_osSupportsWixBasedInstallers>
 
       <_osArchSupportsWixBasedInstallers>$(_osSupportsWixBasedInstallers)</_osArchSupportsWixBasedInstallers>
       <_osArchSupportsWixBasedInstallers Condition="'$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'arm64'">false</_osArchSupportsWixBasedInstallers>
@@ -35,7 +35,7 @@
       <GenerateMSI Condition="'$(_osArchSupportsWixBasedInstallers)' != 'true'">false</GenerateMSI>
       <GenerateExeBundle Condition="'$(_osArchSupportsWixBasedInstallers)' != 'true'">false</GenerateExeBundle>
 
-      <GeneratePkg Condition="'$(OSGroup)' != 'OSX'">false</GeneratePkg>
+      <GeneratePkg Condition="!$([MSBuild]::IsOSPlatform('osx'))">false</GeneratePkg>
     </PropertyGroup>
 
     <!--

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
@@ -28,7 +28,7 @@
   </Target>
   
   <Target Name="GetProjectWithBestTargetFrameworks">
-    <ChooseBestTargetFrameworksTask BuildTargetFrameworks="$(BuildTargetFramework)-$(OSGroup);$(AdditionalBuildTargetFrameworks)"
+    <ChooseBestTargetFrameworksTask BuildTargetFrameworks="$(BuildTargetFramework)-$(BuildOS);$(AdditionalBuildTargetFrameworks)"
                                     SupportedTargetFrameworks="$(TargetFrameworks)"
                                     RuntimeGraph="$(RuntimeGraph)" >
       <Output TaskParameter="BestTargetFrameworks" ItemName="_BestTargetFramework" />

--- a/src/Microsoft.DotNet.CodeAnalysis/build/Microsoft.DotNet.CodeAnalysis.targets
+++ b/src/Microsoft.DotNet.CodeAnalysis/build/Microsoft.DotNet.CodeAnalysis.targets
@@ -2,7 +2,7 @@
 <Project>
 
   <!-- PInvokeChecker data files-->
-  <PropertyGroup Condition="'$(OSGroup)'=='Windows_NT'">
+  <PropertyGroup Condition="'$(OS)'=='Windows_NT'">
     <!-- Opt-in feature -->
     <UseUWPPinvokeAnalyzer Condition="'$(UWPCompatible)'=='true' AND '$(EnablePinvokeUWPAnalyzer)' == 'true'">true</UseUWPPinvokeAnalyzer>
 


### PR DESCRIPTION
OSGroup is dotnet runtime specific property and should not be used in arcade.
The SharedFramework.sdk And Microsoft.Dotnet.CodeAnalysis are 2 projects that use this property.

SharedFramework.Sdk is used in -> runtime and dotnet\windowsDesktop
Microsoft.dotnet.codeanalysis is used in  -> runtime, wpf, buildtools

CodeAnalysis change is restricted to pinvoke checking. I tested the change by building the runtime repo with these new packages.

Fixes https://github.com/dotnet/arcade/issues/4907