### PR TITLE
Revert "Update dependency SymUploader "

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.SymbolUploader.Build.Task" Version="1.1.206105">
+    <Dependency Name="Microsoft.SymbolUploader.Build.Task" Version="1.1.156702">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-symuploader</Uri>
-      <Sha>15ebf70b90a79471d060bae42637350e0773b49d</Sha>
+      <Sha>861806bc0dc685441cb3e8f6bd1ce5ed31e6b32b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SymbolUploader" Version="1.1.206105">
+    <Dependency Name="Microsoft.SymbolUploader" Version="1.1.152002">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-symuploader</Uri>
-      <Sha>15ebf70b90a79471d060bae42637350e0773b49d</Sha>
+      <Sha>165896e7efeecb70f01bd011257ead0f56d32c95</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -47,13 +47,13 @@
     <OctokitVersion>0.32.0</OctokitVersion>
     <DotNetSleetLibVersion>2.2.143</DotNetSleetLibVersion>
     <SwashbuckleAspNetCoreSwaggerVersion>3.0.0</SwashbuckleAspNetCoreSwaggerVersion>
-    <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
-    <SystemCollectionsImmutableVersion>1.7.1</SystemCollectionsImmutableVersion>
+    <SystemBuffersVersion>4.5.0</SystemBuffersVersion>
+    <SystemCollectionsImmutableVersion>1.5.0</SystemCollectionsImmutableVersion>
     <SystemDiagnosticsTraceSourceVersion>4.0.0</SystemDiagnosticsTraceSourceVersion>
     <SystemIOCompressionVersion>4.3.0</SystemIOCompressionVersion>
     <SystemIOPackagingVersion>4.5.0</SystemIOPackagingVersion>
     <SystemIOFileSystemPrimitivesVersion>4.3.0</SystemIOFileSystemPrimitivesVersion>
-    <SystemMemoryVersion>4.5.4</SystemMemoryVersion>
+    <SystemMemoryVersion>4.5.3</SystemMemoryVersion>
     <SystemNumericsVectorsVersion>4.5.0</SystemNumericsVectorsVersion>
     <SystemReflectionMetadataVersion>1.6.0</SystemReflectionMetadataVersion>
     <SystemRuntimeCompilerServicesUnsafeVersion>4.7.0</SystemRuntimeCompilerServicesUnsafeVersion>
@@ -83,7 +83,7 @@
     <XliffTasksVersion>1.0.0-beta.21064.1</XliffTasksVersion>
     <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.20570.1</MicrosoftDotNetMaestroTasksVersion>
     <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.21068.3</MicrosoftDotNetXHarnessCLIVersion>
-    <MicrosoftSymbolUploaderBuildTaskVersion>1.1.206105</MicrosoftSymbolUploaderBuildTaskVersion>
-    <MicrosoftSymbolUploaderVersion>1.1.206105</MicrosoftSymbolUploaderVersion>
+    <MicrosoftSymbolUploaderBuildTaskVersion>1.1.156402</MicrosoftSymbolUploaderBuildTaskVersion>
+    <MicrosoftSymbolUploaderVersion>1.1.152002</MicrosoftSymbolUploaderVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.Cci.Extensions/Microsoft.Cci.Extensions.csproj
+++ b/src/Microsoft.Cci.Extensions/Microsoft.Cci.Extensions.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/GenerateResxSourceTests.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/GenerateResxSourceTests.cs
@@ -19,6 +19,47 @@ namespace Microsoft.DotNet.Arcade.Sdk.Tests
         }
 
         [Theory]
