### PR TITLE
Fix SourceLinkUrl calculation in another place

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
@@ -67,7 +67,7 @@
     <PropertyGroup>
       <!-- Repositories mirrored on devdiv.visualstudio will have '-Trusted' added to their name and this needs to be stripped off before translation
            Eventually, all repos should move to dnceng/internal when possible. -->
-      <ScmRepositoryUrl Condition=" '%(SourceRoot.ScmRepositoryUrl)' != '' and '$([MSBuild]::ValueOrDefault(`%(SourceRoot.ScmRepositoryUrl)`, ``).Contains(`devdiv.visualstudio`))' == 'true' ">$([MSBuild]::ValueOrDefault(`%(SourceRoot.ScmRepositoryUrl)`, ``).ToLower().Replace(`-trusted`,``))</ScmRepositoryUrl>
+      <ScmRepositoryUrl Condition=" '$([MSBuild]::ValueOrDefault(`%(SourceRoot.ScmRepositoryUrl)`, ``).Contains(`devdiv.visualstudio`))' == 'true' ">$([MSBuild]::ValueOrDefault(`%(SourceRoot.ScmRepositoryUrl)`, ``).ToLower().Replace(`-trusted`,``))</ScmRepositoryUrl>
       <ScmRepositoryUrl>$([System.Text.RegularExpressions.Regex]::Replace($(ScmRepositoryUrl), $(_TranslateUrlPattern), $(_TranslateUrlReplacement)))</ScmRepositoryUrl>
     </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
@@ -67,13 +67,13 @@
     <PropertyGroup>
       <!-- Repositories mirrored on devdiv.visualstudio will have '-Trusted' added to their name and this needs to be stripped off before translation
            Eventually, all repos should move to dnceng/internal when possible. -->
-      <ScmRepositoryUrl Condition=" '%(SourceRoot.ScmRepositoryUrl)' != '' and '$([System.String]::Copy(%(SourceRoot.ScmRepositoryUrl)).Contains(`devdiv.visualstudio`))' == 'true' ">$([System.String]::Copy(%(SourceRoot.ScmRepositoryUrl)).ToLower().Replace(`-trusted`,``))</ScmRepositoryUrl>
+      <ScmRepositoryUrl Condition=" '%(SourceRoot.ScmRepositoryUrl)' != '' and '$([MSBuild]::ValueOrDefault(`%(SourceRoot.ScmRepositoryUrl)`, ``).Contains(`devdiv.visualstudio`))' == 'true' ">$([MSBuild]::ValueOrDefault(`%(SourceRoot.ScmRepositoryUrl)`, ``).ToLower().Replace(`-trusted`,``))</ScmRepositoryUrl>
       <ScmRepositoryUrl>$([System.Text.RegularExpressions.Regex]::Replace($(ScmRepositoryUrl), $(_TranslateUrlPattern), $(_TranslateUrlReplacement)))</ScmRepositoryUrl>
     </PropertyGroup>
 
     <ItemGroup>
       <SourceRoot Update="@(SourceRoot)">
-        <ScmRepositoryUrl Condition="$([System.String]::Copy(%(SourceRoot.ScmRepositoryUrl)).Contains(`devdiv.visualstudio`))">$([System.String]::Copy(%(SourceRoot.ScmRepositoryUrl)).ToLower().Replace(`-trusted`,``))</ScmRepositoryUrl>
+        <ScmRepositoryUrl Condition="$([MSBuild]::ValueOrDefault(`%(SourceRoot.ScmRepositoryUrl)`, ``).Contains(`devdiv.visualstudio`))">$([MSBuild]::ValueOrDefault(`%(SourceRoot.ScmRepositoryUrl)`, ``).ToLower().Replace(`-trusted`,``))</ScmRepositoryUrl>
       </SourceRoot>
       <SourceRoot Update="@(SourceRoot)">
         <ScmRepositoryUrl>$([System.Text.RegularExpressions.Regex]::Replace(%(SourceRoot.ScmRepositoryUrl), $(_TranslateUrlPattern), $(_TranslateUrlReplacement)))</ScmRepositoryUrl>


### PR DESCRIPTION
Fallout from https://github.com/dotnet/arcade/issues/7850 again.  I will actually wait until this clears validation to port to 6.0 .

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation  _Since this can't be easily tested as it stands (needs a repo from devdiv.vs)_: I rigged up the following demo that uses the msbuild content as shown in the PR.


```
<Project>
  <ItemGroup>
    <SourceRoot Include="/__w/1/s/.packages/" /> <!-- don't fail on empty -->
    <SourceRoot Include="/__w/1/s/.packages2/">  <!-- correctly lowercase and de-trusted a devdiv  url, AND hit it with update-->
      <ScmRepositoryUrl>https://devdiv.visualstudio.com/MattGal/arcade-validation-trusted.git</ScmRepositoryUrl>
    </SourceRoot>
    <SourceRoot Include="/__w/1/s/.packages3/">  <!-- correctly do nothing to a non devdiv  url -->
      <ScmRepositoryUrl>https://www.github.com/MattGal/arcade-validation-trusted.git</ScmRepositoryUrl>
    </SourceRoot>

  </ItemGroup>
  <Target Name="Build">

    <ItemGroup>
      <SourceRoot> <!-- test the first piece -->
          <ScmRepositoryUrl Condition=" '$([MSBuild]::ValueOrDefault(`%(SourceRoot.ScmRepositoryUrl)`, ``).Contains(`devdiv.visualstudio`))' == 'true' ">$([MSBuild]::ValueOrDefault(`%(SourceRoot.ScmRepositoryUrl)`, ``).ToLower().Replace(`-trusted`,``))</ScmRepositoryUrl>
      </SourceRoot>
    </ItemGroup>

    <ItemGroup>
      <SourceRoot Update="@(SourceRoot)"> <!-- test the second piece -->
        <ScmRepositoryUrl Condition="$([MSBuild]::ValueOrDefault(`%(SourceRoot.ScmRepositoryUrl)`, ``).Contains(`devdiv.visualstudio`))">$([MSBuild]::ValueOrDefault(`%(SourceRoot.ScmRepositoryUrl)`, ``).ToLower().Replace(`mattgal`,`okthisworkedtoo`))</ScmRepositoryUrl>
      </SourceRoot>
    </ItemGroup>

    <Message Importance="High" Text="@(SourceRoot->'%(Identity):%(ScmRepositoryUrl)')" />
  </Target>
</Project>


```
Output:
```
Microsoft (R) Build Engine version 16.11.0+0538acc04 for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  /__w/1/s/.packages/:;/__w/1/s/.packages2/:https://devdiv.visualstudio.com/okthisworkedtoo/arcade-validation.git;/__w/1/s/.packages3/:https://www.github.com/MattGal/arcade-validation-trusted.git

```

