### PR TITLE
Modify the CreateXHarnessAppleWorkItems task to accept zip files as input

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
@@ -107,7 +107,12 @@ namespace Microsoft.DotNet.Helix.Sdk
 
             appFolderPath = appFolderPath.TrimEnd(Path.DirectorySeparatorChar);
 
-            (workItemName, bool isAlreadyArchived) = GetWorkItemName(workItemName);
+            bool isAlreadyArchived = workItemName.EndsWith(".zip");
+
+            if (isAlreadyArchived || workItemName.EndsWith(".app"))
+            {
+                workItemName = workItemName.Substring(0, workItemName.Length - 4);
+            }
 
             if (!ValidateAppBundlePath(fileSystem, appFolderPath, isAlreadyArchived))
             {
@@ -182,19 +187,6 @@ namespace Microsoft.DotNet.Helix.Sdk
             bool isAlreadyArchived)
         {
             return isAlreadyArchived ? fileSystem.FileExists(appBundlePath) : fileSystem.DirectoryExists(appBundlePath);
-        }
-
-        private (string workItemName, bool isAlreadyArchived) GetWorkItemName(
-            string workItemName)
-        {
-            bool isAlreadyArchived = workItemName.EndsWith(".zip");
-
-            if (isAlreadyArchived || workItemName.EndsWith(".app"))
-            {
-                workItemName = workItemName.Substring(0, workItemName.Length - 4);
-            }
-
-            return (workItemName, isAlreadyArchived);
         }
 
         private string GetDefaultCommand(string target, bool includesTestRunner, bool resetSimulator) =>


### PR DESCRIPTION
In AOT configurations, the size of the test apps we generate can be quite large (100-200MB).  We can run out of disk space quickly if we have a lot of uncompressed .app folders around.  

This change adds accepting zip files as part of the AppBundles item and instead of creating the zip file, we will just make a copy instead.  