### PR TITLE
add support for FreeBSD cross-compilation

### DIFF
--- a/eng/common/cross/toolchain.cmake
+++ b/eng/common/cross/toolchain.cmake
@@ -1,7 +1,11 @@
 set(CROSS_ROOTFS $ENV{ROOTFS_DIR})
 
 set(TARGET_ARCH_NAME $ENV{TARGET_BUILD_ARCH})
-set(CMAKE_SYSTEM_NAME Linux)
+if(EXISTS ${CROSS_ROOTFS}/bin/freebsd-version)
+  set(CMAKE_SYSTEM_NAME FreeBSD)
+else()
+  set(CMAKE_SYSTEM_NAME Linux)
+endif()
 set(CMAKE_SYSTEM_VERSION 1)
 
 if(TARGET_ARCH_NAME STREQUAL "armel")
@@ -27,6 +31,9 @@ elseif(TARGET_ARCH_NAME STREQUAL "arm64")
 elseif(TARGET_ARCH_NAME STREQUAL "x86")
   set(CMAKE_SYSTEM_PROCESSOR i686)
   set(TOOLCHAIN "i686-linux-gnu")
+elseif (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+  set(CMAKE_SYSTEM_PROCESSOR "x86_64")
+  set(triple "x86_64-unknown-freebsd11")
 else()
   message(FATAL_ERROR "Arch is ${TARGET_ARCH_NAME}. Only armel, arm, arm64 and x86 are supported!")
 endif()
@@ -60,6 +67,13 @@ if("$ENV{__DistroRid}" MATCHES "android.*")
 
     # include official NDK toolchain script
     include(${CROSS_ROOTFS}/../build/cmake/android.toolchain.cmake)
+elseif (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    set(CLR_CMAKE_TARGET_OS FreeBSD)
+    # we cross-compile by instructing clang
+    set(CMAKE_C_COMPILER_TARGET ${triple})
+    set(CMAKE_CXX_COMPILER_TARGET ${triple})
+    set(CMAKE_ASM_COMPILER_TARGET ${triple})
+    set(CMAKE_SYSROOT "${CROSS_ROOTFS}")
 else()
     set(CMAKE_SYSROOT "${CROSS_ROOTFS}")
 

--- a/eng/common/cross/toolchain.cmake
+++ b/eng/common/cross/toolchain.cmake
@@ -68,7 +68,6 @@ if("$ENV{__DistroRid}" MATCHES "android.*")
     # include official NDK toolchain script
     include(${CROSS_ROOTFS}/../build/cmake/android.toolchain.cmake)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
-    set(CLR_CMAKE_TARGET_OS FreeBSD)
     # we cross-compile by instructing clang
     set(CMAKE_C_COMPILER_TARGET ${triple})
     set(CMAKE_CXX_COMPILER_TARGET ${triple})


### PR DESCRIPTION
This is follow-up on  #5100. Small part of the cross-compilation lives in arcade. (and this file is only used for cross-compilation)  Rest will go to runtime repo. With all the changes we can build FreeBSD binaries on Linux using `./build.sh -cross -os FreeBSD`