+        [InlineData(true, false, false, "TestStrings.EmitFormatMethods.cs.txt")]
+        [InlineData(false, false, false, "TestStrings.Default.cs.txt")]
+        [InlineData(false, true, true, "TestStrings.AsConstants.cs.txt")]
+        [InlineData(false, false, true, "TestStrings.OmitGetResourceString.cs.txt")]
+        public void GeneratesCSharp(bool emitFormatMethods, bool asConstants, bool omitGetResourceString, string expectedFileName)
+        {
+            var resx = Path.Combine(AppContext.BaseDirectory, "testassets", "Resources", "TestStrings.resx");
+            var actualFile = Path.Combine(AppContext.BaseDirectory, Path.GetRandomFileName());
+
+            var engine = new MockEngine(_output);
+            var task = new GenerateResxSource
+            {
+                BuildEngine = engine,
+                ResourceFile = resx,
+                ResourceName = "Microsoft.DotNet.TestStrings",
+                ResourceClassName = "Microsoft.DotNet.TestStrings",
+                EmitFormatMethods = emitFormatMethods,
+                AsConstants = asConstants,
+                OmitGetResourceString = omitGetResourceString,
+                Language = "C#",
+                OutputPath = actualFile,
+            };
+
+            var expectedFile = Path.Combine(AppContext.BaseDirectory, "testassets", "Resources", expectedFileName);
+
+            if (File.Exists(actualFile))
+            {
+                File.Delete(actualFile);
+            }
+
+            Assert.True(task.Execute(), "Task failed");
+
+            Assert.Empty(engine.Warnings);
+
+            Assert.True(File.Exists(actualFile), "Actual file does not exist");
+            var actualFileContents = File.ReadAllText(actualFile);
+            _output.WriteLine(actualFileContents);
+            Assert.Equal(File.ReadAllText(expectedFile), actualFileContents, ignoreLineEndingDifferences: true);
+        }
+
+        [Theory]
         [InlineData("a", "a")]
         [InlineData("A", "A")]
         [InlineData("_A", "_A")]

