### PR TITLE
Add docs for using XHarness via Helix SDK

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/Readme.md
@@ -196,6 +196,9 @@ Given a local folder `$(TestFolder)` containing `runtests.cmd`, this will run `r
 </Project>
 ```
 
+### iOS/Android workload support (XHarness)
+The Helix SDK also supports execution of Android/iOS/WASM workloads where you only need to point it to an Android .apk or an iOS/tvOS/WatchOS .app bundle and it will execute these using a tool called XHarness on a specified emulator/device/JS engine. You can read more about this [here](https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md).
+
 ### Custom Helix WorkItem functionality
 There are times when a work item may detect that the machine being executed on is in a (possibly transient) undesirable state.  Additionally there can be times when a work item would like to request its machine be rebooted after execution (for instance, when a file handle is mysteriously open from another process).  The following functionality has been added to request both of these and can be used either from within a python script or any command line.
 

--- a/src/Microsoft.DotNet.Helix/Sdk/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/Readme.md
@@ -196,8 +196,8 @@ Given a local folder `$(TestFolder)` containing `runtests.cmd`, this will run `r
 </Project>
 ```
 
-### iOS/Android workload support (XHarness)
-The Helix SDK also supports execution of Android/iOS/WASM workloads where you only need to point it to an Android .apk or an iOS/tvOS/WatchOS .app bundle and it will execute these using a tool called XHarness on a specified emulator/device/JS engine. You can read more about this [here](https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md).
+### iOS/Android/WASM workload support (XHarness)
+The Helix SDK also supports execution of Android/iOS/WASM workloads where you only need to point it to an Android .apk or an iOS/tvOS/WatchOS .app bundle and it will execute these using a tool called XHarness on a specified emulator/device/JS engine. The workloads have to run on Helix queues that are ready for these types of jobs, meaning they have emulators installed, devices connected or JS engine installed. You can read more about this [here](https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md).
 
 ### Custom Helix WorkItem functionality
 There are times when a work item may detect that the machine being executed on is in a (possibly transient) undesirable state.  Additionally there can be times when a work item would like to request its machine be rebooted after execution (for instance, when a file handle is mysteriously open from another process).  The following functionality has been added to request both of these and can be used either from within a python script or any command line.

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
@@ -21,12 +21,12 @@ This is automatically included as a Helix Correlation Payload for the job when X
 ## How to use
 
 There are three main ways how to use XHarness through the Helix SDK:
