### PR TITLE
Rename `ios` to `apple` when working with XHarness

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
@@ -11,10 +11,10 @@ namespace Microsoft.DotNet.Helix.Sdk
     /// <summary>
     /// MSBuild custom task to create HelixWorkItems for provided iOS app bundle paths.
     /// </summary>
-    public class CreateXHarnessiOSWorkItems : XHarnessTaskBase
+    public class CreateXHarnessAppleWorkItems : XHarnessTaskBase
     {
-        private const string EntryPointScriptName = "xharness-helix-job.ios.sh";
-        private const string RunnerScriptName = "xharness-runner.ios.sh";
+        private const string EntryPointScriptName = "xharness-helix-job.apple.sh";
+        private const string RunnerScriptName = "xharness-runner.apple.sh";
         private const int DefaultLaunchTimeoutInMinutes = 10;
         private const string LaunchTimeoutPropName = "LaunchTimeout";
         private const string TargetsPropName = "Targets";
@@ -166,7 +166,7 @@ namespace Microsoft.DotNet.Helix.Sdk
 
         private async Task AddFileToPayload(string payloadArchivePath, string fileName)
         {
-            var thisAssembly = typeof(CreateXHarnessiOSWorkItems).Assembly;
+            var thisAssembly = typeof(CreateXHarnessAppleWorkItems).Assembly;
             using Stream fileStream = thisAssembly.GetManifestResourceStream($"{thisAssembly.GetName().Name}.tools.xharness_runner.{fileName}");
             using FileStream archiveStream = new FileStream(payloadArchivePath, FileMode.Open);
             using ZipArchive archive = new ZipArchive(archiveStream, ZipArchiveMode.Update);

--- a/src/Microsoft.DotNet.Helix/Sdk/Microsoft.DotNet.Helix.Sdk.csproj
+++ b/src/Microsoft.DotNet.Helix/Sdk/Microsoft.DotNet.Helix.Sdk.csproj
@@ -20,8 +20,8 @@
     <ProjectReference Include="..\JobSender\Microsoft.DotNet.Helix.JobSender.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'"> 
-    <Compile Include="..\..\Common\Internal\AssemblyResolver.cs" /> 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <Compile Include="..\..\Common\Internal\AssemblyResolver.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -31,10 +31,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="tools\xharness-runner\xharness-helix-job.ios.sh">
+    <EmbeddedResource Include="tools\xharness-runner\xharness-helix-job.apple.sh">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </EmbeddedResource>
-    <EmbeddedResource Include="tools\xharness-runner\xharness-runner.ios.sh">
+    <EmbeddedResource Include="tools\xharness-runner\xharness-runner.apple.sh">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="tools\xharness-runner\xharness-helix-job.android.sh">

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.props
@@ -19,7 +19,7 @@
   <UsingTask TaskName="GetHelixWorkItems" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)"/>
   <UsingTask TaskName="CreateXUnitWorkItems" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)"/>
   <UsingTask TaskName="CreateXHarnessAndroidWorkItems" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)"/>
-  <UsingTask TaskName="CreateXHarnessiOSWorkItems" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)"/>
+  <UsingTask TaskName="CreateXHarnessAppleWorkItems" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)"/>
   <UsingTask TaskName="CreateTestsForWorkItems" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)"/>
   <UsingTask TaskName="StartAzurePipelinesTestRun" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)"/>
   <UsingTask TaskName="StopAzurePipelinesTestRun" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)"/>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
@@ -22,7 +22,7 @@ This is automatically included as a Helix Correlation Payload for the job when X
 
 There are three main ways how to use XHarness through the Helix SDK:
 - Specify the apks/app bundles using the `XHarnessApkToTest` and `XHarnessAppBundleToTest` items as described below and everything will be taken care of from there. You no longer specify the `HelixCommand` to be executed. Each apk/app bundle will be processed as a separate Helix work item.
