### PR TITLE
[release/5.0] Update tag references to dotnet-buildtools/prereqs (#7608)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ variables:
 resources:
   containers:
   - container: LinuxContainer
-    image: microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-0cd4667-20170319080304
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-14.04-cross-0cd4667-20170319080304
 
 stages:
 - stage: build


### PR DESCRIPTION
## Description

backport of https://github.com/dotnet/arcade/pull/7608 to fix build breaks when trying to initialize containers

## Customer Impact

the 5.0 build will be broken forever and ever

## Regression

No

## Risk

None. This is working in main and release/3.x

## Workarounds

None
