### PR TITLE
Log client's IP when running build / restore operations

### DIFF
--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -187,7 +187,7 @@ function InitializeCustomToolset {
 }
 
 function Build {
-  TryToLogClientIp
+  TryLogClientIpAddress
   InitializeToolset
   InitializeCustomToolset
 

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -187,6 +187,7 @@ function InitializeCustomToolset {
 }
 
 function Build {
+  TryToLogClientIp
   InitializeToolset
   InitializeCustomToolset
 

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -83,6 +83,7 @@ try {
   }
 
   if ($restore) {
+    Try-LogClientIpAddress
     Build 'Restore'
   }
 

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -399,6 +399,13 @@ function StopProcesses {
   return 0
 }
 
+function TryToLogClientIp () {
+  echo 'Attempting to log this client''s IP for Azure Package feed telemetry purposes'
+  if command -v curl > /dev/null; then
+    curl -s 'http://co1.msedge.net/fdv2/diagnostics.aspx' | grep ' IP: '
+  fi
+}
+
 function MSBuild {
   local args=$@
   if [[ "$pipelines_log" == true ]]; then

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -399,7 +399,7 @@ function StopProcesses {
   return 0
 }
 
-function TryToLogClientIp () {
+function TryLogClientIpAddress () {
   echo 'Attempting to log this client''s IP for Azure Package feed telemetry purposes'
   if command -v curl > /dev/null; then
     curl -s 'http://co1.msedge.net/fdv2/diagnostics.aspx' | grep ' IP: '


### PR DESCRIPTION
https://github.com/dotnet/core-eng/issues/13691 - Log client's IP when running build / restore to try to narrow down AzDO package feed issues

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation (run as part of the PR's validation build).

See [this build](https://dev.azure.com/dnceng/public/_build/results?buildId=1299488&view=logs&j=a83666f7-a1cf-595f-f6cb-b187860111f1) for what this will add to builds, e.g.:

```
__DistroRid: linux-arm
Attempting to log this clients IP for Azure Package feed telemetry purposes
Socket IP: 51.143.9.60
Client IP: 51.143.9.60
/__w/1/s/.dotnet/sdk/6.0.100-rc.1.21411.28/MSBuild.dll /nologo -logger:/__w/1/s/.packages/microsoft.dotnet.arcade.sdk/6.0.0-beta.21413.4/tools/netcoreapp3.1/Microsoft.DotNet.ArcadeLogging.dll -maxcpucount /m -verbosity:m /v:minimal /bl:/__w/1/s/artifacts/log/Checked/Build.binlog /clp:Summary /nr:false /p:TreatWarningsAsErrors=true /p:ContinuousIntegrationBuild=true /p:Configuration=Checked /p:RepoRoot=/__w/1/s/ /p:Restore=true /p:Build=true /p:Rebuild=false /p:Test=false /p:Pack=false /p:IntegrationTest=false /p:PerformanceTest=false /p:Sign=false /p:Publish=false /p:Subset=clr.corelib+clr.nativecorelib+clr.tools+clr.packages+clr.paltestlist /p:CrossBuild=True /p:TargetArchitecture=arm /p:BuildArchitecture=x64 /p:CMakeArgs= /warnaserror /__w/1/s/.packages/microsoft.dotnet.arcade.sdk/6.0.0-beta.21413.4/tools/Build.proj
  Determining projects to restore...
  Restored /__w/1/s/.packages/microsoft.dotnet.arcade.sdk/6.0.0-beta.21413.4/tools/Tools.proj (in 13.92 sec).
  Determining projects to restore...
  Restored /__w/1/s/src/coreclr/tools/runincontext/runincontext.csproj (in 351 ms).
```
