### PR TITLE
Include generated symbol packages in ItemsToSignPostBuild

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -66,6 +66,9 @@
         <OriginalPackage>%(PackagesToPublish.Identity)</OriginalPackage>
         <IsShipping>%(PackagesToPublish.IsShipping)</IsShipping>
       </SymbolPackagesToGenerate>
+
+      <!-- If PostBuildSign is true, then we need to include newly generated packages in ItemsToSignPostBuild. -->
+      <ItemsToSignPostBuild Include="@(SymbolPackagesToGenerate->'%(Filename)%(Extension)')" Condition="'$(PostBuildSign)' == 'true'" />
     </ItemGroup>
 
     <!--


### PR DESCRIPTION
These are generated very late, after Sign.props has been imported.