### PR TITLE
Remove TargetPlatform from Tfm only for frameworks older than net5.0

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.props
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.props
@@ -12,12 +12,11 @@
     <DotNetBuildTasksTargetFrameworkSdkAssembly Condition="'$(DotNetBuildTasksTargetFrameworkSdkAssembly)' == '' AND '$(MSBuildRuntimeType)' != 'core'">..\tools\net472\Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.dll</DotNetBuildTasksTargetFrameworkSdkAssembly>
     <_OriginalTargetFramework>$(TargetFramework)</_OriginalTargetFramework>
     <TargetFrameworkPattern><![CDATA[(?<v1>netstandard2.0|netstandard2.1|net461|net462|net47|netcoreapp2.0|netcoreapp2.1|netcoreapp3.1|netcoreapp3.0)(-[^;]+)]]></TargetFrameworkPattern>
-    <TargetFrameworkWithoutSuffix>$(TargetFramework)</TargetFrameworkWithoutSuffix>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.Contains('-'))">
     <TargetFrameworkSuffix>$(TargetFramework.SubString($([MSBuild]::Add($(TargetFramework.IndexOf('-')), 1))))</TargetFrameworkSuffix>
-    <TargetFrameworkWithoutSuffix>$(TargetFramework.SubString(0, $(TargetFramework.IndexOf('-'))))</TargetFrameworkWithoutSuffix>
+    <!-- Strip away the TargetPlatform during the build because the assets file and nuget generated files does not know about the TargetPlatform for frameworks older than net5.0.-->
     <TargetFramework>$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFramework)', '$(TargetFrameworkPattern)', '${v1}'))</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.props
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.props
@@ -11,10 +11,13 @@
     <DotNetBuildTasksTargetFrameworkSdkAssembly Condition="'$(DotNetBuildTasksTargetFrameworkSdkAssembly)' == '' AND '$(MSBuildRuntimeType)' == 'core'">..\tools\netcoreapp2.1\Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.dll</DotNetBuildTasksTargetFrameworkSdkAssembly>
     <DotNetBuildTasksTargetFrameworkSdkAssembly Condition="'$(DotNetBuildTasksTargetFrameworkSdkAssembly)' == '' AND '$(MSBuildRuntimeType)' != 'core'">..\tools\net472\Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.dll</DotNetBuildTasksTargetFrameworkSdkAssembly>
     <_OriginalTargetFramework>$(TargetFramework)</_OriginalTargetFramework>
+    <TargetFrameworkPattern><![CDATA[(?<v1>netstandard2.0|netstandard2.1|net461|net462|net47|netcoreapp2.0|netcoreapp2.1|netcoreapp3.1|netcoreapp3.0)(-[^;]+)]]></TargetFrameworkPattern>
+    <TargetFrameworkWithoutSuffix>$(TargetFramework)</TargetFrameworkWithoutSuffix>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.Contains('-'))">
     <TargetFrameworkSuffix>$(TargetFramework.SubString($([MSBuild]::Add($(TargetFramework.IndexOf('-')), 1))))</TargetFrameworkSuffix>
-    <TargetFramework>$(TargetFramework.SubString(0, $(TargetFramework.IndexOf('-'))))</TargetFramework>
+    <TargetFrameworkWithoutSuffix>$(TargetFramework.SubString(0, $(TargetFramework.IndexOf('-'))))</TargetFrameworkWithoutSuffix>
+    <TargetFramework>$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFramework)', '$(TargetFrameworkPattern)', '${v1}'))</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.props
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.props
@@ -11,7 +11,7 @@
     <DotNetBuildTasksTargetFrameworkSdkAssembly Condition="'$(DotNetBuildTasksTargetFrameworkSdkAssembly)' == '' AND '$(MSBuildRuntimeType)' == 'core'">..\tools\netcoreapp2.1\Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.dll</DotNetBuildTasksTargetFrameworkSdkAssembly>
     <DotNetBuildTasksTargetFrameworkSdkAssembly Condition="'$(DotNetBuildTasksTargetFrameworkSdkAssembly)' == '' AND '$(MSBuildRuntimeType)' != 'core'">..\tools\net472\Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.dll</DotNetBuildTasksTargetFrameworkSdkAssembly>
     <_OriginalTargetFramework>$(TargetFramework)</_OriginalTargetFramework>
