### PR TITLE
Get xcopy-msbuild from dotnet-eng feed

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -329,7 +329,7 @@ function InitializeXCopyMSBuild([string]$packageVersion, [bool]$install) {
     Create-Directory $packageDir
     Write-Host "Downloading $packageName $packageVersion"
     $ProgressPreference = 'SilentlyContinue' # Don't display the console progress UI - it's a huge perf hit
-    Invoke-WebRequest "https://dotnet.myget.org/F/roslyn-tools/api/v2/package/$packageName/$packageVersion/" -OutFile $packagePath
+    Invoke-WebRequest "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/flat2/$packageName/$packageVersion/$packageName.$packageVersion.nupkg" -OutFile $packagePath
     Unzip $packagePath $packageDir
   }
 


### PR DESCRIPTION
## Description

Download Roslyn.MSBuild packages from the dotnet-eng Azure Artifacts feed instead of the roslyn-tools MyGet feed.

This is part of solving dotnet/arcade#5385. See also the same change in main branch dotnet/arcade#5784.

## Customer Impact

Builds getting msbuild via this path will fail once MyGet is shut down.

## Regression

No

## Risk

Low. This same Roslyn.MSBuild packages are now available from a different location. 

## Workarounds

N/A