### PR TITLE
Fix Msi version string generation

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateMsiVersion.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateMsiVersion.cs
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
             var minor = int.Parse(Minor) << 22;
             var patch = int.Parse(Patch) << 18;
 
-            var buildNumberMajor = int.Parse(BuildNumberMajor) & 0x3FFF << 4;
+            var buildNumberMajor = (int.Parse(BuildNumberMajor) & 0x3FFF) << 4;
             var buildNumberMinor = int.Parse(BuildNumberMinor) & 0xF;
 
             var msiVersionNumber = major | minor | patch | buildNumberMajor | buildNumberMinor;


### PR DESCRIPTION
Based on operator precedence, `0x3FFF << 4` was happening first, ensuring that we always cut off the lower 4 bits of the build number when generating an Msi version.

The good news appears to be that the Major and Minor stay the same or go up, though the patch value will go down.

Before: A build number major value of 30327 or 30328 and build number value of 9 would generate `48.0.30329`
After: `48.3.26489` and `48.3.26505`, respectively.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
