### PR TITLE
Increase parallelism in sourceline and symbols validation

### DIFF
--- a/eng/common/post-build/sourcelink-validation.ps1
+++ b/eng/common/post-build/sourcelink-validation.ps1
@@ -14,7 +14,7 @@ param(
 $global:RepoFiles = @{}
 
 # Maximum number of jobs to run in parallel
-$MaxParallelJobs = 6
+$MaxParallelJobs = 16
 
 # Wait time between check for system load
 $SecondsBetweenLoadChecks = 10

--- a/eng/common/post-build/symbols-validation.ps1
+++ b/eng/common/post-build/symbols-validation.ps1
@@ -8,7 +8,7 @@ param(
 )
 
 # Maximum number of jobs to run in parallel
-$MaxParallelJobs = 6
+$MaxParallelJobs = 16
 
 # Max number of retries
 $MaxRetry = 5


### PR DESCRIPTION
These two powershell scripts allowed for 6 parallel jobs. Going up to 16 significantly improves the performance of these jobs in the release pipeline (from 1.5hrs to 1 hr for symbols validation and 4.9hrs to 1.9hrs for sourcelink validation).

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
