### PR TITLE
Tweaks to aka.ms link generation 

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
@@ -86,6 +86,7 @@
       <AkaMSTenant Condition="'$(AkaMSTenant)' == ''">ncd</AkaMSTenant>
       <AkaMSOwners Condition="'$(AkaMSOwners)' == ''">dn-bot</AkaMSOwners>
       <AkaMSCreatedBy Condition="'$(AkaMSCreatedBy)' == ''">dn-bot</AkaMSCreatedBy>
+      <AkaMSGroupOwner Condition="'$(AkaMSGroupOwner)' == ''">dotnetes</AkaMSCreatedBy>
       <PublishSpecialClrFiles Condition="'$(PublishSpecialClrFiles)' == ''">false</PublishSpecialClrFiles>
       <InstallersFeedKey>$(InstallersAzureAccountKey)</InstallersFeedKey>
       <InternalInstallersFeedKey>$(InternalInstallersAzureAccountKey)</InternalInstallersFeedKey>
@@ -122,6 +123,7 @@
       AkaMSClientSecret="$(AkaMSClientSecret)"
       AkaMSTenant="$(AkaMSTenant)"
       AkaMSOwners="$(AkaMSOwners)"
+      AkaMSGroupOwner="$(AkaMSGroupOwner)"
       AkaMSCreatedBy="$(AkaMSCreatedBy)" 
       MsdlToken="$(MsdlToken)"
       SymWebToken="$(SymWebToken)"

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
@@ -86,7 +86,7 @@
       <AkaMSTenant Condition="'$(AkaMSTenant)' == ''">ncd</AkaMSTenant>
       <AkaMSOwners Condition="'$(AkaMSOwners)' == ''">dn-bot</AkaMSOwners>
       <AkaMSCreatedBy Condition="'$(AkaMSCreatedBy)' == ''">dn-bot</AkaMSCreatedBy>
-      <AkaMSGroupOwner Condition="'$(AkaMSGroupOwner)' == ''">dotnetes</AkaMSCreatedBy>
+      <AkaMSGroupOwner Condition="'$(AkaMSGroupOwner)' == ''">dotnetes</AkaMSGroupOwner>
       <PublishSpecialClrFiles Condition="'$(PublishSpecialClrFiles)' == ''">false</PublishSpecialClrFiles>
       <InstallersFeedKey>$(InstallersAzureAccountKey)</InstallersFeedKey>
       <InternalInstallersFeedKey>$(InternalInstallersAzureAccountKey)</InternalInstallersFeedKey>

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksManager.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksManager.cs
@@ -351,7 +351,8 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links.src
                         targetUrl = link.TargetUrl,
                         lastModifiedBy = linkCreatedOrUpdatedBy,
                         description = link.Description,
-                        groupOwner = linkGroupOwner
+                        groupOwner = linkGroupOwner,
+                        isAllowParam = true
                     };
                 }));
             }
@@ -369,7 +370,8 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links.src
                         groupOwner = linkGroupOwner,
                         // Create specific items
                         createdBy = linkCreatedOrUpdatedBy,
-                        isVanity = !string.IsNullOrEmpty(link.ShortUrl)
+                        isVanity = !string.IsNullOrEmpty(link.ShortUrl),
+                        isAllowParam = true
                     };
                 }));
             }

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/CreateAkaMSLinks.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/CreateAkaMSLinks.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 namespace Microsoft.DotNet.Deployment.Tasks.Links
 {
     /// <summary>
-    /// Computes the checksum for a single file.
+    /// Creates or updates, in bulk, a set of aka.ms (redirection) links
     /// </summary>
     public class CreateAkaMSLinks : AkaMSLinksBase
     {


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/6847 for context. 

Two changes to aka.ms link generation:
- Add the ability to plumb through security group owner to PublishArtifactsInManifest.  Default will be 'dotnetes' (Dotnet Engineering Services team)
- Add isAllowParam = true to all links for authentication query strings.