### PR TITLE
Fix non-POSIX compliant line in Helix reporter run

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.sh
@@ -14,7 +14,7 @@ if [ ! -f $ENV_PATH/bin/python ]; then
   rm -rf $ENV_PATH
   rm -rf $TMP_ENV_PATH
   $HELIX_PYTHONPATH -m virtualenv --no-site-packages $TMP_ENV_PATH
-  mv -T $TMP_ENV_PATH $ENV_PATH
+  mv $TMP_ENV_PATH $ENV_PATH
 fi
 
 # Removing pythonpath forces a clean installation of the Azure DevOps client, but subsequent commands may use HELIX libraries


### PR DESCRIPTION
The option `-T` fails at OSX and is not necessary here as we know the target path does not exist.