### PR TITLE
Remove UsingToolNetFrameworkReferenceAssemblies

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,7 +6,6 @@
     <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
     <!-- Opt-out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
-    <UsingToolNetFrameworkReferenceAssemblies Condition="'$(DotNetBuildFromSource)' != 'true'">true</UsingToolNetFrameworkReferenceAssemblies>
     <!-- Libs -->
     <CommandLineParserVersion>2.2.1</CommandLineParserVersion>
     <CredentialManagementVersion>1.0.2</CredentialManagementVersion>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -40,7 +40,6 @@
     <UsingToolVSSDK Condition="'$(UsingToolVSSDK)' == ''">false</UsingToolVSSDK>
     <UsingToolIbcOptimization Condition="'$(UsingToolIbcOptimization)' == ''">false</UsingToolIbcOptimization>
     <UsingToolVisualStudioIbcTraining Condition="'$(UsingToolVisualStudioIbcTraining)' == ''">false</UsingToolVisualStudioIbcTraining>
-    <UsingToolNetFrameworkReferenceAssemblies Condition="'$(UsingToolNetFrameworkReferenceAssemblies)' == ''">false</UsingToolNetFrameworkReferenceAssemblies>
     <UsingToolNuGetRepack Condition="'$(UsingToolNuGetRepack)' == ''">false</UsingToolNuGetRepack>
     <UsingToolSymbolUploader Condition="'$(UsingToolSymbolUploader)' == ''">false</UsingToolSymbolUploader>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
@@ -128,13 +128,6 @@
 
   </Choose>
 
-  <!-- 
-    Implements proposal https://github.com/dotnet/designs/pull/33.
-  -->
-  <ItemGroup Condition="'$(UsingToolNetFrameworkReferenceAssemblies)' == 'true'">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="$(MicrosoftNetFrameworkReferenceAssembliesVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(EnableRichCodeNavigation)' == 'true'">
     <PackageReference Include="RichCodeNav.EnvVarDump" Version="$(RichCodeNavPackageVersion)" IsImplicitlyDefined="true" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
Superseded by https://github.com/dotnet/sdk/commit/206ec63efbad03af4c5ce30850179b4397514855 which adds a PackageReference to the reference assembly package automatically now. Controllable via the `AutomaticallyUseReferenceAssemblyPackages` flag.