--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/MinimalRepoTests.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/MinimalRepoTests.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.Arcade.Sdk.Tests
+{
+    [Collection(TestProjectCollection.Name)]
+    public class MinimalRepoTests
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly TestProjectFixture _fixture;
+
+        public MinimalRepoTests(ITestOutputHelper output, TestProjectFixture fixture)
+        {
+            _output = output;
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public void MinimalRepoBuildsWithoutErrors()
+        {
+            var app = _fixture.CreateTestApp("MinimalRepo");
+            var exitCode = app.ExecuteBuild(_output,
+                // these properties are required for projects that are not in a git repo
+                "/p:EnableSourceLink=false",
+                "/p:EnableSourceControlManagerQueries=false");
+            Assert.Equal(0, exitCode);
+        }
+
+        [Fact]
+        public void MinimalRepoWithFinalVersions()
+        {
+            var app = _fixture.CreateTestApp("MinimalRepo");
+            var exitCode = app.ExecuteBuild(_output,
+                // these properties are required for projects that are not in a git repo
+                "/p:EnableSourceLink=false",
+                "/p:EnableSourceControlManagerQueries=false",
+                "/p:DotNetFinalVersionKind=release");
+            Assert.Equal(0, exitCode);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/RepoWithConditionalProjectsToBuildTests.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/RepoWithConditionalProjectsToBuildTests.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.Arcade.Sdk.Tests
+{
+    [Collection(TestProjectCollection.Name)]
+    public class RepoWithConditionalProjectsToBuildTests
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly TestProjectFixture _fixture;
+
+        public RepoWithConditionalProjectsToBuildTests(ITestOutputHelper output, TestProjectFixture fixture)
+        {
+            _output = output;
+            _fixture = fixture;
+        }
+
+        [Theory]
+        [InlineData(false, 1, false)]
+        [InlineData(false, 1, true)]
+        [InlineData(true, 2, false)]
+        [InlineData(true, 2, true)]
+        public void RepoProducesPackages(bool buildAdditionalProject, int expectedPackages, bool stablePackages)
+        {
+            var app = _fixture.CreateTestApp("RepoWithConditionalProjectsToBuild");
+            var packArg = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? "-pack"
+                : "--pack";
+            var finalVersionKindarg = stablePackages ? "/p:DotNetFinalVersionKind=release" : "/p:DotNetFinalVersionKind=prerelease";
+            var exitCode = app.ExecuteBuild(_output,
+                packArg,
+                $"/p:ShouldBuildMaybe={buildAdditionalProject}",
+                // these properties are required for projects that are not in a git repo
+                "/p:EnableSourceLink=false",
+                "/p:EnableSourceControlManagerQueries=false",
+                finalVersionKindarg);
+            Assert.Equal(0, exitCode);
+            var nupkgFiles = Directory.GetFiles(Path.Combine(app.WorkingDirectory, "artifacts", "packages", "Debug", "Shipping"), "*.nupkg");
+
+            _output.WriteLine("Packages produced:");
+
+            foreach(var file in nupkgFiles)
+            {
+                _output.WriteLine(file);
+            }
+
+            Assert.Equal(expectedPackages, nupkgFiles.Length);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
-    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <!-- This is here so that we agree with the feed tasks project's transitive reference to NewtonSoft.Json and Azure.Core -->
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Azure.Core" Version="1.0.2.0" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/HarvestPackageTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/HarvestPackageTests.cs
@@ -81,6 +81,93 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
             return result;
         }
 
+        [Fact]
+        public void TestSimpleLibPackage()
+        {
+            var task = new HarvestPackage()
+            {
+                BuildEngine = _engine,
+                Frameworks = _frameworks,
+                HarvestAssets = true,
+                IncludeAllPaths = true,
+                PackageId = "System.Collections.Immutable",
+                PackageVersion = "1.5.0",
+                RuntimeFile = "runtime.json"
+            };
+
+            task.PackagesFolders = new[] { FindPackageFolder(task.PackageId, task.PackageVersion) };
+            
+            _log.Reset();
+            task.Execute();
+
+            _log.ErrorsLogged.Should().Be(0);
+            _log.WarningsLogged.Should().Be(0);
+            task.HarvestedFiles.Should().HaveCount(8);
+            var ns10asset = task.HarvestedFiles.FirstOrDefault(f => f.GetMetadata("TargetFramework") == "netstandard1.0");
+            ns10asset.Should().NotBeNull();
+            ns10asset.GetMetadata("AssemblyVersion").Should().Be("1.2.3.0");
+            task.SupportedFrameworks.Should().HaveCount(_frameworks.Length);
+        }
+
+        [Fact]
+        public void TestRefLibPackage()
+        {
+            var task = new HarvestPackage()
+            {
+                BuildEngine = _engine,
+                Frameworks = _frameworks,
+                HarvestAssets = true,
+                IncludeAllPaths = true,
+                PackageId = "Microsoft.Win32.Registry",
+                PackageVersion = "4.3.0",
+                RuntimeFile = "runtime.json"
+            };
+            task.PackagesFolders = new[] { FindPackageFolder(task.PackageId, task.PackageVersion) };
+
+            _log.Reset();
+            task.Execute();
+
+            _log.ErrorsLogged.Should().Be(0);
+            _log.WarningsLogged.Should().Be(0);
+            task.HarvestedFiles.Should().HaveCount(17);
+            var net46asset = task.HarvestedFiles.FirstOrDefault(f => f.GetMetadata("TargetFramework") == "net46");
+            net46asset.Should().NotBeNull();
+            net46asset.GetMetadata("AssemblyVersion").Should().Be("4.0.1.0");
+            task.SupportedFrameworks.Should().HaveCount(6);
+        }
+
+
+        [Fact]
+        public void TestSplitPackage()
+        {
+            var task = new HarvestPackage()
+            {
+                BuildEngine = _engine,
+                Frameworks = _frameworks,
+                HarvestAssets = true,
+                IncludeAllPaths = true,
+                PackageId = "System.Runtime",
+                PackageVersion = "4.3.0",
+                RuntimeFile = "runtime.json",
+                RuntimePackages = new []
+                {
+                    CreateRuntimePackage("runtime.any.System.Runtime", "4.3.0"),
+                    CreateRuntimePackage("runtime.aot.System.Runtime", "4.3.0")
+                }
+            };
+            task.PackagesFolders = new[] { FindPackageFolder(task.PackageId, task.PackageVersion) };
+
+            _log.Reset();
+            task.Execute();
+
+            _log.ErrorsLogged.Should().Be(0);
+            _log.WarningsLogged.Should().Be(0);
+            task.HarvestedFiles.Should().HaveCount(79);
+            task.HarvestedFiles.Should().Contain(f => f.GetMetadata("AssemblyVersion") == "4.1.0.0");
+            task.SupportedFrameworks.Should().HaveCount(_frameworks.Length);
+            task.SupportedFrameworks.Should().NotContain(f => f.GetMetadata("Version") == "unknown");
+        }
+
         private ITaskItem CreateRuntimePackage(string packageId, string version)
         {
             var item = new TaskItem(packageId);

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/Microsoft.DotNet.Build.Tasks.Packaging.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/Microsoft.DotNet.Build.Tasks.Packaging.Tests.csproj
@@ -26,7 +26,7 @@
   <!-- test packages - these packages aren't needed for compilation but are copied
                        to the output and used for testing. -->
   <ItemGroup>
-    <TestPackage Include="System.Collections.Immutable" Version="1.7.1" />
+    <TestPackage Include="System.Collections.Immutable" Version="1.5.0" />
     <TestPackage Include="Microsoft.Win32.Registry" Version="4.3.0" />
     <TestPackage Include="System.Runtime" Version="4.3.0" />
     <TestPackage Include="runtime.any.System.Runtime" Version="4.3.0" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/NuGetAssetResolverTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/tests/NuGetAssetResolverTests.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using NuGet.Frameworks;
+using Xunit;
+using Xunit.Abstractions;
+using FluentAssertions;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
+{
+    public class NuGetAssetResolverTests
+    {
+        private Log _log;
+
+
+        public NuGetAssetResolverTests(ITestOutputHelper output)
+        {
+            _log = new Log(output);
+        }
+
+        [Fact]
+        public void RuntimeResolutionTest()
+        {
+            string[] items =
+            {
+                "runtimes/any/lib/netcore50/System.Xml.XmlSerializer.dll",
+                "runtimes/aot/lib/netcore50/_._"
+            };
+
+            NuGetAssetResolver resolver = new NuGetAssetResolver("runtime.json", items);
+
+            var runtimeItems = resolver.GetRuntimeItems(NuGetFramework.Parse("netcore50"), "win10-x64-aot");
+
+            runtimeItems.Should().NotBeNull();
+            runtimeItems.Items.Should().HaveCount(1);
+
+            // Fails due to https://github.com/NuGet/Home/issues/1676
+            // Assert.Equal(items[1], runtimeItems.Items.FirstOrDefault().Path);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests.csproj
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests.csproj
@@ -8,7 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.7.179" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.RemoteExecutor/tests/RemoteExecutorTests.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/tests/RemoteExecutorTests.cs
@@ -12,6 +12,17 @@ namespace Microsoft.DotNet.RemoteExecutor.Tests
 {
     public class RemoteExecutorTests
     {
+        [Fact]
+        public void AsyncAction_ThrowException()
+        {
+            Assert.Throws<RemoteExecutionException>(() =>
+                RemoteExecutor.Invoke(async () =>
+                {
+                    Assert.True(false);
+                    await Task.Delay(1);
+                }, new RemoteInvokeOptions { RollForward = "Major" }).Dispose()
+            );
+        }
 
         [Fact]
         public void AsyncAction()
@@ -20,6 +31,19 @@ namespace Microsoft.DotNet.RemoteExecutor.Tests
             {
                 await Task.Delay(1);
             }, new RemoteInvokeOptions { RollForward = "Major" }).Dispose();
+        }
+
+        [Fact]
+        public void AsyncFunc_ThrowException()
+        {
+            Assert.Throws<RemoteExecutionException>(() =>
+                RemoteExecutor.Invoke(async () =>
+                {
+                    Assert.True(false);
+                    await Task.Delay(1);
+                    return 1;
+                }, new RemoteInvokeOptions { RollForward = "Major" }).Dispose()
+            );
         }
 
         [Fact]
@@ -32,6 +56,16 @@ namespace Microsoft.DotNet.RemoteExecutor.Tests
                     return 1;
                 }, new RemoteInvokeOptions { RollForward = "Major" }).Dispose()
             );
+        }
+
+        [Fact]
+        public void AsyncFunc_NoThrow_ValidReturnCode()
+        {
+            RemoteExecutor.Invoke(async () =>
+            {
+                await Task.Delay(1);
+                return RemoteExecutor.SuccessExitCode;
+            }, new RemoteInvokeOptions { RollForward = "Major" }).Dispose();
         }
     }
 }


### PR DESCRIPTION
Reverts dotnet/arcade#6792


Not all the tests mentioned have to be deleted. 

Only HarvestPackageTest can be deleted