### PR TITLE
Add options to be able to specify specific feeds for PublishArtifactsInManifest

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
@@ -93,6 +93,12 @@
       <InternalInstallersFeedKey>$(InternalInstallersAzureAccountKey)</InternalInstallersFeedKey>
       <ChecksumsFeedKey>$(ChecksumsAzureAccountKey)</ChecksumsFeedKey>
       <InternalChecksumsFeedKey>$(InternalChecksumsAzureAccountKey)</InternalChecksumsFeedKey>
+      <UseSpecifiedFeeds Condition="'$(UseSpecifiedFeeds)' == ''">false</UseSpecifiedFeeds>
+      <InstallersFeed>$(InstallersFeed)</InstallersFeed>
+      <ChecksumsFeed>$(ChecksumsFeed)</ChecksumsFeed>
+      <TransportFeed>$(TransportFeed)</TransportFeed>
+      <ShippingFeed>$(ShippingFeed)</ShippingFeed>
+      <SymbolsFeed>$(SymbolsFeed)</SymbolsFeed>
     </PropertyGroup>
 
     <Error
@@ -131,7 +137,13 @@
       SymbolPublishingExclusionsFile="$(SymbolPublishingExclusionsFile)"
       PdbArtifactsBasePath="$(PDBArtifactsBasePath)"
       PublishSpecialClrFiles="$(PublishSpecialClrFiles)"
-      BuildQuality="$(BuildQuality)" />
+      BuildQuality="$(BuildQuality)"
+      UseSpecifiedFeeds="$(UseSpecifiedFeeds)"
+      InstallersFeed="$(InstallersFeed)"
+      ChecksumsFeed="$(ChecksumsFeed)"
+      TransportFeed="$(TransportFeed)"
+      ShippingFeed="$(ShippingFeed)"
+      SymbolsFeed="$(SymbolsFeed)" />
   </Target>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
@@ -93,12 +93,7 @@
       <InternalInstallersFeedKey>$(InternalInstallersAzureAccountKey)</InternalInstallersFeedKey>
       <ChecksumsFeedKey>$(ChecksumsAzureAccountKey)</ChecksumsFeedKey>
       <InternalChecksumsFeedKey>$(InternalChecksumsAzureAccountKey)</InternalChecksumsFeedKey>
-      <UseSpecifiedFeeds Condition="'$(UseSpecifiedFeeds)' == ''">false</UseSpecifiedFeeds>
-      <InstallersFeed>$(InstallersFeed)</InstallersFeed>
-      <ChecksumsFeed>$(ChecksumsFeed)</ChecksumsFeed>
-      <TransportFeed>$(TransportFeed)</TransportFeed>
-      <ShippingFeed>$(ShippingFeed)</ShippingFeed>
-      <SymbolsFeed>$(SymbolsFeed)</SymbolsFeed>
+      <AllowFeedOverrides Condition="'$(AllowFeedOverrides)' == ''">false</AllowFeedOverrides>
     </PropertyGroup>
 
     <Error
@@ -138,12 +133,12 @@
       PdbArtifactsBasePath="$(PDBArtifactsBasePath)"
       PublishSpecialClrFiles="$(PublishSpecialClrFiles)"
       BuildQuality="$(BuildQuality)"
-      UseSpecifiedFeeds="$(UseSpecifiedFeeds)"
-      InstallersFeed="$(InstallersFeed)"
-      ChecksumsFeed="$(ChecksumsFeed)"
-      TransportFeed="$(TransportFeed)"
-      ShippingFeed="$(ShippingFeed)"
-      SymbolsFeed="$(SymbolsFeed)" />
+      AllowFeedOverrides="$(AllowFeedOverrides)"
+      InstallersFeedOverride="$(InstallersFeedOverride)"
+      ChecksumsFeedOverride="$(ChecksumsFeedOverride)"
+      TransportFeedOverride="$(TransportFeedOverride)"
+      ShippingFeedOverride="$(ShippingFeedOverride)"
+      SymbolsFeedOverride="$(SymbolsFeedOverride)" />
   </Target>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -112,7 +112,13 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public string AzureStorageTargetFeedKey { get; set; }
 
