### PR TITLE
Improve workaround for core-eng #9132

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.bat
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.bat
@@ -1,6 +1,6 @@
 
-set ENV_PATH=%USERPROFILE%\.vsts-env
-set TMP_ENV_PATH=%USERPROFILE%\.vsts-env-tmp
+set ENV_PATH=%USERPROFILE%\.azdo-env
+set TMP_ENV_PATH=%USERPROFILE%\.azdo-env-tmp
 
 REM Removing pythonpath forces a clean installation of the Azure DevOps client, but subsequent commands may use HELIX libraries
 set _OLD_PYTHONPATH=%PYTHONPATH%
@@ -12,7 +12,7 @@ if NOT EXIST %ENV_PATH%\Scripts\python.exe (
   rmdir /Q /S %TMP_ENV_PATH%
   rmdir /Q /S %ENV_PATH%
   %HELIX_PYTHONPATH% -m virtualenv --no-site-packages %TMP_ENV_PATH%
-  rename %TMP_ENV_PATH% .vsts-env
+  rename %TMP_ENV_PATH% .azdo-env
 )
 
 %ENV_PATH%\Scripts\python.exe -c "import azure.devops" || %ENV_PATH%\Scripts\python.exe -m pip install azure-devops==5.0.0b9

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.sh
@@ -6,8 +6,8 @@ set -x
 
 script_path=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 
-ENV_PATH=$HOME/.vsts-env
-TMP_ENV_PATH=$HOME/.vsts-env-tmp
+ENV_PATH=$HOME/.azdo-env
+TMP_ENV_PATH=$HOME/.azdo-env-tmp
 date -u +"%FT%TZ"
 
 if [ ! -f $ENV_PATH/bin/python ]; then


### PR DESCRIPTION
I just realized that we can solve this without changing the helix client, just using a new temp directory we keep caching but which won't be broken by folders created by older Helix SDKs