### PR TITLE
Shorten tool path when installing XHarness locally

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
@@ -36,7 +36,7 @@
       We do this so that we avoid all of the machines installing the tool too and ddosing the NuGet feed
     -->
     <InstallDotNetTool Name="$(_XHarnessPackageName)"
-                       DestinationPath="$(ArtifactsTmpDir)Microsoft.DotNet.XHarness.CLI"
+                       DestinationPath="$(ArtifactsTmpDir)"
                        Version="$(_XHarnessPackageVersion)"
                        Source="$(XHarnessPackageSource)"
                        TargetFramework="$(XHarnessTargetFramework)"


### PR DESCRIPTION
The path was actually needlessly long which could cause problems with the `dotnet tool install` command

The name of the package was repeated twice for no reason:

> artifacts\tmp\Debug\Microsoft.DotNet.XHarness.CLI\Microsoft.DotNet.XHarness.CLI\1.0.0-prerelease.21558.2