### PR TITLE
Update dependencies from dotnet/sourcelink

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -51,14 +51,14 @@
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>a1f528d854ee057290682490a74e59a809fe453f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.1.0-beta-21423-02">
+    <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.1.0-beta-21480-02">
       <Uri>https://github.com/dotnet/sourcelink</Uri>
-      <Sha>6dcc7d005e38829efb6714d2ecfc4c0cb383e7d9</Sha>
+      <Sha>8031e5220baf2acad991e661d8308b783d2acf3e</Sha>
       <SourceBuild RepoName="sourcelink" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.SourceLink.AzureRepos.Git" Version="1.1.0-beta-21423-02">
+    <Dependency Name="Microsoft.SourceLink.AzureRepos.Git" Version="1.1.0-beta-21480-02">
       <Uri>https://github.com/dotnet/sourcelink</Uri>
-      <Sha>6dcc7d005e38829efb6714d2ecfc4c0cb383e7d9</Sha>
+      <Sha>8031e5220baf2acad991e661d8308b783d2acf3e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DiaSymReader.Pdb2Pdb" Version="1.1.0-beta2-19575-01">
       <Uri>https://github.com/dotnet/symreader-converter</Uri>


### PR DESCRIPTION
Picking up latest dotnet/sourcelink.  This is needed in order to flow https://github.com/dotnet/sourcelink/pull/742 which is required to eliminate some source-build patches (https://github.com/dotnet/source-build/issues/2348).  The version of sourcelink the Installer picks up is tied to arcade (https://github.com/dotnet/installer/blob/release/6.0.1xx/eng/Version.Details.xml#L219).
