### PR TITLE
 remove workaround for the artifacts credential provider where we clear the nuget http cache

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -602,11 +602,7 @@ function MSBuild() {
   if ($pipelinesLog) {
     $buildTool = InitializeBuildTool
 
-    # Work around issues with Azure Artifacts credential provider
-    # https://github.com/dotnet/arcade/issues/3932
     if ($ci -and $buildTool.Tool -eq 'dotnet') {
-      dotnet nuget locals http-cache -c
-
       $env:NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS = 20
       $env:NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS = 20
       Write-PipelineSetVariable -Name 'NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS' -Value '20'

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -391,11 +391,7 @@ function MSBuild {
     InitializeBuildTool
     InitializeToolset
 
-    # Work around issues with Azure Artifacts credential provider
-    # https://github.com/dotnet/arcade/issues/3932
     if [[ "$ci" == true ]]; then
-      "$_InitializeBuildTool" nuget locals http-cache -c
-
       export NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS=20
       export NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS=20
       Write-PipelineSetVariable -name "NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS" -value "20"


### PR DESCRIPTION
It looks like we can remove the workaround of clearing the http cache on every msbuild invocation, and the credential provider won't crash mid-restore anymore.

The environment variables are still necessary, but I think we can just keep them forever.

I'll run a couple more tests against runtime and aspnetcore to make sure, as some of my test builds have been deleted already.
runtime: https://dnceng.visualstudio.com/internal/_build/results?buildId=790360&view=results
aspnetcore: https://dnceng.visualstudio.com/internal/_build/results?buildId=790361&view=results

https://github.com/dotnet/arcade/issues/3932

