### PR TITLE
Exclude inboxed analyzers from VerifyClosure task

### DIFF
--- a/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -457,6 +457,9 @@
 
     <ItemGroup Condition="'$(PlatformPackageType)' == 'RuntimePack'">
       <IgnoredReference Include="@(RuntimePackAsset->'%(FileName)')" />
+      <!-- Ignore inboxed analyzers -->
+      <IgnoredReference Include="@(Reference->'%(FileName)')" 
+          Condition="$([System.String]::Copy('%(FullPath)').IndexOf('analyzers')) > 0"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(PlatformPackageType)' == 'TargetingPack'">


### PR DESCRIPTION
As per https://github.com/dotnet/designs/blob/main/accepted/2021/InboxSourceGenerators.md inboxed source generators are placed under ref/ folder, and need to be excluded from RuntimePack reference check.

Fixes broken build https://github.com/dotnet/windowsdesktop/pull/1803


Tested locally manually modifying C:\Development\windowsdesktop\.packages\microsoft.dotnet.sharedframework.sdk\6.0.0-beta.21363.2\targets\sharedfx.targets and getting the build to pass:
![image](https://user-images.githubusercontent.com/4403806/125752027-6832a5c6-d93d-4a14-b28b-c757fad4a975.png)
