### PR TITLE
Use blob.core.windows instead of azureedge for Helix CLI acquisition

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/FindDotNetCliPackage.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/FindDotNetCliPackage.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.Helix.Sdk
     public class FindDotNetCliPackage : BaseTask
     {
         private static readonly HttpClient _client = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true });
-        private const string DotNetCliAzureFeed = "https://dotnetcli.azureedge.net/dotnet";
+        private const string DotNetCliAzureFeed = "https://dotnetcli.blob.core.windows.net/dotnet";
 
         /// <summary>
         ///   'LTS' or 'Current'


### PR DESCRIPTION

Since Helix agents tend to be in the same data center or geolocated in the Western US, this isn't a perf degradation (gain, in some cases) but also when executed at Helix scale, means a substantial savings

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation (PR testing of this will use the new path)
