### PR TITLE
Make LaunchTimeout optional in XHarness Helix SDK

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
@@ -100,7 +100,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             TimeSpan launchTimeout = TimeSpan.FromMinutes(DefaultLaunchTimeoutInMinutes);
             if (appBundleItem.TryGetMetadata(LaunchTimeoutPropName, out string launchTimeoutProp))
             {
-                if (!TimeSpan.TryParse(launchTimeoutProp, out launchTimeout) || launchTimeout.Ticks < 0)
+                if (!string.IsNullOrEmpty(launchTimeoutProp) && !TimeSpan.TryParse(launchTimeoutProp, out launchTimeout) || launchTimeout.Ticks < 0)
                 {
                     Log.LogError($"Invalid value \"{launchTimeoutProp}\" provided in <{LaunchTimeoutPropName}>");
                     return null;


### PR DESCRIPTION
I am getting following in dotnet/xharness#297:
```
C:\Users\prvysoky\.nuget\packages\microsoft.dotnet.helix.sdk\5.0.0-beta.20411.8\tools\xharness-runner\XHarnessRunner.targets(103,5): error :
Invalid value "" provided in <LaunchTimeout>
[D:\github\xharness\tests\integration-tests\iOS\iOS.Helix.SDK.Tests.proj]
```

Even though I don't understand why `TryGetMetadata` returns `true` if I don't specify `<LaunchTimeout>` property at all:
![image](https://user-images.githubusercontent.com/7013027/90411836-9fe80080-e0ac-11ea-9233-9ab2311370aa.png)