-    <TargetFrameworkPattern><![CDATA[(?<v1>netstandard2.0|netstandard2.1|net461|net462|net47|netcoreapp2.0|netcoreapp2.1|netcoreapp3.1|netcoreapp3.0)(-[^;]+)]]></TargetFrameworkPattern>
+    <TargetFrameworkPattern><![CDATA[(?<v1>((netstandard|netcoreapp)[1-9\.]+)|(net[1-4][1-9\.]+))(-[^;]+)]]></TargetFrameworkPattern>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.Contains('-'))">

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.props
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.props
@@ -11,12 +11,12 @@
     <DotNetBuildTasksTargetFrameworkSdkAssembly Condition="'$(DotNetBuildTasksTargetFrameworkSdkAssembly)' == '' AND '$(MSBuildRuntimeType)' == 'core'">..\tools\netcoreapp2.1\Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.dll</DotNetBuildTasksTargetFrameworkSdkAssembly>
     <DotNetBuildTasksTargetFrameworkSdkAssembly Condition="'$(DotNetBuildTasksTargetFrameworkSdkAssembly)' == '' AND '$(MSBuildRuntimeType)' != 'core'">..\tools\net472\Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.dll</DotNetBuildTasksTargetFrameworkSdkAssembly>
     <_OriginalTargetFramework>$(TargetFramework)</_OriginalTargetFramework>
-    <TargetFrameworkPattern><![CDATA[(?<v1>((netstandard|netcoreapp)[1-9\.]+)|(net[1-4][1-9\.]+))(-[^;]+)]]></TargetFrameworkPattern>
+    <TargetFrameworkPattern>(((netstandard|netcoreapp)[0-9\.]+)|(net[1-4][1-9\.]+))(-[^;]+)</TargetFrameworkPattern>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.Contains('-'))">
     <TargetFrameworkSuffix>$(TargetFramework.SubString($([MSBuild]::Add($(TargetFramework.IndexOf('-')), 1))))</TargetFrameworkSuffix>
     <!-- Strip away the TargetPlatform during the build because the assets file and nuget generated files does not know about the TargetPlatform for frameworks older than net5.0.-->
-    <TargetFramework>$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFramework)', '$(TargetFrameworkPattern)', '${v1}'))</TargetFramework>
+    <TargetFramework>$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFramework)', '$(TargetFrameworkPattern)', '${1}'))</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
@@ -6,7 +6,7 @@
 
   <!-- Strip away the TargetPlatforms during the graph build restore for frameworks older than net5.0 -->
   <PropertyGroup Condition="'$(IsGraphBuild)' == 'true' and '$(MSBuildRestoreSessionId)' != ''">
-    <TargetFrameworks Condition="'$(TargetFrameworks)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '$(TargetFrameworkPattern)', '${v1}'))</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '$(TargetFrameworkPattern)', '${1}'))</TargetFrameworks>
   </PropertyGroup>
 
   <!-- We filter _InnerBuildProjects items during DispatchToInnerBuilds and Clean to only run for best target frameworks. -->

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
@@ -4,7 +4,7 @@
   <UsingTask TaskName="ChooseBestTargetFrameworksTask" AssemblyFile="$(DotNetBuildTasksTargetFrameworkSdkAssembly)" />
   <UsingTask TaskName="AddTargetFrameworksToProjectTask" AssemblyFile="$(DotNetBuildTasksTargetFrameworkSdkAssembly)" />
 
-  <!-- Strip away the TargetFrameworkSuffix during the graph build. -->
+  <!-- Strip away the TargetPlatforms during the graph build restore for frameworks older than net5.0 -->
   <PropertyGroup Condition="'$(IsGraphBuild)' == 'true' and '$(MSBuildRestoreSessionId)' != ''">
     <TargetFrameworks Condition="'$(TargetFrameworks)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '$(TargetFrameworkPattern)', '${v1}'))</TargetFrameworks>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
@@ -6,7 +6,7 @@
 
   <!-- Strip away the TargetFrameworkSuffix during the graph build. -->
   <PropertyGroup Condition="'$(IsGraphBuild)' == 'true' and '$(MSBuildRestoreSessionId)' != ''">
-    <TargetFrameworks Condition="'$(TargetFrameworks)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '(-[^;]+)', ''))</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '$(TargetFrameworkPattern)', '${v1}'))</TargetFrameworks>
   </PropertyGroup>
 
   <!-- We filter _InnerBuildProjects items during DispatchToInnerBuilds and Clean to only run for best target frameworks. -->
@@ -40,7 +40,7 @@
       <_BuildTargetFrameworkWithoutOS Include="$([MSBuild]::Unescape($([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '(-[^;]+)', ''))))" />
       <!-- TODO: Find a better way to filter out non applicable TargetOS values for .NET Framework. -->
       <_BuildTargetFrameworkWithTargetOS Include="@(_BuildTargetFrameworkWithoutOS->Distinct()->'%(Identity)-$(TargetOS)')"
-                                         Condition="'$(TargetOS)' == 'Windows_NT' or !$([System.String]::Copy('%(Identity)').StartsWith('net4'))" />
+                                         Condition="'$(TargetOS)' == 'windows' or !$([System.String]::Copy('%(Identity)').StartsWith('net4'))" />
     </ItemGroup>
     
     <ChooseBestTargetFrameworksTask BuildTargetFrameworks="@(_BuildTargetFrameworkWithTargetOS);$(AdditionalBuildTargetFrameworks)"


### PR DESCRIPTION
- adding regex to remove targetplatforms in targetframeworks for restore for older frameworks.
- adding regex to remove targetplatform in tfm for build on older frameworks.