### PR TITLE
Use ubuntu & debian instead of unix & freebsd

### DIFF
--- a/src/Microsoft.DotNet.PackageValidation/GetCompatiblePackageTargetFrameworks.cs
+++ b/src/Microsoft.DotNet.PackageValidation/GetCompatiblePackageTargetFrameworks.cs
@@ -141,17 +141,20 @@ namespace Microsoft.DotNet.PackageValidation
                 if (item.AssetType == AssetType.RuntimeAsset)
                 {
                     string testRid = item.Rid;
+                    string testArch = "-x64";
                     if (testRid == "unix")
                     {
-                        testRid = "ubuntu";
+                        if (!rids.Contains("linux" + testArch))
+                            rids.Add("linux" + testArch);
+                        
+                        if (!rids.Contains("osx" + testArch))
+                            rids.Add("osx" + testArch);
                     }
-                    else if (testRid == "freebsd")
+                    else
                     {
-                        testRid = "debian";
-                    }
-                    string testArch = "-x64";
-                    if (!rids.Contains(testRid + testArch))
-                        rids.Add(testRid + testArch);
+                        if (!rids.Contains(testRid + testArch))
+                            rids.Add(testRid + testArch);
+                    }             
                 }
             }
             return string.Join(";", rids);

--- a/src/Microsoft.DotNet.PackageValidation/GetCompatiblePackageTargetFrameworks.cs
+++ b/src/Microsoft.DotNet.PackageValidation/GetCompatiblePackageTargetFrameworks.cs
@@ -140,8 +140,18 @@ namespace Microsoft.DotNet.PackageValidation
             {
                 if (item.AssetType == AssetType.RuntimeAsset)
                 {
-                    if (!rids.Contains(item.Rid + "-x64"))
-                        rids.Add(item.Rid + "-x64");
+                    string testRid = item.Rid;
+                    if (testRid == "unix")
+                    {
+                        testRid = "ubuntu";
+                    }
+                    else if (testRid == "freebsd")
+                    {
+                        testRid = "debian";
+                    }
+                    string testArch = "-x64";
+                    if (!rids.Contains(testRid + testArch))
+                        rids.Add(testRid + testArch);
                 }
             }
             return string.Join(";", rids);


### PR DESCRIPTION
It seems like unix and freebsd are not known rids
```
NETSDK1056: Project is targeting runtime 'freebsd' but did not resolve any runtime-specific packages
NETSDK1056: Project is targeting runtime 'unix-x64' but did not resolve any runtime-specific packages
```