### PR TITLE
Updated .NET Library license

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Licenses/MicrosoftDotNetLibrary.txt
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Licenses/MicrosoftDotNetLibrary.txt
@@ -2,147 +2,143 @@
 
 # MICROSOFT .NET LIBRARY
 
-These license terms are an agreement between Microsoft Corporation (or based on
-where you live, one of its affiliates) and you. They apply to the software
-named above. The terms also apply to any Microsoft services or updates for the
-software, except to the extent those have different terms.
+These license terms are an agreement between you and Microsoft
+Corporation (or based on where you live, one of its affiliates). They
+apply to the software named above. The terms also apply to any Microsoft
+services or updates for the software, except to the extent those have
+different terms.
 
 IF YOU COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE RIGHTS BELOW.
 
 1. INSTALLATION AND USE RIGHTS. 
-You may install and use any number of copies of the software to design, develop
-and test you're applications. You may modify, copy, distribute or deploy any
-.js files contained in the software as part of your applications. 
+You may install and use any number of copies of the software to develop
+and test your applications. 
 
-2. THIRD PARTY COMPONENTS. The software may include third party components with
-separate legal notices or governed by other agreements, as may be described in
-the ThirdPartyNotices file(s) accompanying the software.
+2. THIRD PARTY COMPONENTS. The software may include third party components
+  with separate legal notices or governed by other agreements, as may be 
+  described in the ThirdPartyNotices file(s) accompanying the software.
 
-3. ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.
-  a. DISTRIBUTABLE CODE.  In addition to the .js files described above, the
-     software is comprised of Distributable Code. "Distributable Code" is 
-     code that you are permitted to distribute in programs you develop if you
-     comply with the terms below.
+3. ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.
+  a. DISTRIBUTABLE CODE.  The software is comprised of Distributable Code.
+  “Distributable Code” is code that you are permitted to distribute in 
+  applications you develop if you comply with the terms below.
 
     i. Right to Use and Distribute. 
        - You may copy and distribute the object code form of the software.
-       - Third Party Distribution. You may permit distributors of your programs
-         to copy and distribute the Distributable Code as part of those
-         programs.
-
-    ii. Distribution Requirements. For any Distributable Code you distribute, 
+       - Third Party Distribution. You may permit distributors of your
+         applications to copy and distribute the Distributable Code as part
+         of those applications.
+    
+    ii. Distribution Requirements. For any Distributable Code you distribute,
         you must
-       - use the Distributable Code in your programs and not as a standalone
-         distribution;
+       - use the Distributable Code in your applications and not as a
+         standalone distribution;
        - require distributors and external end users to agree to terms that
-         protect it at least as much as this agreement;
-       - display your valid copyright notice on your programs; and
+         protect it at least as much as this agreement; and
        - indemnify, defend, and hold harmless Microsoft from any claims,
-         including attorneys' fees, related to the distribution or use of
-         your applications, except to the extent that any claim is based solely
-         on the Distributable Code.
-
-    iii. Distribution Restrictions. You may not
-       - alter any copyright, trademark or patent notice in the Distributable
-         Code;
-       - use Microsoft's trademarks in your programs' names or in a way that
-         suggests your programs come from or are endorsed by Microsoft;
-       - include Distributable Code in malicious, deceptive or unlawful
-         programs; or
+         including attorneys’ fees, related to the distribution or use of
+         your applications, except to the extent that any claim is based
+         solely on the unmodified Distributable Code.
+         
+    iii. Distribution Restrictions. You may not
+       - use Microsoft’s trademarks in your applications’ names or in a way
+         that suggests your applications come from or are endorsed by
+         Microsoft; or
        - modify or distribute the source code of any Distributable Code so
-         that any part of it becomes subject to an Excluded License. 
-         An Excluded License is one that requires, as a condition of use,
-         modification or distribution, that
-       - the code be disclosed or distributed in source code form; or
-       - others have the right to modify it.
+         that any part of it becomes subject to an Excluded License. An
+         “Excluded License” is one that requires, as a condition of use,
+         modification or distribution of code, that (i) it be disclosed or
+         distributed in source code form; or (ii) others have the right to
+         modify it.
 
 4. DATA.
-  a. Data Collection. The software may collect information about you and your 
-     use of the software, and send that to Microsoft. Microsoft may use this 
+  a. Data Collection. The software may collect information about you and your
+     use of the software, and send that to Microsoft. Microsoft may use this
      information to provide services and improve our products and services.
      You may opt-out of many of these scenarios, but not all, as described in
