### PR TITLE
[release/5.0] Add support for additional DotNetRuntime (#7158)

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/Readme.md
@@ -144,6 +144,23 @@ Given a local folder `$(TestFolder)` containing `runtests.cmd`, this will run `r
   </PropertyGroup>
 
   <!--
+    Optional additional dotnet runtimes or SDKs for correlation payloads
+    PackageType (defaults to runtime)
+    Channel (defaults to Current)
+  -->
+  <ItemGroup>
+    <!-- Includes the 6.0.0-preview.4.21178.6 dotnet runtime package version from the Current channel, using the DotNetCliRuntime -->
+    <AdditionalDotNetPackage Include="6.0.0-preview.4.21178.6">
+      <!-- 'sdk', 'runtime' or 'aspnetcore-runtime' -->
+      <PackageType>runtime</PackageType>
+      <!-- 'Current' or 'LTS', determines what channel 'latest' version pulls from -->
+      <Channel>Current</Channel>
+    </AdditionalDotNetPackage>
+    <!-- Includes the 6.0.0-preview.4.21175.1 version, using the default runtime packageType, DotNetCliRuntime, and Current channel  -->
+    <AdditionalDotNetPackage Include="6.0.0-preview.4.21175.1" />
+  </ItemGroup>
+  
+  <!--
     XUnit Runner
       Enabling this will create one work item for each xunit test project specified.
       This is enabled by specifying one or more XUnitProject items

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.targets
@@ -18,4 +18,27 @@
       <HelixPreCommands Condition="!$(IsPosixShell)">$(HelixPreCommands);set DOTNET_ROOT=%HELIX_CORRELATION_PAYLOAD%\$(DotNetCliDestination);set DOTNET_CLI_TELEMETRY_OPTOUT=1</HelixPreCommands>
     </PropertyGroup>
   </Target>
+  
+  <Target Name="AddAdditionalRuntimes" 
+          Condition="@(AdditionalDotNetPackage->Count()) != 0"
+          AfterTargets="Build" 
+          Outputs="%(AdditionalDotNetPackage.Identity)">
+    <PropertyGroup>
+      <_channel>%(AdditionalDotNetPackage.Channel)</_channel>
+      <_channel Condition=" '$(_channel)' == '' ">Current</_channel>
+      <_packageType>%(AdditionalDotNetPackage.PackageType)</_packageType>
+      <_packageType Condition=" '$(_packageType)' == '' ">runtime</_packageType>
+    </PropertyGroup>
+
+    <Message Text = "Adding correlation payload for additional .NET Core package: Version: '%(AdditionalDotNetPackage.Identity)'  Runtime: '$(DotNetCliRuntime)' PackageType: '$(_packageType)' Channel: '$(_channel)' "/>
+    <FindDotNetCliPackage Version="%(AdditionalDotNetPackage.Identity)" Runtime="$(DotNetCliRuntime)" PackageType="$(_packageType)" Channel="$(_channel)">
+      <Output TaskParameter="PackageUri" PropertyName="DotNetCliPackageUri"/>
+    </FindDotNetCliPackage>
+    <ItemGroup>
+      <HelixCorrelationPayload Include="dotnet-additional">
+        <Uri>$(DotNetCliPackageUri)</Uri>
+        <Destination>$(DotNetCliDestination)</Destination>
+      </HelixCorrelationPayload>
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
## Description

https://github.com/dotnet/arcade/issues/7378

Cherry-pick of https://github.com/dotnet/arcade/commit/b61eaae19626f8e52614b5162ca518f1c6c56751 to mitigate SSL issues when trying to download the install scripts. 

## Customer Impact

Without this change, ASPNetCore's servicing builds are having a high rate of failure during the script downloads

## Regression

No

## Risk

How risky is this change?

Low

## Workarounds

no
