### PR TITLE
Workaround for https://github.com/dotnet/arcade/issues/7371

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.py
@@ -98,10 +98,10 @@ def check_passed_to_workaround_ado_api_failure(dirs_to_check: List[str]) -> bool
 
     if found_a_result:
         if failure_count_found == 0:
-            print("Reporter script has failed, but we were able to find XUnit test results with no failures.")
+            print("Reporter script has failed, but XUnit test results show no failures.")
             return True
         else:
-            print("Reporter script has failed, but we were able to find XUnit test results with failures ({})"
+            print("Reporter script has failed, and we were able to find XUnit test results with failures ({})"
                   .format(str(failure_count_found)))
     else:
         print("Tried to mitigate but no results files found.")
@@ -116,7 +116,7 @@ def get_failure_count(test_results_path: str):
             if '<assembly ' in line:
                 match = total_regex.search(line)
                 if match is not None:
-                    fail_count = int(match.groups()[0])
+                    fail_count += int(match.groups()[0])
                 break
     return fail_count
 


### PR DESCRIPTION
Have azure-pipelines reporter parse XML for failures if ADO fails for any reason, return 0 if we actually passed until the Helix Client does this itself.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation

Since this is a weird error-case from an API we don't have a way to mock, I created this run where every worker in the Azure-DevOps reporter crashes.  Note in that run the non-XUnit results were expected to and did fail because I didn't check for them; this is just to mitigate the main stream scenario of XUnit results.  If we need to keep this workaround for a longer time can implement that.

[Helix Log](https://helixre8s23ayyeko0k025g8.blob.core.windows.net/dotnet-arcade-refs-pull-7422-merge-549cb266990a41dcbd/Microsoft.DotNet.Build.Tasks.Feed.Tests.dll/console.f56ee88b.log?sv=2019-07-07&se=2021-06-09T22%3A18%3A25Z&sr=c&sp=rl&sig=7Biw48l%2B1r9zAR3jRNPtTu22lSzxan2xQ9SFNt%2FVQzg%3D)

```
Reporting has failed.  Running mitigation for https://github.com/dotnet/arcade/issues/7371
Searching 'C:\h\w\A8DD094C\w\B173094F\e' for test results files
Found results file C:\h\w\A8DD094C\w\B173094F\e\testResults.xml 
Searching 'C:\h\w\A8DD094C\w\B173094F\uploads' for test results files
Reporter script has failed, but we were able to find XUnit test results with no failures.
```
