### PR TITLE
Support cancellation of Helix Jobs being waited on when the build is cancelled

### DIFF
--- a/src/Microsoft.DotNet.Helix/JobSender/ISentJob.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/ISentJob.cs
@@ -16,6 +16,11 @@ namespace Microsoft.DotNet.Helix.Client
         string CorrelationId { get; }
 
         /// <summary>
+        /// Token allowing cancellation of this specific job without other credentials
+        /// </summary>
+        string HelixCancellationToken { get; }
+
+        /// <summary>
         /// URI for blob storage container with the results.
         /// </summary>
         string ResultsContainerUri { get; }

--- a/src/Microsoft.DotNet.Helix/JobSender/SentJob.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/SentJob.cs
@@ -10,12 +10,14 @@ namespace Microsoft.DotNet.Helix.Client
         {
             JobApi = jobApi;
             CorrelationId = newJob.Name;
+            HelixCancellationToken = newJob.CancellationToken;
             ResultsContainerUri = resultsContainerUri;
             ResultsContainerReadSAS = resultsContainerReadSAS;
         }
 
         public IJob JobApi { get; }
         public string CorrelationId { get; }
+        public string HelixCancellationToken { get; }
         public string ResultsContainerUri { get; }
         public string ResultsContainerReadSAS { get; }
 

--- a/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
@@ -47,6 +47,12 @@ namespace Microsoft.DotNet.Helix.Sdk
         public string JobCorrelationId { get; set; }
 
         /// <summary>
+        ///   A string value which allows cancellation of only the job used to generate it (to support anonymous scenarios)
+        /// </summary>
+        [Output]
+        public string JobCancellationToken { get; set; }
+
+        /// <summary>
         ///   When the task finishes, the results container uri should be available in case we want to download files.
         /// </summary>
         [Output]
@@ -236,6 +242,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                 cancellationToken.ThrowIfCancellationRequested();
                 ISentJob job = await def.SendAsync(msg => Log.LogMessage(msg), cancellationToken);
                 JobCorrelationId = job.CorrelationId;
+                JobCancellationToken = job.HelixCancellationToken;
                 ResultsContainerUri = job.ResultsContainerUri;
                 ResultsContainerReadSAS = job.ResultsContainerReadSAS;
                 cancellationToken.ThrowIfCancellationRequested();

--- a/src/Microsoft.DotNet.Helix/Sdk/WaitForHelixJobCompletion.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/WaitForHelixJobCompletion.cs
@@ -58,7 +58,8 @@ namespace Microsoft.DotNet.Helix.Sdk
                 {
                     if (string.IsNullOrEmpty(helixJobCancellationToken))
                     {
-                        Log.LogWarning($"{nameof(CancelHelixJobsOnTaskCancellation)} is set to 'true', but no value provided for {nameof(helixJobCancellationToken)}");
+                        Log.LogWarning($"{nameof(CancelHelixJobsOnTaskCancellation)} is set to 'true', but no value was provided for {nameof(helixJobCancellationToken)}");
+                        return;
                     }
                     Log.LogWarning($"Build task was cancelled while waiting on job '{jobName}'.  Attempting to cancel this job in Helix...");
                     await HelixApi.Job.CancelAsync(jobName, helixJobCancellationToken);

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
@@ -57,6 +57,7 @@
                   WorkItems="@(HelixWorkItem)"
                   HelixProperties="@(HelixProperties)">
       <Output TaskParameter="JobCorrelationId" PropertyName="HelixJobId"/>
+      <Output TaskParameter="JobCancellationToken" PropertyName="HelixJobCancellationToken"/>
       <Output TaskParameter="ResultsContainerUri" PropertyName="HelixResultsContainer"/>
       <Output TaskParameter="ResultsContainerReadSAS" PropertyName="HelixResultsContainerReadSAS"/>
     </SendHelixJob>
@@ -66,6 +67,7 @@
         <HelixTargetQueue>$(HelixTargetQueue)</HelixTargetQueue>
         <ResultsContainerUri>$(HelixResultsContainer)</ResultsContainerUri>
         <ResultsContainerReadSAS>$(HelixResultsContainerReadSAS)</ResultsContainerReadSAS>
+        <HelixJobCancellationToken>$(HelixJobCancellationToken)</HelixJobCancellationToken>
       </SentJob>
     </ItemGroup>
 

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MultiQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MultiQueue.targets
@@ -22,6 +22,7 @@
 
   <PropertyGroup>
     <WaitForWorkItemCompletion Condition="'$(WaitForWorkItemCompletion)' != 'false'">true</WaitForWorkItemCompletion>
+    <CancelHelixJobsIfBuildCancelled Condition="'$(CancelHelixJobsIfBuildCancelled)' != 'false'">true</CancelHelixJobsIfBuildCancelled>
     <FailOnWorkItemFailure Condition="'$(FailOnWorkItemFailure)' != 'false'">true</FailOnWorkItemFailure>
     <FailOnMissionControlTestFailure Condition="'$(FailOnMissionControlTestFailure)' != 'true'">false</FailOnMissionControlTestFailure>
   </PropertyGroup>
@@ -55,6 +56,7 @@
       Condition="$(WaitForWorkItemCompletion)"
       AccessToken="$(HelixAccessToken)"
       BaseUri="$(HelixBaseUri)"
+      CancelHelixJobsOnTaskCancellation="$(CancelHelixJobsIfBuildCancelled)"
       Jobs="@(SentJob)" />
 
     <GetHelixWorkItems


### PR DESCRIPTION
Make the default behavior (opt-out by setting /p:CancelHelixJobsIfBuildCancelled=false) to cancel ongoing helix job runs for builds where the build waiting on Helix is cancelled
 
https://github.com/dotnet/core-eng/issues/8345

There's definitely something funky about the other side of this (there's supposed to be a cute log made for cancelled work items that got lost; that will need to be addressed in another issue in dotnet-helix-machines repo)

I will attempt to push a commit midway through the first run to demonstrate the functionality.