### PR TITLE
Enable post build signing flow

### DIFF
--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -268,7 +268,9 @@ Customization of Authenticode signing process.
 
 Configurable item groups:
 - `ItemsToSign`
-  List of files to sign in-place. May list individual files to sign (e.g. .dll, .exe, .ps1, etc.) as well as container files (.nupkg, .vsix, .zip, etc.). All files embedded in a container file are signed (recursively) unless specified otherwise.
+  List of files to sign in-place, during the build. May list individual files to sign (e.g. .dll, .exe, .ps1, etc.) as well as container files (.nupkg, .vsix, .zip, etc.). All files embedded in a container file are signed (recursively) unless specified otherwise.
+- `ItemsToSignPostBuild`
+  List of file names (without paths) to sign in post build. May only contain files that are published. All files embedded in a container file are signed (recursively) unless specified otherwise.
 - `FileSignInfo`
   Specifies Authenticode certificate to use to sign files with given file name.
 - `FileExtensionSignInfo`
@@ -280,7 +282,13 @@ Configurable item groups:
 
 Properties:
 - `AllowEmptySignList`
-  True to allow ItemsToSign to be empty (the repository doesn't have any file to sign).
+  True to allow ItemsToSign to be empty (the repository doesn't have any file to sign in-build).
+- `AllowEmptyPostBuildSignList`
+  True to allow ItemsToSignPostBuild to be empty (the repository doesn't have any file to sign post-build).
+- `PostBuildSign`
+  If true
+    - `ItemsToSignPostBuild` is tracked during the publishing process and these files will be signed during post-build.
+    - `ItemsToSignPostBuild` is populated with the default arcade `ItemsToSign`.
 
 See [Signing.md](https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Signing.md#arguments-metadata) for details.
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -135,6 +135,9 @@
       <ManifestBuildData Include="AzureDevOpsBranch=$(BUILD_SOURCEBRANCH)" />
     </ItemGroup>
     
+    <Error Condition="'$(AllowEmptySignPostBuildList)' != 'true' AND '@(ItemsToSignPostBuild)' == ''" 
+           Text="List of files to sign post-build is empty. Make sure that ItemsToSignPostBuild is configured correctly." />
+
     <!--
       The user can set `PublishingVersion` via eng\Publishing.props
     -->
@@ -143,7 +146,7 @@
       AzureDevOpsProject="$(SYSTEM_TEAMPROJECT)"
       AzureDevOpsBuildId="$(BUILD_BUILDID)"
       ItemsToPush="@(ItemsToPushToBlobFeed)"
-      ItemsToSign="@(ItemsToSign)"
+      ItemsToSign="@(ItemsToSignPostBuild)"
       StrongNameSignInfo="@(StrongNameSignInfo)"
       CertificatesSignInfo="@(CertificatesSignInfo)"                                
       FileSignInfo="@(FileSignInfo)"
@@ -260,7 +263,7 @@
       AzureDevOpsCollectionUri="$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)"
       AzureDevOpsProject="$(SYSTEM_TEAMPROJECT)"
       AzureDevOpsBuildId="$(BUILD_BUILDID)"
-      ItemsToSign="@(ItemsToSign)"
+      ItemsToSign="@(ItemsToSignPostBuild)"
       StrongNameSignInfo="@(StrongNameSignInfo)"
       FileSignInfo="@(FileSignInfo)"
       FileExtensionSignInfo="@(FileExtensionSignInfo)"

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/GenerateBuildManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/GenerateBuildManifest.proj
@@ -28,13 +28,16 @@
   <UsingTask TaskName="GenerateBuildManifest" AssemblyFile="$(PkgMicrosoft_DotNet_Build_Tasks_Feed)\tools\netcoreapp2.1\Microsoft.DotNet.Build.Tasks.Feed.dll" />
 
   <Import Project="../Sign.props" />
+
+  <Error Condition="'$(AllowEmptySignPostBuildList)' != 'true' AND '@(ItemsToSignPostBuild)' == ''"
+      Text="List of files to sign post-build is empty. Make sure that ItemsToSignPostBuild is configured correctly." />
   
   <Target Name="Execute">
     <GenerateBuildManifest Artifacts="@(ItemsToPush)"
                            AzureDevOpsCollectionUri="$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)"
                            AzureDevOpsProject="$(SYSTEM_TEAMPROJECT)"
                            AzureDevOpsBuildId="$(BUILD_BUILDID)"
-                           ItemsToSign="@(ItemsToSign)"
+                           ItemsToSign="@(ItemsToSignPostBuild)"
                            StrongNameSignInfo="@(StrongNameSignInfo)"
                            FileSignInfo="@(FileSignInfo)"
                            FileExtensionSignInfo="@(FileExtensionSignInfo)"

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -14,10 +14,13 @@
     <_DefaultItemsToSign Include="$(ArtifactsPackagesDir)**\*.nupkg" />
     <_DefaultItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.vsix" />
     <_DefaultItemsToSign Include="$(VisualStudioBuildPackagesDir)**\*.nupkg" />
+    <!-- Sign wixpacks to correspond to msi/exe signing -->
+    <_ItemsToOnlySignPostBuild Include="$(ArtifactsPackagesDir)**\*.wixpack.zip" />
 
     <!-- If PostBuildSign == true, these are added to ItemsToSignPostBuild, otherwise these are added to ItemsToSign -->
     <ItemsToSign Include="@(_DefaultItemsToSign)" Condition="'$(PostBuildSign)' != 'true'" />
     <ItemsToSignPostBuild Include="@(_DefaultItemsToSign->'%(Filename)%(Extension)')" Condition="'$(PostBuildSign)' == 'true'" />
+    <ItemsToSignPostBuild Include="@(_ItemsToOnlySignPostBuild->'%(Filename)%(Extension)')" Condition="'$(PostBuildSign)' == 'true'" />
 
     <!-- Default certificate/strong-name to be used for all files with PKT=="31bf3856ad364e35". -->
     <StrongNameSignInfo Include="MsSharedLib72" PublicKeyToken="31bf3856ad364e35" CertificateName="Microsoft400" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -45,8 +45,8 @@
          These flags are split (rather than just a single check based on PostBuildSign == true/false because
          some repos may do both in-build and post-build signing. -->
     <!-- Control whether an empty ItemsToSign item group is allowed when calling SignToolTask. -->
-    <AllowEmptySignList Condition="'$(PostBuildSign)' != 'true'">false</AllowEmptySignPostBuildList>
-    <AllowEmptySignList Condition="'$(PostBuildSign)' == 'true'">true</AllowEmptySignPostBuildList>
+    <AllowEmptySignList Condition="'$(PostBuildSign)' != 'true'">false</AllowEmptySignList>
+    <AllowEmptySignList Condition="'$(PostBuildSign)' == 'true'">true</AllowEmptySignList>
     <!-- Control whether an empty ItemsToSignPostBuild item group is allowed during publishing -->
     <AllowEmptySignPostBuildList Condition="'$(PostBuildSign)' != 'true'">true</AllowEmptySignPostBuildList>
     <AllowEmptySignPostBuildList Condition="'$(PostBuildSign)' == 'true'">false</AllowEmptySignPostBuildList>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -11,9 +11,13 @@
     <CertificatesSignInfo Include="3PartySHA2" DualSigningAllowed="true" />
 
     <!-- List of container files that will be opened and checked for files that need to be signed. -->
-    <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.nupkg" />
-    <ItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.vsix" />
-    <ItemsToSign Include="$(VisualStudioBuildPackagesDir)**\*.nupkg" />
+    <_DefaultItemsToSign Include="$(ArtifactsPackagesDir)**\*.nupkg" />
+    <_DefaultItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.vsix" />
+    <_DefaultItemsToSign Include="$(VisualStudioBuildPackagesDir)**\*.nupkg" />
+
+    <!-- If PostBuildSign == true, these are added to ItemsToSignPostBuild, otherwise these are added to ItemsToSign -->
+    <ItemsToSign Include="@(_DefaultItemsToSign)" Condition="'$(PostBuildSign)' != 'true'" />
+    <ItemsToSignPostBuild Include="@(_DefaultItemsToSign)" Condition="'$(PostBuildSign)' == 'true'" />
 
     <!-- Default certificate/strong-name to be used for all files with PKT=="31bf3856ad364e35". -->
     <StrongNameSignInfo Include="MsSharedLib72" PublicKeyToken="31bf3856ad364e35" CertificateName="Microsoft400" />
@@ -37,8 +41,15 @@
   </ItemGroup>
 
   <PropertyGroup>
+    <!-- Flags for controlling whether empty signing lists are detected for in build and post-build signing.
+         These flags are split (rather than just a single check based on PostBuildSign == true/false because
+         some repos may do both in-build and post-build signing. -->
     <!-- Control whether an empty ItemsToSign item group is allowed when calling SignToolTask. -->
-    <AllowEmptySignList>false</AllowEmptySignList>
+    <AllowEmptySignList Condition="'$(PostBuildSign)' != 'true'">false</AllowEmptySignPostBuildList>
+    <AllowEmptySignList Condition="'$(PostBuildSign)' == 'true'">true</AllowEmptySignPostBuildList>
+    <!-- Control whether an empty ItemsToSignPostBuild item group is allowed during publishing -->
+    <AllowEmptySignPostBuildList Condition="'$(PostBuildSign)' != 'true'">true</AllowEmptySignPostBuildList>
+    <AllowEmptySignPostBuildList Condition="'$(PostBuildSign)' == 'true'">false</AllowEmptySignPostBuildList>
 
     <NETCORE_ENGINEERING_TELEMETRY>Signing</NETCORE_ENGINEERING_TELEMETRY>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -17,7 +17,7 @@
 
     <!-- If PostBuildSign == true, these are added to ItemsToSignPostBuild, otherwise these are added to ItemsToSign -->
     <ItemsToSign Include="@(_DefaultItemsToSign)" Condition="'$(PostBuildSign)' != 'true'" />
-    <ItemsToSignPostBuild Include="@(_DefaultItemsToSign)" Condition="'$(PostBuildSign)' == 'true'" />
+    <ItemsToSignPostBuild Include="@(_DefaultItemsToSign->'%(Filename)%(Extension)')" Condition="'$(PostBuildSign)' == 'true'" />
 
     <!-- Default certificate/strong-name to be used for all files with PKT=="31bf3856ad364e35". -->
     <StrongNameSignInfo Include="MsSharedLib72" PublicKeyToken="31bf3856ad364e35" CertificateName="Microsoft400" />


### PR DESCRIPTION
This change makes post build signing more formalized in arcade.
Addresses https://github.com/dotnet/arcade/issues/6205

If PostBuildSign=true, then ItemsToSign is by default blank, and artifacts to sign are included in the manifest.
If PostBuildSign=false or not set, the normal flow is used.