### PR TITLE
Port Arcade PR 6315 to release/3.x

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/Helpers.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/Helpers.cs
@@ -10,5 +10,11 @@ namespace Microsoft.DotNet.Helix.Sdk
 
         public static string ProductVersion { get; } =
             typeof(Helpers).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+
+        public static string CleanWorkItemName(string workItemName)
+        {
+            var convertedName = workItemName.Replace('/', '-');
+            return convertedName;
+        }
     }
 }


### PR DESCRIPTION
## Description

Port a change to prevent accessing all possible helix work items from a 100% failure scenario in parallel. This became necessary as Helix API now has a 90s gateway timeout that we're not likely to increase.  See https://github.com/dotnet/core-eng/issues/11037 for more details. 

## Customer Impact

All Helix API users (automated and otherwise) may experience errors / slowdown while a run without this change is being finished in AzDO.

## Regression

No

## Risk

Minor, low risk Change, validated by linked PR that intentionally fails.

## Workarounds

None for users.  We're still looking at how best to deal with this from the Helix API (such as changing the files API to not use SQL connections, increasing instances, etc)
