### PR TITLE
Small cleanup and send aka.ms link prefix for stable

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/SetupTargetFeedConfigV3Tests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/SetupTargetFeedConfigV3Tests.cs
@@ -75,12 +75,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                         ChecksumsTargetStaticFeed,
                         FeedType.AzureStorageFeed,
                         ChecksumsTargetStaticFeedKey,
-                        string.Empty,
-                        AssetSelection.All,
+                        latestLinkShortUrlPrefix: $"{LatestLinkShortUrlPrefix}/{BuildQuality}",
+                        assetSelection: AssetSelection.All,
                         isolated: true,
                         @internal: false,
                         allowOverwrite: true,
-                        symbolTargetType,
+                        symbolTargetType: symbolTargetType,
                         filenamesToExclude: FilesToExclude));
 
                 foreach (var contentType in Installers)
@@ -91,12 +91,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                             InstallersTargetStaticFeed,
                             FeedType.AzureStorageFeed,
                             InstallersTargetStaticFeedKey,
-                            string.Empty,
-                            AssetSelection.All,
+                            latestLinkShortUrlPrefix: $"{LatestLinkShortUrlPrefix}/{BuildQuality}",
+                            assetSelection: AssetSelection.All,
                             isolated: true,
                             @internal: false,
                             allowOverwrite: true,
-                            symbolTargetType,
+                            symbolTargetType: symbolTargetType,
                             filenamesToExclude: FilesToExclude));
                 }
             }
@@ -107,12 +107,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                     StablePackageFeed,
                     FeedType.AzDoNugetFeed,
                     AzureDevOpsFeedsKey,
-                    string.Empty,
-                    AssetSelection.ShippingOnly,
+                    latestLinkShortUrlPrefix: string.Empty,
+                    assetSelection: AssetSelection.ShippingOnly,
                     isolated: true,
                     @internal: false,
                     allowOverwrite: false,
-                    symbolTargetType,
+                    symbolTargetType: symbolTargetType,
                     filenamesToExclude: FilesToExclude));
 
             expectedFeeds.Add(
@@ -121,12 +121,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                     StableSymbolsFeed,
                     FeedType.AzDoNugetFeed,
                     AzureDevOpsFeedsKey,
-                    string.Empty,
-                    AssetSelection.All,
+                    latestLinkShortUrlPrefix: string.Empty,
+                    assetSelection: AssetSelection.All,
                     isolated: true,
                     @internal: false,
                     allowOverwrite: false,
-                    symbolTargetType,
+                    symbolTargetType: symbolTargetType,
                     filenamesToExclude: FilesToExclude));
 
             expectedFeeds.Add(
@@ -135,12 +135,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                     AzureDevOpsStaticTransportFeed,
                     FeedType.AzDoNugetFeed,
                     AzureDevOpsFeedsKey,
-                    string.Empty,
-                    AssetSelection.NonShippingOnly,
+                    latestLinkShortUrlPrefix: string.Empty,
+                    assetSelection: AssetSelection.NonShippingOnly,
                     isolated: false,
                     @internal: false,
                     allowOverwrite: false,
-                    symbolTargetType,
+                    symbolTargetType: symbolTargetType,
                     filenamesToExclude: FilesToExclude));
 
             var buildEngine = new MockBuildEngine();
@@ -189,12 +189,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                             InstallersTargetStaticFeed,
                             FeedType.AzureStorageFeed,
                             InstallersTargetStaticFeedKey,
-                            $"{LatestLinkShortUrlPrefix}/{BuildQuality}",
-                            AssetSelection.All,
+                            latestLinkShortUrlPrefix: $"{LatestLinkShortUrlPrefix}/{BuildQuality}",
+                            assetSelection: AssetSelection.All,
                             isolated: false,
                             @internal: true,
                             allowOverwrite: false,
-                            symbolTargetType,
+                            symbolTargetType: symbolTargetType,
                             filenamesToExclude: FilesToExclude));
                 }
 
@@ -204,12 +204,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                         ChecksumsTargetStaticFeed,
                         FeedType.AzureStorageFeed,
                         ChecksumsTargetStaticFeedKey,
-                        $"{LatestLinkShortUrlPrefix}/{BuildQuality}",
-                        AssetSelection.All,
+                        latestLinkShortUrlPrefix: $"{LatestLinkShortUrlPrefix}/{BuildQuality}",
+                        assetSelection: AssetSelection.All,
                         isolated: false,
                         @internal: true,
                         allowOverwrite: false,
-                        symbolTargetType,
+                        symbolTargetType: symbolTargetType,
                         filenamesToExclude: FilesToExclude));
 
             }
@@ -220,12 +220,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                     AzureDevOpsStaticShippingFeed,
                     FeedType.AzDoNugetFeed,
                     AzureDevOpsFeedsKey,
