### PR TITLE
Fix inconsistent NuGet restore generation

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -488,10 +488,11 @@ function GetNuGetPackageCachePath() {
   if ($env:NUGET_PACKAGES -eq $null) {
     # Use local cache on CI to ensure deterministic build,
     # use global cache in dev builds to avoid cost of downloading packages.
+    # For directory normalization, see also: https://github.com/NuGet/Home/issues/7968
     if ($useGlobalNuGetCache) {
-      $env:NUGET_PACKAGES = Join-Path $env:UserProfile '.nuget\packages'
+      $env:NUGET_PACKAGES = Join-Path $env:UserProfile '.nuget\packages\'
     } else {
-      $env:NUGET_PACKAGES = Join-Path $RepoRoot '.packages'
+      $env:NUGET_PACKAGES = Join-Path $RepoRoot '.packages\'
     }
   }
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -239,7 +239,7 @@
 
     <MSBuild Projects="@(_ProjectToRestore)"
              Properties="@(_SolutionBuildProps);__BuildPhase=SolutionRestore;_NETCORE_ENGINEERING_TELEMETRY=Restore;MSBuildRestoreSessionId=$([System.Guid]::NewGuid())"
-             RemoveProperties="$(_RemoveProps)"
+             RemoveProperties="$(_RemoveProps);TreatWarningsAsErrors"
              Targets="Restore"
              SkipNonexistentTargets="true"
              BuildInParallel="%(_ProjectToRestore.RestoreInParallel)"


### PR DESCRIPTION
This change corrects cases where command line restore operations using
the arcade tools failed to produce the same NuGet restore result that
Visual Studio produces for the same project. This failure led to
unnecessary regeneration of these files each time the IDE was opened or
a command line build was performed, thus leading to reduced productivity
and, in some cases, reduced reliability.