### PR TITLE
add property to disable building the manifest file

### DIFF
--- a/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -360,7 +360,7 @@
   </Target>
 
   <Target Name="_CreatePlatformManifest" DependsOnTargets="_GenerateTemplatedPlatformManifest;_GeneratePlatformManifestFromRuntimePack"
-          Condition="'$(PlatformPackageType)' == 'TargetingPack' and '$(SkipGeneratingPlatformManifest)' == ''">
+          Condition="'$(PlatformPackageType)' == 'TargetingPack' and '$(CreatePlatformManifest)' != 'false'">
     <ItemGroup>
       <_PlatformManifestFile Include="$(IntermediateOutputPath)PlatformManifest.txt" TargetPath="data" GeneratedBuildFile="true" />
     </ItemGroup>

--- a/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -360,7 +360,7 @@
   </Target>
 
   <Target Name="_CreatePlatformManifest" DependsOnTargets="_GenerateTemplatedPlatformManifest;_GeneratePlatformManifestFromRuntimePack"
-          Condition="'$(PlatformPackageType)' == 'TargetingPack'">
+          Condition="'$(PlatformPackageType)' == 'TargetingPack' and '$(SkipGeneratingPlatformManifest)' == ''">
     <ItemGroup>
       <_PlatformManifestFile Include="$(IntermediateOutputPath)PlatformManifest.txt" TargetPath="data" GeneratedBuildFile="true" />
     </ItemGroup>


### PR DESCRIPTION
We want to pin the platform manifest for the ref packs, hence adding a property to disable creation of new platform manifest file during servicing.