### PR TITLE
Build only requested cross arch

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
@@ -341,11 +341,11 @@
           DependsOnTargets="_GetTargetOSArchInfo"
           Returns="@(_CrossArchMsi)">
     <MSBuild
-      Condition="'@(CrossArchMsiToBuild)' != ''"
+      Condition="'@(CrossArchMsiToBuild)' != '' and '$(InstallerTargetArchitecture)' != '$(TargetArchitecture)'"
       Projects="$(MSBuildProjectFullPath)"
       Targets="CreateWixInstaller"
       Properties="
-        InstallerTargetArchitecture=%(CrossArchMsiToBuild.Identity);
+        InstallerTargetArchitecture=$(InstallerTargetArchitecture);
         CrossArchContentsArch=$(TargetArchitecture);
         GenerateMSI=true">
       <Output TaskParameter="TargetOutputs" ItemName="_CrossArchMsi" />


### PR DESCRIPTION
### To double check:

* [ x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation

Validated with full dotnet/runtime builds for x64 and arm64 architectures and verified produced packages and their contents.

### Fix description:

Fixes https://github.com/dotnet/arcade/issues/7139

The following is incorrect:
https://github.com/dotnet/arcade/blob/1cabae2d525d5d0d9af6da245e8424a6931bb19f/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets#L348

It will iterate on all items in CrossArchMsiToBuild.

But we are already iterating on all items in CrossArchMsiToBuild since CreateCrossArchWixInstaller is invoked from:
https://github.com/dotnet/arcade/blob/1cabae2d525d5d0d9af6da245e8424a6931bb19f/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets#L409

So, instead, we should use InstallerTargetArchitecture, which is the iterator.

Also, updating build condition to avoid building MSIs for cross arch that matches target arch.