### PR TITLE
Add -NoBinaryLog switch to opt-out of binlog in CI

### DIFF
--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -20,7 +20,7 @@ Param(
   [switch] $publish,
   [switch] $clean,
   [switch][Alias('bl')]$binaryLog,
-  [switch][Alias('nobl')]$noCIBinaryLog,
+  [switch][Alias('nobl')]$excludeCIBinlog,
   [switch] $ci,
   [switch] $prepareMachine,
   [switch] $help,
@@ -59,7 +59,7 @@ function Print-Usage() {
   Write-Host "Advanced settings:"
   Write-Host "  -projects <value>       Semi-colon delimited list of sln/proj's to build. Globbing is supported (*.sln)"
   Write-Host "  -ci                     Set when running on CI server"
-  Write-Host "  -noCIBinaryLog          Don't output binary log (short: -nobl)"
+  Write-Host "  -excludeCIBinlog          Don't output binary log (short: -nobl)"
   Write-Host "  -prepareMachine         Prepare machine for CI run, clean up processes after build"
   Write-Host "  -warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
   Write-Host "  -msbuildEngine <value>  Msbuild engine to use to run build ('dotnet', 'vs', or unspecified)."
@@ -136,7 +136,7 @@ try {
   }
 
   if ($ci) {
-    if (-not $noCIBinaryLog) {
+    if (-not $excludeCIBinlog) {
       $binaryLog = $true
     }
     $nodeReuse = $false

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -59,7 +59,7 @@ function Print-Usage() {
   Write-Host "Advanced settings:"
   Write-Host "  -projects <value>       Semi-colon delimited list of sln/proj's to build. Globbing is supported (*.sln)"
   Write-Host "  -ci                     Set when running on CI server"
-  Write-Host "  -noBinaryLog            Don't output binary log (useful when running on CI server) (short: -nobl)"
+  Write-Host "  -noBinaryLog            Don't output binary log (short: -nobl)"
   Write-Host "  -prepareMachine         Prepare machine for CI run, clean up processes after build"
   Write-Host "  -warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
   Write-Host "  -msbuildEngine <value>  Msbuild engine to use to run build ('dotnet', 'vs', or unspecified)."

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -20,6 +20,7 @@ Param(
   [switch] $publish,
   [switch] $clean,
   [switch][Alias('bl')]$binaryLog,
+  [switch][Alias('nobl')]$noBinaryLog,
   [switch] $ci,
   [switch] $prepareMachine,
   [switch] $help,
@@ -58,6 +59,7 @@ function Print-Usage() {
   Write-Host "Advanced settings:"
   Write-Host "  -projects <value>       Semi-colon delimited list of sln/proj's to build. Globbing is supported (*.sln)"
   Write-Host "  -ci                     Set when running on CI server"
+  Write-Host "  -noBinaryLog            Don't output binary log (useful when running on CI server) (short: -nobl)"
   Write-Host "  -prepareMachine         Prepare machine for CI run, clean up processes after build"
   Write-Host "  -warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
   Write-Host "  -msbuildEngine <value>  Msbuild engine to use to run build ('dotnet', 'vs', or unspecified)."
@@ -134,7 +136,9 @@ try {
   }
 
   if ($ci) {
-    $binaryLog = $true
+    if (-not $noBinaryLog) {
+      $binaryLog = $true
+    }
     $nodeReuse = $false
   }
 

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -20,7 +20,7 @@ Param(
   [switch] $publish,
   [switch] $clean,
   [switch][Alias('bl')]$binaryLog,
-  [switch][Alias('nobl')]$excludeCIBinlog,
+  [switch][Alias('nobl')]$excludeCIBinarylog,
   [switch] $ci,
   [switch] $prepareMachine,
   [switch] $help,
@@ -59,7 +59,7 @@ function Print-Usage() {
   Write-Host "Advanced settings:"
   Write-Host "  -projects <value>       Semi-colon delimited list of sln/proj's to build. Globbing is supported (*.sln)"
   Write-Host "  -ci                     Set when running on CI server"
-  Write-Host "  -excludeCIBinlog          Don't output binary log (short: -nobl)"
+  Write-Host "  -excludeCIBinarylog     Don't output binary log (short: -nobl)"
   Write-Host "  -prepareMachine         Prepare machine for CI run, clean up processes after build"
   Write-Host "  -warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
   Write-Host "  -msbuildEngine <value>  Msbuild engine to use to run build ('dotnet', 'vs', or unspecified)."
@@ -136,7 +136,7 @@ try {
   }
 
   if ($ci) {
-    if (-not $excludeCIBinlog) {
+    if (-not $excludeCIBinarylog) {
       $binaryLog = $true
     }
     $nodeReuse = $false

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -20,7 +20,7 @@ Param(
   [switch] $publish,
   [switch] $clean,
   [switch][Alias('bl')]$binaryLog,
-  [switch][Alias('nobl')]$noBinaryLog,
+  [switch][Alias('nobl')]$noCIBinaryLog,
   [switch] $ci,
   [switch] $prepareMachine,
   [switch] $help,
@@ -59,7 +59,7 @@ function Print-Usage() {
   Write-Host "Advanced settings:"
   Write-Host "  -projects <value>       Semi-colon delimited list of sln/proj's to build. Globbing is supported (*.sln)"
   Write-Host "  -ci                     Set when running on CI server"
-  Write-Host "  -noBinaryLog            Don't output binary log (short: -nobl)"
+  Write-Host "  -noCIBinaryLog          Don't output binary log (short: -nobl)"
   Write-Host "  -prepareMachine         Prepare machine for CI run, clean up processes after build"
   Write-Host "  -warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
   Write-Host "  -msbuildEngine <value>  Msbuild engine to use to run build ('dotnet', 'vs', or unspecified)."
@@ -136,7 +136,7 @@ try {
   }
 
   if ($ci) {
-    if (-not $noBinaryLog) {
+    if (-not $noCIBinaryLog) {
       $binaryLog = $true
     }
     $nodeReuse = $false

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -32,7 +32,7 @@ usage()
   echo "Advanced settings:"
   echo "  --projects <value>       Project or solution file(s) to build"
   echo "  --ci                     Set when running on CI server"
-  echo "  --excludeCIBinlog          Don't output binary log (short: -nobl)"
+  echo "  --excludeCIBinarylog     Don't output binary log (short: -nobl)"
   echo "  --prepareMachine         Prepare machine for CI run, clean up processes after build"
   echo "  --nodeReuse <value>      Sets nodereuse msbuild parameter ('true' or 'false')"
   echo "  --warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
@@ -100,7 +100,7 @@ while [[ $# > 0 ]]; do
     -binarylog|-bl)
       binary_log=true
       ;;
-    -excludeCIBinlog|-nobl)
+    -excludeCIBinarylog|-nobl)
       exclude_ci_binary_log=true
       ;;
     -pipelineslog|-pl)

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -32,7 +32,7 @@ usage()
   echo "Advanced settings:"
   echo "  --projects <value>       Project or solution file(s) to build"
   echo "  --ci                     Set when running on CI server"
-  echo "  --noCIBinaryLog          Don't output binary log (short: -nobl)"
+  echo "  --excludeCIBinlog          Don't output binary log (short: -nobl)"
   echo "  --prepareMachine         Prepare machine for CI run, clean up processes after build"
   echo "  --nodeReuse <value>      Sets nodereuse msbuild parameter ('true' or 'false')"
   echo "  --warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
@@ -69,7 +69,7 @@ clean=false
 warn_as_error=true
 node_reuse=true
 binary_log=false
-no_ci_binary_log=false
+exclude_ci_binary_log=false
 pipelines_log=false
 
 projects=''
@@ -100,8 +100,8 @@ while [[ $# > 0 ]]; do
     -binarylog|-bl)
       binary_log=true
       ;;
-    -noCIBinarylog|-nobl)
-      no_ci_binary_log=true
+    -excludeCIBinlog|-nobl)
+      exclude_ci_binary_log=true
       ;;
     -pipelineslog|-pl)
       pipelines_log=true
@@ -162,7 +162,7 @@ done
 if [[ "$ci" == true ]]; then
   pipelines_log=true
   node_reuse=false
-  if [[ "$no_ci_binary_log" == false ]]; then
+  if [[ "$exclude_ci_binary_log" == false ]]; then
     binary_log=true
   fi
 fi

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -32,7 +32,7 @@ usage()
   echo "Advanced settings:"
   echo "  --projects <value>       Project or solution file(s) to build"
   echo "  --ci                     Set when running on CI server"
-  echo "  --noBinaryLog            Don't output binary log"
+  echo "  --noCIBinaryLog          Don't output binary log (short: -nobl)"
   echo "  --prepareMachine         Prepare machine for CI run, clean up processes after build"
   echo "  --nodeReuse <value>      Sets nodereuse msbuild parameter ('true' or 'false')"
   echo "  --warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
@@ -69,7 +69,7 @@ clean=false
 warn_as_error=true
 node_reuse=true
 binary_log=false
-no_binary_log=false
+no_ci_binary_log=false
 pipelines_log=false
 
 projects=''
@@ -100,8 +100,8 @@ while [[ $# > 0 ]]; do
     -binarylog|-bl)
       binary_log=true
       ;;
-    -noBinarylog|-nobl)
-      no_binary_log=true
+    -noCIBinarylog|-nobl)
+      no_ci_binary_log=true
       ;;
     -pipelineslog|-pl)
       pipelines_log=true
@@ -162,7 +162,7 @@ done
 if [[ "$ci" == true ]]; then
   pipelines_log=true
   node_reuse=false
-  if [[ "$no_binary_log" == false ]]; then
+  if [[ "$no_ci_binary_log" == false ]]; then
     binary_log=true
   fi
 fi

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -162,7 +162,7 @@ done
 if [[ "$ci" == true ]]; then
   pipelines_log=true
   node_reuse=false
-  if [[ "$binary_log" == false ]]; then
+  if [[ "$no_binary_log" == false ]]; then
     binary_log=true
   fi
 fi

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -32,6 +32,7 @@ usage()
   echo "Advanced settings:"
   echo "  --projects <value>       Project or solution file(s) to build"
   echo "  --ci                     Set when running on CI server"
+  echo "  --noBinaryLog            Don't output binary log (useful when running on CI server) (short: -nobl)"
   echo "  --prepareMachine         Prepare machine for CI run, clean up processes after build"
   echo "  --nodeReuse <value>      Sets nodereuse msbuild parameter ('true' or 'false')"
   echo "  --warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
@@ -68,6 +69,7 @@ clean=false
 warn_as_error=true
 node_reuse=true
 binary_log=false
+no_binary_log=false
 pipelines_log=false
 
 projects=''
@@ -97,6 +99,9 @@ while [[ $# > 0 ]]; do
       ;;
     -binarylog|-bl)
       binary_log=true
+      ;;
+    -noBinarylog|-nobl)
+      no_binary_log=true
       ;;
     -pipelineslog|-pl)
       pipelines_log=true
@@ -156,8 +161,10 @@ done
 
 if [[ "$ci" == true ]]; then
   pipelines_log=true
-  binary_log=true
   node_reuse=false
+  if [[ "$binary_log=false" ]]; then
+    binary_log=true
+  fi
 fi
 
 . "$scriptroot/tools.sh"

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -32,7 +32,7 @@ usage()
   echo "Advanced settings:"
   echo "  --projects <value>       Project or solution file(s) to build"
   echo "  --ci                     Set when running on CI server"
-  echo "  --noBinaryLog            Don't output binary log (useful when running on CI server) (short: -nobl)"
+  echo "  --noBinaryLog            Don't output binary log"
   echo "  --prepareMachine         Prepare machine for CI run, clean up processes after build"
   echo "  --nodeReuse <value>      Sets nodereuse msbuild parameter ('true' or 'false')"
   echo "  --warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
@@ -162,7 +162,7 @@ done
 if [[ "$ci" == true ]]; then
   pipelines_log=true
   node_reuse=false
-  if [[ "$binary_log=false" ]]; then
+  if [[ "$binary_log" == false ]]; then
     binary_log=true
   fi
 fi

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -8,10 +8,10 @@
 [string]$configuration = if (Test-Path variable:configuration) { $configuration } else { 'Debug' }
 
 # Set to true to opt out of outputting binary log while running in CI
-[bool]$noCIBinaryLog = if (Test-Path variable:noCIBinaryLog) { $noCIBinaryLog } else { $false }
+[bool]$excludeCIBinlog = if (Test-Path variable:excludeCIBinlog) { $excludeCIBinlog } else { $false }
 
 # Set to true to output binary log from msbuild. Note that emitting binary log slows down the build.
-[bool]$binaryLog = if (Test-Path variable:binaryLog) { $binaryLog } else { $ci -and !$noCIBinaryLog }
+[bool]$binaryLog = if (Test-Path variable:binaryLog) { $binaryLog } else { $ci -and !$excludeCIBinlog }
 
 # Set to true to use the pipelines logger which will enable Azure logging output.
 # https://github.com/Microsoft/azure-pipelines-tasks/blob/master/docs/authoring/commands.md
@@ -607,8 +607,8 @@ function MSBuild() {
 #
 function MSBuild-Core() {
   if ($ci) {
-    if (!$binaryLog -and !$noCIBinaryLog) {
-      Write-PipelineTelemetryError -Category 'Build' -Message 'Binary log must be enabled in CI build, or explicitly opted-out from with the -noCIBinaryLog switch.'
+    if (!$binaryLog -and !$excludeCIBinlog) {
+      Write-PipelineTelemetryError -Category 'Build' -Message 'Binary log must be enabled in CI build, or explicitly opted-out from with the -excludeCIBinlog switch.'
       ExitWithExitCode 1
     }
 

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -7,16 +7,11 @@
 # Build configuration. Common values include 'Debug' and 'Release', but the repository may use other names.
 [string]$configuration = if (Test-Path variable:configuration) { $configuration } else { 'Debug' }
 
-# Set to true to output binary log from msbuild. Note that emitting binary log slows down the build.
-[bool]$binaryLog = if (Test-Path variable:binaryLog) { $binaryLog } else { $ci }
-
-# Set to true to opt out of outputing binary log while running in CI
+# Set to true to opt out of outputting binary log while running in CI
 [bool]$noBinaryLog = if (Test-Path variable:noBinaryLog) { $noBinaryLog } else { $false }
 
-# Correct the value of $binaryLog if the user wants to opt out while running in CI
-if ($ci -and $noBinaryLog) {
-  $binaryLog = $false
-}
+# Set to true to output binary log from msbuild. Note that emitting binary log slows down the build.
+[bool]$binaryLog = if (Test-Path variable:binaryLog) { $binaryLog } else { $ci -and !$noBinaryLog }
 
 # Set to true to use the pipelines logger which will enable Azure logging output.
 # https://github.com/Microsoft/azure-pipelines-tasks/blob/master/docs/authoring/commands.md

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -8,10 +8,10 @@
 [string]$configuration = if (Test-Path variable:configuration) { $configuration } else { 'Debug' }
 
 # Set to true to opt out of outputting binary log while running in CI
-[bool]$excludeCIBinlog = if (Test-Path variable:excludeCIBinlog) { $excludeCIBinlog } else { $false }
+[bool]$excludeCIBinarylog = if (Test-Path variable:excludeCIBinarylog) { $excludeCIBinarylog } else { $false }
 
 # Set to true to output binary log from msbuild. Note that emitting binary log slows down the build.
-[bool]$binaryLog = if (Test-Path variable:binaryLog) { $binaryLog } else { $ci -and !$excludeCIBinlog }
+[bool]$binaryLog = if (Test-Path variable:binaryLog) { $binaryLog } else { $ci -and !$excludeCIBinarylog }
 
 # Set to true to use the pipelines logger which will enable Azure logging output.
 # https://github.com/Microsoft/azure-pipelines-tasks/blob/master/docs/authoring/commands.md
@@ -607,8 +607,8 @@ function MSBuild() {
 #
 function MSBuild-Core() {
   if ($ci) {
-    if (!$binaryLog -and !$excludeCIBinlog) {
-      Write-PipelineTelemetryError -Category 'Build' -Message 'Binary log must be enabled in CI build, or explicitly opted-out from with the -excludeCIBinlog switch.'
+    if (!$binaryLog -and !$excludeCIBinarylog) {
+      Write-PipelineTelemetryError -Category 'Build' -Message 'Binary log must be enabled in CI build, or explicitly opted-out from with the -excludeCIBinarylog switch.'
       ExitWithExitCode 1
     }
 

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -8,10 +8,10 @@
 [string]$configuration = if (Test-Path variable:configuration) { $configuration } else { 'Debug' }
 
 # Set to true to opt out of outputting binary log while running in CI
-[bool]$noBinaryLog = if (Test-Path variable:noBinaryLog) { $noBinaryLog } else { $false }
+[bool]$noCIBinaryLog = if (Test-Path variable:noCIBinaryLog) { $noCIBinaryLog } else { $false }
 
 # Set to true to output binary log from msbuild. Note that emitting binary log slows down the build.
-[bool]$binaryLog = if (Test-Path variable:binaryLog) { $binaryLog } else { $ci -and !$noBinaryLog }
+[bool]$binaryLog = if (Test-Path variable:binaryLog) { $binaryLog } else { $ci -and !$noCIBinaryLog }
 
 # Set to true to use the pipelines logger which will enable Azure logging output.
 # https://github.com/Microsoft/azure-pipelines-tasks/blob/master/docs/authoring/commands.md
@@ -607,8 +607,8 @@ function MSBuild() {
 #
 function MSBuild-Core() {
   if ($ci) {
-    if (!$binaryLog -and !$noBinaryLog) {
-      Write-PipelineTelemetryError -Category 'Build' -Message 'Binary log must be enabled in CI build, or explicitly opted-out from with the -noBinaryLog switch.'
+    if (!$binaryLog -and !$noCIBinaryLog) {
+      Write-PipelineTelemetryError -Category 'Build' -Message 'Binary log must be enabled in CI build, or explicitly opted-out from with the -noCIBinaryLog switch.'
       ExitWithExitCode 1
     }
 

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -19,10 +19,10 @@ fi
 configuration=${configuration:-'Debug'}
 
 # Set to true to opt out of outputting binary log while running in CI
-no_ci_binary_log=${no_ci_binary_log:-false}
+exclude_ci_binary_log=${exclude_ci_binary_log:-false}
 
 # Set to true to output binary log from msbuild. Note that emitting binary log slows down the build.
-binary_log=${binary_log:-$ci && -n $no_ci_binary_log}
+binary_log=${binary_log:-$ci && -n $exclude_ci_binary_log}
 
 # Turns on machine preparation/clean up code that changes the machine state (e.g. kills build processes).
 prepare_machine=${prepare_machine:-false}
@@ -406,7 +406,7 @@ function MSBuild {
 
 function MSBuild-Core {
   if [[ "$ci" == true ]]; then
-    if [[ "$binary_log" != true && "$no_ci_binary_log" != true ]]; then
+    if [[ "$binary_log" != true && "$exclude_ci_binary_log" != true ]]; then
       Write-PipelineTelemetryError -category 'Build'  "Binary log must be enabled in CI build, or explicitly opted-out from with the -noBinaryLog switch."
       ExitWithExitCode 1
     fi

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -24,11 +24,6 @@ no_ci_binary_log=${no_ci_binary_log:-false}
 # Set to true to output binary log from msbuild. Note that emitting binary log slows down the build.
 binary_log=${binary_log:-$ci && -n $no_ci_binary_log}
 
-# Correct the value of $binaryLog if the user wants to opt out while running in CI
-if [[ "$ci" == true && "$no_ci_binary_log" == true ]]; then
-  binary_log=false
-fi
-
 # Turns on machine preparation/clean up code that changes the machine state (e.g. kills build processes).
 prepare_machine=${prepare_machine:-false}
 

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -21,8 +21,14 @@ configuration=${configuration:-'Debug'}
 # Set to true to opt out of outputting binary log while running in CI
 exclude_ci_binary_log=${exclude_ci_binary_log:-false}
 
+if [[ "$ci" == true && "$exclude_ci_binary_log" == false ]]; then
+  binary_log_default=true
+else
+  binary_log_default=false
+fi
+
 # Set to true to output binary log from msbuild. Note that emitting binary log slows down the build.
-binary_log=${binary_log:-$ci && -n $exclude_ci_binary_log}
+binary_log=${binary_log:-$binary_log_default}
 
 # Turns on machine preparation/clean up code that changes the machine state (e.g. kills build processes).
 prepare_machine=${prepare_machine:-false}

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -21,13 +21,13 @@ configuration=${configuration:-'Debug'}
 # Set to true to output binary log from msbuild. Note that emitting binary log slows down the build.
 binary_log=${binary_log:-$ci}
 
-# Set to true to opt out of outputing binary log while running in CI
+# Set to true to opt out of outputting binary log while running in CI
 no_binary_log=${no_binary_log:-false}
 
 # Correct the value of $binaryLog if the user wants to opt out while running in CI
 if [[ "$ci" == true && "$no_binary_log" == true ]]; then
   binary_log=false
-}
+fi
 
 # Turns on machine preparation/clean up code that changes the machine state (e.g. kills build processes).
 prepare_machine=${prepare_machine:-false}

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -18,14 +18,14 @@ fi
 # Build configuration. Common values include 'Debug' and 'Release', but the repository may use other names.
 configuration=${configuration:-'Debug'}
 
-# Set to true to output binary log from msbuild. Note that emitting binary log slows down the build.
-binary_log=${binary_log:-$ci}
-
 # Set to true to opt out of outputting binary log while running in CI
-no_binary_log=${no_binary_log:-false}
+no_ci_binary_log=${no_ci_binary_log:-false}
+
+# Set to true to output binary log from msbuild. Note that emitting binary log slows down the build.
+binary_log=${binary_log:-$ci && -n $no_ci_binary_log}
 
 # Correct the value of $binaryLog if the user wants to opt out while running in CI
-if [[ "$ci" == true && "$no_binary_log" == true ]]; then
+if [[ "$ci" == true && "$no_ci_binary_log" == true ]]; then
   binary_log=false
 fi
 
@@ -411,7 +411,7 @@ function MSBuild {
 
 function MSBuild-Core {
   if [[ "$ci" == true ]]; then
-    if [[ "$binary_log" != true && "$no_binary_log" != true ]]; then
+    if [[ "$binary_log" != true && "$no_ci_binary_log" != true ]]; then
       Write-PipelineTelemetryError -category 'Build'  "Binary log must be enabled in CI build, or explicitly opted-out from with the -noBinaryLog switch."
       ExitWithExitCode 1
     fi

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -19,8 +19,15 @@ fi
 configuration=${configuration:-'Debug'}
 
 # Set to true to output binary log from msbuild. Note that emitting binary log slows down the build.
-# Binary log must be enabled on CI.
 binary_log=${binary_log:-$ci}
+
+# Set to true to opt out of outputing binary log while running in CI
+no_binary_log=${no_binary_log:-false}
+
+# Correct the value of $binaryLog if the user wants to opt out while running in CI
+if [[ "$ci" == true && "$no_binary_log" == true ]]; then
+  binary_log=false
+}
 
 # Turns on machine preparation/clean up code that changes the machine state (e.g. kills build processes).
 prepare_machine=${prepare_machine:-false}
@@ -404,8 +411,8 @@ function MSBuild {
 
 function MSBuild-Core {
   if [[ "$ci" == true ]]; then
-    if [[ "$binary_log" != true ]]; then
-      Write-PipelineTelemetryError -category 'Build'  "Binary log must be enabled in CI build."
+    if [[ "$binary_log" != true && "$no_binary_log" != true ]]; then
+      Write-PipelineTelemetryError -category 'Build'  "Binary log must be enabled in CI build, or explicitly opted-out from with the -noBinaryLog switch."
       ExitWithExitCode 1
     fi
 


### PR DESCRIPTION
Some repos may want to opt-out of creating a binlog while in CI. For example currently, the AspNetCore binlog is currently large enough that it's hitting an msbuild error causing the build to OOM occasionally: https://github.com/dotnet/aspnetcore/pull/21478. This PR adds a `-NoBinaryLog` switch that can be passed along with `-CI` to opt out of producing a binlog. It's kind of an ugly solution, but I couldn't think of another one that wasn't breaking. Changing the behavior of `-CI` would break repos that assumed passing `-CI` would create a binlog, and changing `-Bl` from a switch to a bool would break folks in a similar way. I'm open to suggestions, though.