### PR TITLE
Add ability to turn off telemetry in SignTool

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -30,8 +30,8 @@
       <_DesktopMSBuildRequired>false</_DesktopMSBuildRequired>
       <_DesktopMSBuildRequired Condition="'$(_DryRun)' != 'true' and '$(MSBuildRuntimeType)' == 'Core'">true</_DesktopMSBuildRequired>
       <!-- We have telemetry turned off only for linux signing in release pipeline. Issue tracking this https://github.com/dotnet/arcade/issues/7621 -->
-      <_TurnOffTelemetry>true</_TurnOffTelemetry>
-      <_TurnOffTelemetry Condition="'$(TurnOffTelemetry)' == ''">false</_TurnOffTelemetry>
+      <_DisableTelemetry>false</_DisableTelemetry>
+      <_DisableTelemetry Condition="'$(DisableTelemetry)' != ''">$(DisableTelemetry)</_DisableTelemetry>
     </PropertyGroup>
 
     <Error Condition="'$(AllowEmptySignList)' != 'true' AND '@(ItemsToSign)' == ''" 
@@ -65,6 +65,6 @@
         MSBuildPath="$(_DesktopMSBuildPath)"
         SNBinaryPath="$(NuGetPackageRoot)sn\$(SNVersion)\sn.exe"
         MicroBuildCorePath="$(NuGetPackageRoot)microbuild.core\$(MicroBuildCoreVersion)"
-        TurnOffTelemetry="$(_TurnOffTelemetry)/>
+        DisableTelemetry="$(_DisableTelemetry)/>
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -62,6 +62,7 @@
         LogDir="$(ArtifactsLogDir)"
         MSBuildPath="$(_DesktopMSBuildPath)"
         SNBinaryPath="$(NuGetPackageRoot)sn\$(SNVersion)\sn.exe"
-        MicroBuildCorePath="$(NuGetPackageRoot)microbuild.core\$(MicroBuildCoreVersion)"/>
+        MicroBuildCorePath="$(NuGetPackageRoot)microbuild.core\$(MicroBuildCoreVersion)"
+        TurnOffTelemetry="$(TurnOffTelemetry)/>
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -29,7 +29,9 @@
 
       <_DesktopMSBuildRequired>false</_DesktopMSBuildRequired>
       <_DesktopMSBuildRequired Condition="'$(_DryRun)' != 'true' and '$(MSBuildRuntimeType)' == 'Core'">true</_DesktopMSBuildRequired>
-      <_TurnOffTelemetry Condition="'$(TurnOffTelemetry)' == ''">false</_TestSign>
+      <!-- We have telemetry turned off only for linux signing in release pipeline. Issue tracking this https://github.com/dotnet/arcade/issues/7621 -->
+      <_TurnOffTelemetry>true</_TurnOffTelemetry>
+      <_TurnOffTelemetry Condition="'$(TurnOffTelemetry)' == ''">false</_TurnOffTelemetry>
     </PropertyGroup>
 
     <Error Condition="'$(AllowEmptySignList)' != 'true' AND '@(ItemsToSign)' == ''" 
@@ -63,6 +65,6 @@
         MSBuildPath="$(_DesktopMSBuildPath)"
         SNBinaryPath="$(NuGetPackageRoot)sn\$(SNVersion)\sn.exe"
         MicroBuildCorePath="$(NuGetPackageRoot)microbuild.core\$(MicroBuildCoreVersion)"
-        TurnOffTelemetry="$(TurnOffTelemetry)/>
+        TurnOffTelemetry="$(_TurnOffTelemetry)/>
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -29,7 +29,6 @@
 
       <_DesktopMSBuildRequired>false</_DesktopMSBuildRequired>
       <_DesktopMSBuildRequired Condition="'$(_DryRun)' != 'true' and '$(MSBuildRuntimeType)' == 'Core'">true</_DesktopMSBuildRequired>
-      <!-- We have telemetry turned off only for linux signing in release pipeline. Issue tracking this https://github.com/dotnet/arcade/issues/7621 -->
       <_DisableTelemetry>false</_DisableTelemetry>
       <_DisableTelemetry Condition="'$(DisableTelemetry)' != ''">$(DisableTelemetry)</_DisableTelemetry>
     </PropertyGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -29,6 +29,7 @@
 
       <_DesktopMSBuildRequired>false</_DesktopMSBuildRequired>
       <_DesktopMSBuildRequired Condition="'$(_DryRun)' != 'true' and '$(MSBuildRuntimeType)' == 'Core'">true</_DesktopMSBuildRequired>
+      <_TurnOffTelemetry Condition="'$(TurnOffTelemetry)' == ''">false</_TestSign>
     </PropertyGroup>
 
     <Error Condition="'$(AllowEmptySignList)' != 'true' AND '@(ItemsToSign)' == ''" 

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -38,6 +38,7 @@ namespace Microsoft.DotNet.SignTool
 
         /// <summary>
         /// Turn off Telmetry is added to turn off telemetry for linux signing in release pipeline, but by default its always false
+        /// Issue tracking this https://github.com/dotnet/arcade/issues/7621
         /// </summary>
         public bool TurnOffTelemetry {get; set;}
         

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.SignTool
         /// Turn off Telmetry is added to turn off telemetry for linux signing in release pipeline, but by default its always false
         /// Issue tracking this https://github.com/dotnet/arcade/issues/7621
         /// </summary>
-        public bool TurnOffTelemetry {get; set;}
+        public bool DisableTelemetry {get; set;}
         
         /// <summary>
         /// True to perform strong name check on signed files.
@@ -269,7 +269,7 @@ namespace Microsoft.DotNet.SignTool
             }
             finally
             {
-                if (!TurnOffTelemetry)
+                if (!DisableTelemetry)
                 {
                     telemetry.SendEvents();
                 }

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -268,7 +268,7 @@ namespace Microsoft.DotNet.SignTool
             }
             finally
             {
-                if (TurnOffTelemetry)
+                if (!TurnOffTelemetry)
                 {
                     telemetry.SendEvents();
                 }

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -37,6 +37,11 @@ namespace Microsoft.DotNet.SignTool
         public bool TestSign { get; set; }
 
         /// <summary>
+        /// Turn off Telmetry is added to turn off telemetry for linux signing in release pipeline, but by default its always false
+        /// </summary>
+        public bool TurnOffTelemetry {get; set;}
+        
+        /// <summary>
         /// True to perform strong name check on signed files.
         /// If enabled it will require SNBinaryPath to be informed.
         /// </summary>
@@ -263,7 +268,10 @@ namespace Microsoft.DotNet.SignTool
             }
             finally
             {
-                telemetry.SendEvents();
+                if (TurnOffTelemetry)
+                {
+                    telemetry.SendEvents();
+                }
             }
         }
 

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -37,8 +37,7 @@ namespace Microsoft.DotNet.SignTool
         public bool TestSign { get; set; }
 
         /// <summary>
-        /// Turn off Telmetry is added to turn off telemetry for linux signing in release pipeline, but by default its always false
-        /// Issue tracking this https://github.com/dotnet/arcade/issues/7621
+        /// Enable or disable telemetry
         /// </summary>
         public bool DisableTelemetry {get; set;}
         


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation

Workaround for https://github.com/dotnet/arcade/issues/7621

Adding turning off telemetry flag, to turn off telemetry in release pipeline for linux files. 