### PR TITLE
[release/6.0] x64 on arm64 fixes

### DIFF
--- a/src/Common/wix/dotnethome_x64.wxs
+++ b/src/Common/wix/dotnethome_x64.wxs
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <?ifndef Platform?>
+    <?define Platform = "$(sys.BUILDARCH)"?>
+  <?endif?>
+
+  <!-- InstallerArchitecture matches the expected values for PROCESSOR_ARCHITECTURE 
+       https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details  -->
+  <?if $(var.Platform)~=x86?>
+    <?define InstallerArchitecture="X86"?>
+  <?elseif $(var.Platform)~=x64?>
+    <?define InstallerArchitecture="AMD64"?>
+  <?elseif $(var.Platform)~=arm64?>
+    <?define InstallerArchitecture="ARM64"?>
+  <?else?>
+    <?error Unknown platform, $(var.Platform) ?>?
+  <?endif?>
+
+  <Fragment>
+    <!-- Identify when installing in emulation as when PROCESSOR_ARCHITECTURE does not match the installer architecture
+          https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details -->
+    <SetProperty Action="Set_NON_NATIVE_ARCHITECTURE" Id="NON_NATIVE_ARCHITECTURE" Value="true" Before="CostFinalize">
+      NOT %PROCESSOR_ARCHITECTURE="$(var.InstallerArchitecture)"
+    </SetProperty>
+  </Fragment>
+
+  <?if $(var.Platform)~=x64?>
+  <Fragment>
+    <!-- When running in a non-native architecture and user hasn't specified install directory,
+         install to an x64 subdirectory.
+         This is only define for x64, since x86 has redirection and no other native architecture can install ARM64 today -->
+    <SetProperty Action="Set_DOTNETHOME_NON_NATIVE_ARCHITECTURE" Id="DOTNETHOME" Value="[ProgramFiles64Folder]dotnet\x64\" After="Set_NON_NATIVE_ARCHITECTURE">
+      NON_NATIVE_ARCHITECTURE AND NOT DOTNETHOME
+    </SetProperty>
+  </Fragment>
+  <?endif?>
+</Wix>

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/Microsoft.DotNet.Build.Tasks.Installers.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/Microsoft.DotNet.Build.Tasks.Installers.csproj
@@ -25,6 +25,7 @@
     <None Include="build/**/*.*" Pack="true">
       <PackagePath>build</PackagePath>
     </None>
+    <None Include="..\Common\wix\dotnethome_x64.wxs" Link="build\wix\product\dotnethome_x64.wxs" PackagePath="%(Link)" Pack="true" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
@@ -399,7 +399,7 @@
              RemoveProperties="@(_GlobalPropertiesToRemoveForPublish)"  />
     <PropertyGroup>
       <_MacOSVersionComponent Condition="'$(IncludeVersionInMacOSComponentName)' == 'true'">.$(InstallerPackageVersion)</_MacOSVersionComponent>
-      <_MacOSComponentName Condition="'$(_MacOSComponentName)' == ''">com.microsoft.dotnet.$(MacOSComponentNamePackType)$(_MacOSVersionComponent).component.osx.x64</_MacOSComponentName>
+      <_MacOSComponentName Condition="'$(_MacOSComponentName)' == ''">com.microsoft.dotnet.$(MacOSComponentNamePackType)$(_MacOSVersionComponent).component.osx.$(InstallerTargetArchitecture)</_MacOSComponentName>
       <_MacOSSharedInstallDir>/usr/local/share/dotnet</_MacOSSharedInstallDir>
 
       <_pkgArgs></_pkgArgs>

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/bundle/bundle.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/bundle/bundle.wxs
@@ -43,9 +43,7 @@
       <PayloadGroupRef Id="DotnetCoreBAPayloads" />
     </BootstrapperApplicationRef>
 
