### PR TITLE
Fixup Native VER_PRODUCTVERSION_STR string

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
@@ -82,7 +82,7 @@
 #undef VER_PRODUCTVERSION
 #define VER_PRODUCTVERSION          $(_WindowsFileVersion)
 #undef VER_PRODUCTVERSION_STR
-#define VER_PRODUCTVERSION_STR      "$(_WindowsFileVersion)$(_SourceBuildInfo)"
+#define VER_PRODUCTVERSION_STR      "$(Version)$(_SourceBuildInfo)"
 #undef VER_FILEVERSION
 #define VER_FILEVERSION             $(_WindowsFileVersion)
 #undef VER_FILEVERSION_STR


### PR DESCRIPTION
Fixes #4339 

Ensures that C++ binaries' version resource has a product version string that is human-readable, and uses a string that is (nearly) identical with the ones used by C# assemblies.

**[Before]** 

![image](https://user-images.githubusercontent.com/20246435/83088541-d7648500-a048-11ea-857f-9ffb1551a188.png)

**[After]**

![image](https://user-images.githubusercontent.com/20246435/83088529-cca9f000-a048-11ea-8008-72670fca2923.png)
