### PR TITLE
Improve publishing performance (by a lot)

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
@@ -74,7 +74,7 @@
       Text="No manifest file was found in the provided path: $(ManifestsBasePath)" />
 
     <!-- 
-      **Iterate** publishing assets from each manifest file. 
+      Publish artifacts from all manifests.
     -->
     <PublishArtifactsInManifest
       InternalBuild="$(IsInternalBuild)"

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
@@ -82,7 +82,7 @@
       BARBuildId="$(BARBuildId)"
       MaestroApiEndpoint="$(MaestroApiEndpoint)"
       BuildAssetRegistryToken="$(BuildAssetRegistryToken)"
-      AssetManifestPath="%(ManifestFiles.Identity)"
+      AssetManifestPaths="@(ManifestFiles)"
       BlobAssetsBasePath="$(BlobBasePath)"
       PackageAssetsBasePath="$(PackageBasePath)"
       NugetPath="$(NugetPath)"

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
@@ -212,14 +212,6 @@
         Type="AzDoNugetFeed"
         Token="$(AzureDevOpsStaticTransportFeedKey)" />
 
-      <TargetFeedConfig
-        AssetSelection="NonShippingOnly"
-        Include="Symbols"
-        TargetURL="$(AzureDevOpsStaticSymbolsFeed)"
-        Isolated="false"
-        Type="AzDoNugetFeed"
-        Token="$(AzureDevOpsStaticSymbolsFeedKey)" />
-
       <!-- These feeds are marked as isolated even though they are not. We allow overwrite
            the old data with the new. -->
       <TargetFeedConfig
@@ -306,8 +298,15 @@
           - Installers and checksums to desired storage accounts.
     -->
     <ItemGroup Condition="'@(TargetFeedConfig)' == '' AND '$(IsStableBuild)' == 'false' AND '$(IsInternalBuild)' == 'false'">
-      <TargetFeedConfig
-        Include="Package;Symbols;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX;Badge;Other"
+      <TargetFeedConfig Condition="'$(PublishInstallersAndChecksums)' == 'true'"
+        Include="Symbols"
+        TargetURL="$(TargetStaticFeed)"
+        Isolated="false"
+        Type="AzureStorageFeed"
+        Token="$(AzureStorageTargetFeedPAT)" />
+
+      <TargetFeedConfig Condition="'$(PublishInstallersAndChecksums)' != 'true'"
+        Include="Symbols;OSX;Deb;Rpm;Node;BinaryLayout;Installer;Checksum;Maven;VSIX;Badge;Other"
         TargetURL="$(TargetStaticFeed)"
         Isolated="false"
         Type="AzureStorageFeed"
@@ -344,13 +343,6 @@
         Type="AzDoNugetFeed"
         Token="$(AzureDevOpsStaticTransportFeedKey)"
         AssetSelection="NonShippingOnly" />
-
-      <TargetFeedConfig
-        Include="Symbols"
-        TargetURL="$(AzureDevOpsStaticSymbolsFeed)"
-        Isolated="false"
-        Type="AzDoNugetFeed"
-        Token="$(AzureDevOpsStaticSymbolsFeedKey)" />
     </ItemGroup>
 
     <Error

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -88,10 +88,10 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public ITaskItem[] TargetFeedConfig { get; set; }
 
         /// <summary>
-        /// Full path to the assets to publish manifest.
+        /// Full path to the assets to publish manifest(s)
         /// </summary>
         [Required]
-        public string AssetManifestPath { get; set; }
+        public ITaskItem[] AssetManifestPaths { get; set; }
 
         /// <summary>
         /// Full path to the folder containing blob assets.
@@ -127,7 +127,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         /// <summary>
         /// Maximum number of parallel uploads for the upload tasks
         /// </summary>
-        public int MaxClients { get; set; } = 8;
+        public int MaxClients { get; set; } = 16;
 
         /// <summary>
         /// Directory where "nuget.exe" is installed. This will be used to publish packages.
