### PR TITLE
[release/3.x] Send `System.PullRequest.TargetBranch` in job created by SendHelixJob

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
@@ -198,7 +198,28 @@ namespace Microsoft.DotNet.Helix.Sdk
                     }
                 }
 
-                def = AddBuildVariableProperty(def, "System.PullRequest.TargetBranch", "System.PullRequest.TargetBranch");
+                def = AddBuildVariableProperty(def, "CollectionUri", "System.CollectionUri");
+                def = AddBuildVariableProperty(def, "Project", "System.TeamProject");
+                def = AddBuildVariableProperty(def, "BuildNumber", "Build.BuildNumber");
+                def = AddBuildVariableProperty(def, "BuildId", "Build.BuildId");
+                def = AddBuildVariableProperty(def, "DefinitionName", "Build.DefinitionName");
+                def = AddBuildVariableProperty(def, "DefinitionId", "System.DefinitionId");
+                def = AddBuildVariableProperty(def, "Reason", "Build.Reason");
+                var variablesToCopy = new[]
+                {
+                    "System.JobId",
+                    "System.JobName",
+                    "System.JobAttempt",
+                    "System.PhaseName",
+                    "System.PhaseAttempt",
+                    "System.PullRequest.TargetBranch",
+                    "System.StageName",
+                    "System.StageAttempt",
+                };
+                foreach (var name in variablesToCopy)
+                {
+                    def = AddBuildVariableProperty(def, name, name);
+                }
 
                 // don't send the job if we have errors
                 if (Log.HasLoggedErrors)

--- a/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
@@ -198,6 +198,8 @@ namespace Microsoft.DotNet.Helix.Sdk
                     }
                 }
 
+                def = AddBuildVariableProperty(def, "System.PullRequest.TargetBranch", "System.PullRequest.TargetBranch");
+
                 // don't send the job if we have errors
                 if (Log.HasLoggedErrors)
                 {
@@ -215,6 +217,26 @@ namespace Microsoft.DotNet.Helix.Sdk
             }
 
             cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        private IJobDefinition AddBuildVariableProperty(IJobDefinition def, string key, string azdoVariableName)
+        {
+            string envName = FromAzdoVariableNameToEnvironmentVariableName(azdoVariableName);
+
+            var value = Environment.GetEnvironmentVariable(envName);
+            if (string.IsNullOrEmpty(value))
+            {
+                return def;
+            }
+
+            def.WithProperty(key, value);
+            Log.LogMessage($"Added build variable property '{key}' (value: '{value}') to job definition.");
+            return def;
+        }
+
+        private static string FromAzdoVariableNameToEnvironmentVariableName(string name)
+        {
+            return name.Replace('.', '_').ToUpper();
         }
 
         private IJobDefinition AddProperty(IJobDefinition def, ITaskItem property)


### PR DESCRIPTION
## Description

This change is part of moving servicing jobs to COGS subscription: https://github.com/dotnet/core-eng/issues/11639.

We need to include `System.PullRequest.TargetBranch` pipeline variable in Helix job properties to be able to redirect PR test jobs to servicing subscription. Currently Helix API has no way to tell if the PR was created for `main` or `release/*` branch.

I also added other properties that are send in `main` for consistency and backported `SendHelixJob.AddBuildVariableProperty()` method from the latest code because it was not yet implemented here.

Related issue: https://github.com/dotnet/arcade/issues/7074

## Customer Impact

There is no customer impact. Only effect is that additional properties will be attached to Helix job.

## Regression

No

## Risk

The risk of this change is very low. Change is very small and the same code already runs on main.

## Workarounds

There is no workaround available. Without this change we won't be able to redirect servicing PR test jobs to COGS subscription.
