### PR TITLE
[workloads] Add optional VS redist pack project

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
@@ -111,6 +111,15 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
         }
 
         /// <summary>
+        /// Gets or sets whether a corresponding VS redist pack project should be generated for the MSI.
+        /// </summary>
+        public bool GenerateTransportAuthoring
+        {
+            get;
+            set;
+        } = false;
+
+        /// <summary>
         /// Generate a set of MSIs for the specified platforms using the specified NuGet package.
         /// </summary>
         /// <param name="sourcePackage">The NuGet package to convert into an MSI.</param>
@@ -289,6 +298,11 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                 // Generate a .csproj to build a NuGet payload package to carry the MSI and JSON manifest
                 msi.SetMetadata(Metadata.PackageProject, GeneratePackageProject(msi.ItemSpec, msiJsonPath, platform, nupkg));
 
+                if (GenerateTransportAuthoring)
+                {
+                    msi.SetMetadata(Metadata.TransportPackageProject, GenerateTransportPackageProject(msi.ItemSpec, msiJsonPath, platform, nupkg));
+                }
+
                 msis.Add(msi);
             }
 
@@ -374,6 +388,63 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             writer.Close();
 
             return msiPackageProject;
+        }
+
+        private string GenerateTransportPackageProject(string msiPath, string msiJsonPath, string platform, NugetPackage nupkg)
+        {
+            string msiTransportPackageProject = Path.Combine(MsiTransportPackageDirectory, platform, nupkg.Id, "msi-transport.csproj");
+            string msiTransportPackageProjectDir = Path.GetDirectoryName(msiTransportPackageProject);
+
+            Log?.LogMessage($"Generating package project: '{msiTransportPackageProject}'");
+
+            if (Directory.Exists(msiTransportPackageProjectDir))
+            {
+                Directory.Delete(msiTransportPackageProjectDir, recursive: true);
+            }
+
+            Directory.CreateDirectory(msiTransportPackageProjectDir);
+
+            XmlWriterSettings settings = new XmlWriterSettings
+            {
+                Indent = true,
+                IndentChars = "  ",
+            };
+
+            XmlWriter writer = XmlWriter.Create(msiTransportPackageProject, settings);
+
+            writer.WriteStartElement("Project");
+            writer.WriteAttributeString("Sdk", "Microsoft.NET.Sdk");
+
+            writer.WriteStartElement("PropertyGroup");
+            writer.WriteElementString("TargetFramework", "net5.0");
+            writer.WriteElementString("GeneratePackageOnBuild", "true");
+            writer.WriteElementString("IncludeBuildOutput", "false");
+            writer.WriteElementString("IsPackable", "true");
+            writer.WriteElementString("SuppressDependenciesWhenPacking", "true");
+            writer.WriteElementString("NoWarn", "$(NoWarn);NU5128");
+            writer.WriteElementString("PackageId", $"VS.Redist.{nupkg.Id}.Msi.{platform}");
+            writer.WriteElementString("PackageVersion", $"{nupkg.Version}");
+            writer.WriteElementString("Description", nupkg.Description);
+
+            if (!string.IsNullOrWhiteSpace(nupkg.Authors))
+            {
+                writer.WriteElementString("Authors", nupkg.Authors);
+            }
+
+            if (!string.IsNullOrWhiteSpace(nupkg.Copyright))
+            {
+                writer.WriteElementString("Copyright", nupkg.Copyright);
+            }
+
+            writer.WriteEndElement(); // PropertyGroup
+            writer.WriteStartElement("ItemGroup");
+            WriteItem(writer, "None", msiPath, @"\");
+            writer.WriteEndElement(); // ItemGroup
+            writer.WriteEndElement(); // Project
+            writer.Flush();
+            writer.Close();
+
+            return msiTransportPackageProject;
         }
 
         private void WriteItem(XmlWriter writer, string itemName, string include, string packagePath)

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateTaskBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateTaskBase.cs
@@ -50,6 +50,11 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
         public string MsiPackageDirectory => Path.Combine(SourceDirectory, "msiPackage");
 
         /// <summary>
+        /// Root directory for .csproj sources to build transport NuGet packages.
+        /// </summary>
+        public string MsiTransportPackageDirectory => Path.Combine(SourceDirectory, "redis");
+
+        /// <summary>
         /// The directory containing the WiX toolset binaries.
         /// </summary>
         [Required]

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Metadata.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Metadata.cs
@@ -16,6 +16,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
         public const string SourcePackage = "SourcePackage";
         public const string SwixProject = "SwixProject";
         public const string Title = "Title";
+        public const string TransportPackageProject = "TransportPackageProject";
         public const string Version = "Version";
         public const string WixObj = "WixObj";
     }


### PR DESCRIPTION
Arcade does already support creation of VS insertion transport packages
via `Microsoft.DotNet.Build.Tasks.Installers`, however this addition
will help xamarin/maui teams who have not fully onboarded to building
with arcade.

Sample usage:

    <GenerateManifestMsi
        IntermediateBaseOutputPath="$(IntermediateOutputPath)"
        GenerateTransportAuthoring="true"
        OutputPath="$(OutputPath)"
        ManifestId="%(WorkloadPackages.Id)"
        MsiVersion="%(WorkloadPackages.MsiVersion)"
        SdkVersion="%(WorkloadPackages.SdkVersion)"
        WixToolsetPath="$(WixToolsetPath)"
        WorkloadManifestPackage="%(WorkloadPackages.Identity)" >
      <Output TaskParameter="Msis" ItemName="ManifestMsis" />
    </GenerateManifestMsi>
    <MSBuild Projects="%(ManifestMsis.PackageProject)" Targets="Restore;Pack" Properties="OutputPath=$(MsiNuGetOutputPath)" />
    <MSBuild Projects="%(ManifestMsis.TransportPackageProject)" Targets="Restore;Pack" Properties="OutputPath=$(MsiNuGetOutputPath)" />
