### PR TITLE
Include internal license file in a NuSpec file entries

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.targets
@@ -35,8 +35,12 @@
     <PackageLicenseFile>License.txt</PackageLicenseFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(PackageLicenseExpressionInternal)' != '' and '$(IsPackable)' == 'true' and '$(PackageLicenseFullPath)' == ''">
+    <PackageLicenseFullPath>$(MSBuildThisFileDirectory)Licenses\$(PackageLicenseExpressionInternal).txt</PackageLicenseFullPath>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(PackageLicenseExpressionInternal)' != '' and '$(IsPackable)' == 'true'">
-    <None Include="$(MSBuildThisFileDirectory)Licenses\$(PackageLicenseExpressionInternal).txt" Pack="true" PackagePath="$(PackageLicenseFile)" Visible="false" />
+    <None Include="$(PackageLicenseFullPath)" Pack="true" PackagePath="$(PackageLicenseFile)" Visible="false" />
   </ItemGroup>
 
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -92,6 +92,11 @@
         <license type="file">$(PackageLicenseFile)</license>
       </_LicenseElement>
 
+      <_LicenseFileElement/>
+      <_LicenseFileElement Condition="'$(PackageLicenseFile)' != ''">
+        <file src="$(PackageLicenseFullPath)" target="$(PackageLicenseFile)" />
+      </_LicenseFileElement>
+
       <_TagsElement/>
       <_TagsElement Condition="'$(PackageTags)' != ''">
         <tags>$(PackageTags.Replace(';', ' '))</tags>
@@ -137,6 +142,7 @@
 
       <_CommonFileElements>
         $(_IconFileElement)
+        $(_LicenseFileElement)
       </_CommonFileElements>
     </PropertyGroup>
 


### PR DESCRIPTION
NuGet pack fails to create a package for a project in an internal repo that sets `PackageLicenseExpressionInternal` and uses hand-written .nuspec. This is because `CommonFileElements` variable is missing `<file src="path to license file"/>` element. 