### PR TITLE
Disable progress bar for web request to ge client IP

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -881,7 +881,10 @@ function Try-LogClientIpAddress()
     Write-Host "Attempting to log this client's IP for Azure Package feed telemetry purposes"
     try
     {
+        $originalProgressPreference = $ProgressPreference
+        $ProgressPreference = "SilentlyContinue"
         $result = Invoke-WebRequest -Uri "http://co1.msedge.net/fdv2/diagnostics.aspx" -UseBasicParsing
+        $ProgressPreference = $originalProgressPreference
         $lines = $result.Content.Split([Environment]::NewLine) 
         $socketIp = $lines | Select-String -Pattern "^Socket IP:.*"
         Write-Host $socketIp


### PR DESCRIPTION
Without this running `dotnet.cmd` from repo root (for example dotnet/runtime) will popup a quick powershell progress bar. Whic is pretty distracting and looks really suspicious (since it's really hard to read what's going on).

Fixes https://github.com/dotnet/arcade/issues/7779.