### PR TITLE
Support finding the dotnet executable on non-windows platform in tools.ps1

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -285,7 +285,7 @@ function InstallDotNet([string] $dotnetRoot,
 # Throws on failure.
 #
 function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements = $null) {
-  if (-not IsWindowsPlatform) {
+  if (-not (IsWindowsPlatform)) {
     throw "Cannot initialize Visual Studio on non-Windows"
   }
 
@@ -393,7 +393,7 @@ function InitializeXCopyMSBuild([string]$packageVersion, [bool]$install) {
 # or $null if no instance meeting the requirements is found on the machine.
 #
 function LocateVisualStudio([object]$vsRequirements = $null){
-  if (-not IsWindowsPlatform) {
+  if (-not (IsWindowsPlatform)) {
     throw "Cannot run vswhere on non-Windows platforms."
   }
 
@@ -677,7 +677,7 @@ function GetMSBuildBinaryLogCommandLineArgument($arguments) {
   return $null
 }
 
-function GetExecutableFileName($baseName)} {
+function GetExecutableFileName($baseName) {
   if (IsWindowsPlatform) {
     return "$baseName.exe"
   } else {

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -124,10 +124,8 @@ function InitializeDotNetCli([bool]$install, [bool]$createSdkLocationFile) {
 
   # Find the first path on %PATH% that contains the dotnet.exe
   if ($useInstalledDotNetCli -and (-not $globalJsonHasRuntimes) -and ($env:DOTNET_INSTALL_DIR -eq $null)) {
-    $dotnetCmd = Get-Command 'dotnet.exe' -ErrorAction SilentlyContinue
-    if ($dotnetCmd -eq $null) {
-      $dotnetCmd = Get-Command 'dotnet' -ErrorAction SilentlyContinue
-    }
+    $dotnetExecutable = GetExecutableFileName 'dotnet'
+    $dotnetCmd = Get-Command $dotnetExecutable -ErrorAction SilentlyContinue
 
     if ($dotnetCmd -ne $null) {
       $env:DOTNET_INSTALL_DIR = Split-Path $dotnetCmd.Path -Parent
@@ -287,7 +285,7 @@ function InstallDotNet([string] $dotnetRoot,
 # Throws on failure.
 #
 function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements = $null) {
-  if ([environment]::OSVersion.Platform -ne [PlatformID]::Win32NT) {
+  if (-not IsWindowsPlatform) {
     throw "Cannot initialize Visual Studio on non-Windows"
   }
 
@@ -395,7 +393,7 @@ function InitializeXCopyMSBuild([string]$packageVersion, [bool]$install) {
 # or $null if no instance meeting the requirements is found on the machine.
 #
 function LocateVisualStudio([object]$vsRequirements = $null){
-  if ([Environment]::OSVersion.Platform -ne [PlatformID]::Win32NT) {
+  if (-not IsWindowsPlatform) {
     throw "Cannot run vswhere on non-Windows platforms."
   }
 
@@ -464,14 +462,7 @@ function InitializeBuildTool() {
       Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "/global.json must specify 'tools.dotnet'."
       ExitWithExitCode 1
     }
-    $dotnetPath = Join-Path $dotnetRoot 'dotnet.exe'
-    if (-not (Test-Path $dotnetPath)) {
-      $dotnetPath = Join-Path $dotnetRoot 'dotnet'
-
-      if (-not (Test-Path $dotnetPath)) {
-        throw "Could not find dotnet executable!"
-      }
-    }
+    $dotnetPath = GetExecutableFileName 'dotnet'
     $buildTool = @{ Path = $dotnetPath; Command = 'msbuild'; Tool = 'dotnet'; Framework = 'netcoreapp2.1' }
   } elseif ($msbuildEngine -eq "vs") {
     try {
@@ -684,6 +675,18 @@ function GetMSBuildBinaryLogCommandLineArgument($arguments) {
   }
 
   return $null
+}
+
+function GetExecutableFileName($baseName)} {
+  if (IsWindowsPlatform) {
+    return "$baseName.exe"
+  } else {
+    return $baseName
+  }
+}
+
+function IsWindowsPlatform() {
+  return [environment]::OSVersion.Platform -eq [PlatformID]::Win32NT
 }
 
 . $PSScriptRoot\pipeline-logging-functions.ps1

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -678,10 +678,11 @@ function GetMSBuildBinaryLogCommandLineArgument($arguments) {
 }
 
 function GetExecutableFileName($baseName) {
-  return if (IsWindowsPlatform) {
-    "$baseName.exe"
-  } else {
-    $baseName
+  if (IsWindowsPlatform) {
+    return "$baseName.exe"
+  }
+  else {
+    return $baseName
   }
 }
 

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -462,7 +462,7 @@ function InitializeBuildTool() {
       Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "/global.json must specify 'tools.dotnet'."
       ExitWithExitCode 1
     }
-    $dotnetPath = GetExecutableFileName 'dotnet'
+    $dotnetPath = Join-Path $dotnetRoot (GetExecutableFileName 'dotnet')
     $buildTool = @{ Path = $dotnetPath; Command = 'msbuild'; Tool = 'dotnet'; Framework = 'netcoreapp2.1' }
   } elseif ($msbuildEngine -eq "vs") {
     try {
@@ -678,10 +678,10 @@ function GetMSBuildBinaryLogCommandLineArgument($arguments) {
 }
 
 function GetExecutableFileName($baseName) {
-  if (IsWindowsPlatform) {
-    return "$baseName.exe"
+  return if (IsWindowsPlatform) {
+    "$baseName.exe"
   } else {
-    return $baseName
+    $baseName
   }
 }
 


### PR DESCRIPTION
Today, `tools.ps1` hardcodes the assumption that executables end in .exe, because it assumes that it will only run on Windows. In roslyn, we are creating a few helper scripts for things like running tests in vscode, and it would be very helpful for us to not have to maintain two copies of these scripts between Windows and non-windows. We're using PowershellCore as a global tool on Mac/Linux, but things like `InitializeBuildTool` don't work today because of this hardcoding.

I'm specifically _not_ trying to push for all of arcade's functionality to be done only in Powershell: in particular, I understand the argument around chicken-or-egg of which comes first, PSCore or the script that needs to install dotnet in order to install PSCore. However, by making a few simple changes around not hard-coding dotnet.exe our desired scenarios work, and we don't have to maintain multiple copies of our scripts to run tests, run builds of specific projects, or invoke code generators.

/cc @jaredpar @RikkiGibson. Fixes https://github.com/dotnet/arcade/issues/5403.