### PR TITLE
Change boolean properties in BuildIdentity to be booleans

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/BuildManifestUtilTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/BuildManifestUtilTests.cs
@@ -385,9 +385,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                         modelFromItems.Identity.Branch,
                         modelFromItems.Identity.Commit,
                         modelFromItems.Identity.Attributes.Select(kv => $"{kv.Key}={kv.Value}").ToArray(),
-                        bool.Parse(modelFromItems.Identity.IsStable),
+                        modelFromItems.Identity.IsStable,
                         modelFromItems.Identity.PublishingVersion,
-                        bool.Parse(modelFromItems.Identity.IsReleaseOnlyPackageVersion),
+                        modelFromItems.Identity.IsReleaseOnlyPackageVersion,
                         modelFromItems.SigningInformation);
 
                 // Read the xml file back in and create a model from it.
@@ -401,8 +401,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                 modelFromItems.Identity.BuildId.Should().Be(_testAzdoBuildId);
                 modelFromItems.Identity.Commit.Should().Be(_testBuildCommit);
                 modelFromItems.Identity.PublishingVersion.Should().Be(VersionTools.BuildManifest.Model.PublishingInfraVersion.Next);
-                modelFromItems.Identity.IsReleaseOnlyPackageVersion.Should().Be("False");
-                modelFromItems.Identity.IsStable.Should().Be("True");
+                modelFromItems.Identity.IsReleaseOnlyPackageVersion.Should().BeFalse();
+                modelFromItems.Identity.IsStable.Should().BeTrue();
                 modelFromFile.Artifacts.Blobs.Should().SatisfyRespectively(
                     blob =>
                     {

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
@@ -264,7 +264,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
 
             BuildIdentity buildIdentity = new BuildIdentity
             {
-                IsReleaseOnlyPackageVersion = isReleaseOnlyPackageVersion.ToString()
+                IsReleaseOnlyPackageVersion = isReleaseOnlyPackageVersion
             };
             BuildModel buildModel = new BuildModel(buildIdentity)
             {

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PushToAzureDevOpsArtifacts.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PushToAzureDevOpsArtifacts.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
             var initialAssetsLocation = "cloud";
             var isStable = false;
             var isReleaseOnlyPackageVersion = false;
-            var expectedManifestContent = $"<Build PublishingVersion=\"{(int)PublishingInfraVersion.Latest}\" BuildId=\"{buildId}\" InitialAssetsLocation=\"{initialAssetsLocation}\" IsReleaseOnlyPackageVersion=\"{isReleaseOnlyPackageVersion}\" IsStable=\"{isStable}\" />";
+            var expectedManifestContent = $"<Build PublishingVersion=\"{(int)PublishingInfraVersion.Latest}\" BuildId=\"{buildId}\" InitialAssetsLocation=\"{initialAssetsLocation}\" IsReleaseOnlyPackageVersion=\"{isReleaseOnlyPackageVersion.ToString().ToLower()}\" IsStable=\"{isStable.ToString().ToLower()}\" />";
 
             var buildEngine = new MockBuildEngine();
             var task = new PushToAzureDevOpsArtifacts
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
             var isStable = false;
             var publishingInfraVersion = "456";
             var isReleaseOnlyPackageVersion = false;
-            var expectedManifestContent = $"<Build PublishingVersion=\"{publishingInfraVersion}\" BuildId=\"{buildId}\" InitialAssetsLocation=\"{initialAssetsLocation}\" IsReleaseOnlyPackageVersion=\"{isReleaseOnlyPackageVersion}\" IsStable=\"{isStable}\" />";
+            var expectedManifestContent = $"<Build PublishingVersion=\"{publishingInfraVersion}\" BuildId=\"{buildId}\" InitialAssetsLocation=\"{initialAssetsLocation}\" IsReleaseOnlyPackageVersion=\"{isReleaseOnlyPackageVersion.ToString().ToLower()}\" IsStable=\"{isStable.ToString().ToLower()}\" />";
 
             var buildEngine = new MockBuildEngine();
             var task = new PushToAzureDevOpsArtifacts

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildManifestUtil.cs
@@ -243,9 +243,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         BuildId = manifestBuildId,
                         Branch = manifestBranch,
                         Commit = manifestCommit,
-                        IsStable = isStableBuild.ToString(),
+                        IsStable = isStableBuild,
                         PublishingVersion = publishingVersion,
-                        IsReleaseOnlyPackageVersion = isReleaseOnlyPackageVersion.ToString()
+                        IsReleaseOnlyPackageVersion = isReleaseOnlyPackageVersion
                     });
 
             buildModel.Artifacts.Blobs.AddRange(blobArtifacts);

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -261,8 +261,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         /// </summary>
         public void CheckForStableAssetsInNonIsolatedFeeds()
         {
-            if ((!string.IsNullOrEmpty(BuildModel.Identity.IsReleaseOnlyPackageVersion) && bool.Parse(BuildModel.Identity.IsReleaseOnlyPackageVersion))
-                || SkipSafetyChecks)
+            if (BuildModel.Identity.IsReleaseOnlyPackageVersion || SkipSafetyChecks)
             {
                 return;
             }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
@@ -108,7 +108,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                     var targetFeedsSetup = new SetupTargetFeedConfigV3(
                         InternalBuild,
-                        BuildModel.Identity.IsStable.Equals("true", System.StringComparison.OrdinalIgnoreCase),
+                        BuildModel.Identity.IsStable,
                         BuildModel.Identity.Name,
                         BuildModel.Identity.Commit,
                         AzureStorageTargetFeedKey,

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/BuildIdentity.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/BuildIdentity.cs
@@ -69,16 +69,48 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
             set { Attributes[nameof(Commit)] = value; }
         }
 
-        public string IsStable
+        public bool IsStable
         {
-            get { return Attributes.GetOrDefault(nameof(IsStable)); }
-            set { Attributes[nameof(IsStable)] = value; }
+            get
+            {
+                string value = Attributes.GetOrDefault(nameof(IsStable));
+
+                if (string.IsNullOrEmpty(value))
+                {
+                    return false;
+                }
+                else
+                {
+                    return bool.Parse(value);
+                }
+            }
+
+            set
+            {
+                Attributes[nameof(IsStable)] = value.ToString().ToLower();
+            }
         }
 
-        public string IsReleaseOnlyPackageVersion
+        public bool IsReleaseOnlyPackageVersion
         {
-            get { return Attributes.GetOrDefault(nameof(IsReleaseOnlyPackageVersion)); }
-            set { Attributes[nameof(IsReleaseOnlyPackageVersion)] = value; }
+            get
+            {
+                string value = Attributes.GetOrDefault(nameof(IsReleaseOnlyPackageVersion));
+
+                if (string.IsNullOrEmpty(value))
+                {
+                    return false;
+                }
+                else
+                {
+                    return bool.Parse(value);
+                }
+            }
+
+            set
+            {
+                Attributes[nameof(IsReleaseOnlyPackageVersion)] = value.ToString().ToLower();
+            }
         }
 
         public string VersionStamp

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/SigningInformationModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/SigningInformationModel.cs
@@ -179,7 +179,7 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
         public bool DualSigningAllowed
         {
             get { return bool.Parse(Attributes.GetOrDefault(nameof(DualSigningAllowed))); }
-            set { Attributes[nameof(DualSigningAllowed)] = value.ToString(); }
+            set { Attributes[nameof(DualSigningAllowed)] = value.ToString().ToLower(); }
         }
         public override string ToString() => $"Certificate \"{Include}\" has DualSigningAllowed set to {DualSigningAllowed}";
 

--- a/src/Microsoft.DotNet.VersionTools/tests/BuildManifest/ManifestModelTests.cs
+++ b/src/Microsoft.DotNet.VersionTools/tests/BuildManifest/ManifestModelTests.cs
@@ -466,7 +466,7 @@ namespace Microsoft.DotNet.VersionTools.Tests.BuildManifest
         private BuildModel CreateSigningInformationBuildManifestModel()
         {
             return new BuildModel(new BuildIdentity { Name = "SigningInformationBuildManifest", BuildId = "123", Branch = "refs/heads/Test", 
-                Commit = "test_commit", IsStable = "False", PublishingVersion = (PublishingInfraVersion)3 })
+                Commit = "test_commit", IsStable = false, PublishingVersion = (PublishingInfraVersion)3 })
             {
                 Artifacts = new ArtifactSet
                 {

--- a/src/Microsoft.DotNet.VersionTools/tests/BuildManifest/ManifestModelTests.cs
+++ b/src/Microsoft.DotNet.VersionTools/tests/BuildManifest/ManifestModelTests.cs
@@ -617,7 +617,7 @@ namespace Microsoft.DotNet.VersionTools.Tests.BuildManifest
 ";
 
         private const string ExampleBuildStringWithSigningInformation = @"
-<Build PublishingVersion=""3"" Name=""SigningInformationBuildManifest"" BuildId=""123"" Branch=""refs/heads/Test"" Commit=""test_commit"" IsStable=""False"">
+<Build PublishingVersion=""3"" Name=""SigningInformationBuildManifest"" BuildId=""123"" Branch=""refs/heads/Test"" Commit=""test_commit"" IsStable=""false"">
   <Package Id=""ArcadeSdkTest"" Version=""5.0.0"" />
   <Package Id=""TestPackage"" Version=""5.0.0"" />
   <Blob Id=""assets/symbols/test.nupkg""/>


### PR DESCRIPTION
bool.ToString() yields an upper case T or F on true or false. But xml reading doesn't recognize this as a valid boolean value. Instead, use booleans throughout, and ensure that the backing store for the attributes has the lower case version