### PR TITLE
Print queue name with job ID when waiting for job completion

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/WaitForHelixJobCompletion.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/WaitForHelixJobCompletion.cs
@@ -20,17 +20,17 @@ namespace Microsoft.DotNet.Helix.Sdk
             // Wait 1 second to allow helix to register the job creation
             await Task.Delay(1000, cancellationToken);
 
-            List<string> jobNames = Jobs.Select(j => j.GetMetadata("Identity")).ToList();
+            List<(string jobName, string queueName)> jobNames = Jobs.Select(j => (j.GetMetadata("Identity"), j.GetMetadata("HelixTargetQueue"))).ToList();
 
             cancellationToken.ThrowIfCancellationRequested();
-            await Task.WhenAll(jobNames.Select(n => WaitForHelixJobAsync(n, cancellationToken)));
+            await Task.WhenAll(jobNames.Select(n => WaitForHelixJobAsync(n.jobName, n.queueName, cancellationToken)));
         }
 
-        private async Task WaitForHelixJobAsync(string jobName, CancellationToken cancellationToken)
+        private async Task WaitForHelixJobAsync(string jobName, string queueName, CancellationToken cancellationToken)
         {
             await Task.Yield();
             cancellationToken.ThrowIfCancellationRequested();
-            Log.LogMessage(MessageImportance.High, $"Waiting for completion of job {jobName}");
+            Log.LogMessage(MessageImportance.High, $"Waiting for completion of job {jobName} on {queueName}");
 
             for (;; await Task.Delay(10000, cancellationToken).ConfigureAwait(false)) // delay every time this loop repeats
             {
@@ -38,11 +38,11 @@ namespace Microsoft.DotNet.Helix.Sdk
                 var pf = await HelixApi.Job.PassFailAsync(jobName, cancellationToken).ConfigureAwait(false);
                 if (pf.Working == 0 && pf.Total != 0)
                 {
-                    Log.LogMessage(MessageImportance.High, $"Job {jobName} is completed with {pf.Total} finished work items.");
+                    Log.LogMessage(MessageImportance.High, $"Job {jobName} on {queueName} is completed with {pf.Total} finished work items.");
                     return;
                 }
 
-                Log.LogMessage($"Job {jobName} is not yet completed with Pending: {pf.Working}, Finished: {pf.Total - pf.Working}");
+                Log.LogMessage($"Job {jobName} on {queueName} is not yet completed with Pending: {pf.Working}, Finished: {pf.Total - pf.Working}");
                 cancellationToken.ThrowIfCancellationRequested();
             }
         }


### PR DESCRIPTION
Resolves dotnet/arcade#5260 by printing a job's target queue alongside the job ID in the "waiting" log messages. 