### PR TITLE
Fix bug in ActiveIssueDiscoverer with condition member names

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ActiveIssueDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ActiveIssueDiscoverer.cs
@@ -61,11 +61,11 @@ namespace Microsoft.DotNet.XUnitExtensions
 
             if (calleeType != null && conditionMemberNames != null)
             {
-                if (!DiscovererHelpers.Evaluate(calleeType, conditionMemberNames))
+                if (DiscovererHelpers.Evaluate(calleeType, conditionMemberNames))
                 {
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing);
                 }
-            }        
+            }
             else if (DiscovererHelpers.TestPlatformApplies(platforms) &&
                 DiscovererHelpers.TestRuntimeApplies(runtimes) &&
                 DiscovererHelpers.TestFrameworkApplies(frameworks))


### PR DESCRIPTION
In https://github.com/dotnet/arcade/pull/5376 the logic was copied from the ConditionalFactDiscoverer but this is wrong.
For ActiveIssue we want to _skip_ the test if the condition is true, rather than the other way round.