-                    string.Empty,
-                    AssetSelection.ShippingOnly,
+                    latestLinkShortUrlPrefix: string.Empty,
+                    assetSelection: AssetSelection.ShippingOnly,
                     isolated: false,
                     @internal: true,
                     allowOverwrite: false,
-                    symbolTargetType,
+                    symbolTargetType: symbolTargetType,
                     filenamesToExclude: FilesToExclude));
 
             expectedFeeds.Add(
@@ -234,12 +234,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                     AzureDevOpsStaticTransportFeed,
                     FeedType.AzDoNugetFeed,
                     AzureDevOpsFeedsKey,
-                    string.Empty,
-                    AssetSelection.NonShippingOnly,
+                    latestLinkShortUrlPrefix: string.Empty,
+                    assetSelection: AssetSelection.NonShippingOnly,
                     isolated: false,
                     @internal: true,
                     allowOverwrite: false,
-                    symbolTargetType,
+                    symbolTargetType: symbolTargetType,
                     filenamesToExclude: FilesToExclude));
 
             expectedFeeds.Add(
@@ -248,12 +248,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                     AzureDevOpsStaticSymbolsFeed,
                     FeedType.AzDoNugetFeed,
                     AzureDevOpsFeedsKey,
-                    string.Empty,
-                    AssetSelection.All,
+                    latestLinkShortUrlPrefix: string.Empty,
+                    assetSelection: AssetSelection.All,
                     isolated: false,
                     @internal: true,
                     allowOverwrite: false,
-                    symbolTargetType,
+                    symbolTargetType: symbolTargetType,
                     filenamesToExclude: FilesToExclude));
 
             var buildEngine = new MockBuildEngine();
@@ -298,12 +298,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                         ChecksumsTargetStaticFeed,
                         FeedType.AzureStorageFeed,
                         ChecksumsTargetStaticFeedKey,
-                        $"{LatestLinkShortUrlPrefix}/{BuildQuality}",
-                        AssetSelection.All,
+                        latestLinkShortUrlPrefix: $"{LatestLinkShortUrlPrefix}/{BuildQuality}",
+                        assetSelection: AssetSelection.All,
                         isolated: false,
                         @internal: false,
                         allowOverwrite: false,
-                        symbolTargetType,
+                        symbolTargetType: symbolTargetType,
                         filenamesToExclude: FilesToExclude));
 
                 foreach (var contentType in Installers)
@@ -314,12 +314,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                             InstallersTargetStaticFeed,
                             FeedType.AzureStorageFeed,
                             InstallersTargetStaticFeedKey,
-                            $"{LatestLinkShortUrlPrefix}/{BuildQuality}",
-                            AssetSelection.All,
+                            latestLinkShortUrlPrefix: $"{LatestLinkShortUrlPrefix}/{BuildQuality}",
+                            assetSelection: AssetSelection.All,
                             isolated: false,
                             @internal: false,
                             allowOverwrite: false,
-                            symbolTargetType,
+                            symbolTargetType: symbolTargetType,
                             filenamesToExclude: FilesToExclude));
                 }
             }
@@ -330,12 +330,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                     PublishingConstants.LegacyDotNetBlobFeedURL,
                     FeedType.AzureStorageFeed,
                     AzureStorageTargetFeedPAT,
-                    string.Empty,
-                    AssetSelection.All,
+                    latestLinkShortUrlPrefix: string.Empty,
+                    assetSelection: AssetSelection.All,
                     isolated: false,
                     @internal: false,
                     allowOverwrite: false,
-                    symbolTargetType,
+                    symbolTargetType: symbolTargetType,
                     filenamesToExclude: FilesToExclude));
 
             expectedFeeds.Add(
@@ -344,12 +344,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                     AzureDevOpsStaticShippingFeed,
                     FeedType.AzDoNugetFeed,
                     AzureDevOpsFeedsKey,
-                    string.Empty,
-                    AssetSelection.ShippingOnly,
+                    latestLinkShortUrlPrefix: string.Empty,
+                    assetSelection: AssetSelection.ShippingOnly,
                     isolated: false,
                     @internal: false,
                     allowOverwrite: false,
-                    symbolTargetType,
+                    symbolTargetType: symbolTargetType,
                     filenamesToExclude: FilesToExclude));
 
             expectedFeeds.Add(
@@ -358,12 +358,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                     AzureDevOpsStaticTransportFeed,
                     FeedType.AzDoNugetFeed,
                     AzureDevOpsFeedsKey,
-                    string.Empty,
-                    AssetSelection.NonShippingOnly,
+                    latestLinkShortUrlPrefix: string.Empty,
+                    assetSelection: AssetSelection.NonShippingOnly,
                     isolated: false,
                     @internal: false,
                     allowOverwrite: false,
-                    symbolTargetType,
+                    symbolTargetType: symbolTargetType,
                     filenamesToExclude: FilesToExclude));
 
             var buildEngine = new MockBuildEngine();

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigV3.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             string azureDevOpsFeedsKey,
             IBuildEngine buildEngine,
             SymbolTargetType symbolTargetType,
