### PR TITLE
Make Android package name non-mandatory for XHarness workloads

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-reporter.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-reporter.py
@@ -28,6 +28,8 @@ if not os.path.isfile(diagnostics_file):
 # The JSON should be an array of objects (one per each executed XHarness command)
 operations = json.load(open(diagnostics_file))
 
+print(f"[XHarness reporter] Reporting {len(operations)} events from diagnostics file `{diagnostics_file}`")
+
 for operation in operations:
     custom_dimensions = dict()
 

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.ps1
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.ps1
@@ -12,8 +12,8 @@ param (
     [string]$app,
     [Parameter(Mandatory)]
     [string]$timeout,
-    [Parameter(Mandatory)]
-    [string]$package_name,
+    [Parameter()]
+    [string]$package_name = $null,
     [Parameter()]
     [int]$expected_exit_code = 0,
     [Parameter()]


### PR DESCRIPTION
Resolves following issue:
```
xharness-helix-job.android.ps1 : Cannot bind argument to parameter 'package_name' because it is an empty string.
    + CategoryInfo          : InvalidData: (:) [xharness-helix-job.android.ps1], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : ParameterArgumentValidationErrorEmptyStringNotAllowed,xharness-helix-job.android.ps1
```