### PR TITLE
Pass the correct BuildNumberMinor value to GenerateMsiVersion task

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets
@@ -64,7 +64,7 @@
       Minor="$(MinorVersion)"
       Patch="$(PatchVersion)"
       BuildNumberMajor="$(BuildNumberMajor)"
-      BuildNumberMinor="$(BuildNumberMajor)">
+      BuildNumberMinor="$(BuildNumberMinor)">
       <Output TaskParameter="MsiVersion" PropertyName="MsiVersionString" />
     </GenerateMsiVersion>
   </Target>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/arcade/issues/6690

This enables distinct MSI versions of the builds produced in the same day.