### PR TITLE
Flatten the aka.ms links to just be the shortlink prefix and the filename

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/LatestLinksManager.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/LatestLinksManager.cs
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         /// <remarks>
         public string GetLatestShortUrlForBlob(TargetFeedConfig feedConfig, BlobArtifactModel blob)
         {
-            string blobIdWithoutVersions = Path.GetFileName(blob.Id);
+            string blobIdWithoutVersions = VersionIdentifier.RemoveVersions(Path.GetFileName(blob.Id));
 
             return Path.Combine(feedConfig.LatestLinkShortUrlPrefix, blobIdWithoutVersions).Replace("\\", "/");
         }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/LatestLinksManager.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/LatestLinksManager.cs
@@ -71,7 +71,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                 AkaMSLink newLink = new AkaMSLink
                 {
-                    ShortUrl = GetLatestShortUrlForBlob(feedConfig, blob),
+                    ShortUrl = GetLatestShortUrlForBlob(feedConfig, blob, feedConfig.Flatten),
                     TargetUrl = actualTargetUrl
                 };
                 Logger.LogMessage(MessageImportance.High, $"  {Path.GetFileName(blob.Id)}");
@@ -91,9 +91,14 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         /// <param name="blob">Blob</param>
         /// <returns>Short url prefix for the blob.</returns>
         /// <remarks>
-        public string GetLatestShortUrlForBlob(TargetFeedConfig feedConfig, BlobArtifactModel blob)
+        public string GetLatestShortUrlForBlob(TargetFeedConfig feedConfig, BlobArtifactModel blob, bool flatten)
         {
-            string blobIdWithoutVersions = VersionIdentifier.RemoveVersions(Path.GetFileName(blob.Id));
+            string blobIdWithoutVersions = VersionIdentifier.RemoveVersions(blob.Id);
+
+            if (flatten)
+            {
+                blobIdWithoutVersions = Path.GetFileName(blobIdWithoutVersions);
+            }
 
             return Path.Combine(feedConfig.LatestLinkShortUrlPrefix, blobIdWithoutVersions).Replace("\\", "/");
         }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/LatestLinksManager.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/LatestLinksManager.cs
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         /// <remarks>
         public string GetLatestShortUrlForBlob(TargetFeedConfig feedConfig, BlobArtifactModel blob)
         {
-            string blobIdWithoutVersions = VersionIdentifier.RemoveVersions(blob.Id);
+            string blobIdWithoutVersions = Path.GetFileName(blob.Id);
 
             return Path.Combine(feedConfig.LatestLinkShortUrlPrefix, blobIdWithoutVersions).Replace("\\", "/");
         }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
@@ -143,7 +143,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 PublicAndInternalSymbolTargets,
                 filenamesToExclude: FilenamesToExclude),
 
