### PR TITLE
Increment MicrosoftDotNetXHarnessCLIVersion

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -76,7 +76,7 @@
     <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>5.0.0-beta.20261.9</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
     <XliffTasksVersion>1.0.0-beta.20206.1</XliffTasksVersion>
     <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.20224.5</MicrosoftDotNetMaestroTasksVersion>
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20271.1</MicrosoftDotNetXHarnessCLIVersion>
+    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20277.1</MicrosoftDotNetXHarnessCLIVersion>
     <MicrosoftSymbolUploaderBuildTaskVersion>1.1.125701</MicrosoftSymbolUploaderBuildTaskVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Needed for improved retry behavior to deal with sporadic issue where `devices -l` does not return devices.