### PR TITLE
fix case where output directory doesn't exist

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixCommandPackageDropBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixCommandPackageDropBase.cs
@@ -120,6 +120,10 @@ namespace Microsoft.DotNet.Build.Tasks.Installers.src
             ProcessToolSpecificCommandLineParameters(packageDropOutputFolder, commandString);
             commandString.AppendLine();
             commandString.AppendLine("endlocal");
+            if(!Directory.Exists(packageDropOutputFolder))
+            {
+                Directory.CreateDirectory(packageDropOutputFolder);
+            }
             File.WriteAllText(commandFilename, commandString.ToString());
         }
 


### PR DESCRIPTION
Fixes https://dev.azure.com/dnceng/public/_build/results?buildId=817855&view=logs&j=2222de35-8455-5ef3-8655-d7b771ed54f9&t=661986e5-4210-5432-efd4-be70b326bea0&l=53

```
F:\workspace\_work\1\s\src\Installers\Windows\Wix.targets(93,5): error MSB4018: System.IO.DirectoryNotFoundException: Could not find a part of the path 'F:\workspace\_work\1\s\artifacts\packages\Release\NonShipping\aspnetcore-runtime-5.0.0-ci-win-arm64.msi.wixpack.zip'. [F:\workspace\_work\1\s\src\Installers\Windows\SharedFramework\SharedFramework.wixproj]
F:\workspace\_work\1\s\src\Installers\Windows\Wix.targets(93,5): error MSB4018:    at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath) [F:\workspace\_work\1\s\src\Installers\Windows\SharedFramework\SharedFramework.wixproj]
F:\workspace\_work\1\s\src\Installers\Windows\Wix.targets(93,5): error MSB4018:    at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost) [F:\workspace\_work\1\s\src\Installers\Windows\SharedFramework\SharedFramework.wixproj]
F:\workspace\_work\1\s\src\Installers\Windows\Wix.targets(93,5): error MSB4018:    at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share) [F:\workspace\_work\1\s\src\Installers\Windows\SharedFramework\SharedFramework.wixproj]
F:\workspace\_work\1\s\src\Installers\Windows\Wix.targets(93,5): error MSB4018:    at System.IO.Compression.ZipFile.Open(String archiveFileName, ZipArchiveMode mode, Encoding entryNameEncoding) [F:\workspace\_work\1\s\src\Installers\Windows\SharedFramework\SharedFramework.wixproj]
F:\workspace\_work\1\s\src\Installers\Windows\Wix.targets(93,5): error MSB4018:    at System.IO.Compression.ZipFile.DoCreateFromDirectory(String sourceDirectoryName, String destinationArchiveFileName, Nullable`1 compressionLevel, Boolean includeBaseDirectory, Encoding entryNameEncoding) [F:\workspace\_work\1\s\src\Installers\Windows\SharedFramework\SharedFramework.wixproj]
F:\workspace\_work\1\s\src\Installers\Windows\Wix.targets(93,5): error MSB4018:    at Microsoft.DotNet.Build.Tasks.Installers.src.CreateWixCommandPackageDropBase.ProcessWixCommand(String packageDropOutputFolder, String toolExecutable, String originalCommand) in /_/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixCommandPackageDropBase.cs:line 65 [F:\workspace\_work\1\s\src\Installers\Windows\SharedFramework\SharedFramework.wixproj]
F:\workspace\_work\1\s\src\Installers\Windows\Wix.targets(93,5): error MSB4018:    at Microsoft.DotNet.Build.Tasks.Installers.CreateLightCommandPackageDrop.Execute() in /_/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLightCommandPackageDrop.cs:line 33 [F:\workspace\_work\1\s\src\Installers\Windows\SharedFramework\SharedFramework.wixproj]
F:\workspace\_work\1\s\src\Installers\Windows\Wix.targets(93,5): error MSB4018:    at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute() [F:\workspace\_work\1\s\src\Installers\Windows\SharedFramework\SharedFramework.wixproj]
F:\workspace\_work\1\s\src\Installers\Windows\Wix.targets(93,5): error MSB4018:    at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext() [F:\workspace\_work\1\s\src\Installers\Windows\SharedFramework\SharedFramework.wixproj]

```
