### PR TITLE
[workloads] Allow disabling most parallelization

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateVisualStudioWorkload.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateVisualStudioWorkload.cs
@@ -109,6 +109,15 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
         }
 
         /// <summary>
+        /// Generate msis in parallel.
+        /// </summary>
+        public bool RunInParallel
+        {
+            get;
+            set;
+        } = true;
+
+        /// <summary>
         /// The paths of the generated .swixproj files.
         /// </summary>
         [Output]
@@ -182,6 +191,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                 IntermediateBaseOutputPath = this.IntermediateBaseOutputPath,
                 OutputPath = this.OutputPath,
                 PackagesPath = this.PackagesPath,
+                RunInParallel = this.RunInParallel,
                 ShortNames = this.ShortNames,
                 SuppressIces = this.SuppressIces,
                 WixToolsetPath = this.WixToolsetPath,


### PR DESCRIPTION
The changes in 7168d63 did fix Android msi generation issues for me
locally, but CI attempts have still been failing.  A new `RunInParallel`
task parameter has been added to allow consumers to opt-out of most
parallelization until these issues are fixed.