### PR TITLE
Update Drop.App version

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -69,7 +69,7 @@
     Default versions
   -->
   <PropertyGroup>
-    <DropAppVersion Condition="'$(DropAppVersion)' == ''">18.165.29912-buildid11693003</DropAppVersion>
+    <DropAppVersion Condition="'$(DropAppVersion)' == ''">18.169.30122-buildid12194732</DropAppVersion>
     <MicroBuildPluginsSwixBuildVersion Condition="'$(MicroBuildPluginsSwixBuildVersion)' == ''">1.0.422</MicroBuildPluginsSwixBuildVersion>
     <MicroBuildCoreVersion Condition="'$(MicroBuildCoreVersion)' == ''">0.2.0</MicroBuildCoreVersion>
     <MicrosoftDotNetIBCMergeVersion Condition="'$(MicrosoftDotNetIBCMergeVersion)' == ''">5.0.6-beta.19203.1</MicrosoftDotNetIBCMergeVersion>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -69,7 +69,7 @@
     Default versions
   -->
   <PropertyGroup>
-    <DropAppVersion Condition="'$(DropAppVersion)' == ''">17.144.28413-buildid7983345</DropAppVersion>
+    <DropAppVersion Condition="'$(DropAppVersion)' == ''">18.165.29912-buildid11693003</DropAppVersion>
     <MicroBuildPluginsSwixBuildVersion Condition="'$(MicroBuildPluginsSwixBuildVersion)' == ''">1.0.422</MicroBuildPluginsSwixBuildVersion>
     <MicroBuildCoreVersion Condition="'$(MicroBuildCoreVersion)' == ''">0.2.0</MicroBuildCoreVersion>
     <MicrosoftDotNetIBCMergeVersion Condition="'$(MicrosoftDotNetIBCMergeVersion)' == ''">5.0.6-beta.19203.1</MicrosoftDotNetIBCMergeVersion>


### PR DESCRIPTION
Old `drop.exe` has an issue with a recent Windows security update, which
causes failures like

```
ContentStore.Exceptions.CacheException: Could not download into the
cache: ErrorMessage=[FileNotFoundException:
System.IO.FileNotFoundException: Could not find file
'C:\_cache\contents\Shared\VSO0\ED8\ED878A5B6B0E382A858F9F34A562E42BFE8A70032E7E900F13CF4EE3621D8E4900.blob'.
```

When downloading drop data. The Azure Artifacts team recommends updating
to 18.164.29918 or newer.

Port of #5239 to master.