### PR TITLE
Make XHarness logs readable recursively

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
@@ -174,8 +174,8 @@ if [ $exit_code -eq 81 ] && [[ "$target" =~ "device" ]]; then
     touch './.reboot'
 fi
 
-# The simulator logs comming from the sudo-spawned Simulator.app are not readable by the helix uploader
-chmod -R 0777 "$output_directory"
+# The simulator logs comming from the sudo-spawned Simulator.app are not readable/deletable by the helix uploader
+chmod -R 0766 "$output_directory"
 
 # Remove empty files
 find "$output_directory" -name "*.log" -maxdepth 1 -size 0 -print -delete

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
@@ -175,7 +175,7 @@ if [ $exit_code -eq 81 ] && [[ "$target" =~ "device" ]]; then
 fi
 
 # The simulator logs comming from the sudo-spawned Simulator.app are not readable by the helix uploader
-chmod 0644 "$output_directory"/*.log
+chmod -R 0777 "$output_directory"
 
 # Remove empty files
 find "$output_directory" -name "*.log" -maxdepth 1 -size 0 -print -delete


### PR DESCRIPTION
Files are created with bad permissions thanks to the `launchctl` workaround. Some of the logs produced by the Mono VM team are in folders so we need to chmod them recursively.

Resolves #7900