### PR TITLE
Add retry capability to symbols-validation

### DIFF
--- a/eng/common/post-build/symbols-validation.ps1
+++ b/eng/common/post-build/symbols-validation.ps1
@@ -10,7 +10,7 @@ param(
 $MaxParallelJobs = 6
 
 # Max number of retries
-$MaxRetry = 3
+$MaxRetry = 5
 
 # Wait time between check for system load
 $SecondsBetweenLoadChecks = 10

--- a/eng/common/post-build/symbols-validation.ps1
+++ b/eng/common/post-build/symbols-validation.ps1
@@ -34,7 +34,7 @@ $CountMissingSymbols = {
   if (!(Test-Path $PackagePath)) {
     Write-PipelineTaskError "Input file does not exist: $PackagePath"
     return [pscustomobject]@{
-      result = $ERROR_FILEDOESNOTEXIST
+      result = $using:ERROR_FILEDOESNOTEXIST
       packagePath = $PackagePath
     }
   }
@@ -57,7 +57,7 @@ $CountMissingSymbols = {
     Write-Host "Something went wrong extracting $PackagePath"
     Write-Host $_
     return [pscustomobject]@{
-      result = $ERROR_BADEXTRACT
+      result = $using:ERROR_BADEXTRACT
       packagePath = $PackagePath
     }
   }

--- a/eng/common/post-build/symbols-validation.ps1
+++ b/eng/common/post-build/symbols-validation.ps1
@@ -131,9 +131,9 @@ $CountMissingSymbols = {
         else {
           return $null
         }
-
-        return $null
       }
+      
+      return $null
     }
 
       $SymbolsOnMSDL = & $FirstMatchingSymbolDescriptionOrDefault $FileName '--microsoft-symbol-server' $SymbolsPath

--- a/eng/common/post-build/symbols-validation.ps1
+++ b/eng/common/post-build/symbols-validation.ps1
@@ -68,7 +68,7 @@ $CountMissingSymbols = {
       $FileName = $_.FullName
       if ($FileName -Match '\\ref\\') {
         Write-Host "`t Ignoring reference assembly file " $FileName
-        continue
+        return
       }
 
       $FirstMatchingSymbolDescriptionOrDefault = {


### PR DESCRIPTION
When running on a large number of symbols packages, we can occasionally get 503 errors. This doesn't mean that the symbols don't exist on SymWeb/MSDL, only that when trying to access them, something went wrong, either a network issue, or too many requests at once, etc. In that case, retry. Testing suggested that 3 attempts was plenty (all but one failure was successful on the first retry. That last one required 2 retries).

This change also fixes up some returns from CountMissingSymbols, which hadn't updated to the new model.

Fixes https://github.com/dotnet/core-eng/issues/11256