### PR TITLE
Mark internal channel configs as internal

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
@@ -426,7 +426,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
             // ".NET Internal Tooling",
             new TargetChannelConfig(
                 551,
-                false,
+                true,
                 PublishingInfraVersion.All,
                 akaMSChannelName: string.Empty,
                 FeedDotNetToolsInternalShipping,
@@ -644,7 +644,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
             // ".NET Core 3.1 Internal Servicing",
             new TargetChannelConfig(
                 550,
-                false,
+                true,
                 PublishingInfraVersion.All,
                 akaMSChannelName: "internal/3.1",
                 FeedDotNet31InternalShipping,


### PR DESCRIPTION
We noticed a couple incorrect internal bool values in publishing constants while investigating [this build](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=4544454&view=logs&j=5efe09e7-d552-5578-8f7a-2fec74a23f0f)

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
