### PR TITLE
Make promotion pipeline support receiving multiple channels ID to promote

### DIFF
--- a/eng/common/templates/post-build/channels/generic-public-channel.yml
+++ b/eng/common/templates/post-build/channels/generic-public-channel.yml
@@ -25,7 +25,7 @@ stages:
   - job: publish_symbols
     displayName: Symbol Publishing
     dependsOn: setupMaestroVars
-    condition: or(contains(dependencies.setupMaestroVars.outputs['setReleaseVars.InitialChannels'], format('[{0}]', ${{ parameters.channelId }} )), eq(dependencies.setupMaestroVars.outputs['setReleaseVars.PromoteToMaestroChannelId'], ${{ parameters.channelId }}))
+    condition: contains(dependencies.setupMaestroVars.outputs['setReleaseVars.TargetChannels'], format('[{0}]', ${{ parameters.channelId }} ))
     variables:
       - group: DotNet-Symbol-Server-Pats
       - name: AzDOProjectName
@@ -99,7 +99,7 @@ stages:
         value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOBuildId'] ]
       - name: ArtifactsCategory
         value: ${{ coalesce(variables._DotNetArtifactsCategory, '.NETCore') }}
-    condition: or(contains(dependencies.setupMaestroVars.outputs['setReleaseVars.InitialChannels'], format('[{0}]', ${{ parameters.channelId }} )), eq(dependencies.setupMaestroVars.outputs['setReleaseVars.PromoteToMaestroChannelId'], ${{ parameters.channelId }}))
+    condition: contains(dependencies.setupMaestroVars.outputs['setReleaseVars.TargetChannels'], format('[{0}]', ${{ parameters.channelId }} ))
     pool:
       vmImage: 'windows-2019'
     steps:

--- a/eng/common/templates/post-build/common-variables.yml
+++ b/eng/common/templates/post-build/common-variables.yml
@@ -63,7 +63,7 @@ variables:
   - name: MaestroApiAccessToken
     value: $(MaestroAccessToken)
   - name: MaestroApiVersion
-    value: "2019-01-16"
+    value: "2020-02-20"
 
   - name: SourceLinkCLIVersion
     value: 3.0.0

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -54,10 +54,8 @@ stages:
     displayName: Post-build Checks
     dependsOn: setupMaestroVars
     variables:
-      - name: InitialChannels
-        value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.InitialChannels'] ]
-      - name: PromoteToMaestroChannelId
-        value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.PromoteToMaestroChannelId'] ]
+      - name: TargetChannels
+        value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.TargetChannels'] ]
     pool:
       vmImage: 'windows-2019'
     steps:
@@ -65,7 +63,7 @@ stages:
         displayName: Maestro Channels Consistency
         inputs:
           filePath: $(Build.SourcesDirectory)/eng/common/post-build/check-channel-consistency.ps1
-          arguments: -PromoteToChannels "$(InitialChannels)[$(PromoteToMaestroChannelId)]"
+          arguments: -PromoteToChannels "$(TargetChannels)"
             -AvailableChannelIds ${{parameters.NetEngLatestChannelId}},${{parameters.NetEngValidationChannelId}},${{parameters.NetDev5ChannelId}},${{parameters.GeneralTestingChannelId}},${{parameters.NETCoreToolingDevChannelId}},${{parameters.NETCoreToolingReleaseChannelId}},${{parameters.NETInternalToolingChannelId}},${{parameters.NETCoreExperimentalChannelId}},${{parameters.NetEngServicesIntChannelId}},${{parameters.NetEngServicesProdChannelId}},${{parameters.Net5Preview2ChannelId}},${{parameters.Net5Preview3ChannelId}},${{parameters.NetCoreSDK313xxChannelId}},${{parameters.NetCoreSDK313xxInternalChannelId}}
 
   - job:

--- a/eng/common/templates/post-build/setup-maestro-vars.yml
+++ b/eng/common/templates/post-build/setup-maestro-vars.yml
@@ -5,7 +5,9 @@ jobs:
     - template: common-variables.yml
     - name: BuildId
       value: $[ coalesce(variables.BARBuildId, 0) ]
