### PR TITLE
Adding cmdline flag to validate unused diffs on baseline

### DIFF
--- a/src/Microsoft.Cci.Extensions/Filters/BaselineDifferenceFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/BaselineDifferenceFilter.cs
@@ -42,8 +42,7 @@ namespace Microsoft.Cci.Filters
                 if (filteredLine.StartsWith("Compat issues with assembly", StringComparison.OrdinalIgnoreCase))
                     continue;
 
-                if (!_ignoreDifferences.ContainsKey(filteredLine))
-                    _ignoreDifferences.Add(filteredLine, false);
+                _ignoreDifferences[filteredLine] = false;
             }
         }
 

--- a/src/Microsoft.Cci.Extensions/Filters/BaselineDifferenceFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/BaselineDifferenceFilter.cs
@@ -2,20 +2,24 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Microsoft.Cci.Differs;
 
 namespace Microsoft.Cci.Filters
 {
     public class BaselineDifferenceFilter : IDifferenceFilter
     {
-        private readonly HashSet<string> _ignoreDifferences = new HashSet<string>();
+        private readonly Dictionary<string, bool> _ignoreDifferences = new Dictionary<string, bool>();
         private readonly IDifferenceFilter _filter;
+        private readonly bool _treatUnusedDifferencesAsIssues;
 
-        public BaselineDifferenceFilter(IDifferenceFilter filter)
+        public BaselineDifferenceFilter(IDifferenceFilter filter, bool treatUnusedDifferencesAsIssues)
         {
             _filter = filter;
+            _treatUnusedDifferencesAsIssues = treatUnusedDifferencesAsIssues;
         }
 
         public void AddBaselineFile(string baselineFile)
@@ -35,21 +39,40 @@ namespace Microsoft.Cci.Filters
                 if (string.IsNullOrWhiteSpace(filteredLine))
                     continue;
 
-                _ignoreDifferences.Add(filteredLine);
+                if (filteredLine.StartsWith("Compat issues with assembly", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                if (!_ignoreDifferences.ContainsKey(filteredLine))
+                    _ignoreDifferences.Add(filteredLine, false);
             }
         }
 
         public bool Include(Difference difference)
         {
             // Is the entire rule ignored?
-            if (_ignoreDifferences.Contains(difference.Id))
+            if (_ignoreDifferences.ContainsKey(difference.Id))
+            {
+                _ignoreDifferences[difference.Id] = true;
                 return false;
+            }
 
             // Is the specific violation of the rule ignored?
-            if (_ignoreDifferences.Contains(difference.ToString()))
+            var diff = difference.ToString();
+            if (_ignoreDifferences.ContainsKey(diff))
+            {
+                _ignoreDifferences[diff] = true;
                 return false;
+            }
 
             return _filter.Include(difference);
+        }
+
+        public IEnumerable<string> GetUnusedBaselineDifferences()
+        {
+            if (!_treatUnusedDifferencesAsIssues)
+                return Enumerable.Empty<string>();
+
+            return _ignoreDifferences.Where(i => !i.Value).Select(i => i.Key);
         }
     }
 }

--- a/src/Microsoft.Cci.Extensions/Filters/BaselineDifferenceFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/BaselineDifferenceFilter.cs
@@ -39,7 +39,8 @@ namespace Microsoft.Cci.Filters
                 if (string.IsNullOrWhiteSpace(filteredLine))
                     continue;
 
-                if (filteredLine.StartsWith("Compat issues with assembly", StringComparison.OrdinalIgnoreCase))
+                if (filteredLine.StartsWith("Compat issues with assembly", StringComparison.OrdinalIgnoreCase) || 
+                    filteredLine.StartsWith("Total Issues"))
                     continue;
 
                 _ignoreDifferences[filteredLine] = false;

--- a/src/Microsoft.Cci.Extensions/Traversers/DifferenceTraverser.cs
+++ b/src/Microsoft.Cci.Extensions/Traversers/DifferenceTraverser.cs
@@ -74,5 +74,7 @@ namespace Microsoft.Cci.Traversers
         public virtual void Visit(Difference difference)
         {
         }
+
+        protected IDifferenceFilter DifferenceFilter => _filter;
     }
 }

--- a/src/Microsoft.DotNet.ApiCompat/DifferenceWriter.cs
+++ b/src/Microsoft.DotNet.ApiCompat/DifferenceWriter.cs
@@ -2,14 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
+using System.Composition;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using Microsoft.Cci.Differs;
 using Microsoft.Cci.Filters;
 using Microsoft.Cci.Mappings;
 using Microsoft.Cci.Traversers;
-using System.Composition;
 
 namespace Microsoft.Cci.Writers
 {
@@ -42,6 +44,20 @@ namespace Microsoft.Cci.Writers
                     OutputDifferences(header, _differences);
                     _totalDifferences += _differences.Count;
                     _differences.Clear();
+                }
+            }
+
+            if (DifferenceFilter is BaselineDifferenceFilter filter)
+            {
+                var unusedBaselineDifferences = filter.GetUnusedBaselineDifferences();
+                if (unusedBaselineDifferences.Any())
+                {
+                    _writer.WriteLine($"{Environment.NewLine}*** Invalid/Unused baseline differences ***");
+                    foreach (var diff in unusedBaselineDifferences)
+                    {
+                        _writer.WriteLine(diff);
+                        _totalDifferences++;
+                    }
                 }
             }
 


### PR DESCRIPTION
ApiCompat currently has infrastructure to support known valid diffs. This is used when a valid break happens and we would like to ignore it, making ApiCompat to not report that item as an error/break/issue.
We use --baseline to provide a file (or a list of files) that contains all the list of valid diffs.
One issue with current approach is that sometimes those baselines files can carry garbage/unused diffs.
As different versions of an assembly is progressing is important to keep some hygiene on those files.
On those changes we are adding a flag (--validate-baseline) that can be provided to report if baseline file has those unused diffs.

Here is an example:

without --validate-baseline
```
Compat issues with assembly Mono.Android:
CannotChangeAttribute : Attribute 'Android.Runtime.RegisterAttribute' on 'Java.Util.Concurrent.Atomic.Striped64' changed from '[RegisterAttribute("java/util/concurrent/atomic/Striped64", DoNotGenerateAcw=true, ApiSince=24)]' in the contract to '[RegisterAttribute("java/util/concurrent/atomic/Striped64", DoNotGenerateAcw=true)]' in the implementation.
Total Issues: 1
```

with --validate-baseline
```
Compat issues with assembly Mono.Android:
CannotChangeAttribute : Attribute 'Android.Runtime.RegisterAttribute' on 'Java.Util.Concurrent.Atomic.Striped64' changed from '[RegisterAttribute("java/util/concurrent/atomic/Striped64", DoNotGenerateAcw=true, ApiSince=24)]' in the contract to '[RegisterAttribute("java/util/concurrent/atomic/Striped64", DoNotGenerateAcw=true)]' in the implementation.

*** Invalid/Unused baseline differences ***
CannotChangeAttribute : Attribute 'Android.Runtime.RegisterAttribute' on 'Java.Util.Concurrent.Atomic.Striped69' changed from '[RegisterAttribute("java/util/concurrent/atomic/Test", DoNotGenerateAcw=true, ApiSince=24)]' in the contract to '[RegisterAttribute("java/util/concurrent/atomic/Striped64", DoNotGenerateAcw=true)]' in the implementation.
Total Issues: 2
```