### PR TITLE
Fix a build break when using new GenApi

### DIFF
--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Types.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Types.cs
@@ -25,8 +25,7 @@ namespace Microsoft.Cci.Writers.CSharp
             // But we need also consider if this attribute is filtered out or not but I guess
             // we have the same problem with all the fake attributes at this point.
 
-            if (type.IsClass && type.Layout != LayoutKind.Auto ||
-                type.IsStruct && (type.Layout != LayoutKind.Sequential || type.Alignment != 0 || type.SizeOf != 0 || type.StringFormat != StringFormatKind.Ansi))
+            if ((type.IsStruct || type.IsClass) && type.Layout != LayoutKind.Auto)
             {
                 FakeCustomAttribute structLayout = new FakeCustomAttribute("System.Runtime.InteropServices", "StructLayoutAttribute");
                 string layoutKind = string.Format("System.Runtime.InteropServices.LayoutKind.{0}", type.Layout.ToString());


### PR DESCRIPTION
- example failure in https://dev.azure.com/dnceng/internal/_build/results?buildId=601199
- undo a small part of #4585 (@1faec9a821cf767d349c7ff18c544876be28cf2d - unfortunately likely to be GC'd soon)
  - restore generation of `[StructLayout]` attributes on most value types