### PR TITLE
Fix testRunTitle change

### DIFF
--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -197,7 +197,7 @@ jobs:
         testResultsFiles: '*.xml' 
         searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
         ${{ if eq(parameters.testRunTitle, '') }}:
-          testRunTitle: ${{ parameters.name }}-xunit
+          testRunTitle: ${{ coalesce(parameters.name, '$(System.JobName)') }}-xunit
         ${{ if ne(parameters.testRunTitle, '') }}:
           testRunTitle: ${{ parameters.testRunTitle }}
         mergeTestResults: ${{ parameters.mergeTestResults }}

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -25,7 +25,7 @@ parameters:
   enablePublishTestResults: false
   enablePublishUsingPipelines: false
   mergeTestResults: false
-  testRunTitle: $(AgentOsName)-$(BuildConfiguration)-xunit
+  testRunTitle: ''
   name: ''
   preSteps: []
   runAsPublic: false
@@ -196,7 +196,10 @@ jobs:
         testResultsFormat: 'xUnit'
         testResultsFiles: '*.xml' 
         searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
-        testRunTitle: ${{ parameters.testRunTitle }}
+        ${{ if eq(parameters.testRunTitle, '') }}:
+          testRunTitle: ${{ parameters.name }}-xunit
+        ${{ if ne(parameters.testRunTitle, '') }}:
+          testRunTitle: ${{ parameters.testRunTitle }}
         mergeTestResults: ${{ parameters.mergeTestResults }}
       continueOnError: true
       condition: always()

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -196,10 +196,7 @@ jobs:
         testResultsFormat: 'xUnit'
         testResultsFiles: '*.xml' 
         searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
-        ${{ if eq(parameters.testRunTitle, '') }}:
-          testRunTitle: ${{ coalesce(parameters.name, '$(System.JobName)') }}-xunit
-        ${{ if ne(parameters.testRunTitle, '') }}:
-          testRunTitle: ${{ parameters.testRunTitle }}
+        testRunTitle: ${{ coalesce(parameters.testRunTitle, parameters.name, '$(System.JobName)') }}-xunit
         mergeTestResults: ${{ parameters.mergeTestResults }}
       continueOnError: true
       condition: always()


### PR DESCRIPTION
Fixes an issue I noticed in #5156 when setting up Arcade in a new repo (cc @davidfowl)

The variables `AgentOsName` and `BuildConfiguration` appear to be specific to dotnet/aspnetcore, which means when other repos use this template they get test results that look like this:

![Azure DevOps Test Run entry with the name `$(AgentOsName)-$(BuildConfiguration)-xunit_2`](https://user-images.githubusercontent.com/7574/78075798-0ec0f900-735a-11ea-8f37-b302ec7128d0.png)

With this change, I use the job name instead as the default value (unless overridden) and the default looks much better (at least in my test repo):

![3 Azure DevOps Test Run entries with the names `Ubuntu_16_04-xunit_2`, `macOS_10_14-xunit_2`, `Windows-xunit_2`](https://user-images.githubusercontent.com/7574/78075899-3617c600-735a-11ea-8502-67d05309a10c.png)

