### PR TITLE
Fix for Arcade-services symbol publishing

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -73,6 +73,14 @@
     <Copy SourceFiles="@(SymbolPackagesToGenerate->'%(OriginalPackage)')" DestinationFiles="@(SymbolPackagesToGenerate)" />
 
     <ItemGroup>
+      <!--
+        These packages from Arcade-Services include some native libraries that
+        our current symbol uploader can't handle. Below is a workaround until
+        we get issue: https://github.com/dotnet/arcade/issues/2457 sorted.
+      -->
+      <SymbolPackagesToGenerate Remove="$(SymbolPackagesDir)**/Microsoft.DotNet.Darc.*" />
+      <SymbolPackagesToGenerate Remove="$(SymbolPackagesDir)**/Microsoft.DotNet.Maestro.Tasks.*" />
+      
       <ItemsToPushToBlobFeed Include="@(PackagesToPublish);@(ExistingSymbolPackages);@(SymbolPackagesToGenerate)">
         <ManifestArtifactData Condition="'%(IsShipping)' != 'true'">NonShipping=true</ManifestArtifactData>
       </ItemsToPushToBlobFeed>
@@ -190,14 +198,6 @@
         Publish Portable PDBs contained in symbol packages.
       -->
       <PackagesToPublishToSymbolServer Include="@(ExistingSymbolPackages);@(SymbolPackagesToGenerate)"/>
-
-      <!--
-        These packages from Arcade-Services include some native libraries that
-        our current symbol uploader can't handle. Below is a workaround until
-        we get issue: https://github.com/dotnet/arcade/issues/2457 sorted.
-      -->
-      <PackagesToPublishToSymbolServer Remove="$(BlobBasePath)\Microsoft.DotNet.Darc.*" />
-      <PackagesToPublishToSymbolServer Remove="$(BlobBasePath)\Microsoft.DotNet.Maestro.Tasks.*" />
     </ItemGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
Closes: #4919 

Proper fix to prevent attempt to publish symbol packages from Arcade services that contains files that the symbol uploader cannot currently handle.

This problem only affects PR builds. I tested the fix in this PR: https://github.com/dotnet/arcade-services/pull/1004