### PR TITLE
Forward PYTHONPATH to XHarness iOS script

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
@@ -168,7 +168,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                                         $"--timeout \"{testTimeout}\" " +
                                         $"--launch-timeout \"{launchTimeout}\" " +
                                          "--xharness-cli-path \"$XHARNESS_CLI_PATH\" " +
-                                         "--helix-python-path \"$HELIX_PYTHONPATH\" " +
+                                         "--helix-python-bin \"$HELIX_PYTHONPATH\" " +
                                          "--python-path \"$PYTHONPATH\" " +
                                          "--command " + (includesTestRunner ? "test" : "run") +
                                         (expectedExitCode != 0 ? $" --expected-exit-code \"{expectedExitCode}\"" : string.Empty) +

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
@@ -169,6 +169,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                                         $"--launch-timeout \"{launchTimeout}\" " +
                                          "--xharness-cli-path \"$XHARNESS_CLI_PATH\" " +
                                          "--helix-python-path \"$HELIX_PYTHONPATH\" " +
+                                         "--python-path \"$PYTHONPATH\" " +
                                          "--command " + (includesTestRunner ? "test" : "run") +
                                         (expectedExitCode != 0 ? $" --expected-exit-code \"{expectedExitCode}\"" : string.Empty) +
                                         (!string.IsNullOrEmpty(XcodeVersion) ? $" --xcode-version \"{XcodeVersion}\"" : string.Empty) +

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
@@ -14,7 +14,8 @@ launch_timeout=''
 xharness_cli_path=''
 xcode_version=''
 app_arguments=''
-helix_python_path=''
+helix_python_bin=''
+python_path=''
 expected_exit_code=0
 command='test'
 
@@ -61,8 +62,12 @@ while [[ $# -gt 0 ]]; do
         command="$2"
         shift
         ;;
-      --helix-python-path)
-        helix_python_path="$2"
+      --helix-python-bin)
+        helix_python_bin="$2"
+        shift
+        ;;
+      --python_path)
+        python_path="$2"
         shift
         ;;
       *)
@@ -87,8 +92,12 @@ if [ -z "$xharness_cli_path" ]; then
     die "XHarness path wasn't provided";
 fi
 
-if [ -z "$helix_python_path" ]; then
-    die "--helix-python-path path wasn't provided";
+if [ -z "$helix_python_bin" ]; then
+    die "--helix-python-bin wasn't provided";
+fi
+
+if [ -z "$python_path" ]; then
+    die "--python-path wasn't provided";
 fi
 
 if [ -n "$app_arguments" ]; then
@@ -141,8 +150,10 @@ fi
 # The only solution is to reboot the machine, so we request a work item retry + MacOS reboot when this happens
 # 83 - timeout in installation
 if [ $exit_code -eq 83 ]; then
-    "$helix_python_path" -c "from helix.workitemutil import request_infra_retry; request_infra_retry('Retrying because iOS Simulator application install hung')"
-    "$helix_python_path" -c "from helix.workitemutil import request_reboot; request_reboot('Rebooting because iOS Simulator application install hung ')"
+    # Since we run this script using launchctl to run in a GUI-capable user session, some of the env vars are not set here
+    export PYTHON_PATH=$PYTHON_PATH:$python_path
+    "$helix_python_bin" -c "from helix.workitemutil import request_infra_retry; request_infra_retry('Retrying because iOS Simulator application install hung')"
+    "$helix_python_bin" -c "from helix.workitemutil import request_reboot; request_reboot('Rebooting because iOS Simulator application install hung ')"
     exit $exit_code
 fi
 

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/ios-helix-job-payload.sh
@@ -66,7 +66,7 @@ while [[ $# -gt 0 ]]; do
         helix_python_bin="$2"
         shift
         ;;
-      --python_path)
+      --python-path)
         python_path="$2"
         shift
         ;;


### PR DESCRIPTION
When iOS simulators slow down / freeze up, we detect this, retry the work item and reboot the machine.
Since the iOS payload script is run through `launchctl` to run in a user session with GUI rendering, we lose some of the env vars on the way so we have to pass them down.

This PR re-initializes the `PYTHONPATH` variable.

Resolves: https://github.com/dotnet/runtime/issues/45181

Example problem this solves:
```
+ /usr/local/bin/python3 -c 'from helix.workitemutil import request_infra_retry; request_infra_retry('\''Retrying because iOS Simulator application install hung'\'')'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'helix'
+ /usr/local/bin/python3 -c 'from helix.workitemutil import request_reboot; request_reboot('\''Rebooting because iOS Simulator application install hung '\'')'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'helix'
```
https://helixre107v0xdeko0k025g8.blob.core.windows.net/dotnet-runtime-refs-pull-45839-merge-13b48d1686ba4343b7/Microsoft.Bcl.AsyncInterfaces.Tests/console.fa2f6cc5.log?sv=2019-07-07&se=2020-12-29T16%3A46%3A22Z&sr=c&sp=rl&sig=tn4cgwt0brU45SKlzBlHEbsrbDNIhpZNsqrQkidt7Ss%3D