### PR TITLE
ArPow: Add supplemental intermediate nupkg infra

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
@@ -15,7 +15,7 @@
           Condition="'$(ArcadeInnerBuildFromSource)' != 'true'"
           DependsOnTargets="
             ReportPrebuiltUsage;
-            PackSourceBuildIntermediateNupkg" />
+            PackSourceBuildIntermediateNupkgs" />
 
   <Target Name="WritePrebuiltUsageData">
     <ItemGroup>
@@ -73,39 +73,80 @@
   </Target>
 
   <!--
-    Create a source-build intermediate NuGet package for dependency transport.
+    Copies the intermediate nupkg project to 'artifacts/' so the repo's global.json is in an
+    ancestor dir. This helps ensure the same version of Arcade is used throughout the build.
   -->
-  <Target Name="PackSourceBuildIntermediateNupkg"
-          DependsOnTargets="GetSourceBuildIntermediateNupkgNameConvention">
+  <Target Name="CopyIntermediateNupkgProjToProjectDirectory">
     <PropertyGroup>
       <SourceBuildIntermediateProjFile>$(MSBuildThisFileDirectory)SourceBuildIntermediate.proj</SourceBuildIntermediateProjFile>
       <SourceBuildIntermediateProjTargetFile>$(ArtifactsObjDir)ArcadeGeneratedProjects\SourceBuildIntermediate\SourceBuildIntermediate.proj</SourceBuildIntermediateProjTargetFile>
     </PropertyGroup>
 
-    <!-- Find the repository's global LICENSE file to apply. -->
-    <Microsoft.DotNet.Arcade.Sdk.GetLicenseFilePath
-      Condition="'$(DetectSourceBuildIntermediateNupkgLicense)' == 'true'"
-      Directory="$(RepoRoot)">
-      <Output TaskParameter="Path" PropertyName="SourceBuildIntermediateNupkgLicenseFile"/>
-    </Microsoft.DotNet.Arcade.Sdk.GetLicenseFilePath>
-
-    <!-- Copy the project to artifacts/ so that the repo's global.json is in an ancestor dir. -->
     <Copy
       SourceFiles="$(SourceBuildIntermediateProjFile)"
       DestinationFiles="$(SourceBuildIntermediateProjTargetFile)" />
 
-    <ItemGroup>
-      <SourceBuildIntermediatePackTarget Include="Restore;Pack" />
-    </ItemGroup>
-
+    <!-- Run a restore so the SDK doesn't complain. Nothing should actually get restored. -->
     <MSBuild
       Projects="$(SourceBuildIntermediateProjTargetFile)"
-      Targets="%(SourceBuildIntermediatePackTarget.Identity)"
+      Targets="Restore"
+      Properties="
+        SourceBuildArcadeTargetsFile=$(MSBuildThisFileDirectory)SourceBuildArcade.targets;
+        " />
+  </Target>
+
+  <Target Name="GetLicenseFileForIntermediateNupkgPack"
+          Condition="'$(DetectSourceBuildIntermediateNupkgLicense)' == 'true'">
+    <!-- Find the repository's global LICENSE file to apply. -->
+    <Microsoft.DotNet.Arcade.Sdk.GetLicenseFilePath Directory="$(RepoRoot)">
+      <Output TaskParameter="Path" PropertyName="DetectedLicenseFile"/>
+    </Microsoft.DotNet.Arcade.Sdk.GetLicenseFilePath>
+
+    <!-- Copy it to a file with '.txt' extension to avoid running into this NuGet problem: https://github.com/NuGet/Home/issues/7601 -->
+    <PropertyGroup>
+      <SourceBuildIntermediateNupkgLicenseFile>$(ArtifactsObjDir)ArcadeGeneratedProjects\SourceBuildIntermediate\LICENSE.txt</SourceBuildIntermediateNupkgLicenseFile>
+    </PropertyGroup>
+
+    <Copy
+      SourceFiles="$(DetectedLicenseFile)"
+      DestinationFiles="$(SourceBuildIntermediateNupkgLicenseFile)" />
+  </Target>
+
+  <!--
+    Create source-build intermediate NuGet package and supplemental intermediate NuGet packages (if
+    necessary) for dependency transport to downstream repos.
+  -->
+  <Target Name="PackSourceBuildIntermediateNupkgs"
+          DependsOnTargets="
+            CopyIntermediateNupkgProjToProjectDirectory;
+            GetLicenseFileForIntermediateNupkgPack;
+            GetCategorizedIntermediateNupkgContents;
+            GetSourceBuildIntermediateNupkgNameConvention">
+    <ItemGroup>
+      <IntermediateNupkgProject Include="$(SourceBuildIntermediateProjFile)" />
+
+      <IntermediateNupkgProject
+        Include="$(SourceBuildIntermediateProjFile)"
+        AdditionalProperties="
+          SupplementalIntermediateNupkgCategory=%(SupplementalIntermediateNupkgCategory.Identity)" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <IntermediateNupkgBuildMessage>Building intermediate nupkg</IntermediateNupkgBuildMessage>
+      <IntermediateNupkgBuildMessage>$(IntermediateNupkgBuildMessage), and supplemental nupkgs for @(SupplementalIntermediateNupkgCategory, ', ')</IntermediateNupkgBuildMessage>
+    </PropertyGroup>
+
+    <Message Importance="High" Text="$(IntermediateNupkgBuildMessage)..." />
+
+    <MSBuild
+      Projects="@(IntermediateNupkgProject)"
+      Targets="Pack"
       Properties="
         CurrentRepoSourceBuildArtifactsPackagesDir=$(CurrentRepoSourceBuildArtifactsPackagesDir);
         SourceBuildArcadeTargetsFile=$(MSBuildThisFileDirectory)SourceBuildArcade.targets;
         SourceBuildIntermediateNupkgLicenseFile=$(SourceBuildIntermediateNupkgLicenseFile);
