### PR TITLE
Remove xml declaration from Tools.csproj

### DIFF
--- a/eng/common/internal/Tools.csproj
+++ b/eng/common/internal/Tools.csproj
@@ -1,5 +1,4 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
-<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>


### PR DESCRIPTION
I believe  this arcade change -  https://github.com/dotnet/arcade/commit/0602cfaab1dfdbf7802dd3d2876fd17cf4ae04a7#diff-66405aea4552bcba6afbd43543f2e1861c9c6982c32bcc1983bda5b1f6e90958 - is causing our signed builds to fail with:

```
D:\workspace\_work\1\s\eng\common\internal\Tools.csproj(2,3): error MSB4025: The project file could not be loaded. Unexpected XML declaration. The XML declaration must be the first node in the document, and no white space characters are allowed to appear before it. Line 2, position 3.
```