### PR TITLE
Use xcode-select when no Xcode version supplied in XHarness Helix SDK

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Reflection;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 
@@ -40,18 +39,6 @@ namespace Microsoft.DotNet.Helix.Sdk
             if (!IsPosixShell)
             {
                 Log.LogError("IsPosixShell was specified as false for an iOS work item; these can only run on MacOS devices currently.");
-                return false;
-            }
-
-            if (string.IsNullOrEmpty(XcodeVersion))
-            {
-                Log.LogError("No Xcode version was specified.");
-                return false;
-            }
-
-            if (!Regex.IsMatch(XcodeVersion, "[0-9]+\\.[0-9]+"))
-            {
-                Log.LogError($"Xcode version '{XcodeVersion}' was in an invalid format. Expected format is [major].[minor] format, e.g. 11.4.");
                 return false;
             }
 
@@ -164,8 +151,8 @@ namespace Microsoft.DotNet.Helix.Sdk
                                         $"--targets \"{targets}\" " +
                                         $"--timeout {testTimeout.TotalSeconds} " +
                                         $"--launch-timeout {launchTimeout.TotalSeconds} " +
-                                         "--xharness-cli-path \"$XHARNESS_CLI_PATH\" " +
-                                        $"--xcode-version {XcodeVersion}" +
+                                         "--xharness-cli-path \"$XHARNESS_CLI_PATH\"" +
+                                        (!string.IsNullOrEmpty(XcodeVersion) ? $" --xcode-version \"{XcodeVersion}\"" : string.Empty) +
                                         (!string.IsNullOrEmpty(AppArguments) ? $" --app-arguments \"{AppArguments}\"" : string.Empty);
 
             Log.LogMessage(MessageImportance.Low, $"Generated XHarness command: {xharnessRunCommand}");

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
@@ -103,7 +103,7 @@ You can configure the execution further via MSBuild properties:
 
 ```xml
 <PropertyGroup>
-  <!-- Optional: Specific version of Xcode to use -->
+  <!-- Optional: Specific version of Xcode to use. If omitted, xcode-select is used to determine the version -->
   <XHarnessXcodeVersion>11.4</XHarnessXcodeVersion>
 </PropertyGroup>
 ```

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.props
@@ -6,6 +6,5 @@
     <_HelixMonoQueueTargets>$(_HelixMonoQueueTargets);$(MSBuildThisFileDirectory)XHarnessRunner.targets</_HelixMonoQueueTargets>
 
     <XHarnessPackageSource Condition=" '$(XHarnessPackageSource)' == '' ">https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet-eng/nuget/v3/index.json</XHarnessPackageSource>
-    <XHarnessXcodeVersion Condition=" '$(XHarnessXcodeVersion)' == '' ">11.5</XHarnessXcodeVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
@@ -11,7 +11,7 @@ xharness_cli_path=''
 xcode_version=''
 app_arguments=''
 
-while [[ $# > 0 ]]; do
+while [[ $# -gt 0 ]]; do
     opt="$(echo "$1" | awk '{print tolower($0)}')"
     case "$opt" in
       --app)
@@ -56,7 +56,7 @@ done
 
 function die ()
 {
-    echo $1 1>&2
+    echo "$1" 1>&2
     exit 1
 }
 
@@ -84,14 +84,14 @@ if [ -z "$xharness_cli_path" ]; then
     die "XHarness path wasn't provided";
 fi
 
-if [ ! -z "$app_arguments" ]; then
+if [ -n "$app_arguments" ]; then
     app_arguments="-- $app_arguments";
 fi
 
 set +e
 
 if [ -z "$xcode_version" ]; then
-    xcode_path=$(dirname $(dirname $(xcode-select -p)))
+    xcode_path="$(dirname "$(dirname "$(xcode-select -p)")")"
 else
     xcode_path="/Applications/Xcode${xcode_version/./}.app"
 fi
@@ -108,11 +108,11 @@ dotnet exec "$xharness_cli_path" ios test  \
     --app="$app"                           \
     --output-directory="$output_directory" \
     --targets="$targets"                   \
-    --timeout=$timeout                     \
-    --launch-timeout=$launch_timeout       \
+    --timeout="$timeout"                   \
+    --launch-timeout="$launch_timeout"     \
     --xcode="$xcode_path"                  \
     -v                                     \
-    $app_arguments
+    "$app_arguments"
 
 exit_code=$?
 
@@ -122,7 +122,7 @@ sudo pkill -9 -f "$simulator_app"
 # The simulator logs comming from the sudo-spawned Simulator.app are not readable by the helix uploader
 chmod 0644 "$output_directory"/*.log
 
-test_results=`ls "$output_directory"/xunit-*.xml`
+test_results=$(ls "$output_directory"/xunit-*.xml)
 
 if [ ! -f "$test_results" ]; then
     echo "Failed to find xUnit tests results in the output directory. Existing files:"

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
@@ -84,18 +84,19 @@ if [ -z "$xharness_cli_path" ]; then
     die "XHarness path wasn't provided";
 fi
 
-if [ -z "$xcode_version" ]; then
-    die "Xcode version wasn't provided";
-fi
-
 if [ ! -z "$app_arguments" ]; then
     app_arguments="-- $app_arguments";
 fi
 
 set +e
 
+if [ -z "$xcode_version" ]; then
+    xcode_path=$(dirname $(dirname $(xcode-select -p)))
+else
+    xcode_path="/Applications/Xcode${xcode_version/./}.app"
+fi
+
 # Restart the simulator to make sure it is tied to the right user session
-xcode_path="/Applications/Xcode${xcode_version/./}.app"
 simulator_app="$xcode_path/Contents/Developer/Applications/Simulator.app"
 sudo pkill -9 -f "$simulator_app"
 open -a "$simulator_app"

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
@@ -112,7 +112,7 @@ dotnet exec "$xharness_cli_path" ios test  \
     --launch-timeout="$launch_timeout"     \
     --xcode="$xcode_path"                  \
     -v                                     \
-    "$app_arguments"
+    $app_arguments
 
 exit_code=$?
 


### PR DESCRIPTION
Allow to omit the Xcode version so that XHarness can use the default one set by `xcode-select -p`

This also fixes an issue where the **Xcode 12.0 beta 4** wasn't targetable at all since the folder was `Xcode12.app` and we were forcing `[major].[minor]` format on the version supplied to the SDK