### PR TITLE
Allow to specify test and work item timeout in the XHarness SDK

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -76,7 +76,7 @@
     <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>5.0.0-beta.20309.1</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
     <XliffTasksVersion>1.0.0-beta.20206.1</XliffTasksVersion>
     <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.20224.5</MicrosoftDotNetMaestroTasksVersion>
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20309.4</MicrosoftDotNetXHarnessCLIVersion>
+    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20315.3</MicrosoftDotNetXHarnessCLIVersion>
     <MicrosoftSymbolUploaderBuildTaskVersion>1.1.125701</MicrosoftSymbolUploaderBuildTaskVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
@@ -5,7 +5,6 @@ using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
-using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.Helix.Sdk
 {
@@ -53,9 +52,9 @@ namespace Microsoft.DotNet.Helix.Sdk
             await Task.Yield();
             string workItemName = Path.GetFileNameWithoutExtension(appPackage.ItemSpec);
 
-            TimeSpan timeout = ParseTimeout();
+            var timeouts = ParseTimeouts();
 
-            string command = ValidateMetadataAndGetXHarnessAndroidCommand(appPackage, timeout);
+            string command = ValidateMetadataAndGetXHarnessAndroidCommand(appPackage, timeouts.TestTimeout);
 
             if (!Path.GetExtension(appPackage.ItemSpec).Equals(".apk", StringComparison.OrdinalIgnoreCase))
             {
@@ -70,7 +69,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                 { "Identity", workItemName },
                 { "PayloadArchive", CreateZipArchiveOfPackage(appPackage.ItemSpec) },
                 { "Command", command },
-                { "Timeout", timeout.ToString() },
+                { "Timeout", timeouts.WorkItemTimeout.ToString() },
             });
         }
 

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
@@ -148,6 +148,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                                         $"--output-directory \"$HELIX_WORKITEM_UPLOAD_ROOT\" " +
                                         $"--targets \"{targets}\" " +
                                         $"--timeout \"{xHarnessTimeout.TotalSeconds}\" " +
+                                        $"--launch-timeout 600 " +
                                         $"--dotnet-root \"$DOTNET_ROOT\" " +
                                         $"--xharness \"$HELIX_CORRELATION_PAYLOAD/xharness-cli/xharness\" " +
                                         $"--xcode-version {XcodeVersion}" +

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
@@ -84,9 +84,9 @@ namespace Microsoft.DotNet.Helix.Sdk
                 workItemName = workItemName.Substring(0, workItemName.Length - 4);
             }
 
-            TimeSpan timeout = ParseTimeout();
+            var timeouts = ParseTimeouts();
 
-            string command = ValidateMetadataAndGetXHarnessiOSCommand(appFolderItem, timeout);
+            string command = ValidateMetadataAndGetXHarnessiOSCommand(appFolderItem, timeouts.TestTimeout);
 
             Log.LogMessage($"Creating work item with properties Identity: {workItemName}, Payload: {appFolderPath}, Command: {command}");
 
@@ -95,7 +95,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                 { "Identity", workItemName },
                 { "PayloadArchive", await CreateZipArchiveOfFolder(appFolderPath) },
                 { "Command", command },
-                { "Timeout", timeout.ToString() },
+                { "Timeout", timeouts.WorkItemTimeout.ToString() },
             });
         }
 

--- a/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
@@ -20,14 +20,15 @@ namespace Microsoft.DotNet.Helix.Sdk
         public bool IsPosixShell { get; set; }
 
         /// <summary>
-        /// Optional timeout for the actual test execution.
-        /// Defaults to 12 minutes.
+        /// Optional timeout for the actual test execution in the TimeSpan format (e.g. 00:45:00 for 45 minutes).
+        /// Defaults to 00:12:00.
         /// </summary>
         public string TestTimeout { get; set; }
 
         /// <summary>
-        /// Optional timeout for the whole Helix work item run (includes SDK and tool installation).
-        /// Defaults to 20 minutes.
+        /// Optional timeout for the whole Helix work item run (includes SDK and tool installation)
+        /// in the TimeSpan format (e.g. 00:45:00 for 45 minutes).
+        /// Defaults to 00:20:00.
         /// </summary>
         public string WorkItemTimeout { get; set; }
 
