### PR TITLE
Update codeanalysis for genfacades to support new language features

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -26,7 +26,7 @@
     <MicrosoftBuildUtilitiesCoreVersion>15.7.179</MicrosoftBuildUtilitiesCoreVersion>
     <MicrosoftCodeAnalysisAnalyzersVersion>2.6.3</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisCSharpVersion>2.9.0</MicrosoftCodeAnalysisCSharpVersion>
-    <MsbuildTaskMicrosoftCodeAnalysisCSharpVersion>3.4.0</MsbuildTaskMicrosoftCodeAnalysisCSharpVersion>
+    <MsbuildTaskMicrosoftCodeAnalysisCSharpVersion>3.8.0</MsbuildTaskMicrosoftCodeAnalysisCSharpVersion>
     <MicrosoftIdentityModelClientsActiveDirectoryVersion>3.17.2</MicrosoftIdentityModelClientsActiveDirectoryVersion>
     <MicrosoftRestClientRuntimeVersion>2.3.13</MicrosoftRestClientRuntimeVersion>
     <MicrosoftExtensionsDependencyModelVersion>2.1.0</MicrosoftExtensionsDependencyModelVersion>

--- a/src/Microsoft.DotNet.GenFacades/Microsoft.DotNet.GenFacades.csproj
+++ b/src/Microsoft.DotNet.GenFacades/Microsoft.DotNet.GenFacades.csproj
@@ -13,8 +13,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" Publish="false" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" Publish="false" />
-    <!-- Microsoft.CodeAnalysis is also loaded by the msbuild. So this version should match the msbuild version of the assembly. -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MsbuildTaskMicrosoftCodeAnalysisCSharpVersion)" ExcludeAssets="analyzers" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(DotNetBuildOffline)' == 'true'">
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.GenFacades/Microsoft.DotNet.GenFacades.csproj
+++ b/src/Microsoft.DotNet.GenFacades/Microsoft.DotNet.GenFacades.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MsbuildTaskMicrosoftCodeAnalysisCSharpVersion)" ExcludeAssets="analyzers" />
   </ItemGroup>
 
+  <!-- When building offline we need to bump the version of System.Reflection.Metadata that CodeAnalysis package depends on to match what the source build tarball expects. -->
   <ItemGroup Condition="'$(DotNetBuildOffline)' == 'true'">
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
   </ItemGroup>
@@ -28,15 +29,6 @@
     <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Version="4.0.0" />
     <PackageReference Include="System.Diagnostics.FileVersionInfo" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
-  </ItemGroup>
-
-  <!--
-    In the source-build tarball build, Microsoft.CodeAnalysis.CSharp has dependencies on old
-    versions of these packages due to repo build order. Override to lift them to the versions passed
-    in via DotNetPackageVersionPropsPath.
-  -->
-  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
-    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">


### PR DESCRIPTION
Currently if someone tries to use C# 9.0 language features genfacades doesn't parse the syntax tree correctly and could lead to problems, i.e, when adding an attribute to a local function in `PriorityQueue` it causes the parent of `PriorityQueue.UnorderedItemsCollection` to be a `CompilationUnitSyntax` instead of a `ClassDeclarationSyntax`, causing:

```
C:\Users\safern\.nuget\packages\microsoft.dotnet.genfacades\6.0.0-dev\build\Microsoft.DotNet.GenPartialFacadeSource.targets(30,5): error : Unable to cast object of type 'Microsoft.CodeAnalysis.CSharp.Syntax.CompilationUnitSyntax' to type 'Microsoft.CodeAnalysis.CSharp.Syntax.BaseTypeDeclarationSyntax'. [C:\repos\runtime\src\libraries\System.Collections\src\System.Collections.csproj]
```

I tested this on dotnet/runtime and apparently now MSBuild loads tasks in it's own AssemblyLoadContext so now we don't have the restriction of matching the roslyn version that MSBuild depends on. This was fixed on: https://github.com/dotnet/msbuild/pull/4916

cc: @ericstj @stephentoub @Anipik 