### PR TITLE
Add the streaming parameters to V2 publishing

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -341,7 +341,10 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 AkaMSGroupOwner = this.AkaMSGroupOwner,
                 AkaMsOwners = this.AkaMsOwners,
                 AkaMSTenant = this.AkaMSTenant,
-                BuildQuality = this.BuildQuality
+                BuildQuality = this.BuildQuality,
+                UseStreamingPublishing = this.UseStreamingPublishing,
+                StreamingPublishingMaxClients = this.StreamingPublishingMaxClients,
+                NonStreamingPublishingMaxClients = this.NonStreamingPublishingMaxClients
             };
         }
 


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation

When we added Streaming publishing, we didn't update v2 publishing so that it knew about these parameters, though we still would go through the code paths that used some of the variables added by streaming publishing, in particular, the maxCount variables for streaming and non-streaming. This caused a break in creating the SemaphoreSlim, where the maxCount parameters was 0. This change passes these two variables, in addition to UseStreamingPublishing, to the V2 constructor so that the SemaphoreSlim constructor has a non-zero maxCount parameter.