### PR TITLE
Fix ActiveIssue TargetFramework discovery

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ActiveIssueAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ActiveIssueAttribute.cs
@@ -17,6 +17,6 @@ namespace Xunit
         public ActiveIssueAttribute(string issue, TestPlatforms platforms) { }
         public ActiveIssueAttribute(string issue, TargetFrameworkMonikers framework) { }
         public ActiveIssueAttribute(string issue, TestRuntimes runtimes) { }
-        public ActiveIssueAttribute(string issue, TestPlatforms platforms = TestPlatforms.Any, TargetFrameworkMonikers framework = (TargetFrameworkMonikers)0, TestRuntimes runtimes = TestRuntimes.Any) { }
+        public ActiveIssueAttribute(string issue, TestPlatforms platforms = TestPlatforms.Any, TargetFrameworkMonikers framework = TargetFrameworkMonikers.Any, TestRuntimes runtimes = TestRuntimes.Any) { }
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ActiveIssueDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ActiveIssueDiscoverer.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.XUnitExtensions
 
             string issue = ctorArgs.First().ToString();
             TestPlatforms platforms = TestPlatforms.Any;
-            TargetFrameworkMonikers frameworks = (TargetFrameworkMonikers)0;
+            TargetFrameworkMonikers frameworks = TargetFrameworkMonikers.Any;
             TestRuntimes runtimes = TestRuntimes.Any;
             
             foreach (object arg in ctorArgs.Skip(1)) // First argument is the issue number.

--- a/src/Microsoft.DotNet.XUnitExtensions/src/TargetFrameworkMonikers.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/TargetFrameworkMonikers.cs
@@ -9,7 +9,8 @@ namespace Xunit
     [Flags]
     public enum TargetFrameworkMonikers
     {
-        Netcoreapp = 0x1,
-        NetFramework = 0x2
+        Netcoreapp = 1,
+        NetFramework = 2,
+        Any = ~0
     }
 }


### PR DESCRIPTION
Adding the default value `~0` for TargetFrameworkMonikers and setting it in ActiveIssueDiscoverer as otherwise no supplied TargetFrameworkMoniker would be not apply in the filtering.

Same as in PlatformSpecificDiscoverer.