### PR TITLE
Fix GetTargetFrameworks calculation with 5.0 SDK

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/ChooseBestP2PTargetFrameworkTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/ChooseBestP2PTargetFrameworkTask.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk
             for (int i = 0; i < ProjectReferencesWithTargetFrameworks.Length; i++)
             {
                 ITaskItem projectReference = ProjectReferencesWithTargetFrameworks[i];
-                string[] targetFrameworks = projectReference.GetMetadata("TargetFrameworks").Split(';');
+                string[] targetFrameworks = projectReference.GetMetadata("RawTargetFrameworks").Split(';');
                 
                 string bestTargetFramework = targetFrameworkResolver.GetBestSupportedTargetFramework(targetFrameworks, TargetFramework);
                 if (bestTargetFramework == null)

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/ChooseBestP2PTargetFrameworkTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/ChooseBestP2PTargetFrameworkTask.cs
@@ -28,7 +28,12 @@ namespace Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk
             for (int i = 0; i < ProjectReferencesWithTargetFrameworks.Length; i++)
             {
                 ITaskItem projectReference = ProjectReferencesWithTargetFrameworks[i];
-                string[] targetFrameworks = projectReference.GetMetadata("RawTargetFrameworks").Split(';');
+                string targetFrameworksValue = projectReference.GetMetadata("RawTargetFrameworks");
+                if (string.IsNullOrEmpty(targetFrameworksValue))
+                {
+                    targetFrameworksValue = projectReference.GetMetadata("TargetFrameworks");
+                }
+                string[] targetFrameworks = targetFrameworksValue.Split(';');
                 
                 string bestTargetFramework = targetFrameworkResolver.GetBestSupportedTargetFramework(targetFrameworks, TargetFramework);
                 if (bestTargetFramework == null)

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.props
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.props
@@ -1,11 +1,18 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
-<Project TreatAsLocalProperty="TargetFramework">  
+<Project TreatAsLocalProperty="TargetFramework">
+  <!-- Add unparsed TargetFrameworks property to GetTargetFrameworks return item metadata to read from it later. -->
+  <ItemDefinitionGroup>
+    <_ThisProjectBuildMetadata>
+      <RawTargetFrameworks>$(TargetFrameworks)</RawTargetFrameworks>
+    </_ThisProjectBuildMetadata>
+  </ItemDefinitionGroup>
+
   <PropertyGroup>
     <DotNetBuildTasksTargetFrameworkSdkAssembly Condition="'$(DotNetBuildTasksTargetFrameworkSdkAssembly)' == '' AND '$(MSBuildRuntimeType)' == 'core'">..\tools\netcoreapp2.1\Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.dll</DotNetBuildTasksTargetFrameworkSdkAssembly>
     <DotNetBuildTasksTargetFrameworkSdkAssembly Condition="'$(DotNetBuildTasksTargetFrameworkSdkAssembly)' == '' AND '$(MSBuildRuntimeType)' != 'core'">..\tools\net472\Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.dll</DotNetBuildTasksTargetFrameworkSdkAssembly>
     <_OriginalTargetFramework>$(TargetFramework)</_OriginalTargetFramework>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="$(TargetFramework.Contains('-'))">
     <TargetFrameworkSuffix>$(TargetFramework.SubString($([MSBuild]::Add($(TargetFramework.IndexOf('-')), 1))))</TargetFrameworkSuffix>
     <TargetFramework>$(TargetFramework.SubString(0, $(TargetFramework.IndexOf('-'))))</TargetFramework>

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
@@ -25,7 +25,6 @@
     As _InnerBuildProjects items are used in the GetTargetFrameworks path as well (>= .NET 5), we restore the item state.
   -->
   <Target Name="RestoreInnerBuildProjects"
-          BeforeTargets="GetTargetFrameworksWithPlatformFromInnerBuilds"
           AfterTargets="DispatchToInnerBuilds"
           Condition="'@(_OriginalInnerBuildProjects)' != ''">
     <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
@@ -14,8 +14,22 @@
           BeforeTargets="DispatchToInnerBuilds"
           DependsOnTargets="GetProjectWithBestTargetFrameworks">
     <ItemGroup>
+      <_OriginalInnerBuildProjects Include="@(_InnerBuildProjects)" />
       <_InnerBuildProjects Remove="@(_InnerBuildProjects)" />
-      <_InnerBuildProjects Include="@(InnerBuildProjectsWithBestTargetFramework)" />
+      <_InnerBuildProjects Include="@(InnerBuildProjectsWithBestTargetFramework->Distinct())" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    We filter _InnerBuildProjects items during DispatchToInnerBuilds to only run for best target frameworks.
+    As _InnerBuildProjects items are used in the GetTargetFrameworks path as well (>= .NET 5), we restore the item state.
+  -->
+  <Target Name="RestoreInnerBuildProjects"
+          BeforeTargets="GetTargetFrameworksWithPlatformFromInnerBuilds"
+          Condition="'@(_OriginalInnerBuildProjects)' != ''">
+    <ItemGroup>
+      <_InnerBuildProjects Remove="@(_InnerBuildProjects)" />
+      <_InnerBuildProjects Include="@(_OriginalInnerBuildProjects)" />
     </ItemGroup>
   </Target>
   

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
@@ -16,7 +16,7 @@
     <ItemGroup>
       <_OriginalInnerBuildProjects Include="@(_InnerBuildProjects)" />
       <_InnerBuildProjects Remove="@(_InnerBuildProjects)" />
-      <_InnerBuildProjects Include="@(InnerBuildProjectsWithBestTargetFramework->Distinct())" />
+      <_InnerBuildProjects Include="@(InnerBuildProjectsWithBestTargetFramework)" />
     </ItemGroup>
   </Target>
 

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
@@ -26,6 +26,7 @@
   -->
   <Target Name="RestoreInnerBuildProjects"
           BeforeTargets="GetTargetFrameworksWithPlatformFromInnerBuilds"
+          AfterTargets="DispatchToInnerBuilds"
           Condition="'@(_OriginalInnerBuildProjects)' != ''">
     <ItemGroup>
       <_InnerBuildProjects Remove="@(_InnerBuildProjects)" />


### PR DESCRIPTION
https://github.com/dotnet/msbuild/commit/79ab985eb5b6552d96d237d4179237b4b850ca64 changed the GetTargetFrameworks path so that it calls into the inner build projects. We filter the internal _InnerBuildProjects items to only dispatch to selected projects. As these items are now also used in the target framework calculation path, we need to restore the original set of inner build projects to return the correct set of projects with their matching tfm information.

Tested the change locally with dotnet/runtime.

cc @dsplaisted 