### PR TITLE
Port Guardian version ugrade

### DIFF
--- a/eng/common/sdl/packages.config
+++ b/eng/common/sdl/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Guardian.Cli.win10-x64" version="0.20.1"/>
+  <package id="Microsoft.Guardian.Cli" version="0.53.3"/>
 </packages>

--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -83,7 +83,7 @@ jobs:
       continueOnError: ${{ parameters.sdlContinueOnError }}
   - ${{ if eq(parameters.overrideParameters, '') }}:
     - powershell: eng/common/sdl/execute-all-sdl-tools.ps1
-        -GuardianPackageName Microsoft.Guardian.Cli.win10-x64.0.20.1
+        -GuardianPackageName Microsoft.Guardian.Cli.0.53.3
         -NugetPackageDirectory $(Build.SourcesDirectory)\.packages
         -AzureDevOpsAccessToken $(dn-bot-dotnet-build-rw-code-rw)
         ${{ parameters.additionalParameters }}


### PR DESCRIPTION
Description
This change ports the guardian version update from master to release/5.0

Customer Impact
We have been informed that we need to update the version of our guardian version.

Regression
No

Risk
Minimal. It ports the guardian version upgrade.

Workarounds
No