### PR TITLE
ArPow: Don't add to IntermediateNupkgProject if Category is empty

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
@@ -123,17 +123,18 @@
             GetCategorizedIntermediateNupkgContents;
             GetSourceBuildIntermediateNupkgNameConvention">
     <ItemGroup>
-      <IntermediateNupkgProject Include="$(SourceBuildIntermediateProjFile)" />
+      <IntermediateNupkgProject Include="$(SourceBuildIntermediateProjTargetFile)" />
 
       <IntermediateNupkgProject
-        Include="$(SourceBuildIntermediateProjFile)"
+        Include="$(SourceBuildIntermediateProjTargetFile)"
+        Condition=" '%(SupplementalIntermediateNupkgCategory.Identity)' != '' "
         AdditionalProperties="
           SupplementalIntermediateNupkgCategory=%(SupplementalIntermediateNupkgCategory.Identity)" />
     </ItemGroup>
 
     <PropertyGroup>
       <IntermediateNupkgBuildMessage>Building intermediate nupkg</IntermediateNupkgBuildMessage>
-      <IntermediateNupkgBuildMessage>$(IntermediateNupkgBuildMessage), and supplemental nupkgs for @(SupplementalIntermediateNupkgCategory, ', ')</IntermediateNupkgBuildMessage>
+      <IntermediateNupkgBuildMessage Condition=" '@(SupplementalIntermediateNupkgCategory)' != '' ">$(IntermediateNupkgBuildMessage), and supplemental nupkgs for @(SupplementalIntermediateNupkgCategory, ', ')</IntermediateNupkgBuildMessage>
     </PropertyGroup>
 
     <Message Importance="High" Text="$(IntermediateNupkgBuildMessage)..." />


### PR DESCRIPTION
When `SupplementalIntermediateNupkgCategory` is empty, the project is getting added to `IntermediateNupkgProject` twice causing the project to build twice and causing some flaky behavior in CI.  Added a condition to only include the project for `SupplementalIntermediateNupkgCategory` when it is not empty. 

`SourceBuildIntermediateProjFile` -> `SourceBuildIntermediateProjTargetFile` fixes an issue where after creating the copy of the project, later code was using the original project.  This caused issues with sourcelink trying to find repo info when building locally.

Built arcade locally and tested locally building from source to verify this fixed the issue.

Resolves: https://github.com/dotnet/source-build/issues/2066