### PR TITLE
Continuation of https://github.com/dotnet/core-eng/issues/12213 

### DIFF
--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -28,6 +28,10 @@ prepare_machine=${prepare_machine:-false}
 # True to restore toolsets and dependencies.
 restore=${restore:-true}
 
+# Allows restoring .NET Core Runtimes and SDKs from alternative feeds
+runtimeSourceFeed=${runtimeSourceFeed:-""}
+runtimeSourceFeedKey=${runtimeSourceFeedKey:-""}
+
 # Adjusts msbuild verbosity level.
 verbosity=${verbosity:-'minimal'}
 


### PR DESCRIPTION
- It seems Roslyn does not use eng/common/build.sh, and uses arcade/3.x in main, so this was missed in the original work

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation (exercised by all linux + macos ci builds)
