### PR TITLE
Workaround NuGet/Home#9532

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateRuntimeDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateRuntimeDependencies.cs
@@ -142,7 +142,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 Directory.CreateDirectory(destRuntimeFileDir);
             }
 
-            JsonRuntimeFormat.WriteRuntimeGraph(destRuntimeFilePath, runtimeGraph);
+            NuGetUtility.WriteRuntimeGraph(destRuntimeFilePath, runtimeGraph);
 
             return true;
         }

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateRuntimeGraph.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateRuntimeGraph.cs
@@ -163,7 +163,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 if (UpdateRuntimeFiles)
                 {
                     EnsureWritable(RuntimeJson);
-                    JsonRuntimeFormat.WriteRuntimeGraph(RuntimeJson, runtimeGraph);
+                    NuGetUtility.WriteRuntimeGraph(RuntimeJson, runtimeGraph);
                 }
                 else
                 {

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetUtility.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetUtility.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Newtonsoft.Json;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
+using NuGet.RuntimeModel;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -83,6 +85,24 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             return versions.Where(v => VersionUtility.As2PartVersion(v) == new Version(eraMajorVersion, eraMinorVersion))
                            .OrderByDescending(v => v)
                            .FirstOrDefault();
+        }
+
+        public static void WriteRuntimeGraph(string filePath, RuntimeGraph runtimeGraph)
+        {
+            using (var fileStream = new FileStream(filePath, FileMode.Create))
+            using (var textWriter = new StreamWriter(fileStream))
+            using (var jsonWriter = new JsonTextWriter(textWriter))
+            using (var writer = new JsonObjectWriter(jsonWriter))
+            {
+                jsonWriter.Formatting = Formatting.Indented;
+
+                // workaround https://github.com/NuGet/Home/issues/9532
+                writer.WriteObjectStart();
+
+                JsonRuntimeFormat.WriteRuntimeGraph(writer, runtimeGraph);
+
+                writer.WriteObjectEnd();
+            }
         }
 
         internal class NuGetLogger : ILogger

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/RuntimeGraphTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/RuntimeGraphTests.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using NuGet.Frameworks;
+using NuGet.RuntimeModel;
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
+{
+    public class RuntimeGraphTests
+    {
+        [Fact]
+        public void RuntimeGraphRoundTrips()
+        {
+            string file = $"{nameof(RuntimeGraphRoundTrips)}.json";
+
+            if (File.Exists(file))
+            {
+                File.Delete(file);
+            }
+
+            RuntimeGraph runtimeGraph = new RuntimeGraph(new[] { new RuntimeDescription("RID") });
+
+            // Issue: https://github.com/NuGet/Home/issues/9532
+            // When this is fixed, this test should fail. Fix it by deleting the NuGetUtility.WriteRuntimeGraph
+            // method and replacing with JsonRuntimeFormat.WriteRuntimeGraph.
+            NuGetUtility.WriteRuntimeGraph(file, runtimeGraph);
+
+            Assert.True(File.Exists(file));
+
+            RuntimeGraph readRuntimeGraph = JsonRuntimeFormat.ReadRuntimeGraph(file);
+
+            Assert.NotNull(readRuntimeGraph);
+            Assert.Equal(runtimeGraph, readRuntimeGraph);
+        }
+    }
+}


### PR DESCRIPTION
Workaround NuGet/Home#9532

A regression in JsonRuntimeFormat.WriteRuntimeGraph caused it to omit
the root object when writing out the runtime graph.

Workaround this by copying WriteRuntimeGraph(string,RuntimeGraph)
and calling StartObject/EndObject.

Add a test to validate round tripping.  Test should fail when bug is fixed
and we can remove the workaround (and keep the test).