### PR TITLE
Pass reporoot to acquirewixcore target

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets
@@ -27,7 +27,7 @@
     <MSBuild
       Projects="$(AcquireWixProjectFile)"
       Targets="AcquireWixCore"
-      Properties="IntermediateOutputRootPath=$(IntermediateOutputRootPath)" />
+      Properties="IntermediateOutputRootPath=$(IntermediateOutputRootPath);RepoRoot=$(RepoRoot)" />
   </Target>
 
   <Target Name="GetAcquireWixProperties"> 


### PR DESCRIPTION
We're using The SharedFramework sdk to acquire wix tools so that we can use light.exe to create msi's post-build.

When the "AcquireWix" target is called directly, or via something like this..

```xml
  <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" />
  <Target Name="Acquire"
          DependsOnTargets="AcquireWix">
  </Target>
  <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" />  
</Project>
```

... the project blows up with this error...

```text
C:\Users\chcosta\.nuget\packages\microsoft.dotnet.arcade.sdk\5.0.0-beta.20261.9\tools\RepoLayout.props(23,5): error MSB4184: The expression "[MSBuild]::NormalizeDirectory('')" cannot be evaluated. Parameter "path" cannot have zero length. [C:\Users\chcosta\.nuget\packages\microsoft.dotnet.build.tasks.sharedframework.sdk\5.0.0-beta.20261.9\targets\acquire-wix\acquire-wix.proj]
```

It appears that when "AcquireWix" directly invokes "AcquireWixCore" with Properties specified, all of the other properties are removed and AcquireWixCore cannot evaluate https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props#L23

My preference would be to pass "_SuppressSdkImports=true" instead of "RepoRoot=$(RepoRoot)", but wix actually does need Arcade properties / imports so I'm opting to pass along RepoRoot instead.