### PR TITLE
Fix the equals function for TargetFeedConfig

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetFeedConfig.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetFeedConfig.cs
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
 
         public override bool Equals(object obj)
         {
-            return  
+            if (  
                 obj is TargetFeedConfig other &&
                 (ContentType == other.ContentType) &&
                 TargetURL.Equals(other.TargetURL, StringComparison.OrdinalIgnoreCase) &&
@@ -96,8 +96,18 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 (Isolated == other.Isolated) &&
                 (Internal == other.Internal) &&
                 (AllowOverwrite == other.AllowOverwrite) &&
-                FilenamesToExclude.SequenceEqual(other.FilenamesToExclude) &&
-                (Flatten == other.Flatten);
+                (Flatten == other.Flatten))
+            {
+                if (FilenamesToExclude is null)
+                    return config.FilenamesToExclude is null;
+                
+                if (config.FilenamesToExclude is null)
+                    return false;
+                
+                return FilenamesToExclude.SequenceEqual(config.FilenamesToExclude);
+            }
+
+            return false;
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetFeedConfig.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetFeedConfig.cs
@@ -99,12 +99,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 (Flatten == other.Flatten))
             {
                 if (FilenamesToExclude is null)
-                    return config.FilenamesToExclude is null;
+                    return other.FilenamesToExclude is null;
                 
-                if (config.FilenamesToExclude is null)
+                if (other.FilenamesToExclude is null)
                     return false;
                 
-                return FilenamesToExclude.SequenceEqual(config.FilenamesToExclude);
+                return FilenamesToExclude.SequenceEqual(other.FilenamesToExclude);
             }
 
             return false;


### PR DESCRIPTION
A similar change was made to TargetChannelConfig and TargetFeedConfig should be fixed as well.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
