### PR TITLE
Reduce parallelism of publishing upload clients

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -70,13 +70,17 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         [Required]
         public string NugetPath { get; set; }
 
-        private const int StreamingPublishingMaxClients = 20;
-        private const int NonStreamingPublishingMaxClients = 16;
+        private const int StreamingPublishingMaxClients = 16;
+        private const int NonStreamingPublishingMaxClients = 12;
 
         /// <summary>
         /// Maximum number of parallel uploads for the upload tasks.
         /// For streaming publishing, 20 is used as the most optimal.
         /// For non-streaming publishing, 16 is used (there are multiple sets of 16-parallel uploads)
+        ///
+        /// NOTE: Due to the desire to run on hosted agents and drastic memory changes in these VMs 
+        /// (see https://github.com/dotnet/core-eng/issues/13098 for details) these numbers are 
+        /// currently reduced below optimal to prevent OOM.
         /// </summary>
         public int MaxClients { get { return UseStreamingPublishing ? StreamingPublishingMaxClients : NonStreamingPublishingMaxClients; } }
 


### PR DESCRIPTION
See writeup in https://github.com/dotnet/core-eng/issues/13098.  Hosted agents are running < 50% of the RAM they had recently.  I am endeavoring to get this back but it won't be fast if at all.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
