### PR TITLE
Symbol Publishing - Pdbs and dlls 

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,6 +9,7 @@
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="vs-buildservices" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/nuget/v3/index.json" />
+    <add key="general-testing" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/general-testing/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,7 +62,7 @@
     <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>
     <XUnitVSRunnerVersion>2.4.1</XUnitVSRunnerVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.20604.2</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.20608.13</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetSignToolVersion>6.0.0-beta.20604.2</MicrosoftDotNetSignToolVersion>
     <MicrosoftAzureDocumentDBVersion>1.22.0</MicrosoftAzureDocumentDBVersion>
     <MicrosoftAzureCosmosDBTableVersion>1.1.2</MicrosoftAzureCosmosDBTableVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,7 +62,7 @@
     <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>
     <XUnitVSRunnerVersion>2.4.1</XUnitVSRunnerVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.20608.8</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.20604.2</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetSignToolVersion>6.0.0-beta.20604.2</MicrosoftDotNetSignToolVersion>
     <MicrosoftAzureDocumentDBVersion>1.22.0</MicrosoftAzureDocumentDBVersion>
     <MicrosoftAzureCosmosDBTableVersion>1.1.2</MicrosoftAzureCosmosDBTableVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,7 +62,7 @@
     <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>
     <XUnitVSRunnerVersion>2.4.1</XUnitVSRunnerVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.20609.3</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.20608.6</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetSignToolVersion>6.0.0-beta.20604.2</MicrosoftDotNetSignToolVersion>
     <MicrosoftAzureDocumentDBVersion>1.22.0</MicrosoftAzureDocumentDBVersion>
     <MicrosoftAzureCosmosDBTableVersion>1.1.2</MicrosoftAzureCosmosDBTableVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,7 +62,7 @@
     <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>
     <XUnitVSRunnerVersion>2.4.1</XUnitVSRunnerVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.20604.2</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.20608.16</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetSignToolVersion>6.0.0-beta.20604.2</MicrosoftDotNetSignToolVersion>
     <MicrosoftAzureDocumentDBVersion>1.22.0</MicrosoftAzureDocumentDBVersion>
     <MicrosoftAzureCosmosDBTableVersion>1.1.2</MicrosoftAzureCosmosDBTableVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,7 +62,7 @@
     <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>
     <XUnitVSRunnerVersion>2.4.1</XUnitVSRunnerVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.20608.6</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.20609.10</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetSignToolVersion>6.0.0-beta.20604.2</MicrosoftDotNetSignToolVersion>
     <MicrosoftAzureDocumentDBVersion>1.22.0</MicrosoftAzureDocumentDBVersion>
     <MicrosoftAzureCosmosDBTableVersion>1.1.2</MicrosoftAzureCosmosDBTableVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,7 +62,7 @@
     <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>
     <XUnitVSRunnerVersion>2.4.1</XUnitVSRunnerVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.20604.2</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.20608.6</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetSignToolVersion>6.0.0-beta.20604.2</MicrosoftDotNetSignToolVersion>
     <MicrosoftAzureDocumentDBVersion>1.22.0</MicrosoftAzureDocumentDBVersion>
     <MicrosoftAzureCosmosDBTableVersion>1.1.2</MicrosoftAzureCosmosDBTableVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,7 +62,7 @@
     <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>
     <XUnitVSRunnerVersion>2.4.1</XUnitVSRunnerVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.20608.13</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.20604.2</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetSignToolVersion>6.0.0-beta.20604.2</MicrosoftDotNetSignToolVersion>
     <MicrosoftAzureDocumentDBVersion>1.22.0</MicrosoftAzureDocumentDBVersion>
     <MicrosoftAzureCosmosDBTableVersion>1.1.2</MicrosoftAzureCosmosDBTableVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,7 +62,7 @@
     <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>
     <XUnitVSRunnerVersion>2.4.1</XUnitVSRunnerVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.20608.16</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.20604.2</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetSignToolVersion>6.0.0-beta.20604.2</MicrosoftDotNetSignToolVersion>
     <MicrosoftAzureDocumentDBVersion>1.22.0</MicrosoftAzureDocumentDBVersion>
     <MicrosoftAzureCosmosDBTableVersion>1.1.2</MicrosoftAzureCosmosDBTableVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,7 +62,7 @@
     <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>
     <XUnitVSRunnerVersion>2.4.1</XUnitVSRunnerVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.20604.2</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.20608.8</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetSignToolVersion>6.0.0-beta.20604.2</MicrosoftDotNetSignToolVersion>
     <MicrosoftAzureDocumentDBVersion>1.22.0</MicrosoftAzureDocumentDBVersion>
     <MicrosoftAzureCosmosDBTableVersion>1.1.2</MicrosoftAzureCosmosDBTableVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,7 +62,7 @@
     <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>
     <XUnitVSRunnerVersion>2.4.1</XUnitVSRunnerVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.20608.6</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.20609.3</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetSignToolVersion>6.0.0-beta.20604.2</MicrosoftDotNetSignToolVersion>
     <MicrosoftAzureDocumentDBVersion>1.22.0</MicrosoftAzureDocumentDBVersion>
     <MicrosoftAzureCosmosDBTableVersion>1.1.2</MicrosoftAzureCosmosDBTableVersion>

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "5.0.100"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20609.3",
+    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20608.6",
     "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.20604.2"
   }
 }

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "5.0.100"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20604.2",
+    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20608.8",
     "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.20604.2"
   }
 }

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "5.0.100"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20604.2",
+    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20608.16",
     "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.20604.2"
   }
 }

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "5.0.100"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20608.6",
+    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20609.3",
     "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.20604.2"
   }
 }

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "5.0.100"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20608.13",
+    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20604.2",
     "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.20604.2"
   }
 }

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "5.0.100"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20608.6",
+    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20609.10",
     "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.20604.2"
   }
 }

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "5.0.100"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20604.2",
+    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20608.13",
     "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.20604.2"
   }
 }

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "5.0.100"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20608.8",
+    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20604.2",
     "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.20604.2"
   }
 }

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "5.0.100"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20604.2",
+    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20608.6",
     "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.20604.2"
   }
 }

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "5.0.100"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20608.16",
+    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20604.2",
     "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.20604.2"
   }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -358,8 +358,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 IEnumerable<string> filesToSymbolServer = null;
                 if (Directory.Exists(pdbArtifactsBasePath))
                 {
-                    filesToSymbolServer =
-                        Directory.EnumerateFileSystemEntries(pdbArtifactsBasePath);
+                    string[] dlls = Directory.GetFiles(pdbArtifactsBasePath, "*.dll", SearchOption.AllDirectories);
+                    string[] pdbs = Directory.GetFiles(pdbArtifactsBasePath, "*.pdb", SearchOption.AllDirectories);
+                    filesToSymbolServer = dlls.Concat(pdbs);
                 }
 
                 foreach (var server in serversToPublish)

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
@@ -92,20 +92,20 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 {
                     Directory.CreateDirectory(temporarySymbolsLocation);
                 }
