### PR TITLE
Support VS single evaluation mode

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
@@ -9,9 +9,15 @@
     <_OriginalTargetFrameworks>$(TargetFrameworks)</_OriginalTargetFrameworks>
   </PropertyGroup>
 
-  <!-- Strip away placeholder tfms and TargetFrameworkSuffix during the graph build. -->
-  <PropertyGroup Condition="'$(IsGraphBuild)' == 'true' and '$(MSBuildRestoreSessionId)' != ''">
-    <TargetFrameworks Condition="'$(TargetFrameworks)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '(-[^;]+)|(;?_[^;]+)', ''))</TargetFrameworks>
+  <!-- Modify TargetFrameworks during restore property evaluation. -->
+  <PropertyGroup Condition="'$(TargetFrameworks)' != '' and ('$(BuildingInsideVisualStudio)' == 'true' or '$(MSBuildRestoreSessionId)' != '')">
+    <!-- Strip away placeholder TFMs and TargetFrameworkSuffixes. -->
+    <TargetFrameworks>$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '(-[^;]+)|(;?_[^;]+)', ''))</TargetFrameworks>
+    <!-- Remove duplicate TargetFramework values. -->
+    <TargetFrameworks>$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks);', '([^;]+)(?=.*;\1;)', ''))</TargetFrameworks>
+    <TargetFrameworks>$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks);', ';;', ';'))</TargetFrameworks>
+    <!-- TargetFrameworks needs to be unescaped as Trim breaks item batching: https://github.com/microsoft/msbuild/issues/3940. -->
+    <TargetFrameworks>$([MSBuild]::Unescape($(TargetFrameworks.Trim(';'))))</TargetFrameworks>
   </PropertyGroup>
   
   <Target Name="RemovePlaceHolderConfigs"
@@ -47,7 +53,8 @@
 
   <!-- Attaching the TargetFrameworkSuffix after restore for build.-->
   <Target Name="AttachTargetFrameworkSuffixToTargetFrameworks"
-          AfterTargets="Restore">
+          Condition="'$(TargetFrameworks)' != '$(_OriginalTargetFrameworks)'"
+          AfterTargets="_GenerateRestoreGraph;Restore">
     <PropertyGroup>
       <TargetFrameworks>$(_OriginalTargetFrameworks)</TargetFrameworks>
     </PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
@@ -54,7 +54,7 @@
   <!-- Attaching the TargetFrameworkSuffix after restore for build.-->
   <Target Name="AttachTargetFrameworkSuffixToTargetFrameworks"
           Condition="'$(TargetFrameworks)' != '$(_OriginalTargetFrameworks)'"
-          AfterTargets="_GenerateRestoreGraph;Restore">
+          AfterTargets="Restore">
     <PropertyGroup>
       <TargetFrameworks>$(_OriginalTargetFrameworks)</TargetFrameworks>
     </PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
@@ -54,7 +54,7 @@
   <!-- Attaching the TargetFrameworkSuffix after restore for build.-->
   <Target Name="AttachTargetFrameworkSuffixToTargetFrameworks"
           Condition="'$(TargetFrameworks)' != '$(_OriginalTargetFrameworks)'"
-          AfterTargets="Restore">
+          AfterTargets="_GenerateRestoreGraph;Restore">
     <PropertyGroup>
       <TargetFrameworks>$(_OriginalTargetFrameworks)</TargetFrameworks>
     </PropertyGroup>


### PR DESCRIPTION
With the recent change to support RestoreUseStaticGraphEvaluation, the hook point before Restore was removed as it was assumed that the TargetFrameworks modification can be done during evaluation. As VS shares the same evaluation for restore and build, the modification is ignored (as it is conditioned on MSBuildRestoreSessionId and IsGraphBuild). Changing the condition to only check for `MSBuildRestoreSessionId` or `BuildingInsideVisualStudio` (as VS doesn't set MSBuildRestoreSessionId).

Additionally adding a condition to `AttachTargetFrameworkSuffixToTargetFrameworks` to only run if necessary.