### PR TITLE
Add more retries to symbols and sourcelink validation

### DIFF
--- a/eng/common/post-build/sourcelink-validation.ps1
+++ b/eng/common/post-build/sourcelink-validation.ps1
@@ -16,7 +16,7 @@ $global:RepoFiles = @{}
 # Maximum number of jobs to run in parallel
 $MaxParallelJobs = 16
 
-$MaxRetry = 5
+$MaxRetries = 5
 
 # Wait time between check for system load
 $SecondsBetweenLoadChecks = 10
@@ -101,7 +101,7 @@ $ValidatePackage = {
 
                     $totalRetries = 0
 
-                    while ($totalRetries -lt $using:MaxRetry) {
+                    while ($totalRetries -lt $using:MaxRetries) {
                       if ( !($Cache.ContainsKey($FilePath)) ) {
                         try {
                           $Uri = $Link -as [System.URI]
@@ -113,21 +113,19 @@ $ValidatePackage = {
                           else {
                             # If it's not a github link, we want to break out of the loop and not retry.
                             $Status = 0
-                            $totalRetries = $using:MaxRetry
+                            $totalRetries = $using:MaxRetries
                           }
                         }
                         catch {
-                          write-host $_
+                          Write-Host $_
                           $Status = 0
                         }
                       }
 
                       if ($Status -ne 200) {
-                        if ($totalRetries -lt $using:MaxRetry)
-                        {
-                          $totalRetries++
-                        }
-                        else {
+                        $totalRetries++
+                        
+                        if ($totalRetries -ge $using:MaxRetries) {
                           if ($NumFailedLinks -eq 0) {
                             if ($FailedFiles.Value -eq 0) {
                               Write-Host
@@ -159,7 +157,7 @@ $ValidatePackage = {
         }
   }
   catch {
-  
+    Write-Host $_
   }
   finally {
     $zip.Dispose() 

--- a/eng/common/post-build/sourcelink-validation.ps1
+++ b/eng/common/post-build/sourcelink-validation.ps1
@@ -111,7 +111,9 @@ $ValidatePackage = {
                             $Status = (Invoke-WebRequest -Uri $Link -UseBasicParsing -Method HEAD -TimeoutSec 5).StatusCode
                           }
                           else {
+                            # If it's not a github link, we want to break out of the loop and not retry.
                             $Status = 0
+                            $totalRetries = $using:MaxRetry
                           }
                         }
                         catch {

--- a/eng/common/post-build/sourcelink-validation.ps1
+++ b/eng/common/post-build/sourcelink-validation.ps1
@@ -16,6 +16,8 @@ $global:RepoFiles = @{}
 # Maximum number of jobs to run in parallel
 $MaxParallelJobs = 16
 
+$MaxRetry = 5
+
 # Wait time between check for system load
 $SecondsBetweenLoadChecks = 10
 
@@ -29,7 +31,10 @@ $ValidatePackage = {
   # Ensure input file exist
   if (!(Test-Path $PackagePath)) {
     Write-Host "Input file does not exist: $PackagePath"
-    return 1
+    return [pscustomobject]@{
+      result = 1
+      packagePath = $PackagePath
+    }
   }
 
   # Extensions for which we'll look for SourceLink information
@@ -59,7 +64,10 @@ $ValidatePackage = {
 
           # We ignore resource DLLs
           if ($FileName.EndsWith('.resources.dll')) {
-            return
+            return [pscustomobject]@{
+              result = 0
+              packagePath = $PackagePath
+            }
           }
 
           [System.IO.Compression.ZipFileExtensions]::ExtractToFile($_, $TargetFile, $true)
@@ -91,36 +99,49 @@ $ValidatePackage = {
                     $Status = 200
                     $Cache = $using:RepoFiles
 
-                    if ( !($Cache.ContainsKey($FilePath)) ) {
-                      try {
-                        $Uri = $Link -as [System.URI]
-                      
-                        # Only GitHub links are valid
-                        if ($Uri.AbsoluteURI -ne $null -and ($Uri.Host -match 'github' -or $Uri.Host -match 'githubusercontent')) {
-                          $Status = (Invoke-WebRequest -Uri $Link -UseBasicParsing -Method HEAD -TimeoutSec 5).StatusCode
+                    $totalRetries = 0
+
+                    while ($totalRetries -lt $using:MaxRetry) {
+                      if ( !($Cache.ContainsKey($FilePath)) ) {
+                        try {
+                          $Uri = $Link -as [System.URI]
+                        
+                          # Only GitHub links are valid
+                          if ($Uri.AbsoluteURI -ne $null -and ($Uri.Host -match 'github' -or $Uri.Host -match 'githubusercontent')) {
+                            $Status = (Invoke-WebRequest -Uri $Link -UseBasicParsing -Method HEAD -TimeoutSec 5).StatusCode
+                          }
+                          else {
+                            $Status = 0
+                          }
                         }
-                        else {
+                        catch {
+                          write-host $_
                           $Status = 0
                         }
                       }
-                      catch {
-                        write-host $_
-                        $Status = 0
-                      }
-                    }
 
-                    if ($Status -ne 200) {
-                      if ($NumFailedLinks -eq 0) {
-                        if ($FailedFiles.Value -eq 0) {
-                          Write-Host
+                      if ($Status -ne 200) {
+                        if ($totalRetries -lt $using:MaxRetry)
+                        {
+                          $totalRetries++
                         }
-
-                        Write-Host "`tFile $RealPath has broken links:"
+                        else {
+                          if ($NumFailedLinks -eq 0) {
+                            if ($FailedFiles.Value -eq 0) {
+                              Write-Host
+                            }
+  
+                            Write-Host "`tFile $RealPath has broken links:"
+                          }
+  
+                          Write-Host "`t`tFailed to retrieve $Link"
+  
+                          $NumFailedLinks++
+                        }
                       }
-
-                      Write-Host "`t`tFailed to retrieve $Link"
-
-                      $NumFailedLinks++
+                      else {
+                        break
+                      }
                     }
                   }
               }
@@ -220,6 +241,7 @@ function ValidateSourceLinkLinks {
   # Process each NuGet package in parallel
   Get-ChildItem "$InputPath\*.symbols.nupkg" |
     ForEach-Object {
+      Write-Host "Starting $($_.FullName)"
       Start-Job -ScriptBlock $ValidatePackage -ArgumentList $_.FullName | Out-Null
       $NumJobs = @(Get-Job -State 'Running').Count
       
@@ -266,6 +288,10 @@ function InstallSourcelinkCli {
 
 try {
   InstallSourcelinkCli
+
+  foreach ($Job in @(Get-Job)) {
+    Remove-Job -Id $Job.Id
+  }
 
   ValidateSourceLinkLinks 
 }


### PR DESCRIPTION
For sourcelink validation, this change introduces retries.

For symbols validation, this change expands retry scenarios to any failure, not just 503s, as sometimes, dotnet-symbol fails with no real indication why, and we want to retry on all scenarios. Also updates the logging, and separates out the files being downloaded via dotnet-symbol to separate directories based on msdl/symweb, so we don't think we have those files on both when they only exist on one, as our method for confirming if they were downloaded just checked to see if certain paths exist.

Test run on runtime in validate-dotnet: https://dev.azure.com/dnceng/internal/_build/results?buildId=1131182&view=results

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
