### PR TITLE
Reenable physical android testing for XHarness SDK

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -130,20 +130,20 @@ stages:
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''
-        - powershell: eng\common\build.ps1
-            -configuration $(_BuildConfig) 
-            -prepareMachine
-            -ci
-            -restore
-            -test
-            -projects $(Build.SourcesDirectory)\tests\UnitTests.XHarness.Android.WindowsQueues.proj
-            /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.XHarness.Android.WindowsQueues.binlog
-            /p:RestoreUsingNuGetTargets=false
-            /p:XharnessTestARM64_V8A=true
-          displayName: XHarness Android Helix Testing (Windows)
-          env:
-            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-            HelixAccessToken: ''
+          - powershell: eng\common\build.ps1
+              -configuration $(_BuildConfig) 
+              -prepareMachine
+              -ci
+              -restore
+              -test
+              -projects $(Build.SourcesDirectory)\tests\UnitTests.XHarness.Android.WindowsQueues.proj
+              /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.XHarness.Android.WindowsQueues.binlog
+              /p:RestoreUsingNuGetTargets=false
+              /p:XharnessTestARM64_V8A=true
+            displayName: XHarness Android Helix Testing (Windows)
+            env:
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+              HelixAccessToken: ''
         - job: Linux
           timeoutInMinutes: 90
           container: LinuxContainer

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -130,22 +130,20 @@ stages:
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''
-        # We don't have enough hardware to run these tests on Arcade PR given the Arcade XHarness SDK changes infrequently. (https://github.com/dotnet/core-eng/issues/12238)
-        # Until the above issue is resolved, if you are editing the Xharness SDK's Windows side, please exercise this manually.  Contact dnceng for assistance.
-        # - powershell: eng\common\build.ps1
-        #     -configuration $(_BuildConfig) 
-        #     -prepareMachine
-        #     -ci
-        #     -restore
-        #     -test
-        #     -projects $(Build.SourcesDirectory)\tests\UnitTests.XHarness.Android.WindowsQueues.proj
-        #     /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.XHarness.Android.WindowsQueues.binlog
-        #     /p:RestoreUsingNuGetTargets=false
-        #     /p:XharnessTestARM64_V8A=true
-        #   displayName: XHarness Android Helix Testing (Windows)
-        #   env:
-        #     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-        #     HelixAccessToken: ''
+        - powershell: eng\common\build.ps1
+            -configuration $(_BuildConfig) 
+            -prepareMachine
+            -ci
+            -restore
+            -test
+            -projects $(Build.SourcesDirectory)\tests\UnitTests.XHarness.Android.WindowsQueues.proj
+            /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.XHarness.Android.WindowsQueues.binlog
+            /p:RestoreUsingNuGetTargets=false
+            /p:XharnessTestARM64_V8A=true
+          displayName: XHarness Android Helix Testing (Windows)
+          env:
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+            HelixAccessToken: ''
         - job: Linux
           timeoutInMinutes: 90
           container: LinuxContainer


### PR DESCRIPTION
https://github.com/dotnet/core-eng/issues/12238 - we should have sufficient capacity to have these tests back.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation (this change is reenabling tests)
