### PR TITLE
Add parallelism symbol validation

### DIFF
--- a/eng/common/post-build/symbols-validation.ps1
+++ b/eng/common/post-build/symbols-validation.ps1
@@ -6,69 +6,25 @@ param(
   [Parameter(Mandatory=$false)][switch] $Clean                  # Clean extracted symbols directory after checking symbols
 )
 
-function FirstMatchingSymbolDescriptionOrDefault {
-  param( 
-    [string] $FullPath,                  # Full path to the module that has to be checked
-    [string] $TargetServerParam,         # Parameter to pass to `Symbol Tool` indicating the server to lookup for symbols
-    [string] $SymbolsPath
-  )
+# Maximum number of jobs to run in parallel
+$MaxParallelJobs = 6
 
-  $FileName = [System.IO.Path]::GetFileName($FullPath)
-  $Extension = [System.IO.Path]::GetExtension($FullPath)
+# Wait time between check for system load
+$SecondsBetweenLoadChecks = 10
 
-  # Those below are potential symbol files that the `dotnet symbol` might
-  # return. Which one will be returned depend on the type of file we are
-  # checking and which type of file was uploaded.
-
-  # The file itself is returned
-  $SymbolPath = $SymbolsPath + '\' + $FileName
-
-  # PDB file for the module
-  $PdbPath = $SymbolPath.Replace($Extension, '.pdb')
-
-  # PDB file for R2R module (created by crossgen)
-  $NGenPdb = $SymbolPath.Replace($Extension, '.ni.pdb')
-
-  # DBG file for a .so library
-  $SODbg = $SymbolPath.Replace($Extension, '.so.dbg')
-
-  # DWARF file for a .dylib
-  $DylibDwarf = $SymbolPath.Replace($Extension, '.dylib.dwarf')
- 
-  $dotnetSymbolExe = "$env:USERPROFILE\.dotnet\tools"
-  $dotnetSymbolExe = Resolve-Path "$dotnetSymbolExe\dotnet-symbol.exe"
-
-  & $dotnetSymbolExe --symbols --modules --windows-pdbs $TargetServerParam $FullPath -o $SymbolsPath | Out-Null
-
-  if (Test-Path $PdbPath) {
-    return 'PDB'
-  }
-  elseif (Test-Path $NGenPdb) {
-    return 'NGen PDB'
-  }
-  elseif (Test-Path $SODbg) {
-    return 'DBG for SO'
-  }  
-  elseif (Test-Path $DylibDwarf) {
-    return 'Dwarf for Dylib'
-  }  
-  elseif (Test-Path $SymbolPath) {
-    return 'Module'
-  }
-  else {
-    return $null
-  }
-}
-
-function CountMissingSymbols {
+$CountMissingSymbols = {
   param( 
     [string] $PackagePath          # Path to a NuGet package
   )
 
+  . $using:PSScriptRoot\..\tools.ps1
+
+  Add-Type -AssemblyName System.IO.Compression.FileSystem
+
   # Ensure input file exist
   if (!(Test-Path $PackagePath)) {
     Write-PipelineTaskError "Input file does not exist: $PackagePath"
-    ExitWithExitCode 1
+    return 1
   }
   
   # Extensions for which we'll look for symbols
@@ -79,7 +35,7 @@ function CountMissingSymbols {
 
   $PackageId = [System.IO.Path]::GetFileNameWithoutExtension($PackagePath)
   $PackageGuid = New-Guid
-  $ExtractPath = Join-Path -Path $ExtractPath -ChildPath $PackageGuid
+  $ExtractPath = Join-Path -Path $using:ExtractPath -ChildPath $PackageGuid
   $SymbolsPath = Join-Path -Path $ExtractPath -ChildPath 'Symbols'
   
   try {
@@ -94,15 +50,70 @@ function CountMissingSymbols {
   Get-ChildItem -Recurse $ExtractPath |
     Where-Object {$RelevantExtensions -contains $_.Extension} |
     ForEach-Object {
-      if ($_.FullName -Match '\\ref\\') {
-        Write-Host "`t Ignoring reference assembly file " $_.FullName
+      $FileName = $_.FullName
+      if ($FileName -Match '\\ref\\') {
+        Write-Host "`t Ignoring reference assembly file " $FileName
         return
       }
 
-      $SymbolsOnMSDL = FirstMatchingSymbolDescriptionOrDefault $_.FullName '--microsoft-symbol-server' $SymbolsPath
-      $SymbolsOnSymWeb = FirstMatchingSymbolDescriptionOrDefault $_.FullName '--internal-server' $SymbolsPath
+      $FirstMatchingSymbolDescriptionOrDefault = {
+      param( 
+        [string] $FullPath,                  # Full path to the module that has to be checked
+        [string] $TargetServerParam,         # Parameter to pass to `Symbol Tool` indicating the server to lookup for symbols
+        [string] $SymbolsPath
+      )
 
-      Write-Host -NoNewLine "`t Checking file " $_.FullName "... "
+      $FileName = [System.IO.Path]::GetFileName($FullPath)
+      $Extension = [System.IO.Path]::GetExtension($FullPath)
+
+      # Those below are potential symbol files that the `dotnet symbol` might
+      # return. Which one will be returned depend on the type of file we are
+      # checking and which type of file was uploaded.
+
+      # The file itself is returned
+      $SymbolPath = $SymbolsPath + '\' + $FileName
+
+      # PDB file for the module
+      $PdbPath = $SymbolPath.Replace($Extension, '.pdb')
+
+      # PDB file for R2R module (created by crossgen)
+      $NGenPdb = $SymbolPath.Replace($Extension, '.ni.pdb')
+
+      # DBG file for a .so library
+      $SODbg = $SymbolPath.Replace($Extension, '.so.dbg')
+
+      # DWARF file for a .dylib
+      $DylibDwarf = $SymbolPath.Replace($Extension, '.dylib.dwarf')
+    
+      $dotnetSymbolExe = "$env:USERPROFILE\.dotnet\tools"
+      $dotnetSymbolExe = Resolve-Path "$dotnetSymbolExe\dotnet-symbol.exe"
+
+      & $dotnetSymbolExe --symbols --modules --windows-pdbs $TargetServerParam $FullPath -o $SymbolsPath | Out-Null
+
+      if (Test-Path $PdbPath) {
+        return 'PDB'
+      }
+      elseif (Test-Path $NGenPdb) {
+        return 'NGen PDB'
+      }
+      elseif (Test-Path $SODbg) {
+        return 'DBG for SO'
+      }  
+      elseif (Test-Path $DylibDwarf) {
+        return 'Dwarf for Dylib'
+      }  
+      elseif (Test-Path $SymbolPath) {
+        return 'Module'
+      }
+      else {
+        return $null
+      }
+    }
+
+      $SymbolsOnMSDL = & $FirstMatchingSymbolDescriptionOrDefault $FileName '--microsoft-symbol-server' $SymbolsPath
+      $SymbolsOnSymWeb = & $FirstMatchingSymbolDescriptionOrDefault $FileName '--internal-server' $SymbolsPath
+
+      Write-Host -NoNewLine "`t Checking file " $FileName "... "
   
       if ($SymbolsOnMSDL -ne $null -and $SymbolsOnSymWeb -ne $null) {
         Write-Host "Symbols found on MSDL ($SymbolsOnMSDL) and SymWeb ($SymbolsOnSymWeb)"
@@ -124,8 +135,13 @@ function CountMissingSymbols {
       }
     }
   
-  if ($Clean) {
+  if ($using:Clean) {
     Remove-Item $ExtractPath -Recurse -Force
+  }
+
+  if ($MissingSymbols -ne 0)
+  {
+    Write-PipelineTelemetryError -Category 'CheckSymbols' -Message "Missing symbols for $Status modules in the package $FileName"
   }
   
   Pop-Location
@@ -143,6 +159,7 @@ function CheckSymbolsAvailable {
   Get-ChildItem "$InputPath\*.nupkg" |
     ForEach-Object {
       $FileName = $_.Name
+      $FullName = $_.FullName
 
       # These packages from Arcade-Services include some native libraries that
       # our current symbol uploader can't handle. Below is a workaround until
@@ -159,25 +176,39 @@ function CheckSymbolsAvailable {
       }
 
       Write-Host "Validating $FileName "
-      $Status = CountMissingSymbols "$InputPath\$FileName"
 
-      if ($Status -ne 0) {
-        Write-PipelineTelemetryError -Category 'CheckSymbols' -Message "Missing symbols for $Status modules in the package $FileName"
-        
-        if ($ContinueOnError) {
-          $TotalFailures++
-        }
-        else {
-          ExitWithExitCode 1
-        }
+      Start-Job -ScriptBlock $CountMissingSymbols -ArgumentList $FullName
+
+      $NumJobs = @(Get-Job -State 'Running').Count
+      Write-Host $NumJobs
+
+      while ($NumJobs -ge $MaxParallelJobs) {
+        Write-Host "There are $NumJobs validation jobs running right now. Waiting $SecondsBetweenLoadChecks seconds to check again."
+        sleep $SecondsBetweenLoadChecks
+        $NumJobs = @(Get-Job -State 'Running').Count
       }
 
+      foreach ($Job in @(Get-Job -State 'Completed')) {
+        Receive-Job -Id $Job.Id
+        Remove-Job -Id $Job.Id
+      }
       Write-Host
     }
 
-  if ($TotalFailures -ne 0) {
+  foreach ($Job in @(Get-Job)) {
+    $jobResult = Wait-Job -Id $Job.Id | Receive-Job
+
+    if ($jobResult -ne '0') {
+      $TotalFailures++
+    }
+  }
+
+  if ($TotalFailures -gt 0) {
     Write-PipelineTelemetryError -Category 'CheckSymbols' -Message "Symbols missing for $TotalFailures packages"
     ExitWithExitCode 1
+  }
+  else {
+    Write-Host "All symbols validated!"
   }
 }
 
@@ -200,10 +231,12 @@ function InstallDotnetSymbol {
 
 try {
   . $PSScriptRoot\post-build-utils.ps1
-
-  Add-Type -AssemblyName System.IO.Compression.FileSystem
   
   InstallDotnetSymbol
+
+  foreach ($Job in @(Get-Job)) {
+    Remove-Job -Id $Job.Id
+  }
 
   CheckSymbolsAvailable
 }

--- a/eng/common/post-build/symbols-validation.ps1
+++ b/eng/common/post-build/symbols-validation.ps1
@@ -141,7 +141,7 @@ $CountMissingSymbols = {
 
   if ($MissingSymbols -ne 0)
   {
-    Write-PipelineTelemetryError -Category 'CheckSymbols' -Message "Missing symbols for $Status modules in the package $FileName"
+    Write-PipelineTelemetryError -Category 'CheckSymbols' -Message "Missing symbols for $MissingSymbols modules in the package $FileName"
   }
   
   Pop-Location
@@ -177,7 +177,7 @@ function CheckSymbolsAvailable {
 
       Write-Host "Validating $FileName "
 
-      Start-Job -ScriptBlock $CountMissingSymbols -ArgumentList $FullName
+      Start-Job -ScriptBlock $CountMissingSymbols -ArgumentList $FullName | Out-Null
 
       $NumJobs = @(Get-Job -State 'Running').Count
       Write-Host $NumJobs
@@ -190,7 +190,6 @@ function CheckSymbolsAvailable {
 
       foreach ($Job in @(Get-Job -State 'Completed')) {
         Receive-Job -Id $Job.Id
-        Remove-Job -Id $Job.Id
       }
       Write-Host
     }


### PR DESCRIPTION
Adds parallelism similar to sourcelink validation using Start-Job and Receive-Job.

Testing indicates that a testing run that originally took 2hr 44m now will take 57m, cutting the time to almost a third of its original duration.