### PR TITLE
Hashcollision use signedfilecontentkey

### DIFF
--- a/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
+++ b/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
@@ -15,8 +15,6 @@ namespace Microsoft.DotNet.SignTool
 {
     internal sealed class BatchSignUtil
     {
-        internal static readonly StringComparer FilePathComparer = StringComparer.OrdinalIgnoreCase;
-
         private readonly TaskLoggingHelper _log;
         private readonly IBuildEngine _buildEngine;
         private readonly BatchSignInput _batchData;

--- a/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
+++ b/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.SignTool
                 {
                     _log.LogMessage(MessageImportance.Low, file.ToString());
                 }
-                
+
                 return _signTool.Sign(_buildEngine, round, filesToSign);
             }
 

--- a/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
+++ b/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.SignTool
             {
 
                 var filesToSign = files.Where(fileInfo => fileInfo.SignInfo.ShouldSign).ToArray();
-                totalFilesSigned = filesToSign.Count();
+                totalFilesSigned = filesToSign.Length;
                 _log.LogMessage(MessageImportance.High, $"Signing Round {round}: {filesToSign.Length} files to sign.");
 
                 if (filesToSign.Length == 0) return true;
@@ -123,7 +123,7 @@ namespace Microsoft.DotNet.SignTool
                 var enginesToSign = files.Where(fileInfo => fileInfo.SignInfo.ShouldSign && 
                                                 fileInfo.IsWixContainer() &&
                                                 Path.GetExtension(fileInfo.FullPath) == ".exe").ToArray();
-                totalFilesSigned = enginesToSign.Count();
+                totalFilesSigned = enginesToSign.Length;
                 if (enginesToSign.Length == 0)
                 {
                     return true;


### PR DESCRIPTION
Fixes https://github.com/dotnet/core-eng/issues/11108

Also, fix numbering for round files.

Validated with a private build which mmitche confirmed fixes the issue where a .js file from a repo was unintentionally being signed because another repo defined a certificate for it.