### PR TITLE
Add GenerateGuidFromName into sharedframework sdk

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets
@@ -7,6 +7,7 @@
   -->
 
   <UsingTask TaskName="ExecWithRetries" AssemblyFile="$(DotNetBuildTasksSharedFrameworkTaskFile)" />
+  <UsingTask TaskName="GenerateGuidFromName" AssemblyFile="$(DotNetBuildTasksSharedFrameworkTaskFile)" />
   <UsingTask TaskName="StabilizeWixFileId" AssemblyFile="$(DotNetBuildTasksSharedFrameworkTaskFile)" />
 
   <!--


### PR DESCRIPTION
The GenerateGuidFromName task is used in the shared framework SDK but not improted as a UsingTask. I assume this works today as all consumers define the UsingTask.