### PR TITLE
Make PkgProj packable by default

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
@@ -23,8 +23,8 @@
     <!-- Disable the message indicating we are using a preview SDK. That is understood and by design -->
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
 
-    <!-- By default do not build NuGet package for a project. Project may override. -->
-    <IsPackable>false</IsPackable>
+    <!-- By default do not build NuGet package for a non pkgproj project. Project may override. -->
+    <IsPackable Condition="'$(MSBuildProjectExtension)' != '.pkgproj'">false</IsPackable>
 
     <!--
       Official build:

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
@@ -117,6 +117,9 @@
              Text="$(MSBuildProjectName) -> Skipping for this platform."
              Importance="high" />
   </Target>
+  
+  <Target Name="Pack"
+          DependsOnTargets="Build" />
 
   <Target Name="Clean">
     <!-- package version is calculated so read the last version from the marker file. -->


### PR DESCRIPTION
1) Arcade currently sets IsPackable unconditionally to false which we don't want for pkgprojs (which sole purpose is to create a package...)
2) Add the Pack target to pkgproj to make traversal packaging for pkgprojs similar to packable csproj files.