### PR TITLE
Fix sdk-task invocation by not escaping manually

### DIFF
--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -34,7 +34,7 @@ function Print-Usage() {
 function Build([string]$target) {
   $logSuffix = if ($target -eq 'Execute') { '' } else { ".$target" }
   $log = Join-Path $LogDir "$task$logSuffix.binlog"
-  $outputPath = Join-Path $ToolsetDir "$task\\"
+  $outputPath = Join-Path $ToolsetDir "$task\"
 
   MSBuild $taskProject `
     /bl:$log `


### PR DESCRIPTION
Fixes broken official builds and avoid the revert in https://github.com/dotnet/arcade/pull/7507.

Msbuild-task escaped the output path manually which conflicts with the escaping mechanism that I added to tools.ps1 in https://github.com/dotnet/arcade/commit/a4191734058802ac065b0f3270b76d2f0f3a60cd.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
