### PR TITLE
Add temporary solution for OneLocBuild to GitHub

### DIFF
--- a/src/Common/Microsoft.Arcade.Common/FileSystem.cs
+++ b/src/Common/Microsoft.Arcade.Common/FileSystem.cs
@@ -22,11 +22,21 @@ namespace Microsoft.Arcade.Common
             return File.Exists(path);
         }
 
+        public string[] GetFiles(string path, string searchPattern, SearchOption searchOption)
+        {
+            return Directory.GetFiles(path, searchPattern, searchOption);
+        }
+
         public void WriteToFile(string path, string content)
         {
             string dirPath = Path.GetDirectoryName(path);
             Directory.CreateDirectory(dirPath);
             File.WriteAllText(path, content);
+        }
+
+        public string ReadFromFile(string path)
+        {
+            return File.ReadAllText(path);
         }
     }
 }

--- a/src/Common/Microsoft.Arcade.Common/IFileSystem.cs
+++ b/src/Common/Microsoft.Arcade.Common/IFileSystem.cs
@@ -1,11 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+using System.IO;
 
 namespace Microsoft.Arcade.Common
 {
     public interface IFileSystem
     {
         void WriteToFile(string path, string content);
+
+        string ReadFromFile(string path);
+
+        string[] GetFiles(string path, string searchPattern, SearchOption searchOption);
 
         bool FileExists(string path);
 

--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/Microsoft.DotNet.Arcade.Sdk.Tests.csproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/Microsoft.DotNet.Arcade.Sdk.Tests.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
     <PackageReference Include="Moq" Version="4.8.3" />
+    <PackageReference Include="Octokit" Version="$(OctokitVersion)" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/PostOneLocBuildToGitHubTests.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/PostOneLocBuildToGitHubTests.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using FluentAssertions;
 using Microsoft.Arcade.Common;
+using Microsoft.Arcade.Test.Common;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Moq;
@@ -17,6 +19,77 @@ namespace Microsoft.DotNet.Arcade.Sdk.Tests
 {
     public class PostOneLocBuildToGitHubTests
     {
+        private readonly Mock<IGitHubClient> _gitHubClientMock;
+        private readonly Mock<IFileSystem> _fileSystemMock;
+        private readonly Mock<IHelpers> _helpersMock;
 
+        private readonly string _locFilesDir = @"C:\a\loc";
+        private readonly string _gitHubOrg = "dotnet";
+        private readonly string _gitHubRepo = "arcade";
+
+        private readonly PostOneLocBuildToGitHub _task;
+
+        public PostOneLocBuildToGitHubTests()
+        {
+            _fileSystemMock = new Mock<IFileSystem>();
+            _gitHubClientMock = new Mock<IGitHubClient>();
+
+            bool succeeded = false;
+
+            _helpersMock = new Mock<IHelpers>();
+            _helpersMock
+                .Setup(x => x.DirectoryMutexExec(It.IsAny<Func<bool>>(), It.IsAny<string>()))
+                .Callback<Func<bool>, string>((function, path) => {
+                    succeeded = function();
+                })
+                .Returns(() => succeeded);
+
+
+            _task = new PostOneLocBuildToGitHub
+            {
+                LocFilesDirectory = _locFilesDir,
+                GitHubPat = "fake",
+                GitHubOrg = _gitHubOrg,
+                GitHubRepo = _gitHubRepo,
+            };
+        }
+
+        [Fact]
+        public async Task ReturnsExistingOneLocPr()
+        {
+            // Setup
+            IReadOnlyList<PullRequest> prs = new List<PullRequest>
+            {
+                new TestPullRequest { TestTitle = $"A nonsense PR", TestState = ItemState.Open },
+                new TestPullRequest { TestTitle = $"{PostOneLocBuildToGitHub.PrPrefix}04/21/2021", TestState = ItemState.Open },
+                new TestPullRequest { TestTitle = $"A different nonsense PR", TestState = ItemState.Open },
+                new TestPullRequest { TestTitle = $"[DO NOT MERGE] Just testing", TestState = ItemState.Open },
+            };
+
+            _gitHubClientMock
+                .Setup(g => g.PullRequest.GetAllForRepository(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<PullRequestRequest>()))
+                .Returns(Task.FromResult(prs));
+
+            // Act
+            PullRequest foundPr = await _task.FindExistingOneLocPr(_gitHubClientMock.Object);
+
+            // Verify
+            foundPr.Title.Should().Be($"{PostOneLocBuildToGitHub.PrPrefix}04/21/2021");
+        }
+
+        private IServiceCollection CreateMockServiceCollection()
+        {
+            var collection = new ServiceCollection();
+            collection.AddSingleton(_gitHubClientMock.Object);
+            collection.AddSingleton(_fileSystemMock.Object);
+            collection.AddSingleton(_helpersMock.Object);
+            return collection;
+        }
+
+        private class TestPullRequest : PullRequest
+        {
+            public string TestTitle { get { return Title; } set { Title = value; } }
+            public StringEnum<ItemState> TestState { get { return State; } set { State = value; } }
+        }
     }
 }

--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/PostOneLocBuildToGitHubTests.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/PostOneLocBuildToGitHubTests.cs
@@ -25,7 +25,8 @@ namespace Microsoft.DotNet.Arcade.Sdk.Tests
 
         private readonly string _locFilesDir = @"D:\a\1\a\loc\";
         private readonly string _sourcesDir = @"D:\a\1\s\";
-        private readonly string _gitHubOrg = "dotnet";
+        private readonly string _gitHubSourceOrg = "maestro";
+        private readonly string _gitHubTargetOrg = "dotnet";
         private readonly string _gitHubRepo = "arcade";
         private readonly string _gitHubBranch = "main";
 
@@ -73,40 +74,33 @@ D:\a\1\s\src\NetAnalyzers\Core\Microsoft.CodeQuality.Analyzers\xlf\MicrosoftCode
                 LocFilesDirectory = _locFilesDir,
                 SourcesDirectory = _sourcesDir,
                 GitHubPat = "fake",
-                GitHubOrg = _gitHubOrg,
+                GitHubSourceOrg = _gitHubSourceOrg,
+                GitHubTargetOrg = _gitHubTargetOrg,
                 GitHubRepo = _gitHubRepo,
                 GitHubBranch = _gitHubBranch,
             };
         }
 
