### PR TITLE
Remove extraneous quote and remove unnecessary target dependency.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
@@ -356,15 +356,15 @@
     Create macOS pkg installer.
   -->
   <Target Name="CreatePkg"
-          DependsOnTargets="
-            _GetInstallerProperties;
-            _CreateInstallerLayout"
+          DependsOnTargets="_GetInstallerProperties"
           Returns="@(_CreatedPkg)">
     
     <!-- Copy files to layout. -->
     <PropertyGroup>
       <_OutputPathRoot>$(IntermediateOutputPath)output/</_OutputPathRoot>
     </PropertyGroup>
+    
+    <MakeDir Directories="$(_OutputPathRoot)" />
 
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="PublishToDisk"
@@ -417,7 +417,7 @@
     
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="PublishToDisk"
-             Properties="OutputPath=$([MSBuild]::EnsureTrailingSlash('$(_LayoutPackageRoot)'))'"
+             Properties="OutputPath=$([MSBuild]::EnsureTrailingSlash('$(_LayoutPackageRoot)'))"
              RemoveProperties="@(_GlobalPropertiesToRemoveForPublish)"  />
     
     <Copy


### PR DESCRIPTION
The quote was causing the build to fail since the path doesn't exist.

The extra dependency was causing the shared framework to be written out an extra time to disk, which we shouldn't do if we don't need to.