### PR TITLE
[release/5.0] use main branch for publishing

### DIFF
--- a/eng/common/post-build/publish-using-darc.ps1
+++ b/eng/common/post-build/publish-using-darc.ps1
@@ -54,7 +54,7 @@ try {
   --id $buildId `
   --publishing-infra-version $PublishingInfraVersion `
   --default-channels `
-  --source-branch master `
+  --source-branch main `
   --azdev-pat $AzdoToken `
   --bar-uri $MaestroApiEndPoint `
   --password $MaestroToken `


### PR DESCRIPTION
## Description

Use the main branch as the publishing branch in reaction to the renaming of the default branch in arcade: https://github.com/dotnet/core-eng/issues/12145

## Customer Impact

The master branch will be deleted from azure devops in a couple of weeks, so publishing will fail.

## Regression

No

## Risk

Low. The main branch already exists in azure devops and is the only branch that will stay up to date.

## Workarounds

None
