### PR TITLE
Detect the passed in framework and platform in XUnitExtensions dynamically

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
@@ -1,3 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Runtime.InteropServices;
 using Xunit;
 
@@ -5,16 +10,24 @@ namespace Microsoft.DotNet.XUnitExtensions
 {
     internal static class DiscovererHelpers
     {
-        internal static bool TestPlatformApplies(TestPlatforms platforms) =>
+        private static readonly Lazy<bool> s_isMonoRuntime = new Lazy<bool>(() => Type.GetType("Mono.RuntimeStructs") != null);
+        public static bool IsMonoRuntime => s_isMonoRuntime.Value;
+        public static bool IsRunningOnNetCoreApp { get; } = (Environment.Version.Major >= 5 || RuntimeInformation.FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase));
+        public static bool IsRunningOnNetFramework { get; } = RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
+
+        public static bool TestPlatformApplies(TestPlatforms platforms) =>
                 (platforms.HasFlag(TestPlatforms.FreeBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"))) ||
                 (platforms.HasFlag(TestPlatforms.Linux) && RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) ||
                 (platforms.HasFlag(TestPlatforms.NetBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"))) ||
                 (platforms.HasFlag(TestPlatforms.OSX) && RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) ||
                 (platforms.HasFlag(TestPlatforms.Windows) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
         
-        internal static bool TestRuntimeApplies(TestRuntimes runtimes) =>
-                (runtimes.HasFlag(TestRuntimes.Mono) && SkipOnMonoDiscoverer.IsMonoRuntime) ||
-                (runtimes.HasFlag(TestRuntimes.CoreCLR) && !SkipOnMonoDiscoverer.IsMonoRuntime); // assume CoreCLR if it's not Mono
+        public static bool TestRuntimeApplies(TestRuntimes runtimes) =>
+                (runtimes.HasFlag(TestRuntimes.Mono) && IsMonoRuntime) ||
+                (runtimes.HasFlag(TestRuntimes.CoreCLR) && !IsMonoRuntime); // assume CoreCLR if it's not Mono
 
+        public static bool TestFrameworkApplies(TargetFrameworkMonikers frameworks) =>
+                (frameworks.HasFlag(TargetFrameworkMonikers.Netcoreapp) && IsRunningOnNetCoreApp) ||
+                (frameworks.HasFlag(TargetFrameworkMonikers.NetFramework) && IsRunningOnNetFramework);
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ActiveIssueDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ActiveIssueDiscoverer.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
@@ -49,15 +49,14 @@ namespace Microsoft.DotNet.XUnitExtensions
                 }
             }
         
-            if (DiscovererHelpers.TestPlatformApplies(platforms) && DiscovererHelpers.TestRuntimeApplies(runtimes))
+            if (DiscovererHelpers.TestPlatformApplies(platforms) &&
+                DiscovererHelpers.TestRuntimeApplies(runtimes) &&
+                DiscovererHelpers.TestFrameworkApplies(frameworks))
             {
-                if (frameworks.HasFlag(TargetFrameworkMonikers.Netcoreapp))
-                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreappTest);
-                if (frameworks.HasFlag(TargetFrameworkMonikers.NetFramework))
-                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetfxTest);
-                if (frameworks == (TargetFrameworkMonikers)0)
-                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing);
+                return new[] { new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing) };
             }
+
+            return Array.Empty<KeyValuePair<string, string>>();
         }
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/PlatformSpecificDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/PlatformSpecificDiscoverer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using Xunit.Abstractions;
@@ -24,16 +25,10 @@ namespace Microsoft.DotNet.XUnitExtensions
         public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
         {
             TestPlatforms platforms = (TestPlatforms)traitAttribute.GetConstructorArguments().First();
-            if (!platforms.HasFlag(TestPlatforms.Windows))
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonWindowsTest);
-            if (!platforms.HasFlag(TestPlatforms.Linux))
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonLinuxTest);
-            if (!platforms.HasFlag(TestPlatforms.OSX))
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonOSXTest);
-            if (!platforms.HasFlag(TestPlatforms.FreeBSD))
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonFreeBSDTest);
-            if (!platforms.HasFlag(TestPlatforms.NetBSD))
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetBSDTest);
+
+            return DiscovererHelpers.TestPlatformApplies(platforms) ?
+                Array.Empty<KeyValuePair<string, string>>() :
+                new[] { new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing) };
         }
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCoreClrDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCoreClrDiscoverer.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.XUnitExtensions
 
         public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
         {
-            if (!SkipOnMonoDiscoverer.IsMonoRuntime)
+            if (!DiscovererHelpers.IsMonoRuntime)
             {
                 TestPlatforms testPlatforms = TestPlatforms.Any;
                 RuntimeTestModes stressMode = RuntimeTestModes.Any;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnMonoDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnMonoDiscoverer.cs
@@ -13,11 +13,9 @@ namespace Microsoft.DotNet.XUnitExtensions
 {
     public class SkipOnMonoDiscoverer : ITraitDiscoverer
     {
-        private static readonly Lazy<bool> s_isMonoRuntime = new Lazy<bool>(() => Type.GetType("Mono.RuntimeStructs") != null);
-
         public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
         {
-            if (IsMonoRuntime)
+            if (DiscovererHelpers.IsMonoRuntime)
             {
                 TestPlatforms testPlatforms = TestPlatforms.Any;
 
@@ -35,7 +33,5 @@ namespace Microsoft.DotNet.XUnitExtensions
 
             return Array.Empty<KeyValuePair<string, string>>();
         }
-
-        public static bool IsMonoRuntime => s_isMonoRuntime.Value;
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnTargetFrameworkDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnTargetFrameworkDiscoverer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit.Abstractions;
@@ -24,10 +25,10 @@ namespace Microsoft.DotNet.XUnitExtensions
         public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
         {
             TargetFrameworkMonikers frameworks = (TargetFrameworkMonikers)traitAttribute.GetConstructorArguments().First();
-            if (frameworks.HasFlag(TargetFrameworkMonikers.Netcoreapp))
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreappTest);
-            if (frameworks.HasFlag(TargetFrameworkMonikers.NetFramework))
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetfxTest);
+
+            return DiscovererHelpers.TestFrameworkApplies(frameworks) ?
+                new[] { new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing) } :
+                Array.Empty<KeyValuePair<string, string>>();
         }
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/XunitConstants.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/XunitConstants.cs
@@ -8,15 +8,6 @@ namespace Microsoft.DotNet.XUnitExtensions
 {
     public struct XunitConstants
     {
-        internal const string NonFreeBSDTest = "nonfreebsdtests";
-        internal const string NonLinuxTest = "nonlinuxtests";
-        internal const string NonNetBSDTest = "nonnetbsdtests";
-        internal const string NonOSXTest = "nonosxtests";
-        internal const string NonWindowsTest = "nonwindowstests";
-
-        internal static string NonNetcoreappTest = "nonnetcoreapptests";
-        internal static string NonNetfxTest = "nonnetfxtests";
-
         internal const string Failing = "failing";
         internal const string OuterLoop = "outerloop";
 


### PR DESCRIPTION
Contributes towards https://github.com/dotnet/runtime/issues/945

We currently rely on passed in traits
(nonnetcoreapp, nonnetfx, nonwindowstests, etc.) to filter out non
applicable tests. This changes the code to not depend on passed in
traits and instead dynamically discover the framework or platform.

Also cleaning up code by moving the environment checks together and adding a missing copyright header.