### PR TITLE
Adding detection and retargeting of DOTNETHOME

### DIFF
--- a/src/Common/wix/dotnethome_x64.wxs
+++ b/src/Common/wix/dotnethome_x64.wxs
@@ -1,33 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <?ifndef Platform ?>
-    <?define Platform = "$(sys.BUILDARCH)" ?>
-  <?endif ?>
+  <?ifndef Platform?>
+    <?define Platform = "$(sys.BUILDARCH)"?>
+  <?endif?>
 
-  <!-- The following match the expected values for PROCESSOR_ARCHITECTURE
-          https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details -->
+  <!-- InstallerArchitecture matches the expected values for PROCESSOR_ARCHITECTURE 
+       https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details  -->
   <?if $(var.Platform)~=x86?>
     <?define InstallerArchitecture="X86"?>
   <?elseif $(var.Platform)~=x64?>
     <?define InstallerArchitecture="AMD64"?>
   <?elseif $(var.Platform)~=arm64?>
     <?define InstallerArchitecture="ARM64"?>
+  <?else?>
+    <?error Unknown platform, $(var.Platform) ?>?
   <?endif?>
 
   <Fragment>
     <!-- Identify when installing in emulation as when PROCESSOR_ARCHITECTURE does not match the installer architecture
           https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details -->
-    <SetProperty Action="Set_INSTALLING_IN_EMULATION" Id="INSTALLING_IN_EMULATION" Value="true" Before="CostFinalize">
+    <SetProperty Action="Set_NON_NATIVE_ARCHITECTURE" Id="NON_NATIVE_ARCHITECTURE" Value="true" Before="CostFinalize">
       NOT %PROCESSOR_ARCHITECTURE="$(var.InstallerArchitecture)"
     </SetProperty>
   </Fragment>
-    
-  <?if $(var.Platform)=x64?>
+
+  <?if $(var.Platform)~=x64?>
   <Fragment>
-    <!-- When running in x64 emulation and user hasn't specified install directory, install to an x64 subdirectory-->
-    <SetProperty Action="Set_DOTNETHOME_x64" Id="DOTNETHOME" Value="[ProgramFiles64Folder]dotnet\x64\" After="Set_INSTALLING_IN_EMULATION">
-      INSTALLING_IN_EMULATION AND NOT DOTNETHOME
+    <!-- When running in a non-native architecture and user hasn't specified install directory,
+         install to an x64 subdirectory.
+         This is only define for x64, since x86 has redirection and no other native architecture can install ARM64 today -->
+    <SetProperty Action="Set_DOTNETHOME_NON_NATIVE_ARCHITECTURE" Id="DOTNETHOME" Value="[ProgramFiles64Folder]dotnet\x64\" After="Set_NON_NATIVE_ARCHITECTURE">
+      NON_NATIVE_ARCHITECTURE AND NOT DOTNETHOME
     </SetProperty>
   </Fragment>
   <?endif?>

--- a/src/Common/wix/dotnethome_x64.wxs
+++ b/src/Common/wix/dotnethome_x64.wxs
@@ -1,29 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-<?ifndef Platform ?>
-  <?define Platform = "$(sys.BUILDARCH)" ?>
-<?endif ?>
-<!-- Only defined for x64 as that is the only platform we redirect -->
-<?if $(var.Platform)=x64?>
+  <?ifndef Platform ?>
+    <?define Platform = "$(sys.BUILDARCH)" ?>
+  <?endif ?>
+
+  <!-- The following match the expected values for PROCESSOR_ARCHITECTURE
+          https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details -->
+  <?if $(var.Platform)=x86?>
+    <?define InstallerArchitecture="X86"?>
+  <?elseif $(var.Platform)=x64?>
+    <?define InstallerArchitecture="AMD64"?>
+  <?elseif $(var.Platform)=ARM64?>
+    <?define InstallerArchitecture="ARM64"?>
+  <?endif?>
+
   <Fragment>
