### PR TITLE
Switch filter condition from BuildAllConfigurations to BuildTargetFramework

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
@@ -22,7 +22,7 @@
   </Target>
      
   <Target Name="RunOnlyBestTargetFrameworks"
-          Condition="'$(BuildAllConfigurations)' != 'true' or '$(MSBuildProjectExtension)' == '.pkgproj'" 
+          Condition="'$(BuildTargetFramework)' != '' or '$(MSBuildProjectExtension)' == '.pkgproj'" 
           BeforeTargets="DispatchToInnerBuilds"
           DependsOnTargets="GetProjectWithBestTargetFrameworks">
     <ItemGroup>


### PR DESCRIPTION
With https://github.com/dotnet/runtime/pull/35606, we will be able to build for all configurations by default on individual projects hence it doesn't make sense anymore to condition on the `BuildAllConfigurations` property for filtering in the TargetFramework.Sdk. Instead conditioning on `BuildTargetFramework`.

**No merge** before the runtime PR is merged.