### PR TITLE
Add hook to exclude harvested supported frameworks

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
@@ -433,7 +433,7 @@
     </HarvestPackage>
 
     <ItemGroup>
-      <SupportedFramework Include="@(_HarvestedSupportedFramework)" Exclude="@(NotSupportedOnTargetFramework)" />
+      <SupportedFramework Include="@(_HarvestedSupportedFramework)" Exclude="@(NotSupportedOnTargetFramework);@(ExcludeHarvestedSupportedFramework)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
For packages which drop assets intentionally, there's currently no hook to remove supported frameworks that are determined by the harvested package. Adding that to be able to drop assets in the packages without disabling the whole support validation.
