### PR TITLE
Fix armel jessie rootfs atomic error

### DIFF
--- a/eng/common/cross/armel/armel.jessie.patch
+++ b/eng/common/cross/armel/armel.jessie.patch
@@ -1,0 +1,43 @@
+diff -u -r a/usr/include/urcu/uatomic/generic.h b/usr/include/urcu/uatomic/generic.h
+--- a/usr/include/urcu/uatomic/generic.h	2014-10-22 15:00:58.000000000 -0700
++++ b/usr/include/urcu/uatomic/generic.h	2020-10-30 21:38:28.550000000 -0700
+@@ -69,10 +69,10 @@
+ #endif
+ #ifdef UATOMIC_HAS_ATOMIC_SHORT
+ 	case 2:
+-		return __sync_val_compare_and_swap_2(addr, old, _new);
++		return __sync_val_compare_and_swap_2((uint16_t*) addr, old, _new);
+ #endif
+ 	case 4:
+-		return __sync_val_compare_and_swap_4(addr, old, _new);
++		return __sync_val_compare_and_swap_4((uint32_t*) addr, old, _new);
+ #if (CAA_BITS_PER_LONG == 64)
+ 	case 8:
+ 		return __sync_val_compare_and_swap_8(addr, old, _new);
+@@ -109,7 +109,7 @@
+ 		return;
+ #endif
+ 	case 4:
+-		__sync_and_and_fetch_4(addr, val);
++		__sync_and_and_fetch_4((uint32_t*) addr, val);
+ 		return;
+ #if (CAA_BITS_PER_LONG == 64)
+ 	case 8:
+@@ -148,7 +148,7 @@
+ 		return;
+ #endif
+ 	case 4:
+-		__sync_or_and_fetch_4(addr, val);
++		__sync_or_and_fetch_4((uint32_t*) addr, val);
+ 		return;
+ #if (CAA_BITS_PER_LONG == 64)
+ 	case 8:
+@@ -187,7 +187,7 @@
+ 		return __sync_add_and_fetch_2(addr, val);
+ #endif
+ 	case 4:
+-		return __sync_add_and_fetch_4(addr, val);
++		return __sync_add_and_fetch_4((uint32_t*) addr, val);
+ #if (CAA_BITS_PER_LONG == 64)
+ 	case 8:
+ 		return __sync_add_and_fetch_8(addr, val);

--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -336,7 +336,7 @@ elif [[ -n $__CodeName ]]; then
     chroot $__RootfsDir apt-get -f -y install
     chroot $__RootfsDir apt-get -y install $__UbuntuPackages
     chroot $__RootfsDir symlinks -cr /usr
-    chroot $__RootfsDir apt clean
+    chroot $__RootfsDir apt-get clean
 
     if [ $__SkipUnmount == 0 ]; then
         umount $__RootfsDir/* || true
@@ -346,6 +346,12 @@ elif [[ -n $__CodeName ]]; then
         pushd $__RootfsDir
         patch -p1 < $__CrossDir/$__BuildArch/trusty.patch
         patch -p1 < $__CrossDir/$__BuildArch/trusty-lttng-2.4.patch
+        popd
+    fi
+
+    if [[ "$__BuildArch" == "armel" && "$__CodeName" == "jessie" ]]; then
+        pushd $__RootfsDir
+        patch -p1 < $__CrossDir/$__BuildArch/armel.jessie.patch
         popd
     fi
 elif [[ "$__Tizen" == "tizen" ]]; then


### PR DESCRIPTION
This used to be a required fix in Tizen, however updates to that platform made it not required. However, armel jessie still requires it. The patch is similar to fixes reported a few years ago.

Proper PR for https://github.com/dotnet/runtime/pull/44100

Closes https://github.com/dotnet/runtime/issues/44082 once its merged

Note this does not get armel jessie fully working for the dotnet runtime. Still broken by https://github.com/dotnet/runtime/issues/44098