### PR TITLE
Rename light command packages to wixpacks

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLightCommandPackageDrop.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLightCommandPackageDrop.cs
@@ -24,16 +24,13 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
         public string BuiltOutputsFile { get; set; }
         public ITaskItem [] Sice { get; set; }
 
-        [Output]
-        public string LightCommandPackageNameOutput { get; set; }
         // The light command that was originally used to generate the MSI.  This is purely used for informational purposes
         // and to validate that the light command being created by this task is correct (assist with debugging).
         public string OriginalLightCommand { get; set; }
 
         public override bool Execute()
         {
-            LightCommandPackageNameOutput = Path.GetFileNameWithoutExtension(Out);
-            string packageDropOutputFolder = Path.Combine(LightCommandWorkingDir, LightCommandPackageNameOutput);
+            string packageDropOutputFolder = Path.Combine(LightCommandWorkingDir, Path.GetFileName(InstallerFile));
             ProcessWixCommand(packageDropOutputFolder, "light.exe", OriginalLightCommand);
 
             return !Log.HasLoggedErrors;

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLitCommandPackageDrop.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLitCommandPackageDrop.cs
@@ -28,16 +28,13 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
         /// </summary>
         public bool Bf { get; set; }
 
-        [Output]
-        public string LitCommandPackageNameOutput { get; set; }
         // The lot command that was originally used to generate the wixlib.  This is purely used for informational purposes
         // and to validate that the lit command being created by this task is correct (assist with debugging).
         public string OriginalLitCommand { get; set; }
 
         public override bool Execute()
         {
-            LitCommandPackageNameOutput = Path.GetFileNameWithoutExtension(Out);
-            string packageDropOutputFolder = Path.Combine(LitCommandWorkingDir, LitCommandPackageNameOutput);
+            string packageDropOutputFolder = Path.Combine(LitCommandWorkingDir, Path.GetFileName(InstallerFile));
             ProcessWixCommand(packageDropOutputFolder, "lit.exe", OriginalLitCommand);
 
             return !Log.HasLoggedErrors;

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixCommandPackageDropBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixCommandPackageDropBase.cs
@@ -4,6 +4,7 @@
 using Microsoft.Build.Framework;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Text;
 using System.Xml;
@@ -20,6 +21,7 @@ namespace Microsoft.DotNet.Build.Tasks.Installers.src
         private const int _fieldsArtifactPath3 = 2;
         private const int _fieldsArtifactPath6 = 5;
 
+        private readonly string _packageExtension = ".wixpack.zip";
         public bool NoLogo { get; set; }
         /// <summary>
         /// Additional set of base paths that are used for resolving paths.
@@ -30,10 +32,13 @@ namespace Microsoft.DotNet.Build.Tasks.Installers.src
         /// </summary>
         public ITaskItem[] Loc { get; set; }
         [Required]
-        public string Out { get; set; }
+        public string InstallerFile { get; set; }
         public ITaskItem[] WixExtensions { get; set; }
         [Required]
         public ITaskItem[] WixSrcFiles { get; set; }
+
+        [Output]
+        public string OutputFile { get; set; }
 
         protected abstract void ProcessToolSpecificCommandLineParameters(string packageDropOutputFolder, StringBuilder commandString);
 
@@ -49,12 +54,18 @@ namespace Microsoft.DotNet.Build.Tasks.Installers.src
             ProcessLocFiles(packageDropOutputFolder);
 
             CreateCommandFile(toolExecutable, originalCommand, packageDropOutputFolder);
+
+            OutputFile = $"{InstallerFile}{_packageExtension}";
+            if(File.Exists(OutputFile))
+            {
+                File.Delete(OutputFile);
+            }
+            ZipFile.CreateFromDirectory(packageDropOutputFolder, OutputFile);
         }
 
         private void CreateCommandFile(string toolExecutable, string originalCommand, string packageDropOutputFolder)
         {
-            string toolName = Path.GetFileNameWithoutExtension(toolExecutable);
-            string commandFilename = Path.Combine(packageDropOutputFolder, $"{toolName}.cmd");
+            string commandFilename = Path.Combine(packageDropOutputFolder, $"create.cmd");
             StringBuilder commandString = new StringBuilder();
             commandString.AppendLine("@echo off");
             commandString.AppendLine("setlocal");
@@ -66,12 +77,12 @@ namespace Microsoft.DotNet.Build.Tasks.Installers.src
             commandString.AppendLine(")");
             if (originalCommand != null)
             {
-                commandString.AppendLine($"REM Original {toolName} command");
+                commandString.AppendLine($"REM Original command");
                 commandString.AppendLine($"REM {originalCommand }");
             }
-            commandString.AppendLine("REM Modified {toolName} command");
+            commandString.AppendLine("REM Modified command");
             commandString.Append(toolExecutable);
-            commandString.Append($" -out %outputfolder%{Path.GetFileName(Out)}");
+            commandString.Append($" -out %outputfolder%{Path.GetFileName(InstallerFile)}");
             if (NoLogo)
             {
                 commandString.Append(" -nologo");

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixCommandPackageDropBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixCommandPackageDropBase.cs
@@ -34,9 +34,18 @@ namespace Microsoft.DotNet.Build.Tasks.Installers.src
         [Required]
         public string InstallerFile { get; set; }
         public ITaskItem[] WixExtensions { get; set; }
+
+        /// <summary>
+        /// folder to place wixpackage output file
+        /// </summary>
+        [Required]
+        public string OutputFolder { get; set; }
         [Required]
         public ITaskItem[] WixSrcFiles { get; set; }
 
+        /// <summary>
+        /// path of wixpackage file
+        /// </summary>
         [Output]
         public string OutputFile { get; set; }
 
@@ -55,7 +64,7 @@ namespace Microsoft.DotNet.Build.Tasks.Installers.src
 
             CreateCommandFile(toolExecutable, originalCommand, packageDropOutputFolder);
 
-            OutputFile = $"{InstallerFile}{_packageExtension}";
+            OutputFile = Path.Combine(OutputFolder, $"{Path.GetFileName(InstallerFile)}{_packageExtension}");
             if(File.Exists(OutputFile))
             {
                 File.Delete(OutputFile);

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets
@@ -348,18 +348,16 @@
       LightCommandWorkingDir="$(LightCommandObjDir)"
       NoLogo="true"
       Cultures="en-us"
-      Out="$(OutInstallerFile)"
+      InstallerFile="$(OutInstallerFile)"
       WixExtensions="@(WixExtensions)"
       WixSrcFiles="@(WixSrcFile -> '$(WixObjDir)%(Filename).wixobj');@(DirectoryToHarvest -> '%(WixObjFile)')">
-      <Output TaskParameter="LightCommandPackageNameOutput" PropertyName="_LightCommandPackageNameOutput" />
+      <Output TaskParameter="OutputFile" PropertyName="_LightCommandPackageNameOutput" />
     </CreateLightCommandPackageDrop>
 
-    <MakeDir Directories="$(LightCommandPackagesDir)" />
-
-    <ZipDirectory
-      DestinationFile="$(LightCommandPackagesDir)/LightCommandPackage-$(_LightCommandPackageNameOutput).zip"
-      Overwrite="true"
-      SourceDirectory="$(LightCommandObjDir)/$(_LightCommandPackageNameOutput)" />
+    <Move SourceFiles="$(_LightCommandPackageNameOutput)"
+          DestinationFolder="$(ArtifactsNonShippingPackagesDir)" 
+          OverwriteReadonlyFiles="true"
+          Condition="Exists('$(_LightCommandPackageNameOutput)')" />
   </Target>
 
   <!--

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets
@@ -346,6 +346,7 @@
     <CreateLightCommandPackageDrop
       OriginalLightCommand="$(_lightCommand)"
       LightCommandWorkingDir="$(LightCommandObjDir)"
+      OutputFolder="$(ArtifactsNonShippingPackagesDir)"
       NoLogo="true"
       Cultures="en-us"
       InstallerFile="$(OutInstallerFile)"
@@ -353,11 +354,6 @@
       WixSrcFiles="@(WixSrcFile -> '$(WixObjDir)%(Filename).wixobj');@(DirectoryToHarvest -> '%(WixObjFile)')">
       <Output TaskParameter="OutputFile" PropertyName="_LightCommandPackageNameOutput" />
     </CreateLightCommandPackageDrop>
-
-    <Move SourceFiles="$(_LightCommandPackageNameOutput)"
-          DestinationFolder="$(ArtifactsNonShippingPackagesDir)" 
-          OverwriteReadonlyFiles="true"
-          Condition="Exists('$(_LightCommandPackageNameOutput)')" />
   </Target>
 
   <!--


### PR DESCRIPTION
Rename LightCommandPackages from `LightCommandPackage-*.zip` to `*.wixpack.zip`.

Light and Lit packages both now create wixpacks, and both now have a file inside them named `create.cmd` instead of having `light.cmd` for one and `lit.cmd` for the other.

Also, preserves installer filename extension so we can differentiate a bundled msi (extension `.exe`) from a non-bundled msi (extension `.msi`), and not lose data.

Validated changes in windowsdesktop with https://dnceng.visualstudio.com/internal/_build/results?buildId=814424&view=artifacts&type=publishedArtifacts

I'll file issues to update the runtime, installers, and aspnetcore repos to adapt to the new convention where needed.

