### PR TITLE
Include Helix Docker image for test reporting

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelpersTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelpersTests.cs
@@ -43,6 +43,14 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         public void FailOnceThenPass()
         {
             var target = Path.Combine(Path.GetTempPath(), "my-test-file-123456.snt");
+
+            // If we're inside a Helix Docker work item, GetTempPath() is cleaned every execution, 
+            // but the work item's own directory is not (and is writeable from inside Docker), so use it.
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("HELIX_DOCKER_ENTRYPOINT")))
+            {
+                target = Path.Combine(Environment.GetEnvironmentVariable("HELIX_WORKITEM_PAYLOAD"), "my-test-file-123456.snt");
+            }
+
             bool exists = File.Exists(target);
             if (!exists)
             {

--- a/tests/UnitTests.proj
+++ b/tests/UnitTests.proj
@@ -61,7 +61,7 @@
     <HelixTargetQueue Include="Debian.9.Amd64"/>
     <HelixTargetQueue Include="RedHat.7.Amd64"/>
     <HelixTargetQueue Include="Windows.10.Amd64"/>
-    <HelixTargetQueue Include="(Alpine.312.Amd64)ubuntu.1804.amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.12-helix-20210602183830-e873b94"/>
+    <HelixTargetQueue Include="(Debian.10.Amd64)ubuntu.1804.amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-10-helix-amd64-20210304164434-56c6673"/>
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(HelixAccessToken)' == '' ">
@@ -74,7 +74,7 @@
     <HelixTargetQueue Include="Debian.9.Amd64.Open"/>
     <HelixTargetQueue Include="RedHat.7.Amd64.Open"/>
     <HelixTargetQueue Include="Windows.10.Amd64.Open"/>
-    <HelixTargetQueue Include="(Alpine.312.Amd64.Open)ubuntu.1804.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.12-helix-20210602183830-e873b94"/>
+    <HelixTargetQueue Include="(Debian.10.Amd64.Open)ubuntu.1804.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-10-helix-amd64-20210304164434-56c6673"/>
   </ItemGroup>
 
   <PropertyGroup Condition="!$(HelixTargetQueue.StartsWith('Windows'))">

--- a/tests/UnitTests.proj
+++ b/tests/UnitTests.proj
@@ -61,6 +61,7 @@
     <HelixTargetQueue Include="Debian.9.Amd64"/>
     <HelixTargetQueue Include="RedHat.7.Amd64"/>
     <HelixTargetQueue Include="Windows.10.Amd64"/>
+    <HelixTargetQueue Include="(Alpine.312.Amd64)ubuntu.1804.amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.12-helix-20210602183830-e873b94"/>
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(HelixAccessToken)' == '' ">
@@ -73,6 +74,7 @@
     <HelixTargetQueue Include="Debian.9.Amd64.Open"/>
     <HelixTargetQueue Include="RedHat.7.Amd64.Open"/>
     <HelixTargetQueue Include="Windows.10.Amd64.Open"/>
+    <HelixTargetQueue Include="(Alpine.312.Amd64.Open)ubuntu.1804.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.12-helix-20210602183830-e873b94"/>
   </ItemGroup>
 
   <PropertyGroup Condition="!$(HelixTargetQueue.StartsWith('Windows'))">


### PR DESCRIPTION
Follow up from https://github.com/dotnet/arcade/pull/7383.  This means we now depend on the Helix clients to do reporting, and the code path is somewhat different for Docker, so let's test one docker variation (Alpine chosen because it's small, and the original reason the Helix Docker feature exists)

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
