### PR TITLE
Fix signing merge

### DIFF
--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -18,6 +18,8 @@ variables:
       value: False
     - name: _RunAsInternal
       value: True
+    - name: _SignType
+      value: real
     # DotNet-Blob-Feed provides: dotnetfeed-storage-access-key-1
     # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
     # DotNet-HelixApi-Access provides: HelixApiAccessToken
@@ -26,6 +28,9 @@ variables:
     - group: DotNet-HelixApi-Access
     - group: SDL_Settings
     - name: _InternalBuildArgs
-      value: /p:TeamName=$(_TeamName)
+      value: /p:DotNetSignType=$(_SignType)
+        /p:TeamName=$(_TeamName)
         /p:DotNetPublishUsingPipelines=true
         /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+    - name: PostBuildSign
+      value: true


### PR DESCRIPTION
In #6969 , I accidentally pushed a change that I thought I was only validating via official builds.  I didn't intend for this to actually go into the PR.  We opted to go with the route of using "postbuildsign=true" instead of removing signing entirely.  This change fixes the unintentional push which got merged and resulted in https://dev.azure.com/dnceng/internal/_build/results?buildId=1001483&view=logs&j=fa59fe4e-195c-56fa-189b-58fd241f10dd&t=afa1ce5e-d2bc-56f3-ad78-7883f25a3e3a