### PR TITLE
Support the `xharness ios run` command in Helix SDK

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -35,9 +35,9 @@
       <Uri>https://github.com/dotnet/arcade-services</Uri>
       <Sha>cac955fe259cb611f6a29d09209bd717deb69037</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="1.0.0-prerelease.20575.1">
+    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="1.0.0-prerelease.20576.2">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>91017f18d6125b04b99edb33c2d7f1f7967b2b05</Sha>
+      <Sha>6d3f81c40855bbd0f7b8f1cdfa76cff0f8698c0a</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.8.0-5.20564.22">
       <Uri>https://github.com/dotnet/roslyn</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -78,7 +78,7 @@
     <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>6.0.0-beta.20570.9</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
     <XliffTasksVersion>1.0.0-beta.20568.1</XliffTasksVersion>
     <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.20570.1</MicrosoftDotNetMaestroTasksVersion>
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20575.1</MicrosoftDotNetXHarnessCLIVersion>
+    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20576.2</MicrosoftDotNetXHarnessCLIVersion>
     <MicrosoftSymbolUploaderBuildTaskVersion>1.1.156402</MicrosoftSymbolUploaderBuildTaskVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
@@ -106,7 +106,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             string xharnessRunCommand = $"dotnet exec \"{(IsPosixShell ? "$XHARNESS_CLI_PATH" : "%XHARNESS_CLI_PATH%")}\" android test " +
                                         $"--app \"{Path.GetFileName(appPackage.ItemSpec)}\" " +
                                         $"--output-directory \"{outputDirectory}\" " +
-                                        $"--timeout {xHarnessTimeout.TotalSeconds} " +
+                                        $"--timeout \"{xHarnessTimeout}\" " +
                                         $"-p=\"{androidPackageName}\" " +
                                         "-v " +
                                         (expectedExitCode != 0 ? $" --expected-exit-code \"{expectedExitCode}\" " : string.Empty) +

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
@@ -17,6 +17,8 @@ namespace Microsoft.DotNet.Helix.Sdk
         private const string PayloadScriptName = "ios-helix-job-payload.sh";
         private const int DefaultLaunchTimeoutInMinutes = 10;
         private const string LaunchTimeoutPropName = "LaunchTimeout";
+        private const string TargetsPropName = "Targets";
+        private const string IncludesTestRunnerPropName = "IncludesTestRunner";
 
         /// <summary>
         /// An array of one or more paths to iOS app bundles (folders ending with ".app" usually)
@@ -76,7 +78,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             var (testTimeout, workItemTimeout, expectedExitCode) = ParseMetadata(appBundleItem);
 
             // Validation of any metadata specific to iOS stuff goes here
-            if (!appBundleItem.TryGetMetadata("Targets", out string targets))
+            if (!appBundleItem.TryGetMetadata(TargetsPropName, out string targets))
             {
                 Log.LogError("'Targets' metadata must be specified - " +
                     "expecting list of target device/simulator platforms to execute tests on (e.g. ios-simulator-64)");
@@ -94,9 +96,23 @@ namespace Microsoft.DotNet.Helix.Sdk
                 }
             }
 
+            bool includesTestRunner = true;
+            if (appBundleItem.TryGetMetadata(IncludesTestRunnerPropName, out string includesTestRunnerProp))
+            {
+                if (includesTestRunnerProp.ToLowerInvariant() == "false")
+                {
+                    includesTestRunner = false;
+                }
+            }
+
+            if (includesTestRunner && expectedExitCode != 0)
+            {
+                Log.LogWarning("The ExpectedExitCode property is ignored in the `ios test` scenario");
+            }
+
             string appName = Path.GetFileName(appBundleItem.ItemSpec);
 
-            string command = GetXHarnessCommand(appName, targets, testTimeout, launchTimeout, expectedExitCode);
+            string command = GetXHarnessCommand(appName, targets, testTimeout, launchTimeout, includesTestRunner, expectedExitCode);
 
             Log.LogMessage($"Creating work item with properties Identity: {workItemName}, Payload: {appFolderPath}, Command: {command}");
 
@@ -142,7 +158,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             return outputZipPath;
         }
 
