### PR TITLE
Update Microsoft.Net.Sdk.WorkloadManifestReader - release/6.0 version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -83,7 +83,7 @@
     <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.21427.1</MicrosoftDotNetXHarnessCLIVersion>
     <MicrosoftSymbolUploaderBuildTaskVersion>2.0.0-preview.1.21466.7</MicrosoftSymbolUploaderBuildTaskVersion>
     <MicrosoftSymbolUploaderVersion>2.0.0-preview.1.21466.7</MicrosoftSymbolUploaderVersion>
-    <MicrosoftNetSdkWorkloadManifestReaderVersion>6.0.100-preview.5.21254.11</MicrosoftNetSdkWorkloadManifestReaderVersion>
+    <MicrosoftNetSdkWorkloadManifestReaderVersion>6.0.100-rtm.21515.10</MicrosoftNetSdkWorkloadManifestReaderVersion>
     <MicrosoftDeploymentDotNetReleasesVersion>1.0.0-preview1.1.21116.1</MicrosoftDeploymentDotNetReleasesVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/VisualStudioComponentTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/VisualStudioComponentTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
         public void ItAssignsDefaultValues()
         {
             WorkloadManifest manifest = Create("WorkloadManifest.json");
-            WorkloadDefinition definition = manifest.Workloads.FirstOrDefault().Value;
+            WorkloadDefinition definition = (WorkloadDefinition)manifest.Workloads.FirstOrDefault().Value;
             VisualStudioComponent component = VisualStudioComponent.Create(null, manifest, definition, NoItems, NoItems, NoItems, NoItems);
 
             string swixProjDirectory = RandomPath;
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
         public void ItCanOverrideDefaultValues()
         {
             WorkloadManifest manifest = Create("WorkloadManifest.json");
-            WorkloadDefinition definition = manifest.Workloads.FirstOrDefault().Value;
+            WorkloadDefinition definition = (WorkloadDefinition)manifest.Workloads.FirstOrDefault().Value;
 
             ITaskItem[] resources = new ITaskItem[]
             {
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
         public void ItCreatesSafeComponentIds()
         {
             WorkloadManifest manifest = Create("WorkloadManifest.json");
-            WorkloadDefinition definition = manifest.Workloads.FirstOrDefault().Value;
+            WorkloadDefinition definition = (WorkloadDefinition)manifest.Workloads.FirstOrDefault().Value;
             VisualStudioComponent component = VisualStudioComponent.Create(null, manifest, definition, NoItems, NoItems, NoItems, NoItems);
 
             string swixProjDirectory = RandomPath;
@@ -84,7 +84,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
         public void ItCreatesComponentsWhenWorkloadsDoNotIncludePacks()
         {
             WorkloadManifest manifest = Create("mauiWorkloadManifest.json");
-            WorkloadDefinition definition = manifest.Workloads.FirstOrDefault().Value;
+            WorkloadDefinition definition = (WorkloadDefinition)manifest.Workloads.FirstOrDefault().Value;
             VisualStudioComponent component = VisualStudioComponent.Create(null, manifest, definition, NoItems, NoItems, NoItems, NoItems);
 
             string swixProjDirectory = RandomPath;

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateWorkloadMsis.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateWorkloadMsis.cs
@@ -140,9 +140,11 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             // platform includes Windows
             var workloads = manifests.SelectMany(m => m.Workloads).
                 Select(w => w.Value).
-                Where(wd => (wd.Platforms == null) || wd.Platforms.Any(p => p.StartsWith("win")));
+                Where(wd => wd is WorkloadDefinition).
+                Where(wd => (((WorkloadDefinition)wd).Platforms == null) || ((WorkloadDefinition)wd).Platforms.Any(p => p.StartsWith("win")));
 
-            var packIds = workloads.Where(w => w.Packs != null).SelectMany(w => w.Packs).Distinct();
+            var packIds = workloads.Where(wd => wd is WorkloadDefinition).
+                                    Where(w => (((WorkloadDefinition)w).Packs != null)).SelectMany(w => ((WorkloadDefinition)w).Packs).Distinct();
 
             return manifests.SelectMany(m => m.Packs.Values).
                 Where(p => packIds.Contains(p.Id)).

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/VisualStudioComponent.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/VisualStudioComponent.cs
@@ -249,7 +249,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             // processing direct pack dependencies
             if (workload.Extends?.Count() > 0)
             {
-                foreach (WorkloadDefinitionId dependency in workload.Extends)
+                foreach (WorkloadId dependency in workload.Extends)
                 {
                     // Component dependencies, aka. workload extensions only have minimum version dependencies.
                     component.AddDependency($"{Utils.ToSafeId(dependency.ToString())}", new Version("1.0.0.0"), maxVersion: null);


### PR DESCRIPTION
### To double check:

https://github.com/dotnet/arcade/issues/7880 - same change as already merged in main for rel/6.0 branch, as this was the actually asked-for version .

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
