### PR TITLE
Updating Helix SDK from WindowsAzure.Storage (no longer supported) to Azure.Storage.Blobs

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,7 +13,8 @@
     <LibGit2SharpVersion>0.25.2</LibGit2SharpVersion>
     <log4netVersion>2.0.10</log4netVersion>
     <SystemNetHttpVersion>4.3.4</SystemNetHttpVersion>
-    <AzureStorageBlobsVersion>12.3.0</AzureStorageBlobsVersion>
+    <AzureCoreVersion>1.19.0</AzureCoreVersion>
+    <AzureStorageBlobsVersion>12.10.0</AzureStorageBlobsVersion>
     <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>
     <MicrosoftApplicationInsightsVersion>2.16.0</MicrosoftApplicationInsightsVersion>
     <MicrosoftAzureKeyVaultVersion>3.0.0</MicrosoftAzureKeyVaultVersion>
@@ -62,7 +63,7 @@
     <SystemRuntimeInteropServicesRuntimeInformation>4.3.0</SystemRuntimeInteropServicesRuntimeInformation>
     <SystemTextEncodingsWebVersion>4.7.2</SystemTextEncodingsWebVersion>
     <SystemThreadingTasksExtensionVersion>4.5.2</SystemThreadingTasksExtensionVersion>
-    <SystemValueTupleVersion>4.4.0</SystemValueTupleVersion>
+    <SystemValueTupleVersion>4.5.0</SystemValueTupleVersion>
     <WindowsAzureStorageVersion>8.5.0</WindowsAzureStorageVersion>
     <XUnitVersion>2.4.2-pre.9</XUnitVersion>
     <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.0.2.0" />
+    <PackageReference Include="Azure.Core" Version="$(AzureCoreVersion)" />
     <PackageReference Include="Azure.Storage.Blobs" Version="$(AzureStorageBlobsVersion)" />
     <PackageReference Include="DotNet.SleetLib" Version="$(DotNetSleetLibVersion)" />
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/Microsoft.DotNet.Helix.Client.csproj
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/Microsoft.DotNet.Helix.Client.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.5.0" />
+    <PackageReference Include="Azure.Core" Version="$(AzureCoreVersion)" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />

--- a/src/Microsoft.DotNet.Helix/JobSender/Microsoft.DotNet.Helix.JobSender.csproj
+++ b/src/Microsoft.DotNet.Helix/JobSender/Microsoft.DotNet.Helix.JobSender.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs" Version="$(AzureStorageBlobsVersion)" /> 
     <PackageReference Include="Microsoft.Data.OData" Version="$(MicrosoftDataODataVersion)" />
     <PackageReference Include="System.IO.Compression" Version="$(SystemIOCompressionVersion)" />
     <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
-    <PackageReference Include="WindowsAzure.Storage" Version="$(WindowsAzureStorageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Helix/JobSender/StorageHelpers/ApiBlobHelper.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/StorageHelpers/ApiBlobHelper.cs
@@ -1,9 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure;
+using Azure.Storage.Blobs;
 using Microsoft.DotNet.Helix.Client.Models;
