### PR TITLE
Allow specifying AzDO org in CreateAzureDevOpsFeed

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishSignedAssets.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishSignedAssets.proj
@@ -14,6 +14,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <NETCORE_ENGINEERING_TELEMETRY>Publish</NETCORE_ENGINEERING_TELEMETRY>
+    <AzureDevOpsOrg Condition="'$(AzureDevOpsOrg)' == ''">dnceng</AzureDevOpsOrg>
   </PropertyGroup>
 
   <Target Name="Execute">
@@ -37,7 +38,8 @@
     <CreateAzureDevOpsFeed
         IsInternal="$(IsInternalBuild)"
         AzureDevOpsPersonalAccessToken="$(AzdoTargetFeedPAT)"
-        FeedName="$(FeedName)-shipping">
+        FeedName="$(FeedName)-shipping"
+        AzureDevOpsOrg="$(AzureDevOpsOrg)">
       <Output TaskParameter="TargetFeedURL" PropertyName="ShippingAzdoPackageFeedURL"/>
     </CreateAzureDevOpsFeed>
 
@@ -45,7 +47,8 @@
     <CreateAzureDevOpsFeed
         IsInternal="$(IsInternalBuild)"
         AzureDevOpsPersonalAccessToken="$(AzdoTargetFeedPAT)"
-        FeedName="$(FeedName)-nonshipping">
+        FeedName="$(FeedName)-nonshipping"
+        AzureDevOpsOrg="$(AzureDevOpsOrg)">
       <Output TaskParameter="TargetFeedURL" PropertyName="NonShippingAzdoPackageFeedURL"/>
     </CreateAzureDevOpsFeed>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishToSymbolServers.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishToSymbolServers.proj
@@ -44,6 +44,7 @@
       <PublishToMSDL Condition="'$(PublishToMSDL)' == ''">true</PublishToMSDL>
       <PublishToSymbolServer Condition="'@(FilesToPublishToSymbolServer)' == '' and '@(PackagesToPublishToSymbolServer)' == ''">false</PublishToSymbolServer>
       <PublishSpecialClrFiles Condition="'$(PublishSpecialClrFiles)' == ''">true</PublishSpecialClrFiles>
+      <DryRun Condition="'$(DryRun)' == ''">false</DryRun>
     </PropertyGroup>
 
     <Message
@@ -96,7 +97,7 @@
                     SymbolServerPath="%(SymbolServerTargets.Identity)"
                     ExpirationInDays="$(DotNetSymbolExpirationInDays)"
                     VerboseLogging="true"
