### PR TITLE
[release/3.x] re-enable signing validation and update signcheck version

### DIFF
--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -1,6 +1,6 @@
 parameters:
   enableSourceLinkValidation: false
-  enableSigningValidation: false
+  enableSigningValidation: true
   enableSymbolValidation: false
   enableNugetValidation: true
   publishInstallersAndChecksums: false

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Versions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Versions.props
@@ -9,7 +9,7 @@
     <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.19616.1</MicrosoftDotNetMaestroTasksVersion>
     <MicrosoftDotNetBuildTasksVisualStudioVersion>$(ArcadeSdkVersion)</MicrosoftDotNetBuildTasksVisualStudioVersion>
     <MicrosoftDotNetBuildTasksFeedVersion Condition="'$(MicrosoftDotNetBuildTasksFeedVersion)' == ''">2.2.0-beta.20459.5</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetSignCheckVersion Condition="'$(MicrosoftDotNetSignCheckVersion)' == ''">1.0.0-beta.19509.6</MicrosoftDotNetSignCheckVersion>
+    <MicrosoftDotNetSignCheckVersion Condition="'$(MicrosoftDotNetSignCheckVersion)' == ''">1.0.0-beta.20569.8</MicrosoftDotNetSignCheckVersion>
     <MicrosoftSymbolUploaderBuildTaskVersion Condition="'$(MicrosoftSymbolUploaderBuildTaskVersion)' == ''">1.0.0-beta-64414-01</MicrosoftSymbolUploaderBuildTaskVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Last part of https://github.com/dotnet/arcade/pull/6596, where I re-enable signing validation in arcade, and I bump the version of signcheck to the one that has the fix.