### PR TITLE
Bump LZMA-SDK version to avoid CG warning

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
+++ b/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
@@ -15,7 +15,7 @@
     <IsTool>true</IsTool>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="LZMA-SDK" Version="18.1.0" />
+    <PackageReference Include="LZMA-SDK" Version="19.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.OLE.Interop" Version="7.10.6071" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="NuGet.Common" Version="4.7.0" />

--- a/src/SignCheck/Microsoft.SignCheck/Verification/LzmaVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/LzmaVerifier.cs
@@ -8,7 +8,7 @@ namespace Microsoft.SignCheck.Verification
 {
     public class LzmaVerifier : FileVerifier
     {
-        public LzmaVerifier(Log log, Exclusions exclusions, SignatureVerificationOptions options) : base(log, exclusions, options, fileExtension: "lzma")
+        public LzmaVerifier(Log log, Exclusions exclusions, SignatureVerificationOptions options) : base(log, exclusions, options, fileExtension: ".lzma")
         {
 
         }


### PR DESCRIPTION
Update LZMA-SDK from version 18.1.0 to 19.0.0 to take the MIT license. 

Because this library only exposes a subset of the total "lzma sdk", it happens that there are [no code changes between these versions](https://github.com/monemihir/LZMA-SDK/compare/de673a7b4fcbbc0798ec3830aa6314534a16899b...7c123efdaa886bd4a413d6157ff9793d8a20ce12). 

This project doesn't have unit tests and I'm not familiar with anything that holds signatures in an LZMA archive (the code seems to look for ".lzma"), so I have not been able to actually run this code path. Any advice welcome. 

Given the simplicity of the library change I think this is safe to take.