### PR TITLE
Implement writing the .version file for shared frameworks in the shared framework SDK.

### DIFF
--- a/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -406,18 +406,27 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="_CreateVersionsFile" DependsOnTargets="InitializeSourceControlInformationFromSourceControlManager">
+  <Target Name="_CreateVersionsFile"
+          DependsOnTargets="InitializeSourceControlInformationFromSourceControlManager"
+          Condition="'$(DisableSourceLink)' != 'true'">
     <ItemGroup>
       <_VersionsFile Include="$(IntermediateOutputPath)$(SharedFrameworkName).versions.txt" TargetPath="" GeneratedBuildFile="true" />
+      <!-- The presence of the .version file is used by VS to detect a valid installation of the shared framework into a .NET Runtime/SDK install. -->
+      <_DotVersionFile Include="$(IntermediateOutputPath).version" PublishOnly="true" GeneratedBuildFile="true" />
     </ItemGroup>
     <WriteLinesToFile
       Lines="$(SourceRevisionId);$(Version)"
       File="@(_VersionsFile)"
       Overwrite="true"
       WriteOnlyWhenDifferent="true" />
+    <WriteLinesToFile
+      Lines="$(SourceRevisionId);$(Version)"
+      File="@(_DotVersionFile)"
+      Overwrite="true"
+      WriteOnlyWhenDifferent="true" />
     <ItemGroup>
-      <FileWrites Include="@(_VersionsFile)" />
-      <FilesToPackage Include="@(_VersionsFile)" />
+      <FileWrites Include="@(_VersionsFile);@(_DotVersionFile)" />
+      <FilesToPackage Include="@(_VersionsFile);@(_DotVersionFile)" />
     </ItemGroup>
   </Target>
 
@@ -510,14 +519,14 @@
       <IncludeBuildOutput>true</IncludeBuildOutput>
     </PropertyGroup>
     <ItemGroup>
-      <_PackageFiles Include="@(_FilesToPackage)" PackagePath="%(_FilesToPackage.TargetPath)" Condition="'%(_FilesToPackage.IsSymbolFile)' != 'true'" />
+      <_PackageFiles Include="@(_FilesToPackage)" PackagePath="%(_FilesToPackage.TargetPath)" Condition="'%(_FilesToPackage.IsSymbolFile)' != 'true' and '%(_FilesToPackage.PublishOnly)' != 'true'" />
       <!-- 
            We need to handle symbol files specially so they get correctly filtered out of the implementation package.
            The base of the TargetPath attribute is $(BuildOutputTargetFolder)/%(TargetFramework), so we have to
            modify the TargetPath metadata with that base path in mind.
       -->
       <_TargetPathsToSymbols Include="@(_FilesToPackage)"
-                             Condition="'%(_FilesToPackage.IsSymbolFile)' == 'true'"
+                             Condition="'%(_FilesToPackage.IsSymbolFile)' == 'true' and '%(_FilesToPackage.PublishOnly)' != 'true'"
                              TargetFramework="$(TargetFramework)"
                              TargetPath="$([MSBuild]::MakeRelative($([MSBuild]::NormalizePath('$(BuildOutputTargetFolder)/$(TargetFramework)')), $([MSBuild]::NormalizePath('%(_FilesToPackage.TargetPath)', '%(Filename)%(Extension)'))))"/>
     </ItemGroup>

--- a/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -412,7 +412,10 @@
     <ItemGroup>
       <_VersionsFile Include="$(IntermediateOutputPath)$(SharedFrameworkName).versions.txt" TargetPath="" GeneratedBuildFile="true" />
       <!-- The presence of the .version file is used by VS to detect a valid installation of the shared framework into a .NET Runtime/SDK install. -->
-      <_DotVersionFile Include="$(IntermediateOutputPath).version" PublishOnly="true" GeneratedBuildFile="true" />
+      <_DotVersionFile Include="$(IntermediateOutputPath).version"
+                       PublishOnly="true"
+                       GeneratedBuildFile="true"
+                       Condition="'$(PlatformPackageType)' == 'RuntimePack'" />
     </ItemGroup>
     <WriteLinesToFile
       Lines="$(SourceRevisionId);$(Version)"


### PR DESCRIPTION
Moving the change https://github.com/dotnet/runtime/pull/47717 to the shared tooling for all shared frameworks.