### PR TITLE
Make XHarness CLI test fail the build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -193,7 +193,6 @@ stages:
               /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.XHarness.CLI.binlog
               /p:RestoreUsingNuGetTargets=false
             displayName: XHarness CLI pre-install Helix Testing
-            continueOnError: true
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''


### PR DESCRIPTION
This steps was failing because one of the machines didn't have `xcode-select` pointing to the Xcode installation but to the Xcode command line tools. That's why it only failed occasionally when it hit this one machine.

I verified that this machine was the only one with this issue:
```sql
WorkItems
| where QueueName == "osx.1015.amd64.open" and Started > now()-30d and FriendlyName == "xharness-ios-state" and Status != "Pass"
```

The step should fail the build and is stable otherwise.

Resolves https://github.com/dotnet/xharness/issues/337

Error message improved here https://github.com/dotnet/xharness/pull/349