### PR TITLE
Upgrade Arcade to a 5.0 SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100-preview.5.20230.2"
+    "dotnet": "5.0.100-preview.5.20251.2"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20221.14",

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.1.101"
+    "dotnet": "5.0.100-preview.5.20227.9"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20221.14",

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100-preview.5.20228.8"
+    "dotnet": "5.0.100-preview.5.20230.2"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20221.14",

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100-preview.5.20227.9"
+    "dotnet": "5.0.100-preview.5.20228.8"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20221.14",


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/5394

To support the net5.0 TFM change we need to update the SDK for a newer NuGet.