### PR TITLE
[release/3.x] Detect Musl when decoding a feed key for dotnet-install

### DIFF
--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -210,7 +210,14 @@ function InstallDotNet {
 
       local runtimeSourceFeedKey=''
       if [[ -n "${7:-}" ]]; then
-        decodedFeedKey=`echo $7 | base64 --decode`
+        # The 'base64' binary on alpine uses '-d' and doesn't support '--decode'
+        # '-d'. To work around this, do a simple detection and switch the parameter
+        # accordingly.
+        decodeArg="--decode"
+        if base64 --help 2>&1 | grep -q "BusyBox"; then
+            decodeArg="-d"
+        fi
+        decodedFeedKey=`echo $7 | base64 $decodeArg`
         runtimeSourceFeedKey="--feed-credential $decodedFeedKey"
       fi
 


### PR DESCRIPTION
## Description

On linux musl, the parameters to decode are not the same as all other linux/osx variants. Detect and pass appropriate parameters

## Customer Impact

Can't build internal servicing releases. This got fixed in the aspnetcore repo common during the last 3.1 intenral build, but never ported.

## Regression

No

## Risk

Low. It has been used before.

## Workarounds

Alter eng/common in the repo.