### PR TITLE
Add passthrough properties for specifying additional arguments to wix tools

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets
@@ -244,7 +244,8 @@
           -cg %(ComponentGroupName) ^
           -srd ^
           -dr %(DirectoryRef) ^
-          -out %(WixSourceFile)" />
+          -out %(WixSourceFile)
+          $(AdditionalHeatArgs)" />
 
       <CandleVariables Include="InstallFiles" Value="true" />
     </ItemGroup>
@@ -305,6 +306,7 @@
       <_wixArgs>$(_wixArgs) @(CandleVariables -> '-d%(Identity)="%(Value)"', ' ')</_wixArgs>
       <_wixArgs>$(_wixArgs) @(WixSrcFile -> '"%(FullPath)"', ' ')</_wixArgs>
       <_wixArgs>$(_wixArgs) @(DirectoryToHarvest -> '"%(WixSourceFile)"', ' ')</_wixArgs>
+      <_wixArgs>$(_wixArgs) $(AdditionalCandleArgs)</_wixArgs>
     </PropertyGroup>
 
     <Exec
@@ -327,6 +329,7 @@
       <_wixArgs>$(_wixArgs) @(WixExtensions -> '-ext %(Identity)', ' ')</_wixArgs>
       <_wixArgs>$(_wixArgs) @(WixSrcFile -> '"$(WixObjDir)%(Filename).wixobj"', ' ')</_wixArgs>
       <_wixArgs>$(_wixArgs) @(DirectoryToHarvest -> '"%(WixObjFile)"', ' ')</_wixArgs>
+      <_wixArgs>$(_wixArgs) $(AdditionalLightArgs)</_wixArgs>
       <_lightCommand>light.exe $(_wixArgs)</_lightCommand>
     </PropertyGroup>
 


### PR DESCRIPTION
We don't have any way to suppress validation rules in our installers (or provide any other parameters to the WiX tools).  I'm a bit surprised we decided to write our own wix.targets rather than rely on those that [shipped with wix](https://github.com/wixtoolset/wix3/blob/develop/src/tools/WixTasks/wix.targets), but I'm not going to change that here.

I'm adding some pass-through properties so that we can define our own additional arguments to the common wix tools we use to build installers.

I specifically needed this to suppress `ICE80: This 32BitComponent CCCCCCC uses 64BitDirectory DDDDDD`.  Our product explicitly has a design where it will store it's installation location (which may be a 64-bit directory for the 64-bit product) in the 32-bit registry hive.  I hit this when moving the registry key to the host, we didn't hit it in the SDK since the SDK "hid" this from the ICE validation by laundering the directory as a property instead.  I could workaround it by laundering through a property but that's unnecessary runtime complexity.  Better to just suppress the overzealous build time validation.
