### PR TITLE
Don't output stdout from lld check in init-compiler.sh 

### DIFF
--- a/eng/common/native/init-compiler.sh
+++ b/eng/common/native/init-compiler.sh
@@ -113,7 +113,7 @@ fi
 
 # Only lld version >= 9 can be considered stable
 if [[ "$compiler" == "clang" && "$majorVersion" -ge 9 ]]; then
-    if "$CC" -fuse-ld=lld -Wl,--version 2>/dev/null; then
+    if "$CC" -fuse-ld=lld -Wl,--version >/dev/null 2>&1; then
         LDFLAGS="-fuse-ld=lld"
     fi
 fi

--- a/eng/common/native/init-compiler.sh
+++ b/eng/common/native/init-compiler.sh
@@ -2,6 +2,7 @@
 #
 # This file detects the C/C++ compiler and exports it to the CC/CXX environment variables
 #
+# NOTE: some scripts source this file and rely on stdout being empty, make sure to not output anything here! 
 
 if [[ "$#" -lt 3 ]]; then
   echo "Usage..."


### PR DESCRIPTION
Another fallout from #8189 / #8219.

This caused an issue in https://github.com/dotnet/runtime/pull/61668 because https://github.com/dotnet/runtime/blob/c00b06826ca4d333ef69d51e523ef7bd309b8631/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/NativeExports.csproj#L33 sources the init-compiler.sh and uses the stdout from it and we were outputting the stdout of the lld check which broke this.

Before:

```
# bash -c 'source "eng/common/native/init-compiler.sh" "eng/common/native/" x64 clang && echo $CC'
LLD 10.0.1 (compatible with GNU linkers)
/usr/bin/clang-10
```

After:

```
# bash -c 'source "eng/common/native/init-compiler.sh" "eng/common/native/" x64 clang && echo $CC'
/usr/bin/clang-10
```
