### PR TITLE
Workloads: Tooling changes to MSI and SWIX generation

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/GenerateVisualStudioWorkloadTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/GenerateVisualStudioWorkloadTests.cs
@@ -117,7 +117,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
         }
 
         [Fact]
-        public void ItSkipsAbstractManifests()
+        public void ItIncludesAbstractManifests()
         {
             var buildTask = new GenerateVisualStudioWorkload()
             {
@@ -132,11 +132,14 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             };
 
             Assert.True(buildTask.Execute());
-            string outputPath = Path.GetDirectoryName(buildTask.SwixProjects[0].GetMetadata("FullPath"));
-            string componentSwr = File.ReadAllText(Path.Combine(outputPath, "component.swr"));
-            Assert.Single(buildTask.SwixProjects);
+            string blazorOutputPath = Path.GetDirectoryName(buildTask.SwixProjects[0].GetMetadata("FullPath"));
+            string blazorComponentSwr = File.ReadAllText(Path.Combine(blazorOutputPath, "component.swr"));
             Assert.Contains(@"package name=microsoft.net.sdk.blazorwebassembly.aot
-        version=6.0.0.0", componentSwr);
+        version=6.0.0.0", blazorComponentSwr);
+            string androidOutputPath = Path.GetDirectoryName(buildTask.SwixProjects[1].GetMetadata("FullPath"));
+            string androidComponentSwr = File.ReadAllText(Path.Combine(androidOutputPath, "component.swr"));
+            Assert.Contains(@"package name=microsoft.net.runtime.android
+        version=6.0.0.0", androidComponentSwr);
         }
 
         [Fact]

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/VisualStudioDependencyTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/VisualStudioDependencyTests.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
+{
+    public class VisualStudioDependencyTests
+    {
+        [Theory]
+        [InlineData("1.0.0", null, "[1.0.0,)")]
+        [InlineData("1.0.0", "2.0.0", "[1.0.0,2.0.0)")]
+        [InlineData("1.0.0", "1.0.0", "[1.0.0]")]
+        public void ItGeneratesVersionRanges(string minVersion, string maxVersion, string expectedVersionRange)
+        {
+            Version v1 = string.IsNullOrWhiteSpace(minVersion) ? null : new Version(minVersion);
+            Version v2 = string.IsNullOrWhiteSpace(maxVersion) ? null : new Version(maxVersion);
+
+            VisualStudioDependency dep = new VisualStudioDependency("foo", v1, v2);
+
+            Assert.Equal(expectedVersionRange, dep.GetVersion());
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
@@ -236,6 +236,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                 MsiProperties msiProps = new MsiProperties
                 {
                     InstallSize = MsiUtils.GetInstallSize(msiPath),
+                    Payload = Path.GetFileName(msiPath),
                     ProductCode = MsiUtils.GetProperty(msiPath, "ProductCode"),
                     ProductVersion = MsiUtils.GetProperty(msiPath, "ProductVersion"),
                     ProviderKeyName = $"{nupkg.Id},{nupkg.Version},{platform}",
@@ -330,7 +331,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
 
             writer.WriteStartElement("ItemGroup");
             WriteItem(writer, "None", msiPath, @"\data");
-            WriteItem(writer, "None", msiJsonPath, @"\data");
+            WriteItem(writer, "None", msiJsonPath, @"\data\msi.json");
             WriteItem(writer, "None", licenseTextPath, @"\");
             writer.WriteEndElement();
 

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateVisualStudioWorkload.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateVisualStudioWorkload.cs
@@ -222,14 +222,6 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
 
             foreach (WorkloadDefinition workloadDefinition in manifest.Workloads.Values)
             {
-                // Abstract workloads can only be extended, so we can't generate items for this yet. Might need to do a second pass
-                // if there are other manifests that extend the workload.
-                if (workloadDefinition.IsAbstract)
-                {
-                    Log?.LogMessage(MessageImportance.High, $"{workloadDefinition.Id} is abstract and will be skipped.");
-                    continue;
-                }
-
                 if ((workloadDefinition.Platforms?.Count > 0) && (!workloadDefinition.Platforms.Any(p => p.StartsWith("win"))))
                 {
                     Log?.LogMessage(MessageImportance.High, $"{workloadDefinition.Id} platforms does not support Windows and will be skipped ({string.Join(", ", workloadDefinition.Platforms)}).");

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiProperties.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiProperties.cs
@@ -17,6 +17,12 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             set;
         }
 
+        public string Payload
+        {
+            get;
+            set;
+        }
+
         public string ProductCode
         {
             get;

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/SwixTemplate/component.swixproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/SwixTemplate/component.swixproj
@@ -5,13 +5,10 @@
     <OutputLocalized>false</OutputLocalized>
     <OutputType>manifest</OutputType>
     <OutputPath>$(ManifestOutputPath)</OutputPath>
-    
-    <!-- Default to no, making this a component group. -->
-    <IsUIGroup Condition="'$(IsUIGroup)'==''">no</IsUIGroup>
   </PropertyGroup>
 
   <PropertyGroup>
-    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);IsUIGroup=$(IsUIGroup)</PackagePreprocessorDefinitions>
+    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions)</PackagePreprocessorDefinitions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/SwixTemplate/component.swr
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/SwixTemplate/component.swr
@@ -5,6 +5,6 @@ package name=__VS_PACKAGE_NAME__
         vs.package.type=component
 
 vs.properties
-  isUiGroup=$(IsUIGroup)
+  isUiGroup=__VS_IS_UI_GROUP__
 
 vs.dependencies

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/VisualStudioDependency.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/VisualStudioDependency.cs
@@ -18,18 +18,53 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             get;            
         }
 
-        /// <summary>
-        /// The version of the dependent.
-        /// </summary>
-        public Version Version
+        public Version MinVersion
         {
             get;
         }
 
-        public VisualStudioDependency(string id, Version version)
+        public Version MaxVersion
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Creates a dependency with an exact version.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="version"></param>
+        public VisualStudioDependency(string id, Version version) : this(id, version, version)
+        {
+
+        }
+        
+        /// <summary>
+        /// Creates a dependency with a minimum and maximum versions.
+        /// </summary>
+        /// <param name="id">The Visual Studio package ID. The ID applies to packages, components, component groups, etc.</param>
+        /// <param name="minVersion">The minimum required version, inclusive.</param>
+        /// <param name="maxVersion">The maximum version, exclusive. May be <see langword="null"/> if there is only a minimum requirement. If
+        /// equal to <paramref name="minVersion"/>, an exact version requirement is created, e.g. [1.2.0].</param>
+        public VisualStudioDependency(string id, Version minVersion, Version maxVersion)
         {
             Id = id;
-            Version = version;
+            MinVersion = minVersion;
+            MaxVersion = maxVersion;
+        }
+
+        public string GetVersion()
+        {
+            if ((MaxVersion != null) && (MinVersion == MaxVersion))
+            {
+                return $"[{MinVersion}]";
+            }
+
+            if (MaxVersion == null)
+            {
+                return $"[{MinVersion},)";
+            }
+
+            return $"[{MinVersion},{MaxVersion})";
         }
     }
 }


### PR DESCRIPTION
- Add the generated MSI name to the JSON manifest for workload pack payload packages. This is required to ensure CLI caching understands potential name shortening to address VS caching issues with long paths.
- Generate ComponentGroups for abstract workloads
- Change SWIX dependency versions to be minimum only, with no upper bound, e.g. [4.0,)
