### PR TITLE
Fix WebAssembly support in RemoteExecutor.

### DIFF
--- a/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
@@ -49,7 +49,13 @@ namespace Microsoft.DotNet.RemoteExecutor
 
         static RemoteExecutor()
         {
-            string processFileName = Process.GetCurrentProcess().MainModule.FileName;
+            ProcessModule mainModule = Process.GetCurrentProcess().MainModule;
+            if (mainModule == null)
+            {
+                return;
+            }
+
+            string processFileName = mainModule.FileName;
             HostRunnerName = System.IO.Path.GetFileName(processFileName);
 
             if (PlatformDetection.IsInAppContainer)

--- a/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
@@ -49,13 +49,11 @@ namespace Microsoft.DotNet.RemoteExecutor
 
         static RemoteExecutor()
         {
-            ProcessModule mainModule = Process.GetCurrentProcess().MainModule;
-            if (mainModule == null)
+            string processFileName = Process.GetCurrentProcess().MainModule?.FileName;
+            if (processFileName == null)
             {
                 return;
             }
-
-            string processFileName = mainModule.FileName;
             HostRunnerName = System.IO.Path.GetFileName(processFileName);
 
             if (PlatformDetection.IsInAppContainer)

--- a/src/Microsoft.DotNet.RemoteExecutor/src/RemoteInvokeOptions.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/RemoteInvokeOptions.cs
@@ -54,6 +54,7 @@ namespace Microsoft.DotNet.RemoteExecutor
             RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS")) ||
             RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID")) ||
             RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS")) ||
-            RuntimeInformation.IsOSPlatform(OSPlatform.Create("WATCHOS"));
+            RuntimeInformation.IsOSPlatform(OSPlatform.Create("WATCHOS")) ||
+            RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"));
     }
 }


### PR DESCRIPTION
Under WebAssembly, there is no process or main module, so Process.MainModule returns null.