### PR TITLE
Update the SDK to 5.0.100 (RTW)

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100-rc.2.20479.15"
+    "dotnet": "5.0.100"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20552.5",


### PR DESCRIPTION
Manual "cherry-pick" of https://github.com/dotnet/arcade/commit/6f54e001de0c52e52578e5252cb279f5bc9a2eb6 into master. Doing this as it would be odd if we would use an older SDK in release/5.0 than in master. Also now is probably a good time to update to a stable SDK.

cc @markwilkie 