### PR TITLE
Fix generated wix command line parameter

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/CreateLightCommandPackageDrop.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/CreateLightCommandPackageDrop.cs
@@ -122,7 +122,7 @@ namespace Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk.src
             }
             if (Cultures != null)
             {
-                commandString += $" -culture:{Cultures}";
+                commandString += $" -cultures:{Cultures}";
             }
             if (Loc != null)
             {


### PR DESCRIPTION
The generated command line should have 'cultures' instead of 'culture'.