### PR TITLE
Cherry picking fix from https://github.com/dotnet/arcade/issues/7850 from main->release/6.0

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
@@ -67,7 +67,7 @@
     <PropertyGroup>
       <!-- Repositories mirrored on devdiv.visualstudio will have '-Trusted' added to their name and this needs to be stripped off before translation
            Eventually, all repos should move to dnceng/internal when possible. -->
-      <ScmRepositoryUrl Condition="$(ScmRepositoryUrl.Contains(`devdiv.visualstudio`))">$(ScmRepositoryUrl.ToLower().Replace(`-trusted`,``))</ScmRepositoryUrl>
+      <ScmRepositoryUrl Condition=" '%(SourceRoot.ScmRepositoryUrl)' != '' and '$([System.String]::Copy(%(SourceRoot.ScmRepositoryUrl)).Contains(`devdiv.visualstudio`))' == 'true' ">$([System.String]::Copy(%(SourceRoot.ScmRepositoryUrl)).ToLower().Replace(`-trusted`,``))</ScmRepositoryUrl>
       <ScmRepositoryUrl>$([System.Text.RegularExpressions.Regex]::Replace($(ScmRepositoryUrl), $(_TranslateUrlPattern), $(_TranslateUrlReplacement)))</ScmRepositoryUrl>
     </PropertyGroup>
 


### PR DESCRIPTION
Address https://github.com/dotnet/arcade/issues/7850 - handle the lack of a ScmRepositoryUrl when batch updating (#7852)

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
