### PR TITLE
Fix provider key for manifest MSI

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
@@ -184,7 +184,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                     candle.PreprocessorDefinitions.Add($@"ProductCode={productCode}");
                     candle.PreprocessorDefinitions.Add($@"UpgradeCode={upgradeCode}");
                     // Override the default provider key
-                    candle.PreprocessorDefinitions.Add($@"DependencyProviderKey={nupkg.Id},{platform}");
+                    candle.PreprocessorDefinitions.Add($@"DependencyProviderKeyName={ManifestId},{SdkFeatureBandVersion},{platform}");
                     candle.PreprocessorDefinitions.Add($@"ProductName={productName}");
                     candle.PreprocessorDefinitions.Add($@"Platform={platform}");
                     candle.PreprocessorDefinitions.Add($@"SourceDir={packageContentsDataDirectory}");


### PR DESCRIPTION
Ensure the dependency provider key for a workload manifest installer is set to ```<Manifest ID>,<SDK Feature Band>,<Platform>```

![image](https://user-images.githubusercontent.com/7409981/124437125-98186580-dd2b-11eb-9803-76713ce76b12.png)
