### PR TITLE
[release/6.0] Fix sourcelink repository url (#7844)

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
@@ -73,6 +73,9 @@
 
     <ItemGroup>
       <SourceRoot Update="@(SourceRoot)">
+        <ScmRepositoryUrl Condition="$([System.String]::Copy(%(SourceRoot.ScmRepositoryUrl)).Contains(`devdiv.visualstudio`))">$([System.String]::Copy(%(SourceRoot.ScmRepositoryUrl)).ToLower().Replace(`-trusted`,``))</ScmRepositoryUrl>
+      </SourceRoot>
+      <SourceRoot Update="@(SourceRoot)">
         <ScmRepositoryUrl>$([System.Text.RegularExpressions.Regex]::Replace(%(SourceRoot.ScmRepositoryUrl), $(_TranslateUrlPattern), $(_TranslateUrlReplacement)))</ScmRepositoryUrl>
       </SourceRoot>
     </ItemGroup>


### PR DESCRIPTION
* Fix sourcelink repository url

When we updated the ScmRepositoryUrl to handle devdiv links, we never updated the version used in SourceRoot, which is used by sourcelink, and also needed to be updated to remove -trusted from the link. By not removing -trusted, the translation pattern can't identify the url as something that needs to be translated, and so just uses the azdo url. This change adds the code to remove -trusted to fix the issue.

* Remove second item group

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
