### PR TITLE
move back to hosted pool for publishing job

### DIFF
--- a/eng/publishing/v3/publish-assets.yml
+++ b/eng/publishing/v3/publish-assets.yml
@@ -25,15 +25,8 @@ jobs:
     - name: AzDOAccount
       value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOBuildAccount'] ]
 
-  # Using non-hosted build agents to (hopefully temporarily) work around OOMs
-  # See https://github.com/dotnet/core-eng/issues/13098 for context
-  ${{ if eq(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/dnceng/') }}:
-    pool:
-      name: NetCoreInternal-Pool
-      queue: BuildPool.Server.Amd64.VS2019
-  ${{ if ne(variables['System.TeamFoundationCollectionUri'], 'https://dev.azure.com/dnceng/') }}:
-    pool:
-      vmImage: 'windows-2019'
+  pool:
+    vmImage: 'windows-2019'
   steps:
     - task: DownloadBuildArtifacts@0
       displayName: Download Build Assets


### PR DESCRIPTION
https://github.com/dotnet/core-eng/issues/13098

Since we stopped using the HttpClient response buffer during the download phase, we have reduced our memory usage enough that it looks like we are able to publish using the fv- hosted machines. 


I ran the following promotion builds to validate:
* Aspnetcore: https://dev.azure.com/dnceng/internal/_build/results?buildId=1261346&view=results
* Runtime : https://dev.azure.com/dnceng/internal/_build/results?buildId=1261280&view=results
* Installer: https://dev.azure.com/dnceng/internal/_build/results?buildId=1261345&view=results

Once this is merged I'll keep an eye out for the promotion pipeline to see if we hit any more OOMs.  