### PR TITLE
Backport #6880 to release/3.x

### DIFF
--- a/eng/common/internal-feed-operations.ps1
+++ b/eng/common/internal-feed-operations.ps1
@@ -64,7 +64,6 @@ function SetupCredProvider {
   }
 
   if (($endpoints | Measure-Object).Count -gt 0) {
-      # Create the JSON object. It should look like '{"endpointCredentials": [{"endpoint":"http://example.index.json", "username":"optional", "password":"accesstoken"}]}'
       $endpointCredentials = @{endpointCredentials=$endpoints} | ConvertTo-Json -Compress
 
      # Create the environment variables the AzDo way

--- a/eng/common/internal-feed-operations.sh
+++ b/eng/common/internal-feed-operations.sh
@@ -62,7 +62,6 @@ function SetupCredProvider {
   endpoints+=']'
 
   if [ ${#endpoints} -gt 2 ]; then 
-      # Create the JSON object. It should look like '{"endpointCredentials": [{"endpoint":"http://example.index.json", "username":"optional", "password":"accesstoken"}]}'
       local endpointCredentials="{\"endpointCredentials\": "$endpoints"}"
 
       echo "##vso[task.setvariable variable=VSS_NUGET_EXTERNAL_FEED_ENDPOINTS]$endpointCredentials"


### PR DESCRIPTION
## Description

Cherry-pick of #6880 into release/3.x branch so Roslyn can close its credscan bugs without worrying about them coming back after we update Arcade again.

cc @MattGal @riarenas @davidwengier

## Customer Impact

The process for dealing with these credscan bugs is very cumbersome. They keep coming back.

## Regression

No

## Risk

Very low. Just removing comments that are being flagged as credentials.

## Workarounds

No. The exception process for these bugs doesn't play well with files that are shared among multiple repositories
