### PR TITLE
Use checkboxes in issue template, with additional guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/default-arcade-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/default-arcade-issue-template.md
@@ -7,5 +7,8 @@ assignees: ''
 
 ---
 
--  Is this issue blocking (yes/no)
--  Is this issue causing unreasonable pain (yes/no)
+<!-- If these statements apply, replace [ ] with [x] before filing your issue. -->
+- [ ] This issue is blocking <!-- Describe below what is blocked. -->
+- [ ] This issue is causing unreasonable pain
+
+<!-- Write your issue description below. -->


### PR DESCRIPTION
For https://github.com/dotnet/arcade/issues/4629. Add a clearer way to fill out the template, and include more guidance.

The comment describes filling in the checkbox before filing (so it shows up in email notifications and for any tooling we might have tracking these), but clicking after the fact works too. Makes it easy to fix up if you forget, and defaults to "not on fire".

This lacks an "I forgot to fill this out" state, which might be bad if we solely rely on that to bubble up blocking issues.

---

Example:

```
<!-- If these statements apply, replace [ ] with [x] before filing your issue. -->
- [ ] This issue is blocking <!-- Describe below what is blocked. -->
- [x] This issue is causing unreasonable pain

<!-- Write your issue description below. -->
Foo bar
```

> <!-- If these statements apply, replace [ ] with [x] before filing your issue. -->
> - [ ] This issue is blocking <!-- Describe below what is blocked. -->
> - [x] This issue is causing unreasonable pain
> 
> <!-- Write your issue description below. -->
> Foo bar