### PR TITLE
Preserve original non-zero exit code when XHarness iOS test fails

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
@@ -127,7 +127,7 @@ if [ ! -f "$test_results" ]; then
     echo "Failed to find xUnit tests results in the output directory. Existing files:"
     ls -la "$output_directory"
 
-    if [ "$exit_code" == "0" ]; then
+    if [ $exit_code -eq 0 ]; then
         exit_code=1
     fi
 

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
@@ -128,7 +128,7 @@ if [ ! -f "$test_results" ]; then
     ls -la "$output_directory"
 
     if [ $exit_code -eq 0 ]; then
-        exit_code=1
+        exit_code=5
     fi
 
     exit $exit_code

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
@@ -126,7 +126,12 @@ test_results=`ls "$output_directory"/xunit-*.xml`
 if [ ! -f "$test_results" ]; then
     echo "Failed to find xUnit tests results in the output directory. Existing files:"
     ls -la "$output_directory"
-    exit 1
+
+    if [ "$exit_code" == "0" ]; then
+        exit_code=1
+    fi
+
+    exit $exit_code
 fi
 
 echo "Found test results in $output_directory/$test_results. Renaming to testResults.xml to prepare for Helix upload"


### PR DESCRIPTION
Kusto logs are hard to navigate if we lose this information