### PR TITLE
Update Azure.Core to 1.5.0 deal with deadlocks

### DIFF
--- a/src/Microsoft.DotNet.Helix/Client/CSharp/Microsoft.DotNet.Helix.Client.csproj
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/Microsoft.DotNet.Helix.Client.csproj
@@ -11,11 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.0.2" />
+    <PackageReference Include="Azure.Core" Version="1.5.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.1" />
 
     <PackageReference Include="Microsoft.DotNet.SwaggerGenerator.MSBuild" Version="$(MicrosoftDotNetSwaggerGeneratorMSBuildVersion)" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
Our services keep deadlocking on calls to SDK's backed by the Azure.Core pipelines,
and when spelunking through the code, it does appear that some of the streams aren't disposed,
which could cause this problem if a bunch of connections are open.

The newer versions don't have this problem, based on more spelunking,
so hopefully the deadlocks will go away.