### PR TITLE
Fix aka.ms links when no ChannelNames given

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
@@ -125,6 +125,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         shortLinkUrls.Add($"dotnet/{akaMSChannelName}/{BuildQuality}");
                     }
 
+                    // If there are no channel names, default to dotnet/
+                    if (!targetChannelConfig.AkaMSChannelNames.Any())
+                    {
+                        shortLinkUrls.Add("dotnet/");
+                    }
+
                     var targetFeedsSetup = new SetupTargetFeedConfigV3(
                         targetChannelConfig: targetChannelConfig,
                         isInternalBuild: targetChannelConfig.IsInternal,


### PR DESCRIPTION
When there are no AkaMSChannelNames, we used to default to using dotnet/ as the short link url. When we switched to multiple possible channel names, we removed that default, so any channel with nothing in the list would just not create aka.ms links. This change returns to the previous behavior to use the default dotnet/ short link url.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
