### PR TITLE
Update ArPow build to build with current TFM

### DIFF
--- a/eng/TargetFrameworkDefaults.props
+++ b/eng/TargetFrameworkDefaults.props
@@ -6,7 +6,7 @@
   -->
   <PropertyGroup>
     <TargetFrameworkForNETSDK>netcoreapp3.1</TargetFrameworkForNETSDK>
-    <TargetFrameworkForNETSDK Condition="'$(DotNetBuildFromSource)' == 'true'">net5.0</TargetFrameworkForNETSDK>
+    <TargetFrameworkForNETSDK Condition="'$(DotNetBuildFromSource)' == 'true'">net6.0</TargetFrameworkForNETSDK>
   </PropertyGroup>
 
 </Project>

--- a/src/Common/Microsoft.Arcade.Common.Tests/Microsoft.Arcade.Common.Tests.csproj
+++ b/src/Common/Microsoft.Arcade.Common.Tests/Microsoft.Arcade.Common.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Common/Microsoft.Arcade.Common/Microsoft.Arcade.Common.csproj
+++ b/src/Common/Microsoft.Arcade.Common/Microsoft.Arcade.Common.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Common/Microsoft.Arcade.Test.Common/Microsoft.Arcade.Test.Common.csproj
+++ b/src/Common/Microsoft.Arcade.Test.Common/Microsoft.Arcade.Test.Common.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
@@ -19,7 +19,7 @@
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
     <EnableGeneratedPackageContent>false</EnableGeneratedPackageContent>
     <_GeneratedVersionFilePath>$(IntermediateOutputPath)DefaultVersions.Generated.props</_GeneratedVersionFilePath>
-    <NoWarn>3021;NU5105</NoWarn>
+    <NoWarn>3021;NU5105;SYSLIB0013</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/CalculateAssemblyAndFileVersions.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/CalculateAssemblyAndFileVersions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
     /// File version has 4 parts and need to increase every official build.This is especially important when building MSIs.
     /// See https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md#assembly-version.
     /// </summary>
