### PR TITLE
Reboot+retry for Simulator hangs only (not devices, Mac Catalyst)

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.apple.sh
@@ -15,13 +15,12 @@ exit_code=$?
 
 # This handles an issue where Simulators get reeaally slow and they start failing to install apps
 # The only solution is to reboot the machine, so we request a work item retry + MacOS reboot when this happens
-# 83 - timeout in installation
-installation_timeout_exit_code=83
+# 123 - timeout in installation on Simulators
+installation_timeout_exit_code=123
 if [ $exit_code -eq $installation_timeout_exit_code ]; then
     # Since we run the payload script using launchctl, env vars are not set there and we have to do this part here
     "$HELIX_PYTHONPATH" -c "from helix.workitemutil import request_infra_retry; request_infra_retry('Retrying because iOS Simulator application install hung')"
     "$HELIX_PYTHONPATH" -c "from helix.workitemutil import request_reboot; request_reboot('Rebooting because iOS Simulator application install hung ')"
-    exit $exit_code
 fi
 
 exit $exit_code

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
@@ -164,6 +164,12 @@ if [ $exit_code -eq 80 ]; then
     sudo pkill -9 -f "$simulator_app"
 fi
 
+# If we have a launch failure AND we are on simulators, we need to signal that we want a reboot+retry
+# The script that is running this one will notice and request Helix to do it
+if [ $exit_code -eq 83 ] && [[ "$targets" =~ "simulator" ]]; then
+    exit_code=123
+fi
+
 # The simulator logs comming from the sudo-spawned Simulator.app are not readable by the helix uploader
 chmod 0644 "$output_directory"/*.log
 


### PR DESCRIPTION
From now on, we will also have a dedicated exit code (123) in Kusto so that we can analyze how often this happens
