### PR TITLE
Onboard Arcade to OneLocBuild

### DIFF
--- a/Documentation/OneLocBuild.md
+++ b/Documentation/OneLocBuild.md
@@ -26,6 +26,7 @@ you will want to conditionalize this step with the following:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
 ```
 To prevent OneLocBuild from running in the public project where it will fail.
+
 3. Run the pipeline you want to use OneLocBuild on your test branch.
 4. Open a ticket with the localization team using
    [this template](https://ceapex.visualstudio.com/CEINTL/_workitems/create/Loc%20Request?templateId=60b0dcf9-9892-4910-934e-d5becddd1bc1&ownerId=c2e38d3d-0e9e-429f-955d-6e39fc6f0457).

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,9 +26,12 @@ stages:
 - stage: build
   displayName: Build
   jobs:
-  - template: /eng/common/templates/job/onelocbuild.yml
-    parameters:
-      CreatePr: false
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), if eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+    - template: /eng/common/templates/job/onelocbuild.yml
+      parameters:
+        MirrorRepo: arcade
+        LclSource: lclFilesFromPackage
+        LclPackageId: 'LCL-JUNO-PROD-ARCADE'
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
       artifacts:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,9 @@ stages:
 - stage: build
   displayName: Build
   jobs:
+  - template: /eng/common/templates/job/onelocbuild.yml
+    parameters:
+      CreatePr: false
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
       artifacts:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ stages:
 - stage: build
   displayName: Build
   jobs:
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), if eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
     - template: /eng/common/templates/job/onelocbuild.yml
       parameters:
         MirrorRepo: arcade


### PR DESCRIPTION
Closes https://github.com/dotnet/core-eng/issues/13517.

Arcade now has localized files so we need to onboard to OneLocBuild. This does that.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
