### PR TITLE
Fix path bug in DownloadFromResultsContainer.targets

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/download-results/DownloadFromResultsContainer.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/download-results/DownloadFromResultsContainer.targets
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <HelixResultsDestinationDir Condition="'$(HelixResultsDestinationDir)' == '' AND '$(BUILD_SOURCESDIRECTORY)' != ''">$([MSBuild]::NormalizeDirectory('$(BUILD_SOURCESDIRECTORY)', 'artifacts', helixresults'))</HelixResultsDestinationDir>
+      <HelixResultsDestinationDir Condition="'$(HelixResultsDestinationDir)' == '' AND '$(BUILD_SOURCESDIRECTORY)' != ''">$([MSBuild]::NormalizeDirectory($(BUILD_SOURCESDIRECTORY), 'artifacts', helixresults'))</HelixResultsDestinationDir>
 
       <_shouldDownloadResults>false</_shouldDownloadResults>
       <_shouldDownloadResults Condition="'@(_workItemsWithDownloadMetadata)' != '' AND '$(HelixResultsDestinationDir)' != ''">true</_shouldDownloadResults>


### PR DESCRIPTION
https://github.com/dotnet/arcade/pull/6179/files  fixed an issue with downloading helix files, but it was still reproing with following errors (reference https://github.com/dotnet/runtime/pull/59489#discussion_r715811711).

````
D:\workspace\_work\1\s\.packages\microsoft.dotnet.helix.sdk\7.0.0-beta.21463.4\tools\download-results\DownloadFromResultsContainer.targets(24,5): error MSB4018: The "DownloadFromResultsContainer" task failed unexpectedly. [D:\workspace\_work\1\s\src\coreclr\scripts\exploratory.proj]
D:\workspace\_work\1\s\.packages\microsoft.dotnet.helix.sdk\7.0.0-beta.21463.4\tools\download-results\DownloadFromResultsContainer.targets(24,5): error MSB4018: System.IO.IOException: The filename, directory name, or volume label syntax is incorrect. : 'D:\workspace\_work\1\s\src\coreclr\scripts\$([MSBuild]::NormalizeDirectory('$(BUILD_SOURCESDIRECTORY)', 'artifacts', helixresults'))\9e889cb3-8222-4f97-b8c4-c95ff9d8fa88' [D:\workspace\_work\1\s\src\coreclr\scripts\exploratory.proj]
D:\workspace\_work\1\s\.packages\microsoft.dotnet.helix.sdk\7.0.0-beta.21463.4\tools\download-results\DownloadFromResultsContainer.targets(24,5): error MSB4018:    at System.IO.FileSystem.CreateDirectory(String fullPath, Byte[] securityDescriptor) [D:\workspace\_work\1\s\src\coreclr\scripts\exploratory.proj]
D:\workspace\_work\1\s\.packages\microsoft.dotnet.helix.sdk\7.0.0-beta.21463.4\tools\download-results\DownloadFromResultsContainer.targets(24,5): error MSB4018:    at System.IO.Directory.CreateDirectory(String path) [D:\workspace\_work\1\s\src\coreclr\scripts\exploratory.proj]
D:\workspace\_work\1\s\.packages\microsoft.dotnet.helix.sdk\7.0.0-beta.21463.4\tools\download-results\DownloadFromResultsContainer.targets(24,5): error MSB4018:    at Microsoft.DotNet.Helix.Sdk.DownloadFromResultsContainer.ExecuteCore() in /_/src/Microsoft.DotNet.Helix/Sdk/DownloadFromResultsContainer.cs:line 66 [D:\workspace\_work\1\s\src\coreclr\scripts\exploratory.proj]
D:\workspace\_work\1\s\.packages\microsoft.dotnet.helix.sdk\7.0.0-beta.21463.4\tools\download-results\DownloadFromResultsContainer.targets(24,5): error MSB4018:    at Microsoft.DotNet.Helix.Sdk.DownloadFromResultsContainer.Execute() in /_/src/Microsoft.DotNet.Helix/Sdk/DownloadFromResultsContainer.cs:line 58 [D:\workspace\_work\1\s\src\coreclr\scripts\exploratory.proj]
D:\workspace\_work\1\s\.packages\microsoft.dotnet.helix.sdk\7.0.0-beta.21463.4\tools\download-results\DownloadFromResultsContainer.targets(24,5): error MSB4018:    at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute() [D:\workspace\_work\1\s\src\coreclr\scripts\exploratory.proj]
D:\workspace\_work\1\s\.packages\microsoft.dotnet.helix.sdk\7.0.0-beta.21463.4\tools\download-results\DownloadFromResultsContainer.targets(24,5): error MSB4018:    at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(ITaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask) [D:\workspace\_work\1\s\src\coreclr\scripts\exploratory.proj]
##[error].packages\microsoft.dotnet.helix.sdk\7.0.0-beta.21463.4\tools\download-results\DownloadFromResultsContainer.targets(24,5): error MSB4018: (NETCORE_ENGINEERING_TELEMETRY=Build) The "DownloadFromResultsContainer" task failed unexpectedly.
System.IO.IOException: The filename, directory name, or volume label syntax is incorrect. : 'D:\workspace\_work\1\s\src\coreclr\scripts\$([MSBuild]::NormalizeDirectory('$(BUILD_SOURCESDIRECTORY)', 'artifacts', helixresults'))\9e889cb3-8222-4f97-b8c4-c95ff9d8fa88'
   at System.IO.FileSystem.CreateDirectory(String fullPath, Byte[] securityDescriptor)
   at System.IO.Directory.CreateDirectory(String path)
   at Microsoft.DotNet.Helix.Sdk.DownloadFromResultsContainer.ExecuteCore() in /_/src/Microsoft.DotNet.Helix/Sdk/DownloadFromResultsContainer.cs:line 66
   at Microsoft.DotNet.Helix.Sdk.DownloadFromResultsContainer.Execute() in /_/src/Microsoft.DotNet.Helix/Sdk/DownloadFromResultsContainer.cs:line 58
   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
   at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(ITaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask)


```

Looks like there was a surrounding `'` that should not be there.