### PR TITLE
Update-default-xcopy-msbuild

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -312,7 +312,7 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
     return $global:_MSBuildExe
   }
 
-  $vsMinVersionReqdStr = '16.5'
+  $vsMinVersionReqdStr = '16.8.0-preview3'
   $vsMinVersionReqd = [Version]::new($vsMinVersionReqdStr)
 
   if (!$vsRequirements) { $vsRequirements = $GlobalJson.tools.vs }


### PR DESCRIPTION
As seen here: https://dev.azure.com/dnceng/internal/_build/results?buildId=816756&view=logs&j=0a6c679f-72be-5867-422e-acb741a068a3&t=d8e44ddf-8ea2-5518-25e7-4300471a271a , @ViktorHofer 's recent changes bring us to a version where 16.8 is required. 

