### PR TITLE
Package Microsoft.DotNet.SignCheck

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
+++ b/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
@@ -8,7 +8,7 @@
     <SignAssembly>false</SignAssembly>
     <RootNamespace>Microsoft.SignCheck</RootNamespace>
     <!-- This assembly is bundled in the Microsoft.DotNet.SignCheck package and is not mean to be used as a class library package. -->
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
   <PropertyGroup Label="Nuget Package Settings">


### PR DESCRIPTION
My work to add signing validation in the dotnet-release repo would be more efficient if I could get access to SignCheckTask there by using the Microsoft.DotNet.SignCheck package.  This PR is to ensure that the package will be properly published.