### PR TITLE
Retry PublishArtifacts download on all exceptions

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishToSymbolServerTest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishToSymbolServerTest.cs
@@ -216,7 +216,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                     "1234",
                     "test.txt",
                     path));
-            Assert.Contains($"Failed to download local file '{path}' after {publishTask.RetryHandler.MaxAttempts} attempts.  See inner exception for details,", actualError.Message);
+            Assert.Contains($"Failed to download local file '{path}' after {publishTask.RetryHandler.MaxAttempts} attempts.  See inner exception for details.", actualError.Message);
         }
 
         [Theory]
@@ -259,7 +259,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                     "1234",
                     "test.txt",
                     path));
-            Assert.Contains($"Failed to download local file '{path}' after {publishTask.RetryHandler.MaxAttempts} attempts.  See inner exception for details,", actualError.Message);
+            Assert.Contains($"Failed to download local file '{path}' after {publishTask.RetryHandler.MaxAttempts} attempts.  See inner exception for details.", actualError.Message);
         }
 
         [Theory]

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -957,9 +957,10 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                     return true;
                 }
-                catch (Exception toStore) when (toStore is HttpRequestException || toStore is TaskCanceledException || toStore is SocketException)
+                catch (Exception toStore)
                 {
                     mostRecentlyCaughtException = toStore;
+                    Log.LogMessage(MessageImportance.Normal, $"Download failed due to {toStore.GetType().FullName}: {toStore.Message}");
                     return false;
                 }
             }).ConfigureAwait(false);

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -960,7 +960,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 catch (Exception toStore)
                 {
                     mostRecentlyCaughtException = toStore;
-                    Log.LogMessage(MessageImportance.Normal, $"Download failed due to {toStore.GetType().FullName}: {toStore.Message}");
                     return false;
                 }
             }).ConfigureAwait(false);
@@ -968,7 +967,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             if (!success)
             {
                 throw new Exception(
-                    $"Failed to download local file '{path}' after {RetryHandler.MaxAttempts} attempts.  See inner exception for details, {mostRecentlyCaughtException}");
+                    $"Failed to download local file '{path}' after {RetryHandler.MaxAttempts} attempts.  See inner exception for details.", mostRecentlyCaughtException);
             }
         }
 


### PR DESCRIPTION
Follow-on of dotnet/arcade#7736, stronger resolution to the periodic download failure reported in dotnet/core-eng#13952.