### PR TITLE
Add support for LangIDOnPath templates to LocProject.json generation

### DIFF
--- a/eng/common/generate-locproject.ps1
+++ b/eng/common/generate-locproject.ps1
@@ -66,10 +66,19 @@ $locJson = @{
                     }
                     if ($continue)
                     {
-                        return @{
-                            SourceFile = $sourceFile
-                            CopyOption = "LangIDOnName"
-                            OutputPath = $outputPath
+                        if ($_.Directory.Name -eq 'en' -and $_.Extension -eq '.json') {
+                            return @{
+                                SourceFile = $sourceFile
+                                CopyOption = "LangIDOnPath"
+                                OutputPath = "$($_.Directory.Parent.FullName | Resolve-Path -Relative)\"
+                            }
+                        }
+                        else {
+                            return @{
+                                SourceFile = $sourceFile
+                                CopyOption = "LangIDOnName"
+                                OutputPath = $outputPath
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Closes dotnet/core-eng#12673.

Some repos (like winforms) use templates that have langcodes as directories (e.g. `en\strings.json`, `fr\string.json`). This PR adds support for that.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
