### PR TITLE
Fix RemoteExecutor for VS testhost

### DIFF
--- a/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.RemoteExecutor
                     string directory = GetDirectoryName(GetDirectoryName(GetDirectoryName(runtimePath)));
                     if (directory != string.Empty)
                     {
-                        string dotnetExe = IOPath.Combine(GetDirectoryName(GetDirectoryName(GetDirectoryName(runtimePath))), hostName);
+                        string dotnetExe = IOPath.Combine(directory, hostName);
                         if (File.Exists(dotnetExe))
                         {
                             HostRunner = dotnetExe;

--- a/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Xunit;
+using IOPath = System.IO.Path;
 
 namespace Microsoft.DotNet.RemoteExecutor
 {
@@ -59,10 +60,15 @@ namespace Microsoft.DotNet.RemoteExecutor
 
                 // Running with an apphost, eg. Visual Studio testhost. We should attempt to find and use dotnet.exe.
                 // This is a Windows-only workaround.
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !HostRunner.EndsWith("dotnet.exe", StringComparison.OrdinalIgnoreCase))
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) 
+                    && !IOPath.GetFileName(HostRunner).Equals("dotnet.exe", StringComparison.OrdinalIgnoreCase))
                 {
-                    string runtimePath = System.IO.Path.GetDirectoryName(typeof(object).Assembly.Location);
-                    string dotnetExe = System.IO.Path.Combine(runtimePath, "..", "..", "..", "dotnet.exe");
+                    string runtimePath = IOPath.GetDirectoryName(typeof(object).Assembly.Location);
+
+                    // In case we are running the app via a runtime, dotnet.exe is located 3 folders above the runtime. Example:
+                    // runtime    ->  C:\Program Files\dotnet\shared\Microsoft.NETCore.App\5.0.6\
+                    // dotnet.exe ->  C:\Program Files\dotnet\shared\dotnet.exe
+                    string dotnetExe = IOPath.Combine(IOPath.GetDirectoryName(IOPath.GetDirectoryName(IOPath.GetDirectoryName(runtimePath))), "dotnet.exe");
                     if (File.Exists(dotnetExe))
                     {
                         HostRunner = dotnetExe;

--- a/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
@@ -61,7 +61,8 @@ namespace Microsoft.DotNet.RemoteExecutor
                 string hostName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet";
 
                 // Partially addressing https://github.com/dotnet/arcade/issues/6371
-                // Running with an apphost, eg. Visual Studio testhost. We should attempt to find and use dotnet.exe.
+                // We expect to run tests with dotnet. However in certain scenarios we may have a different apphost (e.g. Visual Studio testhost).
+                // Attempt to find and use dotnet.
                 if (!IOPath.GetFileName(HostRunner).Equals(hostName, StringComparison.OrdinalIgnoreCase))
                 {
                     string runtimePath = IOPath.GetDirectoryName(typeof(object).Assembly.Location);

--- a/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
@@ -58,20 +58,21 @@ namespace Microsoft.DotNet.RemoteExecutor
             {
                 HostRunner = processFileName;
 
+                string hostName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet";
                 // Running with an apphost, eg. Visual Studio testhost. We should attempt to find and use dotnet.exe.
                 // This is a Windows-only workaround.
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) 
-                    && !IOPath.GetFileName(HostRunner).Equals("dotnet.exe", StringComparison.OrdinalIgnoreCase))
+                if (!IOPath.GetFileName(HostRunner).Equals(hostName, StringComparison.OrdinalIgnoreCase))
                 {
                     string runtimePath = IOPath.GetDirectoryName(typeof(object).Assembly.Location);
 
                     // In case we are running the app via a runtime, dotnet.exe is located 3 folders above the runtime. Example:
                     // runtime    ->  C:\Program Files\dotnet\shared\Microsoft.NETCore.App\5.0.6\
                     // dotnet.exe ->  C:\Program Files\dotnet\shared\dotnet.exe
+                    // This should also work on Unix and locally built runtime/testhost.
                     string directory = GetDirectoryName(GetDirectoryName(GetDirectoryName(runtimePath)));
                     if (directory != string.Empty)
                     {
-                        string dotnetExe = IOPath.Combine(GetDirectoryName(GetDirectoryName(GetDirectoryName(runtimePath))), "dotnet.exe");
+                        string dotnetExe = IOPath.Combine(GetDirectoryName(GetDirectoryName(GetDirectoryName(runtimePath))), hostName);
                         if (File.Exists(dotnetExe))
                         {
                             HostRunner = dotnetExe;

--- a/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
@@ -68,10 +68,14 @@ namespace Microsoft.DotNet.RemoteExecutor
                     // In case we are running the app via a runtime, dotnet.exe is located 3 folders above the runtime. Example:
                     // runtime    ->  C:\Program Files\dotnet\shared\Microsoft.NETCore.App\5.0.6\
                     // dotnet.exe ->  C:\Program Files\dotnet\shared\dotnet.exe
-                    string dotnetExe = IOPath.Combine(IOPath.GetDirectoryName(IOPath.GetDirectoryName(IOPath.GetDirectoryName(runtimePath))), "dotnet.exe");
-                    if (File.Exists(dotnetExe))
+                    string directory = GetDirectoryName(GetDirectoryName(GetDirectoryName(runtimePath)));
+                    if (directory != string.Empty)
                     {
-                        HostRunner = dotnetExe;
+                        string dotnetExe = IOPath.Combine(GetDirectoryName(GetDirectoryName(GetDirectoryName(runtimePath))), "dotnet.exe");
+                        if (File.Exists(dotnetExe))
+                        {
+                            HostRunner = dotnetExe;
+                        }
                     }
                 }
             }
@@ -80,7 +84,9 @@ namespace Microsoft.DotNet.RemoteExecutor
                 HostRunner = Path;
             }
 
-            HostRunnerName = System.IO.Path.GetFileName(HostRunner);
+            HostRunnerName = IOPath.GetFileName(HostRunner);
+
+            static string GetDirectoryName(string path) => string.IsNullOrEmpty(path) ? string.Empty : IOPath.GetDirectoryName(path);
         }
 
         private static bool IsNetCore() =>

--- a/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
@@ -59,8 +59,9 @@ namespace Microsoft.DotNet.RemoteExecutor
                 HostRunner = processFileName;
 
                 string hostName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet";
+
+                // Partially addressing https://github.com/dotnet/arcade/issues/6371
                 // Running with an apphost, eg. Visual Studio testhost. We should attempt to find and use dotnet.exe.
-                // This is a Windows-only workaround.
                 if (!IOPath.GetFileName(HostRunner).Equals(hostName, StringComparison.OrdinalIgnoreCase))
                 {
                     string runtimePath = IOPath.GetDirectoryName(typeof(object).Assembly.Location);

--- a/src/Microsoft.DotNet.RemoteExecutor/tests/RemoteExecutorTests.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/tests/RemoteExecutorTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.RemoteExecutor.Tests
 {
     public class RemoteExecutorTests
     {
-        [Fact(Skip = "Remote executor is broken in VS test explorer")]
+        [Fact]
         public void AsyncAction_ThrowException()
         {
             Assert.Throws<RemoteExecutionException>(() =>
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.RemoteExecutor.Tests
             );
         }
 
-        [Fact(Skip = "Remote executor is broken in VS test explorer")]
+        [Fact]
         public void AsyncAction()
         {
             RemoteExecutor.Invoke(async () =>
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.RemoteExecutor.Tests
             }, new RemoteInvokeOptions { RollForward = "Major" }).Dispose();
         }
 
-        [Fact(Skip = "Remote executor is broken in VS test explorer")]
+        [Fact]
         public void AsyncFunc_ThrowException()
         {
             Assert.Throws<RemoteExecutionException>(() =>
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.RemoteExecutor.Tests
             );
         }
 
-        [Fact(Skip = "Remote executor is broken in VS test explorer")]
+        [Fact]
         public void AsyncFunc_InvalidReturnCode()
         {
             Assert.Throws<TrueException>(() =>
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.RemoteExecutor.Tests
             );
         }
 
-        [Fact(Skip = "Remote executor is broken in VS test explorer")]
+        [Fact]
         public void AsyncFunc_NoThrow_ValidReturnCode()
         {
             RemoteExecutor.Invoke(async () =>


### PR DESCRIPTION
### Description

Address #6371 for cases when VS testhost is the runner. ~The fix is Windows-specific.~

/cc @vitek-karas @ViktorHofer @JimBobSquarePants @RussKie 

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation

The validation process above looks very complicated, I have no opportunity to go through it. Note that the change enables disabled tests. I did a local run with both Visual Studio and `dotnet test`.