### PR TITLE
Make check-channel-consistency actually fail the build if config is inconsistent

### DIFF
--- a/eng/common/post-build/check-channel-consistency.ps1
+++ b/eng/common/post-build/check-channel-consistency.ps1
@@ -15,10 +15,20 @@ try {
   # is available in YAML
   $PromoteToChannelsIds = $PromoteToChannels -split "\D" | Where-Object { $_ }
 
+  $HasErrors = $false
+
   foreach ($id in $PromoteToChannelsIds) {
     if (($id -ne 0) -and ($id -notin $AvailableChannelIds)) {
       Write-PipelineTaskError -Message "Channel $id is not present in the post-build YAML configuration! This is an error scenario. Please contact @dnceng."
+      $HasErrors = $true
     }
+  }
+
+  # The `Write-PipelineTaskError` doesn't error the script and we might report several errors
+  # in the previous lines. The check below makes sure that we return an error state from the
+  # script if we reported any validation error
+  if ($HasErrors) {
+    ExitWithExitCode 1 
   }
 
   Write-Host 'done.'

--- a/eng/common/post-build/check-channel-consistency.ps1
+++ b/eng/common/post-build/check-channel-consistency.ps1
@@ -15,19 +15,19 @@ try {
   # is available in YAML
   $PromoteToChannelsIds = $PromoteToChannels -split "\D" | Where-Object { $_ }
 
-  $HasErrors = $false
+  $hasErrors = $false
 
   foreach ($id in $PromoteToChannelsIds) {
     if (($id -ne 0) -and ($id -notin $AvailableChannelIds)) {
       Write-PipelineTaskError -Message "Channel $id is not present in the post-build YAML configuration! This is an error scenario. Please contact @dnceng."
-      $HasErrors = $true
+      $hasErrors = $true
     }
   }
 
   # The `Write-PipelineTaskError` doesn't error the script and we might report several errors
   # in the previous lines. The check below makes sure that we return an error state from the
   # script if we reported any validation error
-  if ($HasErrors) {
+  if ($hasErrors) {
     ExitWithExitCode 1 
   }
 


### PR DESCRIPTION
Closes: https://github.com/dotnet/arcade/issues/5646

Track if any error was reported and if so fail the build after reporting all errors.

Tested here: https://dnceng.visualstudio.com/internal/_build/results?buildId=685173&view=results