### PR TITLE
Add GeneratePlatformNotSupportedAdditionalParameters

### DIFF
--- a/src/Microsoft.DotNet.GenAPI/build/Microsoft.DotNet.GenAPI.targets
+++ b/src/Microsoft.DotNet.GenAPI/build/Microsoft.DotNet.GenAPI.targets
@@ -103,6 +103,7 @@
       <GenAPIArgs Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' or '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">$(GenAPIArgs) --throw "$(GeneratePlatformNotSupportedAssemblyMessage)"</GenAPIArgs>
       <GenAPIArgs Condition="'$(GeneratePlatformNotSupportedAssemblyWithGlobalPrefix)' == 'true'">$(GenAPIArgs) --global</GenAPIArgs>
       <GenAPIArgs Condition="'$(GeneratePlatformNotSupportedAssemblyHeaderFile)' != ''">$(GenAPIArgs) --header-file "$(GeneratePlatformNotSupportedAssemblyHeaderFile)"</GenAPIArgs>
+      <GenAPIArgs Condition="'$(GeneratePlatformNotSupportedAdditionalParameters)' != ''">$(GenAPIArgs) $(GeneratePlatformNotSupportedAdditionalParameters)</GenAPIArgs>
     </PropertyGroup>
 
     <Exec Command="$(_GenAPICommand) $(GenAPIArgs)" 


### PR DESCRIPTION
Add a property that permits parameters to pass through to GenApi when
generating not supported source.  This allows us to exclude types from
the generated source (among other things).

I need this to put together a sample for https://github.com/dotnet/runtime/issues/698.