### PR TITLE
Fixing restore against latest VS builds

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -1,5 +1,5 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
-<Project>
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="BuildStep.props" />
 
   <!-- Properties requires by NuGet.targets to restore PackageReferences -->


### PR DESCRIPTION
Fixing restore against the latest VS builds. With the recent .NET 5 changes Nuget relies on the TargetFrameworkIdentifier and TargetFrameworkVersion that specifying Microsoft.NET.Sdk helps with.