### PR TITLE
Set IsImplicitlyDefined=true on Rich Nav package reference

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
@@ -136,6 +136,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(EnableRichCodeNavigation)' == 'true'">
-    <PackageReference Include="RichCodeNav.EnvVarDump" Version="$(RichCodeNavPackageVersion)" PrivateAssets="all" />
+    <PackageReference Include="RichCodeNav.EnvVarDump" Version="$(RichCodeNavPackageVersion)" IsImplicitlyDefined="true" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The aspnetcore repository needs this package reference to be implicitly defined. See [this pull request](https://github.com/dotnet/aspnetcore/pull/26822#issuecomment-719759979) for more context