### PR TITLE
Update hosted VS 2017 usage to 2019, including private pool provider builds

### DIFF
--- a/azure-pipelines-code-mirror.yml
+++ b/azure-pipelines-code-mirror.yml
@@ -10,7 +10,7 @@ jobs:
     jobs:
     - job: Merge_GitHub_to_Azure_DevOps
       pool:
-        name: Hosted VS2017
+        vmImage: windows-2019
       variables:
       - name: WorkingDirectoryName
         value: repo-dir

--- a/azure-pipelines-merge-mirror.yml
+++ b/azure-pipelines-merge-mirror.yml
@@ -10,7 +10,7 @@ jobs:
     jobs:
     - job: Merge_GitHub_to_Azure_DevOps
       pool:
-        name: Hosted VS2017
+        vmImage: windows-2019
       variables:
       - name: WorkingDirectoryName
         value: repo-dir

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,10 +56,10 @@ stages:
           # Will eventually change this to two BYOC pools.
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
             name: NetCore1ESPool-Svc-Public
-            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2017.Open
+            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
             name: NetCore1ESPool-Svc-Internal
-            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2017
+            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
         variables:
         - _Script: eng\common\cibuild.cmd
         - _ValidateSdkArgs: ''

--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -19,7 +19,7 @@ jobs:
   variables:
     - group: DotNet-VSTS-Bot
   pool:
-    name: Hosted VS2017
+    vmImage: windows-2019
   steps:
   - checkout: self
     clean: true

--- a/eng/common/templates/job/onelocbuild.yml
+++ b/eng/common/templates/job/onelocbuild.yml
@@ -4,7 +4,7 @@ parameters:
 
   # Optional: A defined YAML pool - https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=vsts&tabs=schema#pool
   pool:
-    vmImage: vs2017-win2016
+    vmImage: windows-2019
 
   CeapexPat: $(dn-bot-ceapex-package-r) # PAT for the loc AzDO instance https://dev.azure.com/ceapex
   GithubPat: $(BotAccount-dotnet-bot-repo-PAT)

--- a/eng/common/templates/jobs/jobs.yml
+++ b/eng/common/templates/jobs/jobs.yml
@@ -74,7 +74,7 @@ jobs:
         - ${{ each job in parameters.jobs }}:
           - ${{ job.job }}
       pool:
-        vmImage: vs2017-win2016
+        vmImage: windows-2019
       runAsPublic: ${{ parameters.runAsPublic }}
       publishUsingPipelines: ${{ parameters.enablePublishUsingPipelines }}
       enablePublishBuildArtifacts: ${{ parameters.enablePublishBuildArtifacts }}
@@ -87,4 +87,4 @@ jobs:
       dependsOn:
         - Asset_Registry_Publish
       pool:
-        vmImage: vs2017-win2016
+        vmImage: windows-2019


### PR DESCRIPTION
This change is in anticipation of the win2016-vs2017 image's deprecation this month, tracking issue https://github.com/dotnet/core-eng/issues/14783

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation (validated in main first and this is (mostly) covered by PR builds.

### ASK Mode template information:

## Description

Hosted windows images based off Server 2016 / VS 2017 are being deprecated starting this month, and fully removed (will cause build failure) in March 2022.  The oldest VS available after this time will be VS 2019.  This change updates to an image that will last through at least 2023, and makes the parallel change in the 1ES pool provider images used.

## Customer Impact

If not addressed, all builds using hosted images in Arcade and repositories dependent on this branch of Arcade will break, making updating or using common yaml template functionality broken.

## Regression

No

## Risk

Low-to-medium; Most Arcade builds don't depend on the installed copy of VS of the machine, but since the eng/common folders are changed as well, teams building VS-sensitive components in other repos may have to fix up their build to succeed on VS > 2017.

## Workarounds

No workaround without changing source can solve this problem as the deprecated image name / vmImage tag is in the source.
