### PR TITLE
Set EmbedUntrackedSources to true by default (#4063)

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
@@ -15,6 +15,7 @@
     <DevelopmentDependency>false</DevelopmentDependency>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
 
     <PackageIcon>Icon.png</PackageIcon>
     <PackageIconFullPath>$(MSBuildThisFileDirectory)Assets\DotNetPackageIcon.png</PackageIconFullPath>


### PR DESCRIPTION
## Description

Port #4063 to 3.x

## Customer Impact

Enables embedding generated source files to PDB by default. Required for Source Link validation.

## Regression

No

## Risk

Small.

## Workarounds

None.

