### PR TITLE
Fix TestPlatformApplies when Any is used.

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
@@ -20,6 +20,7 @@ namespace Microsoft.DotNet.XUnitExtensions
         public static bool IsRunningOnNetFramework { get; } = RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
 
         public static bool TestPlatformApplies(TestPlatforms platforms) =>
+                (platforms.HasFlag(TestPlatforms.Any) ||
                 (platforms.HasFlag(TestPlatforms.FreeBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"))) ||
                 (platforms.HasFlag(TestPlatforms.Linux) && RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) ||
                 (platforms.HasFlag(TestPlatforms.NetBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"))) ||

--- a/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.XUnitExtensions
         public static bool IsRunningOnNetFramework { get; } = RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
 
         public static bool TestPlatformApplies(TestPlatforms platforms) =>
-                (platforms.HasFlag(TestPlatforms.Any) ||
+                (platforms.HasFlag(TestPlatforms.Any)) ||
                 (platforms.HasFlag(TestPlatforms.FreeBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"))) ||
                 (platforms.HasFlag(TestPlatforms.Linux) && RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) ||
                 (platforms.HasFlag(TestPlatforms.NetBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"))) ||


### PR DESCRIPTION
If the method receives a TestPlatform.Any flag it does not need to test
against all the platforms, since they are all included. Simply check for
that value first to make sure that we will return true.

This was discovered when trying to get the Traits on iOS and Android in
the ActiveIssue attribute which was returning none.