### PR TITLE
Filter TargetFrameworks for outer build Clean target

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
@@ -8,10 +8,11 @@
   <PropertyGroup Condition="'$(IsGraphBuild)' == 'true' and '$(MSBuildRestoreSessionId)' != ''">
     <TargetFrameworks Condition="'$(TargetFrameworks)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '(-[^;]+)', ''))</TargetFrameworks>
   </PropertyGroup>
-     
+
+  <!-- We filter _InnerBuildProjects items during DispatchToInnerBuilds and Clean to only run for best target frameworks. -->
   <Target Name="RunOnlyBestTargetFrameworks"
-          Condition="'$(BuildTargetFramework)' != '' or '$(MSBuildProjectExtension)' == '.pkgproj'" 
-          BeforeTargets="DispatchToInnerBuilds"
+          Condition="'$(IsCrossTargetingBuild)' == 'true' and ('$(BuildTargetFramework)' != '' or '$(MSBuildProjectExtension)' == '.pkgproj')" 
+          BeforeTargets="DispatchToInnerBuilds;Clean"
           DependsOnTargets="GetProjectWithBestTargetFrameworks">
     <ItemGroup>
       <_OriginalInnerBuildProjects Include="@(_InnerBuildProjects)" />
@@ -20,12 +21,10 @@
     </ItemGroup>
   </Target>
 
-  <!--
-    We filter _InnerBuildProjects items during DispatchToInnerBuilds to only run for best target frameworks.
-    As _InnerBuildProjects items are used in the GetTargetFrameworks path as well (>= .NET 5), we restore the item state.
-  -->
+  <!-- As _InnerBuildProjects items are used in the GetTargetFrameworks path as well (>= .NET 5), we restore the item state. -->
   <Target Name="RestoreInnerBuildProjects"
-          AfterTargets="DispatchToInnerBuilds"
+          BeforeTargets="GetTargetFrameworksWithPlatformFromInnerBuilds"
+          AfterTargets="DispatchToInnerBuilds;Clean"
           Condition="'@(_OriginalInnerBuildProjects)' != ''">
     <ItemGroup>
       <_InnerBuildProjects Remove="@(_InnerBuildProjects)" />


### PR DESCRIPTION
We filter TargetFrameworks when calling build or any target that uses DispatchToInnerBuilds. We want to keep building and cleaning in sync, we now also filter when invoking Clean without passing in a target framework.

Fixes https://github.com/dotnet/arcade/issues/6139

cc @ericstj 