-- Specify the `XHarnessAndroidProject` or `XHarnessiOSProject` task items which will point to projects that produce apks/app bundles from their `Build` target.
+- Specify the `XHarnessAndroidProject` or `XHarnessAppleProject` task items which will point to projects that produce apks/app bundles from their `Build` target.
   - Examples - [iOS](https://github.com/dotnet/arcade/blob/master/tests/XHarness/XHarness.TestAppBundle.proj) and [Android](https://github.com/dotnet/arcade/blob/master/tests/XHarness/XHarness.TestApk.proj)
 - Only request the XHarness dotnet tool to be pre-installed for the Helix job for you and then call the XHarness tool yourself as shown below.
 
@@ -95,11 +95,11 @@ You can also specify some metadata that will help you configure the run better:
     <!-- Optional: Timeout for how long it takes to install and boot the app and start running the first test -->
     <LaunchTimeout>00:10:00</LaunchTimeout>
 
-    <!-- Optional (`ios run` command only): Expected exit code of the iOS/tvOS application. XHarness exits with 0 when the app exits with this code -->
+    <!-- Optional (`apple run` command only): Expected exit code of the iOS/tvOS application. XHarness exits with 0 when the app exits with this code -->
     <!-- Please note that exit code detection may not be reliable across iOS/tvOS versions -->
     <ExpectedExitCode>3</ExpectedExitCode>
     
-    <!-- Optional: For apps that don't contain unit tests, they can be run using the `ios run` command instead of `ios test` -->
+    <!-- Optional: For apps that don't contain unit tests, they can be run using the `apple run` command instead of `apple test` -->
     <!-- Default is true -->
     <IncludesTestRunner>false</IncludesTestRunner>
   </XHarnessAppBundleToTest>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
@@ -77,15 +77,15 @@
     </MSBuild>
   </Target>
 
-  <Target Name="BuildXHarnessiOSProjects"
-          Condition=" '@(XHarnessiOSProject)' != '' "
+  <Target Name="BuildXHarnessAppleProjects"
+          Condition=" '@(XHarnessAppleProject)' != '' "
           BeforeTargets="CoreBuild"
-          Outputs="%(XHarnessiOSProject.Identity)%(XHarnessiOSProject.AdditionalProperties)">
+          Outputs="%(XHarnessAppleProject.Identity)%(XHarnessAppleProject.AdditionalProperties)">
     <PropertyGroup>
-      <_CurrentXHarnessiOSProject>%(XHarnessiOSProject.Identity)</_CurrentXHarnessiOSProject>
-      <_CurrentAdditionalProperties>%(XHarnessiOSProject.AdditionalProperties)</_CurrentAdditionalProperties>
+      <_CurrentXHarnessAppleProject>%(XHarnessAppleProject.Identity)</_CurrentXHarnessAppleProject>
+      <_CurrentAdditionalProperties>%(XHarnessAppleProject.AdditionalProperties)</_CurrentAdditionalProperties>
     </PropertyGroup>
-    <MSBuild Projects="$(_CurrentXHarnessiOSProject)" Targets="Build" Properties="$(_CurrentAdditionalProperties)">
+    <MSBuild Projects="$(_CurrentXHarnessAppleProject)" Targets="Build" Properties="$(_CurrentAdditionalProperties)">
       <Output TaskParameter="TargetOutputs" ItemName="XHarnessAppBundleToTest" />
     </MSBuild>
   </Target>
@@ -99,14 +99,14 @@
     </CreateXHarnessAndroidWorkItems>
   </Target>
 
-  <Target Name="CreateiOSWorkItems"
+  <Target Name="CreateAppleWorkItems"
           Condition=" '@(XHarnessAppBundleToTest)' != '' "
           BeforeTargets="CoreTest">
-    <CreateXHarnessiOSWorkItems AppBundles="@(XHarnessAppBundleToTest)"
+    <CreateXHarnessAppleWorkItems AppBundles="@(XHarnessAppBundleToTest)"
                                 IsPosixShell="$(IsPosixShell)"
                                 XcodeVersion="$(XHarnessXcodeVersion)">
       <Output TaskParameter="WorkItems" ItemName="HelixWorkItem"/>
-    </CreateXHarnessiOSWorkItems>
+    </CreateXHarnessAppleWorkItems>
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.apple.sh
@@ -8,9 +8,9 @@
 
 set -x
 
-chmod +x xharness-runner.ios.sh
+chmod +x xharness-runner.apple.sh
 helix_runner_uid=$(id -u)
-sudo launchctl asuser "$helix_runner_uid" sh ./xharness-runner.ios.sh "$@"
+sudo launchctl asuser "$helix_runner_uid" sh ./xharness-runner.apple.sh "$@"
 exit_code=$?
 
 # This handles an issue where Simulators get reeaally slow and they start failing to install apps

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
@@ -109,7 +109,7 @@ export XHARNESS_LOG_WITH_TIMESTAMPS=true
 # We include $app_arguments non-escaped and not arrayed because it might contain several extra arguments
 # which come from outside and are appeneded behind "--" and forwarded to the iOS application from XHarness.
 # shellcheck disable=SC2086,SC2090
-dotnet exec "$xharness_cli_path" ios $command \
+dotnet exec "$xharness_cli_path" apple $command \
     --app="$app"                              \
     --output-directory="$output_directory"    \
     --targets="$targets"                      \

--- a/tests/UnitTests.XHarness.iOS.IncludeCliOnly.proj
+++ b/tests/UnitTests.XHarness.iOS.IncludeCliOnly.proj
@@ -23,7 +23,7 @@
   <!-- We test that the XHarness CLI is pre-installed and issue the state command -->
   <ItemGroup>
     <HelixWorkItem Include="xharness-ios-state">
-      <Command>dotnet exec "$XHARNESS_CLI_PATH" ios state</Command>
+      <Command>dotnet exec "$XHARNESS_CLI_PATH" apple state</Command>
       <Timeout>00:03:00</Timeout>
     </HelixWorkItem>
   </ItemGroup>

--- a/tests/UnitTests.XHarness.iOS.proj
+++ b/tests/UnitTests.XHarness.iOS.proj
@@ -24,8 +24,8 @@
 
   <!-- Test project which builds app bundle to run via XHarness -->
   <ItemGroup>
-    <XHarnessiOSProject Include="$(MSBuildThisFileDirectory)XHarness\XHarness.TestAppBundle.proj" />
-    <XHarnessiOSProject Include="$(MSBuildThisFileDirectory)XHarness\XHarness.RunAppBundle.proj" />
+    <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)XHarness\XHarness.TestAppBundle.proj" />
+    <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)XHarness\XHarness.RunAppBundle.proj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(HelixAccessToken)' != '' ">


### PR DESCRIPTION
XHarness changed naming of things in https://github.com/dotnet/xharness/issues/400 and we just follow in the SDK