### PR TITLE
Fix asynchronous nuget push and other bugs

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
@@ -380,7 +380,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                 }
             };
 
-            Func<string, string, ProcessExecutionResult> testRunAndLogProcess = (string fakeExePath, string fakeExeArgs) =>
+            Func<string, string, Task<ProcessExecutionResult>> testRunAndLogProcess = (string fakeExePath, string fakeExeArgs) =>
             {
                 Debug.WriteLine($"Called mocked RunProcessAndGetOutputs() :  ExePath = {fakeExePath}, ExeArgs = {fakeExeArgs}");
                 Assert.Equal(fakeExePath, fakeNugetExeName);
@@ -394,7 +394,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                 {
                     result.ExitCode = 1;
                 }
-                return result;
+                return Task.FromResult(result);
             };
 
             await task.PushNugetPackageAsync(

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -624,25 +624,25 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             string feedVisibility,
             string feedName,
             Func<string, string, HttpClient, MsBuildUtils.TaskLoggingHelper, Task<PackageFeedStatus>> CompareLocalPackageToFeedPackageCallBack = null,
-            Func<string, string, ProcessExecutionResult> RunProcessAndGetOutputsCallBack = null
+            Func<string, string, Task<ProcessExecutionResult>> RunProcessAndGetOutputsCallBack = null
             )
         {
             // Using these callbacks we can mock up functionality when testing.
             CompareLocalPackageToFeedPackageCallBack ??= GeneralUtils.CompareLocalPackageToFeedPackage;
-            RunProcessAndGetOutputsCallBack ??= GeneralUtils.RunProcessAndGetOutputs;
+            RunProcessAndGetOutputsCallBack ??= GeneralUtils.RunProcessAndGetOutputsAsync;
             ProcessExecutionResult nugetResult = null;
+            var packageStatus = GeneralUtils.PackageFeedStatus.Unknown;
 
             try
             {
                 Log.LogMessage(MessageImportance.Normal, $"Pushing local package {localPackageLocation} to target feed {feedConfig.TargetURL}"); 
-                var packageStatus = GeneralUtils.PackageFeedStatus.Unknown;
                 int attemptIndex = 0;
 
                 do
                 {
                     attemptIndex++;
                     // The feed key when pushing to AzDo feeds is "AzureDevOps" (works with the credential helper).
-                    nugetResult = RunProcessAndGetOutputsCallBack(NugetPath, $"push \"{localPackageLocation}\" -Source \"{feedConfig.TargetURL}\" -NonInteractive -ApiKey AzureDevOps -Verbosity quiet");
+                    nugetResult = await RunProcessAndGetOutputsCallBack(NugetPath, $"push \"{localPackageLocation}\" -Source \"{feedConfig.TargetURL}\" -NonInteractive -ApiKey AzureDevOps -Verbosity quiet");
 
                     if (nugetResult.ExitCode == 0)
                     {
@@ -685,7 +685,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 {
                     Log.LogError($"Failed to publish package '{id}@{version}' to '{feedConfig.TargetURL}' after {MaxRetryCount} attempts. (Final status: {packageStatus})");
                 }
-                else if (!Log.HasLoggedErrors)
+                else
                 {
                     Log.LogMessage(MessageImportance.High, $"Succeeded publishing package '{localPackageLocation}' to feed {feedConfig.TargetURL}");
                 }
@@ -694,7 +694,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             {
                 Log.LogError($"Unexpected exception pushing package '{id}@{version}': {e.Message}");
             }
-            if (Log.HasLoggedErrors && nugetResult?.ExitCode != 0)
+
+            if (packageStatus != GeneralUtils.PackageFeedStatus.ExistsAndIdenticalToLocal && nugetResult?.ExitCode != 0)
             {
                 Log.LogError($"Output from nuget.exe: {Environment.NewLine}StdOut:{Environment.NewLine}{nugetResult.StandardOut}{Environment.NewLine}StdErr:{Environment.NewLine}{nugetResult.StandardError}");
             }


### PR DESCRIPTION
- Somehow the async nuget push got lost at some point. This resolves this by asynchronously waiting for process exit.
- Fixes an issue where we would log the output of all nuget failures even in non-failure cases, if another failure happened. The primary case for this is if a package push fails, but the file on the feed is the same as what we are pushing. This is not an error case, but if another operation in publishing fails, we'll erroneously log it.
- Fixes an issue where we would not log a package as succcesfully pushed if there was another error in publishing.