-        [Fact]
-        public async Task MakesPr()
-        {
-            IReadOnlyList<PullRequest> prs = new List<PullRequest>
-            {
-                new TestPullRequest { TestTitle = $"A nonsense PR", TestState = ItemState.Open, TestBase = new TestGitReference { TestLabel = $"{_gitHubOrg}:{_gitHubBranch}" } },
-                new TestPullRequest { TestTitle = $"{PostOneLocBuildToGitHub.PrPrefix}04/21/2021", TestState = ItemState.Open, TestBase = new TestGitReference { TestLabel = $"{_gitHubOrg}:{_gitHubBranch}" } },
-                new TestPullRequest { TestTitle = $"A different nonsense PR", TestState = ItemState.Open, TestBase = new TestGitReference { TestLabel = $"{_gitHubOrg}:{_gitHubBranch}" } },
-                new TestPullRequest { TestTitle = $"[DO NOT MERGE] Just testing", TestState = ItemState.Open, TestBase = new TestGitReference { TestLabel = $"{_gitHubOrg}:{_gitHubBranch}" } },
-            };
-
-            _fileSystemMock.Setup(f => f.FileExists(It.IsAny<string>()))
-                .Returns(true);
-            _fileSystemMock.Setup(f => f.ReadFromFile(It.IsAny<string>()))
-                .Returns(_prDiffFileContent);
-            
-            _gitHubClientMock
-                .Setup(g => g.PullRequest.GetAllForRepository(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<PullRequestRequest>()))
-                .Returns(Task.FromResult(prs));
-
-            await Task.Delay(10);
-        }
-
         //[Fact]
