### PR TITLE
Add arcade-powered source-build intermediate nupkg tooling

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/SourceBuild/AddSourceToNuGetConfig.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/SourceBuild/AddSourceToNuGetConfig.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Copied from https://github.com/dotnet/source-build/blob/76ed853be34c0745c638066193a275a443522266/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/AddSourceToNuGetConfig.cs
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.Arcade.Sdk.SourceBuild
+{
+    /*
+     * This task adds a source to a well-formed NuGet.Config file. If a source with `SourceName` is already present, then
+     * the path of the source is changed. Otherwise, the source is added as the first source in the list, after any clear
+     * elements (if present).
+     */
+    public class AddSourceToNuGetConfig : Task
+    {
+        [Required]
+        public string NuGetConfigFile { get; set; }
+
+        [Required]
+        public string SourceName { get; set; }
+
+        [Required]
+        public string SourcePath { get; set; }
+
+        public override bool Execute()
+        {
+            XDocument d = XDocument.Load(NuGetConfigFile);
+            XElement packageSourcesElement = d.Root.Descendants().First(e => e.Name == "packageSources");
+            XElement toAdd = new XElement("add", new XAttribute("key", SourceName), new XAttribute("value", SourcePath));
+            XElement clearTag = new XElement("clear");
+
+            XElement exisitingSourceBuildElement = packageSourcesElement.Descendants().FirstOrDefault(e => e.Name == "add" && e.Attribute(XName.Get("key")).Value == SourceName);
+            XElement lastClearElement = packageSourcesElement.Descendants().LastOrDefault(e => e.Name == "clear");
+
+            if (exisitingSourceBuildElement != null)
+            {
+                exisitingSourceBuildElement.ReplaceWith(toAdd);
+            }
+            else if (lastClearElement != null)
+            {
+                lastClearElement.AddAfterSelf(toAdd);
+            }
+            else
+            {
+                packageSourcesElement.AddFirst(toAdd);
+                packageSourcesElement.AddFirst(clearTag);
+            }
+
+            using (FileStream fs = new FileStream(NuGetConfigFile, FileMode.Create, FileAccess.ReadWrite))
+            {
+                d.Save(fs);
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/SourceBuild/ReadSourceBuildIntNupkgDependencies.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/SourceBuild/ReadSourceBuildIntNupkgDependencies.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.Arcade.Sdk.SourceBuild
+{
+    /// <summary>
+    /// Reads entries in a Version.Details.xml file to find intermediate nupkg
+    /// dependencies. For each dependency with a "SourceBuildRepoName" element,
+    /// adds an item to the "Dependencies" output.
+    /// </summary>
+    public class ReadSourceBuildIntNupkgDependencies : Task
+    {
+        [Required]
+        public string VersionDetailsXmlFile { get; set; }
+
+        /// <summary>
+        /// %(Identity): Name attribute of the dependency element.
+        /// %(Version): Version attribute of the dependency element.
+        /// </summary>
+        [Output]
+        public ITaskItem[] Dependencies { get; set; }
+
+        public override bool Execute()
+        {
+            XElement root = XElement.Load(VersionDetailsXmlFile, LoadOptions.PreserveWhitespace);
+
+            XName CreateQualifiedName(string plainName)
+            {
+                return root.GetDefaultNamespace().GetName(plainName);
+            }
+
+            Dependencies = root
+                .Elements()
+                .Elements(CreateQualifiedName("Dependency"))
+                .Where(d => d.Element(CreateQualifiedName("SourceBuildRepoName")) != null)
+                .Select(d =>
+                {
+                    string name = d.Attribute("Name")?.Value;
+
+                    if (string.IsNullOrEmpty(name))
+                    {
+                        Log.LogError($"Dependency Name null or empty in '{VersionDetailsXmlFile}' element {d}");
+                        return null;
+                    }
+
+                    string version = d.Attribute("Version")?.Value;
+
+                    if (string.IsNullOrEmpty(version))
+                    {
+                        Log.LogError($"Dependency Version null or empty in '{VersionDetailsXmlFile}' element {d}");
+                        return null;
+                    }
+
+                    return new TaskItem(
+                        name,
+                        new Dictionary<string, string>
+                        {
+                            ["Version"] = version
+                        });
+                })
+                .ToArray();
+
+            return !Log.HasLoggedErrors;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/SourceBuild/ReadSourceBuildIntermediateNupkgDependencies.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/SourceBuild/ReadSourceBuildIntermediateNupkgDependencies.cs
@@ -1,10 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
@@ -16,7 +15,7 @@ namespace Microsoft.DotNet.Arcade.Sdk.SourceBuild
     /// dependencies. For each dependency with a "SourceBuildRepoName" element,
     /// adds an item to the "Dependencies" output.
     /// </summary>
-    public class ReadSourceBuildIntNupkgDependencies : Task
+    public class ReadSourceBuildIntermediateNupkgDependencies : Task
     {
         [Required]
         public string VersionDetailsXmlFile { get; set; }

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -48,6 +48,8 @@
 
   <Import Project="RepoLayout.props"/>
 
+  <Import Project="SourceBuild/SourceBuildArcade.targets" Condition="'$(ArcadeBuildFromSource)' == 'true'" />
+
   <!-- Allow for repo specific Build properties such as the list of Projects to build -->
   <Import Project="$(RepositoryEngineeringDir)Build.props" Condition="Exists('$(RepositoryEngineeringDir)Build.props')" />
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/Noop.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/Noop.proj
@@ -1,0 +1,13 @@
+<!--
+  This project does nothing when run. It can be used as a ProjectToBuild: this makes ProjectToBuild
+  non-empty to avoid the default behavior of finding projects to build in the root, but still not do
+  anything. Used during source-build to no-op the entire default "outer" Arcade build.
+-->
+<Project>
+
+  <Target Name="Restore" />
+  <Target Name="Build" />
+  <Target Name="Pack" />
+  <Target Name="Test" />
+
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/README.md
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/README.md
@@ -1,0 +1,47 @@
+# Running source-build
+
+These args control parts of source-build:
+
+* `/p:ArcadeBuildFromSource=true` - Enable simple developer machine repro defaults.
+* Not implemented but recognized as potentially useful:
+  * Disable Git repo isolation (slightly faster, but not recommended for dev machines). We may want to use this for CI.
+  * Clone and build upstreams from source rather than using intermediate nupkgs.
+    * Not as useful as it sounds: this is only the "production" build so building this way is still not appropriate for a typical Linux distro archive.
+
+*All* source-build functionality is brought in only when `ArcadeBuildFromSource`
+is set to true, to ensure the new MSBuild props/targets don't introduce bugs
+into ordinary builds.
+
+File issues encountered with this directory's tooling in the
+[dotnet/source-build](https://github.com/dotnet/source-build) repository rather
+than [dotnet/arcade](https://github.com/dotnet/arcade) to contact the team
+maintaining this functionality directly.
+
+## MSBuild execution
+
+The source-build targets work by having the build noop, and instead recursively
+call an inner build after some setup. The targets work roughly like this:
+
+* Run `./build.sh /p:ArcadeBuildFromSource=true`
+  * Run `dotnet msbuild ... Build.proj /p:ArcadeBuildFromSource=true`
+    * [Hook] Before **Outer Execute**:
+      * Clone the source into `artifacts/source-build/self/src`
+      * Assemble a build command by appending to the `dotnet msbuild` call.
+      * Run `dotnet msbuild ... Build.proj /p:ArcadeBuildFromSource=true ... /p:ArcadeInnerBuildFromSource=true`
+        * [Hook] Before **Inner Execute**:
+          * Compile source-build MSBuild tasks. (Temporary, should migrate to Arcade task DLL.)
+        * During **Inner Execute**:
+          * `MSBuild Projects=Tools.proj Targets=Restore`
+            * [Hook] Inject intermediate nupkg package reference through MSBuild task.
+            * [Hook] After Restore, copy the extracted source-built nupkgs to a new dir and inject the dir into the NuGet.config.
+          * The build happens!
+        * **Inner Execute** complete!
+      * Create intermediate nupkg that contains the inner source-build's artifacts.
+        * MSBuild `Projects=SourceBuildIntermediate.proj Targets=Restore;Pack`
+      * Empty out the list of `ProjectToBuild`, because we already built them from source.
+        * Put `Noop.proj` in the list as a sentinel value.
+    * During **Outer Execute**:
+      * MSBuild `Projects=Tools.proj Targets=Restore`
+        * Does nothing interesting.
+      * "Builds" `Noop.proj`, doing nothing.
+    * **Outer Execute** complete!

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -1,0 +1,9 @@
+<Project>
+
+  <Import Project="SourceBuildArcadeIntercept.targets" />
+
+  <!-- Repo extensibility point. -->
+  <Import Project="$(RepositoryEngineeringDir)SourceBuild.props" Condition="Exists('$(RepositoryEngineeringDir)SourceBuild.props')" />
+  <Import Project="$(RepositoryEngineeringDir)SourceBuild.targets" Condition="Exists('$(RepositoryEngineeringDir)SourceBuild.targets')" />
+
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeIntercept.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeIntercept.targets
@@ -1,0 +1,178 @@
+<Project>
+
+  <!--
+    These targets inject source-build into Arcade's build process.
+  -->
+
+  <PropertyGroup>
+    <SourceBuildOutputDir Condition="'$(SourceBuildOutputDir)' == ''">$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'source-build'))</SourceBuildOutputDir>
+    <SourceBuildSelfDir>$([MSBuild]::NormalizeDirectory('$(SourceBuildOutputDir)', 'self'))</SourceBuildSelfDir>
+    <CurrentRepoSourceBuildArtifactsDir>$([MSBuild]::NormalizeDirectory('$(SourceBuildSelfDir)', 'artifacts'))</CurrentRepoSourceBuildArtifactsDir>
+    <CurrentRepoSourceBuildSourceDir>$([MSBuild]::NormalizeDirectory('$(SourceBuildSelfDir)', 'src'))</CurrentRepoSourceBuildSourceDir>
+    <CurrentRepoSourceBuildPackageCache>$([MSBuild]::NormalizeDirectory('$(SourceBuildSelfDir)', 'package-cache'))</CurrentRepoSourceBuildPackageCache>
+
+    <CurrentRepoSourceBuildArtifactsPackagesDir>$([MSBuild]::NormalizeDirectory('$(CurrentRepoSourceBuildArtifactsDir)', 'packages', '$(Configuration)'))</CurrentRepoSourceBuildArtifactsPackagesDir>
+    <CurrentRepoSourceBuildBinlogFile>$([MSBuild]::NormalizePath('$(CurrentRepoSourceBuildArtifactsDir)', 'sourcebuild.binlog'))</CurrentRepoSourceBuildBinlogFile>
+
+    <InnerSourceBuildRepoRoot Condition="'$(InnerSourceBuildRepoRoot)' == ''">$(CurrentRepoSourceBuildSourceDir)</InnerSourceBuildRepoRoot>
+
+    <CleanInnerSourceBuildRepoRoot Condition="'$(CleanInnerSourceBuildRepoRoot)' == ''">true</CleanInnerSourceBuildRepoRoot>
+  </PropertyGroup>
+
+  <Target Name="ExecuteWithSourceBuiltTooling"
+          DependsOnTargets="
+            BuildUpstreamRepos;
+            GetSourceBuildCommandConfiguration;
+            RunInnerSourceBuildCommand;
+            PackSourceBuildIntermediateNupkg;
+            PackSourceBuildTarball"
+          Condition="
+            '$(ArcadeBuildFromSource)' == 'true' and
+            '$(ArcadeInnerBuildFromSource)' != 'true'"
+          BeforeTargets="Execute" />
+
+  <!--
+    Use BeforeTargets="ExecuteInnerSourceBuild" to trigger when the inner build is happening.
+  -->
+  <Target Name="ExecuteInnerSourceBuild" />
+
+  <!--
+    HookExecuteInnerSourceBuild triggers ExecuteInnerSourceBuild only if it's the right time. A
+    BeforeTargets on HookExecuteInnerSourceBuild would always execute because BeforeTargets runs
+    even if the condition isn't met, so we need this indirection.
+  -->
+  <Target Name="HookExecuteInnerSourceBuild"
+          Condition="
+            '$(ArcadeBuildFromSource)' == 'true' and
+            '$(ArcadeInnerBuildFromSource)' == 'true'"
+          DependsOnTargets="ExecuteInnerSourceBuild"
+          BeforeTargets="Execute"/>
+
+  <!--
+    Build upstream repos from source.
+
+    TODO: (arcade-sb) Support building upstreams from source based on int nupkgs. For now this
+    target is overridden in any repo that implements the upstream build from source. It involves a
+    lot of source-build infra that will be more gradually moved. Same for PackSourceBuildTarball.
+  -->
+  <Target Name="BuildUpstreamRepos"
+          Condition="'$(BuildUpstreamRepos)' == 'true'">
+    <Error Text="NotImplemented" />
+  </Target>
+
+  <Target Name="PackSourceBuildTarball"
+          Condition="'$(PackSourceBuildTarball)' == 'true'">
+    <Error Text="NotImplemented" />
+  </Target>
+
+  <!--
+    Set up build args to append to the passed build command. These args specify what is unique about
+    building from source, such as non-overlapping artifacts dirs and package caches.
+
+    Use BeforeTargets="GetSourceBuildCommandConfiguration" or set props/items to customize.
+  -->
+  <Target Name="GetSourceBuildCommandConfiguration">
+    <PropertyGroup>
+      <!-- Track that this is the inner build to prevent infinite recursion. -->
+      <InnerBuildArgs>$(InnerBuildArgs) /p:ArcadeInnerBuildFromSource=true</InnerBuildArgs>
+      <!-- Set DotNetBuildFromSource to avoid publishing. -->
+      <InnerBuildArgs>$(InnerBuildArgs) /p:DotNetBuildFromSource=true</InnerBuildArgs>
+      <!-- Use a fresh clone of the repo so that source-build modifications are isolated. -->
+      <InnerBuildArgs>$(InnerBuildArgs) /p:RepoRoot=$(InnerSourceBuildRepoRoot)</InnerBuildArgs>
+      <!-- Override the artifacts dir to cleanly separate the inner build from outer build. -->
+      <InnerBuildArgs>$(InnerBuildArgs) /p:ArtifactsDir=$(CurrentRepoSourceBuildArtifactsDir)</InnerBuildArgs>
+      <!-- Set a custom binlog location to avoid clashing over the currenly specified file. -->
+      <InnerBuildArgs>$(InnerBuildArgs) /bl:$(CurrentRepoSourceBuildBinlogFile)</InnerBuildArgs>
+
+      <!-- The inner build needs to reference the overall output dir for nupkg transport etc. -->
+      <InnerBuildArgs>$(InnerBuildArgs) /p:SourceBuildOutputDir=$(SourceBuildOutputDir)</InnerBuildArgs>
+      <InnerBuildArgs>$(InnerBuildArgs) /p:SourceBuiltBlobFeedDir=$(SourceBuiltBlobFeedDir)</InnerBuildArgs>
+
+      <!-- Work around issue where local clone may cause failure using non-origin remote fallback: https://github.com/dotnet/sourcelink/issues/629 -->
+      <InnerBuildArgs>$(InnerBuildArgs) /p:EnableSourceControlManagerQueries=false</InnerBuildArgs>
+      <InnerBuildArgs>$(InnerBuildArgs) /p:EnableSourceLink=false</InnerBuildArgs>
+      <InnerBuildArgs>$(InnerBuildArgs) /p:DeterministicSourcePaths=false</InnerBuildArgs>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <!-- Override package cache to separate source-built packages from upstream. -->
+      <InnerBuildEnv Include="NUGET_PACKAGES=$(CurrentRepoSourceBuildPackageCache)" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Clone the repo to a new location. Source-build targets will change the source dynamically.
+    Creating a fresh clone avoids overwriting existing work or making subtle changes that might
+    accidentally get added to the user's existing work via a 'git add .'. Since the clone also has
+    access to the git data, this also makes it easy to see what changes the source-build infra has
+    made, for diagnosis or exploratory purposes.
+  -->
+  <Target Name="PrepareInnerSourceBuildRepoRoot">
+    <PropertyGroup>
+      <_GitCloneToDirArgs />
+      <_GitCloneToDirArgs>$(_GitCloneToDirArgs) --source &quot;$(RepoRoot)&quot;</_GitCloneToDirArgs>
+      <_GitCloneToDirArgs>$(_GitCloneToDirArgs) --dest &quot;$(InnerSourceBuildRepoRoot)&quot;</_GitCloneToDirArgs>
+      <_GitCloneToDirArgs>$(_GitCloneToDirArgs) --copy-wip</_GitCloneToDirArgs>
+
+      <_GitCloneToDirArgs Condition="'$(CleanInnerSourceBuildRepoRoot)' == 'true'">$(_GitCloneToDirArgs) --clean</_GitCloneToDirArgs>
+    </PropertyGroup>
+
+    <Exec Command="$(MSBuildThisFileDirectory)git-clone-to-dir.sh $(_GitCloneToDirArgs)" />
+  </Target>
+
+  <Target Name="RunInnerSourceBuildCommand"
+          DependsOnTargets="PrepareInnerSourceBuildRepoRoot">
+    <PropertyGroup>
+      <!-- Prevent any projects from building in the outside build: they would use prebuilts. -->
+      <PreventPrebuiltBuild>true</PreventPrebuiltBuild>
+
+      <!--
+        Normally, the inner build should run using the original build command with some extra args
+        appended. Allow the repo to override this default behavior if the repo is e.g. not onboarded
+        enough on Arcade for this to work nicely.
+      -->
+      <BaseInnerSourceBuildCommand Condition="'$(BaseInnerSourceBuildCommand)' == ''">$(ARCADE_BUILD_TOOL_COMMAND)</BaseInnerSourceBuildCommand>
+    </PropertyGroup>
+
+    <Exec
+      Command="$(BaseInnerSourceBuildCommand) $(InnerBuildArgs)"
+      WorkingDirectory="$(InnerSourceBuildRepoRoot)"
+      EnvironmentVariables="@(InnerBuildEnv)"
+      IgnoreStandardErrorWarningFormat="true" />
+  </Target>
+
+  <!--
+    Create a source-build intermediate NuGet package for dependency transport.
+  -->
+  <Target Name="PackSourceBuildIntermediateNupkg">
+    <PropertyGroup>
+      <SourceBuildIntermediateProjFile>$(MSBuildThisFileDirectory)SourceBuildIntermediate.proj</SourceBuildIntermediateProjFile>
+      <SourceBuildIntermediateProjTargetFile>$(ArtifactsObjDir)ArcadeGeneratedProjects\SourceBuildIntermediate\SourceBuildIntermediate.proj</SourceBuildIntermediateProjTargetFile>
+    </PropertyGroup>
+
+    <!-- Copy the project to artifacts/ so that the repo's global.json is in an ancestor dir. -->
+    <Copy
+      SourceFiles="$(SourceBuildIntermediateProjFile)"
+      DestinationFiles="$(SourceBuildIntermediateProjTargetFile)" />
+
+    <ItemGroup>
+      <SourceBuildIntermediatePackTarget Include="Restore;Pack" />
+    </ItemGroup>
+
+    <MSBuild
+      Projects="$(SourceBuildIntermediateProjTargetFile)"
+      Targets="%(SourceBuildIntermediatePackTarget.Identity)"
+      Properties="CurrentRepoSourceBuildArtifactsPackagesDir=$(CurrentRepoSourceBuildArtifactsPackagesDir)" />
+  </Target>
+
+  <Target Name="PreventPrebuiltBuild"
+          DependsOnTargets="ExecuteWithSourceBuiltTooling"
+          Condition="'$(PreventPrebuiltBuild)' == 'true'"
+          BeforeTargets="Execute">
+    <ItemGroup>
+      <ProjectToBuild Remove="@(ProjectToBuild)" />
+      <ProjectToBuild Include="$(MSBuildThisFileDirectory)Noop.proj" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
@@ -1,17 +1,17 @@
 <Project>
 
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SourceBuild.AddSourceToNuGetConfig" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SourceBuild.ReadSourceBuildIntNupkgDependencies" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SourceBuild.ReadSourceBuildIntermediateNupkgDependencies" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
 
   <Target Name="CollectSourceBuildIntermediateNupkgDependencies"
           Condition="
             '$(ArcadeBuildFromSource)' == 'true' and
             '$(ArcadeInnerBuildFromSource)' == 'true'"
           BeforeTargets="CollectPackageReferences">
-    <ReadSourceBuildIntNupkgDependencies
+    <ReadSourceBuildIntermediateNupkgDependencies
       VersionDetailsXmlFile="$([MSBuild]::NormalizePath('$(RepositoryEngineeringDir)', 'Version.Details.xml'))">
       <Output TaskParameter="Dependencies" ItemName="VersionDetailsSourceBuildElement" />
-    </ReadSourceBuildIntNupkgDependencies>
+    </ReadSourceBuildIntermediateNupkgDependencies>
 
     <PropertyGroup>
       <SourceBuildIntNupkgRid Condition="'$(SourceBuildIntNupkgRid)' == ''">linux-x64</SourceBuildIntNupkgRid>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
@@ -1,0 +1,60 @@
+<Project>
+
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SourceBuild.AddSourceToNuGetConfig" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SourceBuild.ReadSourceBuildIntNupkgDependencies" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
+
+  <Target Name="CollectSourceBuildIntermediateNupkgDependencies"
+          Condition="
+            '$(ArcadeBuildFromSource)' == 'true' and
+            '$(ArcadeInnerBuildFromSource)' == 'true'"
+          BeforeTargets="CollectPackageReferences">
+    <ReadSourceBuildIntNupkgDependencies
+      VersionDetailsXmlFile="$([MSBuild]::NormalizePath('$(RepositoryEngineeringDir)', 'Version.Details.xml'))">
+      <Output TaskParameter="Dependencies" ItemName="VersionDetailsSourceBuildElement" />
+    </ReadSourceBuildIntNupkgDependencies>
+
+    <PropertyGroup>
+      <SourceBuildIntNupkgRid Condition="'$(SourceBuildIntNupkgRid)' == ''">linux-x64</SourceBuildIntNupkgRid>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'@(VersionDetailsSourceBuildElement)' != ''">
+      <SourceBuildIntNupkgReference
+        Include="%(VersionDetailsSourceBuildElement.Identity).$(SourceBuildIntNupkgRid)"
+        ExactVersion="%(VersionDetailsSourceBuildElement.Version)" />
+      <PackageReference
+        Include="@(SourceBuildIntNupkgReference)"
+        Version="[%(ExactVersion)]"/>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="SetUpSourceBuildIntermediateNupkgCache"
+          Condition="
+            '$(ArcadeBuildFromSource)' == 'true' and
+            '$(ArcadeInnerBuildFromSource)' == 'true' and
+            '@(SourceBuildIntNupkgReference)' != ''"
+          AfterTargets="Restore">
+    <PropertyGroup>
+      <SourceBuiltNupkgCacheDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsObjDir)', 'source-built-upstream-cache'))</SourceBuiltNupkgCacheDir>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <IntNupkgSourceDir Include="$([MSBuild]::NormalizeDirectory(
+        '$(NuGetPackageRoot)',
+        '$([System.String]::new(`%(SourceBuildIntNupkgReference.Identity)`).ToLowerInvariant())',
+        '$([System.String]::new(`%(SourceBuildIntNupkgReference.ExactVersion)`).ToLowerInvariant())',
+        'artifacts'))" />
+
+      <SourceBuiltNupkgFile Include="%(IntNupkgSourceDir.Identity)**\*.nupkg" />
+    </ItemGroup>
+
+    <Copy
+      SourceFiles="@(SourceBuiltNupkgFile)"
+      DestinationFiles="@(SourceBuiltNupkgFile -> '$(SourceBuiltNupkgCacheDir)%(Filename)%(Extension)')" />
+
+    <AddSourceToNuGetConfig
+      NuGetConfigFile="$(RestoreConfigFile)"
+      SourceName="source-build-int-nupkg-cache"
+      SourcePath="$(SourceBuiltNupkgCacheDir)" />
+  </Target>
+
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
@@ -14,15 +14,15 @@
     </ReadSourceBuildIntermediateNupkgDependencies>
 
     <PropertyGroup>
-      <SourceBuildIntNupkgRid Condition="'$(SourceBuildIntNupkgRid)' == ''">linux-x64</SourceBuildIntNupkgRid>
+      <SourceBuildIntermediateNupkgRid Condition="'$(SourceBuildIntermediateNupkgRid)' == ''">linux-x64</SourceBuildIntermediateNupkgRid>
     </PropertyGroup>
 
     <ItemGroup Condition="'@(VersionDetailsSourceBuildElement)' != ''">
-      <SourceBuildIntNupkgReference
-        Include="%(VersionDetailsSourceBuildElement.Identity).$(SourceBuildIntNupkgRid)"
+      <SourceBuildIntermediateNupkgReference
+        Include="%(VersionDetailsSourceBuildElement.Identity).$(SourceBuildIntermediateNupkgRid)"
         ExactVersion="%(VersionDetailsSourceBuildElement.Version)" />
       <PackageReference
-        Include="@(SourceBuildIntNupkgReference)"
+        Include="@(SourceBuildIntermediateNupkgReference)"
         Version="[%(ExactVersion)]"/>
     </ItemGroup>
   </Target>
@@ -31,20 +31,20 @@
           Condition="
             '$(ArcadeBuildFromSource)' == 'true' and
             '$(ArcadeInnerBuildFromSource)' == 'true' and
-            '@(SourceBuildIntNupkgReference)' != ''"
+            '@(SourceBuildIntermediateNupkgReference)' != ''"
           AfterTargets="Restore">
     <PropertyGroup>
       <SourceBuiltNupkgCacheDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsObjDir)', 'source-built-upstream-cache'))</SourceBuiltNupkgCacheDir>
     </PropertyGroup>
 
     <ItemGroup>
-      <IntNupkgSourceDir Include="$([MSBuild]::NormalizeDirectory(
+      <IntermediateNupkgSourceDir Include="$([MSBuild]::NormalizeDirectory(
         '$(NuGetPackageRoot)',
-        '$([System.String]::new(`%(SourceBuildIntNupkgReference.Identity)`).ToLowerInvariant())',
-        '$([System.String]::new(`%(SourceBuildIntNupkgReference.ExactVersion)`).ToLowerInvariant())',
+        '$([System.String]::new(`%(SourceBuildIntermediateNupkgReference.Identity)`).ToLowerInvariant())',
+        '$([System.String]::new(`%(SourceBuildIntermediateNupkgReference.ExactVersion)`).ToLowerInvariant())',
         'artifacts'))" />
 
-      <SourceBuiltNupkgFile Include="%(IntNupkgSourceDir.Identity)**\*.nupkg" />
+      <SourceBuiltNupkgFile Include="%(IntermediateNupkgSourceDir.Identity)**\*.nupkg" />
     </ItemGroup>
 
     <Copy

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
@@ -1,0 +1,54 @@
+<Project>
+
+  <!-- Shield this project from nonstandard Directory.Build.props/targets. -->
+  <PropertyGroup>
+    <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+  </PropertyGroup>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <!-- Repository extension point -->
+  <Import Project="$(RepositoryEngineeringDir)SourceBuild.props" Condition="Exists('$(RepositoryEngineeringDir)SourceBuild.props')" />
+  <Import Project="$(RepositoryEngineeringDir)SourceBuild.targets" Condition="Exists('$(RepositoryEngineeringDir)SourceBuild.targets')" />
+
+  <PropertyGroup>
+    <SourceBuildPackageRid Condition="'$(SourceBuildPackageRid)' == ''">linux-x64</SourceBuildPackageRid>
+    <GitHubRepositoryName Condition="'$(GitHubRepositoryName)' == ''">no-repo-name-defined</GitHubRepositoryName>
+
+    <Copyright Condition="'$(Copyright)' == ''">$(CopyrightNetFoundation)</Copyright>
+    <PackageLicenseExpression Condition="'$(PackageLicenseExpression)' == ''">MIT</PackageLicenseExpression>
+
+    <IsPackable>true</IsPackable>
+    <IsShipping>false</IsShipping>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+
+    <!-- NuGet excludes nupkgs by default: disable this behavior. -->
+    <NoDefaultExcludes>true</NoDefaultExcludes>
+
+    <EnableDefaultSourceBuildIntermediateItems Condition="'$(EnableDefaultSourceBuildIntermediateItems)' == ''">true</EnableDefaultSourceBuildIntermediateItems>
+
+    <!-- Arbitrary TargetFramework to appease SDK. -->
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(EnableDefaultSourceBuildIntermediateItems)' == 'true'">
+    <Content Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)**\*.nupkg" PackagePath="artifacts" />
+    <Content Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)**\*.tar.gz" PackagePath="artifacts" />
+  </ItemGroup>
+
+  <Target Name="InitializeSourceBuildIntermediatePackageId"
+          BeforeTargets="GenerateNuspec;InitializeStandardNuspecProperties">
+    <PropertyGroup>
+      <PackageId>Microsoft.SourceBuild.Intermediate.$(GitHubRepositoryName).$(SourceBuildPackageRid)</PackageId>
+    </PropertyGroup>
+  </Target>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+
+  <Target Name="Build" />
+
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/git-clone-to-dir.sh
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/git-clone-to-dir.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+usage() {
+  echo "$0 [options]"
+  echo "Creates a git clone of <source> into <dest> directory, optionally saving WIP changes."
+  echo ""
+  echo "Required:"
+  echo "  --source <dir>  (Required) The source Git directory."
+  echo "  --dest <dir>    (Required) The destination Git directory. Created if doesn't exist."
+  echo ""
+  echo "Optional:"
+  echo "  --clean     If dest directory already exists, delete it."
+  echo "  --copy-wip  Transfer most types of uncommitted change into the"
+  echo "              destination directory. Useful for dev workflows."
+  echo "  -h --help   Print help and exit."
+}
+
+# An alternative to "git clone" would be to use a "git worktree". Potential benefits:
+# * This has more integration with the user's normal repo. If they make ad-hoc changes in the
+#   worktree, it is easy to cherry-pick onto the developer's "real" branch.
+# * A worktree uses a '.git' file rather than a full '.git' directory, which might have storage
+#   implications. (However, a local clone's '.git' directory uses hard links to save space/time,
+#   so it's not certain that this affects performance at all.)
+# 
+# Downside of worktrees:
+# * Some configuration is set up in '.git/worktrees' which may be difficult to coordinate
+#   properly. In particular, if the user is already using worktrees for their own purposes, we
+#   would have to be careful that running source-build in one worktree doesn't interfere with
+#   source-build in the other worktree.
+
+set -euo pipefail
+
+while [[ $# > 0 ]]; do
+  opt="$(echo "$1" | awk '{print tolower($0)}')"
+  case "$opt" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --source)
+      sourceDir="$2"
+      shift
+      ;;
+    --dest)
+      destDir="$2"
+      shift
+      ;;
+    --clean)
+      clean=1
+      ;;
+    --copy-wip)
+      copyWip=1
+      ;;
+    *)
+      echo "Unrecognized option: $1"
+      echo ""
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+[ ! -d "${sourceDir:-}" ] && echo "--source not a directory: $sourceDir" && exit 1
+
+[ ! "${destDir:-}" ] && echo "--dest not specified" && exit 1
+
+if [ -e "$destDir" ]; then
+  echo "Destination already exists!"
+  if [ -f "$destDir" ]; then
+    echo "Existing destination is a regular file, not a directory. This is unusual: aborting."
+    exit 1
+  elif [ "${clean:-}" ]; then
+    echo "Clean is enabled: removing $destDir and continuing..."
+    rm -rf "$destDir"
+  else
+    echo "Clean is not enabled: aborting."
+    exit 1
+  fi
+fi
+
+if [ ! -e "$destDir" ]; then
+  mkdir -p "$destDir"
+
+  if [ "${copyWip:-}" ]; then
+    echo "WIP copying is enabled"
+    # Copy over changes that haven't been committed, for dev inner loop.
+    # This gets changes (whether staged or not) but misses untracked files.
+    stashCommit=$(cd "$sourceDir"; git stash create)
+
+    if [ "$stashCommit" ]; then
+      echo "Created temporary stash $stashCommit to transfer WIP changes..."
+    fi
+  fi
+
+  echo "Creating empty clone at: $destDir"
+  git clone --no-checkout "$sourceDir" "$destDir"
+
+  (
+    cd "$destDir"
+    echo "Checking out sources..."
+    # If no changes were stashed, stashCommit is empty string, and this is a simple checkout.
+    git checkout ${stashCommit:-}
+  )
+
+  echo "Clone complete: $sourceDir -> $destDir"
+fi

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -43,6 +43,8 @@
     <Exec Command='"$(DotNetTool)" tool restore' WorkingDirectory="$(RepoRoot)" />
   </Target>
 
