### PR TITLE
Revert "set DOTNET_CLI_HOME  to repo local path during CI (#5775)"

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -112,12 +112,9 @@ function InitializeDotNetCli([bool]$install, [bool]$createSdkLocationFile) {
   # Disable first run since we do not need all ASP.NET packages restored.
   $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
-  # On CI:
-  # Disable telemetry
-  # Set the CLI home directory to the build machine's workspace.
+  # Disable telemetry on CI.
   if ($ci) {
     $env:DOTNET_CLI_TELEMETRY_OPTOUT=1
-    $env:DOTNET_CLI_HOME=$env:AGENT_BUILDDIRECTORY
   }
 
   # Source Build uses DotNetCoreSdkDir variable

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -110,12 +110,9 @@ function InitializeDotNetCli {
   # Disable first run since we want to control all package sources
   export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
-  # On CI:
-  # Disable telemetry
-  # Set the CLI home directory to the build machine's workspace.
+  # Disable telemetry on CI
   if [[ $ci == true ]]; then
     export DOTNET_CLI_TELEMETRY_OPTOUT=1
-    export DOTNET_CLI_HOME=$AGENT_BUILDDIRECTORY
   fi
 
   # LTTNG is the logging infrastructure used by Core CLR. Need this variable set


### PR DESCRIPTION
This reverts commit 8f61e5f14f60ff825a0befff291703ccdfa52f53.

It's causing failures in arcade validation against aspnetcore.