### PR TITLE
[API Compat] Fix attribute comparison in type members

### DIFF
--- a/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/AttributeDifference.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/AttributeDifference.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Cci.Differs.Rules
             if (implMethod == null || contractMethod == null)
                 return DifferenceType.Unknown;
 
-            bool changed = CheckAttributeDifferences(differences, implMethod, implMethod.Attributes, implMethod.Attributes);
+            bool changed = CheckAttributeDifferences(differences, implMethod, implMethod.Attributes, contractMethod.Attributes);
 
             IParameterDefinition[] method1Params = implMethod.Parameters.ToArray();
             IParameterDefinition[] method2Params = contractMethod.Parameters.ToArray();

--- a/src/Microsoft.DotNet.ApiCompat/tests/AttributeDifferenceTests.cs
+++ b/src/Microsoft.DotNet.ApiCompat/tests/AttributeDifferenceTests.cs
@@ -22,9 +22,10 @@ namespace Microsoft.DotNet.ApiCompat.Tests
             Assert.Contains("CannotRemoveAttribute : Attribute 'AttributeDifference.FooAttribute' exists on 'AttributeDifference.AttributeDifferenceClass1' in the implementation but not the contract.", runOutput);
             Assert.Contains("CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on generic param 'T' on member 'AttributeDifference.AttributeDifferenceClass1.GenericMethodWithAttribute<T>()' in the implementation but not the contract.", runOutput);
             Assert.Contains("CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on generic param 'T' on member 'AttributeDifference.AttributeDifferenceClass1.GenericMethodWithAttribute<T>()' in the implementation but not the contract.", runOutput);
+            Assert.Contains("CannotRemoveAttribute : Attribute 'AttributeDifference.FooAttribute' exists on 'AttributeDifference.AttributeDifferenceClass1.MethodWithAttribute()' in the implementation but not the contract.", runOutput);
             Assert.Contains("CannotRemoveAttribute : Attribute 'AttributeDifference.FooAttribute' exists on parameter 'myParameter' on member 'AttributeDifference.AttributeDifferenceClass1.MethodWithAttribute(System.String, System.Object)' in the implementation but not the contract.", runOutput);
             Assert.Contains("CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on generic param 'TOne' on member 'AttributeDifference.AttributeDifferenceGenericCLass<TOne, TTwo>' in the implementation but not the contract.", runOutput);
-            Assert.Contains("Total Issues: 5", runOutput);
+            Assert.Contains("Total Issues: 6", runOutput);
         }
 
         [Fact]

--- a/src/Microsoft.DotNet.ApiCompat/tests/TestProjects/AttributeDifference/Contract/AttributeDifference.cs
+++ b/src/Microsoft.DotNet.ApiCompat/tests/TestProjects/AttributeDifference/Contract/AttributeDifference.cs
@@ -10,6 +10,7 @@ namespace AttributeDifference
     {
         public string MethodWithAttribute(string myParameter, [DefaultValue("myObject")] object myObject) => throw null;
         public T GenericMethodWithAttribute<T>() => throw null;
+        public void MethodWithAttribute() { }
     }
     public class AttributeDifferenceGenericCLass<TOne, [DefaultValue("TTwo")] TTwo>
     {

--- a/src/Microsoft.DotNet.ApiCompat/tests/TestProjects/AttributeDifference/Implementation/AttributeDifferenceClass1.cs
+++ b/src/Microsoft.DotNet.ApiCompat/tests/TestProjects/AttributeDifference/Implementation/AttributeDifferenceClass1.cs
@@ -13,6 +13,8 @@ namespace AttributeDifference
     {
         public string MethodWithAttribute([Foo] string myParameter, [DefaultValue("myObject")] object myObject) => myParameter;
         public T GenericMethodWithAttribute<[DefaultValue("T")] T>() => default(T);
+        [Foo]
+        public void MethodWithAttribute() { }
     }
 
     public class AttributeDifferenceGenericCLass<[DefaultValue("TOne")] TOne, [DefaultValue("TTwo")] TTwo>


### PR DESCRIPTION
When adding support to diff attributes on parameters and type parameters: https://github.com/dotnet/arcade/commit/45a923c53b4a297dd42fc2f112a1917fa3c96032 I regressed the attribute checking on type members (methods, properties, fields, etc).

This fixes that issue and adds a test to cover that scenario. 

This was found as many PRs that expected to be failing didn't fail, i.e: https://github.com/dotnet/runtime/pull/50894

Once this is merged I will get this flowing to dotnet/runtime and fix whatever issues were introduced in that 2 month gap. 

cc: @tlakollo @vitek-karas @ericstj @eerhardt 
