### PR TITLE
Control output location for resulting files

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLightCommandPackageDrop.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLightCommandPackageDrop.cs
@@ -97,7 +97,7 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
             // Write Light command to file
             string commandFilename = Path.Combine(packageDropOutputFolder, "light.cmd");
             string commandString = string.Empty;
-            commandString += "set outputfolder=%1";
+            commandString += "set outputfolder=%1" + Environment.NewLine;
             if(OriginalLightCommand != null)
             {
                 commandString += "REM Original light command" + Environment.NewLine;

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLightCommandPackageDrop.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLightCommandPackageDrop.cs
@@ -97,6 +97,7 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
             // Write Light command to file
             string commandFilename = Path.Combine(packageDropOutputFolder, "light.cmd");
             string commandString = string.Empty;
+            commandString += "set outputfolder=%1";
             if(OriginalLightCommand != null)
             {
                 commandString += "REM Original light command" + Environment.NewLine;
@@ -104,7 +105,7 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
             }
             commandString += "REM Modified light command" + Environment.NewLine;
             commandString += "light.exe";
-            commandString += $" -out {Path.GetFileName(Out)}";
+            commandString += $" -out %outputfolder%{Path.GetFileName(Out)}";
             if (NoLogo)
             {
                 commandString += " -nologo";
@@ -126,7 +127,7 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
             }
             if(PdbOut != null)
             {
-                commandString += $" -pdbout {PdbOut}";
+                commandString += $" -pdbout %outputfolder%{PdbOut}";
             }
             if(WixProjectFile != null)
             {


### PR DESCRIPTION
Additional support for https://github.com/dotnet/arcade/issues/5988

We want to have a known location for the resulting exe/msi files after packaging them with the light.cmd script so that it makes it easier to copy them back into the drop. 