### PR TITLE
Add a check to exit sourcelink validation early if InputPath doesn't exit

### DIFF
--- a/eng/common/post-build/sourcelink-validation.ps1
+++ b/eng/common/post-build/sourcelink-validation.ps1
@@ -22,6 +22,11 @@ $RetryWaitTimeInSeconds = 30
 # Wait time between check for system load
 $SecondsBetweenLoadChecks = 10
 
+if (!$InputPath -or !(Test-Path $InputPath)){
+  Write-Host "No files to validate."
+  ExitWithExitCode 0
+}
+
 $ValidatePackage = {
   param( 
     [string] $PackagePath                                 # Full path to a Symbols.NuGet package


### PR DESCRIPTION
If the $InputPath parameter is a directory that doesn't exist, we should exit sourcelink-validation early.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
