### PR TITLE
Rename XHarness apk/app bundle items

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
@@ -15,11 +15,9 @@ namespace Microsoft.DotNet.Helix.Sdk
     {
         /// <summary>
         /// An array of one or more paths to application packages (.apk for Android)
-        /// that will be used to create Helix work items.  
-        /// [Optional] Arguments: a string of arguments to be passed directly to the XHarness runner
-        /// [Optional] DeviceOutputPath: Location on the device where output files are generated
+        /// that will be used to create Helix work items.
         /// </summary>
-        public ITaskItem[] AppPackages { get; set; }
+        public ITaskItem[] Apks { get; set; }
 
         /// <summary>
         /// The main method of this MSBuild task which calls the asynchronous execution method and
@@ -38,7 +36,7 @@ namespace Microsoft.DotNet.Helix.Sdk
         /// <returns></returns>
         private async Task ExecuteAsync()
         {
-            WorkItems = (await Task.WhenAll(AppPackages.Select(PrepareWorkItem))).Where(wi => wi != null).ToArray();
+            WorkItems = (await Task.WhenAll(Apks.Select(PrepareWorkItem))).Where(wi => wi != null).ToArray();
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.Helix.Sdk
         /// An array of one or more paths to iOS app bundles (folders ending with ".app" usually)
         /// that will be used to create Helix work items.
         /// </summary>
-        public ITaskItem[] AppFolders { get; set; }
+        public ITaskItem[] AppBundles { get; set; }
 
         /// <summary>
         /// Xcode version to use in the [major].[minor] format, e.g. 11.4
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.Helix.Sdk
         /// <returns></returns>
         private async Task ExecuteAsync()
         {
-            WorkItems = (await Task.WhenAll(AppFolders.Select(PrepareWorkItem))).Where(wi => wi != null).ToArray();
+            WorkItems = (await Task.WhenAll(AppBundles.Select(PrepareWorkItem))).Where(wi => wi != null).ToArray();
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
@@ -21,7 +21,7 @@ This is automatically included as a Helix Correlation Payload for the job when X
 ## How to use
 
 There are three main ways how to use XHarness through the Helix SDK:
-- Specify the apks/app bundles using the `XHarnessPackageToTest` and `XHarnessAppFolderToTest` items as described below and everything will be taken care of from there. You no longer specify the `HelixCommand` to be executed. Each apk/app bundle will be processed as a separate Helix work item.
+- Specify the apks/app bundles using the `XHarnessApkToTest` and `XHarnessAppBundleToTest` items as described below and everything will be taken care of from there. You no longer specify the `HelixCommand` to be executed. Each apk/app bundle will be processed as a separate Helix work item.
 - Specify the `XHarnessAndroidProject` or `XHarnessiOSProject` task items which will point to projects that produce apks/app bundles from their `Build` target.
   - Examples - [iOS](https://github.com/dotnet/arcade/blob/master/tests/XHarness/XHarness.TestAppBundle.proj) and [Android](https://github.com/dotnet/arcade/blob/master/tests/XHarness/XHarness.TestApk.proj)
 - Only request the XHarness dotnet tool to be pre-installed for the Helix job for you and then call the XHarness tool yourself as shown below.
@@ -52,7 +52,7 @@ There are some required configuration properties that need to be set for XHarnes
 
 ### Calling the XHarness tool directly
 
-In case you decide to request the SDK to pre-install the XHarness tool only without any specific payload, you just don't specify `XHarnessPackageToTest` or `XHarnessAppFolderToTest` items and you specify the Helix command directly.
+In case you decide to request the SDK to pre-install the XHarness tool only without any specific payload, you just don't specify `XHarnessApkToTest` or `XHarnessAppBundleToTest` items and you specify the Helix command directly.
 There will be an environmental variable called `XHARNESS_CLI_PATH` set that will point to the XHarness CLI DLL that needs to be run using `dotnet exec` like so:
 
 ```xml
@@ -66,15 +66,15 @@ There will be an environmental variable called `XHARNESS_CLI_PATH` set that will
 
 ### iOS/tvOS/WatchOS .app bundle payloads
 
-To execute .app bundles, declare one or more `XHarnessAppFolderToTest` items:
+To execute .app bundles, declare one or more `XHarnessAppBundleToTest` items:
 
 ```xml
 <ItemGroup>
   <!-- Find all directories named *.app -->
-  <XHarnessAppFolderToTest Include="$([System.IO.Directory]::GetDirectories('$(TestArchiveTestsRoot)', '*.app', System.IO.SearchOption.AllDirectories))">
+  <XHarnessAppBundleToTest Include="$([System.IO.Directory]::GetDirectories('$(TestArchiveTestsRoot)', '*.app', System.IO.SearchOption.AllDirectories))">
     <Targets>ios-device</Targets>
     <Targets>ios-simulator-64_13.5</Targets>
-  </XHarnessAppFolderToTest>
+  </XHarnessAppBundleToTest>
 </ItemGroup>
 ```
 
@@ -85,14 +85,14 @@ You can also specify some metadata that will help you configure the run better:
 
 ```xml
 <ItemGroup>
-  <XHarnessAppFolderToTest Include=".\appbundles\Contoso.Example.Tests.app">
+  <XHarnessAppBundleToTest Include=".\appbundles\Contoso.Example.Tests.app">
     <!-- Timeout for the overall run of the whole Helix work item (including Simulator booting, app installation..) -->
     <WorkItemTimeout>00:20:00</WorkItemTimeout>
 
     <!-- Timeout for the actual test run (when TestRunner starts execution of tests) -->
     <!-- Should be smaller than WorkItemTimeout by several minutes -->
     <TestTimeout>00:12:00</TestTimeout>
-  </XHarnessAppFolderToTest>
+  </XHarnessAppBundleToTest>
 </ItemGroup>
 ```
 
@@ -107,17 +107,17 @@ You can configure the execution further via MSBuild properties:
 
 ### Android .apk payloads
 
-To execute .apks, declare one or more `XHarnessPackageToTest` items:
+To execute .apks, declare one or more `XHarnessApkToTest` items:
 
 ```xml
 <ItemGroup>
-  <XHarnessPackageToTest Include="$(TestArchiveTestsRoot)apk\x64\System.Numerics.Vectors.Tests.apk">
+  <XHarnessApkToTest Include="$(TestArchiveTestsRoot)apk\x64\System.Numerics.Vectors.Tests.apk">
     <!-- Package name: this comes from metadata inside the apk itself -->
     <AndroidPackageName>net.dot.System.Numerics.Vectors.Tests</AndroidPackageName>
 
     <!-- If there are > 1 instrumentation class inside the package, we need to know the name of which to use -->
     <AndroidInstrumentationName>net.dot.MonoRunner</AndroidInstrumentationName>
-  </XHarnessPackageToTest>
+  </XHarnessApkToTest>
 </ItemGroup>
 ```
 
@@ -125,14 +125,14 @@ You can also specify some metadata that will help you configure the run better:
 
 ```xml
 <ItemGroup>
-  <XHarnessAppFolderToTest Include="$(TestArchiveTestsRoot)**\*.apk">
+  <XHarnessAppBundleToTest Include="$(TestArchiveTestsRoot)**\*.apk">
     <!-- Timeout for the overall run of the whole Helix work item (including Simulator booting, app installation..) -->
     <WorkItemTimeout>00:20:00</WorkItemTimeout>
 
     <!-- Timeout for the actual test run (when TestRunner starts execution of tests) -->
     <!-- Should be smaller than WorkItemTimeout by several minutes -->
     <TestTimeout>00:12:00</TestTimeout>
-  </XHarnessAppFolderToTest>
+  </XHarnessAppBundleToTest>
 </ItemGroup>
 ```
 

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
@@ -71,7 +71,7 @@
       <_CurrentAdditionalProperties>%(XHarnessAndroidProject.AdditionalProperties)</_CurrentAdditionalProperties>
     </PropertyGroup>
     <MSBuild Projects="$(_CurrentXHarnessAndroidProject)" Targets="Build" Properties="$(_CurrentAdditionalProperties)">
-      <Output TaskParameter="TargetOutputs" ItemName="XHarnessPackageToTest" />
+      <Output TaskParameter="TargetOutputs" ItemName="XHarnessApkToTest" />
     </MSBuild>
   </Target>
 
@@ -84,29 +84,29 @@
       <_CurrentAdditionalProperties>%(XHarnessiOSProject.AdditionalProperties)</_CurrentAdditionalProperties>
     </PropertyGroup>
     <MSBuild Projects="$(_CurrentXHarnessiOSProject)" Targets="Build" Properties="$(_CurrentAdditionalProperties)">
-      <Output TaskParameter="TargetOutputs" ItemName="XHarnessAppFolderToTest" />
+      <Output TaskParameter="TargetOutputs" ItemName="XHarnessAppBundleToTest" />
     </MSBuild>
   </Target>
 
   <Target Name="CreateAndroidWorkItems"
-          Condition=" '@(XHarnessPackageToTest)' != '' "
+          Condition=" '@(XHarnessApkToTest)' != '' "
           BeforeTargets="CoreTest">
-    <CreateXHarnessAndroidWorkItems AppPackages="@(XHarnessPackageToTest)"
+    <CreateXHarnessAndroidWorkItems Apks="@(XHarnessApkToTest)"
                                     IsPosixShell="$(IsPosixShell)"
-                                    WorkItemTimeout="%(XHarnessPackageToTest.WorkItemTimeout)"
-                                    TestTimeout="%(XHarnessPackageToTest.TestTimeout)">
+                                    WorkItemTimeout="%(XHarnessApkToTest.WorkItemTimeout)"
+                                    TestTimeout="%(XHarnessApkToTest.TestTimeout)">
       <Output TaskParameter="WorkItems" ItemName="HelixWorkItem"/>
     </CreateXHarnessAndroidWorkItems>
   </Target>
 
   <Target Name="CreateiOSWorkItems"
-          Condition=" '@(XHarnessAppFolderToTest)' != '' "
+          Condition=" '@(XHarnessAppBundleToTest)' != '' "
           BeforeTargets="CoreTest">
-    <CreateXHarnessiOSWorkItems AppFolders="@(XHarnessAppFolderToTest)"
+    <CreateXHarnessiOSWorkItems AppBundles="@(XHarnessAppBundleToTest)"
                                 IsPosixShell="$(IsPosixShell)"
                                 XcodeVersion="$(XHarnessXcodeVersion)"
-                                WorkItemTimeout="%(XHarnessAppFolderToTest.WorkItemTimeout)"
-                                TestTimeout="%(XHarnessAppFolderToTest.TestTimeout)">
+                                WorkItemTimeout="%(XHarnessAppBundleToTest.WorkItemTimeout)"
+                                TestTimeout="%(XHarnessAppBundleToTest.TestTimeout)">
       <Output TaskParameter="WorkItems" ItemName="HelixWorkItem"/>
     </CreateXHarnessiOSWorkItems>
   </Target>

--- a/tests/XHarness/XHarness.TestApk.proj
+++ b/tests/XHarness/XHarness.TestApk.proj
@@ -7,7 +7,7 @@
     <XHarnessX64TestApkUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/android/test-apk/x86_64/System.Numerics.Vectors.Tests-x64.apk</XHarnessX64TestApkUrl>
   </PropertyGroup>
 
-  <Target Name="Build" Returns="@(XHarnessPackageToTest)" >
+  <Target Name="Build" Returns="@(XHarnessApkToTest)" >
     <Error Condition=" '$(ArtifactsTmpDir)' == ''" Text="Not downloading APK because ArtifactsTmpDir property is unset" />
     <DownloadFile SourceUrl="$(XHarnessX86TestApkUrl)" DestinationFolder="$(ArtifactsTmpDir)XHarness.TestApk\x86" SkipUnchangedFiles="True" Retries="5">
       <Output TaskParameter="DownloadedFile" ItemName="DownloadedApkFile" />
@@ -21,7 +21,7 @@
 
     <ItemGroup>
       <!-- We're not set up currently to build APK files as part of normal builds, so this downloads existing ones for now -->
-      <XHarnessPackageToTest Include="@(DownloadedApkFile)">
+      <XHarnessApkToTest Include="@(DownloadedApkFile)">
 
         <!-- Package name: this comes from metadata inside the apk itself -->
         <AndroidPackageName>net.dot.System.Numerics.Vectors.Tests</AndroidPackageName>
@@ -29,7 +29,7 @@
         <!-- If there are > 1 instrumentation class inside the package, we need to know the name of which to use -->
         <AndroidInstrumentationName>net.dot.MonoRunner</AndroidInstrumentationName>
 
-      </XHarnessPackageToTest>
+      </XHarnessApkToTest>
     </ItemGroup>
   </Target>
 

--- a/tests/XHarness/XHarness.TestAppBundle.proj
+++ b/tests/XHarness/XHarness.TestAppBundle.proj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <!-- We're not set up currently to build app bundles as part of normal builds, so this downloads existing ones for now -->
-  <Target Name="Build" Returns="@(XHarnessAppFoldersToTest)">
+  <Target Name="Build" Returns="@(XHarnessAppBundleToTest)">
     <Error Condition=" '$(ArtifactsTmpDir)' == ''" Text="Not downloading AppBundle because ArtifactsTmpDir property is unset" />
     <DownloadFile SourceUrl="$(XHarnessAppBundleUrl)" DestinationFolder="$(ArtifactsTmpDir)XHarness.TestAppBundle" SkipUnchangedFiles="True" Retries="5">
       <Output TaskParameter="DownloadedFile" ItemName="ZippedAppBundle" />
@@ -19,11 +19,11 @@
     <Exec Command="tar -xzf @(ZippedAppBundle) -C $(ArtifactsTmpDir)XHarness.TestAppBundle" />
 
     <ItemGroup>
-      <XHarnessAppFoldersToTest Include="$(ArtifactsTmpDir)XHarness.TestAppBundle/$(XHarnessAppBundleName)">
+      <XHarnessAppBundleToTest Include="$(ArtifactsTmpDir)XHarness.TestAppBundle/$(XHarnessAppBundleName)">
         <Targets>ios-simulator-64_13.5</Targets>
         <TestTimeout>00:15:00</TestTimeout>
         <WorkItemTimeout>00:30:00</WorkItemTimeout>
-      </XHarnessAppFoldersToTest>
+      </XHarnessAppBundleToTest>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
No one is using this SDK yet so renaming few things that were unclear in the time we were first writing it but will be in accordance with the terminology in `dotnet/xharness` and `dotnet/runtime` (and even the E2E tests in this repo)