### PR TITLE
fix parameter name

### DIFF
--- a/eng/common/templates/steps/perf-send-to-helix.yml
+++ b/eng/common/templates/steps/perf-send-to-helix.yml
@@ -29,7 +29,7 @@ steps:
     sendParams: $(Build.SourcesDirectory)/eng/common/performance/${{ parameters.ProjectFile }} /restore /t:Test /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
     displayName: ${{ parameters.DisplayNamePrefix }}
     condition: ${{ parameters.condition }}
-    continueOnError: ${{ parameters.continueOnError }}
+    shouldContinueOnError: ${{ parameters.continueOnError }}
     environment:
       BuildConfig: $(_BuildConfig)
       HelixSource: ${{ parameters.HelixSource }}


### PR DESCRIPTION
We're calling the template with the wrong parameter name.

https://github.com/dotnet/runtime/blob/062ae9697dc040d50b128af094f465fb3d8bb0f0/eng/pipelines/common/templates/runtimes/send-to-helix-inner-step.yml#L8