### PR TITLE
Set dotnet_cli_home to repo root instead of relying in azdo variables …

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -114,10 +114,10 @@ function InitializeDotNetCli([bool]$install, [bool]$createSdkLocationFile) {
 
   # On CI:
   # Disable telemetry
-  # Set the CLI home directory to the build machine's workspace.
+  # Set the CLI home directory to the repo root.
   if ($ci) {
     $env:DOTNET_CLI_TELEMETRY_OPTOUT=1
-    $env:DOTNET_CLI_HOME=$env:AGENT_BUILDDIRECTORY
+    $env:DOTNET_CLI_HOME=$RepoRoot
   }
 
   # Source Build uses DotNetCoreSdkDir variable

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -112,10 +112,10 @@ function InitializeDotNetCli {
 
   # On CI:
   # Disable telemetry
-  # Set the CLI home directory to the build machine's workspace.
+  # Set the CLI home directory to the repo root.
   if [[ $ci == true ]]; then
     export DOTNET_CLI_TELEMETRY_OPTOUT=1
-    export DOTNET_CLI_HOME=$AGENT_BUILDDIRECTORY
+    export DOTNET_CLI_HOME=$repo_root
   fi
 
   # LTTNG is the logging infrastructure used by Core CLR. Need this variable set


### PR DESCRIPTION
…to fix local build and docker scenarios

Validated with this build that was previously failing: https://dev.azure.com/dnceng/internal/_build/results?buildId=735315&view=results

Better fix for https://github.com/dotnet/arcade/issues/5402

