### PR TITLE
Deduplicate XHarness Apple/Android code in Helix SDK

### DIFF
--- a/src/Common/Microsoft.Arcade.Common/FileSystem.cs
+++ b/src/Common/Microsoft.Arcade.Common/FileSystem.cs
@@ -36,5 +36,7 @@ namespace Microsoft.Arcade.Common
         public void FileCopy(string sourceFileName, string destFileName) => File.Copy(sourceFileName, destFileName);
 
         public Stream GetFileStream(string path, FileMode mode, FileAccess access) => new FileStream(path, mode, access);
+
+        public FileAttributes GetAttributes(string path) => File.GetAttributes(path);
     }
 }

--- a/src/Common/Microsoft.Arcade.Common/IFileSystem.cs
+++ b/src/Common/Microsoft.Arcade.Common/IFileSystem.cs
@@ -31,5 +31,7 @@ namespace Microsoft.Arcade.Common
         void FileCopy(string sourceFileName, string destFileName);
 
         Stream GetFileStream(string path, FileMode mode, FileAccess access);
+
+        FileAttributes GetAttributes(string path);
     }
 }

--- a/src/Common/Microsoft.Arcade.Test.Common/MockFileSystem.cs
+++ b/src/Common/Microsoft.Arcade.Test.Common/MockFileSystem.cs
@@ -59,6 +59,18 @@ namespace Microsoft.Arcade.Test.Common
         public Stream GetFileStream(string path, FileMode mode, FileAccess access)
             => FileExists(path) ? new MemoryStream() : new MockFileStream(this, path);
 
+        public FileAttributes GetAttributes(string path)
+        {
+            var attributes = FileAttributes.Normal;
+
+            if (Directories.Contains(path))
+            {
+                attributes |= FileAttributes.Directory;
+            }
+
+            return  attributes;
+        }
+
         #endregion
 
         /// <summary>

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAndroidWorkItemsTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAndroidWorkItemsTests.cs
@@ -88,9 +88,9 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             _zipArchiveManager
                 .Verify(x => x.ArchiveFile("/apks/System.Foo.apk", payloadArchive), Times.Once);
             _zipArchiveManager
-                .Verify(x => x.AddResourceFileToArchive<CreateXHarnessAndroidWorkItems>(payloadArchive, It.Is<string>(s => s.Contains("xharness-helix-job.android.sh")), "xharness-helix-job.android.sh"), Times.AtLeastOnce);
+                .Verify(x => x.AddResourceFileToArchive<XHarnessTaskBase>(payloadArchive, It.Is<string>(s => s.Contains("xharness-helix-job.android.sh")), "xharness-helix-job.android.sh"), Times.AtLeastOnce);
             _zipArchiveManager
-                .Verify(x => x.AddResourceFileToArchive<CreateXHarnessAndroidWorkItems>(payloadArchive, It.Is<string>(s => s.Contains("xharness-helix-job.android.ps1")), "xharness-helix-job.android.ps1"), Times.AtLeastOnce);
+                .Verify(x => x.AddResourceFileToArchive<XHarnessTaskBase>(payloadArchive, It.Is<string>(s => s.Contains("xharness-helix-job.android.ps1")), "xharness-helix-job.android.ps1"), Times.AtLeastOnce);
         }
 
         [Fact]
@@ -104,7 +104,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 CreateApk("apks/System.Bar.apk", "System.Bar"),
             };
 
-            _fileSystem.Files.Add("apks/xharness-apk-payload-system.foo.zip", "archive");
+            _fileSystem.Files.Add("apks/xharness-payload-system.foo.zip", "archive");
 
             // Act
             using var provider = collection.BuildServiceProvider();
