### PR TITLE
[release/6.0] Add check for translations in mac pkg installers

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateMacOSDistributionFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateMacOSDistributionFile.cs
@@ -44,14 +44,18 @@ namespace Microsoft.DotNet.SharedFramework.Sdk
     var machine = system.sysctl(""hw.machine"");
     var cputype = system.sysctl(""hw.cputype"");
     var cpu64 = system.sysctl(""hw.cpu64bit_capable"");
+    var translated = system.sysctl(""sysctl.proc_translated"");
     system.log(""Machine type: "" + machine);
     system.log(""Cpu type: "" + cputype);
     system.log(""64-bit: "" + cpu64);
-
+    system.log(""Translated: "" + translated);
+    
     // From machine.h
     // CPU_TYPE_X86_64 = CPU_TYPE_X86 | CPU_ARCH_ABI64 = 0x010000007 = 16777223
     // CPU_TYPE_X86 = 7
     var result = machine == ""amd64"" || machine == ""x86_64"" || cputype == ""16777223"" || (cputype == ""7"" && cpu64 == ""1"");
+    // We may be running under translation (Rosetta) that makes it seem like system is x64, if so assume machine is not actually x64
+    result = result && (translated != ""1"");
     system.log(""IsX64Machine: "" + result);
     return result;
 }";


### PR DESCRIPTION
Backport of missed commit https://github.com/dotnet/arcade/commit/42b72b125d07dbc8fb3145fc10a8f332961bc0ba

## Customer Impact

Installing x64 runtime bundle result in bits being installed to the wrong location.

## Testing

Manual installation on M1 to confirm fix

## Risk

Low.  This change was made and tested in main and has been present there for a month.  I missed it when collecting all the commits for backport.