### PR TITLE
Stop supporting multiple targets in XHarness Helix SDK

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -39,9 +39,9 @@
       <Uri>https://github.com/dotnet/arcade-services</Uri>
       <Sha>cac955fe259cb611f6a29d09209bd717deb69037</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="1.0.0-prerelease.21271.1">
+    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="1.0.0-prerelease.21303.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>98970876f4d21e6da5198a5c41de51ab1101089f</Sha>
+      <Sha>debdb2b11d810cea0435f5d086c0bf17b3ee6402</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.10.0-4.21273.6">
       <Uri>https://github.com/dotnet/roslyn</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -80,7 +80,7 @@
     <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>6.0.0-beta.21277.1</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
     <XliffTasksVersion>1.0.0-beta.21277.1</XliffTasksVersion>
     <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.21228.1</MicrosoftDotNetMaestroTasksVersion>
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.21271.1</MicrosoftDotNetXHarnessCLIVersion>
+    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.21303.1</MicrosoftDotNetXHarnessCLIVersion>
     <MicrosoftSymbolUploaderBuildTaskVersion>1.1.156402</MicrosoftSymbolUploaderBuildTaskVersion>
     <MicrosoftSymbolUploaderVersion>1.1.152002</MicrosoftSymbolUploaderVersion>
     <MicrosoftNetSdkWorkloadManifestReaderVersion>6.0.100-preview.5.21254.11</MicrosoftNetSdkWorkloadManifestReaderVersion>

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAppleWorkItemsTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAppleWorkItemsTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             var command = workItem.GetMetadata("Command");
             command.Should().Contain("System.Foo.app");
-            command.Should().Contain("--targets \"ios-device_13.5\"");
+            command.Should().Contain("--target \"ios-device_13.5\"");
             command.Should().Contain("--timeout \"00:08:55\"");
             command.Should().Contain("--launch-timeout \"00:02:33\"");
 