-        string stablePackagesFeed = null,
+            string stablePackagesFeed = null,
             string stableSymbolsFeed = null,
             List<string> filesToExclude = null,
             bool flatten = true) 
@@ -84,34 +84,16 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             }
             else
             {
-                if (IsInternalBuild)
-                {
-                    return NonStableInternalFeeds();
-                }
-                else
-                {
-                    return NonStablePublicFeeds();
-                }
+                return NonStableFeeds();
             }
         }
 
-        private List<TargetFeedConfig> NonStablePublicFeeds()
+        private List<TargetFeedConfig> NonStableFeeds()
         {
             List<TargetFeedConfig> targetFeedConfigs = new List<TargetFeedConfig>();
 
             if (PublishInstallersAndChecksums)
             {
-                targetFeedConfigs.Add(
-                    new TargetFeedConfig(
-                        TargetFeedContentType.Checksum,
-                        ChecksumsTargetStaticFeed,
-                        FeedType.AzureStorageFeed,
-                        ChecksumsAzureAccountKey,
-                        LatestLinkShortUrlPrefix,
-                        symbolTargetType: SymbolTargetType,
-                        filenamesToExclude: FilesToExclude,
-                        flatten: Flatten));
-
                 foreach (var contentType in Installers)
                 {
                     targetFeedConfigs.Add(
@@ -120,104 +102,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                             InstallersTargetStaticFeed,
                             FeedType.AzureStorageFeed,
                             InstallersAzureAccountKey,
-                            LatestLinkShortUrlPrefix,
+                            latestLinkShortUrlPrefix: LatestLinkShortUrlPrefix,
+                            @internal: IsInternalBuild,
                             symbolTargetType: SymbolTargetType,
                             filenamesToExclude: FilesToExclude,
                             flatten: Flatten));
                 }
-            }
-
-            targetFeedConfigs.Add(
-                new TargetFeedConfig(
-                    TargetFeedContentType.Symbols,
-                    PublishingConstants.LegacyDotNetBlobFeedURL,
-                    FeedType.AzureStorageFeed,
-                    AzureStorageTargetFeedPAT,
-                    symbolTargetType: SymbolTargetType,
-                    filenamesToExclude: FilesToExclude,
-                    flatten: Flatten));
-
-            targetFeedConfigs.Add(
-                new TargetFeedConfig(
-                    TargetFeedContentType.Package,
-                    AzureDevOpsStaticShippingFeed,
-                    FeedType.AzDoNugetFeed,
-                    AzureDevOpsFeedsKey,
-                    assetSelection: AssetSelection.ShippingOnly,
-                    symbolTargetType: SymbolTargetType,
-                    filenamesToExclude: FilesToExclude,
-                    flatten: Flatten));
-
-            targetFeedConfigs.Add(
-                new TargetFeedConfig(
-                    TargetFeedContentType.Package,
-                    AzureDevOpsStaticTransportFeed,
-                    FeedType.AzDoNugetFeed,
-                    AzureDevOpsFeedsKey,
-                    assetSelection: AssetSelection.NonShippingOnly,
-                    symbolTargetType: SymbolTargetType,
-                    filenamesToExclude: FilesToExclude,
-                    flatten: Flatten));
-
-            return targetFeedConfigs;
-        }
-
-        private List<TargetFeedConfig>  NonStableInternalFeeds()
-        {
-            List<TargetFeedConfig> targetFeedConfigs = new List<TargetFeedConfig>
-            {
-                new TargetFeedConfig(
-                    TargetFeedContentType.Package,
-                    AzureDevOpsStaticShippingFeed,
-                    FeedType.AzDoNugetFeed,
-                    AzureDevOpsFeedsKey,
-                    assetSelection: AssetSelection.ShippingOnly,
-                    symbolTargetType: SymbolTargetType,
-                    @internal: true,
-                    filenamesToExclude: FilesToExclude,
-                    flatten: Flatten
-                ),
-
-                new TargetFeedConfig(
-                    TargetFeedContentType.Package,
-                    AzureDevOpsStaticTransportFeed,
-                    FeedType.AzDoNugetFeed,
-                    AzureDevOpsFeedsKey,
-                    assetSelection: AssetSelection.NonShippingOnly,
-                    symbolTargetType: SymbolTargetType,
-                    @internal: true,
-                    filenamesToExclude: FilesToExclude,
-                    flatten: Flatten
-                ),
-
-                new TargetFeedConfig(
-                    TargetFeedContentType.Symbols,
-                    AzureDevOpsStaticSymbolsFeed,
-                    FeedType.AzDoNugetFeed,
-                    AzureDevOpsFeedsKey,
-                    symbolTargetType: SymbolTargetType,
-                    @internal: true,
-                    filenamesToExclude: FilesToExclude,
-                    flatten: Flatten)
-            };
-
-            if (PublishInstallersAndChecksums)
-            {
-                foreach (var contentType in Installers)
-                {
-                    targetFeedConfigs.Add(
-                        new TargetFeedConfig(
-                            contentType,
-                            InstallersTargetStaticFeed,
-                            FeedType.AzureStorageFeed,
-                            InstallersAzureAccountKey,
-                            LatestLinkShortUrlPrefix,
-                            symbolTargetType: SymbolTargetType,
-                            @internal: true,
-                            filenamesToExclude: FilesToExclude,
-                            flatten: Flatten
-                        ));
-                }
 
                 targetFeedConfigs.Add(
                     new TargetFeedConfig(
@@ -225,13 +115,67 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         ChecksumsTargetStaticFeed,
                         FeedType.AzureStorageFeed,
                         ChecksumsAzureAccountKey,
-                        LatestLinkShortUrlPrefix,
+                        latestLinkShortUrlPrefix: LatestLinkShortUrlPrefix,
+                        @internal: IsInternalBuild,
                         symbolTargetType: SymbolTargetType,
-                        @internal: true,
                         filenamesToExclude: FilesToExclude,
-                        flatten: Flatten
-                    ));
+                        flatten: Flatten));
             }
