### PR TITLE
Package signtool as NOT a development dependency

### DIFF
--- a/src/Microsoft.DotNet.SignTool/Microsoft.DotNet.SignTool.csproj
+++ b/src/Microsoft.DotNet.SignTool/Microsoft.DotNet.SignTool.csproj
@@ -9,6 +9,8 @@
     <Description>Build artifact signing tool</Description>
     <PackageTags>Arcade Build Tool Signing</PackageTags>
     <DevelopmentDependency>false</DevelopmentDependency>
+    <!-- NU5128 is required because we are packaging identical assemblies in tools and lib folders
+         See https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5128 -->
     <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
   <ItemGroup>
@@ -32,7 +34,7 @@
     <Reference Include="WindowsBase"/>
   </ItemGroup>
 
-
+  <!-- Copy assemblies into lib folder so they can be used as a development dependency -->
   <Target Name="PackageAssembliesInLib" BeforeTargets="GenerateNuspec">
     <ItemGroup>
       <_PackageFiles Include="@(_PackageFiles)" Condition="$([System.String]::Copy(%(_PackageFiles.PackagePath)).Contains('tools/'))">

--- a/src/Microsoft.DotNet.SignTool/Microsoft.DotNet.SignTool.csproj
+++ b/src/Microsoft.DotNet.SignTool/Microsoft.DotNet.SignTool.csproj
@@ -8,7 +8,8 @@
     <IsPackable>true</IsPackable>
     <Description>Build artifact signing tool</Description>
     <PackageTags>Arcade Build Tool Signing</PackageTags>
-    <DevelopmentDependency>true</DevelopmentDependency>
+    <DevelopmentDependency>false</DevelopmentDependency>
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Common\AssemblyResolution.cs" Link="src\AssemblyResolution.cs" />
@@ -30,6 +31,15 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="WindowsBase"/>
   </ItemGroup>
+
+
+  <Target Name="PackageAssembliesInLib" BeforeTargets="GenerateNuspec">
+    <ItemGroup>
+      <_PackageFiles Include="@(_PackageFiles)" Condition="$([System.String]::Copy(%(_PackageFiles.PackagePath)).Contains('tools/'))">
+        <PackagePath>$([System.String]::Copy('%(PackagePath)').Replace('tools', 'lib'))</PackagePath>
+      </_PackageFiles>
+    </ItemGroup>
+  </Target>
 
   <Import Project="$(RepoRoot)eng\BuildTask.targets" />
 </Project>


### PR DESCRIPTION
This change allows us to use signtool as a package library.

Validated no regressions in function with https://dnceng.visualstudio.com/internal/_build/results?buildId=808166&

@missymessa , I'll setup a branch with the project I used to validate functionality of signtool as a package library, so you can use it as reference.