### PR TITLE
Removed unused wix preprocessor variables

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets
@@ -176,8 +176,6 @@
       <LocDirName Include="$([System.String]::new('%(LocFile.RecursiveDir)').TrimEnd('\'))" />
 
       <CandleVariables Include="DisplayVersion" Value="$(MajorVersion).$(MinorVersion).$(PatchVersion).$(BuildNumberMajor)" />
-      <CandleVariables Include="ProductBandVersion" Value="$(MajorVersion).$(MinorVersion)" />
-      <CandleVariables Include="FrameworkDisplayVersion" Value="$(ProductVersion)" />
       <CandleVariables Include="LcidList" Value="@(LocDirName)" />
       <CandleVariables Include="BundleThmDir" Value="$(BundleThemeDirectory)" />
 


### PR DESCRIPTION
These wix preprocessor variables aren't used in the wix files and also did an org wide search which doesn't show any hits.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
