### PR TITLE
SignCheck: Support exclusions for nested containers (#6810)

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/SignCheckResources.Designer.cs
+++ b/src/SignCheck/Microsoft.SignCheck/SignCheckResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.SignCheck {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class SignCheckResources {
@@ -255,6 +255,15 @@ namespace Microsoft.SignCheck {
         internal static string DetailTimestampSkipped {
             get {
                 return ResourceManager.GetString("DetailTimestampSkipped", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Virtual path: {0}.
+        /// </summary>
+        internal static string DetailVirtualPath {
+            get {
+                return ResourceManager.GetString("DetailVirtualPath", resourceCulture);
             }
         }
         

--- a/src/SignCheck/Microsoft.SignCheck/SignCheckResources.resx
+++ b/src/SignCheck/Microsoft.SignCheck/SignCheckResources.resx
@@ -183,6 +183,9 @@
   <data name="DetailTimestampSkipped" xml:space="preserve">
     <value>Timestamp: Skipped</value>
   </data>
+  <data name="DetailVirtualPath" xml:space="preserve">
+    <value>Virtual path: {0}</value>
+  </data>
   <data name="DetailVsixMultipleSignatures" xml:space="preserve">
     <value>Multiple signatures found.</value>
   </data>

--- a/src/SignCheck/Microsoft.SignCheck/Verification/ArchiveVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/ArchiveVerifier.cs
@@ -62,11 +62,12 @@ namespace Microsoft.SignCheck.Verification
                     // and we need to ensure they are extracted before we verify the MSIs.
                     foreach (string fullName in archiveMap.Keys)
                     {
-                        SignatureVerificationResult archiveEntryResult = VerifyFile(archiveMap[fullName], svr.Filename, fullName);
+                        SignatureVerificationResult result = VerifyFile(archiveMap[fullName], svr.Filename,
+                            Path.Combine(svr.VirtualPath, fullName), fullName);
 
                         // Tag the full path into the result detail
-                        archiveEntryResult.AddDetail(DetailKeys.File, SignCheckResources.DetailFullName, fullName);
-                        svr.NestedResults.Add(archiveEntryResult);
+                        result.AddDetail(DetailKeys.File, SignCheckResources.DetailFullName, fullName);
+                        svr.NestedResults.Add(result);
                     }
                     DeleteDirectory(tempPath);
                 }

--- a/src/SignCheck/Microsoft.SignCheck/Verification/AuthentiCodeVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/AuthentiCodeVerifier.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Linq;
-using Microsoft.SignCheck.Logging;
 using System.ComponentModel;
+using System.Linq;
 using System.Runtime.InteropServices;
+using Microsoft.SignCheck.Logging;
 
 namespace Microsoft.SignCheck.Verification
 {
@@ -25,9 +25,9 @@ namespace Microsoft.SignCheck.Verification
         {
         }
 
-        public override SignatureVerificationResult VerifySignature(string path, string parent)
+        public override SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath)
         {
-            SignatureVerificationResult svr = VerifyAuthentiCode(path, parent);
+            SignatureVerificationResult svr = VerifyAuthentiCode(path, parent, virtualPath);
 
             if (FinalizeResult)
             {
@@ -39,9 +39,9 @@ namespace Microsoft.SignCheck.Verification
             return svr;
         }
 
-        protected SignatureVerificationResult VerifyAuthentiCode(string path, string parent)
+        protected SignatureVerificationResult VerifyAuthentiCode(string path, string parent, string virtualPath)
         {
-            var svr = new SignatureVerificationResult(path, parent);
+            var svr = new SignatureVerificationResult(path, parent, virtualPath);
             uint hresult = AuthentiCode.IsSigned(path);
             svr.IsAuthentiCodeSigned = hresult == 0;
             svr.IsSigned = svr.IsAuthentiCodeSigned;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/CabVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/CabVerifier.cs
@@ -12,10 +12,10 @@ namespace Microsoft.SignCheck.Verification
 
         }
 
-        public override SignatureVerificationResult VerifySignature(string path, string parent)
+        public override SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath)
         {
             // Defer to the base class to verify the AuthentiCode signature
-            return base.VerifySignature(path, parent);
+            return base.VerifySignature(path, parent, virtualPath);
         }
     }
 }

--- a/src/SignCheck/Microsoft.SignCheck/Verification/DetailKeys.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/DetailKeys.cs
@@ -9,6 +9,7 @@ namespace Microsoft.SignCheck.Verification
         public const string Error = "Error";
         public const string File = "File";
         public const string Misc = "Misc";
+
         // Classifier for signatures other than AuthentiCode/StrongName
         public const string Signature = "Signature";
         public const string StrongName = "StrongName";

--- a/src/SignCheck/Microsoft.SignCheck/Verification/Exclusions.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Exclusions.cs
@@ -69,7 +69,7 @@ namespace Microsoft.SignCheck.Verification
             return _exclusions.Contains(exclusion);
         }
 
-        public bool IsExcluded(string path, string parent, string containerPath, IEnumerable<Exclusion> exclusions)
+        public bool IsExcluded(string path, string parent, string virtualPath, string containerPath, IEnumerable<Exclusion> exclusions)
         {
             foreach (Exclusion e in exclusions)
             {
@@ -77,7 +77,7 @@ namespace Microsoft.SignCheck.Verification
                 //    Example: bar.dll;*.zip --> Exclude any occurence of bar.dll that is in a zip file
                 //             bar.dll;foo.zip --> Exclude bar.dll only if it is contained inside foo.zip
                 //             foo.exe;; --> Exclude any occurance of foo.exe and ignore the parent
-                if (IsMatch(e.FilePatterns, Path.GetFileName(containerPath)) || IsMatch(e.FilePatterns, containerPath) || IsMatch(e.FilePatterns, path) || IsMatch(e.FilePatterns, Path.GetFileName(path)))
+                if (IsMatch(e.FilePatterns, Path.GetFileName(containerPath)) || IsMatch(e.FilePatterns, containerPath) || IsMatch(e.FilePatterns, path) || IsMatch(e.FilePatterns, Path.GetFileName(path)) || IsMatch(e.FilePatterns, virtualPath))
                 {
                     if ((e.ParentFiles.Length == 0) || (e.ParentFiles.All(pf => String.IsNullOrEmpty(pf))) || IsMatch(e.ParentFiles, parent))
                     {
@@ -103,11 +103,12 @@ namespace Microsoft.SignCheck.Verification
         /// </summary>
         /// <param name="path">The path of the file on disk.</param>
         /// <param name="parent">The parent (container) of the file.</param>
+        /// <param name="virtualPath">The full path of the parent (container).</param>
         /// <param name="containerPath">The path of the file in the container. May be null if the file is not embedded in a container.</param>
         /// <returns></returns>
-        public bool IsExcluded(string path, string parent, string containerPath)
+        public bool IsExcluded(string path, string parent, string virtualPath, string containerPath)
         {
-            return IsExcluded(path, parent, containerPath, _exclusions);
+            return IsExcluded(path, parent, virtualPath, containerPath, _exclusions);
         }
 
         /// <summary>
@@ -115,12 +116,12 @@ namespace Microsoft.SignCheck.Verification
         /// </summary>
         /// <param name="path"></param>
         /// <returns></returns>
-        public bool IsDoNotSign(string path, string parent, string containerPath)
+        public bool IsDoNotSign(string path, string parent, string virtualPath, string containerPath)
         {
             // Get all the exclusions with DO-NOT-SIGN markers and check only against those
             IEnumerable<Exclusion> doNotSignExclusions = _exclusions.Where(e => e.Comment.Contains("DO-NOT-SIGN")).ToArray();
 
-            return (doNotSignExclusions.Count() > 0) && (IsExcluded(path, parent, containerPath, doNotSignExclusions));
+            return (doNotSignExclusions.Count() > 0) && (IsExcluded(path, parent, virtualPath, containerPath, doNotSignExclusions));
         }
 
         /// <summary>

--- a/src/SignCheck/Microsoft.SignCheck/Verification/ExeVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/ExeVerifier.cs
@@ -17,10 +17,10 @@ namespace Microsoft.SignCheck.Verification
 
         }
 
-        public override SignatureVerificationResult VerifySignature(string path, string parent)
+        public override SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath)
         {
             // Let the base class take care of verifying the AuthentiCode/StrongName
-            SignatureVerificationResult svr = base.VerifySignature(path, parent);
+            SignatureVerificationResult svr = base.VerifySignature(path, parent, virtualPath);
 
             if (VerifyRecursive)
             {
@@ -41,8 +41,8 @@ namespace Microsoft.SignCheck.Verification
                         {
                             foreach (string file in Directory.EnumerateFiles(svr.TempPath, "*.*", SearchOption.AllDirectories))
                             {
-                                SignatureVerificationResult bundleEntryResult = VerifyFile(Path.GetFullPath(file), svr.Filename, Path.GetFileName(file));
-                                //CheckAndUpdateExclusion(bundleEntryResult, "*"+Path.GetFileName(file), file, svr.Filename);
+                                var payloadPath = Path.Combine(svr.VirtualPath, Path.GetFileName(file));
+                                SignatureVerificationResult bundleEntryResult = VerifyFile(Path.GetFullPath(file), svr.Filename, payloadPath, Path.GetFileName(file));
                                 svr.NestedResults.Add(bundleEntryResult);
                             }
                         }

--- a/src/SignCheck/Microsoft.SignCheck/Verification/FileVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/FileVerifier.cs
@@ -147,9 +147,9 @@ namespace Microsoft.SignCheck.Verification
         /// <param name="path">The path of the file to verify</param>
         /// <param name="parent">The parent file of the file to verify or null if this is a top-level file.</param>
         /// <returns>A SignatureVerificationResult containing detail about the verification result.</returns>
-        public virtual SignatureVerificationResult VerifySignature(string path, string parent)
+        public virtual SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath)
         {
-            return SignatureVerificationResult.UnsupportedFileTypeResult(path, parent);
+            return SignatureVerificationResult.UnsupportedFileTypeResult(path, parent, virtualPath);
         }
 
         /// <summary>
@@ -160,14 +160,13 @@ namespace Microsoft.SignCheck.Verification
         /// <param name="containerPath">The path of the file in the container. This may differ from the path on disk as containers are flattened. It's
         /// primarily intended to help with exclusions and report more readable names.</param>
         /// <returns>The verification result.</returns>
-        public SignatureVerificationResult VerifyFile(string path, string parent, string containerPath)
+        public SignatureVerificationResult VerifyFile(string path, string parent, string virtualPath, string containerPath)
         {
             Log.WriteMessage(LogVerbosity.Detailed, String.Format(SignCheckResources.ProcessingFile, Path.GetFileName(path), String.IsNullOrEmpty(parent) ? SignCheckResources.NA : parent));
 
             FileVerifier fileVerifier = GetFileVerifier(path);
-            SignatureVerificationResult svr = fileVerifier.VerifySignature(path, parent);
-
-            svr.IsDoNotSign = Exclusions.IsDoNotSign(path, parent, containerPath);
+            SignatureVerificationResult svr = fileVerifier.VerifySignature(path, parent, virtualPath);
+            svr.IsDoNotSign = Exclusions.IsDoNotSign(path, parent, virtualPath, containerPath);
 
             if ((svr.IsDoNotSign) && (svr.IsSigned))
             {
@@ -177,7 +176,7 @@ namespace Microsoft.SignCheck.Verification
 
             if ((!svr.IsDoNotSign) && (!svr.IsSigned))
             {
-                svr.IsExcluded = Exclusions.IsExcluded(path, parent, containerPath);
+                svr.IsExcluded = Exclusions.IsExcluded(path, parent, virtualPath, containerPath);
 
                 if ((svr.IsExcluded))
                 {
@@ -195,6 +194,11 @@ namespace Microsoft.SignCheck.Verification
             if (String.IsNullOrEmpty(parent))
             {
                 svr.AddDetail(DetailKeys.File, SignCheckResources.DetailFullName, svr.FullPath);
+            }
+
+            if (!String.IsNullOrEmpty(virtualPath))
+            {
+                svr.AddDetail(DetailKeys.File, SignCheckResources.DetailVirtualPath, svr.VirtualPath);
             }
 
             return svr;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/FileVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/FileVerifier.cs
@@ -176,7 +176,7 @@ namespace Microsoft.SignCheck.Verification
 
             if ((!svr.IsDoNotSign) && (!svr.IsSigned))
             {
-                svr.IsExcluded = Exclusions.IsExcluded(path, parent, virtualPath, containerPath);
+                svr.IsExcluded = Exclusions.IsExcluded(path, parent, svr.VirtualPath, containerPath);
 
                 if ((svr.IsExcluded))
                 {

--- a/src/SignCheck/Microsoft.SignCheck/Verification/JarVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/JarVerifier.cs
@@ -16,11 +16,11 @@ namespace Microsoft.SignCheck.Verification
 
         }
 
-        public override SignatureVerificationResult VerifySignature(string path, string parent)
+        public override SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath)
         {
             if (VerifyJarSignatures)
             {
-                var svr = new SignatureVerificationResult(path, parent);
+                var svr = new SignatureVerificationResult(path, parent, virtualPath);
 
                 try
                 {
@@ -60,7 +60,7 @@ namespace Microsoft.SignCheck.Verification
                 return svr;
             }
 
-            return SignatureVerificationResult.UnsupportedFileTypeResult(path, parent);
+            return SignatureVerificationResult.UnsupportedFileTypeResult(path, parent, virtualPath);
         }
     }
 }

--- a/src/SignCheck/Microsoft.SignCheck/Verification/LzmaVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/LzmaVerifier.cs
@@ -13,10 +13,10 @@ namespace Microsoft.SignCheck.Verification
 
         }
 
-        public override SignatureVerificationResult VerifySignature(string path, string parent)
+        public override SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath)
         {
             // LZMA is just an unsigned stream
-            var svr = SignatureVerificationResult.UnsupportedFileTypeResult(path, parent);
+            var svr = SignatureVerificationResult.UnsupportedFileTypeResult(path, parent, virtualPath);
             string fullPath = svr.FullPath;
             svr.AddDetail(DetailKeys.File, SignCheckResources.DetailSigned, SignCheckResources.NA);
 
@@ -32,7 +32,7 @@ namespace Microsoft.SignCheck.Verification
                 // LZMA files are just compressed streams. Decompress and then try to verify the decompressed file.
                 LZMAUtils.Decompress(fullPath, destinationFile);
 
-                svr.NestedResults.Add(VerifyFile(destinationFile, parent, containerPath: null));
+                svr.NestedResults.Add(VerifyFile(destinationFile, parent, Path.Combine(svr.VirtualPath, destinationFile), containerPath: null));
             }
 
             return svr;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/MsiVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/MsiVerifier.cs
@@ -18,9 +18,9 @@ namespace Microsoft.SignCheck.Verification
 
         }
 
-        public override SignatureVerificationResult VerifySignature(string path, string parent)
+        public override SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath)
         {
-            SignatureVerificationResult svr = base.VerifySignature(path, parent);
+            SignatureVerificationResult svr = base.VerifySignature(path, parent, virtualPath);
 
             if (VerifyRecursive)
             {
@@ -52,9 +52,8 @@ namespace Microsoft.SignCheck.Verification
 
                         foreach (string key in installPackage.Files.Keys)
                         {
-                            SignatureVerificationResult packageFileResult = VerifyFile(installPackage.Files[key].TargetPath, svr.Filename, containerPath: null);
+                            SignatureVerificationResult packageFileResult = VerifyFile(installPackage.Files[key].TargetPath, svr.Filename, Path.Combine(svr.VirtualPath, originalFiles[key]), containerPath: null);
                             packageFileResult.AddDetail(DetailKeys.File, SignCheckResources.DetailFullName, originalFiles[key]);
-                            //CheckAndUpdateExclusion(packageFileResult, packageFileResult.Filename, originalFiles[key], svr.Filename);
                             svr.NestedResults.Add(packageFileResult);
                         }
                     }
@@ -76,7 +75,7 @@ namespace Microsoft.SignCheck.Verification
                         {
                             string binaryFile = Path.Combine(svr.TempPath, (string)record["Name"]);
                             StructuredStorage.SaveStream(record, svr.TempPath);
-                            SignatureVerificationResult binaryStreamResult = VerifyFile(binaryFile, svr.Filename, containerPath: null);
+                            SignatureVerificationResult binaryStreamResult = VerifyFile(binaryFile, svr.Filename, Path.Combine(svr.VirtualPath, (string)record["Name"]), containerPath: null);
                             binaryStreamResult.AddDetail(DetailKeys.Misc, SignCheckResources.FileExtractedFromBinaryTable);
                             svr.NestedResults.Add(binaryStreamResult);
                             record.Close();

--- a/src/SignCheck/Microsoft.SignCheck/Verification/MsiVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/MsiVerifier.cs
@@ -73,9 +73,10 @@ namespace Microsoft.SignCheck.Verification
 
                         foreach (Record record in view)
                         {
-                            string binaryFile = Path.Combine(svr.TempPath, (string)record["Name"]);
+                            string binaryFile = (string)record["Name"];
+                            string binaryFilePath = Path.Combine(svr.TempPath, binaryFile);
                             StructuredStorage.SaveStream(record, svr.TempPath);
-                            SignatureVerificationResult binaryStreamResult = VerifyFile(binaryFile, svr.Filename, Path.Combine(svr.VirtualPath, (string)record["Name"]), containerPath: null);
+                            SignatureVerificationResult binaryStreamResult = VerifyFile(binaryFilePath, svr.Filename, Path.Combine(svr.VirtualPath, binaryFile), containerPath: null);
                             binaryStreamResult.AddDetail(DetailKeys.Misc, SignCheckResources.FileExtractedFromBinaryTable);
                             svr.NestedResults.Add(binaryStreamResult);
                             record.Close();

--- a/src/SignCheck/Microsoft.SignCheck/Verification/MspVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/MspVerifier.cs
@@ -15,10 +15,10 @@ namespace Microsoft.SignCheck.Verification
 
         }
 
-        public override SignatureVerificationResult VerifySignature(string path, string parent)
+        public override SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath)
         {
             // Defer to the base class to check the AuthentiCode signature
-            SignatureVerificationResult svr = base.VerifySignature(path, parent);
+            SignatureVerificationResult svr = base.VerifySignature(path, parent, virtualPath);
 
             if (VerifyRecursive)
             {
@@ -26,7 +26,7 @@ namespace Microsoft.SignCheck.Verification
 
                 foreach (string file in Directory.EnumerateFiles(svr.TempPath))
                 {
-                    svr.NestedResults.Add(VerifyFile(file, svr.Filename, containerPath: null));
+                    svr.NestedResults.Add(VerifyFile(file, svr.Filename, Path.Combine(svr.VirtualPath, file), containerPath: null));
                 }
 
                 DeleteDirectory(svr.TempPath);

--- a/src/SignCheck/Microsoft.SignCheck/Verification/MsuVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/MsuVerifier.cs
@@ -19,9 +19,9 @@ namespace Microsoft.SignCheck.Verification
 
         }
 
-        public override SignatureVerificationResult VerifySignature(string path, string parent)
+        public override SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath)
         {
-            SignatureVerificationResult svr = base.VerifySignature(path, parent);
+            SignatureVerificationResult svr = base.VerifySignature(path, parent, virtualPath);
 
             if (VerifyRecursive)
             {
@@ -33,7 +33,7 @@ namespace Microsoft.SignCheck.Verification
                 foreach (string cabFile in Directory.EnumerateFiles(svr.TempPath))
                 {
                     string cabFileFullName = Path.GetFullPath(cabFile);
-                    SignatureVerificationResult cabEntryResult = VerifyFile(cabFile, svr.Filename, cabFileFullName);
+                    SignatureVerificationResult cabEntryResult = VerifyFile(cabFile, svr.Filename, Path.Combine(svr.VirtualPath, cabFile), cabFileFullName);
 
                     // Tag the full path into the result detail
                     cabEntryResult.AddDetail(DetailKeys.File, SignCheckResources.DetailFullName, cabFileFullName);

--- a/src/SignCheck/Microsoft.SignCheck/Verification/NupkgVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/NupkgVerifier.cs
@@ -19,9 +19,9 @@ namespace Microsoft.SignCheck.Verification
 
         }
 
-        public override SignatureVerificationResult VerifySignature(string path, string parent)
+        public override SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath) 
         {
-            SignatureVerificationResult svr = new SignatureVerificationResult(path, parent);
+            SignatureVerificationResult svr = new SignatureVerificationResult(path, parent, virtualPath);
             string fullPath = svr.FullPath;
 
             svr.IsSigned = IsSigned(fullPath);

--- a/src/SignCheck/Microsoft.SignCheck/Verification/PortableExecutableVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/PortableExecutableVerifier.cs
@@ -30,10 +30,10 @@ namespace Microsoft.SignCheck.Verification
         /// <param name="path"></param>
         /// <param name="parent"></param>
         /// <returns></returns>
-        public override SignatureVerificationResult VerifySignature(string path, string parent)
+        public override SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath)
         {
             // Defer to the base implementation to check the AuthentiCode signature.
-            SignatureVerificationResult svr = base.VerifySignature(path, parent);
+            SignatureVerificationResult svr = base.VerifySignature(path, parent, virtualPath);
             PEHeader = new PortableExecutableHeader(svr.FullPath);
 
             if (VerifyStrongNameSignature)

--- a/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationManager.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationManager.cs
@@ -116,7 +116,7 @@ namespace Microsoft.SignCheck.Verification
             {
                 FileVerifier fileVerifier = GetFileVerifier(file);
                 SignatureVerificationResult result;
-                result = fileVerifier.VerifySignature(file, parent: null);
+                result = fileVerifier.VerifySignature(file, parent: null, virtualPath: Path.GetFileName(file));
 
                 if ((Options & SignatureVerificationOptions.GenerateExclusion) == SignatureVerificationOptions.GenerateExclusion)
                 {
@@ -124,7 +124,7 @@ namespace Microsoft.SignCheck.Verification
                     Log.WriteMessage(LogVerbosity.Diagnostic, SignCheckResources.DiagGenerateExclusion, result.Filename, result.ExclusionEntry);
                 }
 
-                result.IsDoNotSign = Exclusions.IsDoNotSign(file, parent: null, containerPath: null);
+                result.IsDoNotSign = Exclusions.IsDoNotSign(file, parent: null, virtualPath: null, containerPath: null);
 
                 if ((result.IsDoNotSign) && (result.IsSigned))
                 {
@@ -134,7 +134,7 @@ namespace Microsoft.SignCheck.Verification
 
                 if ((!result.IsDoNotSign) && (!result.IsSigned))
                 {
-                    result.IsExcluded = Exclusions.IsExcluded(file, parent: null, containerPath: null);
+                    result.IsExcluded = Exclusions.IsExcluded(file, parent: null, virtualPath: null, containerPath: null);
 
                     if ((result.IsExcluded))
                     {

--- a/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationResult.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationResult.cs
@@ -128,7 +128,6 @@ namespace Microsoft.SignCheck.Verification
         public string VirtualPath
         {
             get;
-            set;
         }
 
         /// <summary>
@@ -271,7 +270,6 @@ namespace Microsoft.SignCheck.Verification
             var signatureVerificationResult = new SignatureVerificationResult(path, parent, virtualPath)
             {
                 IsSkipped = true,
-                VirtualPath = !string.IsNullOrEmpty(virtualPath) ? virtualPath.Replace('\\', '/') : virtualPath
             };
 
             signatureVerificationResult.AddDetail(DetailKeys.File, SignCheckResources.DetailSkippedUnsupportedFileType);

--- a/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationResult.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationResult.cs
@@ -125,6 +125,12 @@ namespace Microsoft.SignCheck.Verification
             set;
         }
 
+        public string VirtualPath
+        {
+            get;
+            set;
+        }
+
         /// <summary>
         /// A set of results for nested files. For example, if recursive verification is enabled and a file contains embedded files, e.g. an MSI, then
         /// this property will contain the verification results of the embedded files.
@@ -179,7 +185,7 @@ namespace Microsoft.SignCheck.Verification
             }
         }
 
-        public SignatureVerificationResult(string path, string parent)
+        public SignatureVerificationResult(string path, string parent, string virtualPath)
         {
             if (String.IsNullOrEmpty(path))
             {
@@ -188,6 +194,7 @@ namespace Microsoft.SignCheck.Verification
 
             Filename = Path.GetFileName(path);
             FullPath = Path.GetFullPath(path);
+            VirtualPath = !string.IsNullOrEmpty(virtualPath) ? virtualPath.Replace('\\', '/') : virtualPath;
 
             AddDetail(DetailKeys.File, Filename);
         }
@@ -259,11 +266,12 @@ namespace Microsoft.SignCheck.Verification
         /// </summary>
         /// <param name="path">The path to the file that is unsupported</param>
         /// <returns>A SignatureVerificationResult indicating the file is unsupported..</returns>
-        public static SignatureVerificationResult UnsupportedFileTypeResult(string path, string parent)
+        public static SignatureVerificationResult UnsupportedFileTypeResult(string path, string parent, string virtualPath)
         {
-            var signatureVerificationResult = new SignatureVerificationResult(path, parent)
+            var signatureVerificationResult = new SignatureVerificationResult(path, parent, virtualPath)
             {
-                IsSkipped = true
+                IsSkipped = true,
+                VirtualPath = !string.IsNullOrEmpty(virtualPath) ? virtualPath.Replace('\\', '/') : virtualPath
             };
 
             signatureVerificationResult.AddDetail(DetailKeys.File, SignCheckResources.DetailSkippedUnsupportedFileType);
@@ -279,7 +287,7 @@ namespace Microsoft.SignCheck.Verification
         /// <returns></returns>
         public static SignatureVerificationResult ExcludedFileResult(string path, string parent)
         {
-            var signatureVerificationResult = new SignatureVerificationResult(path, parent)
+            var signatureVerificationResult = new SignatureVerificationResult(path, parent, null)
             {
                 IsExcluded = true
             };

--- a/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationResult.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationResult.cs
@@ -193,7 +193,7 @@ namespace Microsoft.SignCheck.Verification
 
             Filename = Path.GetFileName(path);
             FullPath = Path.GetFullPath(path);
-            VirtualPath = !string.IsNullOrEmpty(virtualPath) ? virtualPath.Replace('\\', '/') : virtualPath;
+            VirtualPath = virtualPath?.Replace('\\', '/');
 
             AddDetail(DetailKeys.File, Filename);
         }
@@ -269,7 +269,7 @@ namespace Microsoft.SignCheck.Verification
         {
             var signatureVerificationResult = new SignatureVerificationResult(path, parent, virtualPath)
             {
-                IsSkipped = true,
+                IsSkipped = true
             };
 
             signatureVerificationResult.AddDetail(DetailKeys.File, SignCheckResources.DetailSkippedUnsupportedFileType);

--- a/src/SignCheck/Microsoft.SignCheck/Verification/UnsupportedFileVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/UnsupportedFileVerifier.cs
@@ -10,9 +10,9 @@ namespace Microsoft.SignCheck.Verification
 
         }
 
-        public override SignatureVerificationResult VerifySignature(string path, string parent)
+        public override SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath)
         {
-            return SignatureVerificationResult.UnsupportedFileTypeResult(path, parent);
+            return SignatureVerificationResult.UnsupportedFileTypeResult(path, parent, virtualPath);
         }
     }
 }

--- a/src/SignCheck/Microsoft.SignCheck/Verification/VsixVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/VsixVerifier.cs
@@ -21,9 +21,9 @@ namespace Microsoft.SignCheck.Verification
 
         }
 
-        public override SignatureVerificationResult VerifySignature(string path, string parent)
+        public override SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath)
         {
-            var svr = new SignatureVerificationResult(path, parent);
+            var svr = new SignatureVerificationResult(path, parent, virtualPath);
             string fullPath = svr.FullPath;
             svr.IsSigned = IsSigned(fullPath, svr);
             svr.AddDetail(DetailKeys.File, SignCheckResources.DetailSigned, svr.IsSigned);

--- a/src/SignCheck/Microsoft.SignCheck/Verification/XmlVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/XmlVerifier.cs
@@ -17,18 +17,18 @@ namespace Microsoft.SignCheck.Verification
 
         }
 
-        public override SignatureVerificationResult VerifySignature(string path, string parent)
+        public override SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath)
         {
             if (VerifyXmlSignatures)
             {
                 X509Certificate2 xmlCertificate;
-                var svr = new SignatureVerificationResult(path, parent);
+                var svr = new SignatureVerificationResult(path, parent, virtualPath);
                 svr.IsSigned = IsSigned(svr.FullPath, out xmlCertificate);
                 svr.AddDetail(DetailKeys.File, SignCheckResources.DetailSigned, svr.IsSigned);
                 return svr;
             }
 
-            return SignatureVerificationResult.UnsupportedFileTypeResult(path, parent);
+            return SignatureVerificationResult.UnsupportedFileTypeResult(path, parent, virtualPath);
         }
 
         // See: https://msdn.microsoft.com/en-us/library/ms148731(v=vs.110).aspx

--- a/src/SignCheck/Microsoft.SignCheck/Verification/ZipVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/ZipVerifier.cs
@@ -12,9 +12,9 @@ namespace Microsoft.SignCheck.Verification
 
         }
 
-        public override SignatureVerificationResult VerifySignature(string path, string parent)
+        public override SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath)
         {
-            var svr = SignatureVerificationResult.UnsupportedFileTypeResult(path, parent);
+            var svr = SignatureVerificationResult.UnsupportedFileTypeResult(path, parent, virtualPath);
             string fullPath = svr.FullPath;
             svr.AddDetail(DetailKeys.File, SignCheckResources.DetailSigned, SignCheckResources.NA);
 

--- a/src/SignCheck/SignCheck/Microsoft.DotNet.SignCheck.csproj
+++ b/src/SignCheck/SignCheck/Microsoft.DotNet.SignCheck.csproj
@@ -1,4 +1,4 @@
-﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(MSBuildThisFileDirectory)/../Microsoft.SignCheck/ResxWorkaround.props" />
   <PropertyGroup>


### PR DESCRIPTION
Support exclusion patterns that can span multiple containers (addresses #6810). Previously, only the hashed parent container could be excluded. With this change, simpler exclusion patterns can be authored, e.g.

```
*/artifacts/*/Microsoft.SourceLink.GitLab.1.1.0-ci.nupkg/*.dll;;
```

yields the following results for nested nupkg files

```
[File] Microsoft.SourceBuild.Intermediate.sourcelink.1.1.0-ci.nupkg, Signed: False
  [File] 0a4aded6ef9770c8c522d21bb9906e71.nupkg, Signed: False, Virtual path: Microsoft.SourceBuild.Intermediate.sourcelink.1.1.0-ci.nupkg/artifacts/Shipping/Microsoft.SourceLink.GitLab.1.1.0-ci.nupkg, Full Name: artifacts/Shipping/Microsoft.SourceLink.GitLab.1.1.0-ci.nupkg
    [File] 4e82e7f3ac71cbe89e40763ec5b4696c.dll, Signed: False, Excluded, Virtual path: Microsoft.SourceBuild.Intermediate.sourcelink.1.1.0-ci.nupkg/artifacts/Shipping/Microsoft.SourceLink.GitLab.1.1.0-ci.nupkg/tools/net5.0/Microsoft.SourceLink.GitLab.dll, Full Name: tools/net5.0/Microsoft.SourceLink.GitLab.dll

```
