### PR TITLE
Add option to reset Apple simulators in Helix SDK

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
@@ -67,7 +67,7 @@ To execute .app bundles, declare one or more `XHarnessAppBundleToTest` items:
 The `<Targets>` metadata is a required configuration that tells XHarness which kind of device/Simulator to target.
 Use the XHarness CLI help command to find more (see the `--targets` option).
 
-You can also specify some metadata that will help you configure the run better:
+You can also specify some additional metadata that will help you configure the run better:
 
 ```xml
 <ItemGroup>
@@ -89,6 +89,10 @@ You can also specify some metadata that will help you configure the run better:
     <!-- Optional: For apps that don't contain unit tests, they can be run using the `apple run` command instead of `apple test` -->
     <!-- Default is true -->
     <IncludesTestRunner>false</IncludesTestRunner>
+
+    <!-- Optional: Before and after the run, erases all simulator data and resets it for a clean state -->
+    <!-- Default is false -->
+    <ResetSimulator>true</ResetSimulator>
   </XHarnessAppBundleToTest>
 </ItemGroup>
 ```
@@ -128,7 +132,7 @@ To execute .apks, declare one or more `XHarnessApkToTest` items:
 </ItemGroup>
 ```
 
-You can also specify some metadata that will help you configure the run better:
+You can also specify some additional metadata that will help you configure the run better:
 
 ```xml
 <ItemGroup>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
@@ -16,6 +16,7 @@ xcode_version=''
 app_arguments=''
 expected_exit_code=0
 includes_test_runner=false
+reset_simulator=false
 
 while [[ $# -gt 0 ]]; do
     opt="$(echo "$1" | tr "[:upper:]" "[:lower:]")"
@@ -58,6 +59,9 @@ while [[ $# -gt 0 ]]; do
         ;;
       --includes-test-runner)
         includes_test_runner=true
+        ;;
+      --reset-simulator)
+        reset_simulator=true
         ;;
     esac
     shift

--- a/tests/UnitTests.XHarness.iOS.Simulator.proj
+++ b/tests/UnitTests.XHarness.iOS.Simulator.proj
@@ -17,8 +17,8 @@
     <HelixType>test/product/</HelixType>
     <TestRunNamePrefix>$(AGENT_JOBNAME)</TestRunNamePrefix>
     <IncludeXHarnessCli>true</IncludeXHarnessCli>
-    <EnableXUnitReporter>true</EnableXUnitReporter>
-    <EnableAzurePipelinesReporter>true</EnableAzurePipelinesReporter>
+    <EnableXUnitReporter>false</EnableXUnitReporter>
+    <EnableAzurePipelinesReporter>false</EnableAzurePipelinesReporter>
     <HelixBaseUri>https://helix.dot.net</HelixBaseUri>
   </PropertyGroup>
 

--- a/tests/UnitTests.XHarness.iOS.Simulator.proj
+++ b/tests/UnitTests.XHarness.iOS.Simulator.proj
@@ -17,8 +17,8 @@
     <HelixType>test/product/</HelixType>
     <TestRunNamePrefix>$(AGENT_JOBNAME)</TestRunNamePrefix>
     <IncludeXHarnessCli>true</IncludeXHarnessCli>
-    <EnableXUnitReporter>false</EnableXUnitReporter>
-    <EnableAzurePipelinesReporter>false</EnableAzurePipelinesReporter>
+    <EnableXUnitReporter>true</EnableXUnitReporter>
+    <EnableAzurePipelinesReporter>true</EnableAzurePipelinesReporter>
     <HelixBaseUri>https://helix.dot.net</HelixBaseUri>
   </PropertyGroup>
 


### PR DESCRIPTION
We should have the capability ready in case we want to spawn jobs that will reset the simulators across Helix