### PR TITLE
Send the XHarness target OS telemetry property when available

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-reporter.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-reporter.py
@@ -41,6 +41,8 @@ for operation in operations:
             custom_dimensions['target'] = operation['target'] + '_' + operation['targetOS']
         else:
             custom_dimensions['target'] = operation['target']
+    elif 'targetOS' in operation:
+        custom_dimensions['target'] = operation['targetOS']
 
     app_insights.send_metric('XHarnessOperation', operation['exitCode'], properties=custom_dimensions)
     app_insights.send_metric('XHarnessOperationDuration', operation['duration'], properties=custom_dimensions)


### PR DESCRIPTION
In `android run` command, we only send the API version, not the architecture