### PR TITLE
Add support for runtimeconfig options to RemoteExecutor.

### DIFF
--- a/src/Microsoft.DotNet.RemoteExecutor/src/RemoteInvokeOptions.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/RemoteInvokeOptions.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.RemoteExecutor
         /// <remarks>
         /// This option only works with .NET Core processes.
         /// </remarks>
-        public IDictionary<string, string> RuntimeConfigurationOptions { get; } = new Dictionary<string, string>();
+        public IDictionary<string, object> RuntimeConfigurationOptions { get; } = new Dictionary<string, object>();
 
         public bool RunAsSudo
         {

--- a/src/Microsoft.DotNet.RemoteExecutor/src/RemoteInvokeOptions.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/RemoteInvokeOptions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -35,6 +36,14 @@ namespace Microsoft.DotNet.RemoteExecutor
         public int ExpectedExitCode { get; set; } = RemoteExecutor.SuccessExitCode;
 
         public string ExceptionFile { get; } = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+        /// <summary>
+        /// Gets the runtimeconfig options (or AppContext settings) to set for the remote process.
+        /// </summary>
+        /// <remarks>
+        /// This option only works with .NET Core processes.
+        /// </remarks>
+        public IDictionary<string, string> RuntimeConfigurationOptions { get; } = new Dictionary<string, string>();
 
         public bool RunAsSudo
         {


### PR DESCRIPTION
This allows for tests to add AppContext/runtimeconfig.json settings in the remote process.

This is necessary to enable a test for the new EventSource feature switch: https://github.com/dotnet/runtime/pull/38129#discussion_r443003856