### PR TITLE
Remove component governance from public CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,7 +66,8 @@ stages:
             $(_InternalBuildArgs)
             /p:Test=false
           displayName: Windows Build / Publish
-        - task: ComponentGovernanceComponentDetection@0
+        - ${{ if eq(variables._RunAsPublic, False) }}:
+          - task: ComponentGovernanceComponentDetection@0
       - ${{ if eq(variables._RunAsPublic, True) }}:
         - job: Linux
           container: LinuxContainer


### PR DESCRIPTION
Removes Component Governance from public CI builds which should unblock arcade PRs.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
