### PR TITLE
Enhancing MembersMustExist and InterfacesShouldHaveSameMembers messages

### DIFF
--- a/src/Microsoft.Cci.Extensions/Extensions/CSharp/CSharpCciExtensions.cs
+++ b/src/Microsoft.Cci.Extensions/Extensions/CSharp/CSharpCciExtensions.cs
@@ -466,6 +466,17 @@ namespace Microsoft.Cci.Extensions.CSharp
             return null;
         }
 
+        public static string GetReturnTypeName(this ITypeDefinitionMember member)
+        {
+            var returnType = member.GetReturnType();
+            if (TypeHelper.TypesAreEquivalent(returnType, member.ContainingTypeDefinition.PlatformType.SystemVoid))
+            {
+                return "void";
+            }
+
+            return returnType.FullName();
+        }
+
         public static IFieldDefinition GetHiddenBaseField(this IFieldDefinition field, ICciFilter filter = null)
         {
             foreach (ITypeReference baseClassRef in field.ContainingTypeDefinition.GetAllBaseTypes())
@@ -940,5 +951,33 @@ namespace Microsoft.Cci.Extensions.CSharp
 
             return (false, null);
         };
+
+        public static string GetVisibilityName(this TypeMemberVisibility visibility)
+        {
+            return visibility switch
+            {
+                TypeMemberVisibility.Assembly => "internal",
+                TypeMemberVisibility.Family => "protected",
+                TypeMemberVisibility.FamilyOrAssembly => "protected internal",
+                TypeMemberVisibility.FamilyAndAssembly => "private protected",
+                _ => visibility.ToString().ToLowerInvariant(),
+            };
+        }
+
+        public static string GetVisibilityName(this ITypeDefinition type)
+        {
+            return TypeHelper.TypeVisibilityAsTypeMemberVisibility(type).GetVisibilityName();
+        }
+
+        public static string GetVisibilityName(this ITypeDefinitionMember member)
+        {
+            Contract.Requires(member != null);
+            return member.Visibility.GetVisibilityName();
+        }
+
+        public static string GetMemberViolationMessage(this ITypeDefinitionMember member, string memberMessage, string message1, string message2)
+        {
+            return $"{memberMessage} '{member.GetVisibilityName()} {member.GetReturnTypeName()} {member.FullName()}' {message1} but {message2}.";
+        }
     }
 }

--- a/src/Microsoft.DotNet.ApiCompat/Rules/Compat/CannotAddAbstractMembers.cs
+++ b/src/Microsoft.DotNet.ApiCompat/Rules/Compat/CannotAddAbstractMembers.cs
@@ -26,8 +26,7 @@ namespace Microsoft.Cci.Differs.Rules
                 if (contractType != null && (contractType.IsEffectivelySealed() || (contractType.IsInterface && mapping.ContainingType[0].IsInterface)))
                     return DifferenceType.Unknown;
 
-                differences.AddIncompatibleDifference(this,
-                    $"Member '{impl.FullName()}' is abstract in the {Implementation} but is missing in the {Contract}.");
+                differences.AddIncompatibleDifference(this, impl.GetMemberViolationMessage("Member", $"is abstract in the {Implementation}", $"is missing in the {Contract}"));
                 return DifferenceType.Changed;
             }
             return DifferenceType.Unknown;

--- a/src/Microsoft.DotNet.ApiCompat/Rules/Compat/CannotMakeAbstract.cs
+++ b/src/Microsoft.DotNet.ApiCompat/Rules/Compat/CannotMakeAbstract.cs
@@ -17,9 +17,7 @@ namespace Microsoft.Cci.Differs.Rules
 
             if (impl.IsAbstract() && !contract.IsAbstract())
             {
-                differences.AddIncompatibleDifference("CannotMakeMemberAbstract",
-                    $"Member '{impl.FullName()}' is abstract in the {Implementation} but is not abstract in the {Contract}.");
-
+                differences.AddIncompatibleDifference("CannotMakeMemberAbstract", impl.GetMemberViolationMessage("Member", $"is abstract in the {Implementation}", $"is not abstract in the {Contract}"));
                 return DifferenceType.Changed;
             }
 

--- a/src/Microsoft.DotNet.ApiCompat/Rules/Compat/CannotMakeMoreVisible.cs
+++ b/src/Microsoft.DotNet.ApiCompat/Rules/Compat/CannotMakeMoreVisible.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Extensions;
+using Microsoft.Cci.Extensions.CSharp;
 using Microsoft.Cci.Writers.CSharp;
 
 namespace Microsoft.Cci.Differs.Rules