-     the product documentation.  There are also some features in the software
-     that may enable you and Microsoft to collect data from users of your 
+     the software documentation. There are also some features in the software
+     that may enable you and Microsoft to collect data from users of your
      applications. If you use these features, you must comply with applicable
      law, including providing appropriate notices to users of your applications
-     together with a copy of Microsoft's privacy statement. Our privacy
-     statement is located at https://go.microsoft.com/fwlink/?LinkID=824704.
-     You can learn more about data collection and use in the help documentation
-     and our privacy statement. Your use of the software operates as your
-     consent to these practices.
-  b. Processing of Personal Data. To the extent Microsoft is a processor or
-     subprocessor of personal data in connection with the software, Microsoft 
-     makes the commitments in the European Union General Data Protection
-     Regulation Terms of the Online Services Terms to all customers effective 
-     May 25, 2018, at http://go.microsoft.com/?linkid=9840733.
+     together with Microsoft’s privacy statement. Our privacy statement is
+     located at https://go.microsoft.com/fwlink/?LinkID=824704. You can learn
+     more about data collection and its use from the software documentation and
+     our privacy statement. Your use of the software operates as your consent
+     to these practices.
+  b. Processing of Personal Data. To the extent Microsoft is a processor or
+     subprocessor of personal data in connection with the software, Microsoft
+     makes the commitments in the European Union General Data Protection Regulation
+     Terms of the Online Services Terms to all customers effective May 25, 2018,
+     at https://docs.microsoft.com/en-us/legal/gdpr.
 
-5. SCOPE OF LICENSE. The software is licensed, not sold. This agreement only
-   gives you some rights to use the software. Microsoft reserves all other 
-   rights. Unless applicable law gives you more rights despite this limitation,
-   you may use the software only as expressly permitted in this agreement.
-   In doing so, you must comply with any technical limitations in the software
-   that only allow you to use it in certain ways. You may not
-  - work around any technical limitations in the software;
-  - reverse engineer, decompile or disassemble the software, or otherwise
-    attempt to derive the source code for the software, except and to the
-    extent required by third party licensing terms governing use of certain
-    open source components that may be included in the software;
-  - remove, minimize, block or modify any notices of Microsoft or its suppliers
-    in the software; 
-  - use the software in any way that is against the law; or
-  - share, publish, rent or lease the software, provide the software as a
-    stand-alone offering for others to use, or transfer the software or this
-    agreement to any third party.
+5. Scope of License. The software is licensed, not sold. This agreement only gives
+   you some rights to use the software. Microsoft reserves all other rights. Unless
+   applicable law gives you more rights despite this limitation, you may use the
+   software only as expressly permitted in this agreement. In doing so, you must
+   comply with any technical limitations in the software that only allow you to use
+   it in certain ways. You may not
+   - work around any technical limitations in the software;
+   - reverse engineer, decompile or disassemble the software, or
+    otherwise attempt to derive the source code for the software, except
+    and to the extent required by third party licensing terms governing
+    use of certain open source components that may be included in the
+    software;
+   - remove, minimize, block or modify any notices of Microsoft or its
+    suppliers in the software;
+   - use the software in any way that is against the law; or
+   - share, publish, rent or lease the software, provide the software as
+    a stand-alone offering for others to use, or transfer the software
+    or this agreement to any third party.
 
-6. EXPORT RESTRICTIONS. You must comply with all domestic and international
-   export laws and regulations that apply to the software, which include
-   restrictions on destinations, end users, and end use. For further
-   information on export restrictions, visit www.microsoft.com/exporting.  
+6. Export Restrictions. You must comply with all domestic and international export
+   laws and regulations that apply to the software, which include restrictions on
+   destinations, end users, and end use. For further information on export
+   restrictions, visit www.microsoft.com/exporting. 
 
-7. SUPPORT SERVICES. Because this software is "as is," we may not provide
-   support services for it.
+7. SUPPORT SERVICES. Because this software is “as is,” we may not provide support
+   services for it.
 
-8. ENTIRE AGREEMENT. This agreement, and the terms for supplements, updates,
+8. Entire Agreement. This agreement, and the terms for supplements, updates,
    Internet-based services and support services that you use, are the entire
    agreement for the software and support services.
 
-9. APPLICABLE LAW.  If you acquired the software in the United States,
-   Washington law applies to interpretation of and claims for breach of this
-   agreement, and the laws of the state where you live apply to all other
-   claims. If you acquired the software in any other country, its laws apply.
+9. Applicable Law. If you acquired the software in the United States, Washington
+   law applies to interpretation of and claims for breach of this agreement, and
+   the laws of the state where you live apply to all other claims. If you acquired
+   the software in any other country, its laws apply.
 
 10. CONSUMER RIGHTS; REGIONAL VARIATIONS. This agreement describes certain legal
