### PR TITLE
Fix build of PNSE assemblies with `--no-dependencies`

### DIFF
--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacadesNotSupported.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacadesNotSupported.targets
@@ -22,7 +22,8 @@
       <Targets>GetCompileItems</Targets>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>ReferenceSources</OutputItemType>
-      <BuildReference Condition="'$(BuildingInsideVisualStudio)' == 'true'">false</BuildReference>
+      <!-- MSBuild ignores the Target name in these cases and invokes GetTargetPath, avoid that by disabling build -->
+      <BuildReference Condition="'$(BuildingInsideVisualStudio)' == 'true' or '$(BuildProjectReferences)' != 'true'">false</BuildReference>
     </ProjectReference>
   </ItemGroup>
 
@@ -41,7 +42,7 @@
       Projects="@(ProjectReference)"
       Targets="GetCompileItems"
       Properties="%(ProjectReference.SetTargetFramework)"
-      Condition="'%(ProjectReference.Identity)' == '$(ContractProject)' and '$(BuildingInsideVisualStudio)' == 'true'">
+      Condition="'%(ProjectReference.Targets)' == 'GetCompileItems' and ('$(BuildingInsideVisualStudio)' == 'true' or '$(BuildProjectReferences)' != 'true')">
       <Output TaskParameter="TargetOutputs" ItemName="ReferenceSources" />
     </MSBuild>
     


### PR DESCRIPTION
When working on https://github.com/dotnet/runtime/pull/46999 I noticed that `dotnet build --no-dependencies` didn't work for PNSE assemblies.  Basically MSBuild treats this similarly to when building a sln.  See conditions here: https://github.com/dotnet/msbuild/blob/9954584470022a3d81401189e78443196ee266f9/src/Tasks/Microsoft.Common.CurrentVersion.targets#L1875

This permits --no-dependencies to work. 