### PR TITLE
Specify LastExit scope

### DIFF
--- a/Documentation/Policy/PowershellBestPractices.md
+++ b/Documentation/Policy/PowershellBestPractices.md
@@ -101,7 +101,11 @@ if ($LASTEXITCODE -ne 0) {
 }
 ```
 
-*There is a known issue when using `$LASTEXITCODE` in release builds where PowerShell will report that the variable has not been set. As a workaround, simply set `$LASTEXITCODE = 0` at the top of your script.*
+To set it in a PowerShell script, e.g. to ensure a known value at the start of a script, reference the variable in the global scope. 
+
+```powershell
+$global:LASTEXITCODE = 0
+```
 
 ## Set StrictMode and ErrorActionPreference at the top of every file
 

--- a/eng/common/sdl/execute-all-sdl-tools.ps1
+++ b/eng/common/sdl/execute-all-sdl-tools.ps1
@@ -32,7 +32,7 @@ try {
   $ErrorActionPreference = 'Stop'
   Set-StrictMode -Version 2.0
   $disableConfigureToolsetImport = $true
-  $LASTEXITCODE = 0
+  $global:LASTEXITCODE = 0
 
   # `tools.ps1` checks $ci to perform some actions. Since the SDL
   # scripts don't necessarily execute in the same agent that run the

--- a/eng/common/sdl/init-sdl.ps1
+++ b/eng/common/sdl/init-sdl.ps1
@@ -10,7 +10,7 @@ Param(
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
 $disableConfigureToolsetImport = $true
-$LASTEXITCODE = 0
+$global:LASTEXITCODE = 0
 
 # `tools.ps1` checks $ci to perform some actions. Since the SDL
 # scripts don't necessarily execute in the same agent that run the

--- a/eng/common/sdl/run-sdl.ps1
+++ b/eng/common/sdl/run-sdl.ps1
@@ -13,7 +13,7 @@ Param(
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
 $disableConfigureToolsetImport = $true
-$LASTEXITCODE = 0
+$global:LASTEXITCODE = 0
 
 try {
   # `tools.ps1` checks $ci to perform some actions. Since the SDL


### PR DESCRIPTION
Specify global scope in prepping LastExit to avoid shadowing.


I confirmed the scope-change behavior work as expected locally, and verified that this change did not cause any SDL failures in SDK, runtime or aspnetcore repositories. 