### PR TITLE
Skip cache when installing XHarness from a local .nupkg

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/InstallDotNetTool.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/InstallDotNetTool.cs
@@ -64,6 +64,11 @@ namespace Microsoft.DotNet.Helix.Sdk
         public string WorkingDirectory { get; set; }
 
         /// <summary>
+        /// Do not use a cached .nupkg when installing
+        /// </summary>
+        public bool NoCache { get; set; } = false;
+
+        /// <summary>
         /// Location of where the tool was installed (including the version)
         /// </summary>
         [Output]
@@ -139,6 +144,11 @@ namespace Microsoft.DotNet.Helix.Sdk
             {
                 args.Add("--add-source");
                 args.Add(Source);
+            }
+
+            if (NoCache)
+            {
+                args.Add("--no-cache");
             }
 
             args.Add(Name);

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
@@ -27,7 +27,8 @@
     <Message Condition=" '$(XHarnessNupkgPath)' != '' " Text="XHarnessNupkgPath is set so XHarnessPackageSource will be ignored" Importance="normal" />
 
     <PropertyGroup Condition=" '$(XHarnessNupkgPath)' != '' ">
-      <XHarnessPackageSource>$([System.IO.Path]::GetDirectoryName($(XHarnessNupkgPath))) --no-cache</XHarnessPackageSource>
+      <XHarnessPackageSource>$([System.IO.Path]::GetDirectoryName($(XHarnessNupkgPath)))</XHarnessPackageSource>
+      <XHarnessNoCache>true</XHarnessNoCache>
     </PropertyGroup>
 
     <!--
@@ -40,7 +41,8 @@
                        Source="$(XHarnessPackageSource)"
                        TargetFramework="$(XHarnessTargetFramework)"
                        WorkingDirectory="$(ArtifactsTmpDir)"
-                       DotnetPath="$(DotNetTool)">
+                       DotnetPath="$(DotNetTool)"
+                       NoCache="$(XHarnessNoCache)">
       <Output TaskParameter="ToolPath" PropertyName="_XHarnessCliPath" />
     </InstallDotNetTool>
 


### PR DESCRIPTION
This stopped working as the `--add-source` parameter's value was now "path/to/nupkg --no-cache" and `--no-cache` wasn't a separate option
