### PR TITLE
[release/3.x] Migrate to 1ES hosted pools

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,11 +55,11 @@ stages:
           # For public or PR jobs, use the hosted pool.  For internal jobs use the internal pool.
           # Will eventually change this to two BYOC pools.
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-            name: NetCorePublic-Pool
-            queue: BuildPool.Windows.10.Amd64.VS2017.Open
+            name: NetCore1ESPool-Svc-Public
+            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2017.Open
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            name: NetCoreInternal-Pool
-            queue: BuildPool.Windows.10.Amd64.VS2017
+            name: NetCore1ESPool-Svc-Internal
+            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2017
         variables:
         - _Script: eng\common\cibuild.cmd
         - _ValidateSdkArgs: ''
@@ -150,11 +150,11 @@ stages:
           container: LinuxContainer
           pool:
             ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-              name:  NetCorePublic-Pool
-              queue: BuildPool.Ubuntu.1804.Amd64.Open
+              name:  NetCore1ESPool-Svc-Public
+              demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
             ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-              name:  NetCoreInternal-Pool
-              queue: BuildPool.Ubuntu.1804.Amd64
+              name:  NetCore1ESPool-Svc-Internal
+              demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
           variables:
           - HelixApiAccessToken: ''
           - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
## Description

We need to migrate pools to 1ES hosted pools. Only the yamls have to be changed. The supported functionality stays the same.

Tracking issue: https://github.com/dotnet/core-eng/issues/14276

## Customer Impact

If this change is not made then the old pools may stop working after the end of month and arcade builds won't be able to run.

## Regression

No

## Risk

Not risky - new pools have the same functionality as the old ones.

## Workarounds

No workaround available.