### PR TITLE
Ignore case when searching for PinvokeAnalyzer files

### DIFF
--- a/src/Microsoft.DotNet.CodeAnalysis/Analyzers/PinvokeAnalyzer.cs
+++ b/src/Microsoft.DotNet.CodeAnalysis/Analyzers/PinvokeAnalyzer.cs
@@ -28,8 +28,8 @@ namespace Microsoft.DotNet.CodeAnalysis.Analyzers
 
         public override void OnCompilationStart(CompilationStartAnalysisContext obj)
         {
-            _allowedPinvokeFile = obj.Options.AdditionalFiles.FirstOrDefault(f => Path.GetFileName(f.Path).Contains("PinvokeAnalyzer_"));
-            _exceptionFile = obj.Options.AdditionalFiles.FirstOrDefault(f => Path.GetFileName(f.Path).Contains("PinvokeAnalyzerExceptionList.analyzerdata"));
+            _allowedPinvokeFile = obj.Options.AdditionalFiles.FirstOrDefault(f => Path.GetFileName(f.Path).IndexOf("PinvokeAnalyzer_", StringComparison.OrdinalIgnoreCase) >= 0);
+            _exceptionFile = obj.Options.AdditionalFiles.FirstOrDefault(f => Path.GetFileName(f.Path).IndexOf("PinvokeAnalyzerExceptionList.analyzerdata", StringComparison.OrdinalIgnoreCase) >= 0);
             obj.RegisterSymbolAction(AnalyzeMethod, SymbolKind.Method);
         }
 


### PR DESCRIPTION
Ignoring case when searching for PinvokeAnalyzer files. We currently have one file in dotnet/runtime which wasn't detected because of case sensitive check: https://github.com/dotnet/runtime/blob/master/src/libraries/System.Net.Http/src/PInvokeAnalyzerExceptionList.analyzerdata.

I'm sure this code can be cleaned-up further but I'm not planning to do as part of this PR.