### PR TITLE
Dont copy .nupkg as .symbol.nupkgs

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -18,8 +18,6 @@
     DotNetSignType                  Specifies the signing type: 'real' (default), 'test'.
     DotNetRuntimeSourceFeed         Storage account to lookup for the .Net runtime files
     DotNetRuntimeSourceFeedKey      In case the storage account to fetch the .Net runtime files are private this should contain a SAS token.
-    DotNetNupkgContainsPortablePdb  Will the generated NuGet packages contain Portable PDBs. 
-                                    If true, .nupkg files will be duplicated as .symbols.nupkg if they don't exist already. Default to true.
 
     ContinuousIntegrationBuild      "true" when building on a CI server (PR build or official build)
     Restore                         "true" to restore toolset and solution
@@ -87,9 +85,6 @@
       <!-- IsRunningFromVisualStudio may be true even when running msbuild.exe from command line. This generally means that MSBUild is Visual Studio installation and therefore we need to find NuGet.targets in a different location.  -->
       <_NuGetRestoreTargets>$(MSBuildToolsPath)\NuGet.targets</_NuGetRestoreTargets>
       <_NuGetRestoreTargets Condition="'$([MSBuild]::IsRunningFromVisualStudio())' == 'true'">$(MSBuildToolsPath32)\..\..\..\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.targets</_NuGetRestoreTargets>
-
-      <!-- If `DotNetNupkgContainsPortablePdb` is not set we default it to true. -->
-      <DotNetNupkgContainsPortablePdb Condition="'$(DotNetNupkgContainsPortablePdb)' == ''">true</DotNetNupkgContainsPortablePdb>
 
       <!-- If `DotNetPublishUsingPipelines` is not set we default it to false. -->
       <DotNetPublishUsingPipelines Condition="'$(DotNetPublishUsingPipelines)' == ''">false</DotNetPublishUsingPipelines>
@@ -165,7 +160,6 @@
     <ItemGroup>
       <_PublishProps Include="@(_CommonProps)"/>
       <_PublishProps Include="DotNetOutputBlobFeedDir=$(_DotNetOutputBlobFeedDir)" Condition="'$(_DotNetOutputBlobFeedDir)' != ''" />
-      <_PublishProps Include="DotNetNupkgContainsPortablePdb=$(DotNetNupkgContainsPortablePdb)" />
 
       <!-- Used in a few places in the stack to decide if publishing was enabled or not. -->
       <_PublishProps Include="Publish=$(Publish)"/>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -18,6 +18,8 @@
     DotNetSignType                  Specifies the signing type: 'real' (default), 'test'.
     DotNetRuntimeSourceFeed         Storage account to lookup for the .Net runtime files
     DotNetRuntimeSourceFeedKey      In case the storage account to fetch the .Net runtime files are private this should contain a SAS token.
+    DotNetNupkgContainsPortablePdb  Will the generated NuGet packages contain Portable PDBs. 
+                                    If true, .nupkg files will be duplicated as .symbols.nupkg if they don't exist already. Default to true.
 
     ContinuousIntegrationBuild      "true" when building on a CI server (PR build or official build)
     Restore                         "true" to restore toolset and solution
@@ -86,9 +88,12 @@
       <_NuGetRestoreTargets>$(MSBuildToolsPath)\NuGet.targets</_NuGetRestoreTargets>
       <_NuGetRestoreTargets Condition="'$([MSBuild]::IsRunningFromVisualStudio())' == 'true'">$(MSBuildToolsPath32)\..\..\..\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.targets</_NuGetRestoreTargets>
 
+      <!-- If `DotNetNupkgContainsPortablePdb` is not set we default it to true. -->
+      <DotNetNupkgContainsPortablePdb Condition="'$(DotNetNupkgContainsPortablePdb)' == ''">true</DotNetNupkgContainsPortablePdb>
+
       <!-- If `DotNetPublishUsingPipelines` is not set we default it to false. -->
       <DotNetPublishUsingPipelines Condition="'$(DotNetPublishUsingPipelines)' == ''">false</DotNetPublishUsingPipelines>
