### PR TITLE
Add SignCheck exclusion rule that by default skips checking nupkgs inside a nupkg

### DIFF
--- a/src/SignCheck/SignCheck/SignCheck.cs
+++ b/src/SignCheck/SignCheck/SignCheck.cs
@@ -176,9 +176,10 @@ namespace SignCheck
             Exclusions.Add(new Exclusion("*wixuiwixca*;*.msi;WiX custom action"));
             Exclusions.Add(new Exclusion("*wixca*;*.msi;Wix custom action"));
             Exclusions.Add(new Exclusion("*wixstdba.dll*;*.exe;WiX standard bundle application"));
-            Exclusions.Add(new Exclusion("Microsoft.SourceBuild.Intermediate.*.nupkg;;Arcade-powered source-build intermediate nupkg"));
-            Exclusions.Add(new Exclusion("*;Microsoft.SourceBuild.Intermediate.*.nupkg;Arcade-powered source-build intermediate nupkg"));
-            Exclusions.Add(new Exclusion("*;*.nupkg;Arcade-powered source-build intermediate nupkg"));
+            // Add exclusions for arcade-powered source-build's intermediate nupkgs.
+            Exclusions.Add(new Exclusion("Microsoft.SourceBuild.Intermediate.*.nupkg;;Arcade-powered source-build intermediate nupkg, DO-NOT-SIGN, https://github.com/dotnet/arcade/issues/6810"));
+            Exclusions.Add(new Exclusion("*;Microsoft.SourceBuild.Intermediate.*.nupkg;Arcade-powered source-build intermediate nupkg, DO-NOT-SIGN, https://github.com/dotnet/arcade/issues/6810"));
+            Exclusions.Add(new Exclusion("*;*.nupkg;Arcade-powered source-build intermediate nupkg, DO-NOT-SIGN, https://github.com/dotnet/arcade/issues/6810"));
 
             if (!Directory.Exists(_appData))
             {

--- a/src/SignCheck/SignCheck/SignCheck.cs
+++ b/src/SignCheck/SignCheck/SignCheck.cs
@@ -176,6 +176,9 @@ namespace SignCheck
             Exclusions.Add(new Exclusion("*wixuiwixca*;*.msi;WiX custom action"));
             Exclusions.Add(new Exclusion("*wixca*;*.msi;Wix custom action"));
             Exclusions.Add(new Exclusion("*wixstdba.dll*;*.exe;WiX standard bundle application"));
+            Exclusions.Add(new Exclusion("Microsoft.SourceBuild.Intermediate.*.nupkg;;Arcade-powered source-build intermediate nupkg"));
+            Exclusions.Add(new Exclusion("*;Microsoft.SourceBuild.Intermediate.*.nupkg;Arcade-powered source-build intermediate nupkg"));
+            Exclusions.Add(new Exclusion("*;*.nupkg;Arcade-powered source-build intermediate nupkg"));
 
             if (!Directory.Exists(_appData))
             {


### PR DESCRIPTION
Arcade-powered source-build's intermediate nupkgs contain nupkgs, and are intentionally not signed. Right now exclusion paths only let you specify the parent (not ancestor), so `*.nupkg` is needed to exclude the inner nupkg contents.

See https://github.com/dotnet/arcade/issues/6810 for discussion.