### PR TITLE
Enable app end signal workaround for iOS/tvOS 14+ devices (+ enable device E2E tests)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -185,20 +185,19 @@ stages:
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''
-          # TODO (prvysoky): This will be enabled once we get a better app to test with (core-eng/11893)
-          # - script: eng/common/build.sh
-          #     -configuration $(_BuildConfig)
-          #     -prepareMachine
-          #     -ci
-          #     -restore
-          #     -test
-          #     -projects $(Build.SourcesDirectory)/tests/UnitTests.XHarness.iOS.Device.proj
-          #     /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.XHarness.iOS.Device.binlog
-          #     /p:RestoreUsingNuGetTargets=false
-          #   displayName: XHarness iOS Device Helix Testing
-          #   env:
-          #     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-          #     HelixAccessToken: ''
+          - script: eng/common/build.sh
+              -configuration $(_BuildConfig)
+              -prepareMachine
+              -ci
+              -restore
+              -test
+              -projects $(Build.SourcesDirectory)/tests/UnitTests.XHarness.iOS.Device.proj
+              /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.XHarness.iOS.Device.binlog
+              /p:RestoreUsingNuGetTargets=false
+            displayName: XHarness iOS Device Helix Testing
+            env:
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+              HelixAccessToken: ''
           - script: eng/common/build.sh
               -configuration $(_BuildConfig) 
               -prepareMachine

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
@@ -157,6 +157,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                         ? $"--launch-timeout \"$launch_timeout\" "
                         : $"--expected-exit-code $expected_exit_code ") +
                     (resetSimulator ? $"--reset-simulator " : string.Empty) +
+                    (target.Contains("device") ? $"--signal-app-end " : string.Empty) + // iOS/tvOS 14+ workaround
                     "--xcode \"$xcode_path\" " +
                     "-v " +
                     (!string.IsNullOrEmpty(AppArguments) ? "-- " + AppArguments : string.Empty);

--- a/tests/UnitTests.XHarness.iOS.Device.proj
+++ b/tests/UnitTests.XHarness.iOS.Device.proj
@@ -24,7 +24,7 @@
 
   <!-- Test project which builds app bundle to run via XHarness -->
   <ItemGroup>
-    <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)XHarness\XHarness.Device.AppleRun.proj" />
+    <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)XHarness\XHarness.Device.AppleTest.proj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/XHarness/XHarness.Device.AppleTest.proj
+++ b/tests/XHarness/XHarness.Device.AppleTest.proj
@@ -3,8 +3,8 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
 
   <PropertyGroup>
-    <XHarnessRunAppBundleName>HelloiOS.app</XHarnessRunAppBundleName>
-    <XHarnessRunAppBundleUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/ios/test-app/ios-device/$(XHarnessRunAppBundleName).unsigned.zip</XHarnessRunAppBundleUrl>
+    <XHarnessRunAppBundleName>System.Buffers.Tests.app</XHarnessRunAppBundleName>
+    <XHarnessRunAppBundleUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/ios/test-app/ios-device/$(XHarnessRunAppBundleName).zip</XHarnessRunAppBundleUrl>
   </PropertyGroup>
 
   <!-- We're not set up currently to build app bundles as part of normal builds, so this downloads existing ones for now -->
@@ -21,11 +21,9 @@
     <ItemGroup>
       <XHarnessAppBundleToTest Include="$(ArtifactsTmpDir)XHarness.RunDeviceAppBundle/$(XHarnessRunAppBundleName)">
         <TestTarget>ios-device</TestTarget>
-        <WorkItemTimeout>00:05:00</WorkItemTimeout>
-        <TestTimeout>00:04:00</TestTimeout>
-        <LaunchTimeout>00:03:00</LaunchTimeout>
-        <IncludesTestRunner>false</IncludesTestRunner>
-        <ExpectedExitCode>200</ExpectedExitCode>
+        <WorkItemTimeout>00:12:00</WorkItemTimeout>
+        <TestTimeout>00:10:00</TestTimeout>
+        <LaunchTimeout>00:07:00</LaunchTimeout>
       </XHarnessAppBundleToTest>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
Follow up for https://github.com/dotnet/xharness/issues/574
Resolves https://github.com/dotnet/core-eng/issues/11893