### PR TITLE
Create New ArcadeLogging library

### DIFF
--- a/Arcade.sln
+++ b/Arcade.sln
@@ -16,6 +16,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.GitSync", "src\Microsoft.DotNet.GitSync\Microsoft.DotNet.GitSync.csproj", "{F7E1C1EF-C234-41BA-A24F-FAD5F357562C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Arcade.Sdk", "src\Microsoft.DotNet.Arcade.Sdk\Microsoft.DotNet.Arcade.Sdk.csproj", "{747A5C75-6069-4C45-8049-AEAA1D864105}"
+	ProjectSection(ProjectDependencies) = postProject
+		{9B882C83-60B1-420D-A2D0-273433F11AB8} = {9B882C83-60B1-420D-A2D0-273433F11AB8}
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Helix.JobSender", "src\Microsoft.DotNet.Helix\JobSender\Microsoft.DotNet.Helix.JobSender.csproj", "{D6FFE1CC-98D6-425F-95D2-E40122D96E80}"
 EndProject

--- a/Arcade.sln
+++ b/Arcade.sln
@@ -16,9 +16,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.GitSync", "src\Microsoft.DotNet.GitSync\Microsoft.DotNet.GitSync.csproj", "{F7E1C1EF-C234-41BA-A24F-FAD5F357562C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Arcade.Sdk", "src\Microsoft.DotNet.Arcade.Sdk\Microsoft.DotNet.Arcade.Sdk.csproj", "{747A5C75-6069-4C45-8049-AEAA1D864105}"
-	ProjectSection(ProjectDependencies) = postProject
-		{9B882C83-60B1-420D-A2D0-273433F11AB8} = {9B882C83-60B1-420D-A2D0-273433F11AB8}
-	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Helix.JobSender", "src\Microsoft.DotNet.Helix\JobSender\Microsoft.DotNet.Helix.JobSender.csproj", "{D6FFE1CC-98D6-425F-95D2-E40122D96E80}"
 EndProject
@@ -126,9 +123,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.SourceBuil
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Arcade.Common", "src\Microsoft.Arcade.Common\Microsoft.Arcade.Common.csproj", "{40799495-6741-43FD-B013-7CBE4A48A963}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.Internal.DependencyInjection.Testing", "src\Microsoft.DotNet.Internal.DependencyInjection.Testing\Microsoft.DotNet.Internal.DependencyInjection.Testing.csproj", "{5B75BEBE-58A8-409D-8069-5210E87AA99A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Internal.DependencyInjection.Testing", "src\Microsoft.DotNet.Internal.DependencyInjection.Testing\Microsoft.DotNet.Internal.DependencyInjection.Testing.csproj", "{5B75BEBE-58A8-409D-8069-5210E87AA99A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.VersionTools.Tasks.Tests", "src\Microsoft.DotNet.VersionTools.Tasks.Tests\Microsoft.DotNet.VersionTools.Tasks.Tests.csproj", "{E941EDE6-3FFB-4776-A4CE-750755D57817}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.ArcadeLogging", "src\Microsoft.DotNet.ArcadeLogging\Microsoft.DotNet.ArcadeLogging.csproj", "{73496668-336D-4D43-9093-C17862E78BCE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -796,6 +795,18 @@ Global
 		{E941EDE6-3FFB-4776-A4CE-750755D57817}.Release|x64.Build.0 = Release|Any CPU
 		{E941EDE6-3FFB-4776-A4CE-750755D57817}.Release|x86.ActiveCfg = Release|Any CPU
 		{E941EDE6-3FFB-4776-A4CE-750755D57817}.Release|x86.Build.0 = Release|Any CPU
+		{73496668-336D-4D43-9093-C17862E78BCE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{73496668-336D-4D43-9093-C17862E78BCE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{73496668-336D-4D43-9093-C17862E78BCE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{73496668-336D-4D43-9093-C17862E78BCE}.Debug|x64.Build.0 = Debug|Any CPU
+		{73496668-336D-4D43-9093-C17862E78BCE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{73496668-336D-4D43-9093-C17862E78BCE}.Debug|x86.Build.0 = Debug|Any CPU
+		{73496668-336D-4D43-9093-C17862E78BCE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{73496668-336D-4D43-9093-C17862E78BCE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{73496668-336D-4D43-9093-C17862E78BCE}.Release|x64.ActiveCfg = Release|Any CPU
+		{73496668-336D-4D43-9093-C17862E78BCE}.Release|x64.Build.0 = Release|Any CPU
+		{73496668-336D-4D43-9093-C17862E78BCE}.Release|x86.ActiveCfg = Release|Any CPU
+		{73496668-336D-4D43-9093-C17862E78BCE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -646,6 +646,10 @@ function MSBuild() {
     $toolsetBuildProject = InitializeToolset
     $path = Split-Path -parent $toolsetBuildProject
     $path = Join-Path $path (Join-Path $buildTool.Framework 'Microsoft.DotNet.ArcadeLogging.dll')
+    if (-not (Test-Path $path)) {
+      $path = Split-Path -parent $toolsetBuildProject
+      $path = Join-Path $path (Join-Path $buildTool.Framework 'Microsoft.DotNet.Arcade.Sdk.dll')
+    }
     $args += "/logger:$path"
   }
 

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -645,7 +645,7 @@ function MSBuild() {
 
     $toolsetBuildProject = InitializeToolset
     $path = Split-Path -parent $toolsetBuildProject
-    $path = Join-Path $path (Join-Path $buildTool.Framework 'Microsoft.DotNet.Arcade.Sdk.dll')
+    $path = Join-Path $path (Join-Path $buildTool.Framework 'Microsoft.DotNet.ArcadeLogging.dll')
     $args += "/logger:$path"
   }
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
@@ -63,6 +63,10 @@
     <Compile Include="..\Common\AssemblyResolution.cs" Link="src\AssemblyResolution.cs" />
     <Compile Remove="src\InstallDotNetCore.cs" Condition="'$(DotNetBuildFromSource)' == 'true'" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.DotNet.ArcadeLogging\Microsoft.DotNet.ArcadeLogging.csproj" />
+  </ItemGroup>
   
   <Target Name="_GenerateSdkVersionFile" Inputs="$(MSBuildAllProjects)" Outputs="$(_GeneratedVersionFilePath)" BeforeTargets="GenerateNuSpec">
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/PipelinesLogger.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/PipelinesLogger.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
     /// 
     /// https://github.com/Microsoft/azure-pipelines-tasks/blob/601dd2f0a3e671b19b55bcf139f554a09f3414da/docs/authoring/commands.md
     /// </summary>
-    public sealed class PipelinesLogger : ILogger
+    public class PipelinesLogger : ILogger
     {
         private readonly MessageBuilder _builder = new MessageBuilder();
         private readonly Dictionary<BuildEventContext, Guid> _buildEventContextMap = new Dictionary<BuildEventContext, Guid>(BuildEventContextComparer.Instance);

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/PipelinesLogger.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/PipelinesLogger.cs
@@ -400,14 +400,6 @@ namespace Microsoft.DotNet.Arcade.Sdk
             Skipped,
         }
 
-        public sealed class MessageBuilder
-            public void Start(string kind)
-            public void AddProperty(string name, string value)
-            public void AddProperty(string name, DateTimeOffset value) => AddProperty(name, value.ToString("O"));
-            public void AddProperty(string name, int value) => AddProperty(name, value.ToString());
-            public void AddProperty(string name, Guid value) => AddProperty(name, value.ToString("D"));
-            public void Finish(string message = null)
-            public string GetMessage()
         /// <summary>
         /// Compares two event contexts on ProjectContextId and NodeId only.
         /// NOTE: Copied from MSBuild ParallelLoggerHelpers.cs.

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/PipelinesLogger.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/PipelinesLogger.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
     /// 
     /// https://github.com/Microsoft/azure-pipelines-tasks/blob/601dd2f0a3e671b19b55bcf139f554a09f3414da/docs/authoring/commands.md
     /// </summary>
-    public class PipelinesLogger : ILogger
+    public sealed class PipelinesLogger : ILogger
     {
         private readonly MessageBuilder _builder = new MessageBuilder();
         private readonly Dictionary<BuildEventContext, Guid> _buildEventContextMap = new Dictionary<BuildEventContext, Guid>(BuildEventContextComparer.Instance);
@@ -400,6 +400,14 @@ namespace Microsoft.DotNet.Arcade.Sdk
             Skipped,
         }
 
+        public sealed class MessageBuilder
+            public void Start(string kind)
+            public void AddProperty(string name, string value)
+            public void AddProperty(string name, DateTimeOffset value) => AddProperty(name, value.ToString("O"));
+            public void AddProperty(string name, int value) => AddProperty(name, value.ToString());
+            public void AddProperty(string name, Guid value) => AddProperty(name, value.ToString("D"));
+            public void Finish(string message = null)
+            public string GetMessage()
         /// <summary>
         /// Compares two event contexts on ProjectContextId and NodeId only.
         /// NOTE: Copied from MSBuild ParallelLoggerHelpers.cs.

--- a/src/Microsoft.DotNet.ArcadeLogging/MessageBuilder.cs
+++ b/src/Microsoft.DotNet.ArcadeLogging/MessageBuilder.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Microsoft.DotNet.Arcade.Sdk
+namespace Microsoft.DotNet.ArcadeLogging
 {
     public sealed class MessageBuilder
     {

--- a/src/Microsoft.DotNet.ArcadeLogging/Microsoft.DotNet.ArcadeLogging.csproj
+++ b/src/Microsoft.DotNet.ArcadeLogging/Microsoft.DotNet.ArcadeLogging.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.ArcadeLogging/Microsoft.DotNet.ArcadeLogging.csproj
+++ b/src/Microsoft.DotNet.ArcadeLogging/Microsoft.DotNet.ArcadeLogging.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build" Version="15.7.179" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.DotNet.ArcadeLogging/PipelinesLogger.cs
+++ b/src/Microsoft.DotNet.ArcadeLogging/PipelinesLogger.cs
@@ -2,12 +2,10 @@ using Microsoft.Build.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Diagnostics;
 using System.IO;
-using System.Text;
 using System.Collections;
 
-namespace Microsoft.DotNet.Arcade.Sdk
+namespace Microsoft.DotNet.ArcadeLogging
 {
     /// <summary>
     /// Logger for converting MSBuild error messages to the Azure Pipelines Tasks format


### PR DESCRIPTION
It seems my earlier PR (https://github.com/dotnet/arcade/pull/6535/) was insufficient to make MessageBuilder functionality available to other repos.  Following advice from @alexperovich I'm moving MessageBuilder to a new library, along with PipelinesLogger (so that other people can access it more easily).