### PR TITLE
Fix regression in CoreClrConfigurationDetection

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/CoreClrConfigurationDetection.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/CoreClrConfigurationDetection.cs
@@ -21,7 +21,7 @@ namespace Xunit
         public static bool IsGCStress3 => CompareGCStressModeAsLower(GetEnvironmentVariableValue("GCStress"), "0x3", "3");
         public static bool IsGCStressC => CompareGCStressModeAsLower(GetEnvironmentVariableValue("GCStress"), "0xC", "C");
 
-        public static bool IsGCStress => GetEnvironmentVariableValue("GCStress") != string.Empty;
+        public static bool IsGCStress => !string.Equals(GetEnvironmentVariableValue("GCStress"), "0", StringComparison.InvariantCulture);
 
         public static bool IsCheckedRuntime => AssemblyConfigurationEquals("Checked");
         public static bool IsReleaseRuntime => AssemblyConfigurationEquals("Release");


### PR DESCRIPTION
In 16988fc6f9799e2a119167b1730953778e2b0b53 the refactoring added `IsGCStress` and used it in the `IsStressTest` property.
However the `GetEnvironmentVariableValue("GCStress") != string.Empty` is always true since `GetEnvironmentVariableValue` will return the string "0" if the env variable isn't set.

This in turn caused `StressModeApplies` to return false for `RuntimeTestModes.RegularRun` which made the `SkipOnCoreClr` attribute a no-op in regular runs. Discovered while looking at failures in  https://github.com/dotnet/runtime/pull/61668.

/cc @jkoritzinsky 