### PR TITLE
Increase job timeout for publishing job

### DIFF
--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -250,6 +250,7 @@ stages:
     - job:
       displayName: Publish Using Darc
       dependsOn: setupMaestroVars
+      timeoutInMinutes: 120
       variables:
         - name: BARBuildId
           value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]


### PR DESCRIPTION
The publishing job is just launching another build and waiting on it. This other job has a longer timeout. So there's not a point in having this time out and fail, when the publishing job will succeed and promote the build.