### PR TITLE
Define default value for 'force' and pass arguments as array

### DIFF
--- a/eng/common/pipeline-logging-functions.sh
+++ b/eng/common/pipeline-logging-functions.sh
@@ -31,26 +31,21 @@ function Write-PipelineTelemetryError {
     return
   fi
 
-  message="(NETCORE_ENGINEERING_TELEMETRY=$telemetry_category) $message"
-  function_args+=("$message")
   if [[ $force == true ]]; then
     function_args+=("-force")
   fi
-
-  Write-PipelineTaskError $function_args
+  message="(NETCORE_ENGINEERING_TELEMETRY=$telemetry_category) $message"
+  function_args+=("$message")
+  Write-PipelineTaskError ${function_args[@]}
 }
 
 function Write-PipelineTaskError {
-  if [[ $force != true ]] && [[ "$ci" != true ]]; then
-    echo "$@" >&2
-    return
-  fi
-
   local message_type="error"
   local sourcepath=''
   local linenumber=''
   local columnnumber=''
   local error_code=''
+  local force=false
 
   while [[ $# -gt 0 ]]; do
     opt="$(echo "${1/#--/-}" | awk '{print tolower($0)}')"
@@ -75,6 +70,9 @@ function Write-PipelineTaskError {
         error_code=$2
         shift
         ;;
+      -force|-f)
+        force=true
+        ;;
       *)
         break
         ;;
@@ -82,6 +80,11 @@ function Write-PipelineTaskError {
 
     shift
   done
+
+  if [[ $force != true ]] && [[ "$ci" != true ]]; then
+    echo "$@" >&2
+    return
+  fi
 
   local message="##vso[task.logissue"
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/5387

Define default value for `Force` in `Write-PipelineTaskError` function and don't reference until after arguments have been parsed.

Also, fix how `Write-PipelineTelemetryError` function is passing arguments to `Write-PipelineTaskError` function.

FYI @hughbe 