### PR TITLE
Revert "Saving sdk.txt using utf8"

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -166,7 +166,7 @@ function InitializeDotNetCli([bool]$install, [bool]$createSdkLocationFile) {
       $sdkCacheFileTemp = Join-Path $ToolsetDir $([System.IO.Path]::GetRandomFileName())
     }
     until (!(Test-Path $sdkCacheFileTemp))
-    Set-Content -Path $sdkCacheFileTemp -Value $dotnetRoot -Encoding utf8
+    Set-Content -Path $sdkCacheFileTemp -Value $dotnetRoot
 
     try {
       Move-Item -Force $sdkCacheFileTemp (Join-Path $ToolsetDir 'sdk.txt')


### PR DESCRIPTION
This reverts commit 56241026081186c1620b28ae1e578e9552decda4 as [we see](https://dev.azure.com/dnceng/internal/_build/results?buildId=1022466&view=logs&j=128f4634-3e62-52f1-6764-cb4c2b8330d4&t=b8c89dd4-cf97-54b0-cf34-fb7a4a8c3935&s=ff05ad62-bb9a-53b6-ce9f-72f329a63e7c):

```
  D:\workspace\_work\1\s\dotnet.cmd D:\workspace\_work\1\s\artifacts\bin\coreclr\windows.x64.Release\crossgen2\crossgen2.dll -o:D:\workspace\_work\1\s\artifacts\bin\coreclr\windows.x64.Release\System.Private.CoreLib.dll -r:D:\workspace\_work\1\s\artifacts\bin\coreclr\windows.x64.Release\IL\*.dll --targetarch:x64 -O D:\workspace\_work\1\s\artifacts\bin\coreclr\windows.x64.Release\IL\System.Private.CoreLib.dll --pdb --pdb-path:D:\workspace\_work\1\s\artifacts\bin\coreclr\windows.x64.Release\PDB
  D:\workspace\_work\1\s\.dotnet
  The filename, directory name, or volume label syntax is incorrect.
```

Unsolves #6960