### PR TITLE
Error signalization fix

### DIFF
--- a/eng/common/native/install-tool.ps1
+++ b/eng/common/native/install-tool.ps1
@@ -105,7 +105,7 @@ try {
     Write-Error "There are multiple copies of $ToolName in $($ToolInstallDirectory): `n$(@($ToolFilePath | out-string))"
     exit 1
   } elseif (@($ToolFilePath).Length -Lt 1) {
-    Write-Host "$ToolName was not found in $ToolFilePath."
+    Write-Host "$ToolName was not found in $ToolInstallDirectory."
     exit 1
   }
 


### PR DESCRIPTION
`ToolFilePath` is always empty here.

I noticed the problem when trying to repeatedly run native toolset bootstrapping in wpf:

```
C:\Source\wpf> .\eng\common\init-tools-native.cmd
Processing C:\Source\wpf\global.json
strawberry-perl was not found in .
strawberry-perl installation failed
```

With the patch the error reporting is now:

```
C:\Source\wpf> .\eng\common\init-tools-native.cmd
Processing C:\Source\wpf\global.json
strawberry-perl was not found in C:\Users\lulansky\.netcoreeng\native\bin\strawberry-perl\5.28.1.1-1\.
strawberry-perl installation failed
```

There is still the underlying issue, but I'm keeping research of that for another day.