### PR TITLE
Revert "Update NuGet dependencies (#6989)"

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,7 +44,7 @@
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
     <SystemTextJsonVersion>4.7.0</SystemTextJsonVersion>
     <NuGetVersioningVersion>4.4.0</NuGetVersioningVersion>
-    <NuGetVersion>5.9.0-preview.2</NuGetVersion>
+    <NuGetVersion>5.6.0-preview.2.6489</NuGetVersion>
     <OctokitVersion>0.32.0</OctokitVersion>
     <DotNetSleetLibVersion>2.2.143</DotNetSleetLibVersion>
     <SwashbuckleAspNetCoreSwaggerVersion>3.0.0</SwashbuckleAspNetCoreSwaggerVersion>


### PR DESCRIPTION
This is blocking Arcade's validation flow, and is stopping us from getting publishing for preview 2 working: https://github.com/dotnet/arcade/issues/7004