### PR TITLE
Fix create directory

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -55,10 +55,13 @@ set-strictmode -version 2.0
 $ErrorActionPreference = 'Stop'
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-function Create-Directory([string[]] $path) {
-  if (!(Test-Path $path)) {
-    New-Item -path $path -force -itemType 'Directory' | Out-Null
-  }
+function Create-Directory {
+    param(
+      [Parameter(Mandatory)]
+      [string[]] $Path
+    )
+
+    New-Item -Path $Path -Force -ItemType 'Directory' | Out-Null
 }
 
 function Unzip([string]$zipfile, [string]$outpath) {

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -55,13 +55,8 @@ set-strictmode -version 2.0
 $ErrorActionPreference = 'Stop'
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-function Create-Directory {
-    param(
-      [Parameter(Mandatory)]
-      [string[]] $Path
-    )
-
-    New-Item -Path $Path -Force -ItemType 'Directory' | Out-Null
+function Create-Directory ([string[]] $path) {
+    New-Item -Path $path -Force -ItemType 'Directory' | Out-Null
 }
 
 function Unzip([string]$zipfile, [string]$outpath) {


### PR DESCRIPTION
Closes: #4594

Avoid checking if directory exists, because without looping over all paths, we would not create the directory when at least one of them exists. Instead let the New-Item figure it out for us.