### PR TITLE
Do not kill the iOS simulator between work items

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
@@ -96,9 +96,8 @@ else
     xcode_path="/Applications/Xcode${xcode_version/./}.app"
 fi
 
-# Restart the simulator to make sure it is tied to the right user session
+# Start the simulator if it was not run already
 simulator_app="$xcode_path/Contents/Developer/Applications/Simulator.app"
-sudo pkill -9 -f "$simulator_app"
 open -a "$simulator_app"
 
 export XHARNESS_DISABLE_COLORED_OUTPUT=true
@@ -116,8 +115,12 @@ dotnet exec "$xharness_cli_path" ios test  \
 
 exit_code=$?
 
-# Kill the simulator after we're done
-sudo pkill -9 -f "$simulator_app"
+# Kill the simulator just in case when we fail to launch the app
+# 80 - app crash
+# 83 - app launch failure
+if [ $exit_code -eq 80 ] || [ $exit_code -eq 83 ]; then
+    sudo pkill -9 -f "$simulator_app"
+fi
 
 # The simulator logs comming from the sudo-spawned Simulator.app are not readable by the helix uploader
 chmod 0644 "$output_directory"/*.log

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
@@ -96,7 +96,7 @@ else
     xcode_path="/Applications/Xcode${xcode_version/./}.app"
 fi
 
-# Start the simulator if it was not run already
+# Start the simulator if it is not running already
 simulator_app="$xcode_path/Contents/Developer/Applications/Simulator.app"
 open -a "$simulator_app"
 


### PR DESCRIPTION
Since we run 500+ work items per machine per day, this will be a significant speed up.

It is not 100% this won't break some cases when the simulator is spawned in a wrong user session but the `sudo launchctl` we use to run the whole job should do the trick.