### PR TITLE
Update destination for dotnet-cli to avoid collisions

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.targets
@@ -8,7 +8,7 @@
     <ItemGroup>
       <HelixCorrelationPayload Include="dotnet-cli">
         <Uri>$(DotNetCliPackageUri)</Uri>
-        <Destination>dotnet</Destination>
+        <Destination>dotnet-cli</Destination>
       </HelixCorrelationPayload>
     </ItemGroup>
     <PropertyGroup>


### PR DESCRIPTION
In dotnet/runtime we submit our own dotnet host which is used to invoke VSTest's testhost. Still we require a full sdk to invoke dotnet test (which invokes vstest.console). When settings IncludeDotNetCli to true, we get a collision as our dotnet file conflicts with the dotnet folder that is bootstrapped by the Helix SDK. Changing the helix destination for dotnet-cli to dotnet-cli to avoid such collisions.

I expect no one to depend on the hardcoded path as dotnet is added to the %PATH% anyway but before merging this we should double check.

cc @safern @MattGal