-    public class CalculateAssemblyAndFileVersions : Task
+    public class CalculateAssemblyAndFileVersions : Microsoft.Build.Utilities.Task
     {
         private const int MaxMinor = 654;
         private const int MaxBuild = 9999;

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/CheckRequiredDotNetVersion.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/CheckRequiredDotNetVersion.cs
@@ -11,7 +11,7 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.Arcade.Sdk
 {
-    public class CheckRequiredDotNetVersion : Task
+    public class CheckRequiredDotNetVersion : Microsoft.Build.Utilities.Task
     {
         private static readonly string s_cacheKey = "CheckRequiredDotNetVersion-6ED0A075-A4B3-46B1-97D4-448558D515D3";
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/CompareVersions.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/CompareVersions.cs
@@ -7,7 +7,7 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.Arcade.Sdk
 {
-    public class CompareVersions : Task
+    public class CompareVersions : Microsoft.Build.Utilities.Task
     {
         [Required]
         public string Left { get; set; }

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs
@@ -13,7 +13,7 @@ using Tasks = System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Arcade.Sdk
 {
-    public class DownloadFile : Task, ICancelableTask
+    public class DownloadFile : Microsoft.Build.Utilities.Task, ICancelableTask
     {
         /// <summary>
         /// List of URls to attempt download from. Accepted metadata are:

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/ExtractNgenMethodList.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/ExtractNgenMethodList.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
     /// Used to convert a raw XML dump from IBCMerge into the set of methods which will be NGEN'd when 
     /// partial NGEN is enabled
     /// </summary>
-    public sealed class ExtractNgenMethodList : Task
+    public sealed class ExtractNgenMethodList : Microsoft.Build.Utilities.Task
     {
         /// <summary>
         /// This is the XML file produced by passing -dxml to ibcmerge. It will be transformed into the set of

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateChecksums.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateChecksums.cs
@@ -9,7 +9,7 @@ using System.Security.Cryptography;
 
 namespace Microsoft.DotNet.Arcade.Sdk
 {
-    public class GenerateChecksums : Task
+    public class GenerateChecksums : Microsoft.Build.Utilities.Task
     {
         /// <summary>
         /// An item collection of files for which to generate checksums.  Each item must have metadata

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateResxSource.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateResxSource.cs
@@ -14,7 +14,7 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.Arcade.Sdk
 {
-    public sealed class GenerateResxSource : Task
+    public sealed class GenerateResxSource : Microsoft.Build.Utilities.Task
     {
         private const int maxDocCommentLength = 256;
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateSourcePackageSourceLinkTargetsFile.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateSourcePackageSourceLinkTargetsFile.cs
@@ -89,7 +89,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
             }
 
             var relativePathToSourceRoot = projectDir.Substring(innerMostRootItemSpec.Length);
-            var contentFilesSourceLinkUrl = innerMostRootSourceLinkUrl.Replace("*", Uri.EscapeUriString(relativePathToSourceRoot.Replace('\\', '/')) + "*");
+            var contentFilesSourceLinkUrl = innerMostRootSourceLinkUrl.Replace("*", Uri.EscapeDataString(relativePathToSourceRoot.Replace('\\', '/')) + "*");
             return GetTargetsFileContent(PackageId, contentFilesSourceLinkUrl);
         }
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateSourcePackageSourceLinkTargetsFile.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateSourcePackageSourceLinkTargetsFile.cs
@@ -89,7 +89,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
             }
 
             var relativePathToSourceRoot = projectDir.Substring(innerMostRootItemSpec.Length);
-            var contentFilesSourceLinkUrl = innerMostRootSourceLinkUrl.Replace("*", Uri.EscapeDataString(relativePathToSourceRoot.Replace('\\', '/')) + "*");
+            var contentFilesSourceLinkUrl = innerMostRootSourceLinkUrl.Replace("*", Uri.EscapeUriString(relativePathToSourceRoot.Replace('\\', '/')) + "*");
             return GetTargetsFileContent(PackageId, contentFilesSourceLinkUrl);
         }
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateSourcePackageSourceLinkTargetsFile.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GenerateSourcePackageSourceLinkTargetsFile.cs
@@ -12,7 +12,7 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.Arcade.Sdk
 {
-    public sealed class GenerateSourcePackageSourceLinkTargetsFile : Task
+    public sealed class GenerateSourcePackageSourceLinkTargetsFile : Microsoft.Build.Utilities.Task
     {
         [Required]
         public string ProjectDirectory { get; set; }

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GetAssemblyFullName.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GetAssemblyFullName.cs
@@ -7,7 +7,7 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.Arcade.Sdk
 {
-    public class GetAssemblyFullName : Task
+    public class GetAssemblyFullName : Microsoft.Build.Utilities.Task
     {
         [Required]
         public ITaskItem[] Items { get; set; }

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GetLicenseFilePath.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GetLicenseFilePath.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
     /// Finds a license file in the given directory.
     /// File is considered a license file if its name matches 'license(.txt|.md|)', ignoring case.
     /// </summary>
-    public class GetLicenseFilePath : Task
+    public class GetLicenseFilePath : Microsoft.Build.Utilities.Task
     {
         /// <summary>
         /// Full path to the directory to search for the license file.

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/GroupItemsBy.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/GroupItemsBy.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
     /// ]]>
     /// 
     /// </summary>
-    public sealed class GroupItemsBy : Task
+    public sealed class GroupItemsBy : Microsoft.Build.Utilities.Task
     {
         /// <summary>
         /// Items to group by their ItemSpec.

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
     {
         static InstallDotNetCore() => AssemblyResolution.Initialize();
 #else
-    public class InstallDotNetCore : Task
+    public class InstallDotNetCore : Microsoft.Build.Utilities.Task
     {
 #endif
         public string VersionsPropsPath { get; set; }

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/LocateDotNet.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/LocateDotNet.cs
@@ -10,7 +10,7 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.Arcade.Sdk
 {
-    public class LocateDotNet : Task
+    public class LocateDotNet : Microsoft.Build.Utilities.Task
     {
         private static readonly string s_cacheKey = "LocateDotNet-FCDFF825-F35B-4601-9CB5-74DCA498B589";
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/SaveItems.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/SaveItems.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
     /// This task writes msbuild Items with their metadata to a props file.
     /// Useful to statically save a status of an Item that will be used later on by just importing the generated file.
     /// </summary>
-    public class SaveItems : Task
+    public class SaveItems : Microsoft.Build.Utilities.Task
     {
         [Required]
         public string ItemName { get; set; }

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/SetCorFlags.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/SetCorFlags.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
     {
         static SetCorFlags() => AssemblyResolution.Initialize();
 #else
-    public class SetCorFlags : Task
+    public class SetCorFlags : Microsoft.Build.Utilities.Task
     {
 #endif
         [Required]

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/SingleError.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/SingleError.cs
@@ -6,7 +6,7 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.Arcade.Sdk
 {
-    public sealed class SingleError : Task
+    public sealed class SingleError : Microsoft.Build.Utilities.Task
     {
         private static readonly string s_cacheKeyPrefix = "SingleError-F88E25C6-1488-4E81-A458-A0921794E6E3:";
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/SourceBuild/AddSourceToNuGetConfig.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/SourceBuild/AddSourceToNuGetConfig.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Arcade.Sdk.SourceBuild
     /// also by default adds a 'clear' element if none exists, to avoid
     /// unintended leaks from the build environment.
     /// </summary>
-    public class AddSourceToNuGetConfig : Task
+    public class AddSourceToNuGetConfig : Microsoft.Build.Utilities.Task
     {
         [Required]
         public string NuGetConfigFile { get; set; }

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/SourceBuild/ReadSourceBuildIntermediateNupkgDependencies.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/SourceBuild/ReadSourceBuildIntermediateNupkgDependencies.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Arcade.Sdk.SourceBuild
     /// Reads entries in a Version.Details.xml file to find intermediate nupkg dependencies. For
     /// each dependency with a "SourceBuild" element, adds an item to the "Dependencies" output.
     /// </summary>
-    public class ReadSourceBuildIntermediateNupkgDependencies : Task
+    public class ReadSourceBuildIntermediateNupkgDependencies : Microsoft.Build.Utilities.Task
     {
         [Required]
         public string VersionDetailsXmlFile { get; set; }

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/Unsign.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/Unsign.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
     {
         static Unsign() => AssemblyResolution.Initialize();
 #else
-    public class Unsign : Task
+    public class Unsign : Microsoft.Build.Utilities.Task
     {
 #endif
         [Required]

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/ValidateLicense.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/ValidateLicense.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
     /// <summary>
     /// Checks that the content of two license files is the same modulo line breaks, leading and trailing whitespace.
     /// </summary>
-    public class ValidateLicense : Task
+    public class ValidateLicense : Microsoft.Build.Utilities.Task
     {
         /// <summary>
         /// Full path to the file that contains the license text to be validated.

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/ConfigureInputFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/ConfigureInputFeed.cs
@@ -8,7 +8,7 @@ using System;
 
 namespace Microsoft.DotNet.Build.Tasks.Feed
 {
-    public class ConfigureInputFeed : Task
+    public class ConfigureInputFeed : Microsoft.Build.Utilities.Task
     {
         [Required]
         public ITaskItem[] EnableFeeds { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/LaunchDebugger.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/LaunchDebugger.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 
 namespace Microsoft.DotNet.Build.Tasks.Feed
 {
-    public class LaunchDebugger : Task
+    public class LaunchDebugger : Microsoft.Build.Utilities.Task
     {
         public override bool Execute()
         {

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureConnectionStringBuildTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureConnectionStringBuildTask.cs
@@ -6,7 +6,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.Build.CloudTestTasks
 {
-    public abstract class AzureConnectionStringBuildTask : Task
+    public abstract class AzureConnectionStringBuildTask : Microsoft.Build.Utilities.Task
     {
         /// <summary>
         /// Azure Storage account connection string.  Supersedes Account Key / Name.  

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateNuSpec.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateNuSpec.cs
@@ -19,7 +19,7 @@ using System.Xml.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks.Packaging
 {
-    public class GenerateNuSpec : Task
+    public class GenerateNuSpec : Microsoft.Build.Utilities.Task
     {
         private static readonly XNamespace NuSpecXmlNamespace = @"http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd";
 

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetRuntimeJsonValues.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetRuntimeJsonValues.cs
@@ -9,7 +9,7 @@ using System.Linq;
 namespace Microsoft.DotNet.Build.Tasks.Packaging
 {
     // Read a runtime.json file into an msbuild item group
-    public class GetRuntimeJsonValues : Task
+    public class GetRuntimeJsonValues : Microsoft.Build.Utilities.Task
     {
         // runtime.json file path
         [Required]

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetRuntimeTargets.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetRuntimeTargets.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks.Packaging
 {
-    public class GetRuntimeTargets : Task
+    public class GetRuntimeTargets : Microsoft.Build.Utilities.Task
     {
         // runtime.json file path
         [Required]

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
@@ -87,7 +87,7 @@
   <Target Name="FindRuntimeJson" Inputs="%(_candidatPackageFolders.Identity)" Outputs="unused">
     <PropertyGroup>
       <_candidatePackageFolder>%(_candidatPackageFolders.Identity)</_candidatePackageFolder>
-      <_runtimeJsonSubPath>Microsoft.NETCore.Platforms\2.1.0\runtime.json</_runtimeJsonSubPath>
+      <_runtimeJsonSubPath>Microsoft.NETCore.Platforms\$(MicrosoftNETCorePlatformsVersion)\runtime.json</_runtimeJsonSubPath>
       <_runtimeJsonPath Condition="'$(_runtimeJsonPath)' == '' AND Exists('$(_candidatePackageFolder)\$(_runtimeJsonSubPath)')">$(_candidatePackageFolder)\$(_runtimeJsonSubPath)</_runtimeJsonPath>
       <_runtimeJsonPath Condition="'$(_runtimeJsonPath)' == '' AND Exists('$(_candidatePackageFolder)\$(_runtimeJsonSubPath.ToLower())')">$(_candidatePackageFolder)\$(_runtimeJsonSubPath.ToLower())</_runtimeJsonPath>
     </PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Templating/src/GenerateFileFromTemplate.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Templating/src/GenerateFileFromTemplate.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.Build.Tasks.Templating
     /// </code>
     /// </example>
     /// </summary>
-    public class GenerateFileFromTemplate : Task
+    public class GenerateFileFromTemplate : Microsoft.Build.Utilities.Task
     {
         /// <summary>
         /// The template file using the variable syntax <c>${VarName}</c>.

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/FindLatestDrop.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/FindLatestDrop.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio
     /// <summary>
     /// Find the latest drop in a JSON list of VS drops.
     /// </summary>
-    public sealed class FindLatestDrop : Task
+    public sealed class FindLatestDrop : Microsoft.Build.Utilities.Task
     {
         /// <summary>
         /// Full path to JSON file containing list of drops.

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GenerateTrainingInputFiles.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GenerateTrainingInputFiles.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio
     /// Generates OptProf training input files for VS components listed in OptProf.json file and 
     /// their VSIX files located in the specified directory.
     /// </summary>
-    public sealed class GenerateTrainingInputFiles : Task
+    public sealed class GenerateTrainingInputFiles : Microsoft.Build.Utilities.Task
     {
         /// <summary>
         /// Absolute path to the OptProf.json config file.

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GenerateTrainingPropsFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GenerateTrainingPropsFile.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio
     /// <summary>
     /// Generates a .props file pointing to a drops URL where IBC optimization inputs will be uploaded.
     /// </summary>
-    public sealed class GenerateTrainingPropsFile : Task
+    public sealed class GenerateTrainingPropsFile : Microsoft.Build.Utilities.Task
     {
         private const string ProductDropNamePrefix = "Products/";
 

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GetRunSettingsSessionConfiguration.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/OptProf/GetRunSettingsSessionConfiguration.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio
     /// Calculates the SessionConfiguration to be used in .runsettings for OptProf training 
     /// based on given OptProf.json configuration and VS bootstrapper information.
     /// </summary>
-    public sealed class GetRunSettingsSessionConfiguration : Task
+    public sealed class GetRunSettingsSessionConfiguration : Microsoft.Build.Utilities.Task
     {
         /// <summary>
         /// Absolute path to the OptProf.json config file.

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/Vsix/FinalizeInsertionVsixFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/Vsix/FinalizeInsertionVsixFile.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio
     /// 
     /// Replaces Experimental="true" attribute of the Installation element with SystemComponent="true" in the VSIX manifest file.
     /// </summary>
-    public sealed class FinalizeInsertionVsixFile : Task
+    public sealed class FinalizeInsertionVsixFile : Microsoft.Build.Utilities.Task
     {
         private const string VsixManifestPartName = "/extension.vsixmanifest";
         private const string VsixNamespace = "http://schemas.microsoft.com/developer/vsx-schema/2011";

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/Vsix/GetPkgDefAssemblyDependencyGuid.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/Vsix/GetPkgDefAssemblyDependencyGuid.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Build.Tasks.VisualStudio
     /// Calculates Guid used in .pkgdef files for codeBase and bindingRedirect entries.
     /// The implementation matches Microsoft.VisualStudio.Shell.ProvideDependentAssemblyAttribute.
     /// </summary>
-    public sealed class GetPkgDefAssemblyDependencyGuid : Task
+    public sealed class GetPkgDefAssemblyDependencyGuid : Microsoft.Build.Utilities.Task
     {
         [Required]
         public ITaskItem[] Items { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateTaskBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateTaskBase.cs
@@ -10,7 +10,7 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.Build.Tasks.Workloads
 {
-    public abstract class GenerateTaskBase : Task
+    public abstract class GenerateTaskBase : Microsoft.Build.Utilities.Task
     {
         public const int MaxPayloadRelativePath = 182;
 

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateVisualStudioManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateVisualStudioManifest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
     /// MSBuild task for generating a Visual Studio manifest project (.vsmanproj). The generated project can be used
     /// to create a manifest (.vsman) by merging JSON manifest files produced from one or more SWIX project.
     /// </summary>
-    public class GenerateVisualStudioManifest : Task
+    public class GenerateVisualStudioManifest : Microsoft.Build.Utilities.Task
     {
         /// <summary>
         /// The base path where the project source will be generated.

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GetWorkloadPackPackageReferences.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GetWorkloadPackPackageReferences.cs
@@ -12,7 +12,7 @@ using Microsoft.NET.Sdk.WorkloadManifestReader;
 
 namespace Microsoft.DotNet.Build.Tasks.Workloads
 {
-    public class GetWorkloadPackPackageReferences : Task
+    public class GetWorkloadPackPackageReferences : Microsoft.Build.Utilities.Task
     {
         public string ProjectFile
         {

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/Microsoft.DotNet.Deployment.Tasks.Links.csproj
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/Microsoft.DotNet.Deployment.Tasks.Links.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">net6.0</TargetFrameworks>
 
     <IsPackable>true</IsPackable>
     <Description>Aka.ms link manager</Description>

--- a/src/Microsoft.DotNet.GenFacades/Microsoft.DotNet.GenFacades.csproj
+++ b/src/Microsoft.DotNet.GenFacades/Microsoft.DotNet.GenFacades.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworkForNETSDK);net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">$(TargetFrameworkForNETSDK)</TargetFrameworks>
     <PackageType>MSBuildSdk</PackageType>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IsPackable>true</IsPackable>

--- a/src/Microsoft.DotNet.Helix/Sdk/BaseTask.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/BaseTask.cs
@@ -2,7 +2,7 @@ using Task = Microsoft.Build.Utilities.Task;
 
 namespace Microsoft.DotNet.Helix
 {
-    public abstract partial class BaseTask : Task
+    public abstract partial class BaseTask : Microsoft.Build.Utilities.Task
     {
     }
 }

--- a/src/Microsoft.DotNet.NuGetRepack/tasks/Microsoft.DotNet.NuGetRepack.Tasks.csproj
+++ b/src/Microsoft.DotNet.NuGetRepack/tasks/Microsoft.DotNet.NuGetRepack.Tasks.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">net6.0</TargetFrameworks>
 
     <IsPackable>true</IsPackable>
     <PackageType>MSBuildSdk</PackageType>

--- a/src/Microsoft.DotNet.NuGetRepack/tasks/src/ReplacePackageParts.cs
+++ b/src/Microsoft.DotNet.NuGetRepack/tasks/src/ReplacePackageParts.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.Tools
     {
         static ReplacePackageParts() => AssemblyResolution.Initialize();
 #else
-    public sealed class ReplacePackageParts : Task
+    public sealed class ReplacePackageParts : Microsoft.Build.Utilities.Task
     {
 #endif
         /// <summary>

--- a/src/Microsoft.DotNet.NuGetRepack/tasks/src/UpdatePackageVersionTask.cs
+++ b/src/Microsoft.DotNet.NuGetRepack/tasks/src/UpdatePackageVersionTask.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Tools
     {
         static UpdatePackageVersionTask() => AssemblyResolution.Initialize();
 #else
-    public class UpdatePackageVersionTask : Task
+    public class UpdatePackageVersionTask : Microsoft.Build.Utilities.Task
     {
 #endif
         public string VersionKind { get; set; }

--- a/src/Microsoft.DotNet.PackageTesting/Microsoft.DotNet.PackageTesting.csproj
+++ b/src/Microsoft.DotNet.PackageTesting/Microsoft.DotNet.PackageTesting.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">net6.0</TargetFrameworks>
     <PackageType>MSBuildSdk</PackageType>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IsPackable>true</IsPackable>

--- a/src/Microsoft.DotNet.SharedFramework.Sdk/Microsoft.DotNet.SharedFramework.Sdk.csproj
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/Microsoft.DotNet.SharedFramework.Sdk.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">net6.0</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
 

--- a/src/Microsoft.DotNet.SignTool/Microsoft.DotNet.SignTool.csproj
+++ b/src/Microsoft.DotNet.SignTool/Microsoft.DotNet.SignTool.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>Latest</LangVersion>
     <IsPackable>true</IsPackable>

--- a/src/Microsoft.DotNet.SourceBuild/tasks/src/ReadNuGetPackageInfos.cs
+++ b/src/Microsoft.DotNet.SourceBuild/tasks/src/ReadNuGetPackageInfos.cs
@@ -10,7 +10,7 @@ using System.Linq;
 
 namespace Microsoft.DotNet.SourceBuild.Tasks
 {
-    public class ReadNuGetPackageInfos : Task
+    public class ReadNuGetPackageInfos : Microsoft.Build.Utilities.Task
     {
         [Required]
         public string[] PackagePaths { get; set; }

--- a/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/ValidateUsageAgainstBaseline.cs
+++ b/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/ValidateUsageAgainstBaseline.cs
@@ -12,7 +12,7 @@ using System.Xml.Linq;
 
 namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
 {
-    public class ValidateUsageAgainstBaseline : Task
+    public class ValidateUsageAgainstBaseline : Microsoft.Build.Utilities.Task
     {
         [Required]
         public string DataFile { get; set; }

--- a/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/WritePackageUsageData.cs
+++ b/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/WritePackageUsageData.cs
@@ -17,7 +17,7 @@ using Task = Microsoft.Build.Utilities.Task;
 
 namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
 {
-    public class WritePackageUsageData : Task
+    public class WritePackageUsageData : Microsoft.Build.Utilities.Task
     {
         public string[] RestoredPackageFiles { get; set; }
         public string[] TarballPrebuiltPackageFiles { get; set; }

--- a/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/WriteUsageReports.cs
+++ b/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/WriteUsageReports.cs
@@ -12,7 +12,7 @@ using System.Xml.Linq;
 
 namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
 {
-    public class WriteUsageReports : Task
+    public class WriteUsageReports : Microsoft.Build.Utilities.Task
     {
         private const string SnapshotPrefix = "PackageVersions.props.pre.";
         private const string SnapshotSuffix = ".xml";

--- a/src/Microsoft.DotNet.SourceBuild/tasks/src/WriteBuildOutputProps.cs
+++ b/src/Microsoft.DotNet.SourceBuild/tasks/src/WriteBuildOutputProps.cs
@@ -13,7 +13,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.SourceBuild.Tasks
 {
-    public class WriteBuildOutputProps : Task
+    public class WriteBuildOutputProps : Microsoft.Build.Utilities.Task
     {
         private static readonly Regex InvalidElementNameCharRegex = new Regex(@"(^|[^A-Za-z0-9])(?<FirstPartChar>.)");
 

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.MSBuild/GenerateSwaggerCode.cs
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.MSBuild/GenerateSwaggerCode.cs
@@ -13,7 +13,7 @@ using Task = Microsoft.Build.Utilities.Task;
 
 namespace Microsoft.DotNet.SwaggerGenerator.MSBuild
 {
-    public class GenerateSwaggerCode : Task
+    public class GenerateSwaggerCode : Microsoft.Build.Utilities.Task
     {
         [Required]
         public string SwaggerDocumentUri { get; set; }

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/DependencyUpdateTask.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/DependencyUpdateTask.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.VersionTools.Dependencies
     /// A task that can be performed to update dependency versions to values in BuildInfos. Has
     /// properties that describe the task to be performed.
     /// </summary>
-    public class DependencyUpdateTask : Task<DependencyUpdateResults>
+    public class DependencyUpdateTask : Microsoft.Build.Utilities.Task<DependencyUpdateResults>
     {
         /// <summary>
         /// The dependency infos that were used to create this update task.

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/DependencyUpdateTask.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Dependencies/DependencyUpdateTask.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.VersionTools.Dependencies
     /// A task that can be performed to update dependency versions to values in BuildInfos. Has
     /// properties that describe the task to be performed.
     /// </summary>
-    public class DependencyUpdateTask : Microsoft.Build.Utilities.Task<DependencyUpdateResults>
+    public class DependencyUpdateTask : Task<DependencyUpdateResults>
     {
         /// <summary>
         /// The dependency infos that were used to create this update task.

--- a/src/Microsoft.DotNet.VersionTools/tasks/Microsoft.DotNet.VersionTools.Tasks.csproj
+++ b/src/Microsoft.DotNet.VersionTools/tasks/Microsoft.DotNet.VersionTools.Tasks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">net6.0</TargetFrameworks>
     <PackageType>MSBuildSdk</PackageType>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.VersionTools/tasks/src/BaseDependenciesTask.cs
+++ b/src/Microsoft.DotNet.VersionTools/tasks/src/BaseDependenciesTask.cs
@@ -23,7 +23,7 @@ using System.Xml.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks.VersionTools
 {
-    public abstract class BaseDependenciesTask : Task
+    public abstract class BaseDependenciesTask : Microsoft.Build.Utilities.Task
     {
         internal const string RawUrlMetadataName = "RawUrl";
         internal const string RawVersionsBaseUrlMetadataName = "RawVersionsBaseUrl";

--- a/src/Microsoft.DotNet.VersionTools/tasks/src/SubmitPullRequest.cs
+++ b/src/Microsoft.DotNet.VersionTools/tasks/src/SubmitPullRequest.cs
@@ -12,7 +12,7 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks.VersionTools
 {
-    public class SubmitPullRequest : Task
+    public class SubmitPullRequest : Microsoft.Build.Utilities.Task
     {
         [Required]
         public string PullRequestServiceType { get; set; }


### PR DESCRIPTION

This PR has 3 items:
  1. Update the TFM to build with to only include net6.0.  Source-build only builds with the current TFM.
  2. Remove a couple of test projects that don't need to be built for source-build.
  3. Update the path to `runtime.json` in `Microsoft.DotNet.Build.Tasks.Packaging.csproj`.  The version of `Microsoft.NETCore.Platforms` is defined via a PVP variable, but the search path was hardcoded to 2.1.0.  If a different version of `Microsoft.NETCore.Platforms` is used (as happens in the source-build offline build), the path is incorrect.