### PR TITLE
Add PublishSpecialClrFiles property to symbol publishing

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishToSymbolServers.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishToSymbolServers.proj
@@ -13,6 +13,7 @@
       - DotNetSymbolServerTokenSymWeb : PAT to access SymWeb.
       - DotNetSymbolExpirationInDays  : Expiration days for published packages. Default is 3650.
       - SymbolPublishingExclusionsFile : Path to file containing exclusion list to be used by Symbol Uploader.
+      - PublishSpecialClrFiles : If true, publish the DAC, DBI and SOS using the coreclr index. If false, don't do any special indexing.
   -->
 
   <PropertyGroup>
@@ -49,6 +50,7 @@
       <PublishToSymWeb Condition="'$(PublishToSymWeb)' == ''">true</PublishToSymWeb>
       <PublishToMSDL Condition="'$(PublishToMSDL)' == ''">true</PublishToMSDL>
       <PublishToSymbolServer Condition="'@(FilesToPublishToSymbolServer)' == '' and '@(PackagesToPublishToSymbolServer)' == ''">false</PublishToSymbolServer>
+      <PublishSpecialClrFiles Condition="'$(PublishSpecialClrFiles)' == ''">true</PublishSpecialClrFiles>
     </PropertyGroup>
 
     <Message
@@ -90,6 +92,7 @@
                     DryRun="false"
                     ConvertPortablePdbsToWindowsPdbs="false"
                     PdbConversionTreatAsWarning=""
+                    PublishSpecialClrFiles=$(PublishSpecialClrFiles)
                     Condition="$(PublishToSymbolServer) and $(PublishToMSDL)"/>
 
     <!-- 
@@ -108,6 +111,7 @@
                     DryRun="false"
                     ConvertPortablePdbsToWindowsPdbs="false"
                     PdbConversionTreatAsWarning=""
+                    PublishSpecialClrFiles=$(PublishSpecialClrFiles)
                     Condition="$(PublishToSymbolServer) and $(PublishToSymWeb)"/>
   </Target>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishToSymbolServers.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishToSymbolServers.proj
@@ -92,7 +92,7 @@
                     DryRun="false"
                     ConvertPortablePdbsToWindowsPdbs="false"
                     PdbConversionTreatAsWarning=""
-                    PublishSpecialClrFiles=$(PublishSpecialClrFiles)
+                    PublishSpecialClrFiles="$(PublishSpecialClrFiles)"
                     Condition="$(PublishToSymbolServer) and $(PublishToMSDL)"/>
 
     <!-- 
@@ -111,7 +111,7 @@
                     DryRun="false"
                     ConvertPortablePdbsToWindowsPdbs="false"
                     PdbConversionTreatAsWarning=""
-                    PublishSpecialClrFiles=$(PublishSpecialClrFiles)
+                    PublishSpecialClrFiles="$(PublishSpecialClrFiles)"
                     Condition="$(PublishToSymbolServer) and $(PublishToSymWeb)"/>
   </Target>
 


### PR DESCRIPTION
The diagnostics repo needs a way to disable the special indexing the symbol uploader does. SOS, DAC and DBI modules are also indexed with coreclr's index when this is enabled.  The symbol publishing failures for the diagnostics repo because the packages contain multiple sos.dll/libsos.so/libsos.dylib one for each architecture and causes "DUP" file errors.

The runtime repo is the only one that needs to this special indexing enabled and this feature should be changed to be opt-in but until this change gets into arcade and the runtime repo is changed to opt-in, the default needs to stay "enabled".  