-            // ".NET Preview 1",
+            // ".NET 6 Preview 1",
             new TargetChannelConfig(
                 1670,
                 false,
@@ -252,7 +252,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 FeedDotNetEngSymbols,
                 FeedForChecksums,
                 FeedForInstallers,
-                PublicAndInternalSymbolTargets),
+                PublicAndInternalSymbolTargets,
+                flatten: false),
 
             // ".NET 5 Eng",
             new TargetChannelConfig(
@@ -265,7 +266,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 FeedDotNetEngSymbols,
                 FeedForChecksums,
                 FeedForInstallers,
-                PublicAndInternalSymbolTargets),
+                PublicAndInternalSymbolTargets,
+                flatten: false),
 
             // ".NET Eng - Validation",
             new TargetChannelConfig(
@@ -278,7 +280,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 FeedDotNetEngSymbols,
                 FeedForChecksums,
                 FeedForInstallers,
-                PublicAndInternalSymbolTargets),
+                PublicAndInternalSymbolTargets,
+                flatten: false),
 
             // ".NET 5 Eng - Validation",
             new TargetChannelConfig(
@@ -291,7 +294,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 FeedDotNetEngSymbols,
                 FeedForChecksums,
                 FeedForInstallers,
-                PublicAndInternalSymbolTargets),
+                PublicAndInternalSymbolTargets,
+                flatten: false),
 
             // "General Testing",
             new TargetChannelConfig(
@@ -331,7 +335,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 FeedForChecksums,
                 FeedForInstallers,
                 PublicAndInternalSymbolTargets,
-                filenamesToExclude: FilenamesToExclude),
+                filenamesToExclude: FilenamesToExclude,
+                flatten: false),
 
             // ".NET Core Tooling Release",
             new TargetChannelConfig(
@@ -345,7 +350,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 FeedForChecksums,
                 FeedForInstallers,
                 PublicAndInternalSymbolTargets,
-                filenamesToExclude: FilenamesToExclude),
+                filenamesToExclude: FilenamesToExclude,
+                flatten: false),
 
             // ".NET Internal Tooling",
             new TargetChannelConfig(
@@ -359,7 +365,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 FeedInternalForChecksums,
                 FeedInternalForInstallers,
                 PublicAndInternalSymbolTargets,
-                filenamesToExclude: FilenamesToExclude),
+                filenamesToExclude: FilenamesToExclude,
+                flatten: false),
 
             // ".NET Core Experimental",
             new TargetChannelConfig(
@@ -373,7 +380,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 FeedForChecksums,
                 FeedForInstallers,
                 PublicAndInternalSymbolTargets,
-                filenamesToExclude: FilenamesToExclude),
+                filenamesToExclude: FilenamesToExclude,
+                flatten: false),
 
             // ".NET Eng Services - Int",
             new TargetChannelConfig(
@@ -387,7 +395,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 FeedForChecksums,
                 FeedForInstallers,
                 PublicAndInternalSymbolTargets,
-                filenamesToExclude: FilenamesToExclude),
+                filenamesToExclude: FilenamesToExclude,
+                flatten: false),
 
             // ".NET Eng Services - Prod",
             new TargetChannelConfig(
@@ -401,7 +410,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 FeedForChecksums,
                 FeedForInstallers,
                 PublicAndInternalSymbolTargets,
-                filenamesToExclude: FilenamesToExclude),
+                filenamesToExclude: FilenamesToExclude,
+                flatten: false),
 
             // ".NET 3 Tools",
             new TargetChannelConfig(
@@ -415,7 +425,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 FeedForChecksums,
                 FeedForInstallers,
                 PublicAndInternalSymbolTargets,
-                filenamesToExclude: FilenamesToExclude),
+                filenamesToExclude: FilenamesToExclude,
+                flatten: false),
 
             // ".NET 3 Tools - Validation",
             new TargetChannelConfig(
@@ -429,7 +440,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 FeedForChecksums,
                 FeedForInstallers,
                 PublicAndInternalSymbolTargets,
-                filenamesToExclude: FilenamesToExclude),
+                filenamesToExclude: FilenamesToExclude,
+                flatten: false),
 
             // ".NET Core Tooling Dev",
             new TargetChannelConfig(
@@ -443,7 +455,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 FeedForChecksums,
                 FeedForInstallers,
                 PublicAndInternalSymbolTargets,
-                filenamesToExclude: FilenamesToExclude),
+                filenamesToExclude: FilenamesToExclude,
+                flatten: false),
 
             // ".NET Core Tooling Release",
             new TargetChannelConfig(
@@ -457,7 +470,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 FeedForChecksums,
                 FeedForInstallers,
                 PublicAndInternalSymbolTargets,
-                filenamesToExclude: FilenamesToExclude),
+                filenamesToExclude: FilenamesToExclude,
+                flatten: false),
 
             // ".NET Core 3.1 Dev",
             new TargetChannelConfig(
@@ -639,7 +653,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 FeedForChecksums,
                 FeedForInstallers,
                 PublicAndInternalSymbolTargets,
-                filenamesToExclude: FilenamesToExclude),
+                filenamesToExclude: FilenamesToExclude,
+                flatten: false),
 
             // "VS 16.7",
             new TargetChannelConfig(
@@ -653,7 +668,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 FeedForChecksums,
                 FeedForInstallers,
                 PublicAndInternalSymbolTargets,
-                filenamesToExclude: FilenamesToExclude),
+                filenamesToExclude: FilenamesToExclude,
+                flatten: false),
 
             // "VS 16.8",
             new TargetChannelConfig(
@@ -667,7 +683,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 FeedForChecksums,
                 FeedForInstallers,
                 PublicAndInternalSymbolTargets,
-                filenamesToExclude: FilenamesToExclude),
+                filenamesToExclude: FilenamesToExclude,
+                flatten: false),
 
             // "VS 16.9",
             new TargetChannelConfig(
@@ -681,7 +698,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 FeedForChecksums,
                 FeedForInstallers,
                 PublicAndInternalSymbolTargets,
-                filenamesToExclude: FilenamesToExclude),
+                filenamesToExclude: FilenamesToExclude,
+                flatten: false),
 
             // "VS 16.10",
             new TargetChannelConfig(
@@ -695,7 +713,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 FeedForChecksums,
                 FeedForInstallers,
                 PublicAndInternalSymbolTargets,
-                filenamesToExclude: FilenamesToExclude),
+                filenamesToExclude: FilenamesToExclude,
+                flatten: false),
 
             // "VS Master",
             new TargetChannelConfig(
@@ -709,7 +728,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 FeedForChecksums,
                 FeedForInstallers,
                 PublicAndInternalSymbolTargets,
-                filenamesToExclude: FilenamesToExclude),
+                filenamesToExclude: FilenamesToExclude,
+                flatten: false),
 
             // ".NET Libraries",
             new TargetChannelConfig(
@@ -723,7 +743,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 FeedForChecksums,
                 FeedForInstallers,
                 PublicAndInternalSymbolTargets,
-                filenamesToExclude: FilenamesToExclude),
+                filenamesToExclude: FilenamesToExclude,
+                flatten: false),
         };
         #endregion
     }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigV3.cs
