### PR TITLE
Add GetPkgDefAssemblyDependencyGuid task (#5241)

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/GetAssemblyFullNameTests.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/GetAssemblyFullNameTests.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Utilities;
+using System.Collections.Generic;
+using System.Linq;
+using TestUtilities;
+using Xunit;
+
+namespace Microsoft.DotNet.Arcade.Sdk.Tests
+{
+    public class GetAssemblyFullNameTests
+    {
+        [Fact]
+        public void PathInMetadata()
+        {
+            var objectAssembly = typeof(object).Assembly;
+            var thisAssembly = typeof(GetAssemblyFullNameTests).Assembly;
+
+            var task = new GetAssemblyFullName()
+            {
+                Items = new TaskItem[]
+                {
+                    new TaskItem("Item", new Dictionary<string, string> { { "SomePath", objectAssembly.Location } }),
+                    new TaskItem("Item", new Dictionary<string, string> { { "SomePath", thisAssembly.Location } }),
+                },
+                PathMetadata = "SomePath",
+                FullNameMetadata = "SomeFullName"
+            };
+
+            bool result = task.Execute();
+
+            AssertEx.Equal(new[]
+           {
+                objectAssembly.FullName,
+                thisAssembly.FullName
+            }, task.ItemsWithFullName.Select(i => i.GetMetadata("SomeFullName")));
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void PathInItemSpec()
+        {
+            var objectAssembly = typeof(object).Assembly;
+            var thisAssembly = typeof(GetAssemblyFullNameTests).Assembly;
+
+            var task = new GetAssemblyFullName()
+            {
+                Items = new TaskItem[]
+                {
+                    new TaskItem(objectAssembly.Location),
+                    new TaskItem(thisAssembly.Location),
+                },
+                FullNameMetadata = "SomeFullName"
+            };
+
+            bool result = task.Execute();
+
+            AssertEx.Equal(new[]
+            {
+                objectAssembly.FullName,
+                thisAssembly.FullName
+            }, task.ItemsWithFullName.Select(i => i.GetMetadata("SomeFullName")));
+
+            Assert.True(result);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GetAssemblyFullName.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GetAssemblyFullName.cs
@@ -13,7 +13,6 @@ namespace Microsoft.DotNet.Arcade.Sdk
         [Required]
         public ITaskItem[] Items { get; set; }
 
-        [Required]
         public string PathMetadata { get; set; }
 
         [Required]
@@ -28,7 +27,8 @@ namespace Microsoft.DotNet.Arcade.Sdk
 
             foreach (var item in Items)
             {
-                item.SetMetadata(FullNameMetadata, AssemblyName.GetAssemblyName(item.GetMetadata(PathMetadata)).FullName);
+                var assemblyPath = string.IsNullOrEmpty(PathMetadata) ? item.ItemSpec : item.GetMetadata(PathMetadata);
+                item.SetMetadata(FullNameMetadata, AssemblyName.GetAssemblyName(assemblyPath).FullName);
             }
 
             return true;

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.VsixBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.VsixBuild.targets
@@ -20,11 +20,7 @@
          Writes a stub file to component intermediate directory.
   -->
 
-  <PropertyGroup>
-    <_VisualStudioBuildTasksAssembly>$(NuGetPackageRoot)microsoft.dotnet.build.tasks.visualstudio\$(MicrosoftDotNetBuildTasksVisualStudioVersion)\tools\net472\Microsoft.DotNet.Build.Tasks.VisualStudio.dll</_VisualStudioBuildTasksAssembly>
-  </PropertyGroup>
-
-  <UsingTask TaskName="Microsoft.DotNet.Build.Tasks.VisualStudio.FinalizeInsertionVsixFile" AssemblyFile="$(_VisualStudioBuildTasksAssembly)" />
+  <UsingTask TaskName="Microsoft.DotNet.Build.Tasks.VisualStudio.FinalizeInsertionVsixFile" AssemblyFile="$(ArcadeVisualStudioBuildTasksAssembly)" />
 
   <PropertyGroup>
     <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.props
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
+  <PropertyGroup>
+    <ArcadeVisualStudioBuildTasksAssembly>$(NuGetPackageRoot)microsoft.dotnet.build.tasks.visualstudio\$(MicrosoftDotNetBuildTasksVisualStudioVersion)\tools\net472\Microsoft.DotNet.Build.Tasks.VisualStudio.dll</ArcadeVisualStudioBuildTasksAssembly>
+  </PropertyGroup>
 
   <!-- Default settings for VSIX projects -->
 

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests/Vsix/GetPkgDefAssemblyDependencyGuidTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests/Vsix/GetPkgDefAssemblyDependencyGuidTests.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Utilities;
+using System.Collections.Generic;
+using System.Linq;
+using TestUtilities;
+using Xunit;
+
+namespace Microsoft.DotNet.Build.Tasks.VisualStudio.UnitTests
+{
+    public class GetPkgDefAssemblyDependencyGuidTests
+    {
+        [Fact]
+        public void InputInMetadata()
+        {
+            var task = new GetPkgDefAssemblyDependencyGuid()
+            {
+                Items = new TaskItem[]
+                {
+                    new TaskItem("Item", new Dictionary<string, string> { { "SomeInput", "SomeValue" } }),
+                    new TaskItem("Item", new Dictionary<string, string> { { "SomeInput", "\U00012345" } }),
+                    new TaskItem("Item", new Dictionary<string, string> { { "SomeInput", "\uD800" } }), // unpaired surrogate treated as invalid character
+                    new TaskItem("Item", new Dictionary<string, string> { { "SomeInput", "\uD801" } }), // unpaired surrogate treated as invalid character
+                    new TaskItem("Item", new Dictionary<string, string> { { "SomeInput", "" } }), // empty is skipped
+                },
+                InputMetadata = "SomeInput",
+                OutputMetadata = "SomeOutput"
+            };
+
+            bool result = task.Execute();
+
+            AssertEx.Equal(new[]
+            {
+                "{9E8E5D98-C082-B764-01E5-9ECA6FB4364E}",
+                "{ECDA244C-DF2C-D4A2-4AD3-6E9106192060}",
+                "{C178F940-C17A-1FA7-F265-D0B78A9C9915}",
+                "{C178F940-C17A-1FA7-F265-D0B78A9C9915}",
+                "",
+            }, task.OutputItems.Select(i => i.GetMetadata("SomeOutput")));
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void InputInItemSpec()
+        {
+            var task = new GetPkgDefAssemblyDependencyGuid()
+            {
+                Items = new TaskItem[]
+                {
+                    new TaskItem("SomeValue"),
+                },
+                OutputMetadata = "SomeOutput"
+            };
+
+            bool result = task.Execute();
+
+            AssertEx.Equal(new[]
+            {
+                "{9E8E5D98-C082-B764-01E5-9ECA6FB4364E}",
+            }, task.OutputItems.Select(i => i.GetMetadata("SomeOutput")));
+
+            Assert.True(result);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/Vsix/GetPkgDefAssemblyDependencyGuid.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/Vsix/GetPkgDefAssemblyDependencyGuid.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.Build.Tasks.VisualStudio
+{
+    /// <summary>
+    /// Calculates Guid used in .pkgdef files for codeBase and bindingRedirect entries.
+    /// The implementation matches Microsoft.VisualStudio.Shell.ProvideDependentAssemblyAttribute.
+    /// </summary>
+    public sealed class GetPkgDefAssemblyDependencyGuid : Task
+    {
+        [Required]
+        public ITaskItem[] Items { get; set; }
+
+        public string InputMetadata { get; set; }
+
+        [Required]
+        public string OutputMetadata { get; set; }
+
+        [Output]
+        public ITaskItem[] OutputItems { get; set; }
+
+        public override bool Execute()
+        {
+            ExecuteImpl();
+            return !Log.HasLoggedErrors;
+        }
+
+        private void ExecuteImpl()
+        {
+            OutputItems = Items;
+           
+            foreach (var item in Items)
+            {
+                var value = string.IsNullOrEmpty(InputMetadata) ? item.ItemSpec : item.GetMetadata(InputMetadata);
+                if (string.IsNullOrEmpty(value))
+                {
+                    continue;
+                }
+
+                byte[] fullHash;
+                using (var sha2 = SHA256.Create())
+                {
+                    fullHash = sha2.ComputeHash(Encoding.UTF8.GetBytes(value));
+                }
+
+                int targetBlockSize = Marshal.SizeOf(typeof(Guid));
+
+                // SHA256 will produce a 32 byte hash, but GUIDs are only 16 bytes in size, so we simply partition the hash array into
+                // two 16 byte arrays (via Take and Skip) and then Zip them together into a resultant 16 byte array by XORing the 
+                // corresponding byte from each array and storing the result.
+                byte[] reducedHash = fullHash.Take(targetBlockSize).Zip(fullHash.Skip(targetBlockSize), (b1, b2) => (byte)(b1 ^ b2)).ToArray();
+                Debug.Assert(reducedHash.Length == targetBlockSize);
+
+                item.SetMetadata(OutputMetadata, new Guid(reducedHash).ToString("B").ToUpperInvariant());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Add GetPkgDefAssemblyDependencyGuid task

Port https://github.com/dotnet/arcade/pull/5241 to 3.x

## Customer Impact

Improvements to Roslyn build are blocked (https://github.com/dotnet/roslyn/pull/43302)

## Regression

No

## Risk

Small.

## Workarounds

None.