### PR TITLE
Follow-up cleanup to restore static graph binlog

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -205,12 +205,7 @@
       <_SolutionRestoreProps Include="__BuildPhase=SolutionRestore" />
       <_SolutionRestoreProps Include="_NETCORE_ENGINEERING_TELEMETRY=Restore" />
       <_SolutionRestoreProps Include="MSBuildRestoreSessionId=$([System.Guid]::NewGuid())" />
-    </ItemGroup>
-    
-    <ItemGroup Condition="'$(RestoreUseStaticGraphEvaluation)' == 'true'">
-      <_SolutionRestoreProps Include="RestoreUseStaticGraphEvaluation=true" />
-      <!-- Enable binlog generation during static graph restore evaluation -->
-      <_SolutionRestoreProps Include="RESTORE_TASK_BINLOG_PARAMETERS=$(ArtifactsLogDir)Restore.binlog" />
+      <_SolutionRestoreProps Include="RestoreUseStaticGraphEvaluation=$(RestoreUseStaticGraphEvaluation)" />
     </ItemGroup>
     
     <PropertyGroup>
@@ -250,6 +245,13 @@
 
       <!-- Invoke the 'Restore' target on solutions and projects which do not support NuGet. -->
       <_ProjectToRestore Include="@(ProjectToBuild)" Exclude="@(_ProjectToRestoreWithNuGet)" />
+    </ItemGroup>
+
+    <!-- Enable binlog generation during static graph restore evaluation -->
+    <ItemGroup Condition="'$(GenerateRestoreUseStaticGraphEvaluationBinlog)' == 'true'">
+      <_ProjectToRestore>
+        <AdditionalProperties>RESTORE_TASK_BINLOG_PARAMETERS=$(ArtifactsLogDir)Restore-%(Filename)%(Extension).binlog</AdditionalProperties>
+      </_ProjectToRestore>
     </ItemGroup>
 
     <MSBuild Projects="@(_ProjectToRestore)"


### PR DESCRIPTION
Changing the binlog generation to opt-in. Also making sure that the binlog name contains the file name to avoid duplicate file writes.