### PR TITLE
Provide more, and further-spaced-out retry times

### DIFF
--- a/src/Microsoft.DotNet.Helix/Client/CSharp/HelixApiOptions.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/HelixApiOptions.cs
@@ -1,15 +1,24 @@
 using Azure.Core;
+using System;
 
 namespace Microsoft.DotNet.Helix.Client
 {
     partial class HelixApiOptions
     {
+        // See https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Azure.Core/src/RetryOptions.cs for values this overrides
+        const int DefaultRetryDelaySeconds = 10;
+        const int DefaultMaxRetryCount = 5;
+
         partial void InitializeOptions()
         {
             if (Credentials != null)
             {
                 AddPolicy(new HelixApiTokenAuthenticationPolicy(Credentials), HttpPipelinePosition.PerCall);
             }
+
+            // Users should not generally need to modify these but can do so after creating a HelixApi object if needed
+            Retry.Delay = TimeSpan.FromSeconds(DefaultRetryDelaySeconds);
+            Retry.MaxRetries = DefaultMaxRetryCount;
         }
     }
 }

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/HelixApiOptions.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/HelixApiOptions.cs
@@ -6,8 +6,8 @@ namespace Microsoft.DotNet.Helix.Client
     partial class HelixApiOptions
     {
         // See https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Azure.Core/src/RetryOptions.cs for values this overrides
-        const int DefaultRetryDelaySeconds = 10;
-        const int DefaultMaxRetryCount = 5;
+        public const int DefaultRetryDelaySeconds = 10;
+        public const int DefaultMaxRetryCount = 5;
 
         partial void InitializeOptions()
         {


### PR DESCRIPTION
See https://github.com/dotnet/core-eng/issues/10928 for context.  

It seems we don't retry enough, and we retry too soon.  This sets the effective defaults to 5 retries with 10s delay with exponential backup (for retries 2-5), 