### PR TITLE
Extend TestPlatforms with iOS, tvOS, Android and WebAssembly

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.sharedfx.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.sharedfx.targets
@@ -221,6 +221,10 @@
       <RuntimeGraphGeneratorRuntime Condition="$([MSBuild]::IsOSPlatform('freebsd'))">freebsd</RuntimeGraphGeneratorRuntime>
       <RuntimeGraphGeneratorRuntime Condition="$([MSBuild]::IsOSPlatform('netbsd'))">netbsd</RuntimeGraphGeneratorRuntime>
       <RuntimeGraphGeneratorRuntime Condition="$([MSBuild]::IsOSPlatform('sunos'))">sunos</RuntimeGraphGeneratorRuntime>
+      <RuntimeGraphGeneratorRuntime Condition="$([MSBuild]::IsOSPlatform('ios'))">ios</RuntimeGraphGeneratorRuntime>
+      <RuntimeGraphGeneratorRuntime Condition="$([MSBuild]::IsOSPlatform('tvos'))">tvos</RuntimeGraphGeneratorRuntime>
+      <RuntimeGraphGeneratorRuntime Condition="$([MSBuild]::IsOSPlatform('android'))">android</RuntimeGraphGeneratorRuntime>
+      <RuntimeGraphGeneratorRuntime Condition="$([MSBuild]::IsOSPlatform('wasm'))">wasm</RuntimeGraphGeneratorRuntime>
       <RuntimeGraphGeneratorRuntime Condition="'$(RuntimeGraphGeneratorRuntime)'==''">linux</RuntimeGraphGeneratorRuntime>
     </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.sharedfx.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.sharedfx.targets
@@ -224,7 +224,7 @@
       <RuntimeGraphGeneratorRuntime Condition="$([MSBuild]::IsOSPlatform('ios'))">ios</RuntimeGraphGeneratorRuntime>
       <RuntimeGraphGeneratorRuntime Condition="$([MSBuild]::IsOSPlatform('tvos'))">tvos</RuntimeGraphGeneratorRuntime>
       <RuntimeGraphGeneratorRuntime Condition="$([MSBuild]::IsOSPlatform('android'))">android</RuntimeGraphGeneratorRuntime>
-      <RuntimeGraphGeneratorRuntime Condition="$([MSBuild]::IsOSPlatform('browser'))">wasm</RuntimeGraphGeneratorRuntime>
+      <RuntimeGraphGeneratorRuntime Condition="$([MSBuild]::IsOSPlatform('browser'))">browser</RuntimeGraphGeneratorRuntime>
       <RuntimeGraphGeneratorRuntime Condition="'$(RuntimeGraphGeneratorRuntime)'==''">linux</RuntimeGraphGeneratorRuntime>
     </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.sharedfx.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.sharedfx.targets
@@ -224,7 +224,7 @@
       <RuntimeGraphGeneratorRuntime Condition="$([MSBuild]::IsOSPlatform('ios'))">ios</RuntimeGraphGeneratorRuntime>
       <RuntimeGraphGeneratorRuntime Condition="$([MSBuild]::IsOSPlatform('tvos'))">tvos</RuntimeGraphGeneratorRuntime>
       <RuntimeGraphGeneratorRuntime Condition="$([MSBuild]::IsOSPlatform('android'))">android</RuntimeGraphGeneratorRuntime>
-      <RuntimeGraphGeneratorRuntime Condition="$([MSBuild]::IsOSPlatform('wasm'))">wasm</RuntimeGraphGeneratorRuntime>
+      <RuntimeGraphGeneratorRuntime Condition="$([MSBuild]::IsOSPlatform('browser'))">wasm</RuntimeGraphGeneratorRuntime>
       <RuntimeGraphGeneratorRuntime Condition="'$(RuntimeGraphGeneratorRuntime)'==''">linux</RuntimeGraphGeneratorRuntime>
     </PropertyGroup>
 

--- a/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
@@ -26,8 +26,8 @@ namespace Microsoft.DotNet.XUnitExtensions
                 (platforms.HasFlag(TestPlatforms.NetBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"))) ||
                 (platforms.HasFlag(TestPlatforms.OSX) && RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) ||
                 (platforms.HasFlag(TestPlatforms.SunOS) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("SUNOS"))) ||
-                (platforms.HasFlag(TestPlatforms.IOS) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS"))) ||
-                (platforms.HasFlag(TestPlatforms.TvOS) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS"))) ||
+                (platforms.HasFlag(TestPlatforms.iOS) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS"))) ||
+                (platforms.HasFlag(TestPlatforms.tvOS) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS"))) ||
                 (platforms.HasFlag(TestPlatforms.Android) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"))) ||
                 (platforms.HasFlag(TestPlatforms.Browser) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"))) ||
                 (platforms.HasFlag(TestPlatforms.Windows) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows));

--- a/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
@@ -26,6 +26,10 @@ namespace Microsoft.DotNet.XUnitExtensions
                 (platforms.HasFlag(TestPlatforms.NetBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"))) ||
                 (platforms.HasFlag(TestPlatforms.OSX) && RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) ||
                 (platforms.HasFlag(TestPlatforms.SunOS) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("SUNOS"))) ||
+                (platforms.HasFlag(TestPlatforms.IOS) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS"))) ||
+                (platforms.HasFlag(TestPlatforms.TvOS) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS"))) ||
+                (platforms.HasFlag(TestPlatforms.Android) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"))) ||
+                (platforms.HasFlag(TestPlatforms.Wasm) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("WEBASSEMBLY"))) ||
                 (platforms.HasFlag(TestPlatforms.Windows) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
         
         public static bool TestRuntimeApplies(TestRuntimes runtimes) =>

--- a/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.XUnitExtensions
                 (platforms.HasFlag(TestPlatforms.IOS) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS"))) ||
                 (platforms.HasFlag(TestPlatforms.TvOS) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS"))) ||
                 (platforms.HasFlag(TestPlatforms.Android) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"))) ||
-                (platforms.HasFlag(TestPlatforms.Wasm) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("WEBASSEMBLY"))) ||
+                (platforms.HasFlag(TestPlatforms.Browser) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"))) ||
                 (platforms.HasFlag(TestPlatforms.Windows) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
         
         public static bool TestRuntimeApplies(TestRuntimes runtimes) =>

--- a/src/Microsoft.DotNet.XUnitExtensions/src/TestPlatforms.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/TestPlatforms.cs
@@ -15,11 +15,11 @@ namespace Xunit
         FreeBSD = 8,
         NetBSD = 16,
         SunOS = 32,
-        IOS = 64,
-        TvOS = 128,
+        iOS = 64,
+        tvOS = 128,
         Android = 256,
-        Wasm = 512,
-        AnyUnix = FreeBSD | Linux | NetBSD | OSX | SunOS | IOS | TvOS | Android,
+        Browser = 512,
+        AnyUnix = FreeBSD | Linux | NetBSD | OSX | SunOS | iOS | tvOS | Android | Browser,
         Any = ~0
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/TestPlatforms.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/TestPlatforms.cs
@@ -15,7 +15,11 @@ namespace Xunit
         FreeBSD = 8,
         NetBSD = 16,
         SunOS = 32,
-        AnyUnix = FreeBSD | Linux | NetBSD | OSX | SunOS,
+        IOS = 64,
+        TvOS = 128,
+        Android = 256,
+        Wasm = 512,
+        AnyUnix = FreeBSD | Linux | NetBSD | OSX | SunOS | IOS | TvOS | Android,
         Any = ~0
     }
 }


### PR DESCRIPTION
To be able to use `[ActiveIssue]` for these platforms only.