### PR TITLE
Work around implicit usings breaking change

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
@@ -22,6 +22,9 @@
 
     <!-- Disable the message indicating we are using a preview SDK. That is understood and by design -->
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+    
+    <!-- Workaround breaking change in .NET SDK. See https://github.com/dotnet/sdk/issues/19521 -->
+    <DisableImplicitNamespaceImports>true<DisableImplicitNamespaceImports/>
 
     <!-- By default do not build NuGet package for a non pkgproj project. Project may override. -->
     <IsPackable Condition="'$(MSBuildProjectExtension)' != '.pkgproj'">false</IsPackable>


### PR DESCRIPTION
Work around https://github.com/dotnet/sdk/issues/19521

Without this workaround Arcade update breaks builds, e.g. https://github.com/dotnet/sourcelink/pull/729/checks?check_run_id=3280200935


