### PR TITLE
Time-constrain user commands in XHarness workloads

### DIFF
--- a/src/Common/Microsoft.Arcade.Common/ZipArchiveManager.cs
+++ b/src/Common/Microsoft.Arcade.Common/ZipArchiveManager.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Arcade.Common
             await content.CopyToAsync(targetStream);
         }
 
-        private static Stream GetResourceFileContent<TAssembly>(string resourceFileName)
+        public static Stream GetResourceFileContent<TAssembly>(string resourceFileName)
         {
             Assembly assembly = typeof(TAssembly).Assembly;
             return assembly.GetManifestResourceStream($"{assembly.GetName().Name}.{resourceFileName}");

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAndroidWorkItemsTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAndroidWorkItemsTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             var workItem = _task.WorkItems.First();
             workItem.GetMetadata("Identity").Should().Be("System.Foo");
-            workItem.GetMetadata("Timeout").Should().Be("00:15:42");
+            workItem.GetMetadata("Timeout").Should().Be("00:16:02");
 
             var payloadArchive = workItem.GetMetadata("PayloadArchive");
             payloadArchive.Should().NotBeNullOrEmpty();
@@ -178,7 +178,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             var workItem = _task.WorkItems.First();
             workItem.GetMetadata("Identity").Should().Be("System.Foo");
-            workItem.GetMetadata("Timeout").Should().Be("00:15:42");
+            workItem.GetMetadata("Timeout").Should().Be("00:16:02");
 
             var payloadArchive = workItem.GetMetadata("PayloadArchive");
             payloadArchive.Should().NotBeNullOrEmpty();

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAppleWorkItemsTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAppleWorkItemsTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             var workItem = _task.WorkItems.First();
             workItem.GetMetadata("Identity").Should().Be("System.Foo");
-            workItem.GetMetadata("Timeout").Should().Be("00:15:42");
+            workItem.GetMetadata("Timeout").Should().Be("00:16:02");
 
             var payloadArchive = workItem.GetMetadata("PayloadArchive");
             payloadArchive.Should().NotBeNullOrEmpty();
@@ -225,7 +225,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             var workItem = _task.WorkItems.First();
             workItem.GetMetadata("Identity").Should().Be("System.Foo");
-            workItem.GetMetadata("Timeout").Should().Be("00:15:42");
+            workItem.GetMetadata("Timeout").Should().Be("00:16:02");
 
             var payloadArchive = workItem.GetMetadata("PayloadArchive");
             payloadArchive.Should().NotBeNullOrEmpty();

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
@@ -25,6 +25,7 @@ namespace Microsoft.DotNet.Helix.Sdk
 
         private const string PosixAndroidWrapperScript = "xharness-helix-job.android.sh";
         private const string NonPosixAndroidWrapperScript = "xharness-helix-job.android.ps1";
+        private const string NonPosixAndroidHeaderScript = "xharness-helix-job.android.header.ps1";
 
         /// <summary>
         /// Boolean true if this is a posix shell, false if not.
@@ -107,6 +108,12 @@ namespace Microsoft.DotNet.Helix.Sdk
 
             string command = GetHelixCommand(appPackage, apkName, androidPackageName, workItemTimeout, testTimeout, expectedExitCode);
 
+            if (!IsPosixShell)
+            {
+                // For windows, we need to add a .ps1 header to turn the script into a cmdlet
+                customCommands = GetPowerShellHeader() + customCommands;
+            }
+
             string workItemZip = await CreatePayloadArchive(
                 zipArchiveManager,
                 fileSystem,
@@ -179,6 +186,14 @@ namespace Microsoft.DotNet.Helix.Sdk
             Log.LogMessage(MessageImportance.Low, $"Generated XHarness command: {xharnessRunCommand}");
 
             return xharnessRunCommand;
+        }
+
+        private static string GetPowerShellHeader()
+        {
+            using Stream stream = ZipArchiveManager.GetResourceFileContent<CreateXHarnessAndroidWorkItems>(
+                ScriptNamespace + NonPosixAndroidHeaderScript);
+            using StreamReader reader = new(stream);
+            return reader.ReadToEnd();
         }
     }
 }

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
@@ -163,6 +163,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             string dash = IsPosixShell ? "--" : "-";
             string xharnessRunCommand = $"{xharnessHelixWrapperScript} " +
                 $"{dash}app \"{apkName}\" " +