-    rights. You may have other rights, including consumer rights, under
-    the laws of your state or country. Separate and apart from your relationship
-    with Microsoft, you may also have rights with respect to the party from
-    which you acquired the software. This agreement does not change those other
-    rights if the laws of your state or country do not permit it to do so.
-    For example, if you acquired the software in one of the below regions, or
-    mandatory country law applies, then the following provisions apply to you:
-  a) Australia. You have statutory guarantees under the Australian Consumer Law
-     and nothing in this agreement is intended to affect those rights.
-  b) Canada. If you acquired this software in Canada, you may stop receiving
-     updates by turning off the automatic update feature, disconnecting your
-     device from the Internet (if and when you re-connect to the Internet,
-     however, the software will resume checking for and installing updates),
-     or uninstalling the software. The product documentation, if any, may also
-     specify how to turn off updates for your specific device or software.
-  c) Germany and Austria.
-     (i) Warranty. The software will perform substantially as described in any
-         Microsoft materials that accompany it. However, Microsoft gives no
-         contractual guarantee in relation to the software.
-     (ii) Limitation of Liability. In case of intentional conduct, gross
-          negligence, claims based on the Product Liability Act, as well as in
-          case of death or personal or physical injury, Microsoft is liable
-          according to the statutory law.
-
+    rights. You may have other rights, including consumer rights, under the laws
+    of your state or country. Separate and apart from your relationship with Microsoft,
+    you may also have rights with respect to the party from which you acquired the
+    software. This agreement does not change those other rights if the laws of your
+    state or country do not permit it to do so. For example, if you acquired the software
+    in one of the below regions, or mandatory country law applies, then the following
+    provisions apply to you:
+    a) Australia. You have statutory guarantees under the Australian Consumer Law and
+       nothing in this agreement is intended to affect those rights.
+    b) Canada. If you acquired this software in Canada, you may stop receiving updates
+       by turning off the automatic update feature, disconnecting your device from the
+       Internet (if and when you re-connect to the Internet, however, the software will
+       resume checking for and installing updates), or uninstalling the software. The
+       product documentation, if any, may also specify how to turn off updates for your
+       specific device or software.
+    c) Germany and Austria.
+       (i) Warranty. The software will perform substantially as described in
+           any Microsoft materials that accompany it. However, Microsoft gives no
+           contractual guarantee in relation to the software.
+       (ii) Limitation of Liability. In case of intentional conduct, gross
+            negligence, claims based on the Product Liability Act, as well as in
+            case of death or personal or physical injury, Microsoft is liable
+            according to the statutory law.
+  
   Subject to the foregoing clause (ii), Microsoft will only be liable for slight
   negligence if Microsoft is in breach of such material contractual obligations,
   the fulfillment of which facilitate the due performance of this agreement, the
-  breach of which would endanger the purpose of this agreement and the
-  compliance with which a party may constantly trust in (so-called 
-  "cardinal obligations"). In other cases of slight negligence, Microsoft will
-  not be liable for slight negligence
+  breach of which would endanger the purpose of this agreement and the compliance
+  with which a party may constantly trust in (so-called "cardinal obligations").
+  In other cases of slight negligence, Microsoft will not be liable for slight
+  negligence
 
 11. DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED "AS-IS." YOU BEAR THE RISK
     OF USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES OR CONDITIONS.
@@ -154,52 +150,51 @@ the ThirdPartyNotices file(s) accompanying the software.
     MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00. YOU CANNOT
     RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS, SPECIAL,
     INDIRECT OR INCIDENTAL DAMAGES.
+    
+    This limitation applies to (a) anything related to the software,
+    services, content (including code) on third party Internet sites, or
+    third party applications; and (b) claims for breach of contract, breach
+    of warranty, guarantee or condition, strict liability, negligence, or
+    other tort to the extent permitted by applicable law.
+    
+    It also applies even if Microsoft knew or should have known about the
+    possibility of the damages. The above limitation or exclusion may not
+    apply to you because your state or country may not allow the exclusion
+    or limitation of incidental, consequential or other damages.
 
-This limitation applies to (a) anything related to the software, services,
-content (including code) on third party Internet sites, or third party
-applications; and (b) claims for breach of contract, breach of warranty,
-guarantee or condition, strict liability, negligence, or other tort to the
-extent permitted by applicable law.
+Please note: As this software is distributed in Quebec, Canada, some of
+the clauses in this agreement are provided below in French.
 
