### PR TITLE
Update workload pack tasks

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/testassets/MonoWorkloadManifest.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/testassets/MonoWorkloadManifest.json
@@ -1,0 +1,273 @@
+{
+  "version": "6.0.0-preview.7.21358.4",
+  "depends-on": {
+    "Microsoft.NET.Workload.Emscripten": "6.0.0-preview.7.21330.1"
+  },
+  "workloads": {
+    "microsoft-net-sdk-blazorwebassembly-aot": {
+      "description": "Browser Runtime native performance tools",
+      "packs": [
+        "Microsoft.NET.Runtime.WebAssembly.Sdk",
+        "Microsoft.NETCore.App.Runtime.Mono.browser-wasm",
+        "Microsoft.NETCore.App.Runtime.AOT.Cross.browser-wasm",
+        "Microsoft.NET.Runtime.Emscripten.Node",
+        "Microsoft.NET.Runtime.Emscripten.Python",
+        "Microsoft.NET.Runtime.Emscripten.Sdk"
+      ],
+      "extends": [ "microsoft-net-runtime-mono-tooling", "microsoft-net-sdk-emscripten" ],
+      "platforms": [ "win-x64", "linux-x64", "osx-x64", "osx-arm64" ]
+    },
+    "microsoft-net-runtime-android": {
+      "abstract": true,
+      "description": "Android Mono Runtime",
+      "packs": [
+        "Microsoft.NETCore.App.Runtime.Mono.android-arm",
+        "Microsoft.NETCore.App.Runtime.Mono.android-arm64",
+        "Microsoft.NETCore.App.Runtime.Mono.android-x64",
+        "Microsoft.NETCore.App.Runtime.Mono.android-x86"
+      ],
+      "extends": [ "microsoft-net-runtime-mono-tooling" ],
+      "platforms": [ "win-x64", "linux-x64", "osx-x64", "osx-arm64" ]
+    },
+    "microsoft-net-runtime-android-aot": {
+      "abstract": true,
+      "description": "Android Mono AOT Workload",
+      "packs": [
+        "Microsoft.NETCore.App.Runtime.AOT.Cross.android-x86",
+        "Microsoft.NETCore.App.Runtime.AOT.Cross.android-x64",
+        "Microsoft.NETCore.App.Runtime.AOT.Cross.android-arm",
+        "Microsoft.NETCore.App.Runtime.AOT.Cross.android-arm64"
+      ],
+      "extends": [ "microsoft-net-runtime-android" ],
+      "platforms": [ "win-x64", "linux-x64", "osx-x64", "osx-arm64" ]
+    },
+    "microsoft-net-runtime-ios": {
+      "abstract": true,
+      "description": "iOS Mono Runtime and AOT Workload",
+      "packs": [
+        "Microsoft.NETCore.App.Runtime.Mono.ios-arm",
+        "Microsoft.NETCore.App.Runtime.Mono.ios-arm64",
+        "Microsoft.NETCore.App.Runtime.Mono.iossimulator",
+        "Microsoft.NETCore.App.Runtime.Mono.iossimulator-x86",
+        "Microsoft.NETCore.App.Runtime.AOT.Cross.ios-arm",
+        "Microsoft.NETCore.App.Runtime.AOT.Cross.ios-arm64",
+        "Microsoft.NETCore.App.Runtime.AOT.Cross.iossimulator",
+        "Microsoft.NETCore.App.Runtime.AOT.Cross.iossimulator-x86"
+      ],
+      "extends": [ "microsoft-net-runtime-mono-tooling" ],
+      "platforms": [ "osx-arm64", "osx-x64" ]
+    },
+    "microsoft-net-runtime-maccatalyst": {
+      "abstract": true,
+      "description": "MacCatalyst Mono Runtime and AOT Workload",
+      "packs": [
+        "Microsoft.NETCore.App.Runtime.Mono.maccatalyst",
+        "Microsoft.NETCore.App.Runtime.AOT.Cross.maccatalyst"
+      ],
+      "extends": [ "microsoft-net-runtime-mono-tooling" ],
+      "platforms": [ "osx-arm64", "osx-x64" ]
+    },
+    "microsoft-net-runtime-tvos": {
+      "abstract": true,
+      "description": "tvOS Mono Runtime and AOT Workload",
+      "packs": [
+        "Microsoft.NETCore.App.Runtime.Mono.tvos-arm64",
+        "Microsoft.NETCore.App.Runtime.Mono.tvossimulator",
+        "Microsoft.NETCore.App.Runtime.AOT.Cross.tvos-arm64",
+        "Microsoft.NETCore.App.Runtime.AOT.Cross.tvossimulator"
+      ],
+      "extends": [ "microsoft-net-runtime-mono-tooling" ],
+      "platforms": [ "osx-arm64", "osx-x64" ]
+    },
+    "microsoft-net-runtime-mono-tooling": {
+      "abstract": true,
+      "description": "Shared native build tooling for Mono runtime",
+      "packs": [
+        "Microsoft.NET.Runtime.MonoAOTCompiler.Task",
+        "Microsoft.NET.Runtime.MonoTargets.Sdk",
+      ],
+    }
+  },
+  "packs": {
+    "Microsoft.NET.Runtime.MonoAOTCompiler.Task": {
+      "kind": "Sdk",
+      "version": "6.0.0-preview.7.21358.4"
+    },
+    "Microsoft.NET.Runtime.MonoTargets.Sdk": {
+      "kind": "Sdk",
+      "version": "6.0.0-preview.7.21358.4"
+    },
+    "Microsoft.NET.Runtime.WebAssembly.Sdk": {
+      "kind": "Sdk",
+      "version": "6.0.0-preview.7.21358.4"
+    },
+    "Microsoft.NETCore.App.Runtime.Mono.android-arm": {
+      "kind": "framework",
+      "version": "6.0.0-preview.7.21358.4"
+    },
+    "Microsoft.NETCore.App.Runtime.Mono.android-arm64": {
+      "kind": "framework",
+      "version": "6.0.0-preview.7.21358.4"
+    },
+    "Microsoft.NETCore.App.Runtime.Mono.android-x64": {
+      "kind": "framework",
+      "version": "6.0.0-preview.7.21358.4"
+    },
+    "Microsoft.NETCore.App.Runtime.Mono.android-x86": {
+      "kind": "framework",
+      "version": "6.0.0-preview.7.21358.4"
+    },
+    "Microsoft.NETCore.App.Runtime.AOT.Cross.android-x86": {
+      "kind": "Sdk",
+      "version": "6.0.0-preview.7.21358.4",
+      "alias-to": {
+        "win-x64": "Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-x86",
+        "linux-x64": "Microsoft.NETCore.App.Runtime.AOT.linux-x64.Cross.android-x86",
+        "osx-x64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-x86",
+        "osx-arm64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-x86"
+      }
+    },
+    "Microsoft.NETCore.App.Runtime.AOT.Cross.android-x64": {
+      "kind": "Sdk",
+      "version": "6.0.0-preview.7.21358.4",
+      "alias-to": {
+        "win-x64": "Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-x64",
+        "linux-x64": "Microsoft.NETCore.App.Runtime.AOT.linux-x64.Cross.android-x64",
+        "osx-x64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-x64",
+        "osx-arm64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-x64"
+      }
+    },
+    "Microsoft.NETCore.App.Runtime.AOT.Cross.android-arm": {
+      "kind": "Sdk",
+      "version": "6.0.0-preview.7.21358.4",
+      "alias-to": {
+        "win-x64": "Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-arm",
+        "linux-x64": "Microsoft.NETCore.App.Runtime.AOT.linux-x64.Cross.android-arm",
+        "osx-x64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-arm",
+        "osx-arm64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-arm"
+      }
+    },
+    "Microsoft.NETCore.App.Runtime.AOT.Cross.android-arm64": {
+      "kind": "Sdk",
+      "version": "6.0.0-preview.7.21358.4",
+      "alias-to": {
+        "win-x64": "Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-arm64",
+        "linux-x64": "Microsoft.NETCore.App.Runtime.AOT.linux-x64.Cross.android-arm64",
+        "osx-x64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-arm64",
+        "osx-arm64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-arm64"
+      }
+    },
+    "Microsoft.NETCore.App.Runtime.Mono.maccatalyst": {
+      "kind": "framework",
+      "version": "6.0.0-preview.7.21358.4",
+      "alias-to": {
+        "osx-arm64": "Microsoft.NETCore.App.Runtime.Mono.maccatalyst-arm64",
+        "osx-x64": "Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64"
+      }
+    },
+    "Microsoft.NETCore.App.Runtime.Mono.ios-arm" : {
+      "kind": "framework",
+      "version": "6.0.0-preview.7.21358.4"
+    },
+    "Microsoft.NETCore.App.Runtime.Mono.ios-arm64" : {
+      "kind": "framework",
+      "version": "6.0.0-preview.7.21358.4"
+    },
+    "Microsoft.NETCore.App.Runtime.Mono.iossimulator" : {
+      "kind": "framework",
+      "version": "6.0.0-preview.7.21358.4",
+      "alias-to": {
+        "osx-arm64": "Microsoft.NETCore.App.Runtime.Mono.iossimulator-arm64",
+        "osx-x64": "Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64"
+      }
+    },
+    "Microsoft.NETCore.App.Runtime.Mono.iossimulator-x86" : {
+      "kind": "framework",
+      "version": "6.0.0-preview.7.21358.4",
+      "alias-to": {
+        "osx-x64": "Microsoft.NETCore.App.Runtime.Mono.iossimulator-x86"
+      }
+    },
+    "Microsoft.NETCore.App.Runtime.AOT.Cross.tvos-arm64": {
+      "kind": "Sdk",
+      "version": "6.0.0-preview.7.21358.4",
+      "alias-to": {
+        "osx-x64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.tvos-arm64",
+        "osx-arm64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.tvos-arm64",
+      }
+    },
+    "Microsoft.NETCore.App.Runtime.Mono.tvos-arm64" : {
+      "kind": "framework",
+      "version": "6.0.0-preview.7.21358.4"
+    },
+    "Microsoft.NETCore.App.Runtime.Mono.tvossimulator" : {
+      "kind": "framework",
+      "version": "6.0.0-preview.7.21358.4",
+      "alias-to": {
+        "osx-arm64": "Microsoft.NETCore.App.Runtime.Mono.tvossimulator-arm64",
+        "osx-x64": "Microsoft.NETCore.App.Runtime.Mono.tvossimulator-x64"
+      }
+    },
+    "Microsoft.NETCore.App.Runtime.AOT.Cross.maccatalyst": {
+      "kind": "Sdk",
+      "version": "6.0.0-preview.7.21358.4",
+      "alias-to": {
+        "osx-arm64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.maccatalyst-arm64",
+        "osx-x64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.maccatalyst-x64"
+      }
+    },
+    "Microsoft.NETCore.App.Runtime.AOT.Cross.tvossimulator": {
+      "kind": "Sdk",
+      "version": "6.0.0-preview.7.21358.4",
+      "alias-to": {
+        "osx-arm64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.tvossimulator-arm64",
+        "osx-x64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.tvossimulator-x64"
+      }
+    },
+    "Microsoft.NETCore.App.Runtime.AOT.Cross.ios-arm": {
+      "kind": "Sdk",
+      "version": "6.0.0-preview.7.21358.4",
+      "alias-to": {
+        "osx-x64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.ios-arm",
+        "osx-arm64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.ios-arm",
+      }
+    },
+    "Microsoft.NETCore.App.Runtime.AOT.Cross.ios-arm64": {
+      "kind": "Sdk",
+      "version": "6.0.0-preview.7.21358.4",
+      "alias-to": {
+        "osx-x64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.ios-arm64",
+        "osx-arm64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.ios-arm64",
+      }
+    },
+    "Microsoft.NETCore.App.Runtime.AOT.Cross.iossimulator": {
+      "kind": "Sdk",
+      "version": "6.0.0-preview.7.21358.4",
+      "alias-to": {
+        "osx-arm64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.iossimulator-arm64",
+        "osx-x64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.iossimulator-x64"
+      }
+    },
+    "Microsoft.NETCore.App.Runtime.AOT.Cross.iossimulator-x86": {
+      "kind": "Sdk",
+      "version": "6.0.0-preview.7.21358.4",
+      "alias-to": {
+        "osx-x64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.iossimulator-x86"
+      }
+    },
+    "Microsoft.NETCore.App.Runtime.AOT.Cross.browser-wasm": {
+      "kind": "Sdk",
+      "version": "6.0.0-preview.7.21358.4",
+      "alias-to": {
+        "win-x64": "Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.browser-wasm",
+        "linux-x64": "Microsoft.NETCore.App.Runtime.AOT.linux-x64.Cross.browser-wasm",
+        "osx-x64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.browser-wasm",
+        "osx-arm64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.browser-wasm"
+      }
+    },
+    "Microsoft.NETCore.App.Runtime.Mono.browser-wasm" : {
+      "kind": "framework",
+      "version": "6.0.0-preview.7.21358.4"
+    },
+  }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
@@ -5,11 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Xml;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.Deployment.DotNet.Releases;
-using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.Build.Tasks.Workloads
 {
@@ -244,7 +244,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                     };
 
                     string msiJsonPath = Path.Combine(Path.GetDirectoryName(msiPath), Path.GetFileNameWithoutExtension(msiPath) + ".json");
-                    File.WriteAllText(msiJsonPath, JsonConvert.SerializeObject(msiProps));
+                    File.WriteAllText(msiJsonPath, JsonSerializer.Serialize<MsiProperties>(msiProps));
 
                     TaskItem msi = new(light.OutputFile);
                     msi.SetMetadata(Metadata.Platform, platform);

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
@@ -239,7 +239,8 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                         ProductCode = MsiUtils.GetProperty(msiPath, "ProductCode"),
                         ProductVersion = MsiUtils.GetProperty(msiPath, "ProductVersion"),
                         ProviderKeyName = $"{nupkg.Id},{nupkg.Version},{platform}",
-                        UpgradeCode = MsiUtils.GetProperty(msiPath, "UpgradeCode")
+                        UpgradeCode = MsiUtils.GetProperty(msiPath, "UpgradeCode"),
+                        RelatedProducts = MsiUtils.GetRelatedProducts(msiPath)
                     };
 
                     string msiJsonPath = Path.Combine(Path.GetDirectoryName(msiPath), Path.GetFileNameWithoutExtension(msiPath) + ".json");
