### PR TITLE
Avoid attempting to publish symbols that are not actually .symbols.nupkg

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/GeneralTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/GeneralTests.cs
@@ -33,6 +33,19 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
         }
 
         [Theory]
+        [InlineData("foo/bar/baz/bop.symbols.nupkg", true)]
+        [InlineData("foo/bar/baz/bop.symbols.nupkg.sha512", false)]
+        [InlineData("foo/bar/baz/bip.snupkg.sha512", false)]
+        [InlineData("foo/bar/baz/bip.snupkg", true)]
+        [InlineData("foo/bar/baz/bip.SNUpkg", true)]
+        [InlineData("foo/bar/baz/bop.SYMBOLS.nupkg", true)]
+        [InlineData("foo/bar/symbols.nupkg/bop.nupkg", false)]
+        public void IsSymbolPackage(string package, bool isSymbolPackage)
+        {
+            GeneralUtils.IsSymbolPackage(package).Should().Be(isSymbolPackage);
+        }
+
+        [Theory]
         [InlineData(HttpStatusCode.OK, true)]
         [InlineData(HttpStatusCode.Accepted, true)]
         [InlineData(HttpStatusCode.BadRequest, false)]

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildModelFactory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildModelFactory.cs
@@ -149,8 +149,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     continue;
                 }
 
-                var isSymbolsPackage = artifact.ItemSpec.EndsWith(".symbols.nupkg", StringComparison.OrdinalIgnoreCase)
-                    || artifact.ItemSpec.EndsWith(".snupkg", StringComparison.OrdinalIgnoreCase);
+                var isSymbolsPackage = GeneralUtils.IsSymbolPackage(artifact.ItemSpec);
 
                 if (artifact.ItemSpec.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase) && !isSymbolsPackage)
                 {

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -404,7 +404,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             foreach (var asset in buildAssets)
             {
                 var name = asset.Key;
-                if (name.Contains(".symbols.nupkg"))
+                if (GeneralUtils.IsSymbolPackage(name))
                 {
                     symbolsToPublish.Add(Path.GetFileName(name));
                 }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
@@ -252,7 +252,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         {
             foreach (var blobAsset in buildModel.Artifacts.Blobs)
             {
-                if (blobAsset.Id.EndsWith(".symbols.nupkg", StringComparison.OrdinalIgnoreCase))
+                if (GeneralUtils.IsSymbolPackage(blobAsset.Id))
                 {
                     var sourceFile = Path.Combine(BlobAssetsBasePath, Path.GetFileName(blobAsset.Id));
                     var destinationFile = Path.Combine(symbolTemporaryLocation, Path.GetFileName(blobAsset.Id));

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/GeneralUtils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/GeneralUtils.cs
@@ -19,6 +19,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
     public static class GeneralUtils
     {
         public const string SymbolPackageSuffix = ".symbols.nupkg";
+        public const string SnupkgPackageSuffix = ".snupkg";
         public const string PackageSuffix = ".nupkg";
         public const string PackagesCategory = "PACKAGE";
 
@@ -367,6 +368,16 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             } 
         }
 
+        /// <summary>
+        ///     Determine whether a file name or path is a symbol package.
+        /// </summary>
+        /// <param name="name">File anme or path</param>
+        /// <returns>True if the item is a symbol package, false otherwise</returns>
+        public static bool IsSymbolPackage(string name)
+        {
+            return name.EndsWith(SymbolPackageSuffix, StringComparison.OrdinalIgnoreCase) ||
+                name.EndsWith(SnupkgPackageSuffix, StringComparison.OrdinalIgnoreCase);
+        }
 
         private static System.Threading.Tasks.Task WaitForProcessExitAsync(Process process)
         {


### PR DESCRIPTION
If repos generated a .symbols.nupkg.sha512, it would get caught in the current code
There were enough instances of this test in Microsoft.DotNet.Build.Tasks.Feed to pull it out into common code and add a test.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
