### PR TITLE
Reenable Android XHarness testing 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -140,8 +140,6 @@ stages:
               /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.XHarness.Android.binlog
               /p:RestoreUsingNuGetTargets=false
             displayName: XHarness Android Helix Testing
-            # Workaround until https://github.com/dotnet/xharness/issues/232 is fixed
-            continueOnError: true
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''

--- a/tests/XHarness/XHarness.TestApk.proj
+++ b/tests/XHarness/XHarness.TestApk.proj
@@ -3,8 +3,8 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
 
   <PropertyGroup>
-    <XHarnessX86TestApkUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/android/test-apk/x86/System.Numerics.Vectors.Tests-x86.apk</XHarnessX86TestApkUrl>
-    <XHarnessX64TestApkUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/android/test-apk/x86_64/System.Numerics.Vectors.Tests-x64.apk</XHarnessX64TestApkUrl>
+    <XHarnessX86TestApkUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/android/test-apk/x86/System.Buffers.Tests-x86.apk</XHarnessX86TestApkUrl>
+    <XHarnessX64TestApkUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/android/test-apk/x86_64/System.Buffers.Tests-x64.apk</XHarnessX64TestApkUrl>
   </PropertyGroup>
 
   <Target Name="Build" Returns="@(XHarnessApkToTest)" >
@@ -24,7 +24,7 @@
       <XHarnessApkToTest Include="@(DownloadedApkFile)">
 
         <!-- Package name: this comes from metadata inside the apk itself -->
-        <AndroidPackageName>net.dot.System.Numerics.Vectors.Tests</AndroidPackageName>
+        <AndroidPackageName>net.dot.System.Buffers.Tests</AndroidPackageName>
 
         <!-- If there are > 1 instrumentation class inside the package, we need to know the name of which to use -->
         <AndroidInstrumentationName>net.dot.MonoRunner</AndroidInstrumentationName>


### PR DESCRIPTION
https://github.com/dotnet/core-eng/issues/11268
- Use newer, different test APKs for health check 
- Update yaml to fail on failure (should be addressed by emulators having more memory)