### PR TITLE
Revert back to 5.0-preview.1 API

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         [Required]
         public string AzureDevOpsPersonalAccessToken { get; set; }
 
-        public string AzureDevOpsFeedsApiVersion { get; set; } = "5.0";
+        public string AzureDevOpsFeedsApiVersion { get; set; } = "5.0-preview.1";
 
         public static string AzureDevOpsOrg { get; set; } = "dnceng";
 


### PR DESCRIPTION
It looks like even though the API is in 6.0, the REST api actually didn't exit preview in 5.0