### PR TITLE
Handle Helix retry+reboot outside of launchctl

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 
@@ -14,7 +13,8 @@ namespace Microsoft.DotNet.Helix.Sdk
     /// </summary>
     public class CreateXHarnessiOSWorkItems : XHarnessTaskBase
     {
-        private const string PayloadScriptName = "ios-helix-job-payload.sh";
+        private const string EntrypointScriptName = "xharness-helix-job.ios.sh";
+        private const string RunnerScriptName = "xharness-runner.ios.sh";
         private const int DefaultLaunchTimeoutInMinutes = 10;
         private const string LaunchTimeoutPropName = "LaunchTimeout";
         private const string TargetsPropName = "Targets";
@@ -111,8 +111,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             }
 
             string appName = Path.GetFileName(appBundleItem.ItemSpec);
-
-            string command = GetXHarnessCommand(appName, targets, testTimeout, launchTimeout, includesTestRunner, expectedExitCode);
+            string command = GetHelixCommand(appName, targets, testTimeout, launchTimeout, includesTestRunner, expectedExitCode);
 
             Log.LogMessage($"Creating work item with properties Identity: {workItemName}, Payload: {appFolderPath}, Command: {command}");
 
@@ -124,6 +123,19 @@ namespace Microsoft.DotNet.Helix.Sdk
                 { "Timeout", workItemTimeout.ToString() },
             });
         }
+
+        private string GetHelixCommand(string appName, string targets, TimeSpan testTimeout, TimeSpan launchTimeout, bool includesTestRunner, int expectedExitCode) =>
+            $"chmod +x {EntrypointScriptName} && ./{EntrypointScriptName} " +
+            $"--app \"$HELIX_WORKITEM_ROOT/{appName}\" " +
+             "--output-directory \"$HELIX_WORKITEM_UPLOAD_ROOT\" " +
+            $"--targets \"{targets}\" " +
+            $"--timeout \"{testTimeout}\" " +
+            $"--launch-timeout \"{launchTimeout}\" " +
+             "--xharness-cli-path \"$XHARNESS_CLI_PATH\" " +
+             "--command " + (includesTestRunner ? "test" : "run") +
+            (expectedExitCode != 0 ? $" --expected-exit-code \"{expectedExitCode}\"" : string.Empty) +
+            (!string.IsNullOrEmpty(XcodeVersion) ? $" --xcode-version \"{XcodeVersion}\"" : string.Empty) +
+            (!string.IsNullOrEmpty(AppArguments) ? $" --app-arguments \"{AppArguments}\"" : string.Empty);
 
         private async Task<string> CreateZipArchiveOfFolder(string folderToZip)
         {
@@ -145,46 +157,22 @@ namespace Microsoft.DotNet.Helix.Sdk
 
             ZipFile.CreateFromDirectory(folderToZip, outputZipPath, CompressionLevel.Fastest, includeBaseDirectory: true);
 
-            // Add the payload script
-            Log.LogMessage($"Adding the Helix job payload script into the ziparchive");
-
-            using FileStream zipToOpen = new FileStream(outputZipPath, FileMode.Open);
-            using ZipArchive archive = new ZipArchive(zipToOpen, ZipArchiveMode.Update);
-            ZipArchiveEntry entry = archive.CreateEntry(PayloadScriptName);
-            using StreamWriter zipEntryWriter = new StreamWriter(entry.Open());
-            using FileStream payloadScriptStream = GetPayloadScriptStream();
-            await payloadScriptStream.CopyToAsync(zipEntryWriter.BaseStream);
+            Log.LogMessage($"Adding the Helix job payload scripts into the ziparchive");
+            await AddFileToPayload(outputZipPath, EntrypointScriptName);
+            await AddFileToPayload(outputZipPath, RunnerScriptName);
 
             return outputZipPath;
         }
 
