### PR TITLE
Add <LaunchTimeout> to  XHarness Helix SDK and make timeouts configurable per work item

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
@@ -50,9 +50,9 @@ namespace Microsoft.DotNet.Helix.Sdk
             await Task.Yield();
             string workItemName = Path.GetFileNameWithoutExtension(appPackage.ItemSpec);
 
-            var timeouts = ParseTimeouts();
+            var (testTimeout, workItemTimeout) = ParseTimeouts(appPackage);
 
-            string command = ValidateMetadataAndGetXHarnessAndroidCommand(appPackage, timeouts.TestTimeout);
+            string command = ValidateMetadataAndGetXHarnessAndroidCommand(appPackage, testTimeout);
 
             if (!Path.GetExtension(appPackage.ItemSpec).Equals(".apk", StringComparison.OrdinalIgnoreCase))
             {
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                 { "Identity", workItemName },
                 { "PayloadArchive", CreateZipArchiveOfPackage(appPackage.ItemSpec) },
                 { "Command", command },
-                { "Timeout", timeouts.WorkItemTimeout.ToString() },
+                { "Timeout", workItemTimeout.ToString() },
             });
         }
 

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
@@ -16,6 +16,8 @@ namespace Microsoft.DotNet.Helix.Sdk
     public class CreateXHarnessiOSWorkItems : XHarnessTaskBase
     {
         private const string PayloadScriptName = "ios-helix-job-payload.sh";
+        private const int DefaultLaunchTimeoutInMinutes = 10;
+        private const string LaunchTimeoutPropName = "LaunchTimeout";
 
         /// <summary>
         /// An array of one or more paths to iOS app bundles (folders ending with ".app" usually)
@@ -71,12 +73,12 @@ namespace Microsoft.DotNet.Helix.Sdk
         /// </summary>
         /// <param name="appFolderPath">Path to application package</param>
         /// <returns>An ITaskItem instance representing the prepared HelixWorkItem.</returns>
-        private async Task<ITaskItem> PrepareWorkItem(ITaskItem appFolderItem)
+        private async Task<ITaskItem> PrepareWorkItem(ITaskItem appBundleItem)
         {
             // Forces this task to run asynchronously
             await Task.Yield();
 
-            string appFolderPath = appFolderItem.ItemSpec.TrimEnd(Path.DirectorySeparatorChar);
+            string appFolderPath = appBundleItem.ItemSpec.TrimEnd(Path.DirectorySeparatorChar);
             
             string workItemName = Path.GetFileName(appFolderPath);
             if (workItemName.EndsWith(".app"))
@@ -84,9 +86,29 @@ namespace Microsoft.DotNet.Helix.Sdk
                 workItemName = workItemName.Substring(0, workItemName.Length - 4);
             }
 
-            var timeouts = ParseTimeouts();
+            var (testTimeout, workItemTimeout) = ParseTimeouts(appBundleItem);
 
-            string command = ValidateMetadataAndGetXHarnessiOSCommand(appFolderItem, timeouts.TestTimeout);
+            // Validation of any metadata specific to iOS stuff goes here
+            if (!appBundleItem.GetRequiredMetadata(Log, "Targets", out string targets))
+            {
+                Log.LogError("'Targets' metadata must be specified - " +
+                    "expecting list of target device/simulator platforms to execute tests on (e.g. ios-simulator-64)");
+                return null;
+            }
+
+            // Optional timeout for the how long it takes for the app to be installed, booted and tests start executing
+            TimeSpan launchTimeout = TimeSpan.FromMinutes(DefaultLaunchTimeoutInMinutes);
+            if (!appBundleItem.GetRequiredMetadata(Log, LaunchTimeoutPropName, out string launchTimeoutProp))
+            {
+                if (!TimeSpan.TryParse(launchTimeoutProp, out launchTimeout) || launchTimeout.Ticks < 0)
+                {
+                    Log.LogError($"Invalid value \"{launchTimeoutProp}\" provided in <{LaunchTimeoutPropName}>");
+                }
+            }
+
+            string appName = Path.GetFileName(appBundleItem.ItemSpec);
+
+            string command = GetXHarnessCommand(appName, targets, testTimeout, launchTimeout);
 
             Log.LogMessage($"Creating work item with properties Identity: {workItemName}, Payload: {appFolderPath}, Command: {command}");
 
@@ -95,7 +117,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                 { "Identity", workItemName },
                 { "PayloadArchive", await CreateZipArchiveOfFolder(appFolderPath) },
                 { "Command", command },
-                { "Timeout", timeouts.WorkItemTimeout.ToString() },
+                { "Timeout", workItemTimeout.ToString() },
             });
         }
 
