### PR TITLE
Exclude Newtonsoft.Json dependency from pkg

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
@@ -60,7 +60,11 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
     <!--Need to reference version 2.8.2 of CodeAnalysis so that we don't have downgrade issues with System.Reflection.Metadata version-->
     <PackageReference Include="Microsoft.CodeAnalysis" Version="2.8.2" Condition="'$(DotNetBuildFromSource)' != 'true'" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <!-- Don't include Newtonsoft.Json as a package dependency on .NETCoreApp.
+      The SDK currently uses Newtonsoft.Json 11.0.1. -->
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.1">
+      <Publish Condition="'$(TargetFramework)' != 'net472'">false</Publish>
+    </PackageReference>
     <PackageReference Include="NuGet.Commands" Version="$(NuGetVersion)" />
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetVersion)" />
     <PackageReference Include="NuGet.ProjectModel" Version="$(NuGetVersion)" />


### PR DESCRIPTION
On .NETCoreApp, exclude the Newtonsoft.Json dependency in Packaging
package as the SDK already comes with its own copy which is being loaded
into its own ALC. If the Newtonsoft.Json dependency is present in the
package, unification during runtime won't work as the two Newtonsoft
assemblies are loaded into different ALCs. This would then result in a
MissingMethodException when trying to use exchange types from
Newtonsoft.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
