### PR TITLE
Increase BuildTasksFeed attempts from 1 to 5

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/GeneralUtils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/GeneralUtils.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public const string SymbolPackageSuffix = ".symbols.nupkg";
         public const string PackageSuffix = ".nupkg";
         public const string PackagesCategory = "PACKAGE";
-        public const int MaxRetries = 1;
+        public const int DefaultMaxAttempts = 5;
 
         /// <summary>
         ///  Enum describing the states of a given package on a feed
@@ -135,7 +135,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
             ExponentialRetry RetryHandler = new ExponentialRetry
             {
-                MaxAttempts = MaxRetries
+                MaxAttempts = DefaultMaxAttempts
             };
 
             bool success = await RetryHandler.RunAsync(async attempt =>
@@ -212,7 +212,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
             ExponentialRetry RetryHandler = new ExponentialRetry
             {
-                MaxAttempts = MaxRetries
+                MaxAttempts = DefaultMaxAttempts
             };
 
             bool success = await RetryHandler.RunAsync(async attempt =>


### PR DESCRIPTION
Changes the default number of attempts in BuildTasksFeed from 1 to 5 and renames the variable from "retry" to "attempt" to minimize confusion.

https://github.com/dotnet/core-eng/issues/10431