### PR TITLE
Improve exception logging while publishing to blob storage

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/AzureStorageAssetPublisher.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/AzureStorageAssetPublisher.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Threading;
 using Azure.Storage.Blobs;
 using Microsoft.Build.Utilities;
@@ -45,7 +46,15 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 }
 
                 _log.LogMessage($"Uploading '{file}' to '{blobPath}'");
-                await blobClient.UploadAsync(file);
+
+                try
+                {
+                    await blobClient.UploadAsync(file);
+                }
+                catch (Exception e)
+                {
+                    _log.LogError($"Unexpected exception publishing file {file} to {blobPath}: {e.Message}");
+                }
             }
         }
     }


### PR DESCRIPTION
There can still be errors while uploading files to blob storage, even after confirming that the file doesn't already exist at the given location. See: https://dev.azure.com/dnceng/internal/_build/results?buildId=1443383&view=logs&j=8667c75e-c9c8-5a72-3326-7d35d151733c&t=648bbdf3-1356-5b63-95ae-560e1b5f90bf. Today, that exception is thrown, but since everything is async, it isn't clear what package was having an issue publishing.

This change adds a try/catch around the call to UploadAsync, and will long the file name and blob path along with the exception message if UploadAsync throws an exception.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
