### PR TITLE
Be explicit about downooading timeout

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -294,6 +294,7 @@ function InstallDotNet([string] $dotnetRoot,
   $installParameters = @{
     Version = $version
     InstallDir = $dotnetRoot
+    DownloadTimeout = 1200
   }
 
   if ($architecture) { $installParameters.Architecture = $architecture }


### PR DESCRIPTION
I use new parameter in `dotnet-install.ps1`
so downloading timeout would be explicitly managed in source control.
Thats more friendlier for contributors with slow internet connections.

Without that, I have to constantly looking for timeout location during download.
This change simplifies such hunt. 
