### PR TITLE
Add calleeType / conditionMemberNames to ActiveIssueAttribute

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ActiveIssueAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ActiveIssueAttribute.cs
@@ -14,7 +14,7 @@ namespace Xunit
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = true)]
     public class ActiveIssueAttribute : Attribute, ITraitAttribute
     {
-        public Type CalleeType { get; private set;}
+        public Type CalleeType { get; private set; }
         public string[] ConditionMemberNames { get; private set; }
 
         public ActiveIssueAttribute(string issue, TestPlatforms platforms) { }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ActiveIssueAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ActiveIssueAttribute.cs
@@ -14,9 +14,17 @@ namespace Xunit
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = true)]
     public class ActiveIssueAttribute : Attribute, ITraitAttribute
     {
+        public Type CalleeType { get; private set;}
+        public string[] ConditionMemberNames { get; private set; }
+
         public ActiveIssueAttribute(string issue, TestPlatforms platforms) { }
         public ActiveIssueAttribute(string issue, TargetFrameworkMonikers framework) { }
         public ActiveIssueAttribute(string issue, TestRuntimes runtimes) { }
         public ActiveIssueAttribute(string issue, TestPlatforms platforms = TestPlatforms.Any, TargetFrameworkMonikers framework = TargetFrameworkMonikers.Any, TestRuntimes runtimes = TestRuntimes.Any) { }
+        public ActiveIssueAttribute(string issue, Type calleeType, params string[] conditionMemberNames)
+        {
+            CalleeType = calleeType;
+            ConditionMemberNames = conditionMemberNames;
+        }
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
@@ -3,6 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using Xunit;
 
@@ -29,5 +33,25 @@ namespace Microsoft.DotNet.XUnitExtensions
         public static bool TestFrameworkApplies(TargetFrameworkMonikers frameworks) =>
                 (frameworks.HasFlag(TargetFrameworkMonikers.Netcoreapp) && IsRunningOnNetCoreApp) ||
                 (frameworks.HasFlag(TargetFrameworkMonikers.NetFramework) && IsRunningOnNetFramework);
+
+        internal static bool Evaluate(Type calleeType, string[] conditionMemberNames)
+        {
+            foreach (string entry in conditionMemberNames)
+            {
+                // Null condition member names are silently tolerated.
+                if (string.IsNullOrWhiteSpace(entry)) continue;
+
+                MethodInfo conditionMethodInfo = ConditionalTestDiscoverer.LookupConditionalMethod(calleeType, entry);
+                if (conditionMethodInfo == null)
+                {
+                    throw new InvalidOperationException($"Unable to get MethodInfo, please check input for {entry}.");
+                }
+
+                // If one of the conditions is false, then return the category failing trait.
+                if (!(bool)conditionMethodInfo.Invoke(null, null)) return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
@@ -47,7 +47,6 @@ namespace Microsoft.DotNet.XUnitExtensions
                     throw new InvalidOperationException($"Unable to get MethodInfo, please check input for {entry}.");
                 }
 
-                // If one of the conditions is false, then return the category failing trait.
                 if (!(bool)conditionMethodInfo.Invoke(null, null)) return false;
             }
 

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ActiveIssueDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ActiveIssueDiscoverer.cs
@@ -32,6 +32,8 @@ namespace Microsoft.DotNet.XUnitExtensions
             TestPlatforms platforms = TestPlatforms.Any;
             TargetFrameworkMonikers frameworks = TargetFrameworkMonikers.Any;
             TestRuntimes runtimes = TestRuntimes.Any;
+            Type calleeType = null;
+            string[] conditionMemberNames = null;
             
             foreach (object arg in ctorArgs.Skip(1)) // First argument is the issue number.
             {
@@ -47,16 +49,29 @@ namespace Microsoft.DotNet.XUnitExtensions
                 {
                     runtimes = (TestRuntimes)arg;
                 }
+                else if (arg is Type)
+                {
+                    calleeType = (Type)arg;
+                }
+                else if (arg is string[])
+                {
+                    conditionMemberNames = (string[])arg;
+                }
             }
-        
-            if (DiscovererHelpers.TestPlatformApplies(platforms) &&
+
+            if (calleeType != null && conditionMemberNames != null)
+            {
+                if (!DiscovererHelpers.Evaluate(calleeType, conditionMemberNames))
+                {
+                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing);
+                }
+            }        
+            else if (DiscovererHelpers.TestPlatformApplies(platforms) &&
                 DiscovererHelpers.TestRuntimeApplies(runtimes) &&
                 DiscovererHelpers.TestFrameworkApplies(frameworks))
             {
-                return new[] { new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing) };
+                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing);
             }
-
-            return Array.Empty<KeyValuePair<string, string>>();
         }
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ConditionalClassDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ConditionalClassDiscoverer.cs
@@ -47,22 +47,7 @@ namespace Microsoft.DotNet.XUnitExtensions
                 return true;
             }
 
-            foreach (string entry in conditionMemberNames)
-            {
-                // Null condition member names are silently tolerated.
-                if (string.IsNullOrWhiteSpace(entry)) continue;
-
-                MethodInfo conditionMethodInfo = ConditionalTestDiscoverer.LookupConditionalMethod(calleeType, entry);
-                if (conditionMethodInfo == null)
-                {
-                    throw new InvalidOperationException($"Unable to get MethodInfo, please check input for {entry}.");
-                }
-
-                // If one of the conditions is false, then return the category failing trait.
-                if (!(bool)conditionMethodInfo.Invoke(null, null)) return false;
-            }
-
-            return true;
+            return DiscovererHelpers.Evaluate(calleeType, conditionMemberNames);
         }
     }
 }


### PR DESCRIPTION
This adds the same type invoking mechanism that exists in ConditionalClass, Theory, and Fact.  Allows ActiveIssue to be a bit more expressive when skipping:

```c#
[ActiveIssue("https://github.com/...", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoInterpreter))]
```