### PR TITLE
[release/3.x] Fixup update-dependencies by adding the SDK to the path prior to execution

### DIFF
--- a/eng/validate-sdk.ps1
+++ b/eng/validate-sdk.ps1
@@ -92,6 +92,11 @@ try {
 
   Write-Host "Updating Dependencies using Darc..."
 
+  # Initialize the cli so the runtime is on the path. Should just use the same version installed
+  # when common\cibuild.cmd was run.
+  $dotNetRoot = InitializeDotNetCli $true
+  $env:PATH = "$dotNetRoot;$env:PATH"
+
   . .\common\darc-init.ps1
   CheckExitCode "Running darc-init"
 


### PR DESCRIPTION
Fixes the build, which was broken by the 3.0 netcoreapp dependency from a recent arcade-services update.