-    - name: PromoteToChannelId
+    - name: PromoteToMaestroChannels
+      value: $[ coalesce(variables.PromoteToChannelIds, 0) ]
+    - name: PromoteToMaestroChannel 
       value: $[ coalesce(variables.PromoteToMaestroChannelId, 0) ]
   pool:
     vmImage: 'windows-2019'
@@ -14,7 +16,7 @@ jobs:
 
     - task: DownloadBuildArtifacts@0
       displayName: Download Release Configs
-      condition: eq(variables.PromoteToChannelId, 0)
+      condition: eq(variables.PromoteToChannelIds, 0)
       inputs:
         buildType: current
         artifactName: ReleaseConfigs
@@ -26,20 +28,16 @@ jobs:
         targetType: inline
         script: |
           try {
-            if ($Env:PromoteToChannelId -eq 0) {
+            if ($Env:PromoteToMaestroChannels -eq 0 -and $Env:PromoteToMaestroChannel -eq 0) {
               $Content = Get-Content $(Build.StagingDirectory)/ReleaseConfigs/ReleaseConfigs.txt
 
               $BarId = $Content | Select -Index 0
-
-              $Channels = ""
-              $Content | Select -Index 1 | ForEach-Object { $Channels += "$_ ," }
-              
+              $Channels = $Content | Select -Index 1             
               $IsStableBuild = $Content | Select -Index 2
 
               $AzureDevOpsProject = $Env:System_TeamProject
               $AzureDevOpsBuildDefinitionId = $Env:System_DefinitionId
               $AzureDevOpsBuildId = $Env:Build_BuildId
-              $PromoteToMaestroChannelId = 0
             }
             else {
               $buildApiEndpoint = "${Env:MaestroApiEndPoint}/api/builds/${Env:BARBuildId}?api-version=${Env:MaestroApiVersion}"
@@ -51,25 +49,23 @@ jobs:
               $buildInfo = try { Invoke-WebRequest -Method Get -Uri $buildApiEndpoint -Headers $apiHeaders | ConvertFrom-Json } catch { Write-Host "Error: $_" }
              
               $BarId = $Env:BARBuildId
-              $Channels = 'None'
+              $Channels = $Env:PromoteToMaestroChannels -split ","
+              $Channels = $Channels -join "]["
+              $Channels = "[$Channels][$Env:PromoteToMaestroChannel]"
 
-              #TODO: Fix this once this issue is done: https://github.com/dotnet/arcade/issues/3834
-              $IsStableBuild = 'False'
-
+              $IsStableBuild = $buildInfo.stable
               $AzureDevOpsProject = $buildInfo.azureDevOpsProject
               $AzureDevOpsBuildDefinitionId = $buildInfo.azureDevOpsBuildDefinitionId
               $AzureDevOpsBuildId = $buildInfo.azureDevOpsBuildId
-              $PromoteToMaestroChannelId = $Env:PromoteToMaestroChannelId
             }
 
             Write-Host "##vso[task.setvariable variable=BARBuildId;isOutput=true]$BarId"
-            Write-Host "##vso[task.setvariable variable=InitialChannels;isOutput=true]$Channels"
+            Write-Host "##vso[task.setvariable variable=TargetChannels;isOutput=true]$Channels"
             Write-Host "##vso[task.setvariable variable=IsStableBuild;isOutput=true]$IsStableBuild"
 
             Write-Host "##vso[task.setvariable variable=AzDOProjectName;isOutput=true]$AzureDevOpsProject"
             Write-Host "##vso[task.setvariable variable=AzDOPipelineId;isOutput=true]$AzureDevOpsBuildDefinitionId"
             Write-Host "##vso[task.setvariable variable=AzDOBuildId;isOutput=true]$AzureDevOpsBuildId"
-            Write-Host "##vso[task.setvariable variable=PromoteToMaestroChannelId;isOutput=true]$PromoteToMaestroChannelId"
           }
           catch {
             Write-Host $_

--- a/eng/common/templates/post-build/setup-maestro-vars.yml
+++ b/eng/common/templates/post-build/setup-maestro-vars.yml
@@ -16,7 +16,7 @@ jobs:
 
     - task: DownloadBuildArtifacts@0
       displayName: Download Release Configs
-      condition: eq(variables.PromoteToChannelIds, 0)
+      condition: and(eq(variables.PromoteToMaestroChannels, 0), eq(variables.PromoteToMaestroChannel, 0))
       inputs:
         buildType: current
         artifactName: ReleaseConfigs

--- a/eng/promote-build.yml
+++ b/eng/promote-build.yml
@@ -3,6 +3,7 @@
 #
 #   - BARBuildId                                    ; Maestro++/BAR ID of the build to be promoted
 #   - PromoteToMaestroChannelId                     ; To which Maestro++ the build should be promoted to
+#   - PromoteToChannelIds                           ; Comma-separated list of Maestro++ channel's ID that the build must be promoted to
 #   - EnableSourceLinkValidation                    ; Whether source link validation should be performed
 #   - EnableNugetValidation                         ; Whether NuGet metadata validation should be performed
 #   - EnableSigningValidation                       ; Whether signing validation should be performed
@@ -38,7 +39,6 @@ stages:
               # Keeping this script inline so that we don't need to checkout the whole repo to use just one file
               try {
                   $buildApiEndpoint = "$(MaestroApiEndPoint)/api/builds/$(BARBuildId)?api-version=$(MaestroApiVersion)"
-                  $channelApiEndpoint = "$(MaestroApiEndPoint)/api/channels/$(PromoteToMaestroChannelId)?api-version=$(MaestroApiVersion)"
 
                   $apiHeaders = New-Object 'System.Collections.Generic.Dictionary[[String],[String]]'
                   $apiHeaders.Add('Accept', 'application/json')
@@ -51,11 +51,15 @@ stages:
                     exit 1
                   }
 
-                  $channelInfo = try { Invoke-WebRequest -Method Get -Uri $channelApiEndpoint -Headers $apiHeaders | ConvertFrom-Json } catch { Write-Host "Error: $_" }
+                  $channels = $(PromoteToChannelIds) -split ","
+                  foreach ($channelId in $channels) {
+                    $channelApiEndpoint = "$(MaestroApiEndPoint)/api/channels/${channelId}?api-version=$(MaestroApiVersion)"
+                    $channelInfo = try { Invoke-WebRequest -Method Get -Uri $channelApiEndpoint -Headers $apiHeaders | ConvertFrom-Json } catch { Write-Host "Error: $_" }
 
-                  if (!$channelInfo) {
-                    Write-Host "Channel with ID $(PromoteToMaestroChannelId) was not found in BAR. Aborting."
-                    exit 1
+                    if (!$channelInfo) {
+                      Write-Host "Channel with ID ${channelId} was not found in BAR. Aborting."
+                      exit 1
+                    }
                   }
                   
                   $azureDevOpsBuildNumber = $buildInfo.azureDevOpsBuildNumber
@@ -70,7 +74,7 @@ stages:
                     $azureDevOpsRepository = $azureDevOpsRepository -replace '["/:<>\\|?@*"]', '_'
                   }
 
-                  $buildNumberName = "Promoting $azureDevOpsRepository build $azureDevOpsBuildNumber to channel ${channelName}#"
+                  $buildNumberName = "Promoting $azureDevOpsRepository build $azureDevOpsBuildNumber to channel(s) $(PromoteToChannelIds)#"
 
                   # Maximum buildnumber length is 255 chars
                   if ($buildNumberName.Length -GT 255) {
@@ -110,4 +114,3 @@ stages:
     signingValidationAdditionalParameters: $(SigningValidationAdditionalParameters)
 
     BARBuildId: $(BARBuildId)
-    PromoteToMaestroChannelId: $(PromoteToMaestroChannelId)


### PR DESCRIPTION
Relates to: https://github.com/dotnet/arcade/issues/5134

Prep work to propose a change in `Darc add-build-to-channel` to be able to promote a build to all default channels.

Tested in a few builds in the DncEng promotion pipeline & Arcade pipeline:
- https://dnceng.visualstudio.com/internal/_build/results?buildId=594924&view=results
- https://dnceng.visualstudio.com/internal/_build/results?buildId=594269&view=results
- https://dnceng.visualstudio.com/internal/_build/results?buildId=594290&view=results
- https://dnceng.visualstudio.com/internal/_build/results?buildId=594291&view=results
