### PR TITLE
Fix Azure Graph Service endpoint used for IP checking

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -900,7 +900,7 @@ function Try-LogClientIpAddress()
     Write-Host "Attempting to log this client's IP for Azure Package feed telemetry purposes"
     try
     {
-        $result = Invoke-WebRequest -Uri "http://co1.msedge.net/fdv2/diagnostics.aspx" -UseBasicParsing
+        $result = Invoke-WebRequest -Uri "http://co1r5a.msedge.net/fdv2/diagnostics.aspx" -UseBasicParsing
         $lines = $result.Content.Split([Environment]::NewLine) 
         $socketIp = $lines | Select-String -Pattern "^Socket IP:.*"
         Write-Host $socketIp

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -408,7 +408,7 @@ function StopProcesses {
 function TryLogClientIpAddress () {
   echo 'Attempting to log this client''s IP for Azure Package feed telemetry purposes'
   if command -v curl > /dev/null; then
-    curl -s 'http://co1.msedge.net/fdv2/diagnostics.aspx' | grep ' IP: ' || true
+    curl -s 'http://co1r5a.msedge.net/fdv2/diagnostics.aspx' | grep ' IP: ' || true
   fi
 }
 


### PR DESCRIPTION
 (continuation from https://github.com/dotnet/core-eng/issues/13691)

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation  (just improves diagnosability of -ci specifying builds by logging their effective IP as seem by the Azure Graph Service)
