### PR TITLE
restrict "tools.vs" property match, use xcopied msbuild

### DIFF
--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -59,14 +59,15 @@ try {
 
   if( $msbuildEngine -eq "vs") {
     # Ensure desktop MSBuild is available for sdk tasks.
-    if( -not ($GlobalJson.tools.PSObject.Properties.Name -match "vs" )) {
+    if( -not ($GlobalJson.tools.PSObject.Properties.Name -contains "vs" )) {
       $GlobalJson.tools | Add-Member -Name "vs" -Value (ConvertFrom-Json "{ `"version`": `"16.4`" }") -MemberType NoteProperty
     }
     if( -not ($GlobalJson.tools.PSObject.Properties.Name -match "xcopy-msbuild" )) {
       $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "16.4.0-alpha" -MemberType NoteProperty
     }
 
-    InitializeXCopyMSBuild $GlobalJson.tools."xcopy-msbuild" -install $true
+    $xcopyMSBuildToolsFolder = InitializeXCopyMSBuild $GlobalJson.tools."xcopy-msbuild" -install $true
+    $global:_MSBuildExe = "$($xcopyMSBuildToolsFolder)\MSBuild\Current\Bin\MSBuild.exe"
   }
 
   $taskProject = GetSdkTaskProject $task


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/5362

Sdk builds failing because of 

```
##[error](NETCORE_ENGINEERING_TELEMETRY=InitializeToolset) The property 'vs' cannot be found on this object. Verify that the property exists. 
```

Use an exact match for property key.

Explicitly use restored MSBuild, otherwise Arcade scripts will try to use VS' MSBuild but get confused on where to find the .NET SDK because dotnet/sdk repo does not explicitly define "sdk" in "global.json".  This, leads to errors like this...

```
  It was not possible to find any installed .NET Core SDKs
  Did you mean to run .NET Core SDK commands? Install a .NET Core SDK from:
      https://aka.ms/dotnet-download
C:\gh\dotnet\sdk\.packages\microsoft.dotnet.arcade.sdk\5.0.0-beta.20221.14\tools\SdkTasks\SigningValidation.proj : error : Unable to locate the .NET Core SDK. Check that it is installed and that the version specified in global.json (if any) matches the installed version.
```

Validated with a build of dotnet/sdk - https://dev.azure.com/dnceng/internal/_build/results?buildId=622114&view=results

FYI @dsplaisted 