### PR TITLE
Only use PackageDescriptionFile if Description isn't already provided

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
@@ -49,7 +49,6 @@
     <Title>$(Id)</Title>
     <Authors>Microsoft</Authors>
     <Owners>microsoft,dotnetframework</Owners>
-    <Description>TODO</Description>
     <IconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</IconUrl>
     <Tags></Tags>
     <RequireLicenseAcceptance Condition="'$(RequireLicenseAcceptance)' == ''">false</RequireLicenseAcceptance>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
@@ -856,6 +856,7 @@
   </Target>
 
   <Target Name="GetPackageDescription"
+          Condition="'$(Description)' == '' and '$(PackageDescription)' == ''"
           DependsOnTargets="GetSyncInfo">
     <PropertyGroup>
       <UseRuntimePackageDescription Condition="'$(UseRuntimePackageDescription)' == '' AND $(BaseId.StartsWith('runtime.native'))">true</UseRuntimePackageDescription>


### PR DESCRIPTION
Allows to set the Description via msbuild instead of via a PackageDescriptionFile.