### PR TITLE
Fix MSBuild escaping issues

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/GetHelixWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/GetHelixWorkItems.cs
@@ -49,15 +49,27 @@ namespace Microsoft.DotNet.Helix.Sdk
 
             var workItems = new List<ITaskItem>();
 
-            IDictionary CreateWorkItemMetadata(string name)
+            Dictionary<string, string> CreateWorkItemMetadata(string name)
             {
-                var metadata = job.CloneCustomMetadata();
+                Dictionary<string, string> metadata = job.CloneCustomMetadata() as Dictionary<string, string>;
                 metadata["JobName"] = jobName;
                 metadata["WorkItemName"] = name;
                 var consoleUri = HelixApi.Options.BaseUri.AbsoluteUri.TrimEnd('/') + $"/api/2019-06-17/jobs/{jobName}/workitems/{Uri.EscapeDataString(name)}/console";
                 metadata["ConsoleOutputUri"] = consoleUri;
 
                 return metadata;
+            }
+
+            ITaskItem2 CreateTaskItem(string workItemName, Dictionary<string, string> metadata)
+            {
+                var workItem = (ITaskItem2) new TaskItem(workItemName);
+
+                foreach(KeyValuePair<string, string> entry in metadata)
+                {
+                    workItem.SetMetadataValueLiteral(entry.Key, entry.Value);
+                }
+
+                return workItem;
             }
 
             foreach (string name in status.Passed)
@@ -67,7 +79,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                 var metadata = CreateWorkItemMetadata(wi);
                 metadata["Failed"] = "false";
 
-                workItems.Add(new TaskItem($"{jobName}/{wi}", metadata));
+                workItems.Add(CreateTaskItem($"{jobName}/{wi}", metadata));
             }
 
             foreach (string name in status.Failed)
@@ -90,14 +102,14 @@ namespace Microsoft.DotNet.Helix.Sdk
                                 .ToImmutableList();
                     }
 
-                    metadata["UploadedFiles"] = JsonConvert.SerializeObject(files).Replace("%", "%25");
+                    metadata["UploadedFiles"] = JsonConvert.SerializeObject(files);
                 }
                 catch (Exception ex)
                 {
                     Log.LogWarningFromException(ex);
                 }
 
-                workItems.Add(new TaskItem($"{jobName}/{wi}", metadata));
+                workItems.Add(CreateTaskItem($"{jobName}/{wi}", metadata));
                 await Task.Delay(DelayBetweenHelixApiCallsInMs, cancellationToken);
             }
 

--- a/src/Microsoft.DotNet.Helix/Sdk/GetHelixWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/GetHelixWorkItems.cs
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.Helix.Sdk
 
             Dictionary<string, string> CreateWorkItemMetadata(string name)
             {
-                Dictionary<string, string> metadata = job.CloneCustomMetadata() as Dictionary<string, string>;
+                var metadata = job.CloneCustomMetadata() as Dictionary<string, string>;
                 metadata["JobName"] = jobName;
                 metadata["WorkItemName"] = name;
                 var consoleUri = HelixApi.Options.BaseUri.AbsoluteUri.TrimEnd('/') + $"/api/2019-06-17/jobs/{jobName}/workitems/{Uri.EscapeDataString(name)}/console";
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.Helix.Sdk
 
             ITaskItem2 CreateTaskItem(string workItemName, Dictionary<string, string> metadata)
             {
-                var workItem = (ITaskItem2) new TaskItem(workItemName);
+                ITaskItem2 workItem = new TaskItem(workItemName);
 
                 foreach(KeyValuePair<string, string> entry in metadata)
                 {

--- a/src/Microsoft.DotNet.Helix/Sdk/GetHelixWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/GetHelixWorkItems.cs
@@ -49,9 +49,9 @@ namespace Microsoft.DotNet.Helix.Sdk
 
             var workItems = new List<ITaskItem>();
 
-            Dictionary<string, string> CreateWorkItemMetadata(string name)
+            IDictionary<string, string> CreateWorkItemMetadata(string name)
             {
-                var metadata = job.CloneCustomMetadata() as Dictionary<string, string>;
+                var metadata = job.CloneCustomMetadata() as IDictionary<string, string>;
                 metadata["JobName"] = jobName;
                 metadata["WorkItemName"] = name;
                 var consoleUri = HelixApi.Options.BaseUri.AbsoluteUri.TrimEnd('/') + $"/api/2019-06-17/jobs/{jobName}/workitems/{Uri.EscapeDataString(name)}/console";
@@ -60,7 +60,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                 return metadata;
             }
 
-            ITaskItem2 CreateTaskItem(string workItemName, Dictionary<string, string> metadata)
+            ITaskItem2 CreateTaskItem(string workItemName, IDictionary<string, string> metadata)
             {
                 ITaskItem2 workItem = new TaskItem(workItemName);
 


### PR DESCRIPTION
MSBuild does some weird escaping of strings in metadata when we use the basic constructor (ie, it removes any escaping behavior/assumes % as an escape character and compresses \\). We do not want that behavior. We want all characters to be treated as the literal character. This change modifies how we save the metadata by using ITaskItem2 and SetMetadataValueLiteral.

Impact to the customer:
* Customer will now get log urls that have been properly escaped so they are navigable.
* Customer will no longer see json deserialization errors if uploaded file has backslashes in either the name or link.

Fixes #6163 and #6490.