### PR TITLE
[DO NOT MERGE] Arcade 7371 intentional failure

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/run.py
@@ -42,6 +42,8 @@ class UploadWorker(Thread):
         self.__print("starting...")
         while True:
             try:
+                with workerFailedLock:
+                    workerFailed = True
                 item = self.queue.get()
                 self.__process(item)
             except:


### PR DESCRIPTION
See https://github.com/dotnet/arcade/pull/7421.  This is that change plus one to force the helix reporting to always fall into the failure code path to prove it works.
