### PR TITLE
Align local build SCCSID on Unix

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
@@ -25,20 +25,24 @@
       <Output TaskParameter="FileVersion" PropertyName="FileVersion"/>
     </Microsoft.DotNet.Arcade.Sdk.CalculateAssemblyAndFileVersions>
 
+    <PropertyGroup>
+      <PlaceholderVersion>42.42.42.42424</PlaceholderVersion>
+    </PropertyGroup>
+
     <PropertyGroup Condition="'$(VersionSuffixDateStamp)' == ''">
       <!--
         Set FileVersion to a distinct version that's greater than any shipping version.
         This makes it possible to install binaries produced by a dev build over product binaries,
         provided that the installer only requires higher version.
       -->
-      <FileVersion>42.42.42.42424</FileVersion>
+      <FileVersion>$(PlaceholderVersion)</FileVersion>
 
       <!--
         Respect version explicitly set by the project.
         The default .NET Core SDK implementation sets AssemblyVersion from NuGet package version,
         which we want to override in dev builds.
       -->
-      <AssemblyVersion Condition="'$(AssemblyVersion)' == ''">42.42.42.42</AssemblyVersion>
+      <AssemblyVersion Condition="'$(AssemblyVersion)' == ''">$(PlaceholderVersion)</AssemblyVersion>
     </PropertyGroup>
   </Target>
 
@@ -57,8 +61,9 @@
           DependsOnTargets="$(GenerateNativeVersionFileDependsOn)">
 
     <!-- To support builds without a source control provider available, allow this property to be unset. -->
-    <PropertyGroup Condition="'$(SourceRevisionId)' != ''">
-      <_SourceBuildInfo> %40Commit: $(SourceRevisionId)</_SourceBuildInfo>
+    <PropertyGroup>
+      <_SourceBuildInfo Condition="'$(SourceRevisionId)' != ''"> %40Commit: $(SourceRevisionId)</_SourceBuildInfo>
+      <_SourceBuildInfo Condition="'$(SourceRevisionId)' == ''"> %40Commit: N/A</_SourceBuildInfo>
     </PropertyGroup>
 
    <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
@@ -112,6 +117,8 @@
 
     <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
       <NativeVersionFile Condition="'$(NativeVersionFile)' == ''">$(ArtifactsObjDir)_version.c</NativeVersionFile>
+      <SccsidVersion Condition="'$(FileVersion)' != '$(PlaceholderVersion)'">$(FileVersion)</SccsidVersion>
+      <SccsidVersion Condition="'$(FileVersion)' == '$(PlaceholderVersion)'">N/A</SccsidVersion>
 
       <!--
         There isn't a defacto standard for including version information in a native binary on unix so we defined a static
@@ -120,7 +127,7 @@
       -->
       <_NativeVersionFileContents>
 <![CDATA[
-static char sccsid[] __attribute__((used)) = "@(#)Version $(FileVersion)$(_SourceBuildInfo)";
+static char sccsid[] __attribute__((used)) = "@(#)Version $(SccsidVersion)$(_SourceBuildInfo)";
  ]]>
       </_NativeVersionFileContents>
     </PropertyGroup>


### PR DESCRIPTION
Before, the local build with `./build.sh` generates `_version.c` like:

```c
static char sccsid[] __attribute__((used)) = "@(#)Version 42.42.42.42424";
```

with `./build.sh -p:DisableSourceLink=false`, it still uses the placeholder version but with full form:

```c
static char sccsid[] __attribute__((used)) = "@(#)Version 42.42.42.42424 @Commit: 83b726a0042866fed6eea01f1d288ae3ac768b1e";
```

with `./build.sh -p:OfficialBuildId=$(date +%Y%m%d)-99`, it produces the full form:
```c
static char sccsid[] __attribute__((used)) = "@(#)Version 7.0.21.47199 @Commit: 83b726a0042866fed6eea01f1d288ae3ac768b1e";
```
---
After, with `./build.sh`:
```c
static char sccsid[] __attribute__((used)) = "@(#)Version N/A @Commit: N/A";
```
with `./build.sh -p:DisableSourceLink=false`:

```c
static char sccsid[] __attribute__((used)) = "@(#)Version N/A @Commit: 83b726a0042866fed6eea01f1d288ae3ac768b1e";
```

and `./build.sh -p:OfficialBuildId=$(date +%Y%m%d)-99` continues to produce full form as before.

cc @jkoritzinsky