@@ -33,6 +33,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         private List<string> FilesToExclude { get; }
 
+        private bool Flatten { get; }
+
         public SetupTargetFeedConfigV3(bool isInternalBuild,
             bool isStableBuild,
             string repositoryName,
@@ -52,7 +54,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             SymbolTargetType symbolTargetType,
         string stablePackagesFeed = null,
             string stableSymbolsFeed = null,
-            List<string> filesToExclude = null) 
+            List<string> filesToExclude = null,
+            bool flatten = true) 
             : base(isInternalBuild, isStableBuild, repositoryName, commitSha, azureStorageTargetFeedPAT, publishInstallersAndChecksums, installersTargetStaticFeed, installersAzureAccountKey, checksumsTargetStaticFeed, checksumsAzureAccountKey, azureDevOpsStaticShippingFeed, azureDevOpsStaticTransportFeed, azureDevOpsStaticSymbolsFeed, latestLinkShortUrlPrefix, azureDevOpsFeedsKey)
         {
             BuildEngine = buildEngine;
@@ -60,6 +63,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             StablePackagesFeed = stablePackagesFeed;
             SymbolTargetType = symbolTargetType;
             FilesToExclude = filesToExclude ?? new List<string>();
+            Flatten = flatten;
         }
 
         public override List<TargetFeedConfig> Setup()
@@ -105,7 +109,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         ChecksumsAzureAccountKey,
                         LatestLinkShortUrlPrefix,
                         symbolTargetType: SymbolTargetType,
-                        filenamesToExclude: FilesToExclude));
+                        filenamesToExclude: FilesToExclude,
+                        flatten: Flatten));
 
                 foreach (var contentType in Installers)
                 {
@@ -117,7 +122,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                             InstallersAzureAccountKey,
                             LatestLinkShortUrlPrefix,
                             symbolTargetType: SymbolTargetType,
-                            filenamesToExclude: FilesToExclude));
+                            filenamesToExclude: FilesToExclude,
+                            flatten: Flatten));
                 }
             }
 
@@ -128,7 +134,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     FeedType.AzureStorageFeed,
                     AzureStorageTargetFeedPAT,
                     symbolTargetType: SymbolTargetType,
-                    filenamesToExclude: FilesToExclude));
+                    filenamesToExclude: FilesToExclude,
+                    flatten: Flatten));
 
             targetFeedConfigs.Add(
                 new TargetFeedConfig(
@@ -138,7 +145,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     AzureDevOpsFeedsKey,
                     assetSelection: AssetSelection.ShippingOnly,
                     symbolTargetType: SymbolTargetType,
-                    filenamesToExclude: FilesToExclude));
+                    filenamesToExclude: FilesToExclude,
+                    flatten: Flatten));
 
             targetFeedConfigs.Add(
                 new TargetFeedConfig(
@@ -148,7 +156,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     AzureDevOpsFeedsKey,
                     assetSelection: AssetSelection.NonShippingOnly,
                     symbolTargetType: SymbolTargetType,
-                    filenamesToExclude: FilesToExclude));
+                    filenamesToExclude: FilesToExclude,
+                    flatten: Flatten));
 
             return targetFeedConfigs;
         }
