### PR TITLE
Set env var ARCADE_BUILD_TOOL_COMMAND to build command, for source-build 5.0

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -633,6 +633,8 @@ function MSBuild-Core() {
     }
   }
 
+  $env:ARCADE_BUILD_TOOL_COMMAND = "$($buildTool.Path) $cmdArgs"
+
   $exitCode = Exec-Process $buildTool.Path $cmdArgs
 
   if ($exitCode -ne 0) {

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -422,11 +422,17 @@ function MSBuild-Core {
     warnaserror_switch="/warnaserror"
   fi
 
-  "$_InitializeBuildTool" "$_InitializeBuildToolCommand" /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse $warnaserror_switch /p:TreatWarningsAsErrors=$warn_as_error /p:ContinuousIntegrationBuild=$ci "$@" || {
-    local exit_code=$?
-    Write-PipelineTelemetryError -category 'Build'  "Build failed (exit code '$exit_code')."
-    ExitWithExitCode $exit_code
+  function RunBuildTool {
+    export ARCADE_BUILD_TOOL_COMMAND="$_InitializeBuildTool $@"
+
+    "$_InitializeBuildTool" "$@" || {
+      local exit_code=$?
+      Write-PipelineTaskError "Build failed (exit code '$exit_code')."
+      ExitWithExitCode $exit_code
+    }
   }
+
+  RunBuildTool "$_InitializeBuildToolCommand" /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse $warnaserror_switch /p:TreatWarningsAsErrors=$warn_as_error /p:ContinuousIntegrationBuild=$ci "$@"
 }
 
 ResolvePath "${BASH_SOURCE[0]}"


### PR DESCRIPTION
See https://github.com/dotnet/arcade/issues/5116. (But I think this name for the env var is better.)

/cc @crummel @dseefeld 