### PR TITLE
Allow multiple [SkipOnCoreClr]

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnCoreClrAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/SkipOnCoreClrAttribute.cs
@@ -7,7 +7,7 @@ using Xunit.Sdk;
 namespace Xunit
 {
     [TraitDiscoverer("Microsoft.DotNet.XUnitExtensions.SkipOnCoreClrDiscoverer", "Microsoft.DotNet.XUnitExtensions")]
-    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
     public class SkipOnCoreClrAttribute : Attribute, ITraitAttribute
     {
         internal SkipOnCoreClrAttribute() { }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCoreClrDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCoreClrDiscoverer.cs
@@ -13,13 +13,20 @@ namespace Microsoft.DotNet.XUnitExtensions
 {
     public class SkipOnCoreClrDiscoverer : ITraitDiscoverer
     {
-        private static readonly Lazy<bool> s_isJitStress = new Lazy<bool>(() => !string.Equals(GetEnvironmentVariableValue("COMPlus_JitStress"), "0", StringComparison.InvariantCulture));
-        private static readonly Lazy<bool> s_isJitStressRegs = new Lazy<bool>(() => !string.Equals(GetEnvironmentVariableValue("COMPlus_JitStressRegs"), "0", StringComparison.InvariantCulture));
-        private static readonly Lazy<bool> s_isJitMinOpts = new Lazy<bool>(() => string.Equals(GetEnvironmentVariableValue("COMPlus_JITMinOpts"), "1", StringComparison.InvariantCulture));
-        private static readonly Lazy<bool> s_isTailCallStress = new Lazy<bool>(() => string.Equals(GetEnvironmentVariableValue("COMPlus_TailcallStress"), "1", StringComparison.InvariantCulture));
-        private static readonly Lazy<bool> s_isZapDisable = new Lazy<bool>(() => string.Equals(GetEnvironmentVariableValue("COMPlus_ZapDisable"), "1", StringComparison.InvariantCulture));
-        private static readonly Lazy<bool> s_isGCStress3 = new Lazy<bool>(() => CompareGCStressModeAsLower(GetEnvironmentVariableValue("COMPlus_GCStress"), "0x3", "3"));
-        private static readonly Lazy<bool> s_isGCStressC = new Lazy<bool>(() => CompareGCStressModeAsLower(GetEnvironmentVariableValue("COMPlus_GCStress"), "0xC", "C"));
+        private static readonly Lazy<bool> s_isJitStress = new Lazy<bool>(() => !string.Equals(GetEnvironmentVariableValue("COMPlus_JitStress"), "0", StringComparison.InvariantCulture) &&
+            !string.Equals(GetEnvironmentVariableValue("DOTNET_JitStress"), "0", StringComparison.InvariantCulture));
+        private static readonly Lazy<bool> s_isJitStressRegs = new Lazy<bool>(() => !string.Equals(GetEnvironmentVariableValue("COMPlus_JitStressRegs"), "0", StringComparison.InvariantCulture) &&
+            !string.Equals(GetEnvironmentVariableValue("DOTNET_JitStressRegs"), "0", StringComparison.InvariantCulture));
+        private static readonly Lazy<bool> s_isJitMinOpts = new Lazy<bool>(() => string.Equals(GetEnvironmentVariableValue("COMPlus_JITMinOpts"), "1", StringComparison.InvariantCulture) ||
+            string.Equals(GetEnvironmentVariableValue("DOTNET_JITMinOpts"), "1", StringComparison.InvariantCulture));
+        private static readonly Lazy<bool> s_isTailCallStress = new Lazy<bool>(() => string.Equals(GetEnvironmentVariableValue("COMPlus_TailcallStress"), "1", StringComparison.InvariantCulture) ||
+            string.Equals(GetEnvironmentVariableValue("DOTNET_TailcallStress"), "1", StringComparison.InvariantCulture));
+        private static readonly Lazy<bool> s_isZapDisable = new Lazy<bool>(() => string.Equals(GetEnvironmentVariableValue("COMPlus_ZapDisable"), "1", StringComparison.InvariantCulture) ||
+            string.Equals(GetEnvironmentVariableValue("DOTNET_ZapDisable"), "1", StringComparison.InvariantCulture));
+        private static readonly Lazy<bool> s_isGCStress3 = new Lazy<bool>(() => CompareGCStressModeAsLower(GetEnvironmentVariableValue("COMPlus_GCStress"), "0x3", "3") ||
+            CompareGCStressModeAsLower(GetEnvironmentVariableValue("DOTNET_GCStress"), "0x3", "3"));
+        private static readonly Lazy<bool> s_isGCStressC = new Lazy<bool>(() => CompareGCStressModeAsLower(GetEnvironmentVariableValue("COMPlus_GCStress"), "0xC", "C") ||
+            CompareGCStressModeAsLower(GetEnvironmentVariableValue("DOTNET_GCStress"), "0xC", "C"));
         private static readonly Lazy<bool> s_isCheckedRuntime = new Lazy<bool>(() => IsCheckedRuntime());
         private static readonly Lazy<bool> s_isReleaseRuntime = new Lazy<bool>(() => IsReleaseRuntime());
         private static readonly Lazy<bool> s_isDebugRuntime = new Lazy<bool>(() => IsDebugRuntime());

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCoreClrDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/SkipOnCoreClrDiscoverer.cs
@@ -13,20 +13,13 @@ namespace Microsoft.DotNet.XUnitExtensions
 {
     public class SkipOnCoreClrDiscoverer : ITraitDiscoverer
     {
-        private static readonly Lazy<bool> s_isJitStress = new Lazy<bool>(() => !string.Equals(GetEnvironmentVariableValue("COMPlus_JitStress"), "0", StringComparison.InvariantCulture) &&
-            !string.Equals(GetEnvironmentVariableValue("DOTNET_JitStress"), "0", StringComparison.InvariantCulture));
-        private static readonly Lazy<bool> s_isJitStressRegs = new Lazy<bool>(() => !string.Equals(GetEnvironmentVariableValue("COMPlus_JitStressRegs"), "0", StringComparison.InvariantCulture) &&
-            !string.Equals(GetEnvironmentVariableValue("DOTNET_JitStressRegs"), "0", StringComparison.InvariantCulture));
-        private static readonly Lazy<bool> s_isJitMinOpts = new Lazy<bool>(() => string.Equals(GetEnvironmentVariableValue("COMPlus_JITMinOpts"), "1", StringComparison.InvariantCulture) ||
-            string.Equals(GetEnvironmentVariableValue("DOTNET_JITMinOpts"), "1", StringComparison.InvariantCulture));
-        private static readonly Lazy<bool> s_isTailCallStress = new Lazy<bool>(() => string.Equals(GetEnvironmentVariableValue("COMPlus_TailcallStress"), "1", StringComparison.InvariantCulture) ||
-            string.Equals(GetEnvironmentVariableValue("DOTNET_TailcallStress"), "1", StringComparison.InvariantCulture));
-        private static readonly Lazy<bool> s_isZapDisable = new Lazy<bool>(() => string.Equals(GetEnvironmentVariableValue("COMPlus_ZapDisable"), "1", StringComparison.InvariantCulture) ||
-            string.Equals(GetEnvironmentVariableValue("DOTNET_ZapDisable"), "1", StringComparison.InvariantCulture));
-        private static readonly Lazy<bool> s_isGCStress3 = new Lazy<bool>(() => CompareGCStressModeAsLower(GetEnvironmentVariableValue("COMPlus_GCStress"), "0x3", "3") ||
-            CompareGCStressModeAsLower(GetEnvironmentVariableValue("DOTNET_GCStress"), "0x3", "3"));
-        private static readonly Lazy<bool> s_isGCStressC = new Lazy<bool>(() => CompareGCStressModeAsLower(GetEnvironmentVariableValue("COMPlus_GCStress"), "0xC", "C") ||
-            CompareGCStressModeAsLower(GetEnvironmentVariableValue("DOTNET_GCStress"), "0xC", "C"));
+        private static readonly Lazy<bool> s_isJitStress = new Lazy<bool>(() => !string.Equals(GetEnvironmentVariableValue("JitStress"), "0", StringComparison.InvariantCulture));
+        private static readonly Lazy<bool> s_isJitStressRegs = new Lazy<bool>(() => !string.Equals(GetEnvironmentVariableValue("JitStressRegs"), "0", StringComparison.InvariantCulture));
+        private static readonly Lazy<bool> s_isJitMinOpts = new Lazy<bool>(() => string.Equals(GetEnvironmentVariableValue("JITMinOpts"), "1", StringComparison.InvariantCulture));
+        private static readonly Lazy<bool> s_isTailCallStress = new Lazy<bool>(() => string.Equals(GetEnvironmentVariableValue("TailcallStress"), "1", StringComparison.InvariantCulture));
+        private static readonly Lazy<bool> s_isZapDisable = new Lazy<bool>(() => string.Equals(GetEnvironmentVariableValue("ZapDisable"), "1", StringComparison.InvariantCulture));
+        private static readonly Lazy<bool> s_isGCStress3 = new Lazy<bool>(() => CompareGCStressModeAsLower(GetEnvironmentVariableValue("GCStress"), "0x3", "3"));
+        private static readonly Lazy<bool> s_isGCStressC = new Lazy<bool>(() => CompareGCStressModeAsLower(GetEnvironmentVariableValue("GCStress"), "0xC", "C"));
         private static readonly Lazy<bool> s_isCheckedRuntime = new Lazy<bool>(() => IsCheckedRuntime());
         private static readonly Lazy<bool> s_isReleaseRuntime = new Lazy<bool>(() => IsReleaseRuntime());
         private static readonly Lazy<bool> s_isDebugRuntime = new Lazy<bool>(() => IsDebugRuntime());
@@ -88,7 +81,8 @@ namespace Microsoft.DotNet.XUnitExtensions
             s_isJitStress.Value ||
             s_isJitMinOpts.Value;
 
-        private static string GetEnvironmentVariableValue(string name) => Environment.GetEnvironmentVariable(name) ?? "0";
+        private static string GetEnvironmentVariableValue(string name) =>
+            Environment.GetEnvironmentVariable("DOTNET_" + name) ?? Environment.GetEnvironmentVariable("COMPlus_" + name) ?? "0";
 
         private static bool IsCheckedRuntime() => AssemblyConfigurationEquals("Checked");
 

--- a/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeTestModes.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeTestModes.cs
@@ -17,22 +17,22 @@ namespace Xunit
         // JitStress, JitStressRegs, JitMinOpts and TailcallStress enable
         // various modes in the JIT that cause us to exercise more code paths,
         // and generate different kinds of code
-        JitStress = 1 << 1, // COMPlus_JitStress is set.
-        JitStressRegs = 1 << 2, // COMPlus_JitStressRegs is set.
-        JitMinOpts = 1 << 3, // COMPlus_JITMinOpts is set.
-        TailcallStress = 1 << 4, // COMPlus_TailcallStress is set.
+        JitStress = 1 << 1, // DOTNET_JitStress (or COMPlus_JitStress) is set.
+        JitStressRegs = 1 << 2, // DOTNET_JitStressRegs (or COMPlus_JitStressRegs) is set.
+        JitMinOpts = 1 << 3, // DOTNET_JITMinOpts (or COMPlus_JITMinOpts) is set.
+        TailcallStress = 1 << 4, // DOTNET_TailcallStress (or COMPlus_TailcallStress) is set.
 
         // ZapDisable says to not use NGEN or ReadyToRun images.
         // This means we JIT everything.
-        ZapDisable = 1 << 5, // COMPlus_ZapDisable is set.
+        ZapDisable = 1 << 5, // DOTNET_ZapDisable (or COMPlus_ZapDisable) is set.
 
         // GCStress3 forces a GC at various locations, typically transitions
         // to/from the VM from managed code. 
-        GCStress3 = 1 << 6,  // COMPlus_GCStress includes mode 0x3.
+        GCStress3 = 1 << 6,  // DOTNET_GCStress (or COMPlus_GCStress) includes mode 0x3.
 
         // GCStressC forces a GC at every JIT-generated code instruction,
         // including in NGEN/ReadyToRun code.
-        GCStressC = 1 << 7, // COMPlus_GCStress includes mode 0xC.
+        GCStressC = 1 << 7, // DOTNET_GCStress (or COMPlus_GCStress) includes mode 0xC.
         AnyGCStress = GCStress3 | GCStressC // Disable when any GCStress is exercised.
     }
 }


### PR DESCRIPTION
Currently, we can specify multiple conditions with `[SkipOnCoreClr]` that get checked with `AND` semantics. To achieve `OR` semantics, we need to specify it multiple times (just like `[ActiveIssue]`), which is currently not possible. For context, see https://github.com/dotnet/runtime/pull/59564#issuecomment-926809062.

In second commit, I have added `DOTNET_` variables for each `COMPlus_` one. This is because CoreCLR (despite still supports `COMPlus_`) now considers `COMPlus_` as legacy convention and prefers `DOTNET_`. See https://github.com/dotnet/runtime/blob/b0159122f3570decd8ced6228681a210e2711de6/src/coreclr/inc/clrconfignocache.h#L77
