### PR TITLE
Support RestoreUseStaticGraphEvaluation

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -208,6 +208,8 @@
       As a perf optimization, the Properties list here should match exactly with
       the properties passed to the "Restore" target a few lines below.
       This helps MSBuild cache the result of _IsProjectRestoreSupported.
+      No need to call into the nuget internal target when restoring using
+      the new msbuild static graph APIs (RestoreUseStaticGraphEvaluation=true).
     -->
     <MSBuild Projects="@(ProjectToBuild)"
              Properties="@(_SolutionBuildProps);__BuildPhase=SolutionRestore;_NETCORE_ENGINEERING_TELEMETRY=Restore"
@@ -215,7 +217,7 @@
              Targets="_IsProjectRestoreSupported"
              SkipNonexistentTargets="true"
              BuildInParallel="true"
-             Condition="'$(RestoreUsingNuGetTargets)' != 'false' and '%(ProjectToBuild.Extension)' != '.sln' and '$(Restore)' == 'true'">
+             Condition="'$(RestoreUsingNuGetTargets)' != 'false' and '%(ProjectToBuild.Extension)' != '.sln' and '$(RestoreUseStaticGraphEvaluation)' != 'true' and '$(Restore)' == 'true'">
 
       <Output TaskParameter="TargetOutputs" ItemName="_ProjectToRestoreWithNuGet" />
     </MSBuild>

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
@@ -8,6 +8,12 @@
   <PropertyGroup>
     <_OriginalTargetFrameworks>$(TargetFrameworks)</_OriginalTargetFrameworks>
   </PropertyGroup>
+
+  <!-- Strip the TargetFrameworkSuffix during the graph build. -->
+  <PropertyGroup Condition="'$(IsGraphBuild)' == 'true' And '$(MSBuildRestoreSessionId)' != ''">
+    <TargetFrameworks Condition="'$(TargetFrameworks)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '-[^;]+', ''))</TargetFrameworks>
+    <TargetFramework Condition="'$(TargetFramework)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFramework)', '-[^;]+', ''))</TargetFramework>
+  </PropertyGroup>
   
   <Target Name="RemovePlaceHolderConfigs"
           Condition="'$(MSBuildProjectExtension)' != '.pkgproj'"
@@ -42,7 +48,7 @@
 
   <!-- Restore does not take into account TargetFrameworkSuffix, so we remove the it from the TargetFramework before restore.-->
   <Target Name="StripTargetFrameworkSuffixFromTargetFrameworks"
-          Condition="'$(TargetFrameworks)' != ''"
+          Condition="'$(TargetFrameworks)' != '' and '$(RestoreUseStaticGraphEvaluation)' != 'true'"
           BeforeTargets="_GetRestoreTargetFrameworksOutput;_GetRestoreTargetFrameworksAsItems">
     <ItemGroup>
       <_TargetFrameworks Include="$(TargetFrameworks)" />
@@ -60,6 +66,7 @@
 
   <!-- Attaching the TargetFrameworkSuffix after restore for build.-->
   <Target Name="AttachTargetFrameworkSuffixToTargetFrameworks"
+          Condition="'$(RestoreUseStaticGraphEvaluation)' != 'true'"
           AfterTargets="_GenerateRestoreGraph">    
     <PropertyGroup>
       <TargetFrameworks>$(_OriginalTargetFrameworks)</TargetFrameworks>

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
@@ -13,7 +13,6 @@
   <PropertyGroup Condition="'$(IsGraphBuild)' == 'true'">
     <TargetFrameworks Condition="'$(TargetFrameworks)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '_[^;]+;?', ''))</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '-[^;]+', ''))</TargetFrameworks>
-    <TargetFramework Condition="'$(TargetFramework)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFramework)', '-[^;]+', ''))</TargetFramework>
   </PropertyGroup>
   
   <Target Name="RemovePlaceHolderConfigs"
