### PR TITLE
Support RID-specific intermediate nupkgs for arcade-powered source-build

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/SourceBuild/ReadSourceBuildIntermediateNupkgDependencies.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/SourceBuild/ReadSourceBuildIntermediateNupkgDependencies.cs
@@ -10,19 +10,29 @@ using System.Xml.Linq;
 namespace Microsoft.DotNet.Arcade.Sdk.SourceBuild
 {
     /// <summary>
-    /// Reads entries in a Version.Details.xml file to find intermediate nupkg
-    /// dependencies. For each dependency with a "SourceBuildRepoName" element,
-    /// adds an item to the "Dependencies" output.
+    /// Reads entries in a Version.Details.xml file to find intermediate nupkg dependencies. For
+    /// each dependency with a "SourceBuild" element, adds an item to the "Dependencies" output.
     /// </summary>
     public class ReadSourceBuildIntermediateNupkgDependencies : Task
     {
         [Required]
         public string VersionDetailsXmlFile { get; set; }
 
+        [Required]
+        public string SourceBuildIntermediateNupkgPrefix { get; set; }
+
         /// <summary>
-        /// %(Identity): Value of the SourceBuildRepoName element of the dependency element.
-        /// %(Name): Name attribute of the dependency element. Informational.
-        /// %(Version): Version attribute of the dependency element.
+        /// The intermediate nupkg RID to use if any RID-specific intermediate nupkgs are required.
+        /// If this parameter isn't specified, RID-specific intermediate nupkgs can't be used and
+        /// this task fails.
+        /// </summary>
+        public string SourceBuildIntermediateNupkgRid { get; set; }
+
+        /// <summary>
+        /// %(Identity): NuGet package ID.
+        /// %(ExactVersion): NuGet package version. This can be used to look up the restored package
+        ///   contents in a package cache.
+        /// %(Version): NuGet package version, wrapped in "[version]" syntax for exact match.
         /// </summary>
         [Output]
         public ITaskItem[] Dependencies { get; set; }
@@ -41,37 +51,67 @@ namespace Microsoft.DotNet.Arcade.Sdk.SourceBuild
                 .Elements(CreateQualifiedName("Dependency"))
                 .Select(d =>
                 {
-                    string sourceBuildRepoName = d.Element(CreateQualifiedName("SourceBuildRepoName"))?.Value;
+                    XElement sourceBuildElement = d.Element(CreateQualifiedName("SourceBuild"));
 
-                    if (string.IsNullOrEmpty(sourceBuildRepoName))
+                    if (sourceBuildElement == null)
                     {
                         // Ignore element: doesn't represent a source-build dependency.
                         return null;
                     }
 
-                    string name = d.Attribute("Name")?.Value ?? string.Empty;
+                    string repoName = sourceBuildElement.Attribute("RepoName")?.Value;
 
-                    if (string.IsNullOrEmpty(name))
+                    if (string.IsNullOrEmpty(repoName))
+                    {
+                        Log.LogError($"Dependency SourceBuild RepoName null or empty in '{VersionDetailsXmlFile}' element {d}");
+                        return null;
+                    }
+
+                    string dependencyName = d.Attribute("Name")?.Value ?? string.Empty;
+
+                    if (string.IsNullOrEmpty(dependencyName))
                     {
                         // Log name missing as FYI, but this is not an error case for source-build.
                         Log.LogMessage($"Dependency Name null or empty in '{VersionDetailsXmlFile}' element {d}");
                     }
 
-                    string version = d.Attribute("Version")?.Value;
+                    string dependencyVersion = d.Attribute("Version")?.Value;
 
-                    if (string.IsNullOrEmpty(version))
+                    if (string.IsNullOrEmpty(dependencyVersion))
                     {
                         // We need a version to bring down an intermediate nupkg. Fail.
                         Log.LogError($"Dependency Version null or empty in '{VersionDetailsXmlFile}' element {d}");
                         return null;
                     }
 
+                    string identity = SourceBuildIntermediateNupkgPrefix + repoName;
+
+                    bool.TryParse(
+                        sourceBuildElement.Attribute("ManagedOnly")?.Value,
+                        out bool managedOnly);
+
+                    // If RID-specific, add the RID to the end of the identity.
+                    if (!managedOnly)
+                    {
+                        if (string.IsNullOrEmpty(SourceBuildIntermediateNupkgRid))
+                        {
+                            Log.LogError(
+                                $"Parameter {nameof(SourceBuildIntermediateNupkgRid)} was " +
+                                "not specified, indicating this project depends only on managed " +
+                                "inputs. However, source-build element is not ManagedOnly: " +
+                                sourceBuildElement);
+                            return null;
+                        }
+
+                        identity += "." + SourceBuildIntermediateNupkgRid;
+                    }
+
                     return new TaskItem(
-                        sourceBuildRepoName,
+                        identity,
                         new Dictionary<string, string>
                         {
-                            ["Name"] = name,
-                            ["Version"] = version
+                            ["Version"] = $"[{dependencyVersion}]",
+                            ["ExactVersion"] = dependencyVersion
                         });
                 })
                 .Where(d => d != null)

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -26,12 +26,31 @@
   </PropertyGroup>
 
   <Target Name="GetSourceBuildIntermediateNupkgNameConvention">
-    <PropertyGroup>
-      <SourceBuildIntermediateNupkgRid Condition="'$(SourceBuildIntermediateNupkgRid)' == ''">linux-x64</SourceBuildIntermediateNupkgRid>
-      <SourceBuildIntermediateNupkgPrefix Condition="'$(SourceBuildIntermediateNupkgPrefix)' == ''">Microsoft.SourceBuild.Intermediate.</SourceBuildIntermediateNupkgPrefix>
-      <SourceBuildIntermediateNupkgSuffix Condition="'$(SourceBuildIntermediateNupkgSuffix)' == ''">.$(SourceBuildIntermediateNupkgRid)</SourceBuildIntermediateNupkgSuffix>
+    <Error
+      Condition="'$(SourceBuildNonPortable)' == 'true' and '$(TargetRid)' == ''"
+      Text="TargetRid is not specified! Specify it to build non-portable. Automatic RID detection works for portable build only." />
 
-      <GitHubRepositoryName Condition="'$(GitHubRepositoryName)' == ''">no-repo-name-defined</GitHubRepositoryName>
+    <PropertyGroup Condition="'$(TargetRid)' == ''">
+      <HostArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</HostArchitecture>
+      <SourceBuildTargetArchitecture Condition="'$(SourceBuildTargetArchitecture)' == ''">$(HostArchitecture)</SourceBuildTargetArchitecture>
+
+      <SourceBuildTargetPortableOSPlatform Condition="$([MSBuild]::IsOSPlatform('windows'))">win</SourceBuildTargetPortableOSPlatform>
+      <SourceBuildTargetPortableOSPlatform Condition="$([MSBuild]::IsOSPlatform('osx'))">osx</SourceBuildTargetPortableOSPlatform>
+      <SourceBuildTargetPortableOSPlatform Condition="$([MSBuild]::IsOSPlatform('linux'))">linux</SourceBuildTargetPortableOSPlatform>
+      <SourceBuildTargetPortableOSPlatform Condition="'$(SourceBuildTargetPortableOSPlatform)'==''">linux</SourceBuildTargetPortableOSPlatform>
+
+      <!-- By default, build for the portable OS platform with host machine architecture. -->
+      <TargetRid>$(SourceBuildTargetPortableOSPlatform)-$(SourceBuildTargetArchitecture)</TargetRid>
+    </PropertyGroup>
+
+    <!-- If this repo builds only managed outputs, no RID is used for the intermediate nupkg. -->
+    <PropertyGroup Condition="'$(SourceBuildManagedOnly)' != 'true'">
+      <SourceBuildIntermediateNupkgRid Condition="'$(SourceBuildIntermediateNupkgRid)' == ''">$(TargetRid)</SourceBuildIntermediateNupkgRid>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <SourceBuildIntermediateNupkgPrefix>Microsoft.SourceBuild.Intermediate.</SourceBuildIntermediateNupkgPrefix>
+      <SourceBuildIntermediateNupkgSuffix Condition="'$(SourceBuildIntermediateNupkgRid)' != ''">.$(SourceBuildIntermediateNupkgRid)</SourceBuildIntermediateNupkgSuffix>
     </PropertyGroup>
   </Target>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -26,9 +26,9 @@
   </PropertyGroup>
 
   <Target Name="GetSourceBuildIntermediateNupkgNameConvention">
-    <Error
-      Condition="'$(SourceBuildNonPortable)' == 'true' and '$(TargetRid)' == ''"
-      Text="TargetRid is not specified! Specify it to build non-portable. Automatic RID detection works for portable build only." />
+    <PropertyGroup Condition="'$(SourceBuildNonPortable)' == 'true' and '$(TargetRid)' == ''">
+      <TargetRid>$([System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier)</TargetRid>
+    </PropertyGroup>
 
     <PropertyGroup Condition="'$(TargetRid)' == ''">
       <HostArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</HostArchitecture>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
@@ -17,17 +17,14 @@
           DependsOnTargets="GetSourceBuildIntermediateNupkgNameConvention"
           BeforeTargets="CollectPackageReferences">
     <ReadSourceBuildIntermediateNupkgDependencies
-      VersionDetailsXmlFile="$([MSBuild]::NormalizePath('$(RepositoryEngineeringDir)', 'Version.Details.xml'))">
-      <Output TaskParameter="Dependencies" ItemName="VersionDetailsSourceBuildElement" />
+      VersionDetailsXmlFile="$([MSBuild]::NormalizePath('$(RepositoryEngineeringDir)', 'Version.Details.xml'))"
+      SourceBuildIntermediateNupkgPrefix="$(SourceBuildIntermediateNupkgPrefix)"
+      SourceBuildIntermediateNupkgRid="$(SourceBuildIntermediateNupkgRid)">
+      <Output TaskParameter="Dependencies" ItemName="SourceBuildIntermediateNupkgReference" />
     </ReadSourceBuildIntermediateNupkgDependencies>
 
-    <ItemGroup Condition="'@(VersionDetailsSourceBuildElement)' != ''">
-      <SourceBuildIntermediateNupkgReference
-        Include="$(SourceBuildIntermediateNupkgPrefix)%(VersionDetailsSourceBuildElement.Identity)$(SourceBuildIntermediateNupkgSuffix)"
-        ExactVersion="%(VersionDetailsSourceBuildElement.Version)" />
-      <PackageReference
-        Include="@(SourceBuildIntermediateNupkgReference)"
-        Version="[%(SourceBuildIntermediateNupkgReference.ExactVersion)]"/>
+    <ItemGroup>
+      <PackageReference Include="@(SourceBuildIntermediateNupkgReference)" />
     </ItemGroup>
   </Target>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
@@ -40,6 +40,8 @@
   <Target Name="InitializeSourceBuildIntermediatePackageId"
           DependsOnTargets="GetSourceBuildIntermediateNupkgNameConvention"
           BeforeTargets="GenerateNuspec;InitializeStandardNuspecProperties">
+    <Error Condition="'$(GitHubRepositoryName)' == ''" Text="GitHubRepositoryName property is not defined." />
+
     <PropertyGroup>
       <PackageId>$(SourceBuildIntermediateNupkgPrefix)$(GitHubRepositoryName)$(SourceBuildIntermediateNupkgSuffix)</PackageId>
     </PropertyGroup>


### PR DESCRIPTION
This changes the Version.Details.xml spec for intermediate nupkg dependencies to add a way to tell if the dependency is RID-specific or not (https://github.com/dotnet/source-build/issues/1722). If managed-only, then it isn't RID-specific. If not, then the RID of the intermediate nupkg must match the current building RID exactly.

```diff
     <Dependency Name="Microsoft.NETCore.ILAsm" Version="5.0.0-preview.4.20202.18">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>0375524a91a47ca4db3ee1be548f74bab7e26e76</Sha>
-      <SourceBuildRepoName>runtime</SourceBuildRepoName>
+      <SourceBuild RepoName="runtime" />
     </Dependency>
     <Dependency Name="Foo" Version="5.0.0-preview.4.20202.18">
       <Uri>https://github.com/dotnet/sdk</Uri>
       <Sha>abcdef123</Sha>
-      <SourceBuildRepoName>sdk</SourceBuildRepoName>
+      <SourceBuild RepoName="sdk" ManagedOnly="true" />
     </Dependency>
```

This also introduces RID-specific intermediate nupkg production. `TargetRid` is always passed in by CI, and the repo can set `SourceBuildManagedOnly` in `eng/SourceBuild.props`. The RID is tacked on the end of the package ID if one is necessary.
E.g. `Microsoft.SourceBuild.Intermediate.source-build-reference-packages.6.0.0-dev.nupkg` (managed-only)

Note: normally there are more RID categories: managed-only (no RID), native portable (`linux-x64`), and native non-portable (`fedora.32-x64`). Portable *vs.* non-portable doesn't really affect us here, because we will never use a portable int nupkg to build a non-portable int nupkg. This is also why we don't need RID graph resolution--in fact, if we ever actually resolved a non-portable RID reference to use a portable RID int nupkg, that would indicate a build problem!

The non-portable RIDs are for build validation purposes along the way, answering "Does dotnet/runtime throw build errors when we build it in non-portable mode?" and "Can dotnet/installer properly consume non-portable dotnet/runtime outputs?". Portable RIDs are used to produce tarballs out of dotnet/installer that can be run on a broad variety of distros. So, we need both, but they don't mix together.

I'm working now on running a few configurations of dotnet/source-build-reference-packages's official build to try this out, in particular with the source-build templates we're working on in there.

/cc @mmitche, would appreciate if you have a few minutes to check that my goals/assumptions here make sense. 🙂 