### PR TITLE
Initial support for automated testing via Xharness

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -128,6 +128,19 @@ stages:
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''
+          - powershell: eng\common\build.ps1
+              -configuration $(_BuildConfig) 
+              -prepareMachine
+              -ci
+              -restore
+              -test
+              -projects $(Build.SourcesDirectory)\tests\UnitTests.XHarness.Android.proj
+              /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.XHarness.binlog
+              /p:RestoreUsingNuGetTargets=false
+            displayName: XHarness Android Helix Testing
+            env:
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+              HelixAccessToken: ''              
         - job: Linux
           container: LinuxContainer
           pool:

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -76,5 +76,6 @@
     <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>5.0.0-beta.20228.4</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
     <XliffTasksVersion>1.0.0-beta.20206.1</XliffTasksVersion>
     <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.20224.5</MicrosoftDotNetMaestroTasksVersion>
+    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20255.4</MicrosoftDotNetXHarnessCLIVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -76,6 +76,6 @@
     <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>5.0.0-beta.20228.4</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
     <XliffTasksVersion>1.0.0-beta.20206.1</XliffTasksVersion>
     <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.20224.5</MicrosoftDotNetMaestroTasksVersion>
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20255.4</MicrosoftDotNetXHarnessCLIVersion>
+    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20257.2</MicrosoftDotNetXHarnessCLIVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.Helix.Sdk
+{
+    /// <summary>
+    /// MSBuild custom task to create HelixWorkItems for provided Android application packages.
+    /// </summary>
+    public class CreateXHarnessAndroidWorkItems : XHarnessTaskBase
+    {
+        /// <summary>
+        /// An array of one or more paths to application packages (.apk for Android)
+        /// that will be used to create Helix work items.  
+        /// [Optional] Arguments: a string of arguments to be passed directly to the XHarness runner
+        /// [Optional] DeviceOutputPath: Location on the device where output files are generated
+        /// </summary>
+        public ITaskItem[] AppPackages { get; set; }
+
+        /// <summary>
+        /// The main method of this MSBuild task which calls the asynchronous execution method and
+        /// collates logged errors in order to determine the success of HelixWorkItems
+        /// </summary>
+        /// <returns>A boolean value indicating the success of HelixWorkItem creation</returns>
+        public override bool Execute()
+        {
+            ExecuteAsync().GetAwaiter().GetResult();
+            return !Log.HasLoggedErrors;
+        }
+
+        /// <summary>
+        /// Create work items for XHarness test execution
+        /// </summary>
+        /// <returns></returns>
+        private async Task ExecuteAsync()
+        {
+            WorkItems = (await Task.WhenAll(AppPackages.Select(PrepareWorkItem))).Where(wi => wi != null).ToArray();
+        }
+
+        /// <summary>
+        /// Prepares HelixWorkItem that can run on a device (currently Android or iOS) using XHarness
+        /// </summary>
+        /// <param name="appPackage">Path to application package</param>
+        /// <returns>An ITaskItem instance representing the prepared HelixWorkItem.</returns>
+        private async Task<ITaskItem> PrepareWorkItem(ITaskItem appPackage)
+        {
+            // Forces this task to run asynchronously
+            await Task.Yield();
+            string workItemName = $"xharness-{Path.GetFileNameWithoutExtension(appPackage.ItemSpec)}";
+
+            TimeSpan timeout = TimeSpan.FromMinutes(15);
+            if (!string.IsNullOrEmpty(WorkItemTimeout))
+            {
+                if (!TimeSpan.TryParse(WorkItemTimeout, out timeout))
+                {
+                    Log.LogWarning($"Invalid value \"{WorkItemTimeout}\" provided for XHarnessWorkItemTimeout; falling back to default value of \"00:015:00\" (15 minutes)");
+                    timeout = TimeSpan.FromMinutes(15);
+                }
+            }
+
+            string command = ValidateMetadataAndGetXHarnessAndroidCommand(appPackage, timeout);
+
+            if (!Path.GetExtension(appPackage.ItemSpec).Equals(".apk", StringComparison.OrdinalIgnoreCase))
+            {
+                Log.LogError($"Unsupported app package type: {Path.GetFileName(appPackage.ItemSpec)}");
+                return null;
+            }
+
+            Log.LogMessage($"Creating work item with properties Identity: {workItemName}, Payload: {appPackage.ItemSpec}, Command: {command}");
+
+            return new Microsoft.Build.Utilities.TaskItem(workItemName, new Dictionary<string, string>()
+            {
+                { "Identity", workItemName },
+                { "PayloadArchive", CreateZipArchiveOfPackage(appPackage.ItemSpec) },
+                { "Command", command },
+                { "Timeout", timeout.ToString() },
+            });
+        }
+
+        private string CreateZipArchiveOfPackage(string fileToZip)
+        {
+            string directoryOfPackage = Path.GetDirectoryName(fileToZip);
+            string fileName = $"xharness-apk-payload-{Path.GetFileNameWithoutExtension(fileToZip).ToLowerInvariant()}.zip";
+            string outputZipAbsolutePath = Path.Combine(directoryOfPackage, fileName);
+            using (FileStream fs = File.OpenWrite(outputZipAbsolutePath))
+            {
+                using (var zip = new ZipArchive(fs, ZipArchiveMode.Create, false))
+                {
+                    zip.CreateEntryFromFile(fileToZip, Path.GetFileName(fileToZip));
+                }
+            }
+            return outputZipAbsolutePath;
+        }
+
+        private string ValidateMetadataAndGetXHarnessAndroidCommand(ITaskItem appPackage, TimeSpan xHarnessTimeout)
+        {
+            // Validation of any metadata specific to Android stuff goes here
+            if (!appPackage.GetRequiredMetadata(Log, "AndroidPackageName", out string androidPackageName))
+            {
+                Log.LogError("AndroidPackageName metadata must be specified; this may match, but can vary from file name");
+                return null;
+            }
+
+            appPackage.TryGetMetadata("Arguments", out string arguments);
+            appPackage.TryGetMetadata("AndroidInstrumentationName", out string androidInstrumentationName);
+            appPackage.TryGetMetadata("DeviceOutputPath", out string deviceOutputPath);
+
+            string outputPathArg = string.IsNullOrEmpty(deviceOutputPath) ? string.Empty : $"--dev-out={deviceOutputPath}";
+            string instrumentationArg = string.IsNullOrEmpty(androidInstrumentationName) ? string.Empty : $"-i={androidInstrumentationName}";
+
+            string outputUploadDirectory = IsPosixShell ? "$HELIX_WORKITEM_UPLOAD_ROOT" : "%HELIX_WORKITEM_UPLOAD_ROOT%";
+            string xharnessRunCommand = $"xharness android test --app {Path.GetFileName(appPackage.ItemSpec)} --output-directory={outputUploadDirectory} " +
+                                          $"--timeout={xHarnessTimeout.TotalSeconds} -p={androidPackageName} {outputPathArg} {instrumentationArg} {arguments} -v=1";
+
+            Log.LogMessage(MessageImportance.Low, $"Generated XHarness command: {xharnessRunCommand}");
+
+            return xharnessRunCommand;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
@@ -113,8 +113,8 @@ namespace Microsoft.DotNet.Helix.Sdk
             string outputPathArg = string.IsNullOrEmpty(deviceOutputPath) ? string.Empty : $"--dev-out={deviceOutputPath}";
             string instrumentationArg = string.IsNullOrEmpty(androidInstrumentationName) ? string.Empty : $"-i={androidInstrumentationName}";
 
-            string outputUploadDirectory = IsPosixShell ? "$HELIX_WORKITEM_UPLOAD_ROOT" : "%HELIX_WORKITEM_UPLOAD_ROOT%";
-            string xharnessRunCommand = $"xharness android test --app {Path.GetFileName(appPackage.ItemSpec)} --output-directory={outputUploadDirectory} " +
+            string outputDirectory = IsPosixShell ? "$HELIX_WORKITEM_ROOT" : "%HELIX_WORKITEM_ROOT%";
+            string xharnessRunCommand = $"xharness android test --app {Path.GetFileName(appPackage.ItemSpec)} --output-directory={outputDirectory} " +
                                           $"--timeout={xHarnessTimeout.TotalSeconds} -p={androidPackageName} {outputPathArg} {instrumentationArg} {arguments} -v=1";
 
             Log.LogMessage(MessageImportance.Low, $"Generated XHarness command: {xharnessRunCommand}");

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.Helix.Sdk
 
             string outputDirectory = IsPosixShell ? "$HELIX_WORKITEM_ROOT" : "%HELIX_WORKITEM_ROOT%";
             string xharnessRunCommand = $"xharness android test --app {Path.GetFileName(appPackage.ItemSpec)} --output-directory={outputDirectory} " +
-                                          $"--timeout={xHarnessTimeout.TotalSeconds} -p={androidPackageName} {outputPathArg} {instrumentationArg} {arguments} -v=1";
+                                          $"--timeout={xHarnessTimeout.TotalSeconds} -p={androidPackageName} {outputPathArg} {instrumentationArg} {arguments} -v";
 
             Log.LogMessage(MessageImportance.Low, $"Generated XHarness command: {xharnessRunCommand}");
 

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessIosWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessIosWorkItems.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.Helix.Sdk
+{
+    /// <summary>
+    /// MSBuild custom task to create HelixWorkItems for provided iOS application folder paths.
+    /// </summary>
+    public class CreateXHarnessIosWorkItems : XHarnessTaskBase
+    {
+        /// <summary>
+        /// An array of one or more paths to application packages (.apk for Android)
+        /// that will be used to create Helix work items.  
+        /// [Optional] Arguments: a string of arguments to be passed directly to the XHarness runner
+        /// [Optional] DeviceOutputPath: Location on the device where output files are generated
+        /// </summary>
+        public ITaskItem[] AppFolders { get; set; }
+
+        /// <summary>
+        /// The main method of this MSBuild task which calls the asynchronous execution method and
+        /// collates logged errors in order to determine the success of HelixWorkItems
+        /// </summary>
+        /// <returns>A boolean value indicating the success of HelixWorkItem creation</returns>
+        public override bool Execute()
+        {
+            if (!IsPosixShell)
+            {
+                Log.LogError("IsPosixShell was specified as false for an iOS work item; these can only run on MacOS devices currently.");
+                return false;
+            }
+            ExecuteAsync().GetAwaiter().GetResult();
+            return !Log.HasLoggedErrors;
+        }
+
+        /// <summary>
+        /// Create work items for XHarness test execution
+        /// </summary>
+        /// <returns></returns>
+        private async Task ExecuteAsync()
+        {
+            WorkItems = (await Task.WhenAll(AppFolders.Select(PrepareWorkItem))).Where(wi => wi != null).ToArray();
+        }
+
+        /// <summary>
+        /// Prepares HelixWorkItem that can run on an iOS device using XHarness
+        /// </summary>
+        /// <param name="appFolderPath">Path to application package</param>
+        /// <returns>An ITaskItem instance representing the prepared HelixWorkItem.</returns>
+        private async Task<ITaskItem> PrepareWorkItem(ITaskItem appFolderPath)
+        {
+            // Forces this task to run asynchronously
+            await Task.Yield();
+            string workItemName = $"xharness-{Path.GetDirectoryName(appFolderPath.ItemSpec)}";
+
+            TimeSpan timeout = TimeSpan.FromMinutes(15);
+            if (!string.IsNullOrEmpty(WorkItemTimeout))
+            {
+                if (!TimeSpan.TryParse(WorkItemTimeout, out timeout))
+                {
+                    Log.LogWarning($"Invalid value \"{WorkItemTimeout}\" provided for XHarnessWorkItemTimeout; falling back to default value of \"00:015:00\" (15 minutes)");
+                    timeout = TimeSpan.FromMinutes(15);
+                }
+            }
+
+            string command = ValidateMetadataAndGetXHarnessIosCommand(appFolderPath, timeout);
+
+            Log.LogMessage($"Creating work item with properties Identity: {workItemName}, Payload: {appFolderPath.ItemSpec}, Command: {command}");
+
+            return new Microsoft.Build.Utilities.TaskItem(workItemName, new Dictionary<string, string>()
+            {
+                { "Identity", workItemName },
+                { "PayloadArchive", CreateZipArchiveOfFolder(appFolderPath.ItemSpec, "./") },
+                { "Command", command },
+                { "Timeout", timeout.ToString() },
+            });
+        }
+
+        private string CreateZipArchiveOfFolder(string folderToZip, string outputFolder)
+        {
+            if (!Directory.Exists(folderToZip))
+            {
+                Log.LogError($"Cannot find path containing app: {folderToZip}");
+                return string.Empty;
+            }
+
+            string fileName = $"xharness-ios-app-payload-{Path.GetDirectoryName(folderToZip).ToLowerInvariant()}.zip";
+            string outputZipAbsolutePath = Path.Combine(outputFolder, fileName);
+            ZipFile.CreateFromDirectory(folderToZip, outputZipAbsolutePath);
+            return outputZipAbsolutePath;
+        }
+
+        private string ValidateMetadataAndGetXHarnessIosCommand(ITaskItem appFolderPath, TimeSpan xHarnessTimeout)
+        {
+            // Validation of any metadata specific to iOS stuff goes here
+            if (!appFolderPath.GetRequiredMetadata(Log, "Targets", out string targets))
+            {
+                Log.LogError("'Targets' metadata must be specified; this may match, but can vary from file name");
+                return null;
+            }
+
+            string workDirectory = "$HELIX_WORKITEM_ROOT";
+            string xharnessRunCommand = $"xharness ios test --app {workDirectory}/{Path.GetFileName(appFolderPath.ItemSpec)} +" +
+                                        $" --output-directory=$HELIX_WORKITEM_UPLOAD_ROOT --targets={targets}" +
+                                        $"--timeout={xHarnessTimeout.TotalSeconds} --working-directory={workDirectory} " +
+                                        $"-v";
+
+            Log.LogMessage(MessageImportance.Low, $"Generated XHarness command: {xharnessRunCommand}");
+
+            return xharnessRunCommand;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.Helix.Sdk
+{
+    /// <summary>
+    /// MSBuild custom task to create HelixWorkItems for provided Android application packages.
+    /// </summary>
+    public abstract class XHarnessTaskBase : BaseTask
+    {
+        /// <summary>
+        /// Boolean true if this is a posix shell, false if not.
+        /// This does not need to be set by a user; it is automatically determined in Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
+        /// </summary>
+        [Required]
+        public bool IsPosixShell { get; set; }
+
+        /// <summary>
+        /// Optional timeout for all created workitems
+        /// Defaults to 1200s
+        /// </summary>
+        public string WorkItemTimeout { get; set; }
+
+        /// <summary>
+        /// An array of ITaskItems of type HelixWorkItem
+        /// </summary>
+        [Output]
+        public ITaskItem[] WorkItems { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MultiQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MultiQueue.targets
@@ -2,7 +2,7 @@
 <Project InitialTargets="ValidateTargetQueues">
   <PropertyGroup>
     <!-- Split up HelixTargetQueues list
-         In order to support all delimiters (commas, plus and semicolons).
+         In order to support all delimiters (commas, pluses and semicolons).
          Note that queues will never have ',', '+' or ';' in their name, and this greatly simplifies providing a queue list in *nix.
     -->
     <_ProcessedTargetQueues>$([System.String]::Copy('$(HelixTargetQueues)').Replace(',',';').Replace('+',';'))</_ProcessedTargetQueues>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.props
@@ -17,6 +17,8 @@
   <UsingTask TaskName="FindDotNetCliPackage" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)"/>
   <UsingTask TaskName="GetFailedWorkItems" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)"/>
   <UsingTask TaskName="CreateXUnitWorkItems" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)"/>
+  <UsingTask TaskName="CreateXHarnessAndroidWorkItems" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)"/>
+  <UsingTask TaskName="CreateXHarnessIosWorkItems" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)"/>
   <UsingTask TaskName="CreateFailedTestsForFailedWorkItems" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)"/>
   <UsingTask TaskName="StartAzurePipelinesTestRun" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)"/>
   <UsingTask TaskName="StopAzurePipelinesTestRun" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)"/>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <_XHarnessPackageName>Microsoft.DotNet.XHarness.CLI</_XHarnessPackageName>
+    <_XharnessRunnerPackageFeed Condition="'$(_XharnessRunnerPackageFeed)'==''">https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet-eng/nuget/v3/index.json</_XharnessRunnerPackageFeed>
+    <!-- MicrosoftDotNetXHarnessCLIVersion comes from eng\Versions.props -->
+    <_XHarnessPackageVersion Condition="'$(XHarnessPackageVersion)' == ''">$(MicrosoftDotNetXHarnessCLIVersion)</_XHarnessPackageVersion>
+    <_HelixMonoQueueTargets>$(_HelixMonoQueueTargets);$(MSBuildThisFileDirectory)XHarnessRunner.targets</_HelixMonoQueueTargets>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
@@ -1,0 +1,63 @@
+<Project>
+
+  <Target Name="SpecifyXHarnessCliVersion"
+          Condition="'@(XHarnessProject)' != ''"
+          BeforeTargets="AddDotNetSdk">
+    <PropertyGroup>
+      <IncludeDotNetCli>true</IncludeDotNetCli>
+      <DotNetCliPackageType>sdk</DotNetCliPackageType>
+      <DotNetCliVersion>3.1.201</DotNetCliVersion>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="AddXHarnessRunner"
+          Condition="'@(XHarnessProject)' != ''"
+          BeforeTargets="CoreTest">
+
+    <!-- When using a dotnet 'tool' that is not installed globally, we must set DOTNET_ROOT. 
+         This is because a framework dependent dotnet tool only searches in program files folders for runtimes.
+         When .NET is not already installed there, we set DOTNET_ROOT to help it find the right one. -->
+    <PropertyGroup Condition="$(IsPosixShell)">
+      <HelixPreCommands>$(HelixPreCommands);export DOTNET_ROOT=$HELIX_CORRELATION_PAYLOAD/dotnet</HelixPreCommands>
+      <HelixPreCommands>$(HelixPreCommands);dotnet tool install --tool-path $HELIX_CORRELATION_PAYLOAD/xharness-cli --version $(_XHarnessPackageVersion) --add-source $(_XharnessRunnerPackageFeed) $(_XHarnessPackageName) </HelixPreCommands>
+      <HelixPreCommands>$(HelixPreCommands);export PATH=$HELIX_CORRELATION_PAYLOAD/xharness-cli:$PATH</HelixPreCommands>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="!$(IsPosixShell)">
+      <HelixPreCommands>$(HelixPreCommands);set DOTNET_ROOT=%HELIX_CORRELATION_PAYLOAD%\dotnet</HelixPreCommands>
+      <HelixPreCommands>$(HelixPreCommands);dotnet tool install --tool-path %HELIX_CORRELATION_PAYLOAD%\xharness-cli --version $(_XHarnessPackageVersion) --add-source $(_XharnessRunnerPackageFeed) $(_XHarnessPackageName) </HelixPreCommands>
+      <HelixPreCommands>$(HelixPreCommands);set PATH=%HELIX_CORRELATION_PAYLOAD%\xharness-cli%3B%PATH%</HelixPreCommands>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="BuildXHarnessProjects"
+          Condition="'@(XHarnessProject)' != ''"
+          BeforeTargets="CoreBuild"
+          Outputs="%(XHarnessProject.Identity)%(XHarnessProject.AdditionalProperties)">
+    <PropertyGroup>
+      <_CurrentXHarnessProject>%(XHarnessProject.Identity)</_CurrentXHarnessProject>
+      <_CurrentAdditionalProperties>%(XHarnessProject.AdditionalProperties)</_CurrentAdditionalProperties>
+    </PropertyGroup>
+    <MSBuild Projects="$(_CurrentXHarnessProject)" Targets="Build" Properties="$(_CurrentAdditionalProperties)">
+      <Output TaskParameter="TargetOutputs" ItemName="XHarnessPackageToTest" />
+    </MSBuild>
+  </Target>
+
+  <!-- These will tend to be mutually exclusive in the same build; but it's entirely possible for mac to support both at once... -->
+  <Target Name="CreateAndroidWorkItems"
+        Condition=" '@(XHarnessPackageToTest)' !=  '' "
+        BeforeTargets="CoreTest">
+    <CreateXHarnessAndroidWorkItems AppPackages="@(XHarnessPackageToTest)" IsPosixShell="$(IsPosixShell)" WorkItemTimeout="$(XHarnessWorkItemTimeout)">
+      <Output TaskParameter="WorkItems" ItemName="HelixWorkItem"/>
+    </CreateXHarnessAndroidWorkItems>
+  </Target>
+
+  <Target Name="CreateIosAppWorkItems"
+        Condition=" '@(XHarnessAppFolderToTest)' !=  '' "
+        BeforeTargets="CoreTest">
+    <CreateXHarnessIosWorkItems AppFolders="@(XHarnessAppFolderToTest)" IsPosixShell="$(IsPosixShell)" WorkItemTimeout="$(XHarnessWorkItemTimeout)">
+      <Output TaskParameter="WorkItems" ItemName="HelixWorkItem"/>
+    </CreateXHarnessIosWorkItems>
+  </Target>
+  
+</Project>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xunit-reporter/xunit-reporter.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xunit-reporter/xunit-reporter.py
@@ -12,7 +12,8 @@ log = helix.logs.get_logger()
 acceptableXUnitFileNames = [
     "testResults.xml",
     "test-results.xml",
-    "test_results.xml"
+    "test_results.xml",
+    "TestResults.xUnit.xml"
 ]
 
 class HelixHelper:

--- a/tests/UnitTests.Xharness.Android.proj
+++ b/tests/UnitTests.Xharness.Android.proj
@@ -1,0 +1,47 @@
+<Project DefaultTargets="Test">
+  <!-- See UnitTests.proj in above folder for why this is included directly-from-repo -->
+  <Import Project="$(MSBuildThisFileDirectory)\..\src\Microsoft.DotNet.Helix\Sdk\sdk\Sdk.props"/>
+
+  <PropertyGroup>
+    <MicrosoftDotNetHelixSdkTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)../artifacts/bin/Microsoft.DotNet.Helix.Sdk/$(Configuration)/netcoreapp2.1/publish/Microsoft.DotNet.Helix.Sdk.dll</MicrosoftDotNetHelixSdkTasksAssembly>
+    <MicrosoftDotNetHelixSdkTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)../artifacts/bin/Microsoft.DotNet.Helix.Sdk/$(Configuration)/net472/publish/Microsoft.DotNet.Helix.Sdk.dll</MicrosoftDotNetHelixSdkTasksAssembly>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <HelixType>test/product/</HelixType>
+    <IncludeDotNetCli>true</IncludeDotNetCli>
+    <DotNetCliPackageType>sdk</DotNetCliPackageType>
+    <TestRunNamePrefix>$(AGENT_JOBNAME)</TestRunNamePrefix>
+    <EnableXUnitReporter>true</EnableXUnitReporter>
+    <EnableAzurePipelinesReporter>true</EnableAzurePipelinesReporter>
+    <HelixBaseUri>https://helix.dot.net</HelixBaseUri>
+  </PropertyGroup>
+
+  <!-- New Test Projects which build packages to run through XHarness/XHarness go here -->
+  <ItemGroup>
+    <XHarnessProject Include="$(MSBuildThisFileDirectory)XHarness/XHarness.TestApk.proj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(HelixAccessToken)' != '' ">
+    <HelixTargetQueue Include="ubuntu.1804.amd64.android"/>
+  </ItemGroup>
+
+  <PropertyGroup Condition=" '$(HelixAccessToken)' == '' ">
+    <IsExternal>true</IsExternal>
+    <Creator>$(BUILD_SOURCEVERSIONAUTHOR)</Creator>
+    <Creator Condition=" '$(Creator)' == ''">anon</Creator>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(HelixAccessToken)' == '' ">
+    <HelixTargetQueue Include="ubuntu.1804.amd64.android.open"/>
+  </ItemGroup>
+
+  <!-- Useless stuff to make Arcade SDK happy -->
+  <PropertyGroup>
+    <Language>msbuild</Language>
+  </PropertyGroup>
+  <Target Name="Pack"/>
+
+  <!-- See UnitTests.proj in above folder for why this is included directly-from-repo -->
+  <Import Project="$(MSBuildThisFileDirectory)\..\src\Microsoft.DotNet.Helix\Sdk\sdk\Sdk.targets"/>
+</Project>

