### PR TITLE
Enable Custom build SDK source 

### DIFF
--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -23,6 +23,8 @@ Param(
   [switch][Alias('nobl')]$excludeCIBinarylog,
   [switch] $ci,
   [switch] $prepareMachine,
+  [string] $runtimeSourceFeed = '',
+  [string] $runtimeSourceFeedKey = '',
   [switch] $help,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -76,9 +76,10 @@ projects=''
 configuration='Debug'
 prepare_machine=false
 verbosity='minimal'
+runtime_source_feed=''
+runtime_source_feed_key=''
 
 properties=''
-
 while [[ $# > 0 ]]; do
   opt="$(echo "${1/#--/-}" | awk '{print tolower($0)}')"
   case "$opt" in
@@ -149,6 +150,14 @@ while [[ $# > 0 ]]; do
       ;;
     -nodereuse)
       node_reuse=$2
+      shift
+      ;;
+    -runtimesourcefeed)
+      runtime_source_feed=$2
+      shift
+      ;;
+     -runtimesourcefeedkey)
+      runtime_source_feed_key=$2
       shift
       ;;
     *)

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -223,7 +223,7 @@ function GetDotNetInstallScript([string] $dotnetRoot) {
 }
 
 function InstallDotNetSdk([string] $dotnetRoot, [string] $version, [string] $architecture = '') {
-  InstallDotNet $dotnetRoot $version $architecture
+  InstallDotNet $dotnetRoot $version $architecture '' $false $runtimeSourceFeed $runtimeSourceFeedKey
 }
 
 function InstallDotNet([string] $dotnetRoot,
@@ -250,8 +250,7 @@ function InstallDotNet([string] $dotnetRoot,
   catch {
     Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "Failed to install dotnet runtime '$runtime' from public location."
 
-    # Only the runtime can be installed from a custom [private] location.
-    if ($runtime -and ($runtimeSourceFeed -or $runtimeSourceFeedKey)) {
+    if ($runtimeSourceFeed -or $runtimeSourceFeedKey) {
       if ($runtimeSourceFeed) { $installParameters.AzureFeed = $runtimeSourceFeed }
 
       if ($runtimeSourceFeedKey) {

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -249,7 +249,7 @@ function InstallDotNet([string] $dotnetRoot,
   }
   catch {
     if ($runtimeSourceFeed -or $runtimeSourceFeedKey) {
-      Write-Host "Failed to install dotnet runtime '$runtime' from public location. Trying from '$runtimeSourceFeed'"
+      Write-Host "Failed to install dotnet from public location. Trying from '$runtimeSourceFeed'"
       if ($runtimeSourceFeed) { $installParameters.AzureFeed = $runtimeSourceFeed }
 
       if ($runtimeSourceFeedKey) {
@@ -262,11 +262,11 @@ function InstallDotNet([string] $dotnetRoot,
         & $installScript @installParameters
       }
       catch {
-        Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "Failed to install dotnet runtime '$runtime' from custom location '$runtimeSourceFeed'."
+        Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "Failed to install dotnet from custom location '$runtimeSourceFeed'."
         ExitWithExitCode 1
       }
     } else {
-      Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "Failed to install dotnet runtime '$runtime' from public location."
+      Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "Failed to install dotnet from public location."
       ExitWithExitCode 1
     }
   }

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -57,6 +57,11 @@ set-strictmode -version 2.0
 $ErrorActionPreference = 'Stop'
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
+# If specifies, provides an alternate path for getting .NET Core SDKs and Runtimes. This script will still try public sources first.
+[string]$runtimeSourceFeed = if (Test-Path variable:runtimeSourceFeed) { $runtimeSourceFeed } else { $null }
+# Base-64 encoded SAS token that has permission to storage container described by $runtimeSourceFeed
+[string]$runtimeSourceFeedKey = if (Test-Path variable:runtimeSourceFeedKey) { $runtimeSourceFeedKey } else { $null }
+
 function Create-Directory ([string[]] $path) {
     New-Item -Path $path -Force -ItemType 'Directory' | Out-Null
 }

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -248,9 +248,8 @@ function InstallDotNet([string] $dotnetRoot,
     & $installScript @installParameters
   }
   catch {
-    Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "Failed to install dotnet runtime '$runtime' from public location."
-
     if ($runtimeSourceFeed -or $runtimeSourceFeedKey) {
+      Write-Host "Failed to install dotnet runtime '$runtime' from public location. Trying from '$runtimeSourceFeed'"
       if ($runtimeSourceFeed) { $installParameters.AzureFeed = $runtimeSourceFeed }
 
       if ($runtimeSourceFeedKey) {
@@ -267,6 +266,7 @@ function InstallDotNet([string] $dotnetRoot,
         ExitWithExitCode 1
       }
     } else {
+      Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "Failed to install dotnet runtime '$runtime' from public location."
       ExitWithExitCode 1
     }
   }

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -64,6 +64,10 @@ else
   use_global_nuget_cache=${use_global_nuget_cache:-true}
 fi
 
+# Used when restoring .NET SDK from alternative feeds
+runtime_source_feed=${runtime_source_feed:-''}
+runtime_source_feed_key=${runtime_source_feed_key:-''}
+
 # Resolve any symlinks in the given path.
 function ResolvePath {
   local path=$1
@@ -170,11 +174,11 @@ function InitializeDotNetCli {
 function InstallDotNetSdk {
   local root=$1
   local version=$2
-  local architecture=""
-  if [[ $# == 3 ]]; then
+  local architecture="unset"
+  if [[ $# -ge 3 ]]; then
     architecture=$3
   fi
-  InstallDotNet "$root" "$version" $architecture
+  InstallDotNet "$root" "$version" "$architecture" "sdk" 0 $runtime_source_feed $runtime_source_feed_key
 }
 
 function InstallDotNet {
@@ -185,50 +189,47 @@ function InstallDotNet {
   local install_script=$_GetDotNetInstallScript
 
   local archArg=''
-  if [[ -n "${3:-}" ]]; then
+  if [[ -n "${3:-}" ]] && [ "$3" != 'unset' ]; then
     archArg="--architecture $3"
   fi
   local runtimeArg=''
-  if [[ -n "${4:-}" ]]; then
+  if [[ -n "${4:-}" ]] && [ "$4" != 'sdk' ]; then
     runtimeArg="--runtime $4"
   fi
-
   local skipNonVersionedFilesArg=""
-  if [[ "$#" -ge "5" ]]; then
+  if [[ "$#" -ge "5" ]] && [ $5 -ne 0 ]; then
     skipNonVersionedFilesArg="--skip-non-versioned-files"
   fi
   bash "$install_script" --version $version --install-dir "$root" $archArg $runtimeArg $skipNonVersionedFilesArg || {
     local exit_code=$?
     Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install dotnet SDK from public location (exit code '$exit_code')."
 
-    if [[ -n "$runtimeArg" ]]; then
-      local runtimeSourceFeed=''
-      if [[ -n "${6:-}" ]]; then
-        runtimeSourceFeed="--azure-feed $6"
-      fi
+    local runtimeSourceFeed=''
+    if [[ -n "${6:-}" ]]; then
+      runtimeSourceFeed="--azure-feed $6"
+    fi
 
-      local runtimeSourceFeedKey=''
-      if [[ -n "${7:-}" ]]; then
-        # The 'base64' binary on alpine uses '-d' and doesn't support '--decode'
-        # '-d'. To work around this, do a simple detection and switch the parameter
-        # accordingly.
-        decodeArg="--decode"
-        if base64 --help 2>&1 | grep -q "BusyBox"; then
-            decodeArg="-d"
-        fi
-        decodedFeedKey=`echo $7 | base64 $decodeArg`
-        runtimeSourceFeedKey="--feed-credential $decodedFeedKey"
+    local runtimeSourceFeedKey=''
+    if [[ -n "${7:-}" ]]; then
+      # The 'base64' binary on alpine uses '-d' and doesn't support '--decode'
+      # '-d'. To work around this, do a simple detection and switch the parameter
+      # accordingly.
+      decodeArg="--decode"
+      if base64 --help 2>&1 | grep -q "BusyBox"; then
+          decodeArg="-d"
       fi
+      decodedFeedKey=`echo $7 | base64 $decodeArg`
+      runtimeSourceFeedKey="--feed-credential $decodedFeedKey"
+    fi
 
-      if [[ -n "$runtimeSourceFeed" || -n "$runtimeSourceFeedKey" ]]; then
-        bash "$install_script" --version $version --install-dir "$root" $archArg $runtimeArg $skipNonVersionedFilesArg $runtimeSourceFeed $runtimeSourceFeedKey || {
-          local exit_code=$?
-          Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install dotnet SDK from custom location '$runtimeSourceFeed' (exit code '$exit_code')."
-          ExitWithExitCode $exit_code
-        }
-      else
+    if [[ -n "$runtimeSourceFeed" || -n "$runtimeSourceFeedKey" ]]; then
+      bash "$install_script" --version $version --install-dir "$root" $archArg $runtimeArg $skipNonVersionedFilesArg $runtimeSourceFeed $runtimeSourceFeedKey || {
+        local exit_code=$?
+        Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install dotnet SDK from custom location '$runtimeSourceFeed' (exit code '$exit_code')."
         ExitWithExitCode $exit_code
-      fi
+      }
+    else
+      ExitWithExitCode $exit_code
     fi
   }
 }

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -202,7 +202,7 @@ function InstallDotNet {
   fi
   bash "$install_script" --version $version --install-dir "$root" $archArg $runtimeArg $skipNonVersionedFilesArg || {
     local exit_code=$?
-    Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install dotnet SDK from public location (exit code '$exit_code')."
+    echo "Failed to install dotnet SDK from public location (exit code '$exit_code')."
 
     local runtimeSourceFeed=''
     if [[ -n "${6:-}" ]]; then
@@ -229,6 +229,9 @@ function InstallDotNet {
         ExitWithExitCode $exit_code
       }
     else
+      if [[ $exit_code != 0 ]]; then
+        Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install dotnet SDK from public location (exit code '$exit_code')."
+      fi
       ExitWithExitCode $exit_code
     fi
   }


### PR DESCRIPTION
See https://github.com/dotnet/arcade/issues/5934 for context.  This does the following:

- If build.sh / build.ps1 receives _valid_ values for  -runtimeSourceFeed and -runtimeSourceFeedKey that can be used to resolve a different storage container for the dotnet installer, it will first try to install from public, then try this source.
- Only after both fail (the latter only happening when credentials are provided) do we log a pipeline error; previously the public failure would forcibly fail the build even if the latter step succeeded.