### PR TITLE
Normalize RepoRoot to include trailing slash

### DIFF
--- a/eng/common/dotnet-install.sh
+++ b/eng/common/dotnet-install.sh
@@ -70,7 +70,7 @@ case $cpuname in
     ;;
 esac
 
-dotnetRoot="$repo_root/.dotnet"
+dotnetRoot="${repo_root}.dotnet"
 if [[ $architecture != "" ]] && [[ $architecture != $buildarch ]]; then
   dotnetRoot="$dotnetRoot/$architecture"
 fi

--- a/eng/common/internal-feed-operations.ps1
+++ b/eng/common/internal-feed-operations.ps1
@@ -45,11 +45,11 @@ function SetupCredProvider {
   # Then, we set the 'VSS_NUGET_EXTERNAL_FEED_ENDPOINTS' environment variable to restore from the stable 
   # feeds successfully
 
-  $nugetConfigPath = "$RepoRoot\NuGet.config"
+  $nugetConfigPath = Join-Path "RepoRoot "NuGet.config"
 
   if (-Not (Test-Path -Path $nugetConfigPath)) {
     Write-PipelineTelemetryError -Category 'Build' -Message 'NuGet.config file not found in repo root!'
-    ExitWithExitCode 1  
+    ExitWithExitCode 1
   }
   
   $endpoints = New-Object System.Collections.ArrayList
@@ -85,7 +85,7 @@ function SetupCredProvider {
 
 #Workaround for https://github.com/microsoft/msbuild/issues/4430
 function InstallDotNetSdkAndRestoreArcade {
-  $dotnetTempDir = "$RepoRoot\dotnet"
+  $dotnetTempDir = Join-Path $RepoRoot "dotnet"
   $dotnetSdkVersion="2.1.507" # After experimentation we know this version works when restoring the SDK (compared to 3.0.*)
   $dotnet = "$dotnetTempDir\dotnet.exe"
   $restoreProjPath = "$PSScriptRoot\restore.proj"

--- a/eng/common/internal-feed-operations.ps1
+++ b/eng/common/internal-feed-operations.ps1
@@ -45,7 +45,7 @@ function SetupCredProvider {
   # Then, we set the 'VSS_NUGET_EXTERNAL_FEED_ENDPOINTS' environment variable to restore from the stable 
   # feeds successfully
 
-  $nugetConfigPath = Join-Path "RepoRoot "NuGet.config"
+  $nugetConfigPath = Join-Path $RepoRoot "NuGet.config"
 
   if (-Not (Test-Path -Path $nugetConfigPath)) {
     Write-PipelineTelemetryError -Category 'Build' -Message 'NuGet.config file not found in repo root!'

--- a/eng/common/internal-feed-operations.sh
+++ b/eng/common/internal-feed-operations.sh
@@ -39,7 +39,7 @@ function SetupCredProvider {
   # Then, we set the 'VSS_NUGET_EXTERNAL_FEED_ENDPOINTS' environment variable to restore from the stable 
   # feeds successfully
 
-  local nugetConfigPath="$repo_root/NuGet.config"
+  local nugetConfigPath="{$repo_root}NuGet.config"
 
   if [ ! "$nugetConfigPath" ]; then
     Write-PipelineTelemetryError -category 'Build' "NuGet.config file not found in repo's root!"

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -702,8 +702,11 @@ function MSBuild-Core() {
   }
 
   foreach ($arg in $args) {
-    if ($arg -ne $null -and $arg.Trim() -ne "") {
-      $cmdArgs += " `"`"$arg`"`""
+    if ($null -ne $arg -and $arg.Trim() -ne "") {
+      if ($arg.EndsWith('\')) {
+        $arg = $arg + "\"
+      }
+      $cmdArgs += " `"$arg`""
     }
   }
 

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -774,7 +774,7 @@ function Get-Darc($version) {
 
 . $PSScriptRoot\pipeline-logging-functions.ps1
 
-$RepoRoot = Resolve-Path (Join-Path $PSScriptRoot '..\..')
+$RepoRoot = Resolve-Path (Join-Path $PSScriptRoot '..\..\')
 $EngRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
 $ArtifactsDir = Join-Path $RepoRoot 'artifacts'
 $ToolsetDir = Join-Path $ArtifactsDir 'toolset'

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -703,7 +703,7 @@ function MSBuild-Core() {
 
   foreach ($arg in $args) {
     if ($arg -ne $null -and $arg.Trim() -ne "") {
-      $cmdArgs += " `"$arg`""
+      $cmdArgs += " `"`"$arg`"`""
     }
   }
 

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -484,7 +484,8 @@ _script_dir=`dirname "$_ResolvePath"`
 . "$_script_dir/pipeline-logging-functions.sh"
 
 eng_root=`cd -P "$_script_dir/.." && pwd`
-repo_root=`cd -P "$_script_dir/../../" && pwd`
+repo_root=`cd -P "$_script_dir/../.." && pwd`
+repo_root="{repo_root}/"
 artifacts_dir="${repo_root}artifacts"
 toolset_dir="$artifacts_dir/toolset"
 tools_dir="${repo_root}.tools"

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -485,7 +485,7 @@ _script_dir=`dirname "$_ResolvePath"`
 
 eng_root=`cd -P "$_script_dir/.." && pwd`
 repo_root=`cd -P "$_script_dir/../.." && pwd`
-repo_root="{repo_root}/"
+repo_root="${repo_root}/"
 artifacts_dir="${repo_root}artifacts"
 toolset_dir="$artifacts_dir/toolset"
 tools_dir="${repo_root}.tools"

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -484,14 +484,14 @@ _script_dir=`dirname "$_ResolvePath"`
 . "$_script_dir/pipeline-logging-functions.sh"
 
 eng_root=`cd -P "$_script_dir/.." && pwd`
-repo_root=`cd -P "$_script_dir/../.." && pwd`
-artifacts_dir="$repo_root/artifacts"
+repo_root=`cd -P "$_script_dir/../../" && pwd`
+artifacts_dir="${repo_root}artifacts"
 toolset_dir="$artifacts_dir/toolset"
-tools_dir="$repo_root/.tools"
+tools_dir="${repo_root}.tools"
 log_dir="$artifacts_dir/log/$configuration"
 temp_dir="$artifacts_dir/tmp/$configuration"
 
-global_json_file="$repo_root/global.json"
+global_json_file="${repo_root}global.json"
 # determine if global.json contains a "runtimes" entry
 global_json_has_runtimes=false
 if command -v jq &> /dev/null; then
@@ -504,7 +504,7 @@ fi
 
 # HOME may not be defined in some scenarios, but it is required by NuGet
 if [[ -z $HOME ]]; then
-  export HOME="$repo_root/artifacts/.home/"
+  export HOME="${repo_root}artifacts/.home/"
   mkdir -p "$HOME"
 fi
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -1,5 +1,5 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
-<Project DefaultTargets="Execute" TreatAsLocalProperty="RepoRoot">
+<Project DefaultTargets="Execute">
   <!--
 
   Required parameters:
@@ -33,9 +33,6 @@
   -->
 
   <PropertyGroup>
-    <_RepoRootOriginal>$(RepoRoot)</_RepoRootOriginal>
-    <RepoRoot>$([System.IO.Path]::GetFullPath('$(RepoRoot)/'))</RepoRoot>
-
     <_OriginalProjectsValue>$(Projects)</_OriginalProjectsValue>
   </PropertyGroup>
 
@@ -80,8 +77,8 @@
 
   <Target Name="Execute">
     <Error Text="No projects were found to build. Either the 'Projects' property or 'ProjectToBuild' item group must be specified." Condition="'@(ProjectToBuild)' == ''"/>
-    <Error Text="Property 'RepoRoot' must be specified" Condition="'$(_RepoRootOriginal)' == ''"/>
-    <Error Text="File 'global.json' must exist in directory specified by RepoRoot: '$(_RepoRootOriginal)'" Condition="'$(_RepoRootOriginal)' != '' and !Exists('$(RepoRoot)global.json')"/>
+    <Error Text="Property 'RepoRoot' must be specified" Condition="'$(RepoRoot)' == ''"/>
+    <Error Text="File 'global.json' must exist in directory specified by RepoRoot: '$(RepoRoot)'" Condition="'$(RepoRoot)' != '' and !Exists('$(RepoRoot)global.json')"/>
 
     <PropertyGroup>
       <!-- 'IsRunningFromVisualStudio' may be true even when running msbuild.exe from command line. This generally means that MSBuild is from a Visual Studio installation and therefore we need to find NuGet.targets in a different location. -->


### PR DESCRIPTION
The Arcade SDK defines the RepoRoot repository [with a trailing slash](https://github.com/dotnet/arcade/blob/e81d8c9bdc1de22623657afb23fab210dd04ca82/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props#L23) but the build scripts (build.ps1 and build.sh) pass in the property without a trailing slash which makes the use of it inconsistent and led to this source build patch: https://github.com/dotnet/runtime/blob/23e4735e5cc9956d3f3b351a252f0b1622a14cec/eng/source-build-patches/0004-Add-trailing-path-separator-to-repo_root.patch.

Normalizing the variable in the build scripts so that the property always contains the trailing slash.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