-    <Property Id="PROCESSOR_ARCHITECTURE">
-      <RegistrySearch Id="Search_PROCESSOR_ARCHITECTURE"
-                      Root="HKLM"
-                      Key="SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
-                      Name="PROCESSOR_ARCHITECTURE"
-                      Type="raw" />
-    </Property>
-    
-    <!-- Identify when installing in emulation as when PROCESSOR_ARCHITECTURE is not AMD64
-         https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details -->
-    <SetProperty Action="Set_INSTALLING_IN_EMULATION" Id="INSTALLING_IN_EMULATION" Value="true" Before="Set_DOTNETHOME_x64">
-      NOT PROCESSOR_ARCHITECTURE="AMD64"
+    <!-- Identify when installing in emulation as when PROCESSOR_ARCHITECTURE does not match the installer architecture
+          https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details -->
+    <SetProperty Action="Set_INSTALLING_IN_EMULATION" Id="INSTALLING_IN_EMULATION" Value="true" Before="CostFinalize">
+      NOT %PROCESSOR_ARCHITECTURE="$(var.InstallerArchitecture)"
     </SetProperty>
+  </Fragment>
+    
+  <?if $(var.Platform)=x64?>
+  <Fragment>
     <!-- When running in x64 emulation and user hasn't specified install directory, install to an x64 subdirectory-->
-    <SetProperty Action="Set_DOTNETHOME_x64" Id="DOTNETHOME" Value="[ProgramFiles64Folder]dotnet\x64\" Before="CostFinalize">
+    <SetProperty Action="Set_DOTNETHOME_x64" Id="DOTNETHOME" Value="[ProgramFiles64Folder]dotnet\x64\" After="Set_INSTALLING_IN_EMULATION">
       INSTALLING_IN_EMULATION AND NOT DOTNETHOME
     </SetProperty>
   </Fragment>
-<?endif?>
+  <?endif?>
 </Wix>

--- a/src/Common/wix/dotnethome_x64.wxs
+++ b/src/Common/wix/dotnethome_x64.wxs
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+<?ifndef Platform ?>
+  <?define Platform = "$(sys.BUILDARCH)" ?>
+<?endif ?>
 <!-- Only defined for x64 as that is the only platform we redirect -->
 <?if $(var.Platform)=x64?>
   <Fragment>

--- a/src/Common/wix/dotnethome_x64.wxs
+++ b/src/Common/wix/dotnethome_x64.wxs
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+<!-- Only defined for x64 as that is the only platform we redirect -->
+<?if $(var.Platform)=x64?>
+  <Fragment>
+    <Property Id="PROCESSOR_ARCHITECTURE">
+      <RegistrySearch Id="Search_PROCESSOR_ARCHITECTURE"
+                      Root="HKLM"
+                      Key="SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
+                      Name="PROCESSOR_ARCHITECTURE"
+                      Type="raw" />
+    </Property>
+    
+    <!-- Identify when installing in emulation as when PROCESSOR_ARCHITECTURE is not AMD64
+         https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details -->
+    <SetProperty Id="INSTALLING_IN_EMULATION" Value="true" Before="Set_DOTNETHOME_x64">
+      NOT PROCESSOR_ARCHITECTURE="AMD64"
+    </SetProperty>
+    <!-- When running in x64 emulation and user hasn't specified install directory, install to an x64 subdirectory-->
+    <SetProperty Action="Set_DOTNETHOME_x64" Id="DOTNETHOME" Value="[ProgramFiles64Folder]dotnet\x64\" Before="CostFinalize">
+      INSTALLING_IN_EMULATION AND NOT DOTNETHOME
+    </SetProperty>
+  </Fragment>
+<?endif?>
+</Wix>

--- a/src/Common/wix/dotnethome_x64.wxs
+++ b/src/Common/wix/dotnethome_x64.wxs
@@ -14,7 +14,7 @@
     
     <!-- Identify when installing in emulation as when PROCESSOR_ARCHITECTURE is not AMD64
          https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details -->
-    <SetProperty Id="INSTALLING_IN_EMULATION" Value="true" Before="Set_DOTNETHOME_x64">
+    <SetProperty Action="Set_INSTALLING_IN_EMULATION" Id="INSTALLING_IN_EMULATION" Value="true" Before="Set_DOTNETHOME_x64">
       NOT PROCESSOR_ARCHITECTURE="AMD64"
     </SetProperty>
     <!-- When running in x64 emulation and user hasn't specified install directory, install to an x64 subdirectory-->

--- a/src/Common/wix/dotnethome_x64.wxs
+++ b/src/Common/wix/dotnethome_x64.wxs
@@ -7,11 +7,11 @@
 
   <!-- The following match the expected values for PROCESSOR_ARCHITECTURE
           https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details -->
