### PR TITLE
Enable passing custom properties to NativeProjectReference items with AdditionalProperties metadata

### DIFF
--- a/src/Microsoft.DotNet.CMake.Sdk/build/Microsoft.DotNet.CMake.Sdk.targets
+++ b/src/Microsoft.DotNet.CMake.Sdk/build/Microsoft.DotNet.CMake.Sdk.targets
@@ -67,7 +67,7 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="GetOutputPathForProjectReference" DependsOnTargets="GetRootCMakeListsDirectory;ResolveVSGenerator" Returns="$(_CMakeProjectReferenceFilesLocation)">
+  <Target Name="GetOutputPathForProjectReference" DependsOnTargets="GetRootCMakeListsDirectory;ResolveVSGenerator;IsMultiConfigurationGenerator" Returns="@(_CMakeProjectReferenceFilesLocationItem)">
     <PropertyGroup>
       <_NormalizedReferencedCMakeListsDirectory>$([System.IO.Path]::GetDirectoryName($(ReferencedCMakeLists)))</_NormalizedReferencedCMakeListsDirectory>
     </PropertyGroup>
@@ -83,6 +83,9 @@
       <_CMakeProjectReferenceFilesLocation
         Condition="'$(_CMakeMultiConfigurationGenerator)' == 'true'">$([MSBuild]::NormalizePath('$(_CMakeProjectReferenceFilesLocation)','$(Configuration)'))</_CMakeProjectReferenceFilesLocation>
     </PropertyGroup>
+    <ItemGroup>
+      <_CMakeProjectReferenceFilesLocationItem Include="$(_CMakeProjectReferenceFilesLocation)" IsMultiConfigurationGenerator="_CMakeMultiConfigurationGenerator" />
+    </ItemGroup>
   </Target>
 
   <Target Name="_ResolveVSCompilerToolchainForNonVSGenerators"

--- a/src/Microsoft.DotNet.CMake.Sdk/sdk/ProjectReference.targets
+++ b/src/Microsoft.DotNet.CMake.Sdk/sdk/ProjectReference.targets
@@ -11,15 +11,10 @@
   </Target>
 
   <Target Name="CopyNativeProjectBinaries">
-    <MSBuild Projects="$(ReferencedCMakeProject)"
-      Targets="IsMultiConfigurationGenerator">
-      <Output TaskParameter="TargetOutputs" PropertyName="_IsMultiConfigurationGenerator" />
-    </MSBuild>
-
-    <ItemGroup Condition="'$(_IsMultiConfigurationGenerator)' == 'true'">
+    <ItemGroup Condition="'$(IsMultiConfigurationGenerator)' == 'true'">
       <NativeProjectBinaries Include="$(NativeProjectOutputFolder)\*.*" />
     </ItemGroup>
-    <ItemGroup Condition="'$(_IsMultiConfigurationGenerator)' != 'true'">
+    <ItemGroup Condition="'$(IsMultiConfigurationGenerator)' != 'true'">
 
     <!-- ############################################################### -->
     <!-- The following is required because the single configuration      -->
@@ -122,12 +117,14 @@
 
     <MSBuild Projects="%(NativeProjectReferenceNormalized.CMakeProject)"
       Targets="GetOutputPathForProjectReference"
-      Properties="ReferencedCMakeLists=%(NativeProjectReferenceNormalized.Identity)">
+      Properties="ReferencedCMakeLists=%(NativeProjectReferenceNormalized.Identity);%(NativeProjectReferenceNormalized.AdditionalProperties)">
       <Output TaskParameter="TargetOutputs" ItemName="NativeProjectOutputFoldersToCopy" />
     </MSBuild>
 
     <ItemGroup>
-      <_NativeProjectReferenceToBuild Include="%(NativeProjectReferenceNormalized.CMakeProject)" Condition="'%(NativeProjectReferenceNormalized.BuildNative)' == 'true'" />
+      <_NativeProjectReferenceToBuild Include="%(NativeProjectReferenceNormalized.CMakeProject)"
+                                      Condition="'%(NativeProjectReferenceNormalized.BuildNative)' == 'true'"
+                                      AdditionalProperties="%(NativeProjectReferenceNormalized.AdditionalProperties)" />
     </ItemGroup>
 
     <RemoveDuplicates Inputs="@(_NativeProjectReferenceToBuild)">
@@ -142,7 +139,8 @@
     <MSBuild Projects="$(MSBuildProjectFile)" 
              Targets="CopyNativeProjectBinaries"
              Properties="NativeProjectOutputFolder=%(NativeProjectOutputFoldersToCopy.Identity);
-                         ReferencedCMakeProject=%(NativeProjectOutputFoldersToCopy.MSBuildSourceProjectFile)"
+                         ReferencedCMakeProject=%(NativeProjectOutputFoldersToCopy.MSBuildSourceProjectFile);
+                         IsMultiConfigurationGenerator=%(NativeProjectOutputFoldersToCopy.IsMultiConfigurationGenerator)"
              Condition="'@(NativeProjectReference)' != ''" />
 
   </Target>


### PR DESCRIPTION
Pass down AdditionalProperties for NativeProjectReferences. Precalculate if the generator is multi-config so the CopyNativeProjectBinaries target doesn't need to call into the CMake project.

WinForms team validated these changes.

cc: @RussKie 

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
