### PR TITLE
Add alternative casings for finding NuGet.config file.

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -16,9 +16,13 @@
     Configure NuGet Restore to use NuGet.config file in the repository root.
     We could drop a custom NuGet.config to the containing directory but it's simpler
     if we use the same config for all restore operations.
+    NuGet.Config, NuGet.config, and nuget.config are all allowed casings according to NuGet:
+    https://github.com/NuGet/NuGet.Client/blob/b83566ec2369c4e9fd07e6f95d734dfe370a1e66/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs#L34-L36
   -->
   <PropertyGroup>
-    <RestoreConfigFile>$(RepoRoot)NuGet.config</RestoreConfigFile>
+    <RestoreConfigFile Condition="Exists('$(RepoRoot)NuGet.config')">$(RepoRoot)NuGet.config</RestoreConfigFile>
+    <RestoreConfigFile Condition="Exists('$(RepoRoot)NuGet.Config')">$(RepoRoot)NuGet.Config</RestoreConfigFile>
+    <RestoreConfigFile Condition="Exists('$(RepoRoot)nuget.config')">$(RepoRoot)nuget.config</RestoreConfigFile>
   </PropertyGroup>
 
   <Import Project="$(_NuGetRestoreTargets)" />


### PR DESCRIPTION
This allows us to find `NuGet.config` files that are named `NuGet.Config` or `nuget.config`, all of which are supported by NuGet.  In particular, `nuget.config` is actually the recommended casing for new projects on Linux so this may be increasingly common.

I didn't add an error condition when none of these are found because Arcade does not always need to work with NuGet.config, so this defers the error to when it actually causes a problem.