### PR TITLE
Fix NotSupported assemblies built from VS

### DIFF
--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacadesNotSupported.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacadesNotSupported.targets
@@ -31,7 +31,7 @@
       Projects="@(ProjectReference)"
       Targets="SourceFilesProjectOutputGroup"
       Properties="%(ProjectReference.SetTargetFramework)"
-      Condition="'%(ProjectReference.Targets)' == 'GetCompile' and ('$(BuildingInsideVisualStudio)' == 'true' or '$(BuildProjectReferences)' != 'true')">
+      Condition="'%(ProjectReference.Targets)' == 'SourceFilesProjectOutputGroup' and ('$(BuildingInsideVisualStudio)' == 'true' or '$(BuildProjectReferences)' != 'true')">
       <Output TaskParameter="TargetOutputs" ItemName="_contractSourceFilesGroup" />
     </MSBuild>
 


### PR DESCRIPTION
Related https://github.com/dotnet/runtime/issues/51601