### PR TITLE
Do not forward env variable `XHARNESS_DIAGNOSTICS_PATH`

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.apple.sh
@@ -36,7 +36,6 @@ sudo launchctl asuser "$helix_runner_uid" sh ./xharness-runner.apple.sh \
     $forwarded_args                                                     \
     --app "$HELIX_WORKITEM_ROOT/$app"                                   \
     --output-directory "$HELIX_WORKITEM_UPLOAD_ROOT"                    \
-    --diagnostics-path "$XHARNESS_DIAGNOSTICS_PATH"                     \
 
 exit_code=$?
 

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
@@ -23,10 +23,6 @@ while [[ $# -gt 0 ]]; do
         app="$2"
         shift
         ;;
-      --diagnostics-path)
-        export XHARNESS_DIAGNOSTICS_PATH="$2"
-        shift
-        ;;
       --target)
         target="$2"
         shift


### PR DESCRIPTION
All env vars are now forwarded automatically (https://github.com/dotnet/arcade/pull/7869)