### PR TITLE
Support nuget static graph eval in Build.props

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -199,6 +199,12 @@
     -->
 
     <PropertyGroup>
+      <_SolutionRestoreProps Include="@(_SolutionBuildProps)" />
+      <_SolutionRestoreProps Include="__BuildPhase=SolutionRestore" />
+      <_SolutionRestoreProps Include="_NETCORE_ENGINEERING_TELEMETRY=Restore" />
+      <_SolutionRestoreProps Include="MSBuildRestoreSessionId=$([System.Guid]::NewGuid())" />
+      <_SolutionRestoreProps Include="RestoreUseStaticGraphEvaluation=true" Condition="'$(RestoreUseStaticGraphEvaluation)' == 'true'" />
+
       <!-- This can be set to false as an optimization for repos that don't use NuGet. -->
       <RestoreUsingNuGetTargets Condition="'$(RestoreUsingNuGetTargets)' == ''">true</RestoreUsingNuGetTargets>
     </PropertyGroup>
@@ -212,7 +218,7 @@
       the new msbuild static graph APIs (RestoreUseStaticGraphEvaluation=true).
     -->
     <MSBuild Projects="@(ProjectToBuild)"
-             Properties="@(_SolutionBuildProps);__BuildPhase=SolutionRestore;_NETCORE_ENGINEERING_TELEMETRY=Restore"
+             Properties="@(_SolutionRestoreProps)"
              RemoveProperties="$(_RemoveProps)"
              Targets="_IsProjectRestoreSupported"
              SkipNonexistentTargets="true"
@@ -238,7 +244,7 @@
     </ItemGroup>
 
     <MSBuild Projects="@(_ProjectToRestore)"
-             Properties="@(_SolutionBuildProps);__BuildPhase=SolutionRestore;_NETCORE_ENGINEERING_TELEMETRY=Restore;MSBuildRestoreSessionId=$([System.Guid]::NewGuid())"
+             Properties="@(_SolutionRestoreProps)"
              RemoveProperties="$(_RemoveProps);TreatWarningsAsErrors"
              Targets="Restore"
              SkipNonexistentTargets="true"


### PR DESCRIPTION
This allows to set `RestoreUseStaticGraphEvaluation` in Build.props so that projects invoked via `-projects` can use the new nuget static graph evaluation restore.