### PR TITLE
Add support for additional DotNetRuntime

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/Readme.md
@@ -153,6 +153,23 @@ Given a local folder `$(TestFolder)` containing `runtests.cmd`, this will run `r
   </PropertyGroup>
 
   <!--
+    Including additional dotnet correlation payloads
+    PackageType defaults to runtime
+    Channel defaults to Current
+  -->
+  <ItemGroup>
+    <!-- Includes the specified dotnet package version/packagetype/channel, using the DotNetCliRuntime -->
+    <AdditionalDotNetPackage Include="6.0.0-preview.4.21178.6">
+      <!-- 'sdk', 'runtime' or 'aspnetcore-runtime' -->
+      <PackageType>runtime</PackageType>
+      <!-- 'Current' or 'LTS', determines what channel 'latest' version pulls from -->
+      <Channel>Current</Channel>
+    </AdditionalDotNetPackage>
+    <!-- Includes the specified version, using the default runtime packageType, DotNetCliRuntime, and Current channel  -->
+    <AdditionalDotNetPackage Include="6.0.0-preview.4.21175.1" />
+  </ItemGroup>
+  
+  <!--
     XUnit Runner
       Enabling this will create one work item for each xunit test project specified.
       This is enabled by specifying one or more XUnitProject items

--- a/src/Microsoft.DotNet.Helix/Sdk/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/Readme.md
@@ -153,7 +153,7 @@ Given a local folder `$(TestFolder)` containing `runtests.cmd`, this will run `r
   </PropertyGroup>
 
   <!--
-    Including additional dotnet correlation payloads
+    Optional additional dotnet runtimes or SDKs for correlation payloads
     PackageType (defaults to runtime)
     Channel (defaults to Current)
   -->

--- a/src/Microsoft.DotNet.Helix/Sdk/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/Readme.md
@@ -154,8 +154,8 @@ Given a local folder `$(TestFolder)` containing `runtests.cmd`, this will run `r
 
   <!--
     Including additional dotnet correlation payloads
-    PackageType defaults to runtime
-    Channel defaults to Current
+    PackageType (defaults to runtime)
+    Channel (defaults to Current)
   -->
   <ItemGroup>
     <!-- Includes the 6.0.0-preview.4.21178.6 dotnet runtime package version from the Current channel, using the DotNetCliRuntime -->

--- a/src/Microsoft.DotNet.Helix/Sdk/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/Readme.md
@@ -158,14 +158,14 @@ Given a local folder `$(TestFolder)` containing `runtests.cmd`, this will run `r
     Channel defaults to Current
   -->
   <ItemGroup>
-    <!-- Includes the specified dotnet package version/packagetype/channel, using the DotNetCliRuntime -->
+    <!-- Includes the 6.0.0-preview.4.21178.6 dotnet runtime package version from the Current channel, using the DotNetCliRuntime -->
     <AdditionalDotNetPackage Include="6.0.0-preview.4.21178.6">
       <!-- 'sdk', 'runtime' or 'aspnetcore-runtime' -->
       <PackageType>runtime</PackageType>
       <!-- 'Current' or 'LTS', determines what channel 'latest' version pulls from -->
       <Channel>Current</Channel>
     </AdditionalDotNetPackage>
