### PR TITLE
Additional RPMs for CBL-Mariner

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
@@ -145,6 +145,20 @@
       <ExeBundleInstallerFile>$(PackageOutputPath)$(InstallerFileNameWithoutExtension).exe</ExeBundleInstallerFile>
       <ExeBundleInstallerEngineFile>$(PackageOutputPath)$(InstallerFileNameWithoutExtension)-engine.exe</ExeBundleInstallerEngineFile>
     </PropertyGroup>
+
+    <PropertyGroup Condition="'$(GenerateRpm)' == 'true'">
+      <CreateRPMForCblMariner>true</CreateRPMForCblMariner>
+      <!-- PackageTargetOS is a distro-specific version suffix, used for deps packages, including the one for CBL Mariner.
+           We do not want to create additional CBL Mariner named RPMs of those packages. -->
+      <CreateRPMForCblMariner Condition="'$(PackageTargetOS)' != ''">false</CreateRPMForCblMariner>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(CreateRPMForCblMariner)' == 'true'">
+      <_CblMarinerVersionSuffix>cm.1</_CblMarinerVersionSuffix>
+      <_InstallerBuildPartCblMariner>$(Version)-$(_CblMarinerVersionSuffix)-$(InstallerTargetArchitecture)</_InstallerBuildPartCblMariner>
+      <_InstallerFileNameWithoutExtensionCblMariner>$(InstallerName)-$(_InstallerBuildPartCblMariner)$(CrossArchContentsBuildPart)</_InstallerFileNameWithoutExtensionCblMariner>
+      <_InstallerFileCblMariner>$(PackageOutputPath)$(_InstallerFileNameWithoutExtensionCblMariner)$(InstallerExtension)</_InstallerFileCblMariner>
+    </PropertyGroup>
   </Target>
   
   <!--
@@ -307,6 +321,15 @@
           UseHardlinksIfPossible="False" />
 
     <Message Text="$(MSBuildProjectName) -> $(_InstallerFile)" Importance="high" />
+
+    <Copy Condition="'$(CreateRPMForCblMariner)' == 'true'"
+          SourceFiles="@(GeneratedRpmFiles)"
+          DestinationFiles="$(_InstallerFileCblMariner)"
+          OverwriteReadOnlyFiles="True"
+          SkipUnchangedFiles="False"
+          UseHardlinksIfPossible="False" />
+
+    <Message Text="$(MSBuildProjectName) -> $(_InstallerFileCblMariner)" Importance="high" />
   </Target>
 
   <Target Name="GetRpmInstallerJsonProperties"


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/58141

Adds a copy of RPMs with CBL-Mariner version suffix, in the name. Skips projects that generate distro-specific RPMs (i.e. deps packages).