### PR TITLE
Switch source-build yamls to 1ES hosted pools

### DIFF
--- a/eng/common/templates/job/source-build.yml
+++ b/eng/common/templates/job/source-build.yml
@@ -31,16 +31,6 @@ parameters:
   #   container and pool.
   platform: {}
 
-  # The default VM host AzDO pool. This should be capable of running Docker containers: almost all
-  # source-build builds run in Docker, including the default managed platform.
-  defaultContainerHostPool:
-    ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      name: NetCore1ESPool-Public
-      demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
-    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-      name: NetCore1ESPool-Internal
-      demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
-
 jobs:
 - job: ${{ parameters.jobNamePrefix }}_${{ parameters.platform.name }}
   displayName: Source-Build (${{ parameters.platform.name }})
@@ -52,7 +42,15 @@ jobs:
     container: ${{ parameters.platform.container }}
 
   ${{ if eq(parameters.platform.pool, '') }}:
-    pool: ${{ parameters.defaultContainerHostPool }}
+    # The default VM host AzDO pool. This should be capable of running Docker containers: almost all
+    # source-build builds run in Docker, including the default managed platform.
+    pool:
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        name: NetCore1ESPool-Public
+        demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
   ${{ if ne(parameters.platform.pool, '') }}:
     pool: ${{ parameters.platform.pool }}
 

--- a/eng/common/templates/job/source-build.yml
+++ b/eng/common/templates/job/source-build.yml
@@ -34,7 +34,12 @@ parameters:
   # The default VM host AzDO pool. This should be capable of running Docker containers: almost all
   # source-build builds run in Docker, including the default managed platform.
   defaultContainerHostPool:
-    vmImage: ubuntu-20.04
+    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      name: NetCore1ESPool-Public
+      demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
+    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
 
 jobs:
 - job: ${{ parameters.jobNamePrefix }}_${{ parameters.platform.name }}

--- a/eng/common/templates/job/source-index-stage1.yml
+++ b/eng/common/templates/job/source-index-stage1.yml
@@ -5,13 +5,6 @@ parameters:
   sourceIndexBuildCommand: powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "eng/common/build.ps1 -restore -build -binarylog -ci"
   preSteps: []
   binlogPath: artifacts/log/Debug/Build.binlog
-  pool:
-    ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      name: NetCore1ESPool-Public
-      demands: ImageOverride -equals Build.Windows.10.Amd64.Open
-    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-      name: NetCore1ESPool-Internal
-      demands: ImageOverride -equals Build.Windows.10.Amd64
   condition: ''
   dependsOn: ''
 
@@ -29,7 +22,13 @@ jobs:
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - group: source-dot-net stage1 variables
 
-  pool: ${{ parameters.pool }}
+  pool:
+    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      name: NetCore1ESPool-Public
+      demands: ImageOverride -equals Build.Windows.10.Amd64.Open
+    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals Build.Windows.10.Amd64
   steps:
   - ${{ each preStep in parameters.preSteps }}:
     - ${{ preStep }}

--- a/eng/common/templates/job/source-index-stage1.yml
+++ b/eng/common/templates/job/source-index-stage1.yml
@@ -6,7 +6,12 @@ parameters:
   preSteps: []
   binlogPath: artifacts/log/Debug/Build.binlog
   pool:
-    vmImage: 'windows-2019'
+    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      name: NetCore1ESPool-Public
+      demands: ImageOverride -equals Build.Windows.10.Amd64.Open
+    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals Build.Windows.10.Amd64
   condition: ''
   dependsOn: ''
 

--- a/eng/common/templates/job/source-index-stage1.yml
+++ b/eng/common/templates/job/source-index-stage1.yml
@@ -25,10 +25,10 @@ jobs:
   pool:
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
       name: NetCore1ESPool-Public
-      demands: ImageOverride -equals Build.Windows.10.Amd64.Open
+      demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       name: NetCore1ESPool-Internal
-      demands: ImageOverride -equals Build.Windows.10.Amd64
+      demands: ImageOverride -equals Build.Server.Amd64.VS2019
   steps:
   - ${{ each preStep in parameters.preSteps }}:
     - ${{ preStep }}


### PR DESCRIPTION
This is a follow-up on the previous PR: https://github.com/dotnet/arcade/pull/8108. This one adds conditionals to make it work both on public and internal projects.

Tracking issue: https://github.com/dotnet/arcade/issues/7786
