### PR TITLE
Retry hanging iOS app install work items and reboot the machine

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
@@ -168,7 +168,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                                         $"--timeout \"{testTimeout}\" " +
                                         $"--launch-timeout \"{launchTimeout}\" " +
                                          "--xharness-cli-path \"$XHARNESS_CLI_PATH\" " +
-                                         "--python-path \"$HELIX_PYTHONPATH\" " +
+                                         "--helix-python-path \"$HELIX_PYTHONPATH\" " +
                                          "--command " + (includesTestRunner ? "test" : "run") +
                                         (expectedExitCode != 0 ? $" --expected-exit-code \"{expectedExitCode}\"" : string.Empty) +
                                         (!string.IsNullOrEmpty(XcodeVersion) ? $" --xcode-version \"{XcodeVersion}\"" : string.Empty) +

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
@@ -168,6 +168,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                                         $"--timeout \"{testTimeout}\" " +
                                         $"--launch-timeout \"{launchTimeout}\" " +
                                          "--xharness-cli-path \"$XHARNESS_CLI_PATH\" " +
+                                         "--python-path \"$HELIX_PYTHONPATH\" " +
                                          "--command " + (includesTestRunner ? "test" : "run") +
                                         (expectedExitCode != 0 ? $" --expected-exit-code \"{expectedExitCode}\"" : string.Empty) +
                                         (!string.IsNullOrEmpty(XcodeVersion) ? $" --xcode-version \"{XcodeVersion}\"" : string.Empty) +

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
@@ -14,7 +14,7 @@ launch_timeout=''
 xharness_cli_path=''
 xcode_version=''
 app_arguments=''
-python_path=''
+helix_python_path=''
 expected_exit_code=0
 command='test'
 
@@ -61,8 +61,8 @@ while [[ $# -gt 0 ]]; do
         command="$2"
         shift
         ;;
-      --python-path)
-        python_path="$2"
+      --helix-python-path)
+        helix_python_path="$2"
         shift
         ;;
       *)
@@ -85,6 +85,10 @@ fi
 
 if [ -z "$xharness_cli_path" ]; then
     die "XHarness path wasn't provided";
+fi
+
+if [ -z "$helix_python_path" ]; then
+    die "--helix-python-path path wasn't provided";
 fi
 
 if [ -n "$app_arguments" ]; then
@@ -137,8 +141,8 @@ fi
 # The only solution is to reboot the machine, so we request a work item retry + MacOS reboot when this happens
 # 83 - timeout in installation
 if [ $exit_code -eq 83 ]; then
-    "$python_path" -c "from helix.workitemutil import request_infra_retry; request_infra_retry('Retrying because iOS Simulator application install hung')"
-    "$python_path" -c "from helix.workitemutil import request_reboot; request_reboot('Rebooting because iOS Simulator application install hung ')"
+    "$helix_python_path" -c "from helix.workitemutil import request_infra_retry; request_infra_retry('Retrying because iOS Simulator application install hung')"
+    "$helix_python_path" -c "from helix.workitemutil import request_reboot; request_reboot('Rebooting because iOS Simulator application install hung ')"
     exit $exit_code
 fi
 

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
@@ -14,6 +14,7 @@ launch_timeout=''
 xharness_cli_path=''
 xcode_version=''
 app_arguments=''
+python_path=''
 expected_exit_code=0
 command='test'
 
@@ -58,6 +59,10 @@ while [[ $# -gt 0 ]]; do
         ;;
       --command)
         command="$2"
+        shift
+        ;;
+      --python-path)
+        python_path="$2"
         shift
         ;;
       *)
@@ -124,32 +129,40 @@ exit_code=$?
 
 # Kill the simulator just in case when we fail to launch the app
 # 80 - app crash
-# 83 - app launch failure
-if [ $exit_code -eq 80 ] || [ $exit_code -eq 83 ]; then
+if [ $exit_code -eq 80 ]; then
     sudo pkill -9 -f "$simulator_app"
+fi
+
+# This handles an issue where Simulators get reeaally slow and they start failing to install apps
+# The only solution is to reboot the machine, so we request a work item retry + MacOS reboot when this happens
+# 83 - timeout in installation
+if [ $exit_code -eq 83 ]; then
+    "$python_path" -c "from helix.workitemutil import request_infra_retry; request_infra_retry('Retrying because iOS Simulator application install hung')"
+    "$python_path" -c "from helix.workitemutil import request_reboot; request_reboot('Rebooting because iOS Simulator application install hung ')"
+    exit $exit_code
 fi
 
 # The simulator logs comming from the sudo-spawned Simulator.app are not readable by the helix uploader
 chmod 0644 "$output_directory"/*.log
 
 if [ "$command" == 'test' ]; then
-  test_results=$(ls "$output_directory"/xunit-*.xml)
+    test_results=$(ls "$output_directory"/xunit-*.xml)
 
-  if [ ! -f "$test_results" ]; then
-      echo "Failed to find xUnit tests results in the output directory. Existing files:"
-      ls -la "$output_directory"
+    if [ ! -f "$test_results" ]; then
+        echo "Failed to find xUnit tests results in the output directory. Existing files:"
+        ls -la "$output_directory"
 
-      if [ $exit_code -eq 0 ]; then
-          exit_code=5
-      fi
+        if [ $exit_code -eq 0 ]; then
+            exit_code=5
+        fi
 
-      exit $exit_code
-  fi
+        exit $exit_code
+    fi
 
-  echo "Found test results in $output_directory/$test_results. Renaming to testResults.xml to prepare for Helix upload"
+    echo "Found test results in $output_directory/$test_results. Renaming to testResults.xml to prepare for Helix upload"
 
-  # Prepare test results for Helix to pick up
-  mv "$test_results" "$output_directory/testResults.xml"
+    # Prepare test results for Helix to pick up
+    mv "$test_results" "$output_directory/testResults.xml"
 fi
 
 exit $exit_code


### PR DESCRIPTION
It sometimes happen on machines that processed a large amount of iOS workloads that the iOS Simulator gets really slow until it's unable to install applications in time and iOS workloads start to hang.

When we detect this, we request retry of the workitem and reboot the machine which fixes the problem for the job and the machine.

Verified by:
- I called the queue (50+ machines) with 90 work items and got all Pass
- I returned 2 machines in a bad state into the queue
- I called the queue again and got successful job (2 InfraRetry work items, 2 reboots)
- I called the queue again and got successful job (all Pass)

Resolves: https://github.com/dotnet/xharness/issues/305
Resolves: https://github.com/dotnet/core-eng/issues/11554