-      
+
       <!-- 
         If DotNetPublishUsingPipelines is set we don't publish symbols during the build stage,
         only in the Maestro post-build stages. If DotNetPublishUsingPipelines is NOT set then
@@ -160,6 +165,7 @@
     <ItemGroup>
       <_PublishProps Include="@(_CommonProps)"/>
       <_PublishProps Include="DotNetOutputBlobFeedDir=$(_DotNetOutputBlobFeedDir)" Condition="'$(_DotNetOutputBlobFeedDir)' != ''" />
+      <_PublishProps Include="DotNetNupkgContainsPortablePdb=$(DotNetNupkgContainsPortablePdb)" />
 
       <!-- Used in a few places in the stack to decide if publishing was enabled or not. -->
       <_PublishProps Include="Publish=$(Publish)"/>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -26,6 +26,9 @@
     <IsStableBuild>false</IsStableBuild>
     <IsStableBuild Condition="'$(DotNetFinalVersionKind)' == 'release'">true</IsStableBuild>
 
+    <!-- If `DotNetNupkgContainsPortablePdb` is not set we default it to true. -->
+    <DotNetNupkgContainsPortablePdb Condition="'$(DotNetNupkgContainsPortablePdb)' == ''">true</DotNetNupkgContainsPortablePdb>
+
     <AssetManifestOS Condition="'$(AssetManifestOS)' == ''">$(OS)</AssetManifestOS>
 
     <AssetManifestFileName>$(AssetManifestOS)-$(PlatformName).xml</AssetManifestFileName>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -54,7 +54,7 @@
       <PackagesToPublish Include="$(ArtifactsNonShippingPackagesDir)**/*.nupkg" IsShipping="false" />
       <PackagesToPublish Remove="@(ExistingSymbolPackages)" />
 
-      <PackagesToPublish Update="@(PackagesToPublish)">
+      <PackagesToPublish Update="@(PackagesToPublish)" Condition="'$(DotNetNupkgContainsPortablePdb)' == 'true'">
         <SymbolPackageToGenerate Condition="!Exists('%(RootDir)%(Directory)%(Filename).symbols.nupkg')">$(SymbolPackagesDir)%(Filename).symbols.nupkg</SymbolPackageToGenerate>
       </PackagesToPublish>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -26,8 +26,8 @@
     <IsStableBuild>false</IsStableBuild>
     <IsStableBuild Condition="'$(DotNetFinalVersionKind)' == 'release'">true</IsStableBuild>
 
-    <!-- If `DotNetNupkgContainsPortablePdb` is not set we default it to true. -->
-    <DotNetNupkgContainsPortablePdb Condition="'$(DotNetNupkgContainsPortablePdb)' == ''">true</DotNetNupkgContainsPortablePdb>
+    <!-- If `AutoGenerateSymbolPackages` is not set we default it to true. -->
+    <AutoGenerateSymbolPackages Condition="'$(AutoGenerateSymbolPackages)' == ''">true</AutoGenerateSymbolPackages>
 
     <AssetManifestOS Condition="'$(AssetManifestOS)' == ''">$(OS)</AssetManifestOS>
 
@@ -57,7 +57,7 @@
       <PackagesToPublish Include="$(ArtifactsNonShippingPackagesDir)**/*.nupkg" IsShipping="false" />
       <PackagesToPublish Remove="@(ExistingSymbolPackages)" />
 
-      <PackagesToPublish Update="@(PackagesToPublish)" Condition="'$(DotNetNupkgContainsPortablePdb)' == 'true'">
+      <PackagesToPublish Update="@(PackagesToPublish)" Condition="'$(AutoGenerateSymbolPackages)' == 'true'">
         <SymbolPackageToGenerate Condition="!Exists('%(RootDir)%(Directory)%(Filename).symbols.nupkg')">$(SymbolPackagesDir)%(Filename).symbols.nupkg</SymbolPackageToGenerate>
       </PackagesToPublish>
 


### PR DESCRIPTION
Closes: https://github.com/dotnet/arcade/issues/4519

Some builds produce .nupkgs that are only "resources" and don't contain any PDBs. Adding option to let the build forward that information to Arcade SDK.

I've to still test this in the runtime-assets repository.