@@ -47,9 +48,9 @@ namespace Microsoft.DotNet.Helix.Sdk
             TimeSpan testTimeout = TimeSpan.FromMinutes(DefaultTestTimeoutInMinutes);
             if (!string.IsNullOrEmpty(TestTimeout))
             {
-                if (!TimeSpan.TryParse(TestTimeout, out testTimeout))
+                if (!TimeSpan.TryParse(TestTimeout, out testTimeout) || testTimeout.Ticks < 0)
                 {
-                    Log.LogWarning($"Invalid value \"{TestTimeout}\" provided in WorkItemTimeout; " +
+                    Log.LogWarning($"Invalid value \"{TestTimeout}\" provided in TestTimeout; " +
                         $"falling back to default value of \"00:{DefaultTestTimeoutInMinutes}:00\" ({DefaultTestTimeoutInMinutes} minutes)");
                     testTimeout = TimeSpan.FromMinutes(DefaultTestTimeoutInMinutes);
                 }
@@ -58,7 +59,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             TimeSpan workItemTimeout = TimeSpan.FromMinutes(DefaultWorkItemTimeoutInMinutes);
             if (!string.IsNullOrEmpty(WorkItemTimeout))
             {
-                if (!TimeSpan.TryParse(WorkItemTimeout, out workItemTimeout))
+                if (!TimeSpan.TryParse(WorkItemTimeout, out workItemTimeout) || workItemTimeout.Ticks < 0)
                 {
                     Log.LogWarning($"Invalid value \"{WorkItemTimeout}\" provided in WorkItemTimeout; " +
                         $"falling back to default value of \"00:{DefaultWorkItemTimeoutInMinutes}:00\" ({DefaultWorkItemTimeoutInMinutes} minutes)");

--- a/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
@@ -9,7 +9,8 @@ namespace Microsoft.DotNet.Helix.Sdk
     /// </summary>
     public abstract class XHarnessTaskBase : BaseTask
     {
-        private const int DefaultTimeoutInMinutes = 15;
+        private const int DefaultWorkItemTimeoutInMinutes = 20;
+        private const int DefaultTestTimeoutInMinutes = 12;
 
         /// <summary>
         /// Boolean true if this is a posix shell, false if not.
@@ -19,8 +20,14 @@ namespace Microsoft.DotNet.Helix.Sdk
         public bool IsPosixShell { get; set; }
 
         /// <summary>
-        /// Optional timeout for all created workitems
-        /// Defaults to 1200s
+        /// Optional timeout for the actual test execution.
+        /// Defaults to 12 minutes.
+        /// </summary>
+        public string TestTimeout { get; set; }
+
+        /// <summary>
+        /// Optional timeout for the whole Helix work item run (includes SDK and tool installation).
+        /// Defaults to 20 minutes.
         /// </summary>
         public string WorkItemTimeout { get; set; }
 
@@ -35,20 +42,44 @@ namespace Microsoft.DotNet.Helix.Sdk
         [Output]
         public ITaskItem[] WorkItems { get; set; }
 
-        protected TimeSpan ParseTimeout()
+        protected (TimeSpan TestTimeout, TimeSpan WorkItemTimeout) ParseTimeouts()
         {
-            TimeSpan timeout = TimeSpan.FromMinutes(15);
-            if (!string.IsNullOrEmpty(WorkItemTimeout))
+            TimeSpan testTimeout = TimeSpan.FromMinutes(DefaultTestTimeoutInMinutes);
+            if (!string.IsNullOrEmpty(TestTimeout))
             {
-                if (!TimeSpan.TryParse(WorkItemTimeout, out timeout))
+                if (!TimeSpan.TryParse(TestTimeout, out testTimeout))
                 {
-                    Log.LogWarning($"Invalid value \"{WorkItemTimeout}\" provided for XHarnessWorkItemTimeout; " +
-                        $"falling back to default value of \"00:{DefaultTimeoutInMinutes}:00\" ({DefaultTimeoutInMinutes} minutes)");
-                    timeout = TimeSpan.FromMinutes(DefaultTimeoutInMinutes);
+                    Log.LogWarning($"Invalid value \"{TestTimeout}\" provided in WorkItemTimeout; " +
+                        $"falling back to default value of \"00:{DefaultTestTimeoutInMinutes}:00\" ({DefaultTestTimeoutInMinutes} minutes)");
+                    testTimeout = TimeSpan.FromMinutes(DefaultTestTimeoutInMinutes);
                 }
             }
 
-            return timeout;
+            TimeSpan workItemTimeout = TimeSpan.FromMinutes(DefaultWorkItemTimeoutInMinutes);
+            if (!string.IsNullOrEmpty(WorkItemTimeout))
+            {
+                if (!TimeSpan.TryParse(WorkItemTimeout, out workItemTimeout))
+                {
+                    Log.LogWarning($"Invalid value \"{WorkItemTimeout}\" provided in WorkItemTimeout; " +
+                        $"falling back to default value of \"00:{DefaultWorkItemTimeoutInMinutes}:00\" ({DefaultWorkItemTimeoutInMinutes} minutes)");
+                    workItemTimeout = TimeSpan.FromMinutes(DefaultWorkItemTimeoutInMinutes);
+                }
+            }
+            else if (!string.IsNullOrEmpty(TestTimeout))
+            {
+                // When test timeout was set and work item timeout has not,
+                // we adjust the work item timeout to give enough space for things to work
+                workItemTimeout = TimeSpan.FromMinutes(testTimeout.TotalMinutes + DefaultWorkItemTimeoutInMinutes - DefaultTestTimeoutInMinutes);
+            }
+
+            if (workItemTimeout <= testTimeout)
+            {
+                Log.LogWarning(
+                    $"Work item timeout ({workItemTimeout}) should be larger than test timeout ({testTimeout}) " +
+                    $"to allow the XHarness tool to be initialized properly.");
+            }
+
+            return (TestTimeout: testTimeout, WorkItemTimeout: workItemTimeout);
         }
     }
 }

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
@@ -83,7 +83,8 @@
           BeforeTargets="CoreTest">
     <CreateXHarnessAndroidWorkItems AppPackages="@(XHarnessPackageToTest)"
                                     IsPosixShell="$(IsPosixShell)"
-                                    WorkItemTimeout="$(XHarnessWorkItemTimeout)">
+                                    WorkItemTimeout="%(XHarnessPackageToTest.WorkItemTimeout)"
+                                    TestTimeout="%(XHarnessPackageToTest.TestTimeout)">
       <Output TaskParameter="WorkItems" ItemName="HelixWorkItem"/>
     </CreateXHarnessAndroidWorkItems>
   </Target>
@@ -93,8 +94,9 @@
           BeforeTargets="CoreTest">
     <CreateXHarnessiOSWorkItems AppFolders="@(XHarnessAppFolderToTest)"
                                 IsPosixShell="$(IsPosixShell)"
-                                WorkItemTimeout="$(XHarnessWorkItemTimeout)"
-                                XcodeVersion="$(XHarnessXcodeVersion)">
+                                XcodeVersion="$(XHarnessXcodeVersion)"
+                                WorkItemTimeout="%(XHarnessAppFolderToTest.WorkItemTimeout)"
+                                TestTimeout="%(XHarnessAppFolderToTest.TestTimeout)">
       <Output TaskParameter="WorkItems" ItemName="HelixWorkItem"/>
     </CreateXHarnessiOSWorkItems>
   </Target>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
@@ -6,6 +6,7 @@ app=''
 output_directory=''
 targets=''
 timeout=''
+launch_timeout=''
 dotnet_root=''
 xharness=''
 xcode_version=''
@@ -28,6 +29,10 @@ while [[ $# > 0 ]]; do
         ;;
       --timeout)
         timeout="$2"
+        shift
+        ;;
+      --launch-timeout)
+        launch_timeout="$2"
         shift
         ;;
       --dotnet-root)
@@ -76,6 +81,10 @@ if [ -z "$timeout" ]; then
     die "Test timeout wasn't provided";
 fi
 
+if [ -z "$launch_timeout" ]; then
+    die "Launch timeout wasn't provided";
+fi
+
 if [ -z "$dotnet_root" ]; then
     die "DotNet root path wasn't provided";
 fi
@@ -108,7 +117,8 @@ export XHARNESS_LOG_WITH_TIMESTAMPS=true
     --app="$app"                           \
     --output-directory="$output_directory" \
     --targets="$targets"                   \
-    --timeout="$timeout"                   \
+    --timeout=$timeout                     \
+    --launch-timeout=$launch_timeout       \
     --xcode="$xcode_path"                  \
     -v \
     $app_arguments

--- a/tests/XHarness/XHarness.TestAppBundle.proj
+++ b/tests/XHarness/XHarness.TestAppBundle.proj
@@ -21,7 +21,7 @@
     <ItemGroup>
       <XHarnessAppFoldersToTest Include="$(BaseOutputPath)appbundle/$(XHarnessAppBundleName)">
         <Targets>ios-simulator-64</Targets>
-        <WorkItemTimeout>00:25:00</WorkItemTimeout>
+        <TestTimeout>00:20:00</TestTimeout>
       </XHarnessAppFoldersToTest>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
This allows to specify the timeouts per work item and also distinguish between an overall timeout for the work item measured by the Helix client and an inner timeout for the actual test execution measured by XHarness