+        public bool UseSpecifiedFeeds { get; set; }
+
+        public string ChecksumsFeed { get; set; }
+
         public string ChecksumsFeedKey { get; set; }
+
+        public string InstallersFeed { get; set; }
 
         public string InstallersFeedKey { get; set; }
 
@@ -121,6 +127,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public string InternalCheckSumsFeedKey { get; set; }
 
         public string AzureDevOpsFeedsKey { get; set; }
+
+        public string TransportFeed { get; set; }
+        
+        public string ShippingFeed { get; set; }
+
+        public string SymbolsFeed { get; set; }
 
         /// <summary>
         /// Path to dll and pdb files
@@ -354,7 +366,13 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 MsdlToken = this.MsdlToken,
                 SymbolPublishingExclusionsFile = this.SymbolPublishingExclusionsFile,
                 PublishSpecialClrFiles = this.PublishSpecialClrFiles,
-                BuildQuality = this.BuildQuality
+                BuildQuality = this.BuildQuality,
+                UseSpecifiedFeeds = this.UseSpecifiedFeeds,
+                InstallersFeed = this.InstallersFeed,
+                ChecksumsFeed = this.ChecksumsFeed,
+                ShippingFeed = this.ShippingFeed,
+                TransportFeed = this.TransportFeed,
+                SymbolsFeed = this.SymbolsFeed
             };
         }
     }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -112,13 +112,13 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public string AzureStorageTargetFeedKey { get; set; }
 
-        public bool UseSpecifiedFeeds { get; set; }
+        public bool AllowFeedOverrides { get; set; }
 
-        public string ChecksumsFeed { get; set; }
+        public string ChecksumsFeedOverride { get; set; }
 
         public string ChecksumsFeedKey { get; set; }
 
-        public string InstallersFeed { get; set; }
+        public string InstallersFeedOverride { get; set; }
 
         public string InstallersFeedKey { get; set; }
 
@@ -128,11 +128,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public string AzureDevOpsFeedsKey { get; set; }
 
-        public string TransportFeed { get; set; }
+        public string TransportFeedOverride { get; set; }
         
-        public string ShippingFeed { get; set; }
+        public string ShippingFeedOverride { get; set; }
 
-        public string SymbolsFeed { get; set; }
+        public string SymbolsFeedOverride { get; set; }
 
         /// <summary>
         /// Path to dll and pdb files
@@ -367,12 +367,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 SymbolPublishingExclusionsFile = this.SymbolPublishingExclusionsFile,
                 PublishSpecialClrFiles = this.PublishSpecialClrFiles,
                 BuildQuality = this.BuildQuality,
-                UseSpecifiedFeeds = this.UseSpecifiedFeeds,
-                InstallersFeed = this.InstallersFeed,
-                ChecksumsFeed = this.ChecksumsFeed,
-                ShippingFeed = this.ShippingFeed,
-                TransportFeed = this.TransportFeed,
-                SymbolsFeed = this.SymbolsFeed
+                AllowFeedOverrides = this.AllowFeedOverrides,
+                InstallersFeedOverride = this.InstallersFeedOverride,
+                ChecksumsFeedOverride = this.ChecksumsFeedOverride,
+                ShippingFeedOverride = this.ShippingFeedOverride,
+                TransportFeedOverride = this.TransportFeedOverride,
+                SymbolsFeedOverride = this.SymbolsFeedOverride
             };
         }
     }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
@@ -51,6 +51,18 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public bool PublishSpecialClrFiles { get; set; }
 