@@ -165,7 +174,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     assetSelection: AssetSelection.ShippingOnly,
                     symbolTargetType: SymbolTargetType,
                     @internal: true,
-                    filenamesToExclude: FilesToExclude
+                    filenamesToExclude: FilesToExclude,
+                    flatten: Flatten
                 ),
 
                 new TargetFeedConfig(
@@ -176,7 +186,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     assetSelection: AssetSelection.NonShippingOnly,
                     symbolTargetType: SymbolTargetType,
                     @internal: true,
-                    filenamesToExclude: FilesToExclude
+                    filenamesToExclude: FilesToExclude,
+                    flatten: Flatten
                 ),
 
                 new TargetFeedConfig(
@@ -186,7 +197,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     AzureDevOpsFeedsKey,
                     symbolTargetType: SymbolTargetType,
                     @internal: true,
-                    filenamesToExclude: FilesToExclude)
+                    filenamesToExclude: FilesToExclude,
+                    flatten: Flatten)
             };
 
             if (PublishInstallersAndChecksums)
@@ -201,7 +213,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                             InstallersAzureAccountKey,
                             symbolTargetType: SymbolTargetType,
                             @internal: true,
-                            filenamesToExclude: FilesToExclude
+                            filenamesToExclude: FilesToExclude,
+                            flatten: Flatten
                         ));
                 }
 
@@ -213,7 +226,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         ChecksumsAzureAccountKey,
                         symbolTargetType: SymbolTargetType,
                         @internal: true,
-                        filenamesToExclude: FilesToExclude
+                        filenamesToExclude: FilesToExclude,
+                        flatten: Flatten
                     ));
             }
 
@@ -272,7 +286,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     assetSelection: AssetSelection.ShippingOnly,
                     symbolTargetType: SymbolTargetType,
                     isolated: true,
-                    filenamesToExclude: FilesToExclude));
+                    filenamesToExclude: FilesToExclude,
+                    flatten: Flatten));
 
             targetFeedConfigs.Add(
                 new TargetFeedConfig(
@@ -282,7 +297,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     AzureDevOpsFeedsKey,
                     symbolTargetType: SymbolTargetType,
                     isolated: true,
-                    filenamesToExclude: FilesToExclude));
+                    filenamesToExclude: FilesToExclude,
+                    flatten: Flatten));
 
             targetFeedConfigs.Add(
                 new TargetFeedConfig(
@@ -293,7 +309,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     assetSelection: AssetSelection.NonShippingOnly,
                     symbolTargetType: SymbolTargetType,
                     isolated: false,
-                    filenamesToExclude: FilesToExclude));
+                    filenamesToExclude: FilesToExclude,
+                    flatten: Flatten));
 
             if (PublishInstallersAndChecksums)
             {
@@ -309,7 +326,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                             symbolTargetType: SymbolTargetType,
                             @internal: false,
                             allowOverwrite: true,
-                            filenamesToExclude: FilesToExclude));
+                            filenamesToExclude: FilesToExclude,
+                            flatten: Flatten));
                 }
 
                 targetFeedConfigs.Add(
@@ -322,7 +340,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         symbolTargetType: SymbolTargetType,
                         @internal: false,
                         allowOverwrite: true,
-                        filenamesToExclude: FilesToExclude));
+                        filenamesToExclude: FilesToExclude,
+                        flatten: Flatten));
             }
 
             return targetFeedConfigs;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetChannelConfig.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetChannelConfig.cs
@@ -66,6 +66,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
 
         public List<string> FilenamesToExclude { get; }
 
+        public bool Flatten { get; }
+
         public TargetChannelConfig(
             int id,
             bool isInternal,
@@ -77,7 +79,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
             string checksumsFeed,
             string installersFeed,
             SymbolTargetType symbolTargetType,
-            List<string> filenamesToExclude = null)
+            List<string> filenamesToExclude = null,
+            bool flatten = true)
         {
             Id = id;
             IsInternal = isInternal;
@@ -90,6 +93,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
             InstallersFeed = installersFeed;
             SymbolTargetType = symbolTargetType;
             FilenamesToExclude = filenamesToExclude ?? new List<string>();
+            Flatten = flatten;
         }
 
         public override string ToString()
