### PR TITLE
Enable VerifyClosure target to run independently of other validations

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.packaging.targets
@@ -167,7 +167,7 @@
 
   <Target Name="VerifyClosure"
           DependsOnTargets="GetClosureFiles"
-          Condition="'$(SkipValidatePackage)' != 'true'"
+          Condition="'$(SkipValidatePackage)' != 'true' or '$(ShouldVerifyClosure)' == 'true'"
           Inputs="%(ClosureFile.FileSet)"
           Outputs="batching-on-FileSet-metadata">
     <ItemGroup>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/arcade/issues/6098
Related to the following Runtime PR that needs this change to work: https://github.com/dotnet/runtime/pull/41698

We need to run VerifyClosure target independently of other validations. This change updates the target condition to allow this.