### PR TITLE
Don't assume that IsReleaseOnlyPackageVersion will be set

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -261,7 +261,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         /// </summary>
         public void CheckForStableAssetsInNonIsolatedFeeds()
         {
-            if(bool.Parse(BuildModel.Identity.IsReleaseOnlyPackageVersion) || SkipSafetyChecks)
+            if ((!string.IsNullOrEmpty(BuildModel.Identity.IsReleaseOnlyPackageVersion) && bool.Parse(BuildModel.Identity.IsReleaseOnlyPackageVersion))
+                || SkipSafetyChecks)
             {
                 return;
             }


### PR DESCRIPTION
This is not set in older manifests (5.0 or 3.0) and so should be checked for
null/empty prior to parsing.