-  <?if $(var.Platform)=x86?>
+  <?if $(var.Platform)~=x86?>
     <?define InstallerArchitecture="X86"?>
-  <?elseif $(var.Platform)=x64?>
+  <?elseif $(var.Platform)~=x64?>
     <?define InstallerArchitecture="AMD64"?>
-  <?elseif $(var.Platform)=ARM64?>
+  <?elseif $(var.Platform)~=arm64?>
     <?define InstallerArchitecture="ARM64"?>
   <?endif?>
 

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/Microsoft.DotNet.Build.Tasks.Installers.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/Microsoft.DotNet.Build.Tasks.Installers.csproj
@@ -25,6 +25,7 @@
     <None Include="build/**/*.*" Pack="true">
       <PackagePath>build</PackagePath>
     </None>
+    <None Include="..\Common\wix\dotnethome_x64.wxs" Link="build\wix\product\dotnethome_x64.wxs" PackagePath="%(Link)" Pack="true" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/product/product.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/product/product.wxs
@@ -53,8 +53,8 @@
       </Directory>
     </Directory>
 
-    <?if $(var.Platform) = x64 ?>
-    <CustomActionRef Id="Set_DOTNETHOME_x64" />
+    <?if $(var.Platform)~=x64?>
+    <CustomActionRef Id="Set_DOTNETHOME_NON_NATIVE_ARCHITECTURE" />
     <?endif?>
   </Fragment>
 </Wix>

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/product/product.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/product/product.wxs
@@ -72,7 +72,7 @@
       NOT PROCESSOR_ARCHITECTURE="AMD64"
     </SetProperty>
     <!-- When running in x64 emulation and user hasn't specified install directory, install to an x64 subdirectory-->
-    <SetProperty Action="Set_DOTNETHOME_x64" Id="DOTNETHOME" Value="[$(var.ProgramFilesFolder)]dotnet\x64\" Before="CostFinalize">
+    <SetProperty Action="Set_DOTNETHOME_x64" Id="DOTNETHOME" Value="[$(var.Program_Files)]dotnet\x64\" Before="CostFinalize">
       INSTALLING_IN_EMULATION AND NOT DOTNETHOME
     </SetProperty>
   </Fragment>

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/product/product.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/product/product.wxs
@@ -51,6 +51,29 @@
         <Directory Id="DOTNETHOME" Name="dotnet" />
       </Directory>
     </Directory>
+
+    <?if $(var.Platform) = x64 ?>
+    <CustomActionRef Id="Set_DOTNETHOME_x64" />
+    <?endif?>
   </Fragment>
 
+  <Fragment>
+    <Property Id="PROCESSOR_ARCHITECTURE">
+      <RegistrySearch Id="Search_PROCESSOR_ARCHITECTURE"
+                      Root="HKLM"
+                      Key="SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
+                      Name="PROCESSOR_ARCHITECTURE"
+                      Type="raw" />
+    </Property>
+    
+    <!-- Identify when installing in emulation as when PROCESSOR_ARCHITECTURE is not AMD64
+         https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details -->
+    <SetProperty Id="INSTALLING_IN_EMULATION" Value="true" Before="Set_DOTNETHOME_x64">
+      NOT PROCESSOR_ARCHITECTURE="AMD64"
+    </SetProperty>
+    <!-- When running in x64 emulation and user hasn't specified install directory, install to an x64 subdirectory-->
+    <SetProperty Action="Set_DOTNETHOME_x64" Id="DOTNETHOME" Value="[$(var.ProgramFilesFolder)]dotnet_test\x64\" Before="CostFinalize">
+      INSTALLING_IN_EMULATION AND NOT DOTNETHOME
+    </SetProperty>
+  </Fragment>
 </Wix>

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/product/product.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/product/product.wxs
@@ -72,7 +72,7 @@
       NOT PROCESSOR_ARCHITECTURE="AMD64"
     </SetProperty>
     <!-- When running in x64 emulation and user hasn't specified install directory, install to an x64 subdirectory-->
-    <SetProperty Action="Set_DOTNETHOME_x64" Id="DOTNETHOME" Value="[$(var.ProgramFilesFolder)]dotnet_test\x64\" Before="CostFinalize">
+    <SetProperty Action="Set_DOTNETHOME_x64" Id="DOTNETHOME" Value="[$(var.ProgramFilesFolder)]dotnet\x64\" Before="CostFinalize">
       INSTALLING_IN_EMULATION AND NOT DOTNETHOME
     </SetProperty>
   </Fragment>

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/product/product.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/product/product.wxs
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
 
   <?include "..\variables.wxi" ?>
