### PR TITLE
Allow override of UpgradeCode seed

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets
@@ -96,7 +96,12 @@
   <Target Name="_GetUpgradeCode"
           DependsOnTargets="GetWixBuildConfiguration"
           Condition="'$(UpgradeCode)' == ''">
-    <GenerateGuidFromName Name="$(_OutInstallerFile)">
+
+    <PropertyGroup>
+      <MsiUpgradeCodeSeed Condition="'$(MsiUpgradeCodeSeed)' == ''">$(_OutInstallerFile)</MsiUpgradeCodeSeed>
+    </PropertyGroup>
+
+    <GenerateGuidFromName Name="$(MsiUpgradeCodeSeed)">
       <Output TaskParameter="GeneratedGuid" PropertyName="UpgradeCode" />
     </GenerateGuidFromName>
   </Target>


### PR DESCRIPTION
This allows optional override of UpgradeCode seed in MSI-producing projects, in any consumer repo, i.e. dotnet/runtime.
