### PR TITLE
Fix xcopy-msbuild issues and add support for none

### DIFF
--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -65,8 +65,13 @@ try {
     if( -not ($GlobalJson.tools.PSObject.Properties.Name -match "xcopy-msbuild" )) {
       $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "16.5.0-alpha" -MemberType NoteProperty
     }
+    if ($GlobalJson.tools."xcopy-msbuild".Trim() -ine "none") {
+        $xcopyMSBuildToolsFolder = InitializeXCopyMSBuild $GlobalJson.tools."xcopy-msbuild" -install $true
+    }
+    if ($xcopyMSBuildToolsFolder -eq $null) {
+      throw 'Unable to find Visual Studio that has required version and components installed'
+    }
 
-    $xcopyMSBuildToolsFolder = InitializeXCopyMSBuild $GlobalJson.tools."xcopy-msbuild" -install $true
     $global:_MSBuildExe = "$($xcopyMSBuildToolsFolder)\MSBuild\Current\Bin\MSBuild.exe"
   }
 

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -69,7 +69,7 @@ try {
         $xcopyMSBuildToolsFolder = InitializeXCopyMSBuild $GlobalJson.tools."xcopy-msbuild" -install $true
     }
     if ($xcopyMSBuildToolsFolder -eq $null) {
-      throw 'Unable to find Visual Studio that has required version and components installed'
+      throw 'Unable to get xcopy downloadable version of msbuild'
     }
 
     $global:_MSBuildExe = "$($xcopyMSBuildToolsFolder)\MSBuild\Current\Bin\MSBuild.exe"

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -330,7 +330,9 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
       $xcopyMSBuildVersion = $GlobalJson.tools.'xcopy-msbuild'
       $vsMajorVersion = $xcopyMSBuildVersion.Split('.')[0]
     } else {
+      #if vs version provided in global.json is incompatible then use the default version for xcopy msbuild download
       if($vsMinVersion -lt $vsMinVersionReqd){
+        Write-Host "Using xcopy-msbuild version of $vsMinVersionReqdStr.0-alpha since VS version $vsMinVersionStr provided in global.json is not compatible"
         $vsMajorVersion = $vsMinVersionReqd.Major
         $vsMinorVersion = $vsMinVersionReqd.Minor
       }

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -293,8 +293,11 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
     return $global:_MSBuildExe
   }
 
+  $vsMinVersionReqdStr = '16.5'
+  $vsMinVersionReqd = [Version]::new($vsMinVersionReqdStr)
+
   if (!$vsRequirements) { $vsRequirements = $GlobalJson.tools.vs }
-  $vsMinVersionStr = if ($vsRequirements.version) { $vsRequirements.version } else { '15.9' }
+  $vsMinVersionStr = if ($vsRequirements.version) { $vsRequirements.version } else { $vsMinVersionReqdStr }
   $vsMinVersion = [Version]::new($vsMinVersionStr)
 
   # Try msbuild command available in the environment.
@@ -327,8 +330,16 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
       $xcopyMSBuildVersion = $GlobalJson.tools.'xcopy-msbuild'
       $vsMajorVersion = $xcopyMSBuildVersion.Split('.')[0]
     } else {
-      $vsMajorVersion = $vsMinVersion.Major
-      $xcopyMSBuildVersion = "$vsMajorVersion.$($vsMinVersion.Minor).0-alpha"
+      if($vsMinVersion -lt $vsMinVersionReqd){
+        $vsMajorVersion = $vsMinVersionReqd.Major
+        $vsMinorVersion = $vsMinVersionReqd.Minor
+      }
+      else{
+        $vsMajorVersion = $vsMinVersion.Major
+        $vsMinorVersion = $vsMinVersion.Minor
+      }
+
+      $xcopyMSBuildVersion = "$vsMajorVersion.$vsMinorVersion.0-alpha"
     }
 
     $vsInstallDir = $null


### PR DESCRIPTION
Fixes: 
https://github.com/dotnet/core-eng/issues/9803
https://github.com/dotnet/core-eng/issues/9919

- Add support for xcopy-msbuild : none in sdk-task.ps1
- Ensure a minimum version that is supported is applied in tools.ps1 for xcopy download. The version of VS specified is consistent with what we have in sdk-task.ps1.