### PR TITLE
Log a warning when anyone uses V2 publishing from Arcade 6.0+ 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -130,20 +130,22 @@ stages:
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''
-          - powershell: eng\common\build.ps1
-              -configuration $(_BuildConfig) 
-              -prepareMachine
-              -ci
-              -restore
-              -test
-              -projects $(Build.SourcesDirectory)\tests\UnitTests.XHarness.Android.WindowsQueues.proj
-              /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.XHarness.Android.WindowsQueues.binlog
-              /p:RestoreUsingNuGetTargets=false
-              /p:XharnessTestARM64_V8A=true
-            displayName: XHarness Android Helix Testing (Windows)
-            env:
-              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-              HelixAccessToken: ''
+        # We don't have enough hardware to run these tests on Arcade PR given the Arcade XHarness SDK changes infrequently. (https://github.com/dotnet/core-eng/issues/12238)
+        # Until the above issue is resolved, if you are editing the Xharness SDK's Windows side, please exercise this manually.  Contact dnceng for assistance.
+        # - powershell: eng\common\build.ps1
+        #     -configuration $(_BuildConfig) 
+        #     -prepareMachine
+        #     -ci
+        #     -restore
+        #     -test
+        #     -projects $(Build.SourcesDirectory)\tests\UnitTests.XHarness.Android.WindowsQueues.proj
+        #     /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.XHarness.Android.WindowsQueues.binlog
+        #     /p:RestoreUsingNuGetTargets=false
+        #     /p:XharnessTestARM64_V8A=true
+        #   displayName: XHarness Android Helix Testing (Windows)
+        #   env:
+        #     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        #     HelixAccessToken: ''
         - job: Linux
           timeoutInMinutes: 90
           container: LinuxContainer

--- a/eng/common/templates/post-build/channels/generic-internal-channel.yml
+++ b/eng/common/templates/post-build/channels/generic-internal-channel.yml
@@ -40,7 +40,7 @@ stages:
     pool:
       vmImage: 'windows-2019'
     steps:
-      - script: echo "##vso[task.logissue type=error]Going forward, v2 Arcade publishing is no longer supported. Please read https://github.com/dotnet/arcade/blob/main/Documentation/CorePackages/Publishing.md for details, then contact dnceng if you have further questions."
+      - script: echo "##vso[task.logissue type=warning]Going forward, v2 Arcade publishing is no longer supported. Please read https://github.com/dotnet/arcade/blob/main/Documentation/CorePackages/Publishing.md for details, then contact dnceng if you have further questions."
         displayName: Warn about v2 Arcade Publishing Usage
 
       # This is necessary whenever we want to publish/restore to an AzDO private feed
@@ -113,7 +113,7 @@ stages:
     pool:
       vmImage: 'windows-2019'
     steps:
-      - script: echo "##vso[task.logissue type=error]Going forward, v2 Arcade publishing is no longer supported. Please read https://github.com/dotnet/arcade/blob/main/Documentation/CorePackages/Publishing.md for details, then contact dnceng if you have further questions."
+      - script: echo "##vso[task.logissue type=warning]Going forward, v2 Arcade publishing is no longer supported. Please read https://github.com/dotnet/arcade/blob/main/Documentation/CorePackages/Publishing.md for details, then contact dnceng if you have further questions."
         displayName: Warn about v2 Arcade Publishing Usage
 
       - task: DownloadBuildArtifacts@0

--- a/eng/common/templates/post-build/channels/generic-internal-channel.yml
+++ b/eng/common/templates/post-build/channels/generic-internal-channel.yml
@@ -40,6 +40,9 @@ stages:
     pool:
       vmImage: 'windows-2019'
     steps:
+      - script: echo "##vso[task.logissue type=error]Going forward, v2 Arcade publishing is no longer supported. Please read https://github.com/dotnet/arcade/blob/main/Documentation/CorePackages/Publishing.md for details, then contact dnceng if you have further questions."
+        displayName: Warn about v2 Arcade Publishing Usage
+
       # This is necessary whenever we want to publish/restore to an AzDO private feed
       - task: NuGetAuthenticate@0
         displayName: 'Authenticate to AzDO Feeds'
@@ -110,6 +113,9 @@ stages:
     pool:
       vmImage: 'windows-2019'
     steps:
+      - script: echo "##vso[task.logissue type=error]Going forward, v2 Arcade publishing is no longer supported. Please read https://github.com/dotnet/arcade/blob/main/Documentation/CorePackages/Publishing.md for details, then contact dnceng if you have further questions."
+        displayName: Warn about v2 Arcade Publishing Usage
+
       - task: DownloadBuildArtifacts@0
         displayName: Download Build Assets
         continueOnError: true

--- a/eng/common/templates/post-build/channels/generic-public-channel.yml
+++ b/eng/common/templates/post-build/channels/generic-public-channel.yml
@@ -42,7 +42,7 @@ stages:
     pool:
       vmImage: 'windows-2019'
     steps:
-      - script: echo "##vso[task.logissue type=error]Going forward, v2 Arcade publishing is no longer supported. Please read https://github.com/dotnet/arcade/blob/main/Documentation/CorePackages/Publishing.md for details, then contact dnceng if you have further questions."
+      - script: echo "##vso[task.logissue type=warning]Going forward, v2 Arcade publishing is no longer supported. Please read https://github.com/dotnet/arcade/blob/main/Documentation/CorePackages/Publishing.md for details, then contact dnceng if you have further questions."
         displayName: Warn about v2 Arcade Publishing Usage
 
       - task: DownloadBuildArtifacts@0
@@ -112,7 +112,7 @@ stages:
     pool:
       vmImage: 'windows-2019'
     steps:
-      - script: echo "##vso[task.logissue type=error]Going forward, v2 Arcade publishing is no longer supported. Please read https://github.com/dotnet/arcade/blob/main/Documentation/CorePackages/Publishing.md for details, then contact dnceng if you have further questions."
+      - script: echo "##vso[task.logissue type=warning]Going forward, v2 Arcade publishing is no longer supported. Please read https://github.com/dotnet/arcade/blob/main/Documentation/CorePackages/Publishing.md for details, then contact dnceng if you have further questions."
         displayName: Warn about v2 Arcade Publishing Usage
 
       - task: DownloadBuildArtifacts@0

--- a/eng/common/templates/post-build/channels/generic-public-channel.yml
+++ b/eng/common/templates/post-build/channels/generic-public-channel.yml
@@ -42,6 +42,9 @@ stages:
     pool:
       vmImage: 'windows-2019'
     steps:
+      - script: echo "##vso[task.logissue type=error]Going forward, v2 Arcade publishing is no longer supported. Please read https://github.com/dotnet/arcade/blob/main/Documentation/CorePackages/Publishing.md for details, then contact dnceng if you have further questions."
+        displayName: Warn about v2 Arcade Publishing Usage
+
       - task: DownloadBuildArtifacts@0
         displayName: Download Build Assets
         continueOnError: true
@@ -109,6 +112,9 @@ stages:
     pool:
       vmImage: 'windows-2019'
     steps:
+      - script: echo "##vso[task.logissue type=error]Going forward, v2 Arcade publishing is no longer supported. Please read https://github.com/dotnet/arcade/blob/main/Documentation/CorePackages/Publishing.md for details, then contact dnceng if you have further questions."
+        displayName: Warn about v2 Arcade Publishing Usage
+
       - task: DownloadBuildArtifacts@0
         displayName: Download Build Assets
         continueOnError: true


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/7333

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation

I will be working on testing this out (have to find a functioning v2 pipeline to apply this change to) in the morning.