### PR TITLE
Add ExpectedExitCode parameter to Helix XHarness SDK

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -35,9 +35,9 @@
       <Uri>https://github.com/dotnet/arcade-services</Uri>
       <Sha>cac955fe259cb611f6a29d09209bd717deb69037</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="1.0.0-prerelease.20568.3">
+    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="1.0.0-prerelease.20575.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>8a4b8b3042c1d3d2595be1f97ead95629dc47da2</Sha>
+      <Sha>91017f18d6125b04b99edb33c2d7f1f7967b2b05</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.8.0-5.20564.22">
       <Uri>https://github.com/dotnet/roslyn</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -78,7 +78,7 @@
     <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>6.0.0-beta.20570.9</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
     <XliffTasksVersion>1.0.0-beta.20568.1</XliffTasksVersion>
     <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.20570.1</MicrosoftDotNetMaestroTasksVersion>
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20568.3</MicrosoftDotNetXHarnessCLIVersion>
+    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20575.1</MicrosoftDotNetXHarnessCLIVersion>
     <MicrosoftSymbolUploaderBuildTaskVersion>1.1.156402</MicrosoftSymbolUploaderBuildTaskVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
@@ -109,7 +109,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                                         $"--timeout {xHarnessTimeout.TotalSeconds} " +
                                         $"-p=\"{androidPackageName}\" " +
                                         "-v " +
-                                        (expectedExitCode != 0 ? $" --expected-exit-code \"{expectedExitCode}\"" : string.Empty) +
+                                        (expectedExitCode != 0 ? $" --expected-exit-code \"{expectedExitCode}\" " : string.Empty) +
                                         outputPathArg +
                                         instrumentationArg +
                                         arguments +

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
@@ -50,9 +50,9 @@ namespace Microsoft.DotNet.Helix.Sdk
             await Task.Yield();
             string workItemName = Path.GetFileNameWithoutExtension(appPackage.ItemSpec);
 
-            var (testTimeout, workItemTimeout) = ParseTimeouts(appPackage);
+            var (testTimeout, workItemTimeout, expectedExitCode) = ParseMetadata(appPackage);
 
-            string command = ValidateMetadataAndGetXHarnessAndroidCommand(appPackage, testTimeout);
+            string command = ValidateMetadataAndGetXHarnessAndroidCommand(appPackage, testTimeout, expectedExitCode);
 
             if (!Path.GetExtension(appPackage.ItemSpec).Equals(".apk", StringComparison.OrdinalIgnoreCase))
             {
@@ -86,7 +86,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             return outputZipAbsolutePath;
         }
 
-        private string ValidateMetadataAndGetXHarnessAndroidCommand(ITaskItem appPackage, TimeSpan xHarnessTimeout)
+        private string ValidateMetadataAndGetXHarnessAndroidCommand(ITaskItem appPackage, TimeSpan xHarnessTimeout, int expectedExitCode)
         {
             // Validation of any metadata specific to Android stuff goes here
             if (!appPackage.GetRequiredMetadata(Log, "AndroidPackageName", out string androidPackageName))
@@ -109,6 +109,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                                         $"--timeout {xHarnessTimeout.TotalSeconds} " +
                                         $"-p=\"{androidPackageName}\" " +
                                         "-v " +
+                                        (expectedExitCode != 0 ? $" --expected-exit-code \"{expectedExitCode}\"" : string.Empty) +
                                         outputPathArg +
                                         instrumentationArg +
                                         arguments +

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                 workItemName = workItemName.Substring(0, workItemName.Length - 4);
             }
 
-            var (testTimeout, workItemTimeout) = ParseTimeouts(appBundleItem);
+            var (testTimeout, workItemTimeout, expectedExitCode) = ParseMetadata(appBundleItem);
 
             // Validation of any metadata specific to iOS stuff goes here
             if (!appBundleItem.TryGetMetadata("Targets", out string targets))
@@ -96,7 +96,7 @@ namespace Microsoft.DotNet.Helix.Sdk
 
             string appName = Path.GetFileName(appBundleItem.ItemSpec);
 
-            string command = GetXHarnessCommand(appName, targets, testTimeout, launchTimeout);
+            string command = GetXHarnessCommand(appName, targets, testTimeout, launchTimeout, expectedExitCode);
 
             Log.LogMessage($"Creating work item with properties Identity: {workItemName}, Payload: {appFolderPath}, Command: {command}");
 
