### PR TITLE
Remove deprecated files from 3.x branch

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -174,19 +174,6 @@
       AssetManifestPath="$(AssetManifestFilePath)"
       AssetsTemporaryDirectory="$(TempWorkingDirectory)" />
 
-    <Message
-      Text="##vso[artifact.upload containerfolder=ReleaseConfigs;artifactname=ReleaseConfigs]$(RepositoryEngineeringDir)common/PublishToPackageFeed.proj"
-      Importance="high" />
-
-    <!--
-      The publishing pipeline (implemented by PublishToPackageFeed.proj) will use the Tasks.Feed package
-      to publish packages. The version of Tasks.Feed used will come from DefaultVersions.props
-    -->
-    <Message
-      Text="##vso[artifact.upload containerfolder=ReleaseConfigs;artifactname=ReleaseConfigs]$(MSBuildThisFileDirectory)DefaultVersions.props"
-      Condition="Exists('$(MSBuildThisFileDirectory)DefaultVersions.props')"
-      Importance="high" />
-
     <Copy 
       SourceFiles="$(AssetManifestFilePath)" 
       DestinationFolder="$(TempWorkingDirectory)\$(AssetManifestFileName)" />
@@ -200,11 +187,6 @@
       Lines="&lt;Project>&lt;PropertyGroup>&lt;ArtifactsCategory>$(ArtifactsCategory)&lt;/ArtifactsCategory>&lt;/PropertyGroup>&lt;/Project>"
       Overwrite="true"
       Encoding="Unicode" />
-
-    <Message
-      Text="##vso[artifact.upload containerfolder=ReleaseConfigs;artifactname=ReleaseConfigs]$(MSBuildThisFileDirectory)ArtifactsCategory.props"
-      Importance="high" />
-
 
     <!-- 
         Publish Windows PDBs produced by SymStore.targets (by default, only shipping PDBs are placed there).
@@ -235,15 +217,6 @@
       Text="##vso[artifact.upload containerfolder=PdbArtifacts;artifactname=PdbArtifacts]$(PDBsToPublishTempLocation)"
       Importance="high" 
       Condition="'@(FilesToPublishToSymbolServer)' != ''"/>
-
-    <Message
-      Text="##vso[artifact.upload containerfolder=ReleaseConfigs;artifactname=ReleaseConfigs]$(RepositoryEngineeringDir)common/PublishToSymbolServers.proj"
-      Importance="high" />
-
-    <Message
-      Text="##vso[artifact.upload containerfolder=ReleaseConfigs;artifactname=ReleaseConfigs]$(RepositoryEngineeringDir)common/CheckSymbols.ps1"
-      Importance="high" />
-
   </Target>
 
   <Target Name="PublishSymbols">

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -93,22 +93,6 @@
         MSBuildPath="$(_DesktopMSBuildPath)"
         SNBinaryPath="$(NuGetPackageRoot)sn\$(SNVersion)\sn.exe"
         MicroBuildCorePath="$(NuGetPackageRoot)microbuild.core\$(MicroBuildCoreVersion)"/>
-    
-    <!--
-      Signing.props can be used to include configurations used by signing validation during publishing.
-    -->
-    <Message
-      Text="##vso[artifact.upload containerfolder=ReleaseConfigs;artifactname=ReleaseConfigs]$(RepositoryEngineeringDir)Signing.props"
-      Condition="Exists('$(RepositoryEngineeringDir)Signing.props')"
-      Importance="high" />
-
-    <!--
-      SigningValidation.proj includes the logic to call SignCheck and will be used during release to validate signed packages.
-    -->
-    <Message
-      Text="##vso[artifact.upload containerfolder=ReleaseConfigs;artifactname=ReleaseConfigs]$(RepositoryEngineeringDir)common\SigningValidation.proj"
-      Importance="high" />
-    
   </Target>
 
 </Project>


### PR DESCRIPTION
## Description

These files were used in the infrastructure that relied on release pipelines. We don't need that anymore.

## Customer Impact

None

## Regression

None

## Risk

Very low.