### PR TITLE
Revert symUploader dependency update

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.SymbolUploader.Build.Task" Version="1.1.206105">
+    <Dependency Name="Microsoft.SymbolUploader.Build.Task" Version="1.1.156702">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-symuploader</Uri>
-      <Sha>15ebf70b90a79471d060bae42637350e0773b49d</Sha>
+      <Sha>861806bc0dc685441cb3e8f6bd1ce5ed31e6b32b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SymbolUploader" Version="1.1.206105">
+    <Dependency Name="Microsoft.SymbolUploader" Version="1.1.152002">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-symuploader</Uri>
-      <Sha>15ebf70b90a79471d060bae42637350e0773b49d</Sha>
+      <Sha>165896e7efeecb70f01bd011257ead0f56d32c95</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -83,7 +83,7 @@
     <XliffTasksVersion>1.0.0-beta.21059.1</XliffTasksVersion>
     <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.20570.1</MicrosoftDotNetMaestroTasksVersion>
     <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.21061.3</MicrosoftDotNetXHarnessCLIVersion>
-    <MicrosoftSymbolUploaderBuildTaskVersion>1.1.206105</MicrosoftSymbolUploaderBuildTaskVersion>
+    <MicrosoftSymbolUploaderBuildTaskVersion>1.1.156402</MicrosoftSymbolUploaderBuildTaskVersion>
     <MicrosoftDotNetSymbolUploaderVersion>1.1.152002</MicrosoftDotNetSymbolUploaderVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Revert this PR https://github.com/dotnet/arcade/pull/6769

On updating the version got version mismatch error -> https://dnceng.visualstudio.com/internal/_build/results?buildId=947162&view=logs&j=fa59fe4e-195c-56fa-189b-58fd241f10dd&t=afa1ce5e-d2bc-56f3-ad78-7883f25a3e3a

@riarenas 