### PR TITLE
Wix bundle infra should use a single English WXL file

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/bundle/bundle.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/bundle/bundle.wxs
@@ -63,8 +63,9 @@
 
   <Fragment>
     <PayloadGroup Id="DotnetCoreBAPayloads">
+      <!-- Default/Neutral localized content is US English -->
       <Payload Name="thm.xml" Compressed="yes" SourceFile="$(var.BundleThmDir)\bundle.thm" />
-      <Payload Name="thm.wxl" Compressed="yes" SourceFile="$(var.BundleThmDir)\bundle.wxl" />
+      <Payload Name="thm.wxl" Compressed="yes" SourceFile="$(var.BundleThmDir)\theme\1033\bundle.wxl" />
 
       <Payload Name="bg.png" Compressed="yes" SourceFile="$(var.DotNetBackgroundPngFile)" />
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/arcade/issues/6698

We should use a single English WXL file for neutral and 1033 installer locations - like it's implemented in other repos, i.e. dotnet/installer. This eliminates errors in modifying just one of the files, which can cause Localization process to not pick up the change.

Additional changes would be needed in runtime and WindowsDesktop repos to remove the extra file, once this fix is available in those repos.

Runtime issue: https://github.com/dotnet/runtime/issues/35206
WindowsDesktop issue: https://github.com/dotnet/windowsdesktop/issues/1306