-- Specify the apks/app bundles as described above and everything will be taken care of from there. You no longer specify the `HelixCommand` to be executed. Each apk/app bundle you specify will be processed as a separate Helix work item.
-- Specify the `XHarnessAndroidProject` or `XHarnessiOSProject` task items which will produce apks/app bundles from the `Build` target.
+- Specify the apks/app bundles using the `XHarnessPackageToTest` and `XHarnessAppFolderToTest` items as described below and everything will be taken care of from there. You no longer specify the `HelixCommand` to be executed. Each apk/app bundle will be processed as a separate Helix work item.
+- Specify the `XHarnessAndroidProject` or `XHarnessiOSProject` task items which will point to projects that produce apks/app bundles from their `Build` target.
   - Examples - [iOS](https://github.com/dotnet/arcade/blob/master/tests/XHarness/XHarness.TestAppBundle.proj) and [Android](https://github.com/dotnet/arcade/blob/master/tests/XHarness/XHarness.TestApk.proj)
-- Only request the XHarness dotnet tool to be pre-installed for the Helix job for you and then call it yourself from bash/cmd - see [XHarness tool pre-installation only](#xharness-tool-pre-installation-only).
+- Only request the XHarness dotnet tool to be pre-installed for the Helix job for you and then call the XHarness tool yourself as shown below.
 
-There are some required/optional configuration properties that need to/can be set in any case:
+There are some required configuration properties that need to be set for XHarness to work and some optional to customize the run further:
 
 ```xml
 <PropertyGroup>
@@ -47,6 +47,20 @@ There are some required/optional configuration properties that need to/can be se
 <!-- Required: Configuration that is already needed for the Helix SDK -->
 <ItemGroup Condition=" '$(HelixAccessToken)' == '' ">
   <HelixTargetQueue Include="osx.1015.amd64.open"/>
+</ItemGroup>
+```
+
+### Calling the XHarness tool directly
+
+In case you decide to request the SDK to pre-install the XHarness tool only without any specific payload, you just don't specify `XHarnessPackageToTest` or `XHarnessAppFolderToTest` items and you specify the Helix command directly.
+There will be an environmental variable called `XHARNESS_CLI_PATH` set that will point to the XHarness CLI DLL that needs to be run using `dotnet exec` like so:
+
+```xml
+<ItemGroup>
+  <HelixWorkItem Include="Run WASM tests">
+    <Command Condition="$(IsPosixShell)">dotnet exec $XHARNESS_CLI_PATH wasm test --engine ...</Command>
+    <Command Condition="!$(IsPosixShell)">dotnet exec %XHARNESS_CLI_PATH% wasm test --engine ...</Command>
+  </HelixWorkItem>
 </ItemGroup>
 ```
 
@@ -124,19 +138,4 @@ You can also specify some metadata that will help you configure the run better:
 
 ### WASM payloads
 
-We currently do not support execution of WASM workloads directly, please refer to [XHarness tool pre-installation only](#xharness-tool-pre-installation-only) and call the `xharness wasm test` command manually.
-
-### XHarness tool pre-installation only
-
-In case you decide to request the SDK to pre-install the XHarness tool only without any specific payload, you just don't specify `XHarnessPackageToTest` or `XHarnessAppFolderToTest`
-items and in that case you need to specify the Helix command.
-There will be an environmental variable `XHARNESS_CLI_PATH` set that will point to the XHarness CLI DLL that needs to be run using `dotnet exec` like so:
-
-```xml
-<ItemGroup>
-  <HelixWorkItem Include="Run WASM tests">
-    <!-- Note: Use %XHARNESS_CLI_PATH% for Windows which can be derived from $(IsPosixShell) property -->
-    <Command>dotnet exec $XHARNESS_CLI_PATH wasm test --engine ...</Command>
-  </HelixWorkItem>
-</ItemGroup>
-```
+We currently do not support execution of WASM workloads directly, please call the `xharness wasm test` command manually.

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
@@ -31,6 +31,9 @@ There are some required/optional configuration properties that need to/can be se
 ```xml
 <PropertyGroup>
   <!-- Required: Version of XHarness CLI to use -->
+  <IncludeXHarnessCli>true</IncludeXHarnessCli>
+
+  <!-- Required: Version of XHarness CLI to use -->
   <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20322.1</MicrosoftDotNetXHarnessCLIVersion>
 
   <!-- Optional: Properties that are also valid for the Arcade Helix SDK (some might be needed for CI runs only) -->
@@ -125,21 +128,14 @@ We currently do not support execution of WASM workloads directly, please refer t
 
 ### XHarness tool pre-installation only
 
-In case you decide to request the SDK to pre-install the XHarness tool only without any specific payload, you can do so by setting the `IncludeXHarnessCli` property to `true`:
-
-```xml
-<PropertyGroup>
-  <IncludeXHarnessCli>true</IncludeXHarnessCli>
-  <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20322.1</MicrosoftDotNetXHarnessCLIVersion>
-</PropertyGroup>
-```
-
-There will be an environmental variable set called `XHARNESS_CLI_PATH` set that will point to the XHarness CLI DLL that needs to be run:
+In case you decide to request the SDK to pre-install the XHarness tool only without any specific payload, you just don't specify `XHarnessPackageToTest` or `XHarnessAppFolderToTest`
+items and in that case you need to specify the Helix command.
+There will be an environmental variable `XHARNESS_CLI_PATH` set that will point to the XHarness CLI DLL that needs to be run using `dotnet exec` like so:
 
 ```xml
 <ItemGroup>
   <HelixWorkItem Include="Run WASM tests">
-    <!-- %XHARNESS_CLI_PATH% for Windows which can be derived from $(IsPosixShell) property -->
+    <!-- Note: Use %XHARNESS_CLI_PATH% for Windows which can be derived from $(IsPosixShell) property -->
     <Command>dotnet exec $XHARNESS_CLI_PATH wasm test --engine ...</Command>
   </HelixWorkItem>
 </ItemGroup>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
@@ -134,12 +134,13 @@ In case you decide to request the SDK to pre-install the XHarness tool only with
 </PropertyGroup>
 ```
 
-There will be an MSBuild property `XHarnessCliPath` set that will point to the XHarness CLI dll that needs to be run:
+There will be an environmental variable set called `XHARNESS_CLI_PATH` set that will point to the XHarness CLI DLL that needs to be run:
 
 ```xml
 <ItemGroup>
   <HelixWorkItem Include="Run WASM tests">
-    <Command>dotnet exec $(XHarnessCliPath) wasm test --engine ...</Command>
+    <!-- %XHARNESS_CLI_PATH% for Windows which can be derived from $(IsPosixShell) property -->
+    <Command>dotnet exec $XHARNESS_CLI_PATH wasm test --engine ...</Command>
   </HelixWorkItem>
 </ItemGroup>
 ```

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
@@ -1,0 +1,145 @@
+# XHarness support in Microsoft.DotNet.Helix.Sdk
+
+> This document presumes you are familiar with the usage of Microsoft.DotNet.Helix.Sdk. If not, please [start here](https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Helix/Sdk/Readme.md).
+
+The Helix SDK supports execution of certain **Android/iOS/tvOS/WatchOS/WASM workloads** where you only need to point the SDK to:
+  - an Android .apk,
+  - an iOS/tvOS/WatchOS .app bundle,
+  - or a WASM-ready test DLLs
+
+and it will execute these for you.
+
+The SDK will create a Helix job with the specified payload and send it to Helix, where, using a tool called [XHarness](https://github.com/dotnet/xharness), it will find a suitable test target - an emulator, a real device or a specified JS engine for WASM scenarios - which it will run the workload on.
+
+For these workloads, we currently expect the payload to contain xUnit tests and an [XHarness TestRunner](https://github.com/dotnet/xharness#test-runners) which will run these tests once the application is started.
+Logs will be collected automatically and sent back with the other Helix results.
+The test results themselves can be published to Azure DevOps just like it is supported with regular Helix jobs.
+
+XHarness is a [.NET Core tool](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools) and requires **.NET Core 3.1 runtime** to execute on the Helix agent.
+This is automatically pre-installed for the job when XHarness workload is detected.
+
+## How to use
+
+There are 3 main ways how to use XHarness through the Helix SDK:
+- Specify the apks/app bundles as described above and everything will be taken care of from there. You no longer specify the `HelixCommand` to be executed. Each apk/app bundle you specify will be processed as a separate Helix work item.
+- Specify the `XHarnessAndroidProject` or `XHarnessiOSProject` task items which will produce apks/app bundles from the `Build` target.
+  - Examples - [iOS](https://github.com/dotnet/arcade/blob/master/tests/XHarness/XHarness.TestAppBundle.proj) and [Android](https://github.com/dotnet/arcade/blob/master/tests/XHarness/XHarness.TestApk.proj)
+- Only request the XHarness dotnet tool to be pre-installed for the Helix job for you and then call it yourself from bash/cmd - see [XHarness tool pre-installation only](#xharness-tool-pre-installation-only).
+
+There are some required/optional configuration properties that need to/can be set in any case:
+
+```xml
+<PropertyGroup>
+  <!-- Required: Version of XHarness CLI to use -->
+  <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20322.1</MicrosoftDotNetXHarnessCLIVersion>
+
+  <!-- Optional: Properties that are also valid for the Arcade Helix SDK -->
+  <HelixType>test/product/</HelixType>
+  <HelixBaseUri>https://helix.int-dot.net</HelixBaseUri>
+  <Creator>$(BUILD_SOURCEVERSIONAUTHOR)</Creator>
+  <EnableXUnitReporter>true</EnableXUnitReporter>
+  <EnableAzurePipelinesReporter>true</EnableAzurePipelinesReporter>
+</PropertyGroup>
+
+<!-- Required: Configuration that is already needed for the Helix SDK -->
+<ItemGroup Condition=" '$(HelixAccessToken)' == '' ">
+  <HelixTargetQueue Include="osx.1015.amd64.open"/>
+</ItemGroup>
+```
+
+### iOS/tvOS/WatchOS .app bundle payloads
+
+To execute .app bundles, declare the `XHarnessAppFolderToTest` items:
+
+```xml
+<ItemGroup>
+  <!-- Find all directories named *.app -->
+  <XHarnessAppFolderToTest Include="$([System.IO.Directory]::GetDirectories('$(TestArchiveTestsRoot)', '*.app', System.IO.SearchOption.AllDirectories))">
+    <Targets>ios-device</Targets>
+    <Targets>ios-simulator-64_13.5</Targets>
+  </XHarnessAppFolderToTest>
+</ItemGroup>
+```
+
+The `<Targets>` metadata is a required configuration that tells XHarness which kind of device/Simulator to target.
+Use the XHarness CLI help command to find more (see the `--targets` option).
+
+You can also specify some metadata that will help you configure the run better:
+
+```xml
+<ItemGroup>
+  <XHarnessAppFolderToTest Include=".\appbundles\Contoso.Example.Tests.app">
+    <!-- Timeout for the overall run of the whole Helix work item (including Simulator booting, app installation..) -->
+    <WorkItemTimeout>00:20:00</WorkItemTimeout>
+
+    <!-- Timeout for the actual test run (when TestRunner starts execution of tests) -->
+    <!-- Should be smaller than WorkItemTimeout by several minutes -->
+    <TestTimeout>00:12:00</TestTimeout>
+  </XHarnessAppFolderToTest>
+</ItemGroup>
+```
+
+Furthermore, you can configure the execution further:
+
+```xml
+<PropertyGroup>
+  <!-- Optional: Specific version of Xcode to use -->
+  <XHarnessXcodeVersion>11.4</XHarnessXcodeVersion>
+</PropertyGroup>
+```
+
+### Android .apk payloads
+
+To execute .apks, declare the `XHarnessPackageToTest` items:
+
+```xml
+<ItemGroup>
+  <XHarnessPackageToTest Include="$(TestArchiveTestsRoot)apk\x64\System.Numerics.Vectors.Tests.apk">
+    <!-- Package name: this comes from metadata inside the apk itself -->
+    <AndroidPackageName>net.dot.System.Numerics.Vectors.Tests</AndroidPackageName>
+
+    <!-- If there are > 1 instrumentation class inside the package, we need to know the name of which to use -->
+    <AndroidInstrumentationName>net.dot.MonoRunner</AndroidInstrumentationName>
+  </XHarnessPackageToTest>
+</ItemGroup>
+```
+
+You can also specify some metadata that will help you configure the run better:
+
+```xml
+<ItemGroup>
+  <XHarnessAppFolderToTest Include="$(TestArchiveTestsRoot)**\*.apk">
+    <!-- Timeout for the overall run of the whole Helix work item (including Simulator booting, app installation..) -->
+    <WorkItemTimeout>00:20:00</WorkItemTimeout>
+
+    <!-- Timeout for the actual test run (when TestRunner starts execution of tests) -->
+    <!-- Should be smaller than WorkItemTimeout by several minutes -->
+    <TestTimeout>00:12:00</TestTimeout>
+  </XHarnessAppFolderToTest>
+</ItemGroup>
+```
+
+### WASM payloads
+
+We currently do not support execution of WASM workloads directly, please refer to [XHarness tool pre-installation only](#xharness-tool-pre-installation-only) and call the `xharness wasm test` command manually.
+
+### XHarness tool pre-installation only
+
+In case you decide to request the SDK to pre-install the XHarness tool only without any specific payload, you can do so by setting the `IncludeXHarnessCli` property to `true`:
+
+```xml
+<PropertyGroup>
+  <IncludeXHarnessCli>true</IncludeXHarnessCli>
+  <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20322.1</MicrosoftDotNetXHarnessCLIVersion>
+</PropertyGroup>
+```
+
+There will be an MSBuild property `XHarnessCliPath` set that will point to the XHarness CLI dll that needs to be run:
+
+```xml
+<ItemGroup>
+  <HelixWorkItem Include="Run WASM tests">
+    <Command>dotnet exec $(XHarnessCliPath) wasm test --engine ...</Command>
+  </HelixWorkItem>
+</ItemGroup>
+```

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
@@ -3,24 +3,24 @@
 > This document presumes you are familiar with the usage of Microsoft.DotNet.Helix.Sdk. If not, please [start here](https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Helix/Sdk/Readme.md).
 
 The Helix SDK supports execution of certain **Android/iOS/tvOS/WatchOS/WASM workloads** where you only need to point the SDK to:
-  - an Android .apk,
-  - an iOS/tvOS/WatchOS .app bundle,
-  - or a WASM-ready test DLLs
+  - Android .apks,
+  - iOS/tvOS/WatchOS .app bundles,
+  - WASM-ready test DLLs
 
 and it will execute these for you.
 
-The SDK will create a Helix job with the specified payload and send it to Helix, where, using a tool called [XHarness](https://github.com/dotnet/xharness), it will find a suitable test target - an emulator, a real device or a specified JS engine for WASM scenarios - which it will run the workload on.
+The SDK will create a Helix job with the specified payload and send it to Helix where, using a tool called [XHarness](https://github.com/dotnet/xharness), it will find a suitable test target - an emulator, a real device or a specified JS engine for WASM scenarios - which it will run the workload on.
 
 For these workloads, we currently expect the payload to contain xUnit tests and an [XHarness TestRunner](https://github.com/dotnet/xharness#test-runners) which will run these tests once the application is started.
 Logs will be collected automatically and sent back with the other Helix results.
-The test results themselves can be published to Azure DevOps just like it is supported with regular Helix jobs.
+The test results themselves can be published to Azure DevOps using the same python-based publishing scripts as regular Helix jobs.
 
 XHarness is a [.NET Core tool](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools) and requires **.NET Core 3.1 runtime** to execute on the Helix agent.
-This is automatically pre-installed for the job when XHarness workload is detected.
+This is automatically included as a Helix Correlation Payload for the job when XHarness workload is detected.
 
 ## How to use
 
-There are 3 main ways how to use XHarness through the Helix SDK:
+There are three main ways how to use XHarness through the Helix SDK:
 - Specify the apks/app bundles as described above and everything will be taken care of from there. You no longer specify the `HelixCommand` to be executed. Each apk/app bundle you specify will be processed as a separate Helix work item.
 - Specify the `XHarnessAndroidProject` or `XHarnessiOSProject` task items which will produce apks/app bundles from the `Build` target.
   - Examples - [iOS](https://github.com/dotnet/arcade/blob/master/tests/XHarness/XHarness.TestAppBundle.proj) and [Android](https://github.com/dotnet/arcade/blob/master/tests/XHarness/XHarness.TestApk.proj)
@@ -33,7 +33,7 @@ There are some required/optional configuration properties that need to/can be se
   <!-- Required: Version of XHarness CLI to use -->
   <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20322.1</MicrosoftDotNetXHarnessCLIVersion>
 
-  <!-- Optional: Properties that are also valid for the Arcade Helix SDK -->
+  <!-- Optional: Properties that are also valid for the Arcade Helix SDK (some might be needed for CI runs only) -->
   <HelixType>test/product/</HelixType>
   <HelixBaseUri>https://helix.int-dot.net</HelixBaseUri>
   <Creator>$(BUILD_SOURCEVERSIONAUTHOR)</Creator>
@@ -49,7 +49,7 @@ There are some required/optional configuration properties that need to/can be se
 
 ### iOS/tvOS/WatchOS .app bundle payloads
 
-To execute .app bundles, declare the `XHarnessAppFolderToTest` items:
+To execute .app bundles, declare one or more `XHarnessAppFolderToTest` items:
 
 ```xml
 <ItemGroup>
@@ -79,7 +79,7 @@ You can also specify some metadata that will help you configure the run better:
 </ItemGroup>
 ```
 
-Furthermore, you can configure the execution further:
+You can configure the execution further via MSBuild properties:
 
 ```xml
 <PropertyGroup>
@@ -90,7 +90,7 @@ Furthermore, you can configure the execution further:
 
 ### Android .apk payloads
 
-To execute .apks, declare the `XHarnessPackageToTest` items:
+To execute .apks, declare one or more `XHarnessPackageToTest` items:
 
 ```xml
 <ItemGroup>


### PR DESCRIPTION
@MattGal can you please review this (for my English and in case something is not clear/missing)?

Feel free to make comment suggestions or I also pushed it to `dotnet/arcade` directly so that you can contribute directly if you feel like it.

During writing about the SDK, I came to a conclusion that some of the APIs can be named a bit better:
1. `Targets` metadata should be `Target` because we specify targets by declaring it multiple times:
```
<XHarnessAppFolderToTest Include=".\appbundles\Contoso.Example.Tests.app">
  <Targets>tvos-device</Targets>
  <Targets>ios-simulator-64_13.5</Targets>
</XHarnessAppFolderToTest>
```
2. `XHarnessAppFolderToTest` should be `XHarnessAppBundlesToTest` - plural and in line with how we call it everywhere else
3. `XHarnessPackageToTest` should be `XHarnessApksToTest` - ditto
4. Questionable but `XHarnessXcodeVersion` should be tied to a specific work item, not globally, to allow test 11.4 and 11.5 side by side in one job, but maybe not important
5. We cannot have a non-XHarness and XHarness work items side by side in one job currently, but I don't think we can fix that without a big over-haul. I don't think we need to though..

We can decide to leave it as-is or fix some of them (`1.`, `2.` and `3.`?) once and for all before it gets used wildly and locked down by things depending on it...

Let me know what you think