### PR TITLE
Version light command packages

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/AfterSolutionBuild.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/AfterSolutionBuild.proj
@@ -10,26 +10,6 @@
   <Target Name="IntegrationTest" />
   <Target Name="PerformanceTest" />
 
-  <Import Project="Version.BeforeCommonTargets.targets" />
-  <Import Project="$(RepoRoot)/eng/AfterSolutionBuild.props" Condition="Exists('$(RepoRoot)/eng/AfterSolutionBuild.props')" />
-  <!-- LightCommandPackagesDir is created by the "CreateLightCommandPackageDrop" task which runs in the wix targets
-       https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets.  A default value
-       is defined in Arcade, https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props -->
-  <Target Name="CreateLightCommandPackageZip"
-          Condition="Exists('$(LightCommandPackagesDir)')"
-          AfterTargets="Build">
-    <PropertyGroup>
-      <LightCommandPackagesName>LightCommandPackages</LightCommandPackagesName>
-      <LightCommandPackagesName Condition="'$(Version)' != ''">$(LightCommandPackagesName)-$(Version)</LightCommandPackagesName>
-      <LightCommandPackagesName Condition="'$(LightCommandPackagesNameSuffix)' != ''">$(LightCommandPackagesName)-$(LightCommandPackagesNameSuffix)</LightCommandPackagesName>
-      <LightCommandPackagesName>$(LightCommandPackagesName).zip</LightCommandPackagesName>
-    </PropertyGroup>
-    <ZipDirectory
-      DestinationFile="$(ArtifactsDir)$(LightCommandPackagesName)"
-      Overwrite="true"
-      SourceDirectory="$(LightCommandPackagesDir)" />
-  </Target>
-
   <Import Project="BuildReleasePackages.targets" Condition="'$(UsingToolNuGetRepack)' == 'true'" />
 
   <!-- Repository extension point -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/AfterSolutionBuild.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/AfterSolutionBuild.proj
@@ -1,4 +1,4 @@
-﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
   <Import Project="BuildStep.props" />
 
@@ -10,14 +10,22 @@
   <Target Name="IntegrationTest" />
   <Target Name="PerformanceTest" />
 
+  <Import Project="Version.BeforeCommonTargets.targets" />
+  <Import Project="$(RepoRoot)/eng/AfterSolutionBuild.props" Condition="Exists('$(RepoRoot)/eng/AfterSolutionBuild.props')" />
   <!-- LightCommandPackagesDir is created by the "CreateLightCommandPackageDrop" task which runs in the wix targets
        https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets.  A default value
        is defined in Arcade, https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props -->
   <Target Name="CreateLightCommandPackageZip"
           Condition="Exists('$(LightCommandPackagesDir)')"
           AfterTargets="Build">
+    <PropertyGroup>
+      <LightCommandPackagesName>LightCommandPackages</LightCommandPackagesName>
+      <LightCommandPackagesName Condition="'$(Version)' != ''">$(LightCommandPackagesName)-$(Version)</LightCommandPackagesName>
+      <LightCommandPackagesName Condition="'$(LightCommandPackagesNameSuffix)' != ''">$(LightCommandPackagesName)-$(LightCommandPackagesNameSuffix)</LightCommandPackagesName>
+      <LightCommandPackagesName>$(LightCommandPackagesName).zip</LightCommandPackagesName>
+    </PropertyGroup>
     <ZipDirectory
-      DestinationFile="$(ArtifactsDir)LightCommandPackages.zip"
+      DestinationFile="$(ArtifactsDir)$(LightCommandPackagesName)"
       Overwrite="true"
       SourceDirectory="$(LightCommandPackagesDir)" />
   </Target>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props
@@ -62,6 +62,7 @@
     <VisualStudioSetupInsertionPath>$([MSBuild]::NormalizeDirectory('$(VisualStudioSetupOutputPath)', 'Insertion'))</VisualStudioSetupInsertionPath>
     <VisualStudioSetupIntermediateOutputPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'VSSetup.obj', '$(Configuration)'))</VisualStudioSetupIntermediateOutputPath>
     <VisualStudioBuildPackagesDir>$([MSBuild]::NormalizeDirectory('$(VisualStudioSetupOutputPath)', 'DevDivPackages'))</VisualStudioBuildPackagesDir>