-        private string GetXHarnessCommand(string appName, string targets, TimeSpan testTimeout, TimeSpan launchTimeout, int expectedExitCode)
+        private string GetXHarnessCommand(string appName, string targets, TimeSpan testTimeout, TimeSpan launchTimeout, bool includesTestRunner, int expectedExitCode)
         {
             // We need to call 'sudo launchctl' to spawn the process in a user session with GUI rendering capabilities
             string xharnessRunCommand = $"sudo launchctl asuser `id -u` sh \"{PayloadScriptName}\" " +
@@ -151,7 +167,8 @@ namespace Microsoft.DotNet.Helix.Sdk
                                         $"--targets \"{targets}\" " +
                                         $"--timeout \"{testTimeout}\" " +
                                         $"--launch-timeout \"{launchTimeout}\" " +
-                                         "--xharness-cli-path \"$XHARNESS_CLI_PATH\"" +
+                                         "--xharness-cli-path \"$XHARNESS_CLI_PATH\" " +
+                                         "--command " + (includesTestRunner ? "test" : "run") +
                                         (expectedExitCode != 0 ? $" --expected-exit-code \"{expectedExitCode}\"" : string.Empty) +
                                         (!string.IsNullOrEmpty(XcodeVersion) ? $" --xcode-version \"{XcodeVersion}\"" : string.Empty) +
                                         (!string.IsNullOrEmpty(AppArguments) ? $" --app-arguments \"{AppArguments}\"" : string.Empty);

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
@@ -99,6 +99,10 @@ You can also specify some metadata that will help you configure the run better:
     <!-- Optional (`ios run` command only): Expected exit code of the iOS/tvOS application. XHarness exits with 0 when the app exits with this code -->
     <!-- Please note that exit code detection may not be reliable across iOS/tvOS versions -->
     <ExpectedExitCode>3</ExpectedExitCode>
+    
+    <!-- Optional: For apps that don't contain unit tests, they can be run using the `ios run` command instead of `ios test` -->
+    <!-- Default is true -->
+    <IncludesTestRunner>false</IncludesTestRunner>
   </XHarnessAppBundleToTest>
 </ItemGroup>
 ```

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
@@ -13,7 +13,7 @@ timeout=''
 launch_timeout=''
 xharness_cli_path=''
 xcode_version=''
-other_arguments=''
+app_arguments=''
 expected_exit_code=0
 command='test'
 
@@ -49,7 +49,7 @@ while [[ $# -gt 0 ]]; do
         shift
         ;;
       --app-arguments)
-        other_arguments="$2"
+        app_arguments="$2"
         shift
         ;;
       --expected-exit-code)
@@ -82,15 +82,15 @@ if [ -z "$xharness_cli_path" ]; then
     die "XHarness path wasn't provided";
 fi
 
-if [ -n "$other_arguments" ]; then
-    other_arguments="-- $other_arguments";
+if [ -n "$app_arguments" ]; then
+    app_arguments="-- $app_arguments";
 fi
 
 if [ "$command" == "run" ]; then
-    other_arguments="--expected-exit-code=$expected_exit_code $other_arguments"
+    app_arguments="--expected-exit-code=$expected_exit_code $app_arguments"
 elif [ -n "$launch_timeout" ]; then
     # shellcheck disable=SC2089
-    other_arguments="--launch-timeout=$launch_timeout $other_arguments"
+    app_arguments="--launch-timeout=$launch_timeout $app_arguments"
 fi
 
 set +e
@@ -108,7 +108,7 @@ open -a "$simulator_app"
 export XHARNESS_DISABLE_COLORED_OUTPUT=true
 export XHARNESS_LOG_WITH_TIMESTAMPS=true
 
-# We include $other_arguments non-escaped and not arrayed because it might contain several extra arguments
+# We include $app_arguments non-escaped and not arrayed because it might contain several extra arguments
 # which come from outside and are appeneded behind "--" and forwarded to the iOS application from XHarness.
 # shellcheck disable=SC2086,SC2090
 dotnet exec "$xharness_cli_path" ios $command \
@@ -118,7 +118,7 @@ dotnet exec "$xharness_cli_path" ios $command \
     --timeout="$timeout"                      \
     --xcode="$xcode_path"                     \
     -v                                        \
-    $other_arguments
+    $app_arguments
 
 exit_code=$?
 

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+###
+### This script is used as a payload of Helix jobs that execute iOS/tvOS workloads through XHarness.
+###
+
 set -ex
 
 app=''

--- a/tests/UnitTests.XHarness.iOS.IncludeCliOnly.proj
+++ b/tests/UnitTests.XHarness.iOS.IncludeCliOnly.proj
@@ -2,6 +2,11 @@
   <!-- See UnitTests.proj in above folder for why this is included directly-from-repo -->
   <Import Project="$(MSBuildThisFileDirectory)\..\src\Microsoft.DotNet.Helix\Sdk\sdk\Sdk.props"/>
 
+  <!--
+    This is a project used in integration tests of Arcade.
+    It tests a case where we pre-install the XHarness tool for the job and users can call it themselves.
+   -->
+
   <PropertyGroup>
     <MicrosoftDotNetHelixSdkTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)../artifacts/bin/Microsoft.DotNet.Helix.Sdk/$(Configuration)/netcoreapp2.1/publish/Microsoft.DotNet.Helix.Sdk.dll</MicrosoftDotNetHelixSdkTasksAssembly>
     <MicrosoftDotNetHelixSdkTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)../artifacts/bin/Microsoft.DotNet.Helix.Sdk/$(Configuration)/net472/publish/Microsoft.DotNet.Helix.Sdk.dll</MicrosoftDotNetHelixSdkTasksAssembly>

--- a/tests/UnitTests.XHarness.iOS.proj
+++ b/tests/UnitTests.XHarness.iOS.proj
@@ -2,6 +2,12 @@
   <!-- See UnitTests.proj in above folder for why this is included directly-from-repo -->
   <Import Project="$(MSBuildThisFileDirectory)\..\src\Microsoft.DotNet.Helix\Sdk\sdk\Sdk.props"/>
 
+  <!--
+    This is a project used in integration tests of Arcade.
+    It tests sending iOS (XHarness) workloads using the Helix SDK.
+    It builds two mock projects that do not build iOS apps but only downloads them from a storage account.
+   -->
+
   <PropertyGroup>
     <MicrosoftDotNetHelixSdkTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)../artifacts/bin/Microsoft.DotNet.Helix.Sdk/$(Configuration)/netcoreapp2.1/publish/Microsoft.DotNet.Helix.Sdk.dll</MicrosoftDotNetHelixSdkTasksAssembly>
     <MicrosoftDotNetHelixSdkTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)../artifacts/bin/Microsoft.DotNet.Helix.Sdk/$(Configuration)/net472/publish/Microsoft.DotNet.Helix.Sdk.dll</MicrosoftDotNetHelixSdkTasksAssembly>
@@ -19,6 +25,7 @@
   <!-- Test project which builds app bundle to run via XHarness -->
   <ItemGroup>
     <XHarnessiOSProject Include="$(MSBuildThisFileDirectory)XHarness\XHarness.TestAppBundle.proj" />
+    <XHarnessiOSProject Include="$(MSBuildThisFileDirectory)XHarness\XHarness.RunAppBundle.proj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(HelixAccessToken)' != '' ">

--- a/tests/UnitTests.Xharness.Android.proj
+++ b/tests/UnitTests.Xharness.Android.proj
@@ -31,15 +31,15 @@
     <HelixTargetQueue Include="ubuntu.1804.amd64.android"/>
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(HelixAccessToken)' == '' ">
+    <HelixTargetQueue Include="ubuntu.1804.amd64.android.open"/>
+  </ItemGroup>
+
   <PropertyGroup Condition=" '$(HelixAccessToken)' == '' ">
     <IsExternal>true</IsExternal>
     <Creator>$(BUILD_SOURCEVERSIONAUTHOR)</Creator>
     <Creator Condition=" '$(Creator)' == ''">anon</Creator>
   </PropertyGroup>
-
-  <ItemGroup Condition=" '$(HelixAccessToken)' == '' ">
-    <HelixTargetQueue Include="ubuntu.1804.amd64.android.open"/>
-  </ItemGroup>
 
   <!-- Useless stuff to make Arcade SDK happy -->
   <PropertyGroup>

--- a/tests/UnitTests.Xharness.Android.proj
+++ b/tests/UnitTests.Xharness.Android.proj
@@ -2,6 +2,12 @@
   <!-- See UnitTests.proj in above folder for why this is included directly-from-repo -->
   <Import Project="$(MSBuildThisFileDirectory)\..\src\Microsoft.DotNet.Helix\Sdk\sdk\Sdk.props"/>
 
+  <!--
+    This is a project used in integration tests of Arcade.
+    It tests sending Android (XHarness) workloads using the Helix SDK.
+    It builds a mock project that does not build an APK directly but only downloads it from a storage account.
+   -->
+
   <PropertyGroup>
     <MicrosoftDotNetHelixSdkTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)../artifacts/bin/Microsoft.DotNet.Helix.Sdk/$(Configuration)/netcoreapp2.1/publish/Microsoft.DotNet.Helix.Sdk.dll</MicrosoftDotNetHelixSdkTasksAssembly>
     <MicrosoftDotNetHelixSdkTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)../artifacts/bin/Microsoft.DotNet.Helix.Sdk/$(Configuration)/net472/publish/Microsoft.DotNet.Helix.Sdk.dll</MicrosoftDotNetHelixSdkTasksAssembly>

--- a/tests/XHarness/XHarness.RunAppBundle.proj
+++ b/tests/XHarness/XHarness.RunAppBundle.proj
@@ -3,27 +3,28 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
 
   <PropertyGroup>
-    <XHarnessTestAppBundleName>System.Numerics.Vectors.Tests.app</XHarnessTestAppBundleName>
-    <XHarnessTestAppBundleUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/macos/test-ios-app/$(XHarnessTestAppBundleName).zip</XHarnessTestAppBundleUrl>
+    <XHarnessRunAppBundleName>HelloiOS.app</XHarnessRunAppBundleName>
+    <XHarnessRunAppBundleUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/macos/test-ios-app/$(XHarnessRunAppBundleName).zip</XHarnessRunAppBundleUrl>
   </PropertyGroup>
 
   <!-- We're not set up currently to build app bundles as part of normal builds, so this downloads existing ones for now -->
   <Target Name="Build" Returns="@(XHarnessAppBundleToTest)">
     <Error Condition=" '$(ArtifactsTmpDir)' == ''" Text="Not downloading AppBundle because ArtifactsTmpDir property is unset" />
-    <DownloadFile SourceUrl="$(XHarnessTestAppBundleUrl)" DestinationFolder="$(ArtifactsTmpDir)XHarness.TestAppBundle" SkipUnchangedFiles="True" Retries="5">
+    <DownloadFile SourceUrl="$(XHarnessRunAppBundleUrl)" DestinationFolder="$(ArtifactsTmpDir)XHarness.RunAppBundle" SkipUnchangedFiles="True" Retries="5">
       <Output TaskParameter="DownloadedFile" ItemName="ZippedAppBundle" />
     </DownloadFile>
 
     <Message Text="Downloaded @(ZippedAppBundle) for XHarness Test purposes" Importance="High" />
 
-    <Exec Command="tar -xzf @(ZippedAppBundle) -C $(ArtifactsTmpDir)XHarness.TestAppBundle" />
+    <Exec Command="tar -xzf @(ZippedAppBundle) -C $(ArtifactsTmpDir)XHarness.RunAppBundle" />
 
     <ItemGroup>
-      <XHarnessAppBundleToTest Include="$(ArtifactsTmpDir)XHarness.TestAppBundle/$(XHarnessTestAppBundleName)">
+      <XHarnessAppBundleToTest Include="$(ArtifactsTmpDir)XHarness.RunAppBundle/$(XHarnessRunAppBundleName)">
         <Targets>ios-simulator-64</Targets>
-        <TestTimeout>00:30:00</TestTimeout>
-        <WorkItemTimeout>00:35:00</WorkItemTimeout>
-        <LaunchTimeout>00:20:00</LaunchTimeout>
+        <WorkItemTimeout>00:20:00</WorkItemTimeout>
+        <TestTimeout>00:15:00</TestTimeout>
+        <IncludesTestRunner>false</IncludesTestRunner>
+        <ExpectedExitCode>200</ExpectedExitCode>
       </XHarnessAppBundleToTest>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
Adds a new MSBuild property `IncludesTestRunner` that enables switching to the `ios run` command which only runs an iOS app bundle and detects its exit code without running any unit tests.

Adds integration test that download a test app that returns the 200 exit code and verifies it using the `ExpectedExitCode` property.

Requires XHarness **1.0.0-prerelease.20576.2** and up

Resolves https://github.com/dotnet/core-eng/issues/11502
Resolves https://github.com/dotnet/xharness/issues/365