### PR TITLE
Bring back non-Maestro.Client dependent pieces of Tasks.Feed for .NET 4.7.2

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
 
     <Description>This package provides support for publishing assets to a NuGet protocol based feed.</Description>
@@ -20,12 +20,20 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
     <PackageReference Include="Microsoft.Data.Services.Client" Version="$(MicrosoftDataServicesClientVersion)" />
     <PackageReference Include="Microsoft.Data.OData" Version="$(MicrosoftDataODataVersion)" />
-    <PackageReference Include="Microsoft.DotNet.Maestro.Client" Version="$(MicrosoftDotNetMaestroClientVersion)" />    
+
+    <!-- Maestro.Client stopped supporting .NET 4.7.2 long ago. 
+         This functionality should eventually be moved into an arcade-services package, 
+         but for users consuming other functionality we'll still support 4.7.2 by ifdefing it out. -->
+    <PackageReference Condition="'$(TargetFramework)' != 'net472'" Include="Microsoft.DotNet.Maestro.Client" Version="$(MicrosoftDotNetMaestroClientVersion)" />    
+
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsVersion)" />
     <PackageReference Include="Microsoft.SymbolUploader" Version="$(MicrosoftSymbolUploaderVersion)" />
     <!-- Override the vulnerable version brought in by Microsoft.DotNet.Maestro.Client -->
     <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/AssetPublisherFactory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/AssetPublisherFactory.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if !NET472_OR_GREATER
 using System;
 using Microsoft.Build.Utilities;
 using Microsoft.DotNet.Build.Tasks.Feed.Model;
@@ -33,3 +34,4 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         }
     }
 }
+#endif

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/AzureDevOpsNugetFeedAssetPublisher.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/AzureDevOpsNugetFeedAssetPublisher.cs
@@ -9,6 +9,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using Microsoft.Build.Utilities;
 using Microsoft.DotNet.Build.Tasks.Feed.Model;
+#if !NET472_OR_GREATER
 using Microsoft.DotNet.Maestro.Client.Models;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
@@ -93,3 +94,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         }
     }
 }
+#else
+public class AzureDevOpsNugetFeedAssetPublisher : Task
+{
+    public override bool Execute() => throw new NotSupportedException("AzureDevOpsNugetFeedAssetPublisher depends on Maestro.Client, which has discontinued support for desktop frameworks.");
+}
+#endif

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/AzureStorageAssetPublisher.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/AzureStorageAssetPublisher.cs
@@ -5,11 +5,14 @@ using System;
 using System.Threading;
 using Azure.Storage.Blobs;
 using Microsoft.Build.Utilities;
+#if !NET472_OR_GREATER
 using Microsoft.DotNet.Maestro.Client.Models;
+#endif
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.DotNet.Build.Tasks.Feed
 {
+#if !NET472_OR_GREATER
     public abstract class AzureStorageAssetPublisher : IAssetPublisher
     {
         private readonly TaskLoggingHelper _log;
@@ -58,4 +61,19 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             }
         }
     }
+#else
+    public abstract class AzureStorageAssetPublisher : IAssetPublisher
+    {
+        private readonly TaskLoggingHelper _log;
+
+        protected AzureStorageAssetPublisher(TaskLoggingHelper log)
+        {
+            _log = log;
+        }
+
+        public abstract BlobClient CreateBlobClient(string blobPath);
+
+        public Task PublishAssetAsync(string file, string blobPath, PushOptions options, SemaphoreSlim clientThrottle = null) => throw new NotImplementedException();
+    }
+#endif
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/IAssetPublisher.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/IAssetPublisher.cs
@@ -2,15 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading;
+#if !NET472_OR_GREATER
 using Microsoft.DotNet.Maestro.Client.Models;
+#endif
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.DotNet.Build.Tasks.Feed
 {
     public interface IAssetPublisher
     {
+#if !NET472_OR_GREATER
         LocationType LocationType { get; }
+#endif
 
         Task PublishAssetAsync(string file, string blobPath, PushOptions options, SemaphoreSlim clientThrottle = null);
     }
 }
+

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -4,6 +4,7 @@
 using Microsoft.Arcade.Common;
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.Tasks.Feed.Model;
+#if !NET472_OR_GREATER
 using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.VersionTools.Automation;
 using Microsoft.DotNet.VersionTools.BuildManifest.Model;
@@ -355,3 +356,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         }
     }
 }
+#else
+public class PublishArtifactsInManifest : Microsoft.Build.Utilities.Task
+{
+    public override bool Execute() => throw new System.NotSupportedException("PublishArtifactsInManifest depends on Maestro.Client, which has discontinued support for desktop frameworks.");
+}
+#endif

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV2.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV2.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.Tasks.Feed.Model;
+#if !NET472_OR_GREATER
 using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
 using System;
@@ -226,3 +227,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         }
     }
 }
+#else
+public class PublishArtifactsInManifestV2 : Microsoft.Build.Utilities.Task
+{
+    public override bool Execute() => throw new System.NotSupportedException("PublishArtifactsInManifestV2 depends on Maestro.Client, which has discontinued support for desktop frameworks.");
+}
+#endif

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.Tasks.Feed.Model;
+#if !NET472_OR_GREATER
 using Microsoft.DotNet.Maestro.Client;
 using Microsoft.DotNet.Maestro.Client.Models;
 using Microsoft.DotNet.VersionTools.BuildManifest.Model;
@@ -248,3 +249,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         }
     }
 }
+#else
+public class PublishArtifactsInManifestV3 : Microsoft.Build.Utilities.Task
+{
+    public override bool Execute() => throw new NotSupportedException("PublishArtifactsInManifestV3 depends on Maestro.Client, which has discontinued support for desktop frameworks.");
+}
+#endif

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AssetComparer.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AssetComparer.cs
@@ -1,3 +1,4 @@
+#if !NET472_OR_GREATER
 using Microsoft.DotNet.Maestro.Client.Models;
 using System.Collections.Generic;
 
@@ -35,3 +36,4 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         }
     }
 }
+#endif


### PR DESCRIPTION
### To double check:

(Draft only - testing for https://github.com/dotnet/arcade/issues/8157 to see if this affects any CI testing)

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
