### PR TITLE
Capture .wixobj data to support post-build signing

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
@@ -249,6 +249,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                 msi.SetMetadata(Metadata.Platform, platform);
                 msi.SetMetadata(Metadata.Version, nupkg.ProductVersion);
                 msi.SetMetadata(Metadata.JsonProperties, msiJsonPath);
+                msi.SetMetadata(Metadata.WixObj, candleIntermediateOutputPath);
 
                 if (GenerateSwixAuthoring && IsSupportedByVisualStudio(platform))
                 {

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Metadata.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Metadata.cs
@@ -17,5 +17,6 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
         public const string SwixProject = "SwixProject";
         public const string Title = "Title";
         public const string Version = "Version";
+        public const string WixObj = "WixObj";
     }
 }


### PR DESCRIPTION
Include additional metadata for MSI output parameter when generating workload to capture the intermediate output folder where .wixobj files are stored. The metadata can be passed to the CreateLightCommandPackageDrop task.
