### PR TITLE
Prefer nuget standardized properties

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
@@ -50,7 +50,6 @@
     <Authors>Microsoft</Authors>
     <Owners>microsoft,dotnetframework</Owners>
     <IconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</IconUrl>
-    <Tags></Tags>
     <RequireLicenseAcceptance Condition="'$(RequireLicenseAcceptance)' == ''">false</RequireLicenseAcceptance>
     <Serviceable Condition="'$(Serviceable)' == ''">true</Serviceable>
     <!-- we depend on NuGet v2.12 / v3.4 behavior NuGet doesn't support two different min client versions
@@ -1213,7 +1212,7 @@
                     Authors="$(Authors)"
                     Owners="$(Owners)"
                     Description="$(Description)"
-                    ReleaseNotes="$(ReleaseNotes)"
+                    ReleaseNotes="$(PackageReleaseNotes)"
                     Summary="$(Summary)"
                     Language="$(Language)"
                     ProjectUrl="$(PackageProjectUrl)"
@@ -1223,7 +1222,7 @@
                     PackageLicenseExpression="$(PackageLicenseExpression)"
                     Copyright="$(Copyright)"
                     RequireLicenseAcceptance="$(RequireLicenseAcceptance)"
-                    Tags="$(Tags)"
+                    Tags="$(PackageTags)"
                     DevelopmentDependency="$(DevelopmentDependency)"
                     Dependencies="@(Dependency)"
                     References="@(Reference)"


### PR DESCRIPTION
ReleaseNotes and Tags are the only properties that aren't deprecated which have a different property name on the NuGet side than in Microsoft.DotNet.Build.Tasks.Packaging. The ReleaseNotes rename to PackageReleaseNotes needs an update in the dotnet/runtime repo.