### PR TITLE
Add devdiv.visualstudio URL to the regex used for SourceLink translation

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
@@ -35,18 +35,20 @@
 
   <!-- 
     The convention for names of Azure DevOps repositories mirrored from GitHub is "{GitHub org name}-{GitHub repository name}"
+    In the legacy devdiv.visualstudio instance, it is instead "{GitHub org name}-{GitHub repository name}-Trusted" with no guarantees for casing.
   -->
   <PropertyGroup>
     <!-- There are quite a few git repo forms:
       https://dnceng@dev.azure.com/dnceng/internal/_git/dotnet-arcade-services
       https://dev.azure.com/dnceng/internal/_git/dotnet-arcade-services
       https://dnceng.visualstudio.com/internal/_git/dotnet-arcade-services
+      https://devdiv.visualstudio.com/DevDiv/_git/DotNet-msbuild-Trusted
       dnceng@vs-ssh.visualstudio.com:v3/dnceng/internal/dotnet-arcade-services
       git@ssh.dev.azure.com:v3/dnceng/internal/dotnet-arcade-services
     -->
     <!-- Set DisableSourceLinkUrlTranslation to true when building a tool for internal use where sources only come from internal URIs -->
     <DisableSourceLinkUrlTranslation Condition="'$(DisableSourceLinkUrlTranslation)' == ''">false</DisableSourceLinkUrlTranslation>
-    <_TranslateUrlPattern>(https://dnceng%40dev\.azure\.com/dnceng/internal/_git|https://dev\.azure\.com/dnceng/internal/_git|https://dnceng\.visualstudio\.com/internal/_git|dnceng%40vs-ssh\.visualstudio\.com:v3/dnceng/internal|git%40ssh\.dev\.azure\.com:v3/dnceng/internal)/([^/-]+)-(.+)</_TranslateUrlPattern>
+    <_TranslateUrlPattern>(https://dnceng%40dev\.azure\.com/dnceng/internal/_git|https://dev\.azure\.com/dnceng/internal/_git|https://dnceng\.visualstudio\.com/internal/_git|dnceng%40vs-ssh\.visualstudio\.com:v3/dnceng/internal|git%40ssh\.dev\.azure\.com:v3/dnceng/internal|https://devdiv\.visualstudio\.com/devdiv/_git)/([^/-]+)-(.+)</_TranslateUrlPattern>
     <_TranslateUrlReplacement>https://github.com/$2/$3</_TranslateUrlReplacement>
   </PropertyGroup>
 
@@ -56,6 +58,9 @@
           BeforeTargets="SourceControlManagerPublishTranslatedUrls">
 
     <PropertyGroup>
+      <!-- Repositories mirrored on devdiv.visualstudio will have '-Trusted' added to their name and this needs to be stripped off before translation
+           Eventually, all repos should move to dnceng/internal when possible. -->
+      <ScmRepositoryUrl Condition="$(ScmRepositoryUrl.Contains(`devdiv.visualstudio`))">$(ScmRepositoryUrl.ToLower().Replace(`-trusted`,``))</ScmRepositoryUrl>
       <ScmRepositoryUrl>$([System.Text.RegularExpressions.Regex]::Replace($(ScmRepositoryUrl), $(_TranslateUrlPattern), $(_TranslateUrlReplacement)))</ScmRepositoryUrl>
     </PropertyGroup>
 


### PR DESCRIPTION
(Same change as https://github.com/dotnet/arcade/pull/7304, but for release/5.0)

### To double check:

https://github.com/dotnet/arcade/issues/7255

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation

There aren't any automated validations set up here, but pasting this (exactly what I changed) into a local project file and running it shows it does what i want:

```
<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
  <Target Name="Build">

    <PropertyGroup>
      <ScmRepositoryUrl>https://devdiv.visualstudio.com/DevDiv/_git/DotNet-msbuild-Trusted</ScmRepositoryUrl>
      <_TranslateUrlPattern>(https://dnceng%40dev\.azure\.com/dnceng/internal/_git|https://dev\.azure\.com/dnceng/internal/_git|https://dnceng\.visualstudio\.com/internal/_git|dnceng%40vs-ssh\.visualstudio\.com:v3/dnceng/internal|git%40ssh\.dev\.azure\.com:v3/dnceng/internal|https://devdiv\.visualstudio\.com/devdiv/_git)/([^/-]+)-(.+)</_TranslateUrlPattern>
      <_TranslateUrlReplacement>https://github.com/$2/$3</_TranslateUrlReplacement>
    </PropertyGroup>

    <Message Importance="High" Text="Untranslated URL : $(ScmRepositoryUrl)" />

    <PropertyGroup>
      <ScmRepositoryUrl Condition="$(ScmRepositoryUrl.Contains(`devdiv.visualstudio`))">$(ScmRepositoryUrl.ToLower().Replace(`-trusted`,``))</ScmRepositoryUrl>
      <ScmRepositoryUrl>$([System.Text.RegularExpressions.Regex]::Replace($(ScmRepositoryUrl), $(_TranslateUrlPattern), $(_TranslateUrlReplacement)))</ScmRepositoryUrl>
    </PropertyGroup>

    <Message Importance="High" Text="Translated URL : $(ScmRepositoryUrl)" />

  </Target>
</Project>
```
Output:

```
Microsoft (R) Build Engine version 16.8.3+39993bd9d for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

Build started 4/27/2021 5:28:25 PM.
Project "...fun.proj" on node 1 (default targets).
Build:
  Untranslated URL : https://devdiv.visualstudio.com/DevDiv/_git/DotNet-msbuild-Trusted
  Translated URL : https://github.com/dotnet/msbuild
Done Building Project "...fun.proj" (default targets).


Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:00.06
```