### PR TITLE
Disable automatic SDK references for internal tools

### DIFF
--- a/eng/common/internal/Tools.csproj
+++ b/eng/common/internal/Tools.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+    <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
   </PropertyGroup>
   <ItemGroup>
     <!-- Clear references, the SDK may add some depending on UsuingToolXxx settings, but we only want to restore the following -->


### PR DESCRIPTION
The latest SDK adds an automatic reference to `Microsoft.NETFramework.ReferenceAssemblies` if targeting full framework and the targeting pack can't be found in the machine:

https://github.com/dotnet/sdk/commit/714c051d051fdf66a40c01a2d2c517a2a95dbfdb#diff-81720bb5fb8b13c6dff8490812b4c44a

We should disable these references for repos to be able to restore internal tools with the newest SDK since in internal tools restore we shouldn't need to add nuget.org feed as the restore sources.

cc: @ericstj @tmat @ViktorHofer 