### PR TITLE
Revert "Added extra attribute to manifest to arcade 3.x "

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -30,10 +30,6 @@
     <IsStableBuild>false</IsStableBuild>
     <IsStableBuild Condition="'$(DotNetFinalVersionKind)' == 'release'">true</IsStableBuild>
 
-    <!-- If `IsReleaseOnlyPackageVersion` is set to true, package safety checks can be skipped-->
-    <IsReleaseOnlyPackageVersion>false</IsReleaseOnlyPackageVersion>
-    <IsReleaseOnlyPackageVersion Condition ="'$(PreReleaseVersionLabel)' == '' and '$(AutoGenerateAssemblyVersion)' == 'true'">true</IsReleaseOnlyPackageVersion>
-  
     <AssetManifestOS Condition="'$(AssetManifestOS)' == ''">$(OS)</AssetManifestOS>
 
     <AssetManifestFileName>$(AssetManifestOS)-$(PlatformName).xml</AssetManifestFileName>
@@ -176,8 +172,7 @@
       IsStableBuild="$(IsStableBuild)"
       PublishFlatContainer="false"
       AssetManifestPath="$(AssetManifestFilePath)"
-      AssetsTemporaryDirectory="$(TempWorkingDirectory)" 
-      IsReleaseOnlyPackageVersion="$(IsReleaseOnlyPackageVersion)"/>
+      AssetsTemporaryDirectory="$(TempWorkingDirectory)" />
 
     <Copy 
       SourceFiles="$(AssetManifestFilePath)" 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
@@ -26,8 +26,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             string manifestBranch,
             string manifestCommit,
             string[] manifestBuildData,
-            bool isStableBuild,
-            bool isReleaseOnlyPackageVersion)
+            bool isStableBuild)
         {
             CreateModel(
                 blobArtifacts,
@@ -38,7 +37,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 manifestBranch,
                 manifestCommit,
                 isStableBuild,
-                isReleaseOnlyPackageVersion,
                 log)
                 .WriteAsXml(assetManifestPath, log);
         }
@@ -61,7 +59,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             string repoBranch,
             string repoCommit,
             bool isStableBuild,
-            bool isReleaseOnlyPackageVersion,
             TaskLoggingHelper log)
         {
             if (artifacts == null)
@@ -107,7 +104,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 repoBranch,
                 repoCommit,
                 isStableBuild,
-                isReleaseOnlyPackageVersion,
                 log);
             return buildModel;
         }
@@ -120,7 +116,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             string manifestBranch,
             string manifestCommit,
             bool isStableBuild,
-            bool isReleaseOnlyPackageVersion,
             TaskLoggingHelper log)
         {
             var attributes = MSBuildListSplitter.GetNamedProperties(manifestBuildData);
@@ -136,8 +131,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         BuildId = manifestBuildId,
                         Branch = manifestBranch,
                         Commit = manifestCommit,
-                        IsStable = isStableBuild.ToString(),
-                        IsReleaseOnlyPackageVersion = isReleaseOnlyPackageVersion.ToString()
+                        IsStable = isStableBuild.ToString()
                     });
 
             buildModel.Artifacts.Blobs.AddRange(blobArtifacts);

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/GenerateBuildManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/GenerateBuildManifest.cs
@@ -60,11 +60,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         /// Is this manifest for a stable build?
         /// </summary>
         public bool IsStableBuild { get; set; }
-        
-        /// <summary>
-        /// Is the manifest for Release only package version?
-        /// </summary>
-        public bool IsReleaseOnlyPackageVersion { get; set; }
 
         public override bool Execute()
         {
@@ -78,7 +73,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     RepoBranch,
                     RepoCommit,
                     IsStableBuild,
-                    IsReleaseOnlyPackageVersion,
                     Log);
 
                 buildModel.WriteAsXml(OutputPath, Log);

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
@@ -35,8 +35,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public string AssetManifestPath { get; set; }
 
         public bool IsStableBuild { get; set; }
-        
-        public bool IsReleaseOnlyPackageVersion { get; set; }
 
         public override bool Execute()
         {
@@ -142,8 +140,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         ManifestBranch,
                         ManifestCommit,
                         ManifestBuildData,
-                        IsStableBuild,
-                        IsReleaseOnlyPackageVersion);
+                        IsStableBuild);
                 }
             }
             catch (Exception e)

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBlobFeed.cs
@@ -58,8 +58,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public bool IsStableBuild { get; set; }
 
-        public bool IsReleaseOnlyPackageVersion { get; set; }
-
         public override bool Execute()
         {
             return ExecuteAsync().GetAwaiter().GetResult();
@@ -167,8 +165,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     ManifestBranch,
                     ManifestCommit,
                     ManifestBuildData,
-                    IsStableBuild,
-                    IsReleaseOnlyPackageVersion);
+                    IsStableBuild);
             }
             catch (Exception e)
             {

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/BuildIdentity.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/BuildIdentity.cs
@@ -62,12 +62,6 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
             set { Attributes[nameof(IsStable)] = value; }
         }
 
-        public string IsReleaseOnlyPackageVersion
-        {
-            get { return Attributes.GetOrDefault(nameof(IsReleaseOnlyPackageVersion)); }
-            set { Attributes[nameof(IsReleaseOnlyPackageVersion)] = value; }
-        }
-
         public string VersionStamp
         {
             get { return Attributes.GetOrDefault(nameof(VersionStamp)); }


### PR DESCRIPTION
Reverts dotnet/arcade#6340

Why we don't need this change -> https://github.com/dotnet/arcade/issues/6368
PR here validates the fact that we do not need this change anymore -> https://github.com/dotnet/arcade-services/pull/1434

