### PR TITLE
Retry feed artifact download on SocketException

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Sockets;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -955,7 +956,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                     return true;
                 }
-                catch (Exception toStore) when (toStore is HttpRequestException || toStore is TaskCanceledException)
+                catch (Exception toStore) when (toStore is HttpRequestException || toStore is TaskCanceledException || toStore is SocketException)
                 {
                     mostRecentlyCaughtException = toStore;
                     return false;


### PR DESCRIPTION
Resolves the periodic download failure reported in dotnet/core-eng#13952 by having the download method retry on SocketException. 

I was unable to create a repro to test this change or find a better one. However the logging shows that the force-close should be throwing a SocketException, which is not included in the types of Exceptions that the Download method will retry. So adding it here seems like the best choice.

I've also created a small dashboard in Grafana [[here](https://dotnet-eng-grafana.westus2.cloudapp.azure.com/d/Uw99FXG7z/)] to track occurrences. We can use it to track behavior as this change is rolled out. 