### PR TITLE
Some meta data was dropping, so I included it so it wouldn't get dropped anymore

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/BuildModelFactoryTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/BuildModelFactoryTests.cs
@@ -363,6 +363,19 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                 new TaskItem(localPackagePath, new Dictionary<string, string>()
                 {
                     { "CertificateName", "IHasACert2" }
+                }),
+                // Added per issue: dotnet/arcade#7064
+                new TaskItem("Microsoft.DiaSymReader.dll", new Dictionary<string, string>()
+                {
+                    { "CertificateName", "MicrosoftWin8WinBlue" },
+                    { "TargetFramework", ".NETFramework,Version=v2.0" },
+                    { "PublicKeyToken", "31bf3856ad364e35" }
+                }),
+                new TaskItem("Microsoft.DiaSymReader.dll", new Dictionary<string, string>()
+                {
+                    { "CertificateName", "Microsoft101240624" },
+                    { "TargetFramework", ".NETStandard,Version=v1.1" },
+                    { "PublicKeyToken", "31bf3856ad364e35" }
                 })
             };
 
@@ -476,6 +489,20 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                         item.PublicKeyToken.Should().Be("abcdabcdabcdabcd");
                     });
                 modelFromFile.SigningInformation.FileSignInfo.Should().SatisfyRespectively(
+                    item =>
+                    {
+                        item.Include.Should().Be("Microsoft.DiaSymReader.dll");
+                        item.CertificateName.Should().Be("Microsoft101240624");
+                        item.TargetFramework.Should().Be(".NETStandard,Version=v1.1");
+                        item.PublicKeyToken.Should().Be("31bf3856ad364e35");
+                    },
+                    item =>
+                    {
+                        item.Include.Should().Be("Microsoft.DiaSymReader.dll");
+                        item.CertificateName.Should().Be("MicrosoftWin8WinBlue");
+                        item.TargetFramework.Should().Be(".NETFramework,Version=v2.0");
+                        item.PublicKeyToken.Should().Be("31bf3856ad364e35");
+                    },
                     item =>
                     {
                         item.Include.Should().Be("test-package-a.1.0.0.nupkg");

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/SigningInformationModelFactory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/SigningInformationModelFactory.cs
@@ -73,7 +73,19 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 foreach (var signInfo in fileSignInfo)
                 {
                     var attributes = signInfo.CloneCustomMetadata() as IDictionary<string, string>;
-                    parsedFileSignInfo.Add(new FileSignInfoModel { Include = Path.GetFileName(signInfo.ItemSpec), CertificateName = attributes["CertificateName"] });
+                    var fileSignInfoModel = new FileSignInfoModel { Include = Path.GetFileName(signInfo.ItemSpec), CertificateName = attributes["CertificateName"] };
+                    
+                    if (attributes.ContainsKey("PublicKeyToken"))
+                    {
+                        fileSignInfoModel.PublicKeyToken = attributes["PublicKeyToken"];
+                    }
+                    
+                    if (attributes.ContainsKey("TargetFramework"))
+                    {
+                        fileSignInfoModel.TargetFramework = attributes["TargetFramework"];
+                    }
+
+                    parsedFileSignInfo.Add(fileSignInfoModel);
                 }
             }
             if (fileExtensionSignInfo != null)

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/SigningInformationModelFactory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/SigningInformationModelFactory.cs
@@ -74,15 +74,15 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 {
                     var attributes = signInfo.CloneCustomMetadata() as IDictionary<string, string>;
                     var fileSignInfoModel = new FileSignInfoModel { Include = Path.GetFileName(signInfo.ItemSpec), CertificateName = attributes["CertificateName"] };
-                    
-                    if (attributes.ContainsKey("PublicKeyToken"))
+
+                    if (attributes.TryGetValue("PublicKeyToken", out string publicKeyTokenValue))
                     {
-                        fileSignInfoModel.PublicKeyToken = attributes["PublicKeyToken"];
+                        fileSignInfoModel.PublicKeyToken = publicKeyTokenValue;
                     }
                     
-                    if (attributes.ContainsKey("TargetFramework"))
+                    if (attributes.TryGetValue("TargetFramework", out string targetFrameworkValue))
                     {
-                        fileSignInfoModel.TargetFramework = attributes["TargetFramework"];
+                        fileSignInfoModel.TargetFramework = targetFrameworkValue;
                     }
 
                     parsedFileSignInfo.Add(fileSignInfoModel);

--- a/src/Microsoft.DotNet.VersionTools/tests/BuildManifest/ManifestModelTests.cs
+++ b/src/Microsoft.DotNet.VersionTools/tests/BuildManifest/ManifestModelTests.cs
@@ -139,7 +139,7 @@ namespace Microsoft.DotNet.VersionTools.Tests.BuildManifest
         [InlineData(typeof(ArgumentException), "bar.bat", "foocert2", null, null, "bar.bat", "foocert", null, null)]
         [InlineData(null, "bar.bat", "foocert2", ".NETCoreApp,Version=v5.0", null, "bar.bat", "foocert", ".NETCoreApp,Version=v3.1", null)]
         [InlineData(null, "bar.bat", "foocert2", ".NETCoreApp,Version=v1.0", "aaaaaaaaaaaaaaaa", "bar.bat", "foocert", ".NETCoreApp,Version=v1.0", "aaaaaaaaaaaaaaab")]
-        [InlineData(typeof(ArgumentException), "bar.bat", "foocert2", ".NETCoreApp,Version=v1.0", "aaaaaaaaaaaaaaaa", "bar.bat", "foocert", ".NETCoreApp,Version=v1.0", "aaaaaaaaaaaaaaaa")]
+        [InlineData(typeof(ArgumentException), "bar.bat", "foocert2", ".NETCoreApp,Version=v1.0", "aaaaaaaaaaaaaaaa", "bar.bat", "foocert", ".NETCoreApp,Version=v1.0", "aaaaaaaaaaaaaaaa")]        
         public void ManifestModelToXmlValidatesFileSignInfos(Type exceptionType, params string[] infos)
         {
             if (infos.Length % 4 != 0)
@@ -166,6 +166,36 @@ namespace Microsoft.DotNet.VersionTools.Tests.BuildManifest
             };
 
             VerifyToXml(exceptionType, signInfo);
+        }
+
+        /// <summary>
+        /// Per issue: dotnet/arcade#7064
+        /// </summary>
+        [Fact]
+        public void ValidateSymreaderFileSignInfos()
+        {
+            List<FileSignInfoModel> models = new List<FileSignInfoModel>();            
+            models.Add(new FileSignInfoModel()
+            {
+                Include = "Microsoft.DiaSymReader.dll",
+                CertificateName = "MicrosoftWin8WinBlue",
+                TargetFramework = ".NETFramework,Version=v2.0",
+                PublicKeyToken = "31bf3856ad364e35",
+            });
+            models.Add(new FileSignInfoModel()
+            {
+                Include = "Microsoft.DiaSymReader.dll",
+                CertificateName = "Microsoft101240624",
+                TargetFramework = ".NETStandard,Version=v1.1",
+                PublicKeyToken = "31bf3856ad364e35",
+            });
+
+            SigningInformationModel signInfo = new SigningInformationModel()
+            {
+                FileSignInfo = models
+            };
+
+            signInfo.ToXml().Should().NotBeNull();
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.VersionTools/tests/BuildManifest/ManifestModelTests.cs
+++ b/src/Microsoft.DotNet.VersionTools/tests/BuildManifest/ManifestModelTests.cs
@@ -139,7 +139,7 @@ namespace Microsoft.DotNet.VersionTools.Tests.BuildManifest
         [InlineData(typeof(ArgumentException), "bar.bat", "foocert2", null, null, "bar.bat", "foocert", null, null)]
         [InlineData(null, "bar.bat", "foocert2", ".NETCoreApp,Version=v5.0", null, "bar.bat", "foocert", ".NETCoreApp,Version=v3.1", null)]
         [InlineData(null, "bar.bat", "foocert2", ".NETCoreApp,Version=v1.0", "aaaaaaaaaaaaaaaa", "bar.bat", "foocert", ".NETCoreApp,Version=v1.0", "aaaaaaaaaaaaaaab")]
-        [InlineData(typeof(ArgumentException), "bar.bat", "foocert2", ".NETCoreApp,Version=v1.0", "aaaaaaaaaaaaaaaa", "bar.bat", "foocert", ".NETCoreApp,Version=v1.0", "aaaaaaaaaaaaaaaa")]        
+        [InlineData(typeof(ArgumentException), "bar.bat", "foocert2", ".NETCoreApp,Version=v1.0", "aaaaaaaaaaaaaaaa", "bar.bat", "foocert", ".NETCoreApp,Version=v1.0", "aaaaaaaaaaaaaaaa")]
         public void ManifestModelToXmlValidatesFileSignInfos(Type exceptionType, params string[] infos)
         {
             if (infos.Length % 4 != 0)


### PR DESCRIPTION
TargetFramework and PublicKeyToken meta data was getting dropped during the BuildModelFactory process, so I included them so that the FileSignInfo conflicts wouldn't occur for Symreader. 

Also: Adding this data to existing tests helped find where this issue was, so yay!

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
