### PR TITLE
Update AzDO API calls to use unified version

### DIFF
--- a/eng/common/sdl/init-sdl.ps1
+++ b/eng/common/sdl/init-sdl.ps1
@@ -24,7 +24,7 @@ $ProgressPreference = 'SilentlyContinue'
 # Construct basic auth from AzDO access token; construct URI to the repository's gdn folder stored in that repository; construct location of zip file
 $encodedPat = [Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$AzureDevOpsAccessToken"))
 $escapedRepository = [Uri]::EscapeDataString("/$Repository/$BranchName/.gdn")
-$uri = "https://dev.azure.com/dnceng/internal/_apis/git/repositories/sdl-tool-cfg/Items?path=$escapedRepository&versionDescriptor[versionOptions]=0&`$format=zip&api-version=5.0"
+$uri = "https://dev.azure.com/dnceng/internal/_apis/git/repositories/sdl-tool-cfg/Items?path=$escapedRepository&versionDescriptor[versionOptions]=0&`$format=zip&api-version=6.0"
 $zipFile = "$WorkingDirectory/gdn.zip"
 
 Add-Type -AssemblyName System.IO.Compression.FileSystem

--- a/scripts/duplicate-feed.ps1
+++ b/scripts/duplicate-feed.ps1
@@ -46,7 +46,7 @@ function Get-Package-List($vstsAuthHeader, $account, $visibility, $feed) {
     # Get the list of packages from the source and target
     $listOfPackages = @()
     try {
-        $packageListUri = "https://feeds.dev.azure.com/$account/${visibility}_apis/packaging/Feeds/$feed/packages?api-version=5.1-preview.1"
+        $packageListUri = "https://feeds.dev.azure.com/$account/${visibility}_apis/packaging/Feeds/$feed/packages?api-version=6.0-preview"
         Write-Host "Looking up packages on feed at: $packageListUri"
         $result = Invoke-WebRequest -Headers $vstsAuthHeader $packageListUri
         $resultJson = $result | ConvertFrom-Json

--- a/scripts/launch-mirrors.ps1
+++ b/scripts/launch-mirrors.ps1
@@ -57,9 +57,9 @@ function LaunchMirrorBuild {
             parameters = $(ConvertTo-Json @{BranchToMirror=$branch; GithubRepo=$repo})
         }
         $bodyStr = ConvertTo-Json $body
-        $uri = "${AzDOInstance}/_apis/build/builds?api-version=5.1"
+        $uri = "${AzDOInstance}/_apis/build/builds?api-version=6.0"
         Write-Host "Launching $mirrorType build for $repo @ $branch"
-        $queueResponse = Invoke-WebRequest -Method Post -ContentType "application/json" -Headers $AzDOAuthHeader -Uri "${AzDOInstance}/_apis/build/builds?api-version=5.1" -Body $bodyStr | ConvertFrom-Json
+        $queueResponse = Invoke-WebRequest -Method Post -ContentType "application/json" -Headers $AzDOAuthHeader -Uri "${AzDOInstance}/_apis/build/builds?api-version=6.0" -Body $bodyStr | ConvertFrom-Json
         $buildId = $queueResponse.id
         Write-Host "Launched $AzDOInstance/_build/results?buildId=$buildId"
     }

--- a/src/Microsoft.DotNet.Helix/Sdk/CheckAzurePipelinesTestResults.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CheckAzurePipelinesTestResults.cs
@@ -128,7 +128,7 @@ namespace Microsoft.DotNet.Helix.AzureDevOps
                 {
                     using (var req = new HttpRequestMessage(
                         HttpMethod.Get,
-                        $"{CollectionUri}{TeamProject}/_apis/test/resultsummarybybuild?buildId={BuildId}&api-version=5.1-preview.2")
+                        $"{CollectionUri}{TeamProject}/_apis/test/resultsummarybybuild?buildId={BuildId}&api-version=6.0-preview")
                     )
                     {
                         using (HttpResponseMessage res = await client.SendAsync(req))
@@ -172,7 +172,7 @@ namespace Microsoft.DotNet.Helix.AzureDevOps
                     {
                         using (var req = new HttpRequestMessage(
                             HttpMethod.Get,
-                            $"{CollectionUri}{TeamProject}/_apis/test/runs/{runId}/results?api-version=5.0&outcomes=Failed")
+                            $"{CollectionUri}{TeamProject}/_apis/test/runs/{runId}/results?api-version=6.0&outcomes=Failed")
                         )
                         {
                             using (HttpResponseMessage res = await client.SendAsync(req))

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateFailedTestsForFailedWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateFailedTestsForFailedWorkItems.cs
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                     var req =
                         new HttpRequestMessage(
                             HttpMethod.Post,
-                            $"{CollectionUri}{TeamProject}/_apis/test/Runs/{testRunId}/Results/{testResultId}/attachments?api-version=5.1-preview.1")
+                            $"{CollectionUri}{TeamProject}/_apis/test/Runs/{testRunId}/Results/{testResultId}/attachments?api-version=6.0-preview")
                         {
                             Content = new StringContent(
                                 JsonConvert.SerializeObject(
@@ -84,7 +84,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                     var req =
                         new HttpRequestMessage(
                             HttpMethod.Post,
-                            $"{CollectionUri}{TeamProject}/_apis/test/Runs/{testRunId}/results?api-version=5.1-preview.6")
+                            $"{CollectionUri}{TeamProject}/_apis/test/Runs/{testRunId}/results?api-version=6.0-preview")
                         {
                             Content = new StringContent(
                                 JsonConvert.SerializeObject(

--- a/src/Microsoft.DotNet.Helix/Sdk/StartAzurePipelinesTestRun.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/StartAzurePipelinesTestRun.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.Helix.AzureDevOps
                     var req =
                         new HttpRequestMessage(
                             HttpMethod.Post,
-                            $"{CollectionUri}{TeamProject}/_apis/test/runs?api-version=5.0")
+                            $"{CollectionUri}{TeamProject}/_apis/test/runs?api-version=6.0")
                         {
                             Content = new StringContent(
                                 JsonConvert.SerializeObject(

--- a/src/Microsoft.DotNet.Helix/Sdk/StopAzurePipelinesTestRun.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/StopAzurePipelinesTestRun.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Helix.AzureDevOps
                     using (var req =
                         new HttpRequestMessage(
                             new HttpMethod("PATCH"),
-                            $"{CollectionUri}{TeamProject}/_apis/test/runs/{TestRunId}?api-version=5.0")
+                            $"{CollectionUri}{TeamProject}/_apis/test/runs/{TestRunId}?api-version=6.0")
                         {
                             Content = new StringContent(
                                 JsonConvert.SerializeObject(new JObject { ["state"] = "Completed", }),


### PR DESCRIPTION
We were using a 5.x-preview version in a few places, update and unify to the released 6.0 where possible.