### PR TITLE
Add libatomic.a and keyutils dependencies in tizen rootfs

### DIFF
--- a/eng/common/cross/armel/tizen-fetch.sh
+++ b/eng/common/cross/armel/tizen-fetch.sh
@@ -157,7 +157,7 @@ fetch_tizen_pkgs()
 Inform "Initialize arm base"
 fetch_tizen_pkgs_init standard base
 Inform "fetch common packages"
-fetch_tizen_pkgs armv7l gcc glibc glibc-devel libicu libicu-devel libatomic linux-glibc-devel
+fetch_tizen_pkgs armv7l gcc gcc-devel-static glibc glibc-devel libicu libicu-devel libatomic linux-glibc-devel keyutils keyutils-devel libkeyutils
 Inform "fetch coreclr packages"
 fetch_tizen_pkgs armv7l lldb lldb-devel libgcc libstdc++ libstdc++-devel libunwind libunwind-devel lttng-ust-devel lttng-ust userspace-rcu-devel userspace-rcu
 Inform "fetch corefx packages"


### PR DESCRIPTION
This is required after https://github.com/dotnet/runtime/pull/48254

cc @alpencolt