### PR TITLE
[release/3.x] Update tag references to dotnet-buildtools/prereqs (#7608)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ variables:
 resources:
   containers:
   - container: LinuxContainer
-    image: microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-0cd4667-20170319080304
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-14.04-cross-0cd4667-20170319080304
 
 stages:
 - stage: build


### PR DESCRIPTION
## Description

Description of the change here.
Port https://github.com/dotnet/arcade/pull/7608 to release/3.x branch as per email sent out

## Customer Impact

Customer impact if this change is **not** made.
release/3.x linux builds will fail. Example failure: https://dev.azure.com/dnceng/public/_build/results?buildId=1240004&view=results

## Regression

No

## Risk

None, this just moves where we get the docker image from

## Workarounds

Are there available workarounds for the bug?
Nope.