### PR TITLE
Fix flatten exclusion

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
@@ -166,7 +166,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         AzureDevOpsFeedsKey,
                         BuildEngine = this.BuildEngine,
                         targetChannelConfig.SymbolTargetType,
-                        filesToExclude: targetChannelConfig.FilenamesToExclude);
+                        filesToExclude: targetChannelConfig.FilenamesToExclude,
+                        flatten: targetChannelConfig.Flatten);
 
                     var targetFeedConfigs = targetFeedsSetup.Setup();
 


### PR DESCRIPTION
We weren't passing along the TargetChannelConfig's Flatten designation, so we were flattening when we meant to exclude it.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
