### PR TITLE
Re-enable signing validation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -170,9 +170,6 @@ stages:
 
   - template: eng\common\templates\post-build\post-build.yml
     parameters:
-      # Disabling signing validation until we can get the issues sorted. This should be re-enabled
-      # after https://github.com/dotnet/arcade/issues/5328 is resolved. 
-      enableSigningValidation: false
       # Symbol validation isn't being very reliable lately. This should be enabled back
       # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871
       enableSymbolValidation: false


### PR DESCRIPTION
Closes: https://github.com/dotnet/arcade/issues/5328

Azure DevOps reported that they have rolled out the fix for the issue. I also tested it in [an internal](https://dnceng.visualstudio.com/internal/_build/results?buildId=625332&view=results) build and it worked fine again.