### PR TITLE
Revert "Exclude inboxed analyzers from VerifyClosure task"

### DIFF
--- a/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -457,9 +457,6 @@
 
     <ItemGroup Condition="'$(PlatformPackageType)' == 'RuntimePack'">
       <IgnoredReference Include="@(RuntimePackAsset->'%(FileName)')" />
-      <!-- Ignore inboxed analyzers -->
-      <IgnoredReference Include="@(Reference->'%(FileName)')" 
-          Condition="$([System.String]::Copy('%(FullPath)').IndexOf('analyzers')) > 0"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(PlatformPackageType)' == 'TargetingPack'">


### PR DESCRIPTION
Reverts dotnet/arcade#7624

This hides a product bug that would result in dangling runtime references.

We should not permit product binaries having a reference to design-time assemblies which aren't available at runtime.