### PR TITLE
Fix publish-logs.yml because tabs cause Azdo's yaml parser to cry

### DIFF
--- a/eng/common/templates/steps/publish-logs.yml
+++ b/eng/common/templates/steps/publish-logs.yml
@@ -12,12 +12,12 @@ steps:
       Move-Item -Path $(Build.SourcesDirectory)/artifacts/log/Debug/* $(Build.SourcesDirectory)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
   continueOnError: true
   condition: always()
-  	
+
 - task: PublishBuildArtifacts@1
   displayName: Publish Logs
   inputs:
     PathtoPublish: '$(Build.SourcesDirectory)/PostBuildLogs'
     PublishLocation: Container
     ArtifactName: PostBuildLogs
-  continueOnError: true	
+  continueOnError: true
   condition: always()


### PR DESCRIPTION
Remove some tabs that freak YAML out.

Build is broken as in https://dnceng.visualstudio.com/internal/_build/results?buildId=799427&view=results

Test build with these changes: https://dnceng.visualstudio.com/internal/_build/results?buildId=799462&view=results

Fixes #6103