### PR TITLE
Check to see if path is null OR empty

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -141,7 +141,7 @@ function InitializeDotNetCli([bool]$install, [bool]$createSdkLocationFile) {
 
   # Use dotnet installation specified in DOTNET_INSTALL_DIR if it contains the required SDK version,
   # otherwise install the dotnet CLI and SDK to repo local .dotnet directory to avoid potential permission issues.
-  if ((-not $globalJsonHasRuntimes) -and ($env:DOTNET_INSTALL_DIR -ne $null) -and (Test-Path(Join-Path $env:DOTNET_INSTALL_DIR "sdk\$dotnetSdkVersion"))) {
+  if ((-not $globalJsonHasRuntimes) -and (-not [string]::IsNullOrEmpty($env:DOTNET_INSTALL_DIR)) -and (Test-Path(Join-Path $env:DOTNET_INSTALL_DIR "sdk\$dotnetSdkVersion"))) {
     $dotnetRoot = $env:DOTNET_INSTALL_DIR
   } else {
     $dotnetRoot = Join-Path $RepoRoot '.dotnet'


### PR DESCRIPTION
The BasicRepoTests in Arcade Validation caught this error and will validate the fix when it's in. 

See comments on this PR: https://github.com/dotnet/arcade-validation/pull/2154

### To double check:

* [X] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
