### PR TITLE
don't allocate buffer when downloading files for publishing

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -912,7 +912,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         new CancellationTokenSource(TimeSpan.FromMinutes(TimeoutInMinutes));
 
                     using HttpRequestMessage getMessage = new HttpRequestMessage(HttpMethod.Get, uri);
-                    using HttpResponseMessage response = await client.GetAsync(uri, timeoutTokenSource.Token);
+                    using HttpResponseMessage response = await client.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, timeoutTokenSource.Token);
 
                     response.EnsureSuccessStatusCode();
 


### PR DESCRIPTION
Should fix https://github.com/dotnet/arcade/issues/7660

I produced an arcade sdk package with these changes in https://dev.azure.com/dnceng/internal/_build/results?buildId=1255224&view=results

and used that sdk version to publish a failing installer build here: https://dev.azure.com/dnceng/internal/_build/results?buildId=1255325&view=results