### PR TITLE
Add source-build inner clone shallow repo support

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
@@ -104,10 +104,18 @@
   -->
   <Target Name="PrepareInnerSourceBuildRepoRoot">
     <PropertyGroup>
+      <!--
+        By default, copy WIP. WIP copy helps with local machine dev work. Don't copy WIP if this is
+        a CI build: CI often uses shallow clones, which WIP copying doesn't support.
+      -->
+      <CopyWipIntoInnerSourceBuildRepo Condition="'$(CopyWipIntoInnerSourceBuildRepo)' == '' and '$(ContinuousIntegrationBuild)' == 'true'">false</CopyWipIntoInnerSourceBuildRepo>
+      <CopyWipIntoInnerSourceBuildRepo Condition="'$(CopyWipIntoInnerSourceBuildRepo)' == ''">true</CopyWipIntoInnerSourceBuildRepo>
+
       <_GitCloneToDirArgs />
       <_GitCloneToDirArgs>$(_GitCloneToDirArgs) --source &quot;$(RepoRoot)&quot;</_GitCloneToDirArgs>
       <_GitCloneToDirArgs>$(_GitCloneToDirArgs) --dest &quot;$(InnerSourceBuildRepoRoot)&quot;</_GitCloneToDirArgs>
-      <_GitCloneToDirArgs>$(_GitCloneToDirArgs) --copy-wip</_GitCloneToDirArgs>
+
+      <_GitCloneToDirArgs Condition="'$(CopyWipIntoInnerSourceBuildRepo)' == 'true'">$(_GitCloneToDirArgs) --copy-wip</_GitCloneToDirArgs>
 
       <_GitCloneToDirArgs Condition="'$(CleanInnerSourceBuildRepoRoot)' == 'true'">$(_GitCloneToDirArgs) --clean</_GitCloneToDirArgs>
     </PropertyGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/git-clone-to-dir.sh
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/git-clone-to-dir.sh
@@ -83,18 +83,46 @@ if [ ! -e "$destDir" ]; then
   mkdir -p "$destDir"
 
   if [ "${copyWip:-}" ]; then
-    echo "WIP copying is enabled"
     # Copy over changes that haven't been committed, for dev inner loop.
     # This gets changes (whether staged or not) but misses untracked files.
     stashCommit=$(cd "$sourceDir"; git stash create)
 
     if [ "$stashCommit" ]; then
-      echo "Created temporary stash $stashCommit to transfer WIP changes..."
+      echo "WIP changes detected: created temporary stash $stashCommit to transfer to inner repository..."
+    else
+      echo "No WIP changes detected..."
     fi
   fi
 
   echo "Creating empty clone at: $destDir"
-  git clone --no-checkout "$sourceDir" "$destDir"
+
+  shallowFile="$sourceDir/.git/shallow"
+
+  if [ -f "$shallowFile" ]; then
+    echo "Source repository is shallow..."
+    if [ "${stashCommit:-}" ]; then
+      echo "WIP stash is not supported in a shallow repository: aborting."
+      exit 1
+    fi
+
+    # If source repo is shallow, old versions of Git refuse to clone it to another directory. First,
+    # remove the 'shallow' file to trick Git into allowing the clone.
+    shallowContent=$(cat "$shallowFile")
+    rm "$shallowFile"
+
+    # Then, run the clone:
+    # * 'depth=1' avoids encountering the leaf commit in the shallow repo that points to a parent
+    #   that doesn't exist. (The commit marked "grafted".) Git would fail here, otherwise.
+    # * '--no-local' allows a shallow clone from a git dir on the same filesystem. This means the
+    #   clone will not use hard links and takes up more space. However, since we're doing a shallow
+    #   clone anyway, the difference is probably not significant. (This has not been measured.)
+    git clone --depth=1 --no-local --no-checkout "$sourceDir" "$destDir"
+
+    # Put the 'shallow' file back so operations on the outer Git repo continue to work normally.
+    printf "%s" "$shallowContent" > "$shallowFile"
+  else
+    git clone --no-checkout "$sourceDir" "$destDir"
+  fi
 
   (
     cd "$destDir"


### PR DESCRIPTION
Fixes this issue:

1. The repo builds in the standard managed-only arcade-specified source-build container.
   * `mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343`, `git version 1.8.3.1`
1. The Checkout CI step makes a shallow clone (`--depth=3`).
1. The inner clone script tries to clone the outer repo into a subdirectory.
   * Git fails because it doesn't allow cloning from a shallow repo into another place.
   * `fatal: attempt to fetch/clone from a shallow repository`

Now the script detects `.git/shallow` and works around it.

I clarified the WIP copying log a little, and made sure it's disabled for CI builds because the `git stash` doesn't get copied over when we use the shallow clone workaround. (WIP changes (dirty working tree) are definitely not expected in CI builds, so this is probably a good change anyway.)