### PR TITLE
Fix CA2200 in NuGetUtility.cs

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetUtility.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetUtility.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                             retriesRemaining--;
                             if (retriesRemaining <= 0) {
                                 logger.Log(LogLevel.Error, "Encountered Connection Issue: " + e.ToString() + ", retries exhausted");
-                                throw e;
+                                throw;
                             }
                             logger.Log(LogLevel.Information, "Encountered Connection Issue: " + e.ToString() + ", retrying...");
                             // returns to start of while loop to retry after a delay


### PR DESCRIPTION
CA2200: Re-throwing caught exception changes stack information

When targeting net5.0, analyzer levels are increased by default, and the dotnet/arcade build fails due to CA2200. Fix it to allow higher target frameworks without unnecessarily disabling the analyzer.