### PR TITLE
[release/5.0] Backport of changes to support x64 on arm64

### DIFF
--- a/src/Common/wix/dotnethome_x64.wxs
+++ b/src/Common/wix/dotnethome_x64.wxs
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <?ifndef Platform?>
+    <?define Platform = "$(sys.BUILDARCH)"?>
+  <?endif?>
+
+  <!-- InstallerNativeMachine matches the expected values for image file machine constants
+       https://docs.microsoft.com/en-us/windows/win32/sysinfo/image-file-machine-constants -->
+  <?if $(var.Platform)~=x86?>
+    <?define InstallerNativeMachine=332?>
+  <?elseif $(var.Platform)~=x64?>
+    <?define InstallerNativeMachine=34404?>
+  <?elseif $(var.Platform)~=arm64?>
+    <?define InstallerNativeMachine=43620?>
+  <?else?>
+    <?error Unknown platform, $(var.Platform) ?>
+  <?endif?>
+
+  <Fragment>
+    <!-- Identify when installing in emulation as when WIX_NATIVE_MACHINE does not match the installer 
+         native machine (where supported).  Also detect running under WOW on x86 using VersionNT64, 
+         since WIX_NATIVE_MACHINE cannot be retrieved on older Windows builds. -->
+    <PropertyRef Id="WIX_NATIVE_MACHINE" />
+    <SetProperty Action="Set_NON_NATIVE_ARCHITECTURE" Id="NON_NATIVE_ARCHITECTURE" Value="true" Before="CostFinalize">
+     <?if $(var.Platform)~=x86?>
+      VersionNT64 OR
+     <?endif?>
+      WIX_NATIVE_MACHINE AND NOT WIX_NATIVE_MACHINE="$(var.InstallerNativeMachine)"
+    </SetProperty>
+  </Fragment>
+
+  <?if $(var.Platform)~=x64?>
+  <Fragment>
+    <!-- When running in a non-native architecture and user hasn't specified install directory,
+         install to an x64 subdirectory.
+         This is only define for x64, since x86 has redirection and no other native architecture can install ARM64 today -->
+    <SetProperty Action="Set_DOTNETHOME_NON_NATIVE_ARCHITECTURE" Id="DOTNETHOME" Value="[ProgramFiles64Folder]dotnet\x64\" After="Set_NON_NATIVE_ARCHITECTURE">
+      NON_NATIVE_ARCHITECTURE AND NOT DOTNETHOME
+    </SetProperty>
+  </Fragment>
+  <?endif?>
+</Wix>

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk.csproj
@@ -34,6 +34,7 @@
     <None Include="targets/**/*.*" Pack="true">
       <PackagePath>targets/%(RecursiveDir)%(Filename)%(Extension)</PackagePath>
     </None>
+    <None Include="..\Common\wix\dotnethome_x64.wxs" Link="targets\windows\product\dotnethome_x64.wxs" PackagePath="%(Link)" Pack="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/bundle/bundle.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/bundle/bundle.wxs
@@ -43,9 +43,7 @@
       <PayloadGroupRef Id="DotnetCoreBAPayloads" />
     </BootstrapperApplicationRef>
 
-    <swid:Tag Regid="microsoft.com" InstallPath="[DOTNETHOME]" />
-
-    <Variable Name="DOTNETHOME" Type="string" Value="[$(var.Program_Files)]dotnet" bal:Overridable="no" />
+    <swid:Tag Regid="microsoft.com" InstallPath="[$(var.Program_Files)]dotnet" />
 
     <!-- Variables used solely for localization. -->
     <Variable Name="BUNDLEMONIKER" Type="string" Value="$(var.ProductMoniker) ($(var.TargetArchitectureDescription))" bal:Overridable="no" />
@@ -54,9 +52,7 @@
 
     <Chain DisableSystemRestore="yes" ParallelCache="yes">
       <?foreach chainedFile in $(var.ChainedDotNetPackageFiles)?>
-        <MsiPackage SourceFile="$(var.chainedFile)">
-          <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
-        </MsiPackage>
+        <MsiPackage SourceFile="$(var.chainedFile)" />
       <?endforeach?>
     </Chain>
   </Bundle>

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/product/product.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/product/product.wxs
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
 
   <?include "..\variables.wxi" ?>