-        //public async Task TemporaryTestDeleteBeforeCommitting()
+        //public async Task MakesPr()
         //{
-        //    PostOneLocBuildToGitHub task = new PostOneLocBuildToGitHub();
+        //    IReadOnlyList<PullRequest> prs = new List<PullRequest>
+        //    {
+        //        new TestPullRequest { TestTitle = $"A nonsense PR", TestState = ItemState.Open, TestBase = new TestGitReference { TestLabel = $"{_gitHubTargetOrg}:{_gitHubBranch}" } },
+        //        new TestPullRequest { TestTitle = $"{PostOneLocBuildToGitHub.PrPrefix}04/21/2021", TestState = ItemState.Open, TestBase = new TestGitReference { TestLabel = $"{_gitHubTargetOrg}:{_gitHubBranch}" } },
+        //        new TestPullRequest { TestTitle = $"A different nonsense PR", TestState = ItemState.Open, TestBase = new TestGitReference { TestLabel = $"{_gitHubTargetOrg}:{_gitHubBranch}" } },
+        //        new TestPullRequest { TestTitle = $"[DO NOT MERGE] Just testing", TestState = ItemState.Open, TestBase = new TestGitReference { TestLabel = $"{_gitHubTargetOrg}:{_gitHubBranch}" } },
+        //    };
+
+        //    _fileSystemMock.Setup(f => f.FileExists(It.IsAny<string>()))
+        //        .Returns(true);
+        //    _fileSystemMock.Setup(f => f.ReadFromFile(It.IsAny<string>()))
+        //        .Returns(_prDiffFileContent);
             
+        //    _gitHubClientMock
+        //        .Setup(g => g.PullRequest.GetAllForRepository(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<PullRequestRequest>()))
+        //        .Returns(Task.FromResult(prs));
+
         //}
 
         [Fact]
@@ -115,10 +109,10 @@ D:\a\1\s\src\NetAnalyzers\Core\Microsoft.CodeQuality.Analyzers\xlf\MicrosoftCode
             // Setup
             IReadOnlyList<PullRequest> prs = new List<PullRequest>
             {
-                new TestPullRequest { TestTitle = $"A nonsense PR", TestState = ItemState.Open, TestBase = new TestGitReference { TestLabel = $"{_gitHubOrg}:{_gitHubBranch}" } },
-                new TestPullRequest { TestTitle = $"{PostOneLocBuildToGitHub.PrPrefix}04/21/2021", TestState = ItemState.Open, TestBase = new TestGitReference { TestLabel = $"{_gitHubOrg}:{_gitHubBranch}" } },
-                new TestPullRequest { TestTitle = $"A different nonsense PR", TestState = ItemState.Open, TestBase = new TestGitReference { TestLabel = $"{_gitHubOrg}:{_gitHubBranch}" } },
-                new TestPullRequest { TestTitle = $"[DO NOT MERGE] Just testing", TestState = ItemState.Open, TestBase = new TestGitReference { TestLabel = $"{_gitHubOrg}:{_gitHubBranch}" } },
+                new TestPullRequest { TestTitle = $"A nonsense PR", TestState = ItemState.Open, TestBase = new TestGitReference { TestLabel = $"{_gitHubTargetOrg}:{_gitHubBranch}" } },
+                new TestPullRequest { TestTitle = $"{PostOneLocBuildToGitHub.PrPrefix}04/21/2021", TestState = ItemState.Open, TestBase = new TestGitReference { TestLabel = $"{_gitHubTargetOrg}:{_gitHubBranch}" } },
+                new TestPullRequest { TestTitle = $"A different nonsense PR", TestState = ItemState.Open, TestBase = new TestGitReference { TestLabel = $"{_gitHubTargetOrg}:{_gitHubBranch}" } },
+                new TestPullRequest { TestTitle = $"[DO NOT MERGE] Just testing", TestState = ItemState.Open, TestBase = new TestGitReference { TestLabel = $"{_gitHubTargetOrg}:{_gitHubBranch}" } },
             };
 
             _gitHubClientMock
