### PR TITLE
Put manifest generation behind a switch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,7 +58,8 @@ stages:
           clean: true
         steps:
         - script: eng\common\cibuild.cmd
-            -configuration $(_BuildConfig) 
+            -configuration $(_BuildConfig)
+            -manifest
             -prepareMachine
             $(_InternalBuildArgs)
             /p:Test=false

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -20,6 +20,7 @@ Param(
   [switch] $publish,
   [switch] $clean,
   [switch][Alias('bl')]$binaryLog,
+  [switch] $manifest,
   [switch] $ci,
   [switch] $prepareMachine,
   [switch] $help,
@@ -61,6 +62,7 @@ function Print-Usage() {
   Write-Host "  -prepareMachine         Prepare machine for CI run, clean up processes after build"
   Write-Host "  -warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
   Write-Host "  -msbuildEngine <value>  Msbuild engine to use to run build ('dotnet', 'vs', or unspecified)."
+  Write-Host "  -manifest               Generates a build manifest, including signing metadata.  Requires 'publish' also be specified."
   Write-Host ""
 
   Write-Host "Command line arguments not listed above are passed thru to msbuild."
@@ -100,6 +102,13 @@ function Build {
     $properties = $msbuildArgs
   }
 
+  if ($manifest) {
+    if (-not $publish) {
+      Write-Host "'-publish' is required if '-manifest' is specified."
+      ExitWithExitCode 1
+    }
+  }
+
   MSBuild $toolsetBuildProj `
     $bl `
     $platformArg `
@@ -116,6 +125,7 @@ function Build {
     /p:PerformanceTest=$performanceTest `
     /p:Sign=$sign `
     /p:Publish=$publish `
+    /p:GenerateBuildManifest=$manifest `
     @properties
 }
 

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -208,7 +208,7 @@ function Build {
     /p:PerformanceTest=$performance_test \
     /p:Sign=$sign \
     /p:Publish=$publish \
-    /p:GenerateBuildManifest=$manifest
+    /p:GenerateBuildManifest=$manifest \
     $properties
 
   ExitWithExitCode 0

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -35,6 +35,7 @@ usage()
   echo "  --prepareMachine         Prepare machine for CI run, clean up processes after build"
   echo "  --nodeReuse <value>      Sets nodereuse msbuild parameter ('true' or 'false')"
   echo "  --warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
+  echo "  --manifest               Generates a build manifest, including signing metadata.  Requires 'publish' also be specified."
   echo ""
   echo "Command line arguments not listed above are passed thru to msbuild."
   echo "Arguments can also be passed in with a single hyphen."
@@ -64,6 +65,7 @@ sign=false
 public=false
 ci=false
 clean=false
+manifest=false
 
 warn_as_error=true
 node_reuse=true
@@ -146,6 +148,9 @@ while [[ $# > 0 ]]; do
       node_reuse=$2
       shift
       ;;
+    -manifest)
+      manifest=true
+      ;;
     *)
       properties="$properties $1"
       ;;
@@ -183,6 +188,13 @@ function Build {
     bl="/bl:\"$log_dir/Build.binlog\""
   fi
 
+  if [[ "$manifest" == true ]]; then
+    if [[ ! "$publish" == true ]]; then
+      echo "'--publish' is required if '-manifest' is specified."
+      exit 0
+    fi
+  fi
+
   MSBuild $_InitializeToolset \
     $bl \
     /p:Configuration=$configuration \
@@ -196,6 +208,7 @@ function Build {
     /p:PerformanceTest=$performance_test \
     /p:Sign=$sign \
     /p:Publish=$publish \
+    /p:GenerateBuildManifest=$manifest
     $properties
 
   ExitWithExitCode 0

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -30,6 +30,7 @@
     Pack                            "true" to build NuGet packages and VS insertion manifests
     Sign                            "true" to sign built binaries
     Publish                         "true" to publish artifacts (e.g. symbols)
+    GenerateBuildManifest           "true" to generate a build manifest during publish step.  Requires "Sign" and "Publish" are also true so that signing metadata can be included in the build manifest.
   -->
 
   <PropertyGroup>
@@ -160,6 +161,7 @@
     <ItemGroup>
       <_PublishProps Include="@(_CommonProps)"/>
       <_PublishProps Include="DotNetOutputBlobFeedDir=$(_DotNetOutputBlobFeedDir)" Condition="'$(_DotNetOutputBlobFeedDir)' != ''" />
+      <_PublishProps Include="GenerateBuildManifest=$(GenerateBuildManifest)" />
 
       <!-- Used in a few places in the stack to decide if publishing was enabled or not. -->
       <_PublishProps Include="Publish=$(Publish)"/>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -39,7 +39,8 @@
     <PublishDependsOnTargets Condition="$(PublishToSymbolServer)">$(PublishDependsOnTargets);PublishSymbols</PublishDependsOnTargets>
     <PublishDependsOnTargets Condition="$(PublishToSourceBuildStorage)">$(PublishDependsOnTargets);PublishToSourceBuildStorage</PublishDependsOnTargets>
     <PublishDependsOnTargets Condition="$(DotNetPublishUsingPipelines)">$(PublishDependsOnTargets);PublishToAzureDevOpsArtifacts</PublishDependsOnTargets>
-    <PublishDependsOnTargets>BeforePublish;GenerateBuildManifest;$(PublishDependsOnTargets)</PublishDependsOnTargets>
+    <PublishDependsOnTargets Condition="$(GenerateBuildManifest)">$(PublishDependsOnTargets);GenerateBuildManifest</PublishDependsOnTargets>
+    <PublishDependsOnTargets>BeforePublish;$(PublishDependsOnTargets)</PublishDependsOnTargets>
   </PropertyGroup>
 
   <Import Project="$(NuGetPackageRoot)microsoft.dotnet.build.tasks.feed\$(MicrosoftDotNetBuildTasksFeedVersion)\build\Microsoft.DotNet.Build.Tasks.Feed.targets"/>


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/5255 https://github.com/dotnet/arcade-validation/pull/1409

Puts manifest generation behind a switch (enabled in Arcade), so that I can investigate Linux failures further.

Validated with:
- switch omitted - https://dev.azure.com/dnceng/public/_build/results?buildId=600329&view=results
- switch included - https://dev.azure.com/dnceng/public/_build/results?buildId=600285&view=results