### PR TITLE
Run signcheck in single threaded apartment

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/Verification/AuthentiCode.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/AuthentiCode.cs
@@ -29,7 +29,7 @@ namespace Microsoft.SignCheck.Verification
             WinTrustData data = new WinTrustData()
             {
                 cbStruct = (uint)Marshal.SizeOf(typeof(WinTrustData)),
-                dwProvFlags = Convert.ToUInt32(Provider.WTD_SAFER_FLAG),
+                dwProvFlags = 0,
                 dwStateAction = Convert.ToUInt32(StateAction.WTD_STATEACTION_IGNORE),
                 dwUIChoice = Convert.ToUInt32(UIChoice.WTD_UI_NONE),
                 dwUIContext = 0,

--- a/src/SignCheck/SignCheck/Microsoft.DotNet.SignCheck.csproj
+++ b/src/SignCheck/SignCheck/Microsoft.DotNet.SignCheck.csproj
@@ -31,6 +31,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\Common\Internal\AssemblyResolution.cs" Link="src\AssemblyResolution.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="System.Net" Pack="false" />
   </ItemGroup>
 

--- a/src/SignCheck/SignCheck/SignCheckTask.cs
+++ b/src/SignCheck/SignCheck/SignCheckTask.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 using Microsoft.SignCheck.Logging;
 using System;
 using System.Collections.Generic;
@@ -10,8 +11,12 @@ using System.Linq;
 
 namespace SignCheck
 {
-    public class SignCheckTask : Microsoft.Build.Utilities.Task
+    [Microsoft.Build.Framework.LoadInSeparateAppDomain]
+    [RunInSTA]
+    public class SignCheckTask : AppDomainIsolatedTask
     {
+        static SignCheckTask() => Microsoft.DotNet.AssemblyResolution.Initialize();
+
         public bool EnableJarSignatureVerification
         {
             get;
@@ -85,6 +90,7 @@ namespace SignCheck
 
         public override bool Execute()
         {
+            Microsoft.DotNet.AssemblyResolution.Log = Log;
             Options options = new Options();
             options.EnableJarSignatureVerification = EnableJarSignatureVerification;
             options.EnableXmlSignatureVerification = EnableXmlSignatureVerification;
@@ -143,6 +149,7 @@ namespace SignCheck
             
             var sc = new SignCheck(options);
             int result = sc.Run();
+            Microsoft.DotNet.AssemblyResolution.Log = null;
             return (result == 0 && !Log.HasLoggedErrors);
         }
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/7238

Remove WTD_SAFER_FLAG which is no longer supported - see https://docs.microsoft.com/en-us/windows/win32/api/wintrust/ns-wintrust-wintrust_data

Load task in separate app domain

Use Single Threaded Apartment