### PR TITLE
Remove Bundle override of DOTNETHOME

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/bundle/bundle.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/bundle/bundle.wxs
@@ -43,9 +43,7 @@
       <PayloadGroupRef Id="DotnetCoreBAPayloads" />
     </BootstrapperApplicationRef>
 
-    <swid:Tag Regid="microsoft.com" InstallPath="[DOTNETHOME]" />
-
-    <Variable Name="DOTNETHOME" Type="string" Value="[$(var.Program_Files)]dotnet" bal:Overridable="no" />
+    <swid:Tag Regid="microsoft.com" InstallPath="[$(var.Program_Files)]dotnet" />
 
     <!-- Variables used solely for localization. -->
     <Variable Name="BUNDLEMONIKER" Type="string" Value="$(var.ProductMoniker) ($(var.TargetArchitectureDescription))" bal:Overridable="no" />
@@ -54,9 +52,7 @@
 
     <Chain DisableSystemRestore="yes" ParallelCache="yes">
       <?foreach chainedFile in $(var.ChainedDotNetPackageFiles)?>
-        <MsiPackage SourceFile="$(var.chainedFile)">
-          <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
-        </MsiPackage>
+        <MsiPackage SourceFile="$(var.chainedFile)" />
       <?endforeach?>
     </Chain>
   </Bundle>


### PR DESCRIPTION
The bundle was passing in a hardcoded DOTNETHOME value unconditionally
to MSIs in the chain.  This value doesn't have the redirection we're
adding to the MSI.  We can't add that redirection in the bundle, since
Burn doesn't have conditional variables.  It can only set variables as a
result of a search to either the value of the search (if successful) or
1/0.

An alternate solution to this would be to just make the MSI treat a value of DOTNETHOME=[ProgramFiles64Folder]dotnet in the same way as an unspecified value of DOTNETHOME.  Then we wouldn't have to touch the bundles.  The downside of that is that it wouldn't allow someone to specify a value of `[ProgramFiles64Folder]dotnet` for x64 on an ARM64 machine.

Related https://github.com/dotnet/installer/pull/11843/files#diff-42255eeced0cb7937c40024646092ce85055a361283ed45dec27adbab7996905L124

Here's a sample of the alternate solution we could use in the MSI: https://gist.github.com/ericstj/6edf16be01a4a0fb4eea9ff2afa54f9c/revisions#diff-3acf3c307483c682b16a5942aaca34cf87cc8d81641a5aac5c3e00d7a746f340R66

Thoughts? cc @richlander 
