### PR TITLE
Revert "Work around implicit usings breaking change (#7745)"

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
@@ -22,9 +22,6 @@
 
     <!-- Disable the message indicating we are using a preview SDK. That is understood and by design -->
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
-    
-    <!-- Workaround breaking change in .NET SDK. See https://github.com/dotnet/sdk/issues/19521 -->
-    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
 
     <!-- By default do not build NuGet package for a non pkgproj project. Project may override. -->
     <IsPackable Condition="'$(MSBuildProjectExtension)' != '.pkgproj'">false</IsPackable>


### PR DESCRIPTION
This reverts commit 5f00dd25263e2070c88d5094db7c2727520754b3.

This broke Visual Basic, that requires implicit usings to work. https://github.com/dotnet/winforms/pull/5437

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
