### PR TITLE
Support GenFacadesForceZeroVersionSeeds for source-based facades

### DIFF
--- a/src/Microsoft.DotNet.GenFacades/ClearAssemblyReferenceVersions.cs
+++ b/src/Microsoft.DotNet.GenFacades/ClearAssemblyReferenceVersions.cs
@@ -29,12 +29,12 @@ namespace Microsoft.DotNet.GenFacades
         {
             try
             {
-                using (var stream = File.Open(Assembly, FileMode.Open, FileAccess.ReadWrite, FileShare.Read))
-                using (var peReader = new PEReader(stream))
+                using (FileStream stream = File.Open(Assembly, FileMode.Open, FileAccess.ReadWrite, FileShare.Read))
+                using (PEReader peReader = new PEReader(stream))
                 {
-                    using (var writer = new BinaryWriter(stream))
+                    using (BinaryWriter writer = new BinaryWriter(stream))
                     {
-                        var mdReader = peReader.GetMetadataReader();
+                        MetadataReader mdReader = peReader.GetMetadataReader();
                         int assemblyRefOffset = mdReader.GetTableMetadataOffset(TableIndex.AssemblyRef);
                         int numAssemblyRef = mdReader.GetTableRowCount(TableIndex.AssemblyRef);
                         int sizeAssemblyRefRow = mdReader.GetTableRowSize(TableIndex.AssemblyRef);

--- a/src/Microsoft.DotNet.GenFacades/ClearAssemblyReferenceVersions.cs
+++ b/src/Microsoft.DotNet.GenFacades/ClearAssemblyReferenceVersions.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.DotNet.Build.Tasks;
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace Microsoft.DotNet.GenFacades
+{
+    /// <summary>
+    /// Rewrites an Assembly's references to be version 0.0.0.0.
+    /// </summary>
+    public class ClearAssemblyReferenceVersions : BuildTask
+    {
+        /// <summary>
+        /// Assembly to rewrite.
+        /// </summary>
+        [Required]
+        public string Assembly { get; set; }
+        
+        public override bool Execute()
+        {
+            try
+            {
+                using (var stream = File.Open(Assembly, FileMode.Open, FileAccess.ReadWrite, FileShare.Read))
+                using (var peReader = new PEReader(stream))
+                {
+                    using (var writer = new BinaryWriter(stream))
+                    {
+                        var mdReader = peReader.GetMetadataReader();
+                        int assemblyRefOffset = mdReader.GetTableMetadataOffset(TableIndex.AssemblyRef);
+                        int numAssemblyRef = mdReader.GetTableRowCount(TableIndex.AssemblyRef);
+                        int sizeAssemblyRefRow = mdReader.GetTableRowSize(TableIndex.AssemblyRef);
+
+                        for (int assemblyRefRow = 0; assemblyRefRow < numAssemblyRef; assemblyRefRow++)
+                        {
+                            stream.Position = peReader.PEHeaders.MetadataStartOffset + assemblyRefOffset + assemblyRefRow * sizeAssemblyRefRow;
+                            // see ECMA-335 II.22.5 
+                            // row starts with
+                            // - MajorVersion, MinorVersion, BuildNumber, RevisionNumber (each being 2-byte constants)
+                            // 8 bytes total -> long
+                            writer.Write((long)0);
+                        }
+
+                        // remove signature, if present
+                        // adapted from https://github.com/dotnet/arcade/blob/866b2acd5ffc3c2031c102f6415fd7c6a1a370d5/src/Microsoft.DotNet.Arcade.Sdk/src/Unsign.cs#L58-L65
+                        if (peReader.PEHeaders.PEHeader.CertificateTableDirectory.Size != 0)
+                        {
+                            // see https://docs.microsoft.com/en-us/windows/win32/debug/pe-format#optional-header-data-directories-image-only 
+                            int certificateTableDirectoryOffset = (peReader.PEHeaders.PEHeader.Magic == PEMagic.PE32Plus) ? 144 : 128;
+                            stream.Position = peReader.PEHeaders.PEHeaderStartOffset + certificateTableDirectoryOffset;
+
+                            writer.Write((long)0);
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Log.LogErrorFromException(e, showStackTrace: false);
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.GenFacades/ClearAssemblyReferenceVersions.cs
+++ b/src/Microsoft.DotNet.GenFacades/ClearAssemblyReferenceVersions.cs
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.GenFacades
                             writer.Write((long)0);
                         }
 
-                        // remove signature, if present
+                        // remove signature, if present, since we changed the binary which would break any signature.
                         // adapted from https://github.com/dotnet/arcade/blob/866b2acd5ffc3c2031c102f6415fd7c6a1a370d5/src/Microsoft.DotNet.Arcade.Sdk/src/Unsign.cs#L58-L65
                         if (peReader.PEHeaders.PEHeader.CertificateTableDirectory.Size != 0)
                         {

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenPartialFacadeSource.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenPartialFacadeSource.targets
@@ -47,4 +47,27 @@
       <Compile Condition="Exists('$(OutputSourcePath)')" Include="$(OutputSourcePath)"/>
     </ItemGroup>
   </Target>
+
+  <!-- Support zero version seeds by rewriting the output of the compiler. -->
+  <PropertyGroup>
+    <TargetsTriggeredByCompilation Condition="'$(DesignTimeBuild)' != 'true' AND '$(GenFacadesForceZeroVersionSeeds)' == 'true'">
+      $(TargetsTriggeredByCompilation);ClearAssemblyReferenceVersions
+    </TargetsTriggeredByCompilation>
+  </PropertyGroup>
+
+  <UsingTask TaskName="ClearAssemblyReferenceVersions" AssemblyFile="$(GenFacadesTargetAssemblyPath)" />
+  
+  <Target Name="ClearAssemblyReferenceVersions">
+    <PropertyGroup>
+      <_ClearAssemblyReferenceVersionsAssembly>$(IntermediateOutputPath)$(TargetName)$(TargetExt)</_ClearAssemblyReferenceVersionsAssembly>
+    </PropertyGroup>
+
+    <!-- Copy the original assembly for debugging purposes -->
+    <Copy SourceFiles="$(_ClearAssemblyReferenceVersionsAssembly)"
+          DestinationFolder="$(IntermediateOutputPath)ClearRef/">
+      <Output TaskParameter="CopiedFiles" ItemName="FileWrites" />
+    </Copy>
+
+    <ClearAssemblyReferenceVersions Assembly="$(_ClearAssemblyReferenceVersionsAssembly)" />
+  </Target>
 </Project>


### PR DESCRIPTION
When moving to source-generated facades we didn't initially support zero
versioned seeds.  This turned out to be problematic in servicing, since
our facades have dangling references to assemblies which ship in
packages outside the framework.  Those references would update when the
package was serviced, an application may see the updated shims when
a new shared framework was installed, but not necessarily see the
package update since that would require an app rebuild.

To fix this we're implementing zero-versioned seeds for shims by
rewriting the assembly after compile.