### PR TITLE
Add additional targets to be excluded with ExcludeFromSourcebuild

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Empty.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Empty.targets
@@ -4,8 +4,8 @@
   <!--
     Import this file to suppress all targets while allowing the project to participate in the build.
     Workaround for https://github.com/dotnet/sdk/issues/2071.
-    
-    The targets defined here are not sufficient for the project to be open in Visual Studio without issues though.    
+
+    The targets defined here are not sufficient for the project to be open in Visual Studio without issues though.
   -->
 
   <PropertyGroup>
@@ -19,5 +19,10 @@
   <Target Name="Test"/>
   <Target Name="Pack"/>
   <Target Name="Publish"/>
+  <Target Name="ApplyImplicitVersions"/>
+  <Target Name="_CollectTargetFrameworkForTelemetry"/>
+  <Target Name="ProcessFrameworkReferences"/>
+  <Target Name="CollectPackageReferences"/>
+  <Target Name="_CheckForInvalidConfigurationAndPlatform"/>
 
 </Project>


### PR DESCRIPTION
When ExcludeFromSourceBuild is used, in some conditions, additional targets are included.  Adding these to Empty.targets so they get skipped.

Fixes #7795