### PR TITLE
Skip component detection and codesign validation for some jobs

### DIFF
--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -37,6 +37,12 @@ jobs:
     - name: _BuildConfig
       value: ${{ parameters.configuration }}
     - group: Publish-Build-Assets
+    # Skip component governance and codesign validation for SDL. These jobs
+    # create no content.
+    - name: skipComponentGovernanceDetection
+      value: true
+    - name: runCodesignValidationInjection
+      value: false
 
   steps:
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/common/templates/post-build/common-variables.yml
+++ b/eng/common/templates/post-build/common-variables.yml
@@ -90,3 +90,10 @@ variables:
     value: https://dotnetclimsrc.blob.core.windows.net/dotnet/index.json
   - name: InternalInstallersBlobFeedKey
     value: $(dotnetclimsrc-access-key)
+
+  # Skip component governance and codesign validation for SDL. These jobs
+  # create no content.
+  - name: skipComponentGovernanceDetection
+    value: true
+  - name: runCodesignValidationInjection
+    value: false


### PR DESCRIPTION
We've had an increase in the time for a bunch of standard build tasks
(publishing, validation, and some parts of the build stages). Looking at
some builds seems to show that a lot (all?) of this increase comes from
injected tasks. We don't need these for the following standard templates
because they create no actual content:
- Publish to Build Asset Registry
- All of post build (sdl validation and publishing)
Skip these injected tasks in these cases.