### PR TITLE
Revert "Use 1ES pools for SourceBuild/SourceIndex"

### DIFF
--- a/eng/common/templates/job/source-build.yml
+++ b/eng/common/templates/job/source-build.yml
@@ -34,8 +34,7 @@ parameters:
   # The default VM host AzDO pool. This should be capable of running Docker containers: almost all
   # source-build builds run in Docker, including the default managed platform.
   defaultContainerHostPool:
-    name: NetCore1ESPool-Public
-    demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
+    vmImage: ubuntu-20.04
 
 jobs:
 - job: ${{ parameters.jobNamePrefix }}_${{ parameters.platform.name }}

--- a/eng/common/templates/job/source-index-stage1.yml
+++ b/eng/common/templates/job/source-index-stage1.yml
@@ -6,8 +6,7 @@ parameters:
   preSteps: []
   binlogPath: artifacts/log/Debug/Build.binlog
   pool:
-    name: NetCore1ESPool-Public
-    demands: ImageOverride -equals Build.Windows.10.Amd64.Open
+    vmImage: 'windows-2019'
   condition: ''
   dependsOn: ''
 


### PR DESCRIPTION
Reverts dotnet/arcade#8108

We have to take into account whether to use internal or external pool:
https://dnceng.visualstudio.com/internal/_build/results?buildId=1450459&view=results

Reverting to unblock the internal build
