### PR TITLE
[release/6.0] Make scheduling of upgrade configurable 

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/README.md
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/README.md
@@ -23,6 +23,8 @@ If you have files that need to have a stabilized identity in the MSI file, you c
 
 If you want to create MSIs for the target RID that target other architecture install locations, you can add `CrossArchSdkMsiInstallerArch` items for all of the target architecture install locations you want to generate installers of the current build for.
 
+To control the order in which an older product is removed during an upgrade, set the `MajorUpgradeSchedule` property to a value defined [here](https://wixtoolset.org/documentation/manual/v3/xsd/wix/majorupgrade.html).  The default is `afterInstallInitialize`.
+
 ### Linux package configuration
 
 To add package dependencies for linux packages, add a `LinuxPackageDependency` item with the version in the `Version` metadata.

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/product/product.common.wxi
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/product/product.common.wxi
@@ -3,7 +3,11 @@
 
   <Package Compressed="yes" InstallScope="perMachine" InstallerVersion="$(var.InstallerVersion)" />
 
-  <MajorUpgrade DowngradeErrorMessage="$(var.DowngradeErrorMessage)" Schedule="afterInstallInitialize"/>
+  <?ifndef MajorUpgradeSchedule?>
+    <?define MajorUpgradeSchedule = afterInstallInitialize?>
+  <?endif?>
+
+  <MajorUpgrade DowngradeErrorMessage="$(var.DowngradeErrorMessage)" Schedule="$(var.MajorUpgradeSchedule)"/>
 
   <MediaTemplate CompressionLevel="high" EmbedCab="yes"/>
 

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets
@@ -290,6 +290,7 @@
       <CandleVariables Include="NugetVersion" Value="$(Version)" />
       <CandleVariables Include="TargetArchitectureDescription" Value="$(InstallerTargetArchitecture)$(CrossArchContentsBuildPart)" />
       <CandleVariables Include="UpgradeCode" Value="$(UpgradeCode)" />
+      <CandleVariables Include="MajorUpgradeSchedule" Value="$(MajorUpgradeSchedule)" Condition="'$(MajorUpgradeSchedule)' != ''" />
 
       <!-- If this is a cross-arch MSI, add target arch to the dependency key for uniqueness. -->
       <CandleVariables Include="CrossArchContentsPlatformPart" Value="$(CrossArchContentsBuildPart.Replace('-', '_'))" />


### PR DESCRIPTION
Port of https://github.com/dotnet/arcade/pull/8025 to 6.0.  Necessary to fix PATH reordering bug.

As is, this change does nothing but provides a hook for installers to opt-in to change their scheduling of RemoveExistingProducts in their major upgrade.