### PR TITLE
Don't strip .NETFramework tfms

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.props
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.props
@@ -11,7 +11,7 @@
     <DotNetBuildTasksTargetFrameworkSdkAssembly Condition="'$(DotNetBuildTasksTargetFrameworkSdkAssembly)' == '' AND '$(MSBuildRuntimeType)' == 'core'">..\tools\netcoreapp3.1\Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.dll</DotNetBuildTasksTargetFrameworkSdkAssembly>
     <DotNetBuildTasksTargetFrameworkSdkAssembly Condition="'$(DotNetBuildTasksTargetFrameworkSdkAssembly)' == '' AND '$(MSBuildRuntimeType)' != 'core'">..\tools\net472\Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.dll</DotNetBuildTasksTargetFrameworkSdkAssembly>
     <_OriginalTargetFramework>$(TargetFramework)</_OriginalTargetFramework>
-    <TargetFrameworkPattern>(((netstandard|netcoreapp)[0-9\.]+)|(net[1-4][1-9\.]+))(-[^;]+)</TargetFrameworkPattern>
+    <TargetFrameworkPattern>((netstandard|netcoreapp)[0-9\.]+)(-[^;]+)</TargetFrameworkPattern>
     <TargetFrameworkWithoutSuffix>$(TargetFramework)</TargetFrameworkWithoutSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
With https://github.com/dotnet/runtime/pull/58558, .NETFramework tfms which include a RID (i.e. net461-windows) aren't used and supported in dotnet/runtime anymore. Removing the support from the TargetFramework.Sdk as .NETFramework tfms with a RID aren't supported by NuGet anyways and throw.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
