### PR TITLE
[Workloads] Fix license and icon paths in msi proj

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
@@ -281,10 +281,10 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
 
             Directory.CreateDirectory(msiPackageProjectDir);
 
-            EmbeddedTemplates.Extract("Icon.png", msiPackageProjectDir);
-            EmbeddedTemplates.Extract("LICENSE.TXT", msiPackageProjectDir);
-
-            string licenseTextPath = Path.Combine(msiPackageProjectDir, "LICENSE.TXT");
+            string iconFileName = "Icon.png";
+            string licenseFileName = "LICENSE.TXT";
+            EmbeddedTemplates.Extract(iconFileName, msiPackageProjectDir);
+            EmbeddedTemplates.Extract(licenseFileName, msiPackageProjectDir);
 
             XmlWriterSettings settings = new XmlWriterSettings
             {
@@ -326,7 +326,8 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             writer.WriteStartElement("ItemGroup");
             WriteItem(writer, "None", msiPath, @"\data");
             WriteItem(writer, "None", msiJsonPath, @"\data\msi.json");
-            WriteItem(writer, "None", licenseTextPath, @"\");
+            WriteItem(writer, "None", iconFileName, string.Empty);
+            WriteItem(writer, "None", licenseFileName, @"\");
             writer.WriteEndElement();
 
             writer.WriteEndElement();

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
@@ -307,10 +307,10 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
 
             Directory.CreateDirectory(msiPackageProjectDir);
 
-            EmbeddedTemplates.Extract("Icon.png", msiPackageProjectDir);
-            EmbeddedTemplates.Extract("LICENSE.TXT", msiPackageProjectDir);
-
-            string licenseTextPath = Path.Combine(msiPackageProjectDir, "LICENSE.TXT");
+            string iconFileName = "Icon.png";
+            string licenseFileName = "LICENSE.TXT";
+            EmbeddedTemplates.Extract(iconFileName, msiPackageProjectDir);
+            EmbeddedTemplates.Extract(licenseFileName, msiPackageProjectDir);
 
             XmlWriterSettings settings = new XmlWriterSettings
             {
@@ -352,7 +352,8 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             writer.WriteStartElement("ItemGroup");
             WriteItem(writer, "None", msiPath, @"\data");
             WriteItem(writer, "None", msiJsonPath, @"\data\msi.json");
-            WriteItem(writer, "None", licenseTextPath, @"\");
+            WriteItem(writer, "None", iconFileName, string.Empty);
+            WriteItem(writer, "None", licenseFileName, @"\");
             writer.WriteEndElement();
 
             writer.WriteEndElement();


### PR DESCRIPTION
I was running into a couple of issues when building `msi.csproj` files
generated by the `GenerateVisualStudioWorkload` task:

    C:\Program Files\dotnet\sdk\5.0.301\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(221,5): error : Could not find a part of the path 'C:\Users\peter\source\yaml-templates\nuget-msi-convert\msbuild\obj\Debug\src\msiPackage\x86\Microsoft.Android.Sdk.Windows\obj\Debug\src\msiPackage\x86\Microsoft.Android.Sdk.Windows'.

    C:\Program Files\dotnet\sdk\5.0.301\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(221,5): error NU5046: The icon file 'Icon.png' does not exist in the package.

The first error was a result of the following relative path being
included in the `LICENSE.TXT` item:

    <None Include="obj\Debug\src\msiPackage\x86\Microsoft.Android.Sdk.Windows\LICENSE.TXT" Pack="true" PackagePath="\" />

Since `LICENSE.TXT` is created in the same directory as `msi.proj`, we
can exclude this relative path.

The second error appears to be a result of a missing `Icon.png` item,
which has been added.

The generated pack item content should now look like this:

    <ItemGroup>
      <None Include="C:\Users\peter\source\yaml-templates\nuget-msi-convert\msbuild\bin\Microsoft.Android.Sdk.Windows.30.0.100-ci.main.61-x86.msi" Pack="true" PackagePath="\data" />
      <None Include="C:\Users\peter\source\yaml-templates\nuget-msi-convert\msbuild\bin\Microsoft.Android.Sdk.Windows.30.0.100-ci.main.61-x86.json" Pack="true" PackagePath="\data\msi.json" />
      <None Include="Icon.png" Pack="true" PackagePath="" />
      <None Include="LICENSE.TXT" Pack="true" PackagePath="\" />
    </ItemGroup>
