### PR TITLE
add in correct uname -m for apple silicon

### DIFF
--- a/eng/common/dotnet-install.sh
+++ b/eng/common/dotnet-install.sh
@@ -52,7 +52,7 @@ done
 # Use uname to determine what the CPU is, see https://en.wikipedia.org/wiki/Uname#Examples
 cpuname=$(uname -m)
 case $cpuname in
-  aarch64)
+  aarch64|arm64)
     buildarch=arm64
     ;;
   amd64|x86_64)


### PR DESCRIPTION
On apple silicon hardware `uname -m ` returns arm64. This change lets it be detected correctly to download the right version.