### PR TITLE
Change owner of uploaded files to helix-runner in Apple XHarness workloads

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
@@ -192,6 +192,7 @@ if [ $exit_code -eq 86 ]; then
 fi
 
 # The simulator logs comming from the sudo-spawned Simulator.app are not readable/deletable by the helix uploader
+sudo chown -R helix-runner "$output_directory"
 chmod -R 0766 "$output_directory"
 
 # Remove empty files


### PR DESCRIPTION
Nested directories were not readable and files were not uploaded
Discovered in https://github.com/dotnet/runtime/pull/58870#issuecomment-925827242

Files belong to root as they are created during the `launchctl asuser` workaround