### PR TITLE
Don't force aspnetcore-runtime when <DotNetCliPackageType> is set in XHarnessRunner

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
@@ -4,7 +4,7 @@
     <!-- We then invoke the CLI DLL directly using .NET runtime without the need for .NET SDK -->
     <IncludeDotNetCli>true</IncludeDotNetCli>
     <IncludeXHarnessCli>true</IncludeXHarnessCli>
-    <DotNetCliPackageType>aspnetcore-runtime</DotNetCliPackageType>
+    <DotNetCliPackageType Condition="'$(DotNetCliPackageType)' != 'sdk'">aspnetcore-runtime</DotNetCliPackageType>
     <DotNetCliVersion>3.1.5</DotNetCliVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
There are certain scenarios where we want both xharness and a full sdk. This fix corrects the
problem where aspnetcore-runtime is pulled instead.