### PR TITLE
Fix aka.ms short link when no AkaMSChannelName is supplied

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
@@ -136,6 +136,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                     Log.LogMessage(MessageImportance.High, $"Publishing to this target channel: {targetChannelConfig}");
 
+                    string shortLinkUrl = string.IsNullOrEmpty(targetChannelConfig.AkaMSChannelName) ?
+                        $"dotnet/" : $"dotnet/{targetChannelConfig.AkaMSChannelName}/{BuildQuality}";
+
                     var targetFeedsSetup = new SetupTargetFeedConfigV3(
                         targetChannelConfig.IsInternal,
                         BuildModel.Identity.IsStable,
@@ -150,7 +153,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         targetChannelConfig.ShippingFeed,
                         targetChannelConfig.TransportFeed,
                         targetChannelConfig.SymbolsFeed,
-                        $"dotnet/{targetChannelConfig.AkaMSChannelName}/{BuildQuality}",
+                        shortLinkUrl,
                         AzureDevOpsFeedsKey,
                         BuildEngine = this.BuildEngine,
                         targetChannelConfig.SymbolTargetType,


### PR DESCRIPTION
When no channel name was supplied (it was string.Empty), we would create invalid links. This change reverts back to the original behavior when no channel name is supplied.

Fixes https://github.com/dotnet/arcade/issues/6940.