@@ -55,25 +56,5 @@
     <?if $(var.Platform) = x64 ?>
     <CustomActionRef Id="Set_DOTNETHOME_x64" />
     <?endif?>
-  </Fragment>
-
-  <Fragment>
-    <Property Id="PROCESSOR_ARCHITECTURE">
-      <RegistrySearch Id="Search_PROCESSOR_ARCHITECTURE"
-                      Root="HKLM"
-                      Key="SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
-                      Name="PROCESSOR_ARCHITECTURE"
-                      Type="raw" />
-    </Property>
-    
-    <!-- Identify when installing in emulation as when PROCESSOR_ARCHITECTURE is not AMD64
-         https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details -->
-    <SetProperty Id="INSTALLING_IN_EMULATION" Value="true" Before="Set_DOTNETHOME_x64">
-      NOT PROCESSOR_ARCHITECTURE="AMD64"
-    </SetProperty>
-    <!-- When running in x64 emulation and user hasn't specified install directory, install to an x64 subdirectory-->
-    <SetProperty Action="Set_DOTNETHOME_x64" Id="DOTNETHOME" Value="[$(var.Program_Files)]dotnet\x64\" Before="CostFinalize">
-      INSTALLING_IN_EMULATION AND NOT DOTNETHOME
-    </SetProperty>
   </Fragment>
 </Wix>

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets
@@ -108,6 +108,7 @@
       <WixExtensions Include="WixUtilExtension.dll" />
 
       <WixSrcFile Include="$(MSBuildThisFileDirectory)product/product.wxs" />
+      <WixSrcFile Include="$(MSBuildThisFileDirectory)product/dotnethome_x64.wxs" />
       <WixSrcFile Include="$(MSBuildThisFileDirectory)product/provider.wxs" />
     </ItemGroup>
   </Target>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
@@ -167,7 +167,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                     List<string> sourceFiles = new();
                     string msiSourcePath = Path.Combine(MsiDirectory, $"{nupkg.Id}", $"{nupkg.Version}", platform);
                     sourceFiles.Add(EmbeddedTemplates.Extract("DependencyProvider.wxs", msiSourcePath));
-                    sourceFiles.Add(EmbeddedTemplates.Extract("Directories.wxs", msiSourcePath));
+                    sourceFiles.Add(EmbeddedTemplates.Extract("dotnethome_x64.wxs", msiSourcePath));
                     sourceFiles.Add(EmbeddedTemplates.Extract("ManifestProduct.wxs", msiSourcePath));
 
                     string EulaRtfPath = Path.Combine(msiSourcePath, "eula.rtf");

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
@@ -167,6 +167,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                     List<string> sourceFiles = new();
                     string msiSourcePath = Path.Combine(MsiDirectory, $"{nupkg.Id}", $"{nupkg.Version}", platform);
                     sourceFiles.Add(EmbeddedTemplates.Extract("DependencyProvider.wxs", msiSourcePath));
+                    sourceFiles.Add(EmbeddedTemplates.Extract("Directories.wxs", msiSourcePath));
                     sourceFiles.Add(EmbeddedTemplates.Extract("ManifestProduct.wxs", msiSourcePath));
 
                     string EulaRtfPath = Path.Combine(msiSourcePath, "eula.rtf");

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
@@ -164,6 +164,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                 string msiSourcePath = Path.Combine(MsiDirectory, $"{nupkg.Id}", $"{nupkg.Version}", platform);
                 sourceFiles.Add(EmbeddedTemplates.Extract("DependencyProvider.wxs", msiSourcePath));
                 sourceFiles.Add(EmbeddedTemplates.Extract("Directories.wxs", msiSourcePath));
+                sourceFiles.Add(EmbeddedTemplates.Extract("dotnethome_x64.wxs", msiSourcePath));
                 sourceFiles.Add(EmbeddedTemplates.Extract("Product.wxs", msiSourcePath));
                 sourceFiles.Add(EmbeddedTemplates.Extract("Registry.wxs", msiSourcePath));
 

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Microsoft.DotNet.Build.Tasks.Workloads.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Microsoft.DotNet.Build.Tasks.Workloads.csproj
@@ -52,6 +52,7 @@
     <EmbeddedResource Include="Misc\*.*" />
     <EmbeddedResource Include="MsiTemplate\*.wxs" />
     <EmbeddedResource Include="MsiTemplate\*.wxi" />
