### PR TITLE
Standardize on new two-line license header

### DIFF
--- a/eng/common/internal/Directory.Build.props
+++ b/eng/common/internal/Directory.Build.props
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 </Project>

--- a/src/Common/AssemblyResolution.cs
+++ b/src/Common/AssemblyResolution.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #if NET472
 

--- a/src/Common/AssemblyResolver.cs
+++ b/src/Common/AssemblyResolver.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Common/BuildTask.Desktop.cs
+++ b/src/Common/BuildTask.Desktop.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.Build.Common.Desktop;
 

--- a/src/Common/BuildTask.cs
+++ b/src/Common/BuildTask.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Common/ExponentialRetry.cs
+++ b/src/Common/ExponentialRetry.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Common/IRetryHandler.cs
+++ b/src/Common/IRetryHandler.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Common/Internal/DisposeAction.cs
+++ b/src/Common/Internal/DisposeAction.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace System
 {

--- a/src/Common/TestUtilities/AssertEx.cs
+++ b/src/Common/TestUtilities/AssertEx.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Common/TestUtilities/DiffUtil.cs
+++ b/src/Common/TestUtilities/DiffUtil.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Comparers/ApiComparer.cs
+++ b/src/Microsoft.Cci.Extensions/Comparers/ApiComparer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Comparers/AttributeComparer.cs
+++ b/src/Microsoft.Cci.Extensions/Comparers/AttributeComparer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Cci.Extensions;

--- a/src/Microsoft.Cci.Extensions/Comparers/CciComparers.cs
+++ b/src/Microsoft.Cci.Extensions/Comparers/CciComparers.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Comparers/ICciComparers.cs
+++ b/src/Microsoft.Cci.Extensions/Comparers/ICciComparers.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/Microsoft.Cci.Extensions/Comparers/StringKeyComparer.cs
+++ b/src/Microsoft.Cci.Extensions/Comparers/StringKeyComparer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Comparers/TypeDefinitionComparer.cs
+++ b/src/Microsoft.Cci.Extensions/Comparers/TypeDefinitionComparer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/Microsoft.Cci.Extensions/Dgml/DgmlExtensions.cs
+++ b/src/Microsoft.Cci.Extensions/Dgml/DgmlExtensions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Differs/DifferenceRule.cs
+++ b/src/Microsoft.Cci.Extensions/Differs/DifferenceRule.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using Microsoft.Cci.Mappings;

--- a/src/Microsoft.Cci.Extensions/Differs/DifferenceType.cs
+++ b/src/Microsoft.Cci.Extensions/Differs/DifferenceType.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Cci.Differs
 {

--- a/src/Microsoft.Cci.Extensions/Differs/Differences.cs
+++ b/src/Microsoft.Cci.Extensions/Differs/Differences.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics.Contracts;

--- a/src/Microsoft.Cci.Extensions/Differs/ElementDiffer.cs
+++ b/src/Microsoft.Cci.Extensions/Differs/ElementDiffer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Differs/ElementDifferenceFactory.cs
+++ b/src/Microsoft.Cci.Extensions/Differs/ElementDifferenceFactory.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Differs/ExportDifferenceRuleAttribute.cs
+++ b/src/Microsoft.Cci.Extensions/Differs/ExportDifferenceRuleAttribute.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Differs/IDifferenceRule.cs
+++ b/src/Microsoft.Cci.Extensions/Differs/IDifferenceRule.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Mappings;
 using System.Diagnostics.Contracts;

--- a/src/Microsoft.Cci.Extensions/Differs/IDifferences.cs
+++ b/src/Microsoft.Cci.Extensions/Differs/IDifferences.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.Cci.Extensions/Differs/IDiffingService.cs
+++ b/src/Microsoft.Cci.Extensions/Differs/IDiffingService.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using Microsoft.Cci.Writers.Syntax;

--- a/src/Microsoft.Cci.Extensions/Differs/IElementDifferenceFactory.cs
+++ b/src/Microsoft.Cci.Extensions/Differs/IElementDifferenceFactory.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Mappings;
 

--- a/src/Microsoft.Cci.Extensions/Differs/ListMerger.cs
+++ b/src/Microsoft.Cci.Extensions/Differs/ListMerger.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Differs/Rules/TokenListDiffer.cs
+++ b/src/Microsoft.Cci.Extensions/Differs/Rules/TokenListDiffer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Experimental/APIClosureTypeReferenceVisitor.cs
+++ b/src/Microsoft.Cci.Extensions/Experimental/APIClosureTypeReferenceVisitor.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Experimental/APIEmitter.cs
+++ b/src/Microsoft.Cci.Extensions/Experimental/APIEmitter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Experimental/FilteredAssembly.cs
+++ b/src/Microsoft.Cci.Extensions/Experimental/FilteredAssembly.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Experimental/TrimAPIMutator.cs
+++ b/src/Microsoft.Cci.Extensions/Experimental/TrimAPIMutator.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 //using System;
 //using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Experimental/TypeReferenceSearcher.cs
+++ b/src/Microsoft.Cci.Extensions/Experimental/TypeReferenceSearcher.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Experimental/TypeReferenceVisitor.cs
+++ b/src/Microsoft.Cci.Extensions/Experimental/TypeReferenceVisitor.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Extensions/AccessorType.cs
+++ b/src/Microsoft.Cci.Extensions/Extensions/AccessorType.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Cci.Extensions/Extensions/ApiKind.cs
+++ b/src/Microsoft.Cci.Extensions/Extensions/ApiKind.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Cci.Extensions/Extensions/ApiKindExtensions.cs
+++ b/src/Microsoft.Cci.Extensions/Extensions/ApiKindExtensions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Cci.Extensions/Extensions/AssemblyIdentityHelpers.cs
+++ b/src/Microsoft.Cci.Extensions/Extensions/AssemblyIdentityHelpers.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Globalization;

--- a/src/Microsoft.Cci.Extensions/Extensions/CSharp/CSharpCciExtensions.cs
+++ b/src/Microsoft.Cci.Extensions/Extensions/CSharp/CSharpCciExtensions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Extensions/DocIdExtensions.cs
+++ b/src/Microsoft.Cci.Extensions/Extensions/DocIdExtensions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;

--- a/src/Microsoft.Cci.Extensions/Extensions/MemberExtensions.cs
+++ b/src/Microsoft.Cci.Extensions/Extensions/MemberExtensions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.ComponentModel;

--- a/src/Microsoft.Cci.Extensions/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.Cci.Extensions/Extensions/TypeExtensions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Filters/AttributeMarkedFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/AttributeMarkedFilter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Extensions;
 using System;

--- a/src/Microsoft.Cci.Extensions/Filters/AttributesFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/AttributesFilter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Cci.Extensions/Filters/BaselineDifferenceFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/BaselineDifferenceFilter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Filters/CciFilterExtensions.AndFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/CciFilterExtensions.AndFilter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Cci.Filters
 {

--- a/src/Microsoft.Cci.Extensions/Filters/CciFilterExtensions.NegatedFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/CciFilterExtensions.NegatedFilter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Cci.Filters
 {

--- a/src/Microsoft.Cci.Extensions/Filters/CciFilterExtensions.OrFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/CciFilterExtensions.OrFilter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Cci.Filters
 {

--- a/src/Microsoft.Cci.Extensions/Filters/CciFilterExtensions.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/CciFilterExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Cci.Extensions/Filters/CommonTypesMappingDifferenceFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/CommonTypesMappingDifferenceFilter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/Microsoft.Cci.Extensions/Filters/DifferenceFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/DifferenceFilter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Differs;
 

--- a/src/Microsoft.Cci.Extensions/Filters/DocIdExcludeListFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/DocIdExcludeListFilter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Filters/DocIdIncludeListFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/DocIdIncludeListFilter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Filters/ExcludeAttributesFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/ExcludeAttributesFilter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using Microsoft.Cci.Extensions;

--- a/src/Microsoft.Cci.Extensions/Filters/ExcludeCompilerGeneratedCciFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/ExcludeCompilerGeneratedCciFilter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/Microsoft.Cci.Extensions/Filters/ExcludeOverridesFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/ExcludeOverridesFilter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Linq;
 

--- a/src/Microsoft.Cci.Extensions/Filters/ICciFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/ICciFilter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Filters/IDifferenceFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/IDifferenceFilter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Differs;
 

--- a/src/Microsoft.Cci.Extensions/Filters/IMappingDifferenceFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/IMappingDifferenceFilter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Mappings;
 using Microsoft.Cci.Differs;

--- a/src/Microsoft.Cci.Extensions/Filters/IncludeAllFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/IncludeAllFilter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Cci.Filters
 {

--- a/src/Microsoft.Cci.Extensions/Filters/InternalsAndPublicCciFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/InternalsAndPublicCciFilter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Linq;
 using Microsoft.Cci.Extensions;

--- a/src/Microsoft.Cci.Extensions/Filters/IntersectionFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/IntersectionFilter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.Cci.Extensions/Filters/MappingDifferenceFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/MappingDifferenceFilter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/Microsoft.Cci.Extensions/Filters/NotImplementedFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/NotImplementedFilter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Linq;
 

--- a/src/Microsoft.Cci.Extensions/Filters/PublicAndProtectedFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/PublicAndProtectedFilter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Linq;
 using Microsoft.Cci.Extensions;

--- a/src/Microsoft.Cci.Extensions/Filters/PublicOnlyCciFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/PublicOnlyCciFilter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Linq;
 using Microsoft.Cci.Extensions;

--- a/src/Microsoft.Cci.Extensions/Filters/TypesOnlyMappingDifferenceFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/TypesOnlyMappingDifferenceFilter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Cci.Differs;

--- a/src/Microsoft.Cci.Extensions/HostEnvironment.cs
+++ b/src/Microsoft.Cci.Extensions/HostEnvironment.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Mappings/AssemblyMapping.cs
+++ b/src/Microsoft.Cci.Extensions/Mappings/AssemblyMapping.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Mappings/AssemblySetMapping.cs
+++ b/src/Microsoft.Cci.Extensions/Mappings/AssemblySetMapping.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Mappings/AttributesMapping.cs
+++ b/src/Microsoft.Cci.Extensions/Mappings/AttributesMapping.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Mappings/ElementMapping.cs
+++ b/src/Microsoft.Cci.Extensions/Mappings/ElementMapping.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics.Contracts;

--- a/src/Microsoft.Cci.Extensions/Mappings/MappingSettings.cs
+++ b/src/Microsoft.Cci.Extensions/Mappings/MappingSettings.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using Microsoft.Cci.Comparers;

--- a/src/Microsoft.Cci.Extensions/Mappings/MemberMapping.cs
+++ b/src/Microsoft.Cci.Extensions/Mappings/MemberMapping.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Cci.Extensions/Mappings/NamespaceMapping.cs
+++ b/src/Microsoft.Cci.Extensions/Mappings/NamespaceMapping.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.Cci.Extensions/Mappings/SimpleElementMapping.cs
+++ b/src/Microsoft.Cci.Extensions/Mappings/SimpleElementMapping.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Cci.Differs;

--- a/src/Microsoft.Cci.Extensions/Mappings/TypeMapping.cs
+++ b/src/Microsoft.Cci.Extensions/Mappings/TypeMapping.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.Cci.Extensions/PortingHelpers.cs
+++ b/src/Microsoft.Cci.Extensions/PortingHelpers.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace System.Runtime.CompilerServices
 {

--- a/src/Microsoft.Cci.Extensions/Traversers/AssemblyReferenceTraverser.cs
+++ b/src/Microsoft.Cci.Extensions/Traversers/AssemblyReferenceTraverser.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Traversers/DependencyTraverser.cs
+++ b/src/Microsoft.Cci.Extensions/Traversers/DependencyTraverser.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Filters;
 using System;

--- a/src/Microsoft.Cci.Extensions/Traversers/DifferenceTraverser.cs
+++ b/src/Microsoft.Cci.Extensions/Traversers/DifferenceTraverser.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;

--- a/src/Microsoft.Cci.Extensions/Traversers/DocIdToTypeMappingTraverser.cs
+++ b/src/Microsoft.Cci.Extensions/Traversers/DocIdToTypeMappingTraverser.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using Microsoft.Cci.Extensions;

--- a/src/Microsoft.Cci.Extensions/Traversers/FilteredMetadataTraverser.cs
+++ b/src/Microsoft.Cci.Extensions/Traversers/FilteredMetadataTraverser.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Filters;
 

--- a/src/Microsoft.Cci.Extensions/Traversers/MappingsTypeMemberTraverser.cs
+++ b/src/Microsoft.Cci.Extensions/Traversers/MappingsTypeMemberTraverser.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Traversers/ResolveAllReferencesTraverser.cs
+++ b/src/Microsoft.Cci.Extensions/Traversers/ResolveAllReferencesTraverser.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;

--- a/src/Microsoft.Cci.Extensions/Traversers/SimpleTypeMemberTraverser.cs
+++ b/src/Microsoft.Cci.Extensions/Traversers/SimpleTypeMemberTraverser.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/TypeDependencies.cs
+++ b/src/Microsoft.Cci.Extensions/TypeDependencies.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationHelper.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationHelper.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.IO;

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Attributes.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Attributes.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Enums.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Enums.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Events.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Events.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Linq;
 using Microsoft.Cci.Extensions.CSharp;

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Fields.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Fields.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Generics.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Generics.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Extensions.CSharp;
 using Microsoft.Cci.Writers.Syntax;

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Namespaces.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Namespaces.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Cci.Writers.CSharp
 {

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Properties.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Properties.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Types.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Types.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Extensions;
 using Microsoft.Cci.Extensions.CSharp;

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSharpWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSharpWriter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Writers/DocumentIdWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/DocumentIdWriter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Writers/ICciDeclarationWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/ICciDeclarationWriter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Cci.Writers
 {

--- a/src/Microsoft.Cci.Extensions/Writers/ICciDifferenceWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/ICciDifferenceWriter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Writers/ICciWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/ICciWriter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Writers/IReviewCommentWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/IReviewCommentWriter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Cci.Extensions/Writers/Syntax/HtmlSyntaxWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/Syntax/HtmlSyntaxWriter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics.Contracts;

--- a/src/Microsoft.Cci.Extensions/Writers/Syntax/IStyleSyntaxWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/Syntax/IStyleSyntaxWriter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Cci.Extensions/Writers/Syntax/ISyntaxWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/Syntax/ISyntaxWriter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Writers/Syntax/IndentionSyntaxWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/Syntax/IndentionSyntaxWriter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Writers/Syntax/OpenXmlSyntaxWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/Syntax/OpenXmlSyntaxWriter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Writers/Syntax/StyleHelper.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/Syntax/StyleHelper.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Cci.Extensions/Writers/Syntax/SyntaxStyle.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/Syntax/SyntaxStyle.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Cci.Writers.Syntax
 {

--- a/src/Microsoft.Cci.Extensions/Writers/Syntax/SyntaxToken.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/Syntax/SyntaxToken.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
 

--- a/src/Microsoft.Cci.Extensions/Writers/Syntax/SyntaxTokenType.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/Syntax/SyntaxTokenType.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Writers/Syntax/TextSyntaxWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/Syntax/TextSyntaxWriter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.Cci.Extensions/Writers/Syntax/TokenSyntaxWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/Syntax/TokenSyntaxWriter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Cci.Extensions/Writers/Syntax/UnifiedDiffSyntaxWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/Syntax/UnifiedDiffSyntaxWriter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.Cci.Extensions/Writers/TypeForwardWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/TypeForwardWriter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.ApiCompat/src/ApiCompatRunner.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/ApiCompatRunner.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Cci;

--- a/src/Microsoft.DotNet.ApiCompat/src/DifferenceWriter.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/DifferenceWriter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.ApiCompat/src/ExportCciSettings.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/ExportCciSettings.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Composition;

--- a/src/Microsoft.DotNet.ApiCompat/src/MdilPublicOnlyCciFilter.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/MdilPublicOnlyCciFilter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.ApiCompat/src/NamespaceRemappingComparer.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/NamespaceRemappingComparer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.ApiCompat/src/Program.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/Program.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.ApiCompat
 {

--- a/src/Microsoft.DotNet.ApiCompat/src/PublicEditorBrowsableOnlyCciFilter.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/PublicEditorBrowsableOnlyCciFilter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/AttributeDifference.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/AttributeDifference.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Extensions;
 using System.Linq;

--- a/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/CannotAddAbstractMembers.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/CannotAddAbstractMembers.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Extensions;
 using Microsoft.Cci.Extensions.CSharp;

--- a/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/CannotAddAttributes.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/CannotAddAttributes.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Extensions;
 using Microsoft.Cci.Writers.CSharp;

--- a/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/CannotMakeAbstract.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/CannotMakeAbstract.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Extensions;
 using Microsoft.Cci.Extensions.CSharp;

--- a/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/CannotMakeMoreVisible.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/CannotMakeMoreVisible.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Extensions;
 using Microsoft.Cci.Extensions.CSharp;

--- a/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/CannotMakeNonVirtual.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/CannotMakeNonVirtual.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Extensions;
 using Microsoft.Cci.Extensions.CSharp;

--- a/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/CannotRemoveBaseTypeOrInterface.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/CannotRemoveBaseTypeOrInterface.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Composition;

--- a/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/CannotRemoveGenerics.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/CannotRemoveGenerics.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Cci.Extensions;

--- a/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/CannotSealType.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/CannotSealType.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Extensions;
 using Microsoft.Cci.Extensions.CSharp;

--- a/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/DelegatesMustMatch.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/DelegatesMustMatch.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Composition;

--- a/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/EnumTypesMustMatch.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/EnumTypesMustMatch.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Composition;

--- a/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/EnumValuesMustMatch.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/EnumValuesMustMatch.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Extensions;
 using Microsoft.Cci.Extensions.CSharp;

--- a/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/InterfacesShouldHaveSameMembers.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/InterfacesShouldHaveSameMembers.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Extensions;
 using Microsoft.Cci.Extensions.CSharp;

--- a/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/MembersMustExist.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/MembersMustExist.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Composition;

--- a/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/ParameterModifiersCannotChange.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/ParameterModifiersCannotChange.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/ParameterNamesCannotChange.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/ParameterNamesCannotChange.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
 using System.Linq;

--- a/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/TypeCannotChangeClassification.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/TypeCannotChangeClassification.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Extensions;
 using Microsoft.Cci.Extensions.CSharp;

--- a/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/TypesMustAlwaysImplementIDisposable.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/TypesMustAlwaysImplementIDisposable.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Extensions;
 

--- a/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/TypesMustExist.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/TypesMustExist.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Extensions;
 

--- a/src/Microsoft.DotNet.ApiCompat/src/Rules/InheritanceHierarchyChangeTracker.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/Rules/InheritanceHierarchyChangeTracker.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.ApiCompat/src/Rules/ParameterTypeCannotChange.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/Rules/ParameterTypeCannotChange.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Extensions;
 using Microsoft.Cci.Mappings;

--- a/src/Microsoft.DotNet.ApiCompat/src/build/Microsoft.DotNet.ApiCompat.targets
+++ b/src/Microsoft.DotNet.ApiCompat/src/build/Microsoft.DotNet.ApiCompat.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project DefaultTargets="Build">
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.ApiCompat/tests/AttributeDifferenceTests.cs
+++ b/src/Microsoft.DotNet.ApiCompat/tests/AttributeDifferenceTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.DotNet.ApiCompat/tests/TestProjects/AttributeDifference/Contract/AttributeDifference.cs
+++ b/src/Microsoft.DotNet.ApiCompat/tests/TestProjects/AttributeDifference/Contract/AttributeDifference.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
 

--- a/src/Microsoft.DotNet.ApiCompat/tests/TestProjects/AttributeDifference/Implementation/AttributeDifferenceClass1.cs
+++ b/src/Microsoft.DotNet.ApiCompat/tests/TestProjects/AttributeDifference/Implementation/AttributeDifferenceClass1.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.ComponentModel;

--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/CalculateAssemblyAndFileVersionsTests.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/CalculateAssemblyAndFileVersionsTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/GenerateResxSourceTests.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/GenerateResxSourceTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/GenerateSourcePackageSourceLinkTargetsFileTests.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/GenerateSourcePackageSourceLinkTargetsFileTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.IO;

--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/GetAssemblyFullNameTests.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/GetAssemblyFullNameTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Utilities;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/GetLicenseFilePathTests.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/GetLicenseFilePathTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/GroupItemsByTests.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/GroupItemsByTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Xunit;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/MinimalRepoTests.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/MinimalRepoTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Xunit;
 using Xunit.Abstractions;

--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/RepoWithConditionalProjectsToBuildTests.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/RepoWithConditionalProjectsToBuildTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/Utilities/CollectionExtensions.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/Utilities/CollectionExtensions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/Utilities/TestApp.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/Utilities/TestApp.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/Utilities/TestProjectFixture.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/Utilities/TestProjectFixture.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/ValidateLicenseTests.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/ValidateLicenseTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Xunit;
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>

--- a/src/Microsoft.DotNet.Arcade.Sdk/sdk/Sdk.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/sdk/Sdk.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <PropertyGroup>
     <!-- 

--- a/src/Microsoft.DotNet.Arcade.Sdk/sdk/Sdk.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/sdk/Sdk.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <!--
     If a project specifies ExcludeFromSourceBuild=true during a source build suppress all targets and emulate a no-op

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/CalculateAssemblyAndFileVersions.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/CalculateAssemblyAndFileVersions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Build.Framework;

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/CheckRequiredDotNetVersion.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/CheckRequiredDotNetVersion.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/CompareVersions.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/CompareVersions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/ExtractNgenMethodList.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/ExtractNgenMethodList.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateChecksums.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateChecksums.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateResxSource.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateResxSource.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateSourcePackageSourceLinkTargetsFile.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateSourcePackageSourceLinkTargetsFile.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GetAssemblyFullName.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GetAssemblyFullName.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Reflection;
 using Microsoft.Build.Framework;

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GetLicenseFilePath.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GetLicenseFilePath.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.IO;

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GroupItemsBy.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GroupItemsBy.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/LocateDotNet.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/LocateDotNet.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/SaveItems.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/SaveItems.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Construction;

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/SetCorFlags.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/SetCorFlags.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/SingleError.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/SingleError.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/SourceBuild/AddSourceToNuGetConfig.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/SourceBuild/AddSourceToNuGetConfig.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/SourceBuild/ReadSourceBuildIntermediateNupkgDependencies.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/SourceBuild/ReadSourceBuildIntermediateNupkgDependencies.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/Unsign.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/Unsign.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/ValidateLicense.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/ValidateLicense.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.IO;

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/AfterSigning.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/AfterSigning.proj
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <Import Project="BuildStep.props" />
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/AfterSolutionBuild.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/AfterSolutionBuild.proj
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <Import Project="BuildStep.props" />
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/BeforeCommonTargets.CrossTargeting.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/BeforeCommonTargets.CrossTargeting.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <Import Project="$(_ArcadeOverriddenCustomBeforeMicrosoftCommonCrossTargetingTargets)" Condition="Exists('$(_ArcadeOverriddenCustomBeforeMicrosoftCommonCrossTargetingTargets)')"/>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/BeforeCommonTargets.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <Import Project="$(_ArcadeOverriddenCustomBeforeMicrosoftCommonTargets)" Condition="Exists('$(_ArcadeOverriddenCustomBeforeMicrosoftCommonTargets)')"/>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project DefaultTargets="Execute" TreatAsLocalProperty="RepoRoot">
   <!--
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/BuildReleasePackages.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/BuildReleasePackages.targets
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <PropertyGroup>
     <_NuGetRepackAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(NuGetPackageRoot)microsoft.dotnet.nugetrepack.tasks\$(MicrosoftDotnetNuGetRepackTasksVersion)\tools\net472\Microsoft.DotNet.NuGetRepack.Tasks.dll</_NuGetRepackAssembly>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/BuildStep.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/BuildStep.props
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <Import Project="RepoLayout.props" />
   <Import Project="DefaultVersions.props" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/BuildTasks.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/BuildTasks.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <PropertyGroup>
     <ArcadeSdkBuildTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)net472\Microsoft.DotNet.Arcade.Sdk.dll</ArcadeSdkBuildTasksAssembly>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Compiler.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Compiler.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="$(MicrosoftNetCompilersToolsetVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Directory.Build.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Directory.Build.props
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <!-- This is an empty Directory.Build.props file to prevent the Directory.Build.props file from the repo from being used
        if the toolset package is restored to a subdirectory in the repo -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Directory.Build.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Directory.Build.targets
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <!-- This is an empty Directory.Build.targets file to prevent the Directory.Build.targets file from the repo from being used
        if the toolset package is restored to a subdirectory in the repo -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Empty.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Empty.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project DefaultTargets="Build">
   <!--
     Import this file to suppress all targets while allowing the project to participate in the build.

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateChecksums.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateChecksums.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GenerateChecksums" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateInternalsVisibleTo.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateInternalsVisibleTo.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <PropertyGroup>
     <GeneratedInternalsVisibleToFile>$(IntermediateOutputPath)$(MSBuildProjectName).InternalsVisibleTo$(DefaultLanguageSourceExtension)</GeneratedInternalsVisibleToFile>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateResxSource.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateResxSource.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <!--
     Import NuGet targets to WPF temp projects (workaround for https://github.com/dotnet/sourcelink/issues/91) 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/InstallDotNetCore.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/InstallDotNetCore.targets
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.InstallDotNetCore" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Localization.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Localization.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/MSTest/MSTest.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/MSTest/MSTest.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <ItemGroup>
     <PackageReference Include="Microsoft.TestPlatform" Version="$(MicrosoftTestPlatformVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true"/>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/NUnit/NUnit.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/NUnit/NUnit.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <ItemGroup>
     <PackageReference Include="Microsoft.TestPlatform" Version="$(MicrosoftTestPlatformVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true"/>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Performance.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Performance.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <!-- The 'PerformanceTest' target is only viable for repos building their own performance-test harness. -->
   <Target Name="PerformanceTest" Condition="'$(IsPerformanceTestProject)' == 'true'">

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <PropertyGroup>
     <DeployProjectOutput Condition="'$(DeployProjectOutput)' == ''">$(__DeployProjectOutput)</DeployProjectOutput>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectLayout.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectLayout.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <!--
      Properties describing the layout of the repo specific to the current project.

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project DefaultTargets="Publish">
   <!--
     Documentation for publishing is available here:

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <!--
      Properties describing the layout of the repo.

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <!--
     Include both GitHub and Azure DevOps packages to enable SourceLink in repositories that mirror to Azure DevOps.

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryValidation.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryValidation.proj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project DefaultTargets="Validate">
 
   <Import Project="BuildTasks.props" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Directory.Build.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Directory.Build.props
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project TreatAsLocalProperty="RepoRoot">
   <PropertyGroup>
     <RepoRoot>$([System.IO.Path]::GetFullPath('$(RepoRoot)/'))</RepoRoot>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Directory.Build.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Directory.Build.targets
@@ -1,3 +1,3 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/GenerateBuildManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/GenerateBuildManifest.proj
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Execute">
   <!--
     Optional variables:

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Execute">
   <!--
     The target in this file initially calls `SetupTargetFeeds.proj` to create the list of

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishBuildAssets.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishBuildAssets.proj
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Execute">
   <!--
     Required variables:

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishToSymbolServers.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishToSymbolServers.proj
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Execute">
   <!--
     This MSBuild file is intended to be used as the body of the default 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SetupTargetFeeds.proj
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <!--
     This file main target, namely `SetupTargetFeeds`, is used to create an ItemGroup with

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SignProxy.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SignProxy.proj
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Execute">
   
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SigningValidation.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SigningValidation.proj
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Execute">
   <!--
     This MSBuild file is intended to be used as the body of the default 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Versions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Versions.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <Import Project="..\DefaultVersions.Generated.props"/>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/VisualStudio.BuildIbcTrainingSettings.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/VisualStudio.BuildIbcTrainingSettings.proj
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project DefaultTargets="Execute">
   <!--
     Required parameters:

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Settings.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Settings.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <PropertyGroup>
     <_ArcadeOverriddenCustomBeforeMicrosoftCommonTargets>$(CustomBeforeMicrosoftCommonTargets)</_ArcadeOverriddenCustomBeforeMicrosoftCommonTargets>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project DefaultTargets="Sign">
   <Import Project="BuildStep.props" />
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <ItemGroup>
     <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/Noop.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/Noop.proj
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <!--
   This project does nothing when run. It can be used as a ProjectToBuild: this makes ProjectToBuild
   non-empty to avoid the default behavior of finding projects to build in the root, but still not do

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
   <!-- Repo extensibility point. -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadePublish.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadePublish.targets
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
   <Import Project="SourceBuildArcade.targets" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
   <Import Project="SourceBuildArcade.targets" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
   <!-- Shield this project from nonstandard Directory.Build.props/targets. -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/StrongName.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/StrongName.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/StrongName.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/StrongName.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SymStore.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SymStore.targets
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
   <!-- This file is only imported in CI build. The conversion thus does not affect dev build. -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
   <PropertyGroup Condition="'$(IsPerformanceTestProject)' == ''">

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project InitialTargets="ErrorForMissingTestRunner">
 
   <PropertyGroup Condition="'$(IsTestProject)' == 'true'">

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <Import Project="BuildStep.props" />
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VSTest.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VSTest.targets
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <Target Name="RunTests"
           Outputs="%(TestToRun.ResultsStdOutPath)">

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.AcquireOptimizationData.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.AcquireOptimizationData.targets
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <!-- 
     Properties:

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.BuildIbcTrainingInputs.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.BuildIbcTrainingInputs.targets
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.ImportSdk.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.ImportSdk.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <Import Project="$(VSToolsPath)\vssdk\Microsoft.VsSDK.targets"/>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.InsertionManifests.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.InsertionManifests.targets
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <ItemGroup>
     <_StubFiles Include="$(VisualStudioSetupIntermediateOutputPath)**\*.stub"/>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.swixproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.swixproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <!--
     Required variables:

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <!--
     Required variables:

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.VsixBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.VsixBuild.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <PropertyGroup>
     <ArcadeVisualStudioBuildTasksAssembly>$(NuGetPackageRoot)microsoft.dotnet.build.tasks.visualstudio\$(MicrosoftDotNetBuildTasksVisualStudioVersion)\tools\net472\Microsoft.DotNet.Build.Tasks.VisualStudio.dll</ArcadeVisualStudioBuildTasksAssembly>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <!-- 
     Initialize VsixVersion. The project may specify 3-part prefix if it's different from VersionPrefix.

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
   <!-- Workaround for https://github.com/Microsoft/msbuild/issues/1310 -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <PropertyGroup>
     <UseVSTestRunner Condition="'$(UseVSTestRunner)' != 'true'">false</UseVSTestRunner>

--- a/src/Microsoft.DotNet.AsmDiff/ApiRecordingCSharpDiffWriter.cs
+++ b/src/Microsoft.DotNet.AsmDiff/ApiRecordingCSharpDiffWriter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci;
 using Microsoft.Cci.Extensions;

--- a/src/Microsoft.DotNet.AsmDiff/AssemblyClassification.cs
+++ b/src/Microsoft.DotNet.AsmDiff/AssemblyClassification.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.AsmDiff
 {

--- a/src/Microsoft.DotNet.AsmDiff/AssemblySet.cs
+++ b/src/Microsoft.DotNet.AsmDiff/AssemblySet.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Microsoft.DotNet.AsmDiff/ClassifiedAssembly.cs
+++ b/src/Microsoft.DotNet.AsmDiff/ClassifiedAssembly.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci;
 

--- a/src/Microsoft.DotNet.AsmDiff/Csv/CsvSettings.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/CsvSettings.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Text;
 

--- a/src/Microsoft.DotNet.AsmDiff/Csv/CsvTextWriter.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/CsvTextWriter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.IO;
 using System.Text;

--- a/src/Microsoft.DotNet.AsmDiff/Csv/CsvWriter.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/CsvWriter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.AsmDiff/Csv/DiffAssemblyCsvColumn.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/DiffAssemblyCsvColumn.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Cci.Extensions;

--- a/src/Microsoft.DotNet.AsmDiff/Csv/DiffCsvColumn.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/DiffCsvColumn.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.ObjectModel;

--- a/src/Microsoft.DotNet.AsmDiff/Csv/DiffDifferenceCsvColumn.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/DiffDifferenceCsvColumn.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Cci.Differs;

--- a/src/Microsoft.DotNet.AsmDiff/Csv/DiffIdCsvColumn.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/DiffIdCsvColumn.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Extensions;
 using Microsoft.Cci.Mappings;

--- a/src/Microsoft.DotNet.AsmDiff/Csv/DiffInNewCsvColumn.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/DiffInNewCsvColumn.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Cci.Differs;

--- a/src/Microsoft.DotNet.AsmDiff/Csv/DiffInOldCsvColumn.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/DiffInOldCsvColumn.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Cci.Differs;

--- a/src/Microsoft.DotNet.AsmDiff/Csv/DiffKindCsvColumn.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/DiffKindCsvColumn.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Mappings;
 

--- a/src/Microsoft.DotNet.AsmDiff/Csv/DiffMemberCsvColumn.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/DiffMemberCsvColumn.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci;
 using Microsoft.Cci.Mappings;

--- a/src/Microsoft.DotNet.AsmDiff/Csv/DiffNamespaceCsvColumn.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/DiffNamespaceCsvColumn.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Extensions;
 using Microsoft.Cci.Mappings;

--- a/src/Microsoft.DotNet.AsmDiff/Csv/DiffNewAssemblyCsvColumn.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/DiffNewAssemblyCsvColumn.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.AsmDiff.CSV
 {

--- a/src/Microsoft.DotNet.AsmDiff/Csv/DiffObsoletionCsvColumn.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/DiffObsoletionCsvColumn.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Linq;
 using Microsoft.Cci;

--- a/src/Microsoft.DotNet.AsmDiff/Csv/DiffOldAssemblyCsvColumn.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/DiffOldAssemblyCsvColumn.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.AsmDiff.CSV
 {

--- a/src/Microsoft.DotNet.AsmDiff/Csv/DiffOverrideCsvColumn.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/DiffOverrideCsvColumn.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Extensions.CSharp;
 using Microsoft.Cci.Mappings;

--- a/src/Microsoft.DotNet.AsmDiff/Csv/DiffReturnTypeCsvColumn.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/DiffReturnTypeCsvColumn.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci;
 using Microsoft.Cci.Extensions;

--- a/src/Microsoft.DotNet.AsmDiff/Csv/DiffStaticCsvColumn.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/DiffStaticCsvColumn.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci;
 using Microsoft.Cci.Mappings;

--- a/src/Microsoft.DotNet.AsmDiff/Csv/DiffSubKindCsvColumn.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/DiffSubKindCsvColumn.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Extensions;
 using Microsoft.Cci.Mappings;

--- a/src/Microsoft.DotNet.AsmDiff/Csv/DiffTokensCsvColumn.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/DiffTokensCsvColumn.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.DotNet.AsmDiff/Csv/DiffTypeCsvColumn.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/DiffTypeCsvColumn.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci;
 using Microsoft.Cci.Extensions;

--- a/src/Microsoft.DotNet.AsmDiff/Csv/DiffTypeIdCsvColumn.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/DiffTypeIdCsvColumn.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Extensions;
 using Microsoft.Cci.Mappings;

--- a/src/Microsoft.DotNet.AsmDiff/Csv/DiffTypeIsExposedCsvColumn.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/DiffTypeIsExposedCsvColumn.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Extensions;
 using Microsoft.Cci.Mappings;

--- a/src/Microsoft.DotNet.AsmDiff/Csv/DiffUnsafeCsvColumn.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/DiffUnsafeCsvColumn.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Linq;
 using Microsoft.Cci;

--- a/src/Microsoft.DotNet.AsmDiff/Csv/DiffVirtualityCsvColumn.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/DiffVirtualityCsvColumn.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Cci;

--- a/src/Microsoft.DotNet.AsmDiff/Csv/DiffVisibiliyCsvColumn.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/DiffVisibiliyCsvColumn.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci;
 using Microsoft.Cci.Mappings;

--- a/src/Microsoft.DotNet.AsmDiff/Csv/IDiffCsvColumn.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Csv/IDiffCsvColumn.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Mappings;
 

--- a/src/Microsoft.DotNet.AsmDiff/DiffApiDefinition.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffApiDefinition.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci;
 using Microsoft.Cci.Differs;

--- a/src/Microsoft.DotNet.AsmDiff/DiffCSharpWriter.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffCSharpWriter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.AsmDiff/DiffCciFilter.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffCciFilter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Linq;
 using Microsoft.Cci;

--- a/src/Microsoft.DotNet.AsmDiff/DiffComment.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffComment.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.AsmDiff
 {

--- a/src/Microsoft.DotNet.AsmDiff/DiffConfiguration.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffConfiguration.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.AsmDiff
 {

--- a/src/Microsoft.DotNet.AsmDiff/DiffConfigurationExtensions.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffConfigurationExtensions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.DotNet.AsmDiff/DiffConfigurationOptions.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffConfigurationOptions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.DotNet.AsmDiff/DiffCsvWriter.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffCsvWriter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Threading;

--- a/src/Microsoft.DotNet.AsmDiff/DiffDocument.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffDocument.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/src/Microsoft.DotNet.AsmDiff/DiffEngine.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffEngine.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Differs;
 using Microsoft.Cci.Filters;

--- a/src/Microsoft.DotNet.AsmDiff/DiffFormat.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffFormat.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.AsmDiff
 {

--- a/src/Microsoft.DotNet.AsmDiff/DiffLine.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffLine.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/src/Microsoft.DotNet.AsmDiff/DiffLineKind.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffLineKind.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.AsmDiff
 {

--- a/src/Microsoft.DotNet.AsmDiff/DiffRecorder.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffRecorder.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Writers.Syntax;
 using System;

--- a/src/Microsoft.DotNet.AsmDiff/DiffStyle.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffStyle.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.DotNet.AsmDiff/DiffToken.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffToken.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.AsmDiff
 {

--- a/src/Microsoft.DotNet.AsmDiff/DiffTokenKind.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffTokenKind.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.AsmDiff
 {

--- a/src/Microsoft.DotNet.AsmDiff/MarkdownDiffExporter.cs
+++ b/src/Microsoft.DotNet.AsmDiff/MarkdownDiffExporter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci;
 using Microsoft.Cci.Differs;

--- a/src/Microsoft.DotNet.AsmDiff/MefHelpers.cs
+++ b/src/Microsoft.DotNet.AsmDiff/MefHelpers.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.AsmDiff/Microsoft.DotNet.AsmDiff.csproj
+++ b/src/Microsoft.DotNet.AsmDiff/Microsoft.DotNet.AsmDiff.csproj
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project Sdk="Microsoft.NET.Sdk">
   
   <!-- Most of the code has been ported from https://devdiv.visualstudio.com/DevDiv/_git/CoreFxTools repo.-->

--- a/src/Microsoft.DotNet.AsmDiff/Program.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Program.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using McMaster.Extensions.CommandLineUtils;
 using System;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/GeneralTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/GeneralTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.IO;
 using System.Net;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.Build.Tasks.Feed.Model;
 using MsBuildUtils = Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PushToAzureDevOpsArtifacts.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PushToAzureDevOpsArtifacts.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.Build.Tasks.Feed.Tests.TestDoubles;
 using Microsoft.DotNet.VersionTools.BuildManifest.Model;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/SetupTargetFeedConfigV3Tests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/SetupTargetFeedConfigV3Tests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.Build.Tasks.Feed.Model;
 using Microsoft.DotNet.Build.Tasks.Feed.Tests.TestDoubles;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/TestDoubles/FakeHttpClient.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/TestDoubles/FakeHttpClient.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/TestDoubles/MockBuildEngine.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/TestDoubles/MockBuildEngine.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using System;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/TestDoubles/MockRetryHandler.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/TestDoubles/MockRetryHandler.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/TestDoubles/StubTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/TestDoubles/StubTask.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/TestInputs.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/TestInputs.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.IO;
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/build/Microsoft.DotNet.Build.Tasks.Feed.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/build/Microsoft.DotNet.Build.Tasks.Feed.targets
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project ToolsVersion="12.0" DefaultTargets="PublishPackagesToBlobFeed" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--
     Publish targets:

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/sdk/Sdk.props
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/sdk/Sdk.props
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <!-- Sdk.props file is required to be present for use as an Sdk, we don't have any props that we use though -->
   <Import Project="$(MSBuildThisFileDirectory)..\build\Microsoft.DotNet.Build.Tasks.Feed.props" Condition="Exists('$(MSBuildThisFileDirectory)..\build\Microsoft.DotNet.Build.Tasks.Feed.props')" />

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/sdk/Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/sdk/Sdk.targets
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <Import Project="$(MSBuildThisFileDirectory)..\build\Microsoft.DotNet.Build.Tasks.Feed.targets" />
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BlobFeedAction.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.CloudTestTasks;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BlobUrlInfo.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BlobUrlInfo.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/ConfigureInputFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/ConfigureInputFeed.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Utilities;
 using System.IO;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/CopyBlobDirectory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/CopyBlobDirectory.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using System;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Newtonsoft.Json;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureStorageBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureStorageBlobFeed.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Azure.Storage.Blobs.Models;
 using Microsoft.Build.Framework;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/ExecWithRetriesForNuGetPush.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/ExecWithRetriesForNuGetPush.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/GenerateBuildManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/GenerateBuildManifest.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.Tasks.Feed.Model;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/GetBlobFeedPackageList.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/GetBlobFeedPackageList.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using NuGet.Packaging.Core;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/ParseBlobUrl.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/ParseBlobUrl.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/ParseBuildManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/ParseBuildManifest.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.VersionTools.BuildManifest.Model;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Maestro.Client;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.Tasks.Feed.Model;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV2.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV2.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.Tasks.Feed.Model;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.Tasks.Feed.Model;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushOptions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.Build.Tasks.Feed
 {

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.VersionTools.BuildManifest.Model;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBlobFeed.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.VersionTools.BuildManifest.Model;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/SleetLogger.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/SleetLogger.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using NuGet.Common;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/SleetSettings.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/SleetSettings.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/SleetSource.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/SleetSource.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.Build.Tasks.Feed
 {

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureConnectionStringBuildTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureConnectionStringBuildTask.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Utilities;
 using System.Text.RegularExpressions;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Azure;
 using Azure.Storage;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/CreateAzureContainer.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/CreateAzureContainer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using System.Threading.Tasks;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/GeneralUtils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/GeneralUtils.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/LatestLinksManager.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/LatestLinksManager.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/MSBuildListSplitter.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/MSBuildListSplitter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/UploadToAzure.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/UploadToAzure.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.Build.Tasks.Feed.Model;
 using Microsoft.DotNet.VersionTools.BuildManifest.Model;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigBase.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.Build.Tasks.Feed.Model;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigV3.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.Tasks.Feed.Model;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetChannelConfig.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetChannelConfig.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.BuildManifest.Model;
 using System;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetFeedConfig.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetFeedConfig.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/Microsoft.DotNet.Build.Tasks.Installers.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/Microsoft.DotNet.Build.Tasks.Installers.csproj
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp2.0</TargetFrameworks>

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLightCommandPackageDrop.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLightCommandPackageDrop.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.Tasks.Installers.src;

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLitCommandPackageDrop.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLitCommandPackageDrop.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.Tasks.Installers.src;

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixCommandPackageDropBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixCommandPackageDropBase.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ApplyBaseLine.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ApplyBaseLine.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using System;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ApplyMetaPackages.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ApplyMetaPackages.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ApplyPreReleaseSuffix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ApplyPreReleaseSuffix.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/CreateTrimDependencyGroups.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/CreateTrimDependencyGroups.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Extensions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Extensions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using NuGet;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FilterUnknownPackages.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FilterUnknownPackages.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using System;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Framework.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Framework.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using NuGet.Frameworks;
 using System;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkUtilities.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkUtilities.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using NuGet.Frameworks;
 using System;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateNetStandardSupportTable.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateNetStandardSupportTable.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Newtonsoft.Json;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateNuSpec.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateNuSpec.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GeneratePackageReport.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GeneratePackageReport.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateRuntimeDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateRuntimeDependencies.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Newtonsoft.Json;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateRuntimeGraph.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateRuntimeGraph.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Newtonsoft.Json;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Generations.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Generations.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetApplicableAssetsFromPackageReports.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetApplicableAssetsFromPackageReports.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetApplicableAssetsFromPackages.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetApplicableAssetsFromPackages.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetAssemblyReferences.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetAssemblyReferences.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetInboxFrameworks.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetInboxFrameworks.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetLayoutFiles.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetLayoutFiles.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetMinimumNETStandard.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetMinimumNETStandard.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetPackageDescription.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetPackageDescription.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetPackageDestination.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetPackageDestination.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetPackageFromModule.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetPackageFromModule.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetPackageVersion.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetPackageVersion.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetSupportedPackagesFromPackageReports.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetSupportedPackagesFromPackageReports.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/HarvestPackage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/HarvestPackage.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Metadata.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Metadata.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.Build.Tasks.Packaging
 {

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetAssetResolver.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetAssetResolver.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using NuGet.Client;
 using NuGet.ContentModel;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetPack.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetPack.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using NuGet;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetUtility.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetUtility.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Newtonsoft.Json;
 using NuGet.Common;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NugetPropertyStringProvider.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NugetPropertyStringProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageDirectory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageDirectory.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.Build.Tasks.Packaging
 {

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageIndex.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageIndex.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageItem.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageItem.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using NuGet.Frameworks;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageMetadata.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageMetadata.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Newtonsoft.Json;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PromoteDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PromoteDependencies.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/SplitDependenciesBySupport.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/SplitDependenciesBySupport.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/SplitReferences.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/SplitReferences.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/UpdatePackageIndex.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/UpdatePackageIndex.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Newtonsoft.Json;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidateFrameworkPackage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidateFrameworkPackage.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidateHarvestVersionIsLatestForRelease.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidateHarvestVersionIsLatestForRelease.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidatePackage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidatePackage.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidationTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidationTask.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VerifyClosure.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VerifyClosure.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using System;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VerifyTypes.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VerifyTypes.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using System;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VersionUtility.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VersionUtility.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/ApplyBaseLineTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/ApplyBaseLineTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/CreateTrimDependencyGroupsTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/CreateTrimDependencyGroupsTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/GetLastStablePackageTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/GetLastStablePackageTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/Log.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/Log.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Xunit;
 using Xunit.Abstractions;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/NuGetAssetResolverTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/NuGetAssetResolverTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using NuGet.Frameworks;
 using Xunit;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/NugetPropertyStringProviderTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/NugetPropertyStringProviderTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/PackageIndexTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/PackageIndexTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using NuGet.Frameworks;
 using System;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/RuntimeGraphTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/RuntimeGraphTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using NuGet.Frameworks;
 using NuGet.RuntimeModel;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/TestBuildEngine.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/TestBuildEngine.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using System;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/ValidateHarvestVersionIsLatestForReleaseTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/ValidateHarvestVersionIsLatestForReleaseTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/VersionUtilityTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/VersionUtilityTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk.csproj
@@ -1,4 +1,4 @@
-﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/BuildFPMToolPreReqs.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/BuildFPMToolPreReqs.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Newtonsoft.Json;

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/BuildTask.Desktop.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/BuildTask.Desktop.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk
 {

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/BuildTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/BuildTask.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/CopyNupkgAndChangeVersion.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/CopyNupkgAndChangeVersion.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Newtonsoft.Json.Linq;

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/CreateFrameworkListFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/CreateFrameworkListFile.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using System;

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/ExecWithRetries.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/ExecWithRetries.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // Initially copied from https://github.com/dotnet/buildtools/blob/6736870b84e06b75e7df32bb84d442db1b2afa10/src/Microsoft.DotNet.Build.Tasks/ExecWithRetries.cs
 

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/FileUtilities.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/FileUtilities.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/GenerateCurrentVersion.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/GenerateCurrentVersion.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using System;

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/GenerateDebRepoUploadJsonFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/GenerateDebRepoUploadJsonFile.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using System.IO;

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/GenerateFileVersionProps.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/GenerateFileVersionProps.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Construction;
 using Microsoft.Build.Framework;

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/GenerateGuidFromName.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/GenerateGuidFromName.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using System;

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/GenerateJsonObjectString.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/GenerateJsonObjectString.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using System;

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/GenerateMsiVersion.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/GenerateMsiVersion.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/ProcessSharedFrameworkDeps.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/ProcessSharedFrameworkDeps.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/RuntimeGraphManager.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/RuntimeGraphManager.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyModel;
 using NuGet.Packaging;

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/RuntimeReference.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/RuntimeReference.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyModel;
 using System;

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/StabilizeWixFileId.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/StabilizeWixFileId.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using System;

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/ZipFileCreateFromDirectory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/ZipFileCreateFromDirectory.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/ZipFileExtractToDirectory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/ZipFileExtractToDirectory.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using System;

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/ZipFileGetEntries.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/ZipFileGetEntries.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/AddTargetFrameworksToProjectTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/AddTargetFrameworksToProjectTask.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/ChooseBestP2PTargetFrameworkTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/ChooseBestP2PTargetFrameworkTask.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using System.IO;

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/ChooseBestTargetFrameworksTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/ChooseBestTargetFrameworksTask.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/TargetFrameworkResolver.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/TargetFrameworkResolver.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using NuGet.Client;
 using NuGet.ContentModel;

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/BinPlace.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/BinPlace.targets
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <UsingTask TaskName="ChooseBestTargetFrameworksTask" AssemblyFile="$(DotNetBuildTasksTargetFrameworkSdkAssembly)"/>
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.props
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.props
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project TreatAsLocalProperty="TargetFramework">  
   <PropertyGroup>
     <DotNetBuildTasksTargetFrameworkSdkAssembly Condition="'$(DotNetBuildTasksTargetFrameworkSdkAssembly)' == '' AND '$(MSBuildRuntimeType)' == 'core'">..\tools\netcoreapp2.1\Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.dll</DotNetBuildTasksTargetFrameworkSdkAssembly>

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <UsingTask TaskName="ChooseBestP2PTargetFrameworkTask" AssemblyFile="$(DotNetBuildTasksTargetFrameworkSdkAssembly)" />
   <UsingTask TaskName="ChooseBestTargetFrameworksTask" AssemblyFile="$(DotNetBuildTasksTargetFrameworkSdkAssembly)" />

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/sdk/Sdk.props
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/sdk/Sdk.props
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <Import Project="..\build\Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.props" />
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/sdk/Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/sdk/Sdk.targets
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <Import Project="..\build\Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets" />
   <Import Project="..\build\BinPlace.targets" />

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests/OptProf/FindLatestDropTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests/OptProf/FindLatestDropTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit;

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests/OptProf/GenerateTrainingInputFilesTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests/OptProf/GenerateTrainingInputFilesTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Newtonsoft.Json.Linq;
 using System;

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests/OptProf/GenerateTrainingPropsFileTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests/OptProf/GenerateTrainingPropsFileTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests/OptProf/GetRunSettingsSessionConfigurationTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests/OptProf/GetRunSettingsSessionConfigurationTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests/Vsix/FinalizeInsertionVsixFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests/Vsix/FinalizeInsertionVsixFile.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.Arcade.Sdk.Tests.Utilities;
 using System;

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests/Vsix/GetPkgDefAssemblyDependencyGuidTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio.Tests/Vsix/GetPkgDefAssemblyDependencyGuidTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Utilities;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/FindLatestDrop.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/FindLatestDrop.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GenerateTrainingInputFiles.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GenerateTrainingInputFiles.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GenerateTrainingPropsFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GenerateTrainingPropsFile.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GetRunSettingsSessionConfiguration.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GetRunSettingsSessionConfiguration.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/IbcEntry.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/IbcEntry.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Newtonsoft.Json.Linq;
 using System;

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/AssemblyOptProfTraining.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/AssemblyOptProfTraining.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Newtonsoft.Json;
 

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/JsonSerializerExtensions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/JsonSerializerExtensions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Newtonsoft.Json;
 using System.IO;

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/OptProfFileFilteredTest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/OptProfFileFilteredTest.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Newtonsoft.Json;
 

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/OptProfInstrumentationArgument.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/OptProfInstrumentationArgument.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.using Newtonsoft.Json;
 
 using Newtonsoft.Json;
 

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/OptProfTrainingConfiguration.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/OptProfTrainingConfiguration.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Newtonsoft.Json;
 using System.IO;

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/OptProfTrainingTest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/OptProfTrainingTest.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Newtonsoft.Json;
 

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/ProductOptProfTraining.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/Json/ProductOptProfTraining.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Newtonsoft.Json;
 

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/Vsix/FinalizeInsertionVsixFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/Vsix/FinalizeInsertionVsixFile.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/Vsix/GetPkgDefAssemblyDependencyGuid.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/Vsix/GetPkgDefAssemblyDependencyGuid.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Microsoft.DotNet.CMake.Sdk/Microsoft.DotNet.CMake.Sdk.csproj
+++ b/src/Microsoft.DotNet.CMake.Sdk/Microsoft.DotNet.CMake.Sdk.csproj
@@ -1,4 +1,4 @@
-﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>

--- a/src/Microsoft.DotNet.CodeAnalysis/Analyzers/AppContextDefaultsAnalyzer.cs
+++ b/src/Microsoft.DotNet.CodeAnalysis/Analyzers/AppContextDefaultsAnalyzer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/Microsoft.DotNet.CodeAnalysis/Analyzers/BaseAnalyzer.cs
+++ b/src/Microsoft.DotNet.CodeAnalysis/Analyzers/BaseAnalyzer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis.Diagnostics;
 using System;

--- a/src/Microsoft.DotNet.CodeAnalysis/Analyzers/MembersMustExistAnalyzer.cs
+++ b/src/Microsoft.DotNet.CodeAnalysis/Analyzers/MembersMustExistAnalyzer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/src/Microsoft.DotNet.CodeAnalysis/Analyzers/PinvokeAnalyzer.cs
+++ b/src/Microsoft.DotNet.CodeAnalysis/Analyzers/PinvokeAnalyzer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.CodeAnalysis/Analyzers/ResourceUsageAnalyzer.cs
+++ b/src/Microsoft.DotNet.CodeAnalysis/Analyzers/ResourceUsageAnalyzer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;

--- a/src/Microsoft.DotNet.CodeAnalysis/DiagnosticIds.cs
+++ b/src/Microsoft.DotNet.CodeAnalysis/DiagnosticIds.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.CodeAnalysis
 {

--- a/src/Microsoft.DotNet.CodeAnalysis/Helpers.cs
+++ b/src/Microsoft.DotNet.CodeAnalysis/Helpers.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis;
 

--- a/src/Microsoft.DotNet.CodeAnalysis/build/Microsoft.DotNet.CodeAnalysis.targets
+++ b/src/Microsoft.DotNet.CodeAnalysis/build/Microsoft.DotNet.CodeAnalysis.targets
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <!-- PInvokeChecker data files -->
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLink.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLink.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.Deployment.Tasks.Links.src
 {

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksBase.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksBase.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net.Http;

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksManager.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksManager.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/CreateAkaMSLinks.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/CreateAkaMSLinks.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Deployment.Tasks.Links.src;

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/DeleteAkaMSLinks.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/DeleteAkaMSLinks.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Deployment.Tasks.Links.src;

--- a/src/Microsoft.DotNet.GenAPI/Program.cs
+++ b/src/Microsoft.DotNet.GenAPI/Program.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.GenAPI/SyntaxWriterType.cs
+++ b/src/Microsoft.DotNet.GenAPI/SyntaxWriterType.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.GenAPI
 {

--- a/src/Microsoft.DotNet.GenAPI/TypeListWriter.cs
+++ b/src/Microsoft.DotNet.GenAPI/TypeListWriter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.GenAPI/WriterType.cs
+++ b/src/Microsoft.DotNet.GenAPI/WriterType.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.GenAPI
 {

--- a/src/Microsoft.DotNet.GenAPI/build/Microsoft.DotNet.GenAPI.targets
+++ b/src/Microsoft.DotNet.GenAPI/build/Microsoft.DotNet.GenAPI.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.GenFacades/ClearAssemblyReferenceVersions.cs
+++ b/src/Microsoft.DotNet.GenFacades/ClearAssemblyReferenceVersions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.GenFacades/GenPartialFacadeSource.cs
+++ b/src/Microsoft.DotNet.GenFacades/GenPartialFacadeSource.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.GenFacades/GenPartialFacadeSourceGenerator.cs
+++ b/src/Microsoft.DotNet.GenFacades/GenPartialFacadeSourceGenerator.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.GenFacades/ILRewriter/FacadeGenerationException.cs
+++ b/src/Microsoft.DotNet.GenFacades/ILRewriter/FacadeGenerationException.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.DotNet.GenFacades/ILRewriter/GenFacades.cs
+++ b/src/Microsoft.DotNet.GenFacades/ILRewriter/GenFacades.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.GenFacades/ILRewriter/GenFacadesTask.cs
+++ b/src/Microsoft.DotNet.GenFacades/ILRewriter/GenFacadesTask.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.GenFacades/ILRewriter/TypeReferenceRewriter.cs
+++ b/src/Microsoft.DotNet.GenFacades/ILRewriter/TypeReferenceRewriter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci;
 using Microsoft.Cci.MutableCodeModel;

--- a/src/Microsoft.DotNet.GenFacades/ILRewriter/VersionResourceSerializer.cs
+++ b/src/Microsoft.DotNet.GenFacades/ILRewriter/VersionResourceSerializer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 // This code is from Roslyn/Source/Compilers/Core/CvtRes.cs
 

--- a/src/Microsoft.DotNet.GenFacades/NotSupportedAssemblyGenerator.cs
+++ b/src/Microsoft.DotNet.GenFacades/NotSupportedAssemblyGenerator.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.CodeAnalysis;

--- a/src/Microsoft.DotNet.GenFacades/SourceGenerator.cs
+++ b/src/Microsoft.DotNet.GenFacades/SourceGenerator.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Utilities;
 using Microsoft.DotNet.Build.Tasks;

--- a/src/Microsoft.DotNet.GenFacades/TypeParser.cs
+++ b/src/Microsoft.DotNet.GenFacades/TypeParser.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.targets
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacadesILRewriter.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacadesILRewriter.targets
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <PropertyGroup>
     <!-- reference facades will always have overlapping types so suppress compiler warnings -->

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacadesNotSupported.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacadesNotSupported.targets
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
   <UsingTask TaskName="NotSupportedAssemblyGenerator" AssemblyFile="$(GenFacadesTargetAssemblyPath)" />

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenPartialFacadeSource.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenPartialFacadeSource.targets
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <PropertyGroup>
     <!-- Tell ResolveMatchingContract to run and resolve contract to project reference -->

--- a/src/Microsoft.DotNet.Git.IssueManager/src/Clients/AzureDevOpsClient.cs
+++ b/src/Microsoft.DotNet.Git.IssueManager/src/Clients/AzureDevOpsClient.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Newtonsoft.Json;
 using System;

--- a/src/Microsoft.DotNet.Git.IssueManager/src/Clients/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Git.IssueManager/src/Clients/GitHubClient.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Octokit;
 using System;

--- a/src/Microsoft.DotNet.Git.IssueManager/src/Helpers/RepositoryHelper.cs
+++ b/src/Microsoft.DotNet.Git.IssueManager/src/Helpers/RepositoryHelper.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.Git.IssueManager.Clients;
 using System;

--- a/src/Microsoft.DotNet.Git.IssueManager/src/IssueManager.cs
+++ b/src/Microsoft.DotNet.Git.IssueManager/src/IssueManager.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.Git.IssueManager.Helpers;
 using System;

--- a/src/Microsoft.DotNet.Git.IssueManager/src/Models/AzureDevOpsCommit.cs
+++ b/src/Microsoft.DotNet.Git.IssueManager/src/Models/AzureDevOpsCommit.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.GitSync.CommitManager/CommandLineOptions.cs
+++ b/src/Microsoft.DotNet.GitSync.CommitManager/CommandLineOptions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using CommandLine;
 

--- a/src/Microsoft.DotNet.GitSync.CommitManager/CommitEntity.cs
+++ b/src/Microsoft.DotNet.GitSync.CommitManager/CommitEntity.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.WindowsAzure.Storage.Table;
 

--- a/src/Microsoft.DotNet.GitSync.CommitManager/Program.cs
+++ b/src/Microsoft.DotNet.GitSync.CommitManager/Program.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.GitSync.CommitManager/Table.cs
+++ b/src/Microsoft.DotNet.GitSync.CommitManager/Table.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Table;

--- a/src/Microsoft.DotNet.GitSync/ConfigFile.cs
+++ b/src/Microsoft.DotNet.GitSync/ConfigFile.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using log4net;
 using Microsoft.Azure.KeyVault;

--- a/src/Microsoft.DotNet.GitSync/Configuration.cs
+++ b/src/Microsoft.DotNet.GitSync/Configuration.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Newtonsoft.Json;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.GitSync/EmailManager.cs
+++ b/src/Microsoft.DotNet.GitSync/EmailManager.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using CredentialManagement;
 using log4net;

--- a/src/Microsoft.DotNet.GitSync/NewChanges.cs
+++ b/src/Microsoft.DotNet.GitSync/NewChanges.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/Microsoft.DotNet.GitSync/Program.cs
+++ b/src/Microsoft.DotNet.GitSync/Program.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.GitSync/RepositoryInfo.cs
+++ b/src/Microsoft.DotNet.GitSync/RepositoryInfo.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.DotNet.GitSync/RunResult.cs
+++ b/src/Microsoft.DotNet.GitSync/RunResult.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.GitSync
 {

--- a/src/Microsoft.DotNet.GitSync/Runner.cs
+++ b/src/Microsoft.DotNet.GitSync/Runner.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using log4net;
 using System;

--- a/src/Microsoft.DotNet.Helix/Sdk/FailureCategory.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/FailureCategory.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.Helix
 {

--- a/src/Microsoft.DotNet.Helix/Sdk/LoggerExtensions.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/LoggerExtensions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.NuGetRepack/tasks/src/AssemblyResolution.cs
+++ b/src/Microsoft.DotNet.NuGetRepack/tasks/src/AssemblyResolution.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #if NET472
 

--- a/src/Microsoft.DotNet.NuGetRepack/tests/TestHelpers/FakeBuildEngine.cs
+++ b/src/Microsoft.DotNet.NuGetRepack/tests/TestHelpers/FakeBuildEngine.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using System.Collections;

--- a/src/Microsoft.DotNet.RemoteExecutor/src/MiniDump.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/MiniDump.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.ComponentModel;

--- a/src/Microsoft.DotNet.RemoteExecutor/src/PasteArguments.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/PasteArguments.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.RemoteExecutor/src/Program.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/Program.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutionException.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutionException.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Xunit.Sdk;
 

--- a/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.RemoteExecutor/src/RemoteInvokeHandle.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/RemoteInvokeHandle.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Runtime;
 using System;

--- a/src/Microsoft.DotNet.RemoteExecutor/src/RemoteInvokeOptions.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/RemoteInvokeOptions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.RemoteExecutor/src/build/Microsoft.DotNet.RemoteExecutor.targets
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/build/Microsoft.DotNet.RemoteExecutor.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <PropertyGroup>
     <RemoteExecutorName>Microsoft.DotNet.RemoteExecutor</RemoteExecutorName>

--- a/src/Microsoft.DotNet.RemoteExecutor/tests/RemoteExecutorTests.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/tests/RemoteExecutorTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.RemoteExecutor;
 using System.Threading.Tasks;

--- a/src/Microsoft.DotNet.SignTool.Tests/FakeBuildEngine.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/FakeBuildEngine.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using System.Collections;

--- a/src/Microsoft.DotNet.SignTool.Tests/FakeSignTool.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/FakeSignTool.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Microsoft.DotNet.SignTool.Tests/Microsoft.DotNet.SignTool.Tests.csproj
+++ b/src/Microsoft.DotNet.SignTool.Tests/Microsoft.DotNet.SignTool.Tests.csproj
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>

--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.SignTool.Tests/StreamUtilities.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/StreamUtilities.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
 using System.IO;

--- a/src/Microsoft.DotNet.SignTool/Microsoft.DotNet.SignTool.csproj
+++ b/src/Microsoft.DotNet.SignTool/Microsoft.DotNet.SignTool.csproj
@@ -1,4 +1,4 @@
-﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp2.0</TargetFrameworks>

--- a/src/Microsoft.DotNet.SignTool/src/BatchSignInput.cs
+++ b/src/Microsoft.DotNet.SignTool/src/BatchSignInput.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
+++ b/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.SignTool/src/ByteSequenceComparer.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ByteSequenceComparer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Microsoft.DotNet.SignTool/src/Configuration.cs
+++ b/src/Microsoft.DotNet.SignTool/src/Configuration.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.SignTool/src/ContentUtil.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ContentUtil.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.SignTool/src/ExplicitCertificateKey.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ExplicitCertificateKey.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Microsoft.DotNet.SignTool/src/FileSignInfo.cs
+++ b/src/Microsoft.DotNet.SignTool/src/FileSignInfo.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Immutable;

--- a/src/Microsoft.DotNet.SignTool/src/Hash.cs
+++ b/src/Microsoft.DotNet.SignTool/src/Hash.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.SignTool/src/SignInfo.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignInfo.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Microsoft.DotNet.SignTool/src/SignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignTool.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.SignTool/src/SignToolArgs.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolArgs.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.SignTool
 {

--- a/src/Microsoft.DotNet.SignTool/src/SignToolConstants.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolConstants.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.SignTool/src/SignedFileContentKey.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignedFileContentKey.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Immutable;

--- a/src/Microsoft.DotNet.SignTool/src/ValidationOnlySignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ValidationOnlySignTool.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.IO;
 using Microsoft.Build.Framework;

--- a/src/Microsoft.DotNet.SignTool/src/ZipData.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ZipData.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.SignTool/src/ZipPart.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ZipPart.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.SignTool
 {

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/ClientHelpers.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/ClientHelpers.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Text;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/DependencyUpdateResults.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/DependencyUpdateResults.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Dependencies;
 using Microsoft.DotNet.VersionTools.Dependencies.BuildOutput;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/DependencyUpdateUtils.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/DependencyUpdateUtils.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Dependencies;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/GitHubApi/GitHubApiModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/GitHubApi/GitHubApiModel.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Newtonsoft.Json;
 

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/GitHubApi/GitHubClient.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/GitHubApi/GitHubClient.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/GitHubApi/HttpFailureResponseException.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/GitHubApi/HttpFailureResponseException.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Net;
 using System.Net.Http;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/GitHubApi/IGitHubClient.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/GitHubApi/IGitHubClient.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading.Tasks;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/GitHubApi/NotFastForwardUpdateException.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/GitHubApi/NotFastForwardUpdateException.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/GitHubAuth.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/GitHubAuth.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/GitHubBranch.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/GitHubBranch.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/GitHubProject.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/GitHubProject.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/GitHubVersionsRepoUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/GitHubVersionsRepoUpdater.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
 using System;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/IUpdateBranchNamingStrategy.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/IUpdateBranchNamingStrategy.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.VersionTools.Automation
 {

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/LocalVersionsRepoUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/LocalVersionsRepoUpdater.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
 using System;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/NupkgInfo.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/NupkgInfo.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using NuGet.Packaging;
 using NuGet.Packaging.Core;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/PullRequestCreator.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/PullRequestCreator.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
 using Microsoft.DotNet.VersionTools.Util;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/PullRequestOptions.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/PullRequestOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.VersionTools.Automation
 {

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/SingleBranchNamingStrategy.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/SingleBranchNamingStrategy.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.VersionTools.Automation
 {

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/VersionsRepoUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/VersionsRepoUpdater.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
 using System;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/VstsApi/VstsAdapterClient.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/VstsApi/VstsAdapterClient.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
 using Newtonsoft.Json;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/VstsApi/VstsApiModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/VstsApi/VstsApiModel.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildInfo.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildInfo.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Newtonsoft.Json;
 using NuGet.Versioning;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/BuildManifestChange.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/BuildManifestChange.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.BuildManifest.Model;
 using System;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/BuildManifestClient.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/BuildManifestClient.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Automation;
 using Microsoft.DotNet.VersionTools.Automation.GitHubApi;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/BuildManifestLocation.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/BuildManifestLocation.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Automation;
 using System;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/JoinSemaphoreGroup.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/JoinSemaphoreGroup.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/ManifestChangeOutOfDateException.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/ManifestChangeOutOfDateException.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/ArtifactSet.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/ArtifactSet.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/BlobArtifactModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/BlobArtifactModel.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Util;
 using System;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/BuildIdentity.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/BuildIdentity.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Util;
 using System;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/BuildModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/BuildModel.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Xml.Linq;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/EndpointModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/EndpointModel.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Util;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/OrchestratedBuildModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/OrchestratedBuildModel.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/PackageArtifactModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/PackageArtifactModel.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Util;
 using System;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/SemaphoreModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/SemaphoreModel.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
 {

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/SigningInformationModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/SigningInformationModel.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Util;
 using System;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/XElementParsingExtensions.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/XElementParsingExtensions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/SupplementaryUploadRequest.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/SupplementaryUploadRequest.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.VersionTools.BuildManifest
 {

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/VersionIdentifier.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/VersionIdentifier.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/BuildManifest/OrchestratedBuildDependencyInfo.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/BuildManifest/OrchestratedBuildDependencyInfo.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Automation;
 using Microsoft.DotNet.VersionTools.BuildManifest;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/BuildManifest/OrchestratedBuildIdentityMatch.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/BuildManifest/OrchestratedBuildIdentityMatch.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.BuildManifest.Model;
 using System;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/BuildOutput/BuildDependencyInfo.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/BuildOutput/BuildDependencyInfo.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using NuGet.Packaging.Core;
 using NuGet.Versioning;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/BuildOutput/FilePackageUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/BuildOutput/FilePackageUpdater.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/BuildOutput/FileRegexPackageUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/BuildOutput/FileRegexPackageUpdater.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/BuildOutput/FileRegexReleaseUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/BuildOutput/FileRegexReleaseUpdater.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/BuildOutput/OrchestratedBuild/FileOrchestratedBuildCustomUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/BuildOutput/OrchestratedBuild/FileOrchestratedBuildCustomUpdater.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Dependencies.BuildManifest;
 using System;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/BuildOutput/OrchestratedBuild/FileRegexOrchestratedBuildCustomUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/BuildOutput/OrchestratedBuild/FileRegexOrchestratedBuildCustomUpdater.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Dependencies.BuildManifest;
 using Microsoft.DotNet.VersionTools.Util;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/BuildOutput/OrchestratedBuild/OrchestratedBuildUpdateHelpers.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/BuildOutput/OrchestratedBuild/OrchestratedBuildUpdateHelpers.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.BuildManifest.Model;
 using Microsoft.DotNet.VersionTools.Dependencies.BuildManifest;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/BuildOutput/ProjectJsonUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/BuildOutput/ProjectJsonUpdater.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Util;
 using Newtonsoft.Json;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/BuildOutput/ToolVersionsUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/BuildOutput/ToolVersionsUpdater.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Util;
 using System;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/DependencyReplacement.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/DependencyReplacement.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Util;
 using System;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/DependencyUpdateTask.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/DependencyUpdateTask.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Automation;
 using System;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/FileRegexUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/FileRegexUpdater.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Util;
 using System;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/FileUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/FileUpdater.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Util;
 using System;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/IDependencyInfo.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/IDependencyInfo.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.VersionTools.Dependencies
 {

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/IDependencyUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/IDependencyUpdater.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/Submodule/IndicatorPackageSubmoduleUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/Submodule/IndicatorPackageSubmoduleUpdater.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Dependencies.BuildOutput;
 using NuGet.Packaging.Core;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/Submodule/LatestCommitSubmoduleUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/Submodule/LatestCommitSubmoduleUpdater.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/Submodule/OrchestratedBuildSubmoduleUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/Submodule/OrchestratedBuildSubmoduleUpdater.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Dependencies.BuildManifest;
 using Microsoft.DotNet.VersionTools.Util;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/Submodule/SubmoduleDependencyInfo.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/Submodule/SubmoduleDependencyInfo.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/Submodule/SubmoduleUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/Submodule/SubmoduleUpdater.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Dependencies.BuildOutput;
 using Microsoft.DotNet.VersionTools.Util;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Util/ArgumentEscaper.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Util/ArgumentEscaper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Util/Command.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Util/Command.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Util/CommandResult.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Util/CommandResult.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Text;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Util/EnumerableExtensions.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Util/EnumerableExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Util/FileUtils.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Util/FileUtils.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Util/GitCommand.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Util/GitCommand.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
 using System.Linq;

--- a/src/Microsoft.DotNet.VersionTools/tasks/src/BaseDependenciesTask.cs
+++ b/src/Microsoft.DotNet.VersionTools/tasks/src/BaseDependenciesTask.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.VersionTools/tasks/src/LocalUpdatePublishedVersions.cs
+++ b/src/Microsoft.DotNet.VersionTools/tasks/src/LocalUpdatePublishedVersions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.VersionTools/tasks/src/MsBuildTraceListener.cs
+++ b/src/Microsoft.DotNet.VersionTools/tasks/src/MsBuildTraceListener.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.VersionTools/tasks/src/PullRequestServiceType.cs
+++ b/src/Microsoft.DotNet.VersionTools/tasks/src/PullRequestServiceType.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.Build.Tasks.VersionTools
 {

--- a/src/Microsoft.DotNet.VersionTools/tasks/src/SubmitPullRequest.cs
+++ b/src/Microsoft.DotNet.VersionTools/tasks/src/SubmitPullRequest.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.VersionTools/tasks/src/TraceListenerCollectionExtensions.cs
+++ b/src/Microsoft.DotNet.VersionTools/tasks/src/TraceListenerCollectionExtensions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Utilities;
 using System;

--- a/src/Microsoft.DotNet.VersionTools/tasks/src/UpdateDependencies.cs
+++ b/src/Microsoft.DotNet.VersionTools/tasks/src/UpdateDependencies.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Automation;
 using System.Linq;

--- a/src/Microsoft.DotNet.VersionTools/tasks/src/UpdatePublishedVersions.cs
+++ b/src/Microsoft.DotNet.VersionTools/tasks/src/UpdatePublishedVersions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Microsoft.DotNet.VersionTools/tasks/src/UpdateToRemoteDependencies.cs
+++ b/src/Microsoft.DotNet.VersionTools/tasks/src/UpdateToRemoteDependencies.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.VersionTools.Automation;

--- a/src/Microsoft.DotNet.VersionTools/tasks/src/VerifyDependencies.cs
+++ b/src/Microsoft.DotNet.VersionTools/tasks/src/VerifyDependencies.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Automation;
 using Microsoft.DotNet.VersionTools.Dependencies;

--- a/src/Microsoft.DotNet.VersionTools/tests/BuildManifest/BuildManifestClientTests.cs
+++ b/src/Microsoft.DotNet.VersionTools/tests/BuildManifest/BuildManifestClientTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Automation;
 using Microsoft.DotNet.VersionTools.Automation.GitHubApi;

--- a/src/Microsoft.DotNet.VersionTools/tests/BuildManifest/ManifestModelTests.cs
+++ b/src/Microsoft.DotNet.VersionTools/tests/BuildManifest/ManifestModelTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using Microsoft.DotNet.VersionTools.BuildManifest.Model;

--- a/src/Microsoft.DotNet.VersionTools/tests/BuildManifest/VersionIdentiferTests.cs
+++ b/src/Microsoft.DotNet.VersionTools/tests/BuildManifest/VersionIdentiferTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.IO;

--- a/src/Microsoft.DotNet.VersionTools/tests/BuildManifest/VersionIdentifierTestAsset.cs
+++ b/src/Microsoft.DotNet.VersionTools/tests/BuildManifest/VersionIdentifierTestAsset.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.VersionTools.Tests.BuildManifest
 {

--- a/src/Microsoft.DotNet.VersionTools/tests/Util/XunitTraceListener.cs
+++ b/src/Microsoft.DotNet.VersionTools/tests/Util/XunitTraceListener.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
 using System.Text;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ActiveIssueAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ActiveIssueAttribute.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit.Sdk;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ConditionalClassAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ConditionalClassAttribute.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit.Sdk;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ConditionalFactAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ConditionalFactAttribute.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit.Sdk;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ConditionalTheoryAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ConditionalTheoryAttribute.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit.Sdk;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/OuterLoopAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/OuterLoopAttribute.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit.Sdk;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/PlatformSpecificAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/PlatformSpecificAttribute.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit.Sdk;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnCIAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnCIAttribute.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit.Sdk;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnCoreClrAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnCoreClrAttribute.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit.Sdk;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnMonoAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnMonoAttribute.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit.Sdk;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnTargetFrameworkAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnTargetFrameworkAttribute.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit.Sdk;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/TestCategoryAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/TestCategoryAttribute.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit.Sdk;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/DesktopTraceListener.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/DesktopTraceListener.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ActiveIssueDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ActiveIssueDiscoverer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ConditionalClassDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ConditionalClassDiscoverer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ConditionalFactDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ConditionalFactDiscoverer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ConditionalTestDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ConditionalTestDiscoverer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ConditionalTheoryDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ConditionalTheoryDiscoverer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/OuterLoopTestsDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/OuterLoopTestsDiscoverer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using Xunit.Abstractions;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/PlatformSpecificDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/PlatformSpecificDiscoverer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCIDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCIDiscoverer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCoreClrDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCoreClrDiscoverer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnMonoDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnMonoDiscoverer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnTargetFrameworkDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnTargetFrameworkDiscoverer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/TestCategoryDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/TestCategoryDiscoverer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Extensions/TheoryExtensions.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Extensions/TheoryExtensions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeConfiguration.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeConfiguration.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeTestModes.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeTestModes.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.DotNet.XUnitExtensions/src/SkippedFactTestCase.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/SkippedFactTestCase.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/SkippedTestCase.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/SkippedTestCase.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/SkippedTestMessageBus.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/SkippedTestMessageBus.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/SkippedTheoryTestCase.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/SkippedTheoryTestCase.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/TargetFrameworkMonikers.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/TargetFrameworkMonikers.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.DotNet.XUnitExtensions/src/TestPlatforms.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/TestPlatforms.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.DotNet.XUnitExtensions/src/TestRuntimes.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/TestRuntimes.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.DotNet.XUnitExtensions/src/XunitConstants.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/XunitConstants.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.DotNet.XUnitExtensions/tests/AlphabeticalOrderer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/tests/AlphabeticalOrderer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.XUnitExtensions/tests/ConditionalAttributeTests.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/tests/ConditionalAttributeTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Xunit;
 

--- a/src/SignCheck/Microsoft.SignCheck/Interop/ICLRStrongName.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/ICLRStrongName.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.CompilerServices;

--- a/src/SignCheck/Microsoft.SignCheck/Interop/Ole32.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/Ole32.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/DllCharacteristics.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/DllCharacteristics.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.SignCheck.Interop.PortableExecutable
 {

--- a/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/ImageCor20Header.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/ImageCor20Header.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/ImageDataDirectory.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/ImageDataDirectory.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/ImageDosHeader.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/ImageDosHeader.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/ImageFileCharacteristics.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/ImageFileCharacteristics.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/ImageFileHeader.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/ImageFileHeader.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/ImageMagic.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/ImageMagic.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/ImageNTHeaders.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/ImageNTHeaders.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/ImageOptionalHeader.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/ImageOptionalHeader.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/ImageSectionHeader.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/ImageSectionHeader.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/PortableExecutableHeader.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/PortableExecutableHeader.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/SubSystem.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/SubSystem.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.SignCheck.Interop.PortableExecutable
 {

--- a/src/SignCheck/Microsoft.SignCheck/Interop/Provider.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/Provider.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.SignCheck.Interop
 {

--- a/src/SignCheck/Microsoft.SignCheck/Interop/RevocationChecks.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/RevocationChecks.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.SignCheck.Interop
 {

--- a/src/SignCheck/Microsoft.SignCheck/Interop/STGM.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/STGM.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/SignCheck/Microsoft.SignCheck/Interop/StateAction.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/StateAction.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.SignCheck.Interop
 {

--- a/src/SignCheck/Microsoft.SignCheck/Interop/StructuredStorage.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/StructuredStorage.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/SignCheck/Microsoft.SignCheck/Interop/UIChoice.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/UIChoice.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.SignCheck.Interop
 {

--- a/src/SignCheck/Microsoft.SignCheck/Interop/UnionChoice.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/UnionChoice.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.SignCheck.Interop
 {

--- a/src/SignCheck/Microsoft.SignCheck/Interop/WinCrypt.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/WinCrypt.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/SignCheck/Microsoft.SignCheck/Interop/WinTrust.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/WinTrust.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/SignCheck/Microsoft.SignCheck/Interop/WinTrustData.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/WinTrustData.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/SignCheck/Microsoft.SignCheck/Interop/WinTrustFileInfo.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/WinTrustFileInfo.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/SignCheck/Microsoft.SignCheck/Logging/ConsoleLogger.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Logging/ConsoleLogger.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/SignCheck/Microsoft.SignCheck/Logging/FileLogger.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Logging/FileLogger.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/SignCheck/Microsoft.SignCheck/Logging/ILogger.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Logging/ILogger.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.SignCheck.Logging
 {

--- a/src/SignCheck/Microsoft.SignCheck/Logging/Log.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Logging/Log.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/SignCheck/Microsoft.SignCheck/Logging/LogVerbosity.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Logging/LogVerbosity.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.SignCheck.Logging
 {

--- a/src/SignCheck/Microsoft.SignCheck/Logging/LoggerBase.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Logging/LoggerBase.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.SignCheck.Logging
 {

--- a/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
+++ b/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(MSBuildThisFileDirectory)\ResxWorkaround.props" />
   <PropertyGroup>

--- a/src/SignCheck/Microsoft.SignCheck/Utils.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Utils.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Security.Cryptography;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/ArchiveVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/ArchiveVerifier.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/AuthentiCode.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/AuthentiCode.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.SignCheck.Interop;
 using System;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/AuthentiCodeVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/AuthentiCodeVerifier.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/CabVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/CabVerifier.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.SignCheck.Logging;
 

--- a/src/SignCheck/Microsoft.SignCheck/Verification/DetailKeys.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/DetailKeys.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.SignCheck.Verification
 {

--- a/src/SignCheck/Microsoft.SignCheck/Verification/Exclusion.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Exclusion.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/Exclusions.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Exclusions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/ExeVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/ExeVerifier.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/FileHeaders.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/FileHeaders.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/FileVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/FileVerifier.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/Jar/JarAttributes.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Jar/JarAttributes.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/Jar/JarError.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Jar/JarError.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/Jar/JarFile.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Jar/JarFile.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/Jar/JarIndividualEntry.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Jar/JarIndividualEntry.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/Jar/JarIndividualSection.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Jar/JarIndividualSection.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/Jar/JarManifestFile.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Jar/JarManifestFile.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/Jar/JarManifestFileBase.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Jar/JarManifestFileBase.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/Jar/JarSignatureFile.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Jar/JarSignatureFile.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/Jar/JarUtils.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Jar/JarUtils.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/JarVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/JarVerifier.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/LZMAUtils.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/LZMAUtils.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/LzmaVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/LzmaVerifier.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.IO;
 using Microsoft.SignCheck.Logging;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/MsiVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/MsiVerifier.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/MspVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/MspVerifier.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.IO;
 using Microsoft.SignCheck.Interop;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/MsuVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/MsuVerifier.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/NupkgVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/NupkgVerifier.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 
 using System.Collections.Generic;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/PortableExecutableVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/PortableExecutableVerifier.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.SignCheck.Interop.PortableExecutable;
 using Microsoft.SignCheck.Logging;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationManager.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationManager.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationOptions.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationOptions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationResult.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationResult.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/StrongName.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/StrongName.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/Timestamp.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Timestamp.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/SignCheck/Microsoft.SignCheck/Verification/UnsupportedFileVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/UnsupportedFileVerifier.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.SignCheck.Verification
 {

--- a/src/SignCheck/Microsoft.SignCheck/Verification/VsixVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/VsixVerifier.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/XmlVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/XmlVerifier.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections;
 using System.Linq;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/ZipVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/ZipVerifier.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.SignCheck.Logging;
 

--- a/src/SignCheck/SignCheck/FileStatus.cs
+++ b/src/SignCheck/SignCheck/FileStatus.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/SignCheck/SignCheck/Microsoft.DotNet.SignCheck.csproj
+++ b/src/SignCheck/SignCheck/Microsoft.DotNet.SignCheck.csproj
@@ -1,4 +1,4 @@
-﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(MSBuildThisFileDirectory)/../Microsoft.SignCheck/ResxWorkaround.props" />
   <PropertyGroup>

--- a/src/SignCheck/SignCheck/Options.cs
+++ b/src/SignCheck/SignCheck/Options.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using CommandLine;
 using Microsoft.SignCheck.Logging;

--- a/src/SignCheck/SignCheck/SignCheck.cs
+++ b/src/SignCheck/SignCheck/SignCheck.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/SignCheck/SignCheck/SignCheckTask.cs
+++ b/src/SignCheck/SignCheck/SignCheckTask.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using Microsoft.SignCheck.Logging;

--- a/src/SignCheck/SignCheck/Utils.cs
+++ b/src/SignCheck/SignCheck/Utils.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.IO;


### PR DESCRIPTION
Similar to https://github.com/dotnet/runtime/pull/41783 for arcade.
cc @jkotas