-It also applies even if Microsoft knew or should have known about the possibility
-of the damages. The above limitation or exclusion may not apply to you because
-your state or country may not allow the exclusion or limitation of incidental,
-consequential or other damages.
-Please note: As this software is distributed in Quebec, Canada, some of the
-clauses in this agreement are provided below in French.
- 
-Remarque : Ce logiciel étant distribué au Québec, Canada, certaines des clauses
-dans ce contrat sont fournies ci-dessous en français.
- 
-EXONÉRATION DE GARANTIE. Le logiciel visé par une licence est offert «tel quel».
-Toute utilisation de ce logiciel est à votre seule risque et péril. Microsoft 
-n'accorde aucune autre garantie expresse. Vous pouvez bénéficier de droits
-additionnels en vertu du droit local sur la protection des consommateurs,
-que ce contrat ne peut modifier. La ou elles sont permises par le droit locale,
-les garanties implicites de qualité marchande, d'adéquation à un usage
-particulier et d'absence de contrefaçon sont exclues.
- 
-LIMITATION DES DOMMAGES-INTÉRÊTS ET EXCLUSION DE RESPONSABILITÉ POUR LES 
+Remarque : Ce logiciel étant distribué au Québec, Canada, certaines des
+clauses dans ce contrat sont fournies ci-dessous en français.
+
+EXONÉRATION DE GARANTIE. Le logiciel visé par une licence est offert «
+tel quel ». Toute utilisation de ce logiciel est à votre seule risque et
+péril. Microsoft n’accorde aucune autre garantie expresse. Vous pouvez
+bénéficier de droits additionnels en vertu du droit local sur la
+protection des consommateurs, que ce contrat ne peut modifier. La ou
+elles sont permises par le droit locale, les garanties implicites de
+qualité marchande, d’adéquation à un usage particulier et d’absence de
+contrefaçon sont exclues.
+
+LIMITATION DES DOMMAGES-INTÉRÊTS ET EXCLUSION DE RESPONSABILITÉ POUR LES
 DOMMAGES. Vous pouvez obtenir de Microsoft et de ses fournisseurs une
-indemnisation en cas de dommages directs uniquement à hauteur de 5,00 $ US.
-Vous ne pouvez prétendre à aucune indemnisation pour les autres dommages,
-y compris les dommages spéciaux, indirects ou accessoires et pertes de
-bénéfices.
- 
+indemnisation en cas de dommages directs uniquement à hauteur de 5,00 $
+US. Vous ne pouvez prétendre à aucune indemnisation pour les autres
+dommages, y compris les dommages spéciaux, indirects ou accessoires et
+pertes de bénéfices.
+
 Cette limitation concerne:
-- tout ce qui est relié au logiciel, aux services ou au contenu (y compris le
-  code) figurant sur des sites Internet tiers ou dans des programmes tiers; et
-- les réclamations au titre de violation de contrat ou de garantie, ou au titre
-  de responsabilité stricte, de négligence ou d'une autre faute dans la limite
-  autorisée par la loi en vigueur.
- 
-Elle s'applique également, même si Microsoft connaissait ou devrait connaître
-l'éventualité d'un tel dommage. Si votre pays n'autorise pas l'exclusion ou
-la limitation de responsabilité pour les dommages indirects, accessoires ou 
-de quelque nature que ce soit, il se peut que la limitation ou l'exclusion 
-ci-dessus ne s'appliquera pas à votre égard.
- 
-EFFET JURIDIQUE. Le présent contrat décrit certains droits juridiques. Vous
-pourriez avoir d'autres droits prévus par les lois de votre pays. Le présent
-contrat ne modifie pas les droits que vous confèrent les lois de votre pays si
-celles-ci ne le permettent pas.
+- tout ce qui est relié au logiciel, aux services ou au contenu (y
+compris le code) figurant sur des sites Internet tiers ou dans des
+programmes tiers ; et
+- les réclamations au titre de violation de contrat ou de garantie,
+ou au titre de responsabilité stricte, de négligence ou d’une autre
+faute dans la limite autorisée par la loi en vigueur.
+
+Elle s’applique également, même si Microsoft connaissait ou devrait
+connaître l’éventualité d’un tel dommage. Si votre pays n’autorise pas
+l’exclusion ou la limitation de responsabilité pour les dommages
+indirects, accessoires ou de quelque nature que ce soit, il se peut
+que la limitation ou l’exclusion ci-dessus ne s’appliquera pas à votre
+égard.


### PR DESCRIPTION
When looking for an updated license for .NET libraries shipped from the Unit Testing repo, we got an updated license from CELA. Thought I'd add it to arcade so other repos can use the updated license as well. 

**Note**: Other repos might need to update the license their repo holds given arcade performs a license validation.