### PR TITLE
Adjust the algorithm in GetVersionForSingleSegment

### DIFF
--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/VersionIdentifier.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/VersionIdentifier.cs
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest
 
             int currentIndex = 0;
             // Stack of major.minor.patch.
-            Stack<(int,int)> majorMinorPatchStack = new Stack<(int,int)>(3);
+            Stack<(int versionNumber, int index)> majorMinorPatchStack = new Stack<(int,int)>(3);
             string majorMinorPatch = null;
             int majorMinorPatchIndex = 0;
             StringBuilder versionSuffix = new StringBuilder();

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/VersionIdentifier.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/VersionIdentifier.cs
@@ -93,8 +93,7 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest
 
             int currentIndex = 0;
             // Stack of major.minor.patch.
-            Stack<int> majorMinorPatchStack = new Stack<int>(3);
-            Stack<int> majorMinorPatchIndexStack = new Stack<int>(3);
+            Stack<(int,int)> majorMinorPatchStack = new Stack<(int,int)>(3);
             string majorMinorPatch = null;
             int majorMinorPatchIndex = 0;
             StringBuilder versionSuffix = new StringBuilder();
@@ -130,28 +129,24 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest
                     if ((majorMinorPatchStack.Count == 0 && isNumber) ||
                         (majorMinorPatchStack.Count > 0 && prevDelimiterCharacter == '.' && isNumber))
                     {
-                        majorMinorPatchStack.Push(potentialVersionSegment);
-                        majorMinorPatchIndexStack.Push(currentIndex);
+                        majorMinorPatchStack.Push((potentialVersionSegment, currentIndex));
                     }
                     // Check for partial major.minor.patch cases, like: 2.2.bar or 2.2-100.bleh
                     else if (majorMinorPatchStack.Count > 0 && majorMinorPatchStack.Count < 3 &&
                              (prevDelimiterCharacter != '.' || !isNumber))
                     {
                         majorMinorPatchStack.Clear();
-                        majorMinorPatchIndexStack.Clear();
                     }
                     
                     // Determine whether we are done with major.minor.patch after this update.
                     if (majorMinorPatchStack.Count >= 3 && (prevDelimiterCharacter != '.' || !isNumber || nextDelimiterIndex == -1))
                     {
                         // Done with major.minor.patch, found. Pop the top 3 elements off the stack.
-                        int patch = majorMinorPatchStack.Pop();
-                        int minor = majorMinorPatchStack.Pop();
-                        int major = majorMinorPatchStack.Pop();
-                        majorMinorPatchIndexStack.Pop();
-                        majorMinorPatchIndexStack.Pop();
+                        (int patch, int patchIndex) = majorMinorPatchStack.Pop();
+                        (int minor, int minorIndex) = majorMinorPatchStack.Pop();
+                        (int major, int majorIndex) = majorMinorPatchStack.Pop();
                         majorMinorPatch = $"{major}.{minor}.{patch}";
-                        majorMinorPatchIndex = majorMinorPatchIndexStack.Pop();
+                        majorMinorPatchIndex = majorIndex;
                     }
                 }
                 

--- a/src/Microsoft.DotNet.VersionTools/tests/BuildManifest/VersionIdentiferTests.cs
+++ b/src/Microsoft.DotNet.VersionTools/tests/BuildManifest/VersionIdentiferTests.cs
@@ -34,6 +34,7 @@ namespace Microsoft.DotNet.VersionTools.Tests.BuildManifest
         [InlineData("What-Is-A.FooPackage.2.2.10.0.1", "10.0.1")]
         [InlineData("What-Is-A.FooPackage.2.2.10.0.1-beta.final", "10.0.1-beta.final")]
         [InlineData("What-Is-A.FooPackage.2.2.10.0.1-preview1.12345.1", "10.0.1-preview1.12345.1")]
