### PR TITLE
Default to global property value

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/PipelinesLogger.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/PipelinesLogger.cs
@@ -242,7 +242,10 @@ namespace Microsoft.DotNet.Arcade.Sdk
             }
 
             string propertyCategory = e.Properties?.Cast<DictionaryEntry>().LastOrDefault(p => p.Key.ToString().Equals(s_TelemetryMarker)).Value?.ToString();
-
+            if(string.IsNullOrWhiteSpace(propertyCategory))
+            {
+                propertyCategory = e.GlobalProperties?.LastOrDefault(p => p.Key.ToString().Equals($"_{s_TelemetryMarker}")).Value;
+            }
             var parentId = _buildEventContextMap.TryGetValue(e.ParentProjectBuildEventContext, out var guid)
             ? (Guid?)guid
             : null;


### PR DESCRIPTION
Fixes https://github.com/dotnet/core-eng/issues/9138

I repro'd the issue and have settled on a solution which aligns with @JohnTortugo 's thinking.

> I can think on the following solutions:
> - Patch the PipelineLogger to lookup a property named "_NETCORE_ENGINEERING_TELEMETRY" which includes the leading underscore.
> - Patch the PipelineLogger to lookup the telemetry category in the GlobalProperties list when the category is not found in the .Properties list. This should work given the way we set the property in the SDK.

The issue is that Arcade SDK's Build.proj calls the MSBuild task to `Restore`, `Build`, etc... the specified project.  That project imports the Arcade Sdk which converts `_NETCORE_ENGINEERING_TELEMETRY` marker to `NETCORE_ENGINEERING_TELEMETRY` which is used for the categorization.  That scenario works.  Additionally, there are some targets which get wired in via the Arcade SDK but they are not part of a specific project, so the SDK imports don't occur and the property conversion does not occur.

I think it's fine to default to using the Global property (`_NETCORE_ENGINEERING_TELEMETRY`) since it's what was specified as the default when the MSBuild task was specified.

Validated with local validation.

Sample output:

```
##vso[task.logissue type=error;sourcepath=C:\gh\dotnet\extensions\.packages\microsoft.dotnet.arcade.sdk\5.0.0-dev\tools\SymStore.targets;linenumber=70;columnnumber=5;code=MSB3073;](NETCORE_ENGINEERING_TELEMETRY=Build) The command ""C:\gh\dotnet\extensions\.packages\microsoft.diasymreader.pdb2pdb\1.1.0-beta2-19575-01\tools\Pdb2Pdb.exe" "C:\gh\dotnet\extensions\artifacts\bin\Microsoft.Extensions.Http\Release\netcoreapp5.0\Microsoft.Extensions.Http.dll" /out "C:\gh\dotnet\extensions\artifacts\SymStore\Release\Microsoft.Extensions.Http\netcoreapp5.0\Microsoft.Extensions.Http.pdb" /srcsvrvar SRC_INDEX=public" exited with code 2.```

