### PR TITLE
Add some tests for wix and wix pack

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,6 +16,7 @@
     <log4netVersion>2.0.8</log4netVersion>
     <SystemNetHttpVersion>4.3.4</SystemNetHttpVersion>
     <AzureStorageBlobsVersion>12.3.0</AzureStorageBlobsVersion>
+    <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>
     <MicrosoftAzureKeyVaultVersion>3.0.0</MicrosoftAzureKeyVaultVersion>
     <MicrosoftAzureServicesAppAuthenticationVersion>1.3.1</MicrosoftAzureServicesAppAuthenticationVersion>
     <MicrosoftDataAnalysisVersion>0.1.0</MicrosoftDataAnalysisVersion>

--- a/src/Microsoft.DotNet.SignTool.Tests/Microsoft.DotNet.SignTool.Tests.csproj
+++ b/src/Microsoft.DotNet.SignTool.Tests/Microsoft.DotNet.SignTool.Tests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="System.IO.Packaging" Version="$(SystemIOPackagingVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />

--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -2040,7 +2040,7 @@ $@"
 
             Assert.False(BatchSignUtil.RunWixTool("create.cmd", "foodir", "bardir", null, task.Log));
             Assert.True(task.Log.HasLoggedErrors);
-            Assert.Contains(fakeBuildEngine.LogErrorEvents, e => e.Message.Contains("WixToolsPath must be defined to run wix tooling"));
+            Assert.Contains(fakeBuildEngine.LogErrorEvents, e => e.Message.Contains("WixToolsPath must be defined to run WiX tooling"));
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -12,6 +12,7 @@ using System.Runtime.InteropServices;
 using TestUtilities;
 using Xunit;
 using Xunit.Abstractions;
+using FluentAssertions;
 
 namespace Microsoft.DotNet.SignTool.Tests
 {
@@ -302,7 +303,7 @@ namespace Microsoft.DotNet.SignTool.Tests
             Dictionary<string, List<SignInfo>> strongNameSignInfo,
             Dictionary<ExplicitCertificateKey, string> fileSignInfo,
             Dictionary<string, List<SignInfo>> extensionsSignInfo,
-            string[] expectedXmlElementsPerSingingRound,
+            string[] expectedXmlElementsPerSigningRound,
             ITaskItem[] dualCertificates = null,
             string wixToolsPath = null)
         {
@@ -324,14 +325,15 @@ namespace Microsoft.DotNet.SignTool.Tests
             var afterSigningEngineFilesList = Directory.GetFiles(signToolArgs.TempDir, "*-engine.exe", SearchOption.AllDirectories);
 
             // validate no intermediate msi engine files have populated the drop (they fail signing validation).
-            Assert.True(beforeSigningEngineFilesList.SequenceEqual(afterSigningEngineFilesList));
+            beforeSigningEngineFilesList.SequenceEqual(afterSigningEngineFilesList).Should().BeTrue();
 
             // The list of files that would be signed was captured inside the FakeBuildEngine,
             // here we check if that matches what we expected
-            var actualXmlElementsPerSingingRound = buildEngine.FilesToSign.Select(round => string.Join(Environment.NewLine, round));
-            AssertEx.Equal(expectedXmlElementsPerSingingRound, actualXmlElementsPerSingingRound, comparer: AssertEx.EqualIgnoringWhitespace, itemInspector: s => s.Replace("\"", "\"\""));
+            var actualXmlElementsPerSigningRound = buildEngine.FilesToSign.Select(round => string.Join(Environment.NewLine, round));
+            actualXmlElementsPerSigningRound.Should().Equal(expectedXmlElementsPerSigningRound, (e1, e2) =>
+                AssertEx.EqualIgnoringWhitespace(e1, e2));
 
-            Assert.False(task.Log.HasLoggedErrors);
+            task.Log.HasLoggedErrors.Should().BeFalse();
         }
 
         private void ValidateFileSignInfos(
@@ -349,11 +351,10 @@ namespace Microsoft.DotNet.SignTool.Tests
             var task = new SignToolTask { BuildEngine = engine };
             var signingInput = new Configuration(_tmpDir, itemsToSign, strongNameSignInfo, fileSignInfo, extensionsSignInfo, dualCertificates, task.Log).GenerateListOfFiles();
 
-            AssertEx.Equal(expected, signingInput.FilesToSign.Select(f => f.ToString()));
-            AssertEx.Equal(expectedCopyFiles ?? Array.Empty<string>(), signingInput.FilesToCopy.Select(f => $"{f.Key} -> {f.Value}"));
-
-            AssertEx.Equal(expectedErrors ?? Array.Empty<string>(), engine.LogErrorEvents.Select(w => w.Message));
-            AssertEx.Equal(expectedWarnings ?? Array.Empty<string>(), engine.LogWarningEvents.Select(w => $"{w.Code}: {w.Message}"));
+            signingInput.FilesToSign.Select(f => f.ToString()).Should().BeEquivalentTo(expected);
+            signingInput.FilesToCopy.Select(f => $"{f.Key} -> {f.Value}").Should().BeEquivalentTo(expectedCopyFiles ?? Array.Empty<string>());
+            engine.LogErrorEvents.Select(w => w.Message).Should().BeEquivalentTo(expectedErrors ?? Array.Empty<string>());
+            engine.LogWarningEvents.Select(w => $"{w.Code}: {w.Message}").Should().BeEquivalentTo(expectedWarnings ?? Array.Empty<string>());
         }
 
         [Fact]
