### PR TITLE
[release/5.0] Migrate to 1ES hosted pools

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,11 +43,11 @@ stages:
         timeoutInMinutes: 90
         pool:
           ${{ if eq(variables._RunAsPublic, True) }}:
-            name: NetCorePublic-Pool
-            queue: BuildPool.Server.Amd64.VS2017.Arcade.Open
+            name: NetCore1ESPool-Svc-Public
+            demands: ImageOverride -equals Build.Server.Amd64.VS2017.Open
           ${{ if eq(variables._RunAsInternal, True) }}:
-            name: NetCoreInternal-Pool
-            queue: BuildPool.Server.Amd64.VS2017.Arcade
+            name: NetCore1ESPool-Svc-Internal
+            demands: ImageOverride -equals Build.Server.Amd64.VS2017
         strategy:
           matrix:
             Build_Release:
@@ -69,8 +69,8 @@ stages:
         - job: Linux
           container: LinuxContainer
           pool:
-            name:  NetCorePublic-Pool
-            queue: BuildPool.Ubuntu.1604.Amd64.Arcade.Open
+            name: NetCore1ESPool-Svc-Public
+            demands: ImageOverride -equals Build.Ubuntu.1604.Amd64.Open
           strategy:
             matrix:
               Build_Debug:

--- a/eng/validate-sdk.yml
+++ b/eng/validate-sdk.yml
@@ -19,8 +19,8 @@ jobs:
           name: Logs_ValidateSdk_Windows_NT_Release
     timeoutInMinutes: 90
     pool:
-      name: NetCoreInternal-Pool
-      queue: BuildPool.Server.Amd64.VS2017.Arcade
+      name: NetCore1ESPool-Svc-Internal
+      demands: ImageOverride -equals Build.Server.Amd64.VS2017
     variables:
     - group: DotNet-Blob-Feed
     - group: Publish-Build-Assets


### PR DESCRIPTION
## Description

We need to migrate pools to 1ES hosted pools. Only the yamls have to be changed. The supported functionality stays the same.

Tracking issue: https://github.com/dotnet/core-eng/issues/14276

## Customer Impact

If this change is not made then the old pools may stop working after the end of month and arcade builds won't be able to run.

## Regression

No

## Risk

Not risky - new pools have the same functionality as the old ones.

## Workarounds

No workaround available.