### PR TITLE
Add back PublishInstallersAndChecksums, and flip default to true

### DIFF
--- a/eng/common/post-build/publish-using-darc.ps1
+++ b/eng/common/post-build/publish-using-darc.ps1
@@ -8,7 +8,7 @@ param(
   [Parameter(Mandatory=$false)][string] $EnableSourceLinkValidation,
   [Parameter(Mandatory=$false)][string] $EnableSigningValidation,
   [Parameter(Mandatory=$false)][string] $EnableNugetValidation,
-  [Parameter(Mandatory=$true)][string] $PublishInstallersAndChecksums,
+  [Parameter(Mandatory=$false)][string] $PublishInstallersAndChecksums,
   [Parameter(Mandatory=$false)][string] $ArtifactsPublishingAdditionalParameters,
   [Parameter(Mandatory=$false)][string] $SigningValidationAdditionalParameters
 )
@@ -29,7 +29,7 @@ try {
     $optionalParams.Add("--no-wait") | Out-Null
   }
 
-  if ("true" -eq $PublishInstallersAndChecksums) {
+  if ("false" -ne $PublishInstallersAndChecksums) {
     $optionalParams.Add("--publish-installers-and-checksums") | Out-Null
   }
 
@@ -55,7 +55,6 @@ try {
   --publishing-infra-version $PublishingInfraVersion `
   --default-channels `
   --source-branch master `
-  --publish-installers-and-checksums `
   --azdev-pat $AzdoToken `
   --bar-uri $MaestroApiEndPoint `
   --password $MaestroToken `

--- a/eng/common/templates/post-build/channels/generic-internal-channel.yml
+++ b/eng/common/templates/post-build/channels/generic-internal-channel.yml
@@ -4,7 +4,7 @@ parameters:
   artifactsPublishingAdditionalParameters: ''
   dependsOn:
   - Validate
-  publishInstallersAndChecksums: false
+  publishInstallersAndChecksums: true
   symbolPublishingAdditionalParameters: ''
   stageName: ''
   channelName: ''
@@ -158,7 +158,7 @@ stages:
             /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/'
             /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts/'
             /p:Configuration=Release
-            /p:PublishInstallersAndChecksums=true
+            /p:PublishInstallersAndChecksums=${{ parameters.publishInstallersAndChecksums }}
             /p:ChecksumsTargetStaticFeed=$(InternalChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(InternalChecksumsBlobFeedKey)
             /p:InstallersTargetStaticFeed=$(InternalInstallersBlobFeedUrl)

--- a/eng/common/templates/post-build/channels/generic-public-channel.yml
+++ b/eng/common/templates/post-build/channels/generic-public-channel.yml
@@ -4,7 +4,7 @@ parameters:
   artifactsPublishingAdditionalParameters: ''
   dependsOn:
   - Validate
-  publishInstallersAndChecksums: false
+  publishInstallersAndChecksums: true
   symbolPublishingAdditionalParameters: ''
   stageName: ''
   channelName: ''

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -19,7 +19,7 @@ parameters:
   enableSigningValidation: true
   enableSymbolValidation: false
   enableNugetValidation: true
-  publishInstallersAndChecksums: false
+  publishInstallersAndChecksums: true
   SDLValidationParameters:
     enable: false
     continueOnError: false

--- a/eng/promote-build.yml
+++ b/eng/promote-build.yml
@@ -36,7 +36,7 @@ parameters:
   - name: PublishInstallersAndChecksums
     displayName: Should installers and checksums be published?
     type: boolean 
-    default: false
+    default: true
       
   - name: SymbolPublishingAdditionalParameters
     displayName: Additional (MSBuild) properties for symbol publishing

--- a/eng/publishing/v3/publish-assets.yml
+++ b/eng/publishing/v3/publish-assets.yml
@@ -1,6 +1,6 @@
 parameters:
   artifactsPublishingAdditionalParameters: ''
-  publishInstallersAndChecksums: 'false'
+  publishInstallersAndChecksums: true
   PromoteToChannelIds: ''
 
 jobs:

--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -5,7 +5,7 @@ parameters:
   enableSourceLinkValidation: false
   enableSigningValidation: true
   enableNugetValidation: true
-  publishInstallersAndChecksums: false
+  publishInstallersAndChecksums: true
   useBuildManifest: false
   
   # These parameters let the user customize the call to sdk-task.ps1 for publishing


### PR DESCRIPTION
Addresses https://github.com/dotnet/arcade/pull/6094

Flips default again, and updates all the places I could find the parameter being used, to true.

@epananth , as previously mentioned, [PTAL](https://github.com/dotnet/arcade/pull/6094#discussion_r482512879), I'm not really familiar with the original change here, but I'd like to not break windowdesktop.

If you think that removing the parameter entirely and always including the flag is the right thing to do, then that's fine, but I'd argue that there shouldn't even be a flag, it should just behave that way.



