### PR TITLE
Allow the passing in of msbuildEngine to msbuild.ps1

### DIFF
--- a/eng/common/msbuild.ps1
+++ b/eng/common/msbuild.ps1
@@ -6,6 +6,7 @@ Param(
   [switch] $ci,
   [switch] $prepareMachine,
   [switch] $excludePrereleaseVS,
+  [string] $msbuildEngine = $null,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$extraArgs
 )
 


### PR DESCRIPTION
In repos that need to mix vs and dotnet msbuild engines, and use this script directly, we need to allow for the msbuildEngine to be passed in.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