+  <Import Project="SourceBuild/SourceBuildArcadeTools.targets" Condition="'$(ArcadeBuildFromSource)' == 'true'" />
+
   <!-- Repository extensibility point -->
   <Import Project="$(RepositoryEngineeringDir)Tools.props" Condition="Exists('$(RepositoryEngineeringDir)Tools.props')" />
 


### PR DESCRIPTION
This is the initial step for https://github.com/dotnet/source-build/issues/1635.

The targets so far do a few main things:

* Isolate an inner build from source so that tooling such as the Arcade SDK and .NET SDK can be swapped out and the package caches can be properly isolated to avoid pollution.
  * The idea behind the recursive build has some more detail at https://github.com/dotnet/arcade/issues/5116 (proposal).
* Restore a source-build intermediate nupkg, expand it, and restore from that in the inner source-build.
* Pack up a source-build intermediate nupkg after the build for downstreams to use.

I included a readme with a little overview.

I'm using a completely new property `ArcadeBuildFromSource`, not `DotNetBuildFromSource`, because I want to be 100% sure this won't get triggered by anyone until we roll it out per repo. Also, until we are able to roll it out, we still need to be able to keep using `DotNetBuildFromSource` in dotnet/source-build to keep builds going there as necessary. This is also why the targets are tucked away in their own SourceBuild dir, so no targets/props will be changed whatsoever unless `ArcadeBuildFromSource=true`. My hope is that this makes the bar very low for us to make changes in this dir as we incorporate arcade-powered source-build features.