### PR TITLE
Additional RPMs for CBL-Mariner

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/installer.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/installer.targets
@@ -140,6 +140,15 @@
           UseHardlinksIfPossible="False" />
 
     <Message Text="$(MSBuildProjectName) -> $(InstallerFile)" Importance="high" />
+
+    <Copy Condition="'$(CreateRPMForCblMariner)' == 'true'"
+          SourceFiles="@(GeneratedRpmFiles)"
+          DestinationFiles="$(_InstallerFileCblMariner)"
+          OverwriteReadOnlyFiles="True"
+          SkipUnchangedFiles="False"
+          UseHardlinksIfPossible="False" />
+
+    <Message Text="$(MSBuildProjectName) -> $(_InstallerFileCblMariner)" Importance="high" />
   </Target>
 
   <Target Name="GetRpmInstallerJsonProperties"

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/packaging-tools.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/packaging-tools.targets
@@ -99,6 +99,14 @@
       <CompressedArchiveFile>$(AssetOutputPath)$(InstallerFileNameWithoutExtension)$(CompressedFileExtension)</CompressedArchiveFile>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(InstallerExtension)' == '.rpm'">
+      <CreateRPMForCblMariner>true</CreateRPMForCblMariner>
+      <_CblMarinerVersionSuffix>cm.1</_CblMarinerVersionSuffix>
+      <_InstallerBuildPartCblMariner>$(ProductVersion)-$(_CblMarinerVersionSuffix)-$(TargetArchitecture)</_InstallerBuildPartCblMariner>
+      <_InstallerFileNameWithoutExtensionCblMariner>$(InstallerName)-$(_InstallerBuildPartCblMariner)$(CrossArchContentsBuildPart)</_InstallerFileNameWithoutExtensionCblMariner>
+      <_InstallerFileCblMariner Condition="'$(_InstallerFileCblMariner)' == ''">$(AssetOutputPath)$(_InstallerFileNameWithoutExtensionCblMariner)$(InstallerExtension)</_InstallerFileCblMariner>
+    </PropertyGroup>
+
     <!--
       Set the directory containing contents to include in the archive (zip/tarball). This default
       means the "shared" dir is inside the archive and it can be extracted directly into the dotnet


### PR DESCRIPTION
This is essentially a backport of https://github.com/dotnet/arcade/pull/7812. Not quite, as the infra is slightly different.

In 5.0, shared infra is used for building only few of the RPM packages, i.e. AppHost-Pack. Host, hostfxr, shared runtime and deps packages are produced by infra in runtime repo - that change will be available soon.