### PR TITLE
Make ModifierComparer use type references instead of definition

### DIFF
--- a/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/ParameterModifiersCannotChange.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/Rules/Compat/ParameterModifiersCannotChange.cs
@@ -129,8 +129,8 @@ namespace Microsoft.Cci.Differs.Rules
 
         private class ModifierComparer : IEqualityComparer<ICustomModifier>
         {
-            private readonly static IEqualityComparer<ITypeDefinition> TypeComparer =
-                CciComparers.Default.GetEqualityComparer<ITypeDefinition>();
+            private readonly static IEqualityComparer<ITypeReference> TypeComparer =
+                CciComparers.Default.GetEqualityComparer<ITypeReference>();
 
             private ModifierComparer() { }
 
@@ -144,7 +144,7 @@ namespace Microsoft.Cci.Differs.Rules
                 }
 
                 return x.IsOptional == y.IsOptional &&
-                    TypeComparer.Equals(x.Modifier.ResolvedType, y.Modifier.ResolvedType);
+                    TypeComparer.Equals(x.Modifier, y.Modifier);
             }
 
             public int GetHashCode(ICustomModifier obj)
@@ -154,7 +154,7 @@ namespace Microsoft.Cci.Differs.Rules
                     return 0;
                 }
 
-                return (obj.IsOptional ? 1 : 0) | TypeComparer.GetHashCode(obj.Modifier.ResolvedType) << 1;
+                return (obj.IsOptional ? 1 : 0) | TypeComparer.GetHashCode(obj.Modifier) << 1;
             }
         }
     }


### PR DESCRIPTION
When comparing definitions this was failing if the type couldn't be resolved,
for instance if a type-forwarded dependency was missing or references
were specified at all.

This was inconsistent with our other parameter comparisons which just
evaluate the compare the type reference as a string without considering
assembly.

This does raise a concerning issue, that APICompat doesn't actually
evaluate assembly equivalence of parameters but that's an existing
problem.

Fixes #2102, #7511. 
Related #2136

cc @utpilla