### PR TITLE
Ensure we test on TFMs that have unique RID-specific assets

### DIFF
--- a/src/Microsoft.DotNet.PackageTesting/GetCompatiblePackageTargetFrameworks.cs
+++ b/src/Microsoft.DotNet.PackageTesting/GetCompatiblePackageTargetFrameworks.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.PackageTesting
                 foreach (var packagePath in PackagePaths)
                 {
                     Package package = NupkgParser.CreatePackageObject(packagePath);
-                    List<NuGetFramework> packageTargetFrameworks = package.PackageAssets.Where(t => t.AssetType != AssetType.RuntimeAsset).Select(t => t.TargetFramework).Distinct().ToList();
+                    List<NuGetFramework> packageTargetFrameworks = package.PackageAssets.Select(asset => asset.TargetFramework).Where(tfm => tfm != null).Distinct().ToList();
 
                     List<NuGetFramework> frameworksToTest = GetTestFrameworks(packageTargetFrameworks);
                     testProjects.AddRange(CreateItemFromTestFramework(package.PackageId, package.Version, frameworksToTest, GetRidsFromPackage(package)));

--- a/src/Microsoft.DotNet.PackageTesting/NupkgParser.cs
+++ b/src/Microsoft.DotNet.PackageTesting/NupkgParser.cs
@@ -54,7 +54,8 @@ namespace Microsoft.DotNet.PackageTesting
             else if (filePath.StartsWith("runtimes"))
             {
                 var stringParts = filePath.Split('/');
-                asset = new PackageAsset(NuGetFramework.Parse(stringParts[3]), stringParts[1], filePath, AssetType.RuntimeAsset);
+                NuGetFramework framework = stringParts.Length > 3 ? NuGetFramework.Parse(stringParts[3]) : null;
+                asset = new PackageAsset(framework, stringParts[1], filePath, AssetType.RuntimeAsset);
             }
 
             return asset;


### PR DESCRIPTION
We were missing cases where the RID-specific asset had a different framework than RID agnostic.  As a result we wouldn't test all TFMs that had different assets.

https://github.com/dotnet/runtime/blob/d40dc6eb1398f25d083a818436c54810917e2147/src/libraries/System.Speech/src/System.Speech.csproj#L4
https://github.com/dotnet/runtime/blob/d40dc6eb1398f25d083a818436c54810917e2147/src/libraries/System.Diagnostics.EventLog/src/System.Diagnostics.EventLog.csproj#L4