### PR TITLE
Add Raspberry Pi OS rootfs creation

### DIFF
--- a/eng/common/cross/armv6/sources.list.buster
+++ b/eng/common/cross/armv6/sources.list.buster
@@ -1,0 +1,2 @@
+deb http://raspbian.raspberrypi.org/raspbian/ buster main contrib non-free rpi
+deb-src http://raspbian.raspberrypi.org/raspbian/ buster main contrib non-free rpi

--- a/eng/common/cross/armv6/sources.list.stretch
+++ b/eng/common/cross/armv6/sources.list.stretch
@@ -1,2 +1,0 @@
-deb http://raspbian.raspberrypi.org/raspbian/ stretch main contrib non-free rpi
-deb-src http://raspbian.raspberrypi.org/raspbian/ stretch main contrib non-free rpi

--- a/eng/common/cross/armv6/sources.list.stretch
+++ b/eng/common/cross/armv6/sources.list.stretch
@@ -1,0 +1,2 @@
+deb http://raspbian.raspberrypi.org/raspbian/ stretch main contrib non-free rpi
+deb-src http://raspbian.raspberrypi.org/raspbian/ stretch main contrib non-free rpi

--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -104,8 +104,8 @@ while :; do
             __UbuntuArch=armhf
             __QEMUArch=arm
             __UbuntuRepo="http://raspbian.raspberrypi.org/raspbian/"
-            __CodeName=stretch
-            __LLDB_Package="liblldb-4.0-dev"
+            __CodeName=buster
+            __LLDB_Package="liblldb-6.0-dev"
             __Keyring="/usr/share/keyrings/raspbian-archive-keyring.gpg"
             ;;
         arm64)

--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -106,6 +106,7 @@ while :; do
             __UbuntuRepo="http://raspbian.raspberrypi.org/raspbian/"
             __CodeName=stretch
             __LLDB_Package="liblldb-4.0-dev"
+            __Keyring="/usr/share/keyrings/raspbian-archive-keyring.gpg"
             ;;
         arm64)
             __BuildArch=arm64
@@ -244,6 +245,12 @@ while :; do
     shift
 done
 
+if [ -e "$__Keyring" ]; then
+    __Keyring="--keyring=$__Keyring"
+else
+    __Keyring=""
+fi
+
 if [ "$__BuildArch" == "armel" ]; then
     __LLDB_Package="lldb-3.5-dev"
 fi
@@ -345,7 +352,7 @@ elif [[ "$__CodeName" == "illumos" ]]; then
     wget -P "$__RootfsDir"/usr/include/netpacket https://raw.githubusercontent.com/illumos/illumos-gate/master/usr/src/uts/common/inet/sockmods/netpacket/packet.h
     wget -P "$__RootfsDir"/usr/include/sys https://raw.githubusercontent.com/illumos/illumos-gate/master/usr/src/uts/common/sys/sdt.h
 elif [[ -n $__CodeName ]]; then
-    qemu-debootstrap --arch $__UbuntuArch $__CodeName $__RootfsDir $__UbuntuRepo
+    qemu-debootstrap $__Keyring --arch $__UbuntuArch $__CodeName $__RootfsDir $__UbuntuRepo
     cp $__CrossDir/$__BuildArch/sources.list.$__CodeName $__RootfsDir/etc/apt/sources.list
     chroot $__RootfsDir apt-get update
     chroot $__RootfsDir apt-get -f -y install

--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -99,6 +99,14 @@ while :; do
             __AlpineArch=armv7
             __QEMUArch=arm
             ;;
+        armv6)
+            __BuildArch=armv6
+            __UbuntuArch=armhf
+            __QEMUArch=arm
+            __UbuntuRepo="http://raspbian.raspberrypi.org/raspbian/"
+            __CodeName=stretch
+            __LLDB_Package="liblldb-4.0-dev"
+            ;;
         arm64)
             __BuildArch=arm64
             __UbuntuArch=arm64


### PR DESCRIPTION
Raspberry Pi OS is the standard OS for use on Raspberry Pi single board computers. Primarily, it's a Debian distribution rebuilt to target ARMv6+VFPv2 instead of Debian's ARMv7+VFPv3-D16, to match the first-gen Raspberry Pi's Broadcom BCM2835 SoC.

Building anything (i.e. Hello World) using an ARMv7 crossrootfs will result in a SIGSEGV when executed on BCM2835.

Ref. https://github.com/dotnet/runtime/issues/7764