@@ -132,23 +154,15 @@ namespace Microsoft.DotNet.Helix.Sdk
             return outputZipPath;
         }
 
-        private string ValidateMetadataAndGetXHarnessiOSCommand(ITaskItem appFolderPath, TimeSpan xHarnessTimeout)
+        private string GetXHarnessCommand(string appName, string targets, TimeSpan testTimeout, TimeSpan launchTimeout)
         {
-            // Validation of any metadata specific to iOS stuff goes here
-            if (!appFolderPath.GetRequiredMetadata(Log, "Targets", out string targets))
-            {
-                Log.LogError("'Targets' metadata must be specified - " +
-                    "expecting list of target device/simulator platforms to execute tests on (e.g. ios-simulator-64)");
-                return null;
-            }
-
             // We need to call 'sudo launchctl' to spawn the process in a user session with GUI rendering capabilities
             string xharnessRunCommand = $"sudo launchctl asuser `id -u` sh \"{PayloadScriptName}\" " +
-                                        $"--app \"$HELIX_WORKITEM_ROOT/{Path.GetFileName(appFolderPath.ItemSpec)}\" " +
+                                        $"--app \"$HELIX_WORKITEM_ROOT/{appName}\" " +
                                          "--output-directory \"$HELIX_WORKITEM_UPLOAD_ROOT\" " +
                                         $"--targets \"{targets}\" " +
-                                        $"--timeout \"{xHarnessTimeout.TotalSeconds}\" " +
-                                         "--launch-timeout 900 " +
+                                        $"--timeout {testTimeout.TotalSeconds} " +
+                                        $"--launch-timeout {launchTimeout.TotalSeconds} " +
                                          "--xharness-cli-path \"$XHARNESS_CLI_PATH\" " +
                                         $"--xcode-version {XcodeVersion}" +
                                         (!string.IsNullOrEmpty(AppArguments) ? $" --app-arguments \"{AppArguments}\"" : string.Empty);

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
@@ -89,7 +89,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             var (testTimeout, workItemTimeout) = ParseTimeouts(appBundleItem);
 
             // Validation of any metadata specific to iOS stuff goes here
-            if (!appBundleItem.GetRequiredMetadata(Log, "Targets", out string targets))
+            if (!appBundleItem.TryGetMetadata("Targets", out string targets))
             {
                 Log.LogError("'Targets' metadata must be specified - " +
                     "expecting list of target device/simulator platforms to execute tests on (e.g. ios-simulator-64)");
@@ -98,7 +98,7 @@ namespace Microsoft.DotNet.Helix.Sdk
 
             // Optional timeout for the how long it takes for the app to be installed, booted and tests start executing
             TimeSpan launchTimeout = TimeSpan.FromMinutes(DefaultLaunchTimeoutInMinutes);
-            if (!appBundleItem.GetRequiredMetadata(Log, LaunchTimeoutPropName, out string launchTimeoutProp))
+            if (!appBundleItem.TryGetMetadata(LaunchTimeoutPropName, out string launchTimeoutProp))
             {
                 if (!TimeSpan.TryParse(launchTimeoutProp, out launchTimeout) || launchTimeout.Ticks < 0)
                 {

--- a/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.Helix.Sdk
         {
             // Optional timeout for the actual test execution in the TimeSpan format
             TimeSpan testTimeout = TimeSpan.FromMinutes(DefaultTestTimeoutInMinutes);
-            if (xHarnessAppItem.GetRequiredMetadata(Log, TestTimeoutPropName, out string testTimeoutProp))
+            if (xHarnessAppItem.TryGetMetadata(TestTimeoutPropName, out string testTimeoutProp))
             {
                 if (!TimeSpan.TryParse(testTimeoutProp, out testTimeout) || testTimeout.Ticks < 0)
                 {
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.Helix.Sdk
 
             // Optional timeout for the whole Helix work item run (includes SDK and tool installation)
             TimeSpan workItemTimeout = TimeSpan.FromMinutes(DefaultWorkItemTimeoutInMinutes);
-            if (xHarnessAppItem.GetRequiredMetadata(Log, WorkItemTimeoutPropName, out string workItemTimeoutProp))
+            if (xHarnessAppItem.TryGetMetadata(WorkItemTimeoutPropName, out string workItemTimeoutProp))
             {
                 if (!TimeSpan.TryParse(workItemTimeoutProp, out workItemTimeout) || workItemTimeout.Ticks < 0)
                 {

--- a/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
@@ -12,25 +12,15 @@ namespace Microsoft.DotNet.Helix.Sdk
         private const int DefaultWorkItemTimeoutInMinutes = 20;
         private const int DefaultTestTimeoutInMinutes = 12;
 
+        private const string TestTimeoutPropName = "TestTimeout";
+        private const string WorkItemTimeoutPropName = "WorkItemTimeout";
+
         /// <summary>
         /// Boolean true if this is a posix shell, false if not.
         /// This does not need to be set by a user; it is automatically determined in Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
         /// </summary>
         [Required]
         public bool IsPosixShell { get; set; }
-
-        /// <summary>
-        /// Optional timeout for the actual test execution in the TimeSpan format (e.g. 00:45:00 for 45 minutes).
-        /// Defaults to 00:12:00.
-        /// </summary>
-        public string TestTimeout { get; set; }
-
-        /// <summary>
-        /// Optional timeout for the whole Helix work item run (includes SDK and tool installation)
-        /// in the TimeSpan format (e.g. 00:45:00 for 45 minutes).
-        /// Defaults to 00:20:00.
-        /// </summary>
-        public string WorkItemTimeout { get; set; }
 
         /// <summary>
         /// Extra arguments that will be passed to the iOS/Android/... app that is being run
@@ -43,30 +33,37 @@ namespace Microsoft.DotNet.Helix.Sdk
         [Output]
         public ITaskItem[] WorkItems { get; set; }
 
-        protected (TimeSpan TestTimeout, TimeSpan WorkItemTimeout) ParseTimeouts()
+        /// <summary>
+        /// Parses task item pointing to the app (app bundle/apk) we want to turn into an XHarness job.
+        /// </summary>
+        /// <param name="xHarnessAppItem">MSBuild task item</param>
+        /// <returns>
+        /// Parsed timeouts:
+        ///   - TestTimeout - Optional timeout for the actual test execution
+        ///   - WorkItemTimeout - Optional timeout for the whole Helix work item run (includes SDK and tool installation)
+        /// </returns>
+        protected (TimeSpan TestTimeout, TimeSpan WorkItemTimeout) ParseTimeouts(ITaskItem xHarnessAppItem)
         {
+            // Optional timeout for the actual test execution in the TimeSpan format
             TimeSpan testTimeout = TimeSpan.FromMinutes(DefaultTestTimeoutInMinutes);
-            if (!string.IsNullOrEmpty(TestTimeout))
+            if (!xHarnessAppItem.GetRequiredMetadata(Log, TestTimeoutPropName, out string testTimeoutProp))
             {
-                if (!TimeSpan.TryParse(TestTimeout, out testTimeout) || testTimeout.Ticks < 0)
+                if (!TimeSpan.TryParse(testTimeoutProp, out testTimeout) || testTimeout.Ticks < 0)
                 {
-                    Log.LogWarning($"Invalid value \"{TestTimeout}\" provided in TestTimeout; " +
-                        $"falling back to default value of \"00:{DefaultTestTimeoutInMinutes}:00\" ({DefaultTestTimeoutInMinutes} minutes)");
-                    testTimeout = TimeSpan.FromMinutes(DefaultTestTimeoutInMinutes);
+                    Log.LogError($"Invalid value \"{testTimeoutProp}\" provided in <{TestTimeoutPropName}>");
                 }
             }
 
+            // Optional timeout for the whole Helix work item run (includes SDK and tool installation)
             TimeSpan workItemTimeout = TimeSpan.FromMinutes(DefaultWorkItemTimeoutInMinutes);
-            if (!string.IsNullOrEmpty(WorkItemTimeout))
+            if (!xHarnessAppItem.GetRequiredMetadata(Log, WorkItemTimeoutPropName, out string workItemTimeoutProp))
             {
-                if (!TimeSpan.TryParse(WorkItemTimeout, out workItemTimeout) || workItemTimeout.Ticks < 0)
+                if (!TimeSpan.TryParse(workItemTimeoutProp, out workItemTimeout) || workItemTimeout.Ticks < 0)
                 {
-                    Log.LogWarning($"Invalid value \"{WorkItemTimeout}\" provided in WorkItemTimeout; " +
-                        $"falling back to default value of \"00:{DefaultWorkItemTimeoutInMinutes}:00\" ({DefaultWorkItemTimeoutInMinutes} minutes)");
-                    workItemTimeout = TimeSpan.FromMinutes(DefaultWorkItemTimeoutInMinutes);
+                    Log.LogError($"Invalid value \"{workItemTimeoutProp}\" provided in <{WorkItemTimeoutPropName}>");
                 }
             }
-            else if (!string.IsNullOrEmpty(TestTimeout))
+            else if (!string.IsNullOrEmpty(testTimeoutProp))
             {
                 // When test timeout was set and work item timeout has not,
                 // we adjust the work item timeout to give enough space for things to work

--- a/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.Helix.Sdk
         {
             // Optional timeout for the actual test execution in the TimeSpan format
             TimeSpan testTimeout = TimeSpan.FromMinutes(DefaultTestTimeoutInMinutes);
-            if (!xHarnessAppItem.GetRequiredMetadata(Log, TestTimeoutPropName, out string testTimeoutProp))
+            if (xHarnessAppItem.GetRequiredMetadata(Log, TestTimeoutPropName, out string testTimeoutProp))
             {
                 if (!TimeSpan.TryParse(testTimeoutProp, out testTimeout) || testTimeout.Ticks < 0)
                 {
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.Helix.Sdk
 
             // Optional timeout for the whole Helix work item run (includes SDK and tool installation)
             TimeSpan workItemTimeout = TimeSpan.FromMinutes(DefaultWorkItemTimeoutInMinutes);
-            if (!xHarnessAppItem.GetRequiredMetadata(Log, WorkItemTimeoutPropName, out string workItemTimeoutProp))
+            if (xHarnessAppItem.GetRequiredMetadata(Log, WorkItemTimeoutPropName, out string workItemTimeoutProp))
             {
                 if (!TimeSpan.TryParse(workItemTimeoutProp, out workItemTimeout) || workItemTimeout.Ticks < 0)
                 {

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
@@ -33,7 +33,7 @@ There are some required configuration properties that need to be set for XHarnes
   <!-- Required: Version of XHarness CLI to use -->
   <IncludeXHarnessCli>true</IncludeXHarnessCli>
 
-  <!-- Required: Version of XHarness CLI to use -->
+  <!-- Required: Version of XHarness CLI to use. Check the NuGet feed for current version: https://dev.azure.com/dnceng/public/_packaging?_a=package&feed=dotnet-eng&package=Microsoft.DotNet.XHarness.CLI&protocolType=NuGet -->
   <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20322.1</MicrosoftDotNetXHarnessCLIVersion>
 
   <!-- Optional: Properties that are also valid for the Arcade Helix SDK (some might be needed for CI runs only) -->
@@ -92,6 +92,9 @@ You can also specify some metadata that will help you configure the run better:
     <!-- Timeout for the actual test run (when TestRunner starts execution of tests) -->
     <!-- Should be smaller than WorkItemTimeout by several minutes -->
     <TestTimeout>00:12:00</TestTimeout>
+
+    <!-- Timeout for how long it takes to install and boot the app and start running the first test -->
+    <LaunchTimeout>00:10:00</LaunchTimeout>
   </XHarnessAppBundleToTest>
 </ItemGroup>
 ```
@@ -125,14 +128,14 @@ You can also specify some metadata that will help you configure the run better:
 
 ```xml
 <ItemGroup>
-  <XHarnessAppBundleToTest Include="$(TestArchiveTestsRoot)**\*.apk">
+  <XHarnessApkToTest Include="$(TestArchiveTestsRoot)**\*.apk">
     <!-- Timeout for the overall run of the whole Helix work item (including Simulator booting, app installation..) -->
     <WorkItemTimeout>00:20:00</WorkItemTimeout>
 
     <!-- Timeout for the actual test run (when TestRunner starts execution of tests) -->
     <!-- Should be smaller than WorkItemTimeout by several minutes -->
     <TestTimeout>00:12:00</TestTimeout>
-  </XHarnessAppBundleToTest>
+  </XHarnessApkToTest>
 </ItemGroup>
 ```
 

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
@@ -92,9 +92,7 @@
           Condition=" '@(XHarnessApkToTest)' != '' "
           BeforeTargets="CoreTest">
     <CreateXHarnessAndroidWorkItems Apks="@(XHarnessApkToTest)"
-                                    IsPosixShell="$(IsPosixShell)"
-                                    WorkItemTimeout="%(XHarnessApkToTest.WorkItemTimeout)"
-                                    TestTimeout="%(XHarnessApkToTest.TestTimeout)">
+                                    IsPosixShell="$(IsPosixShell)">
       <Output TaskParameter="WorkItems" ItemName="HelixWorkItem"/>
     </CreateXHarnessAndroidWorkItems>
   </Target>
@@ -104,9 +102,7 @@
           BeforeTargets="CoreTest">
     <CreateXHarnessiOSWorkItems AppBundles="@(XHarnessAppBundleToTest)"
                                 IsPosixShell="$(IsPosixShell)"
-                                XcodeVersion="$(XHarnessXcodeVersion)"
-                                WorkItemTimeout="%(XHarnessAppBundleToTest.WorkItemTimeout)"
-                                TestTimeout="%(XHarnessAppBundleToTest.TestTimeout)">
+                                XcodeVersion="$(XHarnessXcodeVersion)">
       <Output TaskParameter="WorkItems" ItemName="HelixWorkItem"/>
     </CreateXHarnessiOSWorkItems>
   </Target>

--- a/tests/XHarness/XHarness.TestAppBundle.proj
+++ b/tests/XHarness/XHarness.TestAppBundle.proj
@@ -21,8 +21,9 @@
     <ItemGroup>
       <XHarnessAppBundleToTest Include="$(ArtifactsTmpDir)XHarness.TestAppBundle/$(XHarnessAppBundleName)">
         <Targets>ios-simulator-64_13.5</Targets>
-        <TestTimeout>00:15:00</TestTimeout>
-        <WorkItemTimeout>00:30:00</WorkItemTimeout>
+        <TestTimeout>00:30:00</TestTimeout>
+        <WorkItemTimeout>00:35:00</WorkItemTimeout>
+        <LaunchTimeout>00:20:00</LaunchTimeout>
       </XHarnessAppBundleToTest>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
- LaunchTimeout is now configurable (resolves #5921)
- Timeouts can be configured per work item not per whole job (more granular)
- Fixes in docs

