### PR TITLE
Upgrade guardian version to latest

### DIFF
--- a/eng/common/sdl/packages.config
+++ b/eng/common/sdl/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Guardian.Cli" version="0.53.3"/>
+  <package id="Microsoft.Guardian.Cli" version="0.109.0"/>
 </packages>

--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -54,7 +54,7 @@ jobs:
     # The Guardian version specified in 'eng/common/sdl/packages.config'. This value must be kept in
     # sync with the packages.config file.
     - name: DefaultGuardianVersion
-      value: 0.53.3
+      value: 0.109.0
     - name: GuardianVersion
       value: ${{ coalesce(parameters.overrideGuardianVersion, '$(DefaultGuardianVersion)') }}
     - name: GuardianPackagesConfigFile


### PR DESCRIPTION
Upgrades guardian version to 0.109.0. This upgrades our policheck version to 7.0.670, and fixes https://github.com/dotnet/arcade/issues/8226.

Validation pipeline run: https://dev.azure.com/dnceng/internal/_build/results?buildId=1489189&view=logs&j=d5be4b06-a322-5f90-54ec-b848ca73ce8f&t=c22373d9-8b1b-5f4a-dc0b-13dbb42859fb&l=354 (exact line to see policheck version)

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
