### PR TITLE
Fix source-build intermediate nupkg id calculation: use SourceBuildRepoName

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -48,7 +48,7 @@
 
   <Import Project="RepoLayout.props"/>
 
-  <Import Project="SourceBuild/SourceBuildArcade.targets" Condition="'$(ArcadeBuildFromSource)' == 'true'" />
+  <Import Project="SourceBuild/SourceBuildArcadeBuild.targets" Condition="'$(ArcadeBuildFromSource)' == 'true'" />
 
   <!-- Allow for repo specific Build properties such as the list of Projects to build -->
   <Import Project="$(RepositoryEngineeringDir)Build.props" Condition="Exists('$(RepositoryEngineeringDir)Build.props')" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -1,8 +1,16 @@
 <Project>
 
-  <Import Project="SourceBuildArcadeIntercept.targets" />
-
   <!-- Repo extensibility point. -->
   <Import Project="$(RepositoryEngineeringDir)SourceBuild.props" Condition="Exists('$(RepositoryEngineeringDir)SourceBuild.props')" />
+
+  <Target Name="GetSourceBuildIntermediateNupkgNameConvention">
+    <PropertyGroup>
+      <SourceBuildIntermediateNupkgRid Condition="'$(SourceBuildIntermediateNupkgRid)' == ''">linux-x64</SourceBuildIntermediateNupkgRid>
+      <SourceBuildIntermediateNupkgPrefix Condition="'$(SourceBuildIntermediateNupkgPrefix)' == ''">Microsoft.SourceBuild.Intermediate.</SourceBuildIntermediateNupkgPrefix>
+      <SourceBuildIntermediateNupkgSuffix Condition="'$(SourceBuildIntermediateNupkgSuffix)' == ''">.$(SourceBuildIntermediateNupkgRid)</SourceBuildIntermediateNupkgSuffix>
+
+      <GitHubRepositoryName Condition="'$(GitHubRepositoryName)' == ''">no-repo-name-defined</GitHubRepositoryName>
+    </PropertyGroup>
+  </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
@@ -4,6 +4,8 @@
     These targets inject source-build into Arcade's build process.
   -->
 
+  <Import Project="SourceBuildArcade.targets" />
+
   <PropertyGroup>
     <SourceBuildOutputDir Condition="'$(SourceBuildOutputDir)' == ''">$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'source-build'))</SourceBuildOutputDir>
     <SourceBuildSelfDir>$([MSBuild]::NormalizeDirectory('$(SourceBuildOutputDir)', 'self'))</SourceBuildSelfDir>
@@ -150,7 +152,8 @@
   <!--
     Create a source-build intermediate NuGet package for dependency transport.
   -->
-  <Target Name="PackSourceBuildIntermediateNupkg">
+  <Target Name="PackSourceBuildIntermediateNupkg"
+          DependsOnTargets="GetSourceBuildIntermediateNupkgNameConvention">
     <PropertyGroup>
       <SourceBuildIntermediateProjFile>$(MSBuildThisFileDirectory)SourceBuildIntermediate.proj</SourceBuildIntermediateProjFile>
       <SourceBuildIntermediateProjTargetFile>$(ArtifactsObjDir)ArcadeGeneratedProjects\SourceBuildIntermediate\SourceBuildIntermediate.proj</SourceBuildIntermediateProjTargetFile>
@@ -168,7 +171,10 @@
     <MSBuild
       Projects="$(SourceBuildIntermediateProjTargetFile)"
       Targets="%(SourceBuildIntermediatePackTarget.Identity)"
-      Properties="CurrentRepoSourceBuildArtifactsPackagesDir=$(CurrentRepoSourceBuildArtifactsPackagesDir)" />
+      Properties="
+        CurrentRepoSourceBuildArtifactsPackagesDir=$(CurrentRepoSourceBuildArtifactsPackagesDir);
+        SourceBuildArcadeTargetsFile=$(MSBuildThisFileDirectory)SourceBuildArcade.targets;
+        " />
   </Target>
 
   <Target Name="PreventPrebuiltBuild"

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadePublish.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadePublish.targets
@@ -1,5 +1,7 @@
 <Project>
 
+  <Import Project="SourceBuildArcade.targets" />
+
   <!--
     If an inner source-build attempts to publish its packages, theys could find their way onto a dev
     feed and be used unintentionally by downstream repos and devs, or the duplicate packages could

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
@@ -1,5 +1,7 @@
 <Project>
 
