### PR TITLE
Update interactive-mode example of adding an Arcade subscription

### DIFF
--- a/Documentation/DependencyFlowOnboarding.md
+++ b/Documentation/DependencyFlowOnboarding.md
@@ -104,8 +104,9 @@ Target Branch: <target branch for arcade updates, e.g. master>
 Update Frequency: everyDay
 Batchable: False
 Merge Policies:
-- Name: standard
+- Name: Standard
   Properties: {}
+Pull Request Failure Notification Tags: ''
 ```
 
 3. Save and close


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation

---

Updating `Documentation/DependencyFlowOnboarding.md` after going through it:

* With the `standard` Merge Policy, the Maestro++ PR check said `Maestro auto-merge - Not implemented merge policy 'standard'`. Changing to `Standard` (like other subscriptions I see) then closing the PR and triggering a new one seems to have fixed that.

* I noticed `Pull Request Failure Notification Tags: ''` now shows up in interactive mode, but isn't in the doc. It's fairly obvious what it does, and I left it blank, but I figured the example might as well include it.

The non-interactive example appears to do something different--not sure if it's more correct or less correct than interactive. 😄 I'd personally consider removing one of the options to simplify the doc (and its maintenance).

/cc @riarenas @MattGal 