### PR TITLE
Wrapper scripts for XHarness Android work items to infra retry on specific failure modes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -137,10 +137,11 @@ stages:
               -ci
               -restore
               -test
-              -projects $(Build.SourcesDirectory)\tests\UnitTests.XHarness.Android.proj
-              /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.XHarness.Android.binlog
+              -projects $(Build.SourcesDirectory)\tests\UnitTests.XHarness.Android.WindowsQueues.proj
+              /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.XHarness.Android.WindowsQueues.binlog
               /p:RestoreUsingNuGetTargets=false
-            displayName: XHarness Android Helix Testing
+              /p:XharnessTestARM64_V8A=true
+            displayName: XHarness Android Helix Testing (Windows)
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''
@@ -194,6 +195,21 @@ stages:
               /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.XHarness.CLI.binlog
               /p:RestoreUsingNuGetTargets=false
             displayName: XHarness CLI pre-install Helix Testing
+            env:
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+              HelixAccessToken: ''
+          - script: eng/common/build.sh
+              -configuration $(_BuildConfig) 
+              -prepareMachine
+              -ci
+              -restore
+              -test
+              -projects $(Build.SourcesDirectory)/tests/UnitTests.XHarness.Android.LinuxQueues.proj
+              /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.XHarness.Android.LinuxQueues.binlog
+              /p:RestoreUsingNuGetTargets=false
+              /p:XharnessTestX86=true 
+              /p:XharnessTestX86_64=true 
+            displayName: XHarness Android Helix Testing (Linux)
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''

--- a/src/Microsoft.DotNet.Helix/Sdk/Microsoft.DotNet.Helix.Sdk.csproj
+++ b/src/Microsoft.DotNet.Helix/Sdk/Microsoft.DotNet.Helix.Sdk.csproj
@@ -37,6 +37,12 @@
     <EmbeddedResource Include="tools\xharness-runner\xharness-runner.ios.sh">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </EmbeddedResource>
+    <EmbeddedResource Include="tools\xharness-runner\xharness-helix-job.android.sh">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="tools\xharness-runner\xharness-helix-job.android.bat">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </EmbeddedResource>
   </ItemGroup>
 
   <Import Project="$(RepoRoot)eng\BuildTask.targets" />

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.bat
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.bat
@@ -1,0 +1,23 @@
+@echo off
+
+REM This script is used as a payload of Helix jobs that execute Android workloads through XHarness on Windows systems.
+REM This is used as the entrypoint of the work item so that XHarness failures can be detected and (when appropriate)
+REM cause the work item to retry and reboot the Helix agent the work is running on.
+
+REM Currently no special functionality is needed beyond causing infrastructure retry and reboot if the emulators
+REM or devices have trouble, but to add more Helix-specific Android XHarness behaviors, this is one extensibility point.
+
+set ADB_DEVICE_ENUMERATION_FAILURE=85
+
+echo Xharness Helix Wrapper: Arguments: %*
+%*
+set EXIT_CODE=%ERRORLEVEL%
+
+if %EXIT_CODE%==%ADB_DEVICE_ENUMERATION_FAILURE% (
+  echo Encountered ADB_DEVICE_ENUMERATION_FAILURE.  This is typically not a failure of the work item.  We will run it again and reboot this computer to help its devices
+  echo If this occurs repeatedly, please check for architectural mismatch, e.g. sending x86 or x86_64 APKs to an arm64_v8a-only queue.
+  %HELIX_PYTHONPATH% -c "from helix.workitemutil import request_infra_retry; request_infra_retry('Retrying because we could not enumerate all Android devices')"
+  %HELIX_PYTHONPATH% -c "from helix.workitemutil import request_reboot; request_reboot('Rebooting to allow Android emulator or device to restart')"
+) 
+
+exit /B %EXIT_CODE%

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+### This script is used as a payload of Helix jobs that execute Android workloads through XHarness on Linux systems.
+### This is used as the entrypoint of the work item so that XHarness failures can be detected and (when appropriate)
+### cause the work item to retry and reboot the Helix agent the work is running on.
+### 
+### Currently no special functionality is needed beyond causing infrastructure retry and reboot if the emulators
+### or devices have trouble, but to add more Helix-specific Android XHarness behaviors, this is one extensibility point.
+
+set -x
+echo "XHarness Helix Job Wrapper calling '$@'"
+"$@"
+exit_code=$?
+
+# This handles issues where devices or emulators fail to start.
+# The only solution is to reboot the machine, so we request a work item retry + agent reboot when this happens
+# Too see where these values come from, check out https://github.com/dotnet/xharness/blob/master/src/Microsoft.DotNet.XHarness.Common/CLI/ExitCode.cs
+# Avoid any helix-ism in the Xharness!
+
+ADB_DEVICE_ENUMERATION_FAILURE=85 
+if [ $exit_code -eq $ADB_DEVICE_ENUMERATION_FAILURE ]; then
+    echo 'Encountered ADB_DEVICE_ENUMERATION_FAILURE.  This is typically not a failure of the work item.  We will run it again and reboot this computer to help its devices'
+    echo 'If this occurs repeatedly, please check for architectural mismatch, e.g. sending arm64_v8a APKs to an x86_64 / x86 only queue.'
+    # Since we run the payload script using launchctl, env vars are not set there and we have to do this part here
+    "$HELIX_PYTHONPATH" -c "from helix.workitemutil import request_infra_retry; request_infra_retry('Retrying because we could not enumerate all Android devices')"
+    "$HELIX_PYTHONPATH" -c "from helix.workitemutil import request_reboot; request_reboot('Rebooting to allow Android emulator or device to restart.')"
+fi
+
+exit $exit_code

