### PR TITLE
upgrade pkg tool to deal with v2 repos

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -60,7 +60,7 @@ __AlpinePackages+=" openssl-dev"
 __AlpinePackages+=" zlib-dev"
 
 __FreeBSDBase="12.1-RELEASE"
-__FreeBSDPkg="1.10.5"
+__FreeBSDPkg="1.12.0"
 __FreeBSDPackages="libunwind"
 __FreeBSDPackages+=" icu"
 __FreeBSDPackages+=" libinotify"
@@ -250,7 +250,9 @@ elif [[ "$__CodeName" == "freebsd" ]]; then
     # get and build package manager
     wget -O -  https://github.com/freebsd/pkg/archive/${__FreeBSDPkg}.tar.gz  |  tar -C $__RootfsDir/tmp -zxf -
     cd $__RootfsDir/tmp/pkg-${__FreeBSDPkg}
-    ./autogen.sh && ./configure --prefix=$__RootfsDir/host && make install
+    # needed for install to succeed
+    mkdir -p $__RootfsDir/host/etc
+    ./autogen.sh && ./configure --prefix=$__RootfsDir/host && make && make install
     rm -rf $__RootfsDir/tmp/pkg-${__FreeBSDPkg}
     # install packages we need.
     $__RootfsDir/host/sbin/pkg -r $__RootfsDir -C $__RootfsDir/usr/local/etc/pkg.conf update


### PR DESCRIPTION
It seems like April update switched package report to v2 and roots build was failing with 
```
pkg: Repository FreeBSD load error: access repo file(/rootfs/x64/var/db/pkg/repo-FreeBSD.sqlite) failed: No such file or directory
pkg: repository meta /rootfs/x64/var/db/pkg/FreeBSD.meta has wrong version 2
pkg: repository meta /rootfs/x64/var/db/pkg/FreeBSD.meta has wrong version 2
pkg: Repository FreeBSD load error: meta cannot be loaded Success
```

This updates `pkg` version so it can support new format. (other option would be to fix scrip on and repos)

With this building freebsd11 and freebsd12 roots works again. 

Note that there is also version 13 & 14 but it failed to build properly on Linux, primarily because of libfetch and other build changes. I'll investigate so we can eventually build current version but using version 12 unblocks builds for now.

cc: @am11 