### PR TITLE
Don't have the SDK targets try to copy a ref assembly that doesn't exist.

### DIFF
--- a/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.props
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.props
@@ -12,6 +12,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <NoWarn>$(NoWarn);NU5128;NU5131</NoWarn>
     <PackageType>DotnetPlatform</PackageType>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <!-- Stub out the CreatePackageOverrides target. Each repo uses their own implementation. -->


### PR DESCRIPTION
This was encountered when updating the dotnet/windowsdesktop usage of the SDK.