### PR TITLE
Add public symbols feed override option

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
@@ -154,6 +154,7 @@
       TransportFeedOverride="$(TransportFeedOverride)"
       ShippingFeedOverride="$(ShippingFeedOverride)"
       SymbolsFeedOverride="$(SymbolsFeedOverride)" 
+      PublicSymbolsFeedOverride="$(PublicSymbolsFeedOverride)"
       AzdoApiToken="$(AzdoApiToken)"
       ArtifactsBasePath="$(ArtifactsBasePath)"
       BuildId="$(BuildId)"

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -129,6 +129,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public string SymbolsFeedOverride { get; set; }
 
+        public string PublicSymbolsFeedOverride { get; set; }
+
         /// <summary>
         /// Path to dll and pdb files
         /// </summary>
@@ -381,6 +383,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 ShippingFeedOverride = this.ShippingFeedOverride,
                 TransportFeedOverride = this.TransportFeedOverride,
                 SymbolsFeedOverride = this.SymbolsFeedOverride,
+                PublicSymbolsFeedOverride = this.PublicSymbolsFeedOverride,
                 ArtifactsBasePath =  this.ArtifactsBasePath,
                 AzdoApiToken = this.AzdoApiToken,
                 BuildId = this.BuildId,

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
@@ -64,6 +64,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public string SymbolsFeedOverride { get; set; }
 
+        public string PublicSymbolsFeedOverride { get; set; }
+
         public override bool Execute()
         {
             ExecuteAsync().GetAwaiter().GetResult();
@@ -160,6 +162,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         AzureDevOpsFeedsKey,
                         BuildEngine = this.BuildEngine,
                         targetChannelConfig.SymbolTargetType,
+                        azureDevOpsPublicStaticSymbolsFeed: PublicSymbolsFeedOverride,
                         filesToExclude: targetChannelConfig.FilenamesToExclude,
                         flatten: targetChannelConfig.Flatten);
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
@@ -162,7 +162,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         AzureDevOpsFeedsKey,
                         BuildEngine = this.BuildEngine,
                         targetChannelConfig.SymbolTargetType,
-                        azureDevOpsPublicStaticSymbolsFeed: PublicSymbolsFeedOverride,
+                        azureDevOpsPublicStaticSymbolsFeed: GetFeed(null, PublicSymbolsFeedOverride),
                         filesToExclude: targetChannelConfig.FilenamesToExclude,
                         flatten: targetChannelConfig.Flatten);
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigV3.cs
@@ -29,6 +29,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         
         private string StableSymbolsFeed { get; set; }
 
+        private string AzureDevOpsPublicStaticSymbolsFeed { get; set; }
+
         private SymbolTargetType SymbolTargetType { get; set; }
 
         private List<string> FilesToExclude { get; }
@@ -54,6 +56,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             SymbolTargetType symbolTargetType,
             string stablePackagesFeed = null,
             string stableSymbolsFeed = null,
+            string azureDevOpsPublicStaticSymbolsFeed = null,
             List<string> filesToExclude = null,
             bool flatten = true) 
             : base(isInternalBuild, isStableBuild, repositoryName, commitSha, azureStorageTargetFeedPAT, publishInstallersAndChecksums, installersTargetStaticFeed, installersAzureAccountKey, checksumsTargetStaticFeed, checksumsAzureAccountKey, azureDevOpsStaticShippingFeed, azureDevOpsStaticTransportFeed, azureDevOpsStaticSymbolsFeed, latestLinkShortUrlPrefix, azureDevOpsFeedsKey)
@@ -62,6 +65,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             StableSymbolsFeed = stableSymbolsFeed;
             StablePackagesFeed = stablePackagesFeed;
             SymbolTargetType = symbolTargetType;
+            AzureDevOpsPublicStaticSymbolsFeed = azureDevOpsPublicStaticSymbolsFeed;
             FilesToExclude = filesToExclude ?? new List<string>();
             Flatten = flatten;
         }
@@ -156,6 +160,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             if (IsInternalBuild)
             {
                 symbolsFeed = AzureDevOpsStaticSymbolsFeed;
+                symbolsFeedType = FeedType.AzDoNugetFeed;
+                symbolsFeedSecret = AzureDevOpsFeedsKey;
+            }
+            else if (!string.IsNullOrEmpty(AzureDevOpsPublicStaticSymbolsFeed))
+            {
+                symbolsFeed = AzureDevOpsPublicStaticSymbolsFeed;
                 symbolsFeedType = FeedType.AzDoNugetFeed;
                 symbolsFeedSecret = AzureDevOpsFeedsKey;
             }


### PR DESCRIPTION
### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation

For Stage-DotNet, we need to be able to specify a public symbols feed in addition to an internal feed for the internal case. This change allows us to override the public symbols feed.

Test to make sure current behavior doesn't break (ie, no override, we set symbols feed to dotnetfeed): https://dev.azure.com/dnceng/internal/_build/results?buildId=1126165&view=logs&j=ba23343f-f710-5af9-782d-5bd26b102304&t=6e277ba4-1c1e-552d-b96f-db0aeb4be20a&l=233
Test to make sure the override works (note, i tested with a bogus string): https://dev.azure.com/dnceng/internal/_build/results?buildId=1126282&view=logs&j=ba23343f-f710-5af9-782d-5bd26b102304&t=6e277ba4-1c1e-552d-b96f-db0aeb4be20a&l=233