### PR TITLE
Add option to prefer 64bit `msbuild`

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -211,12 +211,12 @@ function InstallDotNetSdk([string] $dotnetRoot, [string] $version, [string] $arc
   InstallDotNet -dotnetRoot $dotnetRoot -version $version -architecture $architecture -skipNonVersionedFiles $false -runtimeSourceFeed $runtimeSourceFeed -runtimeSourceFeedKey $runtimeSourceFeedKey
 }
 
-function InstallDotNet([string] $dotnetRoot, 
-  [string] $version, 
-  [string] $architecture = "", 
-  [string] $runtime = "", 
-  [bool] $skipNonVersionedFiles = $false, 
-  [string] $runtimeSourceFeed = "", 
+function InstallDotNet([string] $dotnetRoot,
+  [string] $version,
+  [string] $architecture = "",
+  [string] $runtime = "",
+  [bool] $skipNonVersionedFiles = $false,
+  [string] $runtimeSourceFeed = "",
   [string] $runtimeSourceFeedKey = "") {
 
   $installScript = GetDotNetInstallScript $dotnetRoot
@@ -323,7 +323,16 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
   }
 
   $msbuildVersionDir = if ([int]$vsMajorVersion -lt 16) { "$vsMajorVersion.0" } else { "Current" }
-  return $global:_MSBuildExe = Join-Path $vsInstallDir "MSBuild\$msbuildVersionDir\Bin\msbuild.exe"
+
+  $local:BinFolder = Join-Path $vsInstallDir "MSBuild\$msbuildVersionDir\Bin"
+  $local:Prefer64bit = if ($vsRequirements.Prefer64bit) { $vsRequirements.Prefer64bit } else { $false }
+  if ($local:Prefer64bit -and (Test-Path(Join-Path $local:BinFolder "amd64"))) {
+    $global:_MSBuildExe = Join-Path $local:BinFolder "amd64\msbuild.exe"
+  } else {
+    $global:_MSBuildExe = Join-Path $local:BinFolder "msbuild.exe"
+  }
+
+  return $global:_MSBuildExe
 }
 
 function InitializeVisualStudioEnvironmentVariables([string] $vsInstallDir, [string] $vsMajorVersion) {
@@ -523,7 +532,7 @@ function InitializeNativeTools() {
   }
 }
 
-function InitializeToolset([string] $runtimeSourceFeed, [string] $runtimeSourceFeedKey) 
+function InitializeToolset([string] $runtimeSourceFeed, [string] $runtimeSourceFeedKey)
 {
   if (Test-Path variable:global:_ToolsetBuildProj) {
     return $global:_ToolsetBuildProj


### PR DESCRIPTION
### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation

I'm trying this out in dotnet/aspnetcore#33497. Starting this in parallel so I don't forget between now and dotnet/aspnetcore's next Arcade update for 3.1.x.

See also conversation in that PR about _why_ this is worth having as an option.