### PR TITLE
Preserve task provided options

### DIFF
--- a/src/SignCheck/SignCheck/SignCheck.cs
+++ b/src/SignCheck/SignCheck/SignCheck.cs
@@ -129,11 +129,7 @@ namespace SignCheck
 
         public SignCheck(Options options)
         {
-            if(options == null)
-            {
-                options = new Options();
-            }
-            HandleOptions(options);
+            HandleOptions(options ?? new Options());
         }
 
         private void HandleOptions(Options options)

--- a/src/SignCheck/SignCheck/SignCheck.cs
+++ b/src/SignCheck/SignCheck/SignCheck.cs
@@ -126,6 +126,7 @@ namespace SignCheck
                 WithParsed(options => HandleOptions(options)).
                 WithNotParsed<Options>(errors => HandleErrors(errors));
         }
+
         public SignCheck(Options options)
         {
             if(options == null)

--- a/src/SignCheck/SignCheck/SignCheck.cs
+++ b/src/SignCheck/SignCheck/SignCheck.cs
@@ -126,6 +126,14 @@ namespace SignCheck
                 WithParsed(options => HandleOptions(options)).
                 WithNotParsed<Options>(errors => HandleErrors(errors));
         }
+        public SignCheck(Options options)
+        {
+            if(options == null)
+            {
+                options = new Options();
+            }
+            HandleOptions(options);
+        }
 
         private void HandleOptions(Options options)
         {

--- a/src/SignCheck/SignCheck/SignCheckTask.cs
+++ b/src/SignCheck/SignCheck/SignCheckTask.cs
@@ -142,8 +142,7 @@ namespace SignCheck
                 options.Verbosity = verbosity;
             }
             
-            var sc = new SignCheck(new string[] { });
-            sc.Options = options;
+            var sc = new SignCheck(options);
             int result = sc.Run();
             return (result == 0 && !Log.HasLoggedErrors);
         }


### PR DESCRIPTION
Signcheck via signcheck MSBuild task was ignoring explicit options (ie, things like a repo provided exclusion file would be ignored).  This change fixes the behavior.

FYI @Tohron, this may affect the project you're working on. 