### PR TITLE
Fix GenerateBuildManifest publish version parsing

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/GenerateBuildManifestTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/GenerateBuildManifestTests.cs
@@ -2,8 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using FluentAssertions;
+using Microsoft.Arcade.Common;
+using Microsoft.Arcade.Test.Common;
+using Microsoft.Build.Utilities;
 using Microsoft.DotNet.Internal.DependencyInjection.Testing;
 using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System.Collections.Generic;
+using System.IO;
 using Xunit;
 
 namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
@@ -29,6 +35,39 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                 )
                 .Should()
                 .BeTrue(message);
+        }
+
+        [Fact]
+        public void ProducesManifestWithNewPublishingVersion()
+        {
+            var manifestPath = Path.Combine("C:", "manifests", "TestManifest.xml");
+            var publishingVersion = "3";
+            var task = new GenerateBuildManifest
+            {
+                BuildEngine = new MockBuildEngine(),
+                Artifacts = new TaskItem[0],
+                OutputPath = manifestPath,
+                BuildData = new string[] { $"InitialAssetsLocation=cloud" },
+                PublishingVersion = publishingVersion,
+            };
+
+            // Mocks
+            Mock<IFileSystem> fileSystemMock = new Mock<IFileSystem>();
+            IList<string> actualPath = new List<string>();
+            IList<string> actualBuildModel = new List<string>();
+            fileSystemMock.Setup(m => m.WriteToFile(Capture.In(actualPath), Capture.In(actualBuildModel))).Verifiable();
+
+            // Dependency Injection setup
+            var collection = new ServiceCollection()
+                .AddSingleton(fileSystemMock.Object)
+                .AddSingleton<IBuildModelFactory, BuildModelFactory>();
+            task.ConfigureServices(collection);
+            using var provider = collection.BuildServiceProvider();
+
+            // Act and Assert
+            task.InvokeExecute(provider).Should().BeTrue();
+            actualPath[0].Should().Be(manifestPath);
+            actualBuildModel[0].Should().Contain($"PublishingVersion=\"{publishingVersion}\"");
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/GenerateBuildManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/GenerateBuildManifest.cs
@@ -35,24 +35,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public string OutputPath { get; set; }
 
         /// <summary>
-        /// The collection URI of the Azure DevOps instance
-        /// </summary>
-        [Required]
-        public string AzureDevOpsCollectionUri { get; set; }
-
-        /// <summary>
-        /// The Azure DevOps project of this build
-        /// </summary>
-        [Required]
-        public string AzureDevOpsProject { get; set; }
-
-        /// <summary>
-        /// The Azure DevOps build ID
-        /// </summary>
-        [Required]
-        public int AzureDevOpsBuildId { get; set; }
-
-        /// <summary>
         /// List of files that need to be signed
         /// </summary>
         public ITaskItem[] ItemsToSign { get; set; }
@@ -135,7 +117,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                 if (!string.IsNullOrEmpty(PublishingVersion)) 
                 {
-                    if (Enum.TryParse(PublishingVersion, ignoreCase: true, out targetPublishingVersion))
+                    if (!Enum.TryParse(PublishingVersion, ignoreCase: true, out targetPublishingVersion))
                     {
                         Log.LogError($"Could not parse '{PublishingVersion}' as a valid publishing infrastructure version.");
                         return false;


### PR DESCRIPTION
The `<GenerateBuildManifest/>` task was erroring every time the
`PublishingVersion` input parameter was used.  The `Enum.TryParse`
success check has been fixed to prevent this.  Additionally, some unused
parameters have been removed from the task.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
