### PR TITLE
Enable requesting retry/reboot on Windows XHarness workloads

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.header.ps1
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.header.ps1
@@ -33,7 +33,7 @@ function xharness() {
 function report_infrastructure_failure($message) {
     Write-Output "Infrastructural problem reported by the user, requesting retry+reboot: $message"
 
-    New-Item -Path "$Env:HELIX_WORKITEM_ROOT" -Name ".retry" -ItemType "file"
-    New-Item -Path "$Env:HELIX_WORKITEM_ROOT" -Name ".reboot" -ItemType "file"
+    New-Item -Path "$Env:HELIX_WORKITEM_ROOT" -Name ".retry" -ItemType "file" -Force
+    New-Item -Path "$Env:HELIX_WORKITEM_ROOT" -Name ".reboot" -ItemType "file" -Force
 }
 

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.header.ps1
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.header.ps1
@@ -36,7 +36,7 @@ function report_infrastructure_failure($message) {
     New-Item -Path "$Env:HELIX_WORKITEM_ROOT" -Name ".retry" -ItemType "file" -Force
     New-Item -Path "$Env:HELIX_WORKITEM_ROOT" -Name ".reboot" -ItemType "file" -Force
 
-    $message | Out-File -FilePath "$Env:HELIX_WORKITEM_ROOT\.retry"
-    $message | Out-File -FilePath "$Env:HELIX_WORKITEM_ROOT\.reboot"
+    $message -replace "['\\]" | Out-File -FilePath "$Env:HELIX_WORKITEM_ROOT\.retry"
+    $message -replace "['\\]" | Out-File -FilePath "$Env:HELIX_WORKITEM_ROOT\.reboot"
 }
 

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.header.ps1
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.header.ps1
@@ -33,7 +33,7 @@ function xharness() {
 function report_infrastructure_failure($message) {
     Write-Output "Infrastructural problem reported by the user, requesting retry+reboot: $message"
 
-    & "$Env:HELIX_PYTHONPATH" -c "from helix.workitemutil import request_infra_retry; request_infra_retry('Retrying because we could not enumerate all Android devices')"
-    & "$Env:HELIX_PYTHONPATH" -c "from helix.workitemutil import request_reboot; request_reboot('Rebooting to allow Android emulator or device to restart')"
+    New-Item -Path "$Env:HELIX_WORKITEM_ROOT" -Name ".retry" -ItemType "file"
+    New-Item -Path "$Env:HELIX_WORKITEM_ROOT" -Name ".reboot" -ItemType "file"
 }
 

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.header.ps1
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.header.ps1
@@ -35,5 +35,8 @@ function report_infrastructure_failure($message) {
 
     New-Item -Path "$Env:HELIX_WORKITEM_ROOT" -Name ".retry" -ItemType "file" -Force
     New-Item -Path "$Env:HELIX_WORKITEM_ROOT" -Name ".reboot" -ItemType "file" -Force
+
+    $message | Out-File -FilePath "$Env:HELIX_WORKITEM_ROOT\.retry"
+    $message | Out-File -FilePath "$Env:HELIX_WORKITEM_ROOT\.reboot"
 }
 

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.ps1
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.ps1
@@ -52,8 +52,8 @@ if ($ev) {
     Write-Output "User command ended with $exit_code"
 }
 
-$retry=$false
-$reboot=$false
+$retry = $false
+$reboot = $false
 
 switch ($exit_code)
 {
@@ -61,8 +61,8 @@ switch ($exit_code)
     85 {
         Write-Error "Encountered ADB_DEVICE_ENUMERATION_FAILURE. This is typically not a failure of the work item. We will run it again and reboot this computer to help its devices"
         Write-Error "If this occurs repeatedly, please check for architectural mismatch, e.g. sending x86 or x86_64 APKs to an arm64_v8a-only queue."
-        $retry=$true
-        $reboot=$true
+        $retry = $true
+        $reboot = $true
         Break
     }
 
@@ -70,9 +70,17 @@ switch ($exit_code)
     78 {
         Write-Error "Encountered PACKAGE_INSTALLATION_FAILURE. This is typically not a failure of the work item. We will try it again on another Helix agent"
         Write-Error "If this occurs repeatedly, please check for architectural mismatch, e.g. requesting installation on arm64_v8a-only queue for x86 or x86_64 APKs."
-        $retry=$true
+        $retry = $true
         Break
     }
+}
+
+if (Test-Path -Path "$Env:HELIX_WORKITEM_ROOT\.retry" -PathType Leaf) {
+    $retry = $true;
+}
+
+if (Test-Path -Path "$Env:HELIX_WORKITEM_ROOT\.reboot" -PathType Leaf) {
+    $reboot = $true;
 }
 
 if ($retry) {

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.ps1
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.ps1
@@ -77,18 +77,28 @@ switch ($exit_code)
 
 if (Test-Path -Path "$Env:HELIX_WORKITEM_ROOT\.retry" -PathType Leaf) {
     $retry = $true;
+    $retry_message = Get-Content -Path "$Env:HELIX_WORKITEM_ROOT\.retry"
 }
 
 if (Test-Path -Path "$Env:HELIX_WORKITEM_ROOT\.reboot" -PathType Leaf) {
     $reboot = $true;
+    $reboot_message = Get-Content -Path "$Env:HELIX_WORKITEM_ROOT\.reboot"
 }
 
 if ($retry) {
-    & "$Env:HELIX_PYTHONPATH" -c "from helix.workitemutil import request_infra_retry; request_infra_retry('Retrying because we could not enumerate all Android devices')"
+    if ([string]::IsNullOrEmpty($retry_message)) {
+        $retry_message = 'Retrying because we could not enumerate all Android devices'
+    }
+
+    & "$Env:HELIX_PYTHONPATH" -c "from helix.workitemutil import request_infra_retry; request_infra_retry('$retry_message')"
 }
 
 if ($reboot) {
-     & "$Env:HELIX_PYTHONPATH" -c "from helix.workitemutil import request_reboot; request_reboot('Rebooting to allow Android emulator or device to restart')"
+    if ([string]::IsNullOrEmpty($reboot_message)) {
+        $reboot_message = 'Rebooting to allow Android emulator to restart'
+    }
+
+     & "$Env:HELIX_PYTHONPATH" -c "from helix.workitemutil import request_reboot; request_reboot('$reboot_message')"
 }
 
 exit $exit_code

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.sh
@@ -105,6 +105,14 @@ case "$exit_code" in
     ;;
 esac
 
+if [ -f "$HELIX_WORKITEM_ROOT/.retry" ]; then
+    retry=true
+fi
+
+if [ -f "$HELIX_WORKITEM_ROOT/.reboot" ]; then
+    reboot=true
+fi
+
 if [ "$retry" == true ]; then
     "$HELIX_PYTHONPATH" -c "from helix.workitemutil import request_infra_retry; request_infra_retry('Retrying because we could not enumerate all Android devices')"
 fi

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.sh
@@ -72,6 +72,13 @@ function xharness() {
     dotnet exec $XHARNESS_CLI_PATH "$@"
 }
 
+function report_infrastructure_failure() {
+    echo "Infrastructural problem reported by the user, requesting retry+reboot: $1"
+
+    echo "$1" > "$HELIX_WORKITEM_ROOT/.retry"
+    echo "$1" > "$HELIX_WORKITEM_ROOT/.reboot"
+}
+
 # Act out the actual commands (and time constrain them to create buffer for the end of this script)
 source command.sh & PID=$! ; (sleep $command_timeout && kill $PID 2> /dev/null & ) ; wait $PID
 
@@ -107,18 +114,28 @@ esac
 
 if [ -f "$HELIX_WORKITEM_ROOT/.retry" ]; then
     retry=true
+    retry_message=$(cat "$HELIX_WORKITEM_ROOT/.retry")
 fi
 
 if [ -f "$HELIX_WORKITEM_ROOT/.reboot" ]; then
     reboot=true
+    reboot_message=$(cat "$HELIX_WORKITEM_ROOT/.reboot")
 fi
 
 if [ "$retry" == true ]; then
-    "$HELIX_PYTHONPATH" -c "from helix.workitemutil import request_infra_retry; request_infra_retry('Retrying because we could not enumerate all Android devices')"
+    if [ -z "$retry_message" ]; then
+        retry_message='Retrying because we could not enumerate all Android devices'
+    fi
+
+    "$HELIX_PYTHONPATH" -c "from helix.workitemutil import request_infra_retry; request_infra_retry('$retry_message')"
 fi
 
 if [ "$reboot" == true ]; then
-    "$HELIX_PYTHONPATH" -c "from helix.workitemutil import request_reboot; request_reboot('Rebooting to allow Android emulator to restart')"
+    if [ -z "$reboot_message" ]; then
+        reboot_message='Rebooting to allow Android emulator to restart'
+    fi
+
+    "$HELIX_PYTHONPATH" -c "from helix.workitemutil import request_reboot; request_reboot('$reboot_message')"
 fi
 
 exit $exit_code

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.sh
@@ -114,12 +114,12 @@ esac
 
 if [ -f "$HELIX_WORKITEM_ROOT/.retry" ]; then
     retry=true
-    retry_message=$(cat "$HELIX_WORKITEM_ROOT/.retry")
+    retry_message=$(cat "$HELIX_WORKITEM_ROOT/.retry" | tr -d "'\\\\")
 fi
 
 if [ -f "$HELIX_WORKITEM_ROOT/.reboot" ]; then
     reboot=true
-    reboot_message=$(cat "$HELIX_WORKITEM_ROOT/.reboot")
+    reboot_message=$(cat "$HELIX_WORKITEM_ROOT/.reboot" | tr -d "'\\\\")
 fi
 
 if [ "$retry" == true ]; then

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.apple.sh
@@ -45,7 +45,7 @@ exit_code=$?
 # Since we run the payload script using launchctl, env vars such as PYTHON_PATH are not set there and we have to do this part here
 # We signal this by creating files
 if [ -f "$HELIX_WORKITEM_ROOT/.retry" ]; then
-    retry_message=$(cat "$HELIX_WORKITEM_ROOT/.retry")
+    retry_message=$(cat "$HELIX_WORKITEM_ROOT/.retry" | tr -d "'\\\\")
 
     if [ -z "$retry_message" ]; then
         retry_message='Retrying because we could not enumerate all Android devices'
@@ -55,7 +55,7 @@ if [ -f "$HELIX_WORKITEM_ROOT/.retry" ]; then
 fi
 
 if [ -f "$HELIX_WORKITEM_ROOT/.reboot" ]; then
-    reboot_message=$(cat "$HELIX_WORKITEM_ROOT/.reboot")
+    reboot_message=$(cat "$HELIX_WORKITEM_ROOT/.reboot" | tr -d "'\\\\")
 
     if [ -z "$reboot_message" ]; then
         reboot_message='Rebooting to allow Android emulator to restart'

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.apple.sh
@@ -45,11 +45,23 @@ exit_code=$?
 # Since we run the payload script using launchctl, env vars such as PYTHON_PATH are not set there and we have to do this part here
 # We signal this by creating files
 if [ -f "$HELIX_WORKITEM_ROOT/.retry" ]; then
-    "$HELIX_PYTHONPATH" -c "from helix.workitemutil import request_infra_retry; request_infra_retry('Retrying work item because XHarness workload requested it')"
+    retry_message=$(cat "$HELIX_WORKITEM_ROOT/.retry")
+
+    if [ -z "$retry_message" ]; then
+        retry_message='Retrying because we could not enumerate all Android devices'
+    fi
+
+    "$HELIX_PYTHONPATH" -c "from helix.workitemutil import request_infra_retry; request_infra_retry('$retry_message')"
 fi
 
 if [ -f "$HELIX_WORKITEM_ROOT/.reboot" ]; then
-    "$HELIX_PYTHONPATH" -c "from helix.workitemutil import request_reboot; request_reboot('Rebooting because XHarness workload requested it')"
+    reboot_message=$(cat "$HELIX_WORKITEM_ROOT/.reboot")
+
+    if [ -z "$reboot_message" ]; then
+        reboot_message='Rebooting to allow Android emulator to restart'
+    fi
+
+    "$HELIX_PYTHONPATH" -c "from helix.workitemutil import request_reboot; request_reboot('$reboot_message')"
 fi
 
 exit $exit_code

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.apple.sh
@@ -49,7 +49,7 @@ if [ -f "$HELIX_WORKITEM_ROOT/.retry" ]; then
 fi
 
 if [ -f "$HELIX_WORKITEM_ROOT/.reboot" ]; then
-    "$HELIX_PYTHONPATH" -c "from helix.workitemutil import request_reboot; request_reboot('Rebooting because XHarness workload requested it)"
+    "$HELIX_PYTHONPATH" -c "from helix.workitemutil import request_reboot; request_reboot('Rebooting because XHarness workload requested it')"
 fi
 
 exit $exit_code

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.apple.sh
@@ -44,11 +44,11 @@ exit_code=$?
 # We usually also ask the work item to be re-tried on a different machine
 # Since we run the payload script using launchctl, env vars such as PYTHON_PATH are not set there and we have to do this part here
 # We signal this by creating files
-if [ -f './.retry' ]; then
+if [ -f "$HELIX_WORKITEM_ROOT/.retry" ]; then
     "$HELIX_PYTHONPATH" -c "from helix.workitemutil import request_infra_retry; request_infra_retry('Retrying work item because XHarness workload requested it')"
 fi
 
-if [ -f './.reboot' ]; then
+if [ -f "$HELIX_WORKITEM_ROOT/.reboot" ]; then
     "$HELIX_PYTHONPATH" -c "from helix.workitemutil import request_reboot; request_reboot('Rebooting because XHarness workload requested it)"
 fi
 

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
@@ -147,8 +147,8 @@ function xharness() {
 function report_infrastructure_failure() {
     echo "Infrastructural problem reported by the user, requesting retry+reboot: $1"
 
-    touch "$HELIX_WORKITEM_ROOT/.retry"
-    touch "$HELIX_WORKITEM_ROOT/.reboot"
+    echo "$1" > "$HELIX_WORKITEM_ROOT/.retry"
+    echo "$1" > "$HELIX_WORKITEM_ROOT/.reboot"
 }
 
 # Act out the actual commands (and time constrain them to create buffer for the end of this script)

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
@@ -147,8 +147,8 @@ function xharness() {
 function report_infrastructure_failure() {
     echo "Infrastructural problem reported by the user, requesting retry+reboot: $1"
 
-    touch './.retry'
-    touch './.reboot'
+    touch "$HELIX_WORKITEM_ROOT/.retry"
+    touch "$HELIX_WORKITEM_ROOT/.reboot"
 }
 
 # Act out the actual commands (and time constrain them to create buffer for the end of this script)


### PR DESCRIPTION
Following the same pattern we already have on Apple, this should help the MonoVM team react to infrastructure failures inside of their Xunit tests (https://github.com/dotnet/runtime/issues/59679)

Also added new capability to allow setting a reason message via the `.retry`/`.reboot` file content