### PR TITLE
Add type exclusion Functionality

### DIFF
--- a/src/Microsoft.DotNet.GenAPI/build/Microsoft.DotNet.GenAPI.targets
+++ b/src/Microsoft.DotNet.GenAPI/build/Microsoft.DotNet.GenAPI.targets
@@ -23,12 +23,6 @@
     </PrepareForRunDependsOn>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' or '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">
-    <AssemblyMetadata Include="NotSupported">
-      <Value>True</Value>
-    </AssemblyMetadata>
-  </ItemGroup>
-
   <Target Name="SetBuildProjectReferences">
     <PropertyGroup>
       <BuildProjectReferences>false</BuildProjectReferences>
@@ -64,56 +58,4 @@
     <Message Text="Generated reference assembly source code: $(GenAPITargetPath)" Importance="high" />
 
   </Target>
-
-  <PropertyGroup Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' or '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">
-    <!-- Tell ResolveMatchingContract to run and resolve contract to project reference -->
-    <ResolveMatchingContract>true</ResolveMatchingContract>
-    <NotSupportedSourceFile>$(IntermediateOutputPath)$(TargetName).notsupported.cs</NotSupportedSourceFile>
-    <CoreCompileDependsOn>GenerateNotSupportedSource;$(CoreCompileDependsOn)</CoreCompileDependsOn>
-    <!-- Not supported sources are created from the ref assembly, we currently don't produce finalizers in dummy assemblies, so we disable ApiCompat to not fail. -->
-    <RunApiCompat>false</RunApiCompat>
-  </PropertyGroup>
-
-  <!-- GenerateNotSupportedSource
-       Inputs:
-         * A contract assembly
-         * Reference assemblies
-
-       Generates source for the contract that throws PlatformNotSupportedException
-  -->
-  <Target Name="GenerateNotSupportedSource" 
-          DependsOnTargets="ResolveMatchingContract"
-          Inputs="@(ReferencePath);@(ResolvedMatchingContract)"
-          Outputs="$(NotSupportedSourceFile)">
-
-    <ItemGroup>
-      <!-- build out a list of directories where dependencies are located -->
-      <_referencePathDirectoriesWithDuplicates Include="@(ReferencePath->'%(RootDir)%(Directory)'->TrimEnd('\'))" />
-      <!-- strip metadata, removing duplicates -->
-      <_referencePathDirectories Include="%(_referencePathDirectoriesWithDuplicates.Identity)" />
-    </ItemGroup>
-
-    <Error Text="No single matching contract found." Condition="'@(ResolvedMatchingContract -> Count())' != '1'" />
-
-    <PropertyGroup>
-      <GenAPIArgs>"%(ResolvedMatchingContract.Identity)"</GenAPIArgs>
-      <GenAPIArgs>$(GenAPIArgs) --lib-path "@(_referencePathDirectories)"</GenAPIArgs>
-      <GenAPIArgs>$(GenAPIArgs) --out "$(NotSupportedSourceFile)"</GenAPIArgs>
-      <GenAPIArgs Condition="'$(LangVersion)' != ''">$(GenAPIArgs) --lang-version "$(LangVersion)"</GenAPIArgs>
-      <GenAPIArgs Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' or '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">$(GenAPIArgs) --throw "$(GeneratePlatformNotSupportedAssemblyMessage)"</GenAPIArgs>
-      <GenAPIArgs Condition="'$(GeneratePlatformNotSupportedAssemblyWithGlobalPrefix)' == 'true'">$(GenAPIArgs) --global</GenAPIArgs>
-      <GenAPIArgs Condition="'$(GeneratePlatformNotSupportedAssemblyHeaderFile)' != ''">$(GenAPIArgs) --header-file "$(GeneratePlatformNotSupportedAssemblyHeaderFile)"</GenAPIArgs>
-      <GenAPIArgs Condition="'$(GeneratePlatformNotSupportedAdditionalParameters)' != ''">$(GenAPIArgs) $(GeneratePlatformNotSupportedAdditionalParameters)</GenAPIArgs>
-    </PropertyGroup>
-
-    <Exec Command="$(_GenAPICommand) $(GenAPIArgs)" 
-          WorkingDirectory="$(ToolRuntimePath)" />
-
-    <ItemGroup>
-      <FileWrites Include="$(NotSupportedSourceFile)" />
-      <Compile Include="$(NotSupportedSourceFile)" />
-    </ItemGroup>
-
-  </Target>
-
 </Project>

--- a/src/Microsoft.DotNet.GenFacades/NotSupportedAssemblyGenerator.cs
+++ b/src/Microsoft.DotNet.GenFacades/NotSupportedAssemblyGenerator.cs
@@ -112,6 +112,14 @@ namespace Microsoft.DotNet.GenFacades
             return node.WithBody(block);
         }
 
+        public override SyntaxNode VisitClassDeclaration(ClassDeclarationSyntax node)
+        {
+            if (_exclusionApis != null && _exclusionApis.Contains(GetFullyQualifiedName(node)))
+                return null;
+
+            return base.VisitClassDeclaration(node);
+        }
+
         public override SyntaxNode VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
         {
             BlockSyntax block = (BlockSyntax)SyntaxFactory.ParseStatement(GetDefaultMessage());

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacadesNotSupported.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacadesNotSupported.targets
@@ -11,6 +11,12 @@
     <NoWarn>$(NoWarn);CA1823;CA1821;CS0169</NoWarn>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' or '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">
+    <AssemblyMetadata Include="NotSupported">
+      <Value>True</Value>
+    </AssemblyMetadata>
+  </ItemGroup>
+
   <ItemGroup Condition="'$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">
     <ProjectReference Include="$(ContractProject)">
       <Targets>GetCompileItems</Targets>


### PR DESCRIPTION
The class exclusion requirement was detected in https://github.com/dotnet/runtime/pull/40296
For some reason browser config is not getting build for system.security.crypto.algorithms in all config leg(will look into it)

Minor clean up, removing the unsed target rather than overwriting it in the runtime repo.