### PR TITLE
Reenable XHarness tests, use both an x86 and x64

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -128,20 +128,19 @@ stages:
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''
-# Disabled until https://github.com/dotnet/core-eng/issues/9820 is addressed              
-#          - powershell: eng\common\build.ps1
-#              -configuration $(_BuildConfig) 
-#              -prepareMachine
-#              -ci
-#              -restore
-#              -test
-#              -projects $(Build.SourcesDirectory)\tests\UnitTests.XHarness.Android.proj
-#              /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.XHarness.binlog
-#              /p:RestoreUsingNuGetTargets=false
-#            displayName: XHarness Android Helix Testing
-#            env:
-#              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-#              HelixAccessToken: ''              
+          - powershell: eng\common\build.ps1
+              -configuration $(_BuildConfig) 
+              -prepareMachine
+              -ci
+              -restore
+              -test
+              -projects $(Build.SourcesDirectory)\tests\UnitTests.XHarness.Android.proj
+              /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.XHarness.binlog
+              /p:RestoreUsingNuGetTargets=false
+            displayName: XHarness Android Helix Testing
+            env:
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+              HelixAccessToken: ''              
         - job: Linux
           container: LinuxContainer
           pool:

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -76,7 +76,7 @@
     <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>5.0.0-beta.20261.9</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
     <XliffTasksVersion>1.0.0-beta.20206.1</XliffTasksVersion>
     <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.20224.5</MicrosoftDotNetMaestroTasksVersion>
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20257.2</MicrosoftDotNetXHarnessCLIVersion>
+    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20268.3</MicrosoftDotNetXHarnessCLIVersion>
     <MicrosoftSymbolUploaderBuildTaskVersion>1.1.125701</MicrosoftSymbolUploaderBuildTaskVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.Helix.Sdk
 
             string outputDirectory = IsPosixShell ? "$HELIX_WORKITEM_ROOT" : "%HELIX_WORKITEM_ROOT%";
             string xharnessRunCommand = $"xharness android test --app {Path.GetFileName(appPackage.ItemSpec)} --output-directory={outputDirectory} " +
-                                          $"--timeout={xHarnessTimeout.TotalSeconds} -p={androidPackageName} {outputPathArg} {instrumentationArg} {arguments} -v";
+                                        $"--timeout={xHarnessTimeout.TotalSeconds} -p={androidPackageName} {outputPathArg} {instrumentationArg} {arguments} -v";
 
             Log.LogMessage(MessageImportance.Low, $"Generated XHarness command: {xharnessRunCommand}");
 

--- a/tests/XHarness/XHarness.TestApk.proj
+++ b/tests/XHarness/XHarness.TestApk.proj
@@ -13,11 +13,9 @@
       <Output TaskParameter="DownloadedFile" ItemName="DownloadedApkFile" />
     </DownloadFile>
 
-    <!-- Disabled until we have both kinds of emulator available, otherwise this will fail
     <DownloadFile SourceUrl="$(XHarnessX64TestApkUrl)" DestinationFolder="$(BaseOutputPath)apk/x86_64" SkipUnchangedFiles="True" Retries="5">
       <Output TaskParameter="DownloadedFile" ItemName="DownloadedApkFile" />
     </DownloadFile> 
-    -->
 
     <Message Text="Downloaded @(DownloadedApkFile) for XHarness Test purposes" Importance="High" />
 


### PR DESCRIPTION
Updated XHarness to work (by explicitly selecting device) when > 1 device or emulator is attached to the machine