### PR TITLE
Add IgnorePatterns for flexible prebuilt baselines

### DIFF
--- a/Arcade.sln
+++ b/Arcade.sln
@@ -115,6 +115,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AttributeDifference.Contrac
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.SourceBuild.Tasks", "src\Microsoft.DotNet.SourceBuild\tasks\Microsoft.DotNet.SourceBuild.Tasks.csproj", "{F9D72AF5-9320-43C8-A24F-CBE294FCED0A}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.SourceBuild.Tasks.Tests", "src\Microsoft.DotNet.SourceBuild\tests\Microsoft.DotNet.SourceBuild.Tasks.Tests.csproj", "{CE5278A3-2442-4309-A543-5BA5C1C76A2A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -709,6 +711,18 @@ Global
 		{F9D72AF5-9320-43C8-A24F-CBE294FCED0A}.Release|x64.Build.0 = Release|Any CPU
 		{F9D72AF5-9320-43C8-A24F-CBE294FCED0A}.Release|x86.ActiveCfg = Release|Any CPU
 		{F9D72AF5-9320-43C8-A24F-CBE294FCED0A}.Release|x86.Build.0 = Release|Any CPU
+		{CE5278A3-2442-4309-A543-5BA5C1C76A2A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CE5278A3-2442-4309-A543-5BA5C1C76A2A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CE5278A3-2442-4309-A543-5BA5C1C76A2A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CE5278A3-2442-4309-A543-5BA5C1C76A2A}.Debug|x64.Build.0 = Debug|Any CPU
+		{CE5278A3-2442-4309-A543-5BA5C1C76A2A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CE5278A3-2442-4309-A543-5BA5C1C76A2A}.Debug|x86.Build.0 = Debug|Any CPU
+		{CE5278A3-2442-4309-A543-5BA5C1C76A2A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CE5278A3-2442-4309-A543-5BA5C1C76A2A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CE5278A3-2442-4309-A543-5BA5C1C76A2A}.Release|x64.ActiveCfg = Release|Any CPU
+		{CE5278A3-2442-4309-A543-5BA5C1C76A2A}.Release|x64.Build.0 = Release|Any CPU
+		{CE5278A3-2442-4309-A543-5BA5C1C76A2A}.Release|x86.ActiveCfg = Release|Any CPU
+		{CE5278A3-2442-4309-A543-5BA5C1C76A2A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -738,6 +752,7 @@ Global
 		{52E92416-5E5F-4A62-A837-9D8554DD2805} = {6F517597-E9E2-43B2-B7E2-757132EA525C}
 		{6F517597-E9E2-43B2-B7E2-757132EA525C} = {E41E23C4-5CB0-4C61-9E05-EEFFEC4B356D}
 		{1CC55B23-6212-4120-BF52-8DED9CFF9FBC} = {6F517597-E9E2-43B2-B7E2-757132EA525C}
+		{CE5278A3-2442-4309-A543-5BA5C1C76A2A} = {C53DD924-C212-49EA-9BC4-1827421361EF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {32B9C883-432E-4FC8-A1BF-090EB033DD5B}

--- a/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/UsageData.cs
+++ b/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/UsageData.cs
@@ -12,6 +12,7 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
         public string CreatedByRid { get; set; }
         public string[] ProjectDirectories { get; set; }
         public PackageIdentity[] NeverRestoredTarballPrebuilts { get; set; }
+        public UsagePattern[] IgnorePatterns { get; set; }
         public Usage[] Usages { get; set; }
 
         public XElement ToXml() => new XElement(
@@ -28,6 +29,10 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
                 NeverRestoredTarballPrebuilts
                     .OrderBy(id => id)
                     .Select(id => id.ToXElement())),
+            IgnorePatterns?.Any() != true ? null : new XElement(
+                nameof(IgnorePatterns),
+                IgnorePatterns
+                    .Select(p => p.ToXml())),
             Usages?.Any() != true ? null : new XElement(
                 nameof(Usages),
                 Usages
@@ -46,6 +51,10 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
             NeverRestoredTarballPrebuilts =
                 (xml.Element(nameof(NeverRestoredTarballPrebuilts))?.Elements()).NullAsEmpty()
                 .Select(XmlParsingHelpers.ParsePackageIdentity)
+                .ToArray(),
+            IgnorePatterns =
+                (xml.Element(nameof(IgnorePatterns))?.Elements()).NullAsEmpty()
+                .Select(UsagePattern.Parse)
                 .ToArray(),
             Usages =
                 (xml.Element(nameof(Usages))?.Elements()).NullAsEmpty()

--- a/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/UsagePattern.cs
+++ b/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/UsagePattern.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
+{
+    public class UsagePattern
+    {
+        public string IdentityRegex { get; set; }
+
+        public string IdentityGlob { get; set; }
+
+        public XElement ToXml() => new XElement(
+            nameof(UsagePattern),
+            IdentityRegex.ToXAttributeIfNotNull(nameof(IdentityRegex)),
+            IdentityGlob.ToXAttributeIfNotNull(nameof(IdentityGlob)));
+
+        public static UsagePattern Parse(XElement xml) => new UsagePattern
+        {
+            IdentityRegex = xml.Attribute(nameof(IdentityRegex))?.Value,
+            IdentityGlob = xml.Attribute(nameof(IdentityGlob))?.Value
+        };
+
+        public Regex CreateRegex()
+        {
+            if (!string.IsNullOrEmpty(IdentityRegex))
+            {
+                return new Regex(IdentityRegex, RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            }
+
+            if (!string.IsNullOrEmpty(IdentityGlob))
+            {
+                // Escape regex characters like '.', but handle '*' as regex '.*'.
+                string regex = Regex.Escape(IdentityGlob).Replace("\\*", ".*");
+
+                return new Regex(
+                    $"^{regex}$",
+                    RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            }
+
+            return new Regex("");
+        }
+    }
+}

--- a/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/UsageValidationData.cs
+++ b/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/UsageValidationData.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
+{
+    public class UsageValidationData
+    {
+        /// <summary>
+        /// A human-readable report of new and removed prebuilts.
+        /// </summary>
+        public XElement Report { get; set; }
+
+        /// <summary>
+        /// The actual usage data from the build. Can be used as a baseline in future runs.
+        /// </summary>
+        public UsageData ActualUsageData { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/ValidateUsageAgainstBaseline.cs
+++ b/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/ValidateUsageAgainstBaseline.cs
@@ -7,6 +7,7 @@ using NuGet.Packaging.Core;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 
 namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
@@ -48,6 +49,25 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
 
             var baseline = UsageData.Parse(XElement.Parse(baselineText));
 
+            UsageValidationData data = GetUsageValidationData(baseline, used);
+
+            Directory.CreateDirectory(Path.GetDirectoryName(OutputBaselineFile));
+            File.WriteAllText(OutputBaselineFile, data.ActualUsageData.ToXml().ToString());
+
+            Directory.CreateDirectory(Path.GetDirectoryName(OutputReportFile));
+            File.WriteAllText(OutputReportFile, data.Report.ToString());
+
+            return !Log.HasLoggedErrors;
+        }
+
+        public UsageValidationData GetUsageValidationData(UsageData baseline, UsageData used)
+        {
+            // Remove prebuilts from the used data if the baseline says to ignore them. Do this
+            // first, so the new generated baseline doesn't list usages that are ignored by a
+            // pattern anyway.
+            ApplyBaselineIgnorePatterns(used, baseline);
+
+            // Find new, removed, and unchanged usage after filtering patterns.
             Comparison<PackageIdentity> diff = Compare(
                 used.Usages.Select(u => u.GetIdentityWithoutRid()).Distinct(),
                 baseline.Usages.Select(u => u.GetIdentityWithoutRid()).Distinct());
@@ -72,6 +92,7 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
                             .Where(u => diff.Added.Contains(u.GetIdentityWithoutRid()))
                             .Select(u => u.ToXml())));
             }
+
             if (diff.Removed.Any())
             {
                 tellUserToUpdateBaseline = true;
@@ -81,6 +102,7 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
 
                 report.Add(new XElement("Removed", diff.Removed.Select(id => id.ToXElement())));
             }
+
             if (diff.Unchanged.Any())
             {
                 Log.LogMessage(
@@ -113,13 +135,9 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
             {
                 usage.AssetsFile = null;
             }
+
+            used.ProjectDirectories = null;
             used.Usages = used.Usages.Distinct().ToArray();
-
-            Directory.CreateDirectory(Path.GetDirectoryName(OutputBaselineFile));
-            File.WriteAllText(OutputBaselineFile, used.ToXml().ToString());
-
-            Directory.CreateDirectory(Path.GetDirectoryName(OutputReportFile));
-            File.WriteAllText(OutputReportFile, report.ToString());
 
             if (tellUserToUpdateBaseline)
             {
@@ -135,13 +153,37 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
                         $"different from the baseline found at '{BaselineDataFile}'";
                 }
 
-                Log.LogWarning(
+                Log.LogMessage(
+                    MessageImportance.High,
                     $"Prebuilt usages are {baselineNotFoundWarning}. If it's acceptable to " +
                     "update the baseline, copy the contents of the automatically generated " +
                     $"baseline '{OutputBaselineFile}'.");
             }
 
-            return !Log.HasLoggedErrors;
+            return new UsageValidationData
+            {
+                Report = report,
+                ActualUsageData = used
+            };
+        }
+
+        private static void ApplyBaselineIgnorePatterns(UsageData actual, UsageData baseline)
+        {
+            Regex[] ignoreUsageRegexes = baseline.IgnorePatterns.NullAsEmpty()
+                .Select(p => p.CreateRegex())
+                .ToArray();
+
+            actual.IgnorePatterns = baseline.IgnorePatterns;
+
+            var ignoredUsages = actual.Usages
+                .Where(usage =>
+                {
+                    string id = $"{usage.PackageIdentity.Id}/{usage.PackageIdentity.Version}";
+                    return ignoreUsageRegexes.Any(r => r.IsMatch(id));
+                })
+                .ToArray();
+
+            actual.Usages = actual.Usages.Except(ignoredUsages).ToArray();
         }
 
         private static Comparison<T> Compare<T>(IEnumerable<T> actual, IEnumerable<T> baseline)

--- a/src/Microsoft.DotNet.SourceBuild/tests/Microsoft.DotNet.SourceBuild.Tasks.Tests.csproj
+++ b/src/Microsoft.DotNet.SourceBuild/tests/Microsoft.DotNet.SourceBuild.Tasks.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <LangVersion>Latest</LangVersion>
+    <SignAssembly>false</SignAssembly>
+    <!-- Allow these tests to run on a later (e.g. 5.0) runtime if an exact match isn't present. -->
+    <RollForward>Major</RollForward>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\tasks\Microsoft.DotNet.SourceBuild.Tasks.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" Publish="false" />
+    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" Publish="false" />
+    <PackageReference Include="Moq" Version="$(MoqVersion)" />
+    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetVersion)" />
+    <PackageReference Include="NuGet.Packaging" Version="$(NuGetVersion)" />
+    <PackageReference Include="NuGet.ProjectModel" Version="$(NuGetVersion)" />
+    <PackageReference Include="NuGet.Versioning" Version="$(NuGetVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.DotNet.SourceBuild/tests/Microsoft.DotNet.SourceBuild.Tasks.Tests.csproj
+++ b/src/Microsoft.DotNet.SourceBuild/tests/Microsoft.DotNet.SourceBuild.Tasks.Tests.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" Publish="false" />
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" Publish="false" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
+    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <PackageReference Include="NuGet.Frameworks" Version="$(NuGetVersion)" />
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetVersion)" />

--- a/src/Microsoft.DotNet.SourceBuild/tests/ValidateUsageAgainstBaselineTests.cs
+++ b/src/Microsoft.DotNet.SourceBuild/tests/ValidateUsageAgainstBaselineTests.cs
@@ -1,0 +1,117 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Framework;
+using Microsoft.DotNet.SourceBuild.Tasks.UsageReport;
+using Moq;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using System.Linq;
+using System.Xml.Linq;
+using Xunit;
+
+namespace Microsoft.DotNet.SourceBuild.Tasks.Tests
+{
+    public class ValidateUsageAgainstBaselineTests
+    {
+        public Usage SimpleUsage(string idVersion)
+        {
+            var parts = idVersion.Split('/');
+            return new Usage
+            {
+                PackageIdentity = new PackageIdentity(parts[0], NuGetVersion.Parse(parts[1]))
+            };
+        }
+
+        public UsageData SimpleUsageData(params string[] ids) => new UsageData
+        {
+            Usages = ids.Select(SimpleUsage).ToArray()
+        };
+
+        [Fact]
+        public void NewUsageShowsInReport()
+        {
+            var mockEngine = new Mock<IBuildEngine>(MockBehavior.Loose);
+            var task = new ValidateUsageAgainstBaseline { BuildEngine = mockEngine.Object };
+
+            var baseline = SimpleUsageData("A/1.0.0");
+            var used = SimpleUsageData("A/1.0.0", "B/1.0.0");
+            var data = task.GetUsageValidationData(baseline, used);
+
+            Assert.Equal(
+                XElement
+                    .Parse(@"<BaselineComparison> <New> <Usage Id=""B"" Version=""1.0.0"" /> </New> </BaselineComparison>")
+                    .ToString(),
+                data.Report.ToString());
+        }
+
+        [Fact]
+        public void IgnoredNewUsagesAreNotOnGeneratedBaseline()
+        {
+            var mockEngine = new Mock<IBuildEngine>(MockBehavior.Loose);
+            var task = new ValidateUsageAgainstBaseline { BuildEngine = mockEngine.Object };
+
+            var baseline = SimpleUsageData();
+            baseline.IgnorePatterns = new[]
+            {
+                new UsagePattern { IdentityGlob = "A/*" },
+                new UsagePattern { IdentityGlob = "B/*" },
+                new UsagePattern { IdentityRegex = "Ca[tr]/.*" },
+            };
+
+            var used = SimpleUsageData("A/1.0.0", "B/1.0.0", "Cat/1.2.3", "Car/1.4.5");
+
+            var data = task.GetUsageValidationData(baseline, used);
+
+            Assert.Empty(data.ActualUsageData.Usages);
+        }
+
+        [Fact]
+        public void IgnoredBaselineUsagesAreRemoved()
+        {
+            var mockEngine = new Mock<IBuildEngine>(MockBehavior.Loose);
+            var task = new ValidateUsageAgainstBaseline { BuildEngine = mockEngine.Object };
+
+            var baseline = SimpleUsageData("A/1.0.0", "B/1.0.0");
+            baseline.IgnorePatterns = new[]
+            {
+                new UsagePattern { IdentityGlob = "A/*" },
+            };
+
+            var used = SimpleUsageData("A/1.0.0", "B/1.0.0");
+
+            var data = task.GetUsageValidationData(baseline, used);
+
+            Assert.Equal(
+                baseline.Usages.Skip(1).Select(u => u.PackageIdentity).ToArray(),
+                data.ActualUsageData.Usages.Select(u => u.PackageIdentity).ToArray());
+        }
+
+        [Fact]
+        public void IgnorePatternsPassThroughToGeneratedBaseline()
+        {
+            var mockEngine = new Mock<IBuildEngine>(MockBehavior.Loose);
+            var task = new ValidateUsageAgainstBaseline { BuildEngine = mockEngine.Object };
+
+            var baseline = SimpleUsageData();
+            baseline.IgnorePatterns = new[]
+            {
+                new UsagePattern { IdentityGlob = "*/*" },
+                new UsagePattern { IdentityGlob = "Pizza/42.0.0" },
+                new UsagePattern { IdentityRegex = "[Az]*" },
+            };
+
+            var used = SimpleUsageData();
+
+            var data = task.GetUsageValidationData(baseline, used);
+
+            Assert.Equal(baseline.IgnorePatterns.Length, data.ActualUsageData.IgnorePatterns.Length);
+
+            foreach (var (a, b) in baseline.IgnorePatterns.Zip(data.ActualUsageData.IgnorePatterns, (a, b) => (a, b)))
+            {
+                Assert.Equal(a.IdentityGlob, b.IdentityGlob);
+                Assert.Equal(a.IdentityRegex, b.IdentityRegex);
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.SourceBuild/tests/WriteBuildOutputPropsTests.cs
+++ b/src/Microsoft.DotNet.SourceBuild/tests/WriteBuildOutputPropsTests.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Microsoft.DotNet.SourceBuild.Tasks.Tests
+{
+    public class WriteBuildOutputPropsTests
+    {
+        [Fact]
+        public void TestPropertyNameHelpers()
+        {
+            Assert.Equal(
+                "MicrosoftNETCoreAppRefPackageVersion",
+                WriteBuildOutputProps.GetPropertyName("Microsoft.NETCore.App.Ref"));
+
+            Assert.Equal(
+                "MicrosoftNETCoreAppRefVersion",
+                WriteBuildOutputProps.GetAlternatePropertyName("Microsoft.NETCore.App.Ref"));
+        }
+    }
+}


### PR DESCRIPTION
This change adds support for `IgnorePatterns` to the prebuilt usage baseline file. This means a repo on arcade-powered source-build can have this content at `eng/SourceBuildPrebuiltBaseline.xml` to ignore all prebuilt usage when onboarding:

```xml
<UsageData>
  <IgnorePatterns>
    <UsagePattern IdentityGlob="*/*" />
  </IgnorePatterns>
</UsageData>
```

Then, usage can be gradually decreased and the `UsagePattern`s can be tweaked to be more specific to the repo. The eventual goal is to allow necessary prebuilts (e.g. cycles in the dependency graph), but make unexpected new prebuilts show up as PR validation failures. This is for https://github.com/dotnet/source-build/issues/1715

It supports regex via `IdentityRegex` for even more flexibility if needed.

The ignored usage still shows up in the more detailed reports for analysis, but they don't cause an error. (Or cause a warning--because warnings are treated as errors in Arcade.)

I'm also planning to port this to dotnet/source-build for more sustainability there: https://github.com/dotnet/source-build/issues/1726.

This PR also adds a simple test project for a few scenarios I wanted to verify. (This is the test project I tried to add in https://github.com/dotnet/arcade/pull/6121, but I'd backed it out when I didn't want to spend the time to figure out why it was failing in CI.)