### PR TITLE
enable cg2 by default in sharedfx

### DIFF
--- a/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -3,6 +3,8 @@
     <PackageLicenseFile Condition="'$(PackageLicenseExpression)' == ''">$([System.IO.Path]::GetFileName('$(LicenseFile)'))</PackageLicenseFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <PublishReadyToRun Condition="'$(PublishReadyToRun)' == '' and '$(PlatformPackageType)' == 'RuntimePack' and '$(Configuration)' == 'Release'">true</PublishReadyToRun>
+    <!-- For .NET 6 and higher, default to using Crossgen2 in non-composite mode if PublishReadyToRun == true -->
+    <PublishReadyToRunUseCrossgen2 Condition="'$(PublishReadyToRunUseCrossgen2)' == '' and '$(PublishReadyToRun)' == 'true' and '$(_TargetFrameworkVersionWithoutV)' >= '6.0'">true</PublishReadyToRunUseCrossgen2>
     <PublishReadyToRunEmitSymbols>true</PublishReadyToRunEmitSymbols>
     <PublishReadyToRunShowWarnings>true</PublishReadyToRunShowWarnings>
     <AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>$(AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder);.map;.dbg;.debug;.dwarf</AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>


### PR DESCRIPTION
Updating sharedfx.targets to use crossgen2 by default for ReadyToRun, similar change has been done within the [sdk ](https://github.com/davidwrighton/sdk/blob/94febe75edde0d224f1e5b3aa9260075b9e783cf/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets#L16)but that doesnt seem to take effect while building with sharedFx.targets. 

With active work to decomm crossgen1 need to get this propagated to all repos so we could resolve any outstanding issues. 

I have validated that WindowsDesktop repo does use crossgen2 if I manually update its sharedFx.targets with this change. 