### PR TITLE
Fix shallow clone support for abnormal workdirs

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/git-clone-to-dir.sh
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/git-clone-to-dir.sh
@@ -81,58 +81,64 @@ if [ -e "$destDir" ]; then
   fi
 fi
 
-if [ ! -e "$destDir" ]; then
-  mkdir -p "$destDir"
+(
+  # This script uses "--git-dir" later on to detect a shallow submodule. "--git-dir" may give us a
+  # relative path. The version of Git we use doesn't have "--absolute-git-dir". To keep things
+  # simple, change to the repo's directory and work from there.
+  cd "$sourceDir"
 
-  if [ "${copyWip:-}" ]; then
-    # Copy over changes that haven't been committed, for dev inner loop.
-    # This gets changes (whether staged or not) but misses untracked files.
-    stashCommit=$(cd "$sourceDir"; git stash create)
+  if [ ! -e "$destDir" ]; then
+    mkdir -p "$destDir"
 
-    if [ "$stashCommit" ]; then
-      echo "WIP changes detected: created temporary stash $stashCommit to transfer to inner repository..."
+    if [ "${copyWip:-}" ]; then
+      # Copy over changes that haven't been committed, for dev inner loop.
+      # This gets changes (whether staged or not) but misses untracked files.
+      stashCommit=$(cd "$sourceDir"; git stash create)
+
+      if [ "$stashCommit" ]; then
+        echo "WIP changes detected: created temporary stash $stashCommit to transfer to inner repository..."
+      else
+        echo "No WIP changes detected..."
+      fi
+    fi
+
+    echo "Creating empty clone at: $destDir"
+
+    shallowFile="$(git rev-parse --git-dir)/shallow"
+
+    if [ -f "$shallowFile" ]; then
+      echo "Source repository is shallow..."
+      if [ "${stashCommit:-}" ]; then
+        echo "WIP stash is not supported in a shallow repository: aborting."
+        exit 1
+      fi
+
+      # If source repo is shallow, old versions of Git refuse to clone it to another directory. First,
+      # remove the 'shallow' file to trick Git into allowing the clone.
+      shallowContent=$(cat "$shallowFile")
+      rm "$shallowFile"
+
+      # Then, run the clone:
+      # * 'depth=1' avoids encountering the leaf commit in the shallow repo that points to a parent
+      #   that doesn't exist. (The commit marked "grafted".) Git would fail here, otherwise.
+      # * '--no-local' allows a shallow clone from a git dir on the same filesystem. This means the
+      #   clone will not use hard links and takes up more space. However, since we're doing a shallow
+      #   clone anyway, the difference is probably not significant. (This has not been measured.)
+      git clone --depth=1 --no-local --no-checkout "$sourceDir" "$destDir"
+
+      # Put the 'shallow' file back so operations on the outer Git repo continue to work normally.
+      printf "%s" "$shallowContent" > "$shallowFile"
     else
-      echo "No WIP changes detected..."
-    fi
-  fi
-
-  echo "Creating empty clone at: $destDir"
-
-  sourceGitDir=$(cd "$sourceDir" && git rev-parse --git-dir)
-  shallowFile="$sourceGitDir/shallow"
-
-  if [ -f "$shallowFile" ]; then
-    echo "Source repository is shallow..."
-    if [ "${stashCommit:-}" ]; then
-      echo "WIP stash is not supported in a shallow repository: aborting."
-      exit 1
+      git clone --no-checkout "$sourceDir" "$destDir"
     fi
 
-    # If source repo is shallow, old versions of Git refuse to clone it to another directory. First,
-    # remove the 'shallow' file to trick Git into allowing the clone.
-    shallowContent=$(cat "$shallowFile")
-    rm "$shallowFile"
+    (
+      cd "$destDir"
+      echo "Checking out sources..."
+      # If no changes were stashed, stashCommit is empty string, and this is a simple checkout.
+      git checkout ${stashCommit:-}
+    )
 
-    # Then, run the clone:
-    # * 'depth=1' avoids encountering the leaf commit in the shallow repo that points to a parent
-    #   that doesn't exist. (The commit marked "grafted".) Git would fail here, otherwise.
-    # * '--no-local' allows a shallow clone from a git dir on the same filesystem. This means the
-    #   clone will not use hard links and takes up more space. However, since we're doing a shallow
-    #   clone anyway, the difference is probably not significant. (This has not been measured.)
-    git clone --depth=1 --no-local --no-checkout "$sourceDir" "$destDir"
-
-    # Put the 'shallow' file back so operations on the outer Git repo continue to work normally.
-    printf "%s" "$shallowContent" > "$shallowFile"
-  else
-    git clone --no-checkout "$sourceDir" "$destDir"
+    echo "Clone complete: $sourceDir -> $destDir"
   fi
-
-  (
-    cd "$destDir"
-    echo "Checking out sources..."
-    # If no changes were stashed, stashCommit is empty string, and this is a simple checkout.
-    git checkout ${stashCommit:-}
-  )
-
-  echo "Clone complete: $sourceDir -> $destDir"
-fi
+)


### PR DESCRIPTION
(Ignore whitespace recommended for review: enclosed main body with subshell.)

Shallow clone support wasn't working when the workdir wasn't the same as the repo dir. This caused issues in enabling dotnet/source-build CI: https://github.com/dotnet/source-build/pull/2002.

To fix this, just `cd` to the source directory before the main body. It seems nice to avoid depending on the working dir in util scripts generally, but with old versions of Git involved, this seems like the cleanest way to make it work reliably.