### PR TITLE
Add SkipOnPlatform attribute to Microsoft.DotNet.XUnitExtensions

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnPlatformAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnPlatformAttribute.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+    [TraitDiscoverer("Microsoft.DotNet.XUnitExtensions.SkipOnPlatformDiscoverer", "Microsoft.DotNet.XUnitExtensions")]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    public class SkipOnPlatformAttribute : Attribute, ITraitAttribute
+    {
+        internal SkipOnPlatformAttribute() { }
+        public SkipOnPlatformAttribute(string reason, TestPlatforms testPlatforms) { }
+    }
+}

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnPlatformDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnPlatformDiscoverer.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.XUnitExtensions
     {
         public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
         {
-            TestPlatforms testPlatforms = TestPlatforms.Any;
+            TestPlatforms testPlatforms = (TestPlatforms)0;
 
             // Last argument is either the TestPlatform or the test platform to skip the test on.
             if (traitAttribute.GetConstructorArguments().LastOrDefault() is TestPlatforms tp)

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnPlatformDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnPlatformDiscoverer.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.DotNet.XUnitExtensions
+{
+    public class SkipOnPlatformDiscoverer : ITraitDiscoverer
+    {
+        public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
+        {
+            TestPlatforms testPlatforms = TestPlatforms.Any;
+
+            // Last argument is either the TestPlatform or the test platform to skip the test on.
+            if (traitAttribute.GetConstructorArguments().LastOrDefault() is TestPlatforms tp)
+            {
+                testPlatforms = tp;
+            }
+
+            if (DiscovererHelpers.TestPlatformApplies(testPlatforms))
+            {
+                return new[] { new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing) };
+            }
+
+            return Array.Empty<KeyValuePair<string, string>>();
+        }
+    }
+}


### PR DESCRIPTION
In dotnet/runtime we have a bunch of test assemblies that don't make sense on some platforms, e.g. Browser.
Right now we're skipping them via `[SkipOnMono("reason", TestPlatforms.Browser)]` but there's nothing that inherently ties this to Mono other than the current implementation.

Add a more generic SkipOnPlatform attribute that we can use instead.
