### PR TITLE
Fix CMake generator on Unix/macOS

### DIFF
--- a/src/Microsoft.DotNet.CMake.Sdk/README.md
+++ b/src/Microsoft.DotNet.CMake.Sdk/README.md
@@ -64,6 +64,22 @@ Here are a list of MSBuild properties that this SDK consumes:
 
 ### Simple Example Project
 
+To get started, add `Microsoft.DotNet.CMake.Sdk` under `msbuild-sdks` in `global.json`:
+```json
+{
+  ...
+  "msbuild-sdks": {
+    ...
+    "Microsoft.DotNet.CMake.Sdk": "version",
+    ...
+  },
+  ...
+}
+```
+
+To use this SDK, you need to define a native project and then reference it from your managed code project using NativeProjectReference.
+
+#### Defining Native Project
 If you want to drive a native CMake build with this SDK, add a .proj file next to your CMakeLists.txt with the following content:
 
 ```xml
@@ -76,7 +92,7 @@ If you want to drive a native CMake build with this SDK, add a .proj file next t
 
 Building this project will configure and build the CMakeLists.txt project with the default generator provided by the SDK (Visual Studio on Windows, Unix Makefiles off-Windows).
 
-### Using NativeProjectReference to reference Native assets
+#### Referencing Native assets with NativeProjectReference
 
 An important feature of the Microsoft.DotNet.CMake.Sdk is that it enables the user to reference their native assets from a managed project. This is the most valuable in a testing scenario such as the CoreCLR test tree since it does not currently do any special handling of multiple architectures.
 

--- a/src/Microsoft.DotNet.CMake.Sdk/build/Microsoft.DotNet.CMake.Sdk.props
+++ b/src/Microsoft.DotNet.CMake.Sdk/build/Microsoft.DotNet.CMake.Sdk.props
@@ -10,8 +10,8 @@
     <CMakeGenerator Condition="!$([MSBuild]::IsOSPlatform(Windows))">Unix Makefiles</CMakeGenerator>
     <CMakeCompilerToolchain Condition="$([MSBuild]::IsOSPlatform(Windows))">MSVC</CMakeCompilerToolchain>
     <CMakeCompilerToolchain Condition="!$([MSBuild]::IsOSPlatform(Windows))">clang</CMakeCompilerToolchain>
-    <_CMakeMultiConfigurationGenerator>False</_CMakeMultiConfigurationGenerator>
-    <_CMakePassArchitectureToGenerator>False</_CMakePassArchitectureToGenerator>
+    <_CMakeMultiConfigurationGenerator>false</_CMakeMultiConfigurationGenerator>
+    <_CMakePassArchitectureToGenerator>false</_CMakePassArchitectureToGenerator>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.CMake.Sdk/build/Microsoft.DotNet.CMake.Sdk.targets
+++ b/src/Microsoft.DotNet.CMake.Sdk/build/Microsoft.DotNet.CMake.Sdk.targets
@@ -43,7 +43,7 @@
       StandardOutputImportance="Low">
       <Output TaskParameter="ConsoleOutput" PropertyName="_HighestCompatibleVSVersion" />
     </Exec>
-    
+
     <Error Condition="'$(_HighestCompatibleVSVersion)' == ''" Text="Unable to find a VS installation with the MSVC tools for the '$(Platform)' architecture." />
 
     <PropertyGroup>
@@ -116,7 +116,7 @@
     <Error Condition="$([MSBuild]::IsOsPlatform(Windows))" Text="This SDK does not support using non-MSVC toolchains on Windows." />
     <PropertyGroup>
       <CMakeCompilerSearchScript>
-      . $([MSBuild]::MakeRelative('$(MSBuildProjectDirectory)', '$(RepositoryEngineeringDir)common/native/find-native-compiler.sh') $(CMakeCompilerToolchain) $(CMakeCompilerMajorVersion) $(CMakeCompilerMinorVersion)
+      . $([MSBuild]::MakeRelative('$(MSBuildProjectDirectory)', '$(RepositoryEngineeringDir)common/native/find-native-compiler.sh')) $(CMakeCompilerToolchain) $(CMakeCompilerMajorVersion) $(CMakeCompilerMinorVersion)
       </CMakeCompilerSearchScript>
     </PropertyGroup>
   </Target>
@@ -169,7 +169,7 @@
 
   <Target Name="Configure"
     DependsOnTargets="GetConfigScript">
-    <Exec Command="
+    <Exec WorkingDirectory="$(MSBuildProjectDirectory)" Command="
       $(CMakeCompilerSearchScript)
       $(CMakeConfigScript)" />
   </Target>
@@ -179,11 +179,11 @@
       <!-- Don't set IntermediateAssembly since this is not produced -->
       <IntermediateAssembly Remove="@(IntermediateAssembly)" />
     </ItemGroup>
-    <Exec Command="
+    <Exec WorkingDirectory="$(MSBuildProjectDirectory)" Command="
       $(CMakeCompilerSearchScript)
       $(CMakeBuildScript)" />
   </Target>
-  
+
   <Target Name="GenerateBringupScript" DependsOnTargets="GetConfigScript;GetBuildScript">
     <Error Condition="'$(BringupScriptOutputFile)' == ''" Text="An output file for the bringup script must be specified" />
     <PropertyGroup>

--- a/src/Microsoft.DotNet.CMake.Sdk/build/Microsoft.DotNet.CMake.Sdk.targets
+++ b/src/Microsoft.DotNet.CMake.Sdk/build/Microsoft.DotNet.CMake.Sdk.targets
@@ -136,7 +136,7 @@
     <ItemGroup>
       <_CMakeArguments Include="-G &quot;$(CMakeGenerator)&quot;" />
       <_CMakeArguments Condition="'$(CMakeToolset)' != ''" Include="-T $(CMakeToolset)" />
-      <_CMakeArguments Condition="'$(_CMakePassArchitectureToGenerator)' != ''" Include="-A $(Platform)" />
+      <_CMakeArguments Condition="'$(_CMakePassArchitectureToGenerator)' == 'true'" Include="-A $(Platform)" />
       <_CMakeArguments Condition="'$(CMakeOutputDir)' != ''" Include="-B &quot;$(CMakeOutputDir)&quot;" />
       <_CMakeArguments Condition="'$(CMakeLists)' != ''" Include="-S &quot;$(_NormalizedCMakeListsDirectory)&quot;" />
       <_CMakeDefineArguments Include="@(CMakeDefines->'-D%(Identity)=%(Value)')" />


### PR DESCRIPTION
Fixes bug in https://github.com/dotnet/arcade/pull/4533

We set `_CMakePassArchitectureToGenerator` to `False`:
```
  <PropertyGroup Condition="'$(CMakeGenerator)' == ''">
    <CMakeGenerator Condition="$([MSBuild]::IsOSPlatform(Windows))">Visual Studio</CMakeGenerator>
    <CMakeGenerator Condition="!$([MSBuild]::IsOSPlatform(Windows))">Unix Makefiles</CMakeGenerator>
    <CMakeCompilerToolchain Condition="$([MSBuild]::IsOSPlatform(Windows))">MSVC</CMakeCompilerToolchain>
    <CMakeCompilerToolchain Condition="!$([MSBuild]::IsOSPlatform(Windows))">clang</CMakeCompilerToolchain>
    <_CMakeMultiConfigurationGenerator>false</_CMakeMultiConfigurationGenerator>
    <_CMakePassArchitectureToGenerator>false</_CMakePassArchitectureToGenerator>
  </PropertyGroup>
```

However, when we check this parameter, we compare it the empty string
```
      <_CMakeArguments Condition="'$(_CMakePassArchitectureToGenerator)' != ''" Include="-A $(Platform)" />

```

Therefore, we always pass the platform as a parameter, causing problems.

See https://github.com/dotnet/arcade/pull/4533

/cc @jkoritzinsky