### PR TITLE
Warn if no default channel is configured for the build

### DIFF
--- a/eng/common/post-build/check-channel-consistency.ps1
+++ b/eng/common/post-build/check-channel-consistency.ps1
@@ -7,7 +7,7 @@ try {
   . $PSScriptRoot\post-build-utils.ps1
 
   if ($PromoteToChannels -eq "") {
-    Write-PipelineTaskError -Type 'warning' -Message "This build won't publish asset as it's not configured to any Maestro channel. If that wasn't intended use Darc to configure a default channel for the build or to promote it to a channel."
+    Write-PipelineTaskError -Type 'warning' -Message "This build won't publish assets as it's not configured to any Maestro channel. If that wasn't intended use Darc to configure a default channel using add-default-channel for this branch or to promote it to a channel using add-build-to-channel. See https://github.com/dotnet/arcade/blob/master/Documentation/Darc.md#assigning-an-individual-build-to-a-channel for more info."
     ExitWithExitCode 0
   }
 

--- a/eng/common/post-build/check-channel-consistency.ps1
+++ b/eng/common/post-build/check-channel-consistency.ps1
@@ -6,6 +6,11 @@ param(
 try {
   . $PSScriptRoot\post-build-utils.ps1
 
+  if ($PromoteToChannels -eq "") {
+    Write-PipelineTaskError -Type 'warning' -Message "This build won't publish asset as it's not configured to any Maestro channel. If that wasn't intended use Darc to configure a default channel for the build or to promote it to a channel."
+    ExitWithExitCode 0
+  }
+
   # Check that every channel that Maestro told to promote the build to 
   # is available in YAML
   $PromoteToChannelsIds = $PromoteToChannels -split "\D" | Where-Object { $_ }


### PR DESCRIPTION
Relates to: https://github.com/dotnet/arcade/issues/3503#issuecomment-606880655

Emit a warning with instructions on how to configure a default channel or promote a build if no default channel is configured for the build.