### PR TITLE
Run _GenerateResxSource target before BeforeCompile target.

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateResxSource.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateResxSource.targets
@@ -22,7 +22,7 @@
     Note: Targets that generate Compile items are expected to run before BeforeCompile targets (common targets convention).
   -->
   <Target Name="_GenerateResxSource"
-          BeforeTargets="BeforeCompile"
+          BeforeTargets="BeforeCompile;CoreCompile"
           DependsOnTargets="PrepareResourceNames;
                             _GetEmbeddedResourcesWithSourceGeneration;
                             _BatchGenerateResxSource">

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateResxSource.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateResxSource.targets
@@ -18,8 +18,11 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <!--
+    Note: Targets that generate Compile items are expected to run before BeforeCompile targets (common targets convention).
+  -->
   <Target Name="_GenerateResxSource"
-          BeforeTargets="CoreCompile"
+          BeforeTargets="BeforeCompile"
           DependsOnTargets="PrepareResourceNames;
                             _GetEmbeddedResourcesWithSourceGeneration;
                             _BatchGenerateResxSource">


### PR DESCRIPTION
## Description

Port #4062 and #4134 to 3.x

## Customer Impact

Fixes embedding generated source files to PDB. Required for Source Link validation.

## Regression

No

## Risk

Some. It is possible that some custom targets depend on the previous (incorrect) ordering.

## Workarounds

None.

