### PR TITLE
Revert "Make param the default (#6094)"

### DIFF
--- a/eng/common/post-build/publish-using-darc.ps1
+++ b/eng/common/post-build/publish-using-darc.ps1
@@ -8,7 +8,7 @@ param(
   [Parameter(Mandatory=$false)][string] $EnableSourceLinkValidation,
   [Parameter(Mandatory=$false)][string] $EnableSigningValidation,
   [Parameter(Mandatory=$false)][string] $EnableNugetValidation,
-  [Parameter(Mandatory=$false)][string] $PublishInstallersAndChecksums,
+  [Parameter(Mandatory=$true)][string] $PublishInstallersAndChecksums,
   [Parameter(Mandatory=$false)][string] $ArtifactsPublishingAdditionalParameters,
   [Parameter(Mandatory=$false)][string] $SigningValidationAdditionalParameters
 )
@@ -29,7 +29,7 @@ try {
     $optionalParams.Add("--no-wait") | Out-Null
   }
 
-  if ("false" -ne $PublishInstallersAndChecksums) {
+  if ("true" -eq $PublishInstallersAndChecksums) {
     $optionalParams.Add("--publish-installers-and-checksums") | Out-Null
   }
 
@@ -55,6 +55,7 @@ try {
   --publishing-infra-version $PublishingInfraVersion `
   --default-channels `
   --source-branch master `
+  --publish-installers-and-checksums `
   --azdev-pat $AzdoToken `
   --bar-uri $MaestroApiEndPoint `
   --password $MaestroToken `


### PR DESCRIPTION
This reverts commit b131e409f534512385324056218d355027ddad32.

The build promotion pipeline is failing because there's no artifact category found. 

A new arcade-services deployment is required for this to be the default.