-        " />
+        "
+      BuildInParallel="true"/>
   </Target>
 
   <Import Project="SourceBuildArcade.targets" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -26,6 +26,8 @@
 
     <!-- By default, use the license file from the root of the repo for the intermediate nupkg. -->
     <DetectSourceBuildIntermediateNupkgLicense Condition="'$(DetectSourceBuildIntermediateNupkgLicense)' == ''">true</DetectSourceBuildIntermediateNupkgLicense>
+
+    <EnableDefaultSourceBuildIntermediateItems Condition="'$(EnableDefaultSourceBuildIntermediateItems)' == ''">true</EnableDefaultSourceBuildIntermediateItems>
   </PropertyGroup>
 
   <Target Name="GetSourceBuildIntermediateNupkgNameConvention">
@@ -55,6 +57,43 @@
       <SourceBuildIntermediateNupkgPrefix>Microsoft.SourceBuild.Intermediate.</SourceBuildIntermediateNupkgPrefix>
       <SourceBuildIntermediateNupkgSuffix Condition="'$(SourceBuildIntermediateNupkgRid)' != ''">.$(SourceBuildIntermediateNupkgRid)</SourceBuildIntermediateNupkgSuffix>
     </PropertyGroup>
+  </Target>
+
+  <!--
+    Get the list of nupkg contents, categorized into supplemental categories if necessary. By
+    default, all non-symbol-package nupkg files and tar.gz files in
+    'artifacts/packages/{configuration}' are packed in the intermediate nupkg.
+
+    To configure this, add a target to eng/SourceBuild.props with
+    'BeforeTargets="GetCategorizedIntermediateNupkgContents"' that sets up
+    'IntermediateNupkgArtifactFile' items with optional 'Category' metadata.
+
+    When 'Category' is set, this tooling produces one supplemental intermediate nupkg per named
+    category. All files not in a category are put into the "main" intermediate nupkg.
+  -->
+  <Target Name="GetCategorizedIntermediateNupkgContents">
+    <ItemGroup Condition="'$(EnableDefaultSourceBuildIntermediateItems)' == 'true'">
+      <!-- Catch-all: anything not in a category gets packed in the 'main' intermediate nupkg. -->
+      <IntermediateNupkgArtifactFile Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)**\*.nupkg" />
+      <IntermediateNupkgArtifactFile Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)**\*.tar.gz" />
+      <!-- Don't pack any symbol packages: not needed for downstream source-build CI. -->
+      <IntermediateNupkgArtifactFile Remove="$(CurrentRepoSourceBuildArtifactsPackagesDir)**\*.symbols.nupkg" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <IntermediateNupkgFile Include="@(IntermediateNupkgArtifactFile)" PackagePath="artifacts" />
+
+      <!-- Report goes into the 'main' intermediate nupkg. -->
+      <IntermediateNupkgFile Include="$(SourceBuildSelfPrebuiltReportDir)**\*" PackagePath="prebuilt-report" />
+    </ItemGroup>
+
+    <RemoveDuplicates Inputs="@(IntermediateNupkgFile)">
+      <Output TaskParameter="Filtered" ItemName="IntermediatePackageFile" />
+    </RemoveDuplicates>
+
+    <ItemGroup>
+      <SupplementalIntermediateNupkgCategory Include="%(IntermediatePackageFile.Category)" />
+    </ItemGroup>
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
@@ -24,8 +24,6 @@
     <!-- NuGet excludes nupkgs by default: disable this behavior. -->
     <NoDefaultExcludes>true</NoDefaultExcludes>
 
