### PR TITLE
Correct the version of xcopy msbuild.

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -312,8 +312,14 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
     return $global:_MSBuildExe
   }
 
-  $vsMinVersionReqdStr = '16.8.0-preview3'
+  # Minimum VS version to require.
+  $vsMinVersionReqdStr = '16.8'
   $vsMinVersionReqd = [Version]::new($vsMinVersionReqdStr)
+
+  # If the version of msbuild is going to be xcopied,
+  # use this version. Version matches a package here:
+  # https://dev.azure.com/dnceng/public/_packaging?_a=package&feed=dotnet-eng&package=RoslynTools.MSBuild&protocolType=NuGet&version=16.8.0-preview3&view=overview
+  $defaultXCopyMSBuildVersion = '16.8.0-preview3'
 
   if (!$vsRequirements) { $vsRequirements = $GlobalJson.tools.vs }
   $vsMinVersionStr = if ($vsRequirements.version) { $vsRequirements.version } else { $vsMinVersionReqdStr }
@@ -349,23 +355,29 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
       $xcopyMSBuildVersion = $GlobalJson.tools.'xcopy-msbuild'
       $vsMajorVersion = $xcopyMSBuildVersion.Split('.')[0]
     } else {
-      #if vs version provided in global.json is incompatible then use the default version for xcopy msbuild download
+      #if vs version provided in global.json is incompatible (too low) then use the default version for xcopy msbuild download
       if($vsMinVersion -lt $vsMinVersionReqd){
-        Write-Host "Using xcopy-msbuild version of $vsMinVersionReqdStr.0-alpha since VS version $vsMinVersionStr provided in global.json is not compatible"
-        $vsMajorVersion = $vsMinVersionReqd.Major
-        $vsMinorVersion = $vsMinVersionReqd.Minor
+        Write-Host "Using xcopy-msbuild version of $defaultXCopyMSBuildVersion since VS version $vsMinVersionStr provided in global.json is not compatible"
+        $xcopyMSBuildVersion = $defaultXCopyMSBuildVersion
       }
       else{
+        # If the VS version IS compatible, look for an xcopy msbuild package
+        # with a version matching VS.
+        # Note: If this version does not exist, then an explicit version of xcopy msbuild
+        # can be specified in global.json. This will be required for pre-release versions of msbuild.
         $vsMajorVersion = $vsMinVersion.Major
         $vsMinorVersion = $vsMinVersion.Minor
+        $xcopyMSBuildVersion = "$vsMajorVersion.$vsMinorVersion.0"
+        Write-Host "Using xcopy-msbuild version of $xcopyMSBuildVersion to match VS version $vsMinVersionStr provided in global.json."
       }
-
-      $xcopyMSBuildVersion = "$vsMajorVersion.$vsMinorVersion.0-alpha"
     }
 
     $vsInstallDir = $null
     if ($xcopyMSBuildVersion.Trim() -ine "none") {
         $vsInstallDir = InitializeXCopyMSBuild $xcopyMSBuildVersion $install
+        if ($vsInstallDir -eq $null) {
+            throw "Could not xcopy msbuild. Please check that package 'RoslynTools.MSBuild @ $xcopyMSBuildVersion' on exists feed 'dotnet-eng'."
+        }
     }
     if ($vsInstallDir -eq $null) {
       throw 'Unable to find Visual Studio that has required version and components installed'

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -376,7 +376,7 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
     if ($xcopyMSBuildVersion.Trim() -ine "none") {
         $vsInstallDir = InitializeXCopyMSBuild $xcopyMSBuildVersion $install
         if ($vsInstallDir -eq $null) {
-            throw "Could not xcopy msbuild. Please check that package 'RoslynTools.MSBuild @ $xcopyMSBuildVersion' on exists feed 'dotnet-eng'."
+            throw "Could not xcopy msbuild. Please check that package 'RoslynTools.MSBuild @ $xcopyMSBuildVersion' exists on feed 'dotnet-eng'."
         }
     }
     if ($vsInstallDir -eq $null) {

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -368,7 +368,6 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
         $vsMajorVersion = $vsMinVersion.Major
         $vsMinorVersion = $vsMinVersion.Minor
         $xcopyMSBuildVersion = "$vsMajorVersion.$vsMinorVersion.0"
-        Write-Host "Using xcopy-msbuild version of $xcopyMSBuildVersion to match VS version $vsMinVersionStr provided in global.json."
       }
     }
 


### PR DESCRIPTION
The min VS version cannot be conveyed with preview tags, so use 16.8 instead. Also fixup a place in here were there was an assumption that the xcopy msbuild would always end in 0.-alpha. This is an incorrect assumption, and in hard to identify code. Instead, pull out the default package version next to the min vs version and rework the code so that it doesn't assume suffixes. To use preview versions that aren't the default, repos should specify the xcopy msbuild specifically in global.json

I don't think this will break anyone. Because the min default is changing, in order to hit the code path that assumes a 16.8.0 package, the user would have had to specify a min VS version in their global json that has a major.minor that is newer than 16.8. This doesn't exist yet, so we shouldn't hit this path.