@@ -181,14 +181,19 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         {
             try
             {
-                Log.LogMessage(MessageImportance.High, "Publishing artifacts to feed.");
-
-                if (string.IsNullOrWhiteSpace(AssetManifestPath) || !File.Exists(AssetManifestPath))
+                foreach (var assetManifestPath in AssetManifestPaths)
                 {
-                    Log.LogError($"Problem reading asset manifest path from '{AssetManifestPath}'");
+                    Log.LogMessage(MessageImportance.High, $"Publishing artifacts in {assetManifestPath.ItemSpec}.");
+                    string fileName = assetManifestPath.ItemSpec;
+                    if (string.IsNullOrWhiteSpace(fileName) || !File.Exists(fileName))
+                    {
+                        Log.LogError($"Problem reading asset manifest path from '{fileName}'");
+                    }
                 }
 
-                var buildModel = BuildManifestUtil.ManifestFileToModel(AssetManifestPath, Log);
+
+                IEnumerable<BuildModel> buildModels = AssetManifestPaths.Select(
+                    assetManifestPath => BuildManifestUtil.ManifestFileToModel(assetManifestPath.ItemSpec, Log));
 
                 // Parsing the manifest may fail for several reasons
                 if (Log.HasLoggedErrors)
@@ -200,6 +205,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 // of the assets being published so we can add a new location for them.
                 IMaestroApi client = ApiFactory.GetAuthenticated(MaestroApiEndpoint, BuildAssetRegistryToken);
                 Maestro.Client.Models.Build buildInformation = await client.Builds.GetBuildAsync(BARBuildId);
+                Dictionary<string, List<Asset>> buildAssets = CreateBuildAssetDictionary(buildInformation);
 
                 await ParseTargetFeedConfigAsync();
 
@@ -209,7 +215,10 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     return false;
                 }
 
-                SplitArtifactsInCategories(buildModel);
+                foreach (var buildModel in buildModels)
+                {
+                    SplitArtifactsInCategories(buildModel);
+                }
 
                 // Return errors from the safety checks
                 if (Log.HasLoggedErrors)
@@ -217,9 +226,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     return false;
                 }
 
-                await HandlePackagePublishingAsync(client, buildInformation);
-
-                await HandleBlobPublishingAsync(client, buildInformation);
+                await Task.WhenAll(new Task[] {
+                        HandlePackagePublishingAsync(client, buildAssets),
+                        HandleBlobPublishingAsync(client, buildAssets)
+                    }
+                );
             }
             catch (Exception e)
             {
@@ -227,6 +238,67 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             }
 
             return !Log.HasLoggedErrors;