@@ -130,7 +124,7 @@ D:\a\1\s\src\NetAnalyzers\Core\Microsoft.CodeQuality.Analyzers\xlf\MicrosoftCode
 
             // Verify
             foundPr.Title.Should().Be($"{PostOneLocBuildToGitHub.PrPrefix}04/21/2021");
-            foundPr.Base.Label.Should().Be($"{_gitHubOrg}:{_gitHubBranch}");
+            foundPr.Base.Label.Should().Be($"{_gitHubTargetOrg}:{_gitHubBranch}");
         }
 
         [Fact]
@@ -139,9 +133,9 @@ D:\a\1\s\src\NetAnalyzers\Core\Microsoft.CodeQuality.Analyzers\xlf\MicrosoftCode
             // Setup
             IReadOnlyList<PullRequest> prs = new List<PullRequest>
             {
-                new TestPullRequest { TestTitle = $"A nonsense PR", TestState = ItemState.Open, TestBase = new TestGitReference { TestLabel = $"{_gitHubOrg}:{_gitHubBranch}" } },
-                new TestPullRequest { TestTitle = $"A different nonsense PR", TestState = ItemState.Open, TestBase = new TestGitReference { TestLabel = $"{_gitHubOrg}:{_gitHubBranch}" } },
-                new TestPullRequest { TestTitle = $"[DO NOT MERGE] Just testing", TestState = ItemState.Open, TestBase = new TestGitReference { TestLabel = $"{_gitHubOrg}:{_gitHubBranch}" } },
+                new TestPullRequest { TestTitle = $"A nonsense PR", TestState = ItemState.Open, TestBase = new TestGitReference { TestLabel = $"{_gitHubTargetOrg}:{_gitHubBranch}" } },
+                new TestPullRequest { TestTitle = $"A different nonsense PR", TestState = ItemState.Open, TestBase = new TestGitReference { TestLabel = $"{_gitHubTargetOrg}:{_gitHubBranch}" } },
+                new TestPullRequest { TestTitle = $"[DO NOT MERGE] Just testing", TestState = ItemState.Open, TestBase = new TestGitReference { TestLabel = $"{_gitHubTargetOrg}:{_gitHubBranch}" } },
             };
 
             _gitHubClientMock

--- a/src/Microsoft.DotNet.Arcade.Sdk.Tests/PostOneLocBuildToGitHubTests.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk.Tests/PostOneLocBuildToGitHubTests.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Arcade.Common;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Moq;
+using Octokit;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.DotNet.Arcade.Sdk.Tests
+{
+    public class PostOneLocBuildToGitHubTests
+    {
+
+    }
+}

--- a/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
     <PackageReference Include="NuGet.Versioning" Version="$(NuGetVersioningVersion)" />
+    <PackageReference Include="Octokit" Version="$(OctokitVersion)" />
     <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/PostOneLocBuildToGitHub.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/PostOneLocBuildToGitHub.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Arcade.Common;
