### PR TITLE
Make iOS integration tests fail the build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -180,7 +180,6 @@ stages:
               /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.XHarness.iOS.binlog
               /p:RestoreUsingNuGetTargets=false
             displayName: XHarness iOS Helix Testing
-            continueOnError: true
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''


### PR DESCRIPTION
I fixed the issues in iOS and it is stable now. We should get notified about possible next failures (someone breaking the SDK..)