### PR TITLE
Bump SDK used by XHarness while we're on RC1

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
@@ -10,7 +10,7 @@
       <DotNetCliVersion Condition=" '$(DotNetCliVersion)' == '' ">$(AspNetCoreRuntimeVersion)</DotNetCliVersion>
     -->
     <DotNetCliPackageType>sdk</DotNetCliPackageType>
-    <DotNetCliVersion>6.0.100-rc.1.21379.2</DotNetCliVersion>
+    <DotNetCliVersion>6.0.100-rc.1.21430.12</DotNetCliVersion>
     <DotNetCliVersion Condition=" '$(DotNetCliVersion)' == '$(BundledNETCoreAppPackageVersion)' AND '$(DotNetCliPackageType)' == 'aspnetcore-runtime' ">$(AspNetCoreRuntimeVersion)</DotNetCliVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Follow-up for https://github.com/dotnet/arcade/pull/7814 because the versions don't match
Fixing issues down the line https://dev.azure.com/dnceng/public/_build/results?buildId=1333882&view=results
