### PR TITLE
[release/5.0] update to latest released SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.400"
+    "dotnet": "5.0.401"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.21409.4",

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100"
+    "dotnet": "5.0.400"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.21409.4",


### PR DESCRIPTION
## Description

We are updating the minimum .net sdk in .net 5 release branches from 5.0.100 to the latest released (5.0.400) to resolve issues with NuGet signing verification. Newer SDKs have this verification disabled.

## Customer Impact

We know that at least runtime is seeing issues in their 5.0 branch: dotnet/runtime#57849, more repos might be impacted, specifically in Linux and macOs jobs. 


## Regression

No, More details available at https://github.com/NuGet/Announcements/issues/56

## Risk

Relatively low, we don't expect breaking changes in servicing

## Workarounds

Each individual affected repo would have to update their sdk manually. 