### PR TITLE
Add TargetFrameworkWithoutSuffix msbuild property

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.props
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.props
@@ -12,10 +12,12 @@
     <DotNetBuildTasksTargetFrameworkSdkAssembly Condition="'$(DotNetBuildTasksTargetFrameworkSdkAssembly)' == '' AND '$(MSBuildRuntimeType)' != 'core'">..\tools\net472\Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.dll</DotNetBuildTasksTargetFrameworkSdkAssembly>
     <_OriginalTargetFramework>$(TargetFramework)</_OriginalTargetFramework>
     <TargetFrameworkPattern>(((netstandard|netcoreapp)[0-9\.]+)|(net[1-4][1-9\.]+))(-[^;]+)</TargetFrameworkPattern>
+    <TargetFrameworkWithoutSuffix>$(TargetFramework)</TargetFrameworkWithoutSuffix>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.Contains('-'))">
     <TargetFrameworkSuffix>$(TargetFramework.SubString($([MSBuild]::Add($(TargetFramework.IndexOf('-')), 1))))</TargetFrameworkSuffix>
+    <TargetFrameworkWithoutSuffix>$(TargetFramework.SubString(0, $(TargetFramework.IndexOf('-'))))</TargetFrameworkWithoutSuffix>
     <!-- Strip away the TargetPlatform during the build because the assets file and nuget generated files does not know about the TargetPlatform for frameworks older than net5.0.-->
     <TargetFramework>$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFramework)', '$(TargetFrameworkPattern)', '${1}'))</TargetFramework>
   </PropertyGroup>


### PR DESCRIPTION
We are doing this substring of operations for the ref assemblies and for paths, we will also require this for packaging system.
So i am reviving this property.