### PR TITLE
[5.0] Publish to multiple channels

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ variables:
 resources:
   containers:
   - container: LinuxContainer
-    image: microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-0cd4667-20170319080304
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-14.04-cross-0cd4667-20170319080304
 
 stages:
 - stage: build

--- a/eng/common/post-build/publish-using-darc.ps1
+++ b/eng/common/post-build/publish-using-darc.ps1
@@ -15,8 +15,8 @@ param(
 
 try {
   . $PSScriptRoot\post-build-utils.ps1
-  # Hard coding darc version till the next arcade-services roll out, cos this version has required API changes for darc add-build-to-channel
-  $darc = Get-Darc "1.1.0-beta.20418.1"
+
+  $darc = Get-Darc 
 
   $optionalParams = [System.Collections.ArrayList]::new()
 

--- a/eng/promote-build.yml
+++ b/eng/promote-build.yml
@@ -89,7 +89,7 @@ stages:
                     exit 1
                   }
 
-                  $channels = ${Env:PromoteToChannelIds} -split ","
+                  $channels = ${Env:PromoteToChannelIds} -split "-"
                   foreach ($channelId in $channels) {
                     $channelApiEndpoint = "$(MaestroApiEndPoint)/api/channels/${channelId}?api-version=$(MaestroApiVersion)"
                     $channelInfo = try { Invoke-WebRequest -Method Get -Uri $channelApiEndpoint -Headers $apiHeaders | ConvertFrom-Json } catch { Write-Host "Error: $_" }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BlobFeedAction.cs
@@ -190,8 +190,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 }
                 else
                 {
-                    Log.LogMessage($"Uploading {item} to {relativeBlobPath}.");
-                    await blobUtils.UploadBlockBlobAsync(item.ItemSpec, relativeBlobPath);
+                    using (FileStream stream =
+                        new FileStream(item.ItemSpec, FileMode.Open, FileAccess.Read, FileShare.Read))
+                    {
+                        Log.LogMessage($"Uploading {item} to {relativeBlobPath}.");
+                        await blobUtils.UploadBlockBlobAsync(item.ItemSpec, relativeBlobPath, stream);
+                    }
                 }
             }
             catch (Exception exc)

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -181,7 +181,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         IMaestroApi client = ApiFactory.GetAuthenticated(MaestroApiEndpoint, BuildAssetRegistryToken);
                         Maestro.Client.Models.Build buildInformation = await client.Builds.GetBuildAsync(BARBuildId);
 
-                        var targetChannelsIds = TargetChannels.Split(',').Select(ci => int.Parse(ci));
+                        var targetChannelsIds = TargetChannels.Split('-').Select(ci => int.Parse(ci));
 
                         foreach (var targetChannelId in targetChannelsIds)
                         {

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             {
                 List<int> targetChannelsIds = new List<int>();
 
-                foreach (var channelIdStr in TargetChannels.Split(','))
+                foreach (var channelIdStr in TargetChannels.Split('-'))
                 {
                     if (!int.TryParse(channelIdStr, out var channelId))
                     {

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             }
         }
 
-        public async Task UploadBlockBlobAsync(string filePath, string blobPath)
+        public async Task UploadBlockBlobAsync(string filePath, string blobPath, Stream stream)
         {
             BlobClient blob = GetBlob(blobPath.Replace("\\", "/"));
             BlobHttpHeaders headers = GetBlobHeadersByExtension(filePath);
@@ -83,7 +83,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                 try
                 {
                     await blob.UploadAsync(
-                        filePath,
+                        stream,
                         headers)
                         .ConfigureAwait(false);
                     return true;


### PR DESCRIPTION
## Description

Backporting https://github.com/dotnet/arcade/pull/6754 to fix the problem happening at https://dnceng.visualstudio.com/internal/_build/results?buildId=1239601&view=logs&j=5efe09e7-d552-5578-8f7a-2fec74a23f0f&t=35b72edb-be70-5f87-c665-5997021c18e3&l=13 :

```
Channel with ID 1299,1300 was not found in BAR. Aborting.
```

(Those are correct default channels, the validation should succeed.)

## Customer Impact

Blocked 5.0 publishing for dotnet-wpf-int

## Regression

Yes

## Risk

Low risk as the code is already running for `main` for some time (but @epananth can add more details)

## Workarounds

Disable `(2405) https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int @ release/5.0 -> .NET 5` default channel association so that there is only one target channel. I did that for now to get 5.0.9 flow going (and [it works](https://dnceng.visualstudio.com/internal/_build/results?buildId=1239839&view=results)), @ryalanms beware. Not sure how sustainable is to switch stuff like this (but it's true that 5.0 won't be serviced for long).