### PR TITLE
Don't include an assembly version at all for native files.

### DIFF
--- a/src/Microsoft.DotNet.SharedFramework.Sdk/src/GeneratePlatformManifestEntriesFromTemplate.cs
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/src/GeneratePlatformManifestEntriesFromTemplate.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.SharedFramework.Sdk
                     string fileVersion = string.Empty;
                     if (isNativeEntry)
                     {
-                        assemblyVersion = "0.0.0.0";
+                        assemblyVersion = "";
                     }
                     else
                     {
@@ -75,7 +75,8 @@ namespace Microsoft.DotNet.SharedFramework.Sdk
                     {
                         Name = entryTemplate.ItemSpec,
                         AssemblyVersion = assemblyVersion,
-                        FileVersion = fileVersion
+                        FileVersion = fileVersion,
+                        IsNative = isNativeEntry
                     });
                 }
             }
@@ -83,7 +84,7 @@ namespace Microsoft.DotNet.SharedFramework.Sdk
             PlatformManifestEntries = entries.Select(entry =>
                 {
                     var item = new TaskItem(entry.Name);
-                    if (string.IsNullOrEmpty(entry.AssemblyVersion))
+                    if (string.IsNullOrEmpty(entry.AssemblyVersion) && !entry.IsNative)
                     {
                         Log.LogError($"The platform manifest entry for '{entry.Name}' does not have a fallback assembly version specified and is not built on this platform.");
                     }

--- a/src/Microsoft.DotNet.SharedFramework.Sdk/src/PlatformManifestEntry.cs
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/src/PlatformManifestEntry.cs
@@ -9,5 +9,6 @@ namespace Microsoft.DotNet.SharedFramework.Sdk
         public string Name { get; set; }
         public string AssemblyVersion { get; set; }
         public string FileVersion { get; set; }
+        public bool IsNative { get; set; }
     }
 }


### PR DESCRIPTION
Native files need to have a blank assembly version, not a 0.0.0.0 assembly version. 

Contributes to unblocking https://github.com/dotnet/installer/pull/9172

cc: @dsplaisted 