### PR TITLE
Add iOS/Android pass-through arguments

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
@@ -106,8 +106,16 @@ namespace Microsoft.DotNet.Helix.Sdk
             string instrumentationArg = string.IsNullOrEmpty(androidInstrumentationName) ? string.Empty : $"-i={androidInstrumentationName}";
 
             string outputDirectory = IsPosixShell ? "$HELIX_WORKITEM_UPLOAD_ROOT" : "%HELIX_WORKITEM_UPLOAD_ROOT%";
-            string xharnessRunCommand = $"xharness android test --app {Path.GetFileName(appPackage.ItemSpec)} --output-directory={outputDirectory} " +
-                                        $"--timeout={xHarnessTimeout.TotalSeconds} -p={androidPackageName} {outputPathArg} {instrumentationArg} {arguments} -v";
+            string xharnessRunCommand = $"xharness android test " +
+                                        $"--app {Path.GetFileName(appPackage.ItemSpec)} " +
+                                        $"--output-directory={outputDirectory} " +
+                                        $"--timeout={xHarnessTimeout.TotalSeconds} " +
+                                        $"-p={androidPackageName} " +
+                                        $"{outputPathArg} " +
+                                        $"{instrumentationArg} " +
+                                        $"{arguments} " +
+                                        $"-v" +
+                                        (!string.IsNullOrEmpty(AppArguments) ? $" -- {AppArguments}" : string.Empty);
 
             Log.LogMessage(MessageImportance.Low, $"Generated XHarness command: {xharnessRunCommand}");
 

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
@@ -102,19 +102,19 @@ namespace Microsoft.DotNet.Helix.Sdk
             appPackage.TryGetMetadata("AndroidInstrumentationName", out string androidInstrumentationName);
             appPackage.TryGetMetadata("DeviceOutputPath", out string deviceOutputPath);
 
-            string outputPathArg = string.IsNullOrEmpty(deviceOutputPath) ? string.Empty : $"--dev-out={deviceOutputPath}";
-            string instrumentationArg = string.IsNullOrEmpty(androidInstrumentationName) ? string.Empty : $"-i={androidInstrumentationName}";
+            string outputPathArg = string.IsNullOrEmpty(deviceOutputPath) ? string.Empty : $"--dev-out={deviceOutputPath} ";
+            string instrumentationArg = string.IsNullOrEmpty(androidInstrumentationName) ? string.Empty : $"-i={androidInstrumentationName} ";
 
             string outputDirectory = IsPosixShell ? "$HELIX_WORKITEM_UPLOAD_ROOT" : "%HELIX_WORKITEM_UPLOAD_ROOT%";
-            string xharnessRunCommand = $"xharness android test " +
+            string xharnessRunCommand = "xharness android test " +
                                         $"--app {Path.GetFileName(appPackage.ItemSpec)} " +
                                         $"--output-directory={outputDirectory} " +
                                         $"--timeout={xHarnessTimeout.TotalSeconds} " +
                                         $"-p={androidPackageName} " +
-                                        $"{outputPathArg} " +
-                                        $"{instrumentationArg} " +
-                                        $"{arguments} " +
-                                        $"-v" +
+                                        "-v " +
+                                        outputPathArg +
+                                        instrumentationArg +
+                                        arguments +
                                         (!string.IsNullOrEmpty(AppArguments) ? $" -- {AppArguments}" : string.Empty);
 
             Log.LogMessage(MessageImportance.Low, $"Generated XHarness command: {xharnessRunCommand}");

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
@@ -150,7 +150,8 @@ namespace Microsoft.DotNet.Helix.Sdk
                                         $"--timeout \"{xHarnessTimeout.TotalSeconds}\" " +
                                         $"--dotnet-root \"$DOTNET_ROOT\" " +
                                         $"--xharness \"$HELIX_CORRELATION_PAYLOAD/xharness-cli/xharness\" " +
-                                        $"--xcode-version {XcodeVersion}";
+                                        $"--xcode-version {XcodeVersion}" +
+                                        (!string.IsNullOrEmpty(AppArguments) ? $" --app-arguments \"{AppArguments}\"" : string.Empty);
 
             Log.LogMessage(MessageImportance.Low, $"Generated XHarness command: {xharnessRunCommand}");
 

