### PR TITLE
Fix GenerateBuildManifest invocation

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/GenerateBuildManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/GenerateBuildManifest.proj
@@ -29,9 +29,9 @@
 
   <Import Project="../Sign.props" />
 
-  <Target Name="_ValidateItemsToSignPostBuild">
-    <Error Condition="'$(AllowEmptySignPostBuildList)' != 'true' AND '@(ItemsToSignPostBuild)' == ''"
-           Text="List of files to sign post-build is empty. Make sure that ItemsToSignPostBuild is configured correctly." />
+  <Target Name="_ValidateItemsToSignPostBuild"
+          Condition="'$(AllowEmptySignPostBuildList)' != 'true' AND '@(ItemsToSignPostBuild)' == ''">
+    <Error Text="List of files to sign post-build is empty. Make sure that ItemsToSignPostBuild is configured correctly." />
   </Target>
   
   <Target Name="Execute">

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/GenerateBuildManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/GenerateBuildManifest.proj
@@ -1,5 +1,5 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
-<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Execute">
+<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Execute" InitialTargets="_ValidateItemsToSignPostBuild">
   <!--
     Optional variables:
       AssetManifestFilePath      Output file path for manifest file
@@ -29,8 +29,10 @@
 
   <Import Project="../Sign.props" />
 
-  <Error Condition="'$(AllowEmptySignPostBuildList)' != 'true' AND '@(ItemsToSignPostBuild)' == ''"
-      Text="List of files to sign post-build is empty. Make sure that ItemsToSignPostBuild is configured correctly." />
+  <Target Name="_ValidateItemsToSignPostBuild">
+    <Error Condition="'$(AllowEmptySignPostBuildList)' != 'true' AND '@(ItemsToSignPostBuild)' == ''"
+           Text="List of files to sign post-build is empty. Make sure that ItemsToSignPostBuild is configured correctly." />
+  </Target>
   
   <Target Name="Execute">
     <GenerateBuildManifest Artifacts="@(ItemsToPush)"


### PR DESCRIPTION
```
C:\git\vstest\packages\microsoft.dotnet.arcade.sdk\6.0.0-beta.20522.2\tools\SdkTasks\GenerateBuildManifest.proj(32,3): error : The <Error> tag is no longer supported as a child of the <Project> element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the <Project> element.
```
