### PR TITLE
Disable remote executor on Mac Catalyst

### DIFF
--- a/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
@@ -72,6 +72,7 @@ namespace Microsoft.DotNet.RemoteExecutor
             !RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS")) &&
             !RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID")) &&
             !RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS")) &&
+            !RuntimeInformation.IsOSPlatform(OSPlatform.Create("MACCATALYST")) &&
             !RuntimeInformation.IsOSPlatform(OSPlatform.Create("WATCHOS")) &&
             !RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")) &&
             // The current RemoteExecutor design is not compatible with single file


### PR DESCRIPTION
It seems limitations on process handling from iOS carry over into Mac Catalyst, this is causing lots of runtime.git library failures