### PR TITLE
[release/5.0] Remove setlocal and endlocal on create.cmd script (#6497)

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixCommandPackageDropBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixCommandPackageDropBase.cs
@@ -81,7 +81,6 @@ namespace Microsoft.DotNet.Build.Tasks.Installers.src
             string commandFilename = Path.Combine(packageDropOutputFolder, $"create.cmd");
             StringBuilder commandString = new StringBuilder();
             commandString.AppendLine("@echo off");
-            commandString.AppendLine("setlocal");
             commandString.AppendLine("set outputfolder=%1");
             commandString.AppendLine("if \"%outputfolder%\" NEQ \"\" (");
             commandString.AppendLine("  if \"%outputfolder:~-1%\" NEQ \"\\\" ( ");
@@ -123,7 +122,6 @@ namespace Microsoft.DotNet.Build.Tasks.Installers.src
             }
             ProcessToolSpecificCommandLineParameters(packageDropOutputFolder, commandString);
             commandString.AppendLine();
-            commandString.AppendLine("endlocal");
             if(!Directory.Exists(packageDropOutputFolder))
             {
                 Directory.CreateDirectory(packageDropOutputFolder);


### PR DESCRIPTION
## Description

Port #6497 
The endlocal returns an exitcode, so this always ignores the exit code of the wix command.
We don't even call this script in the same process as the caller, so no need for it anyway.

## Customer Impact

If a wix tool fails in post build signing, failure would not be reported.

## Regression

No

## Risk

V low

## Workarounds

No workarounds.