+                $"{dash}command_timeout {(int)s_telemetryBuffer.TotalSeconds} " +
                 $"{dash}timeout \"{xHarnessTimeout}\" " +
                 $"{dash}package_name \"{androidPackageName}\" " +
                 (expectedExitCode != 0 ? $" {dash}expected_exit_code \"{expectedExitCode}\" " : string.Empty) +

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
@@ -150,7 +150,13 @@ namespace Microsoft.DotNet.Helix.Sdk
                 $"{ devOutArg } { instrumentationArg } { exitCodeArg } { extraArguments } { passthroughArgs }";
         }
 
-        private string GetHelixCommand(ITaskItem appPackage, string apkName, string androidPackageName, TimeSpan xHarnessTimeout, int expectedExitCode)
+        private string GetHelixCommand(
+            ITaskItem appPackage,
+            string apkName,
+            string androidPackageName,
+            TimeSpan workItemTimeout,
+            TimeSpan xHarnessTimeout,
+            int expectedExitCode)
         {
             appPackage.TryGetMetadata(MetadataNames.AndroidInstrumentationName, out string androidInstrumentationName);
             appPackage.TryGetMetadata(MetadataNames.DeviceOutputPath, out string deviceOutputPath);
@@ -163,7 +169,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             string dash = IsPosixShell ? "--" : "-";
             string xharnessRunCommand = $"{xharnessHelixWrapperScript} " +
                 $"{dash}app \"{apkName}\" " +
-                $"{dash}command_timeout {(int)s_telemetryBuffer.TotalSeconds} " +
+                $"{dash}command_timeout {(int)workItemTimeout.TotalSeconds} " +
                 $"{dash}timeout \"{xHarnessTimeout}\" " +
                 $"{dash}package_name \"{androidPackageName}\" " +
                 (expectedExitCode != 0 ? $" {dash}expected_exit_code \"{expectedExitCode}\" " : string.Empty) +

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                 apkName = apkName.Replace(".zip", ".apk");
             }
 