@@ -26,7 +27,7 @@ namespace Microsoft.Cci.Differs.Rules
                 if (contract.Visibility != TypeMemberVisibility.Family && contract.Visibility != TypeMemberVisibility.FamilyOrAssembly)
                 {
                     differences.AddIncompatibleDifference(this,
-                        $"Visibility of member '{impl.FullName()}' is '{impl.Visibility}' in the {Implementation} but '{contract.Visibility}' in the {Contract}.");
+                        $"Visibility of member '{impl.FullName()}' is '{impl.GetVisibilityName()}' in the {Implementation} but '{contract.GetVisibilityName()}' in the {Contract}.");
                     return DifferenceType.Changed;
                 }
             }
@@ -49,7 +50,7 @@ namespace Microsoft.Cci.Differs.Rules
                 if (contract.GetVisibility() != TypeMemberVisibility.Family && contract.GetVisibility() != TypeMemberVisibility.FamilyOrAssembly)
                 {
                     differences.AddIncompatibleDifference(this,
-                        $"Visibility of type '{impl.FullName()}' is '{impl.GetVisibility()}' in the {Implementation} but '{contract.GetVisibility()}' in the {Contract}.");
+                        $"Visibility of type '{impl.FullName()}' is '{impl.GetVisibilityName()}' in the {Implementation} but '{contract.GetVisibilityName()}' in the {Contract}.");
                     return DifferenceType.Changed;
                 }
             }

--- a/src/Microsoft.DotNet.ApiCompat/Rules/Compat/CannotMakeNonVirtual.cs
+++ b/src/Microsoft.DotNet.ApiCompat/Rules/Compat/CannotMakeNonVirtual.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Cci.Differs.Rules
             bool isContractOverridable = IsOverridable(contract);
 
             /*
-            //@todo: Move to a separate rule that's only run in "strict" mode. 
+            //@todo: Move to a separate rule that's only run in "strict" mode.
             if (isImplInhertiable && !isContractInheritiable)
             {
                 // This is separate because it can be noisy and is generally allowed as long as it is reviewed properly.
@@ -33,9 +33,7 @@ namespace Microsoft.Cci.Differs.Rules
 
             if (isContractOverridable && !isImplOverridable)
             {
-                differences.AddIncompatibleDifference("CannotMakeMemberNonVirtual",
-                    $"Member '{impl.FullName()}' is non-virtual in the {Implementation} but is virtual in the {Contract}.");
-
+                differences.AddIncompatibleDifference("CannotMakeMemberNonVirtual", impl.GetMemberViolationMessage("Member", $"is non-virtual in the {Implementation}", $"is virtual in the {Contract}"));
                 return DifferenceType.Changed;
             }
 


### PR DESCRIPTION
ApiCompat reports MembersMustExist and InterfacesShouldHaveSameMembers without identify the return type.
This is very confusing in cases the return type is the culprit of the message.

here is an example:

from:
```
interface Foo {
  bool Bar();
}
```

to:
```
interface Foo {
  int Bar();
}
```

ApiCompat does not report it as the return type was changed, which is fine, however it reports as:
`MembersMustExist : Member 'Foo.Bar' does not exist in the implementation but it does exist in the contract.`

but if you look on the IL, the method is there, which causes some confusion.

We should enhance the message to:
`MembersMustExist : Member 'Foo.Bar -> System.Boolean' does not exist in the implementation but it does exist in the contract.`

Other tools are actually already using this format that I am proposing above, see
i.e.: PublicApiAnalyzers
https://github.com/dotnet/roslyn-analyzers/tree/master/src/PublicApiAnalyzers

for consistency with those other tools, would be nice to have the extra **`-> returnType`** on the message.

InterfacesShouldHaveSameMembers example on how the message is misleading, on the same run it reports the method is missing but is also there:

Current:
```
InterfacesShouldHaveSameMembers : Interface member 'MyAssembly.IFoo.Bar()' is present in the implementation but not in the contract.
InterfacesShouldHaveSameMembers : Interface member 'MyAssembly.IFoo.Bar()' is present in the contract but not in the implementation.
```

Proposed:
```
InterfacesShouldHaveSameMembers : Interface member 'MyAssembly.IFoo.Bar() -> System.Int32' is present in the implementation but not in the contract.
InterfacesShouldHaveSameMembers : Interface member 'MyAssembly.IFoo.Bar() -> System.Boolean' is present in the contract but not in the implementation.
```

Updating the changes to be more similar the C# declaration, i.e.:
`System.String TestDefaultInterface.IFoo.Bar.get()` instead of `TestDefaultInterface.IFoo.Bar.get() -> System.String`