@@ -190,9 +190,9 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             _zipArchiveManager
                 .Verify(x => x.ArchiveFile(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
             _zipArchiveManager
-                .Verify(x => x.AddResourceFileToArchive<CreateXHarnessAndroidWorkItems>(payloadArchive, It.Is<string>(s => s.Contains("xharness-helix-job.android.sh")), "xharness-helix-job.android.sh"), Times.AtLeastOnce);
+                .Verify(x => x.AddResourceFileToArchive<XHarnessTaskBase>(payloadArchive, It.Is<string>(s => s.Contains("xharness-helix-job.android.sh")), "xharness-helix-job.android.sh"), Times.AtLeastOnce);
             _zipArchiveManager
-                .Verify(x => x.AddResourceFileToArchive<CreateXHarnessAndroidWorkItems>(payloadArchive, It.Is<string>(s => s.Contains("xharness-helix-job.android.ps1")), "xharness-helix-job.android.ps1"), Times.AtLeastOnce);
+                .Verify(x => x.AddResourceFileToArchive<XHarnessTaskBase>(payloadArchive, It.Is<string>(s => s.Contains("xharness-helix-job.android.ps1")), "xharness-helix-job.android.ps1"), Times.AtLeastOnce);
         }
 
         [Fact]

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAppleWorkItemsTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAppleWorkItemsTests.cs
@@ -96,9 +96,9 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             _zipArchiveManager
                 .Verify(x => x.ArchiveDirectory("/apps/System.Foo.app", payloadArchive, true), Times.Once);
             _zipArchiveManager
-                .Verify(x => x.AddResourceFileToArchive<CreateXHarnessAppleWorkItems>(payloadArchive, It.Is<string>(s => s.Contains("xharness-helix-job.apple.sh")), "xharness-helix-job.apple.sh"), Times.Once);
+                .Verify(x => x.AddResourceFileToArchive<XHarnessTaskBase>(payloadArchive, It.Is<string>(s => s.Contains("xharness-helix-job.apple.sh")), "xharness-helix-job.apple.sh"), Times.Once);
             _zipArchiveManager
-                .Verify(x => x.AddResourceFileToArchive<CreateXHarnessAppleWorkItems>(payloadArchive, It.Is<string>(s => s.Contains("xharness-runner.apple.sh")), "xharness-runner.apple.sh"), Times.Once);
+                .Verify(x => x.AddResourceFileToArchive<XHarnessTaskBase>(payloadArchive, It.Is<string>(s => s.Contains("xharness-runner.apple.sh")), "xharness-runner.apple.sh"), Times.Once);
             _zipArchiveManager
                 .Verify(x => x.AddContentToArchive(payloadArchive, "command.sh", It.Is<string>(s => s.Contains("xharness apple test"))), Times.Once);
         }
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 CreateAppBundle("apps/System.Bar.app", "ios-simulator-64_13.5"),
             };
 
-            _fileSystem.Files.Add("apps/xharness-app-payload-system.foo.zip", "archive");
+            _fileSystem.Files.Add("apps/xharness-payload-system.foo.zip", "archive");
 
             // Act
             using var provider = collection.BuildServiceProvider();
@@ -242,9 +242,9 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             _zipArchiveManager
                 .Verify(x => x.ArchiveDirectory("/apps/System.Foo.app", payloadArchive, true), Times.Never);
             _zipArchiveManager
-                .Verify(x => x.AddResourceFileToArchive<CreateXHarnessAppleWorkItems>(payloadArchive, It.Is<string>(s => s.Contains("xharness-helix-job.apple.sh")), "xharness-helix-job.apple.sh"), Times.Once);
+                .Verify(x => x.AddResourceFileToArchive<XHarnessTaskBase>(payloadArchive, It.Is<string>(s => s.Contains("xharness-helix-job.apple.sh")), "xharness-helix-job.apple.sh"), Times.Once);
             _zipArchiveManager
