### PR TITLE
Move from a soon-to-be-deprecated preview AzDO API

### DIFF
--- a/eng/common/sdl/init-sdl.ps1
+++ b/eng/common/sdl/init-sdl.ps1
@@ -24,7 +24,7 @@ $ProgressPreference = 'SilentlyContinue'
 # Construct basic auth from AzDO access token; construct URI to the repository's gdn folder stored in that repository; construct location of zip file
 $encodedPat = [Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$AzureDevOpsAccessToken"))
 $escapedRepository = [Uri]::EscapeDataString("/$Repository/$BranchName/.gdn")
-$uri = "https://dev.azure.com/dnceng/internal/_apis/git/repositories/sdl-tool-cfg/Items?path=$escapedRepository&versionDescriptor[versionOptions]=0&`$format=zip&api-version=5.0-preview.1"
+$uri = "https://dev.azure.com/dnceng/internal/_apis/git/repositories/sdl-tool-cfg/Items?path=$escapedRepository&versionDescriptor[versionOptions]=0&`$format=zip&api-version=5.0"
 $zipFile = "$WorkingDirectory/gdn.zip"
 
 Add-Type -AssemblyName System.IO.Compression.FileSystem

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         [Required]
         public string AzureDevOpsPersonalAccessToken { get; set; }
 
-        public string AzureDevOpsFeedsApiVersion { get; set; } = "5.0-preview.1";
+        public string AzureDevOpsFeedsApiVersion { get; set; } = "5.0";
 
         public static string AzureDevOpsOrg { get; set; } = "dnceng";
 

--- a/src/Microsoft.DotNet.Git.IssueManager/src/Clients/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Git.IssueManager/src/Clients/AzureDevOpsClient.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.Git.IssueManager.Clients
         private static readonly Regex LegacyRepositoryUriPattern = new Regex(
             @"^https://(?<account>[a-zA-Z0-9]+)\.visualstudio\.com/(?<project>[a-zA-Z0-9-]+)/_git/(?<repo>[a-zA-Z0-9-\.]+)");
 
-        private const string DefaultApiVersion = "5.0-preview.1";
+        private const string DefaultApiVersion = "5.0";
 
         public static async Task<string> GetCommitAuthorAsync(
             string repositoryUrl,

--- a/src/Microsoft.DotNet.Helix/Sdk/StartAzurePipelinesTestRun.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/StartAzurePipelinesTestRun.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.Helix.AzureDevOps
                     var req =
                         new HttpRequestMessage(
                             HttpMethod.Post,
-                            $"{CollectionUri}{TeamProject}/_apis/test/runs?api-version=5.0-preview.2")
+                            $"{CollectionUri}{TeamProject}/_apis/test/runs?api-version=5.0")
                         {
                             Content = new StringContent(
                                 JsonConvert.SerializeObject(

--- a/src/Microsoft.DotNet.Helix/Sdk/StopAzurePipelinesTestRun.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/StopAzurePipelinesTestRun.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Helix.AzureDevOps
                     using (var req =
                         new HttpRequestMessage(
                             new HttpMethod("PATCH"),
-                            $"{CollectionUri}{TeamProject}/_apis/test/runs/{TestRunId}?api-version=5.0-preview.2")
+                            $"{CollectionUri}{TeamProject}/_apis/test/runs/{TestRunId}?api-version=5.0")
                         {
                             Content = new StringContent(
                                 JsonConvert.SerializeObject(new JObject { ["state"] = "Completed", }),

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/VstsApi/VstsAdapterClient.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/VstsApi/VstsAdapterClient.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.VersionTools.Automation.VstsApi
     /// </summary>
     public class VstsAdapterClient : IGitHubClient
     {
-        private const string DefaultVstsApiVersion = "5.0-preview.1";
+        private const string DefaultVstsApiVersion = "5.0";
 
         private static JsonSerializerSettings s_jsonSettings = new JsonSerializerSettings
         {


### PR DESCRIPTION
The way I verified these changes is that

* I wrote some integration tests against `VstsAdapterClient`.
* ... and against `AzureDevOpsClient.GetCommitAuthorAsync`.
* Then I compared our usages against the current API documentation manually.

Please let me know what would you do to see that this doesn't break anything.

Also, if you think it's reasonable to check in integration tests of this kind, let me know. I'm tempted to do so, but I'm not sure whether it's worth the cost (PATs and their limited maximum expiration is not great).