+  <Import Project="SourceBuildArcade.targets" />
+
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SourceBuild.AddSourceToNuGetConfig" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SourceBuild.ReadSourceBuildIntermediateNupkgDependencies" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
 
@@ -7,19 +9,16 @@
           Condition="
             '$(ArcadeBuildFromSource)' == 'true' and
             '$(ArcadeInnerBuildFromSource)' == 'true'"
+          DependsOnTargets="GetSourceBuildIntermediateNupkgNameConvention"
           BeforeTargets="CollectPackageReferences">
     <ReadSourceBuildIntermediateNupkgDependencies
       VersionDetailsXmlFile="$([MSBuild]::NormalizePath('$(RepositoryEngineeringDir)', 'Version.Details.xml'))">
       <Output TaskParameter="Dependencies" ItemName="VersionDetailsSourceBuildElement" />
     </ReadSourceBuildIntermediateNupkgDependencies>
 
-    <PropertyGroup>
-      <SourceBuildIntermediateNupkgRid Condition="'$(SourceBuildIntermediateNupkgRid)' == ''">linux-x64</SourceBuildIntermediateNupkgRid>
-    </PropertyGroup>
-
     <ItemGroup Condition="'@(VersionDetailsSourceBuildElement)' != ''">
       <SourceBuildIntermediateNupkgReference
-        Include="%(VersionDetailsSourceBuildElement.Identity).$(SourceBuildIntermediateNupkgRid)"
+        Include="$(SourceBuildIntermediateNupkgPrefix)%(VersionDetailsSourceBuildElement.Identity)$(SourceBuildIntermediateNupkgSuffix)"
         ExactVersion="%(VersionDetailsSourceBuildElement.Version)" />
       <PackageReference
         Include="@(SourceBuildIntermediateNupkgReference)"

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
@@ -9,13 +9,10 @@
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
-  <!-- Repository extension point -->
-  <Import Project="$(RepositoryEngineeringDir)SourceBuild.props" Condition="Exists('$(RepositoryEngineeringDir)SourceBuild.props')" />
+  <!-- Import common functionality, including repo extension point. -->
+  <Import Project="$(SourceBuildArcadeTargetsFile)" />
 
   <PropertyGroup>
-    <SourceBuildPackageRid Condition="'$(SourceBuildPackageRid)' == ''">linux-x64</SourceBuildPackageRid>
-    <GitHubRepositoryName Condition="'$(GitHubRepositoryName)' == ''">no-repo-name-defined</GitHubRepositoryName>
-
     <Copyright Condition="'$(Copyright)' == ''">$(CopyrightNetFoundation)</Copyright>
     <PackageLicenseExpression Condition="'$(PackageLicenseExpression)' == ''">MIT</PackageLicenseExpression>
 
@@ -39,9 +36,10 @@
   </ItemGroup>
 
   <Target Name="InitializeSourceBuildIntermediatePackageId"
+          DependsOnTargets="GetSourceBuildIntermediateNupkgNameConvention"
           BeforeTargets="GenerateNuspec;InitializeStandardNuspecProperties">
     <PropertyGroup>
-      <PackageId>Microsoft.SourceBuild.Intermediate.$(GitHubRepositoryName).$(SourceBuildPackageRid)</PackageId>
+      <PackageId>$(SourceBuildIntermediateNupkgPrefix)$(GitHubRepositoryName)$(SourceBuildIntermediateNupkgSuffix)</PackageId>
     </PropertyGroup>
   </Target>
 


### PR DESCRIPTION
The intent is that SourceBuildRepoName gets added to an existing element so the source-build intermediate nupkg comes automatically with updates to that existing dependency. Change the Version.Details.xml task to return that value as the identity, and the targets to use it that way.

Also rearrange the targets so the logic to calculate intermediate nupkg IDs is shared between the restore and production side. This change aligns the source-build targets files more closely with the projects that import them.

---

More info about the intent is at https://github.com/dotnet/arcade/issues/5320. I didn't have a dependency in SBRP that worked in the intended way (since SBRP is leaf, it's kind of artificial) so my initial implementation wasn't quite right.

/cc @mmitche (thanks for the quick reviews so far :+1:)