-    <LightCommandPackagesDir>$(ArtifactsDir)LightCommandPackages/</LightCommandPackagesDir>
+    <LightCommandObjDir>$(ArtifactsObjDir)/LightCommandPackages</LightCommandObjDir>
+    <LightCommandPackagesDir>$(ArtifactsNonShippingPackagesDir)</LightCommandPackagesDir>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props
@@ -62,7 +62,5 @@
     <VisualStudioSetupInsertionPath>$([MSBuild]::NormalizeDirectory('$(VisualStudioSetupOutputPath)', 'Insertion'))</VisualStudioSetupInsertionPath>
     <VisualStudioSetupIntermediateOutputPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'VSSetup.obj', '$(Configuration)'))</VisualStudioSetupIntermediateOutputPath>
     <VisualStudioBuildPackagesDir>$([MSBuild]::NormalizeDirectory('$(VisualStudioSetupOutputPath)', 'DevDivPackages'))</VisualStudioBuildPackagesDir>
-    <LightCommandObjDir>$(ArtifactsObjDir)/LightCommandPackages</LightCommandObjDir>
-    <LightCommandPackagesDir>$(ArtifactsNonShippingPackagesDir)</LightCommandPackagesDir>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/CreateLightCommandPackageDrop.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/CreateLightCommandPackageDrop.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk.src
         private const int _fieldsArtifactPath2 = 1;
 
         [Required]
-        public string LightCommandPackageDir { get; set; }
+        public string LightCommandWorkingDir { get; set; }
         public bool NoLogo { get; set; }
         public bool Fv { get; set; }
         public string PdbOut { get; set; }
@@ -37,13 +37,17 @@ namespace Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk.src
         [Required]
         public ITaskItem [] WixSrcFiles { get; set; }
 
+        [Output]
+        public string LightCommandPackageNameOutput { get; set; }
         // The light command that was originally used to generate the MSI.  This is purely used for informational purposes
         // and to validate that the light command being created by this task is correct (assist with debugging).
         public string OriginalLightCommand { get; set; }
 
         public override bool ExecuteCore()
         {
-            string packageDropOutputFolder = Path.Combine(LightCommandPackageDir, Path.GetFileNameWithoutExtension(Out));
+            LightCommandPackageNameOutput = Path.GetFileNameWithoutExtension(Out);
+            string packageDropOutputFolder = Path.Combine(LightCommandWorkingDir, LightCommandPackageNameOutput);
+
             if (!Directory.Exists(packageDropOutputFolder))
             {
                 Directory.CreateDirectory(packageDropOutputFolder);

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/packaging-tools.props
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/packaging-tools.props
@@ -16,6 +16,9 @@
     <InstallerSourceIntermediateOutputDir>$(ArtifactsObjDir)$(InstallerSourceOSPlatformConfig)\$(MSBuildProjectName)\</InstallerSourceIntermediateOutputDir>
 
     <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
+
+    <LightCommandObjDir>$(ArtifactsObjDir)/LightCommandPackages</LightCommandObjDir>
+    <LightCommandPackagesDir>$(ArtifactsNonShippingPackagesDir)</LightCommandPackagesDir>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets
@@ -329,13 +329,20 @@
 
     <CreateLightCommandPackageDrop
       OriginalLightCommand="$(_lightCommand)"
-      LightCommandPackageDir="$(LightCommandPackagesDir)"
+      LightCommandWorkingDir="$(LightCommandObjDir)"
       NoLogo="true"
       Cultures="en-us"
       Out="$(OutInstallerFile)"
       WixExtensions="@(WixExtensions)"
       WixSrcFiles="@(WixSrcFile -> '$(WixObjDir)%(Filename).wixobj');@(DirectoryToHarvest -> '%(WixObjFile)')"
-      Condition="'$(EnableCreateLightCommandPackageDrop)' == 'true'" />
+      Condition="'$(EnableCreateLightCommandPackageDrop)' == 'true'">
+      <Output TaskParameter="LightCommandPackageNameOutput" PropertyName="_LightCommandPackageNameOutput" />
+    </CreateLightCommandPackageDrop>
+
+    <ZipDirectory
+      DestinationFile="$(LightCommandPackagesDir)/LightCommandPackage-$(_LightCommandPackageNameOutput).zip"
+      Overwrite="true"
+      SourceDirectory="$(LightCommandObjDir)/$(_LightCommandPackageNameOutput)" />
   </Target>
 
   <!--


### PR DESCRIPTION
Fixes https://github.com/dotnet/core-eng/issues/9825

Creates packages named via Arcade versioning semantics like 

- `LightCommandPackages-5.0.0-ci.zip` - local dev build

or 

- `LightCommandPackages-5.0.0-ci-win-x64.zip` - local dev build in a repo which defines an optional suffix via `eng/AfterSolutionBuild.props`

FYI @NikolaMilosavljevic 