### PR TITLE
Add multiple baseline and exclusion file support to APICompat

### DIFF
--- a/src/Microsoft.Cci.Extensions/Extensions/DocIdExtensions.cs
+++ b/src/Microsoft.Cci.Extensions/Extensions/DocIdExtensions.cs
@@ -85,22 +85,18 @@ namespace Microsoft.Cci.Extensions
             return "<Unknown Reference Type>";
         }
 
-        public static HashSet<string> ReadDocIds(string docIdsFile)
+        public static IEnumerable<string> ReadDocIds(string docIdsFile)
         {
-            HashSet<string> ids = new HashSet<string>();
-
             if (!File.Exists(docIdsFile))
-                return ids;
+                yield break;
 
             foreach (string id in File.ReadAllLines(docIdsFile))
             {
                 if (string.IsNullOrWhiteSpace(id) || id.StartsWith("#") || id.StartsWith("//"))
                     continue;
 
-                ids.Add(id.Trim());
+                yield return id.Trim();
             }
-
-            return ids;
         }
     }
 }

--- a/src/Microsoft.Cci.Extensions/Filters/BaselineDifferenceFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/BaselineDifferenceFilter.cs
@@ -10,21 +10,18 @@ namespace Microsoft.Cci.Filters
 {
     public class BaselineDifferenceFilter : IDifferenceFilter
     {
-        private readonly HashSet<string> _ignoreDifferences;
+        private readonly HashSet<string> _ignoreDifferences = new HashSet<string>();
         private readonly IDifferenceFilter _filter;
 
-        public BaselineDifferenceFilter(IDifferenceFilter filter, string baselineFile)
+        public BaselineDifferenceFilter(IDifferenceFilter filter)
         {
             _filter = filter;
-            _ignoreDifferences = ReadBaselineFile(baselineFile);
         }
 
-        private HashSet<string> ReadBaselineFile(string baselineFile)
+        public void AddBaselineFile(string baselineFile)
         {
-            HashSet<string> ignoreList = new HashSet<string>();
-
             if (!File.Exists(baselineFile))
-                return ignoreList;
+                return;
 
             foreach (var line in File.ReadAllLines(baselineFile))
             {
@@ -38,10 +35,8 @@ namespace Microsoft.Cci.Filters
                 if (string.IsNullOrWhiteSpace(filteredLine))
                     continue;
 
-                ignoreList.Add(filteredLine);
+                _ignoreDifferences.Add(filteredLine);
             }
-
-            return ignoreList;
         }
 
         public bool Include(Difference difference)

--- a/src/Microsoft.Cci.Extensions/Filters/DocIdExcludeListFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/DocIdExcludeListFilter.cs
@@ -23,9 +23,9 @@ namespace Microsoft.Cci.Filters
             _excludeMembers = excludeMembers;
         }
 
-        public DocIdExcludeListFilter(string whiteListFilePath, bool excludeMembers)
+        public DocIdExcludeListFilter(string excludeListFilePath, bool excludeMembers)
         {
-            _docIds = DocIdExtensions.ReadDocIds(whiteListFilePath);
+            _docIds = new HashSet<string>(DocIdExtensions.ReadDocIds(excludeListFilePath));
             _excludeMembers = excludeMembers;
         }
 

--- a/src/Microsoft.Cci.Extensions/Filters/DocIdIncludeListFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/DocIdIncludeListFilter.cs
@@ -20,9 +20,9 @@ namespace Microsoft.Cci.Filters
             _docIds = new HashSet<string>(docIds);
         }
 
-        public DocIdIncludeListFilter(string whiteListFilePath)
+        public DocIdIncludeListFilter(string includeListFilePath)
         {
-            _docIds = DocIdExtensions.ReadDocIds(whiteListFilePath);
+            _docIds = new HashSet<string>(DocIdExtensions.ReadDocIds(includeListFilePath));
         }
 
         public bool AlwaysIncludeNonEmptyTypes { get; set; }

--- a/src/Microsoft.Cci.Extensions/Filters/ExcludeAttributesFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/ExcludeAttributesFilter.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Cci.Filters
         public ExcludeAttributesFilter(string attributeDocIdFile, bool includeForwardedTypes = false)
             : base(excludeAttributes: false, includeForwardedTypes: includeForwardedTypes)
         {
-            _attributeDocIds = DocIdExtensions.ReadDocIds(attributeDocIdFile);
+            _attributeDocIds = new HashSet<string>(DocIdExtensions.ReadDocIds(attributeDocIdFile));
         }
 
         public override bool Include(ICustomAttribute attribute)

--- a/src/Microsoft.DotNet.ApiCompat/Program.cs
+++ b/src/Microsoft.DotNet.ApiCompat/Program.cs
@@ -229,12 +229,9 @@ namespace Microsoft.DotNet.ApiCompat
                         throw new FileNotFoundException("File {0} was not found!", file);
                     }
 
-
                     addFile(file);
                 }
             }
-
-            return;
         }
 
         private static TextWriter GetOutput(string outFilePath)

--- a/src/Microsoft.DotNet.ApiCompat/Rules/Compat/AttributeDifference.cs
+++ b/src/Microsoft.DotNet.ApiCompat/Rules/Compat/AttributeDifference.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Microsoft.DotNet.ApiCompat/Rules/Compat/AttributeDifference.cs
+++ b/src/Microsoft.DotNet.ApiCompat/Rules/Compat/AttributeDifference.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -142,11 +142,17 @@ namespace Microsoft.Cci.Differs.Rules
 
     public class AttributeFilter : IAttributeFilter
     {
-        private HashSet<string> ignorableAttributes;
+        private readonly HashSet<string> ignorableAttributes = new HashSet<string>();
 
-        public AttributeFilter(string docIdList)
+        public AttributeFilter()
+        { }
+
+        public void AddIgnoreAttributeFile(string filePath)
         {
-            ignorableAttributes = DocIdExtensions.ReadDocIds(docIdList);
+            foreach(string id in DocIdExtensions.ReadDocIds(filePath))
+            {
+                ignorableAttributes.Add(id);
+            }
         }
 
         public bool ShouldExclude(string attributeDocID)


### PR DESCRIPTION
This permits more than one file for baselines and api lists.

Needed for https://github.com/dotnet/runtime/pull/33300