### PR TITLE
Add post-build functionality to SignTool

### DIFF
--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -269,7 +269,7 @@ namespace Microsoft.DotNet.SignTool
             {
                 var orderedItemsToSkipStrongName = ItemsToSkipStrongNameCheckPostBuild.OrderBy(i => i.GetMetadata("BARBuildID")).ToArray();
                 ItemsToSkipStrongNameCheck = new string[orderedItemsToSkipStrongName.Length];
-                Array.Copy(orderedItemsToSkipStrongName, ItemsToSkipStrongNameCheck, orderedItemsToSkipStrongName.Length);
+                Array.Copy(orderedItemsToSkipStrongName.Select(i => i.ItemSpec).ToArray(), ItemsToSkipStrongNameCheck, orderedItemsToSkipStrongName.Length);
             }
 
             // Based on the ordered set of BARBuildIds we start adding TaskItems to a map keeping track of things


### PR DESCRIPTION
Fixes: https://github.com/dotnet/core-eng/issues/10815

Make SignTool understand post-build metadata i.e. having a BARBuildId per item. 

The actual signing doesn't change at all.