### PR TITLE
Fix swallow exception when async function is executed

### DIFF
--- a/src/Microsoft.DotNet.RemoteExecutor/src/Program.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/Program.cs
@@ -61,6 +61,10 @@ namespace Microsoft.DotNet.RemoteExecutor
                 {
                     exitCode = task.GetAwaiter().GetResult();
                 }
+                else if (result is Task resultValueTask)
+                {
+                    resultValueTask.GetAwaiter().GetResult();
+                }
                 else if (result is int exit)
                 {
                     exitCode = exit;
@@ -105,7 +109,7 @@ namespace Microsoft.DotNet.RemoteExecutor
             catch (PlatformNotSupportedException)
             {
             }
-            
+
             return exitCode;
         }
 

--- a/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
@@ -156,14 +156,6 @@ namespace Microsoft.DotNet.RemoteExecutor
         /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
         /// <param name="method">The method to invoke.</param>
         /// <param name="options">Options to use for the invocation.</param>
-        public static RemoteInvokeHandle Invoke(Func<int> method, RemoteInvokeOptions options = null)
-        {
-            return Invoke(GetMethodInfo(method), Array.Empty<string>(), options);
-        }
-
-        /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
-        /// <param name="method">The method to invoke.</param>
-        /// <param name="options">Options to use for the invocation.</param>
         public static RemoteInvokeHandle Invoke(Func<Task<int>> method, RemoteInvokeOptions options = null)
         {
             return Invoke(GetMethodInfo(method), Array.Empty<string>(), options);
@@ -200,6 +192,71 @@ namespace Microsoft.DotNet.RemoteExecutor
             string arg2, string arg3, RemoteInvokeOptions options = null)
         {
             return Invoke(GetMethodInfo(method), new[] { arg1, arg2, arg3 }, options);
+        }
+
+        /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
+        /// <param name="method">The method to invoke.</param>
+        /// <param name="options">Options to use for the invocation.</param>
+        public static RemoteInvokeHandle Invoke(Func<Task> method, RemoteInvokeOptions options = null)
+        {
+            // There's no exit code to check
+            options = options ?? new RemoteInvokeOptions();
+            options.CheckExitCode = false;
+
+            return Invoke(GetMethodInfo(method), Array.Empty<string>(), options);
+        }
+
+        /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
+        /// <param name="method">The method to invoke.</param>
+        /// <param name="arg">The argument to pass to the method.</param>
+        /// <param name="options">Options to use for the invocation.</param>
+        public static RemoteInvokeHandle Invoke(Func<string, Task> method, string arg,
+            RemoteInvokeOptions options = null)
+        {
+            // There's no exit code to check
+            options = options ?? new RemoteInvokeOptions();
+            options.CheckExitCode = false;
+
+            return Invoke(GetMethodInfo(method), new[] { arg }, options);
+        }
+
+        /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
+        /// <param name="method">The method to invoke.</param>
+        /// <param name="arg1">The first argument to pass to the method.</param>
+        /// <param name="arg2">The second argument to pass to the method.</param>
+        /// <param name="options">Options to use for the invocation.</param>
+        public static RemoteInvokeHandle Invoke(Func<string, string, Task> method, string arg1, string arg2,
+            RemoteInvokeOptions options = null)
+        {
+            // There's no exit code to check
+            options = options ?? new RemoteInvokeOptions();
+            options.CheckExitCode = false;
+
+            return Invoke(GetMethodInfo(method), new[] { arg1, arg2 }, options);
+        }
+
+        /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
+        /// <param name="method">The method to invoke.</param>
+        /// <param name="arg1">The first argument to pass to the method.</param>
+        /// <param name="arg2">The second argument to pass to the method.</param>
+        /// <param name="arg3">The third argument to pass to the method.</param>
+        /// <param name="options">Options to use for the invocation.</param>
+        public static RemoteInvokeHandle Invoke(Func<string, string, string, Task> method, string arg1,
+            string arg2, string arg3, RemoteInvokeOptions options = null)
+        {
+            // There's no exit code to check
+            options = options ?? new RemoteInvokeOptions();
+            options.CheckExitCode = false;
+
+            return Invoke(GetMethodInfo(method), new[] { arg1, arg2, arg3 }, options);
+        }
+
+        /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
+        /// <param name="method">The method to invoke.</param>
+        /// <param name="options">Options to use for the invocation.</param>
+        public static RemoteInvokeHandle Invoke(Func<int> method, RemoteInvokeOptions options = null)
+        {
+            return Invoke(GetMethodInfo(method), Array.Empty<string>(), options);
         }
 
         /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
@@ -284,7 +341,10 @@ namespace Microsoft.DotNet.RemoteExecutor
 
             // Verify the specified method returns an int (the exit code) or nothing,
             // and that if it accepts any arguments, they're all strings.
-            Assert.True(method.ReturnType == typeof(void) || method.ReturnType == typeof(int) || method.ReturnType == typeof(Task<int>));
+            Assert.True(method.ReturnType == typeof(void)
+                || method.ReturnType == typeof(int)
+                || method.ReturnType == typeof(Task)
+                || method.ReturnType == typeof(Task<int>));
             Assert.All(method.GetParameters(), pi => Assert.Equal(typeof(string), pi.ParameterType));
 
             // And make sure it's in this assembly.  This isn't critical, but it helps with deployment to know

--- a/src/Microsoft.DotNet.RemoteExecutor/tests/Microsoft.DotNet.RemoteExecutor.Tests.csproj
+++ b/src/Microsoft.DotNet.RemoteExecutor/tests/Microsoft.DotNet.RemoteExecutor.Tests.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <LangVersion>Latest</LangVersion>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\Microsoft.DotNet.RemoteExecutor.csproj" />
+  </ItemGroup>
+ 
+</Project>

--- a/src/Microsoft.DotNet.RemoteExecutor/tests/RemoteExecutorTests.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/tests/RemoteExecutorTests.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.RemoteExecutor;
+using System.Threading.Tasks;
+
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.DotNet.RemoteExecutor.Tests
+{
+    public class RemoteExecutorTests
+    {
+        [Fact]
+        public void AsyncAction_ThrowException()
+        {
+            Assert.Throws<RemoteExecutionException>(() =>
+                RemoteExecutor.Invoke(async () =>
+                {
+                    Assert.True(false);
+                    await Task.Delay(1);
+                }).Dispose()
+            );
+        }
+
+        [Fact]
+        public void AsyncAction()
+        {
+            RemoteExecutor.Invoke(async () =>
+            {
+                await Task.Delay(1);
+            }).Dispose();
+        }
+
+        [Fact]
+        public void AsyncFunc_ThrowException()
+        {
+            Assert.Throws<RemoteExecutionException>(() =>
+                RemoteExecutor.Invoke(async () =>
+                {
+                    Assert.True(false);
+                    await Task.Delay(1);
+                    return 1;
+                }).Dispose()
+            );
+        }
+
+        [Fact]
+        public void AsyncFunc_InvalidReturnCode()
+        {
+            Assert.Throws<TrueException>(() =>
+                RemoteExecutor.Invoke(async () =>
+                {
+                    await Task.Delay(1);
+                    return 1;
+                }).Dispose()
+            );
+        }
+
+        [Fact]
+        public void AsyncFunc_NoThrow_ValidReturnCode()
+        {
+            RemoteExecutor.Invoke(async () =>
+            {
+                await Task.Delay(1);
+                return RemoteExecutor.SuccessExitCode;
+            }).Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Added overload for Function<Task> to prevent casting Function<Task> to Action which prevents async callbacks without return value swallow exceptions.

fixes #4912