### PR TITLE
Remove placeholder configs from restore

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
@@ -46,6 +46,8 @@
           BeforeTargets="CollectPackageReferences">
     <ItemGroup>
       <_TargetFrameworks Include="$(TargetFrameworks)" />
+      <!-- Remove placeholders from restore. -->
+      <_TargetFrameworks Remove="@(_TargetFrameworks)" Condition="$([System.String]::new('%(Identity)').StartsWith('_'))" />
       <_TargetFrameworks Length="$([System.String]::new('%(Identity)').IndexOf('-'))"/>
       <_TargetFrameworks Condition="'%(Length)' == '-1'" Length="$([System.String]::new('%(Identity)').Length)"/>
       <_TargetFrameworksWithoutTargetFrameworkSuffix Include="$([System.String]::new('%(_TargetFrameworks.Identity)').Substring(0, '%(_TargetFrameworks.Length)'))" />


### PR DESCRIPTION
Fixes the restore of projects with placeholder configs in them:

```
C:\git\runtime4\src\libraries\System.ComponentModel.Composition\ref>dotnet restore /bl
C:\Program Files\dotnet\sdk\3.1.200-preview-014850\MSBuild.dll -nologo -distributedlogger:Microsoft.DotNet.Tools.MSBuild.MSBuildLogger,C:\Program Files\dotnet\sdk\3.1.200-preview-014850\dotnet.dll*Microsoft.DotNet.Tools.MSBuild.MSBuildForwardingLogger,C:\Program Files\dotnet\sdk\3.1.200-preview-014850\dotnet.dll -maxcpucount -target:Restore -verbosity:m /bl .\System.ComponentModel.Composition.csproj
C:\Program Files\dotnet\sdk\3.1.200-preview-014850\NuGet.targets(123,5): error : Invalid restore input. Invalid target framework 'unsupported'. Input files: C:\git\runtime4\src\libraries\System.ComponentModel.Composition\ref\System.ComponentModel.Composition.csproj. [C:\git\runtime4\src\libraries\System.ComponentModel.Composition\ref\System.ComponentModel.Composition.csproj]
```