### PR TITLE
[release/3.x] Backport #5226 and #5249

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -173,6 +173,12 @@
     -->
 
     <PropertyGroup>
+      <_SolutionRestoreProps Include="@(_SolutionBuildProps)" />
+      <_SolutionRestoreProps Include="__BuildPhase=SolutionRestore" />
+      <_SolutionRestoreProps Include="_NETCORE_ENGINEERING_TELEMETRY=Restore" />
+      <_SolutionRestoreProps Include="MSBuildRestoreSessionId=$([System.Guid]::NewGuid())" />
+      <_SolutionRestoreProps Include="RestoreUseStaticGraphEvaluation=true" Condition="'$(RestoreUseStaticGraphEvaluation)' == 'true'" />
+
       <!-- This can be set to false as an optimization for repos that don't use NuGet. -->
       <RestoreUsingNuGetTargets Condition="'$(RestoreUsingNuGetTargets)' == ''">true</RestoreUsingNuGetTargets>
 
@@ -188,7 +194,7 @@
       This helps MSBuild cache the result of _IsProjectRestoreSupported.
     -->
     <MSBuild Projects="@(ProjectToBuild)"
-             Properties="@(_SolutionBuildProps);__BuildPhase=SolutionRestore;_NETCORE_ENGINEERING_TELEMETRY=Restore"
+             Properties="@(_SolutionRestoreProps)"
              RemoveProperties="$(_RemoveProps)"
              Targets="_IsProjectRestoreSupported"
              SkipNonexistentTargets="true"
@@ -214,8 +220,8 @@
     </ItemGroup>
 
     <MSBuild Projects="@(_ProjectToRestore)"
-             Properties="@(_SolutionBuildProps);__BuildPhase=SolutionRestore;_NETCORE_ENGINEERING_TELEMETRY=Restore"
-             RemoveProperties="$(_RemoveProps)"
+             Properties="@(_SolutionRestoreProps)"
+             RemoveProperties="$(_RemoveProps);TreatWarningsAsErrors"
              Targets="Restore"
              SkipNonexistentTargets="true"
              BuildInParallel="%(_ProjectToRestore.RestoreInParallel)"

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -172,13 +172,15 @@
         We invalidate the cache by changing the value of __BuildPhase property.
     -->
 
-    <PropertyGroup>
+    <ItemGroup>
       <_SolutionRestoreProps Include="@(_SolutionBuildProps)" />
       <_SolutionRestoreProps Include="__BuildPhase=SolutionRestore" />
       <_SolutionRestoreProps Include="_NETCORE_ENGINEERING_TELEMETRY=Restore" />
       <_SolutionRestoreProps Include="MSBuildRestoreSessionId=$([System.Guid]::NewGuid())" />
       <_SolutionRestoreProps Include="RestoreUseStaticGraphEvaluation=true" Condition="'$(RestoreUseStaticGraphEvaluation)' == 'true'" />
-
+    </ItemGroup>
+    
+    <PropertyGroup>
       <!-- This can be set to false as an optimization for repos that don't use NuGet. -->
       <RestoreUsingNuGetTargets Condition="'$(RestoreUsingNuGetTargets)' == ''">true</RestoreUsingNuGetTargets>
 


### PR DESCRIPTION
Trying to unblock dotnet/aspnetcore#33197 by setting `$(MSBuildRestoreSessionId)` more. Includes:
- @ViktorHofer's #5226
- @riarenas's #5249 (a fixup of #5226)

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation

I have confirmed this change enables dotnet/aspnetcore#33197 to build and test successfully. Since the original changes lacked specific tests and nothing failed here, I'm not automating new tests.