### PR TITLE
Arcade-powered source-build initial minor changes

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -266,4 +266,6 @@
       ManifestPath="$(ArtifactsLogDir)/manifest.props" />
   </Target>
 
+  <Import Project="SourceBuild/SourceBuildArcadePublish.targets" Condition="'$(ArcadeBuildFromSource)' == 'true'" />
+
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -4,6 +4,5 @@
 
   <!-- Repo extensibility point. -->
   <Import Project="$(RepositoryEngineeringDir)SourceBuild.props" Condition="Exists('$(RepositoryEngineeringDir)SourceBuild.props')" />
-  <Import Project="$(RepositoryEngineeringDir)SourceBuild.targets" Condition="Exists('$(RepositoryEngineeringDir)SourceBuild.targets')" />
 
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeIntercept.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeIntercept.targets
@@ -7,9 +7,15 @@
   <PropertyGroup>
     <SourceBuildOutputDir Condition="'$(SourceBuildOutputDir)' == ''">$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'source-build'))</SourceBuildOutputDir>
     <SourceBuildSelfDir>$([MSBuild]::NormalizeDirectory('$(SourceBuildOutputDir)', 'self'))</SourceBuildSelfDir>
-    <CurrentRepoSourceBuildArtifactsDir>$([MSBuild]::NormalizeDirectory('$(SourceBuildSelfDir)', 'artifacts'))</CurrentRepoSourceBuildArtifactsDir>
     <CurrentRepoSourceBuildSourceDir>$([MSBuild]::NormalizeDirectory('$(SourceBuildSelfDir)', 'src'))</CurrentRepoSourceBuildSourceDir>
     <CurrentRepoSourceBuildPackageCache>$([MSBuild]::NormalizeDirectory('$(SourceBuildSelfDir)', 'package-cache'))</CurrentRepoSourceBuildPackageCache>
+
+    <!--
+      Keep artifacts/ inside source dir so that ancestor-based file lookups find the inner repo, not
+      the outer repo. The inner repo global.json and NuGet.config files may have been modified by
+      source-build, and we want projects inside the artifacts/ dir to respect that.
+    -->
+    <CurrentRepoSourceBuildArtifactsDir>$([MSBuild]::NormalizeDirectory('$(CurrentRepoSourceBuildSourceDir)', 'artifacts'))</CurrentRepoSourceBuildArtifactsDir>
 
     <CurrentRepoSourceBuildArtifactsPackagesDir>$([MSBuild]::NormalizeDirectory('$(CurrentRepoSourceBuildArtifactsDir)', 'packages', '$(Configuration)'))</CurrentRepoSourceBuildArtifactsPackagesDir>
     <CurrentRepoSourceBuildBinlogFile>$([MSBuild]::NormalizePath('$(CurrentRepoSourceBuildArtifactsDir)', 'sourcebuild.binlog'))</CurrentRepoSourceBuildBinlogFile>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadePublish.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadePublish.targets
@@ -1,0 +1,22 @@
+<Project>
+
+  <!--
+    If an inner source-build attempts to publish its packages, theys could find their way onto a dev
+    feed and be used unintentionally by downstream repos and devs, or the duplicate packages could
+    break the build in a confusing way. This target should detect this and break the build in a
+    clear way, instead.
+
+    If this happens, it's likely caused by incompatible build scripts vs. the source-build job
+    template. Publish may need to be disabled in eng/SourceBuild.props.
+  -->
+  <Target Name="EnsureSourceBuildInnerBuildDoesNotPublish"
+          Condition="'$(ArcadeInnerBuildFromSource)' == 'true'"
+          BeforeTargets="
+            Publish;
+            PublishSymbols;
+            PublishToSourceBuildStorage;
+            PublishToAzureDevOpsArtifacts">
+    <Error Text="Detected unexpected attempt by inner source-build to publish artifacts." />
+  </Target>
+
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
@@ -11,7 +11,6 @@
 
   <!-- Repository extension point -->
   <Import Project="$(RepositoryEngineeringDir)SourceBuild.props" Condition="Exists('$(RepositoryEngineeringDir)SourceBuild.props')" />
-  <Import Project="$(RepositoryEngineeringDir)SourceBuild.targets" Condition="Exists('$(RepositoryEngineeringDir)SourceBuild.targets')" />
 
   <PropertyGroup>
     <SourceBuildPackageRid Condition="'$(SourceBuildPackageRid)' == ''">linux-x64</SourceBuildPackageRid>


### PR DESCRIPTION
* Simplify: just SourceBuild.props, no .targets
  * It's normal for there to be only one extension point named `.props` that you add both props and targets to. (`eng/Build.props`, `eng/Publishing.props`.) No need to get more specific for source-build.
* Keep artifacts dir in inner source dir
  * Explanation inline.
* Add EnsureSourceBuildInnerBuildDoesNotPublish
  * Explanation inline. Small sanity check. Missed in initial migration from dotnet/source-build-reference-packages.

/cc @mmitche 