### PR TITLE
fix xml syntax in projectDefaults.props

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
@@ -24,7 +24,7 @@
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     
     <!-- Workaround breaking change in .NET SDK. See https://github.com/dotnet/sdk/issues/19521 -->
-    <DisableImplicitNamespaceImports>true<DisableImplicitNamespaceImports/>
+    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
 
     <!-- By default do not build NuGet package for a non pkgproj project. Project may override. -->
     <IsPackable Condition="'$(MSBuildProjectExtension)' != '.pkgproj'">false</IsPackable>


### PR DESCRIPTION
Typo caught by arcade-validation: https://github.com/dotnet/arcade-validation/pull/2476