+    <EmbeddedResource Include="..\..\Common\wix\dotnethome_x64.wxs" Link="MsiTemplate\dotnethome_x64.wxs" />
     <EmbeddedResource Include="SwixTemplate\*.swr" />
     <EmbeddedResource Include="SwixTemplate\*.swixproj" />
     <EmbeddedResource Include="SwixTemplate\*.vsmanproj" />

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/Directories.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/Directories.wxs
@@ -16,5 +16,29 @@
         </Directory>
       </Directory>
     </Directory>
+
+    <?if $(var.Platform) = x64 ?>
+    <CustomActionRef Id="Set_DOTNETHOME_x64" />
+    <?endif?>
+  </Fragment>
+
+  <Fragment>
+    <Property Id="PROCESSOR_ARCHITECTURE">
+      <RegistrySearch Id="Search_PROCESSOR_ARCHITECTURE"
+                      Root="HKLM"
+                      Key="SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
+                      Name="PROCESSOR_ARCHITECTURE"
+                      Type="raw" />
+    </Property>
+    
+    <!-- Identify when installing in emulation as when PROCESSOR_ARCHITECTURE is not AMD64
+         https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details -->
+    <SetProperty Id="INSTALLING_IN_EMULATION" Value="true" Before="Set_DOTNETHOME_x64">
+      NOT PROCESSOR_ARCHITECTURE="AMD64"
+    </SetProperty>
+    <!-- When running in x64 emulation and user hasn't specified install directory, install to an x64 subdirectory-->
+    <SetProperty Action="Set_DOTNETHOME_x64" Id="DOTNETHOME" Value="[$(var.ProgramFilesFolder)]dotnet_test\x64\" Before="CostFinalize">
+      INSTALLING_IN_EMULATION AND NOT DOTNETHOME
+    </SetProperty>
   </Fragment>
 </Wix>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/Directories.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/Directories.wxs
@@ -17,8 +17,8 @@
       </Directory>
     </Directory>
 
-    <?if $(var.Platform) = x64 ?>
-    <CustomActionRef Id="Set_DOTNETHOME_x64" />
+    <?if $(var.Platform)~=x64?>
+    <CustomActionRef Id="Set_DOTNETHOME_NON_NATIVE_ARCHITECTURE" />
     <?endif?>
   </Fragment>
 </Wix>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/Directories.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/Directories.wxs
@@ -21,24 +21,4 @@
     <CustomActionRef Id="Set_DOTNETHOME_x64" />
     <?endif?>
   </Fragment>
-
-  <Fragment>
-    <Property Id="PROCESSOR_ARCHITECTURE">
-      <RegistrySearch Id="Search_PROCESSOR_ARCHITECTURE"
-                      Root="HKLM"
-                      Key="SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
-                      Name="PROCESSOR_ARCHITECTURE"
-                      Type="raw" />
-    </Property>
-    
-    <!-- Identify when installing in emulation as when PROCESSOR_ARCHITECTURE is not AMD64
-         https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details -->
-    <SetProperty Id="INSTALLING_IN_EMULATION" Value="true" Before="Set_DOTNETHOME_x64">
-      NOT PROCESSOR_ARCHITECTURE="AMD64"
-    </SetProperty>
-    <!-- When running in x64 emulation and user hasn't specified install directory, install to an x64 subdirectory-->
-    <SetProperty Action="Set_DOTNETHOME_x64" Id="DOTNETHOME" Value="[$(var.ProgramFilesFolder)]dotnet\x64\" Before="CostFinalize">
-      INSTALLING_IN_EMULATION AND NOT DOTNETHOME
-    </SetProperty>
-  </Fragment>
 </Wix>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/Directories.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/Directories.wxs
@@ -37,7 +37,7 @@
       NOT PROCESSOR_ARCHITECTURE="AMD64"
     </SetProperty>
     <!-- When running in x64 emulation and user hasn't specified install directory, install to an x64 subdirectory-->
