### PR TITLE
Update BuildTask.targets (port of #5330)

### DIFF
--- a/eng/BuildTask.targets
+++ b/eng/BuildTask.targets
@@ -4,6 +4,8 @@
     <IsPackable>true</IsPackable>
     <!-- Build Tasks should not include any dependencies -->
     <SuppressDependenciesWhenPacking Condition="'$(SuppressDependenciesWhenPacking)' == ''">true</SuppressDependenciesWhenPacking>
+    <!-- Build Tasks should have this set per https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md#recommended-settings -->
+    <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
## Description

Sets AutoGenerateAssemblyVersion for all build task projects.

## Customer Impact

This issue will still happen https://github.com/dotnet/arcade/issues/5326
Customers using Arcade.Sdk can't easily use different versions side-by-side.

## Regression

No

## Risk

Low

## Workarounds

None