### PR TITLE
Fix path to layout package root.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
@@ -417,7 +417,7 @@
     
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="PublishToDisk"
-             Properties="OutputPath=$(_LayoutPackageRoot)"
+             Properties="OutputPath=$([MSBuild]::EnsureHasTrailingSlash('$(_LayoutPackageRoot)'))'"
              RemoveProperties="@(_GlobalPropertiesToRemoveForPublish)"  />
     
     <Copy


### PR DESCRIPTION
This was causing files for RPM, Deb, and Pkg installers to not be added to the archives.

Discovered while running final validation checks on https://github.com/dotnet/runtime/pull/38457/