### PR TITLE
Allow for additional GitHub issue state to be set

### DIFF
--- a/src/Microsoft.DotNet.Git.IssueManager/src/Clients/GitHubClient.cs
+++ b/src/Microsoft.DotNet.Git.IssueManager/src/Clients/GitHubClient.cs
@@ -3,9 +3,11 @@
 
 using Octokit;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Microsoft.DotNet.Git.IssueManager.Helpers;
 
 namespace Microsoft.DotNet.Git.IssueManager.Clients
 {
@@ -38,7 +40,10 @@ namespace Microsoft.DotNet.Git.IssueManager.Clients
             string repositoryUrl,
             string issueTitle,
             string issueDescription,
-            string personalAccessToken)
+            string personalAccessToken,
+            int? milestone = null,
+            IEnumerable<string> labels = null,
+            IEnumerable<string> assignees = null)
         {
             (string owner, string repoName) = ParseRepoUri(repositoryUrl);
 
@@ -48,8 +53,19 @@ namespace Microsoft.DotNet.Git.IssueManager.Clients
 
             NewIssue issueToBeCreated = new NewIssue(issueTitle)
             {
-                Body = issueDescription
+                Body = issueDescription,
+                Milestone = milestone
             };
+
+            if (labels is not null)
+            {
+                issueToBeCreated.Labels.AddRange(labels);
+            }
+
+            if (assignees is not null)
+            {
+                issueToBeCreated.Assignees.AddRange(assignees);
+            }
 
             Issue createdIssue = await client.Issue.Create(owner, repoName, issueToBeCreated);
 

--- a/src/Microsoft.DotNet.Git.IssueManager/src/Helpers/CollectionExtensions.cs
+++ b/src/Microsoft.DotNet.Git.IssueManager/src/Helpers/CollectionExtensions.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Microsoft.DotNet.Git.IssueManager.Helpers
+{
+    internal static class CollectionExtensions
+    {
+        public static void AddRange<T>(this Collection<T> collection, IEnumerable<T> items)
+        {
+            foreach (T item in items)
+            {
+                collection.Add(item);
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Git.IssueManager/src/Helpers/RepositoryHelper.cs
+++ b/src/Microsoft.DotNet.Git.IssueManager/src/Helpers/RepositoryHelper.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.DotNet.Git.IssueManager.Clients;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Git.IssueManager.Helpers
@@ -42,7 +43,10 @@ namespace Microsoft.DotNet.Git.IssueManager.Helpers
             string repositoryUrl,
             string issueTitle,
             string issueDescription,
-            string gitHubPersonalAccessToken)
+            string gitHubPersonalAccessToken,
+            int? milestone = null,
+            IEnumerable<string> labels = null,
+            IEnumerable<string> assignees = null)
         {
             if (Uri.TryCreate(repositoryUrl, UriKind.Absolute, out Uri parsedUri))
             {
@@ -53,7 +57,8 @@ namespace Microsoft.DotNet.Git.IssueManager.Helpers
                         throw new ArgumentException("A GitHub personal access token is needed for this operation.");
                     }
 
-                    return await GitHubClient.CreateNewIssueAsync(repositoryUrl, issueTitle, issueDescription, gitHubPersonalAccessToken);
+                    return await GitHubClient.CreateNewIssueAsync(
+                        repositoryUrl, issueTitle, issueDescription, gitHubPersonalAccessToken, milestone, labels, assignees);
                 }
 
                 throw new NotImplementedException("Creating issues is not currently supported for an Azure DevOps repo.");

--- a/src/Microsoft.DotNet.Git.IssueManager/src/Helpers/RepositoryHelper.cs
+++ b/src/Microsoft.DotNet.Git.IssueManager/src/Helpers/RepositoryHelper.cs
@@ -58,7 +58,13 @@ namespace Microsoft.DotNet.Git.IssueManager.Helpers
                     }
 
                     return await GitHubClient.CreateNewIssueAsync(
-                        repositoryUrl, issueTitle, issueDescription, gitHubPersonalAccessToken, milestone, labels, assignees);
+                        repositoryUrl,
+                        issueTitle,
+                        issueDescription,
+                        gitHubPersonalAccessToken,
+                        milestone,
+                        labels,
+                        assignees);
                 }
 
                 throw new NotImplementedException("Creating issues is not currently supported for an Azure DevOps repo.");

--- a/src/Microsoft.DotNet.Git.IssueManager/src/IssueManager.cs
+++ b/src/Microsoft.DotNet.Git.IssueManager/src/IssueManager.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.DotNet.Git.IssueManager.Helpers;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Git.IssueManager
@@ -53,13 +54,19 @@ namespace Microsoft.DotNet.Git.IssueManager
         public async Task<int> CreateNewIssueAsync(
             string repositoryUrl,
             string issueTitle,
-            string issueDescription)
+            string issueDescription,
+            int? milestone = null,
+            IEnumerable<string> labels = null,
+            IEnumerable<string> assignees = null)
         {
             return await RepositoryHelper.CreateNewIssueAsync(
                 repositoryUrl,
                 issueTitle,
                 issueDescription,
-                GitHubPersonalAccessToken);
+                GitHubPersonalAccessToken,
+                milestone,
+                labels,
+                assignees);
         }
     }
 }


### PR DESCRIPTION
I want to be able to use `IssueManager` to create issues and also need to be able to set the issue label.  I've updated the API to allow labels to be set in addition to the rest of the available state that can be set: milestone and assignees.