### PR TITLE
Add Policheck suppression file to Arcade SDL tool execution

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -264,4 +264,5 @@ stages:
         -TsaIterationPath $(_TsaIterationPath)
         -TsaRepositoryName "Arcade"
         -TsaCodebaseName "Arcade"
-        -TsaPublish $True'
+        -TsaPublish $True
+        -PoliCheckAdditionalRunConfigParams @("UserExclusionPath < $(Build.SourcesDirectory)/eng/PoliCheckExclusions.xml")'

--- a/eng/PoliCheckExclusions.xml
+++ b/eng/PoliCheckExclusions.xml
@@ -1,0 +1,3 @@
+<PoliCheckExclusions>
+  <Exclusion Type="FileName">MICROSOFTDOTNETLIBRARY.TXT</Exclusion>
+</PoliCheckExclusions>


### PR DESCRIPTION
tools/Licenses/MicrosoftDotNetLibrary.txt is lawyer-approved and needs to be ignored in scans.