### PR TITLE
Publish log folder without configuration

### DIFF
--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -196,7 +196,7 @@ jobs:
     - task: PublishBuildArtifacts@1
       displayName: Publish Logs
       inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
+        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log'
         PublishLocation: Container
         ArtifactName: ${{ coalesce(parameters.enablePublishBuildArtifacts.artifactName, '$(Agent.Os)_$(Agent.JobName)' ) }}
       continueOnError: true


### PR DESCRIPTION
In https://dev.azure.com/dnceng/internal/_build/results?buildId=1250178&view=results we hit an issue where the "Restore internal tools" step failed, but AzDO only highlights the failure in the "Publish Logs" step because the directory didn't exist.
This happens because the restore step writes a file in `D:\workspace\_work\1\s\artifacts\log\Debug\` but the publish logs step only looks for the `Release` directory and fails if it doesn't exist.

Publish the whole log folder instead, which is what we do in other similar steps anyway.
