### PR TITLE
Fix Mac OS package versioning

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
@@ -125,6 +125,10 @@
       <InstallerPackageRelease>$([System.String]::Copy('$(InstallerPackageRelease)').Replace('-', '_'))</InstallerPackageRelease>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(GeneratePkg)' == 'true'">
+      <InstallerPackageVersion Condition="'$(IncludePreReleaseLabelInPackageVersion)' == 'true'">$(VersionPrefix)-$(VersionSuffix)</InstallerPackageVersion>
+    </PropertyGroup>
+
     <PropertyGroup>
       <_InstallerIntermediatesDir>$(IntermediateOutputPath)$(InstallerName)/$(InstallerPackageVersion)/</_InstallerIntermediatesDir>
 
@@ -371,14 +375,14 @@
              Properties="OutputPath=$(_OutputPathRoot)"
              RemoveProperties="@(_GlobalPropertiesToRemoveForPublish)"  />
     <PropertyGroup>
-      <_MacOSVersionComponent Condition="'$(IncludeVersionInMacOSComponentName)' == 'true'">.$(ProductVersion)</_MacOSVersionComponent>
+      <_MacOSVersionComponent Condition="'$(IncludeVersionInMacOSComponentName)' == 'true'">.$(InstallerPackageVersion)</_MacOSVersionComponent>
       <_MacOSComponentName Condition="'$(_MacOSComponentName)' == ''">com.microsoft.dotnet.$(MacOSComponentNamePackType)$(_MacOSVersionComponent).component.osx.x64</_MacOSComponentName>
       <_MacOSSharedInstallDir>/usr/local/share/dotnet</_MacOSSharedInstallDir>
 
       <_pkgArgs></_pkgArgs>
       <_pkgArgs>$(_pkgArgs) --root $(_OutputPathRoot)</_pkgArgs>
       <_pkgArgs>$(_pkgArgs) --identifier $(_MacOSComponentName)</_pkgArgs>
-      <_pkgArgs>$(_pkgArgs) --version $(ProductVersion)</_pkgArgs>
+      <_pkgArgs>$(_pkgArgs) --version $(InstallerPackageVersion)</_pkgArgs>
       <_pkgArgs>$(_pkgArgs) --install-location $(_MacOSSharedInstallDir)</_pkgArgs>
       <_pkgArgs Condition="'$(MacOSScriptsDirectory)' != ''">$(_pkgArgs) --scripts $(MacOSScriptsDirectory)</_pkgArgs>
       <_pkgArgs>$(_pkgArgs) $(_InstallerFile)</_pkgArgs>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/54735

Enables preview versioning for Mac OS packages, which enables SxS installation. This matches the preview experience for other platforms.

Validated build and installation of Mac OS packages - working as expected.
