### PR TITLE
Move builldpool queues from 16.04 -> 18.04

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -151,10 +151,10 @@ stages:
           pool:
             ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
               name:  NetCorePublic-Pool
-              queue: BuildPool.Ubuntu.1604.Amd64.Open
+              queue: BuildPool.Ubuntu.1804.Amd64.Open
             ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
               name:  NetCoreInternal-Pool
-              queue: BuildPool.Ubuntu.1604.Amd64
+              queue: BuildPool.Ubuntu.1804.Amd64
           variables:
           - HelixApiAccessToken: ''
           - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
16.04 is EOL this Friday

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
(The linked CI build will be validation)