### PR TITLE
fix lldb dependency for alpine

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -28,9 +28,10 @@ __UbuntuPackages="build-essential"
 __AlpinePackages="alpine-base"
 __AlpinePackages+=" build-base"
 __AlpinePackages+=" linux-headers"
-__AlpinePackagesEdgeTesting=" lldb-dev"
-__AlpinePackagesEdgeMain=" llvm9-libs"
+__AlpinePackagesEdgeCommunity=" lldb-dev"
+__AlpinePackagesEdgeMain=" llvm10-libs"
 __AlpinePackagesEdgeMain+=" python3"
+__AlpinePackagesEdgeMain+=" libedit"
 
 # symlinks fixer
 __UbuntuPackages+=" symlinks"
@@ -232,9 +233,9 @@ if [[ "$__CodeName" == "alpine" ]]; then
       add $__AlpinePackagesEdgeMain
 
     $__ApkToolsDir/apk-tools-$__ApkToolsVersion/apk \
-      -X http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+      -X http://dl-cdn.alpinelinux.org/alpine/edge/community \
       -U --allow-untrusted --root $__RootfsDir --arch $__AlpineArch --initdb \
-      add $__AlpinePackagesEdgeTesting
+      add $__AlpinePackagesEdgeCommunity
 
     rm -r $__ApkToolsDir
 elif [[ "$__CodeName" == "freebsd" ]]; then

--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -17,6 +17,8 @@ __CodeName=xenial
 __CrossDir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 __InitialDir=$PWD
 __BuildArch=arm
+__AlpineArch=armv7
+__QEMUArch=arm
 __UbuntuArch=armhf
 __UbuntuRepo="http://ports.ubuntu.com/"
 __LLDB_Package="liblldb-3.9-dev"
@@ -80,7 +82,7 @@ while :; do
         arm)
             __BuildArch=arm
             __UbuntuArch=armhf
-            __AlpineArch=armhf
+            __AlpineArch=armv7
             __QEMUArch=arm
             ;;
         arm64)


### PR DESCRIPTION
seems like builds are failing now for docker image. https://dev.azure.com/dnceng/public/_build/results?buildId=588559&view=logs&jobId=3012228e-90b6-5976-0402-d029a5543688&j=3012228e-90b6-5976-0402-d029a5543688&t=a5a6cb49-5a23-5742-9034-291dfa7d263b


```
fetch http://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/APKINDEX.tar.gz
(1/9) Installing libffi (3.2.1-r6)
(2/9) Installing llvm9-libs (9.0.1-r1)
(3/9) Installing libbz2 (1.0.8-r1)
(4/9) Installing expat (2.2.9-r1)
(5/9) Installing gdbm (1.13-r1)
(6/9) Installing xz-libs (5.2.5-r0)
(7/9) Installing readline (8.0.4-r0)
(8/9) Installing sqlite-libs (3.31.1-r1)
(9/9) Installing python3 (3.8.2-r1)
Executing busybox-1.29.3-r10.trigger
OK: 369 MiB in 96 packages
fetch http://dl-cdn.alpinelinux.org/alpine/edge/testing/aarch64/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  lldb-dev (missing):
    required by: world[lldb-dev]
```

this is essentially fix suggested by @am11. We may not consume new images quite yet but it would at least stabilize docker build. 