### PR TITLE
Add -Force to Write-PipelineTelemetryError calls in sdl scripts

### DIFF
--- a/eng/common/pipeline-logging-functions.ps1
+++ b/eng/common/pipeline-logging-functions.ps1
@@ -65,12 +65,12 @@ function Write-PipelineTaskError {
     }
 
     if(($Type -ne 'error') -and ($Type -ne 'warning')) {
-    Write-Host $Message
-    return
+        Write-Host $Message
+        return
     }
     $PSBoundParameters.Remove('Force') | Out-Null      
     if(-not $PSBoundParameters.ContainsKey('Type')) {
-    $PSBoundParameters.Add('Type', 'error')
+        $PSBoundParameters.Add('Type', 'error')
     }
     Write-LogIssue @PSBoundParameters
   }

--- a/eng/common/sdl/execute-all-sdl-tools.ps1
+++ b/eng/common/sdl/execute-all-sdl-tools.ps1
@@ -33,6 +33,10 @@ try {
   $disableConfigureToolsetImport = $true
   $LASTEXITCODE = 0
 
+  # `tools.ps1` checks $ci to perform some actions. Since the SDL
+  # scripts don't necessarily execute in the same agent that run the
+  # build.ps1/sh script this variable isn't automatically set.
+  $ci = $true
   . $PSScriptRoot\..\tools.ps1
 
   #Replace repo names to the format of org/repo

--- a/eng/common/sdl/extract-artifact-packages.ps1
+++ b/eng/common/sdl/extract-artifact-packages.ps1
@@ -6,10 +6,6 @@ param(
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
 
-# `tools.ps1` checks $ci to perform some actions. Since the post-build
-# scripts don't necessarily execute in the same agent that run the
-# build.ps1/sh script this variable isn't automatically set.
-$ci = $true
 $disableConfigureToolsetImport = $true
 
 function ExtractArtifacts {
@@ -29,6 +25,10 @@ function ExtractArtifacts {
 }
 
 try {
+  # `tools.ps1` checks $ci to perform some actions. Since the SDL
+  # scripts don't necessarily execute in the same agent that run the
+  # build.ps1/sh script this variable isn't automatically set.
+  $ci = $true
   . $PSScriptRoot\..\tools.ps1
 
   $ExtractPackage = {

--- a/eng/common/sdl/init-sdl.ps1
+++ b/eng/common/sdl/init-sdl.ps1
@@ -12,6 +12,10 @@ Set-StrictMode -Version 2.0
 $disableConfigureToolsetImport = $true
 $LASTEXITCODE = 0
 
+# `tools.ps1` checks $ci to perform some actions. Since the SDL
+# scripts don't necessarily execute in the same agent that run the
+# build.ps1/sh script this variable isn't automatically set.
+$ci = $true
 . $PSScriptRoot\..\tools.ps1
 
 # Don't display the console progress UI - it's a huge perf hit

--- a/eng/common/sdl/init-sdl.ps1
+++ b/eng/common/sdl/init-sdl.ps1
@@ -58,6 +58,6 @@ try {
 }
 catch {
   Write-Host $_.ScriptStackTrace
-  Write-PipelineTelemetryError -Category 'Sdl' -Message $_
+  Write-PipelineTelemetryError -Force -Category 'Sdl' -Message $_
   ExitWithExitCode 1
 }

--- a/eng/common/sdl/push-gdn.ps1
+++ b/eng/common/sdl/push-gdn.ps1
@@ -12,6 +12,10 @@ $disableConfigureToolsetImport = $true
 $LASTEXITCODE = 0
 
 try {
+  # `tools.ps1` checks $ci to perform some actions. Since the SDL
+  # scripts don't necessarily execute in the same agent that run the
+  # build.ps1/sh script this variable isn't automatically set.
+  $ci = $true
   . $PSScriptRoot\..\tools.ps1
 
   # We create the temp directory where we'll store the sdl-config repository

--- a/eng/common/sdl/run-sdl.ps1
+++ b/eng/common/sdl/run-sdl.ps1
@@ -16,6 +16,10 @@ $disableConfigureToolsetImport = $true
 $LASTEXITCODE = 0
 
 try {
+  # `tools.ps1` checks $ci to perform some actions. Since the SDL
+  # scripts don't necessarily execute in the same agent that run the
+  # build.ps1/sh script this variable isn't automatically set.
+  $ci = $true
   . $PSScriptRoot\..\tools.ps1
 
   # We store config files in the r directory of .gdn

--- a/eng/common/sdl/run-sdl.ps1
+++ b/eng/common/sdl/run-sdl.ps1
@@ -64,6 +64,6 @@ try {
 }
 catch {
   Write-Host $_.ScriptStackTrace
-  Write-PipelineTelemetryError -Category 'Sdl' -Message $_
+  Write-PipelineTelemetryError -Force -Category 'Sdl' -Message $_
   ExitWithExitCode 1
 }


### PR DESCRIPTION
Closes: https://github.com/dotnet/core-eng/issues/9017

Guardian scripts are definitely reporting errors (which is why we fail the legs). There doesn't seem to be anything wrong with Write-PipelineTelemetryError, which suggests that somewhere in the sdl scripts, we aren't forcing the calls to be written correctly. The only thing I can tell is there are a few places that are missing the -Force option, so adding those. We haven't seen these failures in a while, and they are not reproducible. 