### PR TITLE
Saving sdk.txt using utf8

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -166,7 +166,7 @@ function InitializeDotNetCli([bool]$install, [bool]$createSdkLocationFile) {
       $sdkCacheFileTemp = Join-Path $ToolsetDir $([System.IO.Path]::GetRandomFileName())
     }
     until (!(Test-Path $sdkCacheFileTemp))
-    Set-Content -Path $sdkCacheFileTemp -Value $dotnetRoot
+    Set-Content -Path $sdkCacheFileTemp -Value $dotnetRoot -Encoding utf8
 
     try {
       Move-Item -Force $sdkCacheFileTemp (Join-Path $ToolsetDir 'sdk.txt')


### PR DESCRIPTION
This is going to work with runtime's `dotnet.cmd` after adding something like `chcp 65001` to that script.

If I understand the situation properly, `Set-Content -Encoding` changed defaults between different versions of PowerShell from "[system's active code page](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/set-content?view=powershell-5.1)" to "[utf8NoBOM](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/set-content?view=powershell-7)". It's probably better for us to fix that value more often than not.

Solves #6960