### PR TITLE
Add null checks back in Verify* types

### DIFF
--- a/src/Microsoft.DotNet.PackageTesting/VerifyClosure.cs
+++ b/src/Microsoft.DotNet.PackageTesting/VerifyClosure.cs
@@ -126,7 +126,9 @@ namespace Microsoft.DotNet.PackageTesting
 
         private void LoadIgnoredReferences()
         {
-            foreach (var ignoredReference in IgnoredReferences.DefaultIfEmpty())
+            if (IgnoredReferences == null or IgnoredReferences.Length == 0) return;
+        
+            foreach (var ignoredReference in IgnoredReferences)
             {
                 var name = ignoredReference.ItemSpec;
                 var versionString = ignoredReference.GetMetadata("Version");


### PR DESCRIPTION
Regressed with https://github.com/dotnet/arcade/commit/a50c27610c6a060c677090b801636cd7149cd591 as the code paths don't protect anymore against null.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