-    <SetProperty Action="Set_DOTNETHOME_x64" Id="DOTNETHOME" Value="[$(var.ProgramFilesFolder)]dotnet_test\x64\" Before="CostFinalize">
+    <SetProperty Action="Set_DOTNETHOME_x64" Id="DOTNETHOME" Value="[$(var.ProgramFilesFolder)]dotnet\x64\" Before="CostFinalize">
       INSTALLING_IN_EMULATION AND NOT DOTNETHOME
     </SetProperty>
   </Fragment>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/ManifestProduct.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/ManifestProduct.wxs
@@ -23,13 +23,21 @@
       NOT WIX_DOWNGRADE_DETECTED
     </Condition>
 
-    <DirectoryRef Id="DOTNETHOME">
-      <Directory Id="ManifestDir" Name="sdk-manifests">
-        <Directory Id="VersionDir" Name="$(var.SdkFeatureBandVersion)">
-          <Directory Id="ManifestIdDir" Name="$(var.ManifestId)" />
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="$(var.ProgramFilesFolder)">
+        <Directory Id="DOTNETHOME" Name="dotnet">
+          <Directory Id="ManifestDir" Name="sdk-manifests">
+            <Directory Id="VersionDir" Name="$(var.SdkFeatureBandVersion)">
+              <Directory Id="ManifestIdDir" Name="$(var.ManifestId)" />
+            </Directory>
+          </Directory>
         </Directory>
       </Directory>
-    </DirectoryRef>
+    </Directory>
+
+    <?if $(var.Platform) = x64 ?>
+    <CustomActionRef Id="Set_DOTNETHOME_x64" />
+    <?endif?>
 
     <MediaTemplate CompressionLevel="high" EmbedCab="yes" />
 

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/ManifestProduct.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/ManifestProduct.wxs
@@ -23,17 +23,13 @@
       NOT WIX_DOWNGRADE_DETECTED
     </Condition>
 
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="$(var.ProgramFilesFolder)">
-        <Directory Id="DOTNETHOME" Name="dotnet">
-          <Directory Id="ManifestDir" Name="sdk-manifests">
-            <Directory Id="VersionDir" Name="$(var.SdkFeatureBandVersion)">
-              <Directory Id="ManifestIdDir" Name="$(var.ManifestId)" />
-            </Directory>
-          </Directory>
+    <DirectoryRef Id="DOTNETHOME">
+      <Directory Id="ManifestDir" Name="sdk-manifests">
+        <Directory Id="VersionDir" Name="$(var.SdkFeatureBandVersion)">
+          <Directory Id="ManifestIdDir" Name="$(var.ManifestId)" />
         </Directory>
       </Directory>
-    </Directory>
+    </DirectoryRef>
 
     <MediaTemplate CompressionLevel="high" EmbedCab="yes" />
 

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/ManifestProduct.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/ManifestProduct.wxs
@@ -35,8 +35,8 @@
       </Directory>
     </Directory>
 
-    <?if $(var.Platform) = x64 ?>
-    <CustomActionRef Id="Set_DOTNETHOME_x64" />
+    <?if $(var.Platform)~=x64?>
+    <CustomActionRef Id="Set_DOTNETHOME_NON_NATIVE_ARCHITECTURE" />
     <?endif?>
 
     <MediaTemplate CompressionLevel="high" EmbedCab="yes" />

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/Registry.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/Registry.wxs
@@ -6,7 +6,7 @@
     <Feature Id="F_RegistryKeys" Absent="disallow" AllowAdvertise="no" Description="Registry keys."
              Display="hidden" InstallDefault="local" Level="1" Title="Workload Pack Registration" TypicalDefault="install">
       <Component Id="C_InstalledPack" Win64="$(var.Win64)" Directory="TARGETDIR">
-        <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\dotnet\InstalledPacks\$(var.PackageId)\$(var.PackageVersion)">
+        <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\dotnet\InstalledPacks\$(var.Platform)\$(var.PackageId)\$(var.PackageVersion)">
           <RegistryValue Name="DependencyProviderKey" Type="string" Value="$(var.DependencyProviderKeyName)" KeyPath="yes"/>
           <RegistryValue Name="ProductCode" Type="string" Value="$(var.ProductCode)"/>
           <RegistryValue Name="UpgradeCode" Type="string" Value="$(var.UpgradeCode)"/>


### PR DESCRIPTION
When x64 is installed on non-x64 machine, place in an x64 subdirectory.

This is still a WIP.  We could share this with both Installers and workloads SDK, perhaps with just a common source file.  I'd also like to better understand once putting together some consumption PRs upstack.