### PR TITLE
Update Arcade dependency to help with publishing HttpClient timeouts

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -11,25 +11,25 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.21403.5">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.21405.8">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>9fc83fbf76339c9dec4f5a8bf4718df2d42992a3</Sha>
+      <Sha>68277100891db502c5493ea1d335e74059d196aa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="6.0.0-beta.21403.5">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="6.0.0-beta.21405.8">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>9fc83fbf76339c9dec4f5a8bf4718df2d42992a3</Sha>
+      <Sha>68277100891db502c5493ea1d335e74059d196aa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SignTool" Version="6.0.0-beta.21403.5">
+    <Dependency Name="Microsoft.DotNet.SignTool" Version="6.0.0-beta.21405.8">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>9fc83fbf76339c9dec4f5a8bf4718df2d42992a3</Sha>
+      <Sha>68277100891db502c5493ea1d335e74059d196aa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="6.0.0-beta.21403.5">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="6.0.0-beta.21405.8">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>9fc83fbf76339c9dec4f5a8bf4718df2d42992a3</Sha>
+      <Sha>68277100891db502c5493ea1d335e74059d196aa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SwaggerGenerator.MSBuild" Version="6.0.0-beta.21403.5">
+    <Dependency Name="Microsoft.DotNet.SwaggerGenerator.MSBuild" Version="6.0.0-beta.21405.8">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>9fc83fbf76339c9dec4f5a8bf4718df2d42992a3</Sha>
+      <Sha>68277100891db502c5493ea1d335e74059d196aa</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Maestro.Client" Version="1.1.0-beta.20258.6">
       <Uri>https://github.com/dotnet/arcade-services</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -65,8 +65,8 @@
     <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>
     <XUnitVSRunnerVersion>2.4.1</XUnitVSRunnerVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.21403.5</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetSignToolVersion>6.0.0-beta.21403.5</MicrosoftDotNetSignToolVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.21405.8</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetSignToolVersion>6.0.0-beta.21405.8</MicrosoftDotNetSignToolVersion>
     <MicrosoftAzureDocumentDBVersion>1.22.0</MicrosoftAzureDocumentDBVersion>
     <MicrosoftAzureCosmosDBTableVersion>1.1.2</MicrosoftAzureCosmosDBTableVersion>
     <MicrosoftAspNetCoreAllVersion>2.0.0</MicrosoftAspNetCoreAllVersion>
@@ -77,7 +77,7 @@
     <MicrosoftDotNetMaestroClientVersion>1.1.0-beta.20258.6</MicrosoftDotNetMaestroClientVersion>
     <MicrosoftSourceLinkGitHubVersion>1.1.0-beta-21309-01</MicrosoftSourceLinkGitHubVersion>
     <MicrosoftSourceLinkAzureReposGitVersion>1.1.0-beta-21309-01</MicrosoftSourceLinkAzureReposGitVersion>
-    <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>6.0.0-beta.21403.5</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
+    <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>6.0.0-beta.21405.8</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
     <MicrosoftDotNetXliffTasksVersion>1.0.0-beta.21405.1</MicrosoftDotNetXliffTasksVersion>
     <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.21378.2</MicrosoftDotNetMaestroTasksVersion>
     <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.21378.1</MicrosoftDotNetXHarnessCLIVersion>

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "6.0.100-rc.1.21379.2"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21403.5",
-    "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.21403.5"
+    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21405.8",
+    "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.21405.8"
   }
 }


### PR DESCRIPTION
Manual dependency update to get the changes from https://github.com/dotnet/arcade/pull/7719 to help unblock publishing in installer and runtime repos which are presenting HttpClient timeouts during blob uploads. 

Opening as @AlitzelMendez is getting throttled when trying to update dependencies locally. 