@@ -368,9 +369,9 @@ namespace Microsoft.DotNet.SignTool.Tests
             var task = new SignToolTask { BuildEngine = new FakeBuildEngine() };
             var signingInput = new Configuration(_tmpDir, itemsToSign, strongNameSignInfo, fileSignInfo, s_fileExtensionSignInfo, null, task.Log).GenerateListOfFiles();
 
-            Assert.Empty(signingInput.FilesToSign);
-            Assert.Empty(signingInput.ZipDataMap);
-            Assert.False(task.Log.HasLoggedErrors);
+            signingInput.FilesToSign.Should().BeEmpty();
+            signingInput.ZipDataMap.Should().BeEmpty();
+            task.Log.HasLoggedErrors.Should().BeFalse();
         }
 
         [Fact]
@@ -389,7 +390,7 @@ namespace Microsoft.DotNet.SignTool.Tests
                 SNBinaryPath = CreateTestResource("fake.sn.exe")
             };
 
-            Assert.True(task.Execute());
+            task.Execute().Should().BeTrue();
         }
 
         [Fact]
@@ -409,7 +410,7 @@ namespace Microsoft.DotNet.SignTool.Tests
                 SNBinaryPath = null,
             };
 
-            Assert.True(task.Execute());
+            task.Execute().Should().BeTrue();
         }
 
         [Fact]
@@ -747,6 +748,7 @@ $@"<FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "CoreLibCr
         }
 
         [SkippableFact]
+        [Trait("Category", "SkipWhenLiveUnitTesting")]
         public void DoubleNestedContainer()
         {
             Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
@@ -1163,6 +1165,7 @@ $@"
         }
 #endif
         [SkippableFact]
+        [Trait("Category", "SkipWhenLiveUnitTesting")]
         public void SignMsiEngine()
         {
             Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
@@ -1203,7 +1206,9 @@ $@"<FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "Container
             wixToolsPath: GetWixToolPath());
 
         }
+
         [SkippableFact]
+        [Trait("Category", "SkipWhenLiveUnitTesting")]
         public void MsiWithWixpack()
         {
             Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
@@ -1652,7 +1657,7 @@ $@"
                 { "CollisionPriorityId", "123" }
             }));
 
-            Assert.False(runTask(fileExtensionSignInfo: fileExtensionSignInfo.ToArray()));
+            runTask(fileExtensionSignInfo: fileExtensionSignInfo.ToArray()).Should().BeFalse();
         }
         [Fact]
         public void ValidateParseFileExtensionEntriesForDifferentCollisionPriorityIdSucceeds()
@@ -1674,7 +1679,7 @@ $@"
                 { "CollisionPriorityId", "456" }
             }));
 
-            Assert.True(runTask(fileExtensionSignInfo: fileExtensionSignInfo.ToArray()));
+            runTask(fileExtensionSignInfo: fileExtensionSignInfo.ToArray()).Should().BeTrue();
         }
 
         private bool runTask(ITaskItem[] itemsToSign = null, ITaskItem[] strongNameSignInfo = null, ITaskItem[] fileExtensionSignInfo = null)
