### PR TITLE
Write the whole error in extract-artifact-packages

### DIFF
--- a/eng/common/sdl/extract-artifact-packages.ps1
+++ b/eng/common/sdl/extract-artifact-packages.ps1
@@ -63,7 +63,7 @@ try {
           }
     }
     catch {
-      Write-Host $_.ScriptStackTrace
+      Write-Host $_
       Write-PipelineTelemetryError -Force -Category 'Sdl' -Message $_
       ExitWithExitCode 1
     }
@@ -74,7 +74,7 @@ try {
   Measure-Command { ExtractArtifacts }
 }
 catch {
-  Write-Host $_.ScriptStackTrace
+  Write-Host $_
   Write-PipelineTelemetryError -Force -Category 'Sdl' -Message $_
   ExitWithExitCode 1
 }


### PR DESCRIPTION
We need to write the whole error the the console so we can actually tell what went wrong.