### PR TITLE
Add MSBuildRestoreSessionId property to restore

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -238,7 +238,7 @@
     </ItemGroup>
 
     <MSBuild Projects="@(_ProjectToRestore)"
-             Properties="@(_SolutionBuildProps);__BuildPhase=SolutionRestore;_NETCORE_ENGINEERING_TELEMETRY=Restore"
+             Properties="@(_SolutionBuildProps);__BuildPhase=SolutionRestore;_NETCORE_ENGINEERING_TELEMETRY=Restore;MSBuildRestoreSessionId=$([System.Guid]::NewGuid())"
              RemoveProperties="$(_RemoveProps)"
              Targets="Restore"
              SkipNonexistentTargets="true"

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <!-- Strip away placeholder tfms and TargetFrameworkSuffix during the graph build. -->
-  <PropertyGroup Condition="'$(IsGraphBuild)' == 'true'">
+  <PropertyGroup Condition="'$(IsGraphBuild)' == 'true' and '$(MSBuildRestoreSessionId)' != ''">
     <TargetFrameworks Condition="'$(TargetFrameworks)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '_[^;]+;?', ''))</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '-[^;]+', ''))</TargetFrameworks>
   </PropertyGroup>


### PR DESCRIPTION
MSBuild usually sets this property to invalidate the cache but that only happens during evaluation of the invoked project. Invoking restore on projects explicitly means that we need to set that property manually. Setting this is general goodness, as we can condition on it so that we know that we are inside the restore phase.