@@ -1922,7 +1927,7 @@ $@"
                 new ITaskItem[0], task.Log)
                 .GenerateListOfFiles();
 
-            Assert.True(task.Log.HasLoggedErrors);
+            task.Log.HasLoggedErrors.Should().BeTrue();
         }
 
         [Theory]
@@ -1957,7 +1962,7 @@ $@"
                 task.Log)
                 .GenerateListOfFiles();
 
-            Assert.False(task.Log.HasLoggedErrors);
+            task.Log.HasLoggedErrors.Should().BeFalse();
         }
 
         [Fact]
@@ -1994,8 +1999,10 @@ $@"
         [SkippableTheory]
         [InlineData(true)]
         [InlineData(false)]
+        [Trait("Category", "SkipWhenLiveUnitTesting")]
         public void RunWixToolRunsOrFailsProperly(bool deleteWixobjBeforeRunningTool)
         {
+            Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
             var task = new SignToolTask { BuildEngine = new FakeBuildEngine() };
 
             const string expectedExe = "MsiBootstrapper.exe";
@@ -2019,8 +2026,8 @@ $@"
                     File.Delete(Path.Combine(workingDir, "Bundle.wixobj"));
                 }
 
-                Assert.Equal(!deleteWixobjBeforeRunningTool, BatchSignUtil.RunWixTool(createFileName, outputDir, workingDir, wixToolsPath, task.Log));
-                Assert.Equal(!deleteWixobjBeforeRunningTool, File.Exists(outputFileName));
+                BatchSignUtil.RunWixTool(createFileName, outputDir, workingDir, wixToolsPath, task.Log).Should().Be(!deleteWixobjBeforeRunningTool);
+                File.Exists(outputFileName).Should().Be(!deleteWixobjBeforeRunningTool);
             }
             finally
             {
@@ -2038,9 +2045,9 @@ $@"
             var fakeBuildEngine = new FakeBuildEngine();
             var task = new SignToolTask { BuildEngine = fakeBuildEngine };
 
-            Assert.False(BatchSignUtil.RunWixTool("create.cmd", "foodir", "bardir", null, task.Log));
-            Assert.True(task.Log.HasLoggedErrors);
-            Assert.Contains(fakeBuildEngine.LogErrorEvents, e => e.Message.Contains("WixToolsPath must be defined to run WiX tooling"));
+            BatchSignUtil.RunWixTool("create.cmd", "foodir", "bardir", null, task.Log).Should().BeFalse();
+            task.Log.HasLoggedErrors.Should().BeTrue();
+            fakeBuildEngine.LogErrorEvents.Should().Contain(e => e.Message.Contains("WixToolsPath must be defined to run WiX tooling"));
         }
 
         /// <summary>
@@ -2054,9 +2061,9 @@ $@"
             var fakeBuildEngine = new FakeBuildEngine();
             var task = new SignToolTask { BuildEngine = fakeBuildEngine };
 
-            Assert.False(BatchSignUtil.RunWixTool("create.cmd", "foodir", "bardir", "totally/wix/tools", task.Log));
-            Assert.True(task.Log.HasLoggedErrors);
-            Assert.Contains(fakeBuildEngine.LogErrorEvents, e => e.Message.Contains($"WixToolsPath '{totalWixToolDir}' not found."));
+            BatchSignUtil.RunWixTool("create.cmd", "foodir", "bardir", "totally/wix/tools", task.Log).Should().BeFalse();
+            task.Log.HasLoggedErrors.Should().BeTrue();
+            fakeBuildEngine.LogErrorEvents.Should().Contain(e => e.Message.Contains($"WixToolsPath '{totalWixToolDir}' not found."));
         }
     }
 }


### PR DESCRIPTION
Covers scenarios here https://github.com/dotnet/arcade/issues/6366
Adds tests for:
- Null or unavailable wix tools paths should return appropriate error messages.
- Execution of a wix tool should return a passing result and the output file should be created
- If the wix tool fails, method should return a failing result and output file should not exist.

Refactored some of the wix tool logic into BatchSignUtil. This reduces ZipData's wixpack knowledge to very minimal.