### PR TITLE
Remove source-build intermediate nupkgs from signing validation

### DIFF
--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -147,6 +147,9 @@ stages:
             pipeline: $(AzDOPipelineId)
             buildId: $(AzDOBuildId)
             artifactName: PackageArtifacts
+            itemPattern: |
+              **
+              !**/Microsoft.SourceBuild.Intermediate.*.nupkg
 
         # This is necessary whenever we want to publish/restore to an AzDO private feed
         # Since sdk-task.ps1 tries to restore packages we need to do this authentication here

--- a/eng/publishing/v3/signing-validation.yml
+++ b/eng/publishing/v3/signing-validation.yml
@@ -22,6 +22,9 @@ jobs:
         pipeline: $(AzDOPipelineId)
         buildId: $(AzDOBuildId)
         artifactName: PackageArtifacts
+        itemPattern: |
+          **
+          !**/Microsoft.SourceBuild.Intermediate.*.nupkg
 
     # This is necessary whenever we want to publish/restore to an AzDO private feed
     # Since sdk-task.ps1 tries to restore packages we need to do this authentication here


### PR DESCRIPTION
Exclude arcade-powered source-build intermediate nupkgs from the signing validation step via an exclusion item pattern.

Unblocks adding arcade-powered source-build to official builds that have signing validation turned on.

For https://github.com/dotnet/arcade/issues/6806.

Ideally we can remove this in the future and add functionality in SignCheck to do it in a more global way: https://github.com/dotnet/arcade/issues/6810.