### PR TITLE
Collect system log for failed Apple XHarness work items

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
@@ -17,6 +17,7 @@ expected_exit_code=0
 includes_test_runner=false
 reset_simulator=false
 
+# Ignore shellcheck lint warning about unused variables (they can be used in the sourced script)
 # shellcheck disable=SC2034
 while [[ $# -gt 0 ]]; do
     opt="$(echo "$1" | tr "[:upper:]" "[:lower:]")"


### PR DESCRIPTION
Includes last 2MB of system logs when non-successful XHarness run happens.

Example log produced (AppleTV queue):
https://helixre8s23ayyeko0k025g8.blob.core.windows.net/arcade-master-bb216063e24f47aeb5/zipped-apps/1/system.log?sv=2019-07-07&se=2021-11-07T11%3A40%3A28Z&sr=c&sp=rl&sig=Mn7HdREClzK0D%2FikVdFG0%2FBDWn6TUuT%2B0Ps93w7CZA0%3D

Resolves https://github.com/dotnet/xharness/issues/702
Resolves https://github.com/dotnet/arcade/issues/7789

