### PR TITLE
SkipOnCIAttribute env var for local developers and mobile runners to set when helix or azdo env vars are not set

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCIDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCIDiscoverer.cs
@@ -17,7 +17,9 @@ namespace Microsoft.DotNet.XUnitExtensions
     {
         public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
         {
-            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT")) || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS")))
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_CI") ||
+                !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT")) ||
+                !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS")))
             {
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing);
             }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCIDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCIDiscoverer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.XUnitExtensions
     {
         public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
         {
-            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_CI") ||
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_CI")) ||
                 !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT")) ||
                 !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS")))
             {


### PR DESCRIPTION
Since the plan is to remove RunTests scripts from regular runs and in mobile runners like wasm or iOS we need to set an env var when initializing the runner and running on CI, this adds a hook for that, without knowing the internals of AzDo or Helix.

cc: @akoeplinger @ViktorHofer 