### PR TITLE
Fix InitializeDotNetCli call in darc-init.sh

### DIFF
--- a/eng/common/darc-init.sh
+++ b/eng/common/darc-init.sh
@@ -53,7 +53,7 @@ fi
 function InstallDarcCli {
   local darc_cli_package_name="microsoft.dotnet.darc"
 
-  InitializeDotNetCli
+  InitializeDotNetCli true
   local dotnet_root=$_InitializeDotNetCli
 
   if [ -z "$toolpath" ]; then


### PR DESCRIPTION
In the ps1 script, we set install to true, but in the sh script, we weren't, so tools.sh would see that install is not set, and assume dotnet was already installed in the expected place, which isn't true. This change adds true to the InitializeDotNetCli call so that dotnet will be installed if needed when running darc-init.sh

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
