### PR TITLE
Make pkgproj support source package source linking

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Microsoft.DotNet.Build.Tasks.Packaging.props
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Microsoft.DotNet.Build.Tasks.Packaging.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <IsPackable Condition="'$(MSBuildProjectExtension)' == '.pkgproj'">true</IsPackable>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
@@ -41,6 +41,7 @@
   <PropertyGroup>
     <BaseId>$(MSBuildProjectName)</BaseId>
     <Id>$(IdPrefix)$(BaseId)</Id>
+    <PackageId>$(Id)</PackageId>
     <PackedPackageNamePrefix Condition="'$(PackedPackageNamePrefix)' == ''">transport</PackedPackageNamePrefix>
     <PackedPackageId>$(PackedPackageNamePrefix).$(Id)</PackedPackageId>
     <!-- It is by design that the Title matches the Id. We want users to get an assembly view. -->
@@ -327,47 +328,15 @@
   </Target>
 
   <Target Name="ConvertItems"
-          DependsOnTargets="ExpandProjectReferences;AddPlaceholders">
-    <CreateItem Include="@(ProjectReferenceOutput)">
-      <Output TaskParameter="Include"
-              ItemName="File"/>
-    </CreateItem>
+          DependsOnTargets="$(BeforePack);ExpandProjectReferences;AddPlaceholders">
     <ItemGroup>
-      <_LinkedContentFiles Include="@(Content)"
-                           Condition="'%(Content.Link)' != ''" />
-      <_UnlinkedContentFiles Include="@(Content)"
-                             Condition="'%(Content.Link)' == ''" />
-    </ItemGroup>
-    <CreateItem Include="@(_LinkedContentFiles)"
-                AdditionalMetadata="TargetPath=%(Link)">
-      <Output TaskParameter="Include"
-              ItemName="File"/>
-    </CreateItem>
-    <CreateItem Include="@(_UnlinkedContentFiles)"
-                AdditionalMetadata="TargetPath=%(RelativeDir)">
-      <Output TaskParameter="Include"
-              ItemName="File"/>
-    </CreateItem>
-
-    <!-- We need to special case library files in later phases. In order to make this
-         easier, we add custom metadata 'IsLibrary' that indicates whether the file is
-         targeting the lib folder or not. -->
-
-    <ItemGroup>
-      <_FileWithIsLibrary Include="@(File)"
-                          Condition="'%(File.TargetPath)' == 'lib' OR
-                                     $([System.String]::Copy('%(File.TargetPath)').ToLower().StartsWith('lib\')) OR
-                                     $([System.String]::Copy('%(File.TargetPath)').ToLower().StartsWith('lib/'))">
-        <PackageDirectory>Lib</PackageDirectory>
-      </_FileWithIsLibrary>
-      <_FileWithIsLibrary Include="@(File)"
-                          Condition="'%(File.TargetPath)' != 'lib' AND
-                                     !$([System.String]::Copy('%(File.TargetPath)').ToLower().StartsWith('lib\')) AND
-                                     !$([System.String]::Copy('%(File.TargetPath)').ToLower().StartsWith('lib/'))">
-        <PackageDirectory></PackageDirectory>
-      </_FileWithIsLibrary>
-      <File Remove="@(File)" />
-      <File Include="@(_FileWithIsLibrary)" />
+      <!-- PkgProj includes all Content, and None only when Pack=True-->
+      <_additionalFiles Include="@(Content)" />
+      <_additionalFiles Include="@(None)" Condition="'%(None.Pack)' == 'true'" />
+      
+      <File Include="@(_additionalFiles)" Condition="'%(_additionalFiles.PackagePath)' != ''" TargetPath="%(_additionalFiles.PackagePath)" />
+      <File Include="@(_additionalFiles)" Condition="'%(_additionalFiles.PackagePath)' == '' AND '%(_additionalFiles.Link)' != ''" TargetPath="%(_additionalFiles.Link)" />
+      <File Include="@(_additionalFiles)" Condition="'%(_additionalFiles.PackagePath)' == '' AND '%(_additionalFiles.Link)' == ''" TargetPath="%(_additionalFiles.RelativeDir)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Arcade will generate targets with sourcelink information and include those
in a package, but we weren't benefiting from this in pkgproj because we
were missing a couple properties and didn't include None items in the package.

Needed for https://github.com/dotnet/runtime/issues/37921