### PR TITLE
Making ConvertPortablePdbsToWindowsPdbs settable

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
@@ -69,6 +69,8 @@
           - InternalInstallersTargetStaticFeedKey
           - InternalChecksumsTargetStaticFeed
           - InternalChecksumsTargetStaticFeedKey
+
+    NOTE: For symbol publishing using V3, ConvertPortablePdbsToWindowsPdbs is always set to false, because this is an expensive task so this is done in the staging pipeline post signing.
   -->
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishToSymbolServers.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishToSymbolServers.proj
@@ -37,6 +37,9 @@
       <PackagesToPublishToSymbolServer Remove="$(BlobBasePath)\Microsoft.DotNet.Maestro.Tasks.*" />
     </ItemGroup>
 
+    <!--
+    ConvertPortablePdbsToWindowsPdbs is set to true only in staging pipeline, because this is an expensive task and we don't want to do it for every build.
+    -->
     <PropertyGroup>
       <DotNetSymbolExpirationInDays Condition="'$(DotNetSymbolExpirationInDays)' == ''">3650</DotNetSymbolExpirationInDays>
       <PublishToSymbolServer>true</PublishToSymbolServer>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -494,6 +494,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                                 try
                                 {
+                                    // ConvertPortablePdbsToWindowsPdbs is always set to false, 
+                                    // because this is an expensive task so this is done in the staging pipeline post signing.
                                     await PublishSymbolsHelper.PublishAsync(
                                         Log,
                                         serverPath,
@@ -560,6 +562,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     
                     try
                     {
+                        // ConvertPortablePdbsToWindowsPdbs is always set to false,
+                        // because this is an expensive task so this is done in the staging pipeline post signing.
                         await PublishSymbolsHelper.PublishAsync(
                             Log,
                             serverPath,
@@ -686,6 +690,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     
                     try
                     {
+                        // ConvertPortablePdbsToWindowsPdbs is always set to false,
+                        // because this is an expensive task so this is done in the staging pipeline post signing.
                         await PublishSymbolsHelper.PublishAsync(
                             Log,
                             serverPath,


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation

Issue => https://github.com/dotnet/arcade/issues/7988

Part 1 : Make ConvertPortablePdbsToWindowsPdbs settable, so that we can set the value for this param in staging pipeline, 
