### PR TITLE
Avoid false positives when reporting excluded files (#5549)

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/Verification/DetailKeys.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/DetailKeys.cs
@@ -16,5 +16,6 @@ namespace Microsoft.SignCheck.Verification
 
         public static readonly string[] ResultKeysVerbose = { File, Error, AuthentiCode, StrongName, Signature, Misc };
         public static readonly string[] ResultKeysNormal = { File, Error };
+        public static readonly string[] ResultKeysExcluded = { File };
     }
 }

--- a/src/SignCheck/SignCheck/SignCheck.cs
+++ b/src/SignCheck/SignCheck/SignCheck.cs
@@ -345,7 +345,7 @@ namespace SignCheck
                     ((!result.IsSigned) && (!result.IsSkipped) && (!result.IsExcluded) && ((FileStatus & FileStatus.UnsignedFiles) != 0)))
                 {
                     LoggedResults = true;
-                    Log.WriteMessage(LogVerbosity.Minimum, String.Empty.PadLeft(indent) + result.ToString(ResultDetails));
+                    Log.WriteMessage(LogVerbosity.Minimum, String.Empty.PadLeft(indent) + result.ToString(result.IsExcluded ? DetailKeys.ResultKeysExcluded : ResultDetails));
                 }
 
                 if (((!result.IsSigned) && (!(result.IsSkipped || result.IsExcluded))) || (result.IsSigned && result.IsDoNotSign))


### PR DESCRIPTION
Fixes: #5549 
Excluded files won't report errors. By default they would be included in the final results, but will be omitted.

To see them, you need to include excluded files in reporting, e.g. ```--file-status UnsignedFiles,ExcludedFiles```

When they are reported, it will now look as follows:

```
[File] 952da8af494c2c7533faca1c2477a873.js, Signed: False, Excluded, Full Name: Scripts/jquery-1.3.2-vsdoc.js
```