-    <EnableDefaultSourceBuildIntermediateItems Condition="'$(EnableDefaultSourceBuildIntermediateItems)' == ''">true</EnableDefaultSourceBuildIntermediateItems>
-
     <!-- Arbitrary TargetFramework to appease SDK. -->
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
@@ -38,20 +36,45 @@
     <None Include="$(SourceBuildIntermediateNupkgLicenseFile)" Pack="true" PackagePath="$(PackageLicenseFile)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(EnableDefaultSourceBuildIntermediateItems)' == 'true'">
-    <Content Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)**\*.nupkg" PackagePath="artifacts" />
-    <Content Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)**\*.tar.gz" PackagePath="artifacts" />
-    <Content Include="$(SourceBuildSelfPrebuiltReportDir)**\*" PackagePath="prebuilt-report" />
-  </ItemGroup>
-
   <Target Name="InitializeSourceBuildIntermediatePackageId"
           DependsOnTargets="GetSourceBuildIntermediateNupkgNameConvention"
           BeforeTargets="GenerateNuspec;InitializeStandardNuspecProperties">
     <Error Condition="'$(GitHubRepositoryName)' == ''" Text="GitHubRepositoryName property is not defined." />
 
     <PropertyGroup>
-      <PackageId>$(SourceBuildIntermediateNupkgPrefix)$(GitHubRepositoryName)$(SourceBuildIntermediateNupkgSuffix)</PackageId>
+      <PackageId>$(GitHubRepositoryName)</PackageId>
+      <PackageId Condition="'$(SupplementalIntermediateNupkgCategory)' != ''">$(PackageId).$(SupplementalIntermediateNupkgCategory)</PackageId>
+
+      <PackageId>$(SourceBuildIntermediateNupkgPrefix)$(PackageId)$(SourceBuildIntermediateNupkgSuffix)</PackageId>
     </PropertyGroup>
+  </Target>
+
+  <Target Name="GetIntermediateNupkgArtifactFiles"
+          DependsOnTargets="
+            GetCategorizedIntermediateNupkgContents;
+            GetSupplementalIntermediateNupkgManifest"
+          BeforeTargets="_GetPackageFiles">
+    <ItemGroup>
+      <Content Include="@(IntermediatePackageFile->WithMetadataValue('Category', '$(SupplementalIntermediateNupkgCategory)'))" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="GetSupplementalIntermediateNupkgManifest"
+          Condition="'$(SupplementalIntermediateNupkgCategory)' == ''"
+          DependsOnTargets="InitializeSourceBuildIntermediatePackageId">
+    <PropertyGroup>
+      <SupplementalIntermediateNupkgManifestFile>$(BaseOutputPath)SupplementalIntermediatePackages.txt</SupplementalIntermediateNupkgManifestFile>
+    </PropertyGroup>
+
+    <WriteLinesToFile
+      File="$(SupplementalIntermediateNupkgManifestFile)"
+      Lines="@(SupplementalIntermediateNupkgCategory->'$(SourceBuildIntermediateNupkgPrefix)$(GitHubRepositoryName).%(Identity)$(SourceBuildIntermediateNupkgSuffix)', '%0A')"
+      Overwrite="true" />
+
+    <ItemGroup>
+      <!-- The list of supplemental package ids goes into the "main" intermediate nupkg. -->
+      <Content Include="$(SupplementalIntermediateNupkgManifestFile)" PackagePath="." />
+    </ItemGroup>
   </Target>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />


### PR DESCRIPTION
Adds infra that lets the repo chop up artifacts into categories that are placed in supplemental intermediate nupkgs, to avoid hitting a 500 MB cap that AzDO has declared for its feeds. (I got error responses when I tried to upload ~422 MB packages, so there seems to be a lower unknown soft cap, too.)

Resolves https://github.com/dotnet/source-build/issues/2034.

Design doc at: https://github.com/dotnet/source-build/blob/master/Documentation/planning/arcade-powered-source-build/intermediate-nupkg.md#too-large

I also threw in the workaround for a NuGet issue when the license file is called `LICENSE` with no extension.
Resolves https://github.com/dotnet/source-build/issues/2048.

I tested this in my dotnet/runtime ArPow WIP changes. Usage looks like this:
https://github.com/dagood/runtime/blob/d6602eb37d88007d49acabb5b7a4890a2031f6c5/eng/SourceBuild.props#L97-L140

/cc @omajid 