### PR TITLE
Fix SignCheck failure for .js files

### DIFF
--- a/src/SignCheck/SignCheck/SignCheck.cs
+++ b/src/SignCheck/SignCheck/SignCheck.cs
@@ -488,6 +488,7 @@ namespace SignCheck
             await Task.WhenAll(uris.Select(u => DownloadFileAsync(u)));
         }
 
+        [STAThread]
         static int Main(string[] args)
         {
             // Exit code 3 for help output


### PR DESCRIPTION
SignCheck uses WinVerifyTrust to verify authenticode signatures. For JavaScript files, we ended up getting failures.

CoInitialize was failing with RPC_E_CHANGE_MODE when calling into the Windows Script Host, indicating a possible change in the threading model. By default, C# uses MTA threading. Switching to STA solves the problem.