### PR TITLE
Improve error handling in XHarness iOS SDK

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
@@ -75,12 +75,8 @@ namespace Microsoft.DotNet.Helix.Sdk
         {
             // Forces this task to run asynchronously
             await Task.Yield();
-            
-            string appFolderPath = appFolderItem.ItemSpec;
-            if (appFolderPath.EndsWith("/"))
-            {
-                appFolderPath = appFolderPath.Substring(0, appFolderPath.Length - 1);
-            }
+
+            string appFolderPath = appFolderItem.ItemSpec.TrimEnd(Path.DirectorySeparatorChar);
             
             string workItemName = $"xharness-{Path.GetFileName(appFolderPath)}";
             if (workItemName.EndsWith(".app"))

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
@@ -77,6 +77,10 @@ namespace Microsoft.DotNet.Helix.Sdk
             await Task.Yield();
             
             string appFolderPath = appFolderItem.ItemSpec;
+            if (appFolderPath.EndsWith("/"))
+            {
+                appFolderPath = appFolderPath.Substring(0, appFolderPath.Length - 1);
+            }
             
             string workItemName = $"xharness-{Path.GetFileName(appFolderPath)}";
             if (workItemName.EndsWith(".app"))

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
@@ -14,6 +14,8 @@
           Condition=" '@(XHarnessAppFolderToTest)' != '' OR '@(XHarnessPackageToTest)' != '' OR '@(XHarnessAndroidProject)' != '' OR '@(XHarnessiOSProject)' != '' "
           BeforeTargets="CoreTest">
 
+    <Error Condition=" '$(_XHarnessPackageVersion)' == '' " Text="XHarness CLI version not defined! Please specify it using the MicrosoftDotNetXHarnessCLIVersion property" />
+
     <!-- When XHarnessNupkgPath is set, we send the .nupkg with the job and install the tool from there -->
     <Message Condition=" '$(XHarnessNupkgPath)' != '' " Text="XHarnessNupkgPath is set so XHarnessPackageSource will be ignored" Importance="normal" />
 
@@ -33,7 +35,7 @@
          When .NET is not already installed there, we set DOTNET_ROOT to help it find the right one. -->
     <PropertyGroup Condition="$(IsPosixShell)">
       <HelixPreCommands>$(HelixPreCommands);export DOTNET_ROOT=$HELIX_CORRELATION_PAYLOAD/dotnet</HelixPreCommands>
-      <HelixPreCommands>$(HelixPreCommands);dotnet tool install --tool-path $HELIX_CORRELATION_PAYLOAD/xharness-cli --version $(_XHarnessPackageVersion) --add-source $(XHarnessPackageSource) $(_XHarnessPackageName) </HelixPreCommands>
+      <HelixPreCommands>$(HelixPreCommands);dotnet tool install --tool-path $HELIX_CORRELATION_PAYLOAD/xharness-cli --version $(_XHarnessPackageVersion) --add-source $(XHarnessPackageSource) $(_XHarnessPackageName) || exit 1</HelixPreCommands>
       <HelixPreCommands>$(HelixPreCommands);export PATH=$HELIX_CORRELATION_PAYLOAD/xharness-cli:$PATH</HelixPreCommands>
       <HelixPreCommands>$(HelixPreCommands);export XHARNESS_DISABLE_COLORED_OUTPUT=true</HelixPreCommands>
       <HelixPreCommands>$(HelixPreCommands);export XHARNESS_LOG_WITH_TIMESTAMPS=true</HelixPreCommands>
@@ -41,7 +43,7 @@
 
     <PropertyGroup Condition="!$(IsPosixShell)">
       <HelixPreCommands>$(HelixPreCommands);set DOTNET_ROOT=%HELIX_CORRELATION_PAYLOAD%\dotnet</HelixPreCommands>
-      <HelixPreCommands>$(HelixPreCommands);dotnet tool install --tool-path %HELIX_CORRELATION_PAYLOAD%\xharness-cli --version $(_XHarnessPackageVersion) --add-source $(XHarnessPackageSource) $(_XHarnessPackageName) </HelixPreCommands>
+      <HelixPreCommands>$(HelixPreCommands);dotnet tool install --tool-path %HELIX_CORRELATION_PAYLOAD%\xharness-cli --version $(_XHarnessPackageVersion) --add-source $(XHarnessPackageSource) $(_XHarnessPackageName) || exit /b</HelixPreCommands>
       <HelixPreCommands>$(HelixPreCommands);set PATH=%HELIX_CORRELATION_PAYLOAD%\xharness-cli%3B%PATH%</HelixPreCommands>
       <HelixPreCommands>$(HelixPreCommands);set XHARNESS_DISABLE_COLORED_OUTPUT=true</HelixPreCommands>
       <HelixPreCommands>$(HelixPreCommands);set XHARNESS_LOG_WITH_TIMESTAMPS=true</HelixPreCommands>


### PR DESCRIPTION
- Exit on failed `dotnet tool install`
- Error out on unset XHarness CLI version
- Strip trailing slash of app bundle names for `GetDirectoryName` to point to parent dir