@@ -181,7 +181,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
         private ITaskItem CreateAppBundle(
             string path,
-            string targets,
+            string target,
             string? workItemTimeout = null,
             string? testTimeout = null,
             string? launchTimeout = null,
@@ -191,7 +191,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         {
             var mockBundle = new Mock<ITaskItem>();
             mockBundle.SetupGet(x => x.ItemSpec).Returns(path);
-            mockBundle.Setup(x => x.GetMetadata(CreateXHarnessAppleWorkItems.MetadataNames.Target)).Returns(targets);
+            mockBundle.Setup(x => x.GetMetadata(CreateXHarnessAppleWorkItems.MetadataNames.Target)).Returns(target);
             mockBundle.Setup(x => x.GetMetadata(CreateXHarnessAppleWorkItems.MetadataNames.IncludesTestRunner)).Returns(includesTestRunner.ToString());
 
             if (workItemTimeout != null)

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAppleWorkItemsTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAppleWorkItemsTests.cs
@@ -191,7 +191,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         {
             var mockBundle = new Mock<ITaskItem>();
             mockBundle.SetupGet(x => x.ItemSpec).Returns(path);
-            mockBundle.Setup(x => x.GetMetadata(CreateXHarnessAppleWorkItems.MetadataNames.Targets)).Returns(targets);
+            mockBundle.Setup(x => x.GetMetadata(CreateXHarnessAppleWorkItems.MetadataNames.Target)).Returns(targets);
             mockBundle.Setup(x => x.GetMetadata(CreateXHarnessAppleWorkItems.MetadataNames.IncludesTestRunner)).Returns(includesTestRunner.ToString());
 
             if (workItemTimeout != null)

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/ProvisioningProfileProviderTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/ProvisioningProfileProviderTests.cs
@@ -133,7 +133,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         {
             var mockBundle = new Mock<ITaskItem>();
             mockBundle.SetupGet(x => x.ItemSpec).Returns(path);
-            mockBundle.Setup(x => x.GetMetadata(CreateXHarnessAppleWorkItems.MetadataNames.Targets)).Returns(targets);
+            mockBundle.Setup(x => x.GetMetadata(CreateXHarnessAppleWorkItems.MetadataNames.Target)).Returns(targets);
             return mockBundle.Object;
         }
     }

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Helix.Sdk
 
         public static class MetadataNames
         {
-            public const string Target = "Target";
+            public const string Target = "TestTarget";
             public const string LaunchTimeout = "LaunchTimeout";
             public const string IncludesTestRunner = "IncludesTestRunner";
             public const string ResetSimulator = "ResetSimulator";

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Helix.Sdk
 
         public static class MetadataNames
         {
-            public const string Targets = "Targets";
+            public const string Target = "Target";
             public const string LaunchTimeout = "LaunchTimeout";
             public const string IncludesTestRunner = "IncludesTestRunner";
             public const string ResetSimulator = "ResetSimulator";
@@ -102,14 +102,14 @@ namespace Microsoft.DotNet.Helix.Sdk
             var (testTimeout, workItemTimeout, expectedExitCode, customCommands) = ParseMetadata(appBundleItem);
 
             // Validation of any metadata specific to iOS stuff goes here
-            if (!appBundleItem.TryGetMetadata(MetadataNames.Targets, out string targets))
+            if (!appBundleItem.TryGetMetadata(MetadataNames.Target, out string target))
             {
-                Log.LogError($"'{MetadataNames.Targets}' metadata must be specified - " +
+                Log.LogError($"'{MetadataNames.Target}' metadata must be specified - " +
                     "expecting list of target device/simulator platforms to execute tests on (e.g. ios-simulator-64)");
                 return null;
             }
 
-            targets = targets.ToLowerInvariant();
+            target = target.ToLowerInvariant();
 
             // Optional timeout for the how long it takes for the app to be installed, booted and tests start executing
             TimeSpan launchTimeout = s_defaultLaunchTimeout;
@@ -151,7 +151,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                 customCommands = $"xharness apple {(includesTestRunner ? "test" : "run")} " +
                     "--app \"$app\" " +
                     "--output-directory \"$output_directory\" " +
-                    "--targets \"$targets\" " +
+                    "--target \"$target\" " +
                     "--timeout \"$timeout\" " +
                     (includesTestRunner
                         ? $"--launch-timeout \"$launch_timeout\" "
@@ -163,7 +163,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             }
 
             string appName = fileSystem.GetFileName(appBundleItem.ItemSpec);
-            string helixCommand = GetHelixCommand(appName, targets, testTimeout, launchTimeout, includesTestRunner, expectedExitCode, resetSimulator);
+            string helixCommand = GetHelixCommand(appName, target, testTimeout, launchTimeout, includesTestRunner, expectedExitCode, resetSimulator);
             string payloadArchivePath = await CreateZipArchiveOfFolder(zipArchiveManager, fileSystem, appFolderPath, customCommands);
 
             Log.LogMessage($"Creating work item with properties Identity: {workItemName}, Payload: {appFolderPath}, Command: {helixCommand}");
@@ -179,7 +179,7 @@ namespace Microsoft.DotNet.Helix.Sdk
 
         private string GetHelixCommand(
             string appName,
-            string targets,
+            string target,
             TimeSpan testTimeout,
             TimeSpan launchTimeout,
             bool includesTestRunner,
@@ -188,7 +188,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             =>
             $"chmod +x {EntryPointScript} && ./{EntryPointScript} " +
             $"--app \"{appName}\" " +
-            $"--targets \"{targets}\" " +
+            $"--target \"{target}\" " +
             $"--timeout \"{testTimeout}\" " +
             $"--launch-timeout \"{launchTimeout}\" " +
             (includesTestRunner ? "--includes-test-runner " : string.Empty) +

--- a/src/Microsoft.DotNet.Helix/Sdk/ProvisioningProfileProvider.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/ProvisioningProfileProvider.cs
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.Helix.Sdk
 
             foreach (var appBundle in appBundles)
             {
-                if (!appBundle.TryGetMetadata(CreateXHarnessAppleWorkItems.MetadataNames.Targets, out string bundleTargets))
+                if (!appBundle.TryGetMetadata(CreateXHarnessAppleWorkItems.MetadataNames.Target, out string bundleTargets))
                 {
                     _log.LogError("'Targets' metadata must be specified - " +
                         "expecting list of target device/simulator platforms to execute tests on (e.g. ios-simulator-64)");

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
@@ -59,12 +59,12 @@ To execute .app bundles, declare one or more `XHarnessAppBundleToTest` items:
 <ItemGroup>
   <!-- Find all directories named *.app -->
   <XHarnessAppBundleToTest Include="$([System.IO.Directory]::GetDirectories('$(TestArchiveTestsRoot)', '*.app', System.IO.SearchOption.AllDirectories))">
-    <Target>ios-simulator-64_13.5</Targets>
+    <TestTarget>ios-simulator-64_13.5</TestTarget>
   </XHarnessAppBundleToTest>
 </ItemGroup>
 ```
 
-The `<Target>` metadata is a required configuration that tells XHarness which kind of device/Simulator to target.
+The `<TestTarget>` metadata is a required configuration that tells XHarness which kind of device/Simulator to target.
 Use the XHarness CLI help command to find more (see the `--target` option).
 
 You can also specify some additional metadata that will help you configure the run better:
@@ -163,7 +163,7 @@ Example:
 ```xml
 <ItemGroup>
   <XHarnessAppBundleToTest Include="path\to\Some.iOS.app">
-    <Target>ios-simulator-64</Target>
+    <TestTarget>ios-simulator-64</TestTarget>
     <WorkItemTimeout>00:12:00</WorkItemTimeout>
     <CustomCommands>
       set -e

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
@@ -59,13 +59,13 @@ To execute .app bundles, declare one or more `XHarnessAppBundleToTest` items:
 <ItemGroup>
   <!-- Find all directories named *.app -->
   <XHarnessAppBundleToTest Include="$([System.IO.Directory]::GetDirectories('$(TestArchiveTestsRoot)', '*.app', System.IO.SearchOption.AllDirectories))">
-    <Targets>ios-simulator-64_13.5</Targets>
+    <Target>ios-simulator-64_13.5</Targets>
   </XHarnessAppBundleToTest>
 </ItemGroup>
 ```
 
-The `<Targets>` metadata is a required configuration that tells XHarness which kind of device/Simulator to target.
-Use the XHarness CLI help command to find more (see the `--targets` option).
+The `<Target>` metadata is a required configuration that tells XHarness which kind of device/Simulator to target.
+Use the XHarness CLI help command to find more (see the `--target` option).
 
 You can also specify some additional metadata that will help you configure the run better:
 
@@ -163,17 +163,17 @@ Example:
 ```xml
 <ItemGroup>
   <XHarnessAppBundleToTest Include="path\to\Some.iOS.app">
-    <Targets>ios-simulator-64</Targets>
+    <Target>ios-simulator-64</Target>
     <WorkItemTimeout>00:12:00</WorkItemTimeout>
     <CustomCommands>
       set -e
-      deviceId=`xharness apple device $targets`
-      xharness apple install -t $targets --device "$deviceId" -o "$output_directory" --app=$app
+      deviceId=`xharness apple device $target`
+      xharness apple install -t $target --device "$deviceId" -o "$output_directory" --app=$app
       set +e
       result=0
-      xharness apple just-test -t $targets --device "$deviceId" -o "$output_directory" --app net.dot.Some.iOS --timeout 00:08:00
+      xharness apple just-test -t $target --device "$deviceId" -o "$output_directory" --app net.dot.Some.iOS --timeout 00:08:00
       ((result|=$?))
-      xharness apple uninstall -t $targets --device "$deviceId" -o "$output_directory" --app net.dot.Some.iOS
+      xharness apple uninstall -t $target --device "$deviceId" -o "$output_directory" --app net.dot.Some.iOS
       ((result|=$?))
       exit $result
     </CustomCommands>
@@ -187,7 +187,7 @@ When using `CustomCommands`, several variables will be defined for you for easie
 - `$app` - path to the application
 - `$output_directory` - path under which all files will be uploaded to Helix at the end of the job
   - If a file named `testResults.xml` is found containing xUnit results, it will be uploaded back to Azure DevOps
-- `$targets`, `$timeout`, `$launch_timeout`, `$expected_exit_code`, `$includes_test_runner` - parsed metadata defined on the original `XHarnessAppBundleToTest` MSBuild item
+- `$target`, `$timeout`, `$launch_timeout`, `$expected_exit_code`, `$includes_test_runner` - parsed metadata defined on the original `XHarnessAppBundleToTest` MSBuild item
 
 #### Variables defined for Android scenarios
 Android is currently not supported - coming soon!

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
@@ -8,7 +8,7 @@
 
 app=''
 output_directory=''
-targets=''
+target=''
 timeout=''
 launch_timeout=''
 xharness_cli_path=''
@@ -29,8 +29,8 @@ while [[ $# -gt 0 ]]; do
         output_directory="$2"
         shift
         ;;
-      --targets)
-        targets="$2"
+      --target)
+        target="$2"
         shift
         ;;
       --timeout)
@@ -77,8 +77,8 @@ if [ -z "$app" ]; then
     die "App bundle path wasn't provided";
 fi
 
-if [ -z "$targets" ]; then
-    die "No targets were provided";
+if [ -z "$target" ]; then
+    die "No target were provided";
 fi
 
 if [ -z "$output_directory" ]; then
@@ -96,7 +96,7 @@ else
 fi
 
 # Signing
-if [ "$targets" == 'ios-device' ] || [ "$targets" == 'tvos-device' ]; then
+if [ "$target" == 'ios-device' ] || [ "$target" == 'tvos-device' ]; then
     echo "Real device target detected, application will be signed"
 
     provisioning_profile="$app/embedded.mobileprovision"

--- a/tests/XHarness/XHarness.Device.AppleRun.proj
+++ b/tests/XHarness/XHarness.Device.AppleRun.proj
@@ -20,7 +20,7 @@
 
     <ItemGroup>
       <XHarnessAppBundleToTest Include="$(ArtifactsTmpDir)XHarness.RunDeviceAppBundle/$(XHarnessRunAppBundleName)">
-        <Target>ios-device</Target>
+        <TestTarget>ios-device</TestTarget>
         <WorkItemTimeout>00:05:00</WorkItemTimeout>
         <TestTimeout>00:04:00</TestTimeout>
         <LaunchTimeout>00:03:00</LaunchTimeout>

--- a/tests/XHarness/XHarness.Device.AppleRun.proj
+++ b/tests/XHarness/XHarness.Device.AppleRun.proj
@@ -20,7 +20,7 @@
 
     <ItemGroup>
       <XHarnessAppBundleToTest Include="$(ArtifactsTmpDir)XHarness.RunDeviceAppBundle/$(XHarnessRunAppBundleName)">
-        <Targets>ios-device</Targets>
+        <Target>ios-device</Target>
         <WorkItemTimeout>00:05:00</WorkItemTimeout>
         <TestTimeout>00:04:00</TestTimeout>
         <LaunchTimeout>00:03:00</LaunchTimeout>

--- a/tests/XHarness/XHarness.Simulator.AppleRun.proj
+++ b/tests/XHarness/XHarness.Simulator.AppleRun.proj
@@ -20,7 +20,7 @@
 
     <ItemGroup>
       <XHarnessAppBundleToTest Include="$(ArtifactsTmpDir)XHarness.RunAppBundle/$(XHarnessRunAppBundleName)">
-        <Targets>ios-simulator-64</Targets>
+        <Target>ios-simulator-64</Target>
         <WorkItemTimeout>00:12:00</WorkItemTimeout>
         <TestTimeout>00:08:00</TestTimeout>
         <LaunchTimeout>00:05:00</LaunchTimeout>

--- a/tests/XHarness/XHarness.Simulator.AppleRun.proj
+++ b/tests/XHarness/XHarness.Simulator.AppleRun.proj
@@ -20,7 +20,7 @@
 
     <ItemGroup>
       <XHarnessAppBundleToTest Include="$(ArtifactsTmpDir)XHarness.RunAppBundle/$(XHarnessRunAppBundleName)">
-        <Target>ios-simulator-64</Target>
+        <TestTarget>ios-simulator-64</TestTarget>
         <WorkItemTimeout>00:12:00</WorkItemTimeout>
         <TestTimeout>00:08:00</TestTimeout>
         <LaunchTimeout>00:05:00</LaunchTimeout>

--- a/tests/XHarness/XHarness.Simulator.AppleTest.proj
+++ b/tests/XHarness/XHarness.Simulator.AppleTest.proj
@@ -20,7 +20,7 @@
 
     <ItemGroup>
       <XHarnessAppBundleToTest Include="$(ArtifactsTmpDir)XHarness.TestAppBundle/$(XHarnessTestAppBundleName)">
-        <Target>ios-simulator-64</Target>
+        <TestTarget>ios-simulator-64</TestTarget>
         <TestTimeout>00:05:00</TestTimeout>
         <WorkItemTimeout>00:15:00</WorkItemTimeout>
         <LaunchTimeout>00:06:00</LaunchTimeout>

--- a/tests/XHarness/XHarness.Simulator.AppleTest.proj
+++ b/tests/XHarness/XHarness.Simulator.AppleTest.proj
@@ -20,7 +20,7 @@
 
     <ItemGroup>
       <XHarnessAppBundleToTest Include="$(ArtifactsTmpDir)XHarness.TestAppBundle/$(XHarnessTestAppBundleName)">
-        <Targets>ios-simulator-64</Targets>
+        <Target>ios-simulator-64</Target>
         <TestTimeout>00:05:00</TestTimeout>
         <WorkItemTimeout>00:15:00</WorkItemTimeout>
         <LaunchTimeout>00:06:00</LaunchTimeout>

--- a/tests/XHarness/XHarness.Simulator.CustomCommands.proj
+++ b/tests/XHarness/XHarness.Simulator.CustomCommands.proj
@@ -20,7 +20,7 @@
 
     <ItemGroup>
       <XHarnessAppBundleToTest Include="$(ArtifactsTmpDir)XHarness.CustomCommandsAppBundle/$(XHarnessAppBundleName).app">
-        <Targets>ios-simulator-64</Targets>
+        <Target>ios-simulator-64</Target>
         <WorkItemTimeout>00:15:00</WorkItemTimeout>
         <TestTimeout>00:05:00</TestTimeout>
         <LaunchTimeout>00:05:00</LaunchTimeout>

--- a/tests/XHarness/XHarness.Simulator.CustomCommands.proj
+++ b/tests/XHarness/XHarness.Simulator.CustomCommands.proj
@@ -26,13 +26,13 @@
         <LaunchTimeout>00:05:00</LaunchTimeout>
         <CustomCommands>
           set -ex
-          deviceId=`xharness apple device $targets`
-          xharness apple install -t=$targets --device="$deviceId" -o="$output_directory" --app="$app" -v
+          deviceId=`xharness apple device $target`
+          xharness apple install -t=$target --device="$deviceId" -o="$output_directory" --app="$app" -v
           set +e
           result=0
-          xharness apple just-test -t=$targets --device="$deviceId" -o="$output_directory" --app="net.dot.$(XHarnessAppBundleName)" --launch-timeout=$launch_timeout --timeout=$timeout -v
+          xharness apple just-test -t=$target --device="$deviceId" -o="$output_directory" --app="net.dot.$(XHarnessAppBundleName)" --launch-timeout=$launch_timeout --timeout=$timeout -v
           ((result|=$?))
-          xharness apple uninstall -t=$targets --device="$deviceId" -o="$output_directory" --app="net.dot.$(XHarnessAppBundleName)" -v
+          xharness apple uninstall -t=$target --device="$deviceId" -o="$output_directory" --app="net.dot.$(XHarnessAppBundleName)" -v
           ((result|=$?))
           exit $result
         </CustomCommands>

--- a/tests/XHarness/XHarness.Simulator.CustomCommands.proj
+++ b/tests/XHarness/XHarness.Simulator.CustomCommands.proj
@@ -20,7 +20,7 @@
 
     <ItemGroup>
       <XHarnessAppBundleToTest Include="$(ArtifactsTmpDir)XHarness.CustomCommandsAppBundle/$(XHarnessAppBundleName).app">
-        <Target>ios-simulator-64</Target>
+        <TestTarget>ios-simulator-64</TestTarget>
         <WorkItemTimeout>00:15:00</WorkItemTimeout>
         <TestTimeout>00:05:00</TestTimeout>
         <LaunchTimeout>00:05:00</LaunchTimeout>


### PR DESCRIPTION
We never supported this really and it was deprecated in https://github.com/dotnet/xharness/pull/618

This will be a breaking change in the SDK:
```xml
<Targets>ios-simulator-64</Targets>
```
will change to 
```xml
<TestTarget>ios-simulator-64</TestTarget>
```
