### PR TITLE
Refactor source-index to use its own .net core

### DIFF
--- a/eng/common/templates/job/source-index-stage1.yml
+++ b/eng/common/templates/job/source-index-stage1.yml
@@ -49,12 +49,9 @@ jobs:
 
   - script: $(Agent.TempDirectory)/.source-index/tools/BinLogToSln -i $(BinlogPath) -r $(Build.SourcesDirectory) -n $(Build.Repository.Name) -o .source-index/stage1output
     displayName: Process Binlog into indexable sln
-    env:
-      DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX: 2
 
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - script: $(Agent.TempDirectory)/.source-index/tools/UploadIndexStage1 -i .source-index/stage1output -n $(Build.Repository.Name)
       displayName: Upload stage1 artifacts to source index
       env:
         BLOB_CONTAINER_URL: $(source-dot-net-stage1-blob-container-url)
-        DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX: 2

--- a/eng/common/templates/job/source-index-stage1.yml
+++ b/eng/common/templates/job/source-index-stage1.yml
@@ -34,28 +34,26 @@ jobs:
     inputs:
       packageType: sdk
       version: 3.1.x
-
-  - task: UseDotNet@2
-    displayName: Use .NET Core sdk
-    inputs:
-      useGlobalJson: true
+      installationPath: $(Agent.TempDirectory)/dotnet
+      workingDirectory: $(Agent.TempDirectory)
 
   - script: |
-      dotnet tool install BinLogToSln --version $(SourceIndexPackageVersion) --add-source $(SourceIndexPackageSource) --tool-path .source-index/tools
-      dotnet tool install UploadIndexStage1 --version $(SourceIndexPackageVersion) --add-source $(SourceIndexPackageSource) --tool-path .source-index/tools
-      echo ##vso[task.prependpath]$(Build.SourcesDirectory)/.source-index/tools
+      $(Agent.TempDirectory)/dotnet/dotnet tool install BinLogToSln --version $(SourceIndexPackageVersion) --add-source $(SourceIndexPackageSource) --tool-path $(Agent.TempDirectory)/.source-index/tools
+      $(Agent.TempDirectory)/dotnet/dotnet tool install UploadIndexStage1 --version $(SourceIndexPackageVersion) --add-source $(SourceIndexPackageSource) --tool-path $(Agent.TempDirectory)/.source-index/tools
     displayName: Download Tools
+    # Set working directory to temp directory so 'dotnet' doesn't try to use global.json and use the repo's sdk.
+    workingDirectory: $(Agent.TempDirectory)
 
   - script: ${{ parameters.sourceIndexBuildCommand }}
     displayName: Build Repository
 
-  - script: BinLogToSln -i $(BinlogPath) -r $(Build.SourcesDirectory) -n $(Build.Repository.Name) -o .source-index/stage1output
+  - script: $(Agent.TempDirectory)/.source-index/tools/BinLogToSln -i $(BinlogPath) -r $(Build.SourcesDirectory) -n $(Build.Repository.Name) -o .source-index/stage1output
     displayName: Process Binlog into indexable sln
     env:
       DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX: 2
 
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - script: UploadIndexStage1 -i .source-index/stage1output -n $(Build.Repository.Name)
+    - script: $(Agent.TempDirectory)/.source-index/tools/UploadIndexStage1 -i .source-index/stage1output -n $(Build.Repository.Name)
       displayName: Upload stage1 artifacts to source index
       env:
         BLOB_CONTAINER_URL: $(source-dot-net-stage1-blob-container-url)


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/7747

Validated with https://dev.azure.com/dnceng/internal/_build/results?buildId=1301548&view=logs&j=316d5c15-0c50-544e-8051-e6b14a1ab674&t=78db2542-c627-4140-8a7a-d06178fff4e4

This change modifies the source-index stage to use its own restored sdk (3.1) instead of the one from the repo and then uses explicit paths to the tools instead of modifying the environment path .  The sdk is only used to acquire the global tools and run them, but the process was being intermingled with the sdk which arcade restores from the repo.  

Side note: @ViktorHofer, after this change makes it to runtime, I'm pretty sure you can get rid of https://github.com/dotnet/runtime/blob/main/eng/pipelines/source-index.yml#L10 which is a bit of a hack.  You can probably get rid of that yml file entirely and just reference source-index-stage1.yml, but either way is fine.
