### PR TITLE
using self contained guardian package (#5212)

### DIFF
--- a/eng/common/sdl/packages.config
+++ b/eng/common/sdl/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Guardian.Cli" version="0.7.2"/>
+  <package id="Microsoft.Guardian.Cli.win10-x64" version="0.20.1"/>
 </packages>

--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -65,7 +65,7 @@ jobs:
       continueOnError: ${{ parameters.sdlContinueOnError }}
   - ${{ if eq(parameters.overrideParameters, '') }}:
     - powershell: eng/common/sdl/execute-all-sdl-tools.ps1
-        -GuardianPackageName Microsoft.Guardian.Cli.0.7.2
+        -GuardianPackageName Microsoft.Guardian.Cli.win10-x64.0.20.1
         -NugetPackageDirectory $(Build.SourcesDirectory)\.packages
         -AzureDevOpsAccessToken $(dn-bot-dotnet-build-rw-code-rw)
         ${{ parameters.additionalParameters }}


### PR DESCRIPTION
## Description

This change updates the release/3.x guardian tools to match those used in master.

The version of Guardian used in the release/3.x branch depends on netcore2.2. Azure DevOps hosted pools [recently dropped](https://github.com/actions/virtual-environments/commit/7e0b4b4e05a57c67a153adabf4a6457bdc0fad24#diff-55dcabaaca18e802a555dfb957187fbe) default support for .NET Core 2.2. Current builds running in that set are now failling.

See also dotnet/arcade#5168

## Customer Impact

All 3.x builds with SDL enabled are currently failing. 

## Regression

No

## Risk

Low. Guardian is run as a separate analysis of the repository artifacts. The product itself should not be affected.

## Workarounds

An alternative is to add a task to explicitly install .NET Core 2.2 and continue using the older version of Guardian.