### PR TITLE
Support adding a version tag to the build manifest

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PushToAzureDevOpsArtifacts.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PushToAzureDevOpsArtifacts.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
+{
+    public class PushToAzureDevOpsArtifactsTests
+    {
+        [Fact]
+        public void HasRecordedPublishingVersion()
+        {
+            var targetManifiestPath = $"{Path.GetTempPath()}TestManifest-{Guid.NewGuid()}.xml";
+            var buildId = "1.2.3";
+            var initialAssetsLocation = "cloud";
+            var isStable = false;
+            var expectedManifestContent = $"<Build PublishingVersion=\"{BuildManifestUtil.LatestPublishingInfraVersion}\" BuildId=\"{buildId}\" InitialAssetsLocation=\"{initialAssetsLocation}\" IsStable=\"{isStable}\" />";
+
+            var buildEngine = new MockBuildEngine();
+            var task = new PushToAzureDevOpsArtifacts
+            {
+                BuildEngine = buildEngine,
+                ItemsToPush = new Microsoft.Build.Utilities.TaskItem[0],
+                IsStableBuild = isStable,
+                ManifestBuildId = buildId,
+                ManifestBuildData = new string[] { $"InitialAssetsLocation={initialAssetsLocation}" },
+                AssetManifestPath = targetManifiestPath
+            };
+
+            task.Execute();
+
+            Assert.Equal(expectedManifestContent, File.ReadAllText(targetManifiestPath));
+        }
+
+        [Fact]
+        public void UsesCustomPublishingVersion()
+        {
+            var targetManifiestPath = $"{Path.GetTempPath()}TestManifest-{Guid.NewGuid()}.xml";
+            var buildId = "1.2.3";
+            var initialAssetsLocation = "cloud";
+            var isStable = false;
+            var publishingInfraVersion = "456";
+            var expectedManifestContent = $"<Build PublishingVersion=\"{publishingInfraVersion}\" BuildId=\"{buildId}\" InitialAssetsLocation=\"{initialAssetsLocation}\" IsStable=\"{isStable}\" />";
+
+            var buildEngine = new MockBuildEngine();
+            var task = new PushToAzureDevOpsArtifacts
+            {
+                BuildEngine = buildEngine,
+                ItemsToPush = new Microsoft.Build.Utilities.TaskItem[0],
+                IsStableBuild = isStable,
+                ManifestBuildId = buildId,
+                ManifestBuildData = new string[] { $"InitialAssetsLocation={initialAssetsLocation}" },
+                PublishingVersion = publishingInfraVersion,
+                AssetManifestPath = targetManifiestPath
+            };
+
+            task.Execute();
+
+            Assert.Equal(expectedManifestContent, File.ReadAllText(targetManifiestPath));
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
@@ -15,6 +15,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 {
     public static class BuildManifestUtil
     {
+        public const string LegacyPublishingInfraVersion = "1";
+        public const string LatestPublishingInfraVersion = "2";
+
         public const string AssetsVirtualDir = "assets/";
 
         public static void CreateBuildManifest(TaskLoggingHelper log,
@@ -26,7 +29,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             string manifestBranch,
             string manifestCommit,
             string[] manifestBuildData,
-            bool isStableBuild)
+            bool isStableBuild,
+            string publishingVersion)
         {
             CreateModel(
                 blobArtifacts,
@@ -37,6 +41,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 manifestBranch,
                 manifestCommit,
                 isStableBuild,
+                publishingVersion,
                 log)
                 .WriteAsXml(assetManifestPath, log);
         }
@@ -59,6 +64,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             string repoBranch,
             string repoCommit,
             bool isStableBuild,
+            string publishingVersion,
             TaskLoggingHelper log)
         {
             if (artifacts == null)
@@ -104,6 +110,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 repoBranch,
                 repoCommit,
                 isStableBuild,
+                publishingVersion,
                 log);
             return buildModel;
         }
@@ -116,6 +123,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             string manifestBranch,
             string manifestCommit,
             bool isStableBuild,
+            string publishingVersion,
             TaskLoggingHelper log)
         {
             var attributes = MSBuildListSplitter.GetNamedProperties(manifestBuildData);
@@ -131,7 +139,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         BuildId = manifestBuildId,
                         Branch = manifestBranch,
                         Commit = manifestCommit,
-                        IsStable = isStableBuild.ToString()
+                        IsStable = isStableBuild.ToString(),
+                        PublishingVersion = publishingVersion
                     });
 
             buildModel.Artifacts.Blobs.AddRange(blobArtifacts);

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/GenerateBuildManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/GenerateBuildManifest.cs
@@ -60,6 +60,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         /// Is this manifest for a stable build?
         /// </summary>
         public bool IsStableBuild { get; set; }
