### PR TITLE
Fix VSTest on Windows without globally installed SDK

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VSTest.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VSTest.targets
@@ -45,7 +45,7 @@
           IgnoreExitCode="true"
           Timeout="$(_TestTimeout)"
           <!-- Remove when https://github.com/dotnet/sdk/pull/13619 is merged and consumed. -->
-          EnvironmentVariables="DOTNET_ROOT=$([MSBuild]::ValueOrDefault('$(DOTNET_ROOT)', '$(DotNetTool)'))"
+          EnvironmentVariables="DOTNET_ROOT=$([MSBuild]::ValueOrDefault('$(DOTNET_ROOT)', '$(DotNetRoot)'))"
           ContinueOnError="WarnAndContinue">
       <Output TaskParameter="ExitCode" PropertyName="_TestErrorCode" />
     </Exec>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VSTest.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VSTest.targets
@@ -44,6 +44,8 @@
           WorkingDirectory="$(_TargetDir)"
           IgnoreExitCode="true"
           Timeout="$(_TestTimeout)"
+          <!-- Remove when https://github.com/dotnet/sdk/pull/13619 is merged and consumed. -->
+          EnvironmentVariables="DOTNET_ROOT=$([MSBuild]::ValueOrDefault('$(DOTNET_ROOT)', '$(DotNetTool)'))"
           ContinueOnError="WarnAndContinue">
       <Output TaskParameter="ExitCode" PropertyName="_TestErrorCode" />
     </Exec>


### PR DESCRIPTION
Workaround until tracking issue https://github.com/dotnet/sdk/issues/13611 is fixed. Unblocks https://github.com/mono/linker/pull/1471. Not adding support for x86 intentionally as this is just a workaround.

cc @alexperovich @nohwnd 