### PR TITLE
Allow clean up of files if XHarness fails

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
@@ -96,6 +96,8 @@ export DOTNET_ROOT="$dotnet_root"
 export XHARNESS_DISABLE_COLORED_OUTPUT=true
 export XHARNESS_LOG_WITH_TIMESTAMPS=true
 
+set +e
+
 "$xharness" ios test                       \
     --app="$app"                           \
     --output-directory="$output_directory" \


### PR DESCRIPTION
This makes the `chmod` command run even when the `xharness` command fails and makes the simulator logs readable by `helix-runner`