### PR TITLE
Copy emulator log in case of 85 error

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.sh
@@ -86,8 +86,8 @@ case "$exit_code" in
     # The only solution is to reboot the machine, so we request a work item retry + agent reboot when this happens
     echo 'Encountered ADB_DEVICE_ENUMERATION_FAILURE. This is typically not a failure of the work item. We will run it again and reboot this computer to help its devices'
     echo 'If this occurs repeatedly, please check for architectural mismatch, e.g. sending arm64_v8a APKs to an x86_64 / x86 only queue.'
-    # copy emaultor's log
-    cp /tmp/*-logcat.log $output_directory
+    # Copy emulator log
+    cp /tmp/*-logcat.log "$output_directory"
     retry=true
     reboot=true
     ;;


### PR DESCRIPTION
Resolved https://github.com/dotnet/core-eng/issues/13359

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
