### PR TITLE
Comment fixup for arcade-powered source-build

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/Noop.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/Noop.proj
@@ -1,3 +1,4 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <!--
   This project does nothing when run. It can be used as a ProjectToBuild: this makes ProjectToBuild
   non-empty to avoid the default behavior of finding projects to build in the root, but still not do

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -1,3 +1,4 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
 
   <Import Project="SourceBuildArcadeIntercept.targets" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeIntercept.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeIntercept.targets
@@ -1,3 +1,4 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
 
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadePublish.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadePublish.targets
@@ -1,3 +1,4 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
 
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadePublish.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadePublish.targets
@@ -1,7 +1,7 @@
 <Project>
 
   <!--
-    If an inner source-build attempts to publish its packages, theys could find their way onto a dev
+    If an inner source-build attempts to publish its packages, they could find their way onto a dev
     feed and be used unintentionally by downstream repos and devs, or the duplicate packages could
     break the build in a confusing way. This target should detect this and break the build in a
     clear way, instead.

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
@@ -1,3 +1,4 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
 
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SourceBuild.AddSourceToNuGetConfig" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
@@ -1,3 +1,4 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
 
   <!-- Shield this project from nonstandard Directory.Build.props/targets. -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VSTest.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VSTest.targets
@@ -1,3 +1,4 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
   <Target Name="RunTests"
           Outputs="%(TestToRun.ResultsStdOutPath)">


### PR DESCRIPTION
Fixes comment typo "theys":

https://github.com/dotnet/arcade/blob/fe78432fbfa38368ca16d78e9b29c475c2050e44/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadePublish.targets#L4-L7

and adds missing MSBuild license header comments. One non-arcade-powered-source-build file was missing it too, VSTest.targets.