### PR TITLE
use inclusion list to add DropFromSingleFile attribute

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/CreateFrameworkListFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/CreateFrameworkListFile.cs
@@ -46,6 +46,8 @@ namespace Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk
 
         public string[] TargetFilePrefixes { get; set; }
 
+        public string[] SingleFileHostIncludeList { get; set; }
+
         /// <summary>
         /// Extra attributes to place on the root node.
         /// 
@@ -67,6 +69,8 @@ namespace Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk
                     item => item.ItemSpec,
                     item => item,
                     StringComparer.OrdinalIgnoreCase);
+
+            var singleFileHostIncludeSet = SingleFileHostIncludeList?.ToHashSet();
 
             var usedFileClasses = new HashSet<string>();
 
@@ -183,6 +187,17 @@ namespace Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk
                     else
                     {
                         Log.LogError($"File matches no classification: {f.Filename}");
+                    }
+                }
+
+                if (f.IsNative)
+                {
+                    // presence of inclusion list indicates that 
+                    // all other native files should be marked as "DropFromSingleFile"
+                    if (singleFileHostIncludeSet != null &&
+                        !singleFileHostIncludeSet.Contains(f.Filename))
+                    {
+                        element.Add(new XAttribute("DropFromSingleFile", "true"));
                     }
                 }
 

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/CreateFrameworkListFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/CreateFrameworkListFile.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk
 
         public string[] TargetFilePrefixes { get; set; }
 
-        public string[] SingleFileHostIncludeList { get; set; }
+        public string[] SingleFileHostIncludeFilenames { get; set; }
 
         /// <summary>
         /// Extra attributes to place on the root node.
@@ -70,7 +70,7 @@ namespace Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk
                     item => item,
                     StringComparer.OrdinalIgnoreCase);
 
-            var singleFileHostIncludeSet = SingleFileHostIncludeList?.ToHashSet();
+            var singleFileHostIncludeFilenames = SingleFileHostIncludeFilenames?.ToHashSet();
 
             var usedFileClasses = new HashSet<string>();
 
@@ -194,8 +194,8 @@ namespace Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk
                 {
                     // presence of inclusion list indicates that 
                     // all other native files should be marked as "DropFromSingleFile"
-                    if (singleFileHostIncludeSet != null &&
-                        !singleFileHostIncludeSet.Contains(f.Filename))
+                    if (singleFileHostIncludeFilenames != null &&
+                        !singleFileHostIncludeFilenames.Contains(f.Filename))
                     {
                         element.Add(new XAttribute("DropFromSingleFile", "true"));
                     }


### PR DESCRIPTION
Another take at "mark native files in RuntimeList.xml as `DropFromSingleFile` unless from a specific list of known files" 
see previous attempt at  https://github.com/dotnet/runtime/pull/36047

This time the code that sets the attributes is going to be in Arcade, while the inclusion list will be passed by runtime build, so that the feature could be turned on and configured without further changes on Arcade side.

This whole deal is a step towards  https://github.com/dotnet/sdk/issues/11567