### PR TITLE
#6930: SDL validation fix

### DIFF
--- a/eng/common/sdl/init-sdl.ps1
+++ b/eng/common/sdl/init-sdl.ps1
@@ -42,6 +42,5 @@ try {
 }
 catch {
   Write-Host $_.ScriptStackTrace
-  Write-PipelineTelemetryError -Force -Category 'Sdl' -Message $_
   ExitWithExitCode 1
 }

--- a/eng/common/sdl/init-sdl.ps1
+++ b/eng/common/sdl/init-sdl.ps1
@@ -11,6 +11,12 @@ $ErrorActionPreference = "Stop"
 Set-StrictMode -Version 2.0
 $LASTEXITCODE = 0
 
+# `tools.ps1` checks $ci to perform some actions. Since the SDL
+# scripts don't necessarily execute in the same agent that run the
+# build.ps1/sh script this variable isn't automatically set.
+$ci = $true
+. $PSScriptRoot\..\tools.ps1
+
 # Don't display the console progress UI - it's a huge perf hit
 $ProgressPreference = 'SilentlyContinue'
 
@@ -42,5 +48,6 @@ try {
 }
 catch {
   Write-Host $_.ScriptStackTrace
+  Write-PipelineTelemetryError -Force -Category 'Sdl' -Message $_
   ExitWithExitCode 1
 }


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/6930

## Description

Fixes merge https://github.com/dotnet/arcade/commit/6e8b0da07468ed1653292b1aeb11c9d76da64dea where method Write-PipelineTelemetryError doesn't exist under branch release/3.x and build breaks because of this.

## Customer Impact

Build pipeline is broken.

## Regression

Yes

## Risk

No risk only affects build.

## Workarounds

No