### PR TITLE
Permit undefined properties for manifest

### DIFF
--- a/src/Microsoft.DotNet.AzureDevOps.Build/src/GenerateBuildManifest.cs
+++ b/src/Microsoft.DotNet.AzureDevOps.Build/src/GenerateBuildManifest.cs
@@ -10,11 +10,8 @@ namespace Microsoft.DotNet.AzureDevOps.Build
 {
     public class GenerateAzureDevOpsBuildManifest : Microsoft.Build.Utilities.Task
     {
-        [Required]
         public string AzureDevOpsCollectionUri { get; set; }
-        [Required]
         public string AzureDevOpsProject { get; set; }
-        [Required]
         public int AzureDevOpsBuildId { get; set; }
         [Required]
         public string ManifestPath { get; set; }
@@ -27,8 +24,8 @@ namespace Microsoft.DotNet.AzureDevOps.Build
             ProjectRootElement project = ProjectRootElement.Create();
             var propertyGroup = project.CreatePropertyGroupElement();
             project.AppendChild(propertyGroup);
-            propertyGroup.AddProperty("AzureDevOpsCollectionUri", AzureDevOpsCollectionUri);
-            propertyGroup.AddProperty("AzureDevOpsProject", AzureDevOpsProject);
+            propertyGroup.AddProperty("AzureDevOpsCollectionUri", AzureDevOpsCollectionUri ?? "undefined");
+            propertyGroup.AddProperty("AzureDevOpsProject", AzureDevOpsProject ?? "undefined");
             propertyGroup.AddProperty("AzureDevOpsBuildId", AzureDevOpsBuildId.ToString());
             var itemGroup = project.CreateItemGroupElement();
             project.AppendChild(itemGroup);


### PR DESCRIPTION
Thanks @missymessa for reporting this before it got blasted out to all the repos.  Looks like the validation repos are doing their jobs.

Previous behavior required some variables that are only defined in CI.  This means that even CI builds that ran in a docker container might not have these variables if they didn't inherit the environment.  This also, would likely have broken most local dev builds. :(