### PR TITLE
Correctly determine VS16 by setting lower boundary in vswhere

### DIFF
--- a/src/Microsoft.DotNet.CMake.Sdk/build/Microsoft.DotNet.CMake.Sdk.targets
+++ b/src/Microsoft.DotNet.CMake.Sdk/build/Microsoft.DotNet.CMake.Sdk.targets
@@ -31,7 +31,7 @@
       <_CMakeMultiConfigurationGenerator>true</_CMakeMultiConfigurationGenerator>
       <_CMakePassArchitectureToGenerator>true</_CMakePassArchitectureToGenerator>
       <!-- We limit the VS version range for the generator since CMake only knows about specific VS versions -->
-      <VSGeneratorVersionRange Condition="'$(VSGeneratorVersionRange)' == ''">[,17.0)</VSGeneratorVersionRange>
+      <VSGeneratorVersionRange Condition="'$(VSGeneratorVersionRange)' == ''">[15,17.0)</VSGeneratorVersionRange>
       <!-- Visual Studio uses the Win32 name for the x86 target architecture. -->
       <Platform Condition="'$(Platform)' == 'x86'">Win32</Platform>
     </PropertyGroup>


### PR DESCRIPTION
Resolves #7324
