### PR TITLE
Remove feed URLs in PublishToSymbolServers (release/3.x)

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishToSymbolServers.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishToSymbolServers.proj
@@ -23,8 +23,7 @@
     <RestoreSources>
       https://api.nuget.org/v3/index.json;
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
-      https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json;
-      https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json
     </RestoreSources>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishToSymbolServers.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishToSymbolServers.proj
@@ -19,14 +19,6 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <RestoreSources>
-      https://api.nuget.org/v3/index.json;
-      https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
-      https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json
-    </RestoreSources>
-  </PropertyGroup>
-
   <Target Name="Execute">
     <ItemGroup>
       <FilesToPublishToSymbolServer Include="$(PDBArtifactsDirectory)\**\*.pdb"/>


### PR DESCRIPTION
## Description

This removes the NuGet feeds defined in the PublishToSymbolServers task. The MyGet domain will soon become invalid, and none are actually used. Instead, the package this task needs is retrieved from dotnet-eng, which is defined in the versions.props of the parent directory. 

Same change in the master branch is dotnet/arcade#6691.

## Customer Impact

This task is likely to fail during publishing once MyGet is shut down. NuGet will error if it tries to resolve an invalid feed URL.

## Regression

No

## Risk

Low. Binlogs show that the single package this task needs is actually restored from the `dotnet-eng` feed. This change simply removes invalid and unused feeds. 

## Workarounds

None.