### PR TITLE
Add remoteexecutor config during publish and code cleanup

### DIFF
--- a/src/Microsoft.DotNet.RemoteExecutor/src/build/Microsoft.DotNet.RemoteExecutor.targets
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/build/Microsoft.DotNet.RemoteExecutor.targets
@@ -6,25 +6,31 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <RemoteClientAppConfigFile Condition="'$(RemoteClientAppConfigFile)' == ''">$(OutDir)$(TargetName).exe.config</RemoteClientAppConfigFile>
     <RemoteHostAppConfigFile>$(OutDir)$(RemoteExecutorName).exe.config</RemoteHostAppConfigFile>
   </PropertyGroup>
 
   <Target Name="_CopyRemoteClientAppConfigFile"
-          Condition="Exists('$(RemoteClientAppConfigFile)') and '$(TargetFrameworkIdentifier)' == '.NETFramework'"
           AfterTargets="_CopyAppConfigFile"
-          Inputs="$(RemoteClientAppConfigFile)"
-          Outputs="$(RemoteHostAppConfigFile)">
+          Inputs="@(AppConfigWithTargetPath)"
+          Outputs="$(RemoteHostAppConfigFile)"
+          Condition="'@(AppConfigWithTargetPath)' != '' and '$(RemoteHostAppConfigFile)' != ''">
 
-    <Copy SourceFiles="$(RemoteClientAppConfigFile)"
+    <Copy SourceFiles="@(AppConfigWithTargetPath)"
           DestinationFiles="$(RemoteHostAppConfigFile)"
+          SkipUnchangedFiles="true"
           OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
           Retries="$(CopyRetryCount)"
           RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
           UseHardlinksIfPossible="$(CreateHardLinksForAdditionalFilesIfPossible)"
           UseSymboliclinksIfPossible="$(CreateSymbolicLinksForAdditionalFilesIfPossible)">
-      <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
+    
+    <ItemGroup>
+      <ResolvedFileToPublish Include="$(RemoteHostAppConfigFile)"
+                             RelativePath="$([System.IO.Path]::GetFileName('$(RemoteHostAppConfigFile)'))"
+                             CopyToPublishDirectory="PreserveNewest" />
+    </ItemGroup>
 
   </Target>
 </Project>


### PR DESCRIPTION
Also use the `AppConfigWithTargetPath` item from the SDK instead of calculating it ourselves.