### PR TITLE
Switch argument order in SkipOnPlatformAttribute

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnPlatformAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnPlatformAttribute.cs
@@ -7,10 +7,10 @@ using Xunit.Sdk;
 namespace Xunit
 {
     [TraitDiscoverer("Microsoft.DotNet.XUnitExtensions.SkipOnPlatformDiscoverer", "Microsoft.DotNet.XUnitExtensions")]
-    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
     public class SkipOnPlatformAttribute : Attribute, ITraitAttribute
     {
         internal SkipOnPlatformAttribute() { }
-        public SkipOnPlatformAttribute(string reason, TestPlatforms testPlatforms) { }
+        public SkipOnPlatformAttribute(TestPlatforms testPlatforms, string reason) { }
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnPlatformDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnPlatformDiscoverer.cs
@@ -16,8 +16,8 @@ namespace Microsoft.DotNet.XUnitExtensions
         {
             TestPlatforms testPlatforms = (TestPlatforms)0;
 
-            // Last argument is either the TestPlatform or the test platform to skip the test on.
-            if (traitAttribute.GetConstructorArguments().LastOrDefault() is TestPlatforms tp)
+            // First argument is either the TestPlatform or the test platform to skip the test on.
+            if (traitAttribute.GetConstructorArguments().FirstOrDefault() is TestPlatforms tp)
             {
                 testPlatforms = tp;
             }


### PR DESCRIPTION
While looking at doing the conversion in dotnet/runtime after https://github.com/dotnet/arcade/pull/7184 I noticed that having the `reason` argument as the last argument reads weird, it's better to have the platform as the first argument so it reads more like a sentence.

E.g. instead of

```csharp
[SkipOnPlatform("System.Net.Security is not supported on this platform.", TestPlatforms.Browser)]
```

we have

```csharp
[SkipOnPlatform(TestPlatforms.Browser, "System.Net.Security is not supported on this platform.")]
```

Also allow multiple attributes since the skip reason can be quite different between platforms.
