### PR TITLE
Fixing string definition of TypeMemberVisibility.FamilyAndAssembly

### DIFF
--- a/src/Microsoft.Cci.Extensions/Experimental/APIEmitter.cs
+++ b/src/Microsoft.Cci.Extensions/Experimental/APIEmitter.cs
@@ -154,6 +154,9 @@ namespace Microsoft.Cci.Extensions.Experimental
                     break;
 
                 case TypeMemberVisibility.FamilyAndAssembly:
+                    EmitKeyword("private protected");
+                    break;
+
                 default:
                     EmitKeyword("<Unknown-Visibility>");
                     break;

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.cs
@@ -205,7 +205,7 @@ namespace Microsoft.Cci.Writers.CSharp
                 case TypeMemberVisibility.FamilyOrAssembly:
                     WriteKeyword("protected"); WriteKeyword("internal"); break;
                 case TypeMemberVisibility.FamilyAndAssembly:
-                    WriteKeyword("internal"); WriteKeyword("protected"); break; // Is this right?
+                    WriteKeyword("private"); WriteKeyword("protected"); break;
                 default:
                     WriteKeyword("<Unknown-Visibility>"); break;
             }


### PR DESCRIPTION
We currently emmit/write wrong string content for FamilyAndAssembly
It should translate as => private protected