### PR TITLE
Use short component names for native files

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.dependency.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.dependency.targets
@@ -274,7 +274,7 @@
           DependsOnTargets="GetCorePackagePaths">
     <ItemGroup>
       <!-- Find crossgen tool assets in package cache to allow ExcludeAssets=All. -->
-      <_runtimeCLR Include="$(_runtimePackageDir)**/$(LibraryFilePrefix)coreclr$(LibraryFileExtension)" />
+      <_runtimeCLR Include="$(_runtimePackageDir)**/$(LibPrefix)coreclr$(LibSuffix)" />
       <_runtimeCoreLib Include="$(_runtimePackageDir)**/native/System.Private.CoreLib.dll" />
       <_fxSystemRuntime Include="$(_runtimePackageDir)**/System.Runtime.dll" />
       <_windowsWinMD Condition="'$(_winmdPackageDir)' != ''" Include="$(_winmdPackageDir)**/Windows.winmd" />
@@ -282,7 +282,7 @@
     </ItemGroup>
 
     <PropertyGroup Condition="'@(_runtimeCLR)' != ''">
-      <_crossGenPath>$(_runtimePackageDir)tools$(_crossDir)/crossgen$(ApplicationFileExtension)</_crossGenPath>
+      <_crossGenPath>$(_runtimePackageDir)tools$(_crossDir)/crossgen$(ExeSuffix)</_crossGenPath>
       <_runtimeDirectory>%(_runtimeCLR.RootDir)%(_runtimeCLR.Directory)</_runtimeDirectory>
     </PropertyGroup>
 
@@ -291,8 +291,8 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <_jitPath Condition="'$(_crossDir)' == ''">$(_runtimePackageDir)runtimes/$(PackageRID)/native/$(LibraryFilePrefix)clrjit$(LibraryFileExtension)</_jitPath>
-      <_jitPath Condition="'$(_crossDir)' != ''">$(_runtimePackageDir)runtimes$(_crossDir)/native/$(LibraryFilePrefix)clrjit$(LibraryFileExtension)</_jitPath>
+      <_jitPath Condition="'$(_crossDir)' == ''">$(_runtimePackageDir)runtimes/$(PackageRID)/native/$(LibPrefix)clrjit$(LibSuffix)</_jitPath>
+      <_jitPath Condition="'$(_crossDir)' != ''">$(_runtimePackageDir)runtimes$(_crossDir)/native/$(LibPrefix)clrjit$(LibSuffix)</_jitPath>
     </PropertyGroup>
 
     <PropertyGroup Condition="'@(_fxSystemRuntime)' != ''">

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.packaging.targets
@@ -143,7 +143,7 @@
           Exists('%(FullPath)') AND
           (
             '%(Extension)' == '.dll' OR
-            '%(Extension)' == '$(LibraryFileExtension)'
+            '%(Extension)' == '$(LibSuffix)'
           )"/>
 
       <ClosureFile

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.sharedfx.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.sharedfx.targets
@@ -183,7 +183,7 @@
 
     <ItemGroup>
       <SharedFrameworkSymbols Include="$(CrossgennedPackageSymbolDir)**/*.pdb" />
-      <SharedFrameworkSymbols Include="$(CrossgennedPackageSymbolDir)**/*$(SymbolFileExtension)" />
+      <SharedFrameworkSymbols Include="$(CrossgennedPackageSymbolDir)**/*$(SymbolsSuffix)" />
 
       <SharedFrameworkSymbols
         Include="$(CrossgennedPackageSymbolDir)**/*$(CrossGenSymbolExtension)"

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/packaging-tools.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/packaging-tools.targets
@@ -258,7 +258,7 @@
         Include="@(FindSiblingSymbolsForFile)"
         Exclude="@(WindowsNativeFile)" />
       <NonWindowsSymbolFile
-        Include="@(NonWindowsNativeFile -> '%(Identity)$(SymbolFileExtension)')" />
+        Include="@(NonWindowsNativeFile -> '%(Identity)$(SymbolsSuffix)')" />
 
       <ExistingNonWindowsSymbolFile Include="@(NonWindowsSymbolFile)" Condition="Exists('%(Identity)')" />
 

--- a/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -423,7 +423,7 @@
     <ItemGroup>
       <_closureFiles
         Include="@(FilesToPackage)"
-        Condition="('%(Extension)' == '.dll' or '%(Extension)' == '$(LibraryFileExtension)') and '%(FilesToPackage.Culture)' == ''" />
+        Condition="('%(Extension)' == '.dll' or '%(Extension)' == '$(LibSuffix)') and '%(FilesToPackage.Culture)' == ''" />
       <_closureFileNames Include="@(_closureFiles->'%(FileName)')" Original="%(Identity)" />
 
       <_closureFileNamesFiltered Include="@(_closureFileNames)" Exclude="@(ExcludeFromClosure)"/>
@@ -453,7 +453,7 @@
     <ItemGroup>
       <_dupTypeFiles
          Include="@(FilesToPackage)"
-        Condition="('%(Extension)' == '.dll' or '%(Extension)' == '$(LibraryFileExtension)') and '%(FilesToPackage.Culture)' == ''" />
+        Condition="('%(Extension)' == '.dll' or '%(Extension)' == '$(LibSuffix)') and '%(FilesToPackage.Culture)' == ''" />
       <_dupTypeFileName Include="@(_dupTypeFiles->'%(FileName)')" Original="%(Identity)" />
 
       <_dupTypeFileNamesFiltered Include="@(_dupTypeFileName)" Exclude="@(ExcludeFromDuplicateTypes)"/>


### PR DESCRIPTION
In runtime repo, property names for native files components have been unified in https://github.com/dotnet/runtime/blob/93cbc0974aa0475c586f40645e5b58a4b08ef017/eng/native/naming.props. This PR matches the naming.