@@ -45,24 +44,6 @@
                                       BestTargetFrameworks="@(_BestTargetFramework)" >
       <Output TaskParameter="InnerBuildProjects" ItemName="InnerBuildProjectsWithBestTargetFramework" />
     </AddTargetFrameworksToProjectTask>
-  </Target>
-
-  <!-- Restore does not take into account TargetFrameworkSuffix, so we remove the it from the TargetFramework before restore.-->
-  <Target Name="StripTargetFrameworkSuffixFromTargetFrameworks"
-          Condition="'$(TargetFrameworks)' != '' and '$(RestoreUseStaticGraphEvaluation)' != 'true'"
-          BeforeTargets="_GetRestoreTargetFrameworksOutput;_GetRestoreTargetFrameworksAsItems">
-    <ItemGroup>
-      <_TargetFrameworks Include="$(TargetFrameworks)" />
-      <!-- Remove placeholders from restore. -->
-      <_TargetFrameworks Remove="@(_TargetFrameworks)" Condition="$([System.String]::new('%(Identity)').StartsWith('_'))" />
-      <_TargetFrameworks Length="$([System.String]::new('%(Identity)').IndexOf('-'))"/>
-      <_TargetFrameworks Condition="'%(Length)' == '-1'" Length="$([System.String]::new('%(Identity)').Length)"/>
-      <_TargetFrameworksWithoutTargetFrameworkSuffix Include="$([System.String]::new('%(_TargetFrameworks.Identity)').Substring(0, '%(_TargetFrameworks.Length)'))" />
-    </ItemGroup>
-    
-    <PropertyGroup>
-      <TargetFrameworks>@(_TargetFrameworksWithoutTargetFrameworkSuffix->Distinct())</TargetFrameworks>
-    </PropertyGroup>
   </Target>
 
   <!-- Attaching the TargetFrameworkSuffix after restore for build.-->

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
@@ -9,8 +9,9 @@
     <_OriginalTargetFrameworks>$(TargetFrameworks)</_OriginalTargetFrameworks>
   </PropertyGroup>
 
-  <!-- Strip the TargetFrameworkSuffix during the graph build. -->
+  <!-- Strip away placeholder tfms and TargetFrameworkSuffix during the graph build. -->
   <PropertyGroup Condition="'$(IsGraphBuild)' == 'true' And '$(MSBuildRestoreSessionId)' != ''">
+    <TargetFrameworks Condition="'$(TargetFrameworks)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '_[^;]+;?', ''))</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '-[^;]+', ''))</TargetFrameworks>
     <TargetFramework Condition="'$(TargetFramework)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFramework)', '-[^;]+', ''))</TargetFramework>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <!-- Strip away placeholder tfms and TargetFrameworkSuffix during the graph build. -->
-  <PropertyGroup Condition="'$(IsGraphBuild)' == 'true' And '$(MSBuildRestoreSessionId)' != ''">
+  <PropertyGroup Condition="'$(IsGraphBuild)' == 'true'">
     <TargetFrameworks Condition="'$(TargetFrameworks)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '_[^;]+;?', ''))</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '-[^;]+', ''))</TargetFrameworks>
     <TargetFramework Condition="'$(TargetFramework)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFramework)', '-[^;]+', ''))</TargetFramework>
@@ -67,8 +67,7 @@
 
   <!-- Attaching the TargetFrameworkSuffix after restore for build.-->
   <Target Name="AttachTargetFrameworkSuffixToTargetFrameworks"
-          Condition="'$(RestoreUseStaticGraphEvaluation)' != 'true'"
-          AfterTargets="_GenerateRestoreGraph">    
+          AfterTargets="Restore">
     <PropertyGroup>
       <TargetFrameworks>$(_OriginalTargetFrameworks)</TargetFrameworks>
     </PropertyGroup>


### PR DESCRIPTION
The new RestoreTaskEx only runs a subset of targets and there is no hook point anymore to retrieve the TargetFramework. Stripping the TargetFrameworkSuffix if we are inside the new GraphBuild