### PR TITLE
Include Dependency Frameworks in set of TFMs considered for package testing

### DIFF
--- a/src/Microsoft.DotNet.PackageTesting.Tests/GetCompatibilePackageTargetFrameworksTests.cs
+++ b/src/Microsoft.DotNet.PackageTesting.Tests/GetCompatibilePackageTargetFrameworksTests.cs
@@ -141,6 +141,32 @@ namespace Microsoft.DotNet.PackageTesting.Tests
             CollectionsEqual(expectedTestFrameworks, actualTestFrameworks);
         }
 
+        [Fact]
+        public void GetCompatibleFrameworksFromDependencies()
+        {
+            var dependencyFrameworks = new[]
+            {
+                FrameworkConstants.CommonFrameworks.NetCoreApp21,
+                FrameworkConstants.CommonFrameworks.NetCoreApp31,
+                FrameworkConstants.CommonFrameworks.NetStandard20,
+                FrameworkConstants.CommonFrameworks.NetStandard21,
+                NuGetFramework.Parse("net6.0"),
+            };
+            Package package = new("TestPackage", "1.0.0", Enumerable.Empty<string>(), dependencyFrameworks);
+            IEnumerable<NuGetFramework> actualTestFrameworks = GetCompatiblePackageTargetFrameworks.GetTestFrameworks(package, "netcoreapp3.1");
+
+            var expectedTestFrameworks = new[]
+            {
+                NuGetFramework.Parse("net6.0"),
+                FrameworkConstants.CommonFrameworks.NetCoreApp31,
+                FrameworkConstants.CommonFrameworks.Net461,
+                FrameworkConstants.CommonFrameworks.Net462,
+                FrameworkConstants.CommonFrameworks.NetStandard20,
+                FrameworkConstants.CommonFrameworks.NetStandard21
+            };
+            CollectionsEqual(expectedTestFrameworks, actualTestFrameworks);
+        }
+
         private static void CollectionsEqual<T>(IEnumerable<T> T1, IEnumerable<T> T2)
         {
             foreach (var item in T1)

--- a/src/Microsoft.DotNet.PackageTesting.Tests/GetCompatibilePackageTargetFrameworksTests.cs
+++ b/src/Microsoft.DotNet.PackageTesting.Tests/GetCompatibilePackageTargetFrameworksTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Linq;
 using NuGet.Frameworks;
 using Xunit;
 
@@ -135,7 +136,7 @@ namespace Microsoft.DotNet.PackageTesting.Tests
         [MemberData(nameof(PackageTfmData))]
         public void GetCompatibleFrameworks(List<string> filePaths, List<NuGetFramework> expectedTestFrameworks)
         {
-            Package package = new("TestPackage", "1.0.0", filePaths);
+            Package package = new("TestPackage", "1.0.0", filePaths, Enumerable.Empty<NuGetFramework>());
             IEnumerable<NuGetFramework> actualTestFrameworks = GetCompatiblePackageTargetFrameworks.GetTestFrameworks(package, "netcoreapp3.1");
             CollectionsEqual(expectedTestFrameworks, actualTestFrameworks);
         }

--- a/src/Microsoft.DotNet.PackageTesting/NupkgParser.cs
+++ b/src/Microsoft.DotNet.PackageTesting/NupkgParser.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
+using NuGet.Frameworks;
 using NuGet.Packaging;
 
 namespace Microsoft.DotNet.PackageTesting
@@ -16,7 +17,9 @@ namespace Microsoft.DotNet.PackageTesting
             string packageId = nuspecReader.GetId();
             string version = nuspecReader.GetVersion().ToString();
 
-            return new Package(packageId, version, nupkgReader.GetFiles()?.Where(t => t.EndsWith(packageId + ".dll")));
+            NuGetFramework[] dependencyFrameworks = nuspecReader.GetDependencyGroups().Select(dg => dg.TargetFramework).Where(tfm => tfm != null).ToArray();
+
+            return new Package(packageId, version, nupkgReader.GetFiles()?.Where(t => t.EndsWith(packageId + ".dll")), dependencyFrameworks);
         }
     }
 }

--- a/src/Microsoft.DotNet.PackageTesting/Package.cs
+++ b/src/Microsoft.DotNet.PackageTesting/Package.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.PackageTesting
 {
     public class Package
     {
-        public Package(string packageId, string version, IEnumerable<string> packageAssetPaths)
+        public Package(string packageId, string version, IEnumerable<string> packageAssetPaths, IEnumerable<NuGetFramework> dependencyFrameworks)
         {
             PackageId = packageId;
             Version = version;
@@ -27,6 +27,7 @@ namespace Microsoft.DotNet.PackageTesting
 
             IEnumerable<ContentItem> RuntimeAssets = packageAssets.FindItems(conventions.Patterns.RuntimeAssemblies);
             FrameworksInPackageList.AddRange(RuntimeAssets.Select(t => (NuGetFramework)t.Properties["tfm"]).Distinct());
+            FrameworksInPackageList.AddRange(dependencyFrameworks);
             FrameworksInPackage = FrameworksInPackageList.Distinct();
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/27503

I believe this should fix testing for meta-packages as it will consider Frameworks for testing if they are used in dependency groups (not just files).

I haven't been able to try this out in dotnet/runtime yet and would want to do so before merging.