### PR TITLE
Add support for linux-musl .NET CLI

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
@@ -38,6 +38,21 @@
         <DotNetCliRuntime>osx-x64</DotNetCliRuntime>
       </PropertyGroup>
     </When>
+    <When Condition="$(HelixTargetQueue.ToLowerInvariant().Contains('alpine')) AND $(HelixTargetQueue.ToLowerInvariant().Contains('arm64'))">
+      <PropertyGroup>
+        <DotNetCliRuntime>linux-musl-arm64</DotNetCliRuntime>
+      </PropertyGroup>
+    </When>
+    <When Condition="$(HelixTargetQueue.ToLowerInvariant().Contains('alpine')) AND $(HelixTargetQueue.ToLowerInvariant().Contains('arm32'))">
+      <PropertyGroup>
+        <DotNetCliRuntime>linux-musl-arm</DotNetCliRuntime>
+      </PropertyGroup>
+    </When>
+    <When Condition="$(HelixTargetQueue.ToLowerInvariant().Contains('alpine'))">
+      <PropertyGroup>
+        <DotNetCliRuntime>linux-musl-x64</DotNetCliRuntime>
+      </PropertyGroup>
+    </When>
     <When Condition="$(HelixTargetQueue.ToLowerInvariant().Contains('arm32'))">
       <PropertyGroup>
         <DotNetCliRuntime>linux-arm</DotNetCliRuntime>


### PR DESCRIPTION
We need this support for dotnet/runtime. Didn't do this in a cleaner way, as I wanted the minimal fix since we're going to improve this detection as part of: https://github.com/dotnet/arcade/issues/6166