### PR TITLE
Remove bin directory from build, and artifact upload from test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,7 +65,7 @@ stages:
             $(_InternalBuildArgs)
             /p:Test=false
           displayName: Windows Build / Publish
-        - script: rd /s /q artifacts\bin
+        - script: rd /s /q artifacts\bin && mkdir artifacts\bin
         - task: ComponentGovernanceComponentDetection@0
       - ${{ if eq(variables._RunAsPublic, True) }}:
         - job: Linux

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,6 +66,7 @@ stages:
             $(_InternalBuildArgs)
             /p:Test=false
           displayName: Windows Build / Publish
+        - inline: rd /s /q artifacts/bin
         - task: ComponentGovernanceComponentDetection@0
       - ${{ if eq(variables._RunAsPublic, True) }}:
         - job: Linux
@@ -97,8 +98,6 @@ stages:
       parameters:
         artifacts:
           publish:
-            artifacts:
-              name: Artifacts_Test_$(Agent.OS)_$(_BuildConfig)
             logs: 
               name: Logs_Test_$(Agent.OS)_$(_BuildConfig)
           download: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,7 +65,7 @@ stages:
             $(_InternalBuildArgs)
             /p:Test=false
           displayName: Windows Build / Publish
-        - inline: rd /s /q artifacts/bin
+        - script: rd /s /q artifacts/bin
         - task: ComponentGovernanceComponentDetection@0
       - ${{ if eq(variables._RunAsPublic, True) }}:
         - job: Linux

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,7 +65,7 @@ stages:
             $(_InternalBuildArgs)
             /p:Test=false
           displayName: Windows Build / Publish
-        - script: rd /s /q artifacts/bin
+        - script: rd /s /q artifacts\bin
         - task: ComponentGovernanceComponentDetection@0
       - ${{ if eq(variables._RunAsPublic, True) }}:
         - job: Linux


### PR DESCRIPTION
The bin directory contains thousands of files that we don't care about.

The arcade SDK is going to implicitly upload them all, so just delete them after the build.

The test also doesn't need to upload artifacts at all, nothing is going to download them, so remove all that.