### PR TITLE
Log output from nuget.exe invocation in any push failure scenario

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
@@ -373,7 +373,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                 }
             };
 
-            Func<string, string, ProcessExecutionResult> testRunAngLogProcess = (string fakeExePath, string fakeExeArgs) =>
+            Func<string, string, ProcessExecutionResult> testRunAndLogProcess = (string fakeExePath, string fakeExeArgs) =>
             {
                 Debug.WriteLine($"Called mocked RunProcessAndGetOutputs() :  ExePath = {fakeExePath}, ExeArgs = {fakeExeArgs}");
                 Assert.Equal(fakeExePath, fakeNugetExeName);
@@ -400,7 +400,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                 "feedvisibility", 
                 "feedname",
                 testCompareLocalPackage,
-                testRunAngLogProcess);
+                testRunAndLogProcess);
             if (!expectedFailure && localPackageMatchesFeed)
             {
                 // Successful retry scenario; make sure we ran the # of retries we thought.

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
@@ -373,17 +373,21 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                 }
             };
 
-            Func<string, string, Task<int>> testStartProcessAsync = async (string fakeExePath, string fakeExeArgs) =>
+            Func<string, string, ProcessExecutionResult> testRunAngLogProcess = (string fakeExePath, string fakeExeArgs) =>
             {
-                await (Task.Delay(10)); // To make this actually async
-                Debug.WriteLine($"Called mocked StartProcessAsync() :  ExePath = {fakeExePath}, ExeArgs = {fakeExeArgs}");
-                Assert.Equal(fakeExePath, fakeNugetExeName); 
+                Debug.WriteLine($"Called mocked RunProcessAndGetOutputs() :  ExePath = {fakeExePath}, ExeArgs = {fakeExeArgs}");
+                Assert.Equal(fakeExePath, fakeNugetExeName);
+                ProcessExecutionResult result = new ProcessExecutionResult() { StandardError = "fake stderr", StandardOut = "fake stdout" };
                 timesNugetExeCalled++;
                 if (timesNugetExeCalled >= pushAttemptsBeforeSuccess)
                 {
-                    return 0;
+                    result.ExitCode = 0;
                 }
-                return 1;
+                else
+                {
+                    result.ExitCode = 1;
+                }
+                return result;
             };
 
             await task.PushNugetPackageAsync(
@@ -396,7 +400,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                 "feedvisibility", 
                 "feedname",
                 testCompareLocalPackage,
-                testStartProcessAsync);
+                testRunAngLogProcess);
             if (!expectedFailure && localPackageMatchesFeed)
             {
                 // Successful retry scenario; make sure we ran the # of retries we thought.

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/GeneralUtils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/GeneralUtils.cs
@@ -11,6 +11,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Build.Tasks.Feed
@@ -367,17 +368,20 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         }
 
         /// <summary>
-        ///     Start a process as an async Task.
+        ///   Run, and wait on a process synchronously, returning its full console output and exit code
         /// </summary>
         /// <param name="path">Path to process</param>
         /// <param name="arguments">Process arguments</param>
         /// <returns>Process return code</returns>
-        public static Task<int> StartProcessAsync(string path, string arguments)
+        public static ProcessExecutionResult RunProcessAndGetOutputs(string path, string arguments)
         {
             ProcessStartInfo info = new ProcessStartInfo(path, arguments)
             {
                 UseShellExecute = false,
                 RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8
             };
 
             Process process = new Process
@@ -386,17 +390,61 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 EnableRaisingEvents = true
             };
 
-            var completionSource = new TaskCompletionSource<int>();
+            var stdOut = new StringBuilder();
+            var stdErr = new StringBuilder();
+            var stdoutCompletion = new TaskCompletionSource<bool>();
+            var stderrCompletion = new TaskCompletionSource<bool>();
 
-            process.Exited += (obj, args) =>
+            process.OutputDataReceived += (sender, e) =>
             {
-                completionSource.SetResult(((Process)obj).ExitCode);
-                process.Dispose();
+                if (e.Data != null)
+                {
+                    lock (stdOut)
+                    {
+                        stdOut.AppendLine(e.Data);
+                    }
+                }
+                else
+                {
+                    stdoutCompletion.TrySetResult(true);
+                }
+
+            };
+
+            process.ErrorDataReceived += (sender, e) =>
+            {
+                if (e.Data != null)
+                {
+                    lock (stdErr)
+                    {
+                        stdErr.AppendLine(e.Data);
+                    }
+                }
+                else
+                {
+                    stderrCompletion.TrySetResult(true);
+                }
             };
 
             process.Start();
+            process.BeginErrorReadLine();
+            process.BeginOutputReadLine();
+            process.WaitForExit();
+            // Wait for the last outputs to flush before returning
+            System.Threading.Tasks.Task.WaitAll(new System.Threading.Tasks.Task[] { stderrCompletion.Task, stdoutCompletion.Task }, TimeSpan.FromSeconds(5));
+            return new ProcessExecutionResult()
+            {
+                ExitCode = process.ExitCode,
+                StandardOut = stdOut.ToString(),
+                StandardError = stdErr.ToString()
+            };
+        }
 
-            return completionSource.Task;
+        public class ProcessExecutionResult
+        {
+            public int ExitCode;
+            public string StandardOut;
+            public string StandardError;
         }
     }
 }


### PR DESCRIPTION
See https://github.com/dotnet/core-eng/issues/11151 for details.  

Example build that is publishing using this version of Tasks.Feed:
https://dnceng.visualstudio.com/internal/_build/results?buildId=854759&view=logs&j=63195bb0-7f06-5445-b61c-87174d25221c&t=ca97ea96-4f2b-5b0c-7316-fad13efc6ec9&l=183

(Changed `Publishing packages:` -> `Begin publishing of packages:` to make it clear that it's using the changed version)
