### PR TITLE
Fix crossbuild on CentOS

### DIFF
--- a/eng/common/cross/toolchain.cmake
+++ b/eng/common/cross/toolchain.cmake
@@ -139,6 +139,10 @@ function(add_toolchain_linker_flag Flag)
   set("CMAKE_SHARED_LINKER_FLAGS${CONFIG_SUFFIX}" "${CMAKE_SHARED_LINKER_FLAGS${CONFIG_SUFFIX}} ${Flag}" PARENT_SCOPE)
 endfunction()
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  add_toolchain_linker_flag("-Wl,--rpath-link=${CROSS_ROOTFS}/lib/${TOOLCHAIN}")
+  add_toolchain_linker_flag("-Wl,--rpath-link=${CROSS_ROOTFS}/usr/lib/${TOOLCHAIN}")
+endif()
 
 if(TARGET_ARCH_NAME STREQUAL "armel")
   if(DEFINED TIZEN_TOOLCHAIN) # For Tizen only


### PR DESCRIPTION
This change fixes the crossbuilding to work on CentOS. Clang
frontend presets some of the compiler options based on the
host OS and I guess that's causing the need to add the
`--rpath-link`.