--- a/tests/UnitTests.XHarness.Android.LinuxQueues.proj
+++ b/tests/UnitTests.XHarness.Android.LinuxQueues.proj
@@ -4,7 +4,7 @@
 
   <!--
     This is a project used in integration tests of Arcade.
-    It tests sending Android (XHarness) workloads using the Helix SDK.
+    It tests sending Android (XHarness) workloads using the Helix SDK to Linux-specific queues
     It builds a mock project that does not build an APK directly but only downloads it from a storage account.
    -->
 
@@ -24,7 +24,7 @@
 
   <!-- New Test Projects which build packages to run through XHarness/XHarness go here -->
   <ItemGroup>
-    <XHarnessAndroidProject Include="$(MSBuildThisFileDirectory)XHarness/XHarness.TestApk.proj" />
+    <XHarnessAndroidProject Include="$(MSBuildThisFileDirectory)XHarness/XHarness.TestApks.proj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(HelixAccessToken)' != '' ">

--- a/tests/UnitTests.XHarness.Android.WindowsQueues.proj
+++ b/tests/UnitTests.XHarness.Android.WindowsQueues.proj
@@ -1,0 +1,52 @@
+<Project DefaultTargets="Test">
+  <!-- See UnitTests.proj in above folder for why this is included directly-from-repo -->
+  <Import Project="$(MSBuildThisFileDirectory)\..\src\Microsoft.DotNet.Helix\Sdk\sdk\Sdk.props"/>
+
+  <!--
+    This is a project used in integration tests of Arcade.
+    It tests sending Android (XHarness) workloads using the Helix SDK to Windows-specific queues
+    It builds a mock project that does not build an APK directly but only downloads it from a storage account.
+   -->
+
+  <PropertyGroup>
+    <MicrosoftDotNetHelixSdkTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)../artifacts/bin/Microsoft.DotNet.Helix.Sdk/$(Configuration)/netcoreapp2.1/publish/Microsoft.DotNet.Helix.Sdk.dll</MicrosoftDotNetHelixSdkTasksAssembly>
+    <MicrosoftDotNetHelixSdkTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)../artifacts/bin/Microsoft.DotNet.Helix.Sdk/$(Configuration)/net472/publish/Microsoft.DotNet.Helix.Sdk.dll</MicrosoftDotNetHelixSdkTasksAssembly>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <HelixType>test/product/</HelixType>
+    <TestRunNamePrefix>$(AGENT_JOBNAME)</TestRunNamePrefix>
+    <IncludeXHarnessCli>true</IncludeXHarnessCli>
+    <EnableXUnitReporter>true</EnableXUnitReporter>
+    <EnableAzurePipelinesReporter>true</EnableAzurePipelinesReporter>
+    <HelixBaseUri>https://helix.dot.net</HelixBaseUri>
+  </PropertyGroup>
+
+  <!-- New Test Projects which build packages to run through XHarness/XHarness go here -->
+  <ItemGroup>
+    <XHarnessAndroidProject Include="$(MSBuildThisFileDirectory)XHarness/XHarness.TestApks.proj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(HelixAccessToken)' != '' ">
+    <HelixTargetQueue Include="windows.10.amd64.android"/>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(HelixAccessToken)' == '' ">
+    <HelixTargetQueue Include="windows.10.amd64.android.open" />
+  </ItemGroup>
+
+  <PropertyGroup Condition=" '$(HelixAccessToken)' == '' ">
+    <IsExternal>true</IsExternal>
+    <Creator>$(BUILD_SOURCEVERSIONAUTHOR)</Creator>
+    <Creator Condition=" '$(Creator)' == ''">anon</Creator>
+  </PropertyGroup>
+
+  <!-- Useless stuff to make Arcade SDK happy -->
+  <PropertyGroup>
+    <Language>msbuild</Language>
+  </PropertyGroup>
+  <Target Name="Pack"/>
+
+  <!-- See UnitTests.proj in above folder for why this is included directly-from-repo -->
+  <Import Project="$(MSBuildThisFileDirectory)\..\src\Microsoft.DotNet.Helix\Sdk\sdk\Sdk.targets"/>
+</Project>

