### PR TITLE
Add Helix queue name to failed workitem comment on AzDO

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/CreateFailedTestsForFailedWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateFailedTestsForFailedWorkItems.cs
@@ -22,15 +22,16 @@ namespace Microsoft.DotNet.Helix.Sdk
             foreach (ITaskItem workItem in WorkItems)
             {
                 var jobName = workItem.GetMetadata("JobName");
+                var helixTargetQueue = workItem.GetMetadata("HelixTargetQueue");
                 var workItemName = workItem.GetMetadata("WorkItemName");
                 var testRunId = workItem.GetMetadata("TestRunId");
                 var failed = workItem.GetMetadata("Failed") == "true";
 
-                await CreateFakeTestResultAsync(client, testRunId, jobName, workItemName, failed);
+                await CreateFakeTestResultAsync(client, testRunId, jobName, helixTargetQueue, workItemName, failed);
             }
         }
 
-        private async Task<int> CreateFakeTestResultAsync(HttpClient client, string testRunId, string jobName, string workItemFriendlyName, bool failed)
+        private async Task<int> CreateFakeTestResultAsync(HttpClient client, string testRunId, string jobName, string helixTargetQueue, string workItemFriendlyName, bool failed)
         {
             var testResultData = await RetryAsync(
                 async () =>
@@ -56,6 +57,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                                             ["comment"] = new JObject
                                             {
                                                 ["HelixJobId"] = jobName,
+                                                ["HelixTargetQueue"] = helixTargetQueue,
                                                 ["HelixWorkItemName"] = workItemFriendlyName,
                                             }.ToString(),
                                         }

--- a/src/Microsoft.DotNet.Helix/Sdk/GetHelixWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/GetHelixWorkItems.cs
@@ -34,6 +34,7 @@ namespace Microsoft.DotNet.Helix.Sdk
         private async Task<IEnumerable<ITaskItem>> GetWorkItemsAsync(ITaskItem job, CancellationToken cancellationToken)
         {
             var jobName = job.GetMetadata("Identity");
+            var helixTargetQueue = job.GetMetadata("HelixTargetQueue");
 
             Log.LogMessage($"Getting status of job {jobName}");
 
@@ -53,6 +54,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             {
                 var metadata = job.CloneCustomMetadata() as IDictionary<string, string>;
                 metadata["JobName"] = jobName;
+                metadata["HelixTargetQueue"] = helixTargetQueue;
                 metadata["WorkItemName"] = name;
                 var consoleUri = HelixApi.Options.BaseUri.AbsoluteUri.TrimEnd('/') + $"/api/2019-06-17/jobs/{jobName}/workitems/{Uri.EscapeDataString(name)}/console";
                 metadata["ConsoleOutputUri"] = consoleUri;


### PR DESCRIPTION
When looking at the AzDO test analytics page it's not straightforward to actually see which queue a failed workitem ran on, you need to go to the console log or query Kusto for the job name to figure it out.

Adding the queue name to the comment that shows up on AzDO makes this easier:

![image](https://user-images.githubusercontent.com/1376924/118798938-7c055580-b89e-11eb-96dd-9bed3928eb83.png)
