### PR TITLE
Include manifest ID in upgrade code generation

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
@@ -188,7 +188,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
 
                     // To support upgrades, the UpgradeCode must be stable withing a feature band.
                     // For example, 6.0.101 and 6.0.108 will generate the same GUID for the same platform.
-                    var upgradeCode = Utils.CreateUuid(GenerateMsiBase.UpgradeCodeNamespaceUuid, $"{SdkFeatureBandVersion};{platform}");
+                    var upgradeCode = Utils.CreateUuid(GenerateMsiBase.UpgradeCodeNamespaceUuid, $"{ManifestId};{SdkFeatureBandVersion};{platform}");
                     var productCode = Guid.NewGuid();
                     Log.LogMessage($"UC: {upgradeCode}, PC: {productCode}, {SdkFeatureBandVersion}, {SdkVersion}, {platform}");
 


### PR DESCRIPTION
This helps to ensure that UpgradeCode values are different between manifest installers in the same feature band/platform, but stable within the same manifest, featureband and platform.
