### PR TITLE
[release/5.0] Make scheduling of upgrade configurable

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/product/product.common.wxi
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/product/product.common.wxi
@@ -3,7 +3,11 @@
 
   <Package Compressed="yes" InstallScope="perMachine" InstallerVersion="$(var.InstallerVersion)" />
 
-  <MajorUpgrade DowngradeErrorMessage="$(var.DowngradeErrorMessage)" Schedule="afterInstallInitialize"/>
+  <?ifndef MajorUpgradeSchedule?>
+    <?define MajorUpgradeSchedule = afterInstallInitialize?>
+  <?endif?>
+
+  <MajorUpgrade DowngradeErrorMessage="$(var.DowngradeErrorMessage)" Schedule="$(var.MajorUpgradeSchedule)"/>
 
   <MediaTemplate CompressionLevel="high" EmbedCab="yes"/>
 

--- a/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/targets/windows/wix.targets
@@ -291,6 +291,7 @@
       <CandleVariables Include="NugetVersion" Value="$(ProductVersion)" />
       <CandleVariables Include="TargetArchitectureDescription" Value="$(TargetArchitecture)$(CrossArchContentsBuildPart)" />
       <CandleVariables Include="UpgradeCode" Value="$(UpgradeCode)" />
+      <CandleVariables Include="MajorUpgradeSchedule" Value="$(MajorUpgradeSchedule)" Condition="'$(MajorUpgradeSchedule)' != ''" />
 
       <!-- If this is a cross-arch MSI, add target arch to the dependency key for uniqueness. -->
       <CandleVariables Include="CrossArchContentsPlatformPart" Value="$(CrossArchContentsBuildPart.Replace('-', '_'))" />


### PR DESCRIPTION
Port of #8025 to 5.0. Necessary to fix PATH reordering bug.

Allow for a product to control the scheduling of Major Upgrade. We'll do this in the host installer to make upgrade late and preserve PATH.
