### PR TITLE
Support for building arm64 MSIs

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/packaging-tools.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/packaging-tools.targets
@@ -22,7 +22,7 @@
       <_osSupportsWixBasedInstallers Condition="'$(OS)' != 'Windows_NT'">false</_osSupportsWixBasedInstallers>
 
       <_osArchSupportsWixBasedInstallers>$(_osSupportsWixBasedInstallers)</_osArchSupportsWixBasedInstallers>
-      <_osArchSupportsWixBasedInstallers Condition="'$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'arm64'">false</_osArchSupportsWixBasedInstallers>
+      <_osArchSupportsWixBasedInstallers Condition="'$(TargetArchitecture)' == 'arm'">false</_osArchSupportsWixBasedInstallers>
 
       <!--
         Save the project's GenerateMSI setting. It's possible the current arch of the current OS

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/bundle/bundle.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/bundle/bundle.wxs
@@ -18,7 +18,7 @@
       ((VersionNT &gt; v6.1) OR (VersionNT = v6.1 AND ServicePackLevel &gt;= 1))
     </bal:Condition>
 
-    <?if $(var.Platform)=x64?>
+    <?if $(var.Platform)=x64 or $(var.Platform)=arm64?>
       <bal:Condition Message="#(loc.FailureNotSupportedX86OperatingSystem)">
         VersionNT64
       </bal:Condition>

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/product/product.common.wxi
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/product/product.common.wxi
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Include xmlns="http://schemas.microsoft.com/wix/2006/wi">
 
-  <Package Compressed="yes" InstallScope="perMachine" InstallerVersion="200" />
+  <Package Compressed="yes" InstallScope="perMachine" InstallerVersion="$(var.InstallerVersion)" />
 
   <MajorUpgrade DowngradeErrorMessage="$(var.DowngradeErrorMessage)" Schedule="afterInstallInitialize"/>
 

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/variables.wxi
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/variables.wxi
@@ -16,7 +16,7 @@
   <?if $(var.Platform)=x86?>
     <?define Program_Files="ProgramFilesFolder"?>
     <?define Win64AttributeValue=no?>
-  <?elseif $(var.Platform)=x64?>
+  <?elseif $(var.Platform)=x64 or $(var.Platform)=arm64?>
     <?define Program_Files="ProgramFiles64Folder"?>
     <?define Win64AttributeValue=yes?>
   <?else?>

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets
@@ -183,12 +183,12 @@
             GetBundleWixConfiguration">
     <PropertyGroup>
       <OutInstallerFile Condition="'$(OutInstallerFile)' == ''">$(InstallerFile)</OutInstallerFile>
-      <InstallerVersion>200</InstallerVersion>
       <!--
         Native arm64 MSI packages require version 500 of MSI database schema, see:
         https://docs.microsoft.com/en-us/windows/win32/msi/using-64-bit-windows-installer-packages
       -->
-      <InstallerVersion Condition="'$(MsiArch)' == 'arm64'">500</InstallerVersion>
+      <InstallerVersion Condition="'$(InstallerVersion)' == '' and '$(MsiArch)' == 'arm64'">500</InstallerVersion>
+      <InstallerVersion Condition="'$(InstallerVersion)' == ''">200</InstallerVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets
@@ -27,7 +27,7 @@
       Text="IntermediateOutputRootPath not specified" />
 
     <PropertyGroup>
-      <WixVersion>3.10.4</WixVersion>
+      <WixVersion>3.14.0.4118</WixVersion>
       <WixToolsDir>$(IntermediateOutputRootPath)WixTools.$(WixVersion)/</WixToolsDir>
       <!-- Used in WiX targets to locate files. -->
       <WixInstallPath>$(WixToolsDir)</WixInstallPath>
@@ -183,10 +183,17 @@
             GetBundleWixConfiguration">
     <PropertyGroup>
       <OutInstallerFile Condition="'$(OutInstallerFile)' == ''">$(InstallerFile)</OutInstallerFile>
+      <InstallerVersion>200</InstallerVersion>
+      <!--
+        Native arm64 MSI packages require version 500 of MSI database schema, see:
+        https://docs.microsoft.com/en-us/windows/win32/msi/using-64-bit-windows-installer-packages
+      -->
+      <InstallerVersion Condition="'$(MsiArch)' == 'arm64'">500</InstallerVersion>
     </PropertyGroup>
 
     <ItemGroup>
       <CandleVariables Include="MicrosoftEula" Value="$(MSBuildThisFileDirectory)eula.rtf" />
+      <CandleVariables Include="InstallerVersion" Value="$(InstallerVersion)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
This change adds arm64 Wix support for Shared FX in Arcade, it allows other repos to build arm64 MSIs and Burn bundles. No additional changes are needed for dotnet/runtime and dotnet/windowsdesktop repos, besides picking up a new version of Arcade, that includes this change.

This fixes https://github.com/dotnet/runtime/issues/1529 and expands further on the original plan. We will produce native arm64 MSI, and EXE, packages.

Arm64 requires v5.0 of Windows Installer schema - https://docs.microsoft.com/en-us/windows/win32/msi/using-64-bit-windows-installer-packages

Schema for other architectures is unchanged (v2.0) to allow installation on the same supported set of OS targets.