### PR TITLE
Add missing DependsOnTargets

### DIFF
--- a/src/Microsoft.DotNet.CMake.Sdk/build/Microsoft.DotNet.CMake.Sdk.targets
+++ b/src/Microsoft.DotNet.CMake.Sdk/build/Microsoft.DotNet.CMake.Sdk.targets
@@ -122,7 +122,7 @@
   </Target>
 
   <Target Name="GetConfigScript" Returns="$(CMakeConfigScript)"
-    DependsOnTargets="ResolveVSGenerator;_ResolveVSCompilerToolchainForNonVSGenerators;_ResolveNonMSVCCompilerToolchain;$(CMakeConfigureDependsOn)">
+    DependsOnTargets="ResolveVSGenerator;GetRootCMakeListsDirectory;_ResolveVSCompilerToolchainForNonVSGenerators;_ResolveNonMSVCCompilerToolchain;$(CMakeConfigureDependsOn)">
     <Error Condition="'$(CMakeLists)' == ''" Text="A CMakeLists.txt must be specified via a CMakeLists item." />
     <Error Condition="'$(CMakeOutputDir)' == ''" Text="An output directory must be specified via the CMakeOutputDir property." />
     <Error Condition="!Exists('$(CMakeLists)')" Text="The provided CMakeLists.txt does not exist." />


### PR DESCRIPTION
`GetRootCMakeListsDirectory` is needed since it defines `_NormalizedCMakeListsDirectory` which we use for the `-S` CMake argument. Without it, we were passing an empty string.

Fixes the following `No source directory specified for -S` error when building winforms:

```
EXEC : CMake error : No source directory specified for -S [C:\Users\Vaka\winforms\src\System.Windows.Forms\tests\InteropTests\NativeTests\NativeTests.proj]
C:\Users\Vaka\.nuget\packages\microsoft.dotnet.cmake.sdk\5.0.0-beta.20256.5\build\Microsoft.DotNet.CMake.Sdk.targets(172,5): error MSB3073: The command " [C:\Users\Vaka\winforms\src\System.Windows.Forms\tests\InteropTests\NativeTests\NativeTests.proj]
C:\Users\Vaka\.nuget\packages\microsoft.dotnet.cmake.sdk\5.0.0-beta.20256.5\build\Microsoft.DotNet.CMake.Sdk.targets(172,5): error MSB3073:        [C:\Users\Vaka\winforms\src\System.Windows.Forms\tests\InteropTests\NativeTests\NativeTests.proj]
C:\Users\Vaka\.nuget\packages\microsoft.dotnet.cmake.sdk\5.0.0-beta.20256.5\build\Microsoft.DotNet.CMake.Sdk.targets(172,5): error MSB3073:        [C:\Users\Vaka\winforms\src\System.Windows.Forms\tests\InteropTests\NativeTests\NativeTests.proj]
C:\Users\Vaka\.nuget\packages\microsoft.dotnet.cmake.sdk\5.0.0-beta.20256.5\build\Microsoft.DotNet.CMake.Sdk.targets(172,5): error MSB3073:        cmake -G "Visual Studio 16 2019" -A Win32 -B "C:\Users\Vaka\winforms\artifacts\obj\NativeTests\x86\Debug" -S "" -DCMAKE_INSTALL_PREFIX=C:\Users\Vaka\winforms\artifacts\bin\NativeTests\x86\Debug [C:\Users\Vaka\winforms\src\System.Windows.Forms\tests\InteropTests\NativeTests\NativeTests.proj]
C:\Users\Vaka\.nuget\packages\microsoft.dotnet.cmake.sdk\5.0.0-beta.20256.5\build\Microsoft.DotNet.CMake.Sdk.targets(172,5): error MSB3073:       " exited with code 1. [C:\Users\Vaka\winforms\src\System.Windows.Forms\tests\InteropTests\NativeTests\NativeTests.proj]
```

I'm using CMake version 3.17.3.