### PR TITLE
Don't force version when <DotNetCliVersion> is set in XharnessRunner

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
@@ -5,7 +5,7 @@
     <IncludeDotNetCli>true</IncludeDotNetCli>
     <IncludeXHarnessCli>true</IncludeXHarnessCli>
     <DotNetCliPackageType Condition="'$(DotNetCliPackageType)' != 'sdk'">aspnetcore-runtime</DotNetCliPackageType>
-    <DotNetCliVersion>3.1.5</DotNetCliVersion>
+    <DotNetCliVersion Condition="'$(DotNetCliVersion)' == ''">3.1.5</DotNetCliVersion>
   </PropertyGroup>
 
   <Target Name="AddXHarnessCli"


### PR DESCRIPTION
If we allow sdk as an option, the existing version is not valid. This change gives the ability to set their own.