### PR TITLE
Limit the version range for the VS generator to versions that CMake currently understands.

### DIFF
--- a/src/Microsoft.DotNet.CMake.Sdk/build/Microsoft.DotNet.CMake.Sdk.targets
+++ b/src/Microsoft.DotNet.CMake.Sdk/build/Microsoft.DotNet.CMake.Sdk.targets
@@ -30,6 +30,8 @@
     <PropertyGroup>
       <_CMakeMultiConfigurationGenerator>true</_CMakeMultiConfigurationGenerator>
       <_CMakePassArchitectureToGenerator>true</_CMakePassArchitectureToGenerator>
+      <!-- We limit the VS version range for the generator since CMake only knows about specific VS versions -->
+      <VSGeneratorVersionRange Condition="'$(VSGeneratorVersionRange)' == ''">[,17.0)</VSGeneratorVersionRange>
       <!-- Visual Studio uses the Win32 name for the x86 target architecture. -->
       <Platform Condition="'$(Platform)' == 'x86'">Win32</Platform>
     </PropertyGroup>
@@ -37,7 +39,7 @@
     <Error Condition="'$(_VSNativeCompilerComponentArchName)' == ''" Text="Unable to determine if Visual Studio has MSVC tools installed for the '$(Platform)' architecture." />
 
     <Exec
-      Command="$(VSWherePath) -latest -prerelease -products * -requires $(_VSNativeCompilerComponentName) -property installationVersion"
+      Command="$(VSWherePath) -latest -prerelease -products * -version $(VSGeneratorVersionRange) -requires $(_VSNativeCompilerComponentName) -property installationVersion"
       EchoOff="true"
       ConsoleToMsBuild="true"
       StandardOutputImportance="Low">


### PR DESCRIPTION
Fixes #7324