### PR TITLE
Move MergedManifest.xml to feeds on promotion

### DIFF
--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -87,6 +87,7 @@ jobs:
         PublishLocation: Container
         ArtifactName: ReleaseConfigs
     
-    - template: /eng/common/templates/steps/publish-logs.yml
-      parameters:
-        JobLabel: 'Publish_Artifacts_Logs'     
+    - ${{ if eq(parameters.enablePublishBuildArtifacts, 'true') }}:
+      - template: /eng/common/templates/steps/publish-logs.yml
+        parameters:
+          JobLabel: 'Publish_Artifacts_Logs'     

--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -67,6 +67,7 @@ jobs:
           /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
           /p:PublishUsingPipelines=${{ parameters.publishUsingPipelines }}
           /p:Configuration=$(_BuildConfig)
+          /p:OfficialBuildId=$(OfficialBuildId)
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}
     

--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -86,12 +86,6 @@ jobs:
         PublishLocation: Container
         ArtifactName: ReleaseConfigs
     
-    - ${{ if eq(parameters.enablePublishBuildArtifacts, 'true') }}:
-      - task: PublishBuildArtifacts@1
-        displayName: Publish Logs to VSTS
-        inputs:
-          PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
-          PublishLocation: Container
-          ArtifactName: $(Agent.Os)_PublishBuildAssets
-        continueOnError: true
-        condition: always()      
+    - template: /eng/common/templates/steps/publish-logs.yml
+      parameters:
+        JobLabel: 'Publish_Artifacts_Logs'     

--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -67,7 +67,7 @@ jobs:
           /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
           /p:PublishUsingPipelines=${{ parameters.publishUsingPipelines }}
           /p:Configuration=$(_BuildConfig)
-          /p:OfficialBuildId=$(OfficialBuildId)
+          /p:OfficialBuildId=$(Build.BuildNumber)
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}
     

--- a/eng/common/templates/steps/publish-logs.yml
+++ b/eng/common/templates/steps/publish-logs.yml
@@ -3,21 +3,20 @@ parameters:
   JobLabel: ''
 
 steps:
-- task: Powershell@2
-  displayName: Prepare Binlogs to Upload
+- task: CopyFiles@2
+  displayName: Copy Logs to $(Build.StagingDirectory)\BuildLogs
   inputs:
-    targetType: inline
-    script: |
-      New-Item -ItemType Directory $(Build.SourcesDirectory)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
-      Move-Item -Path $(Build.SourcesDirectory)/artifacts/log/Debug/* $(Build.SourcesDirectory)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
+    SourceFolder: $(Build.SourcesDirectory)\artifacts
+    Contents: |
+      **/*.log
+      **/*.binlog
+    TargetFolder: '$(Build.StagingDirectory)\BuildLogs'
   continueOnError: true
-  condition: always()
-  
-- task: PublishBuildArtifacts@1
-  displayName: Publish Logs
+  condition: succeededOrFailed()
+
+- task: PublishPipelineArtifact@1
+  displayName: Publish BuildLogs
   inputs:
-    PathtoPublish: '$(Build.SourcesDirectory)/PostBuildLogs'
-    PublishLocation: Container
-    ArtifactName: PostBuildLogs
-  continueOnError: true
-  condition: always()
+    targetPath: '$(Build.StagingDirectory)\BuildLogs'
+    artifactName: ${{ parameters.JobLabel }}
+  condition: succeededOrFailed()

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
@@ -72,7 +72,9 @@
     <Error Condition="'$(BlobBasePath)' == '' OR '$(PackageBasePath)' == ''" Text="A valid full path to BlobBasePath and PackageBasePath is required." />
 
     <ItemGroup>
+      <MergedManifest Condition="Exists('$(BlobBasePath)\MergedManifest.xml')" Include="$(BlobBasePath)\MergedManifest.xml" />
       <ManifestFiles Include="$(ManifestsBasePath)\*.xml" />
+      <ManifestFiles Condition="'$(MergedManifest)' != ''" Include="$(MergedManifest)" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
@@ -73,8 +73,8 @@
 
     <ItemGroup>
       <MergedManifest Condition="Exists('$(BlobBasePath)\MergedManifest.xml')" Include="$(BlobBasePath)\MergedManifest.xml" />
-      <ManifestFiles Include="$(ManifestsBasePath)\*.xml" />
-      <ManifestFiles Condition="'$(MergedManifest)' != ''" Include="$(MergedManifest)" />
+      <ManifestFiles Include="@(MergedManifest)" />
+      <ManifestFiles Condition="'@(ManifestFiles)' == ''" Include="$(ManifestsBasePath)\*.xml" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -7,7 +7,8 @@
     <TargetFramework>net472</TargetFramework>
     <!-- Workaround changes from newer MSBuild requiring additional properties --> 
     <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">5</TargetFrameworkVersion>
-    <TargetFrameworkIdentifier  Condition="'$(TargetFrameworkIdentifier)' == ''">.NETFramework</TargetFrameworkIdentifier>     
+    <TargetFrameworkIdentifier  Condition="'$(TargetFrameworkIdentifier)' == ''">.NETFramework</TargetFrameworkIdentifier>
+    <TargetFrameworkMoniker Condition="'$(TargetFrameworkMoniker)' == ''">.NETFramework,Version=v4.7.2</TargetFrameworkMoniker>   
     <MSBuildProjectExtensionsPath>$(BaseIntermediateOutputPath)</MSBuildProjectExtensionsPath>
   </PropertyGroup>
 


### PR DESCRIPTION
Today, MergedManifest.xml is not moved to feeds when a build is promoted to another channel since we always use the AssetManifests' contents. With this change, we'll use the MergeManifest.xml if it exist in the BlobArtifacts folder. MergedManifest.xml should have the contents of all AssetManifests + itself so it is safe to only use it.

To make this work in any kind of publishing, we need to complete https://github.com/dotnet/core-eng/issues/10655 which will come after this PR is merged.

Test build: https://dnceng.visualstudio.com/internal/_build/results?buildId=792435&view=results