### PR TITLE
Support browser wasm in compatible pkg tfms task

### DIFF
--- a/src/Microsoft.DotNet.PackageTesting/GetCompatiblePackageTargetFrameworks.cs
+++ b/src/Microsoft.DotNet.PackageTesting/GetCompatiblePackageTargetFrameworks.cs
@@ -140,7 +140,7 @@ namespace Microsoft.DotNet.PackageTesting
                 if (item.AssetType == AssetType.RuntimeAsset)
                 {
                     string testRid = item.Rid;
-                    string testArch = "-x64";
+                    string testArch = testRid == "browser" ? "-wasm" : "-x64";
                     if (testRid == "unix")
                     {
                         if (!rids.Contains("linux" + testArch))


### PR DESCRIPTION
Because of the default arch value of "-x64", for browser this resolves to "browser-x64" which isn't a supported RID. Defaulting to wasm for browser as a workaround.