### PR TITLE
Add explicit reference to Azure.Core to Tasks.Feed

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Core" Version="$(AzureCoreVersion)" />
     <PackageReference Include="Azure.Storage.Blobs" Version="$(AzureStorageBlobsVersion)" />
     <PackageReference Include="DotNet.SleetLib" Version="$(DotNetSleetLibVersion)" />
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />


### PR DESCRIPTION
Follow up from #8118, trying to prevent failures as seen here: https://dev.azure.com/dnceng/internal/_build/results?buildId=1451176&view=logs&j=33961d73-1e6b-5306-1d3b-c6c083bff7de&t=577fb5b9-bfb7-5430-eb7a-5c5120b89b4d&l=67

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
