### PR TITLE
Use hosted pools for PR builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,8 +44,7 @@ stages:
         timeoutInMinutes: 90
         pool:
           ${{ if eq(variables._RunAsPublic, True) }}:
-            name: NetCorePublic-Pool
-            queue: BuildPool.Server.Amd64.VS2017.Arcade.Open
+            vmImage: windows-latest
           ${{ if eq(variables._RunAsInternal, True) }}:
             name: NetCoreInternal-Pool
             queue: BuildPool.Server.Amd64.VS2017.Arcade
@@ -71,8 +70,7 @@ stages:
         - job: Linux
           container: LinuxContainer
           pool:
-            name:  NetCorePublic-Pool
-            queue: BuildPool.Ubuntu.1604.Amd64.Arcade.Open
+            vmImage: ubuntu-latest
           strategy:
             matrix:
               Build_Debug:


### PR DESCRIPTION
Public builds spend almost 30 minutes waiting for BuildPool machines to then do 2 minutes of building,
let's use the hosted pools