### PR TITLE
Fix sourcelink and symbols validation

### DIFF
--- a/eng/common/post-build/sourcelink-validation.ps1
+++ b/eng/common/post-build/sourcelink-validation.ps1
@@ -210,7 +210,7 @@ function ValidateSourceLinkLinks {
         $NumJobs = @(Get-Job -State 'Running').Count
       }
 
-      fforeach ($Job in @(Get-Job -State 'Completed')) {
+      foreach ($Job in @(Get-Job -State 'Completed')) {
         $jobResult = Receive-Job -Id $Job.Id
         if ($jobResult -ne '0') {
           $ValidationFailures++

--- a/eng/common/post-build/sourcelink-validation.ps1
+++ b/eng/common/post-build/sourcelink-validation.ps1
@@ -196,6 +196,8 @@ function ValidateSourceLinkLinks {
     Remove-Item $ExtractPath -Force -Recurse -ErrorAction SilentlyContinue
   }
 
+  $ValidationFailures = 0
+
   # Process each NuGet package in parallel
   Get-ChildItem "$InputPath\*.symbols.nupkg" |
     ForEach-Object {
@@ -208,18 +210,21 @@ function ValidateSourceLinkLinks {
         $NumJobs = @(Get-Job -State 'Running').Count
       }
 
-      foreach ($Job in @(Get-Job -State 'Completed')) {
-        Receive-Job -Id $Job.Id
+      fforeach ($Job in @(Get-Job -State 'Completed')) {
+        $jobResult = Receive-Job -Id $Job.Id
+        if ($jobResult -ne '0') {
+          $ValidationFailures++
+        }
         Remove-Job -Id $Job.Id
       }
     }
 
-  $ValidationFailures = 0
   foreach ($Job in @(Get-Job)) {
     $jobResult = Wait-Job -Id $Job.Id | Receive-Job
     if ($jobResult -ne '0') {
       $ValidationFailures++
     }
+    Remove-Job -Id $Job.Id
   }
   if ($ValidationFailures -gt 0) {
     Write-PipelineTelemetryError -Category 'SourceLink' -Message "$ValidationFailures package(s) failed validation."

--- a/eng/common/post-build/symbols-validation.ps1
+++ b/eng/common/post-build/symbols-validation.ps1
@@ -189,7 +189,11 @@ function CheckSymbolsAvailable {
       }
 
       foreach ($Job in @(Get-Job -State 'Completed')) {
-        Receive-Job -Id $Job.Id
+        $jobResult = Wait-Job -Id $Job.Id | Receive-Job
+        if ($jobResult -ne '0') {
+          $TotalFailures++
+        }
+        Remove-Job -Id $Job.Id
       }
       Write-Host
     }


### PR DESCRIPTION
While testing adding sourcelink to the release pipeline, I noticed that we were not reporting the correct number of failures. Noteably, there would be packages with broken sourcelink links (as noted by the output text), but we'd report 0 failures. After some investigation, I discovered that that is because once a job is received using Receive-Job, all of its outputs and results are discarded. Additionally, just because a scriptblock returns non-zero, doesn't mean it comes up as "failed." It is reported as "completed." Therefore, when we would receive all of the completed jobs, and then  remove them, we would lose their job result, and not count them as part of the total failures, making it seem like we had fewer sourcelink failures than we did.

The solution for this is to count the failures as we receive the completed jobs. This change fixes that.