### PR TITLE
Add source index job to jobs.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,7 @@ stages:
           manifests: true
       enableMicrobuild: true
       enablePublishUsingPipelines: true
+      enableSourceIndex: true
       workspace:
         clean: all
       jobs:

--- a/eng/common/templates/job/source-index-stage1.yml
+++ b/eng/common/templates/job/source-index-stage1.yml
@@ -1,6 +1,6 @@
 parameters:
   runAsPublic: false
-  sourceIndexPackageVersion: 1.0.0-beta4
+  sourceIndexPackageVersion: 1.0.0-beta5
   sourceIndexPackageSource: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
   sourceIndexBuildCommand: powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "eng/common/build.ps1 -restore -build -binarylog -ci"
   binlogPath: artifacts/log/Debug/Build.binlog

--- a/eng/common/templates/job/source-index-stage1.yml
+++ b/eng/common/templates/job/source-index-stage1.yml
@@ -1,0 +1,46 @@
+parameters:
+  runAsPublic: false
+  sourceIndexPackageVersion: 1.0.0-beta4
+  sourceIndexPackageSource: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
+  sourceIndexBuildCommand: powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "eng/common/build.ps1 -restore -build -binarylog -ci"
+  binlogPath: artifacts/log/Debug/Build.binlog
+  pool:
+    vmImage: vs2017-win2016
+
+jobs:
+- job: SourceIndexStage1
+  variables:
+  - name: SourceIndexPackageVersion
+    value: ${{ parameters.sourceIndexPackageVersion }}
+  - name: SourceIndexPackageSource
+    value: ${{ parameters.sourceIndexPackageSource }}
+  - name: BinlogPath
+    value: ${{ parameters.binlogPath }}
+  - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - group: source-dot-net stage1 variables
+
+  pool: ${{ parameters.pool }}
+  steps:
+  - task: UseDotNet@2
+    displayName: Use .NET Core sdk 3.1
+    inputs:
+      packageType: sdk
+      version: 3.1.x
+
+  - script: |
+      dotnet tool install BinLogToSln --version $(SourceIndexPackageVersion) --add-source $(SourceIndexPackageSource) --tool-path .source-index/tools
+      dotnet tool install UploadIndexStage1 --version $(SourceIndexPackageVersion) --add-source $(SourceIndexPackageSource) --tool-path .source-index/tools
+      echo ##vso[task.prependpath]$(Build.SourcesDirectory)/.source-index/tools
+    displayName: Download Tools
+
+  - script: ${{ parameters.sourceIndexBuildCommand }}
+    displayName: Build Repository
+
+  - script: BinLogToSln -i $(BinlogPath) -r $(Build.SourcesDirectory) -n $(Build.Repository.Name) -o .source-index/stage1output
+    displayName: Process Binlog into indexable sln
+
+  - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - script: UploadIndexStage1 -i .source-index/stage1output -n $(Build.Repository.Name)
+      displayName: Upload stage1 artifacts to source index
+      env:
+        BLOB_CONTAINER_URL: $(source-dot-net-stage1-blob-container-url)

--- a/eng/common/templates/jobs/jobs.yml
+++ b/eng/common/templates/jobs/jobs.yml
@@ -31,6 +31,9 @@ parameters:
   #           See /eng/common/templates/jobs/source-build.yml for options
   sourceBuildParameters: []
 
+  enableSourceIndex: false
+  sourceIndexParams: {}
+
 # Internal resources (telemetry, microbuild) can only be accessed from non-public projects,
 # and some (Microbuild) should only be applied to non-PR cases for internal builds.
 
@@ -57,7 +60,15 @@ jobs:
       ${{ each parameter in parameters.sourceBuildParameters }}:
         ${{ parameter.key }}: ${{ parameter.value }}
 
+- ${{ if eq(parameters.enableSourceIndex, 'true') }}:
+  - template: ../job/source-index-stage1.yml
+    parameters:
+      runAsPublic: ${{ parameters.runAsPublic }}
+      ${{ each parameter in parameters.sourceIndexParams }}:
+        ${{ parameter.key }}: ${{ parameter.value }}
+
 - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  
   - ${{ if or(eq(parameters.enablePublishBuildAssets, true), eq(parameters.artifacts.publish.manifests, 'true'), ne(parameters.artifacts.publish.manifests, '')) }}:
     - template: ../job/publish-build-assets.yml
       parameters:


### PR DESCRIPTION
This change adds an optional source indexing job to the pipeline so that the indexer won't just magically break when the repo gets changed. The job builds and collects the required files for indexing, and uploads them so the indexer can run without large dependencies on how individual repositories build.