### PR TITLE
Fix the public key token in frameworkList

### DIFF
--- a/src/Microsoft.DotNet.SharedFramework.Sdk/src/CreateFrameworkListFile.cs
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/src/CreateFrameworkListFile.cs
@@ -148,7 +148,7 @@ namespace Microsoft.DotNet.SharedFramework.Sdk
                         StringBuilder publicKeyTokenBuilder = new StringBuilder(len * 2);
                         for (int i = 0; i < len; i++)
                         {
-                            publicKeyTokenBuilder.Append(publicKeyToken[i].ToString("x", CultureInfo.InvariantCulture));
+                            publicKeyTokenBuilder.Append(publicKeyToken[i].ToString("x2", CultureInfo.InvariantCulture));
                         }
                         publicKeyTokenHex = publicKeyTokenBuilder.ToString();
                     }


### PR DESCRIPTION
I happened to be referencing this code and noticed it dropped leading 0s from bytes when formatting the public key token.

For example 
`b03f5f7f11d5a3a` produced today
`b03f5f7f11d50a3a` after this fix

