### PR TITLE
[API Compat] Add attribute diffing for generic and regular parameters

### DIFF
--- a/src/Microsoft.DotNet.ApiCompat/tests/AttributeDifferenceTests.cs
+++ b/src/Microsoft.DotNet.ApiCompat/tests/AttributeDifferenceTests.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.IO;
-using System.Reflection;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.ApiCompat.Tests
 {
@@ -22,7 +20,11 @@ namespace Microsoft.DotNet.ApiCompat.Tests
 
             Assert.Contains("CannotRemoveAttribute : Attribute 'System.ComponentModel.DesignerAttribute' exists on 'AttributeDifference.AttributeDifferenceClass1' in the implementation but not the contract.", runOutput);
             Assert.Contains("CannotRemoveAttribute : Attribute 'AttributeDifference.FooAttribute' exists on 'AttributeDifference.AttributeDifferenceClass1' in the implementation but not the contract.", runOutput);
-            Assert.Contains("Total Issues: 2", runOutput);
+            Assert.Contains("CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on generic param 'T' on member 'AttributeDifference.AttributeDifferenceClass1.GenericMethodWithAttribute<T>()' in the implementation but not the contract.", runOutput);
+            Assert.Contains("CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on generic param 'T' on member 'AttributeDifference.AttributeDifferenceClass1.GenericMethodWithAttribute<T>()' in the implementation but not the contract.", runOutput);
+            Assert.Contains("CannotRemoveAttribute : Attribute 'AttributeDifference.FooAttribute' exists on parameter 'myParameter' on member 'AttributeDifference.AttributeDifferenceClass1.MethodWithAttribute(System.String, System.Object)' in the implementation but not the contract.", runOutput);
+            Assert.Contains("CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on generic param 'TOne' on member 'AttributeDifference.AttributeDifferenceGenericCLass<TOne, TTwo>' in the implementation but not the contract.", runOutput);
+            Assert.Contains("Total Issues: 5", runOutput);
         }
 
         [Fact]
@@ -34,7 +36,7 @@ namespace Microsoft.DotNet.ApiCompat.Tests
 
             string runOutput = Helpers.RunApiCompat(_implementationPath, new string[] { _contractPath }, new string[] { excludeAttributesFile.Path }, "implementation", "contract");
             Assert.Contains("CannotRemoveAttribute : Attribute 'System.ComponentModel.DesignerAttribute' exists on 'AttributeDifference.AttributeDifferenceClass1' in the implementation but not the contract.", runOutput);
-            Assert.Contains("Total Issues: 1", runOutput);
+            Assert.Contains("Total Issues: 3", runOutput);
         }
 
         [Fact]
@@ -42,7 +44,7 @@ namespace Microsoft.DotNet.ApiCompat.Tests
         {
             using TempFile excludeAttributesFile = TempFile.Create();
 
-            File.WriteAllLines(excludeAttributesFile.Path, new string[] { "T:System.ComponentModel.DesignerAttribute", "T:AttributeDifference.FooAttribute" });
+            File.WriteAllLines(excludeAttributesFile.Path, new string[] { "T:System.ComponentModel.DesignerAttribute", "T:AttributeDifference.FooAttribute", "T:System.ComponentModel.DefaultValueAttribute" });
 
             string runOutput = Helpers.RunApiCompat(_implementationPath, new string[] { _contractPath }, new string[] { excludeAttributesFile.Path }, null, null);
 

--- a/src/Microsoft.DotNet.ApiCompat/tests/Helpers.cs
+++ b/src/Microsoft.DotNet.ApiCompat/tests/Helpers.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.ApiCompat.Tests
         {
             using var writer = new StringWriter();
 
-            var args = Helpers.GetApiCompatArgs(left, rightDirs, excludeAttributesFile, leftName, rightName);
+            var args = GetApiCompatArgs(left, rightDirs, excludeAttributesFile, leftName, rightName);
             new ApiCompatRunner(writer).Run(args);
 
             return writer.ToString();

--- a/src/Microsoft.DotNet.ApiCompat/tests/TestProjects/AttributeDifference/Contract/AttributeDifference.cs
+++ b/src/Microsoft.DotNet.ApiCompat/tests/TestProjects/AttributeDifference/Contract/AttributeDifference.cs
@@ -8,5 +8,10 @@ namespace AttributeDifference
     [DisplayName("Attribute difference class1")]
     public class AttributeDifferenceClass1
     {
+        public string MethodWithAttribute(string myParameter, [DefaultValue("myObject")] object myObject) => throw null;
+        public T GenericMethodWithAttribute<T>() => throw null;
+    }
+    public class AttributeDifferenceGenericCLass<TOne, [DefaultValue("TTwo")] TTwo>
+    {
     }
 }

--- a/src/Microsoft.DotNet.ApiCompat/tests/TestProjects/AttributeDifference/Implementation/AttributeDifferenceClass1.cs
+++ b/src/Microsoft.DotNet.ApiCompat/tests/TestProjects/AttributeDifference/Implementation/AttributeDifferenceClass1.cs
@@ -11,6 +11,12 @@ namespace AttributeDifference
     [Foo]
     public class AttributeDifferenceClass1
     {
+        public string MethodWithAttribute([Foo] string myParameter, [DefaultValue("myObject")] object myObject) => myParameter;
+        public T GenericMethodWithAttribute<[DefaultValue("T")] T>() => default(T);
+    }
+
+    public class AttributeDifferenceGenericCLass<[DefaultValue("TOne")] TOne, [DefaultValue("TTwo")] TTwo>
+    {
     }
 
     internal class FooAttribute : Attribute { }


### PR DESCRIPTION
We decided before that we were going to do this on the new APICompat, however @eerhardt is having a hard time to fix the linker warnings in dotnet/runtime because of this limitation and since it was a simple change I tackled it to unblock him.

Fixes: https://github.com/dotnet/arcade/issues/5925