### PR TITLE
Log collisionId

### DIFF
--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -317,8 +317,9 @@ namespace Microsoft.DotNet.SignTool.Tests
             var signToolArgs = new SignToolArgs(_tmpDir, microBuildCorePath: "MicroBuildCorePath", testSign: true, msBuildPath: null, _tmpDir, enclosingDir: "", "", wixToolsPath: wixToolsPath);
 
             var signTool = new FakeSignTool(signToolArgs, task.Log);
-            var signingInput = new Configuration(signToolArgs.TempDir, itemsToSign, strongNameSignInfo, fileSignInfo, extensionsSignInfo, dualCertificates, task.Log).GenerateListOfFiles();
-            var util = new BatchSignUtil(task.BuildEngine, task.Log, signTool, signingInput, new string[] { });
+            var configuration = new Configuration(signToolArgs.TempDir, itemsToSign, strongNameSignInfo, fileSignInfo, extensionsSignInfo, dualCertificates, task.Log);
+            var signingInput = configuration.GenerateListOfFiles();
+            var util = new BatchSignUtil(task.BuildEngine, task.Log, signTool, signingInput, new string[] { }, configuration._hashToCollisionIdMap);
 
             var beforeSigningEngineFilesList = Directory.GetFiles(signToolArgs.TempDir, "*-engine.exe", SearchOption.AllDirectories);
             util.Go(doStrongNameCheck: true);

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -250,7 +250,7 @@ namespace Microsoft.DotNet.SignTool
 
                 if (Log.HasLoggedErrors) return;
 
-                var util = new BatchSignUtil(BuildEngine, Log, signTool, signingInput, ItemsToSkipStrongNameCheck?.Select(i => i.ItemSpec).ToArray(), telemetry: telemetry);
+                var util = new BatchSignUtil(BuildEngine, Log, signTool, signingInput, ItemsToSkipStrongNameCheck?.Select(i => i.ItemSpec).ToArray(), configuration._hashToCollisionIdMap, telemetry: telemetry);
 
                 util.SkipZipContainerSignatureMarkerCheck = this.SkipZipContainerSignatureMarkerCheck;
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/6377

Changes output generated by signtool to Include CollisionId

Previous
```
2020-12-07T17:47:24.9322934Z       Round 0: Signing 3380 files.
2020-12-07T17:47:24.9323803Z       File 'ijwhost.dll' Certificate='Microsoft400'
2020-12-07T17:47:24.9324682Z       File 'nethost.dll' Certificate='Microsoft400'
```

New
```
2020-12-07T17:47:24.9322934Z       Round 0: Signing 3380 files.
2020-12-07T17:47:24.9323803Z       File 'ijwhost.dll' Certificate='Microsoft400' Collision Id='69274'
2020-12-07T17:47:24.9324682Z       File 'nethost.dll' Certificate='Microsoft400' Collision Id='69274'
```

https://dnceng.visualstudio.com/internal/_build/results?buildId=910828&view=logs&j=9ff0e0af-24e7-5b0f-fa76-5e12fc9920ef&t=301d9b2b-8353-5bbf-3cfe-879776c7b3b4