### PR TITLE
[release/5.0] Send `System.PullRequest.TargetBranch` in job created by SendHelixJob

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
@@ -207,6 +207,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                 def = AddBuildVariableProperty(def, "DefinitionName", "Build.DefinitionName");
                 def = AddBuildVariableProperty(def, "DefinitionId", "System.DefinitionId");
                 def = AddBuildVariableProperty(def, "Reason", "Build.Reason");
+                def = AddBuildVariableProperty(def, "System.PullRequest.TargetBranch", "System.PullRequest.TargetBranch");
 
                 // don't send the job if we have errors
                 if (Log.HasLoggedErrors)

--- a/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
@@ -200,14 +200,29 @@ namespace Microsoft.DotNet.Helix.Sdk
                         def = AddProperty(def, helixProperty);
                     }
                 }
-                
+
+                def = AddBuildVariableProperty(def, "CollectionUri", "System.CollectionUri");
                 def = AddBuildVariableProperty(def, "Project", "System.TeamProject");
                 def = AddBuildVariableProperty(def, "BuildNumber", "Build.BuildNumber");
                 def = AddBuildVariableProperty(def, "BuildId", "Build.BuildId");
                 def = AddBuildVariableProperty(def, "DefinitionName", "Build.DefinitionName");
                 def = AddBuildVariableProperty(def, "DefinitionId", "System.DefinitionId");
                 def = AddBuildVariableProperty(def, "Reason", "Build.Reason");
-                def = AddBuildVariableProperty(def, "System.PullRequest.TargetBranch", "System.PullRequest.TargetBranch");
+                var variablesToCopy = new[]
+                {
+                    "System.JobId",
+                    "System.JobName",
+                    "System.JobAttempt",
+                    "System.PhaseName",
+                    "System.PhaseAttempt",
+                    "System.PullRequest.TargetBranch",
+                    "System.StageName",
+                    "System.StageAttempt",
+                };
+                foreach (var name in variablesToCopy)
+                {
+                    def = AddBuildVariableProperty(def, name, name);
+                }
 
                 // don't send the job if we have errors
                 if (Log.HasLoggedErrors)


### PR DESCRIPTION
## Description

This change is part of moving servicing jobs to COGS subscription: https://github.com/dotnet/core-eng/issues/11639.

We need to include `System.PullRequest.TargetBranch` pipeline variable in Helix job properties to be able to redirect PR test jobs to servicing subscription. Currently Helix API has no way to tell if the PR was created for `main` or `release/*` branch.

I also added other properties that are send in `main` for consistency.

Related issue: https://github.com/dotnet/arcade/issues/7074

## Customer Impact

There is no customer impact. Only effect is that additional properties will be attached to Helix job.

## Regression

No

## Risk

The risk of this change is very low. Change is very small and the same code already runs on main.

## Workarounds

There is no workaround available. Without this change we won't be able to redirect servicing PR test jobs to COGS subscription.
