### PR TITLE
Detect root license, use for intermediate nupkg

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
@@ -3,6 +3,8 @@
 
   <Import Project="..\BuildStep.props" />
 
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GetLicenseFilePath" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
+
   <PropertyGroup>
     <MicrosoftDotNetSourceBuildTasksBuildDir>$(NuGetPackageRoot)microsoft.dotnet.sourcebuild.tasks\$(MicrosoftDotNetSourceBuildTasksVersion)\build\</MicrosoftDotNetSourceBuildTasksBuildDir>
   </PropertyGroup>
@@ -80,6 +82,13 @@
       <SourceBuildIntermediateProjTargetFile>$(ArtifactsObjDir)ArcadeGeneratedProjects\SourceBuildIntermediate\SourceBuildIntermediate.proj</SourceBuildIntermediateProjTargetFile>
     </PropertyGroup>
 
+    <!-- Find the repository's global LICENSE file to apply. -->
+    <Microsoft.DotNet.Arcade.Sdk.GetLicenseFilePath
+      Condition="'$(DetectSourceBuildIntermediateNupkgLicense)' == 'true'"
+      Directory="$(RepoRoot)">
+      <Output TaskParameter="Path" PropertyName="SourceBuildIntermediateNupkgLicenseFile"/>
+    </Microsoft.DotNet.Arcade.Sdk.GetLicenseFilePath>
+
     <!-- Copy the project to artifacts/ so that the repo's global.json is in an ancestor dir. -->
     <Copy
       SourceFiles="$(SourceBuildIntermediateProjFile)"
@@ -95,6 +104,7 @@
       Properties="
         CurrentRepoSourceBuildArtifactsPackagesDir=$(CurrentRepoSourceBuildArtifactsPackagesDir);
         SourceBuildArcadeTargetsFile=$(MSBuildThisFileDirectory)SourceBuildArcade.targets;
+        SourceBuildIntermediateNupkgLicenseFile=$(SourceBuildIntermediateNupkgLicenseFile);
         " />
   </Target>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -23,6 +23,9 @@
 
     <PrebuiltBaselineDataFileDefault>$(RepositoryEngineeringDir)SourceBuildPrebuiltBaseline.xml</PrebuiltBaselineDataFileDefault>
     <PrebuiltBaselineDataFile Condition="Exists('$(PrebuiltBaselineDataFileDefault)')">$(PrebuiltBaselineDataFileDefault)</PrebuiltBaselineDataFile>
+
+    <!-- By default, use the license file from the root of the repo for the intermediate nupkg. -->
+    <DetectSourceBuildIntermediateNupkgLicense Condition="'$(DetectSourceBuildIntermediateNupkgLicense)' == ''">true</DetectSourceBuildIntermediateNupkgLicense>
   </PropertyGroup>
 
   <Target Name="GetSourceBuildIntermediateNupkgNameConvention">

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
@@ -15,7 +15,6 @@
 
   <PropertyGroup>
     <Copyright Condition="'$(Copyright)' == ''">$(CopyrightNetFoundation)</Copyright>
-    <PackageLicenseExpression Condition="'$(PackageLicenseExpression)' == ''">MIT</PackageLicenseExpression>
 
     <IsPackable>true</IsPackable>
     <IsShipping>false</IsShipping>
@@ -30,6 +29,14 @@
     <!-- Arbitrary TargetFramework to appease SDK. -->
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(SourceBuildIntermediateNupkgLicenseFile)' != ''">
+    <PackageLicenseFile>$([System.IO.Path]::GetFileName('$(SourceBuildIntermediateNupkgLicenseFile)'))</PackageLicenseFile>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(SourceBuildIntermediateNupkgLicenseFile)' != ''">
+    <None Include="$(SourceBuildIntermediateNupkgLicenseFile)" Pack="true" PackagePath="$(PackageLicenseFile)" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(EnableDefaultSourceBuildIntermediateItems)' == 'true'">
     <Content Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)**\*.nupkg" PackagePath="artifacts" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/1981.

By default, use the `GetLicenseFilePath` task from Arcade to find some license.txt at the repo root, and use that for the intermediate nupkg. This is the task that does the validation, so it should at least as reliable as it is. 😄

To disable, set `<DetectSourceBuildIntermediateNupkgLicense>false</>` and provide the license file or expression some other way in `eng/SourceBuild.props`.

Tried it out in sourcelink by pasting over files in the package cache, tried it in SBRP by building Arcade locally and feeding in the nupkgs with a local source. No obvious issues.