### PR TITLE
Fix LightCommand packages support based on failures in dotnet/runtime.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets
@@ -334,10 +334,11 @@
       Cultures="en-us"
       Out="$(OutInstallerFile)"
       WixExtensions="@(WixExtensions)"
-      WixSrcFiles="@(WixSrcFile -> '$(WixObjDir)%(Filename).wixobj');@(DirectoryToHarvest -> '%(WixObjFile)')"
-      Condition="'$(EnableCreateLightCommandPackageDrop)' == 'true'">
+      WixSrcFiles="@(WixSrcFile -> '$(WixObjDir)%(Filename).wixobj');@(DirectoryToHarvest -> '%(WixObjFile)')">
       <Output TaskParameter="LightCommandPackageNameOutput" PropertyName="_LightCommandPackageNameOutput" />
     </CreateLightCommandPackageDrop>
+
+    <MakeDir Directories="$(LightCommandPackagesDir)" />
 
     <ZipDirectory
       DestinationFile="$(LightCommandPackagesDir)/LightCommandPackage-$(_LightCommandPackageNameOutput).zip"


### PR DESCRIPTION
This PR fixes the issues found in the LightCommand support when trying to update the SharedFramework SDK in dotnet/runtime in dotnet/runtime#36889

cc: @chcosta and @jcagme for review.

Unblocks https://github.com/dotnet/runtime/pull/36889