### PR TITLE
Enabling Default Interface methods on ApiCompat

### DIFF
--- a/src/Microsoft.DotNet.ApiCompat/ExportCciSettings.cs
+++ b/src/Microsoft.DotNet.ApiCompat/ExportCciSettings.cs
@@ -16,11 +16,14 @@ namespace Microsoft.DotNet.ApiCompat
         public static IDifferenceOperands  StaticOperands { get; set; }
         public static IAttributeFilter StaticAttributeFilter { get; set; }
 
+        public static IRuleSettings StaticRuleSettings { get; set; }
+
         public ExportCciSettings()
         {
             Settings = StaticSettings;
             Operands = StaticOperands;
             AttributeFilter = StaticAttributeFilter;
+            RuleSettings = StaticRuleSettings;
         }
 
         [Export(typeof(IEqualityComparer<ITypeReference>))]
@@ -31,5 +34,8 @@ namespace Microsoft.DotNet.ApiCompat
 
         [Export(typeof(IAttributeFilter))]
         public IAttributeFilter AttributeFilter { get; }
+
+        [Export(typeof(IRuleSettings))]
+        public IRuleSettings RuleSettings { get; }
     }
 }

--- a/src/Microsoft.DotNet.ApiCompat/Rules/Compat/IRuleSettings.cs
+++ b/src/Microsoft.DotNet.ApiCompat/Rules/Compat/IRuleSettings.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Cci.Differs
+{
+    /// <summary>
+    /// Rule Settings
+    /// </summary>
+    public interface IRuleSettings
+    {
+        /// <summary>
+        /// Gets a value indicating whether DIM rules should be applied.
+        /// </summary>
+        bool AllowDefaultInterfaceMethods { get; }
+    }
+
+    public class RuleSettings : IRuleSettings
+    {
+        public bool AllowDefaultInterfaceMethods { get; set; }
+    }
+}


### PR DESCRIPTION
C# 8 enables default interface methods (DIM) where we can define default methods/properties/constants/events/indexers on interfaces.

ApiCompat should not trigger api breaks when DIM is used.

Because DIM is a feature not yet fully implemented across all languages and also because of compatibility with previous versions, we cannot blindly enable DIM checks on ApiCompat. 
The solution is to add a flag where we can tell the tool to consider the DIM rules.
We are adding --allow-default-interface-methods command option that when it is passed, it will not raise DIM additions as api breaks.