### PR TITLE
Fix path bug in DownloadFromResultsContainer.targets

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/download-results/DownloadFromResultsContainer.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/download-results/DownloadFromResultsContainer.targets
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <HelixResultsDestinationDir Condition="'$(HelixResultsDestinationDir)' == '' AND '$(BUILD_SOURCESDIRECTORY)' != ''">$([MSBuild]::NormalizePath('$(BUILD_SOURCESDIRECTORY)', 'artifacts', helixresults'))</HelixResultsDestinationDir>
+      <HelixResultsDestinationDir Condition="'$(HelixResultsDestinationDir)' == '' AND '$(BUILD_SOURCESDIRECTORY)' != ''">$([MSBuild]::NormalizeDirectory('$(BUILD_SOURCESDIRECTORY)', 'artifacts', helixresults'))</HelixResultsDestinationDir>
 
       <_shouldDownloadResults>false</_shouldDownloadResults>
       <_shouldDownloadResults Condition="'@(_workItemsWithDownloadMetadata)' != '' AND '$(HelixResultsDestinationDir)' != ''">true</_shouldDownloadResults>


### PR DESCRIPTION
Since we're using NormalizePath for a directory, it is evaluating to a literal.

https://dev.azure.com/dnceng/public/_build/results?buildId=814918&view=logs&j=fb000423-50a9-5897-1483-627612d50fb2&t=96127184-4a4c-5e48-afe7-0a46151c4af1

cc: @kunalspathak 