### PR TITLE
Update arcade

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -7,25 +7,25 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.20567.7">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.20570.9">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>a9a80fb35d2e7da21509441d665a40022ce8f1b4</Sha>
+      <Sha>a5ae17bf7c28ef1dfd2d6ca29689256f3e76a4f2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="6.0.0-beta.20567.7">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="6.0.0-beta.20570.9">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>a9a80fb35d2e7da21509441d665a40022ce8f1b4</Sha>
+      <Sha>a5ae17bf7c28ef1dfd2d6ca29689256f3e76a4f2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SignTool" Version="6.0.0-beta.20567.7">
+    <Dependency Name="Microsoft.DotNet.SignTool" Version="6.0.0-beta.20570.9">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>a9a80fb35d2e7da21509441d665a40022ce8f1b4</Sha>
+      <Sha>a5ae17bf7c28ef1dfd2d6ca29689256f3e76a4f2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="6.0.0-beta.20567.7">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="6.0.0-beta.20570.9">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>a9a80fb35d2e7da21509441d665a40022ce8f1b4</Sha>
+      <Sha>a5ae17bf7c28ef1dfd2d6ca29689256f3e76a4f2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SwaggerGenerator.MSBuild" Version="6.0.0-beta.20567.7">
+    <Dependency Name="Microsoft.DotNet.SwaggerGenerator.MSBuild" Version="6.0.0-beta.20570.9">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>a9a80fb35d2e7da21509441d665a40022ce8f1b4</Sha>
+      <Sha>a5ae17bf7c28ef1dfd2d6ca29689256f3e76a4f2</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Maestro.Client" Version="1.1.0-beta.20258.6">
       <Uri>https://github.com/dotnet/arcade-services</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -61,8 +61,8 @@
     <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>
     <XUnitVSRunnerVersion>2.4.1</XUnitVSRunnerVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.20567.7</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetSignToolVersion>6.0.0-beta.20567.7</MicrosoftDotNetSignToolVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.20570.9</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetSignToolVersion>6.0.0-beta.20570.9</MicrosoftDotNetSignToolVersion>
     <MicrosoftAzureDocumentDBVersion>1.22.0</MicrosoftAzureDocumentDBVersion>
     <MicrosoftAzureCosmosDBTableVersion>1.1.2</MicrosoftAzureCosmosDBTableVersion>
     <MicrosoftAspNetCoreAllVersion>2.0.0</MicrosoftAspNetCoreAllVersion>
@@ -75,7 +75,7 @@
     <MicrosoftDotNetMaestroClientVersion>1.1.0-beta.20258.6</MicrosoftDotNetMaestroClientVersion>
     <MicrosoftSourceLinkGitHubVersion>1.1.0-beta-20566-02</MicrosoftSourceLinkGitHubVersion>
     <MicrosoftSourceLinkAzureReposGitVersion>1.1.0-beta-20566-02</MicrosoftSourceLinkAzureReposGitVersion>
-    <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>6.0.0-beta.20567.7</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
+    <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>6.0.0-beta.20570.9</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
     <XliffTasksVersion>1.0.0-beta.20568.1</XliffTasksVersion>
     <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.20570.1</MicrosoftDotNetMaestroTasksVersion>
     <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20568.3</MicrosoftDotNetXHarnessCLIVersion>

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "5.0.100"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20567.7",
-    "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.20567.7"
+    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20570.9",
+    "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.20570.9"
   }
 }


### PR DESCRIPTION
Update arcade to unblock publishing for cases where places have taken a new arcade.
The new arcade doesn't generate certain attributes that are not useful in the signing info node in the manifest, but the arcade currently in use in arcade's master still expects them. This arcade is what is used for publishing, so it's not possible to publish an arcade with altered signing attributes without updating arcade in master with this new arcade.