@@ -105,7 +109,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 $"\n Checksums-feed: '{ChecksumsFeed}' " +
                 $"\n SymbolTargetType: '{SymbolTargetType}' " +
                 $"\n IsInternal: '{IsInternal}'" +
-                $"\n FilenamesToExclude: \n\t{string.Join("\n\t", FilenamesToExclude)}";
+                $"\n FilenamesToExclude: \n\t{string.Join("\n\t", FilenamesToExclude)}" +
+                $"\n Flatten: '{Flatten}'";
         }
 
         public override bool Equals(object other)
@@ -120,7 +125,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                    String.Equals(ChecksumsFeed, config.ChecksumsFeed, StringComparison.OrdinalIgnoreCase) &&
                    String.Equals(InstallersFeed, config.InstallersFeed, StringComparison.OrdinalIgnoreCase) &&
                    IsInternal == config.IsInternal &&
-                   FilenamesToExclude.SequenceEqual(config.FilenamesToExclude);
+                   FilenamesToExclude.SequenceEqual(config.FilenamesToExclude) &&
+                   Flatten == config.Flatten;
         }
 
         public override int GetHashCode()
@@ -135,6 +141,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 ChecksumsFeed, 
                 InstallersFeed,
                 SymbolTargetType,
+                Flatten,
                 string.Join(" ", FilenamesToExclude)).GetHashCode();
         }
     }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetFeedConfig.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetFeedConfig.cs
@@ -54,6 +54,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
 
         public List<string> FilenamesToExclude { get; }
 
+        public bool Flatten { get; }
+
         public TargetFeedConfig(TargetFeedContentType contentType, 
             string targetURL, 
             FeedType type, 
@@ -64,7 +66,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
             bool @internal = false, 
             bool allowOverwrite = false, 
             SymbolTargetType symbolTargetType = SymbolTargetType.None, 
-            List<string> filenamesToExclude = null)
+            List<string> filenamesToExclude = null,
+            bool flatten = true)
         {
             ContentType = contentType;
             TargetURL = targetURL;
@@ -77,6 +80,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
             LatestLinkShortUrlPrefix = latestLinkShortUrlPrefix ?? string.Empty;
             SymbolTargetType = symbolTargetType;
             FilenamesToExclude = filenamesToExclude ?? new List<string>();
+            Flatten = flatten;
         }
 
         public override bool Equals(object obj)
@@ -92,12 +96,13 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 (Isolated == other.Isolated) &&
                 (Internal == other.Internal) &&
                 (AllowOverwrite == other.AllowOverwrite) &&
-                FilenamesToExclude.SequenceEqual(other.FilenamesToExclude);
+                FilenamesToExclude.SequenceEqual(other.FilenamesToExclude) &&
+                (Flatten == other.Flatten);
         }
 
         public override int GetHashCode()
         {
-            return (ContentType, Type, AssetSelection, Isolated, Internal, AllowOverwrite, LatestLinkShortUrlPrefix, TargetURL, Token, string.Join(" ", FilenamesToExclude)).GetHashCode();
+            return (ContentType, Type, AssetSelection, Isolated, Internal, AllowOverwrite, LatestLinkShortUrlPrefix, TargetURL, Token, Flatten, string.Join(" ", FilenamesToExclude)).GetHashCode();
         }
 
         public override string ToString()
@@ -111,7 +116,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 $"\n AllowOverwrite? '{AllowOverwrite}' " +
                 $"\n ShortUrlPrefix: '{LatestLinkShortUrlPrefix}' " +
                 $"\n TargetURL: '{TargetURL}'" +
-                $"\n FilenamesToExclude: \n\t{string.Join("\n\t", FilenamesToExclude)}";
+                $"\n FilenamesToExclude: \n\t{string.Join("\n\t", FilenamesToExclude)}" +
+                $"\n Flatten: '{Flatten}'";
         }
     }
 


### PR DESCRIPTION
This will change our aka.ms links to be much shorter. Instead of `aka.ms/dotnet/<channel>/<quality>/bar/biz/baz/file.ext`, the short link will now be `aka.ms/dotnet/<channel>/<quality>/file.ext`.

Testing: https://dev.azure.com/dnceng/internal/_build/results?buildId=987994&view=logs&j=ba23343f-f710-5af9-782d-5bd26b102304&t=6e277ba4-1c1e-552d-b96f-db0aeb4be20a&l=313