### PR TITLE
Remove the validate-darc call

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,7 +94,7 @@ stages:
               ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
                 _SignType: real
                 _DotNetPublishToBlobFeed : true
-                _Script: eng\validate-sdk.cmd
+                _Script: eng\common\cibuild.cmd
                 _ValidateSdkArgs: -gitHubPat $(BotAccount-dotnet-maestro-bot-PAT) -barToken $(MaestroAccessToken)
             ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
               Build_Debug:
@@ -104,12 +104,6 @@ stages:
         steps:
         - checkout: self
           clean: true
-        - task: UseDotNet@2
-          displayName: 'Install .NET Core 3.1'
-          inputs:
-            packageType: sdk
-            version: 3.1.300
-            installationPath: $(Build.SourcesDirectory)/.dotnet
         # Use utility script to run script command dependent on agent OS.
         - script: $(_Script)
             -configuration $(_BuildConfig) 


### PR DESCRIPTION
Darc requires 3.1 to run (rather than the 3.0 installed by the global.json)
However, there is a breaking change in the 3.1 NuGet packages
that causes Sleet to fail.

This is a change to unblock the builds by going back to 3.0 (which
is the change that caused this break) and removing the darc call.

There is a longer term plan to make the "right" change here,
which is to remove Sleet altogether.

Fixes #5935