### PR TITLE
[release/3.x] Update darc-init.ps1 to match master version

### DIFF
--- a/eng/common/darc-init.ps1
+++ b/eng/common/darc-init.ps1
@@ -1,13 +1,14 @@
 param (
     $darcVersion = $null,
-    $versionEndpoint = "https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16",
-    $verbosity = "m"
+    $versionEndpoint = 'https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16',
+    $verbosity = 'minimal',
+    $toolpath = $null
 )
 
 . $PSScriptRoot\tools.ps1
 
-function InstallDarcCli ($darcVersion) {
-  $darcCliPackageName = "microsoft.dotnet.darc"
+function InstallDarcCli ($darcVersion, $toolpath) {
+  $darcCliPackageName = 'microsoft.dotnet.darc'
 
   $dotnetRoot = InitializeDotNetCli -install:$true
   $dotnet = "$dotnetRoot\dotnet.exe"
@@ -23,11 +24,24 @@ function InstallDarcCli ($darcVersion) {
     $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
   }
 
-  $arcadeServicesSource = 'https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json'
+  $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
 
   Write-Host "Installing Darc CLI version $darcVersion..."
-  Write-Host "You may need to restart your command window if this is the first dotnet tool you have installed."
-  & "$dotnet" tool install $darcCliPackageName --version $darcVersion --add-source "$arcadeServicesSource" -v $verbosity -g --framework netcoreapp2.1
+  Write-Host 'You may need to restart your command window if this is the first dotnet tool you have installed.'
+  if (-not $toolpath) {
+    Write-Host "'$dotnet' tool install $darcCliPackageName --version $darcVersion --add-source '$arcadeServicesSource' -v $verbosity -g"
+    & "$dotnet" tool install $darcCliPackageName --version $darcVersion --add-source "$arcadeServicesSource" -v $verbosity -g
+  }else {
+    Write-Host "'$dotnet' tool install $darcCliPackageName --version $darcVersion --add-source '$arcadeServicesSource' -v $verbosity --tool-path '$toolpath'"
+    & "$dotnet" tool install $darcCliPackageName --version $darcVersion --add-source "$arcadeServicesSource" -v $verbosity --tool-path "$toolpath"
+  }
 }
 
-InstallDarcCli $darcVersion
+try {
+  InstallDarcCli $darcVersion $toolpath
+}
+catch {
+  Write-Host $_.ScriptStackTrace
+  Write-PipelineTelemetryError -Category 'Darc' -Message $_
+  ExitWithExitCode 1
+}


### PR DESCRIPTION
## Description

Update darc-init.ps1 to match master. 3.x version references the wrong feed for new darcs

## Customer Impact

darc-init.ps1 doesnt' work for 3.x

## Regression

No

## Risk

None

## Workarounds

Switch to master before installing darc.