### PR TITLE
Remove disabled sources to enable them

### DIFF
--- a/eng/common/SetupNugetSources.ps1
+++ b/eng/common/SetupNugetSources.ps1
@@ -99,8 +99,9 @@ function InsertMaestroPrivateFeedCredentials($Sources, $Creds, $Username, $Passw
 function EnablePrivatePackageSources($DisabledPackageSources) {
     $maestroPrivateSources = $DisabledPackageSources.SelectNodes("add[contains(@key,'darc-int')]")
     ForEach ($DisabledPackageSource in $maestroPrivateSources) {
-        Write-Host "`tEnsuring private source '$($DisabledPackageSource.key)' is enabled"
-        $DisabledPackageSource.SetAttribute("value", "false")
+        Write-Host "`tEnsuring private source '$($DisabledPackageSource.key)' is enabled by deleting it from disabledPackageSource"
+        # Due to https://github.com/NuGet/Home/issues/10291, we must actually remove the disabled entries
+        $DisabledPackageSources.RemoveChild($DisabledPackageSource)
     }
 }
 

--- a/eng/common/SetupNugetSources.sh
+++ b/eng/common/SetupNugetSources.sh
@@ -158,8 +158,8 @@ if [ "$?" == "0" ]; then
     for DisabledSourceName in ${DisabledDarcIntSources[@]} ; do
         if [[ $DisabledSourceName == darc-int* ]]
             then
-                OldDisableValue="add key=\"$DisabledSourceName\" value=\"true\""
-                NewDisableValue="add key=\"$DisabledSourceName\" value=\"false\""
+                OldDisableValue="<add key=\"$DisabledSourceName\" value=\"true\" />"
+                NewDisableValue="<!-- Reenabled for build : $DisabledSourceName -->"
                 sed -i.bak "s|$OldDisableValue|$NewDisableValue|" $ConfigFile
                 echo "Neutralized disablePackageSources entry for '$DisabledSourceName'"
         fi


### PR DESCRIPTION
Previously we assumed we could  just flip the XML's properties, but Nuget doesn't care about the "value" part of the added disabled sources and may never for release branches.  (@mmitche filed https://github.com/NuGet/Home/issues/10291)

Note: Since there weren't nice XML APIs in bash, I just had it swap the entries for a comment.

Addresses https://github.com/dotnet/core-eng/issues/11435.  I will make parallel PRs to release/3.x and release/5.0 shortly