### PR TITLE
Use the SignedFileContentKey as the key to the engine dictionary in SignTool

### DIFF
--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -786,7 +786,7 @@ $@"<FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "CoreLibCr
 $@"<FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "ContainerSigning", "4", "ABCDEFG/MsiSetup.msi"))}"">
   <Authenticode>Microsoft400</Authenticode>
 </FilesToSign>",
-$@"<FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "engines\\MsiBootstrapper.exe-engine.exe"))}"">
+$@"<FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "engines\\0\\MsiBootstrapper.exe-engine.exe"))}"">
   <Authenticode>Microsoft400</Authenticode>
 </FilesToSign>",
 $@"<FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "ContainerSigning", "4", "MsiBootstrapper.exe"))}"">
@@ -1195,7 +1195,7 @@ $@"
 $@"<FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "ContainerSigning", "0", "ABCDEFG/MsiSetup.msi"))}"">
   <Authenticode>Microsoft400</Authenticode>
 </FilesToSign>",
- $@"<FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "engines", "MsiBootstrapper.exe-engine.exe"))}"">
+ $@"<FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "engines", "0", "MsiBootstrapper.exe-engine.exe"))}"">
   <Authenticode>Microsoft400</Authenticode>
 </FilesToSign>",
  $@"<FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "MsiBootstrapper.exe"))}"">

--- a/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
+++ b/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
@@ -155,10 +155,11 @@ namespace Microsoft.DotNet.SignTool
 
                 Dictionary<SignedFileContentKey, FileSignInfo> engines = new Dictionary<SignedFileContentKey, FileSignInfo>();
                 var workingDirectory = Path.Combine(_signTool.TempDir, "engines");
+                int engineContainer = 0;
                 // extract engines
                 foreach (var file in enginesToSign)
                 {
-                    string engineFileName = $"{Path.Combine(workingDirectory, Guid.NewGuid().ToString(), file.FileName)}{SignToolConstants.MsiEngineExtension}";
+                    string engineFileName = $"{Path.Combine(workingDirectory, $"{engineContainer}", file.FileName)}{SignToolConstants.MsiEngineExtension}";
                     _log.LogMessage(MessageImportance.Normal, $"Extracting engine from {file.FullPath}");
                     if (!RunWixTool("insignia.exe", $"-ib {file.FullPath} -o {engineFileName}",
                         workingDirectory, _signTool.WixToolsPath, _log))
@@ -170,6 +171,7 @@ namespace Microsoft.DotNet.SignTool
                     var fileUniqueKey = new SignedFileContentKey(file.ContentHash, engineFileName);
 
                     engines.Add(fileUniqueKey, file);
+                    engineContainer++;
                 }
 
                 // sign engines


### PR DESCRIPTION
### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation

When performing post-build signing on a drop that has been partially released/partially signed (ie, the installer/sdk is unreleased and unsigned, but the runtime bits are already released/signed but not marked as released in BAR), we ended up in a scenario where we would have collisions in the dictionary that controlled signing the engine files. When we extract and then sign the engines, we create a dictionary of the engines. Before, we were simply using the path to the engine as the key to the dictionary. Additionally, if there were two files with the same name, we would extract their engines to the same place. This change changes both of these things, so that we can perform post-build signing on partially signed drops:

1) Instead of using the path to the extracted engine, we use the SignedFileContentKey
2) Instead of extracting all engines from files with the same file name, use a subdirectory using a counter (so that the directories are deterministic). Since these files have already been determined to be different (they have different hashes), and we have decided to extract engines from them, we should make sure there are no collisions when extracting their engines.

This has been tested in two post-build signing scenarios:

1) No collisions, and should have the same behavior as before: https://dev.azure.com/dnceng/internal/_build/results?buildId=1403818&view=logs&j=9ff0e0af-24e7-5b0f-fa76-5e12fc9920ef&t=04e39753-8cfe-5fb5-2824-43b4c4b51e3b (confirmed that the number of engines signed in Round 2 is the same).
2) Collisions because some files are from builds that have already been signed (ie, the original failure case): https://dev.azure.com/dnceng/internal/_build/results?buildId=1404733&view=logs&j=9ff0e0af-24e7-5b0f-fa76-5e12fc9920ef&t=04e39753-8cfe-5fb5-2824-43b4c4b51e3b (confirmed the number of engines extracted is the same, but there are no collisions, and all files get signed).

Fixes https://github.com/dotnet/arcade/issues/7908