### PR TITLE
New netcorenativeassets location of iOS apps

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.props
@@ -8,6 +8,6 @@
     <XHarnessPackageSource Condition=" '$(XHarnessPackageSource)' == '' ">https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet-eng/nuget/v3/index.json</XHarnessPackageSource>
 
     <!-- Needed for app signing and tied to certificates installed in Helix machines -->
-    <XHarnessAppleProvisioningProfileUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/ios/NET_Apple_Development_iOS.mobileprovision</XHarnessAppleProvisioningProfileUrl>
+    <XHarnessAppleProvisioningProfileUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/macos/signing/NET_Apple_Development_iOS.mobileprovision</XHarnessAppleProvisioningProfileUrl>
   </PropertyGroup>
 </Project>

--- a/tests/XHarness/XHarness.RunAppBundle.Device.proj
+++ b/tests/XHarness/XHarness.RunAppBundle.Device.proj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <XHarnessRunAppBundleName>HelloiOS.app</XHarnessRunAppBundleName>
-    <XHarnessRunAppBundleUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/macos/test-ios-app/$(XHarnessRunAppBundleName).iPhone.unsigned.zip</XHarnessRunAppBundleUrl>
+    <XHarnessRunAppBundleUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/ios/test-app/ios-device/$(XHarnessRunAppBundleName).unsigned.zip</XHarnessRunAppBundleUrl>
   </PropertyGroup>
 
   <!-- We're not set up currently to build app bundles as part of normal builds, so this downloads existing ones for now -->

--- a/tests/XHarness/XHarness.RunAppBundle.proj
+++ b/tests/XHarness/XHarness.RunAppBundle.proj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <XHarnessRunAppBundleName>HelloiOS.app</XHarnessRunAppBundleName>
-    <XHarnessRunAppBundleUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/macos/test-ios-app/$(XHarnessRunAppBundleName).zip</XHarnessRunAppBundleUrl>
+    <XHarnessRunAppBundleUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/ios/test-app/ios-simulator-64/$(XHarnessRunAppBundleName).zip</XHarnessRunAppBundleUrl>
   </PropertyGroup>
 
   <!-- We're not set up currently to build app bundles as part of normal builds, so this downloads existing ones for now -->

--- a/tests/XHarness/XHarness.TestAppBundle.proj
+++ b/tests/XHarness/XHarness.TestAppBundle.proj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <XHarnessTestAppBundleName>System.Numerics.Vectors.Tests.app</XHarnessTestAppBundleName>
-    <XHarnessTestAppBundleUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/ios/test-app/$(XHarnessTestAppBundleName).zip</XHarnessTestAppBundleUrl>
+    <XHarnessTestAppBundleUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/ios/test-app/ios-simulator-64/$(XHarnessTestAppBundleName).zip</XHarnessTestAppBundleUrl>
   </PropertyGroup>
 
   <!-- We're not set up currently to build app bundles as part of normal builds, so this downloads existing ones for now -->

--- a/tests/XHarness/XHarness.TestAppBundle.proj
+++ b/tests/XHarness/XHarness.TestAppBundle.proj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <XHarnessTestAppBundleName>System.Numerics.Vectors.Tests.app</XHarnessTestAppBundleName>
-    <XHarnessTestAppBundleUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/macos/test-ios-app/$(XHarnessTestAppBundleName).zip</XHarnessTestAppBundleUrl>
+    <XHarnessTestAppBundleUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/ios/test-app/$(XHarnessTestAppBundleName).zip</XHarnessTestAppBundleUrl>
   </PropertyGroup>
 
   <!-- We're not set up currently to build app bundles as part of normal builds, so this downloads existing ones for now -->


### PR DESCRIPTION
Since the number of platforms we test grow, I am making it more clear where to find different apps and what platform these apps are for. Follows the pattern of Android apks too.
