### PR TITLE
Fix links to Code of Conduct

### DIFF
--- a/Documentation/Policy/ArcadeContributorGuidance.md
+++ b/Documentation/Policy/ArcadeContributorGuidance.md
@@ -9,7 +9,7 @@ For the most part, contributions to Arcade are straightforward and relatively sm
 * Keep it simple. (don't over engineer or be "clever")
 * Focus on value over conviction.  (of course conviction should help drive the value discussion)
 * Opinions and beliefs must be substantiated with data and a strong business rationale.
-* All discussions (arguments) [must be civil, respectful, productive, and above all - kind](https://microsoft.github.io/codeofconduct/). The focus must always be on the topic, not individuals.
+* All discussions (arguments) [must be civil, respectful, productive, and above all - kind](../../CODE-OF-CONDUCT.md). The focus must always be on the topic, not individuals.
 * Work in 'partnership' (shoulder to shoulder) as opposed to 'us' vs. 'them'.
 
 ## Arcade Core Team

--- a/README.md
+++ b/README.md
@@ -50,8 +50,6 @@ Documentation, tutorials, and guides may be found in the [Start Here](Documentat
 
 - [Issues](https://github.com/dotnet/arcade/issues)
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).  For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
-
 ### License
 
 .NET Core (including the Arcade repo) is licensed under the [MIT license](LICENSE.TXT). 


### PR DESCRIPTION
For more details, see [PR16](https://github.com/dotnet/org-policy/blob/master/doc/PR16.md).