### PR TITLE
Describe that CPDs are transitive in Darc.md

### DIFF
--- a/Documentation/Darc.md
+++ b/Documentation/Darc.md
@@ -431,6 +431,12 @@ referenced in Microsoft.NETCore.App, issues may occur. Specifying a coherent
 parent that ties the corefx dependencies to Microsoft.NETCore.App will avoid
 this.
 
+The *subtree of the coherent parent* is the tree of builds that the parent
+depends on, including transitive dependencies. To perform a coherent parent
+update, Darc searches the assets in the subtree to find the newest version
+matching the dependency that declared the coherent parent. Darc then assigns
+that version to the dependency.
+
 #### Specifying a coherent parent
 
 To specify a coherent parent, add "CoherentParentDependency" attributes in your

--- a/Documentation/Darc.md
+++ b/Documentation/Darc.md
@@ -433,7 +433,7 @@ this.
 
 The *subtree of the coherent parent* is the tree of builds that the parent
 depends on, including transitive dependencies. To perform a coherent parent
-update, Darc searches the assets in the subtree to find the newest version
+update, Darc searches the assets in the subtree to find the newest-built asset
 matching the dependency that declared the coherent parent. Darc then assigns
 that version to the dependency.
 


### PR DESCRIPTION
Add a section that teases apart this sentence to highlight important points I wasn't spotting:

> A dependency with a coherent parent will update its version based on
the version of the dependency that appears within the subtree of the coherent
parent.

1. "Subtree" refers to the transitive tree of dependencies of the coherent parent.
2. It picks the newest version. (I guess this is actually a clarification vs. "the version"?)

/cc @riarenas @JohnTortugo 