### PR TITLE
Don't report unsigned 'donotsign' files as failures

### DIFF
--- a/src/SignCheck/SignCheck/SignCheck.cs
+++ b/src/SignCheck/SignCheck/SignCheck.cs
@@ -313,12 +313,12 @@ namespace SignCheck
                 {
                     TotalSignedFiles++;
                 }
-                else if (!(result.IsExcluded || result.IsSkipped))
+                else if (!(result.IsExcluded || result.IsSkipped) && (!result.IsSigned && !result.IsDoNotSign))
                 {
                     TotalUnsignedFiles++;
                 }
 
-                if (result.IsExcluded)
+                if (result.IsExcluded || (!result.IsSigned && result.IsDoNotSign))
                 {
                     TotalExcludedFiles++;
                 }
@@ -341,13 +341,13 @@ namespace SignCheck
                     ((result.IsSigned) && (result.IsDoNotSign)) ||
                     ((result.NestedResults.Count() > 0) && (Options.Recursive)) ||
                     ((FileStatus & FileStatus.AllFiles) == FileStatus.AllFiles) ||
-                    ((!result.IsSigned) && (!result.IsSkipped) && (!result.IsExcluded) && ((FileStatus & FileStatus.UnsignedFiles) != 0)))
+                    ((!result.IsSigned && !result.IsDoNotSign) && (!result.IsSkipped) && (!result.IsExcluded) && ((FileStatus & FileStatus.UnsignedFiles) != 0)))
                 {
                     LoggedResults = true;
                     Log.WriteMessage(LogVerbosity.Minimum, String.Empty.PadLeft(indent) + result.ToString(result.IsExcluded ? DetailKeys.ResultKeysExcluded : ResultDetails));
                 }
 
-                if (((!result.IsSigned) && (!(result.IsSkipped || result.IsExcluded))) || (result.IsSigned && result.IsDoNotSign))
+                if (((!result.IsSigned) && (!(result.IsSkipped || result.IsExcluded || result.IsDoNotSign))) || (result.IsSigned && result.IsDoNotSign))
                 {
                     NoSignIssues = false;
                 }


### PR DESCRIPTION
Files in the exclusions file which were marked "DO-NOT-SIGN" were getting reported during signcheck as failures.

Example from runtime repo with exclusions [file](https://github.com/dotnet/runtime/blob/master/eng/SignCheckExclusionsFile.txt)

```
Results

[File] runtime.win-x64.Microsoft.NETCore.DotNetAppHost.5.0.0-rtm.20478.6.nupkg, Signed: True
  [File] 7cedc98a84e2a9a20f6451ed6d644e19.exe, Signed: False, Full Name: runtimes/win-x64/native/apphost.exe [Error] HRESULT: 800b0100 (No signature was present in the subject)
  [File] c8ce1d0e11910a4612e1ec778ea67922.exe, Signed: False, Full Name: runtimes/win-x64/native/singlefilehost.exe [Error] HRESULT: 800b0100 (No signature was present in the subject)
  [File] d719bb33a0d07f7b9525b65c1b184da9.dll, Signed: True, Full Name: runtimes/win-x64/native/nethost.dll
  [File] 383b021689a33abd03f4b7ab2874d4ae.dll, Signed: False, Full Name: runtimes/win-x64/native/comhost.dll [Error] HRESULT: 800b0100 (No signature was present in the subject)
  [File] 727b46614a563c4d3dd72babefa66abc.dll, Signed: True, Full Name: runtimes/win-x64/native/ijwhost.dll

Signing issues found
Total Time: 00:00:18.8590522
Total Files: 20, Signed: 3, Unsigned: 3, Skipped: 14, Excluded: 0, Skipped & Excluded: 0
```

This change respects donotsign for unsigned files so they do not get reported as failures.  Additionally (perhaps controversially?), it removes these files from the "total unsigned files" reported and moves them to the "excluded" count.

```
Results

[File] runtime.win-x64.Microsoft.NETCore.DotNetAppHost.5.0.0-rtm.20478.6.nupkg, Signed: True

No signing issues found
Total Time: 00:00:01.0162525
Total Files: 20, Signed: 3, Unsigned: 0, Skipped: 14, Excluded: 3, Skipped & Excluded: 0
```

@joeloff , PTAL