### PR TITLE
Remove load of guardian configuration from sdl-tool-cfg (#6864)

### DIFF
--- a/eng/common/sdl/init-sdl.ps1
+++ b/eng/common/sdl/init-sdl.ps1
@@ -29,18 +29,7 @@ $zipFile = "$WorkingDirectory/gdn.zip"
 
 Add-Type -AssemblyName System.IO.Compression.FileSystem
 $gdnFolder = (Join-Path $WorkingDirectory '.gdn')
-try {
-  # We try to download the zip; if the request fails (e.g. the file doesn't exist), we catch it and init guardian instead
-  Write-Host 'Downloading gdn folder from internal config repostiory...'
-  Invoke-WebRequest -Headers @{ "Accept"="application/zip"; "Authorization"="Basic $encodedPat" } -Uri $uri -OutFile $zipFile
-  if (Test-Path $gdnFolder) {
-    # Remove the gdn folder if it exists (it shouldn't unless there's too much caching; this is just in case)
-    Remove-Item -Force -Recurse $gdnFolder
-  }
-  [System.IO.Compression.ZipFile]::ExtractToDirectory($zipFile, $WorkingDirectory)
-  Write-Host $gdnFolder
-  ExitWithExitCode 0
-} catch [System.Net.WebException] { } # Catch and ignore webexception
+
 try {
   # if the folder does not exist, we'll do a guardian init and push it to the remote repository
   Write-Host 'Initializing Guardian...'


### PR DESCRIPTION
## Description
Fix of SDL pipeline https://github.com/dotnet/core-eng/issues/11902. Cherry picked from master 0e5bd280db3e406d65972a2f971ff019ed42c8a6.

## Customer Impact

Pipeline will fail on SDL step without this change.

## Regression

No

## Risk

Low

## Workarounds

No