+        
+        /// <summary>
+        /// The version of the publishing infrastructure that should be tagged in the manifest.
+        /// </summary>
+        public string PublishingVersion { get; set; }
 
         public override bool Execute()
         {
@@ -73,6 +78,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     RepoBranch,
                     RepoCommit,
                     IsStableBuild,
+                    PublishingVersion ?? BuildManifestUtil.LegacyPublishingInfraVersion,
                     Log);
 
                 buildModel.WriteAsXml(OutputPath, Log);

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
@@ -35,6 +35,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public bool IsStableBuild { get; set; }
 
+        /// <summary>
+        /// Which version should the build manifest be tagged with.
+        /// By default he latest version is used.
+        /// </summary>
+        public string PublishingVersion { get; set; }
+
         public override bool Execute()
         {
             try
@@ -144,7 +150,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         ManifestBranch,
                         ManifestCommit,
                         ManifestBuildData,
-                        IsStableBuild);
+                        IsStableBuild,
+                        PublishingVersion ?? BuildManifestUtil.LatestPublishingInfraVersion);
 
                     Log.LogMessage(MessageImportance.High,
                         $"##vso[artifact.upload containerfolder=AssetManifests;artifactname=AssetManifests]{AssetManifestPath}");

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBlobFeed.cs
@@ -165,7 +165,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     ManifestBranch,
                     ManifestCommit,
                     ManifestBuildData,
-                    IsStableBuild);
+                    IsStableBuild,
+                    BuildManifestUtil.LegacyPublishingInfraVersion);
             }
             catch (Exception e)
             {

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/BuildIdentity.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/BuildIdentity.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Util;
+using System;
 using System.Collections.Generic;
 using System.Xml.Linq;
 
@@ -12,6 +13,7 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
     {
         private static readonly string[] AttributeOrder =
         {
+            nameof(PublishingVersion),
             nameof(Name),
             nameof(BuildId),
             nameof(ProductVersion),
@@ -68,6 +70,19 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
             set { Attributes[nameof(VersionStamp)] = value; }
         }
 
+        public string PublishingVersion
+        {
+            get { return Attributes.GetOrDefault(nameof(PublishingVersion)); }
+
+            set {
+                if (!IsValidPublishingInfraVersion(value))
+                {
+                    throw new ArgumentException($"`{value} not is in the format expected. Valid values are integers.");
+                }
+                Attributes[nameof(PublishingVersion)] = value; 
+            }
+        }
+
         public override string ToString()
         {
             string s = Name;
@@ -102,5 +117,15 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
                 .CreateAttributeDictionary()
                 .ThrowIfMissingAttributes(RequiredAttributes)
         };
+
+        public static bool IsValidPublishingInfraVersion(string version)
+        {
+            if (string.IsNullOrEmpty(version))
+            {
+                return false;
+            }
+
+            return int.TryParse(version, out var _);
+        }
     }
 }


### PR DESCRIPTION
Relates to: https://github.com/dotnet/arcade/issues/5299

Some notes:

- I don't think we need a complex versioning system so I decided to go with just a number.
- I added the option for the user of the task to inform the version tag so that:
  - We can let users specify a version in their `Publishing.props` and keep using an specific version.
  - We can use that while working on a newer version of the infra.

I'll spin up some test builds but I've already ran some tests locally.