### PR TITLE
Bump System.Text.Encodings.Web to resolve CG warning

### DIFF
--- a/src/Microsoft.DotNet.Helix/Client/CSharp/Microsoft.DotNet.Helix.Client.csproj
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/Microsoft.DotNet.Helix.Client.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.1" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
 
     <PackageReference Include="Microsoft.DotNet.SwaggerGenerator.MSBuild" Version="$(MicrosoftDotNetSwaggerGeneratorMSBuildVersion)" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
## Description

Bump System.Text.Encoding.Web from 4.7.1 to 4.7.2. This is a dependency to Microsoft.DotNet.Helix.Client and is needed to resolve a Component Governance warning in dotnet-helix-service. Once merged and published here, I'll update helix-service to take this version.

## Customer Impact

None; this is to fix a warning downstream.

## Regression

No

## Risk

Low. The library is already using version 4.7.1. Moving one "patch" level to 4.7.2 should be safe.

## Workarounds

Instead of changing here, at the level where this version requirement is introduced, I could specifically override the version used in dotnet-helix-services and leave this branch alone. 