### PR TITLE
Increase wait time for Helix pass/fail API calls

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/WaitForHelixJobCompletion.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/WaitForHelixJobCompletion.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             cancellationToken.ThrowIfCancellationRequested();
             Log.LogMessage(MessageImportance.High, $"Waiting for completion of job {jobName} on {queueName}");
 
-            for (;; await Task.Delay(10000, cancellationToken).ConfigureAwait(false)) // delay every time this loop repeats
+            for (;; await Task.Delay(20000, cancellationToken).ConfigureAwait(false)) // delay every time this loop repeats
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 var pf = await HelixApi.Job.PassFailAsync(jobName, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Increase this value to 20s per loop, which should roughly halve the # of pf API calls per minute for the same workload.