### PR TITLE
Fix WriteLinesToFile error for non runtimepack sfx

### DIFF
--- a/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -426,7 +426,8 @@
       Lines="$(SourceRevisionId);$(Version)"
       File="@(_DotVersionFile)"
       Overwrite="true"
-      WriteOnlyWhenDifferent="true" />
+      WriteOnlyWhenDifferent="true"
+      Condition="'@(_DotVersionFile)' != ''" />
     <ItemGroup>
       <FileWrites Include="@(_VersionsFile);@(_DotVersionFile)" />
       <FilesToPackage Include="@(_VersionsFile);@(_DotVersionFile)" />


### PR DESCRIPTION
Fixes .packages/microsoft.dotnet.sharedframework.sdk/6.0.0-beta.21103.4/targets/sharedfx.targets(425,5): error MSB4044: The "WriteLinesToFile" task was not given a value for the required parameter "File".

Fixes https://github.com/dotnet/core-eng/issues/12077

cc @riarenas 