@@ -142,16 +142,17 @@ namespace Microsoft.DotNet.Helix.Sdk
             return outputZipPath;
         }
 
-        private string GetXHarnessCommand(string appName, string targets, TimeSpan testTimeout, TimeSpan launchTimeout)
+        private string GetXHarnessCommand(string appName, string targets, TimeSpan testTimeout, TimeSpan launchTimeout, int expectedExitCode)
         {
             // We need to call 'sudo launchctl' to spawn the process in a user session with GUI rendering capabilities
             string xharnessRunCommand = $"sudo launchctl asuser `id -u` sh \"{PayloadScriptName}\" " +
                                         $"--app \"$HELIX_WORKITEM_ROOT/{appName}\" " +
                                          "--output-directory \"$HELIX_WORKITEM_UPLOAD_ROOT\" " +
                                         $"--targets \"{targets}\" " +
-                                        $"--timeout {testTimeout.TotalSeconds} " +
-                                        $"--launch-timeout {launchTimeout.TotalSeconds} " +
+                                        $"--timeout \"{testTimeout}\" " +
+                                        $"--launch-timeout \"{launchTimeout}\" " +
                                          "--xharness-cli-path \"$XHARNESS_CLI_PATH\"" +
+                                        (expectedExitCode != 0 ? $" --expected-exit-code \"{expectedExitCode}\"" : string.Empty) +
                                         (!string.IsNullOrEmpty(XcodeVersion) ? $" --xcode-version \"{XcodeVersion}\"" : string.Empty) +
                                         (!string.IsNullOrEmpty(AppArguments) ? $" --app-arguments \"{AppArguments}\"" : string.Empty);
 

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
@@ -86,15 +86,19 @@ You can also specify some metadata that will help you configure the run better:
 ```xml
 <ItemGroup>
   <XHarnessAppBundleToTest Include=".\appbundles\Contoso.Example.Tests.app">
-    <!-- Timeout for the overall run of the whole Helix work item (including Simulator booting, app installation..) -->
+    <!-- Optional: Timeout for the overall run of the whole Helix work item (including Simulator booting, app installation..) -->
     <WorkItemTimeout>00:20:00</WorkItemTimeout>
 
-    <!-- Timeout for the actual test run (when TestRunner starts execution of tests) -->
+    <!-- Optional: Timeout for the actual test run (when TestRunner starts execution of tests) -->
     <!-- Should be smaller than WorkItemTimeout by several minutes -->
     <TestTimeout>00:12:00</TestTimeout>
 
-    <!-- Timeout for how long it takes to install and boot the app and start running the first test -->
+    <!-- Optional: Timeout for how long it takes to install and boot the app and start running the first test -->
     <LaunchTimeout>00:10:00</LaunchTimeout>
+
+    <!-- Optional (`ios run` command only): Expected exit code of the iOS/tvOS application. XHarness exits with 0 when the app exits with this code -->
+    <!-- Please note that exit code detection may not be reliable across iOS/tvOS versions -->
+    <ExpectedExitCode>3</ExpectedExitCode>
   </XHarnessAppBundleToTest>
 </ItemGroup>
 ```
@@ -118,7 +122,7 @@ To execute .apks, declare one or more `XHarnessApkToTest` items:
     <!-- Package name: this comes from metadata inside the apk itself -->
     <AndroidPackageName>net.dot.System.Numerics.Vectors.Tests</AndroidPackageName>
 
-    <!-- If there are > 1 instrumentation class inside the package, we need to know the name of which to use -->
+    <!-- If there are > 1 instrumentation classes inside the package, we need to know the name of which to use -->
     <AndroidInstrumentationName>net.dot.MonoRunner</AndroidInstrumentationName>
   </XHarnessApkToTest>
 </ItemGroup>
@@ -129,12 +133,15 @@ You can also specify some metadata that will help you configure the run better:
 ```xml
 <ItemGroup>
   <XHarnessApkToTest Include="$(TestArchiveTestsRoot)**\*.apk">
-    <!-- Timeout for the overall run of the whole Helix work item (including Simulator booting, app installation..) -->
+    <!-- Optional: Timeout for the overall run of the whole Helix work item (including Simulator booting, app installation..) -->
     <WorkItemTimeout>00:20:00</WorkItemTimeout>
 
-    <!-- Timeout for the actual test run (when TestRunner starts execution of tests) -->
+    <!-- Optional: Timeout for the actual test run (when TestRunner starts execution of tests) -->
     <!-- Should be smaller than WorkItemTimeout by several minutes -->
     <TestTimeout>00:12:00</TestTimeout>
+  
+    <!-- Optional: Expected exit code of the instrumentation run. XHarness exits with 0 when the app exits with this code -->
+    <ExpectedExitCode>3</ExpectedExitCode>
   </XHarnessApkToTest>
 </ItemGroup>
 ```

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
@@ -11,6 +11,7 @@ xharness_cli_path=''
 xcode_version=''
 app_arguments=''
 expected_exit_code=0
+command='test'
 
 while [[ $# -gt 0 ]]; do
     opt="$(echo "$1" | awk '{print tolower($0)}')"
@@ -51,6 +52,10 @@ while [[ $# -gt 0 ]]; do
         expected_exit_code="$2"
         shift
         ;;
+      --command)
+        command="$2"
+        shift
+        ;;
       *)
         echo "Invalid argument: $1"
         exit 1
@@ -64,18 +69,6 @@ function die ()
     echo "$1" 1>&2
     exit 1
 }
-
-if [ -z "$app" ]; then
-    die "App name wasn't provided";
-fi
-
-if [ -z "$output_directory" ]; then
-    die "Output directory wasn't provided";
-fi
-
-if [ -z "$targets" ]; then
-    die "List of targets wasn't provided";
-fi
 
 if [ -z "$timeout" ]; then
     die "Test timeout wasn't provided";
@@ -93,6 +86,10 @@ if [ -n "$app_arguments" ]; then
     app_arguments="-- $app_arguments";
 fi
 
+if [ "$command" == "run" ]; then
+    app_arguments="--expected-exit-code=$expected_exit_code $app_arguments"
+fi
+
 set +e
 
 if [ -z "$xcode_version" ]; then
@@ -108,15 +105,15 @@ open -a "$simulator_app"
 export XHARNESS_DISABLE_COLORED_OUTPUT=true
 export XHARNESS_LOG_WITH_TIMESTAMPS=true
 
-dotnet exec "$xharness_cli_path" ios test      \
-    --app="$app"                               \
-    --output-directory="$output_directory"     \
-    --targets="$targets"                       \
-    --timeout="$timeout"                       \
-    --launch-timeout="$launch_timeout"         \
-    --xcode="$xcode_path"                      \
-    --expected-exit-code="$expected_exit_code" \
-    -v                                         \
+# shellcheck disable=SC2086
+dotnet exec "$xharness_cli_path" ios $command \
+    --app="$app"                              \
+    --output-directory="$output_directory"    \
+    --targets="$targets"                      \
+    --timeout="$timeout"                      \
+    --launch-timeout="$launch_timeout"        \
+    --xcode="$xcode_path"                     \
+    -v                                        \
     $app_arguments
 
 exit_code=$?

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
@@ -10,6 +10,7 @@ launch_timeout=''
 xharness_cli_path=''
 xcode_version=''
 app_arguments=''
+expected_exit_code=0
 
 while [[ $# -gt 0 ]]; do
     opt="$(echo "$1" | awk '{print tolower($0)}')"
@@ -44,6 +45,10 @@ while [[ $# -gt 0 ]]; do
         ;;
       --app-arguments)
         app_arguments="$2"
+        shift
+        ;;
+      --expected-exit-code)
+        expected_exit_code="$2"
         shift
         ;;
       *)
@@ -103,14 +108,15 @@ open -a "$simulator_app"
 export XHARNESS_DISABLE_COLORED_OUTPUT=true
 export XHARNESS_LOG_WITH_TIMESTAMPS=true
 
-dotnet exec "$xharness_cli_path" ios test  \
-    --app="$app"                           \
-    --output-directory="$output_directory" \
-    --targets="$targets"                   \
-    --timeout="$timeout"                   \
-    --launch-timeout="$launch_timeout"     \
-    --xcode="$xcode_path"                  \
-    -v                                     \
+dotnet exec "$xharness_cli_path" ios test      \
+    --app="$app"                               \
+    --output-directory="$output_directory"     \
+    --targets="$targets"                       \
+    --timeout="$timeout"                       \
+    --launch-timeout="$launch_timeout"         \
+    --xcode="$xcode_path"                      \
+    --expected-exit-code="$expected_exit_code" \
+    -v                                         \
     $app_arguments
 
 exit_code=$?


### PR DESCRIPTION
Related to https://github.com/dotnet/xharness/issues/364

We will have integration tests for this once we support the `ios run` command.
The `ios run` command support is a follow for this.