### PR TITLE
Revert "Update arcade for publishing (#7005)"

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -11,25 +11,25 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.21123.3">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.21117.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>86c40146b77101a79116bfdcb6f34ef0fd2080b2</Sha>
+      <Sha>99b9f805da070d301d76eac578a46dd75d9e5f7c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="6.0.0-beta.21123.3">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="6.0.0-beta.21117.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>86c40146b77101a79116bfdcb6f34ef0fd2080b2</Sha>
+      <Sha>99b9f805da070d301d76eac578a46dd75d9e5f7c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SignTool" Version="6.0.0-beta.21123.3">
+    <Dependency Name="Microsoft.DotNet.SignTool" Version="6.0.0-beta.21117.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>86c40146b77101a79116bfdcb6f34ef0fd2080b2</Sha>
+      <Sha>99b9f805da070d301d76eac578a46dd75d9e5f7c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="6.0.0-beta.21123.3">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="6.0.0-beta.21117.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>86c40146b77101a79116bfdcb6f34ef0fd2080b2</Sha>
+      <Sha>99b9f805da070d301d76eac578a46dd75d9e5f7c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SwaggerGenerator.MSBuild" Version="6.0.0-beta.21123.3">
+    <Dependency Name="Microsoft.DotNet.SwaggerGenerator.MSBuild" Version="6.0.0-beta.21117.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>86c40146b77101a79116bfdcb6f34ef0fd2080b2</Sha>
+      <Sha>99b9f805da070d301d76eac578a46dd75d9e5f7c</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Maestro.Client" Version="1.1.0-beta.20258.6">
       <Uri>https://github.com/dotnet/arcade-services</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -66,8 +66,8 @@
     <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>
     <XUnitVSRunnerVersion>2.4.1</XUnitVSRunnerVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.21123.3</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetSignToolVersion>6.0.0-beta.21123.3</MicrosoftDotNetSignToolVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.21117.1</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetSignToolVersion>6.0.0-beta.21117.1</MicrosoftDotNetSignToolVersion>
     <MicrosoftAzureDocumentDBVersion>1.22.0</MicrosoftAzureDocumentDBVersion>
     <MicrosoftAzureCosmosDBTableVersion>1.1.2</MicrosoftAzureCosmosDBTableVersion>
     <MicrosoftAspNetCoreAllVersion>2.0.0</MicrosoftAspNetCoreAllVersion>
@@ -80,7 +80,7 @@
     <MicrosoftDotNetMaestroClientVersion>1.1.0-beta.20258.6</MicrosoftDotNetMaestroClientVersion>
     <MicrosoftSourceLinkGitHubVersion>1.1.0-beta-21115-02</MicrosoftSourceLinkGitHubVersion>
     <MicrosoftSourceLinkAzureReposGitVersion>1.1.0-beta-21115-02</MicrosoftSourceLinkAzureReposGitVersion>
-    <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>6.0.0-beta.21123.3</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
+    <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>6.0.0-beta.21117.1</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
     <XliffTasksVersion>1.0.0-beta.21110.1</XliffTasksVersion>
     <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.20570.1</MicrosoftDotNetMaestroTasksVersion>
     <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.21123.1</MicrosoftDotNetXHarnessCLIVersion>

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "5.0.100"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21123.3",
-    "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.21123.3"
+    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21117.1",
+    "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.21117.1"
   }
 }


### PR DESCRIPTION
This reverts commit a65a61342d6dbc24df814ce075d0797f49a3a7b7.

This update resulted in breaking the official build, and publishing in general due to not being able to load the publishing task.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
