### PR TITLE
Revert #5805 - breaking internal tools restore

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -114,10 +114,10 @@ function InitializeDotNetCli([bool]$install, [bool]$createSdkLocationFile) {
 
   # On CI:
   # Disable telemetry
-  # Set the CLI home directory to the repo root.
+  # Set the CLI home directory to the build machine's workspace.
   if ($ci) {
     $env:DOTNET_CLI_TELEMETRY_OPTOUT=1
-    $env:DOTNET_CLI_HOME=$RepoRoot
+    $env:DOTNET_CLI_HOME=$env:AGENT_BUILDDIRECTORY
   }
 
   # Source Build uses DotNetCoreSdkDir variable

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -112,10 +112,10 @@ function InitializeDotNetCli {
 
   # On CI:
   # Disable telemetry
-  # Set the CLI home directory to the repo root.
+  # Set the CLI home directory to the build machine's workspace.
   if [[ $ci == true ]]; then
     export DOTNET_CLI_TELEMETRY_OPTOUT=1
-    export DOTNET_CLI_HOME=$repo_root
+    export DOTNET_CLI_HOME=$AGENT_BUILDDIRECTORY
   fi
 
   # LTTNG is the logging infrastructure used by Core CLR. Need this variable set


### PR DESCRIPTION
Revert "Set dotnet_cli_home to reporoot instead of relying in azdo variables to fix local build and docker scenarios (#5805)"

This reverts commit 04a410484f63cc8cb4be019493d2cd050bdf6b74.