### PR TITLE
Ignore curl failures for no-network build scenario

### DIFF
--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -187,7 +187,10 @@ function InitializeCustomToolset {
 }
 
 function Build {
-  TryLogClientIpAddress
+
+  if [[ "$ci" == true ]]; then
+    TryLogClientIpAddress
+  fi
   InitializeToolset
   InitializeCustomToolset
 

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -83,7 +83,9 @@ try {
   }
 
   if ($restore) {
-    Try-LogClientIpAddress
+    if ($ci) {
+      Try-LogClientIpAddress
+    }
     Build 'Restore'
   }
 

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -154,9 +154,6 @@ function InitializeDotNetCli([bool]$install, [bool]$createSdkLocationFile) {
     return $global:_DotNetInstallDir
   }
 
-  # In case of network error, try to log the current IP for reference
-  Try-LogClientIpAddress
-
   # Don't resolve runtime, shared framework, or SDK from other locations to ensure build determinism
   $env:DOTNET_MULTILEVEL_LOOKUP=0
 
@@ -166,6 +163,9 @@ function InitializeDotNetCli([bool]$install, [bool]$createSdkLocationFile) {
   # Disable telemetry on CI.
   if ($ci) {
     $env:DOTNET_CLI_TELEMETRY_OPTOUT=1
+ 
+    # In case of network error, try to log the current IP for reference
+    Try-LogClientIpAddress
   }
 
   # Source Build uses DotNetCoreSdkDir variable

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -402,7 +402,7 @@ function StopProcesses {
 function TryLogClientIpAddress () {
   echo 'Attempting to log this client''s IP for Azure Package feed telemetry purposes'
   if command -v curl > /dev/null; then
-    curl -s 'http://co1.msedge.net/fdv2/diagnostics.aspx' | grep ' IP: '
+    curl -s 'http://co1.msedge.net/fdv2/diagnostics.aspx' | grep ' IP: ' || true
   fi
 }
 


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/7778 



### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation ( [this build, once succeeded shows a check it fixed](https://dev.azure.com/dnceng/public/_build/results?buildId=1311890&view=logs&j=831e00c8-b695-5bed-0cd5-fb5cb5df32e7) )

