### PR TITLE
Fix upload_root version of xunit reporter behavior

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xunit-reporter/xunit-reporter.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xunit-reporter/xunit-reporter.py
@@ -109,7 +109,7 @@ def main():
     else:
         # Will be uploaded, but we still need to send events.
         # This prevents duplicate uploads and errors from them in logs
-        result_url = '{container}/{file}?{sas}'.format(
+        result_url = '{container}/{file}{sas}'.format(
             container=settings.output_uri,
             file=os.path.basename(results_path),
             sas=settings.output_read_token)

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xunit-reporter/xunit-reporter.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xunit-reporter/xunit-reporter.py
@@ -111,7 +111,7 @@ def main():
         # This prevents duplicate uploads and errors from them in logs
         result_url = '{container}{file}?{sas}'.format(
             container=settings.output_uri,
-            file=urllib.parse.quote(results_path.replace('\\', '/')),
+            file=os.path.basename(results_path),
             sas=settings.output_read_token)
     
     helper.xunit_event(result_url, test_count, os.path.basename(results_path))

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xunit-reporter/xunit-reporter.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xunit-reporter/xunit-reporter.py
@@ -109,7 +109,7 @@ def main():
     else:
         # Will be uploaded, but we still need to send events.
         # This prevents duplicate uploads and errors from them in logs
-        result_url = '{container}{file}?{sas}'.format(
+        result_url = '{container}/{file}?{sas}'.format(
             container=settings.output_uri,
             file=os.path.basename(results_path),
             sas=settings.output_read_token)


### PR DESCRIPTION
In avoiding the duplicate upload, I neglected to construct the results URL.  

Also renamed the event sender functions.  (This is a bug but only in the new codepath)