### PR TITLE
Add support for lit.exe

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLightCommandPackageDrop.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLightCommandPackageDrop.cs
@@ -3,28 +3,16 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
-using System;
-using System.Collections.Generic;
+using Microsoft.DotNet.Build.Tasks.Installers.src;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Xml;
-using System.Xml.Linq;
-using System.Xml.XPath;
 
 namespace Microsoft.DotNet.Build.Tasks.Installers
 {
-    public class CreateLightCommandPackageDrop : BuildTask
+    public class CreateLightCommandPackageDrop : CreateWixCommandPackageDropBase
     {
-        private const int _fieldsArtifactId = 0;
-        private const int _fieldsArtifactPath1 = 6;
-        private const int _fieldsArtifactPath2 = 1;
-        private const int _fieldsArtifactPath3 = 2;
-        private const int _fieldsArtifactPath6 = 5;
-
         [Required]
         public string LightCommandWorkingDir { get; set; }
-        public bool NoLogo { get; set; }
         public bool Fv { get; set; }
         public string PdbOut { get; set; }
         public string Cultures { get; set; }
@@ -32,17 +20,7 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
         public string ContentsFile { get; set; }
         public string OutputsFile { get; set; }
         public string BuiltOutputsFile { get; set; }
-        /// <summary>
-        /// Additional set of base paths that are used for resolving paths.
-        /// </summary>
-        public ITaskItem[] AdditionalBasePaths { get; set; }
-        public ITaskItem [] Loc { get; set; }
         public ITaskItem [] Sice { get; set; }
-        [Required]
-        public string Out { get; set; }
-        public ITaskItem [] WixExtensions { get; set; }
-        [Required]
-        public ITaskItem [] WixSrcFiles { get; set; }
 
         [Output]
         public string LightCommandPackageNameOutput { get; set; }
@@ -54,96 +32,32 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
         {
             LightCommandPackageNameOutput = Path.GetFileNameWithoutExtension(Out);
             string packageDropOutputFolder = Path.Combine(LightCommandWorkingDir, LightCommandPackageNameOutput);
+            ProcessWixCommand(packageDropOutputFolder, "light.exe", OriginalLightCommand);
 
-            if (!Directory.Exists(packageDropOutputFolder))
-            {
-                Directory.CreateDirectory(packageDropOutputFolder);
-            }
+            return !Log.HasLoggedErrors;
+        }
 
-            XmlNamespaceManager nsmgr = new XmlNamespaceManager(new NameTable());
-            nsmgr.AddNamespace("wix", "http://schemas.microsoft.com/wix/2006/objects");
-
-            foreach (var wixSrcFile in WixSrcFiles)
-            {
-                // copy the file to outputPath
-                string newWixSrcFilePath = Path.Combine(packageDropOutputFolder, Path.GetFileName(wixSrcFile.ItemSpec));
-                File.Copy(wixSrcFile.ItemSpec, newWixSrcFilePath, true);
-
-                string wixSrcFileExtension = Path.GetExtension(wixSrcFile.ItemSpec);
-                // These files are typically .wixobj. Occasionally we have a wixlib as input, which
-                // is created using light and is a binary file. When doing post-build signing,
-                // it's replaced in the inputs to the light command after being reconstructed from
-                // its own light command drop.
-                if (wixSrcFileExtension == ".wixlib")
-                {
-                    continue;
-                }
-                else if (wixSrcFileExtension != ".wixobj")
-                {
-                    Log.LogError($"Wix source file extension {wixSrcFileExtension} is not supported.");
-                    continue;
-                }
-
-                ProcessWixObj(newWixSrcFilePath, packageDropOutputFolder, nsmgr);
-            }
-            if (Loc != null)
-            {
-                foreach (var locItem in Loc)
-                {
-                    var destinationPath = Path.Combine(packageDropOutputFolder, Path.GetFileName(locItem.ItemSpec));
-                    File.Copy(locItem.ItemSpec, destinationPath, true);
-                }
-            }
-
-            // Write Light command to file
-            string commandFilename = Path.Combine(packageDropOutputFolder, "light.cmd");
-            StringBuilder commandString = new StringBuilder();
-            commandString.AppendLine("@echo off");
-            commandString.AppendLine("setlocal");
-            commandString.AppendLine("set outputfolder=%1");
-            commandString.AppendLine("if \"%outputfolder%\" NEQ \"\" (");
-            commandString.AppendLine("  if \"%outputfolder:~-1%\" NEQ \"\\\" ( ");
-            commandString.AppendLine("    set outputfolder=%outputfolder%\\");
-            commandString.AppendLine("  )");
-            commandString.AppendLine(")");
-            if(OriginalLightCommand != null)
-            {
-                commandString.AppendLine("REM Original light command");
-                commandString.AppendLine($"REM {OriginalLightCommand }");
-            }
-            commandString.AppendLine("REM Modified light command");
-            commandString.Append("light.exe");
-            commandString.Append($" -out %outputfolder%{Path.GetFileName(Out)}");
-            if (NoLogo)
-            {
-                commandString.Append(" -nologo");
-            }
+        protected override void ProcessToolSpecificCommandLineParameters(string packageDropOutputFolder, StringBuilder commandString)
+        {
             if (Cultures != null)
             {
                 commandString.Append($" -cultures:{Cultures}");
             }
-            if (Loc != null)
-            {
-                foreach (var locItem in Loc)
-                {
-                    commandString.Append($" -loc {Path.GetFileName(locItem.ItemSpec)}");
-                }
-            }
-            if(Fv)
+            if (Fv)
             {
                 commandString.Append(" -fv");
             }
-            if(PdbOut != null)
+            if (PdbOut != null)
             {
                 commandString.Append($" -pdbout %outputfolder%{PdbOut}");
             }
-            if(WixProjectFile != null)
+            if (WixProjectFile != null)
             {
                 var destinationPath = Path.Combine(packageDropOutputFolder, Path.GetFileName(WixProjectFile));
                 File.Copy(WixProjectFile, destinationPath, true);
                 commandString.Append($" -wixprojectfile {Path.GetFileName(WixProjectFile)}");
             }
-            if(ContentsFile != null)
+            if (ContentsFile != null)
             {
                 commandString.Append($" -contentsfile {Path.GetFileName(ContentsFile)}");
             }
@@ -160,189 +74,6 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
                 foreach (var siceItem in Sice)
                 {
                     commandString.Append($" -sice:{siceItem.ItemSpec}");
-                }
-            }
-            if(WixExtensions != null)
-            {
-                foreach(var wixExtension in WixExtensions)
-                {
-                    commandString.Append($" -ext {wixExtension.ItemSpec}");
-                }
-            }
-            if(WixSrcFiles != null)
-            {
-                foreach(var wixSrcFile in WixSrcFiles)
-                {
-                    commandString.Append($" {Path.GetFileName(wixSrcFile.ItemSpec)}");
-                }
-            }
-            commandString.AppendLine();
-            commandString.AppendLine("endlocal");
-            File.WriteAllText(commandFilename, commandString.ToString());
-
-            return !Log.HasLoggedErrors;
-        }
-
-        /// <summary>
-        ///     Process a .wixobj file that is an input to the light command.
-        /// </summary>
-        /// <param name="wixObjFilePath">Path to the wixobj file in its new drop location</param>
-        /// <param name="packageDropOutputFolder">Output light command drop folder</param>
-        /// <param name="nsmgr">xml namespace manager</param>
-        void ProcessWixObj(string wixObjFilePath, string packageDropOutputFolder, XmlNamespaceManager nsmgr)
-        {
-            Log.LogMessage(LogImportance.Normal, $"Creating modified wixobj file '{wixObjFilePath}'...");
-
-            XDocument doc = XDocument.Load(wixObjFilePath);
-            if (doc == null)
-            {
-                Log.LogError($"Failed to open the wixobj file '{wixObjFilePath}'");
-                return;
-            }
-
-            // process fragment - WixFile elements
-            // path in field 7
-            string xpath = "//wix:wixObject/wix:section[@type='fragment']/wix:table[@name='WixFile']/wix:row";
-            ProcessXPath(doc, xpath, packageDropOutputFolder, nsmgr, _fieldsArtifactPath1);
-
-            // process product - WixFile elements
-            // path in field 7
-            xpath = "//wix:wixObject/wix:section[@type='product']/wix:table[@name='WixFile']/wix:row";
-            ProcessXPath(doc, xpath, packageDropOutputFolder, nsmgr, _fieldsArtifactPath1);
-
-            // process fragment - Binary elements
-            // path in field 2
-            xpath = "//wix:wixObject/wix:section[@type='fragment']/wix:table[@name='Binary']/wix:row";
-            ProcessXPath(doc, xpath, packageDropOutputFolder, nsmgr, _fieldsArtifactPath2);
-
-            // process product - Icon elements
-            // path in field 2
-            xpath = "//wix:wixObject/wix:section[@type='product']/wix:table[@name='Icon']/wix:row";
-            ProcessXPath(doc, xpath, packageDropOutputFolder, nsmgr, _fieldsArtifactPath2);
-
-            // process product - WixVariable elements
-            // path in field 2
-            xpath = "//wix:wixObject/wix:section[@type='product']/wix:table[@name='WixVariable']/wix:row";
-            ProcessXPath(doc, xpath, packageDropOutputFolder, nsmgr, _fieldsArtifactPath2);
-
-            // Bundle specific items.
-
-            // path in fields 3 and 6
-            xpath = "//wix:wixObject/wix:section[@type='bundle']/wix:table[@name='Payload']/wix:row";
-            ProcessXPath(doc, xpath, packageDropOutputFolder, nsmgr, _fieldsArtifactPath3, _fieldsArtifactPath6);
-
-            // process WixVariable data
-            // path in field 2
-            xpath = "//wix:wixObject/wix:section[@type='bundle']/wix:table[@name='WixVariable']/wix:row";
-            ProcessXPath(doc, xpath, packageDropOutputFolder, nsmgr, _fieldsArtifactPath2);
-
-            // process Payload, in fragment section, data
-            // path in fields 3 and 6
-            xpath = "//wix:wixObject/wix:section[@type='fragment']/wix:table[@name='Payload']/wix:row";
-            ProcessXPath(doc, xpath, packageDropOutputFolder, nsmgr, _fieldsArtifactPath3, _fieldsArtifactPath6);
-
-            doc.Save(wixObjFilePath);
-        }
-
-        void ProcessXPath(XDocument doc, string xpath, string outputPath, XmlNamespaceManager nsmgr, int pathField1, int pathField2 = 0)
-        {
-            IEnumerable<XElement> iels = doc.XPathSelectElements(xpath, nsmgr);
-            if (iels != null && iels.Count() > 0)
-            {
-
-                foreach (XElement row in iels)
-                {
-                    IEnumerable<XElement> fields = row.XPathSelectElements("wix:field", nsmgr);
-                    if (fields == null || fields.Count() == 0)
-                    {
-                        Log.LogError($"No fields in row ('{xpath}') of document '{doc.BaseUri}'");
-                        continue;
-                    }
-
-                    int count = 0;
-                    string id = null;
-                    string oldPath = null;
-                    string newRelativePath = null;
-                    bool foundArtifact = false;
-                    bool isVariableRef = false;
-
-                    foreach (XElement field in fields)
-                    {
-                        if (count == _fieldsArtifactId)
-                        {
-                            id = field.Value;
-                        }
-                        else if (count == pathField1)
-                        {
-                            oldPath = field.Value;
-
-                            // Potentially make oldPath the absolute if it's not, using the additional base
-                            // paths. It's possible that the path is a variable. In this case,
-                            // we can ignore it.
-                            if (oldPath.StartsWith("!("))
-                            {
-                                isVariableRef = true;
-                                break;
-                            }
-                            else if (!Path.IsPathRooted(oldPath))
-                            {
-                                if (AdditionalBasePaths == null)
-                                {
-                                    // Break here, will log an error below.
-                                    break;
-                                }
-                                foreach (var additionalBasePath in AdditionalBasePaths)
-                                {
-                                    var possiblePath = Path.Combine(additionalBasePath.ItemSpec, oldPath);
-                                    if (File.Exists(possiblePath))
-                                    {
-                                        oldPath = possiblePath;
-                                        foundArtifact = true;
-                                        break;
-                                    }
-                                }
-                            }
-                            else if (File.Exists(oldPath))
-                            {
-                                foundArtifact = true;
-                            }
-                            else
-                            {
-                                break;
-                            }
-
-                            newRelativePath = Path.Combine(id, Path.GetFileName(oldPath));
-                            field.Value = newRelativePath;
-                        }
-                        else if (pathField2 != 0 && count == pathField2)
-                        {
-                            field.Value = newRelativePath;
-                            break;
-                        }
-                        count++;
-                    }
-
-                    if (!isVariableRef)
-                    {
-                        if (foundArtifact)
-                        {
-                            string newFolder = Path.Combine(outputPath, id);
-                            if (!Directory.Exists(newFolder))
-                            {
-                                Directory.CreateDirectory(newFolder);
-                            }
-
-                            File.Copy(oldPath, Path.Combine(outputPath, newRelativePath), true);
-                        }
-                        else if (oldPath == null)
-                        {
-                            Log.LogError($"Could not locate a file within {row}");
-                        }
-                        else
-                        {
-                            Log.LogError($"Could not locate file {oldPath}. Please ensure the file exists and/or pass AdditionalBasePaths for non-rooted file paths.");
-                        }
-                    }
                 }
             }
         }

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLightCommandPackageDrop.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLightCommandPackageDrop.cs
@@ -13,6 +13,9 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
     {
         [Required]
         public string LightCommandWorkingDir { get; set; }
+        /// <summary>
+        /// Add a FileVersion attribute to each assembly in the MsiAssemblyName table (rarely needed).
+        /// </summary>
         public bool Fv { get; set; }
         public string PdbOut { get; set; }
         public string Cultures { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLitCommandPackageDrop.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLitCommandPackageDrop.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.DotNet.Build.Tasks.Installers.src;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.XPath;
+
+namespace Microsoft.DotNet.Build.Tasks.Installers
+{
+    /// <summary>
+    ///     Creates a package drop for wixlibs produced by the lit.exe command
+    ///     This is pretty simple, as the wixobj's used as inputs are simply
+    ///     packaged together into the wixlib.
+    /// </summary>
+    public class CreateLitCommandPackageDrop : CreateWixCommandPackageDropBase
+    {
+        [Required]
+        public string LitCommandWorkingDir { get; set; }
+        public bool Bf { get; set; }
+
+        [Output]
+        public string LitCommandPackageNameOutput { get; set; }
+        // The lot command that was originally used to generate the wixlib.  This is purely used for informational purposes
+        // and to validate that the lit command being created by this task is correct (assist with debugging).
+        public string OriginalLitCommand { get; set; }
+
+        public override bool Execute()
+        {
+            LitCommandPackageNameOutput = Path.GetFileNameWithoutExtension(Out);
+            string packageDropOutputFolder = Path.Combine(LitCommandWorkingDir, LitCommandPackageNameOutput);
+            ProcessWixCommand(packageDropOutputFolder, "lit.exe", OriginalLitCommand);
+
+            return !Log.HasLoggedErrors;
+        }
+
+        protected override void ProcessToolSpecificCommandLineParameters(string packageDropOutputFolder, StringBuilder commandString)
+        {
+            if (Bf)
+            {
+                commandString.Append(" -bf");
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLitCommandPackageDrop.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLitCommandPackageDrop.cs
@@ -24,6 +24,9 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
     {
         [Required]
         public string LitCommandWorkingDir { get; set; }
+        /// <summary>
+        /// Bind files into the library file.
+        /// </summary>
         public bool Bf { get; set; }
 
         [Output]

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixCommandPackageDropBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixCommandPackageDropBase.cs
@@ -235,7 +235,7 @@ namespace Microsoft.DotNet.Build.Tasks.Installers.src
                     string oldPath = null;
                     string newRelativePath = null;
                     bool foundArtifact = false;
-                    bool isVariableRef = false;
+                    bool isVariableOrUriRef = false;
 
                     foreach (XElement field in fields)
                     {
@@ -248,11 +248,11 @@ namespace Microsoft.DotNet.Build.Tasks.Installers.src
                             oldPath = field.Value;
 
                             // Potentially make oldPath the absolute if it's not, using the additional base
-                            // paths. It's possible that the path is a variable. In this case,
+                            // paths. It's possible that the path is a variable or URI. In this case,
                             // we can ignore it.
-                            if (oldPath.StartsWith("!("))
+                            if (oldPath.StartsWith("!(") || oldPath.StartsWith("https"))
                             {
-                                isVariableRef = true;
+                                isVariableOrUriRef = true;
                                 break;
                             }
                             else if (!Path.IsPathRooted(oldPath))
@@ -293,7 +293,7 @@ namespace Microsoft.DotNet.Build.Tasks.Installers.src
                         count++;
                     }
 
-                    if (!isVariableRef)
+                    if (!isVariableOrUriRef)
                     {
                         if (foundArtifact)
                         {

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixCommandPackageDropBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixCommandPackageDropBase.cs
@@ -1,0 +1,317 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.XPath;
+
+namespace Microsoft.DotNet.Build.Tasks.Installers.src
+{
+    public abstract class CreateWixCommandPackageDropBase : BuildTask
+    {
+        private const int _fieldsArtifactId = 0;
+        private const int _fieldsArtifactPath1 = 6;
+        private const int _fieldsArtifactPath2 = 1;
+        private const int _fieldsArtifactPath3 = 2;
+        private const int _fieldsArtifactPath6 = 5;
+
+        public bool NoLogo { get; set; }
+        /// <summary>
+        /// Additional set of base paths that are used for resolving paths.
+        /// </summary>
+        public ITaskItem[] AdditionalBasePaths { get; set; }
+        public ITaskItem[] Loc { get; set; }
+        [Required]
+        public string Out { get; set; }
+        public ITaskItem[] WixExtensions { get; set; }
+        [Required]
+        public ITaskItem[] WixSrcFiles { get; set; }
+
+        protected abstract void ProcessToolSpecificCommandLineParameters(string packageDropOutputFolder, StringBuilder commandString);
+
+        protected void ProcessWixCommand(string packageDropOutputFolder, string toolExecutable, string originalCommand)
+        {
+            if (!Directory.Exists(packageDropOutputFolder))
+            {
+                Directory.CreateDirectory(packageDropOutputFolder);
+            }
+
+            ProcessWixSrcFiles(packageDropOutputFolder);
+
+            ProcessLocFiles(packageDropOutputFolder);
+
+            CreateCommandFile(toolExecutable, originalCommand, packageDropOutputFolder);
+        }
+
+        private void CreateCommandFile(string toolExecutable, string originalCommand, string packageDropOutputFolder)
+        {
+            string toolName = Path.GetFileNameWithoutExtension(toolExecutable);
+            string commandFilename = Path.Combine(packageDropOutputFolder, $"{toolName}.cmd");
+            StringBuilder commandString = new StringBuilder();
+            commandString.AppendLine("@echo off");
+            commandString.AppendLine("setlocal");
+            commandString.AppendLine("set outputfolder=%1");
+            commandString.AppendLine("if \"%outputfolder%\" NEQ \"\" (");
+            commandString.AppendLine("  if \"%outputfolder:~-1%\" NEQ \"\\\" ( ");
+            commandString.AppendLine("    set outputfolder=%outputfolder%\\");
+            commandString.AppendLine("  )");
+            commandString.AppendLine(")");
+            if (originalCommand != null)
+            {
+                commandString.AppendLine($"REM Original {toolName} command");
+                commandString.AppendLine($"REM {originalCommand }");
+            }
+            commandString.AppendLine("REM Modified {toolName} command");
+            commandString.Append(toolExecutable);
+            commandString.Append($" -out %outputfolder%{Path.GetFileName(Out)}");
+            if (NoLogo)
+            {
+                commandString.Append(" -nologo");
+            }
+            if (Loc != null)
+            {
+                foreach (var locItem in Loc)
+                {
+                    commandString.Append($" -loc {Path.GetFileName(locItem.ItemSpec)}");
+                }
+            }
+            if (WixExtensions != null)
+            {
+                foreach (var wixExtension in WixExtensions)
+                {
+                    commandString.Append($" -ext {wixExtension.ItemSpec}");
+                }
+            }
+            if (WixSrcFiles != null)
+            {
+                foreach (var wixSrcFile in WixSrcFiles)
+                {
+                    commandString.Append($" {Path.GetFileName(wixSrcFile.ItemSpec)}");
+                }
+            }
+            commandString.AppendLine();
+            commandString.AppendLine("endlocal");
+            File.WriteAllText(commandFilename, commandString.ToString());
+        }
+
+        /// <summary>
+        ///     Process each of the wix src files
+        /// </summary>
+        /// <param name="packageDropOutputFolder">Drop folder to place artifacts</param>
+        private void ProcessWixSrcFiles(string packageDropOutputFolder)
+        {
+            XmlNamespaceManager nsmgr = new XmlNamespaceManager(new NameTable());
+            nsmgr.AddNamespace("wix", "http://schemas.microsoft.com/wix/2006/objects");
+
+            foreach (var wixSrcFile in WixSrcFiles)
+            {
+                // copy the file to outputPath
+                string newWixSrcFilePath = Path.Combine(packageDropOutputFolder, Path.GetFileName(wixSrcFile.ItemSpec));
+                File.Copy(wixSrcFile.ItemSpec, newWixSrcFilePath, true);
+
+                string wixSrcFileExtension = Path.GetExtension(wixSrcFile.ItemSpec);
+                // These files are typically .wixobj. Occasionally we have a wixlib as input, which
+                // is created using light and is a binary file. When doing post-build signing,
+                // it's replaced in the inputs to the light command after being reconstructed from
+                // its own light command drop.
+                if (wixSrcFileExtension == ".wixlib")
+                {
+                    continue;
+                }
+                else if (wixSrcFileExtension != ".wixobj")
+                {
+                    Log.LogError($"Wix source file extension {wixSrcFileExtension} is not supported.");
+                    continue;
+                }
+
+                ProcessWixObj(newWixSrcFilePath, packageDropOutputFolder, nsmgr);
+            }
+        }
+
+        /// <summary>
+        ///     Process the .wxl files and copy to the local drop folder
+        /// </summary>
+        /// <param name="packageDropOutputFolder">Drop location for wxl files</param>
+        private void ProcessLocFiles(string packageDropOutputFolder)
+        {
+            if (Loc != null)
+            {
+                foreach (var locItem in Loc)
+                {
+                    var destinationPath = Path.Combine(packageDropOutputFolder, Path.GetFileName(locItem.ItemSpec));
+                    File.Copy(locItem.ItemSpec, destinationPath, true);
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Process a .wixobj file that is an input to the light/lit command.
+        /// </summary>
+        /// <param name="wixObjFilePath">Path to the wixobj file in its new drop location</param>
+        /// <param name="packageDropOutputFolder">Output light/lit command drop folder</param>
+        /// <param name="nsmgr">xml namespace manager</param>
+        private void ProcessWixObj(string wixObjFilePath, string packageDropOutputFolder, XmlNamespaceManager nsmgr)
+        {
+            Log.LogMessage(LogImportance.Normal, $"Creating modified wixobj file '{wixObjFilePath}'...");
+
+            XDocument doc = XDocument.Load(wixObjFilePath);
+            if (doc == null)
+            {
+                Log.LogError($"Failed to open the wixobj file '{wixObjFilePath}'");
+                return;
+            }
+
+            // process fragment - WixFile elements
+            // path in field 7
+            string xpath = "//wix:wixObject/wix:section[@type='fragment']/wix:table[@name='WixFile']/wix:row";
+            ProcessXPath(doc, xpath, packageDropOutputFolder, nsmgr, _fieldsArtifactPath1);
+
+            // process product - WixFile elements
+            // path in field 7
+            xpath = "//wix:wixObject/wix:section[@type='product']/wix:table[@name='WixFile']/wix:row";
+            ProcessXPath(doc, xpath, packageDropOutputFolder, nsmgr, _fieldsArtifactPath1);
+
+            // process fragment - Binary elements
+            // path in field 2
+            xpath = "//wix:wixObject/wix:section[@type='fragment']/wix:table[@name='Binary']/wix:row";
+            ProcessXPath(doc, xpath, packageDropOutputFolder, nsmgr, _fieldsArtifactPath2);
+
+            // process product - Icon elements
+            // path in field 2
+            xpath = "//wix:wixObject/wix:section[@type='product']/wix:table[@name='Icon']/wix:row";
+            ProcessXPath(doc, xpath, packageDropOutputFolder, nsmgr, _fieldsArtifactPath2);
+
+            // process product - WixVariable elements
+            // path in field 2
+            xpath = "//wix:wixObject/wix:section[@type='product']/wix:table[@name='WixVariable']/wix:row";
+            ProcessXPath(doc, xpath, packageDropOutputFolder, nsmgr, _fieldsArtifactPath2);
+
+            // Bundle specific items.
+
+            // path in fields 3 and 6
+            xpath = "//wix:wixObject/wix:section[@type='bundle']/wix:table[@name='Payload']/wix:row";
+            ProcessXPath(doc, xpath, packageDropOutputFolder, nsmgr, _fieldsArtifactPath3, _fieldsArtifactPath6);
+
+            // process WixVariable data
+            // path in field 2
+            xpath = "//wix:wixObject/wix:section[@type='bundle']/wix:table[@name='WixVariable']/wix:row";
+            ProcessXPath(doc, xpath, packageDropOutputFolder, nsmgr, _fieldsArtifactPath2);
+
+            // process Payload, in fragment section, data
+            // path in fields 3 and 6
+            xpath = "//wix:wixObject/wix:section[@type='fragment']/wix:table[@name='Payload']/wix:row";
+            ProcessXPath(doc, xpath, packageDropOutputFolder, nsmgr, _fieldsArtifactPath3, _fieldsArtifactPath6);
+
+            doc.Save(wixObjFilePath);
+        }
+
+        private void ProcessXPath(XDocument doc, string xpath, string outputPath, XmlNamespaceManager nsmgr, int pathField1, int pathField2 = 0)
+        {
+            IEnumerable<XElement> iels = doc.XPathSelectElements(xpath, nsmgr);
+            if (iels != null && iels.Count() > 0)
+            {
+
+                foreach (XElement row in iels)
+                {
+                    IEnumerable<XElement> fields = row.XPathSelectElements("wix:field", nsmgr);
+                    if (fields == null || fields.Count() == 0)
+                    {
+                        Log.LogError($"No fields in row ('{xpath}') of document '{doc.BaseUri}'");
+                        continue;
+                    }
+
+                    int count = 0;
+                    string id = null;
+                    string oldPath = null;
+                    string newRelativePath = null;
+                    bool foundArtifact = false;
+                    bool isVariableRef = false;
+
+                    foreach (XElement field in fields)
+                    {
+                        if (count == _fieldsArtifactId)
+                        {
+                            id = field.Value;
+                        }
+                        else if (count == pathField1)
+                        {
+                            oldPath = field.Value;
+
+                            // Potentially make oldPath the absolute if it's not, using the additional base
+                            // paths. It's possible that the path is a variable. In this case,
+                            // we can ignore it.
+                            if (oldPath.StartsWith("!("))
+                            {
+                                isVariableRef = true;
+                                break;
+                            }
+                            else if (!Path.IsPathRooted(oldPath))
+                            {
+                                if (AdditionalBasePaths == null)
+                                {
+                                    // Break here, will log an error below.
+                                    break;
+                                }
+                                foreach (var additionalBasePath in AdditionalBasePaths)
+                                {
+                                    var possiblePath = Path.Combine(additionalBasePath.ItemSpec, oldPath);
+                                    if (File.Exists(possiblePath))
+                                    {
+                                        oldPath = possiblePath;
+                                        foundArtifact = true;
+                                        break;
+                                    }
+                                }
+                            }
+                            else if (File.Exists(oldPath))
+                            {
+                                foundArtifact = true;
+                            }
+                            else
+                            {
+                                break;
+                            }
+
+                            newRelativePath = Path.Combine(id, Path.GetFileName(oldPath));
+                            field.Value = newRelativePath;
+                        }
+                        else if (pathField2 != 0 && count == pathField2)
+                        {
+                            field.Value = newRelativePath;
+                            break;
+                        }
+                        count++;
+                    }
+
+                    if (!isVariableRef)
+                    {
+                        if (foundArtifact)
+                        {
+                            string newFolder = Path.Combine(outputPath, id);
+                            if (!Directory.Exists(newFolder))
+                            {
+                                Directory.CreateDirectory(newFolder);
+                            }
+
+                            File.Copy(oldPath, Path.Combine(outputPath, newRelativePath), true);
+                        }
+                        else if (oldPath == null)
+                        {
+                            Log.LogError($"Could not locate a file within {row}");
+                        }
+                        else
+                        {
+                            Log.LogError($"Could not locate file {oldPath}. Please ensure the file exists and/or pass AdditionalBasePaths for non-rooted file paths.");
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixCommandPackageDropBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixCommandPackageDropBase.cs
@@ -26,6 +26,9 @@ namespace Microsoft.DotNet.Build.Tasks.Installers.src
         /// Additional set of base paths that are used for resolving paths.
         /// </summary>
         public ITaskItem[] AdditionalBasePaths { get; set; }
+        /// <summary>
+        /// Localization files
+        /// </summary>
         public ITaskItem[] Loc { get; set; }
         [Required]
         public string Out { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixCommandPackageDropBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixCommandPackageDropBase.cs
@@ -95,6 +95,7 @@ namespace Microsoft.DotNet.Build.Tasks.Installers.src
                     commandString.Append($" {Path.GetFileName(wixSrcFile.ItemSpec)}");
                 }
             }
+            ProcessToolSpecificCommandLineParameters(packageDropOutputFolder, commandString);
             commandString.AppendLine();
             commandString.AppendLine("endlocal");
             File.WriteAllText(commandFilename, commandString.ToString());


### PR DESCRIPTION
lit.exe is the library generator for WiX. It works similar to light.exe but has fewer options.
Factor the common bits into a base class, then inherent this in two separate tasks to deal with
lit and light separately.