--- a/tests/XHarness/XHarness.TestApks.proj
+++ b/tests/XHarness/XHarness.TestApks.proj
@@ -5,15 +5,21 @@
   <PropertyGroup>
     <XHarnessX86TestApkUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/android/test-apk/x86/System.Buffers.Tests-x86.apk</XHarnessX86TestApkUrl>
     <XHarnessX64TestApkUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/android/test-apk/x86_64/System.Buffers.Tests-x64.apk</XHarnessX64TestApkUrl>
+    <XHarnessARM64V8TestApkUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/android/test-apk/arm64_v8a/System.Buffers.Tests-arm64-v8a.apk</XHarnessARM64V8TestApkUrl>
   </PropertyGroup>
 
   <Target Name="Build" Returns="@(XHarnessApkToTest)" >
     <Error Condition=" '$(ArtifactsTmpDir)' == ''" Text="Not downloading APK because ArtifactsTmpDir property is unset" />
-    <DownloadFile SourceUrl="$(XHarnessX86TestApkUrl)" DestinationFolder="$(ArtifactsTmpDir)XHarness.TestApk\x86" SkipUnchangedFiles="True" Retries="5">
+
+    <DownloadFile Condition="'$(XharnessTestX86)' == 'true'" SourceUrl="$(XHarnessX86TestApkUrl)" DestinationFolder="$(ArtifactsTmpDir)XHarness.TestApk\x86" SkipUnchangedFiles="True" Retries="5">
       <Output TaskParameter="DownloadedFile" ItemName="DownloadedApkFile" />
     </DownloadFile>
 
-    <DownloadFile SourceUrl="$(XHarnessX64TestApkUrl)" DestinationFolder="$(ArtifactsTmpDir)XHarness.TestApk\x86_64" SkipUnchangedFiles="True" Retries="5">
+    <DownloadFile Condition="'$(XharnessTestX86_64)' == 'true'" SourceUrl="$(XHarnessX64TestApkUrl)" DestinationFolder="$(ArtifactsTmpDir)XHarness.TestApk\x86_64" SkipUnchangedFiles="True" Retries="5">
+      <Output TaskParameter="DownloadedFile" ItemName="DownloadedApkFile" />
+    </DownloadFile>
+
+    <DownloadFile Condition="'$(XharnessTestARM64_V8A)' == 'true'" SourceUrl="$(XHarnessARM64V8TestApkUrl)" DestinationFolder="$(ArtifactsTmpDir)XHarness.TestApk\arm64_v8a" SkipUnchangedFiles="True" Retries="5">
       <Output TaskParameter="DownloadedFile" ItemName="DownloadedApkFile" />
     </DownloadFile>
 


### PR DESCRIPTION
Addresses https://github.com/dotnet/core-eng/issues/11797

Through random luck in my testing, I actually hit an ubuntu android emulator machine that was screwed up:

[First log](https://helixre107v0xdeko0k025g8.blob.core.windows.net/dotnet-arcade-xharness-helix-retry-on-fail-10ef45a98deb44809b/System.Buffers.Tests-x64/console.561cc946.log?sv=2019-07-07&se=2021-02-03T18%3A11%3A10Z&sr=c&sp=rl&sig=Ht1Pp9nL9BXn8RGpdfoIAD1iSbbh99HS2hYCQcAxiI8%3D)
[Second log](https://helixre107v0xdeko0k025g8.blob.core.windows.net/dotnet-arcade-xharness-helix-retry-on-fail-10ef45a98deb44809b/System.Buffers.Tests-x64.Attempt.2/console.32076ce1.log?sv=2019-07-07&se=2021-02-03T18%3A11%3A10Z&sr=c&sp=rl&sig=Ht1Pp9nL9BXn8RGpdfoIAD1iSbbh99HS2hYCQcAxiI8%3D)

This demonstrates the mitigation works, even though the retry was on the same machine (after a reboot).  Note the failure to send to AzDO was just because I was running outside of AzDO.

