### PR TITLE
Support ignoremvidmismatch option in ibcmerge

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -82,7 +82,7 @@
     <DropAppVersion Condition="'$(DropAppVersion)' == ''">18.165.29912-buildid11693003</DropAppVersion>
     <MicroBuildPluginsSwixBuildVersion Condition="'$(MicroBuildPluginsSwixBuildVersion)' == ''">1.0.422</MicroBuildPluginsSwixBuildVersion>
     <MicroBuildCoreVersion Condition="'$(MicroBuildCoreVersion)' == ''">0.2.0</MicroBuildCoreVersion>
-    <MicrosoftDotNetIBCMergeVersion Condition="'$(MicrosoftDotNetIBCMergeVersion)' == ''">5.0.7-beta.20159.1</MicrosoftDotNetIBCMergeVersion>
+    <MicrosoftDotNetIBCMergeVersion Condition="'$(MicrosoftDotNetIBCMergeVersion)' == ''">5.1.0-beta.21356.1</MicrosoftDotNetIBCMergeVersion>
     <MicrosoftNETTestSdkVersion Condition="'$(MicrosoftNETTestSdkVersion)' == ''">16.6.1</MicrosoftNETTestSdkVersion>
     <MicrosoftNetFrameworkReferenceAssembliesVersion Condition="'$(MicrosoftNetFrameworkReferenceAssembliesVersion)' == ''">1.0.0-preview.2</MicrosoftNetFrameworkReferenceAssembliesVersion>
     <MicrosoftVSSDKBuildToolsVersion Condition="'$(MicrosoftVSSDKBuildToolsVersion)' == ''">16.9.1050</MicrosoftVSSDKBuildToolsVersion>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
@@ -118,7 +118,7 @@
     <PropertyGroup>
       <_PartialNgenArg/>
       <_PartialNgenArg Condition="'$(ApplyNgenOptimization)' == 'partial'">-partialNGEN</_PartialNgenArg>
-      <__IgnoreMvidMismatchArg/>
+      <_IgnoreMvidMismatchArg/>
       <_IgnoreMvidMismatchArg Condition="'$(IgnoreIbcMergeErrors)' == 'true'">-ignoremvidmismatch</_IgnoreMvidMismatchArg>
     </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
@@ -8,6 +8,7 @@
       EnableNgenOptimization             Set to true to enable NGEN optimization (partial or full).
       EnableNgenOptimizationLogDetails   Set to true to enable NGEN method logging output
       ApplyNgenOptimization              Set to 'partial' or 'full' in a project to embed partial/full NGEN optimization data to the built binary.
+      IgnoreIbcMergeErrors               Set to true to ignore certain errors encountered while running ibcmerge, those problematic IBC files will be ignored.
 
     Items:  
       OptimizeAssembly                   Set of assemblies to apply Partial NGEN optimization data to.
@@ -117,6 +118,8 @@
     <PropertyGroup>
       <_PartialNgenArg/>
       <_PartialNgenArg Condition="'$(ApplyNgenOptimization)' == 'partial'">-partialNGEN</_PartialNgenArg>
+      <__IgnoreMvidMismatchArg/>
+      <_IgnoreMvidMismatchArg Condition="'$(IgnoreIbcMergeErrors)' == 'true'">-ignoremvidmismatch</_IgnoreMvidMismatchArg>
     </PropertyGroup>
 
     <ItemGroup>
@@ -127,7 +130,7 @@
         <!--
           -delete to delete data previously embedded in the binary. 
         -->
-        <IbcMergeArgs>-q -f $(_PartialNgenArg) -minify -delete -mo "%(_AssemblyWithRawIbcData.PreviousAssemblyCopyPath)" "$([MSBuild]::ValueOrDefault('%(_AssemblyWithRawIbcData.IbcFiles)', '').Replace(';', '" "'))"</IbcMergeArgs>
+        <IbcMergeArgs>-q -f $(_PartialNgenArg) $(_IgnoreMvidMismatchArg) -minify -delete -mo "%(_AssemblyWithRawIbcData.PreviousAssemblyCopyPath)" "$([MSBuild]::ValueOrDefault('%(_AssemblyWithRawIbcData.IbcFiles)', '').Replace(';', '" "'))"</IbcMergeArgs>
       </_IbcMergeInvocation>
 
       <_IbcMergeInvocation Include="%(_AssemblyWithRawIbcData.AssemblyFileName) [MergePreviousToCurrent]">


### PR DESCRIPTION
Address the ibcmerge mismatch MVID error encountered in Roslyn build
https://github.com/dotnet/roslyn/issues/53197

The new switch is added in https://devdiv.visualstudio.com/DevDiv/_git/DotNet-IbcMerge/pullrequest/335636

FYI @JoeRobich 