### PR TITLE
Revert "Should not publish the files in SymbolPublishingExclusionFile…

### DIFF
--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -94,31 +94,7 @@ jobs:
         PathtoPublish: '$(Build.StagingDirectory)/ReleaseConfigs.txt'
         PublishLocation: Container
         ArtifactName: ReleaseConfigs
-
-    - task: powershell@2
-      displayName: Check if SymbolPublishingExclusionsFile.txt exists
-      inputs:
-        targetType: inline
-        script: |
-          $symbolExclusionfile = "$(Build.SourcesDirectory)/eng/SymbolPublishingExclusionsFile.txt"
-          if(Test-Path -Path $symbolExclusionfile)
-          {
-            Write-Host "SymbolExclusionFile exists"
-            Write-Host "##vso[task.setvariable variable=SymbolExclusionFile]true"
-          }
-          else{
-           Write-Host "Symbols Exclusion file does not exists"
-           Write-Host "##vso[task.setvariable variable=SymbolExclusionFile]false"
-          }
-
-    - task: PublishBuildArtifacts@1
-      displayName: Publish SymbolPublishingExclusionsFile Artifact
-      condition: eq(variables['SymbolExclusionFile'], 'true') 
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/eng/SymbolPublishingExclusionsFile.txt'
-        PublishLocation: Container
-        ArtifactName: ReleaseConfigs
-        
+    
     - ${{ if eq(parameters.enablePublishBuildArtifacts, 'true') }}:
       - template: /eng/common/templates/steps/publish-logs.yml
         parameters:

--- a/eng/publishing/v3/publish-assets.yml
+++ b/eng/publishing/v3/publish-assets.yml
@@ -43,7 +43,6 @@ jobs:
           AssetManifests/**
           BlobArtifacts/MergedManifest.xml
           PdbArtifacts/**
-          ReleaseConfigs/SymbolPublishingExclusionsFile.txt
         downloadPath: '$(Build.ArtifactStagingDirectory)'
 
     - task: NuGetToolInstaller@1
@@ -85,7 +84,7 @@ jobs:
           /p:AkaMSClientSecret=$(akams-client-secret)
           ${{ parameters.artifactsPublishingAdditionalParameters }}
           /p:PDBArtifactsBasePath='$(Build.ArtifactStagingDirectory)/PDBArtifacts/'
-          /p:SymbolPublishingExclusionsFile='$(Build.ArtifactStagingDirectory)/ReleaseConfigs/SymbolPublishingExclusionsFile.txt'
+          /p:SymbolPublishingExclusionsFile='$(Build.SourcesDirectory)/eng/SymbolPublishingExclusionsFile.txt'
           ${{ parameters.symbolPublishingAdditionalParameters}}
           /p:MsdlToken=$(microsoft-symbol-server-pat)
           /p:SymWebToken=$(symweb-symbol-server-pat)

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -426,26 +426,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             HashSet<TargetFeedConfig> feedConfigsForSymbols = FeedConfigs[symbolCategory];
             Dictionary<string, string> serversToPublish =
                 GetTargetSymbolServers(feedConfigsForSymbols, msdlToken, symWebToken);
-            HashSet<string> excludeFiles = new HashSet<string>();
-            
-            if(File.Exists(symbolPublishingExclusionsFile))
-            {
-                Log.LogMessage(MessageImportance.Normal, $"SymbolPublishingExclusionFile exists");
-                string[] files = File.ReadAllLines(symbolPublishingExclusionsFile);
-
-                foreach(var file in files)
-                {
-                    if(!string.IsNullOrEmpty(file))
-                    {
-                        Log.LogMessage(MessageImportance.Normal, $"Exclude the file {file} from publishing to symbol server");
-                        excludeFiles.Add(file);
-                    }
-                }
-            }
-            else
-            {
-                Log.LogMessage(MessageImportance.Normal, $"SymbolPublishingExclusionFile was not found at ${symbolPublishingExclusionsFile} ");
-            }
 
             if (symbolsToPublish != null && symbolsToPublish.Any())
             {
@@ -491,7 +471,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                                         token,
                                         symbolFiles,
                                         null,
-                                        excludeFiles,
+                                        null,
                                         ExpirationInDays,
                                         false,
                                         publishSpecialClrFiles,
@@ -557,7 +537,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                             token,
                             null,
                             filesToSymbolServer,
-                            excludeFiles,
+                            null,
                             ExpirationInDays,
                             false,
                             publishSpecialClrFiles,


### PR DESCRIPTION
Reverts dotnet/arcade#7433 because it is breaking the runtime official build and blocking package promotion and code flow.

If the test correctly failing lets resolve the issue in the packages.

