### PR TITLE
Pass directory path from call-site

### DIFF
--- a/eng/common/native/init-compiler.sh
+++ b/eng/common/native/init-compiler.sh
@@ -3,9 +3,10 @@
 # This file detects the C/C++ compiler and exports it to the CC/CXX environment variables
 #
 
-if [[ "$#" -lt 2 ]]; then
+if [[ "$#" -lt 3 ]]; then
   echo "Usage..."
-  echo "init-compiler.sh <Architecture> <compiler> <compiler major version> <compiler minor version>"
+  echo "init-compiler.sh <script directory> <Architecture> <compiler> <compiler major version> <compiler minor version>"
+  echo "Specify the script directory."
   echo "Specify the target architecture."
   echo "Specify the name of compiler (clang or gcc)."
   echo "Specify the major version of compiler."
@@ -13,13 +14,14 @@ if [[ "$#" -lt 2 ]]; then
   exit 1
 fi
 
-. "$( cd -P "$( dirname "$0" )" && pwd )"/../pipeline-logging-functions.sh
-
-build_arch="$1"
-compiler="$2"
+nativescriptroot="$1"
+build_arch="$2"
+compiler="$3"
 cxxCompiler="$compiler++"
-majorVersion="$3"
-minorVersion="$4"
+majorVersion="$4"
+minorVersion="$5"
+
+. "$nativescriptroot"/../pipeline-logging-functions.sh
 
 # clear the existing CC and CXX from environment
 CC=

--- a/src/Microsoft.DotNet.CMake.Sdk/build/Microsoft.DotNet.CMake.Sdk.targets
+++ b/src/Microsoft.DotNet.CMake.Sdk/build/Microsoft.DotNet.CMake.Sdk.targets
@@ -121,8 +121,9 @@
   <Target Name="_ResolveNonMSVCCompilerToolchain" Condition="'$(CMakeCompilerToolchain)' != 'MSVC' and '$(CMakeCompilerSearchScript)' == ''">
     <Error Condition="$([MSBuild]::IsOsPlatform(Windows))" Text="This SDK does not support using non-MSVC toolchains on Windows." />
     <PropertyGroup>
+      <_NativeScriptsDir>$([MSBuild]::NormalizeDirectory('$(RepositoryEngineeringDir)', 'common', 'native'))</_NativeScriptsDir>
       <CMakeCompilerSearchScript>
-      . $([MSBuild]::MakeRelative('$(MSBuildProjectDirectory)', '$(RepositoryEngineeringDir)common/native/init-compiler.sh')) $(Platform) $(CMakeCompilerToolchain) $(CMakeCompilerMajorVersion) $(CMakeCompilerMinorVersion)
+      . &quot;$([MSBuild]::MakeRelative('$(MSBuildProjectDirectory)', '$(_NativeScriptsDir)/init-compiler.sh'))&quot; &quot;$(_NativeScriptsDir)&quot; &quot;$(Platform)&quot; &quot;$(CMakeCompilerToolchain)&quot; &quot;$(CMakeCompilerMajorVersion)&quot; &quot;$(CMakeCompilerMinorVersion)&quot;
       </CMakeCompilerSearchScript>
     </PropertyGroup>
   </Target>


### PR DESCRIPTION
When init-compiler is sourced (as opposed to `eval`'d), the script was
throwing an error: `pipeline-logging-functions.sh: No such file or directory`.

Reflecting changes from https://github.com/dotnet/runtime/pull/59858.