+        public bool UseSpecifiedFeeds { get; set; }
+
+        public string InstallersFeed { get; set; }
+
+        public string ChecksumsFeed { get; set; }
+
+        public string ShippingFeed { get; set; }
+
+        public string TransportFeed { get; set; }
+
+        public string SymbolsFeed { get; set; }
+
         public override bool Execute()
         {
             ExecuteAsync().GetAwaiter().GetResult();
@@ -143,13 +155,13 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         BuildModel.Identity.Commit,
                         AzureStorageTargetFeedKey,
                         PublishInstallersAndChecksums,
-                        targetChannelConfig.InstallersFeed,
+                        (UseSpecifiedFeeds && !string.IsNullOrEmpty(InstallersFeed)) ? InstallersFeed : targetChannelConfig.InstallersFeed,
                         targetChannelConfig.IsInternal? InternalInstallersFeedKey : InstallersFeedKey,
-                        targetChannelConfig.ChecksumsFeed,
+                        (UseSpecifiedFeeds && !string.IsNullOrEmpty(ChecksumsFeed)) ? ChecksumsFeed : targetChannelConfig.ChecksumsFeed,
                         targetChannelConfig.IsInternal? InternalCheckSumsFeedKey : CheckSumsFeedKey,
-                        targetChannelConfig.ShippingFeed,
-                        targetChannelConfig.TransportFeed,
-                        targetChannelConfig.SymbolsFeed,
+                        (UseSpecifiedFeeds && !string.IsNullOrEmpty(ShippingFeed)) ? ShippingFeed :targetChannelConfig.ShippingFeed,
+                        (UseSpecifiedFeeds && !string.IsNullOrEmpty(TransportFeed)) ? TransportFeed :targetChannelConfig.TransportFeed,
+                        (UseSpecifiedFeeds && !string.IsNullOrEmpty(SymbolsFeed)) ? SymbolsFeed :targetChannelConfig.SymbolsFeed,
                         shortLinkUrl,
                         AzureDevOpsFeedsKey,
                         BuildEngine = this.BuildEngine,

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
@@ -155,13 +155,13 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         BuildModel.Identity.Commit,
                         AzureStorageTargetFeedKey,
                         PublishInstallersAndChecksums,
-                        (AllowFeedOverrides && !string.IsNullOrEmpty(InstallersFeedOverride)) ? InstallersFeedOverride : targetChannelConfig.InstallersFeed,
+                        GetFeed(targetChannelConfig.InstallersFeed, InstallersFeedOverride),
                         targetChannelConfig.IsInternal? InternalInstallersFeedKey : InstallersFeedKey,
-                        (AllowFeedOverrides && !string.IsNullOrEmpty(ChecksumsFeedOverride)) ? ChecksumsFeedOverride : targetChannelConfig.ChecksumsFeed,
+                        GetFeed(targetChannelConfig.ChecksumsFeed, ChecksumsFeedOverride),
                         targetChannelConfig.IsInternal? InternalCheckSumsFeedKey : CheckSumsFeedKey,
-                        (AllowFeedOverrides && !string.IsNullOrEmpty(ShippingFeedOverride)) ? ShippingFeedOverride :targetChannelConfig.ShippingFeed,
-                        (AllowFeedOverrides && !string.IsNullOrEmpty(TransportFeedOverride)) ? TransportFeedOverride :targetChannelConfig.TransportFeed,
-                        (AllowFeedOverrides && !string.IsNullOrEmpty(SymbolsFeedOverride)) ? SymbolsFeedOverride :targetChannelConfig.SymbolsFeed,
+                        GetFeed(targetChannelConfig.ShippingFeed, ShippingFeedOverride),
+                        GetFeed(targetChannelConfig.TransportFeed, TransportFeedOverride),
+                        GetFeed(targetChannelConfig.SymbolsFeed, SymbolsFeedOverride),
                         shortLinkUrl,
                         AzureDevOpsFeedsKey,
                         BuildEngine = this.BuildEngine,
@@ -288,6 +288,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             {
                 Directory.Delete(temporarySymbolLocation);
             }
+        }
+
+        public string GetFeed(string feed, string feedOverride)
+        {
+            return (AllowFeedOverrides && !string.IsNullOrEmpty(feedOverride)) ? feedOverride : feed;
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
@@ -51,17 +51,17 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public bool PublishSpecialClrFiles { get; set; }
 
-        public bool UseSpecifiedFeeds { get; set; }
+        public bool AllowFeedOverrides { get; set; }
 
-        public string InstallersFeed { get; set; }
+        public string InstallersFeedOverride { get; set; }
 
-        public string ChecksumsFeed { get; set; }
+        public string ChecksumsFeedOverride { get; set; }
 
-        public string ShippingFeed { get; set; }
+        public string ShippingFeedOverride { get; set; }
 
-        public string TransportFeed { get; set; }
+        public string TransportFeedOverride { get; set; }
 
-        public string SymbolsFeed { get; set; }
+        public string SymbolsFeedOverride { get; set; }
 
         public override bool Execute()
         {
@@ -155,13 +155,13 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         BuildModel.Identity.Commit,
                         AzureStorageTargetFeedKey,
                         PublishInstallersAndChecksums,
-                        (UseSpecifiedFeeds && !string.IsNullOrEmpty(InstallersFeed)) ? InstallersFeed : targetChannelConfig.InstallersFeed,
+                        (AllowFeedOverrides && !string.IsNullOrEmpty(InstallersFeedOverride)) ? InstallersFeedOverride : targetChannelConfig.InstallersFeed,
                         targetChannelConfig.IsInternal? InternalInstallersFeedKey : InstallersFeedKey,
-                        (UseSpecifiedFeeds && !string.IsNullOrEmpty(ChecksumsFeed)) ? ChecksumsFeed : targetChannelConfig.ChecksumsFeed,
+                        (AllowFeedOverrides && !string.IsNullOrEmpty(ChecksumsFeedOverride)) ? ChecksumsFeedOverride : targetChannelConfig.ChecksumsFeed,
                         targetChannelConfig.IsInternal? InternalCheckSumsFeedKey : CheckSumsFeedKey,
-                        (UseSpecifiedFeeds && !string.IsNullOrEmpty(ShippingFeed)) ? ShippingFeed :targetChannelConfig.ShippingFeed,
-                        (UseSpecifiedFeeds && !string.IsNullOrEmpty(TransportFeed)) ? TransportFeed :targetChannelConfig.TransportFeed,
-                        (UseSpecifiedFeeds && !string.IsNullOrEmpty(SymbolsFeed)) ? SymbolsFeed :targetChannelConfig.SymbolsFeed,
+                        (AllowFeedOverrides && !string.IsNullOrEmpty(ShippingFeedOverride)) ? ShippingFeedOverride :targetChannelConfig.ShippingFeed,
+                        (AllowFeedOverrides && !string.IsNullOrEmpty(TransportFeedOverride)) ? TransportFeedOverride :targetChannelConfig.TransportFeed,
+                        (AllowFeedOverrides && !string.IsNullOrEmpty(SymbolsFeedOverride)) ? SymbolsFeedOverride :targetChannelConfig.SymbolsFeed,
                         shortLinkUrl,
                         AzureDevOpsFeedsKey,
                         BuildEngine = this.BuildEngine,


### PR DESCRIPTION
This change adds the ability to specify feed overrides in V3 publishing. For publishing out of the dotnet-release repo, we want to be able to publish to special feeds for signed/validated builds. However, we don't want to have to implement duplicate PublishingConstants for those feeds. We simply want to be able to override the feed url. This change adds new parameters to the msbuild task to do just that.

Testing to show that the old behavior still works is here: https://dev.azure.com/dnceng/internal/_build/results?buildId=1003183&view=logs&j=ba23343f-f710-5af9-782d-5bd26b102304&t=6e277ba4-1c1e-552d-b96f-db0aeb4be20a&l=129
Testing to show the override behavior for InstallersFeed here: https://dev.azure.com/dnceng/internal/_build/results?buildId=1003423&view=logs&j=ba23343f-f710-5af9-782d-5bd26b102304&t=6e277ba4-1c1e-552d-b96f-db0aeb4be20a&l=129

Addresses #6939.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
