### PR TITLE
Run XHarness Apple workloads under the `helix-runner` user

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.apple.sh
@@ -31,11 +31,12 @@ set -x
 # so we have to set them again.
 export -p > envvars
 chmod +x xharness-runner.apple.sh
-helix_runner_uid=$(id -u)
-sudo launchctl asuser "$helix_runner_uid" sh ./xharness-runner.apple.sh \
-    $forwarded_args                                                     \
-    --app "$HELIX_WORKITEM_ROOT/$app"                                   \
-    --output-directory "$HELIX_WORKITEM_UPLOAD_ROOT"                    \
+uid=$(id -u)
+username=$(id -un)
+sudo launchctl asuser "$uid" sudo -u "$username" sh ./xharness-runner.apple.sh \
+    $forwarded_args                                                            \
+    --app "$HELIX_WORKITEM_ROOT/$app"                                          \
+    --output-directory "$HELIX_WORKITEM_UPLOAD_ROOT"                           \
 
 exit_code=$?
 

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
@@ -170,10 +170,6 @@ if [ $exit_code -ne 0 ]; then
     sudo log show --style syslog --start "$start_time" --end "$(date '+%Y-%m-%d %H:%M:%S')" | tail -c 2097152 > "$output_directory/system.log"
 fi
 
-# The simulator logs comming from the sudo-spawned Simulator.app are not readable/deletable by the helix uploader
-sudo chown -R helix-runner "$output_directory"
-chmod -R 0766 "$output_directory"
-
 echo "Removing empty log files:"
 find "$output_directory" -name "*.log" -maxdepth 1 -size 0 -print -delete
 


### PR DESCRIPTION
The `launchctl` was making them run under `root`

https://github.com/dotnet/xharness/issues/694