### PR TITLE
Revert "Add ldap libraries to the docker images. (#7197)"

### DIFF
--- a/eng/common/cross/build-android-rootfs.sh
+++ b/eng/common/cross/build-android-rootfs.sh
@@ -106,7 +106,6 @@ __AndroidPackages+=" libandroid-glob"
 __AndroidPackages+=" liblzma"
 __AndroidPackages+=" krb5"
 __AndroidPackages+=" openssl"
-__AndroidPackages+=" openldap"
 
 for path in $(wget -qO- http://termux.net/dists/stable/main/binary-$__AndroidArch/Packages |\
     grep -A15 "Package: \(${__AndroidPackages// /\\|}\)" | grep -v "static\|tool" | grep Filename); do

--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -55,13 +55,11 @@ __UbuntuPackages+=" libcurl4-openssl-dev"
 __UbuntuPackages+=" libkrb5-dev"
 __UbuntuPackages+=" libssl-dev"
 __UbuntuPackages+=" zlib1g-dev"
-__UbuntuPackages+=" libldap2-dev"
 
 __AlpinePackages+=" curl-dev"
 __AlpinePackages+=" krb5-dev"
 __AlpinePackages+=" openssl-dev"
 __AlpinePackages+=" zlib-dev"
-__AlpinePackages+=" openldap-dev"
 
 __FreeBSDBase="12.1-RELEASE"
 __FreeBSDPkg="1.12.0"
@@ -70,13 +68,11 @@ __FreeBSDPackages+=" icu"
 __FreeBSDPackages+=" libinotify"
 __FreeBSDPackages+=" lttng-ust"
 __FreeBSDPackages+=" krb5"
-__FreeBSDPackages+=" libslapi-2.4"
 
 __IllumosPackages="icu-64.2nb2"
 __IllumosPackages+=" mit-krb5-1.16.2nb4"
 __IllumosPackages+=" openssl-1.1.1e"
 __IllumosPackages+=" zlib-1.2.11"
-__IllumosPackages+=" openldap-client-2.4.49"
 
 __UseMirror=0
 


### PR DESCRIPTION
This reverts https://github.com/dotnet/arcade/pull/7197. The solution for https://github.com/dotnet/runtime/pull/51205 has changed and we don't need a native proxy anymore. We ended up calling a different non-vararg API in OpenLdap.