### PR TITLE
Stop ignoring PublishToSymbolServer property

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -94,7 +94,7 @@
         only in the Maestro post-build stages. If DotNetPublishUsingPipelines is NOT set then
         we publish symbols during the build stage.
       -->
-      <PublishToSymbolServer>true</PublishToSymbolServer>
+      <PublishToSymbolServer Condition="'$(PublishToSymbolServer)' == ''">true</PublishToSymbolServer>
       <PublishToSymbolServer Condition="'$(DotNetPublishUsingPipelines)' == 'true'">false</PublishToSymbolServer>
     </PropertyGroup>
 


### PR DESCRIPTION
If the PublishToSymbolServer property is passed in globally it is being ignored as it is overwritten in the Execute target. dotnet/runtime-assets needs to disable that property as there aren't any assets that can/should be published to the symbol server.