### PR TITLE
improve construction of FreeBSD rootfs

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 usage()
 {
     echo "Usage: $0 [BuildArch] [CodeName] [lldbx.y] [--skipunmount] --rootfsdir <directory>]"
@@ -204,7 +206,7 @@ fi
 
 if [ -d "$__RootfsDir" ]; then
     if [ $__SkipUnmount == 0 ]; then
-        umount $__RootfsDir/*
+        umount $__RootfsDir/* || true
     fi
     rm -rf $__RootfsDir
 fi
@@ -236,7 +238,6 @@ if [[ "$__CodeName" == "alpine" ]]; then
 
     rm -r $__ApkToolsDir
 elif [[ "$__CodeName" == "freebsd" ]]; then
-    set -e
     mkdir -p $__RootfsDir/usr/local/etc
     wget -O - https://download.freebsd.org/ftp/releases/amd64/${__FreeBSDBase}/base.txz | tar -C $__RootfsDir -Jxf - ./lib ./usr/lib ./usr/libdata ./usr/include ./usr/share/keys ./etc ./bin/freebsd-version
     # For now, ask for 11 ABI even on 12. This can be revisited later.
@@ -260,7 +261,7 @@ elif [[ -n $__CodeName ]]; then
     chroot $__RootfsDir symlinks -cr /usr
 
     if [ $__SkipUnmount == 0 ]; then
-        umount $__RootfsDir/*
+        umount $__RootfsDir/* || true
     fi
 
     if [[ "$__BuildArch" == "arm" && "$__CodeName" == "trusty" ]]; then

--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -60,7 +60,6 @@ __FreeBSDPackages="libunwind"
 __FreeBSDPackages+=" icu"
 __FreeBSDPackages+=" libinotify"
 __FreeBSDPackages+=" lttng-ust"
-__FreeBSDPackages+=" llvm-90"
 __FreeBSDPackages+=" krb5"
 
 __UnprocessedBuildArgs=
@@ -237,6 +236,7 @@ if [[ "$__CodeName" == "alpine" ]]; then
 
     rm -r $__ApkToolsDir
 elif [[ "$__CodeName" == "freebsd" ]]; then
+    set -e
     mkdir -p $__RootfsDir/usr/local/etc
     wget -O - https://download.freebsd.org/ftp/releases/amd64/${__FreeBSDBase}/base.txz | tar -C $__RootfsDir -Jxf - ./lib ./usr/lib ./usr/libdata ./usr/include ./usr/share/keys ./etc ./bin/freebsd-version
     # For now, ask for 11 ABI even on 12. This can be revisited later.


### PR DESCRIPTION
It seems like we really do not need  llvm inside if the roofs. And that seems to save LOT of space. 

I also bump to a problem that if `build-rootfs.sh` is executed without `sudo`, it silently fails to install packages because it complains about database owner. I missed that and spent some time debuting build instead. So I decided to add -e to catch errors. I'm wondering it that should be done globally but I'm not sure if I can test the impact. So for now, I left it in the FreeBSD branch. 

cc: @janvorli @am11 