### PR TITLE
Add GeneratePackage property to pkgproj infra

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Microsoft.DotNet.Build.Tasks.Packaging.props
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Microsoft.DotNet.Build.Tasks.Packaging.props
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <PropertyGroup>
-    <IsPackable Condition="'$(MSBuildProjectExtension)' == '.pkgproj'">true</IsPackable>
+  <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.pkgproj'">
+    <IsPackable>true</IsPackable>
+    <!-- Additional property which no-ops the pkgproj entrypoint targets for more flexibility during servicing. -->
+    <GeneratePackage Condition="'$(GeneratePackage)' == ''">true</GeneratePackage>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
@@ -103,6 +103,7 @@
 
   <!-- Redefine build to just create the NuSpec only, we'll create the package during ArcProjects phase -->
   <Target Name="Build"
+          Condition="'$(GeneratePackage)' == 'true'"
           DependsOnTargets="$(BuildDependsOn)">
 
     <Message Condition="'$(ShouldCreatePackage)' == 'true'"


### PR DESCRIPTION
<GeneratePackage /> controls if a package should be created when the pkgproj is invoked. This allows to filter at project level instead of at traversal.