-    <swid:Tag Regid="microsoft.com" InstallPath="[DOTNETHOME]" />
-
-    <Variable Name="DOTNETHOME" Type="string" Value="[$(var.Program_Files)]dotnet" bal:Overridable="no" />
+    <swid:Tag Regid="microsoft.com" InstallPath="[$(var.Program_Files)]dotnet" />
 
     <!-- Variables used solely for localization. -->
     <Variable Name="BUNDLEMONIKER" Type="string" Value="$(var.ProductMoniker) ($(var.TargetArchitectureDescription))" bal:Overridable="no" />
@@ -54,9 +52,7 @@
 
     <Chain DisableSystemRestore="yes" ParallelCache="yes">
       <?foreach chainedFile in $(var.ChainedDotNetPackageFiles)?>
-        <MsiPackage SourceFile="$(var.chainedFile)">
-          <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
-        </MsiPackage>
+        <MsiPackage SourceFile="$(var.chainedFile)" />
       <?endforeach?>
     </Chain>
   </Bundle>

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/product/product.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/product/product.wxs
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
 
   <?include "..\variables.wxi" ?>
@@ -51,6 +52,9 @@
         <Directory Id="DOTNETHOME" Name="dotnet" />
       </Directory>
     </Directory>
-  </Fragment>
 
+    <?if $(var.Platform)~=x64?>
+    <CustomActionRef Id="Set_DOTNETHOME_NON_NATIVE_ARCHITECTURE" />
+    <?endif?>
+  </Fragment>
 </Wix>

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets
@@ -108,6 +108,7 @@
       <WixExtensions Include="WixUtilExtension.dll" />
 
       <WixSrcFile Include="$(MSBuildThisFileDirectory)product/product.wxs" />
