### PR TITLE
Fix RuntimeInformation.FrameworkDescription in DiscovererHelpers

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.XUnitExtensions
     {
         private static readonly Lazy<bool> s_isMonoRuntime = new Lazy<bool>(() => Type.GetType("Mono.RuntimeStructs") != null);
         public static bool IsMonoRuntime => s_isMonoRuntime.Value;
-        public static bool IsRunningOnNetCoreApp { get; } = (Environment.Version.Major >= 5 || RuntimeInformation.FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase));
+        public static bool IsRunningOnNetCoreApp { get; } = (Environment.Version.Major >= 5 || RuntimeInformation.FrameworkDescription.StartsWith(".NET", StringComparison.OrdinalIgnoreCase));
         public static bool IsRunningOnNetFramework { get; } = RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
 
         public static bool TestPlatformApplies(TestPlatforms platforms) =>


### PR DESCRIPTION
For reasons unknown, the first part of the IsRunningOnNetCoreApp check (Environment.Version.Major) was returning 0 for iOS & tvOS CI runs.  The second part also failed because FrameworkDescription is no longer .NET Core. As a result, tests that should be skipped were no longer and causing unexpected failures on CI.