--- a/tests/XHarness/XHarness.TestApk.proj
+++ b/tests/XHarness/XHarness.TestApk.proj
@@ -1,0 +1,38 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+
+  <PropertyGroup>
+    <XHarnessX86TestApkUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/android/test-apk/x86/System.Numerics.Vectors.Tests-x86.apk</XHarnessX86TestApkUrl>
+    <XHarnessX64TestApkUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/android/test-apk/x86_64/System.Numerics.Vectors.Tests-x64.apk</XHarnessX64TestApkUrl>
+  </PropertyGroup>
+
+  <Target Name="Build" Returns="@(XHarnessPackageToTest)" >
+    <Error Condition=" '$(BaseOutputPath)' == ''" Text="Not downloading APK because BaseOutputPath property is unset" />
+    <DownloadFile SourceUrl="$(XHarnessX86TestApkUrl)" DestinationFolder="$(BaseOutputPath)apk/x86" SkipUnchangedFiles="True" Retries="5">
+      <Output TaskParameter="DownloadedFile" ItemName="DownloadedApkFile" />
+    </DownloadFile>
+
+    <!-- Disabled until we have both kinds of emulator available, otherwise this will fail
+    <DownloadFile SourceUrl="$(XHarnessX64TestApkUrl)" DestinationFolder="$(BaseOutputPath)apk/x86_64" SkipUnchangedFiles="True" Retries="5">
+      <Output TaskParameter="DownloadedFile" ItemName="DownloadedApkFile" />
+    </DownloadFile> 
+    -->
+
+    <Message Text="Downloaded @(DownloadedApkFile) for XHarness Test purposes" Importance="High" />
+
+    <ItemGroup>
+      <!-- We're not set up currently to build APK files as part of normal builds, so this downloads existing ones for now -->
+      <XHarnessPackageToTest Include="@(DownloadedApkFile)">
+
+        <!-- Package name: this comes from metadata inside the apk itself -->
+        <AndroidPackageName>net.dot.System.Numerics.Vectors.Tests</AndroidPackageName>
+
+        <!-- If there are > 1 instrumentation class inside the package, we need to know the name of which to use -->
+        <AndroidInstrumentationName>net.dot.MonoRunner</AndroidInstrumentationName>
+
+      </XHarnessPackageToTest>      
+    </ItemGroup>
+  </Target>
+  
+</Project>


### PR DESCRIPTION
I believe this is ready to work, but we still need Helix queues in staging that can run Android emulators to be turned on and working.  This PR is mostly to check that the machinery works up to the point that the app fails to run on a Windows machine due to the lack of an Android emulator.

Putting this up here for feedback while I work on:

- Ensure Xharness Android support works on Linux machines
- Get [Ubuntu.1804.Amd64.Android.Open created](https://dnceng.visualstudio.com/internal/_git/dotnet-helix-machines/pullrequest/7609?_a=files)
- Change PR to do XHarness testing on Linux.