+        }
+
+        /// <summary>
+        ///     Lookup an asset in the build asset dictionary by name and version
+        /// </summary>
+        /// <param name="name">Name of asset</param>
+        /// <param name="version">Version of asset</param>
+        /// <returns>Asset if one with the name and version exists, null otherwise</returns>
+        private Asset LookupAsset(string name, string version, Dictionary<string, List<Asset>> buildAssets)
+        {
+            if (!buildAssets.TryGetValue(name, out List<Asset> assetsWithName))
+            {
+                return null;
+            }
+            return assetsWithName.FirstOrDefault(asset => asset.Version == version);
+        }
+
+        /// <summary>
+        ///     Lookup an asset in the build asset dictionary by name only.
+        ///     This is for blob lookup purposes.
+        /// </summary>
+        /// <param name="name">Name of asset</param>
+        /// <returns>
+        ///     Asset if one with the name exists and is the only asset with the name.
+        ///     Throws if there is more than one asset with that name.
+        /// </returns>
+        private Asset LookupAsset(string name, Dictionary<string, List<Asset>> buildAssets)
+        {
+            if (!buildAssets.TryGetValue(name, out List<Asset> assetsWithName))
+            {
+                return null;
+            }
+            return assetsWithName.Single();
+        }
+
+        /// <summary>
+        ///     Build up a map of asset name -> asset list so that we can avoid n^2 lookups when processing assets.
+        ///     We use name only becuase blobs are only looked up by id (version is not recorded in the manifest).
+        ///     This could mean that there might be multiple versions of the same asset in the build.
+        /// </summary>
+        /// <param name="buildInformation">Build information</param>
+        /// <returns>Map of asset name -> list of assets with that name.</returns>
+        private Dictionary<string, List<Asset>> CreateBuildAssetDictionary(Maestro.Client.Models.Build buildInformation)
+        {
+            // Build up a map of asset name -> asset list so that we can avoid n^2 lookups when processing assets.
+            // We use name only becuase blobs are only looked up by id (version is not recorded in the manifest).
+            // This could mean that there might be multiple versions of the same asset in the build.
+            Dictionary<string, List<Asset>> buildAssets = new Dictionary<string, List<Asset>>();
+            foreach (var asset in buildInformation.Assets)
+            {
+                if (buildAssets.TryGetValue(asset.Name, out List<Asset> assetsWithName))
+                {
+                    assetsWithName.Add(asset);
+                }
+                else
+                {
+                    buildAssets.Add(asset.Name, new List<Asset>() { asset });
+                }
+            }
+
+            return buildAssets;
         }
 
         /// <summary>
@@ -456,8 +528,16 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             return isPublic;
         }
 
-        private async Task HandlePackagePublishingAsync(IMaestroApi client, Maestro.Client.Models.Build buildInformation)
+        /// <summary>
+        ///     Handle package publishing for all the feed configs.
+        /// </summary>
+        /// <param name="client">Maestro API client</param>
+        /// <param name="buildAssets">Assets information about build being published.</param>
+        /// <returns>Task</returns>
+        private async Task HandlePackagePublishingAsync(IMaestroApi client, Dictionary<string, List<Asset>> buildAssets)
         {
+            List<Task> publishTasks = new List<Task>();
+
             foreach (var packagesPerCategory in PackagesByCategory)
             {
                 var category = packagesPerCategory.Key;
@@ -480,10 +560,10 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         switch (feedConfig.Type)
                         {
                             case FeedType.AzDoNugetFeed:
-                                await PublishPackagesToAzDoNugetFeedAsync(filteredPackages, client, buildInformation, feedConfig);
+                                publishTasks.Add(PublishPackagesToAzDoNugetFeedAsync(filteredPackages, client, buildAssets, feedConfig));
                                 break;
                             case FeedType.AzureStorageFeed:
-                                await PublishPackagesToAzureStorageNugetFeedAsync(filteredPackages, client, buildInformation, feedConfig);
+                                publishTasks.Add(PublishPackagesToAzureStorageNugetFeedAsync(filteredPackages, client, buildAssets, feedConfig));
                                 break;
                             default:
                                 Log.LogError($"Unknown target feed type for category '{category}': '{feedConfig.Type}'.");
@@ -496,6 +576,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     Log.LogError($"No target feed configuration found for artifact category: '{category}'.");
                 }
             }
+
+            await Task.WhenAll(publishTasks);
         }
 
         private List<PackageArtifactModel> FilterPackages(List<PackageArtifactModel> packages, FeedConfig feedConfig)
@@ -516,7 +598,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             }
         }
 