+
+            targetFeedConfigs.Add(
+                new TargetFeedConfig(
+                    TargetFeedContentType.Package,
+                    AzureDevOpsStaticShippingFeed,
+                    FeedType.AzDoNugetFeed,
+                    AzureDevOpsFeedsKey,
+                    assetSelection: AssetSelection.ShippingOnly,
+                    @internal: IsInternalBuild,
+                    symbolTargetType: SymbolTargetType,
+                    filenamesToExclude: FilesToExclude,
+                    flatten: Flatten));
+
+            targetFeedConfigs.Add(
+                new TargetFeedConfig(
+                    TargetFeedContentType.Package,
+                    AzureDevOpsStaticTransportFeed,
+                    FeedType.AzDoNugetFeed,
+                    AzureDevOpsFeedsKey,
+                    assetSelection: AssetSelection.NonShippingOnly,
+                    @internal: IsInternalBuild,
+                    symbolTargetType: SymbolTargetType,
+                    filenamesToExclude: FilesToExclude,
+                    flatten: Flatten));
+
+            // For symbols, we don't have a blob location where internal symbols can go today,
+            // so a feed is used in this case. This would be a potential performance improvement for internal builds.
+            // This is pretty uncommon though, as non-stable internal builds are quite rare.
+            string symbolsFeed;
+            FeedType symbolsFeedType;
+            string symbolsFeedSecret;
+
+            if (IsInternalBuild)
+            {
+                symbolsFeed = AzureDevOpsStaticSymbolsFeed;
+                symbolsFeedType = FeedType.AzDoNugetFeed;
+                symbolsFeedSecret = AzureDevOpsFeedsKey;
+            }
+            else
+            {
+                symbolsFeed = PublishingConstants.LegacyDotNetBlobFeedURL;
+                symbolsFeedType = FeedType.AzureStorageFeed;
+                symbolsFeedSecret = AzureStorageTargetFeedPAT;
+            }
+
+            targetFeedConfigs.Add(
+                new TargetFeedConfig(
+                    TargetFeedContentType.Symbols,
+                    symbolsFeed,
+                    symbolsFeedType,
+                    symbolsFeedSecret,
+                    symbolTargetType: SymbolTargetType,
+                    @internal: IsInternalBuild,
+                    filenamesToExclude: FilesToExclude,
+                    flatten: Flatten));
 
             return targetFeedConfigs;
         }
@@ -326,6 +270,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                             InstallersAzureAccountKey,
                             isolated: true,
                             symbolTargetType: SymbolTargetType,
+                            latestLinkShortUrlPrefix: LatestLinkShortUrlPrefix,
                             @internal: false,
                             allowOverwrite: true,
                             filenamesToExclude: FilesToExclude,
@@ -340,6 +285,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         ChecksumsAzureAccountKey,
                         isolated: true,
                         symbolTargetType: SymbolTargetType,
+                        latestLinkShortUrlPrefix: LatestLinkShortUrlPrefix,
                         @internal: false,
                         allowOverwrite: true,
                         filenamesToExclude: FilesToExclude,


### PR DESCRIPTION
Stable builds were not sending the aka.ms link prefix. I think this is safe, now that all the blobs are unique, and typically these are internal anyway.
Also, combine NonStableInternalFeeds and NonStablePublicFeeds into one method, as they were basically identical, aside from one tweak around symbols