### PR TITLE
Add (IL)linker opt-in flag

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -47,6 +47,10 @@
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>2fc92d84e746c3aab75f0930278ea6675cd5bb5c</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.0-alpha.1.21109.4">
+      <Uri>https://github.com/mono/linker</Uri>
+      <Sha>b2979aecc948be066551d83acd281a22ad0378a8</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.1.0-beta-21108-02">
       <Uri>https://github.com/dotnet/sourcelink</Uri>
       <Sha>1145841dc46cd37dfb8f4438a577e94f0fb8ecd0</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -36,6 +36,7 @@
     <MicrosoftExtensionsLoggingConsoleVersion>2.1.1</MicrosoftExtensionsLoggingConsoleVersion>
     <MicrosoftNETCorePlatformsVersion>2.1.0</MicrosoftNETCorePlatformsVersion>
     <MicrosoftNetCompilersToolsetVersion>3.9.0-4.21104.8</MicrosoftNetCompilersToolsetVersion>
+    <MicrosoftNetILLinkTasksVersion>6.0.0-alpha.1.21109.4</MicrosoftNetILLinkTasksVersion>
     <MicrosoftNetTestSdkVersion>16.7.1</MicrosoftNetTestSdkVersion>
     <MoqVersion>4.8.3</MoqVersion>
     <MonoOptionsVersion>5.3.0.1</MonoOptionsVersion>

--- a/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
@@ -77,6 +77,7 @@
   <PropertyGroup>
     <ArcadeSdkVersion>$(PackageVersion)</ArcadeSdkVersion>
     <MicrosoftNetCompilersToolsetVersion>$(MicrosoftNetCompilersToolsetVersion)</MicrosoftNetCompilersToolsetVersion>
+    <MicrosoftNetILLinkTasksVersion>$(MicrosoftNetILLinkTasksVersion)</MicrosoftNetILLinkTasksVersion>
     <MicrosoftSourceLinkVersion>$(MicrosoftSourceLinkVersion)</MicrosoftSourceLinkVersion>
     <MicrosoftDiaSymReaderPdb2PdbVersion>$(MicrosoftDiaSymReaderPdb2PdbVersion)</MicrosoftDiaSymReaderPdb2PdbVersion>
     <XliffTasksVersion>$(XliffTasksVersion)</XliffTasksVersion>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -57,10 +57,10 @@
     <UsingToolMicrosoftNetCompilers Condition="'$(UsingToolMicrosoftNetCompilers)' == ''">false</UsingToolMicrosoftNetCompilers>
 
     <!--
-      Use linkers from the Microsoft.NET.ILLink.Tasks package.
-      Repo can set this property to true if it needs to use a different version of the linker than the one in the dotnet SDK.
+      Use IL linker from the Microsoft.NET.ILLink.Tasks package.
+      Repo can set this property to true if it needs to use a different version of the IL linker than the one in the dotnet SDK.
     -->
-    <UsingToolMicrosoftNetLinkers Condition="'$(UsingToolMicrosoftNetLinkers)' == ''">false</UsingToolMicrosoftNetLinkers>
+    <UsingToolMicrosoftNetILLinkTasks Condition="'$(UsingToolMicrosoftNetILLinkTasks)' == ''">false</UsingToolMicrosoftNetILLinkTasks>
   </PropertyGroup>
 
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -55,6 +55,12 @@
       Repo can set this property to true if it needs to use a different version of the compiler than the one in the dotnet SDK.
     -->
     <UsingToolMicrosoftNetCompilers Condition="'$(UsingToolMicrosoftNetCompilers)' == ''">false</UsingToolMicrosoftNetCompilers>
+
+    <!--
+      Use linkers from the Microsoft.NET.ILLink.Tasks package.
+      Repo can set this property to true if it needs to use a different version of the linker than the one in the dotnet SDK.
+    -->
+    <UsingToolMicrosoftNetLinkers Condition="'$(UsingToolMicrosoftNetLinkers)' == ''">false</UsingToolMicrosoftNetLinkers>
   </PropertyGroup>
 
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Linker.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Linker.props
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Project>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="$(MicrosoftNetILLinkTasksVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
+  </ItemGroup>
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Settings.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Settings.props
@@ -21,6 +21,7 @@
   <Import Project="Workarounds.props"/>
 
   <Import Project="Compiler.props" Condition="'$(UsingToolMicrosoftNetCompilers)' == 'true'" />
+  <Import Project="Linker.props" Condition="'$(UsingToolMicrosoftNetLinkers)' == 'true'" />
   <Import Project="VisualStudio.props" Condition="'$(UsingToolVSSDK)' == 'true' and '$(MSBuildRuntimeType)' != 'Core'"/>
 
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Settings.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Settings.props
@@ -21,7 +21,7 @@
   <Import Project="Workarounds.props"/>
 
   <Import Project="Compiler.props" Condition="'$(UsingToolMicrosoftNetCompilers)' == 'true'" />
-  <Import Project="Linker.props" Condition="'$(UsingToolMicrosoftNetLinkers)' == 'true'" />
+  <Import Project="Linker.props" Condition="'$(UsingToolMicrosoftNetILLinkTasks)' == 'true'" />
   <Import Project="VisualStudio.props" Condition="'$(UsingToolVSSDK)' == 'true' and '$(MSBuildRuntimeType)' != 'Core'"/>
 
   <!--


### PR DESCRIPTION
This is similar to the compiler package which overrides what's inbox in dotnet/sdk. Exposing the illinker via a property as an opt-in to guarantee that the right package is used throughout the repository as msbuild caches tasks and even with ALC there is currently no way to prevent that.

TODO post merge:
- Add a subscription from mono/linker --> arcade
- Remove subscription in dotnet/runtime and enable the opt-in flag