-    <!-- Includes the specified version, using the default runtime packageType, DotNetCliRuntime, and Current channel  -->
+    <!-- Includes the 6.0.0-preview.4.21175.1 version, using the default runtime packageType, DotNetCliRuntime, and Current channel  -->
     <AdditionalDotNetPackage Include="6.0.0-preview.4.21175.1" />
   </ItemGroup>
   

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
@@ -6,6 +6,8 @@
     <!-- TODO (https://github.com/dotnet/arcade/issues/7022): We are hardcoding this version to use the one tied to the SDK version from global.json -->
     <DotNetCliVersion Condition=" '$(DotNetCliVersion)' == '' AND '$(DotNetCliPackageType)' == 'aspnetcore-runtime' ">6.0.0-preview.1.21103.6</DotNetCliVersion>
     <DotNetCliVersion Condition=" '$(DotNetCliVersion)' == '' AND '$(DotNetCliPackageType)' == 'sdk' ">$(NETCoreSdkVersion)</DotNetCliVersion>
+    <IncludeDotNetRuntime Condition=" '$(IncludeDotNetRuntime)' != 'true' ">false</IncludeDotNetRuntime>
+    <DotNetRuntimeVersion Condition=" '$(DotNetRuntimeVersion)' == '' ">$(BundledNETCoreAppPackageVersion)</DotNetRuntimeVersion>
     <DotNetCliChannel Condition=" '$(DotNetCliChannel)' == '' ">Current</DotNetCliChannel>
     <DotNetCliDestination>dotnet-cli</DotNetCliDestination>
     <_HelixMonoQueueTargets>$(_HelixMonoQueueTargets);$(MSBuildThisFileDirectory)DotNetCli.targets</_HelixMonoQueueTargets>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
@@ -6,8 +6,6 @@
     <!-- TODO (https://github.com/dotnet/arcade/issues/7022): We are hardcoding this version to use the one tied to the SDK version from global.json -->
     <DotNetCliVersion Condition=" '$(DotNetCliVersion)' == '' AND '$(DotNetCliPackageType)' == 'aspnetcore-runtime' ">6.0.0-preview.1.21103.6</DotNetCliVersion>
     <DotNetCliVersion Condition=" '$(DotNetCliVersion)' == '' AND '$(DotNetCliPackageType)' == 'sdk' ">$(NETCoreSdkVersion)</DotNetCliVersion>
-    <IncludeDotNetRuntime Condition=" '$(IncludeDotNetRuntime)' != 'true' ">false</IncludeDotNetRuntime>
-    <DotNetRuntimeVersion Condition=" '$(DotNetRuntimeVersion)' == '' ">$(BundledNETCoreAppPackageVersion)</DotNetRuntimeVersion>
     <DotNetCliChannel Condition=" '$(DotNetCliChannel)' == '' ">Current</DotNetCliChannel>
     <DotNetCliDestination>dotnet-cli</DotNetCliDestination>
     <_HelixMonoQueueTargets>$(_HelixMonoQueueTargets);$(MSBuildThisFileDirectory)DotNetCli.targets</_HelixMonoQueueTargets>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.targets
@@ -26,12 +26,12 @@
     <PropertyGroup>
       <_channel>%(AdditionalDotNetPackage.Channel)</_channel>
       <_channel Condition=" '$(_channel)' == '' ">Current</_channel>
-      <_package>%(AdditionalDotNetPackage.PackageType)</_package>
-      <_package Condition=" '$(_package)' == '' ">runtime</_package>
+      <_packageType>%(AdditionalDotNetPackage.PackageType)</_packageType>
+      <_packageType Condition=" '$(_packageType)' == '' ">runtime</_packageType>
     </PropertyGroup>
 
-    <Message Text = "FindDotNetCliPackage '%(AdditionalDotNetPackage.Identity)' '$(DotNetCliRuntime)' '$(_package)' '$(_channel)' "/>
-    <FindDotNetCliPackage Version="%(AdditionalDotNetPackage.Identity)" Runtime="$(DotNetCliRuntime)" PackageType="$(_package)" Channel="$(_channel)">
+    <Message Text = "Adding correlation payload for additional .NET Core package: Version: '%(AdditionalDotNetPackage.Identity)'  Runtime: '$(DotNetCliRuntime)' PackageType: '$(_packageType)' Channel: '$(_channel)' "/>
+    <FindDotNetCliPackage Version="%(AdditionalDotNetPackage.Identity)" Runtime="$(DotNetCliRuntime)" PackageType="$(_packageType)" Channel="$(_channel)">
       <Output TaskParameter="PackageUri" PropertyName="DotNetCliPackageUri"/>
     </FindDotNetCliPackage>
     <ItemGroup>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.targets
@@ -5,9 +5,16 @@
     <FindDotNetCliPackage Version="$(DotNetCliVersion)" Runtime="$(DotNetCliRuntime)" PackageType="$(DotNetCliPackageType)" Channel="$(DotNetCliChannel)">
       <Output TaskParameter="PackageUri" PropertyName="DotNetCliPackageUri"/>
     </FindDotNetCliPackage>
+    <FindDotNetCliPackage Condition="$(IncludeDotNetRuntime) == 'true'" Version="$(DotNetRuntimeVersion)" Runtime="$(DotNetCliRuntime)" PackageType="runtime" Channel="$(DotNetCliChannel)">
+      <Output TaskParameter="PackageUri" PropertyName="DotNetRuntimePackageUri"/>
+    </FindDotNetCliPackage>
     <ItemGroup>
       <HelixCorrelationPayload Include="dotnet-cli">
         <Uri>$(DotNetCliPackageUri)</Uri>
+        <Destination>$(DotNetCliDestination)</Destination>
+      </HelixCorrelationPayload>
+      <HelixCorrelationPayload Include="dotnet-runtime" Condition="$(IncludeDotNetRuntime) == 'true'">
+        <Uri>$(DotNetRuntimePackageUri)</Uri>
         <Destination>$(DotNetCliDestination)</Destination>
       </HelixCorrelationPayload>
     </ItemGroup>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.targets
@@ -5,16 +5,9 @@
     <FindDotNetCliPackage Version="$(DotNetCliVersion)" Runtime="$(DotNetCliRuntime)" PackageType="$(DotNetCliPackageType)" Channel="$(DotNetCliChannel)">
       <Output TaskParameter="PackageUri" PropertyName="DotNetCliPackageUri"/>
     </FindDotNetCliPackage>
-    <FindDotNetCliPackage Condition="$(IncludeDotNetRuntime) == 'true'" Version="$(DotNetRuntimeVersion)" Runtime="$(DotNetCliRuntime)" PackageType="runtime" Channel="$(DotNetCliChannel)">
-      <Output TaskParameter="PackageUri" PropertyName="DotNetRuntimePackageUri"/>
-    </FindDotNetCliPackage>
     <ItemGroup>
       <HelixCorrelationPayload Include="dotnet-cli">
         <Uri>$(DotNetCliPackageUri)</Uri>
-        <Destination>$(DotNetCliDestination)</Destination>
-      </HelixCorrelationPayload>
-      <HelixCorrelationPayload Include="dotnet-runtime" Condition="$(IncludeDotNetRuntime) == 'true'">
-        <Uri>$(DotNetRuntimePackageUri)</Uri>
         <Destination>$(DotNetCliDestination)</Destination>
       </HelixCorrelationPayload>
     </ItemGroup>
@@ -24,5 +17,22 @@
       <HelixPreCommands Condition="$(IsPosixShell)">$(HelixPreCommands);export DOTNET_ROOT=$HELIX_CORRELATION_PAYLOAD/$(DotNetCliDestination);export DOTNET_CLI_TELEMETRY_OPTOUT=1</HelixPreCommands>
       <HelixPreCommands Condition="!$(IsPosixShell)">$(HelixPreCommands);set DOTNET_ROOT=%HELIX_CORRELATION_PAYLOAD%\$(DotNetCliDestination);set DOTNET_CLI_TELEMETRY_OPTOUT=1</HelixPreCommands>
     </PropertyGroup>
+  </Target>
+  
+  <Target Name="AddAdditionalRuntimes" 
+          Condition="@(AdditionalDotNetPackage->Count()) != 0"
+          AfterTargets="Build" 
+          Outputs="%(AdditionalDotNetPackage.Identity)">
+
+    <Message Text = "FindDotNetCliPackage '%(AdditionalDotNetPackage.Identity)' '$(DotNetCliRuntime)' '%(AdditionalDotNetPackage.PackageType)' '%(AdditionalDotNetPackage.Channel)' "/>
+    <FindDotNetCliPackage Version="%(AdditionalDotNetPackage.Identity)" Runtime="$(DotNetCliRuntime)" PackageType="%(AdditionalDotNetPackage.PackageType)" Channel="$(DotNetCliChannel)">
+      <Output TaskParameter="PackageUri" PropertyName="DotNetCliPackageUri"/>
+    </FindDotNetCliPackage>
+    <ItemGroup>
+      <HelixCorrelationPayload Include="dotnet-additional">
+        <Uri>$(DotNetCliPackageUri)</Uri>
+        <Destination>$(DotNetCliDestination)</Destination>
+      </HelixCorrelationPayload>
+    </ItemGroup>
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.targets
@@ -25,7 +25,7 @@
           Outputs="%(AdditionalDotNetPackage.Identity)">
 
     <Message Text = "FindDotNetCliPackage '%(AdditionalDotNetPackage.Identity)' '$(DotNetCliRuntime)' '%(AdditionalDotNetPackage.PackageType)' '%(AdditionalDotNetPackage.Channel)' "/>
-    <FindDotNetCliPackage Version="%(AdditionalDotNetPackage.Identity)" Runtime="$(DotNetCliRuntime)" PackageType="%(AdditionalDotNetPackage.PackageType)" Channel="$(DotNetCliChannel)">
+    <FindDotNetCliPackage Version="%(AdditionalDotNetPackage.Identity)" Runtime="$(DotNetCliRuntime)" PackageType="%(AdditionalDotNetPackage.PackageType)" Channel="%(AdditionalDotNetPackage.Channel)">
       <Output TaskParameter="PackageUri" PropertyName="DotNetCliPackageUri"/>
     </FindDotNetCliPackage>
     <ItemGroup>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.targets
@@ -23,9 +23,15 @@
           Condition="@(AdditionalDotNetPackage->Count()) != 0"
           AfterTargets="Build" 
           Outputs="%(AdditionalDotNetPackage.Identity)">
+    <PropertyGroup>
+      <_channel>%(AdditionalDotNetPackage.Channel)</_channel>
+      <_channel Condition=" '$(_channel)' == '' ">Current</_channel>
+      <_package>%(AdditionalDotNetPackage.PackageType)</_package>
+      <_package Condition=" '$(_package)' == '' ">runtime</_package>
+    </PropertyGroup>
 
-    <Message Text = "FindDotNetCliPackage '%(AdditionalDotNetPackage.Identity)' '$(DotNetCliRuntime)' '%(AdditionalDotNetPackage.PackageType)' '%(AdditionalDotNetPackage.Channel)' "/>
-    <FindDotNetCliPackage Version="%(AdditionalDotNetPackage.Identity)" Runtime="$(DotNetCliRuntime)" PackageType="%(AdditionalDotNetPackage.PackageType)" Channel="%(AdditionalDotNetPackage.Channel)">
+    <Message Text = "FindDotNetCliPackage '%(AdditionalDotNetPackage.Identity)' '$(DotNetCliRuntime)' '$(_package)' '$(_channel)' "/>
+    <FindDotNetCliPackage Version="%(AdditionalDotNetPackage.Identity)" Runtime="$(DotNetCliRuntime)" PackageType="$(_package)" Channel="$(_channel)">
       <Output TaskParameter="PackageUri" PropertyName="DotNetCliPackageUri"/>
     </FindDotNetCliPackage>
     <ItemGroup>


### PR DESCRIPTION
Enables

```
    <IncludeDotNetRuntime>true</IncludeDotNetRuntime>
    <DotNetCliVersion>6.0.100-preview.2.21155.3</DotNetCliVersion>
    <DotNetRuntimeVersion>6.0.0-preview.4.21175.1</DotNetRuntimeVersion>
```

Which will install both the sdk and the runtime into the same directory