### PR TITLE
[release/5.0] Fix strict-mode break

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -373,7 +373,7 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
   $msbuildVersionDir = if ([int]$vsMajorVersion -lt 16) { "$vsMajorVersion.0" } else { "Current" }
 
   $local:BinFolder = Join-Path $vsInstallDir "MSBuild\$msbuildVersionDir\Bin"
-  $local:Prefer64bit = if ($vsRequirements.Prefer64bit) { $vsRequirements.Prefer64bit } else { $false }
+  $local:Prefer64bit = if (Get-Member -InputObject $vsRequirements -Name 'Prefer64bit') { $vsRequirements.Prefer64bit } else { $false }
   if ($local:Prefer64bit -and (Test-Path(Join-Path $local:BinFolder "amd64"))) {
     $global:_MSBuildExe = Join-Path $local:BinFolder "amd64\msbuild.exe"
   } else {


### PR DESCRIPTION
- use `Get-Member` instead of assuming `$null` property value
- fixes build break I caused in 0214a32e5fce

### To double check:

* [X] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation

Tested fix locally in the dotnet/aspnetcore repo