### PR TITLE
Fix xliff tasks being loaded even when not needed

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Localization.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Localization.targets
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.XliffTasks" Version="$(MicrosoftDotNetXliffTasksVersion)" PrivateAssets="all" IsImplicitlyDefined="true" Condition="'$(IsShippingAssembly)' == 'true'" />
+    <PackageReference Include="Microsoft.DotNet.XliffTasks" Version="$(MicrosoftDotNetXliffTasksVersion)" PrivateAssets="all" IsImplicitlyDefined="true" Condition="'$(UsingToolXliff)' == 'true' and '$(IsShippingAssembly)' == 'true'" />
   </ItemGroup>
 
 


### PR DESCRIPTION
Fixes an issue created by https://github.com/dotnet/arcade/pull/8233/

After the change above, Xliff tasks package is now loaded even in the cases where it isn't needed.
This causes issues with some repos (and likely others that aren't listed below):
 - https://github.com/dotnet/aspnetcore/pull/38839
 - https://github.com/dotnet/winforms/pull/6263

The dotnet/templating and dotnet/test-templates repos seem to be working fine and are not affected by this bug.

The fix is to correct the usage of flags so that Xliff tasks package will only be loaded when needed.
Tested on local clone of winforms repo. Xliff tasks are no longer referenced unless needed.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
