### PR TITLE
Add 'checkDownloadedFiles: true' to all invocations of DownloadBuildArtifacts

### DIFF
--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -45,6 +45,7 @@ jobs:
             buildId: $(AzDOBuildId)
             artifactName: ${{ artifactName }}
             downloadPath: $(Build.ArtifactStagingDirectory)\artifacts
+            checkDownloadedFiles: true
     - ${{ if eq(parameters.artifactNames, '') }}:
       - task: DownloadBuildArtifacts@0
         displayName: Download Build Artifacts
@@ -57,6 +58,7 @@ jobs:
           downloadType: specific files
           itemPattern: "**"
           downloadPath: $(Build.ArtifactStagingDirectory)\artifacts
+          checkDownloadedFiles: true
   - powershell: eng/common/sdl/extract-artifact-packages.ps1
       -InputPath $(Build.ArtifactStagingDirectory)\artifacts\BlobArtifacts
       -ExtractPath $(Build.ArtifactStagingDirectory)\artifacts\BlobArtifacts

--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -52,6 +52,7 @@ jobs:
       inputs:
         artifactName: AssetManifests
         downloadPath: '$(Build.StagingDirectory)/Download'
+        checkDownloadedFiles: true
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}
     

--- a/eng/common/templates/phases/publish-build-assets.yml
+++ b/eng/common/templates/phases/publish-build-assets.yml
@@ -20,6 +20,7 @@ phases:
           inputs:
             artifactName: AssetManifests
             downloadPath: '$(Build.StagingDirectory)/Download'
+            checkDownloadedFiles: true
           condition: ${{ parameters.condition }}
           continueOnError: ${{ parameters.continueOnError }}
         - task: AzureKeyVault@1

--- a/eng/common/templates/post-build/channels/generic-internal-channel.yml
+++ b/eng/common/templates/post-build/channels/generic-internal-channel.yml
@@ -58,6 +58,7 @@ stages:
             PdbArtifacts/**
             BlobArtifacts/**
           downloadPath: '$(Build.ArtifactStagingDirectory)'
+          checkDownloadedFiles: true
 
       # This is necessary whenever we want to publish/restore to an AzDO private feed
       # Since sdk-task.ps1 tries to restore packages we need to do this authentication here
@@ -124,6 +125,7 @@ stages:
             BlobArtifacts/**
             AssetManifests/**
           downloadPath: '$(Build.ArtifactStagingDirectory)'
+          checkDownloadedFiles: true
 
       - task: NuGetToolInstaller@1
         displayName: 'Install NuGet.exe'

--- a/eng/common/templates/post-build/channels/generic-public-channel.yml
+++ b/eng/common/templates/post-build/channels/generic-public-channel.yml
@@ -56,6 +56,7 @@ stages:
             PdbArtifacts/**
             BlobArtifacts/**
           downloadPath: '$(Build.ArtifactStagingDirectory)'
+          checkDownloadedFiles: true
 
       # This is necessary whenever we want to publish/restore to an AzDO private feed
       # Since sdk-task.ps1 tries to restore packages we need to do this authentication here
@@ -123,6 +124,7 @@ stages:
             BlobArtifacts/**
             AssetManifests/**
           downloadPath: '$(Build.ArtifactStagingDirectory)'
+          checkDownloadedFiles: true
 
       - task: NuGetToolInstaller@1
         displayName: 'Install NuGet.exe'

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -117,6 +117,7 @@ stages:
             pipeline: $(AzDOPipelineId)
             buildId: $(AzDOBuildId)
             artifactName: PackageArtifacts
+            checkDownloadedFiles: true
 
         - task: PowerShell@2
           displayName: Validate
@@ -149,6 +150,7 @@ stages:
             pipeline: $(AzDOPipelineId)
             buildId: $(AzDOBuildId)
             artifactName: PackageArtifacts
+            checkDownloadedFiles: true
             itemPattern: |
               **
               !**/Microsoft.SourceBuild.Intermediate.*.nupkg
@@ -205,6 +207,7 @@ stages:
             pipeline: $(AzDOPipelineId)
             buildId: $(AzDOBuildId)
             artifactName: BlobArtifacts
+            checkDownloadedFiles: true
 
         - task: PowerShell@2
           displayName: Validate

--- a/eng/common/templates/post-build/setup-maestro-vars.yml
+++ b/eng/common/templates/post-build/setup-maestro-vars.yml
@@ -18,6 +18,7 @@ jobs:
         inputs:
           buildType: current
           artifactName: ReleaseConfigs
+          checkDownloadedFiles: true
 
     - task: PowerShell@2
       name: setReleaseVars

--- a/eng/publishing/v3/nuget-validation.yml
+++ b/eng/publishing/v3/nuget-validation.yml
@@ -21,6 +21,7 @@ jobs:
         pipeline: $(AzDOPipelineId)
         buildId: $(AzDOBuildId)
         artifactName: PackageArtifacts
+        checkDownloadedFiles: true
 
     - task: PowerShell@2
       displayName: Validate

--- a/eng/publishing/v3/publish-assets.yml
+++ b/eng/publishing/v3/publish-assets.yml
@@ -41,6 +41,7 @@ jobs:
           AssetManifests/**
           PdbArtifacts/**
         downloadPath: '$(Build.ArtifactStagingDirectory)'
+        checkDownloadedFiles: true
 
     - task: NuGetToolInstaller@1
       displayName: 'Install NuGet.exe'

--- a/eng/publishing/v3/publish-symbols.yml
+++ b/eng/publishing/v3/publish-symbols.yml
@@ -30,6 +30,7 @@ jobs:
           PdbArtifacts/**
           BlobArtifacts/**
         downloadPath: '$(Build.ArtifactStagingDirectory)'
+        checkDownloadedFiles: true
         
     # This is necessary whenever we want to publish/restore to an AzDO private feed
     # Since sdk-task.ps1 tries to restore packages we need to do this authentication here

--- a/eng/publishing/v3/signing-validation.yml
+++ b/eng/publishing/v3/signing-validation.yml
@@ -22,6 +22,7 @@ jobs:
         pipeline: $(AzDOPipelineId)
         buildId: $(AzDOBuildId)
         artifactName: PackageArtifacts
+        checkDownloadedFiles: true
         itemPattern: |
           **
           !**/Microsoft.SourceBuild.Intermediate.*.nupkg

--- a/eng/publishing/v3/sourcelink-validation.yml
+++ b/eng/publishing/v3/sourcelink-validation.yml
@@ -22,6 +22,7 @@ jobs:
         pipeline: $(AzDOPipelineId)
         buildId: $(AzDOBuildId)
         artifactName: BlobArtifacts
+        checkDownloadedFiles: true
 
     - task: PowerShell@2
       displayName: Validate


### PR DESCRIPTION
Following up from https://github.com/dotnet/core-eng/issues/11551; this version of the task is rolled out everywhere arcade is used, so we should opt into the file checking logic. 

### To double check:
* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation (just adds a retry parameter to an existing invocation)
