### PR TITLE
Always use uname -m to detect the CPU name

### DIFF
--- a/eng/common/dotnet-install.sh
+++ b/eng/common/dotnet-install.sh
@@ -49,13 +49,8 @@ while [[ $# > 0 ]]; do
   shift
 done
 
-# Use uname to determine what the CPU is.
-cpuname=$(uname -p)
-# Some Linux platforms report unknown for platform, but the arch for machine.
-if [[ "$cpuname" == "unknown" ]]; then
-  cpuname=$(uname -m)
-fi
-
+# Use uname to determine what the CPU is, see https://en.wikipedia.org/wiki/Uname#Examples
+cpuname=$(uname -m)
 case $cpuname in
   aarch64)
     buildarch=arm64


### PR DESCRIPTION
So that we don't get this spurious warning on macOS: "Unknown CPU $cpuname detected, treating it as x64" (because `uname -p` returns `i386` and `uname -m` returns `x86_64` on macOS)

Looking at https://en.wikipedia.org/wiki/Uname#Examples it's safer to use uname -m rather than uname -p

This is also what is used in the host/runtime that powers Azure Functions: https://github.com/Azure/azure-functions-host/blob/b2af164a9278cae1d86718aa3b6a79f32d6c4401/src/WebJobs.Script.Grpc/generate_protos.sh#L36

Initially submitted on the ASP.NET Core repository, then submitted to the Arcade repository upon explanation: https://github.com/dotnet/aspnetcore/pull/20268#issuecomment-645079794