### PR TITLE
Update common-variables.yml removing deprecated props

### DIFF
--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -2,10 +2,6 @@ variables:
   # Cannot use key:value syntax in root defined variables
   - name: _TeamName
     value: DotNetCore
-  - name: _DotNetArtifactsCategory
-    value: .NETCore
-  - name: _DotNetValidationArtifactsCategory
-    value: .NETCoreValidation
   - name: HelixApiAccessToken
     value: ''
   - name: _RunAsPublic
@@ -30,10 +26,7 @@ variables:
     - group: DotNet-HelixApi-Access
     - group: SDL_Settings
     - name: _InternalBuildArgs
-      value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
-        /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-        /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-        /p:DotNetPublishToBlobFeed=true
+      value: /p:DotNetSignType=$(_SignType) 
+        /p:TeamName=$(_TeamName)
         /p:DotNetPublishUsingPipelines=true
-        /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
         /p:OfficialBuildId=$(BUILD.BUILDNUMBER)


### PR DESCRIPTION
Closes: https://github.com/dotnet/arcade/issues/4971

We don't need to pass these properties anymore to Arcade SDK.

Tested here:
 - https://dnceng.visualstudio.com/internal/_build/results?buildId=544259&view=results
 - https://dnceng.visualstudio.com/internal/_build/results?buildId=544218&view=results