### PR TITLE
Generating Not Supported Assemblies from reference Sources

### DIFF
--- a/src/Microsoft.DotNet.GenFacades/NotSupportedAssemblyGenerator.cs
+++ b/src/Microsoft.DotNet.GenFacades/NotSupportedAssemblyGenerator.cs
@@ -1,0 +1,160 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.DotNet.Build.Tasks;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.DotNet.GenFacades
+{
+    public class NotSupportedAssemblyGenerator : BuildTask
+    {
+        [Required]
+        public ITaskItem[] SourceFiles { get; set; }
+
+        [Required]
+        public string IntermediateOutputPath { get; set; }
+
+        [Required]
+        public string Message { get; set; }
+
+        public string ApiExclusionListPath { get; set; }
+
+        public override bool Execute()
+        {
+           GenerateNotSupportedAssemblyFiles(SourceFiles?.Select(item => item.ItemSpec).ToList(), IntermediateOutputPath, Message, ApiExclusionListPath);
+           return !Log.HasLoggedErrors;
+        }
+
+        public static void GenerateNotSupportedAssemblyFiles(IEnumerable<string> sourceFiles, string intermediatePath, string message, string apiExclusionListPath)
+        {
+            foreach (string sourceFile in sourceFiles)
+            {
+                if (string.IsNullOrEmpty(sourceFile))
+                {
+                    continue;
+                }
+                if (!File.Exists(sourceFile))
+                {
+                    throw new FileNotFoundException($"File {sourceFile} was not found.");
+                }
+                string text = GenerateNotSupportedAssemblyForSourceFile(sourceFile, message, apiExclusionListPath);
+                string path = intermediatePath + Path.GetFileNameWithoutExtension(sourceFile) + ".notSupported.cs";
+                File.WriteAllText(path, text);
+            }
+        }
+
+        public static string GenerateNotSupportedAssemblyForSourceFile(string sourceFile, string Message, string apiExclusionListPath)
+        {
+            string[] temp;
+            SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(File.ReadAllText(sourceFile));
+            if (apiExclusionListPath == null)
+            {
+                temp = null;
+            }
+            else
+            {
+                temp = File.ReadAllLines(Path.GetFullPath(apiExclusionListPath));
+            }
+            var rewriter = new NotSupportedAssmblyRewriter(Message, temp);
+            SyntaxNode root = rewriter.Visit(syntaxTree.GetRoot());
+            return root.GetText().ToString();
+        }
+    }
+
+    internal class NotSupportedAssmblyRewriter : CSharpSyntaxRewriter
+    {
+        private string _message;
+        private List<string> _exclusionApis;
+
+        public NotSupportedAssmblyRewriter(string Message, string[] ExclusionApis)
+        {
+            _message = Message;
+            _exclusionApis = ExclusionApis?.ToList();
+        }
+
+        public override SyntaxNode VisitMethodDeclaration(MethodDeclarationSyntax node)
+        {
+            if (node.Body == null)
+                return node;
+
+            if (_exclusionApis != null && _exclusionApis.Contains(GetMethodDefination(node)))
+                return null;
+
+            string message = "{ throw new System.PlatformNotSupportedException(" + $"{ _message }); "+ " }\n";  
+            var block = (BlockSyntax)SyntaxFactory.ParseStatement(message);
+            var newNode = node.Update(node.AttributeLists,
+                node.Modifiers,
+                node.ReturnType,
+                node.ExplicitInterfaceSpecifier,
+                node.Identifier,
+                node.TypeParameterList,
+                node.ParameterList,
+                node.ConstraintClauses,
+                block,
+                node.SemicolonToken);
+            return newNode;
+        }
+
+        public override SyntaxNode VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
+        {
+            string message = "{ throw new System.PlatformNotSupportedException(" + $"{ _message }); "+ " }\n";        
+            var block = (BlockSyntax)SyntaxFactory.ParseStatement(message);
+            var newNode = node.Update(node.AttributeLists,
+                node.Modifiers,
+                node.Identifier,
+                node.ParameterList,
+                node.Initializer,
+                block,
+                node.SemicolonToken);
+
+            return newNode;
+        }
+
+        public override SyntaxNode VisitAccessorDeclaration(AccessorDeclarationSyntax node)
+        {
+            if (node.Keyword.Text == "set" || node.Body == null)
+                return node;
+            string message = "{ throw new System.PlatformNotSupportedException(" + $"{ _message }); "+ " } ";       
+            var block = (BlockSyntax)SyntaxFactory.ParseStatement(message);
+            var newNode = node.Update(node.AttributeLists,
+                node.Modifiers,
+                node.Keyword,
+                block,
+                node.SemicolonToken);
+
+            return newNode;
+        }
+
+        private string GetFullyQualifiedName(TypeDeclarationSyntax node)
+        {
+            string parent;
+            if (node.Parent is NamespaceDeclarationSyntax)
+            {
+                parent = GetFullyQualifiedName((NamespaceDeclarationSyntax)node.Parent);
+            }
+            else
+            {
+                parent = GetFullyQualifiedName((TypeDeclarationSyntax)node.Parent);
+            }
+            return parent + "." + node.Identifier.ValueText.Trim();
+        }
+
+        private string GetFullyQualifiedName(NamespaceDeclarationSyntax node)
+        {
+            return node.Name.ToFullString().Trim();        
+        }
+
+        private string GetMethodDefination(MethodDeclarationSyntax node)
+        {
+            string methodName = GetFullyQualifiedName((TypeDeclarationSyntax)node.Parent) + "." + node.Identifier.ValueText;
+            return methodName;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.GenFacades/NotSupportedAssemblyGenerator.cs
+++ b/src/Microsoft.DotNet.GenFacades/NotSupportedAssemblyGenerator.cs
@@ -29,9 +29,13 @@ namespace Microsoft.DotNet.GenFacades
         public override bool Execute()
         {
             if (SourceFiles == null || SourceFiles.Length == 0)
+            {
                 Log.LogError("There are no ref source files.");
-
-            GenerateNotSupportedAssemblyFiles(SourceFiles?.Select(item => item.ItemSpec).ToList(), IntermediateOutputPath, Message, ApiExclusionListPath);
+            }
+            else
+            {
+                GenerateNotSupportedAssemblyFiles(SourceFiles.Select(item => item.ItemSpec).ToList(), IntermediateOutputPath, Message, ApiExclusionListPath);
+            }
             return !Log.HasLoggedErrors;
         }
 
@@ -46,6 +50,7 @@ namespace Microsoft.DotNet.GenFacades
                 if (!File.Exists(sourceFile))
                 {
                     Log.LogError($"File {sourceFile} was not found.");
+                    continue;
                 }
                 string text = GenerateNotSupportedAssemblyForSourceFile(sourceFile, message, apiExclusionListPath);
                 string path = Path.Combine(intermediatePath, Path.GetFileNameWithoutExtension(sourceFile) + ".notSupported.cs");

--- a/src/Microsoft.DotNet.GenFacades/NotSupportedAssemblyGenerator.cs
+++ b/src/Microsoft.DotNet.GenFacades/NotSupportedAssemblyGenerator.cs
@@ -14,6 +14,9 @@ using System.Linq;
 
 namespace Microsoft.DotNet.GenFacades
 {
+    /// <summary>
+    /// The class generates an NotSupportedAssembly from the reference sources.
+    /// </summary>
     public class NotSupportedAssemblyGenerator : BuildTask
     {
         [Required]

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.targets
@@ -14,4 +14,5 @@
 
   <Import Condition="'$(IsPartialFacadeAssembly)' == 'true' AND '$(IsReferenceAssembly)' != 'true'" Project="Microsoft.DotNet.GenPartialFacadeSource.targets" />
   <Import Condition="'$(IsPartialFacadeAssembly)' == 'true' AND '$(IsReferenceAssembly)' == 'true'" Project="Microsoft.DotNet.GenFacadesILRewriter.targets" />
+  <Import Project="Microsoft.DotNet.GenFacadesNotSupported.targets" />
 </Project>

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacadesNotSupported.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacadesNotSupported.targets
@@ -42,7 +42,6 @@
     
     <NotSupportedAssemblyGenerator
       SourceFiles="@(UpdateReferencePaths)"
-      IntermediateOutputPath="$(IntermediateOutputPath)"
       Message="$(GeneratePlatformNotSupportedAssembly)"
       ApiExclusionListPath="$(ApiExclusionListPath)" />
     

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacadesNotSupported.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacadesNotSupported.targets
@@ -7,6 +7,7 @@
     <CoreCompileDependsOn>UpdateRefToNonSupportedAssembly;$(CoreCompileDependsOn)</CoreCompileDependsOn>
     <!-- Not supported sources are created from the ref assembly, we currently don't produce finalizers in dummy assemblies, so we disable ApiCompat to not fail. -->
     <RunApiCompat>false</RunApiCompat>
+    <!-- The refs contains some unsed private fields and empty finalizers.-->
     <NoWarn>$(NoWarn);CA1823;CA1821;CS0169</NoWarn>
   </PropertyGroup>
 
@@ -27,7 +28,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="GenerateNotSupportedAssemblySourceFromRef">    
+  <Target Name="GenerateNotSupportedAssemblySourceFromRef">
     <ItemGroup>
       <UpdateReferencePaths Include="@(ReferenceSources)" NotSupportedPath="$(IntermediateOutputPath)\%(Filename).notsupported%(Extension)"/>
     </ItemGroup>

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacadesNotSupported.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacadesNotSupported.targets
@@ -21,6 +21,7 @@
   <Target Name="GetCompileItems"
           Returns="@(CompileItemsWithFullPath)">
     <ItemGroup>
+      <!-- Filtering out the files in the ref folder. -->
       <CompileItemsWithRootedPath Include="@(Compile -> '$([System.IO.Path]::GetFullPath('%(Compile.Identity)'))')" IsRooted="$([System.IO.Path]::IsPathRooted('%(Compile.Identity)'))" />    
       <CompileItemsWithFullPath Include="@(CompileItemsWithRootedPath)" Condition="'%(IsRooted)' == 'false'" />      
     </ItemGroup>

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacadesNotSupported.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacadesNotSupported.targets
@@ -1,0 +1,52 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project>
+    
+  <UsingTask TaskName="NotSupportedAssemblyGenerator" AssemblyFile="$(GenFacadesTargetAssemblyPath)" />
+  
+  <PropertyGroup Condition="'$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">
+    <CoreCompileDependsOn>UpdateRefToNonSupportedAssembly;$(CoreCompileDependsOn)</CoreCompileDependsOn>
+    <!-- Not supported sources are created from the ref assembly, we currently don't produce finalizers in dummy assemblies, so we disable ApiCompat to not fail. -->
+    <RunApiCompat>false</RunApiCompat>
+    <NoWarn>$(NoWarn);CA1823;CA1821;CS0169</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">
+    <ProjectReference Include="$(ContractProject)">
+      <Targets>GetCompileItems</Targets>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>ReferenceSources</OutputItemType>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Target Name="GetCompileItems"
+          Returns="@(CompileItemsWithFullPath)">
+    <ItemGroup>
+      <CompileItemsWithRootedPath Include="@(Compile -> '$([System.IO.Path]::GetFullPath('%(Compile.Identity)'))')" IsRooted="$([System.IO.Path]::IsPathRooted('%(Compile.Identity)'))" />    
+      <CompileItemsWithFullPath Include="@(CompileItemsWithRootedPath)" Condition="'%(IsRooted)' == 'false'" />      
+    </ItemGroup>
+  </Target>
+
+  <Target Name="GenerateNotSupportedAssemblySourceFromRef">    
+    <ItemGroup>
+      <UpdateReferencePaths Include="@(ReferenceSources)" NotSupportedPath="$(IntermediateOutputPath)\%(Filename).notsupported%(Extension)"/>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="UpdateRefToNonSupportedAssembly"
+        DependsOnTargets="GenerateNotSupportedAssemblySourceFromRef"
+        AfterTargets="ResolveProjectReferences"
+        Inputs="@(UpdateReferencePaths)"
+        Outputs="@(UpdateReferencePaths->'%(NotSupportedPath)')" >
+    
+    <NotSupportedAssemblyGenerator
+      SourceFiles="@(UpdateReferencePaths)"
+      IntermediateOutputPath="$(IntermediateOutputPath)"
+      Message="$(GeneratePlatformNotSupportedAssembly)"
+      ApiExclusionListPath="$(ApiExclusionListPath)" />
+    
+    <ItemGroup>
+      <Compile Include="@(UpdateReferencePaths->'%(NotSupportedPath)')" />
+      <FileWrites Include="@(UpdateReferencePaths->'%(NotSupportedPath)')" />
+    </ItemGroup>
+  </Target>
+</Project>


### PR DESCRIPTION
- Get The sources in the ref folder
- parse the sources
- rewrite the ctor, method and accessor bodies

I added the exclusion just for methods bcoz we only use this for methods in the runtime.
We can add a general purpose doc ids in the next one.