### PR TITLE
Fix sourcelink repository url

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
@@ -73,6 +73,12 @@
 
     <ItemGroup>
       <SourceRoot Update="@(SourceRoot)">
+        <ScmRepositoryUrl Condition="$([System.String]::Copy(%(SourceRoot.ScmRepositoryUrl)).Contains(`devdiv.visualstudio`))">$([System.String]::Copy(%(SourceRoot.ScmRepositoryUrl)).ToLower().Replace(`-trusted`,``))</ScmRepositoryUrl>
+      </SourceRoot>
+    </ItemGroup>
+
+    <ItemGroup>
+      <SourceRoot Update="@(SourceRoot)">
         <ScmRepositoryUrl>$([System.Text.RegularExpressions.Regex]::Replace(%(SourceRoot.ScmRepositoryUrl), $(_TranslateUrlPattern), $(_TranslateUrlReplacement)))</ScmRepositoryUrl>
       </SourceRoot>
     </ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
@@ -75,9 +75,6 @@
       <SourceRoot Update="@(SourceRoot)">
         <ScmRepositoryUrl Condition="$([System.String]::Copy(%(SourceRoot.ScmRepositoryUrl)).Contains(`devdiv.visualstudio`))">$([System.String]::Copy(%(SourceRoot.ScmRepositoryUrl)).ToLower().Replace(`-trusted`,``))</ScmRepositoryUrl>
       </SourceRoot>
-    </ItemGroup>
-
-    <ItemGroup>
       <SourceRoot Update="@(SourceRoot)">
         <ScmRepositoryUrl>$([System.Text.RegularExpressions.Regex]::Replace(%(SourceRoot.ScmRepositoryUrl), $(_TranslateUrlPattern), $(_TranslateUrlReplacement)))</ScmRepositoryUrl>
       </SourceRoot>


### PR DESCRIPTION
When we updated the ScmRepositoryUrl to handle devdiv links, we never updated the version used in SourceRoot, which is used by sourcelink, and also needed to be updated to remove -trusted from the link. By not removing -trusted, the translation pattern can't identify the url as something that needs to be translated, and so just uses the azdo url. This change adds the code to remove -trusted to fix the issue.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation

I tested this locally with the following MsBuild target:

```
<ItemGroup>
  <SourceRoot>
    <ScmRepositoryUrl>https://devdiv.visualstudio.com/DevDiv/_git/DotNet-msbuild-Trusted</ScmRepositoryUrl>
  </SourceRoot>
</ItemGroup>

<Message Importance="high" Text="%(SourceRoot.ScmRepositoryUrl)" /> // prints https://devdiv.visualstudio.com/DevDiv/_git/DotNet-msbuild-Trusted

<ItemGroup>
  <SourceRoot Update="@(SourceRoot)">
    <ScmRepositoryUrl Condition="$([System.String]::Copy(%(SourceRoot.ScmRepositoryUrl)).Contains(`devdiv.visualstudio`))">$([System.String]::Copy(%(SourceRoot.ScmRepositoryUrl)).ToLower().Replace(`-trusted`,``))</ScmRepositoryUrl>
  </SourceRoot>
</ItemGroup>

<Message Importance="high" Text="%(SourceRoot.ScmRepositoryUrl)" /> // prints https://devdiv.visualstudio.com/devdiv/_git/dotnet-msbuild

<ItemGroup>
  <SourceRoot Update="@(SourceRoot)">
    <ScmRepositoryUrl>$([System.Text.RegularExpressions.Regex]::Replace(%(SourceRoot.ScmRepositoryUrl), $(_TranslateUrlPattern), $(_TranslateUrlReplacement)))</ScmRepositoryUrl>
  </SourceRoot>
</ItemGroup>

<Message Importance="high" Text="%(SourceRoot.ScmRepositoryUrl)" /> // prints https://github.com/dotnet/msbuild
```

MsBuild quirks, as far as I can tell, require the two separate Updates.