### PR TITLE
Fix parsing of LaunchTimeout in XHarness Helix SDK

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
@@ -98,11 +98,12 @@ namespace Microsoft.DotNet.Helix.Sdk
 
             // Optional timeout for the how long it takes for the app to be installed, booted and tests start executing
             TimeSpan launchTimeout = TimeSpan.FromMinutes(DefaultLaunchTimeoutInMinutes);
-            if (!appBundleItem.TryGetMetadata(LaunchTimeoutPropName, out string launchTimeoutProp))
+            if (appBundleItem.TryGetMetadata(LaunchTimeoutPropName, out string launchTimeoutProp))
             {
                 if (!TimeSpan.TryParse(launchTimeoutProp, out launchTimeout) || launchTimeout.Ticks < 0)
                 {
                     Log.LogError($"Invalid value \"{launchTimeoutProp}\" provided in <{LaunchTimeoutPropName}>");
+                    return null;
                 }
             }
 


### PR DESCRIPTION
The `LaunchTimeout` property was being ignored