### PR TITLE
Correctly set SelfContained to false after processing framework references

### DIFF
--- a/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -24,7 +24,7 @@
   
   <Target Name="_RemoveSelfContainedAfterFrameworkReferenceResolution" AfterTargets="ProcessFrameworkReferences">
     <PropertyGroup>
-      <SelfContained>true</SelfContained>
+      <SelfContained>false</SelfContained>
     </PropertyGroup>
   </Target>
 


### PR DESCRIPTION
This is necessary to fix the runtimeconfig generation for WindowsDesktop.

Contributes to https://github.com/dotnet/sdk/issues/15198