### PR TITLE
Skip validating submodules sourcelinks

### DIFF
--- a/eng/common/post-build/sourcelink-validation.ps1
+++ b/eng/common/post-build/sourcelink-validation.ps1
@@ -107,8 +107,12 @@ $ValidatePackage = {
                         try {
                           $Uri = $Link -as [System.URI]
                         
-                          # Only GitHub links are valid
-                          if ($Uri.AbsoluteURI -ne $null -and ($Uri.Host -match 'github' -or $Uri.Host -match 'githubusercontent')) {
+                          if ($Link -match "submodules") {
+                            # Skip submodule links until sourcelink properly handles submodules
+                            $Status = 200
+                          }
+                          elseif ($Uri.AbsoluteURI -ne $null -and ($Uri.Host -match 'github' -or $Uri.Host -match 'githubusercontent')) {
+                            # Only GitHub links are valid
                             $Status = (Invoke-WebRequest -Uri $Link -UseBasicParsing -Method HEAD -TimeoutSec 5).StatusCode
                           }
                           else {


### PR DESCRIPTION
Currently, sourcelink is broken for submodules, where it will assume that the link is actually in the current repo, rather than having info based on the actual repo the submodule came from. There is work to fix submodule links in sourcelink, but until that fix is in, we should just ignore all links are from submodules.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
