### PR TITLE
Use Contains to figure out dotnet cli runtime

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
@@ -18,22 +18,22 @@
   <Choose>
     <When Condition=" '$(DotNetCliRuntime)' != '' ">
     </When>
-    <When Condition="$(HelixTargetQueue.ToLowerInvariant().StartsWith('windows')) AND $(HelixTargetQueue.ToLowerInvariant().Contains('arm64'))">
+    <When Condition="$(HelixTargetQueue.ToLowerInvariant().Contains('windows')) AND $(HelixTargetQueue.ToLowerInvariant().Contains('arm64'))">
       <PropertyGroup>
         <DotNetCliRuntime>win-arm64</DotNetCliRuntime>
       </PropertyGroup>
     </When>
-    <When Condition="$(HelixTargetQueue.ToLowerInvariant().StartsWith('windows')) AND $(HelixTargetQueue.ToLowerInvariant().Contains('arm32'))">
+    <When Condition="$(HelixTargetQueue.ToLowerInvariant().Contains('windows')) AND $(HelixTargetQueue.ToLowerInvariant().Contains('arm32'))">
       <PropertyGroup>
         <DotNetCliRuntime>win-arm</DotNetCliRuntime>
       </PropertyGroup>
     </When>
-    <When Condition="$(HelixTargetQueue.ToLowerInvariant().StartsWith('windows'))">
+    <When Condition="$(HelixTargetQueue.ToLowerInvariant().Contains('windows'))">
       <PropertyGroup>
         <DotNetCliRuntime>win-x64</DotNetCliRuntime>
       </PropertyGroup>
     </When>
-    <When Condition="$(HelixTargetQueue.ToLowerInvariant().StartsWith('osx'))">
+    <When Condition="$(HelixTargetQueue.ToLowerInvariant().Contains('osx'))">
       <PropertyGroup>
         <DotNetCliRuntime>osx-x64</DotNetCliRuntime>
       </PropertyGroup>


### PR DESCRIPTION
Special queues like jobs that run inside a docker container can start with a helix friendly job name, i.e `(Windows)helix-queue@docker-image-tag`. 

See comment in: https://github.com/dotnet/runtime/pull/39923#issuecomment-692156342