### PR TITLE
Remove Arcade workaround added for WPF temporary projects prior to WP…

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
-  <!--
-    Import NuGet targets to WPF temp projects (workaround for https://github.com/dotnet/sourcelink/issues/91) 
-  -->
-  <Import Project="$(_WpfTempProjectNuGetFilePathNoExt).targets" Condition="'$(_WpfTempProjectNuGetFilePathNoExt)' != '' and Exists('$(_WpfTempProjectNuGetFilePathNoExt).targets')"/>
-
   <!-- 
     Some projects do not import Common targets, so BeforeCommonTargets.targets doesn't get imported. 
     (https://github.com/dotnet/arcade/issues/2676).

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Settings.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Settings.props
@@ -24,8 +24,4 @@
   <Import Project="Linker.props" Condition="'$(UsingToolMicrosoftNetILLinkTasks)' == 'true'" />
   <Import Project="VisualStudio.props" Condition="'$(UsingToolVSSDK)' == 'true' and '$(MSBuildRuntimeType)' != 'Core'"/>
 
-  <!--
-    Import NuGet props to WPF temp projects (workaround for https://github.com/dotnet/sourcelink/issues/91) 
-  -->
-  <Import Project="$(_WpfTempProjectNuGetFilePathNoExt).props" Condition="'$(_WpfTempProjectNuGetFilePathNoExt)' != '' and Exists('$(_WpfTempProjectNuGetFilePathNoExt).props')"/>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.props
@@ -22,8 +22,6 @@
     It's also not necessary to generate these assets.
   -->
   <PropertyGroup Condition="'$(IsWpfTempProject)' == 'true'">
-    <_WpfTempProjectNuGetFilePathNoExt>$(ArtifactsObjDir)$(_TargetAssemblyProjectName)\$(_TargetAssemblyProjectName)$(MSBuildProjectExtension).nuget.g</_WpfTempProjectNuGetFilePathNoExt>
-
     <EnableSourceLink>false</EnableSourceLink>
     <EmbedUntrackedSources>false</EmbedUntrackedSources>
     <DeterministicSourcePaths>false</DeterministicSourcePaths>


### PR DESCRIPTION
Cherry-pick of https://github.com/dotnet/arcade/pull/7994 into main

To fix Roslyn correctness issues with multiple prop imports https://github.com/dotnet/roslyn/pull/57637/checks?check_run_id=4230100423

@sharwell @mmitche 