@@ -51,6 +52,10 @@
         <Directory Id="DOTNETHOME" Name="dotnet" />
       </Directory>
     </Directory>
+
+    <?if $(var.Platform)~=x64?>
+    <CustomActionRef Id="Set_DOTNETHOME_NON_NATIVE_ARCHITECTURE" />
+    <?endif?>
   </Fragment>
 
 </Wix>

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets
@@ -36,7 +36,7 @@
       Text="IntermediateOutputRootPath not specified" />
 
     <PropertyGroup>
-      <WixVersion>3.14.0.4118</WixVersion>
+      <WixVersion>1.0.0-v3.14.0.5722</WixVersion>
       <WixToolsDir>$(IntermediateOutputRootPath)WixTools.$(WixVersion)/</WixToolsDir>
       <!-- Used in WiX targets to locate files. -->
       <WixInstallPath>$(WixToolsDir)</WixInstallPath>
@@ -46,10 +46,10 @@
       <MsiArch>$(TargetArchitecture)</MsiArch>
 
       <AcquireWixProjectFile>$(PackagingToolsDir)acquire-wix\acquire-wix.proj</AcquireWixProjectFile>
-      <WixDownloadFilename>wix.$(WixVersion).zip</WixDownloadFilename>
-      <WixDownloadUrl>https://dotnetcli.azureedge.net/build/wix/$(WixDownloadFilename)</WixDownloadUrl>
+      <WixDownloadFilename>Microsoft.Signed.Wix-$(WixVersion).zip</WixDownloadFilename>
+      <WixDownloadUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/wix/$(WixDownloadFilename)</WixDownloadUrl>
       <WixDestinationPath>$(WixToolsDir)$(WixDownloadFilename)</WixDestinationPath>
-      <WixDownloadSentinel>$(WixToolsDir)WixDownload.$(WixVersion).sentinel</WixDownloadSentinel>
+      <WixDownloadSentinel>$(WixToolsDir)$(WixDownloadFilename).sentinel</WixDownloadSentinel>
     </PropertyGroup>
   </Target>
 
@@ -92,6 +92,7 @@
       <WixExtensions Include="WixUtilExtension.dll" />
 
       <WixSrcFile Include="$(MSBuildThisFileDirectory)product/product.wxs" />
+      <WixSrcFile Include="$(MSBuildThisFileDirectory)product/dotnethome_x64.wxs" />
       <WixSrcFile Include="$(MSBuildThisFileDirectory)product/provider.wxs" />
     </ItemGroup>
   </Target>


### PR DESCRIPTION
Backporting all changes in Arcade to support x64 on arm64. Some of the changes are not applicable in the older codebase, and some others are in a different place (dotnet/runtime).

6.0 changes:
- https://github.com/dotnet/arcade/commit/4fbe444a1a9794fb9affa5ea7236bef92dcf44b9
- https://github.com/dotnet/arcade/commit/225f864e03d9d012a7b7987feb9c1600b9931a67
- https://github.com/dotnet/arcade/commit/a0aa5f36cbf2d3a8570d350711102d7fb6aaefb9
- https://github.com/dotnet/arcade/commit/aa0a3d3b95ea3744a9ea643217766b7b10e8bfbe
- https://github.com/dotnet/arcade/commit/fe23bc12e191c8390d445f1f441ddd3560f341ed
- https://github.com/dotnet/arcade/commit/3abbdb89f63d146a52c999724d409675f6fdcaf2
- https://github.com/dotnet/arcade/commit/b14e0fbfcee98fc5c20d40743e862fd25c9776f6
- https://github.com/dotnet/arcade/commit/c575da80f465e0b5fb98f416be92bb98b2f54b41
- https://github.com/dotnet/arcade/commit/bcd4d30e035e75b9904721d782b035b1a546d73a
- https://github.com/dotnet/arcade/commit/ee8d37dc8994143757d3948348ac66b7b9f736a6
- https://github.com/dotnet/arcade/commit/9eab7b05e57fcc8974884769cc6beb71179ec50e
