### PR TITLE
Fix archive names to match expected pattern with RID at the end.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Archives/build/archives.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Archives/build/archives.targets
@@ -71,7 +71,7 @@
     <PropertyGroup>
       <_OutputPathRoot>$(IntermediateOutputPath)output/</_OutputPathRoot>
       <_ArchiveFileName>$(ArchiveName)-$(Version)</_ArchiveFileName>
-      <_ArchiveFileName Condition="'$(RuntimeIdentifier)' != ''">$(ArchiveName)-$(RuntimeIdentifier)-$(Version)</_ArchiveFileName>
+      <_ArchiveFileName Condition="'$(RuntimeIdentifier)' != ''">$(ArchiveName)-$(Version)-$(RuntimeIdentifier)</_ArchiveFileName>
     </PropertyGroup>
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="PublishToDisk"


### PR DESCRIPTION
Contributes to fixing issues consuming dotnet/runtime upstream after switching over to use the Microsoft.DotNet.Build.Tasks.Archives tooling to build archives.