### PR TITLE
Stop publishing Android apks/iOS app bundles during the Test stage

### DIFF
--- a/tests/XHarness/XHarness.TestApk.proj
+++ b/tests/XHarness/XHarness.TestApk.proj
@@ -9,7 +9,7 @@
 
   <Target Name="Build" Returns="@(XHarnessPackageToTest)" >
     <Error Condition=" '$(ArtifactsTmpDir)' == ''" Text="Not downloading APK because ArtifactsTmpDir property is unset" />
-    <DownloadFile SourceUrl="$(XHarnessX86TestApkUrl)" DestinationFolder="$(ArtifactsTmpDir)/XHarness.TestApk\x86" SkipUnchangedFiles="True" Retries="5">
+    <DownloadFile SourceUrl="$(XHarnessX86TestApkUrl)" DestinationFolder="$(ArtifactsTmpDir)XHarness.TestApk\x86" SkipUnchangedFiles="True" Retries="5">
       <Output TaskParameter="DownloadedFile" ItemName="DownloadedApkFile" />
     </DownloadFile>
 

--- a/tests/XHarness/XHarness.TestApk.proj
+++ b/tests/XHarness/XHarness.TestApk.proj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
   <Target Name="Build" Returns="@(XHarnessPackageToTest)" >
-    <Error Condition=" '$(BaseOutputPath)' == ''" Text="Not downloading APK because BaseOutputPath property is unset" />
-    <DownloadFile SourceUrl="$(XHarnessX86TestApkUrl)" DestinationFolder="$(BaseOutputPath)apk/x86" SkipUnchangedFiles="True" Retries="5">
+    <Error Condition=" '$(ArtifactsTmpDir)' == ''" Text="Not downloading APK because ArtifactsTmpDir property is unset" />
+    <DownloadFile SourceUrl="$(XHarnessX86TestApkUrl)" DestinationFolder="$(ArtifactsTmpDir)/XHarness.TestApk\x86" SkipUnchangedFiles="True" Retries="5">
       <Output TaskParameter="DownloadedFile" ItemName="DownloadedApkFile" />
     </DownloadFile>
 
-    <DownloadFile SourceUrl="$(XHarnessX64TestApkUrl)" DestinationFolder="$(BaseOutputPath)apk/x86_64" SkipUnchangedFiles="True" Retries="5">
+    <DownloadFile SourceUrl="$(XHarnessX64TestApkUrl)" DestinationFolder="$(ArtifactsTmpDir)XHarness.TestApk\x86_64" SkipUnchangedFiles="True" Retries="5">
       <Output TaskParameter="DownloadedFile" ItemName="DownloadedApkFile" />
-    </DownloadFile> 
+    </DownloadFile>
 
     <Message Text="Downloaded @(DownloadedApkFile) for XHarness Test purposes" Importance="High" />
 
@@ -29,8 +29,8 @@
         <!-- If there are > 1 instrumentation class inside the package, we need to know the name of which to use -->
         <AndroidInstrumentationName>net.dot.MonoRunner</AndroidInstrumentationName>
 
-      </XHarnessPackageToTest>      
+      </XHarnessPackageToTest>
     </ItemGroup>
   </Target>
-  
+
 </Project>

--- a/tests/XHarness/XHarness.TestAppBundle.proj
+++ b/tests/XHarness/XHarness.TestAppBundle.proj
@@ -9,17 +9,17 @@
 
   <!-- We're not set up currently to build app bundles as part of normal builds, so this downloads existing ones for now -->
   <Target Name="Build" Returns="@(XHarnessAppFoldersToTest)">
-    <Error Condition=" '$(BaseOutputPath)' == ''" Text="Not downloading AppBundle because BaseOutputPath property is unset" />
-    <DownloadFile SourceUrl="$(XHarnessAppBundleUrl)" DestinationFolder="$(BaseOutputPath)appbundle" SkipUnchangedFiles="True" Retries="5">
+    <Error Condition=" '$(ArtifactsTmpDir)' == ''" Text="Not downloading AppBundle because ArtifactsTmpDir property is unset" />
+    <DownloadFile SourceUrl="$(XHarnessAppBundleUrl)" DestinationFolder="$(ArtifactsTmpDir)XHarness.TestAppBundle" SkipUnchangedFiles="True" Retries="5">
       <Output TaskParameter="DownloadedFile" ItemName="ZippedAppBundle" />
     </DownloadFile>
 
     <Message Text="Downloaded @(ZippedAppBundle) for XHarness Test purposes" Importance="High" />
 
-    <Exec Command="tar -xzf @(ZippedAppBundle) -C $(BaseOutputPath)appbundle" />
+    <Exec Command="tar -xzf @(ZippedAppBundle) -C $(ArtifactsTmpDir)XHarness.TestAppBundle" />
 
     <ItemGroup>
-      <XHarnessAppFoldersToTest Include="$(BaseOutputPath)appbundle/$(XHarnessAppBundleName)">
+      <XHarnessAppFoldersToTest Include="$(ArtifactsTmpDir)XHarness.TestAppBundle/$(XHarnessAppBundleName)">
         <Targets>ios-simulator-64</Targets>
         <TestTimeout>00:20:00</TestTimeout>
       </XHarnessAppFoldersToTest>


### PR DESCRIPTION
For iOS/Android XHarness E2E tests, we download pre-built apps that we send as a Helix job payload.

These are currently being downloaded into a location where we publish pipeline artifacts from.
This change moves the download location to a tmp folder since we don't need to publish them.