### PR TITLE
Backport azdo reporter fix

### DIFF
--- a/Documentation/AzureDevOps/AzureDevOpsOnboarding.md
+++ b/Documentation/AzureDevOps/AzureDevOpsOnboarding.md
@@ -31,7 +31,7 @@
 
 ## GitHub to DncEng Internal mirror
 
-If your repository has internal builds (that is, the repo authenticode signs), you will need to set up a DncEng Internal mirror. This is *required* for internal builds; if your repository only does PR or public CI builds, you can skip this step.
+If your repository has internal builds (that is, the repo Authenticode signs its outputs), you will need to set up a DncEng Internal mirror. This is *required* for internal builds; if your repository only does PR or public CI builds, you can skip this step.
 
 Instructions for setting up the GitHub to dev.azure.com/dnceng/internal mirror are available in the [dev.azure.com/dnceng internal mirror documentation](./internal-mirror.md)
 
@@ -61,7 +61,7 @@ See the [dotnet-bot-github-service-endpoint documentation](https://github.com/do
 
 ## Agent queues
 
-We now use Azure Pool Providers to deploy VMs as build agents.  Workflows defined in yaml that still use the "phases" syntax will not able to take advantage of this feature.  See [this document](https://github.com/dotnet/arcade/blob/master/Documentation/AzureDevOps/PhaseToJobSchemaChange.md) for details how to migrate if you are in this scenario.
+We now use Azure Pool Providers to deploy VMs as build agents. Workflows defined in yaml that still use the "phases" syntax will not able to take advantage of this feature.  See [this document](https://github.com/dotnet/arcade/blob/master/Documentation/AzureDevOps/PhaseToJobSchemaChange.md) for details how to migrate if you are in this scenario.
 
 To use an Azure Pool provider, you need to specify both the name of the pool provider and the Helix Queue it uses.  This looks something like:
 ``` yaml
@@ -71,26 +71,45 @@ To use an Azure Pool provider, you need to specify both the name of the pool pro
 
 Current machine pool recommendations:
 
-### External : (Pool Provider: NetCorePublic-Int-Pool)
-
+### External : (Pool Provider: NetCorePublic-Pool)
 | OS         | Recommended pool     | Pool Provider Queue(s)     | Notes | 
 | ---------- | -------------------- | -------------------------- | ----- |
-| Windows_NT | Hosted VS2017        | buildpool.windows.10.amd64.vs2017.open  | |
-|            |                      | buildpool.windows.10.amd64.vs2019.open     | Not available yet |
-|            |                      | buildpool.windows.10.amd64.vs2019.bt.open  | BuildTools SKU: No interactive VS components |
-|            |                      | buildpool.windows.10.amd64.es.vs2017.open  | Spanish OS, VS2017 |
+| Windows_NT | Hosted VS2017 or 2019| BuildPool.Server.Amd64.Open  | Plain Windows: No VS install |
+|            |                      | BuildPool.Server.Amd64.ES.VS2017.Open | Spanish OS, Server Sku, VS2017 |
+|            |                      | BuildPool.Server.Amd64.VS2017.Open |  |
+|            |                      | BuildPool.Server.Amd64.VS2019.Open |  |
+|            |                      | BuildPool.Server.Amd64.VS2019.Pre.Open | Latest public preview VS 2019 |
+|            |                      | BuildPool.Server.Amd64.VS2019.Pre.ES.Open | Latest public preview VS 2019, Spanish OS |
+|            |                      | BuildPool.Server.Amd64.VS2019.BT.Open |  |
+|            |                      | BuildPool.Server.Wasm.Open | Web Assembly Build Configuration |
+|            |                      | BuildPool.Windows.10.Amd64.Open |  |
+|            |                      | BuildPool.Windows.10.Amd64.ES.VS2017.Open |  |
+|            |                      | BuildPool.Windows.10.Amd64.VS2017.Open |  |
+|            |                      | BuildPool.Windows.10.Amd64.VS2019.Open |  |
+|            |                      | BuildPool.Windows.10.Amd64.VS2019.Pre.Open | Latest public preview VS 2019 |
+|            |                      | BuildPool.Windows.Amd64.VS2019.Pre.ES.Open | Latest public preview VS 2019, Spanish OS |
+|            |                      | BuildPool.Windows.10.Amd64.VS2019.BT.Open |  |
+|            |                      | BuildPool.Windows.10.Wasm.Open | Web Assembly Build Configuration |
 | Linux      | Hosted Ubuntu 1604   | buildpool.ubuntu.1604.amd64.open | |
-| OSX        | Hosted MacOS         | n/a | |
+| MacOS      | Hosted MacOS         | n/a | |
 
-### Internal : (Pool Provider: NetCoreInternal-Int-Pool)
+### Internal : (Pool Provider: NetCoreInternal-Pool)
 
 | OS         | Recommended pool     | Pool Provider Queue(s)      | Notes | 
 | ---------- | -------------------- | --------------------------- | ----- |
-| Windows_NT | Use Pool Provider -> | buildpool.windows.10.amd64.vs2017  | |
-|            |                      | buildpool.windows.10.amd64.vs2019     | Not available yet |
-|            |                      | buildpool.windows.10.amd64.vs2019.bt  | BuildTools SKU: No interactive VS components other than IIS Express |
+| Windows_NT | Use Pool Provider -> | BuildPool.Server.Amd64.VS2017 |     |
+|            |                      | BuildPool.Server.Amd64.VS2019 |     |
+|            |                      | BuildPool.Server.Amd64.VS2017 |     |
+|            |                      | BuildPool.Server.Amd64.VS2019 |     |
+|            |                      | BuildPool.Server.Amd64.VS2019.BT |  |
+|            |                      | BuildPool.Server.Amd64.VS2019.Pre | |
+|            |                      | BuildPool.Windows.10.Amd64.VS2017 | |
+|            |                      | BuildPool.Windows.10.Amd64.VS2019 | |
+|            |                      | BuildPool.Windows.10.Amd64.VS2019.BT| |
+|            |                      | BuildPool.Windows.10.Amd64.VS2019.Pre | |
+|            |                      | BuildPool.Windows.10.Amd64.VS2019.Xaml| |
 | Linux      | Hosted Ubuntu 1604   | buildpool.ubuntu.1604.amd64 |
-| OSX        | Hosted Mac Internal  | |
+| MacOS      | Hosted MacOs Internal| n/a | |
 
 A couple of notes:
 
@@ -102,17 +121,21 @@ A couple of notes:
 
 - BuildPool.Windows queues:
 
-  - Windows Client RS4 or higher
+  - Visual Studio versions are updated to "latest public GA" version on a roughly monthly cadence.  
+  - Windows Client RS4 or higher for "*.Windows.10*," or Server 2019 Images used for "*.Server.*" queues
   - 4 cores
   - 512 GB disk space capacity (not SSD)
-  - BuildPool.Windows.10.Amd64.VS2017 - Visual Studio 2017 15.9
-  - Buildpool.Windows.10.Amd64.ES.VS2017.Open  - Visual Studio 2017 15.9 EN-US on ES-ES OS
-  - BuildPool.Windows.10.Amd64.VS2019 - Visual Studio 2019 16.0
-  - BuildPool.Windows.10.Amd64.VS2019.BT - Visual Studio 2017 16.0 'BuildTools' SKU (no UI)
+  - BuildPool.*.Amd64.VS2017 - Visual Studio 2017 15.X
+  - Buildpool.*.Amd64.ES.VS2017.Open  - Visual Studio 2017 15.X EN-US on an ES-ES OS
+  - BuildPool.*.Amd64.VS2019 - Visual Studio 2019 Enterprise 16.X
+  - BuildPool.*.Amd64.VS2019.ES - Visual Studio 2019 Enterprise 16.X on an ES-ES OS.
+  - BuildPool.*.Amd64.VS2019.Pre - Visual Studio 2019 Enterprise Preview 16.X
+  - BuildPool.*.Amd64.VS2019.BT - Visual Studio 2019 16.X 'BuildTools' SKU (no UI)
+  - BuildPool.*.Wasm - Web Assembly Build Configuration
 
 - BuildPool.Ubuntu queues:
   - Ubuntu 16.04
-  - Docker 18.09.2
+  - Docker 18.09.6
   - 4 cores
   - 512 GB disk space capacity (not SSD)
 

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.bat
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.bat
@@ -1,6 +1,8 @@
 
 set ENV_PATH=%USERPROFILE%\.vsts-env
 set TMP_ENV_PATH=%USERPROFILE%\.vsts-env-tmp
+set PYTHONPATH=
+
 echo  %date%-%time%
 
 if NOT EXIST %ENV_PATH%\Scripts\python.exe (

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.sh
@@ -17,6 +17,8 @@ if [ ! -f $ENV_PATH/bin/python ]; then
   mv -T $TMP_ENV_PATH $ENV_PATH
 fi
 
+export PYTHONPATH=
+
 if $ENV_PATH/bin/python -c "import azure.devops"; then
   echo "azure-devops module already available"
 else

--- a/tests/UnitTests.proj
+++ b/tests/UnitTests.proj
@@ -58,9 +58,9 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(HelixAccessToken)' != '' ">
-    <HelixTargetQueue Include="Debian.9.Amd64"/>
-    <HelixTargetQueue Include="RedHat.7.Amd64"/>
-    <HelixTargetQueue Include="Windows.10.Amd64"/>
+    <HelixTargetQueue Include="Debian.9.Amd64.Arcade"/>
+    <HelixTargetQueue Include="RedHat.7.Amd64.Arcade"/>
+    <HelixTargetQueue Include="Windows.10.Amd64.Arcade"/>
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(HelixAccessToken)' == '' ">
@@ -70,9 +70,9 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(HelixAccessToken)' == '' ">
-    <HelixTargetQueue Include="Debian.9.Amd64.Open"/>
-    <HelixTargetQueue Include="RedHat.7.Amd64.Open"/>
-    <HelixTargetQueue Include="Windows.10.Amd64.Open"/>
+    <HelixTargetQueue Include="Debian.9.Amd64.Arcade.Open"/>
+    <HelixTargetQueue Include="RedHat.7.Amd64.Arcade.Open"/>
+    <HelixTargetQueue Include="Windows.10.Amd64.Arcade.Open"/>
   </ItemGroup>
 
   <PropertyGroup Condition="!$(HelixTargetQueue.StartsWith('Windows'))">


### PR DESCRIPTION
## Description

The 2-26 Helix rollout brought subtle helix client changes which change the way the virtual environment is created by the Azure DevOps reporter.  We missed these because it doesn't cause work items to "fail" unless the actually failed, it simply leaves the AzDO build without test results.

## Customer Impact

Azure DevOps test results will not be visible for release/3.x branches.  Test logs and pass/fail will remain, but users have grown accustomed to historical data in AzDO for their tests.

## Regression

Yes

## Risk

Very low; it's simply unsetting environment variables and is shown to work in https://dev.azure.com/dnceng/public/_build?definitionId=208&_a=summary

## Workarounds

Not really; rolling back the python script changes made to add __init.py__ files everywhere would result in the issue seen before with machines unable to upload logs (or other variants;  the general idea here is "python's site-packages can be modified, possibly in a breaking way, by work items".)