### PR TITLE
Integrate template localizer into arcade

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,6 +9,10 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-symuploader</Uri>
       <Sha>62ceb439e80bf0814d0ffa17f022d4624ea4aa6c</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-alpha.1.21601.1">
+      <Uri>https://github.com/dotnet/templating</Uri>
+      <Sha />
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.21576.4">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -89,5 +89,6 @@
     <MicrosoftDeploymentDotNetReleasesVersion>1.0.0-preview1.1.21116.1</MicrosoftDeploymentDotNetReleasesVersion>
     <!-- Used to flow Source Link version through Arcade SDK -->
     <MicrosoftSourceLinkVersion>$(MicrosoftSourceLinkGitHubVersion)</MicrosoftSourceLinkVersion>
+    <MicrosoftTemplateEngineTasksVersion>7.0.100-alpha.1.21601.1</MicrosoftTemplateEngineTasksVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
@@ -84,6 +84,7 @@
     <MicrosoftDotNetXliffTasksVersion>$(MicrosoftDotNetXliffTasksVersion)</MicrosoftDotNetXliffTasksVersion>
     <MicrosoftDotNetMaestroTasksVersion>$(MicrosoftDotNetMaestroTasksVersion)</MicrosoftDotNetMaestroTasksVersion>
     <MicrosoftSymbolUploaderBuildTaskVersion>$(MicrosoftSymbolUploaderBuildTaskVersion)</MicrosoftSymbolUploaderBuildTaskVersion>
+    <MicrosoftTemplateEngineTasksVersion>$(MicrosoftTemplateEngineTasksVersion)</MicrosoftTemplateEngineTasksVersion>
   </PropertyGroup>
 </Project>]]>
   </_SdkVersionPropsContent>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets
@@ -18,7 +18,7 @@
   <Import Project="Tests.targets" Condition="'$(DisableArcadeTestFramework)' != 'true'" />
 
   <Import Project="Performance.targets" Condition="'$(DisableArcadeTestFramework)' != 'true'" />
-  <Import Project="Localization.targets" Condition="'$(UsingToolXliff)' == 'true'"/>
+  <Import Project="Localization.targets" />
   <Import Project="VisualStudio.targets" Condition="'$(UsingToolVSSDK)' == 'true' and ('$(IsVsixProject)' == 'true' or '$(IsSwixProject)' == 'true' or '$(GeneratePkgDefFile)' == 'true') and '$(MSBuildRuntimeType)' != 'Core'"/>
   <Import Project="OptimizationData.targets" Condition="'$(UsingToolIbcOptimization)' == 'true'"/>
   <Import Project="SymStore.targets" Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(OS)' == 'Windows_NT'"/>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Localization.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Localization.targets
@@ -3,11 +3,11 @@
 <Project>
 
   <!--
+    XliffTasks for localizing .resx files and generating satellite assemblies.
     When not building in CI, automatically sync .xlf files to .resx files on build.
     Otherwise, let the build fail to catch .xlf files that are not up-to-date.
   -->
-
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(UsingToolXliff)' == 'true'">
     <!-- 
       It is only intended to automatically run update during dev cycle. However, it will fail the build on CI if the XLF file is not updated.
       XLF file should be checked in and loc team will update the XLF it with translated version.
@@ -25,4 +25,16 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.XliffTasks" Version="$(MicrosoftDotNetXliffTasksVersion)" PrivateAssets="all" IsImplicitlyDefined="true" Condition="'$(IsShippingAssembly)' == 'true'" />
   </ItemGroup>
+
+
+  <!-- TemplateLocalizer for localizing 'dotnet new' templates -->
+  <PropertyGroup Condition="'$(UsingToolTemplateLocalizer)' == 'true'">
+    <!-- Run localizer when building on dev machine. -->
+    <LocalizeTemplates Condition="'$(LocalizeTemplates)' == '' and '$(ContinuousIntegrationBuild)' != 'true'">true</LocalizeTemplates>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.TemplateEngine.Tasks" Version="$(MicrosoftTemplateEngineTasksVersion)" PrivateAssets="all" IsImplicitlyDefined="true" Condition="'$(UsingToolTemplateLocalizer)' == 'true' and '$(IsShippingAssembly)' == 'true'" />
+  </ItemGroup>
+
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Localization.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Localization.targets
@@ -30,11 +30,11 @@
   <!-- TemplateLocalizer for localizing 'dotnet new' templates -->
   <PropertyGroup Condition="'$(UsingToolTemplateLocalizer)' == 'true'">
     <!-- Run localizer when building on dev machine. -->
-    <LocalizeTemplates Condition="'$(LocalizeTemplates)' == '' and '$(ContinuousIntegrationBuild)' != 'true'">true</LocalizeTemplates>
+    <LocalizeTemplates Condition="'$(ContinuousIntegrationBuild)' != 'true'">true</LocalizeTemplates>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.TemplateEngine.Tasks" Version="$(MicrosoftTemplateEngineTasksVersion)" PrivateAssets="all" IsImplicitlyDefined="true" Condition="'$(UsingToolTemplateLocalizer)' == 'true' and '$(IsShippingAssembly)' == 'true'" />
+    <PackageReference Include="Microsoft.TemplateEngine.Tasks" Version="$(MicrosoftTemplateEngineTasksVersion)" PrivateAssets="all" IsImplicitlyDefined="true" Condition="'$(UsingToolTemplateLocalizer)' == 'true'" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
To allow all repos under dotnet to easily localize templates, we are looking to integrate TemplateLocalizer task into arcade.
I'm not a 100% sure if this is the right way to implement this, so here is an early draft PR.

The intent is to allow turning template localizations on a repo, simply by setting "UsingToolTemplateLocalizer" property to true.
This is very much like how Xliff tools are setup (except for throwing errors on CI), so my changes here are very similar to what was done for Xliff tools.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation (Changes are not unit-testable. But generated arcade.sdk package was tested locally. No issues.)