--- a/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
@@ -9,6 +9,8 @@ namespace Microsoft.DotNet.Helix.Sdk
     /// </summary>
     public abstract class XHarnessTaskBase : BaseTask
     {
+        private const int DefaultTimeoutInMinutes = 15;
+
         /// <summary>
         /// Boolean true if this is a posix shell, false if not.
         /// This does not need to be set by a user; it is automatically determined in Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
@@ -40,10 +42,9 @@ namespace Microsoft.DotNet.Helix.Sdk
             {
                 if (!TimeSpan.TryParse(WorkItemTimeout, out timeout))
                 {
-                    const int defaultTimeoutInMinutes = 15;
                     Log.LogWarning($"Invalid value \"{WorkItemTimeout}\" provided for XHarnessWorkItemTimeout; " +
-                        $"falling back to default value of \"00:{defaultTimeoutInMinutes}:00\" ({defaultTimeoutInMinutes} minutes)");
-                    timeout = TimeSpan.FromMinutes(defaultTimeoutInMinutes);
+                        $"falling back to default value of \"00:{DefaultTimeoutInMinutes}:00\" ({DefaultTimeoutInMinutes} minutes)");
+                    timeout = TimeSpan.FromMinutes(DefaultTimeoutInMinutes);
                 }
             }
 

--- a/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
@@ -23,6 +23,11 @@ namespace Microsoft.DotNet.Helix.Sdk
         public string WorkItemTimeout { get; set; }
 
         /// <summary>
+        /// Extra arguments that will be passed to the iOS/Android/... app that is being run
+        /// </summary>
+        public string AppArguments { get; set; }
+
+        /// <summary>
         /// An array of ITaskItems of type HelixWorkItem
         /// </summary>
         [Output]
@@ -35,8 +40,10 @@ namespace Microsoft.DotNet.Helix.Sdk
             {
                 if (!TimeSpan.TryParse(WorkItemTimeout, out timeout))
                 {
-                    Log.LogWarning($"Invalid value \"{WorkItemTimeout}\" provided for XHarnessWorkItemTimeout; falling back to default value of \"00:015:00\" (15 minutes)");
-                    timeout = TimeSpan.FromMinutes(15);
+                    const int defaultTimeoutInMinutes = 15;
+                    Log.LogWarning($"Invalid value \"{WorkItemTimeout}\" provided for XHarnessWorkItemTimeout; " +
+                        $"falling back to default value of \"00:{defaultTimeoutInMinutes}:00\" ({defaultTimeoutInMinutes} minutes)");
+                    timeout = TimeSpan.FromMinutes(defaultTimeoutInMinutes);
                 }
             }
 

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
@@ -9,6 +9,7 @@ timeout=''
 dotnet_root=''
 xharness=''
 xcode_version=''
+app_arguments=''
 
 while [[ $# > 0 ]]; do
     opt="$(echo "$1" | awk '{print tolower($0)}')"
@@ -39,6 +40,10 @@ while [[ $# > 0 ]]; do
         ;;
       --xcode-version)
         xcode_version="$2"
+        shift
+        ;;
+      --app-arguments)
+        app_arguments="$2"
         shift
         ;;
       *)
@@ -83,6 +88,10 @@ if [ -z "$xcode_version" ]; then
     die "Xcode version wasn't provided";
 fi
 
+if [ ! -z "$app_arguments" ]; then
+    app_arguments="-- $app_arguments";
+fi
+
 # Restart the simulator to make sure it is tied to the right user session
 xcode_path="/Applications/Xcode${xcode_version/./}.app"
 simulator_app="$xcode_path/Contents/Developer/Applications/Simulator.app"
@@ -104,7 +113,8 @@ set +e
     --targets="$targets"                   \
     --timeout="$timeout"                   \
     --xcode="$xcode_path"                  \
-    -v
+    -v \
+    $app_arguments
 
 exit_code=$?
 


### PR DESCRIPTION
Allows to specify extra arguments that will be passed to XHarness in a way that will make sure XHarness flows them to the iOS/Android app