### PR TITLE
Use OutDirName to determine the SymStore subdirectory name

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SymStore.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SymStore.targets
@@ -32,7 +32,7 @@
       <_SymStoreTargetFramework>$(TargetFramework)</_SymStoreTargetFramework>
       <_SymStoreTargetFramework Condition="'$(TargetFrameworkSuffix)' != ''">$(_SymStoreTargetFramework)-$(TargetFrameworkSuffix)</_SymStoreTargetFramework>
 
-      <_SymStoreOutputDir>$(ArtifactsSymStoreDirectory)$(MSBuildProjectName)\$(_SymStoreTargetFramework)\</_SymStoreOutputDir>
+      <_SymStoreOutputDir>$(ArtifactsSymStoreDirectory)$(OutDirName)\$(_SymStoreTargetFramework)\</_SymStoreOutputDir>
       <_SymStoreOutputDir Condition="'$(PlatformName)' != 'AnyCPU'">$(_SymStoreOutputDir)$(PlatformName)\</_SymStoreOutputDir>
 
       <_SymStorePdbPath>$(_SymStoreOutputDir)$(TargetName).pdb</_SymStorePdbPath>


### PR DESCRIPTION
The name has to match the output directory binaries are built to. This directory is constructed in https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectLayout.props#L13 based on `OutDirName`.

Fixes https://github.com/dotnet/arcade/issues/5124