### PR TITLE
Temporarily move publishing to Helix build agents

### DIFF
--- a/eng/publishing/v3/publish-assets.yml
+++ b/eng/publishing/v3/publish-assets.yml
@@ -24,8 +24,11 @@ jobs:
       value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOBuildId'] ]
     - name: AzDOAccount
       value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOBuildAccount'] ]
+  # Using non-hosted build agents to (hopefully temporarily) work around OOMs
+  # See https://github.com/dotnet/core-eng/issues/13098 for context
   pool:
-    vmImage: 'windows-2019'
+    name: NetCoreInternal-Pool
+    queue: BuildPool.Server.Amd64.VS2019
   steps:
     - task: DownloadBuildArtifacts@0
       displayName: Download Build Assets


### PR DESCRIPTION
As seen in https://github.com/dotnet/core-eng/issues/13098 and the linked IcM ticket, we seem to have moved from WIN- to fv- machines and started hitting memory issues.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