-            string command = GetHelixCommand(appPackage, apkName, androidPackageName, testTimeout, expectedExitCode);
+            string command = GetHelixCommand(appPackage, apkName, androidPackageName, workItemTimeout, testTimeout, expectedExitCode);
 
             string workItemZip = await CreatePayloadArchive(
                 zipArchiveManager,

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
@@ -169,11 +169,11 @@ namespace Microsoft.DotNet.Helix.Sdk
             if (customCommands == null)
             {
                 // When no user commands are specified, we add the default `apple test ...` command
-                customCommands = GetDefaultCommand(target, includesTestRunner, resetSimulator);
+                customCommands = GetDefaultCommand(includesTestRunner, resetSimulator);
             }
 
             string appName = isAlreadyArchived ? $"{fileSystem.GetFileNameWithoutExtension(appFolderPath)}.app" : fileSystem.GetFileName(appFolderPath);
-            string helixCommand = GetHelixCommand(appName, target, testTimeout, launchTimeout, includesTestRunner, expectedExitCode, resetSimulator);
+            string helixCommand = GetHelixCommand(appName, target, workItemTimeout, testTimeout, launchTimeout, includesTestRunner, expectedExitCode, resetSimulator);
             string payloadArchivePath = await CreatePayloadArchive(
                 zipArchiveManager,
                 fileSystem,
@@ -197,7 +197,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             return isAlreadyArchived ? fileSystem.FileExists(appBundlePath) : fileSystem.DirectoryExists(appBundlePath);
         }
 
-        private string GetDefaultCommand(string target, bool includesTestRunner, bool resetSimulator) =>
+        private string GetDefaultCommand(bool includesTestRunner, bool resetSimulator) =>
             $"xharness apple {(includesTestRunner ? "test" : "run")} " +
             "--app \"$app\" " +
             "--output-directory \"$output_directory\" " +
@@ -214,6 +214,7 @@ namespace Microsoft.DotNet.Helix.Sdk
         private string GetHelixCommand(
             string appName,
             string target,
+            TimeSpan workItemTimeout,
             TimeSpan testTimeout,
             TimeSpan launchTimeout,
             bool includesTestRunner,
@@ -223,7 +224,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             $"chmod +x {EntryPointScript} && ./{EntryPointScript} " +
             $"--app \"{appName}\" " +
             $"--target \"{target}\" " +
-            $"--command-timeout {(int)s_telemetryBuffer.TotalSeconds} " +
+            $"--command-timeout {(int)workItemTimeout.TotalSeconds} " +
             $"--timeout \"{testTimeout}\" " +
             $"--launch-timeout \"{launchTimeout}\" " +
             (includesTestRunner ? "--includes-test-runner " : string.Empty) +

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Arcade.Common;
 using Microsoft.Build.Framework;
@@ -222,6 +223,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             $"chmod +x {EntryPointScript} && ./{EntryPointScript} " +
             $"--app \"{appName}\" " +
             $"--target \"{target}\" " +
+            $"--command-timeout {(int)s_telemetryBuffer.TotalSeconds} " +
             $"--timeout \"{testTimeout}\" " +
             $"--launch-timeout \"{launchTimeout}\" " +
             (includesTestRunner ? "--includes-test-runner " : string.Empty) +

--- a/src/Microsoft.DotNet.Helix/Sdk/Microsoft.DotNet.Helix.Sdk.csproj
+++ b/src/Microsoft.DotNet.Helix/Sdk/Microsoft.DotNet.Helix.Sdk.csproj
@@ -35,6 +35,9 @@
     <EmbeddedResource Include="tools\xharness-runner\xharness-event-reporter.py">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </EmbeddedResource>
+    <EmbeddedResource Include="tools\xharness-runner\xharness-helix-job.android.header.ps1">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </EmbeddedResource>
     <EmbeddedResource Include="tools\xharness-runner\xharness-helix-job.apple.sh">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </EmbeddedResource>

--- a/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
@@ -14,6 +14,7 @@ namespace Microsoft.DotNet.Helix.Sdk
     {
         private static readonly TimeSpan s_defaultWorkItemTimeout = TimeSpan.FromMinutes(20);
         private static readonly TimeSpan s_defaultTestTimeout = TimeSpan.FromMinutes(12);
+        protected static readonly TimeSpan s_telemetryBuffer = TimeSpan.FromSeconds(20); // extra time to send the XHarness telemetry
 
         public class MetadataName
         {
@@ -101,6 +102,9 @@ namespace Microsoft.DotNet.Helix.Sdk
         protected Build.Utilities.TaskItem CreateTaskItem(string workItemName, string payloadArchivePath, string command, TimeSpan timeout)
         {
             Log.LogMessage($"Creating work item with properties Identity: {workItemName}, Payload: {payloadArchivePath}, Command: {command}");
+
+            // Leave some time at the end of the work item to send the telemetry (in case it times out)
+            timeout += s_telemetryBuffer;
 
             return new(workItemName, new Dictionary<string, string>()
             {

--- a/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             public const string CustomCommands = "CustomCommands";
         }
 
-        private const string ScriptNamespace = "tools.xharness_runner.";
+        protected const string ScriptNamespace = "tools.xharness_runner.";
         private const string CustomCommandsScript = "command";
         private const string DiagnosticsScript = "xharness-event-reporter.py";
 

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.header.ps1
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.header.ps1
@@ -1,0 +1,39 @@
+<#
+This script is used as a payload of Helix jobs that execute Android workloads through XHarness on Windows systems.
+This file is a header of script that gets populated with user's custom commands.
+
+This script is separate as it is executed with a timeout in its own process.
+#>
+
+param (
+    [Parameter(Mandatory)]
+    [string]$output_directory,
+    [Parameter(Mandatory)]
+    [string]$app,
+    [Parameter(Mandatory)]
+    [string]$timeout,
+    [Parameter()]
+    [string]$package_name = $null,
+    [Parameter()]
+    [int]$expected_exit_code = 0,
+    [Parameter()]
+    [string]$device_output_path = $null,
+    [Parameter()]
+    [string]$instrumentation = $null
+)
+
+$ErrorActionPreference="Continue"
+
+# The xharness alias
+function xharness() {
+    dotnet exec $Env:XHARNESS_CLI_PATH @args
+}
+
+# User can call this when they detect a problem they think is caused by the infrastructure
+function report_infrastructure_failure($message) {
+    Write-Output "Infrastructural problem reported by the user, requesting retry+reboot: $message"
+
+    & "$Env:HELIX_PYTHONPATH" -c "from helix.workitemutil import request_infra_retry; request_infra_retry('Retrying because we could not enumerate all Android devices')"
+    & "$Env:HELIX_PYTHONPATH" -c "from helix.workitemutil import request_reboot; request_reboot('Rebooting to allow Android emulator or device to restart')"
+}
+

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.ps1
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.ps1
@@ -42,7 +42,6 @@ $job = [PowerShell]::Create().AddScript({
         $output_directory,
         $app,
         $timeout,
-        $command_timeout,
         $package_name,
         $expected_exit_code,
         $device_output_path,
@@ -51,7 +50,7 @@ $job = [PowerShell]::Create().AddScript({
     $result.ExitCode = 0
     . "$current_dir\command.ps1"
     $result.ExitCode = $LASTEXITCODE
-}).AddArgument($PSScriptRoot).AddArgument($Env:HELIX_WORKITEM_UPLOAD_ROOT).AddArgument($app).AddArgument($timeout).AddArgument($command_timeout).AddArgument($package_name).AddArgument($expected_exit_code).AddArgument($device_output_path).AddArgument($instrumentation).AddArgument($code)
+}).AddArgument($PSScriptRoot).AddArgument($Env:HELIX_WORKITEM_UPLOAD_ROOT).AddArgument($app).AddArgument($timeout).AddArgument($package_name).AddArgument($expected_exit_code).AddArgument($device_output_path).AddArgument($instrumentation).AddArgument($code)
 
 $output = New-Object 'System.Management.Automation.PSDataCollection[psobject]'
 $task = $job.BeginInvoke($output, $output);
@@ -60,11 +59,15 @@ $timer = [Diagnostics.Stopwatch]::StartNew();
 do
 {
     if ($task.IsCompleted) {
+        # This prints the output of the $job (the actual user commands)
+        Write-Output $output;
         $exit_code = $code.ExitCode;
         break;
     }
 
     if ($timer.Elapsed.TotalSeconds -gt $command_timeout) {
+        # This prints the output of the $job (the actual user commands)
+        Write-Output $output;
         Write-Error "User command timed out after $command_timeout seconds!";
         $job.Stop();
         $exit_code = -3;
@@ -72,10 +75,7 @@ do
     }
 
     Start-Sleep -Milliseconds 250;
-} while (1 -eq 1)
-
-# This prints the output of the $job (the actual user commands)
-Write-Output $output;
+} while ($true);
 
 $job.Dispose();
 

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.sh
@@ -12,6 +12,7 @@ echo "XHarness Helix Job Wrapper calling '$@'"
 set -x
 
 app=''
+command_timeout=20
 timeout=''
 package_name=''
 expected_exit_code=0
@@ -24,6 +25,10 @@ while [[ $# -gt 0 ]]; do
     case "$opt" in
       --app)
         app="$2"
+        shift
+        ;;
+      --command_timeout)
+        command_timeout="$2"
         shift
         ;;
       --timeout)
@@ -67,8 +72,8 @@ function xharness() {
     dotnet exec $XHARNESS_CLI_PATH "$@"
 }
 
-# Act out the actual commands
-source command.sh
+# Act out the actual commands (and time constrain them to create buffer for the end of this script)
+source command.sh & PID=$! ; (sleep $command_timeout && kill $PID 2> /dev/null & ) ; wait $PID
 
 exit_code=$?
 

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
@@ -188,7 +188,7 @@ find "$output_directory" -name "*.log" -maxdepth 1 -size 0 -print -delete
 # Rename test result XML so that AzDO reporter recognizes it
 test_results=$(ls "$output_directory"/xunit-*.xml)
 if [ -f "$test_results" ]; then
-    echo "Found test results in $output_directory/$test_results. Renaming to testResults.xml to prepare for Helix upload"
+    echo "Found test results in $test_results. Renaming to testResults.xml to prepare for Helix upload"
 
     # Prepare test results for Helix to pick up
     mv "$test_results" "$output_directory/testResults.xml"

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
@@ -10,6 +10,7 @@ app=''
 target=''
 timeout=''
 launch_timeout=''
+command_timeout=20
 xcode_version=''
 app_arguments=''
 expected_exit_code=0
@@ -29,6 +30,10 @@ while [[ $# -gt 0 ]]; do
         ;;
       --timeout)
         timeout="$2"
+        shift
+        ;;
+      --command-timeout)
+        command_timeout="$2"
         shift
         ;;
       --launch-timeout)
@@ -139,8 +144,8 @@ function xharness() {
     dotnet exec "$XHARNESS_CLI_PATH" "$@"
 }
 
-# Act out the actual commands
-source command.sh
+# Act out the actual commands (and time constrain them to create buffer for the end of this script)
+source command.sh & PID=$! ; (sleep $command_timeout && kill $PID 2> /dev/null & ) ; wait $PID
 exit_code=$?
 
 # Exit code values - https://github.com/dotnet/xharness/blob/main/src/Microsoft.DotNet.XHarness.Common/CLI/ExitCode.cs


### PR DESCRIPTION
We have to make sure that user commands are time-constrained so that we have buffer to call clean-up and send the telemetry at the end of the job.

We do this by bumping the original work item timeout and setting a timeout for the injected user commands.

Resolves #7899