### PR TITLE
Updating microbuild version on 5.0

### DIFF
--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -630,7 +630,7 @@ The steps below assume the following variables to be defined:
 ### Signing plugin installation
 
 ```yml
-- task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
+- task: MicroBuildSigningPlugin@3
   displayName: Install Signing Plugin
   inputs:
     signType: real

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -103,7 +103,7 @@ jobs:
 
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
-      - task: MicroBuildSigningPlugin@2
+      - task: MicroBuildSigningPlugin@3
         displayName: Install MicroBuild plugin
         inputs:
           signType: $(_SignType)

--- a/eng/common/templates/phases/base.yml
+++ b/eng/common/templates/phases/base.yml
@@ -82,7 +82,7 @@ phases:
   - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
     # Internal only resource, and Microbuild signing shouldn't be applied to PRs.
     - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - task: MicroBuildSigningPlugin@2
+      - task: MicroBuildSigningPlugin@3
         displayName: Install MicroBuild plugin
         inputs:
           signType: $(_SignType)


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation

## Description

Updating Microbuild task to v3 per https://github.com/dotnet/arcade/issues/7799

## Customer Impact

Customers are experiencing 403 errors with Microbuild v2 task. This is a known issue, and the recommended fix is to update to v3. 

## Regression

No

## Risk

Minimal

## Workarounds

Workaround would be for customers to update this version in their own yaml. 