### PR TITLE
Support transitive P2P references

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
@@ -66,8 +66,10 @@
     </PropertyGroup>
   </Target>
 
+  <!-- Hook into ResolvePackageDependenciesForBuild to support transitive dependencies. -->
   <Target Name="ResolveP2PReferences"
-          BeforeTargets="AssignProjectConfiguration">
+          BeforeTargets="AssignProjectConfiguration"
+          DependsOnTargets="ResolvePackageDependenciesForBuild">
     <MSBuild Projects="@(ProjectReference)"
              Targets="GetTargetFrameworks"
              ContinueOnError="true"

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
@@ -66,8 +66,12 @@
     </PropertyGroup>
   </Target>
 
-  <!-- Hook into ResolvePackageDependenciesForBuild to support transitive dependencies. -->
+  <!--
+    Runs in a leaf project (csproj) to determine best configuration for ProjectReferences.
+    Make sure to run late enough for transitive dependencies which runs before AssignProjectConfiguration.
+  -->
   <Target Name="ResolveP2PReferences"
+          Condition="'@(ProjectReference)' != ''"
           BeforeTargets="AssignProjectConfiguration"
           DependsOnTargets="ResolvePackageDependenciesForBuild">
     <MSBuild Projects="@(ProjectReference)"


### PR DESCRIPTION
When enabling project restore in dotnet/runtime, transitive dependencies are now resolved but the hook is missing the TargetFramework.Sdk to annotate/filter them.

Port of https://github.com/dotnet/arcade/commit/aa4285be7fab64e2b6e62e4d5688ea50931c407c#diff-65c01698b75e00dac00a586ec65bace1 from the old config system.