### PR TITLE
Fix XHarness props in Helix SDK

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
     <_XHarnessPackageName>Microsoft.DotNet.XHarness.CLI</_XHarnessPackageName>
-    <_XharnessRunnerPackageFeed Condition="'$(_XharnessRunnerPackageFeed)'==''">https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet-eng/nuget/v3/index.json</_XharnessRunnerPackageFeed>
+    <_XHarnessRunnerPackageFeed Condition="'$(_XHarnessRunnerPackageFeed)'==''">https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet-eng/nuget/v3/index.json</_XHarnessRunnerPackageFeed>
     <!-- MicrosoftDotNetXHarnessCLIVersion comes from eng\Versions.props -->
-    <_XHarnessPackageVersion Condition="'$(XHarnessPackageVersion)' == ''">$(MicrosoftDotNetXHarnessCLIVersion)</_XHarnessPackageVersion>
+    <_XHarnessPackageVersion Condition="'$(_XHarnessPackageVersion)' == ''">$(MicrosoftDotNetXHarnessCLIVersion)</_XHarnessPackageVersion>
     <_HelixMonoQueueTargets>$(_HelixMonoQueueTargets);$(MSBuildThisFileDirectory)XHarnessRunner.targets</_HelixMonoQueueTargets>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
@@ -19,7 +19,7 @@
          When .NET is not already installed there, we set DOTNET_ROOT to help it find the right one. -->
     <PropertyGroup Condition="$(IsPosixShell)">
       <HelixPreCommands>$(HelixPreCommands);export DOTNET_ROOT=$HELIX_CORRELATION_PAYLOAD/dotnet</HelixPreCommands>
-      <HelixPreCommands>$(HelixPreCommands);dotnet tool install --tool-path $HELIX_CORRELATION_PAYLOAD/xharness-cli --version $(_XHarnessPackageVersion) --add-source $(_XharnessRunnerPackageFeed) $(_XHarnessPackageName) </HelixPreCommands>
+      <HelixPreCommands>$(HelixPreCommands);dotnet tool install --tool-path $HELIX_CORRELATION_PAYLOAD/xharness-cli --version $(_XHarnessPackageVersion) --add-source $(_XHarnessRunnerPackageFeed) $(_XHarnessPackageName) </HelixPreCommands>
       <HelixPreCommands>$(HelixPreCommands);export PATH=$HELIX_CORRELATION_PAYLOAD/xharness-cli:$PATH</HelixPreCommands>
       <HelixPreCommands>$(HelixPreCommands);export XHARNESS_DISABLE_COLORED_OUTPUT=true</HelixPreCommands>
       <HelixPreCommands>$(HelixPreCommands);export XHARNESS_LOG_WITH_TIMESTAMPS=true</HelixPreCommands>
@@ -27,7 +27,7 @@
 
     <PropertyGroup Condition="!$(IsPosixShell)">
       <HelixPreCommands>$(HelixPreCommands);set DOTNET_ROOT=%HELIX_CORRELATION_PAYLOAD%\dotnet</HelixPreCommands>
-      <HelixPreCommands>$(HelixPreCommands);dotnet tool install --tool-path %HELIX_CORRELATION_PAYLOAD%\xharness-cli --version $(_XHarnessPackageVersion) --add-source $(_XharnessRunnerPackageFeed) $(_XHarnessPackageName) </HelixPreCommands>
+      <HelixPreCommands>$(HelixPreCommands);dotnet tool install --tool-path %HELIX_CORRELATION_PAYLOAD%\xharness-cli --version $(_XHarnessPackageVersion) --add-source $(_XHarnessRunnerPackageFeed) $(_XHarnessPackageName) </HelixPreCommands>
       <HelixPreCommands>$(HelixPreCommands);set PATH=%HELIX_CORRELATION_PAYLOAD%\xharness-cli%3B%PATH%</HelixPreCommands>
       <HelixPreCommands>$(HelixPreCommands);set XHARNESS_DISABLE_COLORED_OUTPUT=true</HelixPreCommands>
       <HelixPreCommands>$(HelixPreCommands);set XHARNESS_LOG_WITH_TIMESTAMPS=true</HelixPreCommands>


### PR DESCRIPTION
This is mostly because of the missing `_` but renames `Xharness` to `XHarness` as well while we're at it