### PR TITLE
Remove log statements about file uploads

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
@@ -164,8 +164,6 @@ namespace Microsoft.DotNet.Helix.Sdk
                     Log.LogMessage($"Setting creator to '{Creator}'");
                 }
 
-                Log.LogMessage(MessageImportance.High, $"Uploading payloads for Job on {TargetQueue}...");
-
                 if (CorrelationPayloads != null)
                 {
                     foreach (ITaskItem correlationPayload in CorrelationPayloads)
@@ -190,8 +188,6 @@ namespace Microsoft.DotNet.Helix.Sdk
                 {
                     def = def.WithCorrelationPayloadDirectory(directory);
                 }
-
-                Log.LogMessage(MessageImportance.High, $"Finished uploading payloads for Job on {TargetQueue}...");
 
                 if (HelixProperties != null)
                 {

--- a/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
@@ -164,8 +164,14 @@ namespace Microsoft.DotNet.Helix.Sdk
                     Log.LogMessage($"Setting creator to '{Creator}'");
                 }
 
-                if (CorrelationPayloads != null)
+                if (CorrelationPayloads == null)
                 {
+                    Log.LogMessage($"No Correlation Payloads for Job on {TargetQueue} set");
+                }
+                else
+                {
+                    Log.LogMessage($"Adding Correlation Payloads for Job on {TargetQueue}...");
+
                     foreach (ITaskItem correlationPayload in CorrelationPayloads)
                     {
                         def = AddCorrelationPayload(def, correlationPayload);


### PR DESCRIPTION
File uploads don't happen until we send the job. Before that, we only add them to the `IJobDefinition`.

I noticed this while uploading from my PC where it immediately says Uploading, Finished, but then takes 5 minutes saying Sending where that is when we really upload.

There are other statements about adding correlation payload in between with lower priority so removing these makes sense.

![image](https://user-images.githubusercontent.com/7013027/100353506-e07de100-2fee-11eb-8234-0ebaa7b8689d.png)
