### PR TITLE
Don't keep waiting of a Job has failures

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/WaitForHelixJobCompletion.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/WaitForHelixJobCompletion.cs
@@ -35,10 +35,24 @@ namespace Microsoft.DotNet.Helix.Sdk
             cancellationToken.ThrowIfCancellationRequested();
             Log.LogMessage(MessageImportance.High, $"Waiting for completion of job {jobName} on {queueName}");
 
+            int iterationCount = 0;
             try
             {
                 for (; ; await Task.Delay(20000, cancellationToken).ConfigureAwait(false)) // delay every time this loop repeats
                 {
+                    // On first try, and ~ every 12 checks (~4 minutes) after, check the job details for errors.
+                    // Jobs with any job-level errors will never finish and we want to investigate these.
+                    if (iterationCount++ % 12 == 0)
+                    {
+                        var jd = await HelixApi.Job.DetailsAsync(jobName, cancellationToken).ConfigureAwait(false);
+                        if (jd.Errors.Count() > 0)
+                        {
+                            string errorMsgs = string.Join(",", jd.Errors.Select(d => d.Message).ToArray());
+                            Log.LogError($"Helix encountered job-level error(s) for this job ({errorMsgs}).  Please contact dnceng with this information.");
+                            return;
+                        }
+                    }
+
                     cancellationToken.ThrowIfCancellationRequested();
                     var pf = await HelixApi.Job.PassFailAsync(jobName, cancellationToken).ConfigureAwait(false);
                     if (pf.Working == 0 && pf.Total != 0)

--- a/src/Microsoft.DotNet.Helix/Sdk/WaitForHelixJobCompletion.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/WaitForHelixJobCompletion.cs
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                         var jd = await HelixApi.Job.DetailsAsync(jobName, cancellationToken).ConfigureAwait(false);
                         if (jd.Errors.Count() > 0)
                         {
-                            string errorMsgs = string.Join(",", jd.Errors.Select(d => d.Message).ToArray());
+                            string errorMsgs = string.Join(",", jd.Errors.Select(d => d.Message));
                             Log.LogError($"Helix encountered job-level error(s) for this job ({errorMsgs}).  Please contact dnceng with this information.");
                             return;
                         }


### PR DESCRIPTION
Addresses https://github.com/dotnet/arcade/issues/6733.  While extremely rare, and poorly  named, these errors currently only mean one thing; the Helix controller failed to enqueue all the work, which means the work will never finish and waiting will not return. 