### PR TITLE
Add cross-org authentication to publish build assets job

### DIFF
--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -37,6 +37,7 @@ jobs:
     - name: _BuildConfig
       value: ${{ parameters.configuration }}
     - group: Publish-Build-Assets
+    - group: AzureDevOps-Artifact-Feeds-Pats
     # Skip component governance and codesign validation for SDL. These jobs
     # create no content.
     - name: skipComponentGovernanceDetection
@@ -56,6 +57,12 @@ jobs:
     
     - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - task: NuGetAuthenticate@0
+
+      - task: PowerShell@2 
+        displayName: Enable cross-org NuGet feed authentication 
+        inputs: 
+          filePath: $(Build.SourcesDirectory)/eng/common/enable-cross-org-publishing.ps1 
+          arguments: -token $(dn-bot-all-orgs-artifact-feeds-rw) 
 
     - task: PowerShell@2
       displayName: Publish Build Assets


### PR DESCRIPTION
Related to https://github.com/dotnet/arcade/issues/6743. Add a step to enable authentication across azdo org boundaries when running the publish build assets job.

Test build: https://dnceng.visualstudio.com/internal/_build/results?buildId=940197&view=results