-using Microsoft.WindowsAzure.Storage.Auth;
-using Microsoft.WindowsAzure.Storage.Blob;
 
 namespace Microsoft.DotNet.Helix.Client
 {
@@ -20,17 +23,18 @@ namespace Microsoft.DotNet.Helix.Client
         public async Task<IBlobContainer> GetContainerAsync(string requestedName, string targetQueue, CancellationToken cancellationToken)
         {
             ContainerInformation info = await _helixApiStorage.NewAsync(new ContainerCreationRequest(30, requestedName, targetQueue), cancellationToken).ConfigureAwait(false);
-            var client = new CloudBlobClient(new Uri($"https://{info.StorageAccountName}.blob.core.windows.net/"), new StorageCredentials(info.WriteToken));
-            CloudBlobContainer container = client.GetContainerReference(info.ContainerName);
+            Uri containerUri = new Uri($"https://{info.StorageAccountName}.blob.core.windows.net/{info.ContainerName}");
+            AzureSasCredential creds = new AzureSasCredential(info.WriteToken);
+            var container = new BlobContainerClient(containerUri, creds, StorageRetryPolicy.GetBlobClientOptionsRetrySettings());
             return new Container(container, info);
         }
 
         private class Container : ContainerBase
         {
-            private readonly CloudBlobContainer _container;
+            private readonly BlobContainerClient _container;
             private readonly ContainerInformation _info;
 
-            public Container(CloudBlobContainer container, ContainerInformation info)
+            public Container(BlobContainerClient container, ContainerInformation info)
             {
                 _container = container;
                 _info = info;
@@ -40,7 +44,7 @@ namespace Microsoft.DotNet.Helix.Client
             public override string ReadSas => _info.ReadToken;
             public override string WriteSas => _info.WriteToken;
 
-            protected override (CloudBlockBlob blob, string sasToken) GetBlob(string blobName)
+            protected override (BlobClient blob, string sasToken) GetBlob(string blobName)
             {
                 string sasToken = _info.ReadToken;
                 if (sasToken.StartsWith("?"))
@@ -48,7 +52,7 @@ namespace Microsoft.DotNet.Helix.Client
                     sasToken = sasToken.Substring(1);
                 }
 
-                CloudBlockBlob blob = _container.GetBlockBlobReference(blobName);
+                BlobClient blob = _container.GetBlobClient(blobName);
                 return (blob, sasToken);
             }
         }

--- a/src/Microsoft.DotNet.Helix/JobSender/StorageHelpers/IBlobContainer.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/StorageHelpers/IBlobContainer.cs
@@ -1,13 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
-using System.Diagnostics;
 using System.IO;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.DotNet.Helix.Client.Models;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Auth;
-using Microsoft.WindowsAzure.Storage.Blob;
 
 namespace Microsoft.DotNet.Helix.Client
 {

--- a/src/Microsoft.DotNet.Helix/JobSender/StorageHelpers/IBlobHelper.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/StorageHelpers/IBlobHelper.cs
@@ -1,13 +1,9 @@
-using System;
-using System.Diagnostics;
-using System.IO;
-using System.Text;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.DotNet.Helix.Client.Models;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Auth;
-using Microsoft.WindowsAzure.Storage.Blob;
+
 
 namespace Microsoft.DotNet.Helix.Client
 {

--- a/src/Microsoft.DotNet.Helix/JobSender/StorageHelpers/StorageRetryPolicy.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/StorageHelpers/StorageRetryPolicy.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Azure.Core;
+using Azure.Storage.Blobs;
+
+namespace Microsoft.DotNet.Helix.Client
+{
+    class StorageRetryPolicy
+    {
+        internal static BlobClientOptions GetBlobClientOptionsRetrySettings()
+        {
+            // If this takes way too long in failure mode, or doesn't retry enough, change the settings here to impact all *BlobHelper classes
+
+            BlobClientOptions options = new BlobClientOptions();
+            options.Retry.Delay = TimeSpan.FromSeconds(5);
+            options.Retry.MaxDelay = TimeSpan.FromSeconds(30);
+            options.Retry.MaxRetries = 10;
+            options.Retry.Mode = RetryMode.Exponential;
+
+            return options;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Helix/Sdk/DownloadFromResultsContainer.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/DownloadFromResultsContainer.cs
@@ -1,12 +1,11 @@
-using Microsoft.Build.Framework;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Auth;
-using Microsoft.WindowsAzure.Storage.Blob;
 using System;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure;
+using Azure.Storage.Blobs;
+using Microsoft.Build.Framework;
 
 namespace Microsoft.DotNet.Helix.Sdk
 {
@@ -100,12 +99,12 @@ namespace Microsoft.DotNet.Helix.Sdk
                         // 1 until helix provides an API to get result files from the "good" iteration run.
                         // https://github.com/dotnet/core-eng/issues/13983
                         var uri = new Uri($"{ResultsContainer}{workItemName}/1/{file}");
-                        CloudBlob blob = string.IsNullOrEmpty(ResultsContainerReadSAS) ? new CloudBlob(uri) : new CloudBlob(uri, new StorageCredentials(ResultsContainerReadSAS));
-                        await blob.DownloadToFileAsync(destinationFile, FileMode.Create);
+                        BlobClient blob = string.IsNullOrEmpty(ResultsContainerReadSAS) ? new BlobClient(uri) : new BlobClient(uri, new AzureSasCredential(ResultsContainerReadSAS));
+                        await blob.DownloadToAsync(destinationFile);
                     }
-                    catch (StorageException e)
+                    catch (RequestFailedException rfe)
                     {
-                        Log.LogWarning($"Failed to download {workItemName}/1/{file} blob from results container: {e.Message}");
+                        Log.LogWarning($"Failed to download {workItemName}/1/{file} blob from results container: {rfe.Message}");
                     }
                 }
             };


### PR DESCRIPTION
Migrate to the actually-in-support version of the C# client library (Azure.Storage.Blobs) and plumb through a generous retry policy to try to prevent failures as noted in the linked issue.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation (running CI validation explicitly exercises this code path)
