### PR TITLE
Optionally include the RID fallback graph in the deps.json.

### DIFF
--- a/src/Microsoft.DotNet.SharedFramework.Sdk/README.md
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/README.md
@@ -46,7 +46,7 @@ If you need to resolve additional managed assemblies, you can add them to the `R
 
 ### Deps file generation
 
-By default, the SDK will generate a .deps.json file for runtime packs named `$(SharedFrameworkName).deps.json`. You can set the `$(SharedFrameworkHostFileNameOverride)` property to instead generate the deps file with the name `$(SharedFrameworkHostFileNameOverride).deps.json`.
+By default, the SDK will generate a .deps.json file for runtime packs named `$(SharedFrameworkName).deps.json`. You can set the `$(SharedFrameworkHostFileNameOverride)` property to instead generate the deps file with the name `$(SharedFrameworkHostFileNameOverride).deps.json`. The RID fallback graph can be included by setting `$(IncludeFallbacksInDepsFile)` to `true`.
 
 ### Runtimeconfig file generation
 

--- a/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -7,6 +7,7 @@
     <PublishReadyToRunShowWarnings>true</PublishReadyToRunShowWarnings>
     <AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>$(AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder);.map;.dbg;.debug;.dwarf</AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>
     <HostJsonTargetPath Condition="'$(HostJsonTargetPath)' == ''">runtimes/$(RuntimeIdentifier)/lib/$(TargetFramework)</HostJsonTargetPath>
+    <IncludeFallbacksInDepsFile Condition="'$(IncludeFallbacksInDepsFile)' == ''">false</IncludeFallbacksInDepsFile>
   </PropertyGroup>
 
 
@@ -172,7 +173,9 @@
                                      Version="$(Version)"
                                      Files="@(_FilesForDepsFile)"
                                      IntermediateOutputPath="$(IntermediateOutputPath)"
-                                     SharedFrameworkDepsNameOverride="$(SharedFrameworkHostFileNameOverride)">
+                                     SharedFrameworkDepsNameOverride="$(SharedFrameworkHostFileNameOverride)"
+                                     RuntimeIdentifierGraph="$(BundledRuntimeIdentifierGraphFile)"
+                                     IncludeFallbacksInDepsFile="$(IncludeFallbacksInDepsFile)">
       <Output TaskParameter="GeneratedDepsFile" ItemName="_SharedFrameworkDepsFile" />
     </GenerateSharedFrameworkDepsFile>
     <ItemGroup>


### PR DESCRIPTION
The Microsoft.NETCore.App framework still needs to include the rid fallback graph to support the hosting layer. This PR enables a shared framework to explicitly opt-in to including the RID fallback graph (so only Microsoft.NETCore.App has to carry it).