### PR TITLE
Port two more fixes

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateResxSource.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateResxSource.cs
@@ -139,7 +139,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
                     case Lang.CSharp:
                         if (AsConstants)
                         {
-                            strings.AppendLine($"{memberIndent}internal const string @{identifier} = \"{name}\");");
+                            strings.AppendLine($"{memberIndent}internal const string @{identifier} = \"{name}\";");
                         }
                         else
                         {

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateResxSource.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateResxSource.cs
@@ -220,9 +220,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
 
                     case Lang.VisualBasic:
                         getStringMethod = $@"{memberIndent}Friend Shared Property Culture As Global.System.Globalization.CultureInfo
-#If Not NET20 Then
 {memberIndent}<Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
-#End If
 {memberIndent}Friend Shared Function GetResourceString(ByVal resourceKey As String, Optional ByVal defaultValue As String = Nothing) As String
 {memberIndent}    Return ResourceManager.GetString(resourceKey, Culture)
 {memberIndent}End Function";


### PR DESCRIPTION
## Description

Two more fixes to resource generation that weren't included in https://github.com/dotnet/arcade/pull/5151

## Customer Impact

Current version of the generator creates invalid VB.

## Regression

No

## Risk

Unknown

## Workarounds

None