### PR TITLE
Re-enable Windows XHarness Helix SDK tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -132,22 +132,20 @@ stages:
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''
-        # We don't have enough hardware to run these tests on Arcade PR given the Arcade XHarness SDK changes infrequently. (https://github.com/dotnet/core-eng/issues/12238)
-        # Until the above issue is resolved, if you are editing the Xharness SDK's Windows side, please exercise this manually.  Contact dnceng for assistance.
-        # - powershell: eng\common\build.ps1
-        #     -configuration $(_BuildConfig) 
-        #     -prepareMachine
-        #     -ci
-        #     -restore
-        #     -test
-        #     -projects $(Build.SourcesDirectory)\tests\UnitTests.XHarness.Android.WindowsQueues.proj
-        #     /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.XHarness.Android.WindowsQueues.binlog
-        #     /p:RestoreUsingNuGetTargets=false
-        #     /p:XharnessTestARM64_V8A=true
-        #   displayName: XHarness Android Helix Testing (Windows)
-        #   env:
-        #     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-        #     HelixAccessToken: ''
+          - powershell: eng\common\build.ps1
+              -configuration $(_BuildConfig) 
+              -prepareMachine
+              -ci
+              -restore
+              -test
+              -projects $(Build.SourcesDirectory)\tests\UnitTests.XHarness.Android.WindowsQueues.proj
+              /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.XHarness.Android.WindowsQueues.binlog
+              /p:RestoreUsingNuGetTargets=false
+              /p:XharnessTestARM64_V8A=true
+            displayName: XHarness Android Helix Testing (Windows)
+            env:
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+              HelixAccessToken: ''
         - job: Linux
           container: LinuxContainer
           pool:


### PR DESCRIPTION
30 machines have been added and we expect/hope this can now succeed.

This reverts commit 1c7f0c60c9201ac9a7a5c639cb72cb412a46b0e4.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation (this is validation)
