### PR TITLE
Update RidSpecificPackProperties in framework.packing.targets

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.packaging.targets
@@ -221,7 +221,7 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(BuildRidSpecificPacks)' == 'true'">
-      <RidSpecificPackProperties>BaseId=$(MSBuildProjectName).$(PackageBuildRID);IdPrefix=</RidSpecificPackProperties>
+      <RidSpecificPackProperties>BaseId=$(MSBuildProjectName)$(RuntimeSpecificFrameworkSuffix).$(PackageBuildRID);IdPrefix=</RidSpecificPackProperties>
     </PropertyGroup>
   </Target>
 


### PR DESCRIPTION
This is a follow up to PR https://github.com/dotnet/runtime/issues/34980
In this PR, `RidSpecificPackProperties` is updated to include a Runtime Specific Framework Suffix.
https://github.com/dotnet/runtime/issues/35107