### PR TITLE
Symbol validation continue on error

### DIFF
--- a/eng/common/post-build/symbols-validation.ps1
+++ b/eng/common/post-build/symbols-validation.ps1
@@ -163,10 +163,10 @@ function CheckSymbolsAvailable {
       Write-Host
     }
 
-    if ($TotalFailures -ne 0) {
-      Write-PipelineTelemetryError -Category 'CheckSymbols' -Message "Symbols missing for $TotalFailures packages"
-      ExitWithExitCode 1
-    }
+  if ($TotalFailures -ne 0) {
+    Write-PipelineTelemetryError -Category 'CheckSymbols' -Message "Symbols missing for $TotalFailures packages"
+    ExitWithExitCode 1
+  }
 }
 
 function InstallDotnetSymbol {

--- a/eng/common/post-build/symbols-validation.ps1
+++ b/eng/common/post-build/symbols-validation.ps1
@@ -1,7 +1,8 @@
 param(
   [Parameter(Mandatory=$true)][string] $InputPath,              # Full path to directory where NuGet packages to be checked are stored
   [Parameter(Mandatory=$true)][string] $ExtractPath,            # Full path to directory where the packages will be extracted during validation
-  [Parameter(Mandatory=$true)][string] $DotnetSymbolVersion     # Version of dotnet symbol to use
+  [Parameter(Mandatory=$true)][string] $DotnetSymbolVersion,    # Version of dotnet symbol to use
+  [Parameter(Mandatory=$false)][switch] $ContinueOnError        # If we should keep checking symbols after an error
 )
 
 function FirstMatchingSymbolDescriptionOrDefault {
@@ -125,6 +126,8 @@ function CheckSymbolsAvailable {
     Remove-Item $ExtractPath -Force  -Recurse -ErrorAction SilentlyContinue
   }
 
+  $TotalFailures = 0
+
   Get-ChildItem "$InputPath\*.nupkg" |
     ForEach-Object {
       $FileName = $_.Name
@@ -148,10 +151,21 @@ function CheckSymbolsAvailable {
 
       if ($Status -ne 0) {
         Write-PipelineTelemetryError -Category 'CheckSymbols' -Message "Missing symbols for $Status modules in the package $FileName"
-        ExitWithExitCode $exitCode
+
+        if ($ContinueOnError) {
+          $TotalFailures++
+        }
+        else {
+          ExitWithExitCode 1
+        }
       }
 
       Write-Host
+    }
+
+    if ($TotalFailures -ne 0) {
+      Write-PipelineTelemetryError -Category 'CheckSymbols' -Message "Symbols missing for $TotalFailures packages"
+      ExitWithExitCode 1
     }
 }
 


### PR DESCRIPTION
For the release pipeline, we would like to validate all of the symbol packages. Currently, we exit as soon as we find one package with missing symbols, which means that we would have to fix the problem for each package sequentially, starting over with the entire pipeline. This change adds an optional parameter, ContinueOnError, that will allow us to note the failed packages individually, and continue to check all of the other packages, failing once we have checked all of them.

This has been tested in the release pipeline, here: https://dev.azure.com/dnceng/internal/_build/results?buildId=582226&view=results

Note that in the test, we found a real issue with a package, the windows Crossgen2 package, where we have 2 copies of the same pdb in the package, which still causes us to fail early. I have validated the change locally without that package, and it successfully checks each package and errors with the correct number of packages that failed.