### PR TITLE
Don't escape script content

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateMacOSDistributionFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateMacOSDistributionFile.cs
@@ -40,8 +40,7 @@ namespace Microsoft.DotNet.SharedFramework.Sdk
 
                 var titleElement = new XElement("title", $"{ProductBrandName} ({TargetArchitecture})");
 
-                var archScriptContent = @"<![CDATA[
-function IsX64Machine() {
+                var archScriptContent = @"function IsX64Machine() {
     var machine = system.sysctl(""hw.machine"");
     var cputype = system.sysctl(""hw.cputype"");
     var cpu64 = system.sysctl(""hw.cpu64bit_capable"");
@@ -59,9 +58,8 @@ function IsX64Machine() {
     result = result && (translated != ""1"");
     system.log(""IsX64Machine: "" + result);
     return result;
-}
-]]>";
-                var scriptElement = new XElement("script", new XText(archScriptContent));
+}";
+                var scriptElement = new XElement("script", new XCData(archScriptContent));
 
                 var choiceElements = BundledPackages
                     .Select(component => new XElement("choice",


### PR DESCRIPTION
Fixes a bug in our mac distribution scripts that were escaping the body of CDATA element.
