### PR TITLE
Allow overriding upgrade code seed and dependency key

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/variables.wxi
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/variables.wxi
@@ -23,7 +23,9 @@
     <?error Invalid Platform ($(var.Platform))?>
   <?endif?>
 
-  <?define DependencyKey   = "$(var.DependencyKeyName)_$(var.BuildVersion)_$(var.Platform)$(var.CrossArchContentsPlatformPart)"?>
+  <?ifndef DependencyKey?>
+    <?define DependencyKey = "$(var.DependencyKeyName)_$(var.BuildVersion)_$(var.Platform)$(var.CrossArchContentsPlatformPart)"?>
+  <?endif?>
   <?define DependencyKeyId = "$(var.DependencyKey)" ?>
 
 </Include>

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets
@@ -96,7 +96,12 @@
   <Target Name="_GetUpgradeCode"
           DependsOnTargets="GetWixBuildConfiguration"
           Condition="'$(UpgradeCode)' == ''">
-    <GenerateGuidFromName Name="$(_OutInstallerFile)">
+
+    <PropertyGroup>
+      <MsiUpgradeCodeSeed Condition="'$(MsiUpgradeCodeSeed)' == ''">$(_OutInstallerFile)</MsiUpgradeCodeSeed>
+    </PropertyGroup>
+
+    <GenerateGuidFromName Name="$(MsiUpgradeCodeSeed)">
       <Output TaskParameter="GeneratedGuid" PropertyName="UpgradeCode" />
     </GenerateGuidFromName>
   </Target>


### PR DESCRIPTION
This allows optional override of UpgradeCode seed and DependencyKey value in MSI-producing projects, in any consumer repo, i.e. dotnet/runtime.

Essentially a forward port of 6.0 changes: https://github.com/dotnet/arcade/pull/8174 and https://github.com/dotnet/arcade/pull/8181