+        [InlineData("What-Is-A.FooPackage.2.2.0.Extra.Stuff.10.0.1-preview1.12345.1", "10.0.1-preview1.12345.1")]
         [InlineData("What-Is-A.FooPackage", null)]
         [InlineData("What-Is-A.FooPackage-2.2-64", null)]
         [InlineData("What-Is-A.FooPackage-2.2.nupkg", null)]

--- a/src/Microsoft.DotNet.VersionTools/tests/BuildManifest/VersionIdentifierTestsAssets.csv
+++ b/src/Microsoft.DotNet.VersionTools/tests/BuildManifest/VersionIdentifierTestsAssets.csv
@@ -4960,4 +4960,4 @@ Microsoft.DotNet.Web.ProjectTemplates.2.2.2.2.7.nupkg,2.2.7,Microsoft.DotNet.Web
 Microsoft.DotNet.Web.Spa.ProjectTemplates.2.2.2.2.7.nupkg,2.2.7,Microsoft.DotNet.Web.Spa.ProjectTemplates.2.2.nupkg
 runtime.win-x64.Microsoft.AspNetCore.All.2.2.7.nupkg,2.2.7,runtime.win-x64.Microsoft.AspNetCore.All.nupkg
 runtime.win-x64.Microsoft.AspNetCore.App.2.2.7.nupkg,2.2.7,runtime.win-x64.Microsoft.AspNetCore.App.nupkg
-assets/symbols/Microsoft.NET.Workload.Mono.ToolChain.Manifest-6.0.100.Msi.x64.6.0.0-preview.7.21377.20.symbols.nupkg
+assets/symbols/Microsoft.NET.Workload.Mono.ToolChain.Manifest-6.0.100.Msi.x64.6.0.0-preview.7.21377.20.symbols.nupkg,6.0.0-preview.7.21377.20,assets/symbols/Microsoft.NET.Workload.Mono.ToolChain.Manifest-6.0.100.Msi.x64.symbols.nupkg

--- a/src/Microsoft.DotNet.VersionTools/tests/BuildManifest/VersionIdentifierTestsAssets.csv
+++ b/src/Microsoft.DotNet.VersionTools/tests/BuildManifest/VersionIdentifierTestsAssets.csv
@@ -4960,3 +4960,4 @@ Microsoft.DotNet.Web.ProjectTemplates.2.2.2.2.7.nupkg,2.2.7,Microsoft.DotNet.Web
 Microsoft.DotNet.Web.Spa.ProjectTemplates.2.2.2.2.7.nupkg,2.2.7,Microsoft.DotNet.Web.Spa.ProjectTemplates.2.2.nupkg
 runtime.win-x64.Microsoft.AspNetCore.All.2.2.7.nupkg,2.2.7,runtime.win-x64.Microsoft.AspNetCore.All.nupkg
 runtime.win-x64.Microsoft.AspNetCore.App.2.2.7.nupkg,2.2.7,runtime.win-x64.Microsoft.AspNetCore.App.nupkg
+assets/symbols/Microsoft.NET.Workload.Mono.ToolChain.Manifest-6.0.100.Msi.x64.6.0.0-preview.7.21377.20.symbols.nupkg


### PR DESCRIPTION
GetVersionForSingleSegment assumes that if we find a fully formed major.minor.patch in the name of a file, followed by something that is not part of the version, that is definitely the version of the file. However, there are instances where there are two well formed major.minor.patch versions in the file name. For example: `Microsoft.NET.Workload.Mono.ToolChain.Manifest-6.0.100.Msi.x64.6.0.0-rc.1.21380.2.symbols.nupkg`. Mono puts the Sdk version in the name of their packages, in addition to the version of the package itself. GetVersionForSingleSegment sees the 6.0.100 followed by .Msi, recognizes that .Msi is not part of a major.minor.patch, and returns 6.0.100, without considering that there is considerably more in the file name that should be considered.

This change adds a dictionary to track every potential version in a segment, and where in the segment the potential version was found. It then will return the version that occurs the latest in the segment.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