-                .Verify(x => x.AddResourceFileToArchive<CreateXHarnessAppleWorkItems>(payloadArchive, It.Is<string>(s => s.Contains("xharness-runner.apple.sh")), "xharness-runner.apple.sh"), Times.Once);
+                .Verify(x => x.AddResourceFileToArchive<XHarnessTaskBase>(payloadArchive, It.Is<string>(s => s.Contains("xharness-runner.apple.sh")), "xharness-runner.apple.sh"), Times.Once);
             _zipArchiveManager
                 .Verify(x => x.AddContentToArchive(payloadArchive, "command.sh", It.Is<string>(s => s.Contains("xharness apple test"))), Times.Once);
         }

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
@@ -91,30 +91,12 @@ namespace Microsoft.DotNet.Helix.Sdk
             IFileSystem fileSystem,
             ITaskItem appBundleItem)
         {
-            // The user can re-use the same .apk for 2 work items so the name of the work item will come from ItemSpec and path from metadata
-            string workItemName;
-            string appFolderPath;
-            if (appBundleItem.TryGetMetadata(MetadataNames.AppBundlePath, out string appPathMetadata) && !string.IsNullOrEmpty(appPathMetadata))
-            {
-                workItemName = appBundleItem.ItemSpec;
-                appFolderPath = appPathMetadata;
-            }
-            else
-            {
-                workItemName = fileSystem.GetFileName(appBundleItem.ItemSpec);
-                appFolderPath = appBundleItem.ItemSpec;
-            }
+            var (workItemName, appFolderPath) = GetNameAndPath(appBundleItem, MetadataNames.AppBundlePath, fileSystem);
 
             appFolderPath = appFolderPath.TrimEnd(Path.DirectorySeparatorChar);
 
-            bool isAlreadyArchived = workItemName.EndsWith(".zip");
-
-            if (isAlreadyArchived)
-            {
-                workItemName = workItemName.Substring(0, workItemName.Length - 4);
-            }
-
-            if (workItemName.EndsWith(".app"))
+            bool isAlreadyArchived = appFolderPath.EndsWith(".zip");
+            if (isAlreadyArchived && workItemName.EndsWith(".app"))
             {
                 // If someone named the zip something.app.zip, we want both gone
                 workItemName = workItemName.Substring(0, workItemName.Length - 4);
@@ -180,7 +162,15 @@ namespace Microsoft.DotNet.Helix.Sdk
 
             string appName = isAlreadyArchived ? $"{fileSystem.GetFileNameWithoutExtension(appFolderPath)}.app" : fileSystem.GetFileName(appFolderPath);
             string helixCommand = GetHelixCommand(appName, target, testTimeout, launchTimeout, includesTestRunner, expectedExitCode, resetSimulator);
-            string payloadArchivePath = await CreateZipArchiveOfFolder(zipArchiveManager, fileSystem, workItemName, isAlreadyArchived, appFolderPath, customCommands);
+            string payloadArchivePath = await CreatePayloadArchive(
+                zipArchiveManager,
+                fileSystem,
+                workItemName,
+                isAlreadyArchived,
+                isPosix: true,
+                appFolderPath,
+                customCommands,
+                new[] { EntryPointScript, RunnerScript });
 
             return CreateTaskItem(workItemName, payloadArchivePath, helixCommand, workItemTimeout);
         }
@@ -227,41 +217,5 @@ namespace Microsoft.DotNet.Helix.Sdk
             $"--expected-exit-code \"{expectedExitCode}\" " +
             (!string.IsNullOrEmpty(XcodeVersion) ? $" --xcode-version \"{XcodeVersion}\"" : string.Empty) +
             (!string.IsNullOrEmpty(AppArguments) ? $" --app-arguments \"{AppArguments}\"" : string.Empty);
-
-        private async Task<string> CreateZipArchiveOfFolder(
-            IZipArchiveManager zipArchiveManager,
-            IFileSystem fileSystem,
-            string workItemName,
-            bool isAlreadyArchived,
-            string folderToZip,
-            string injectedCommands)
-        {
-            string appFolderDirectory = fileSystem.GetDirectoryName(folderToZip);
-            string fileName = $"xharness-app-payload-{workItemName.ToLowerInvariant()}.zip";
-            string outputZipPath = fileSystem.PathCombine(appFolderDirectory, fileName);
-
-            if (fileSystem.FileExists(outputZipPath))
-            {
-                Log.LogMessage($"Zip archive '{outputZipPath}' already exists, overwriting..");
-                fileSystem.DeleteFile(outputZipPath);
-            }
-
-            if (!isAlreadyArchived)
-            {
-                zipArchiveManager.ArchiveDirectory(folderToZip, outputZipPath, true);
-            }
-            else
-            {
-                Log.LogMessage($"App payload '{workItemName}` has already been zipped. Copying to '{outputZipPath}` instead");
-                fileSystem.FileCopy(folderToZip, outputZipPath);
-            }
-
-            Log.LogMessage($"Adding the XHarness job scripts into the payload archive");
-            await zipArchiveManager.AddResourceFileToArchive<CreateXHarnessAppleWorkItems>(outputZipPath, ScriptNamespace + EntryPointScript, EntryPointScript);
-            await zipArchiveManager.AddResourceFileToArchive<CreateXHarnessAppleWorkItems>(outputZipPath, ScriptNamespace + RunnerScript, RunnerScript);
-            await zipArchiveManager.AddContentToArchive(outputZipPath, CustomCommandsScript + ".sh", injectedCommands);
-
-            return outputZipPath;
-        }
     }
 }

--- a/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
 using Microsoft.Arcade.Common;
 using Microsoft.Build.Framework;
 
@@ -106,6 +108,77 @@ namespace Microsoft.DotNet.Helix.Sdk
                 { "Command", command },
                 { "Timeout", timeout.ToString() },
             });
