### PR TITLE
Place mibc data into RuntimeList.xml with AssetType PgoData

### DIFF
--- a/src/Microsoft.DotNet.SharedFramework.Sdk/src/CreateFrameworkListFile.cs
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/src/CreateFrameworkListFile.cs
@@ -87,7 +87,6 @@ namespace Microsoft.DotNet.SharedFramework.Sdk
                     AssemblyName = FileUtilities.GetAssemblyName(item.ItemSpec),
                     FileVersion = FileUtilities.GetFileVersion(item.ItemSpec),
                     IsNative = item.GetMetadata("IsNative") == "true",
-                    IsProfile = item.GetMetadata("IsNative") == "true",
                     IsSymbolFile = item.GetMetadata("IsSymbolFile") == "true",
                     IsPgoData = item.GetMetadata("IsPgoData") == "true",
                     IsResourceFile = item.ItemSpec

--- a/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -130,6 +130,10 @@
       <FilesToPackage Condition="'%(Extension)' == '.pdb' or '%(Extension)' == '.dbg' or '%(Extension)' == '.dwarf'">
         <IsSymbolFile>true</IsSymbolFile>
       </FilesToPackage>
+      <FilesToPackage Condition="'%(Extension)' == '.mibc'">
+        <IsPgoData>true</IsPgoData>
+        <TargetPath>PgoData</TargetPath>
+      </FilesToPackage>
       <FilesToPackage Condition="$([System.String]::new('%(Filename)').Contains('.ni.{')) and 
                                  $([System.String]::new('%(Filename)').EndsWith('}')) and
                                  '%(Extension)' == '.map'">
@@ -380,6 +384,7 @@
       <_FrameworkListRootAttribute Include="FrameworkName" Value="$(SharedFrameworkName)" />
       <_FrameworkListRootAttribute Include="Name" Value="$(SharedFrameworkFriendlyName)" />
       <_FrameworkListTargetFilePrefix Include="ref/;runtimes/" />
+      <_FrameworkListTargetFilePrefix Condition="'$(PlatformPackageType)' == 'RuntimePack'" Include="PgoData" />
     </ItemGroup>
 
     <CreateFrameworkListFile


### PR DESCRIPTION
- Add a new ability to carry along the details of what optimization data may/may not be in a Runtime pack by updating the RuntimeList.xml to hold the right data
- Works in tandem with a PR in the sdk repo to enable optimization data to flow into trimmed and composite R2R scenarios