### PR TITLE
Update sourceIndexPackageVersion manually

### DIFF
--- a/eng/common/templates/job/source-index-stage1.yml
+++ b/eng/common/templates/job/source-index-stage1.yml
@@ -1,6 +1,6 @@
 parameters:
   runAsPublic: false
-  sourceIndexPackageVersion: 1.0.0-beta5
+  sourceIndexPackageVersion: 1.0.1-20210225.1
   sourceIndexPackageSource: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
   sourceIndexBuildCommand: powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "eng/common/build.ps1 -restore -build -binarylog -ci"
   preSteps: []


### PR DESCRIPTION
Use a newer source indexer version which understands how to replay binlogs v10. Tracking issue to keep the source indexer up-to-date: https://github.com/dotnet/arcade/issues/7024.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
