### PR TITLE
[release/5.0] Fix SDL error reporting

### DIFF
--- a/Documentation/Policy/PowershellBestPractices.md
+++ b/Documentation/Policy/PowershellBestPractices.md
@@ -101,7 +101,7 @@ if ($LASTEXITCODE -ne 0) {
 }
 ```
 
-*There is a known issue when using `$LASTEXITCODE` in release builds where PowerShell will report that the variable has not been set. As a workaround, simply set `$LASTEXITCODE = 0` at the top of your script.*
+*There is a known issue when using `$LASTEXITCODE` in release builds where PowerShell will report that the variable has not been set. As a workaround, simply set `$global:LASTEXITCODE = 0` at the top of your script.*
 
 ## Set StrictMode and ErrorActionPreference at the top of every file
 

--- a/eng/common/sdl/execute-all-sdl-tools.ps1
+++ b/eng/common/sdl/execute-all-sdl-tools.ps1
@@ -32,7 +32,7 @@ try {
   $ErrorActionPreference = 'Stop'
   Set-StrictMode -Version 2.0
   $disableConfigureToolsetImport = $true
-  $LASTEXITCODE = 0
+  $global:LASTEXITCODE = 0
 
   # `tools.ps1` checks $ci to perform some actions. Since the SDL
   # scripts don't necessarily execute in the same agent that run the

--- a/eng/common/sdl/execute-all-sdl-tools.ps1
+++ b/eng/common/sdl/execute-all-sdl-tools.ps1
@@ -82,13 +82,22 @@ try {
 
   if ($ArtifactToolsList -and $ArtifactToolsList.Count -gt 0) {
     & $(Join-Path $PSScriptRoot 'run-sdl.ps1') -GuardianCliLocation $guardianCliLocation -WorkingDirectory $workingDirectory -TargetDirectory $ArtifactsDirectory -GdnFolder $gdnFolder -ToolsList $ArtifactToolsList -AzureDevOpsAccessToken $AzureDevOpsAccessToken -UpdateBaseline $UpdateBaseline -GuardianLoggerLevel $GuardianLoggerLevel -CrScanAdditionalRunConfigParams $CrScanAdditionalRunConfigParams -PoliCheckAdditionalRunConfigParams $PoliCheckAdditionalRunConfigParams
+    if ($LASTEXITCODE -ne 0) {
+      ExitWithExitCode $LASTEXITCODE
+    }
   }
   if ($SourceToolsList -and $SourceToolsList.Count -gt 0) {
     & $(Join-Path $PSScriptRoot 'run-sdl.ps1') -GuardianCliLocation $guardianCliLocation -WorkingDirectory $workingDirectory -TargetDirectory $SourceDirectory -GdnFolder $gdnFolder -ToolsList $SourceToolsList -AzureDevOpsAccessToken $AzureDevOpsAccessToken -UpdateBaseline $UpdateBaseline -GuardianLoggerLevel $GuardianLoggerLevel -CrScanAdditionalRunConfigParams $CrScanAdditionalRunConfigParams -PoliCheckAdditionalRunConfigParams $PoliCheckAdditionalRunConfigParams
+    if ($LASTEXITCODE -ne 0) {
+      ExitWithExitCode $LASTEXITCODE
+    }
   }
 
   if ($UpdateBaseline) {
     & (Join-Path $PSScriptRoot 'push-gdn.ps1') -Repository $RepoName -BranchName $BranchName -GdnFolder $GdnFolder -AzureDevOpsAccessToken $AzureDevOpsAccessToken -PushReason 'Update baseline'
+    if ($LASTEXITCODE -ne 0) {
+      ExitWithExitCode $LASTEXITCODE
+    }
   }
 
   if ($TsaPublish) {

--- a/eng/common/sdl/init-sdl.ps1
+++ b/eng/common/sdl/init-sdl.ps1
@@ -10,7 +10,7 @@ Param(
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
 $disableConfigureToolsetImport = $true
-$LASTEXITCODE = 0
+$global:LASTEXITCODE = 0
 
 # `tools.ps1` checks $ci to perform some actions. Since the SDL
 # scripts don't necessarily execute in the same agent that run the

--- a/eng/common/sdl/push-gdn.ps1
+++ b/eng/common/sdl/push-gdn.ps1
@@ -9,7 +9,7 @@ Param(
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
 $disableConfigureToolsetImport = $true
-$LASTEXITCODE = 0
+$global:LASTEXITCODE = 0
 
 try {
   # `tools.ps1` checks $ci to perform some actions. Since the SDL

--- a/eng/common/sdl/push-gdn.ps1
+++ b/eng/common/sdl/push-gdn.ps1
@@ -46,19 +46,26 @@ try {
     Write-PipelineTelemetryError -Force -Category 'Sdl' -Message "Git add failed with exit code $LASTEXITCODE."
     ExitWithExitCode $LASTEXITCODE
   }
-  Write-Host "git -c user.email=`"dn-bot@microsoft.com`" -c user.name=`"Dotnet Bot`" commit -m `"$PushReason for $Repository/$BranchName`""
-  git -c user.email="dn-bot@microsoft.com" -c user.name="Dotnet Bot" commit -m "$PushReason for $Repository/$BranchName"
+  # check if there are any staged changes (0 = no changes, 1 = changes)
+  # if we don't do this and there's nothing to commit `git commit` will return
+  # exit code 1 and we will fail
+  Write-Host "git diff --cached --exit-code"
+  git diff --cached --exit-code
+  Write-Host "git diff exit code: $LASTEXITCODE"
   if ($LASTEXITCODE -ne 0) {
-    Write-PipelineTelemetryError -Force -Category 'Sdl' -Message "Git commit failed with exit code $LASTEXITCODE."
-    ExitWithExitCode $LASTEXITCODE
+    Write-Host "git -c user.email=`"dn-bot@microsoft.com`" -c user.name=`"Dotnet Bot`" commit -m `"$PushReason for $Repository/$BranchName`""
+    git -c user.email="dn-bot@microsoft.com" -c user.name="Dotnet Bot" commit -m "$PushReason for $Repository/$BranchName"
+    if ($LASTEXITCODE -ne 0) {
+      Write-PipelineTelemetryError -Force -Category 'Sdl' -Message "Git commit failed with exit code $LASTEXITCODE."
+      ExitWithExitCode $LASTEXITCODE
+    }
+    Write-Host 'git push'
+    git push
+    if ($LASTEXITCODE -ne 0) {
+      Write-PipelineTelemetryError -Force -Category 'Sdl' -Message "Git push failed with exit code $LASTEXITCODE."
+      ExitWithExitCode $LASTEXITCODE
+    }
   }
-  Write-Host 'git push'
-  git push
-  if ($LASTEXITCODE -ne 0) {
-    Write-PipelineTelemetryError -Force -Category 'Sdl' -Message "Git push failed with exit code $LASTEXITCODE."
-    ExitWithExitCode $LASTEXITCODE
-  }
-
   # Return to the original directory
   Pop-Location
 }

--- a/eng/common/sdl/run-sdl.ps1
+++ b/eng/common/sdl/run-sdl.ps1
@@ -13,7 +13,7 @@ Param(
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
 $disableConfigureToolsetImport = $true
-$LASTEXITCODE = 0
+$global:LASTEXITCODE = 0
 
 try {
   # `tools.ps1` checks $ci to perform some actions. Since the SDL


### PR DESCRIPTION
## Description

Related issue: https://github.com/dotnet/arcade/issues/7616

This PR solves the same issue as similar PR for `3.x` branch: https://github.com/dotnet/arcade/pull/7654

This PR introduces the change to fail the build step when SDL reports errors. On 5.0 we have the same problem as on 3.x - we are shadowing `$LASTEXITCODE` variable by calling `$LASTEXITCODE = 0` at the beginning of scripts. It should be `$global:LASTEXITCODE = 0`.

Example build: https://dev.azure.com/dnceng/internal/_build/results?buildId=1255281
Example build that failed because of SDL error: https://dev.azure.com/dnceng/internal/_build/results?buildId=1255232

## Customer Impact

Without fixing the error handling we may miss security issues reported by the SDL scanner.

## Regression

There can be possible changes in behavior because we were ignoring all errors in SDL step before. Now they will fail the build.

## Risk

The biggest risk is that fixing the error handling will make pipelines fail on SDL stage because of errors that we previously silently ignored.

## Workarounds

If our target is to fail the build on SDL errors then I believe this the minimal amount of changes we have to make. The alternative is to keep track of the issues manually but this seems impractical in the long term.