### PR TITLE
Add CertificatesSignInfo to asset manifest

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Amazon.S3;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.DotNet.Build.Tasks.Feed.Model;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/GenerateBuildManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/GenerateBuildManifest.cs
@@ -70,6 +70,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         /// </summary>
         public ITaskItem[] FileExtensionSignInfo { get; set; }
 
+        public ITaskItem[] CertificatesSignInfo { get; set; }
+
         /// <summary>
         /// The CI build ID.
         /// </summary>
@@ -129,6 +131,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     StrongNameSignInfo,
                     FileSignInfo,
                     FileExtensionSignInfo,
+                    CertificatesSignInfo,
                     BuildId,
                     BuildData,
                     RepoUri,

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
@@ -46,6 +46,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public ITaskItem[] FileExtensionSignInfo { get; set; }
 
+        public ITaskItem[] CertificatesSignInfo { get; set; }
+
         public string AssetManifestPath { get; set; }
 
         public bool IsStableBuild { get; set; }
@@ -167,7 +169,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     }
                     
                     SigningInformationModel signingInformationModel = BuildManifestUtil.CreateSigningInformationModelFromItems(AzureDevOpsCollectionUri, AzureDevOpsProject, AzureDevOpsBuildId,
-                        ItemsToSign, StrongNameSignInfo, FileSignInfo, FileExtensionSignInfo);
+                        ItemsToSign, StrongNameSignInfo, FileSignInfo, FileExtensionSignInfo, CertificatesSignInfo);
 
                     BuildManifestUtil.CreateBuildManifest(Log,
                         blobArtifacts,


### PR DESCRIPTION
Adds CertificatesSignInfo to asset manifest.

Validated with https://dnceng.visualstudio.com/internal/_build/results?buildId=810113&view=results

This doesn't update the merged manifest, I need to look into that next.