### PR TITLE
Use ProductVersion.txt where possible (port PR #7837 to rel/6.0)

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/Microsoft.DotNet.Helix.Sdk.csproj
+++ b/src/Microsoft.DotNet.Helix/Sdk/Microsoft.DotNet.Helix.Sdk.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="NuGet.Versioning" Version="6.0.0-preview.4.230" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 


### PR DESCRIPTION
* Add ProductVersion.txt support where possible; get the version of the inner package from productVersion.txt, NOT from the specified version.  Allows "non-stable" outer container with "stable" inner contents

https://github.com/dotnet/arcade/issues/7836

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation (tested by PR validation build)
