### PR TITLE
Add more logging and fallback to dotnet/install-scripts for curl'ing dotnet-install.sh

### DIFF
--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -263,6 +263,7 @@ function GetDotNetInstallScript {
   local root=$1
   local install_script="$root/dotnet-install.sh"
   local install_script_url="https://dot.net/$dotnetInstallScriptVersion/dotnet-install.sh"
+  local fallback_install_script_url="https://raw.githubusercontent.com/dotnet/install-scripts/master/src/dotnet-install.sh"
 
   if [[ ! -a "$install_script" ]]; then
     mkdir -p "$root"
@@ -273,13 +274,18 @@ function GetDotNetInstallScript {
     if command -v curl > /dev/null; then
       # first, try directly, if this fails we will retry with verbose logging
       curl "$install_script_url" -sSL --retry 10 --create-dirs -o "$install_script" || {
-        echo "curl failed; will now retry with verbose logging."
+        echo "Curl failed; dumping some information about dotnet.microsoft.com for later investigation"
+        echo | openssl s_client -showcerts -servername dotnet.microsoft.com  -connect dotnet.microsoft.com:443
+        echo "Will now retry the same URL with verbose logging."
         with_retries curl "$install_script_url" -sSL --verbose --retry 10 --create-dirs -o "$install_script" || {
+          echo "Verbose attempt failed.  Falling back to the dotnet/install-scripts repository"
+          with_retries curl "$fallback_install_script_url" -sSL --verbose --retry 10 --create-dirs -o "$install_script" || {
           local exit_code=$?
           Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to acquire dotnet install script (exit code '$exit_code')."
           ExitWithExitCode $exit_code
         }
       }
+    }
     else
       with_retries wget -v -O "$install_script" "$install_script_url" || {
         local exit_code=$?

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -263,7 +263,6 @@ function GetDotNetInstallScript {
   local root=$1
   local install_script="$root/dotnet-install.sh"
   local install_script_url="https://dot.net/$dotnetInstallScriptVersion/dotnet-install.sh"
-  local fallback_install_script_url="https://raw.githubusercontent.com/dotnet/install-scripts/master/src/dotnet-install.sh"
 
   if [[ ! -a "$install_script" ]]; then
     mkdir -p "$root"
@@ -278,14 +277,11 @@ function GetDotNetInstallScript {
         echo | openssl s_client -showcerts -servername dotnet.microsoft.com  -connect dotnet.microsoft.com:443
         echo "Will now retry the same URL with verbose logging."
         with_retries curl "$install_script_url" -sSL --verbose --retry 10 --create-dirs -o "$install_script" || {
-          echo "Verbose attempt failed.  Falling back to the dotnet/install-scripts repository"
-          with_retries curl "$fallback_install_script_url" -sSL --verbose --retry 10 --create-dirs -o "$install_script" || {
           local exit_code=$?
           Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to acquire dotnet install script (exit code '$exit_code')."
           ExitWithExitCode $exit_code
         }
       }
-    }
     else
       with_retries wget -v -O "$install_script" "$install_script_url" || {
         local exit_code=$?


### PR DESCRIPTION
See https://github.com/dotnet/core-eng/issues/11391 for context.

From conversations with @wfurt , adding the call to `openssl s_client -showcerts -servername dotnet.microsoft.com  -connect dotnet.microsoft.com:443` should help us understand where the problem lies in the certificate chain when this bug occurs.

After doing this and logging, we'll finally try a fallback to `https://raw.githubusercontent.com/dotnet/install-scripts/master/src/dotnet-install.sh` which is also public and should generally be in synch or slightly ahead of the other URL.