### PR TITLE
Pack arcade-powered source-build intermediate nupkgs before publish step

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -283,11 +283,6 @@
              Targets="@(_SolutionBuildTargets)"
              Condition="'@(_SolutionBuildTargets)' != ''"/>
 
-    <MSBuild Projects="Publish.proj"
-             Properties="@(_PublishProps);_NETCORE_ENGINEERING_TELEMETRY=Publish"
-             Targets="Publish"
-             Condition="'$(Publish)' == 'true' and '$(DotNetBuildFromSource)' != 'true'"/>
-
     <!--
       Perform post-source-build tasks. Validate source-build requirements, such as the prebuilt
       usage baseline, and generate the source-build intermediate nupkg.
@@ -295,5 +290,13 @@
     <MSBuild Projects="SourceBuild\AfterSourceBuild.proj"
              Properties="@(_CommonProps);_NETCORE_ENGINEERING_TELEMETRY=AfterSourceBuild"
              Condition="'$(ArcadeBuildFromSource)' == 'true'"/>
+
+    <!--
+      Publish artifacts.
+    -->
+    <MSBuild Projects="Publish.proj"
+             Properties="@(_PublishProps);_NETCORE_ENGINEERING_TELEMETRY=Publish"
+             Targets="Publish"
+             Condition="'$(Publish)' == 'true' and '$(DotNetBuildFromSource)' != 'true'"/>
   </Target>
 </Project>


### PR DESCRIPTION
In https://github.com/dotnet/arcade/pull/6121, I added `AfterSourceBuild.proj` for prebuilt checks, and moved intermediate nupkg generation to `AfterSourceBuild.proj`. This PR fixes the order so the intermediate nupkg is generated *before* `Publish.proj` runs. Otherwise, the official build fails to find/publish it.

I also added the usual `Publish artifacts.` comment above `Publish.proj` for consistency with the other steps. It might help point out that `Publish.proj` isn't part of `Perform post-source-build tasks`.
