### PR TITLE
[3.x] Fix strict-mode break

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -325,7 +325,7 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
   $msbuildVersionDir = if ([int]$vsMajorVersion -lt 16) { "$vsMajorVersion.0" } else { "Current" }
 
   $local:BinFolder = Join-Path $vsInstallDir "MSBuild\$msbuildVersionDir\Bin"
-  $local:Prefer64bit = if ($vsRequirements.Prefer64bit) { $vsRequirements.Prefer64bit } else { $false }
+  $local:Prefer64bit = if (Get-Member -InputObject $vsRequirements -Name 'Prefer64bit') { $vsRequirements.Prefer64bit } else { $false }
   if ($local:Prefer64bit -and (Test-Path(Join-Path $local:BinFolder "amd64"))) {
     $global:_MSBuildExe = Join-Path $local:BinFolder "amd64\msbuild.exe"
   } else {


### PR DESCRIPTION

## Description

https://github.com/dotnet/arcade/pull/7564 for 3.1 servicing Fixes build break caused by https://github.com/dotnet/arcade/pull/7531
## Customer Impact

All repos that build using VS will be unable to take further arcade updates.

## Regression

Yes

## Risk

How risky is this change?

Not at all. The fix is already in main and in the release/5.x branch

## Workarounds
None