### PR TITLE
Port "ignore nonexistent queue" functionality to release/3.x

### DIFF
--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -154,6 +154,15 @@ namespace Microsoft.DotNet.Helix.Client
 
             var (queueId, dockerTag, queueAlias) = ParseQueueId(TargetQueueId);
 
+            try
+            {
+                QueueInfo queueInfo = await HelixApi.Information.QueueInfoAsync(queueId, CancellationToken.None);
+            }
+            // 404 = this queue does not exist, or did and was removed.
+            catch (RestApiException ex) when ((int)ex.Response?.StatusCode == 404)
+            {
+                throw new ArgumentException($"Helix API does not contain an entry for {queueId}");
+            }
             IBlobContainer storageContainer = await storage.GetContainerAsync(TargetContainerName, queueId);
             var jobList = new List<JobListEntry>();
 

--- a/src/Microsoft.DotNet.Helix/Sdk/HelixTask.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/HelixTask.cs
@@ -23,6 +23,13 @@ namespace Microsoft.DotNet.Helix.Sdk
         /// </summary>
         public string AccessToken { get; set; }
 
+        /// <summary>
+        ///   If <see langword="true"/>, fail when posting jobs to non-existent queues; If <see langword="false"/> allow it and print a warning.
+        ///   Note if an MSBuild sequence starts and waits on jobs, and none are started, this will still fail.
+        ///   Defined on HelixTask so the catch block around Execute() can know about it.
+        /// </summary>
+        public bool FailOnMissingTargetQueue { get; set; } = true;
+
         protected IHelixApi HelixApi { get; private set; }
 
         protected IHelixApi AnonymousApi { get; private set; }
@@ -64,6 +71,17 @@ namespace Microsoft.DotNet.Helix.Sdk
             {
                 // Canceled
                 return false;
+            }
+            catch (ArgumentException argEx) when (argEx.Message.StartsWith("Helix API does not contain an entry "))
+            {
+                if (FailOnMissingTargetQueue)
+                {
+                    Log.LogError(argEx.Message);
+                }
+                else
+                {
+                    Log.LogWarning($"{argEx.Message} (FailOnMissingTargetQueue is false, so this is just a warning.)");
+                }
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.DotNet.Helix/Sdk/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/Readme.md
@@ -1,9 +1,9 @@
 # Microsoft.DotNet.Helix.Sdk
 
-This Package provides Helix Job sending functionality from an MSBuild project file.
+This Package provides Helix Job-sending functionality from an MSBuild project file.
 
 ## Examples
-Each of the following examples require dotnet-cli >= 2.1.300 and need the following files in a directory at or above the example project's directory.
+Each of the following examples require dotnet-cli >= 3.1.x, and need the following files in a directory at or above the example project's directory.
 #### global.json
 ```json
 {
@@ -108,13 +108,21 @@ Given a local folder `$(TestFolder)` containing `runtests.cmd`, this will run `r
     <!-- The helix queue this job should run on. -->
     <HelixTargetQueue>Windows.10.Amd64.Open</HelixTargetQueue>
 
+    <!-- Whether to fail the build if any Helix queues supplied don't exist.
+         If set to false, sending to non-existent Helix Queues will only print a warning. Defaults to true. 
+         Only set this to false if losing this coverage when the target queue is deprecated is acceptable.
+         For any job waiting on runs, this will still cause failure if all queues do not exist as there must be
+         one or more runs started for waiting to not log errors.  Only set if you need it.
+    -->
+    <FailOnMissingTargetQueue>false</FailOnMissingTargetQueue>
+
     <!--
       The set of helix queues to send jobs to.
       This property is multiplexed over just like <TargetFrameworks> for C# projects.
       The project is built once per entry in this list with <HelixTargetQueue> set to the current list element value.
       
     -->
-    <HelixTargetQueues>Ubuntu.1804.Amd64.Open;Ubuntu.1604.Amd64.Open</HelixTargetQueues>
+    <HelixTargetQueues>Ubuntu.1804.Amd64.Open;Ubuntu.1604.Amd64.Open;(Alpine.39.Amd64)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.9-helix-bfcd90a-20200123191053</HelixTargetQueues>
 
     <!-- 'true' to download dotnet cli and add it to the path for every workitem. Default 'false' -->
     <IncludeDotNetCli>true</IncludeDotNetCli>
@@ -131,19 +139,7 @@ Given a local folder `$(TestFolder)` containing `runtests.cmd`, this will run `r
     <FailOnTestFailure>true</FailOnTestFailure>
 
     <!--
-      'true' to enable the xunit reporter. Default 'false'
-      The xunit reporter will report test results from a test results
-      xml file found in the work item working directory.
-      The following file names are accepted:
-        testResults.xml
-        test-results.xml
-        test_results.xml
-    -->
     <EnableXUnitReporter>false</EnableXUnitReporter>
-    <!-- Instruct the sdk to wait for test result ingestion by MC, and fail if there are any failed work items or tests. -->
-    <FailOnMissionControlTestFailure>false</FailOnMissionControlTestFailure>
-
-    <!--
       Commands that are run before each workitem's command
       semicolon-separated; use ';;' to escape a single semicolon
     -->
@@ -174,7 +170,6 @@ Given a local folder `$(TestFolder)` containing `runtests.cmd`, this will run `r
     <!-- Additional command line arguments to pass to xunit.console.exe -->
     <XUnitArguments></XUnitArguments>
   </PropertyGroup>
-
 
   <ItemGroup>
     <!--

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <EnableXUnitReporter Condition=" '$(EnableXUnitReporter)' != 'true' ">false</EnableXUnitReporter>
+    <!-- Helix Queues which do not exist (deprecation, typos, or purposful removal for use reduction) will error by default. 
+         For users that do not want this to break builds (such as in release branch testing) this property allows to downgrade 
+         this failure mode to just a warning, which hopefully still tells the user to remove usage when possible. -->
+    <FailOnMissingTargetQueue Condition=" '$(FailOnMissingTargetQueue)' != 'false' ">true</FailOnMissingTargetQueue>
   </PropertyGroup>
 
   <Choose>
@@ -46,6 +49,7 @@
     </PropertyGroup>
     <SendHelixJob Type="$(HelixType)"
                   TargetQueue="$(HelixTargetQueue)"
+                  FailOnMissingTargetQueue="$(FailOnMissingTargetQueue)"
                   IsPosixShell="$(IsPosixShell)"
                   Creator="$(Creator)"
                   BaseUri="$(HelixBaseUri)"


### PR DESCRIPTION
### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation (tested in PR validation)

## Description

Context: https://github.com/dotnet/core-eng/issues/14572
Port of https://github.com/dotnet/arcade/pull/8069 (bbb41876e62ed525195aef99f50b68c2a77ebf34).  Allows users who want to to ignore non-existent Helix queues, so we don't have to keep every queue that we've ever had in existence in our yaml files forever.

## Customer Impact

This change allows customers to decide whether their build should break (and thus require attention) when sending to and end-of-life-d queue, or just print a warning.  

Without this change, any old queue that has been removed (e.g. OSX.1012.Amd64) will cause failure once the changes to do this are merged.


## Regression

No

## Risk

Low; only two queues we'd remove (osx.1012.amd64, redhat.6.amd64) have been used in the past 30 days, from 3.1 release branches, and these can be left alone until addressed.

## Workarounds

User will have to work around this by removing dead queues manually without this setting available in the Arcade SDK.
