### PR TITLE
Publish using Darc should depend on the publishDependsOn

### DIFF
--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -224,7 +224,7 @@ stages:
 - ${{ if or(ge(parameters.publishingInfraVersion, 3), eq(parameters.inline, 'false')) }}:
   - stage: publish_using_darc
     ${{ if or(eq(parameters.enableNugetValidation, 'true'), eq(parameters.enableSigningValidation, 'true'), eq(parameters.enableSourceLinkValidation, 'true'), eq(parameters.SDLValidationParameters.enable, 'true')) }}:
-      dependsOn: Validate
+      dependsOn: ${{ parameters.publishDependsOn }}
     ${{ if and(ne(parameters.enableNugetValidation, 'true'), ne(parameters.enableSigningValidation, 'true'), ne(parameters.enableSourceLinkValidation, 'true'), ne(parameters.SDLValidationParameters.enable, 'true')) }}:
       dependsOn: ${{ parameters.validateDependsOn }}
     displayName: Publish using Darc


### PR DESCRIPTION
We specify publishDependsOn in the parameters, but hard-coded Validate for publish_using_darc. What this means is that, in particular for arcade, where we Validate the arcade sdk in addition to the normal validation legs, we don't wait for ValidateSdk to finish before publishing using darc. However, we should be waiting for that, so we should be using the publishDependsOn, rather than hard-coding Validate for publish using darc's dependsOn.

Addresses #6696.