-
+/*
                 if (!Directory.Exists(temporaryDllLocation))
                 {
                     Directory.CreateDirectory(Path.GetDirectoryName(temporaryDllLocation));
-                }
+                }*/
 
                 SplitArtifactsInCategories(BuildModel);
                 DeleteSymbolTemporaryFiles(temporarySymbolsLocation);
-                DeleteSymbolTemporaryFiles(temporaryDllLocation);
+               // DeleteSymbolTemporaryFiles(temporaryDllLocation);
 
                 //Copying symbol files to temporary location is required because the symUploader API needs read/write access to the files,
                 //since we publish blobs and symbols in parallel this will cause IO exceptions.
                 CopySymbolFilesToTemporaryLocation(BuildModel, temporarySymbolsLocation);
-                CopyDllFilesToTemporaryLocation(PdbArtifactsBasePath, temporaryDllLocation);
+               // CopyDllFilesToTemporaryLocation(PdbArtifactsBasePath, temporaryDllLocation);
 
                 if (Log.HasLoggedErrors)
                 {
@@ -194,14 +194,14 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 await Task.WhenAll(new Task[] {
                     HandlePackagePublishingAsync(buildAssets),
                     HandleBlobPublishingAsync(buildAssets),
-                    HandleSymbolPublishingAsync(temporaryDllLocation, MsdlToken,
+                    HandleSymbolPublishingAsync(PdbArtifactsBasePath, MsdlToken,
                         SymWebToken, SymbolPublishingExclusionsFile, temporarySymbolsLocation, PublishSpecialClrFiles)
                 });
 
                 DeleteSymbolTemporaryFiles(temporarySymbolsLocation);
-                DeleteSymbolTemporaryFiles(temporaryDllLocation);
+               // DeleteSymbolTemporaryFiles(temporaryDllLocation);
                 DeleteSymbolTemporaryDirectory(temporarySymbolsLocation);
-                DeleteSymbolTemporaryDirectory(temporaryDllLocation);
+               // DeleteSymbolTemporaryDirectory(temporaryDllLocation);
                 Log.LogMessage(MessageImportance.High, "Successfully deleted the temporary symbols directory.");
                 await PersistPendingAssetLocationAsync(client);
             }
@@ -253,7 +253,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 foreach(var file in dlls.Concat(pdbs))
                 {
                     var destinationFile = Path.Combine(dllTemporaryLocation, MakeRelativePath(PdbArtifactsBasePath, file));
-                    Directory.CreateDirectory(Path.GetDirectoryName(destinationFile));
                     Log.LogMessage(MessageImportance.High,
                         $"Copying file {file} to {destinationFile}.");
                     File.Copy(file, destinationFile);
@@ -321,7 +320,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         {
             if (Directory.Exists(temporarySymbolLocation))
             {
-                Directory.Delete(temporarySymbolLocation, true);
+                Directory.Delete(temporarySymbolLocation);
             }
         }
     }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
@@ -95,7 +95,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                 if (!Directory.Exists(temporaryDllLocation))
                 {
-                    Directory.CreateDirectory(temporaryDllLocation);
+                    Directory.CreateDirectory(Path.GetDirectoryName(temporaryDllLocation));
                 }
 
                 SplitArtifactsInCategories(BuildModel);

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
@@ -253,6 +253,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 foreach(var file in dlls.Concat(pdbs))
                 {
                     var destinationFile = Path.Combine(dllTemporaryLocation, MakeRelativePath(PdbArtifactsBasePath, file));
+                    Directory.CreateDirectory(Path.GetDirectoryName(destinationFile));
                     Log.LogMessage(MessageImportance.High,
                         $"Copying file {file} to {destinationFile}.");
                     File.Copy(file, destinationFile);

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
@@ -247,9 +247,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 string [] pdbs = Directory.GetFiles(PdbArtifactsBasePath, "*.pdb", SearchOption.AllDirectories);
                 foreach(var file in dlls.Concat(pdbs))
                 {
+                    var destinationFile = Path.Join(dllTemporaryLocation, Path.GetRelativePath(PdbArtifactsBasePath, file));
                     Log.LogMessage(MessageImportance.High,
                         $"Copying file {file} to {destinationFile}.");
-                    var destinationFile = Path.Join(dllTemporaryLocation, Path.GetRelativePath(PdbArtifactsBasePath, file));
                     File.Copy(file, destinationFile);
                     Log.LogMessage(MessageImportance.High,
                         $"Successfully copied file {file} to {destinationFile}.");

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
@@ -263,7 +263,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         }
 
         /// <summary>
-        /// Creates a relative path from one file or folder to another ( need to use this because this project uses .Net Framework
+        /// Creates a relative path from one file or folder to another ( need to use this because this project uses .Net Framework)
         /// </summary>
         /// <param name="fromPath">Contains the directory that defines the start of the relative path</param>
         /// <param name="toPath">Contains the path that defines the endpoint of the relative path</param>
@@ -320,7 +320,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         {
             if (Directory.Exists(temporarySymbolLocation))
             {
-                Directory.Delete(temporarySymbolLocation);
+                Directory.Delete(temporarySymbolLocation, true);
             }
         }
     }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
@@ -245,22 +245,14 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             {
                 string[] dlls = Directory.GetFiles(PdbArtifactsBasePath, "*.dll", SearchOption.AllDirectories);
                 string [] pdbs = Directory.GetFiles(PdbArtifactsBasePath, "*.pdb", SearchOption.AllDirectories);
-                foreach(var file in dlls)
+                foreach(var file in dlls.Concat(pdbs))
                 {
-                    var sourceFile = Path.Combine(PdbArtifactsBasePath, Path.GetFileName(file));
-                    var destinationFile = Path.Combine(dllTemporaryLocation, Path.GetFileName(file));
-                    File.Copy(sourceFile, destinationFile);
                     Log.LogMessage(MessageImportance.High,
-                        $"Successfully copied file {sourceFile} to {destinationFile}.");
-                }
-
-                foreach(var file in pdbs)
-                {
-                    var sourceFile = Path.Combine(PdbArtifactsBasePath, Path.GetFileName(file));
-                    var destinationFile = Path.Combine(dllTemporaryLocation, Path.GetFileName(file));
-                    File.Copy(sourceFile, destinationFile);
+                        $"Copying file {file} to {destinationFile}.");
+                    var destinationFile = Path.Join(dllTemporaryLocation, Path.GetRelativePath(PdbArtifactsBasePath, file));
+                    File.Copy(file, destinationFile);
                     Log.LogMessage(MessageImportance.High,
-                        $"Successfully copied file {sourceFile} to {destinationFile}.");
+                        $"Successfully copied file {file} to {destinationFile}.");
                 }
             }
         }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetChannelConfig.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetChannelConfig.cs
