### PR TITLE
Use the source directory as the working directory for running sdl

### DIFF
--- a/eng/common/sdl/execute-all-sdl-tools.ps1
+++ b/eng/common/sdl/execute-all-sdl-tools.ps1
@@ -124,7 +124,7 @@ try {
   Exec-BlockVerbosely {
     & $(Join-Path $PSScriptRoot 'run-sdl.ps1') `
       -GuardianCliLocation $guardianCliLocation `
-      -WorkingDirectory $workingDirectory `
+      -WorkingDirectory $SourceDirectory `
       -UpdateBaseline $UpdateBaseline `
       -GdnFolder $gdnFolder
   }


### PR DESCRIPTION
We were using the "working directory," which is one level up from the SourceDirectory passed in. This meant that we were unintentionally getting the .gdn directory and anything else that may be laying around on the machine as part of our working directory. In the Validate-DotNet pipeline, it meant we were scanning more than we were meaning to scan.

This change adjusts our call to run-sdl to use the SourceDirectory (ie what we actually WANT to scan) as the working directory.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
