### PR TITLE
Move call to Write-TelemetryPipelineError in Symbols and sourcelink validation

### DIFF
--- a/eng/common/post-build/symbols-validation.ps1
+++ b/eng/common/post-build/symbols-validation.ps1
@@ -141,11 +141,6 @@ $CountMissingSymbols = {
   if ($using:Clean) {
     Remove-Item $ExtractPath -Recurse -Force
   }
-
-  if ($MissingSymbols -ne 0)
-  {
-    Write-PipelineTelemetryError -Category 'CheckSymbols' -Message "Missing symbols for $MissingSymbols modules in the package $PackagePath"
-  }
   
   Pop-Location
 
@@ -165,6 +160,7 @@ function CheckJobResult(
     $DupedSymbols.Value++
   } 
   elseif ($jobResult.result -ne '0') {
+    Write-PipelineTelemetryError -Category 'CheckSymbols' -Message "Missing symbols for $result modules in the package $packagePath"
     $TotalFailures.Value++
   }
 }
@@ -201,7 +197,6 @@ function CheckSymbolsAvailable {
       Start-Job -ScriptBlock $CountMissingSymbols -ArgumentList $FullName | Out-Null
 
       $NumJobs = @(Get-Job -State 'Running').Count
-      Write-Host $NumJobs
 
       while ($NumJobs -ge $MaxParallelJobs) {
         Write-Host "There are $NumJobs validation jobs running right now. Waiting $SecondsBetweenLoadChecks seconds to check again."


### PR DESCRIPTION
Because the calls to Write-PipelineTelemetryError were inside the Start-Job call, the vso error was being swallowed. Moving this out of the script block and into the CheckJobResult function allows the error to bubble to the top, and means the failure will get logged properly in Kusto.

Validated in the dotnet-release repo:

Symbols-validation: https://dev.azure.com/dnceng/internal/_build/results?buildId=780870&view=logs&j=b30a92fc-e51b-572d-9566-e3b9dae8a01d&t=e564009e-c055-53ef-34ee-0088bca9e3b6
sourcelink-validation: https://dev.azure.com/dnceng/internal/_build/results?buildId=780870&view=logs&j=28bdc2c7-156f-51fb-6444-d4b8da3693ac&t=5b594bea-2a0e-5c7d-83e7-45031086cec4