@@ -106,7 +106,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                    String.Equals(TransportFeed, config.TransportFeed, StringComparison.OrdinalIgnoreCase) &&
                    String.Equals(SymbolsFeed, config.SymbolsFeed, StringComparison.OrdinalIgnoreCase) &&
                    String.Equals(ChecksumsFeed, config.ChecksumsFeed, StringComparison.OrdinalIgnoreCase) &&
-                   String.Equals(InstallersFeed,config.InstallersFeed, StringComparison.OrdinalIgnoreCase)
+                   String.Equals(InstallersFeed, config.InstallersFeed, StringComparison.OrdinalIgnoreCase);
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetChannelConfig.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetChannelConfig.cs
@@ -106,8 +106,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                    TransportFeed.Equals(config.TransportFeed, StringComparison.OrdinalIgnoreCase) &&
                    SymbolsFeed.Equals(config.SymbolsFeed, StringComparison.OrdinalIgnoreCase) &&
                    ChecksumsFeed.Equals(config.ChecksumsFeed, StringComparison.OrdinalIgnoreCase) &&
-                   InstallersFeed.Equals(config.InstallersFeed, StringComparison.OrdinalIgnoreCase) &&
-                   SymbolTargetType == config.SymbolTargetType;
+                   InstallersFeed.Equals(config.InstallersFeed, StringComparison.OrdinalIgnoreCase)
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetChannelConfig.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetChannelConfig.cs
@@ -106,7 +106,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                    TransportFeed.Equals(config.TransportFeed, StringComparison.OrdinalIgnoreCase) &&
                    SymbolsFeed.Equals(config.SymbolsFeed, StringComparison.OrdinalIgnoreCase) &&
                    ChecksumsFeed.Equals(config.ChecksumsFeed, StringComparison.OrdinalIgnoreCase) &&
