### PR TITLE
Fixes the package testing for runtime packages using the dotnet pack task

### DIFF
--- a/src/Microsoft.DotNet.PackageValidation/GetCompatiblePackageTargetFrameworks.cs
+++ b/src/Microsoft.DotNet.PackageValidation/GetCompatiblePackageTargetFrameworks.cs
@@ -26,7 +26,6 @@ namespace Microsoft.DotNet.PackageValidation
         {
             bool result = true;
             List<ITaskItem> testProjects = new List<ITaskItem>();
-
             try
             {
                 Initialize();
@@ -36,7 +35,7 @@ namespace Microsoft.DotNet.PackageValidation
                     List<NuGetFramework> packageTargetFrameworks = package.PackageAssets.Where(t => t.AssetType != AssetType.RuntimeAsset).Select(t => t.TargetFramework).Distinct().ToList();
 
                     List<NuGetFramework> frameworksToTest = GetTestFrameworks(packageTargetFrameworks);
-                    testProjects.AddRange(CreateItemFromTestFramework(package.Title, package.Version, frameworksToTest, GetRidsFromPackage(package)));
+                    testProjects.AddRange(CreateItemFromTestFramework(package.PackageId, package.Version, frameworksToTest, GetRidsFromPackage(package)));
                 }
                 
                 // Removing empty items.
@@ -113,12 +112,12 @@ namespace Microsoft.DotNet.PackageValidation
             }
         }
     
-        public List<ITaskItem> CreateItemFromTestFramework(string title, string version, List<NuGetFramework> testFrameworks, string rids)
+        public List<ITaskItem> CreateItemFromTestFramework(string packageId, string version, List<NuGetFramework> testFrameworks, string rids)
         {
             List<ITaskItem> testprojects = new List<ITaskItem>();
             foreach (var framework in testFrameworks)
             {
-                var supportedPackage = new TaskItem(title);
+                var supportedPackage = new TaskItem(packageId);
                 supportedPackage.SetMetadata("Version", version);
                 supportedPackage.SetMetadata("TargetFramework", framework.ToString());
                 supportedPackage.SetMetadata("TargetFrameworkShort", framework.GetShortFolderName());

--- a/src/Microsoft.DotNet.PackageValidation/NupkgParser.cs
+++ b/src/Microsoft.DotNet.PackageValidation/NupkgParser.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.PackageValidation
             PackageArchiveReader nupkgReader = new PackageArchiveReader(packagePath);
             NuspecReader nuspecReader = nupkgReader.NuspecReader;
 
-            string title = nuspecReader.GetTitle();
+            string packageId = nuspecReader.GetId();
             string version = nuspecReader.GetVersion().ToString();
             IEnumerable<PackageDependencyGroup> dependencyGroups = nuspecReader.GetDependencyGroups();
 
@@ -28,13 +28,13 @@ namespace Microsoft.DotNet.PackageValidation
                 packageDependencies.Add(item.TargetFramework, item.Packages.ToList());
             }
 
-            var files = nupkgReader.GetFiles().ToList().Where(t => t.EndsWith(".dll")).Where(t => t.Contains(title + ".dll"));
+            var files = nupkgReader.GetFiles().ToList().Where(t => t.EndsWith(".dll")).Where(t => t.Contains(packageId + ".dll"));
             foreach (var file in files)
             {
                 packageAssets.Add(ExtractAssetFromFile(file));
             }
 
-            return new Package(title, version, packageAssets, packageDependencies);
+            return new Package(packageId, version, packageAssets, packageDependencies);
         }
 
         public static PackageAsset ExtractAssetFromFile(string filePath)

--- a/src/Microsoft.DotNet.PackageValidation/Package.cs
+++ b/src/Microsoft.DotNet.PackageValidation/Package.cs
@@ -10,12 +10,12 @@ namespace Microsoft.DotNet.PackageValidation
     public class Package
     {
         public List<PackageAsset> PackageAssets { get; set; }
-        public string Title { get; set; }
+        public string PackageId { get; set; }
         public string Version { get; set; }
         public Dictionary<NuGetFramework, List<PackageDependency>> PackageDependencies { get; set; }
-        public Package(string title, string version, List<PackageAsset> packageAssets, Dictionary<NuGetFramework, List<PackageDependency>> packageDependencies)
+        public Package(string packageId, string version, List<PackageAsset> packageAssets, Dictionary<NuGetFramework, List<PackageDependency>> packageDependencies)
         {
-            Title = title;
+            PackageId = packageId;
             Version = version;
             PackageAssets = packageAssets;
             PackageDependencies = packageDependencies;


### PR DESCRIPTION
we no longer manually set the title in the dotnet pack task, hence we will have to replace title with id.