### PR TITLE
Fix template, library pack generation

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsi.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsi.cs
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                 // For a single MSI we always generate all platforms and simply use the ID of the source package for
                 // the SWIX projects.
                 List<ITaskItem> msis = new();
-                msis.AddRange(Generate(SourcePackage, null, OutputPath, GetInstallDir(kind), platforms));
+                msis.AddRange(Generate(SourcePackage, null, OutputPath, kind, platforms));
                 Msis = msis.ToArray();
             }
             catch (Exception e)

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
@@ -116,7 +116,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
         /// <param name="sourcePackage">The NuGet package to convert into an MSI.</param>
         /// <param name="outputPath">The output path of the generated MSI.</param>
         /// <param name="platforms"></param>
-        protected IEnumerable<ITaskItem> Generate(string sourcePackage, string swixPackageId, string outputPath, string installDir, params string[] platforms)
+        protected IEnumerable<ITaskItem> Generate(string sourcePackage, string swixPackageId, string outputPath, WorkloadPackKind kind, params string[] platforms)
         {
             NugetPackage nupkg = new(sourcePackage, Log);
             List<TaskItem> msis = new();
@@ -133,8 +133,28 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             // Extract once, but harvest multiple times because some generated attributes are platform dependent. 
             string packageContentsDirectory = Path.Combine(PackageDirectory, $"{nupkg.Identity}");
             IEnumerable<string> exclusions = GetExlusionPatterns();
-            Log.LogMessage(MessageImportance.Low, $"Extracting '{sourcePackage}' to '{packageContentsDirectory}'");
-            nupkg.Extract(packageContentsDirectory, exclusions);
+            string installDir = GetInstallDir(kind);
+
+            if ((kind != WorkloadPackKind.Library) && (kind != WorkloadPackKind.Template))
+            {
+                Log.LogMessage(MessageImportance.Low, $"Extracting '{sourcePackage}' to '{packageContentsDirectory}'");
+                nupkg.Extract(packageContentsDirectory, exclusions);
+            }
+            else
+            {
+                // Library and template packs are not extracted. We want to harvest the nupkg itself,
+                // instead of the contents. The package is still copied to a separate folder for harvesting
+                // to avoid accidentally pulling in additional files and directories.
+                Log.LogMessage(MessageImportance.Low, $"Copying '{sourcePackage}' to '{packageContentsDirectory}'");
+
+                if (Directory.Exists(packageContentsDirectory))
+                {
+                    Directory.Delete(packageContentsDirectory, recursive: true);
+                }
+                Directory.CreateDirectory(packageContentsDirectory);
+
+                File.Copy(sourcePackage, Path.Combine(packageContentsDirectory, Path.GetFileName(sourcePackage)));
+            }
 
             foreach (string platform in platforms)
             {
@@ -407,7 +427,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             {
                 WorkloadPackKind.Framework or WorkloadPackKind.Sdk => "packs",
                 WorkloadPackKind.Library => "library-packs",
-                WorkloadPackKind.Template => "templates",
+                WorkloadPackKind.Template => "template-packs",
                 WorkloadPackKind.Tool => "tool-packs",
                 _ => throw new ArgumentException($"Unknown package kind: {kind}"),
             };

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateWorkloadMsis.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateWorkloadMsis.cs
@@ -89,7 +89,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
 
                         // Always select the pack ID for the VS MSI package, even when aliased.
                         msis.AddRange(Generate(sourcePackage, swixPackageId,
-                            OutputPath, GetInstallDir(pack.Kind), platforms));
+                            OutputPath, pack.Kind, platforms));
                     }
                 }
 
@@ -111,12 +111,10 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             IEnumerable<WorkloadManifest> manifests = WorkloadManifests.Select(
                 w => WorkloadManifestReader.ReadWorkloadManifest(Path.GetFileNameWithoutExtension(w.ItemSpec), File.OpenRead(w.ItemSpec)));
 
-            // We want all workloads in all manifests iff
-            //   1. The workload isn't abstract
-            //   2. The workload has no platform or at least one platform includes Windows
+            // We want all workloads in all manifests iff the workload has no platform or at least one
+            // platform includes Windows
             var workloads = manifests.SelectMany(m => m.Workloads).
                 Select(w => w.Value).
-                Where(wd => !wd.IsAbstract).
                 Where(wd => (wd.Platforms == null) || wd.Platforms.Any(p => p.StartsWith("win")));
 
             var packIds = workloads.SelectMany(w => w.Packs).Distinct();


### PR DESCRIPTION
- Library and Template packs should consume/install the nupkg itself, instead of contents.
- Fix the template packs install directory
