### PR TITLE
[workloads] Add ProjectUrl to msi packs

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
@@ -376,6 +376,11 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                 writer.WriteElementString("Copyright", nupkg.Copyright);
             }
 
+            if (!string.IsNullOrWhiteSpace(nupkg.ProjectUrl))
+            {
+                writer.WriteElementString("PackageProjectUrl", nupkg.ProjectUrl);
+            }
+
             writer.WriteElementString("PackageLicenseExpression", "MIT");
             writer.WriteEndElement();
 

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
@@ -369,6 +369,11 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                 writer.WriteElementString("Copyright", nupkg.Copyright);
             }
 
+            if (!string.IsNullOrWhiteSpace(nupkg.ProjectUrl))
+            {
+                writer.WriteElementString("PackageProjectUrl", nupkg.ProjectUrl);
+            }
+
             writer.WriteElementString("PackageLicenseExpression", "MIT");
             writer.WriteEndElement();
 

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/NuGetPackage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/NuGetPackage.cs
@@ -72,6 +72,11 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             get;
         }
 
+        public string ProjectUrl
+        {
+            get;
+        }
+
         /// <summary>
         /// The version of the NuGet package.
         /// </summary>
@@ -96,6 +101,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             Description = nuspecReader.GetDescription();
             Copyright = nuspecReader.GetCopyright();
             LicenseData = nuspecReader.GetLicenseMetadata();
+            ProjectUrl = nuspecReader.GetProjectUrl();
         }
 
         /// <summary>


### PR DESCRIPTION
We ran into some publishing issues today due to a missing ProjectUrl:

    Policy violations: The package metadata is missing required ProjectUrl.

Fix this by reading and including any existing ProjectUrl content from
the .nupkg that the .msi was originally generated from.