+using Microsoft.Build.Framework;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Octokit;
@@ -15,7 +16,19 @@ namespace Microsoft.DotNet.Arcade.Sdk
 {
     public class PostOneLocBuildToGitHub : MSBuildTaskBase
     {
+        [Required]
+        public string LocFilesDirectory { get; set; }
 
+        [Required]
+        public string GitHubPat { get; set; }
+
+        [Required]
+        public string GitHubOrg { get; set; }
+
+        [Required]
+        public string GitHubRepo { get; set; }
+
+        public static string PrPrefix = "Localized files from OneLocBuild for ";
 
         public override void ConfigureServices(IServiceCollection collection)
         {
@@ -27,11 +40,27 @@ namespace Microsoft.DotNet.Arcade.Sdk
 
         public bool ExecuteTask(IGitHubClient gitHubClient, IFileSystem fileSystem, IHelpers helpers)
         {
-            
+            gitHubClient.Connection.Credentials = new Credentials("dnbot", GitHubPat);
+
+
 
             return true;
         }
 
+        public async Task<PullRequest> FindExistingOneLocPr(IGitHubClient gitHubClient)
+        {
+            PullRequestRequest filter = new PullRequestRequest { State = ItemStateFilter.Open };
+            var prs = (await gitHubClient.PullRequest.GetAllForRepository(GitHubOrg, GitHubRepo, filter))
+                .Where(pr => pr.Title.StartsWith(PrPrefix));
 
+            if (prs.Count() > 0)
+            {
+                return prs.First();
+            }
+            else
+            {
+                return null;
+            }
+        }
     }
 }

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/PostOneLocBuildToGitHub.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/PostOneLocBuildToGitHub.cs
@@ -6,8 +6,10 @@ using Microsoft.Build.Framework;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Octokit;
+using Octokit.Helpers;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -20,6 +22,9 @@ namespace Microsoft.DotNet.Arcade.Sdk
         public string LocFilesDirectory { get; set; }
 
         [Required]
+        public string SourcesDirectory { get; set; }
+
+        [Required]
         public string GitHubPat { get; set; }
 
         [Required]
@@ -28,7 +33,13 @@ namespace Microsoft.DotNet.Arcade.Sdk
         [Required]
         public string GitHubRepo { get; set; }
 
+        [Required]
+        public string GitHubBranch { get; set; }
+
+        public static string PrDiffFileName = "BinPlaceFileList.txt";
         public static string PrPrefix = "Localized files from OneLocBuild for ";
+
+        private const string _gitFileBlobMode = "100644";
 
         public override void ConfigureServices(IServiceCollection collection)
         {
@@ -40,9 +51,83 @@ namespace Microsoft.DotNet.Arcade.Sdk
 
         public bool ExecuteTask(IGitHubClient gitHubClient, IFileSystem fileSystem, IHelpers helpers)
         {
+            return ExecuteAsync(gitHubClient, fileSystem, helpers).GetAwaiter().GetResult();
+        }
+
+        public async Task<bool> ExecuteAsync(IGitHubClient gitHubClient, IFileSystem fileSystem, IHelpers helpers)
+        {
             gitHubClient.Connection.Credentials = new Credentials("dnbot", GitHubPat);
 
+            string pathToPrDiffFile = Path.Combine(LocFilesDirectory, PrDiffFileName);
+            if (!fileSystem.FileExists(pathToPrDiffFile))
+            {
+                Log.LogError($"PR diff file '{pathToPrDiffFile}' not found.");
+                return false;
+            }
 
+            string[] filesToPr = fileSystem.ReadFromFile(pathToPrDiffFile).Split('\n');
+
+            Reference targetBranch = await gitHubClient.Git.Reference.Get(GitHubOrg, GitHubRepo, $"heads/{GitHubBranch}");
+            Reference newBranch;
+            string branchName;
+            string branchRef;
+
+            // Find out if a PR already exists; if it does, use its branch
+            PullRequest existingPr = await FindExistingOneLocPr(gitHubClient);
+            if (existingPr is not null)
+            {
+                branchName = existingPr.Head.Ref;
+                branchRef = $"heads/{branchName}";
+                newBranch = await gitHubClient.Git.Reference.Get(GitHubOrg, GitHubRepo, branchRef);
+            }
+            // If not, we create a new branch
+            else
+            {
+                branchName = $"OneLocBuild-{new Guid()}";
+                branchRef = $"heads/{branchName}";
+                newBranch = await gitHubClient.Git.Reference.CreateBranch(GitHubOrg, GitHubRepo, branchName, targetBranch);
+            }
+
+            TreeResponse currentTree = await gitHubClient.Git.Tree.Get(GitHubOrg, GitHubRepo, branchRef);
+            NewTree newTree = new NewTree
+            {
+                BaseTree = currentTree.Sha
+            };
+
+            // Add each file to the tree
+            foreach (string file in filesToPr)
+            {
+                string filePath = file.Substring(SourcesDirectory.Length); // equivalent to Path.GetRelativePath()
+                string locdFilePath = fileSystem.GetFiles(LocFilesDirectory, Path.GetFileName(file), SearchOption.AllDirectories).First();
+                string locdFileContent = fileSystem.ReadFromFile(locdFilePath);
+
+                NewTreeItem locdFile = new NewTreeItem
+                {
+                    Path = filePath,
+                    Mode = _gitFileBlobMode,
+                    Type = TreeType.Blob,
+                    Content = locdFileContent,
+                };
+                newTree.Tree.Add(locdFile);
+            }
+
+            TreeResponse treeResponse = await gitHubClient.Git.Tree.Create(GitHubOrg, GitHubRepo, newTree);
+
+            // Create a commit
+            NewCommit newCommit = new NewCommit($"Add localization from OneLocBuild ({DateTimeOffset.Now:yyyy-mm-dd}",
+                treeResponse.Sha,
+                newBranch.Object.Sha);
+            Commit commit = await gitHubClient.Git.Commit.Create(GitHubOrg, GitHubRepo, newCommit);
+
+            ReferenceUpdate update = new ReferenceUpdate(commit.Sha);
+            await gitHubClient.Git.Reference.Update(GitHubOrg, GitHubRepo, branchRef, update);
+
+            // Create a new pull request if one does not exist
+            if (existingPr is null)
+            {
+                NewPullRequest newPr = new NewPullRequest(newCommit.Message, branchName, GitHubBranch);
+                await gitHubClient.PullRequest.Create(GitHubOrg, GitHubRepo, newPr);
+            }
 
             return true;
         }
@@ -51,7 +136,8 @@ namespace Microsoft.DotNet.Arcade.Sdk
         {
             PullRequestRequest filter = new PullRequestRequest { State = ItemStateFilter.Open };
             var prs = (await gitHubClient.PullRequest.GetAllForRepository(GitHubOrg, GitHubRepo, filter))
-                .Where(pr => pr.Title.StartsWith(PrPrefix));
+                .Where(pr => pr.Title.StartsWith(PrPrefix))
+                .Where(pr => pr.Base.Label.Equals($"{GitHubOrg}:{GitHubBranch}", StringComparison.OrdinalIgnoreCase));
 
             if (prs.Count() > 0)
             {

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/PostOneLocBuildToGitHub.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/PostOneLocBuildToGitHub.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Arcade.Common;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Octokit;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Arcade.Sdk
+{
+    public class PostOneLocBuildToGitHub : MSBuildTaskBase
+    {
+
+
+        public override void ConfigureServices(IServiceCollection collection)
+        {
+            collection.TryAddSingleton<IGitHubClient>(new GitHubClient(new ProductHeaderValue("OneLocBuild")));
+            collection.TryAddSingleton<IFileSystem, FileSystem>();
+            collection.TryAddSingleton<IHelpers, Helpers>();
+            collection.TryAddSingleton(Log);
+        }
+
+        public bool ExecuteTask(IGitHubClient gitHubClient, IFileSystem fileSystem, IHelpers helpers)
+        {
+            
+
+            return true;
+        }
+
+
+    }
+}


### PR DESCRIPTION
This is a draft PR so I can get feedback early while I'm still finishing up and writing tests and such. I'm using this locally right now to make loc PRs to the various repos that need them for the upcoming release, but I want to make sure it's at least a little sturdy before we flow it.

An example of a PR created in fsharp: https://github.com/dotnet/fsharp/pull/11491

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
