### PR TITLE
Ensure that the output directory exists when creating installers.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/bundle.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/bundle.targets
@@ -13,6 +13,8 @@
   <Import Project="$(MSBuildThisFileDirectory)wix/wix.targets" />
 
   <Target Name="GenerateBundles" DependsOnTargets="GetBundleGenerationFlags" Condition="'$(SkipInstallerBuild)' != 'true'">
+    <MakeDir Directories="$(PackageOutputPath)" />
+
     <ItemGroup>
       <_InstallerBuildProject Include="$(MSBuildProjectFile)"
                Targets="GenerateExeBundle"

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
@@ -37,7 +37,9 @@
   -->
   <Import Project="$(MSBuildThisFileDirectory)wix/wix.targets" />
 
-  <Target Name="GenerateInstallers" DependsOnTargets="GetInstallerGenerationFlags" Condition="'$(SkipInstallerBuild)' != 'true' and '$(GenerateInstallers)' == 'true'">
+  <Target Name="GenerateInstallers" DependsOnTargets="GetInstallerGenerationFlags" Condition="'$(SkipInstallerBuild)' != 'true' and '$(GenerateInstallers)' == 'true'">    
+    <MakeDir Directories="$(PackageOutputPath)" />
+
     <ItemGroup>
       <_InstallerBuildProject
         Include="$(MSBuildProjectFile)"


### PR DESCRIPTION
I just hit this when running a test official build on https://github.com/dotnet/runtime/pull/38457.

This fixes an intermittent issue where depending on how MSBuild ordered project execution and scheduled target execution, we could try to create an installer file in a directory that doesn't exist (which some tooling doesn't support).