+      <WixSrcFile Include="$(MSBuildThisFileDirectory)product/dotnethome_x64.wxs" />
       <WixSrcFile Include="$(MSBuildThisFileDirectory)product/provider.wxs" />
     </ItemGroup>
   </Target>

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateMacOSDistributionFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateMacOSDistributionFile.cs
@@ -42,11 +42,19 @@ namespace Microsoft.DotNet.SharedFramework.Sdk
 
                 var archScriptContent = @"<![CDATA[
 function IsX64Machine() {
-var machine = system.sysctl(""hw.machine"");
-system.log(""Machine type: "" + machine);
-var result = machine == ""x64"" || machine.endsWith(""_x64"");
-system.log(""IsX64Machine: "" + result);
-return result;
+    var machine = system.sysctl(""hw.foo"");
+    var cputype = system.sysctl(""hw.cputype"");
+    var cpu64 = system.sysctl(""hw.cpu64bit_capable"");
+    system.log(""Machine type: "" + machine);
+    system.log(""Cpu type: "" + cputype);
+    system.log(""64-bit: "" + cpu64);
+
+    // From machine.h
+    // CPU_TYPE_X86_64 = CPU_TYPE_X86 | CPU_ARCH_ABI64 = 0x010000007 = 16777223
+    // CPU_TYPE_X86 = 7
+    var result = machine == ""amd64"" || machine == ""x86_64"" || cputype == ""16777223"" || (cputype == ""7"" && cpu64 == ""1"");
+    system.log(""IsX64Machine: "" + result);
+    return result;
 }
 ]]>";
                 var scriptElement = new XElement("script", new XText(archScriptContent));

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/EmbeddedTemplates.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/EmbeddedTemplates.cs
@@ -64,6 +64,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             {
                 { "DependencyProvider.wxs", $"{s_namespace}.MsiTemplate.DependencyProvider.wxs" },
                 { "Directories.wxs", $"{s_namespace}.MsiTemplate.Directories.wxs" },
+                { "dotnethome_x64.wxs", $"{s_namespace}.MsiTemplate.dotnethome_x64.wxs" },
                 { "ManifestProduct.wxs", $"{s_namespace}.MsiTemplate.ManifestProduct.wxs" },
                 { "Product.wxs", $"{s_namespace}.MsiTemplate.Product.wxs" },
                 { "Registry.wxs", $"{s_namespace}.MsiTemplate.Registry.wxs" },

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
@@ -167,6 +167,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                     List<string> sourceFiles = new();
                     string msiSourcePath = Path.Combine(MsiDirectory, $"{nupkg.Id}", $"{nupkg.Version}", platform);
                     sourceFiles.Add(EmbeddedTemplates.Extract("DependencyProvider.wxs", msiSourcePath));
+                    sourceFiles.Add(EmbeddedTemplates.Extract("dotnethome_x64.wxs", msiSourcePath));
                     sourceFiles.Add(EmbeddedTemplates.Extract("ManifestProduct.wxs", msiSourcePath));
 
                     string EulaRtfPath = Path.Combine(msiSourcePath, "eula.rtf");

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
@@ -176,6 +176,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                 string msiSourcePath = Path.Combine(MsiDirectory, $"{nupkg.Id}", $"{nupkg.Version}", platform);
                 sourceFiles.Add(EmbeddedTemplates.Extract("DependencyProvider.wxs", msiSourcePath));
                 sourceFiles.Add(EmbeddedTemplates.Extract("Directories.wxs", msiSourcePath));
+                sourceFiles.Add(EmbeddedTemplates.Extract("dotnethome_x64.wxs", msiSourcePath));
                 sourceFiles.Add(EmbeddedTemplates.Extract("Product.wxs", msiSourcePath));
                 sourceFiles.Add(EmbeddedTemplates.Extract("Registry.wxs", msiSourcePath));
 

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Microsoft.DotNet.Build.Tasks.Workloads.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Microsoft.DotNet.Build.Tasks.Workloads.csproj
@@ -52,6 +52,7 @@
     <EmbeddedResource Include="Misc\*.*" />
     <EmbeddedResource Include="MsiTemplate\*.wxs" />
     <EmbeddedResource Include="MsiTemplate\*.wxi" />
+    <EmbeddedResource Include="..\..\Common\wix\dotnethome_x64.wxs" Link="MsiTemplate\dotnethome_x64.wxs" />
     <EmbeddedResource Include="SwixTemplate\*.swr" />
     <EmbeddedResource Include="SwixTemplate\*.swixproj" />
     <EmbeddedResource Include="SwixTemplate\*.vsmanproj" />

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/Directories.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/Directories.wxs
@@ -16,5 +16,9 @@
         </Directory>
       </Directory>
     </Directory>
+
+    <?if $(var.Platform)~=x64?>
+    <CustomActionRef Id="Set_DOTNETHOME_NON_NATIVE_ARCHITECTURE" />
+    <?endif?>
   </Fragment>
 </Wix>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/ManifestProduct.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/ManifestProduct.wxs
@@ -35,6 +35,10 @@
       </Directory>
     </Directory>
 
+    <?if $(var.Platform)~=x64?>
+    <CustomActionRef Id="Set_DOTNETHOME_NON_NATIVE_ARCHITECTURE" />
+    <?endif?>
+
     <MediaTemplate CompressionLevel="high" EmbedCab="yes" />
 
     <!-- Record the original package used to generate the MSI -->


### PR DESCRIPTION
Installer work to support x64 on arm64.  This is a cherry-pick of all relevant arcade changes.

This work will require additional changes in Runtime, ASPNETCore, and Installer to achieve the desired side-by-side characteristics of x64 installed on ARM64.

## Customer Impact
Customers want to install our x64 product on arm64 machines in order to run x64 targeted applications.
## Testing
We have tested the Windows - runtime consumption of these in main and confirmed it produces installers which behave as we expect.  We have tested the changes in isolation as well.  It is difficult to test the full end-to-end due to 7.0 not having coherent builds and these changes spanning many repos to realize full end-to-end.
## Risk
Low - as designed these changes should not impact existing working scenarios.  The risk here is that we have a bug that accidentally impacts those scenarios.  We've tried to mitigate that through testing consumption in main.  We'll also mitigate by testing bits out of RC2 branches as soon as these changes flow.
