### PR TITLE
Fixup source link dependencies

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,10 +43,13 @@
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>54793d1934c52506e498790841fbcd15a33c1b05</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceLink" Version="1.0.0-beta2-19554-01">
+    <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.1.0-beta-20206-02">
       <Uri>https://github.com/dotnet/sourcelink</Uri>
-      <Sha>
-      </Sha>
+      <Sha>db7c31800400b6203d2b162255fa46cbaf2f04aa</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.SourceLink.AzureRepos.Git" Version="1.1.0-beta-20206-02">
+      <Uri>https://github.com/dotnet/sourcelink</Uri>
+      <Sha>db7c31800400b6203d2b162255fa46cbaf2f04aa</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DiaSymReader.Pdb2Pdb" Version="1.1.0-beta2-19575-01">
       <Uri>https://github.com/dotnet/symreader-converter</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -72,7 +72,8 @@
     <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta2-19575-01</MicrosoftDiaSymReaderPdb2PdbVersion>
     <MicrosoftDiaSymReaderNativeVersion>1.7.0</MicrosoftDiaSymReaderNativeVersion>
     <MicrosoftDotNetMaestroClientVersion>1.1.0-beta.20258.6</MicrosoftDotNetMaestroClientVersion>
-    <MicrosoftSourceLinkVersion>1.1.0-beta-20206-02</MicrosoftSourceLinkVersion>
+    <MicrosoftSourceLinkGitHubVersion>1.1.0-beta-20206-02</MicrosoftSourceLinkGitHubVersion>
+    <MicrosoftSourceLinkAzureReposGitVersion>1.1.0-beta-20206-02</MicrosoftSourceLinkAzureReposGitVersion>
     <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>5.0.0-beta.20426.1</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
     <XliffTasksVersion>1.0.0-beta.20420.1</XliffTasksVersion>
     <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.20418.2</MicrosoftDotNetMaestroTasksVersion>


### PR DESCRIPTION
Microsoft.SourceLink is not a package, and had no sha. Instead its version should match what eng/Versions.props had, and should be split out into multiple entries so it can be update automatically if needed.