### PR TITLE
Fixes null reference when there are no packs in a workload definition

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/Microsoft.DotNet.Build.Tasks.Workloads.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/Microsoft.DotNet.Build.Tasks.Workloads.Tests.csproj
@@ -19,4 +19,8 @@
   <ItemGroup>
       <Content Include="testassets\**\*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="testassets\mauiWorkloadManifest.json" />
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/VisualStudioComponentTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/VisualStudioComponentTests.cs
@@ -80,6 +80,23 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             Assert.Contains(@"microsoft.net.sdk.blazorwebassembly.aot", componentSwr);
         }
 
+        [Fact]
+        public void ItCreatesComponentsWhenWorkloadsDoNotIncludePacks()
+        {
+            WorkloadManifest manifest = Create("mauiWorkloadManifest.json");
+            WorkloadDefinition definition = manifest.Workloads.FirstOrDefault().Value;
+            VisualStudioComponent component = VisualStudioComponent.Create(null, manifest, definition, NoItems, NoItems, NoItems, NoItems);
+
+            string swixProjDirectory = RandomPath;
+            Directory.CreateDirectory(swixProjDirectory);
+            component.Generate(swixProjDirectory);
+
+            string componentSwr = File.ReadAllText(Path.Combine(swixProjDirectory, "component.swr"));
+
+            Assert.Contains(@"vs.dependency id=maui.mobile", componentSwr);
+            Assert.Contains(@"vs.dependency id=maui.desktop", componentSwr);
+        }
+
         private static WorkloadManifest Create(string filename)
         {
             return WorkloadManifestReader.ReadWorkloadManifest(Path.GetFileNameWithoutExtension(filename),

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/testassets/mauiWorkloadManifest.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/testassets/mauiWorkloadManifest.json
@@ -1,0 +1,12 @@
+{
+  "version": "6.0.100-preview.6.891",
+  "workloads": {
+    "maui": {
+      "description": ".NET MAUI SDK for all platforms",
+      "extends": [
+        "maui-mobile",
+        "maui-desktop"
+      ]
+    }
+  }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateWorkloadMsis.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateWorkloadMsis.cs
@@ -117,7 +117,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                 Select(w => w.Value).
                 Where(wd => (wd.Platforms == null) || wd.Platforms.Any(p => p.StartsWith("win")));
 
-            var packIds = workloads.SelectMany(w => w.Packs).Distinct();
+            var packIds = workloads.Where(w => w.Packs != null).SelectMany(w => w.Packs).Distinct();
 
             return manifests.SelectMany(m => m.Packs.Values).
                 Where(p => packIds.Contains(p.Id)).

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/Directories.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/Directories.wxs
@@ -6,8 +6,10 @@
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="$(var.ProgramFilesFolder)">
         <Directory Id="DOTNETHOME" Name="dotnet">
-          <Directory Id="ManifestDir" Name="sdk-manifests">
-            <Directory Id="VersionDir" Name="$(var.SdkFeatureBandVersion)" />
+          <Directory Id="InstallDir" Name="$(var.InstallDir)">
+            <Directory Id="PackageDir" Name="$(var.PackageId)">
+              <Directory Id="VersionDir" Name="$(var.PackageVersion)" />
+            </Directory>
           </Directory>
         </Directory>
       </Directory>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/VisualStudioComponent.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/VisualStudioComponent.cs
@@ -254,14 +254,17 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                 }
             }
 
-            // Visual Studio is case-insensitive. 
-            IEnumerable<WorkloadPackId> packIds = workload.Packs.Where(p => !missingPackIds.Contains($"{p}", StringComparer.OrdinalIgnoreCase));
-            log?.LogMessage(MessageImportance.Low, $"Packs: {string.Join(", ", packIds.Select(p=>$"{p}"))}");
-
-            foreach (WorkloadPackId packId in packIds)
+            if (workload.Packs != null)
             {
-                log?.LogMessage(MessageImportance.Low, $"Adding component dependency for {packId} ");
-                component.AddDependency(manifest.Packs[packId]);
+                // Visual Studio is case-insensitive. 
+                IEnumerable<WorkloadPackId> packIds = workload.Packs.Where(p => !missingPackIds.Contains($"{p}", StringComparer.OrdinalIgnoreCase));
+                log?.LogMessage(MessageImportance.Low, $"Packs: {string.Join(", ", packIds.Select(p => $"{p}"))}");
+
+                foreach (WorkloadPackId packId in packIds)
+                {
+                    log?.LogMessage(MessageImportance.Low, $"Adding component dependency for {packId} ");
+                    component.AddDependency(manifest.Packs[packId]);
+                }
             }
 
             return component;


### PR DESCRIPTION
- Fixing null reference for workloads that only extend other workloads without specifying direct pack dependencies.
- Fixes directory references for workload pack generation. This was a regression from a change to support manifest MSI