-        private string GetXHarnessCommand(string appName, string targets, TimeSpan testTimeout, TimeSpan launchTimeout, bool includesTestRunner, int expectedExitCode)
+        private async Task AddFileToPayload(string payloadArchivePath, string fileName)
         {
-            // We need to call 'sudo launchctl' to spawn the process in a user session with GUI rendering capabilities
-            string xharnessRunCommand = $"sudo launchctl asuser `id -u` sh \"{PayloadScriptName}\" " +
-                                        $"--app \"$HELIX_WORKITEM_ROOT/{appName}\" " +
-                                         "--output-directory \"$HELIX_WORKITEM_UPLOAD_ROOT\" " +
-                                        $"--targets \"{targets}\" " +
-                                        $"--timeout \"{testTimeout}\" " +
-                                        $"--launch-timeout \"{launchTimeout}\" " +
-                                         "--xharness-cli-path \"$XHARNESS_CLI_PATH\" " +
-                                         "--helix-python-bin \"$HELIX_PYTHONPATH\" " +
-                                         "--python-path \"$PYTHONPATH\" " +
-                                         "--command " + (includesTestRunner ? "test" : "run") +
-                                        (expectedExitCode != 0 ? $" --expected-exit-code \"{expectedExitCode}\"" : string.Empty) +
-                                        (!string.IsNullOrEmpty(XcodeVersion) ? $" --xcode-version \"{XcodeVersion}\"" : string.Empty) +
-                                        (!string.IsNullOrEmpty(AppArguments) ? $" --app-arguments \"{AppArguments}\"" : string.Empty);
-
-            Log.LogMessage(MessageImportance.Low, $"Generated XHarness command: {xharnessRunCommand}");
-
-            return xharnessRunCommand;
-        }
-
-        private static FileStream GetPayloadScriptStream()
-        {
-            var assemblyDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            var scriptPath = Path.Combine(assemblyDirectory, "tools", "xharness-runner", PayloadScriptName);
-            return File.OpenRead(scriptPath);
+            var thisAssembly = typeof(CreateXHarnessiOSWorkItems).Assembly;
+            using Stream fileStream = thisAssembly.GetManifestResourceStream($"{thisAssembly.GetName().Name}.tools.xharness_runner.{fileName}");
+            using FileStream archiveStream = new FileStream(payloadArchivePath, FileMode.Open);
+            using ZipArchive archive = new ZipArchive(archiveStream, ZipArchiveMode.Update);
+            ZipArchiveEntry entry = archive.CreateEntry(fileName);
+            using StreamWriter zipEntryWriter = new StreamWriter(entry.Open());
+            await fileStream.CopyToAsync(zipEntryWriter.BaseStream);
         }
     }
 }

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessiOSWorkItems.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Helix.Sdk
     /// </summary>
     public class CreateXHarnessiOSWorkItems : XHarnessTaskBase
     {
-        private const string EntrypointScriptName = "xharness-helix-job.ios.sh";
+        private const string EntryPointScriptName = "xharness-helix-job.ios.sh";
         private const string RunnerScriptName = "xharness-runner.ios.sh";
         private const int DefaultLaunchTimeoutInMinutes = 10;
         private const string LaunchTimeoutPropName = "LaunchTimeout";
@@ -125,7 +125,7 @@ namespace Microsoft.DotNet.Helix.Sdk
         }
 
         private string GetHelixCommand(string appName, string targets, TimeSpan testTimeout, TimeSpan launchTimeout, bool includesTestRunner, int expectedExitCode) =>
-            $"chmod +x {EntrypointScriptName} && ./{EntrypointScriptName} " +
+            $"chmod +x {EntryPointScriptName} && ./{EntryPointScriptName} " +
             $"--app \"$HELIX_WORKITEM_ROOT/{appName}\" " +
              "--output-directory \"$HELIX_WORKITEM_UPLOAD_ROOT\" " +
             $"--targets \"{targets}\" " +
@@ -158,7 +158,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             ZipFile.CreateFromDirectory(folderToZip, outputZipPath, CompressionLevel.Fastest, includeBaseDirectory: true);
 
             Log.LogMessage($"Adding the Helix job payload scripts into the ziparchive");
-            await AddFileToPayload(outputZipPath, EntrypointScriptName);
+            await AddFileToPayload(outputZipPath, EntryPointScriptName);
             await AddFileToPayload(outputZipPath, RunnerScriptName);
 
             return outputZipPath;

--- a/src/Microsoft.DotNet.Helix/Sdk/Microsoft.DotNet.Helix.Sdk.csproj
+++ b/src/Microsoft.DotNet.Helix/Sdk/Microsoft.DotNet.Helix.Sdk.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
@@ -22,7 +22,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'"> 
     <Compile Include="..\..\Common\AssemblyResolver.cs" /> 
