### PR TITLE
Remove the certificate allowlist from signcheck for nupkg verification

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/Verification/NupkgVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/NupkgVerifier.cs
@@ -14,12 +14,6 @@ namespace Microsoft.SignCheck.Verification
 {
     public class NupkgVerifier : ArchiveVerifier
     {
-        private static List<CertificateHashAllowListEntry> AllowListEntries = new List<CertificateHashAllowListEntry>()
-        {
-            new CertificateHashAllowListEntry(VerificationTarget.Author | VerificationTarget.Repository, SignaturePlacement.PrimarySignature, "3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE", HashAlgorithmName.SHA256),
-            new CertificateHashAllowListEntry(VerificationTarget.Author | VerificationTarget.Repository, SignaturePlacement.PrimarySignature, "0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D", HashAlgorithmName.SHA256)
-        };
-
         public NupkgVerifier(Log log, Exclusions exclusions, SignatureVerificationOptions options) : base(log, exclusions, options, fileExtension: ".nupkg")
         {
 
@@ -42,7 +36,7 @@ namespace Microsoft.SignCheck.Verification
             IEnumerable<ISignatureVerificationProvider> providers = SignatureVerificationProviderFactory.GetSignatureVerificationProviders();
             var packageSignatureVerifier = new PackageSignatureVerifier(providers);
 
-            var verifierSettings = SignedPackageVerifierSettings.GetVerifyCommandDefaultPolicy(clientAllowListEntries: AllowListEntries);
+            var verifierSettings = SignedPackageVerifierSettings.GetVerifyCommandDefaultPolicy();
             IEnumerable<ISignatureVerificationProvider> verificationProviders = SignatureVerificationProviderFactory.GetSignatureVerificationProviders();
             var verifier = new PackageSignatureVerifier(verificationProviders);
 


### PR DESCRIPTION
Removes the specific cert verification from the nupkg verifier. The NuGet team confirmed that this validation goes beyond what NuGet validates when pushing to nuget.org, and since the certs expire, maintaining this list becomes problematic for release branches.

I validated locally that adding it solves the issue seen in https://github.com/dotnet/core-eng/issues/11458 for packages signed with the new certificate.

I'll have a full arcade test build soon to validate whether this unblocks things end to end in a build.