### PR TITLE
Fix tools.sh to match tools.ps1

### DIFF
--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -412,7 +412,7 @@ function MSBuild {
 
     local toolset_dir="${_InitializeToolset%/*}"
     local logger_path="$toolset_dir/$_InitializeBuildToolFramework/Microsoft.DotNet.ArcadeLogging.dll"
-    if [[ ! -d logger_path ]]; then
+    if [[ ! -f logger_path ]]; then
       logger_path="$toolset_dir/$_InitializeBuildToolFramework/Microsoft.DotNet.Arcade.Sdk.dll"
     fi
     args=( "${args[@]}" "-logger:$logger_path" )

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -411,7 +411,10 @@ function MSBuild {
     fi
 
     local toolset_dir="${_InitializeToolset%/*}"
-    local logger_path="$toolset_dir/$_InitializeBuildToolFramework/Microsoft.DotNet.Arcade.Sdk.dll"
+    local logger_path="$toolset_dir/$_InitializeBuildToolFramework/Microsoft.DotNet.ArcadeLogging.dll"
+    if [[ ! -d logger_path ]]; then
+      logger_path="$toolset_dir/$_InitializeBuildToolFramework/Microsoft.DotNet.Arcade.Sdk.dll"
+    fi
     args=( "${args[@]}" "-logger:$logger_path" )
   fi
 


### PR DESCRIPTION
Fixes issue caused by https://github.com/dotnet/arcade/pull/6739 due to tools.ps1 being changed but tools.sh remaining unchanged.