### PR TITLE
Normalize Uris when writing manifests

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/BuildModelFactoryTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/BuildModelFactoryTests.cs
@@ -23,13 +23,16 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
         #region Standard test values
 
         private const string _testAzdoRepoUri = "https://dnceng@dev.azure.com/dnceng/internal/_git/dotnet-buildtest";
+        private const string _normalizedTestAzdoRepoUri = "https://dev.azure.com/dnceng/internal/_git/dotnet-buildtest";
         private const string _testBuildBranch = "foobranch";
         private const string _testBuildCommit = "664996a16fa9228cfd7a55d767deb31f62a65f51";
         private const string _testAzdoBuildId = "89999999";
-        private const string _testInitialLocation = "As they say....Location Location Location!";
+        private const string _testInitialLocation = "https://dnceng.visualstudio.com/project/_apis/build/builds/id/artifacts";
+        private const string _normalizedTestInitialLocation = "https://dev.azure.com/dnceng/project/_apis/build/builds/id/artifacts";
         private static readonly string[] _defaultManifestBuildData = new string[]
         {
-            $"InitialAssetsLocation={_testInitialLocation}"
+            $"InitialAssetsLocation={_testInitialLocation}",
+            $"AzureDevOpsRepository={_testAzdoRepoUri}"
         };
 
         #endregion
@@ -165,6 +168,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                     package.Attributes.Should().Contain("Id", "test-package-a");
                     package.Attributes.Should().Contain("Version", "1.0.0");
                 });
+
+            model.Identity.Attributes.Should().Contain("AzureDevOpsRepository", _normalizedTestAzdoRepoUri);
         }
 
         /// <summary>
@@ -290,7 +295,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
             _taskLoggingHelper.HasLoggedErrors.Should().BeFalse();
 
             // Check that the build model has the initial assets location
-            model.Identity.Attributes.Should().Contain(attributeName, _testInitialLocation);
+            model.Identity.Attributes.Should().Contain(attributeName, _normalizedTestInitialLocation);
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildModelFactory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildModelFactory.cs
@@ -8,6 +8,7 @@ using Microsoft.DotNet.VersionTools.BuildManifest.Model;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
 
@@ -253,14 +254,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         private void NormalizeUrisInBuildData(IDictionary<string, string> attributes)
         {
-            if (attributes.ContainsKey("AzureDevOpsRepository"))
+            foreach(var attribute in attributes.ToList())
             {
-                attributes["AzureDevOpsRepository"] = NormalizeUrl(attributes["AzureDevOpsRepository"]);
-            }
-
-            if (attributes.ContainsKey("InitialAssetsLocation"))
-            {
-                attributes["InitialAssetsLocation"] = NormalizeUrl(attributes["InitialAssetsLocation"]);
+                attributes[attribute.Key] = NormalizeUrl(attribute.Value);
             }
         }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildModelFactory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildModelFactory.cs
@@ -8,6 +8,7 @@ using Microsoft.DotNet.VersionTools.BuildManifest.Model;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks.Feed
@@ -70,6 +71,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         }
 
         private const string AssetsVirtualDir = "assets/";
+
+        private static readonly string AzureDevOpsHostPattern = @"dev\.azure\.com\";
+
+        private readonly Regex LegacyRepositoryUriPattern = new Regex(
+            @"^https://(?<account>[a-zA-Z0-9]+)\.visualstudio\.com/.*");
 
         /// <summary>
         /// Create a build manifest for packages, blobs, and associated signing information
@@ -204,6 +210,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             {
                 _log.LogError("Missing 'location' property from ManifestBuildData");
             }
+
+            NormalizeUrisInBuildData(attributes);
+
             BuildModel buildModel = new BuildModel(
                     new BuildIdentity
                     {
@@ -240,6 +249,49 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         private bool ManifestBuildDataHasLocationInformation(IDictionary<string, string> attributes)
         {
             return attributes.ContainsKey("Location") || attributes.ContainsKey("InitialAssetsLocation");
+        }
+
+        private void NormalizeUrisInBuildData(IDictionary<string, string> attributes)
+        {
+            if (attributes.ContainsKey("AzureDevOpsRepository"))
+            {
+                attributes["AzureDevOpsRepository"] = NormalizeUrl(attributes["AzureDevOpsRepository"]);
+            }
+
+            if (attributes.ContainsKey("InitialAssetsLocation"))
+            {
+                attributes["InitialAssetsLocation"] = NormalizeUrl(attributes["InitialAssetsLocation"]);
+            }
+        }
+
+        /// <summary>
+        // If repoUri includes the user in the account we remove it from URIs like
+        // https://dnceng@dev.azure.com/dnceng/internal/_git/repo
+        // If the URL host is of the form "dnceng.visualstudio.com" like
+        // https://dnceng.visualstudio.com/internal/_git/repo we replace it to "dev.azure.com/dnceng"
+        // for consistency
+        /// </summary>
+        /// <param name="url">The original url</param>
+        /// <returns>Transformed url</returns>
+        private string NormalizeUrl(string repoUri)
+        {
+            if (Uri.TryCreate(repoUri, UriKind.Absolute, out Uri parsedUri))
+            {
+                if (!string.IsNullOrEmpty(parsedUri.UserInfo))
+                {
+                    repoUri = repoUri.Replace($"{parsedUri.UserInfo}@", string.Empty);
+                }
+
+                Match m = LegacyRepositoryUriPattern.Match(repoUri);
+
+                if (m.Success)
+                {
+                    string replacementUri = $"{Regex.Unescape(AzureDevOpsHostPattern)}/{m.Groups["account"].Value}";
+                    repoUri = repoUri.Replace(parsedUri.Host, replacementUri);
+                }
+            }
+
+            return repoUri;
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildModelFactory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildModelFactory.cs
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         private static readonly string AzureDevOpsHostPattern = @"dev\.azure\.com\";
 
         private readonly Regex LegacyRepositoryUriPattern = new Regex(
-            @"^https://(?<account>[a-zA-Z0-9]+)\.visualstudio\.com/.*");
+            @"^https://(?<account>[a-zA-Z0-9]+)\.visualstudio\.com/");
 
         /// <summary>
         /// Create a build manifest for packages, blobs, and associated signing information

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildModelFactory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildModelFactory.cs
@@ -271,7 +271,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         // https://dnceng.visualstudio.com/internal/_git/repo we replace it to "dev.azure.com/dnceng"
         // for consistency
         /// </summary>
-        /// <param name="url">The original url</param>
+        /// <param name="repoUri">The original url</param>
         /// <returns>Transformed url</returns>
         private string NormalizeUrl(string repoUri)
         {

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildModelFactory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildModelFactory.cs
@@ -256,7 +256,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         {
             foreach(var attribute in attributes.ToList())
             {
-                attributes[attribute.Key] = NormalizeUrl(attribute.Value);
+                attributes[attribute.Key] = NormalizeAzureDevOpsUrl(attribute.Value);
             }
         }
 
@@ -269,7 +269,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         /// </summary>
         /// <param name="repoUri">The original url</param>
         /// <returns>Transformed url</returns>
-        private string NormalizeUrl(string repoUri)
+        private string NormalizeAzureDevOpsUrl(string repoUri)
         {
             if (Uri.TryCreate(repoUri, UriKind.Absolute, out Uri parsedUri))
             {


### PR DESCRIPTION
For each manifest, we should normalize the Azure DevOps uris, so that differences between machine state do not affect merging the manifests down the line. We will normalize the AzureDevOpsRepository and the InitialAssetsLocations, if found in the attributes.

Fixes https://github.com/dotnet/arcade/issues/7493. 

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
