### PR TITLE
Source-build template default pool fix; clean up parameters

### DIFF
--- a/eng/common/templates/job/source-build.yml
+++ b/eng/common/templates/job/source-build.yml
@@ -28,6 +28,11 @@ parameters:
   #   container and pool.
   platform: {}
 
+  # The default VM host AzDO pool. This should be capable of running Docker containers: almost all
+  # source-build builds run in Docker, including the default managed platform.
+  defaultContainerHostPool:
+    vmImage: ubuntu-20.04
+
 jobs:
 - job: ${{ parameters.jobNamePrefix }}_${{ parameters.platform.name }}
   displayName: Source-Build (${{ parameters.platform.name }})
@@ -37,6 +42,9 @@ jobs:
 
   ${{ if ne(parameters.platform.container, '') }}:
     container: ${{ parameters.platform.container }}
+
+  ${{ if eq(parameters.platform.pool, '') }}:
+    pool: ${{ parameters.defaultContainerHostPool }}
   ${{ if ne(parameters.platform.pool, '') }}:
     pool: ${{ parameters.platform.pool }}
 

--- a/eng/common/templates/jobs/jobs.yml
+++ b/eng/common/templates/jobs/jobs.yml
@@ -7,7 +7,14 @@ parameters:
 
   # Optional: Enable publishing using release pipelines
   enablePublishUsingPipelines: false
-  
+
+  # Optional: Enable running the source-build jobs to build repo from source
+  enableSourceBuild: false
+
+  # Optional: Parameters for source-build template.
+  #           See /eng/common/templates/jobs/source-build.yml for options
+  sourceBuildParameters: []
+
   graphFileGeneration:
     # Optional: Enable generating the graph files at the end of the build
     enabled: false
@@ -23,13 +30,6 @@ parameters:
   # Optional: should run as a public build even in the internal project
   #           if 'true', the build won't run any of the internal only steps, even if it is running in non-public projects.
   runAsPublic: false
-
-  # Optional: Enable running the source-build jobs to build repo from source
-  runSourceBuild: false
-
-  # Optional: Parameters for source-build template.
-  #           See /eng/common/templates/jobs/source-build.yml for options
-  sourceBuildParameters: []
 
   enableSourceIndex: false
   sourceIndexParams: {}
@@ -53,7 +53,7 @@ jobs:
 
       name: ${{ job.job }}
 
-- ${{ if eq(parameters.runSourceBuild, true) }}:
+- ${{ if eq(parameters.enableSourceBuild, true) }}:
   - template: /eng/common/templates/jobs/source-build.yml
     parameters:
       allCompletedJobId: Source_Build_Complete
@@ -80,7 +80,7 @@ jobs:
         - ${{ if eq(parameters.publishBuildAssetsDependsOn, '') }}:
           - ${{ each job in parameters.jobs }}:
             - ${{ job.job }}
-        - ${{ if eq(parameters.runSourceBuild, true) }}:
+        - ${{ if eq(parameters.enableSourceBuild, true) }}:
           - Source_Build_Complete
         pool:
           vmImage: vs2017-win2016

--- a/eng/common/templates/jobs/source-build.yml
+++ b/eng/common/templates/jobs/source-build.yml
@@ -11,16 +11,14 @@ parameters:
   # See /eng/common/templates/job/source-build.yml
   jobNamePrefix: 'Source_Build'
 
-  # If changed to true, causes this template to include the default platform for a managed-only
-  # repo. The exact Docker image used for this build will be provided by Arcade. This has some risk,
-  # but since the repo is supposed to be managed-only, the risk should be very low.
-  includeDefaultManagedPlatform: false
+  # This is the default platform provided by Arcade, intended for use by a managed-only repo.
   defaultManagedPlatform:
     name: 'Managed'
     container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343'
 
   # Defines the platforms on which to run build jobs. One job is created for each platform, and the
-  # object in this array is sent to the job template as 'platform'.
+  # object in this array is sent to the job template as 'platform'. If no platforms are specified,
+  # one job runs on 'defaultManagedPlatform'.
   platforms: []
 
 jobs:
@@ -32,7 +30,7 @@ jobs:
     dependsOn:
     - ${{ each platform in parameters.platforms }}:
       - ${{ parameters.jobNamePrefix }}_${{ platform.name }}
-    - ${{ if eq(parameters.includeDefaultManagedPlatform, true) }}:
+    - ${{ if eq(length(parameters.platforms), 0) }}:
       - ${{ parameters.jobNamePrefix }}_${{ parameters.defaultManagedPlatform.name }}
 
 - ${{ each platform in parameters.platforms }}:
@@ -41,7 +39,7 @@ jobs:
       jobNamePrefix: ${{ parameters.jobNamePrefix }}
       platform: ${{ platform }}
 
-- ${{ if eq(parameters.includeDefaultManagedPlatform, true) }}:
+- ${{ if eq(length(parameters.platforms), 0) }}:
   - template: /eng/common/templates/job/source-build.yml
     parameters:
       jobNamePrefix: ${{ parameters.jobNamePrefix }}


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/1795 by always setting the vm image to `ubuntu-20.04` by default.

Incorporates suggestions from @tmat based on https://github.com/dotnet/sourcelink/pull/690 (thanks!):
* Rename `runSourceBuild` -> `enableSourceBuild`.
  * Also bring the parameter up closer to the `enable` properties away from the other `run` property. `enable` is much more common for this kind of flag and will fit in nicer.
* Use default platform if and only if 0 platforms are passed.
  * This simplifies the implementation from 3 lines to 1 line of code for ordinary, managed-only, arcade-using repos.
  * This removes the ability to use the default platform if you're also passing in your own platforms. However, this functionality is probably not useful enough to justify the extra lines in ordinary repos. If a repo defines its own platforms, it's only a few more lines to include a copy of the default platform. (This copy won't receive auto-updates, but the custom platforms won't receive auto-updates either, so this seems like a non-issue in context.)
    * It might not be hard to bring this back with some extra conditions, but it doesn't seem worth the yml template bloat.

Only one repo uses these templates/parameters so far (dotnet/source-build-reference-packages) so I'm not concerned about this being a breaking change.