### PR TITLE
[Helix SDK] Install the correct ARM dotnet sdks

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
@@ -17,6 +17,16 @@
   <Choose>
     <When Condition=" '$(DotNetCliRuntime)' != '' ">
     </When>
+    <When Condition="$(HelixTargetQueue.ToLowerInvariant().StartsWith('windows')) AND $(HelixTargetQueue.ToLowerInvariant().Contains('arm64'))">
+      <PropertyGroup>
+        <DotNetCliRuntime>win-arm64</DotNetCliRuntime>
+      </PropertyGroup>
+    </When>
+    <When Condition="$(HelixTargetQueue.ToLowerInvariant().StartsWith('windows')) AND $(HelixTargetQueue.ToLowerInvariant().Contains('arm32'))">
+      <PropertyGroup>
+        <DotNetCliRuntime>win-arm</DotNetCliRuntime>
+      </PropertyGroup>
+    </When>
     <When Condition="$(HelixTargetQueue.ToLowerInvariant().StartsWith('windows'))">
       <PropertyGroup>
         <DotNetCliRuntime>win-x64</DotNetCliRuntime>

--- a/tests/UnitTests.proj
+++ b/tests/UnitTests.proj
@@ -50,9 +50,8 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(HelixAccessToken)' != '' ">
-    <HelixTargetQueue Include="Debian.9.Amd64.Arcade"/>
-    <HelixTargetQueue Include="RedHat.7.Amd64.Arcade"/>
-    <HelixTargetQueue Include="Windows.10.Amd64.Arcade"/>
+    <HelixTargetQueue Include="Windows.10.Arm64"/>
+    <HelixTargetQueue Include="Windows.10.Arm32"/>
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(HelixAccessToken)' == '' ">
@@ -62,9 +61,9 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(HelixAccessToken)' == '' ">
-    <HelixTargetQueue Include="Debian.9.Amd64.Arcade.Open"/>
-    <HelixTargetQueue Include="RedHat.7.Amd64.Arcade.Open"/>
-    <HelixTargetQueue Include="Windows.10.Amd64.Arcade.Open"/>
+    <HelixTargetQueue Include="Windows.10.Arm64.Open"/>
+    <HelixTargetQueue Include="Windows.10.Arm32.Open"/>
+    
   </ItemGroup>
 
   <PropertyGroup Condition="!$(HelixTargetQueue.StartsWith('Windows'))">

--- a/tests/UnitTests.proj
+++ b/tests/UnitTests.proj
@@ -50,8 +50,9 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(HelixAccessToken)' != '' ">
-    <HelixTargetQueue Include="Windows.10.Arm64"/>
-    <HelixTargetQueue Include="Windows.10.Arm32"/>
+    <HelixTargetQueue Include="Debian.9.Amd64.Arcade"/>
+    <HelixTargetQueue Include="RedHat.7.Amd64.Arcade"/>
+    <HelixTargetQueue Include="Windows.10.Amd64.Arcade"/>
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(HelixAccessToken)' == '' ">
@@ -61,9 +62,9 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(HelixAccessToken)' == '' ">
-    <HelixTargetQueue Include="Windows.10.Arm64.Open"/>
-    <HelixTargetQueue Include="Windows.10.Arm32.Open"/>
-    
+    <HelixTargetQueue Include="Debian.9.Amd64.Arcade.Open"/>
+    <HelixTargetQueue Include="RedHat.7.Amd64.Arcade.Open"/>
+    <HelixTargetQueue Include="Windows.10.Amd64.Arcade.Open"/>
   </ItemGroup>
 
   <PropertyGroup Condition="!$(HelixTargetQueue.StartsWith('Windows'))">


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/5926

This takes the changes from https://github.com/dotnet/arcade/pull/5734 which cannot be reopened because the branch is gone.

Validated this fixes things:
Build that tests in arm queues and fails without the Helix SDK change: https://dev.azure.com/dnceng/public/_build/results?buildId=798658&view=results

Build with the change: https://dev.azure.com/dnceng/public/_build/results?buildId=798759&view=results


