### PR TITLE
Use runtime instead of core-setup in Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.dependency.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.dependency.targets
@@ -109,7 +109,7 @@
     <ItemGroup>
       <DependencyVersionFile Content="$([System.IO.File]::ReadAllText('%(Identity)').Trim())" />
 
-      <_VersionsFileLines Include="runtime $(LatestCommit)" />
+      <_VersionsFileLines Include="$(RepositoryUrl) $(LatestCommit)" />
       <_VersionsFileLines Include="@(DependencyVersionFile ->'%(Name) %(Content)')" />
     </ItemGroup>
 

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.dependency.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.dependency.targets
@@ -109,7 +109,7 @@
     <ItemGroup>
       <DependencyVersionFile Content="$([System.IO.File]::ReadAllText('%(Identity)').Trim())" />
 
-      <_VersionsFileLines Include="core-setup $(LatestCommit)" />
+      <_VersionsFileLines Include="runtime $(LatestCommit)" />
       <_VersionsFileLines Include="@(DependencyVersionFile ->'%(Name) %(Content)')" />
     </ItemGroup>
 

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets
@@ -416,8 +416,6 @@
 
       <NupkgOutputFile>$(ArtifactsNonShippingPackagesDir)$(VSInsertionComponentName).$(ProductVersion).nupkg</NupkgOutputFile>
 
-      <ProjectUrlForVS>https://github.com/dotnet/runtime</ProjectUrlForVS>
-
       <!-- Work around NuGet silently ignoring nuspec files in PackTask by changing extension. https://github.com/NuGet/Home/issues/8637 -->
       <MangledNuspecFile>$(MSBuildThisFileDirectory)vs\VS.Redist.Common.Component.nuspec.txt</MangledNuspecFile>
       <VsInsertionNuspecFile>$(IntermediateOutputPath)vs\VS.Redist.Common.Component.nuspec</VsInsertionNuspecFile>
@@ -427,7 +425,7 @@
       <PackProperties>$(PackProperties)ARCH=$(MsiArch);</PackProperties>
       <PackProperties>$(PackProperties)COMPONENT_NAME=$(VSInsertionComponentName);</PackProperties>
       <PackProperties>$(PackProperties)FRIENDLY_NAME=$(VSInsertionComponentFriendlyName);</PackProperties>
-      <PackProperties>$(PackProperties)PROJECT_URL=$(ProjectUrlForVS);</PackProperties>
+      <PackProperties>$(PackProperties)PROJECT_URL=$(RepositoryUrl);</PackProperties>
 
       <PackArgs />
       <PackArgs>$(PackArgs) $(VsInsertionNuspecFile)</PackArgs>

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets
@@ -416,7 +416,7 @@
 
       <NupkgOutputFile>$(ArtifactsNonShippingPackagesDir)$(VSInsertionComponentName).$(ProductVersion).nupkg</NupkgOutputFile>
 
-      <ProjectUrlForVS>https://github.com/dotnet/core-setup</ProjectUrlForVS>
+      <ProjectUrlForVS>https://github.com/dotnet/runtime</ProjectUrlForVS>
 
       <!-- Work around NuGet silently ignoring nuspec files in PackTask by changing extension. https://github.com/NuGet/Home/issues/8637 -->
       <MangledNuspecFile>$(MSBuildThisFileDirectory)vs\VS.Redist.Common.Component.nuspec.txt</MangledNuspecFile>


### PR DESCRIPTION
The name gets embedded inside of the nuget package and since dotnet/core-setup was consolidated into dotnet/runtime this was pretty confusing.

/cc @ViktorHofer @dagood 