### PR TITLE
Support using unversioned lld as linker too

### DIFF
--- a/eng/common/native/init-compiler.sh
+++ b/eng/common/native/init-compiler.sh
@@ -112,7 +112,7 @@ if [[ -z "$CC" ]]; then
 fi
 
 if [[ "$compiler" == "clang" ]]; then
-    if command -v "lld$desired_version" > /dev/null; then
+    if command -v lld || command -v "lld$desired_version" > /dev/null; then
         # Only lld version >= 9 can be considered stable
         if [[ "$majorVersion" -ge 9 ]]; then
             LDFLAGS="-fuse-ld=lld"

--- a/eng/common/native/init-compiler.sh
+++ b/eng/common/native/init-compiler.sh
@@ -112,7 +112,7 @@ if [[ -z "$CC" ]]; then
 fi
 
 if [[ "$compiler" == "clang" ]]; then
-    if command -v lld || command -v "lld$desired_version" > /dev/null; then
+    if "$CC" -fuse-ld=lld -Wl,--version 2>&1; then
         # Only lld version >= 9 can be considered stable
         if [[ "$majorVersion" -ge 9 ]]; then
             LDFLAGS="-fuse-ld=lld"


### PR DESCRIPTION
On Fedora and RHEL the `lld` executable is the plain unversioned `lld`. That's also usable as a linker if it's recent enough.

See https://github.com/dotnet/runtime/pull/58959#issuecomment-933916056
for more details and discussion.

We have been carrying the 6.0 version of this patch for RHEL 8 on arm64 here: https://git.centos.org/rpms/dotnet6.0/blob/c8s/f/SOURCES/runtime-arm64-lld-fix.patch

There was an open question about parsing the lld version using clang like so:

```
$ clang -fuse-ld=lld -Wl,--version
LLD 13.0.0 (compatible with GNU linkers)
```

Is that worth implementing?

cc @am11 @crummel @janvorli 