### PR TITLE
Stop overriding PackageProjectUrl in pkg targets

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
@@ -44,7 +44,7 @@
     <PackageId>$(Id)</PackageId>
     <PackedPackageNamePrefix Condition="'$(PackedPackageNamePrefix)' == ''">transport</PackedPackageNamePrefix>
     <PackedPackageId>$(PackedPackageNamePrefix).$(Id)</PackedPackageId>
-    <PackageProjectUrl>$(ProjectUrl)</PackageProjectUrl>
+    <PackageProjectUrl Condition="'$(PackageProjectUrl)' == ''">$(ProjectUrl)</PackageProjectUrl>
     <!-- It is by design that the Title matches the Id. We want users to get an assembly view. -->
     <Title>$(Id)</Title>
     <Authors>Microsoft</Authors>


### PR DESCRIPTION
This allows to standardize on the public `PackageProjectUrl` property instead of `ProjectUrl`.

