### PR TITLE
Build should fail early if trying to promote to a channel without a YAML implementation

### DIFF
--- a/eng/common/post-build/check-channel-consistency.ps1
+++ b/eng/common/post-build/check-channel-consistency.ps1
@@ -17,7 +17,7 @@ try {
 
   foreach ($id in $PromoteToChannelsIds) {
     if (($id -ne 0) -and ($id -notin $AvailableChannelIds)) {
-      Write-PipelineTaskError -Category 'CheckChannelConsistency' -Message "Channel $id is not present in the post-build YAML configuration! This is an error scenario. Please contact @dnceng."
+      Write-PipelineTaskError -Message "Channel $id is not present in the post-build YAML configuration! This is an error scenario. Please contact @dnceng."
     }
   }
 

--- a/eng/common/post-build/check-channel-consistency.ps1
+++ b/eng/common/post-build/check-channel-consistency.ps1
@@ -17,7 +17,7 @@ try {
 
   foreach ($id in $PromoteToChannelsIds) {
     if (($id -ne 0) -and ($id -notin $AvailableChannelIds)) {
-      Write-PipelineTaskError -Type 'warning' -Message "Channel $id is not present in the post-build YAML configuration!"
+      Write-PipelineTaskError -Category 'CheckChannelConsistency' -Message "Channel $id is not present in the post-build YAML configuration! This is an error scenario. Please contact @dnceng."
     }
   }
 


### PR DESCRIPTION
Closes: #5141 

- We'll soon not need this anymore, but until then I think it's better to have this check.
- If we agree to merge this then we'll need to make sure that Roslyn does have all needed default-channels + YAML files in their 16.6 branch.