### PR TITLE
Fix port of guardian version upgrade

### DIFF
--- a/eng/common/sdl/packages.config
+++ b/eng/common/sdl/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Guardian.Cli.win10-x64" version="0.53.3"/>
+  <package id="Microsoft.Guardian.Cli" version="0.53.3"/>
 </packages>


### PR DESCRIPTION
## Description
In the port over, I missed that the package needed to change as well (to the cross plat package). This fixes that.

## Customer Impact
This fixes what is currently broken for sdl

## Regression
No

## Risk
Minimal. Fixes the package to be the cross plat package.

## Workarounds
No