-                   InstallersFeed.Equals(config.InstallersFeed, StringComparison.OrdinalIgnoreCase)
+                   InstallersFeed.Equals(config.InstallersFeed, StringComparison.OrdinalIgnoreCase);
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetChannelConfig.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetChannelConfig.cs
@@ -101,12 +101,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
             return other is TargetChannelConfig config &&
                    PublishingInfraVersion == config.PublishingInfraVersion &&
                    Id == config.Id &&
-                   AkaMSChannelName.Equals(config.AkaMSChannelName, StringComparison.OrdinalIgnoreCase) &&
-                   ShippingFeed.Equals(config.ShippingFeed, StringComparison.OrdinalIgnoreCase) &&
-                   TransportFeed.Equals(config.TransportFeed, StringComparison.OrdinalIgnoreCase) &&
-                   SymbolsFeed.Equals(config.SymbolsFeed, StringComparison.OrdinalIgnoreCase) &&
-                   ChecksumsFeed.Equals(config.ChecksumsFeed, StringComparison.OrdinalIgnoreCase) &&
-                   InstallersFeed.Equals(config.InstallersFeed, StringComparison.OrdinalIgnoreCase);
+                   String.Equals(AkaMSChannelName, config.AkaMSChannelName, StringComparison.OrdinalIgnoreCase) &&
+                   String.Equals(ShippingFeed, config.ShippingFeed, StringComparison.OrdinalIgnoreCase) &&
+                   String.Equals(TransportFeed, config.TransportFeed, StringComparison.OrdinalIgnoreCase) &&
+                   String.Equals(SymbolsFeed, config.SymbolsFeed, StringComparison.OrdinalIgnoreCase) &&
+                   String.Equals(ChecksumsFeed, config.ChecksumsFeed, StringComparison.OrdinalIgnoreCase) &&
+                   String.Equals(InstallersFeed,config.InstallersFeed, StringComparison.OrdinalIgnoreCase)
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
SymUploader needs read/write access on the files when it tries to upload to the Symbol server.

In order to get around this, we have to copy the files to a temporary location and then upload. 

