### PR TITLE
Fix installation for library and template packs

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
@@ -147,9 +147,9 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                     productName = nupkg.Id;
                 }
 
-                
 
-                
+
+
 
                 // Extract once, but harvest multiple times because some generated attributes are platform dependent. 
                 string packageContentsDirectory = Path.Combine(PackageDirectory, $"{nupkg.Identity}");

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
@@ -134,6 +134,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             string packageContentsDirectory = Path.Combine(PackageDirectory, $"{nupkg.Identity}");
             IEnumerable<string> exclusions = GetExlusionPatterns();
             string installDir = GetInstallDir(kind);
+            string packKind = kind.ToString().ToLowerInvariant();
 
             if ((kind != WorkloadPackKind.Library) && (kind != WorkloadPackKind.Template))
             {
@@ -174,10 +175,14 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                 string packageContentWxs = Path.Combine(msiSourcePath, "PackageContent.wxs");
                 sourceFiles.Add(packageContentWxs);
 
+                string directoryReference = (kind == WorkloadPackKind.Library) || (kind == WorkloadPackKind.Template)
+                    ? "InstallDir"
+                    : PackageContentDirectoryReference;
+
                 HarvestToolTask heat = new(BuildEngine, WixToolsetPath)
                 {
                     ComponentGroupName = PackageContentComponentGroupName,
-                    DirectoryReference = PackageContentDirectoryReference,
+                    DirectoryReference = directoryReference,
                     OutputFile = packageContentWxs,
                     Platform = platform,
                     SourceDirectory = packageContentsDirectory
@@ -216,6 +221,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                 candle.PreprocessorDefinitions.Add($@"SourceDir={packageContentsDirectory}");
                 candle.PreprocessorDefinitions.Add($@"Manufacturer={manufacturer}");
                 candle.PreprocessorDefinitions.Add($@"EulaRtf={EulaRtfPath}");
+                candle.PreprocessorDefinitions.Add($@"PackKind={packKind}");
 
                 // Compiler extension to process dependency provider authoring for package reference counting.
                 candle.Extensions.Add("WixDependencyExtension");

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/Directories.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/Directories.wxs
@@ -7,9 +7,11 @@
       <Directory Id="$(var.ProgramFilesFolder)">
         <Directory Id="DOTNETHOME" Name="dotnet">
           <Directory Id="InstallDir" Name="$(var.InstallDir)">
+            <?if $(var.PackKind) != "library" and $(var.PackKind) != "template"?>
             <Directory Id="PackageDir" Name="$(var.PackageId)">
               <Directory Id="VersionDir" Name="$(var.PackageVersion)" />
             </Directory>
+            <?endif?>
           </Directory>
         </Directory>
       </Directory>


### PR DESCRIPTION
Ensure that library and template packs install directly under the root folder, e.g. dotnet\library-packs (no versioned sub-folders)
