### PR TITLE
Do not overwrite XHarness binlogs in PR Test builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -135,7 +135,7 @@ stages:
               -restore
               -test
               -projects $(Build.SourcesDirectory)\tests\UnitTests.XHarness.Android.proj
-              /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.XHarness.binlog
+              /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.XHarness.Android.binlog
               /p:RestoreUsingNuGetTargets=false
             displayName: XHarness Android Helix Testing
             # Workaround until https://github.com/dotnet/xharness/issues/232 is fixed
@@ -177,7 +177,7 @@ stages:
               -restore
               -test
               -projects $(Build.SourcesDirectory)/tests/UnitTests.XHarness.iOS.proj
-              /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.XHarness.binlog
+              /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.XHarness.iOS.binlog
               /p:RestoreUsingNuGetTargets=false
             displayName: XHarness iOS Helix Testing
             continueOnError: true
@@ -191,7 +191,7 @@ stages:
               -restore
               -test
               -projects $(Build.SourcesDirectory)/tests/UnitTests.XHarness.iOS.IncludeCliOnly.proj
-              /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.XHarness.binlog
+              /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.XHarness.CLI.binlog
               /p:RestoreUsingNuGetTargets=false
             displayName: XHarness CLI pre-install Helix Testing
             continueOnError: true


### PR DESCRIPTION
The CLI pre-install test and the iOS XHarness test steps target the same binlog file and overwrite it losing the iOS one