### PR TITLE
Fix positional parameter issue in symbols-validation

### DIFF
--- a/eng/common/post-build/symbols-validation.ps1
+++ b/eng/common/post-build/symbols-validation.ps1
@@ -114,6 +114,7 @@ $CountMissingSymbols = {
       $totalRetries = 0
 
       while ($totalRetries -lt $using:MaxRetry) {
+
         # Save the output and get diagnostic output
         $output = & $dotnetSymbolExe --symbols --modules $WindowsPdbVerificationParam $TargetServerParam $FullPath -o $SymbolsPath --diagnostics | Out-String
 
@@ -144,8 +145,16 @@ $CountMissingSymbols = {
       return $null
     }
 
-    $SymbolsOnMSDL = & $FirstMatchingSymbolDescriptionOrDefault $FileName '--microsoft-symbol-server' $SymbolsPath $WindowsPdbVerificationParam
-    $SymbolsOnSymWeb = & $FirstMatchingSymbolDescriptionOrDefault $FileName '--internal-server' $SymbolsPath $WindowsPdbVerificationParam
+    $SymbolsOnMSDL = & $FirstMatchingSymbolDescriptionOrDefault `
+        -FullPath $FileName `
+        -TargetServerParam '--microsoft-symbol-server' `
+        -SymbolsPath $SymbolsPath `
+        -WindowsPdbVerificationParam $WindowsPdbVerificationParam
+    $SymbolsOnSymWeb = & $FirstMatchingSymbolDescriptionOrDefault `
+        -FullPath $FileName `
+        -TargetServerParam '--internal-server' `
+        -SymbolsPath $SymbolsPath `
+        -WindowsPdbVerificationParam $WindowsPdbVerificationParam
 
     Write-Host -NoNewLine "`t Checking file " $FileName "... "
   


### PR DESCRIPTION
I added a parameter for WindowsPdbVerification to the code block, but then called the code block with the parameter in the wrong place.
- I am very sorry and won't do it again.
- Verified that the script works as expected now.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
