### PR TITLE
Remove "TryLogClientIpAddress"

### DIFF
--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -188,9 +188,6 @@ function InitializeCustomToolset {
 
 function Build {
 
-  if [[ "$ci" == true ]]; then
-    TryLogClientIpAddress
-  fi
   InitializeToolset
   InitializeCustomToolset
 

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -83,9 +83,6 @@ try {
   }
 
   if ($restore) {
-    if ($ci) {
-      Try-LogClientIpAddress
-    }
     Build 'Restore'
   }
 

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -163,9 +163,6 @@ function InitializeDotNetCli([bool]$install, [bool]$createSdkLocationFile) {
   # Disable telemetry on CI.
   if ($ci) {
     $env:DOTNET_CLI_TELEMETRY_OPTOUT=1
- 
-    # In case of network error, try to log the current IP for reference
-    Try-LogClientIpAddress
   }
 
   # Source Build uses DotNetCoreSdkDir variable
@@ -893,24 +890,6 @@ if (!$disableConfigureToolsetImport) {
       }
     }
   }
-}
-
-function Try-LogClientIpAddress()
-{
-    Write-Host "Attempting to log this client's IP for Azure Package feed telemetry purposes"
-    try
-    {
-        $result = Invoke-WebRequest -Uri "http://co1.msedge.net/fdv2/diagnostics.aspx" -UseBasicParsing
-        $lines = $result.Content.Split([Environment]::NewLine) 
-        $socketIp = $lines | Select-String -Pattern "^Socket IP:.*"
-        Write-Host $socketIp
-        $clientIp = $lines | Select-String -Pattern "^Client IP:.*"
-        Write-Host $clientIp
-    }
-    catch
-    {
-        Write-Host "Unable to get this machine's effective IP address for logging: $_"
-    }
 }
 
 #

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -405,13 +405,6 @@ function StopProcesses {
   return 0
 }
 
-function TryLogClientIpAddress () {
-  echo 'Attempting to log this client''s IP for Azure Package feed telemetry purposes'
-  if command -v curl > /dev/null; then
-    curl -s 'http://co1.msedge.net/fdv2/diagnostics.aspx' | grep ' IP: ' || true
-  fi
-}
-
 function MSBuild {
   local args=$@
   if [[ "$pipelines_log" == true ]]; then


### PR DESCRIPTION
All azure edge sites we use for this purpose (knowing the IP of a client behind a NAT or other masking thing, for checking with partner teams when things go wrong) seemingly will eventually expire and we rarely need the info; this ends up adding a lot of time to source builds

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
