### PR TITLE
Fix argument escaping when running Command

### DIFF
--- a/Arcade.sln
+++ b/Arcade.sln
@@ -133,6 +133,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.PackageVal
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.PackageValidation.Tests", "src\Microsoft.DotNet.PackageValidation.Tests\Microsoft.DotNet.PackageValidation.Tests.csproj", "{8BBF14AC-48F0-4282-910E-48E816021660}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Arcade.Common.Tests", "src\Common\Microsoft.Arcade.Common.Tests\Microsoft.Arcade.Common.Tests.csproj", "{B5E9D9D8-59E0-49F8-9C3C-75138A2D452C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -835,6 +837,18 @@ Global
 		{8BBF14AC-48F0-4282-910E-48E816021660}.Release|x64.Build.0 = Release|Any CPU
 		{8BBF14AC-48F0-4282-910E-48E816021660}.Release|x86.ActiveCfg = Release|Any CPU
 		{8BBF14AC-48F0-4282-910E-48E816021660}.Release|x86.Build.0 = Release|Any CPU
+		{B5E9D9D8-59E0-49F8-9C3C-75138A2D452C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5E9D9D8-59E0-49F8-9C3C-75138A2D452C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B5E9D9D8-59E0-49F8-9C3C-75138A2D452C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B5E9D9D8-59E0-49F8-9C3C-75138A2D452C}.Debug|x64.Build.0 = Debug|Any CPU
+		{B5E9D9D8-59E0-49F8-9C3C-75138A2D452C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B5E9D9D8-59E0-49F8-9C3C-75138A2D452C}.Debug|x86.Build.0 = Debug|Any CPU
+		{B5E9D9D8-59E0-49F8-9C3C-75138A2D452C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B5E9D9D8-59E0-49F8-9C3C-75138A2D452C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B5E9D9D8-59E0-49F8-9C3C-75138A2D452C}.Release|x64.ActiveCfg = Release|Any CPU
+		{B5E9D9D8-59E0-49F8-9C3C-75138A2D452C}.Release|x64.Build.0 = Release|Any CPU
+		{B5E9D9D8-59E0-49F8-9C3C-75138A2D452C}.Release|x86.ActiveCfg = Release|Any CPU
+		{B5E9D9D8-59E0-49F8-9C3C-75138A2D452C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -867,6 +881,7 @@ Global
 		{CE5278A3-2442-4309-A543-5BA5C1C76A2A} = {C53DD924-C212-49EA-9BC4-1827421361EF}
 		{E941EDE6-3FFB-4776-A4CE-750755D57817} = {C53DD924-C212-49EA-9BC4-1827421361EF}
 		{6CA09DC9-E654-4906-A977-1279F6EDC109} = {C53DD924-C212-49EA-9BC4-1827421361EF}
+		{B5E9D9D8-59E0-49F8-9C3C-75138A2D452C} = {C53DD924-C212-49EA-9BC4-1827421361EF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {32B9C883-432E-4FC8-A1BF-090EB033DD5B}

--- a/src/Common/Microsoft.Arcade.Common.Tests/ArgumentEscaperTests.cs
+++ b/src/Common/Microsoft.Arcade.Common.Tests/ArgumentEscaperTests.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+using Microsoft.Arcade.Common;
+using Xunit;
+
+namespace Microsoft.DotNet.Arcade.Sdk.Tests
+{
+    public class ArgumentEscaperTests
+    {
+        [Fact]
+        public void EscapesOnlyArgsWithSpecialCharacters()
+        {
+            var args = new[]
+            {
+                "subcommand",
+                "--not-escaped",
+                "1.0.0-prerelease.21165.2",
+                "--with-space",
+                "/mnt/d/Program Files",
+                "--already-escaped",
+                "\"some value\"",
+                "containing-\"-quote",
+            };
+
+            string escaped = ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(args);
+            escaped.Should().Be(
+                "subcommand " +
+                "--not-escaped 1.0.0-prerelease.21165.2 " +
+                "--with-space \"/mnt/d/Program Files\" " +
+                "--already-escaped \"some value\" " +
+                "\"containing-\\\"-quote\"");
+        }
+    }
+}

--- a/src/Common/Microsoft.Arcade.Common.Tests/Microsoft.Arcade.Common.Tests.csproj
+++ b/src/Common/Microsoft.Arcade.Common.Tests/Microsoft.Arcade.Common.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Moq" Version="4.8.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Arcade.Common\Microsoft.Arcade.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Common/Microsoft.Arcade.Common/ArgumentEscaper.cs
+++ b/src/Common/Microsoft.Arcade.Common/ArgumentEscaper.cs
@@ -1,8 +1,8 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Microsoft.Arcade.Common
@@ -10,55 +10,16 @@ namespace Microsoft.Arcade.Common
     public static class ArgumentEscaper
     {
         /// <summary>
-        /// Undo the processing which took place to create string[] args in Main,
-        /// so that the next process will receive the same string[] args
-        /// 
-        /// See here for more info:
-        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
+        /// Escapes and quote arguments that need it (contain a space, a quote...).
         /// </summary>
-        /// <param name="args"></param>
-        /// <returns></returns>
         public static string EscapeAndConcatenateArgArrayForProcessStart(IEnumerable<string> args)
         {
-            return string.Join(" ", EscapeArgArray(args));
+            return string.Join(" ", args.Select(EscapeArg));
         }
 
         /// <summary>
-        /// Undo the processing which took place to create string[] args in Main,
-        /// so that the next process will receive the same string[] args
+        /// Escapes and quote arguments that need it.
         /// 
-        /// See here for more info:
-        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
-        /// </summary>
-        /// <param name="args"></param>
-        /// <returns></returns>
-        public static string EscapeAndConcatenateArgArrayForCmdProcessStart(IEnumerable<string> args)
-        {
-            return string.Join(" ", EscapeArgArrayForCmd(args));
-        }
-
-        /// <summary>
-        /// Undo the processing which took place to create string[] args in Main,
-        /// so that the next process will receive the same string[] args
-        /// 
-        /// See here for more info:
-        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
-        /// </summary>
-        /// <param name="args"></param>
-        /// <returns></returns>
-        private static IEnumerable<string> EscapeArgArray(IEnumerable<string> args)
-        {
-            var escapedArgs = new List<string>();
-
-            foreach (var arg in args)
-            {
-                escapedArgs.Add(EscapeArg(arg));
-            }
-
-            return escapedArgs;
-        }
-
-        /// <summary>
         /// This prefixes every character with the '^' character to force cmd to
         /// interpret the argument string literally. An alternative option would 
         /// be to do this only for cmd metacharacters.
@@ -66,33 +27,34 @@ namespace Microsoft.Arcade.Common
         /// See here for more info:
         /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
         /// </summary>
-        /// <param name="args"></param>
-        /// <returns></returns>
-        private static IEnumerable<string> EscapeArgArrayForCmd(IEnumerable<string> arguments)
+        public static string EscapeAndConcatenateArgArrayForCmdProcessStart(IEnumerable<string> args)
         {
-            var escapedArgs = new List<string>();
-
-            foreach (var arg in arguments)
-            {
-                escapedArgs.Add(EscapeArgForCmd(arg));
-            }
-
-            return escapedArgs;
+            return string.Join(" ", args.Select(EscapeArgForCmd));
         }
 
-        private static string EscapeArg(string arg)
+        private static string EscapeArg(string argument)
         {
             var sb = new StringBuilder();
 
-            var quoted = ShouldSurroundWithQuotes(arg);
-            if (quoted) sb.Append("\"");
-
-            for (int i = 0; i < arg.Length; ++i)
+            // Don't quote already quoted strings
+            bool quoted = IsQuoted(argument);
+            var shouldQuote = !quoted && ShouldSurroundWithQuotes(argument);
+            if (shouldQuote || quoted)
             {
+                sb.Append("\"");
+            }
+
+            for (int i = 0; i < argument.Length; ++i)
+            {
+                if (quoted && (i == 0 || i == argument.Length - 1))
+                {
+                    continue;
+                }
+
                 var backslashCount = 0;
 
                 // Consume All Backslashes
-                while (i < arg.Length && arg[i] == '\\')
+                while (i < argument.Length && argument[i] == '\\')
                 {
                     backslashCount++;
                     i++;
@@ -101,13 +63,13 @@ namespace Microsoft.Arcade.Common
                 // Escape any backslashes at the end of the arg
                 // This ensures the outside quote is interpreted as
                 // an argument delimiter
-                if (i == arg.Length)
+                if (i == argument.Length)
                 {
                     sb.Append('\\', 2 * backslashCount);
                 }
 
                 // Escape any preceding backslashes and the quote
-                else if (arg[i] == '"')
+                else if (argument[i] == '"')
                 {
                     sb.Append('\\', (2 * backslashCount) + 1);
                     sb.Append('"');
@@ -117,42 +79,34 @@ namespace Microsoft.Arcade.Common
                 else
                 {
                     sb.Append('\\', backslashCount);
-                    sb.Append(arg[i]);
+                    sb.Append(argument[i]);
                 }
             }
 
-            if (quoted) sb.Append("\"");
+            if (shouldQuote || quoted)
+            {
+                sb.Append("\"");
+            }
 
             return sb.ToString();
         }
 
-        /// <summary>
-        /// Prepare as single argument to 
-        /// roundtrip properly through cmd.
-        /// 
-        /// This prefixes every character with the '^' character to force cmd to
-        /// interpret the argument string literally. An alternative option would 
-        /// be to do this only for cmd metacharacters.
-        /// 
-        /// See here for more info:
-        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
-        /// </summary>
-        /// <param name="args"></param>
-        /// <returns></returns>
         private static string EscapeArgForCmd(string argument)
         {
             var sb = new StringBuilder();
 
-            var quoted = ShouldSurroundWithQuotes(argument);
+            var quoted = IsQuoted(argument);
+            var shouldQuote = !quoted && ShouldSurroundWithQuotes(argument);
 
-            if (quoted) sb.Append("^\"");
+            if (shouldQuote)
+            {
+                sb.Append("^\"");
+            }
 
             foreach (var character in argument)
             {
-
                 if (character == '"')
                 {
-
                     sb.Append('^');
                     sb.Append('"');
                     sb.Append('^');
@@ -165,40 +119,24 @@ namespace Microsoft.Arcade.Common
                 }
             }
 
-            if (quoted) sb.Append("^\"");
+            if (shouldQuote)
+            {
+                sb.Append("^\"");
+            }
 
             return sb.ToString();
         }
 
-        /// <summary>
-        /// Prepare as single argument to 
-        /// roundtrip properly through cmd.
-        /// 
-        /// This prefixes every character with the '^' character to force cmd to
-        /// interpret the argument string literally. An alternative option would 
-        /// be to do this only for cmd metacharacters.
-        /// 
-        /// See here for more info:
-        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
-        /// </summary>
-        /// <param name="args"></param>
-        /// <returns></returns>
-        internal static bool ShouldSurroundWithQuotes(string argument)
+        private static bool ShouldSurroundWithQuotes(string argument)
         {
-            // Don't quote already quoted strings
-            if (argument.StartsWith("\"", StringComparison.Ordinal) &&
-                    argument.EndsWith("\"", StringComparison.Ordinal))
-            {
-                return false;
-            }
-
             // Only quote if whitespace exists in the string
-            if (argument.Contains(" ") || argument.Contains("\t") || argument.Contains("\n"))
-            {
-                return true;
-            }
+            return argument.Contains(' ') || argument.Contains('\t') || argument.Contains('\n') || argument.Contains('"');
+        }
 
-            return true;
+
+        private static bool IsQuoted(string argument)
+        {
+            return argument.Length > 1 && (argument[0] == '\"' || argument[argument.Length - 1] == '\"');
         }
     }
 }


### PR DESCRIPTION
I found out the on Linux, commands were failing because every single one of them was escaped, so things like this would fail:
```
dotnet "tool" "install" "--version" ... 
```

I need this change for #7029