### PR TITLE
Only log an error once for work item failure.

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/CheckHelixJobStatus.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CheckHelixJobStatus.cs
@@ -36,8 +36,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                     var workItemName = failedWorkItem.GetMetadata("WorkItemName");
                     var consoleUri = failedWorkItem.GetMetadata("ConsoleOutputUri");
 
-                    Log.LogError(FailureCategory.Test, $"Work item {failedWorkItem} in job {jobName} has failed.");
-                    Log.LogError(FailureCategory.Test, $"Failure log: {consoleUri}{accessTokenSuffix} .");
+                    Log.LogError(FailureCategory.Test, $"Work item {failedWorkItem} in job {jobName} has failed.\nFailure log: {consoleUri}{accessTokenSuffix}");
                 }
             }
 


### PR DESCRIPTION
Logging twice fills the error list with duplicates.