### PR TITLE
Support the stage0 alternate runtime source scenario in release/3.x

### DIFF
--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -22,6 +22,8 @@ Param(
   [switch] $ci,
   [switch] $prepareMachine,
   [switch] $help,
+  [string] $runtimeSourceFeed = "",
+  [string] $runtimeSourceFeedKey = "",
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 
@@ -29,33 +31,35 @@ Param(
 
 function Print-Usage() {
     Write-Host "Common settings:"
-    Write-Host "  -configuration <value>  Build configuration: 'Debug' or 'Release' (short: -c)"
-    Write-Host "  -platform <value>       Platform configuration: 'x86', 'x64' or any valid Platform value to pass to msbuild"
-    Write-Host "  -verbosity <value>      Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
-    Write-Host "  -binaryLog              Output binary log (short: -bl)"
-    Write-Host "  -help                   Print help and exit"
+    Write-Host "  -configuration <value>        Build configuration: 'Debug' or 'Release' (short: -c)"
+    Write-Host "  -platform <value>             Platform configuration: 'x86', 'x64' or any valid Platform value to pass to msbuild"
+    Write-Host "  -verbosity <value>            Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
+    Write-Host "  -binaryLog                    Output binary log (short: -bl)"
+    Write-Host "  -help                         Print help and exit"
     Write-Host ""
 
     Write-Host "Actions:"
-    Write-Host "  -restore                Restore dependencies (short: -r)"
-    Write-Host "  -build                  Build solution (short: -b)"
-    Write-Host "  -rebuild                Rebuild solution"
-    Write-Host "  -deploy                 Deploy built VSIXes"
-    Write-Host "  -deployDeps             Deploy dependencies (e.g. VSIXes for integration tests)"
-    Write-Host "  -test                   Run all unit tests in the solution (short: -t)"
-    Write-Host "  -integrationTest        Run all integration tests in the solution"
-    Write-Host "  -performanceTest        Run all performance tests in the solution"
-    Write-Host "  -pack                   Package build outputs into NuGet packages and Willow components"
-    Write-Host "  -sign                   Sign build outputs"
-    Write-Host "  -publish                Publish artifacts (e.g. symbols)"
+    Write-Host "  -restore                      Restore dependencies (short: -r)"
+    Write-Host "  -build                        Build solution (short: -b)"
+    Write-Host "  -rebuild                      Rebuild solution"
+    Write-Host "  -deploy                       Deploy built VSIXes"
+    Write-Host "  -deployDeps                   Deploy dependencies (e.g. VSIXes for integration tests)"
+    Write-Host "  -test                         Run all unit tests in the solution (short: -t)"
+    Write-Host "  -integrationTest              Run all integration tests in the solution"
+    Write-Host "  -performanceTest              Run all performance tests in the solution"
+    Write-Host "  -pack                         Package build outputs into NuGet packages and Willow components"
+    Write-Host "  -sign                         Sign build outputs"
+    Write-Host "  -publish                      Publish artifacts (e.g. symbols)"
     Write-Host ""
 
     Write-Host "Advanced settings:"
-    Write-Host "  -projects <value>       Semi-colon delimited list of sln/proj's to build. Globbing is supported (*.sln)"
-    Write-Host "  -ci                     Set when running on CI server"
-    Write-Host "  -prepareMachine         Prepare machine for CI run, clean up processes after build"
-    Write-Host "  -warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
-    Write-Host "  -msbuildEngine <value>  Msbuild engine to use to run build ('dotnet', 'vs', or unspecified)."
+    Write-Host "  -projects <value>             Semi-colon delimited list of sln/proj's to build. Globbing is supported (*.sln)"
+    Write-Host "  -ci                           Set when running on CI server"
+    Write-Host "  -prepareMachine               Prepare machine for CI run, clean up processes after build"
+    Write-Host "  -warnAsError <value>          Sets warnaserror msbuild parameter ('true' or 'false')"
+    Write-Host "  -msbuildEngine <value>        Msbuild engine to use to run build ('dotnet', 'vs', or unspecified)."
+    Write-Host "  -runtimeSourceFeed <value>    Alternate feed source for restoring .NET Runtimes and SDKs"
+    Write-Host "  -runtimeSourceFeedKey <value> Key value for non-public values of runtimeSourceFeed"
     Write-Host ""
 
     Write-Host "Command line arguments not listed above are passed thru to msbuild."
@@ -75,7 +79,7 @@ function InitializeCustomToolset {
 }
 
 function Build {
-  $toolsetBuildProj = InitializeToolset
+  $toolsetBuildProj = InitializeToolset -runtimeSourceFeed $runtimeSourceFeed -runtimeSourceFeedKey $runtimeSourceFeedKey
   InitializeCustomToolset
 
   $bl = if ($binaryLog) { "/bl:" + (Join-Path $LogDir "Build.binlog") } else { "" }

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -29,11 +29,14 @@ usage()
   echo ""
 
   echo "Advanced settings:"
-  echo "  --projects <value>       Project or solution file(s) to build"
-  echo "  --ci                     Set when running on CI server"
-  echo "  --prepareMachine         Prepare machine for CI run, clean up processes after build"
-  echo "  --nodeReuse <value>      Sets nodereuse msbuild parameter ('true' or 'false')"
-  echo "  --warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
+  echo "  --projects <value>             Project or solution file(s) to build"
+  echo "  --ci                           Set when running on CI server"
+  echo "  --prepareMachine               Prepare machine for CI run, clean up processes after build"
+  echo "  --nodeReuse <value>            Sets nodereuse msbuild parameter ('true' or 'false')"
+  echo "  --warnAsError <value>          Sets warnaserror msbuild parameter ('true' or 'false')"
+  echo "  --runtimeSourceFeed <value>    Alternate (fallback) source for .NET Runtime and SDK installation"
+  echo "  --runtimeSourceFeedKey <value> Credentials (if needed) for authenticating to runtimeSourceFeed"
+
   echo ""
   echo "Command line arguments not listed above are passed thru to msbuild."
   echo "Arguments can also be passed in with a single hyphen."
@@ -72,6 +75,9 @@ projects=''
 configuration='Debug'
 prepare_machine=false
 verbosity='minimal'
+
+runtimeSourceFeed=''
+runtimeSourceFeedKey=''
 
 properties=''
 
@@ -141,6 +147,14 @@ while [[ $# > 0 ]]; do
       node_reuse=$2
       shift
       ;;
+    -runtimesourcefeed)
+      shift
+      runtimeSourceFeed="$1"
+      ;;
+    -runtimesourcefeedkey)
+      shift
+      runtimeSourceFeedKey="$1"
+      ;;
     *)
       properties="$properties $1"
       ;;
@@ -166,7 +180,7 @@ function InitializeCustomToolset {
 }
 
 function Build {
-  InitializeToolset
+  InitializeToolset $runtimeSourceFeed $runtimeSourceFeedKey
   InitializeCustomToolset
 
   if [[ ! -z "$projects" ]]; then


### PR DESCRIPTION
See https://github.com/dotnet/core-eng/issues/12213 for context

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation (these scripts, at least in their default usage, are required for all PR builds to work)

See [this pipeline execution](https://dev.azure.com/dnceng/internal/_build/results?buildId=1002276&view=logs&j=b4dcca9f-d001-5fb0-d8cc-ac6beba145d5) for an example of this functionality working with a private runtime/ sdk source for ASP .NET Core Tooling repo