### PR TITLE
Stop using `--signal-app-end` in XHarness Apple device workloads

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
@@ -208,7 +208,6 @@ namespace Microsoft.DotNet.Helix.Sdk
                 ? $"--launch-timeout \"$launch_timeout\" "
                 : $"--expected-exit-code $expected_exit_code ") +
             (resetSimulator ? $"--reset-simulator " : string.Empty) +
-            (target.Contains("device") ? $"--signal-app-end " : string.Empty) + // iOS/tvOS 14+ workaround
             (!string.IsNullOrEmpty(AppArguments) ? "-- " + AppArguments : string.Empty);
 
         private string GetHelixCommand(


### PR DESCRIPTION
This workaround is no longer needed with the newest mlaunch