### PR TITLE
Fix init-compiler.sh for older clang

### DIFF
--- a/eng/common/native/init-compiler.sh
+++ b/eng/common/native/init-compiler.sh
@@ -113,7 +113,7 @@ fi
 
 # Only lld version >= 9 can be considered stable
 if [[ "$compiler" == "clang" && "$majorVersion" -ge 9 ]]; then
-    if "$CC" -fuse-ld=lld -Wl,--version 2>&1; then
+    if "$CC" -fuse-ld=lld -Wl,--version 2>/dev/null; then
         LDFLAGS="-fuse-ld=lld"
     fi
 fi

--- a/eng/common/native/init-compiler.sh
+++ b/eng/common/native/init-compiler.sh
@@ -111,12 +111,10 @@ if [[ -z "$CC" ]]; then
     exit 1
 fi
 
-if [[ "$compiler" == "clang" ]]; then
+# Only lld version >= 9 can be considered stable
+if [[ "$compiler" == "clang" && "$majorVersion" -ge 9 ]]; then
     if "$CC" -fuse-ld=lld -Wl,--version 2>&1; then
-        # Only lld version >= 9 can be considered stable
-        if [[ "$majorVersion" -ge 9 ]]; then
-            LDFLAGS="-fuse-ld=lld"
-        fi
+        LDFLAGS="-fuse-ld=lld"
     fi
 fi
 


### PR DESCRIPTION
Latest changes made by PR https://github.com/dotnet/arcade/pull/8189
broke our build:

clang-5.0 : error : invalid linker name in argument '-fuse-ld=lld' [/__w/1/s/src/Microsoft.VisualStudio.Coverage.InstrumentationMethod/Microsoft.VisualStudio.Coverage.InstrumentationMethod.proj]
##[error]clang-5.0(0,0): error : (NETCORE_ENGINEERING_TELEMETRY=Build) invalid linker name in argument '-fuse-ld=lld'

probably the reason is that we use older clang. If I correctly understand that we can check if clang is at least 9 before even checking for this -fuse-id.
