### PR TITLE
Quote workItemName and consoleUri

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/CheckHelixJobStatus.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CheckHelixJobStatus.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                         var workItemName = workItem.GetMetadata("WorkItemName");
                         var consoleUri = workItem.GetMetadata("ConsoleOutputUri");
 
-                        Log.LogError(FailureCategory.Test, $"Work item {workItemName} in job {jobName} has failed.\nFailure log: {consoleUri}{accessTokenSuffix}");
+                        Log.LogError(FailureCategory.Test, $"Work item '{workItemName}' in job {jobName} has failed.\nFailure log: '{consoleUri}{accessTokenSuffix}'");
                     }
                 }
             }

--- a/src/Microsoft.DotNet.Helix/Sdk/CheckHelixJobStatus.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CheckHelixJobStatus.cs
@@ -1,7 +1,5 @@
 using Microsoft.Build.Framework;
 using Newtonsoft.Json;
-using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -37,8 +35,9 @@ namespace Microsoft.DotNet.Helix.Sdk
                         var jobName = workItem.GetMetadata("JobName");
                         var workItemName = workItem.GetMetadata("WorkItemName");
                         var consoleUri = workItem.GetMetadata("ConsoleOutputUri");
+                        var logUrl = System.Uri.EscapeUriString(consoleUri + accessTokenSuffix);
 
-                        Log.LogError(FailureCategory.Test, $"Work item '{workItemName}' in job {jobName} has failed.\nFailure log: '{consoleUri}{accessTokenSuffix}'");
+                        Log.LogError(FailureCategory.Test, $"Work item '{workItemName}' in job {jobName} has failed.\nFailure log: {logUrl}");
                     }
                 }
             }


### PR DESCRIPTION
Seen in dotnet/performance:

```
[...]: error : Work item SDK ASP.NET MVC App Template netcoreapp3.1 Clean Build in job 2db02a82-cc0b-4316-a9ee-e1489413e4a4 has failed. [...]
[...]: error : Failure log: https://helix.dot.net/api/2019-06-17/jobs/2db02a82-cc0b-4316-a9ee-e1489413e4a4/workitems/SDK ASP.NET MVC App Template netcoreapp3.1 Clean Build/console [...]
```

It seems to me that the logs would get more readable if it were clear where the work item and URL ends.