### PR TITLE
Adjust AzDO feed pattern to accommodate dnceng-stage

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
         // https://pkgs.dev.azure.com/dnceng/public/_packaging/public-feed-name/nuget/v3/index.json
         // or https://pkgs.dev.azure.com/dnceng/_packaging/internal-feed-name/nuget/v3/index.json
         public static readonly string AzDoNuGetFeedPattern =
-            @"https://pkgs.dev.azure.com/(?<account>[a-zA-Z0-9]+)/(?<visibility>[a-zA-Z0-9-]+/)?_packaging/(?<feed>.+)/nuget/v3/index.json";
+            @"https://pkgs.dev.azure.com/(?<account>[a-zA-Z0-9-]+)/(?<visibility>[a-zA-Z0-9-]+/)?_packaging/(?<feed>.+)/nuget/v3/index.json";
 
         public enum BuildQuality
         {


### PR DESCRIPTION
Currently the `AzDoNuGetFeedPattern` regex doesn't expect hyphens in the account name and thus fails when attempting to publish to dnceng-stage (see error [here](https://dev.azure.com/dnceng/internal/_build/results?buildId=1296847&view=logs&j=06e47235-ea4e-5696-bf7a-60141ec0f646&t=5ffd51e0-01c5-5aea-5dff-b8160c1a9e7c&l=667)).

This fixes that.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
