### PR TITLE
Use an indexed array instead of an associative array

### DIFF
--- a/eng/common/init-tools-native.sh
+++ b/eng/common/init-tools-native.sh
@@ -10,7 +10,7 @@ force=false
 download_retries=5
 retry_wait_time_seconds=30
 global_json_file="$(dirname "$(dirname "${scriptroot}")")/global.json"
-declare -A native_assets
+declare -a native_assets
 
 . $scriptroot/pipeline-logging-functions.sh
 . $scriptroot/native/common-library.sh

--- a/eng/common/native/common-library.sh
+++ b/eng/common/native/common-library.sh
@@ -148,8 +148,12 @@ function NewScriptShim {
   fi
   
   if [[ ! -f $tool_file_path ]]; then
-    Write-PipelineTelemetryError -category 'NativeToolsBootstrap' "Specified tool file path:'$tool_file_path' does not exist"
-    return 1
+    # try to see if the path is lower cased
+    tool_file_path="$(echo $tool_file_path | tr "[:upper:]" "[:lower:]")" 
+    if [[ ! -f $tool_file_path ]]; then
+      Write-PipelineTelemetryError -category 'NativeToolsBootstrap' "Specified tool file path:'$tool_file_path' does not exist"
+      return 1
+    fi
   fi
 
   local shim_contents=$'#!/usr/bin/env bash\n'


### PR DESCRIPTION
Fixes #7689 

array was being declared as an "Associative array" (`-A`) instead of an "indexed array" (`-a`) which led to the error in the related issue.  

After fixing the array type, I noticed that install-native-tools.sh was reporting another failure.  It seems that he shim file path was being generated based on the tar file name (case-sensitive), but the extracted contents were all lower case, so the shim couldn't find the executable file (cmake).

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
