### PR TITLE
set DOTNET_CLI_HOME to repo local path during CI builds

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -112,9 +112,12 @@ function InitializeDotNetCli([bool]$install, [bool]$createSdkLocationFile) {
   # Disable first run since we do not need all ASP.NET packages restored.
   $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
-  # Disable telemetry on CI.
+  # On CI:
+  # Disable telemetry
+  # Set the CLI home directory to the build machine's workspace.
   if ($ci) {
     $env:DOTNET_CLI_TELEMETRY_OPTOUT=1
+    $env:DOTNET_CLI_HOME=$env:AGENT_BUILDDIRECTORY
   }
 
   # Source Build uses DotNetCoreSdkDir variable

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -110,9 +110,12 @@ function InitializeDotNetCli {
   # Disable first run since we want to control all package sources
   export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
-  # Disable telemetry on CI
+  # On CI:
+  # Disable telemetry
+  # Set the CLI home directory to the build machine's workspace.
   if [[ $ci == true ]]; then
     export DOTNET_CLI_TELEMETRY_OPTOUT=1
+    export DOTNET_CLI_HOME=$AGENT_BUILDDIRECTORY
   fi
 
   # LTTNG is the logging infrastructure used by Core CLR. Need this variable set


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/5402

Tested that the behavior is as expected in these builds:

Windows only: https://dev.azure.com/dnceng/internal/_build/results?buildId=724637&view=results
Windows and Linux: https://dev.azure.com/dnceng/internal/_build/results?buildId=724685&view=results