@@ -305,7 +306,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             writer.WriteElementString("IsPackable", "true");
             writer.WriteElementString("PackageType", "DotnetPlatform");
             writer.WriteElementString("SuppressDependenciesWhenPacking", "true");
-            writer.WriteElementString("NoWarn", "$(NoWarn);NU5128");
+            writer.WriteElementString("NoWarn", "$(NoWarn);NU5128;NU5118");
             writer.WriteElementString("PackageId", $"{nupkg.Id}.Msi.{platform}");
             writer.WriteElementString("PackageVersion", $"{nupkg.Version}");
             writer.WriteElementString("Description", nupkg.Description);
@@ -328,6 +329,9 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             WriteItem(writer, "None", msiPath, @"\data");
             WriteItem(writer, "None", msiJsonPath, @"\data\msi.json");
             WriteItem(writer, "None", licenseFileName, @"\");
+            
+            WriteItem(writer, "None", iconFileName, string.Empty);
+
             writer.WriteEndElement();
 
             writer.WriteEndElement();

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
@@ -332,7 +332,8 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
 
             writer.WriteRaw(@"
 <Target Name=""AddPackageIcon""
-        BeforeTargets=""GenerateNuspec"">
+        BeforeTargets=""GenerateNuspec""
+        Condition=""'$(PackageIcon)' == ''"">
   <PropertyGroup>
     <PackageIcon>Icon.png</PackageIcon>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
@@ -234,6 +234,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                     MsiProperties msiProps = new MsiProperties
                     {
                         InstallSize = MsiUtils.GetInstallSize(msiPath),
+                        Language = Convert.ToInt32(MsiUtils.GetProperty(msiPath, "ProductLanguage")),
                         Payload = Path.GetFileName(msiPath),
                         ProductCode = MsiUtils.GetProperty(msiPath, "ProductCode"),
                         ProductVersion = MsiUtils.GetProperty(msiPath, "ProductVersion"),
@@ -326,7 +327,6 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             writer.WriteStartElement("ItemGroup");
             WriteItem(writer, "None", msiPath, @"\data");
             WriteItem(writer, "None", msiJsonPath, @"\data\msi.json");
-            WriteItem(writer, "None", iconFileName, string.Empty);
             WriteItem(writer, "None", licenseFileName, @"\");
             writer.WriteEndElement();
 

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
@@ -332,7 +332,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
 
             writer.WriteRaw(@"
 <Target Name=""AddPackageIcon""
-        BeforeTargets=""GenerateNuspec""
+        BeforeTargets=""$(GenerateNuspecDependsOn)""
         Condition=""'$(PackageIcon)' == ''"">
   <PropertyGroup>
     <PackageIcon>Icon.png</PackageIcon>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
@@ -5,11 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.Json;
 using System.Xml;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.Deployment.DotNet.Releases;
+using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.Build.Tasks.Workloads
 {
@@ -244,7 +244,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                     };
 
                     string msiJsonPath = Path.Combine(Path.GetDirectoryName(msiPath), Path.GetFileNameWithoutExtension(msiPath) + ".json");
-                    File.WriteAllText(msiJsonPath, JsonSerializer.Serialize<MsiProperties>(msiProps));
+                    File.WriteAllText(msiJsonPath, JsonConvert.SerializeObject(msiProps));
 
                     TaskItem msi = new(light.OutputFile);
                     msi.SetMetadata(Metadata.Platform, platform);
@@ -329,7 +329,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             WriteItem(writer, "None", msiPath, @"\data");
             WriteItem(writer, "None", msiJsonPath, @"\data\msi.json");
             WriteItem(writer, "None", licenseFileName, @"\");
-            
+
             WriteItem(writer, "None", iconFileName, string.Empty);
 
             writer.WriteEndElement();

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
@@ -306,11 +306,10 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             writer.WriteElementString("IsPackable", "true");
             writer.WriteElementString("PackageType", "DotnetPlatform");
             writer.WriteElementString("SuppressDependenciesWhenPacking", "true");
-            writer.WriteElementString("NoWarn", "$(NoWarn);NU5128;NU5118");
+            writer.WriteElementString("NoWarn", "$(NoWarn);NU5128");
             writer.WriteElementString("PackageId", $"{nupkg.Id}.Msi.{platform}");
             writer.WriteElementString("PackageVersion", $"{nupkg.Version}");
             writer.WriteElementString("Description", nupkg.Description);
-            writer.WriteElementString("PackageIcon", "Icon.png");
 
             if (!string.IsNullOrWhiteSpace(nupkg.Authors))
             {
@@ -329,12 +328,21 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             WriteItem(writer, "None", msiPath, @"\data");
             WriteItem(writer, "None", msiJsonPath, @"\data\msi.json");
             WriteItem(writer, "None", licenseFileName, @"\");
+            writer.WriteEndElement(); // ItemGroup
 
-            WriteItem(writer, "None", iconFileName, string.Empty);
+            writer.WriteRaw(@"
+<Target Name=""AddPackageIcon""
+        BeforeTargets=""GenerateNuspec"">
+  <PropertyGroup>
+    <PackageIcon>Icon.png</PackageIcon>
+  </PropertyGroup>
+  <ItemGroup Condition=""'$(IsPackable)' == 'true'"">
+    <None Include=""$(PackageIcon)"" Pack=""true"" PackagePath=""$(PackageIcon)"" Visible=""false"" />
+  </ItemGroup>
+</Target>
+");
 
-            writer.WriteEndElement();
-
-            writer.WriteEndElement();
+            writer.WriteEndElement(); // Project
             writer.Flush();
             writer.Close();
 

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
@@ -5,11 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Xml;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
-using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.Build.Tasks.Workloads
 {
@@ -266,7 +266,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                 };
 
                 string msiJsonPath = Path.Combine(Path.GetDirectoryName(msiPath), Path.GetFileNameWithoutExtension(msiPath) + ".json");
-                File.WriteAllText(msiJsonPath, JsonConvert.SerializeObject(msiProps));
+                File.WriteAllText(msiJsonPath, JsonSerializer.Serialize<MsiProperties>(msiProps));
 
                 TaskItem msi = new(light.OutputFile);
                 msi.SetMetadata(Metadata.Platform, platform);

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
@@ -358,7 +358,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
 
             writer.WriteRaw(@"
 <Target Name=""AddPackageIcon""
-        BeforeTargets=""GenerateNuspec""
+        BeforeTargets=""$(GenerateNuspecDependsOn)""
         Condition=""'$(PackageIcon)' == ''"">
   <PropertyGroup>
     <PackageIcon>Icon.png</PackageIcon>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
@@ -261,7 +261,8 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                     ProductCode = MsiUtils.GetProperty(msiPath, "ProductCode"),
                     ProductVersion = MsiUtils.GetProperty(msiPath, "ProductVersion"),
                     ProviderKeyName = $"{nupkg.Id},{nupkg.Version},{platform}",
-                    UpgradeCode = MsiUtils.GetProperty(msiPath, "UpgradeCode")
+                    UpgradeCode = MsiUtils.GetProperty(msiPath, "UpgradeCode"),
+                    RelatedProducts = MsiUtils.GetRelatedProducts(msiPath)
                 };
 
                 string msiJsonPath = Path.Combine(Path.GetDirectoryName(msiPath), Path.GetFileNameWithoutExtension(msiPath) + ".json");
@@ -331,7 +332,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             writer.WriteElementString("IsPackable", "true");
             writer.WriteElementString("PackageType", "DotnetPlatform");
             writer.WriteElementString("SuppressDependenciesWhenPacking", "true");
-            writer.WriteElementString("NoWarn", "$(NoWarn);NU5128");
+            writer.WriteElementString("NoWarn", "$(NoWarn);NU5128;NU5118");
             writer.WriteElementString("PackageId", $"{nupkg.Id}.Msi.{platform}");
             writer.WriteElementString("PackageVersion", $"{nupkg.Version}");
             writer.WriteElementString("Description", nupkg.Description);

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
@@ -358,7 +358,8 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
 
             writer.WriteRaw(@"
 <Target Name=""AddPackageIcon""
-        BeforeTargets=""GenerateNuspec"">
+        BeforeTargets=""GenerateNuspec""
+        Condition=""'$(PackageIcon)' == ''"">
   <PropertyGroup>
     <PackageIcon>Icon.png</PackageIcon>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
@@ -256,6 +256,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                 MsiProperties msiProps = new MsiProperties
                 {
                     InstallSize = MsiUtils.GetInstallSize(msiPath),
+                    Language = Convert.ToInt32(MsiUtils.GetProperty(msiPath, "ProductLanguage")),
                     Payload = Path.GetFileName(msiPath),
                     ProductCode = MsiUtils.GetProperty(msiPath, "ProductCode"),
                     ProductVersion = MsiUtils.GetProperty(msiPath, "ProductVersion"),
@@ -352,7 +353,6 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             writer.WriteStartElement("ItemGroup");
             WriteItem(writer, "None", msiPath, @"\data");
             WriteItem(writer, "None", msiJsonPath, @"\data\msi.json");
-            WriteItem(writer, "None", iconFileName, string.Empty);
             WriteItem(writer, "None", licenseFileName, @"\");
             writer.WriteEndElement();
 

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
@@ -332,11 +332,10 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             writer.WriteElementString("IsPackable", "true");
             writer.WriteElementString("PackageType", "DotnetPlatform");
             writer.WriteElementString("SuppressDependenciesWhenPacking", "true");
-            writer.WriteElementString("NoWarn", "$(NoWarn);NU5128;NU5118");
+            writer.WriteElementString("NoWarn", "$(NoWarn);NU5128");
             writer.WriteElementString("PackageId", $"{nupkg.Id}.Msi.{platform}");
             writer.WriteElementString("PackageVersion", $"{nupkg.Version}");
             writer.WriteElementString("Description", nupkg.Description);
-            writer.WriteElementString("PackageIcon", "Icon.png");
 
             if (!string.IsNullOrWhiteSpace(nupkg.Authors))
             {
@@ -355,9 +354,21 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             WriteItem(writer, "None", msiPath, @"\data");
             WriteItem(writer, "None", msiJsonPath, @"\data\msi.json");
             WriteItem(writer, "None", licenseFileName, @"\");
-            writer.WriteEndElement();
+            writer.WriteEndElement(); // ItemGroup
 
-            writer.WriteEndElement();
+            writer.WriteRaw(@"
+<Target Name=""AddPackageIcon""
+        BeforeTargets=""GenerateNuspec"">
+  <PropertyGroup>
+    <PackageIcon>Icon.png</PackageIcon>
+  </PropertyGroup>
+  <ItemGroup Condition=""'$(IsPackable)' == 'true'"">
+    <None Include=""$(PackageIcon)"" Pack=""true"" PackagePath=""$(PackageIcon)"" Visible=""false"" />
+  </ItemGroup>
+</Target>
+");
+
+            writer.WriteEndElement(); // Project
             writer.Flush();
             writer.Close();
 

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
@@ -5,11 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.Json;
 using System.Xml;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
+using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.Build.Tasks.Workloads
 {
@@ -266,7 +266,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                 };
 
                 string msiJsonPath = Path.Combine(Path.GetDirectoryName(msiPath), Path.GetFileNameWithoutExtension(msiPath) + ".json");
-                File.WriteAllText(msiJsonPath, JsonSerializer.Serialize<MsiProperties>(msiProps));
+                File.WriteAllText(msiJsonPath, JsonConvert.SerializeObject(msiProps));
 
                 TaskItem msi = new(light.OutputFile);
                 msi.SetMetadata(Metadata.Platform, platform);

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiProperties.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiProperties.cs
@@ -52,5 +52,11 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             get;
             set;
         }
+
+        public IEnumerable<RelatedProduct> RelatedProducts
+        {
+            get;
+            set;
+        }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiProperties.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiProperties.cs
@@ -1,11 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Build.Tasks.Workloads
 {

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiProperties.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiProperties.cs
@@ -17,6 +17,12 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             set;
         }
 
+        public int Language
+        {
+            get;
+            set;
+        }
+
         public string Payload
         {
             get;
@@ -45,6 +51,6 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
         {
             get;
             set;
-        }        
+        }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/ManifestProduct.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/ManifestProduct.wxs
@@ -2,7 +2,7 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <?include Variables.wxi?>
-  <Product Id="$(var.ProductCode)" Name="$(var.ProductName)" Language="1033" Version="$(var.ProductVersion)"
+  <Product Id="$(var.ProductCode)" Name="$(var.ProductName)" Language="$(var.ProductLanguage)" Version="$(var.ProductVersion)"
            Manufacturer="$(var.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
 
     <Package InstallerVersion="$(var.InstallerVersion)" Compressed="yes" InstallScope="perMachine" />

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/Product.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/Product.wxs
@@ -2,7 +2,7 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <?include Variables.wxi?>
-  <Product Id="$(var.ProductCode)" Name="$(var.ProductName)" Language="1033" Version="$(var.ProductVersion)"
+  <Product Id="$(var.ProductCode)" Name="$(var.ProductName)" Language="$(var.ProductLanguage)" Version="$(var.ProductVersion)"
            Manufacturer="$(var.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
 
     <Package InstallerVersion="$(var.InstallerVersion)" Compressed="yes" InstallScope="perMachine" />

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/Registry.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/Registry.wxs
@@ -11,6 +11,7 @@
           <RegistryValue Name="ProductCode" Type="string" Value="$(var.ProductCode)"/>
           <RegistryValue Name="UpgradeCode" Type="string" Value="$(var.UpgradeCode)"/>
           <RegistryValue Name="ProductVersion" Type="string" Value="$(var.ProductVersion)" />
+          <RegistryValue Name="ProductLanguage" Type="integer" Value="$(var.ProductLanguage)" />
         </RegistryKey>
       </Component>
     </Feature>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/Variables.wxi
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/Variables.wxi
@@ -17,6 +17,10 @@
   <?error Unknown platform: $(var.Platform)?>
   <?endif?>
   
+  <?ifndef ProductLanguage?>
+  <?define ProductLanguage=1033?>
+  <?endif?>
+  
   <!-- Default dependency provider key for packs. -->
   <?ifndef DependencyProviderKeyName?>
   <?define DependencyProviderKeyName=$(var.PackageId),$(var.PackageVersion),$(var.Platform)?>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiUtils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiUtils.cs
@@ -29,12 +29,18 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             return files;
         }
 
+        /// <summary>
+        /// Extracts the specified property from the MSI's Property table.
+        /// </summary>
+        /// <param name="packagePath">The path to the MSI package.</param>
+        /// <param name="property">The name of the property to extract.</param>
+        /// <returns>The value of the property.</returns>
         public static string GetProperty(string packagePath, string property)
         {
             using InstallPackage ip = new(packagePath, DatabaseOpenMode.ReadOnly);
             return ip.Property[property];
-            
         }
+
         /// <summary>
         /// Calculate the number of bytes a Windows Installer Package would consume on disk. The function assumes that all files will be installed.
         /// </summary>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/RelatedProduct.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/RelatedProduct.cs
@@ -3,8 +3,6 @@
 
 using System;
 using Microsoft.Deployment.WindowsInstaller;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace Microsoft.DotNet.Build.Tasks.Workloads
 {
@@ -16,16 +14,14 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             get;
             set;
         }
-
-        [JsonConverter(typeof(VersionConverter))]
-        public Version VersionMin
+       
+        public string VersionMin
         {
             get;
             set;
         }
 
-        [JsonConverter(typeof(VersionConverter))]
-        public Version VersionMax
+        public string VersionMax
         {
             get;
             set;
@@ -51,8 +47,8 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             return new RelatedProduct
             {
                 UpgradeCode = (string)record["UpgradeCode"],
-                VersionMin = string.IsNullOrWhiteSpace(versionMin) ? null : Version.Parse(versionMin),
-                VersionMax = string.IsNullOrWhiteSpace(versionMax) ? null : Version.Parse(versionMax),
+                VersionMin = string.IsNullOrWhiteSpace(versionMin) ? null : versionMin,
+                VersionMax = string.IsNullOrWhiteSpace(versionMax) ? null : versionMax,
                 Language = (string)record["Language"],
                 Attributes = (int)record["Attributes"]
             };

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/RelatedProduct.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/RelatedProduct.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Deployment.WindowsInstaller;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Microsoft.DotNet.Build.Tasks.Workloads
 {
@@ -19,12 +17,14 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             set;
         }
 
+        [JsonConverter(typeof(VersionConverter))]
         public Version VersionMin
         {
             get;
             set;
         }
 
+        [JsonConverter(typeof(VersionConverter))]
         public Version VersionMax
         {
             get;

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/RelatedProduct.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/RelatedProduct.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Deployment.WindowsInstaller;
+
+namespace Microsoft.DotNet.Build.Tasks.Workloads
+{
+    // Represents a single row from the MSI Upgrade table.
+    public class RelatedProduct
+    {
+        public string UpgradeCode
+        {
+            get;
+            set;
+        }
+
+        public Version VersionMin
+        {
+            get;
+            set;
+        }
+
+        public Version VersionMax
+        {
+            get;
+            set;
+        }
+
+        public string Language
+        {
+            get;
+            set;
+        }
+
+        public int Attributes
+        {
+            get; 
+            set;
+        }
+
+        public static RelatedProduct Create(Record record)
+        {
+            string versionMin = (string)record["VersionMin"];
+            string versionMax = (string)record["VersionMax"];
+
+            return new RelatedProduct
+            {
+                UpgradeCode = (string)record["UpgradeCode"],
+                VersionMin = string.IsNullOrWhiteSpace(versionMin) ? null : Version.Parse(versionMin),
+                VersionMax = string.IsNullOrWhiteSpace(versionMax) ? null : Version.Parse(versionMax),
+                Language = (string)record["Language"],
+                Attributes = (int)record["Attributes"]
+            };
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/VisualStudioComponent.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/VisualStudioComponent.cs
@@ -243,7 +243,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             IEnumerable<string> missingPackIds = missingPacks.Select(p => p.ItemSpec);
             log?.LogMessage(MessageImportance.Low, $"Missing packs: {string.Join(", ", missingPackIds)}");
 
-            // If the work extends other workloads, we add those as component dependencies before
+            // If the workload extends other workloads, we add those as component dependencies before
             // processing direct pack dependencies
             if (workload.Extends?.Count() > 0)
             {
@@ -263,7 +263,15 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                 foreach (WorkloadPackId packId in packIds)
                 {
                     log?.LogMessage(MessageImportance.Low, $"Adding component dependency for {packId} ");
-                    component.AddDependency(manifest.Packs[packId]);
+
+                    if (manifest.Packs.ContainsKey(packId))
+                    {
+                        component.AddDependency(manifest.Packs[packId]);
+                    }
+                    else
+                    {
+                        log?.LogMessage(MessageImportance.High, $"Missing Visual Studio component dependency, packId: {packId}.");
+                    }
                 }
             }
 


### PR DESCRIPTION
- Extract ProductLanguage into JSON manifest - these will be needed in the CLI to detect related products when dealing with upgrades for manifest MSIs
- Remove icon file from generated csproj
- Only add pack dependencies if they exist