### PR TITLE
Update OneLocBuild stuff for AzDO repos

### DIFF
--- a/eng/common/generate-locproject.ps1
+++ b/eng/common/generate-locproject.ps1
@@ -52,7 +52,7 @@ $locJson = @{
             LanguageSet = $LanguageSet
             LocItems = @(
                 $locFiles | ForEach-Object {
-                    $outputPath = "Localize\$(($_.DirectoryName | Resolve-Path -Relative) + "\")" 
+                    $outputPath = "$(($_.DirectoryName | Resolve-Path -Relative) + "\")" 
                     $continue = $true
                     foreach ($exclusion in $exclusions.Exclusions) {
                         if ($outputPath.Contains($exclusion))

--- a/eng/common/templates/job/onelocbuild.yml
+++ b/eng/common/templates/job/onelocbuild.yml
@@ -46,16 +46,19 @@ jobs:
 
     - task: OneLocBuild@2
       displayName: OneLocBuild
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       inputs:
         locProj: Localize/LocProject.json
         outDir: $(Build.ArtifactStagingDirectory)
         lclSource: ${{ parameters.LclSource }}
         lclPackageId: ${{ parameters.LclPackageId }}
         isCreatePrSelected: ${{ parameters.CreatePr }}
-        repoType: ${{ parameters.RepoType }}
-        gitHubPatVariable: "${{ parameters.GithubPat }}"
         packageSourceAuth: patAuth
         patVariable: ${{ parameters.CeapexPat }}
+        ${{ if eq(parameters.RepoType, 'gitHub') }}:
+          repoType: ${{ parameters.RepoType }}
+          gitHubPatVariable: "${{ parameters.GithubPat }}"
       condition: always()
 
     - task: PublishBuildArtifacts@1


### PR DESCRIPTION
Further testing in AzDO repos revealed a couple of issues that didn't apply to GitHub repos that are addressed in this PR.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
