### PR TITLE
Add null checks around Property iterators

### DIFF
--- a/src/Microsoft.DotNet.AzureDevOps.Build/src/GenerateBuildManifest.cs
+++ b/src/Microsoft.DotNet.AzureDevOps.Build/src/GenerateBuildManifest.cs
@@ -40,17 +40,26 @@ namespace Microsoft.DotNet.AzureDevOps.Build
                     }
                 }
             }
-            foreach (var signInfo in StrongNameSignInfo)
+            if (StrongNameSignInfo != null)
             {
-                itemGroup.AddItem("StrongNameSignInfo", Path.GetFileName(signInfo.ItemSpec), signInfo.CloneCustomMetadata() as Dictionary<string, string>);
+                foreach (var signInfo in StrongNameSignInfo)
+                {
+                    itemGroup.AddItem("StrongNameSignInfo", Path.GetFileName(signInfo.ItemSpec), signInfo.CloneCustomMetadata() as Dictionary<string, string>);
+                }
             }
-            foreach (var signInfo in FileSignInfo)
+            if (FileSignInfo != null)
             {
-                itemGroup.AddItem("FileSignInfo", signInfo.ItemSpec, signInfo.CloneCustomMetadata() as Dictionary<string, string>);
+                foreach (var signInfo in FileSignInfo)
+                {
+                    itemGroup.AddItem("FileSignInfo", signInfo.ItemSpec, signInfo.CloneCustomMetadata() as Dictionary<string, string>);
+                }
             }
-            foreach (var signInfo in FileExtensionSignInfo)
+            if (FileExtensionSignInfo != null)
             {
-                itemGroup.AddItem("FileExtensionSignInfo", signInfo.ItemSpec, signInfo.CloneCustomMetadata() as Dictionary<string, string>);
+                foreach (var signInfo in FileExtensionSignInfo)
+                {
+                    itemGroup.AddItem("FileExtensionSignInfo", signInfo.ItemSpec, signInfo.CloneCustomMetadata() as Dictionary<string, string>);
+                }
             }
             project.Save(ManifestPath);
             return true;


### PR DESCRIPTION
I haven't heard any reports of failures here, but I got nervous that we'd throw an exception if some repo didn't provide default values for signing properties.