### PR TITLE
Fix isolated feed issue

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/SetupTargetFeedConfigV3Tests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/SetupTargetFeedConfigV3Tests.cs
@@ -437,5 +437,18 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
 
             return true;
         }
+
+        [Fact]
+        public void MustHaveSeparateTargetFeedSpecificationsForShippingAndNonShipping()
+        {
+            Action shouldFail = () => new TargetFeedSpecification(new TargetFeedContentType[] { TargetFeedContentType.Package }, "FooFeed", AssetSelection.All);
+            shouldFail.Should().Throw<ArgumentException>();
+
+            Action shouldPassShippingOnly = () => new TargetFeedSpecification(new TargetFeedContentType[] { TargetFeedContentType.Package }, "FooFeed", AssetSelection.ShippingOnly);
+            shouldPassShippingOnly.Should().NotThrow();
+
+            Action shouldPassNonShippingOnly = () => new TargetFeedSpecification(new TargetFeedContentType[] { TargetFeedContentType.Package }, "FooFeed", AssetSelection.NonShippingOnly);
+            shouldPassNonShippingOnly.Should().NotThrow();
+        }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
@@ -155,7 +155,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
 
         private static TargetFeedSpecification[] DotNet31BlazorFeeds =
         {
-            (TargetFeedContentType.Package, FeedDotNet31Blazor),
+            (TargetFeedContentType.Package, FeedDotNet31Blazor, AssetSelection.ShippingOnly),
+            (TargetFeedContentType.Package, FeedDotNet31Blazor, AssetSelection.NonShippingOnly),
             (InstallersAndSymbols, FeedInternalForInstallers),
             (TargetFeedContentType.Checksum, FeedInternalForChecksums),
         };
@@ -204,35 +205,40 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
 
         private static TargetFeedSpecification[] DotNetEngFeeds =
         {
-            (TargetFeedContentType.Package, FeedDotNetEng),
+            (TargetFeedContentType.Package, FeedDotNetEng, AssetSelection.ShippingOnly),
+            (TargetFeedContentType.Package, FeedDotNetEng, AssetSelection.NonShippingOnly),
             (InstallersAndSymbols, FeedForInstallers),
             (TargetFeedContentType.Checksum, FeedForChecksums),
         };
 
         private static TargetFeedSpecification[] DotNetToolsFeeds =
         {
-            (TargetFeedContentType.Package, FeedDotNetTools),
+            (TargetFeedContentType.Package, FeedDotNetTools, AssetSelection.ShippingOnly),
+            (TargetFeedContentType.Package, FeedDotNetTools, AssetSelection.NonShippingOnly),
             (InstallersAndSymbols, FeedForInstallers),
             (TargetFeedContentType.Checksum, FeedForChecksums),
         };
 
         private static TargetFeedSpecification[] DotNetToolsInternalFeeds =
         {
-            (TargetFeedContentType.Package, FeedDotNetToolsInternal),
+            (TargetFeedContentType.Package, FeedDotNetToolsInternal, AssetSelection.ShippingOnly),
+            (TargetFeedContentType.Package, FeedDotNetToolsInternal, AssetSelection.NonShippingOnly),
             (InstallersAndSymbols, FeedInternalForInstallers),
             (TargetFeedContentType.Checksum, FeedInternalForChecksums),
         };
 
         private static TargetFeedSpecification[] DotNetExperimentalFeeds =
         {
-            (TargetFeedContentType.Package, FeedDotNetExperimental),
+            (TargetFeedContentType.Package, FeedDotNetExperimental, AssetSelection.ShippingOnly),
+            (TargetFeedContentType.Package, FeedDotNetExperimental, AssetSelection.NonShippingOnly),
             (InstallersAndSymbols, FeedForInstallers),
             (TargetFeedContentType.Checksum, FeedForChecksums),
         };
 
         private static TargetFeedSpecification[] GeneralTestingFeeds =
         {
-            (TargetFeedContentType.Package, FeedGeneralTesting),
+            (TargetFeedContentType.Package, FeedGeneralTesting, AssetSelection.ShippingOnly),
+            (TargetFeedContentType.Package, FeedGeneralTesting, AssetSelection.NonShippingOnly),
             (InstallersAndSymbols, FeedForInstallers),
             (TargetFeedContentType.Checksum, FeedForChecksums),
             (InstallersAndSymbols, FeedStagingForInstallers),
@@ -241,7 +247,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
 
         private static TargetFeedSpecification[] GeneralTestingInternalFeeds =
         {
-            (TargetFeedContentType.Package, FeedGeneralTestingInternal),
+            (TargetFeedContentType.Package, FeedGeneralTestingInternal, AssetSelection.ShippingOnly),
+            (TargetFeedContentType.Package, FeedGeneralTestingInternal, AssetSelection.NonShippingOnly),
             (InstallersAndSymbols, FeedInternalForInstallers),
             (TargetFeedContentType.Checksum, FeedInternalForChecksums),
             (InstallersAndSymbols, FeedStagingInternalForInstallers),

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetChannelConfig.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetChannelConfig.cs
@@ -153,6 +153,15 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
 
         public TargetFeedSpecification(IEnumerable<TargetFeedContentType> contentTypes, string feedUrl, AssetSelection assets)
         {
+            // A feed targeted for content type 'Package' may not have asset selection 'All'.
+            // During TargetFeedConfig creation, the default feed spec for shipping packages will be ignored and replaced with
+            // a separate target feed config.
+
+            if (assets == AssetSelection.All && contentTypes.Contains(TargetFeedContentType.Package))
+            {
+                throw new ArgumentException($"Target feed specification for {feedUrl} must have a separated asset selection 'ShippingOnly' and 'NonShippingOnly packages");
+            }
+
             ContentTypes = contentTypes.ToImmutableList();
             FeedUrl = feedUrl;
             Assets = assets;


### PR DESCRIPTION
When the new target feed specifications were created, they collapsed down the feed specs for shipping and non-shipping package asset selection in cases where the target would be the same feed. This subtlety was required though, since in case of a stable build, we want just the shipping packages to go to a separate, newly created feed. The current code correct substitutes this if the TargetFeedSpecifications are broken out for ShippingOnly and NonShippingOnly, but there are a number of channels that did not break them out. Instead, it tried to send shipping packages to the isolated feed, and all packages to the non-isolated feed.

To fix this, separate out the TargetFeedSpecifications and put a check into the constructor to ensure that this can't be done accidentally.
Also
- Do a little refactoring for clarity.
- Add a test to ensure that this throws

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
