### PR TITLE
Add back the quotes to sdl configuration

### DIFF
--- a/eng/common/sdl/configure-sdl-tool.ps1
+++ b/eng/common/sdl/configure-sdl-tool.ps1
@@ -69,13 +69,13 @@ try {
     # For some tools, add default and automatic args.
     if ($tool.Name -eq 'credscan') {
       if ($targetDirectory) {
-        $tool.Args += "TargetDirectory < $TargetDirectory"
+        $tool.Args += "`"TargetDirectory < $TargetDirectory`""
       }
-      $tool.Args += "OutputType < pre"
+      $tool.Args += "`"OutputType < pre`""
       $tool.Args += $CrScanAdditionalRunConfigParams
     } elseif ($tool.Name -eq 'policheck') {
       if ($targetDirectory) {
-        $tool.Args += "Target < $TargetDirectory"
+        $tool.Args += "`"Target < $TargetDirectory`""
       }
       $tool.Args += $PoliCheckAdditionalRunConfigParams
     }


### PR DESCRIPTION
When the code for running the configure step in sdl validation was moved, the quotes were removed from the tool args. This prevents us from upgrading the version of guardian, because newer versions of guardian get confused by the triangle brackets. This change adds back the quotes around each tool arg.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
