### PR TITLE
Add restore binlog during static graph evaluation

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -210,7 +210,7 @@
     <ItemGroup Condition="'$(RestoreUseStaticGraphEvaluation)' == 'true'">
       <_SolutionRestoreProps Include="RestoreUseStaticGraphEvaluation=true" />
       <!-- Enable binlog generation during static graph restore evaluation -->
-      <_SolutionRestoreProps Include="RESTORE_TASK_BINLOG_PARAMETERS=$(ArtifactsLogDir)Restore.binlog"  />
+      <_SolutionRestoreProps Include="RESTORE_TASK_BINLOG_PARAMETERS=$(ArtifactsLogDir)Restore.binlog" />
     </ItemGroup>
     
     <PropertyGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -205,7 +205,12 @@
       <_SolutionRestoreProps Include="__BuildPhase=SolutionRestore" />
       <_SolutionRestoreProps Include="_NETCORE_ENGINEERING_TELEMETRY=Restore" />
       <_SolutionRestoreProps Include="MSBuildRestoreSessionId=$([System.Guid]::NewGuid())" />
-      <_SolutionRestoreProps Include="RestoreUseStaticGraphEvaluation=true" Condition="'$(RestoreUseStaticGraphEvaluation)' == 'true'" />
+    </ItemGroup>
+    
+    <ItemGroup Condition="'$(RestoreUseStaticGraphEvaluation)' == 'true'">
+      <_SolutionRestoreProps Include="RestoreUseStaticGraphEvaluation=true" />
+      <!-- Enable binlog generation during static graph restore evaluation -->
+      <_SolutionRestoreProps Include="RESTORE_TASK_BINLOG_PARAMETERS=$(ArtifactsLogDir)Restore.binlog"  />
     </ItemGroup>
     
     <PropertyGroup>


### PR DESCRIPTION
When static graph build is enabled, the NuGet console client evaluates the passed in the project tree outside of msbuild. Generating a binlog of that static graph evaluation to root cause failures during restore.

This came up in https://github.com/dotnet/runtime/issues/45755

cc @jeffkl @safern 