-                    DryRun="false"
+                    DryRun="$(DryRun)"
                     ConvertPortablePdbsToWindowsPdbs="false"
                     PdbConversionTreatAsWarning=""
                     PublishSpecialClrFiles="$(PublishSpecialClrFiles)"

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
@@ -66,9 +66,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         private async Task<bool> ExecuteAsync()
         {
-            _azureDevOpsFeedsBaseUrl = $"https://feeds.dev.azure.com/{AzureDevOpsOrg}/";
             try
             {
+                _azureDevOpsFeedsBaseUrl = $"https://feeds.dev.azure.com/{AzureDevOpsOrg}/";
                 if (CommitSha?.Length < ShaUsableLength)
                 {
                     Log.LogError($"The CommitSHA should be at least {ShaUsableLength} characters long: CommitSha is '{CommitSha}'. Aborting feed creation.");

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
@@ -66,7 +66,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         {
             try
             {
-                string azureDevOpsFeedsBaseUrl = $"https://feeds.dev.azure.com/{AzureDevOpsOrg}/";
                 if (CommitSha?.Length < ShaUsableLength)
                 {
                     Log.LogError($"The CommitSHA should be at least {ShaUsableLength} characters long: CommitSha is '{CommitSha}'. Aborting feed creation.");
@@ -104,6 +103,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     return false;
                 }
 
+                string azureDevOpsFeedsBaseUrl = $"https://feeds.dev.azure.com/{AzureDevOpsOrg}/";
                 do
                 {
                     using (HttpClient client = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true })

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
@@ -47,8 +47,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public string AzureDevOpsOrg { get; set; } = "dnceng";
 
-        private string _azureDevOpsFeedsBaseUrl;
-
         /// <summary>
         /// Number of characters from the commit SHA prefix that should be included in the feed name.
         /// </summary>
@@ -68,7 +66,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         {
             try
             {
-                _azureDevOpsFeedsBaseUrl = $"https://feeds.dev.azure.com/{AzureDevOpsOrg}/";
+                string azureDevOpsFeedsBaseUrl = $"https://feeds.dev.azure.com/{AzureDevOpsOrg}/";
                 if (CommitSha?.Length < ShaUsableLength)
                 {
                     Log.LogError($"The CommitSHA should be at least {ShaUsableLength} characters long: CommitSha is '{CommitSha}'. Aborting feed creation.");
@@ -110,7 +108,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 {
                     using (HttpClient client = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true })
                     {
-                        BaseAddress = new Uri(_azureDevOpsFeedsBaseUrl)
+                        BaseAddress = new Uri(azureDevOpsFeedsBaseUrl)
                     })
                     {
                         client.DefaultRequestHeaders.Add(

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
@@ -118,13 +118,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                             "Basic",
                             Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Format("{0}:{1}", "", AzureDevOpsPersonalAccessToken))));
 
-                        AzureDevOpsArtifactFeed newFeed = new AzureDevOpsArtifactFeed(versionedFeedName);
+                        AzureDevOpsArtifactFeed newFeed = new AzureDevOpsArtifactFeed(versionedFeedName, AzureDevOpsOrg);
 
                         string body = JsonConvert.SerializeObject(newFeed, _serializerSettings);
 
                         HttpRequestMessage postMessage = new HttpRequestMessage(HttpMethod.Post, $"{publicSegment}_apis/packaging/feeds");
                         postMessage.Content = new StringContent(body, Encoding.UTF8, "application/json");
-
                         HttpResponseMessage response = await client.SendAsync(postMessage);
 
                         if (response.StatusCode == HttpStatusCode.Created)
@@ -179,20 +178,24 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
     public class AzureDevOpsArtifactFeed
     {
-        public AzureDevOpsArtifactFeed(string name)
+        public AzureDevOpsArtifactFeed(string name, string organization)
         {
             Name = name;
+            if (organization == "dnceng")
+            {
+                Permissions = new List<Permission>
+                {
+                    // Mimic the permissions added to a feed when created in the browser
+                    new Permission("Microsoft.TeamFoundation.ServiceIdentity;116cce53-b859-4624-9a95-934af41eccef:Build:b55de4ed-4b5a-4215-a8e4-0a0a5f71e7d8", 3),                      // Project Collection Build Service
+                    new Permission("Microsoft.TeamFoundation.ServiceIdentity;116cce53-b859-4624-9a95-934af41eccef:Build:7ea9116e-9fac-403d-b258-b31fcf1bb293", 3),                      // internal Build Service
+                    new Permission("Microsoft.TeamFoundation.Identity;S-1-9-1551374245-1349140002-2196814402-2899064621-3782482097-0-0-0-0-1", 4),                                      // Feed administrators
+                    new Permission("Microsoft.TeamFoundation.Identity;S-1-9-1551374245-1846651262-2896117056-2992157471-3474698899-1-2052915359-1158038602-2757432096-2854636005", 4)   // Feed administrators and contributors
+                };
+            }
         }
 
         public string Name { get; set; }
 
-        public readonly List<Permission> Permissions = new List<Permission>
-        {
-            // Mimic the permissions added to a feed when created in the browser
-            new Permission("Microsoft.TeamFoundation.ServiceIdentity;116cce53-b859-4624-9a95-934af41eccef:Build:b55de4ed-4b5a-4215-a8e4-0a0a5f71e7d8", 3),                      // Project Collection Build Service
-            new Permission("Microsoft.TeamFoundation.ServiceIdentity;116cce53-b859-4624-9a95-934af41eccef:Build:7ea9116e-9fac-403d-b258-b31fcf1bb293", 3),                      // internal Build Service
-            new Permission("Microsoft.TeamFoundation.Identity;S-1-9-1551374245-1349140002-2196814402-2899064621-3782482097-0-0-0-0-1", 4),                                      // Feed administrators
-            new Permission("Microsoft.TeamFoundation.Identity;S-1-9-1551374245-1846651262-2896117056-2992157471-3474698899-1-2052915359-1158038602-2757432096-2854636005", 4)   // Feed administrators and contributors
-        };
+        public List<Permission> Permissions { get; private set; }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
@@ -45,9 +45,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public string AzureDevOpsFeedsApiVersion { get; set; } = "5.0-preview.1";
 
-        public static string AzureDevOpsOrg { get; set; } = "dnceng";
+        public string AzureDevOpsOrg { get; set; } = "dnceng";
 
-        private readonly string AzureDevOpsFeedsBaseUrl = $"https://feeds.dev.azure.com/{AzureDevOpsOrg}/";
+        private string _azureDevOpsFeedsBaseUrl;
 
         /// <summary>
         /// Number of characters from the commit SHA prefix that should be included in the feed name.
@@ -66,6 +66,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         private async Task<bool> ExecuteAsync()
         {
+            _azureDevOpsFeedsBaseUrl = $"https://feeds.dev.azure.com/{AzureDevOpsOrg}/";
             try
             {
                 if (CommitSha?.Length < ShaUsableLength)
@@ -109,7 +110,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 {
                     using (HttpClient client = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true })
                     {
-                        BaseAddress = new Uri(AzureDevOpsFeedsBaseUrl)
+                        BaseAddress = new Uri(_azureDevOpsFeedsBaseUrl)
                     })
                     {
                         client.DefaultRequestHeaders.Add(


### PR DESCRIPTION
I want to be able to create feeds in orgs outside of dnceng, and in order to do that I have to be able to specify this property, so the property can't be static. Changing things up to make that a possibility.

Additionally: allow specifying DryRun in PublishToSymbolServers.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
