### PR TITLE
Update known frameworks to test against

### DIFF
--- a/src/Microsoft.DotNet.PackageTesting.Tests/GetCompatibilePackageTargetFrameworksTests.cs
+++ b/src/Microsoft.DotNet.PackageTesting.Tests/GetCompatibilePackageTargetFrameworksTests.cs
@@ -17,21 +17,16 @@ namespace Microsoft.DotNet.PackageTesting.Tests
         public static IEnumerable<object[]> PackageTFMData => new List<object[]>
         {
             // single target framework in package
-            new object[] {  new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetStandard20}, new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetStandard20, FrameworkConstants.CommonFrameworks.NetCoreApp20, FrameworkConstants.CommonFrameworks.Net463, FrameworkConstants.CommonFrameworks.Net461, FrameworkConstants.CommonFrameworks.Net462} },
-            new object[] {  new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetCoreApp20}, new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetCoreApp20} },
-            new object[] {  new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetCoreApp21}, new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetCoreApp21} },
-            new object[] {  new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.Net461}, new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.Net461} },
-            new object[] {  new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.Net45}, new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.Net45} },
-            new object[] {  new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetCoreApp30}, new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetCoreApp30} },
-            new object[] {  new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetCoreApp31}, new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetCoreApp31} },
-            new object[] {  new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetStandard21}, new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetStandard21, FrameworkConstants.CommonFrameworks.NetCoreApp30 } },
-            new object[] {  new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetStandard12}, new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetStandard12, FrameworkConstants.CommonFrameworks.Net451 } },
+            new object[] {  new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetStandard20 }, new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetStandard20, FrameworkConstants.CommonFrameworks.NetCoreApp31, FrameworkConstants.CommonFrameworks.Net461, FrameworkConstants.CommonFrameworks.Net462 } },
+            new object[] {  new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.Net461 }, new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.Net461 } },
+            new object[] {  new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetCoreApp31 }, new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetCoreApp31 } },
+            new object[] {  new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetStandard21 }, new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetStandard21, FrameworkConstants.CommonFrameworks.NetCoreApp31 } },
 
             // two target frameworks in package
-            new object[] {  new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetStandard20, FrameworkConstants.CommonFrameworks.Net461}, new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetStandard20, FrameworkConstants.CommonFrameworks.NetCoreApp20, FrameworkConstants.CommonFrameworks.Net463, FrameworkConstants.CommonFrameworks.Net461, FrameworkConstants.CommonFrameworks.Net462} },
-            new object[] {  new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetStandard20, FrameworkConstants.CommonFrameworks.NetCoreApp30}, new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetStandard20, FrameworkConstants.CommonFrameworks.NetCoreApp30, FrameworkConstants.CommonFrameworks.NetCoreApp20, FrameworkConstants.CommonFrameworks.Net463, FrameworkConstants.CommonFrameworks.Net461, FrameworkConstants.CommonFrameworks.Net462} },
-            new object[] {  new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetCoreApp30, FrameworkConstants.CommonFrameworks.Net461}, new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetCoreApp30, FrameworkConstants.CommonFrameworks.Net461} },
-            new object[] {  new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetCoreApp30, FrameworkConstants.CommonFrameworks.Net50}, new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetCoreApp30, FrameworkConstants.CommonFrameworks.Net50} },
+            new object[] {  new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetStandard20, FrameworkConstants.CommonFrameworks.Net461 }, new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetStandard20, FrameworkConstants.CommonFrameworks.NetCoreApp31, FrameworkConstants.CommonFrameworks.Net461, FrameworkConstants.CommonFrameworks.Net462 } },
+            new object[] {  new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetStandard20, FrameworkConstants.CommonFrameworks.NetCoreApp31 }, new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetStandard20, FrameworkConstants.CommonFrameworks.NetCoreApp31, FrameworkConstants.CommonFrameworks.Net461, FrameworkConstants.CommonFrameworks.Net462 } },
+            new object[] {  new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetCoreApp31, FrameworkConstants.CommonFrameworks.Net461 }, new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetCoreApp31, FrameworkConstants.CommonFrameworks.Net461 } },
+            new object[] {  new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetCoreApp31, FrameworkConstants.CommonFrameworks.Net50 }, new List<NuGetFramework> { FrameworkConstants.CommonFrameworks.NetCoreApp31, FrameworkConstants.CommonFrameworks.Net50 } },
         };
 
         [Theory]

--- a/src/Microsoft.DotNet.PackageTesting/GetCompatiblePackageTargetFrameworks.cs
+++ b/src/Microsoft.DotNet.PackageTesting/GetCompatiblePackageTargetFrameworks.cs
@@ -72,29 +72,13 @@ namespace Microsoft.DotNet.PackageTesting
         public static void Initialize()
         {
             // Defining the set of known frameworks that we care to test
-            allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.NetCoreApp20);
-            allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.NetCoreApp21);
-            allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.NetCoreApp30);
             allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.NetCoreApp31);
             allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.Net50);
-            allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.Net45);
-            allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.Net451);
-            allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.Net452);
-            allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.Net46);
+            allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.Net60);
             allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.Net461);
             allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.Net462);
-            allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.Net463);
-            allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.NetStandard10);
-            allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.NetStandard11);
-            allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.NetStandard12);
-            allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.NetStandard13);
-            allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.NetStandard14);
-            allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.NetStandard15);
-            allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.NetStandard16);
-            allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.NetStandard17);
             allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.NetStandard20);
             allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.NetStandard21);
-            allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.UAP10);
 
             // creating a map framework in package => frameworks to test based on default compatibilty mapping.
             foreach (var item in DefaultFrameworkMappings.Instance.CompatibilityMappings)

--- a/src/Microsoft.DotNet.PackageTesting/GetCompatiblePackageTargetFrameworks.cs
+++ b/src/Microsoft.DotNet.PackageTesting/GetCompatiblePackageTargetFrameworks.cs
@@ -74,7 +74,6 @@ namespace Microsoft.DotNet.PackageTesting
             // Defining the set of known frameworks that we care to test
             allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.NetCoreApp31);
             allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.Net50);
-            allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.Net60);
             allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.Net461);
             allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.Net462);
             allTargetFrameworks.Add(FrameworkConstants.CommonFrameworks.NetStandard20);


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation

Removing net463 and net46 as these newer shipped a targeting pack and these tfms are already disabled in dotnet/runtime's package validation.

Removing tfms that aren't supported in dotnet/runtime anymore.