### PR TITLE
use intermediate folder to get the implementation dll 

### DIFF
--- a/src/Microsoft.DotNet.GenAPI/build/Microsoft.DotNet.GenAPI.targets
+++ b/src/Microsoft.DotNet.GenAPI/build/Microsoft.DotNet.GenAPI.targets
@@ -37,8 +37,12 @@
 
   <Target Name="GenerateReferenceAssemblySource"
           DependsOnTargets="SetBuildProjectReferences;ResolveAssemblyReferences"
-          Inputs="$(TargetPath)"
+          Inputs="@(IntermediateAssembly)"
           Outputs="$(GenAPITargetPath)">
+
+    <PropertyGroup>
+      <IntermediateTargetPath Condition="'$(IntermediateTargetPath)' == ''">$(IntermediateOutputPath)$(TargetName)$(TargetExt)</IntermediateTargetPath>
+    </PropertyGroup>
 
     <ItemGroup Condition="'$(GenAPILibPath)' == ''">
       <!-- build out a list of directories where dependencies are located -->
@@ -51,7 +55,7 @@
       <GenAPILibPath>@(_referencePathDirectories)</GenAPILibPath>
     </PropertyGroup>
 
-    <Exec Command="$(_GenAPICommand) &quot;$(TargetPath)&quot; --lib-path &quot;$(GenAPILibPath)&quot; --out &quot;$(GenAPITargetPath)&quot; $(GenAPIAdditionalParameters)" />
+    <Exec Command="$(_GenAPICommand) &quot;$(IntermediateTargetPath)&quot; --lib-path &quot;$(GenAPILibPath)&quot; --out &quot;$(GenAPITargetPath)&quot; $(GenAPIAdditionalParameters)" />
 
     <ItemGroup>
       <FileWrites Condition="'$(SkipGenAPITargetPathFileWrite)' != 'true'" Include="$(GenAPITargetPath)"/>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/37179

When we add a new api in the src, the build failed dye to apicompat. hence the implementation is not copied to the bin folder and only is present in the obj folder. this will correct this scenario.