### PR TITLE
Add missing signing metadata

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -138,7 +138,10 @@
     <!--
       The user can set `PublishingVersion` via eng\Publishing.props
     -->
-    <PushToAzureDevOpsArtifacts 
+    <PushToAzureDevOpsArtifacts
+      AzureDevOpsCollectionUri="$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)"
+      AzureDevOpsProject="$(SYSTEM_TEAMPROJECT)"
+      AzureDevOpsBuildId="$(BUILD_BUILDID)"
       ItemsToPush="@(ItemsToPushToBlobFeed)"
       ItemsToSign="@(ItemsToSign)"
       StrongNameSignInfo="@(StrongNameSignInfo)"

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/GenerateBuildManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/GenerateBuildManifest.proj
@@ -31,6 +31,9 @@
   
   <Target Name="Execute">
     <GenerateBuildManifest Artifacts="@(ItemsToPush)"
+                           AzureDevOpsCollectionUri="$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)"
+                           AzureDevOpsProject="$(SYSTEM_TEAMPROJECT)"
+                           AzureDevOpsBuildId="$(BUILD_BUILDID)"
                            ItemsToSign="@(ItemsToSign)"
                            StrongNameSignInfo="@(StrongNameSignInfo)"
                            FileSignInfo="@(FileSignInfo)"

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
@@ -58,6 +58,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public static BuildModel CreateModelFromItems(
             ITaskItem[] artifacts,
+            string azureDevOpsCollectionUri,
+            string azureDevOpsProject,
+            int azureDevOpsBuildId,
             ITaskItem[] itemsToSign,
             ITaskItem[] strongNameSignInfo,
             ITaskItem[] fileSignInfo,
@@ -116,11 +119,18 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 isStableBuild,
                 publishingVersion,
                 log,
-                signingInformationModel: CreateSigningInformationModelFromItems(itemsToSign, strongNameSignInfo, fileSignInfo, fileExtensionSignInfo));
+                signingInformationModel: CreateSigningInformationModelFromItems(azureDevOpsCollectionUri, azureDevOpsProject, azureDevOpsBuildId, itemsToSign, strongNameSignInfo, fileSignInfo, fileExtensionSignInfo));
             return buildModel;
         }
 
-        public static SigningInformationModel CreateSigningInformationModelFromItems(ITaskItem[] itemsToSign, ITaskItem[] strongNameSignInfo, ITaskItem[] fileSignInfo, ITaskItem[] fileExtensionSignInfo)
+        public static SigningInformationModel CreateSigningInformationModelFromItems(
+            string azureDevOpsCollectionUri,
+            string azureDevOpsProject,
+            int azureDevOpsBuildId,
+            ITaskItem[] itemsToSign,
+            ITaskItem[] strongNameSignInfo,
+            ITaskItem[] fileSignInfo,
+            ITaskItem[] fileExtensionSignInfo)
         {
             List<ItemToSignModel> parsedItemsToSign = new List<ItemToSignModel>();
             List<StrongNameSignInfoModel> parsedStrongNameSignInfo = new List<StrongNameSignInfoModel>();
@@ -164,6 +174,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
             return new SigningInformationModel
             {
+                AzureDevOpsCollectionUri = azureDevOpsCollectionUri,
+                AzureDevOpsProject = azureDevOpsProject,
+                AzureDevOpsBuildId = azureDevOpsBuildId,
                 ItemsToSign = parsedItemsToSign,
                 StrongNameSignInfo = parsedStrongNameSignInfo,
                 FileSignInfo = parsedFileSignInfo,

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/GenerateBuildManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/GenerateBuildManifest.cs
@@ -34,6 +34,24 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public string OutputPath { get; set; }
 
         /// <summary>
+        /// The collection URI of the Azure DevOps instance
+        /// </summary>
+        [Required]
+        public string AzureDevOpsCollectionUri { get; set; }
+
+        /// <summary>
+        /// The Azure DevOps project of this build
+        /// </summary>
+        [Required]
+        public string AzureDevOpsProject { get; set; }
+
+        /// <summary>
+        /// The Azure DevOps project of this build
+        /// </summary>
+        [Required]
+        public int AzureDevOpsBuildId { get; set; }
+
+        /// <summary>
         /// List of files that need to be signed
         /// </summary>
         public ITaskItem[] ItemsToSign { get; set; }
@@ -105,6 +123,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                 var buildModel = BuildManifestUtil.CreateModelFromItems(
                     Artifacts,
+                    AzureDevOpsCollectionUri,
+                    AzureDevOpsProject,
+                    AzureDevOpsBuildId,
                     ItemsToSign,
                     StrongNameSignInfo,
                     FileSignInfo,

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/GenerateBuildManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/GenerateBuildManifest.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public string AzureDevOpsProject { get; set; }
 
         /// <summary>
-        /// The Azure DevOps project of this build
+        /// The Azure DevOps build ID
         /// </summary>
         [Required]
         public int AzureDevOpsBuildId { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
@@ -31,6 +31,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public string[] ManifestBuildData { get; set; }
 
+        public string AzureDevOpsCollectionUri { get; set; }
+
+        public string AzureDevOpsProject { get; set; }
+
+        public int AzureDevOpsBuildId { get; set; }
+
         public ITaskItem[] ItemsToSign { get; set; }
 
         public ITaskItem[] StrongNameSignInfo { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
@@ -165,7 +165,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         }
                     }
                     
-                    SigningInformationModel signingInformationModel = BuildManifestUtil.CreateSigningInformationModelFromItems(ItemsToSign, StrongNameSignInfo, FileSignInfo, FileExtensionSignInfo);
+                    SigningInformationModel signingInformationModel = BuildManifestUtil.CreateSigningInformationModelFromItems(AzureDevOpsCollectionUri, AzureDevOpsProject, AzureDevOpsBuildId,
+                        ItemsToSign, StrongNameSignInfo, FileSignInfo, FileExtensionSignInfo);
 
                     BuildManifestUtil.CreateBuildManifest(Log,
                         blobArtifacts,


### PR DESCRIPTION
Should fix the issues with v3.

Example seen in artifacts [here](https://dev.azure.com/dnceng/internal/_build/results?buildId=745678&view=artifacts&type=publishedArtifacts). Failure in that build is an SDL breaking on the licenses it seems like? Unrelated to my changes but might be worth investigating separately if it's not already a known issue.