### PR TITLE
Revert "Add internal runtime args to source build template (#7587)"

### DIFF
--- a/eng/common/templates/steps/source-build.yml
+++ b/eng/common/templates/steps/source-build.yml
@@ -29,11 +29,6 @@ steps:
       officialBuildArgs='/p:DotNetPublishUsingPipelines=true /p:OfficialBuildId=$(BUILD.BUILDNUMBER)'
     fi
 
-    internalRuntimeDownloadArgs=
-    if [ '${{ ne(variables['System.TeamProject'], 'public') }}' = 'True' ]; then
-      internalRuntimeDownloadArgs='--runtime-source-feed https://dotnetclimsrc.blob.core.windows.net/dotnet --runtime-source-feed-key $(dotnetclimsrc-read-sas-token-base64)'
-    fi
-
     targetRidArgs=
     if [ '${{ parameters.platform.targetRID }}' != '' ]; then
       targetRidArgs='/p:TargetRid=${{ parameters.platform.targetRID }}'
@@ -48,7 +43,6 @@ steps:
       --configuration $buildConfig \
       --restore --build --pack $publishArgs -bl \
       $officialBuildArgs \
-      $internalRuntimeDownloadArgs \
       $targetRidArgs \
       /p:SourceBuildNonPortable=${{ parameters.platform.nonPortable }} \
       /p:ArcadeBuildFromSource=true


### PR DESCRIPTION
This reverts commit 05634736a53ee65b0d19cf913d77d1f5d4293ebc.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
