### PR TITLE
Add "call" to prevent the wrapper script from causing exit before ADO reporting

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             string wrapperScriptName = IsPosixShell ? PosixAndroidWrapperScript : NonPosixAndroidWrapperScript;
 
             string xharnessHelixWrapperScript = IsPosixShell ? $"chmod +x ./{wrapperScriptName} && ./{wrapperScriptName}"
-                                                             : $"{wrapperScriptName}";
+                                                             : $"call {wrapperScriptName}";
 
             string xharnessRunCommand = $"{xharnessHelixWrapperScript} " +
                                         $"dotnet exec \"{(IsPosixShell ? "$XHARNESS_CLI_PATH" : "%XHARNESS_CLI_PATH%")}\" android test " +


### PR DESCRIPTION
### To double check:

https://github.com/dotnet/xharness/issues/505

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation (it does not, but will ; currently blocked on disabling these tests due to only 45 machines and Runtime's usage patterns)
