### PR TITLE
[release/5.0] Avoid stable versions when generating the merged manifest (#6474)

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishBuildAssets.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishBuildAssets.proj
@@ -10,6 +10,9 @@
   <PropertyGroup>
     <OfficialBuild>false</OfficialBuild>
     <OfficialBuild Condition="'$(OfficialBuildId)' != ''">true</OfficialBuild>
+    <!-- Block stable versioning so that the merged asset manifest is pushed
+         to a unique location -->
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
   </PropertyGroup>
   
   <Import Project="$(RepoRoot)eng\Versions.props" />


### PR DESCRIPTION
## Description

Avoid stable versions when generating the merged manifest

## Customer Impact

Merged manifest publishing overwrites merged manifests of other builds

## Regression

No

## Risk

Low

## Workarounds

No