### PR TITLE
Escape % characters before setting ITaskItem Metadata 

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/GetFailedWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/GetFailedWorkItems.cs
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                             .ToImmutableList();
                     }
 
-                    metadata["UploadedFiles"] = JsonConvert.SerializeObject(files);
+                    metadata["UploadedFiles"] = JsonConvert.SerializeObject(files).Replace("%", "%25");
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
since MSBuild Encode() is unavailable publicly

Done because https://github.com/dotnet/msbuild/blob/aed5e7ed0b7e031d3e486c63b206902bf825b128/src/Shared/EscapingUtilities.cs#L251-L295 is not public