### PR TITLE
Add user Dev WF (PR) Docs

### DIFF
--- a/Documentation/Projects/Build Analysis/FAQ.md
+++ b/Documentation/Projects/Build Analysis/FAQ.md
@@ -1,0 +1,9 @@
+# Build Analysis Frequently Asked Questions
+
+## How do I reproduce a failure?
+
+We maintain a DevTest Lab configured with access to the same image galleries used in Helix machines that may be used for a virtual machine environment. We also keep a few duplicate of "on premesis" hardware (machines not available as a VM) available for remote access. Contact dnceng for details. 
+
+## Is this useful even if my project does not use Helix?
+
+Yes! The Build Analysis result leverages Azure DevOps history and information to provide context and workflow improvements. Though it may bring additional information for Helix-based execution, it is not required. 

--- a/Documentation/Projects/Build Analysis/FAQ.md
+++ b/Documentation/Projects/Build Analysis/FAQ.md
@@ -1,9 +1,0 @@
-# Build Analysis Frequently Asked Questions
-
-## How do I reproduce a failure?
-
-We maintain a DevTest Lab configured with access to the same image galleries used in Helix machines that may be used for a virtual machine environment. We also keep a few duplicate of "on premesis" hardware (machines not available as a VM) available for remote access. Contact dnceng for details. 
-
-## Is this useful even if my project does not use Helix?
-
-Yes! The Build Analysis result leverages Azure DevOps history and information to provide context and workflow improvements. Though it may bring additional information for Helix-based execution, it is not required. 

--- a/Documentation/Projects/Build Analysis/Introduction.md
+++ b/Documentation/Projects/Build Analysis/Introduction.md
@@ -1,0 +1,30 @@
+# Build Analysis
+
+The Build Analysis Check is a service to improve the Pull Request experience by highlighting build and test information most helpful to .NET developers. Its goal is to make Pull Request results more actionable.
+
+## Contacts
+
+Direct access to the V-Team is available (and welcome!) via the Teams channel "V-Team: Dev WF (PRs)" in the [.NET Core Eng Services Partners Team][]. You may also contact the team via any of the usual means to [Engineering Services][].
+
+## How does it work?
+
+- Highlight most important failure information
+- Add context by combining information in Azure DevOps and Helix
+- Reduce distance to most helpful analysis tools, such as Azure DevOps Test Result History for a particular test or the Helix artifact logs
+
+## What _specifically_ does it do?
+
+See the [specifics](Specifics.md) document.
+
+## How do I get it?
+
+Build Analysis is enabled on a per-repository basis. Contact the "Dev WF" to request it be enabled in your repository.
+
+## How do I use it?
+
+Once enabled, a new GitHub check suite will be included in all pull requests. Navigate to the "Checks" tab, then look for the ".NET Helix" suite.
+
+
+[.NET Core Eng Services Partners Team]: https://teams.microsoft.com/l/team/19%3aa88bb61ffc1a4392ad38ebbc526c86f8%40thread.skype/conversations?groupId=4d73664c-9f2f-450d-82a5-c2f02756606d&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47 ".NET Core Eng Services Partners"
+
+[Engineering Services]: https://github.com/dotnet/core-eng/wiki/How-to-get-a-hold-of-Engineering-Servicing "How to get a hold of Engineering Servicing"

--- a/Documentation/Projects/Build Analysis/Introduction.md
+++ b/Documentation/Projects/Build Analysis/Introduction.md
@@ -2,29 +2,26 @@
 
 The Build Analysis Check is a service to improve the Pull Request experience by highlighting build and test information most helpful to .NET developers. Its goal is to make Pull Request results more actionable.
 
-## Contacts
+## What does it do?
 
-Direct access to the V-Team is available (and welcome!) via the Teams channel "V-Team: Dev WF (PRs)" in the [.NET Core Eng Services Partners Team][]. You may also contact the team via any of the usual means to [Engineering Services][].
-
-## How does it work?
+High-level features include:
 
 - Highlight most important failure information
 - Add context by combining information in Azure DevOps and Helix
 - Reduce distance to most helpful analysis tools, such as Azure DevOps Test Result History for a particular test or the Helix artifact logs
 
-## What _specifically_ does it do?
-
-See the [specifics](Specifics.md) document.
+For more details, see the [specifics](Specifics.md) document.
 
 ## How do I get it?
 
-Build Analysis is enabled on a per-repository basis. Contact the "Dev WF" to request it be enabled in your repository.
+Build Analysis is enabled on a per-repository basis. Contact dnceng to request it be enabled in your repository.
 
 ## How do I use it?
 
 Once enabled, a new GitHub check suite will be included in all pull requests. Navigate to the "Checks" tab, then look for the ".NET Helix" suite.
 
+## Frequently Asked Questions
 
-[.NET Core Eng Services Partners Team]: https://teams.microsoft.com/l/team/19%3aa88bb61ffc1a4392ad38ebbc526c86f8%40thread.skype/conversations?groupId=4d73664c-9f2f-450d-82a5-c2f02756606d&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47 ".NET Core Eng Services Partners"
+### Is this useful even if my project does not use Helix?
 
-[Engineering Services]: https://github.com/dotnet/core-eng/wiki/How-to-get-a-hold-of-Engineering-Servicing "How to get a hold of Engineering Servicing"
+Yes! The Build Analysis result leverages Azure DevOps history and information to provide context and workflow improvements. Though it may bring additional information for Helix-based execution, it is not required. 

--- a/Documentation/Projects/Build Analysis/Specifics.md
+++ b/Documentation/Projects/Build Analysis/Specifics.md
@@ -1,0 +1,15 @@
+# Build Analysis Specifics
+
+The Build Analysis check includes these details:
+
+- Collapse failures of the same name across Jobs and Pipelines to improve discoverability. For example, failures of the same test across multiple operating systems are grouped together. 
+- Highlight a failure's state in the target branch
+- Provide direct links to the most common pages for continuing analysis
+  - Link to the Azure DevOps build
+  - Link to the log of the specific step that failed
+  - Link to the Azure DevOps Test History for the pipeline
+  - Link to test history of the specific test
+  - Link to the Helix artifacts produced by a test
+  - Link to the test execution details 
+
+Each Build Analysis page also includes a "was this helpful" link. This allows you to call out specific highlights or lowlights in your experience with the check. This feedback is then used by the Dev WF team to refine the analysis.


### PR DESCRIPTION
This PR adds user-facing documentation related to the Dev WF (Actionable PRs) effort, and specifically the Build Analysis service. 

My goal is to provide a place for any documentation that might be helpful to a new user in understand the Build Analysis service, the information it presents, how best to interpret the information, etc. 

If feedback is good, I expect this will grow after each milestone to include whatever features and changes were completed. 