### PR TITLE
Emit the hostArchitectures attribute when building the macOS bundle.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateMacOSDistributionFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateMacOSDistributionFile.cs
@@ -60,14 +60,14 @@ namespace Microsoft.DotNet.SharedFramework.Sdk
                 {
                     optionsElement = new XElement("options");
                 }
-                if (optionsElement.Attribute("hostArchitecture") is null)
+                if (optionsElement.Attribute("hostArchitectures") is null)
                 {
                     string hostArchitecture = TargetArchitecture;
                     if (hostArchitecture == "x64")
                     {
                         hostArchitecture = "x86_64";
                     }
-                    optionsElement.Add(new XAttribute("hostArchitecture", hostArchitecture));
+                    optionsElement.Add(new XAttribute("hostArchitectures", hostArchitecture));
                 }
                 
                 if (!templateHasOptions)

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateMacOSDistributionFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateMacOSDistributionFile.cs
@@ -53,7 +53,29 @@ namespace Microsoft.DotNet.SharedFramework.Sdk
                     .Select(component => new XElement("pkg-ref",
                         new XAttribute("id", component.GetMetadata("FileNameWithExtension")),
                         component.GetMetadata("FileNameWithExtension")));
+                        
+                var optionsElement = document.Root.Element("options");
+                bool templateHasOptions = options is not null;
+                if (!templateHasOptions)
+                {
+                    optionsElement = new XElement("options");
+                }
+                if (optionsElement.Attribute("hostArchitecture") is null)
+                {
+                    string hostArchitecture = TargetArchitecture;
+                    if (hostArchitecture == "x64")
+                    {
+                        hostArchitecture = "x86_64";
+                    }
+                    optionsElement.Add(new XAttribute("hostArchitecture", hostArchitecture));
+                }
+                
+                if (!templateHasOptions)
+                {
+                    document.Root.Add(optionsElement);
+                }
 
+                document.Root.Add(titleElement);
                 document.Root.Add(new XElement("choices-outline", choiceLineElements));
                 document.Root.Add(choiceElements);
                 document.Root.Add(pkgRefElements);

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateMacOSDistributionFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateMacOSDistributionFile.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.SharedFramework.Sdk
                         component.GetMetadata("FileNameWithExtension")));
                         
                 var optionsElement = document.Root.Element("options");
-                bool templateHasOptions = options is not null;
+                bool templateHasOptions = optionsElement is not null;
                 if (!templateHasOptions)
                 {
                     optionsElement = new XElement("options");


### PR DESCRIPTION
@sdmaclea can you validate that this change allows us to build an ARM64 distribution bundle on non Big Sur MacOS machines?

Contributes to https://github.com/dotnet/runtime/issues/48388

Fixes https://github.com/dotnet/arcade/issues/7233