+        }
+
+        /// <summary>
+        /// This method parses the name for the Helix work item and path of the app from the item's metadata.
+        /// The user can re-use the same .apk for 2 work items so the name of the work item will come from ItemSpec and path from metadata.
+        /// </summary>
+        protected (string WorkItemName, string AppPath) GetNameAndPath(ITaskItem item, string pathMetadataName, IFileSystem fileSystem)
+        {
+            if (item.TryGetMetadata(pathMetadataName, out string appPathMetadata) && !string.IsNullOrEmpty(appPathMetadata))
+            {
+                return (item.ItemSpec, appPathMetadata);
+            }
+            else
+            {
+                return (fileSystem.GetFileNameWithoutExtension(item.ItemSpec), item.ItemSpec);
+            }
+        }
+
+        protected async Task<string> CreatePayloadArchive(
+            IZipArchiveManager zipArchiveManager,
+            IFileSystem fileSystem,
+            string workItemName,
+            bool isAlreadyArchived,
+            bool isPosix,
+            string pathToZip,
+            string injectedCommands,
+            string[] payloadScripts)
+        {
+            string appFolderDirectory = fileSystem.GetDirectoryName(pathToZip);
+            string fileName = $"xharness-app-payload-{workItemName.ToLowerInvariant()}.zip";
+            string outputZipPath = fileSystem.PathCombine(appFolderDirectory, fileName);
+
+            if (fileSystem.FileExists(outputZipPath))
+            {
+                Log.LogMessage($"Zip archive '{outputZipPath}' already exists, overwriting..");
+                fileSystem.DeleteFile(outputZipPath);
+            }
+
+            if (!isAlreadyArchived)
+            {
+                if (fileSystem.GetAttributes(pathToZip).HasFlag(FileAttributes.Directory))
+                {
+                    zipArchiveManager.ArchiveDirectory(pathToZip, outputZipPath, true);
+                }
+                else
+                {
+                    zipArchiveManager.ArchiveFile(pathToZip, outputZipPath);
+                }
+            }
+            else
+            {
+                Log.LogMessage($"App payload '{workItemName}` has already been zipped. Copying to '{outputZipPath}` instead");
+                fileSystem.FileCopy(pathToZip, outputZipPath);
+            }
+
+            Log.LogMessage($"Adding the XHarness job scripts into the payload archive");
+
+            foreach (var payloadScript in payloadScripts)
+            {
+                await zipArchiveManager.AddResourceFileToArchive<CreateXHarnessAppleWorkItems>(
+                    outputZipPath,
+                    ScriptNamespace + payloadScript,
+                    payloadScript);
+            }
+
+            await zipArchiveManager.AddContentToArchive(
+                outputZipPath,
+                CustomCommandsScript + (isPosix ? ".sh" : ".ps1"),
+                injectedCommands);
+
+            return outputZipPath;
         }
     }
 }

--- a/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
@@ -23,8 +23,8 @@ namespace Microsoft.DotNet.Helix.Sdk
             public const string CustomCommands = "CustomCommands";
         }
 
-        protected const string ScriptNamespace = "tools.xharness_runner.";
-        protected const string CustomCommandsScript = "command";
+        private const string ScriptNamespace = "tools.xharness_runner.";
+        private const string CustomCommandsScript = "command";
 
         /// <summary>
         /// Extra arguments that will be passed to the iOS/Android/... app that is being run
@@ -137,7 +137,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             string[] payloadScripts)
         {
             string appFolderDirectory = fileSystem.GetDirectoryName(pathToZip);
-            string fileName = $"xharness-app-payload-{workItemName.ToLowerInvariant()}.zip";
+            string fileName = $"xharness-payload-{workItemName.ToLowerInvariant()}.zip";
             string outputZipPath = fileSystem.PathCombine(appFolderDirectory, fileName);
 
             if (fileSystem.FileExists(outputZipPath))
@@ -167,7 +167,7 @@ namespace Microsoft.DotNet.Helix.Sdk
 
             foreach (var payloadScript in payloadScripts)
             {
-                await zipArchiveManager.AddResourceFileToArchive<CreateXHarnessAppleWorkItems>(
+                await zipArchiveManager.AddResourceFileToArchive<XHarnessTaskBase>(
                     outputZipPath,
                     ScriptNamespace + payloadScript,
                     payloadScript);


### PR DESCRIPTION
Deduplicating how we parse metadata and create .zip archives in Helix SDK.
- Was supposed to happen in #7811 but we were rushing with it for a client
- No functional changes
- Future work will use this