### PR TITLE
Use OutDirName to determine the SymStore subdirectory name

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SymStore.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SymStore.targets
@@ -24,7 +24,7 @@
       <_TargetPdbPath />
       <_TargetPdbPath Condition="'$(DebugType)' != 'embedded'">$([System.IO.Path]::ChangeExtension($(TargetPath), '.pdb'))</_TargetPdbPath>
 
-      <_SymStoreOutputDir>$(ArtifactsSymStoreDirectory)$(MSBuildProjectName)\$(TargetFramework)\</_SymStoreOutputDir>
+      <_SymStoreOutputDir>$(ArtifactsSymStoreDirectory)$(OutDirName)\$(TargetFramework)\</_SymStoreOutputDir>
       <_SymStorePdbPath>$(_SymStoreOutputDir)$(TargetName).pdb</_SymStorePdbPath>
       <_SymStoreAssemblyPath>$(_SymStoreOutputDir)$(TargetName)$(TargetExt)</_SymStoreAssemblyPath>
 


### PR DESCRIPTION
- the name has to match the output directory binaries are built to. This directory is constructed in
  https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectLayout.props#L13 based on `OutDirName`
- cherry-picked from 559d68489ac81b676efc6a96099593215de3cf4d (#5150) then fixed up

## Description

Because `$(MSBuildProjectName)` is not necessarily unique within a repo e.g. matching ref/ and src/ projects, we can end up overwriting symbols. This one word change ensures symbols always go to unique directories.

## Customer Impact

Without this, customers may be unable to download symbols while debugging.

The issue has recently led to problems pushing new Razor bits into Visual Studio, That could mean we delay getting other fixes to customers.

## Regression

No, this problem has been around for a long time. Was previously missed because symptoms involve a build race and tend not to break _every_ assembly : symbol relationship.

## Risk

Very low.

## Workarounds

No known customer workarounds.

It may be possible to change enough in individual repos to avoid problems. But, something like renaming the non-unique projects is likely much riskier.