### PR TITLE
Move publishing workaround to only https://dev.azure.com/dnceng/

### DIFF
--- a/eng/publishing/v3/publish-assets.yml
+++ b/eng/publishing/v3/publish-assets.yml
@@ -27,11 +27,11 @@ jobs:
 
   # Using non-hosted build agents to (hopefully temporarily) work around OOMs
   # See https://github.com/dotnet/core-eng/issues/13098 for context
-  - ${{ if eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/dnceng/') }}:
+  ${{ if eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/dnceng/') }}:
     pool:
       name: NetCoreInternal-Pool
       queue: BuildPool.Server.Amd64.VS2019
-  - ${{ if ne(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/dnceng/') }}:
+  ${{ if ne(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/dnceng/') }}:
     pool:
       vmImage: 'windows-2019'
   steps:

--- a/eng/publishing/v3/publish-assets.yml
+++ b/eng/publishing/v3/publish-assets.yml
@@ -24,11 +24,16 @@ jobs:
       value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOBuildId'] ]
     - name: AzDOAccount
       value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOBuildAccount'] ]
+
   # Using non-hosted build agents to (hopefully temporarily) work around OOMs
   # See https://github.com/dotnet/core-eng/issues/13098 for context
-  pool:
-    name: NetCoreInternal-Pool
-    queue: BuildPool.Server.Amd64.VS2019
+  - ${{ if eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/dnceng/') }}:
+    pool:
+      name: NetCoreInternal-Pool
+      queue: BuildPool.Server.Amd64.VS2019
+  - ${{ if ne(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/dnceng/') }}:
+    pool:
+      vmImage: 'windows-2019'
   steps:
     - task: DownloadBuildArtifacts@0
       displayName: Download Build Assets


### PR DESCRIPTION
### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation


#### Devdiv test build (the != dnceng case)
D:\Git\aspnetcore\eng>darc add-build-to-channel --id 91426 --channel "VS 17.0" --source-branch core-eng-13098 --publishing-infra-version 3 --publish-installers-and-checksums
Build 91426 will be assigned to target channel(s) once this build finishes publishing assets: https://dev.azure.com/devdiv/devdiv/_build/results?buildId=4800464

####  DncEng test build (the == dnceng case)
D:\Git\aspnetcore\eng>darc add-build-to-channel --id 91603 --channel "General Testing" --source-branch core-eng-13098 --publishing-infra-version 3 --publish-installers-and-checksums
Build 91603 will be assigned to target channel(s) once this build finishes publishing assets: https://dev.azure.com/dnceng/internal/_build/results?buildId=1156419
