### PR TITLE
[release/5.0] re-enable signing validation

### DIFF
--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -16,7 +16,7 @@ parameters:
   PromoteToChannelIds: ''
 
   enableSourceLinkValidation: false
-  enableSigningValidation: false
+  enableSigningValidation: true
   enableSymbolValidation: false
   enableNugetValidation: true
   publishInstallersAndChecksums: true


### PR DESCRIPTION
Final step of https://github.com/dotnet/core-eng/issues/11458 for the release/5.0 branch. I'll wait until there's a new arcade version with the fixed signcheck before merging.