### PR TITLE
Permit inclusion of build-time binaries in pkgproj

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
@@ -250,17 +250,17 @@
 
     <ItemGroup>
       <_FilesToPackage Remove="@(_FilesToPackage)" Condition="'$(ExcludeReferenceAssets)' == 'true' AND '%(_FilesToPackage.IsReferenceAsset)' == 'true'" />
+      
+      <!-- Some packages support legacy portable profiles where dependencies are provided by targeting pack -->
+      <_FilesToPackage Condition="'%(_FilesToPackage.HarvestDependencies)' == '' AND !$([System.String]::Copy('%(_FilesToPackage.TargetFramework)').StartsWith('portable-'))">
+        <!-- Only harvest files from ref/lib/runtimes dir-->
+        <HarvestDependencies Condition="$([System.String]::Copy('%(_FilesToPackage.TargetPath)').StartsWith('ref')) OR
+                                        $([System.String]::Copy('%(_FilesToPackage.TargetPath)').StartsWith('lib')) OR
+                                        $([System.String]::Copy('%(_FilesToPackage.TargetPath)').StartsWith('runtimes'))">true</HarvestDependencies>
+      </_FilesToPackage>
       <File Include="@(_FilesToPackage)">
         <PackageId>$(Id)</PackageId>
         <PackageVersion>$(PackageVersion)</PackageVersion>
-      </File>
-
-      <!-- Some packages support legacy portable profiles where dependencies are provided by targeting pack -->
-      <File Condition="'%(File.HarvestDependencies)' == '' AND !$([System.String]::Copy('%(File.TargetFramework)').StartsWith('portable-'))">
-        <!-- Only harvest files from ref/lib/runtimes dir-->
-        <HarvestDependencies Condition="$([System.String]::Copy('%(File.TargetPath)').StartsWith('ref')) OR
-                                        $([System.String]::Copy('%(File.TargetPath)').StartsWith('lib')) OR
-                                        $([System.String]::Copy('%(File.TargetPath)').StartsWith('runtimes'))">true</HarvestDependencies>
       </File>
     </ItemGroup>
   </Target>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
@@ -253,20 +253,16 @@
       <File Include="@(_FilesToPackage)">
         <PackageId>$(Id)</PackageId>
         <PackageVersion>$(PackageVersion)</PackageVersion>
-        <!-- Some packages support legacy portable profiles where dependencies are provided by targeting pack -->
-        <HarvestDependencies Condition="!$([System.String]::Copy('%(_FilesToPackage.TargetFramework)').StartsWith('portable-'))">true</HarvestDependencies>
+      </File>
+
+      <!-- Some packages support legacy portable profiles where dependencies are provided by targeting pack -->
+      <File Condition="'%(File.HarvestDependencies)' == '' AND !$([System.String]::Copy('%(File.TargetFramework)').StartsWith('portable-'))">
+        <!-- Only harvest files from ref/lib/runtimes dir-->
+        <HarvestDependencies Condition="$([System.String]::Copy('%(File.TargetPath)').StartsWith('ref')) OR
+                                        $([System.String]::Copy('%(File.TargetPath)').StartsWith('lib')) OR
+                                        $([System.String]::Copy('%(File.TargetPath)').StartsWith('runtimes'))">true</HarvestDependencies>
       </File>
     </ItemGroup>
-
-    <Error Condition="'$(SkipPackageFileCheck)' != 'true' AND
-                      '$(IsFrameworkPackage)' != 'true' AND
-                      '%(File.SkipPackageFileCheck)' != 'true' AND
-                      '%(File.FileName)' != '_' AND
-                      '%(File.FileName)%(File.Extension)' != 'runtime.json' AND
-                      '%(File.Extension)' != '.cs' AND
-                      '%(File.Extension)' != '.vb' AND
-                      !$(ID.Contains('%(File.FileName)'))"
-           Text="Package $(ID) contains file with name %(File.FileName).  If this is expected you can disable this filename checking for this item or package by setting SkipPackageFileCheck = true" />
   </Target>
   <!-- END project refs-->
 


### PR DESCRIPTION
PkgProj assumes that every dll that goes into a package is either a
reference or implementation assembly for with the same name
as the package.

The same-name requirement was a bad one, this just gets in the way when
we need to suppress it.  The requirement is not imposed by NuGet Pack
target.

We were also examining all DLLs in the package for assembly references
to raise to PackageReferences, but this should only be done for
ref/lib/runtime assets.

This should unblock packaging of analyzer in pkgproj.
@kevinwkt @layomia 