### PR TITLE
Fix parameter passing in publish-using-darc

### DIFF
--- a/eng/common/post-build/publish-using-darc.ps1
+++ b/eng/common/post-build/publish-using-darc.ps1
@@ -22,12 +22,12 @@ try {
   $optionalParams = [System.Collections.ArrayList]::new()
 
   if ("" -ne $ArtifactsPublishingAdditionalParameters) {
-    $optionalParams.Add("artifact-publishing-parameters") | Out-Null
+    $optionalParams.Add("--artifact-publishing-parameters") | Out-Null
     $optionalParams.Add($ArtifactsPublishingAdditionalParameters) | Out-Null
   }
 
   if ("" -ne $SymbolPublishingAdditionalParameters) {
-    $optionalParams.Add("symbol-publishing-parameters") | Out-Null
+    $optionalParams.Add("--symbol-publishing-parameters") | Out-Null
     $optionalParams.Add($SymbolPublishingAdditionalParameters) | Out-Null
   }
 


### PR DESCRIPTION
Looks like my fix for this in c6f24c0d1264f6f80ceb39d2b0477d054c3f8ffc was incomplete, as I copy-pasted a bug in the previous line. This change fixes that. I am not sure why darc doesn't error out, but this is needed as #6679 changed the default value of a flag the symuploader task used to have. The flag only really matters in runtime, so the new default is better as long as that PR doesn't make it to any servicing branch. However, we do need this to be able to pass down the flag.

Currently testing in https://dnceng.visualstudio.com/internal/_build/results?buildId=927862