### PR TITLE
[release/5.0] Add support for repo-defined runtime.json for shared framework build

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/ProcessSharedFrameworkDeps.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/ProcessSharedFrameworkDeps.cs
@@ -6,6 +6,7 @@ using Microsoft.Build.Utilities;
 using Microsoft.Extensions.DependencyModel;
 using NuGet.Common;
 using NuGet.ProjectModel;
+using NuGet.RuntimeModel;
 using System;
 using System.IO;
 using System.Linq;
@@ -28,6 +29,8 @@ namespace Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk
 
         [Required]
         public string BuildTasksAssemblyPath { get; set; }
+
+        public string RuntimeIdentifierGraph { get; set; }
 
         public override bool Execute()
         {
@@ -53,7 +56,7 @@ namespace Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk
             }
 
             var manager = new RuntimeGraphManager();
-            var graph = manager.Collect(lockFile);
+            RuntimeGraph graph = string.IsNullOrEmpty(RuntimeIdentifierGraph) ? manager.Collect(lockFile) : JsonRuntimeFormat.ReadRuntimeGraph(RuntimeIdentifierGraph);
             var expandedGraph = manager.Expand(graph, Runtime);
 
             var trimmedRuntimeLibraries = context.RuntimeLibraries;

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.sharedfx.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/framework.sharedfx.targets
@@ -246,6 +246,7 @@
                                 DepsFilePath="$(SharedFrameworkDepsDestinationFile)"
                                 PackagesToRemove="@(TrimPkgsFromDeps)"
                                 Runtime="$(RuntimeGraphGeneratorRuntime)"
+                                RuntimeIdentifierGraph="$(BundledRuntimeIdentifierGraphFile)"
                                 BuildTasksAssemblyPath="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll" />
   </Target>
 


### PR DESCRIPTION
## Customer Impact
Framework dependent applications running on new RIDs cannot load RID-specific assets.   New RIDs are not well supported.

## Testing
Built shared framework.  TODO: Manually inspect 5.x shared frameworks.

## Risk
Minimal. This should result in behavior similar to 6.0 build and should restore a flow similar to what we had in 3.x.

Fixes https://github.com/dotnet/runtime/issues/50739

Note this is a PR to 5.0 servicing, not sure when it is OK to merge it.  Once merged and ingested into dotnet/runtime we should validate it's working correctly by examining the framework deps files for RIDs added in servicing.

I used the same property used in 6.0 which points to the repo's copy of runtime.json.  It should be defined here:
https://github.com/dotnet/runtime/blob/74905e767eb7b971636310965b66bf5dfd6a3545/eng/liveBuilds.targets#L203-L206
https://github.com/dotnet/runtime/blob/74905e767eb7b971636310965b66bf5dfd6a3545/Directory.Build.props#L74