### PR TITLE
[release/5.0] Remove the certificate allowlist for nupkg verification.

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/Verification/NupkgVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/NupkgVerifier.cs
@@ -14,12 +14,6 @@ namespace Microsoft.SignCheck.Verification
 {
     public class NupkgVerifier : ArchiveVerifier
     {
-        private static List<CertificateHashAllowListEntry> AllowListEntries = new List<CertificateHashAllowListEntry>()
-        {
-            new CertificateHashAllowListEntry(VerificationTarget.Author | VerificationTarget.Repository, SignaturePlacement.PrimarySignature, "3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE", HashAlgorithmName.SHA256),
-            new CertificateHashAllowListEntry(VerificationTarget.Author | VerificationTarget.Repository, SignaturePlacement.PrimarySignature, "0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D", HashAlgorithmName.SHA256)
-        };
-
         public NupkgVerifier(Log log, Exclusions exclusions, SignatureVerificationOptions options) : base(log, exclusions, options, fileExtension: ".nupkg")
         {
 
@@ -42,7 +36,7 @@ namespace Microsoft.SignCheck.Verification
             IEnumerable<ISignatureVerificationProvider> providers = SignatureVerificationProviderFactory.GetSignatureVerificationProviders();
             var packageSignatureVerifier = new PackageSignatureVerifier(providers);
 
-            var verifierSettings = SignedPackageVerifierSettings.GetVerifyCommandDefaultPolicy(clientAllowListEntries: AllowListEntries);
+            var verifierSettings = SignedPackageVerifierSettings.GetVerifyCommandDefaultPolicy();
             IEnumerable<ISignatureVerificationProvider> verificationProviders = SignatureVerificationProviderFactory.GetSignatureVerificationProviders();
             var verifier = new PackageSignatureVerifier(verificationProviders);
 


### PR DESCRIPTION
## Description

release/5.0 port of https://github.com/dotnet/arcade/pull/6593 to unblock signing validation

## Customer Impact

signing validation jobs will fail

## Regression

No, a cert update + not knowing a lot about this particular allowlist came back to bite us when a new certificate came into play

## Risk

Low. This removes some extra validation that NuGet confirmed is not necessary, and a test build of arcade master succeeded with the same change: https://dev.azure.com/dnceng/internal/_build/results?buildId=892591&view=results

## Workarounds

repositories can disable signing validation altogether, which would be dangerous