### PR TITLE
Allow SourceLink to be disabled

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
@@ -9,6 +9,13 @@
     <PackageReference Include="Microsoft.SourceLink.AzureRepos.Git" Version="$(MicrosoftSourceLinkVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
 
+  <!-- Opt-in switch to disable source link (i.e. for local builds). -->
+  <PropertyGroup Condition="'$(DisableSourceLink)' == 'true'">
+    <EnableSourceLink>false</EnableSourceLink>
+    <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
+    <DeterministicSourcePaths>false</DeterministicSourcePaths>
+  </PropertyGroup>
+
   <!--
     Set the SourceRoot to repo root to facilitate deterministic source paths when SCM queries are disabled.
     Set the RepositoryUrl to the Build.Repository.Uri Azure DevOps build variable if on CI, otherwise to local repo path.

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
@@ -42,17 +42,22 @@
     </PropertyGroup>
   </Target>
 
+  <PropertyGroup>
+    <GenerateNativeVersionFileDependsOn>_InitializeAssemblyVersion</GenerateNativeVersionFileDependsOn>
+    <GenerateNativeVersionFileDependsOn Condition="'$(DisableSourceLink)' != 'true'">$(GenerateNativeVersionFileDependsOn);
+                                                                                     InitializeSourceControlInformationFromSourceControlManager</GenerateNativeVersionFileDependsOn>
+  </PropertyGroup>
+
   <!--
     GenerateNativeVersionFile target is a standalone target intended to be pulled into a build once as
     a pre-step before kicking off a native build. It will generate a _version.h or _version.c depending
     on the OS it is targeting.
   -->
   <Target Name="GenerateNativeVersionFile"
-          DependsOnTargets="_InitializeAssemblyVersion;InitializeSourceControlInformationFromSourceControlManager">
+          DependsOnTargets="$(GenerateNativeVersionFileDependsOn)">
 
-    <Error Condition="'$(SourceRevisionId)' == ''" Text="SourceRevisionId is not set, which means the SourceLink targets are not included in the build. Those are needed to produce a correct sha for our build outputs." />
-
-    <PropertyGroup>
+    <!-- To support builds without a source control provider available, allow this property to be unset. -->
+    <PropertyGroup Condition="'$(SourceRevisionId)' != ''">
       <_SourceBuildInfo> %40Commit: $(SourceRevisionId)</_SourceBuildInfo>
     </PropertyGroup>
 


### PR DESCRIPTION
Apparently this is how core-setup and other repositories handled this in the past. Bringing this property block into Arcade and support `GenerateNativeVersionFile` to run without a source control provider.