### PR TITLE
Update dotnet sdk

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "6.0.100-preview.6.21355.2"
+    "dotnet": "6.0.100-rc.1.21379.2"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21378.2",

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <IncludeDotNetCli Condition=" '$(IncludeDotNetCli)' != 'true' ">false</IncludeDotNetCli>
-    <AspNetCoreRuntimeVersion>6.0.0-preview.6.21355.2</AspNetCoreRuntimeVersion>
+    <AspNetCoreRuntimeVersion>6.0.0-rc.1.21378.2</AspNetCoreRuntimeVersion>
     <DotNetCliPackageType Condition=" '$(DotNetCliPackageType)' == '' ">runtime</DotNetCliPackageType>
     <DotNetCliVersion Condition=" '$(DotNetCliVersion)' == '' AND '$(DotNetCliPackageType)' == 'runtime' ">$(BundledNETCoreAppPackageVersion)</DotNetCliVersion>
     <!-- TODO (https://github.com/dotnet/arcade/issues/7022): We are hardcoding this version to use the one tied to the SDK version from global.json -->


### PR DESCRIPTION
Continuing the work from dotnet/arcade#7690, but I don't have push access to the source branch so starting a new PR here. 

Arcade CI fails when checking the aspnetcore runtime version. This updates that version. 