### PR TITLE
Allow override of Linux install root

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
@@ -458,6 +458,7 @@
   <Target Name="_GetCommonJsonProperties">
     <PropertyGroup>
       <FullLicenseText>$([System.IO.File]::ReadAllText('$(LicenseFile)').Replace('%0A', '\n').Replace('"', '\"'))</FullLicenseText>
+      <LinuxInstallRoot Condition="'$(LinuxInstallRoot)' == ''">/usr/share/dotnet</LinuxInstallRoot>
     </PropertyGroup>
 
     <ItemGroup>
@@ -494,7 +495,7 @@
       <_CommonLinuxPackageProperty Include="short_description" String="$(_ShortDescription)" />
       <_CommonLinuxPackageProperty Include="maintainer_name" String=".NET Team" />
       <_CommonLinuxPackageProperty Include="maintainer_email" String="dotnetpackages@dotnetfoundation.org" />
-      <_CommonLinuxPackageProperty Include="install_root" String="/usr/share/dotnet" />
+      <_CommonLinuxPackageProperty Include="install_root" String="$(LinuxInstallRoot)" />
       <_CommonLinuxPackageProperty Include="long_description" String=".NET is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform and is supported by Microsoft. We hope you enjoy using it! If you do, please consider joining the active community of developers that are contributing to the project on GitHub (https://github.com/dotnet/core). We happily accept issues and PRs." />
       <_CommonLinuxPackageProperty Include="homepage" String="https://github.com/dotnet/core" />
       <_CommonLinuxPackageProperty Include="copyright" String="2017 Microsoft" />


### PR DESCRIPTION
This is a simple change to allow override of Linux install root value. It can be used by projects in repos that consume this infra, like dotnet/runtime.