-        private async Task HandleBlobPublishingAsync(IMaestroApi client, Maestro.Client.Models.Build buildInformation)
+        private async Task HandleBlobPublishingAsync(IMaestroApi client, Dictionary<string, List<Asset>> buildAssets)
         {
             foreach (var blobsPerCategory in BlobsByCategory)
             {
@@ -540,10 +622,10 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         switch (feedConfig.Type)
                         {
                             case FeedType.AzDoNugetFeed:
-                                await PublishBlobsToAzDoNugetFeedAsync(filteredBlobs, client, buildInformation, feedConfig);
+                                await PublishBlobsToAzDoNugetFeedAsync(filteredBlobs, client, buildAssets, feedConfig);
                                 break;
                             case FeedType.AzureStorageFeed:
-                                await PublishBlobsToAzureStorageNugetFeedAsync(filteredBlobs, client, buildInformation, feedConfig);
+                                await PublishBlobsToAzureStorageNugetFeedAsync(filteredBlobs, client, buildAssets, feedConfig);
                                 break;
                             default:
                                 Log.LogError($"Unknown target feed type for category '{category}': '{feedConfig.Type}'.");
@@ -648,24 +730,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         private async Task PublishPackagesToAzDoNugetFeedAsync(
             List<PackageArtifactModel> packagesToPublish,
             IMaestroApi client,
-            Maestro.Client.Models.Build buildInformation,
+            Dictionary<string, List<Asset>> buildAssets,
             FeedConfig feedConfig)
         {
-            foreach (var package in packagesToPublish)
-            {
-                var assetRecord = buildInformation.Assets
-                    .Where(a => a.Name.Equals(package.Id) && a.Version.Equals(package.Version))
-                    .FirstOrDefault();
-
-                if (assetRecord == null)
-                {
-                    Log.LogError($"Asset with Id {package.Id}, Version {package.Version} isn't registered on the BAR Build with ID {BARBuildId}");
-                    continue;
-                }
-
-                await TryAddAssetLocationAsync(client, assetRecord, feedConfig, AddAssetLocationToAssetAssetLocationType.NugetFeed);
-            }
-
             await PushNugetPackagesAsync(packagesToPublish, feedConfig, maxClients: MaxClients,
                 async (feed, httpClient, package, feedAccount, feedVisibility, feedName) =>
                 {
@@ -676,7 +743,16 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         return;
                     }
 
-                    await PushNugetPackageAsync(feed, httpClient, localPackagePath, package.Id, package.Version, feedAccount, feedVisibility, feedName);
+                    Asset assetRecord = LookupAsset(package.Id, package.Version, buildAssets);
+                    if (assetRecord == null)
+                    {
+                        Log.LogError($"Asset with Id {package.Id}, Version {package.Version} isn't registered on the BAR Build with ID {BARBuildId}");
+                    }
+
+                    await Task.WhenAll(new Task[] {
+                        TryAddAssetLocationAsync(client, assetRecord, feedConfig, AddAssetLocationToAssetAssetLocationType.NugetFeed),
+                        PushNugetPackageAsync(feed, httpClient, localPackagePath, package.Id, package.Version, feedAccount, feedVisibility, feedName),
+                    });
                 });
         }
 
@@ -1013,28 +1089,13 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         private async Task PublishBlobsToAzDoNugetFeedAsync(
             List<BlobArtifactModel> blobsToPublish,
             IMaestroApi client,
-            Maestro.Client.Models.Build buildInformation,
+            Dictionary<string, List<Asset>> buildAssets,
             FeedConfig feedConfig)
         {
             List<BlobArtifactModel> packagesToPublish = new List<BlobArtifactModel>();
 
             foreach (var blob in blobsToPublish)
             {
-                var assetRecord = buildInformation.Assets
-                    .Where(a => a.Name.Equals(blob.Id))
-                    .FirstOrDefault();
-
-                if (assetRecord == null)
-                {
-                    Log.LogError($"Asset with Id {blob.Id} isn't registered on the BAR Build with ID {BARBuildId}");
-                    continue;
-                }
-
-                if (await TryAddAssetLocationAsync(client, assetRecord, feedConfig, AddAssetLocationToAssetAssetLocationType.Container) == false)
-                {
-                    continue;
-                }
-
                 // Applies to symbol packages and core-sdk's VS feed packages
                 if (blob.Id.EndsWith(PackageSuffix, StringComparison.OrdinalIgnoreCase))
                 {
@@ -1049,33 +1110,44 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             await PushNugetPackagesAsync<BlobArtifactModel>(packagesToPublish, feedConfig, maxClients: MaxClients,
                 async (feed, httpClient, blob, feedAccount, feedVisibility, feedName) =>
                 {
-                    // Determine the local path to the blob
-                    string fileName = Path.GetFileName(blob.Id);
-                    string localBlobPath = Path.Combine(BlobAssetsBasePath, fileName);
-                    if (!File.Exists(localBlobPath))
+                    // Lookup just by name
+                    Asset assetRecord = LookupAsset(blob.Id, buildAssets);
+                    if (assetRecord == null)
                     {
-                        Log.LogError($"Could not locate '{blob.Id} at '{localBlobPath}'");
-                        return;
+                        Log.LogError($"Asset with Id {blob.Id} isn't registered on the BAR Build with ID {BARBuildId}");
                     }
-
-                    string id;
-                    string version;
-                    // Determine package ID and version by asking the nuget libraries
-                    using (var packageReader = new NuGet.Packaging.PackageArchiveReader(localBlobPath))
+                    // Only attempt to push if the package doesn't have
+                    // that location already.
+                    else if (await TryAddAssetLocationAsync(client, assetRecord, feedConfig, AddAssetLocationToAssetAssetLocationType.Container))
                     {
-                        PackageIdentity packageIdentity = packageReader.GetIdentity();
-                        id = packageIdentity.Id;
-                        version = packageIdentity.Version.ToString();
-                    }
+                        // Determine the local path to the blob
+                        string fileName = Path.GetFileName(blob.Id);
+                        string localBlobPath = Path.Combine(BlobAssetsBasePath, fileName);
+                        if (!File.Exists(localBlobPath))
+                        {
+                            Log.LogError($"Could not locate '{blob.Id} at '{localBlobPath}'");
+                            return;
+                        }
 
-                    await PushNugetPackageAsync(feed, httpClient, localBlobPath, id, version, feedAccount, feedVisibility, feedName);
+                        string id;
+                        string version;
+                        // Determine package ID and version by asking the nuget libraries
+                        using (var packageReader = new NuGet.Packaging.PackageArchiveReader(localBlobPath))
+                        {
+                            PackageIdentity packageIdentity = packageReader.GetIdentity();
+                            id = packageIdentity.Id;
+                            version = packageIdentity.Version.ToString();
+                        }
+
+                        await PushNugetPackageAsync(feed, httpClient, localBlobPath, id, version, feedAccount, feedVisibility, feedName);
+                    }
                 });
         }
 
         private async Task PublishPackagesToAzureStorageNugetFeedAsync(
             List<PackageArtifactModel> packagesToPublish,
             IMaestroApi client,
-            Maestro.Client.Models.Build buildInformation,
+            Dictionary<string, List<Asset>> buildAssets,
             FeedConfig feedConfig)
         {
             var packages = packagesToPublish.Select(p =>
@@ -1101,28 +1173,28 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 PassIfExistingItemIdentical = true
             };
 
-            foreach (var package in packagesToPublish)
+            await Task.WhenAll(new Task[]
             {
-                var assetRecord = buildInformation.Assets
-                    .Where(a => a.Name.Equals(package.Id) && a.Version.Equals(package.Version))
-                    .FirstOrDefault();
-
-                if (assetRecord == null)
+                Task.WhenAll(packagesToPublish.Select(async package =>
                 {
-                    Log.LogError($"Asset with Id {package.Id}, Version {package.Version} isn't registered on the BAR Build with ID {BARBuildId}");
-                    continue;
-                }
-
-                await TryAddAssetLocationAsync(client, assetRecord, feedConfig, AddAssetLocationToAssetAssetLocationType.NugetFeed);
-            }
-
-            await blobFeedAction.PushToFeedAsync(packages, pushOptions);
+                    Asset assetRecord = LookupAsset(package.Id, package.Version, buildAssets);
+                    if (assetRecord == null)
+                    {
+                        Log.LogError($"Asset with Id {package.Id}, Version {package.Version} isn't registered on the BAR Build with ID {BARBuildId}");
+                    }
+                    else
+                    {
+                        await TryAddAssetLocationAsync(client, assetRecord, feedConfig, AddAssetLocationToAssetAssetLocationType.NugetFeed);
+                    }
+                })),
+                blobFeedAction.PushToFeedAsync(packages, pushOptions)
+            });
         }
 
         private async Task PublishBlobsToAzureStorageNugetFeedAsync(
             List<BlobArtifactModel> blobsToPublish,
             IMaestroApi client,
-            Maestro.Client.Models.Build buildInformation,
+            Dictionary<string, List<Asset>> buildAssets,
             FeedConfig feedConfig)
         {
             var blobs = blobsToPublish
@@ -1154,22 +1226,27 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 PassIfExistingItemIdentical = true
             };
 
-            foreach (BlobArtifactModel blob in blobsToPublish)
-            {
-                Asset assetRecord = buildInformation.Assets
-                    .Where(a => a.Name.Equals(blob.Id))
-                    .SingleOrDefault();
-
-                if (assetRecord == null)
+            await Task.WhenAll(new Task[]
                 {
-                    Log.LogError($"Asset with Id {blob.Id} isn't registered on the BAR Build with ID {BARBuildId}");
-                    continue;
+                    Task.WhenAll(blobsToPublish.Select(async blob =>
+                    {
+                        Asset assetRecord = LookupAsset(blob.Id, buildAssets);
+
+                        if (assetRecord == null)
+                        {
+                            Log.LogError($"Asset with Id {blob.Id} isn't registered on the BAR Build with ID {BARBuildId}");
+                        }
+                        else
+                        {
+                            await TryAddAssetLocationAsync(client, assetRecord, feedConfig, AddAssetLocationToAssetAssetLocationType.Container);
+                        }
+                    })),
+                    blobFeedAction.PublishToFlatContainerAsync(blobs, maxClients: MaxClients, pushOptions)
                 }
+            );
 
-                await TryAddAssetLocationAsync(client, assetRecord, feedConfig, AddAssetLocationToAssetAssetLocationType.Container);
-            }
-
-            await blobFeedAction.PublishToFlatContainerAsync(blobs, maxClients: MaxClients, pushOptions);
+            // The latest links should be updated only after the publishing is complete, to avoid
+            // dead links in the interim.
             await CreateOrUpdateLatestLinksAsync(blobsToPublish, feedConfig);
         }
 


### PR DESCRIPTION
Improve the publishing performance by doing a number of optimizations
- Pass all manifests to the publish task at once and read them in bulk. The publishing machines have two cores, so repos with lots of manifests (e.g. core-sdk and aspnetcore) were seeing less benefit from parallelism in the publish task
- Increase the max upload parallelism to 16
- Change the overall publish process to use async/await much more heavily.
- Remove publishes of symbol packages to azdo feeds for public non-stable builds. It's possible this could be extended to stable/internal builds with some additional work. These still go to blob storage.
- Remove publishes of installers/checksums to the static azdo blob storage (dotnet-core) if publishing is already sending these the installer/checksum locations (dotnetcli, etc.)
- Remove publishes to dotnet-core for packages.

After these changes, the future critical path publishing time (runtime, aspnetcore, sdk, and core-sdk) goes from ~130 mins to ~22 mins. About 40-50% of that appears to be prep time for publishing (downloading artifacts, etc.)
- Runtime (99th) - 35 mins to 11 mins
- aspnetcore - 50m to 4m
- Sdk - 5.75m to 2m
- core-sdk - 33m to 4.5m