-  </ItemGroup> 
+  </ItemGroup>
 
   <ItemGroup>
     <None Include="**\*.py;**\*.bat;**\*.sh" Pack="true">
@@ -31,9 +31,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="tools\xharness-runner\ios-helix-job-payload.sh">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <None Include="tools\xharness-runner\xharness-helix-job.ios.sh" />
+    <EmbeddedResource Include="tools\xharness-runner\xharness-helix-job.ios.sh">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <None Include="tools\xharness-runner\xharness-runner.ios.sh" />
+    <EmbeddedResource Include="tools\xharness-runner\xharness-runner.ios.sh">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </EmbeddedResource>
   </ItemGroup>
 
   <Import Project="$(RepoRoot)eng\BuildTask.targets" />

--- a/src/Microsoft.DotNet.Helix/Sdk/Microsoft.DotNet.Helix.Sdk.csproj
+++ b/src/Microsoft.DotNet.Helix/Sdk/Microsoft.DotNet.Helix.Sdk.csproj
@@ -31,11 +31,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="tools\xharness-runner\xharness-helix-job.ios.sh" />
     <EmbeddedResource Include="tools\xharness-runner\xharness-helix-job.ios.sh">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </EmbeddedResource>
-    <None Include="tools\xharness-runner\xharness-runner.ios.sh" />
     <EmbeddedResource Include="tools\xharness-runner\xharness-runner.ios.sh">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </EmbeddedResource>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
@@ -72,7 +72,6 @@ To execute .app bundles, declare one or more `XHarnessAppBundleToTest` items:
 <ItemGroup>
   <!-- Find all directories named *.app -->
   <XHarnessAppBundleToTest Include="$([System.IO.Directory]::GetDirectories('$(TestArchiveTestsRoot)', '*.app', System.IO.SearchOption.AllDirectories))">
-    <Targets>ios-device</Targets>
     <Targets>ios-simulator-64_13.5</Targets>
   </XHarnessAppBundleToTest>
 </ItemGroup>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.ios.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.ios.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+###
+### This script is used as a payload of Helix jobs that execute iOS/tvOS workloads through XHarness.
+### This is the entrypoint of the job that goes on to spawn the real payload in user session with
+### GUI rendering capabilities.
+###
+
+set -x
+
+chmod +x xharness-runner.ios.sh
+helix_runner_uid=$(id -u)
+sudo launchctl asuser "$helix_runner_uid" sh ./xharness-runner.ios.sh "$@"
+exit_code=$?
+
+# This handles an issue where Simulators get reeaally slow and they start failing to install apps
+# The only solution is to reboot the machine, so we request a work item retry + MacOS reboot when this happens
+# 83 - timeout in installation
+if [ $exit_code -eq 83 ]; then
+    # Since we run the payload script using launchctl, env vars are not set there and we have to do this part here
+    "$HELIX_PYTHONPATH" -c "from helix.workitemutil import request_infra_retry; request_infra_retry('Retrying because iOS Simulator application install hung')"
+    "$HELIX_PYTHONPATH" -c "from helix.workitemutil import request_reboot; request_reboot('Rebooting because iOS Simulator application install hung ')"
+    exit $exit_code
+fi
+
+exit $exit_code

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.ios.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.ios.sh
@@ -16,7 +16,8 @@ exit_code=$?
 # This handles an issue where Simulators get reeaally slow and they start failing to install apps
 # The only solution is to reboot the machine, so we request a work item retry + MacOS reboot when this happens
 # 83 - timeout in installation
-if [ $exit_code -eq 83 ]; then
+installation_timeout_exit_code=83
+if [ $exit_code -eq $installation_timeout_exit_code ]; then
     # Since we run the payload script using launchctl, env vars are not set there and we have to do this part here
     "$HELIX_PYTHONPATH" -c "from helix.workitemutil import request_infra_retry; request_infra_retry('Retrying because iOS Simulator application install hung')"
     "$HELIX_PYTHONPATH" -c "from helix.workitemutil import request_reboot; request_reboot('Rebooting because iOS Simulator application install hung ')"


### PR DESCRIPTION
The python code wasn't working without environmental variables which get lost after `launchctl` so we handle them outside of it.