### PR TITLE
Revert "Disable iOS integration test (#6776)"

### DIFF
--- a/tests/UnitTests.XHarness.iOS.proj
+++ b/tests/UnitTests.XHarness.iOS.proj
@@ -25,8 +25,7 @@
   <!-- Test project which builds app bundle to run via XHarness -->
   <ItemGroup>
     <XHarnessiOSProject Include="$(MSBuildThisFileDirectory)XHarness\XHarness.TestAppBundle.proj" />
-    <!-- TODO: Disabled until dotnet/xharness#413 is resolved -->
-    <!-- <XHarnessiOSProject Include="$(MSBuildThisFileDirectory)XHarness\XHarness.RunAppBundle.proj" /> -->
+    <XHarnessiOSProject Include="$(MSBuildThisFileDirectory)XHarness\XHarness.RunAppBundle.proj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(HelixAccessToken)' != '' ">


### PR DESCRIPTION
This reverts commit c54099e5d7b0c7668bdb963aad15d9a8f1f1d8fe.

Issue was fixed in https://github.com/dotnet/xharness/pull/414