### PR TITLE
Fix sequencing of TargetFrameworkSuffix stripping

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
@@ -43,7 +43,7 @@
   <!-- Restore does not take into account TargetFrameworkSuffix, so we remove the it from the TargetFramework before restore.-->
   <Target Name="StripTargetFrameworkSuffixFromTargetFrameworks"
           Condition="'$(TargetFrameworks)' != ''"
-          BeforeTargets="CollectPackageReferences">
+          BeforeTargets="_GetRestoreTargetFrameworksOutput;_GetRestoreTargetFrameworksAsItems">
     <ItemGroup>
       <_TargetFrameworks Include="$(TargetFrameworks)" />
       <!-- Remove placeholders from restore. -->
@@ -60,7 +60,7 @@
 
   <!-- Attaching the TargetFrameworkSuffix after restore for build.-->
   <Target Name="AttachTargetFrameworkSuffixToTargetFrameworks"
-          AfterTargets="Restore">    
+          AfterTargets="_GenerateRestoreGraph">    
     <PropertyGroup>
       <TargetFrameworks>$(_OriginalTargetFrameworks)</TargetFrameworks>
     </PropertyGroup>


### PR DESCRIPTION
Hooking into `CollectPackageReferences` for stripping the `TargetFrameworkSuffix` is a big hammer and unnecessary as the exact targets that read the TargetFrameworks value are `_GetRestoreTargetFrameworksOutput;_GetRestoreTargetFrameworksAsItems`. Those targets are always invoked as part of the _GenerateRestoreGraph on which we hook the attaching of the TargetFarmeworkSuffix then.

Keeping the hook on `CollectPackageReferences` doesn't guarantee that attaching of the Suffix later as that target is also called outside of the Restore phase. This fixes that and allows P2P OS-specific references.