### PR TITLE
Move common parts of sdl templates to additional templates

### DIFF
--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -51,14 +51,9 @@ jobs:
       value: ${{ parameters.AzDOPipelineId }}
     - name: AzDOBuildId
       value: ${{ parameters.AzDOBuildId }}
-    # The Guardian version specified in 'eng/common/sdl/packages.config'. This value must be kept in
-    # sync with the packages.config file.
-    - name: DefaultGuardianVersion
-      value: 0.109.0
+    - template: /eng/common/templates/variables/sdl-variables.yml
     - name: GuardianVersion
       value: ${{ coalesce(parameters.overrideGuardianVersion, '$(DefaultGuardianVersion)') }}
-    - name: GuardianPackagesConfigFile
-      value: $(Build.SourcesDirectory)\eng\common\sdl\packages.config
   pool:
     vmImage: windows-2019
   steps:
@@ -125,57 +120,11 @@ jobs:
       displayName: Extract Archive Artifacts
       continueOnError: ${{ parameters.sdlContinueOnError }}
   
-  - ${{ if ne(parameters.overrideGuardianVersion, '') }}:
-    - powershell: |
-        $content = Get-Content $(GuardianPackagesConfigFile)
-
-        Write-Host "packages.config content was:`n$content"
-
-        $content = $content.Replace('$(DefaultGuardianVersion)', '$(GuardianVersion)')
-        $content | Set-Content $(GuardianPackagesConfigFile)
-
-        Write-Host "packages.config content updated to:`n$content"
-      displayName: Use overridden Guardian version ${{ parameters.overrideGuardianVersion }}
-
-  - task: NuGetToolInstaller@1
-    displayName: 'Install NuGet.exe'
-  - task: NuGetCommand@2
-    displayName: 'Install Guardian'
-    inputs:
-      restoreSolution: $(Build.SourcesDirectory)\eng\common\sdl\packages.config
-      feedsToUse: config
-      nugetConfigPath: $(Build.SourcesDirectory)\eng\common\sdl\NuGet.config
-      externalFeedCredentials: GuardianConnect
-      restoreDirectory: $(Build.SourcesDirectory)\.packages
-
-  - ${{ if ne(parameters.overrideParameters, '') }}:
-    - powershell: ${{ parameters.executeAllSdlToolsScript }} ${{ parameters.overrideParameters }}
-      displayName: Execute SDL
-      continueOnError: ${{ parameters.sdlContinueOnError }}
-  - ${{ if eq(parameters.overrideParameters, '') }}:
-    - powershell: ${{ parameters.executeAllSdlToolsScript }}
-        -GuardianPackageName Microsoft.Guardian.Cli.$(GuardianVersion)
-        -NugetPackageDirectory $(Build.SourcesDirectory)\.packages
-        -AzureDevOpsAccessToken $(dn-bot-dotnet-build-rw-code-rw)
-        ${{ parameters.additionalParameters }}
-      displayName: Execute SDL
-      continueOnError: ${{ parameters.sdlContinueOnError }}
-
-  - ${{ if ne(parameters.publishGuardianDirectoryToPipeline, 'false') }}:
-    # We want to publish the Guardian results and configuration for easy diagnosis. However, the
-    # '.gdn' dir is a mix of configuration, results, extracted dependencies, and Guardian default
-    # tooling files. Some of these files are large and aren't useful during an investigation, so
-    # exclude them by simply deleting them before publishing. (As of writing, there is no documented
-    # way to selectively exclude a dir from the pipeline artifact publish task.)
-    - task: DeleteFiles@1
-      displayName: Delete Guardian dependencies to avoid uploading
-      inputs:
-        SourceFolder: $(Agent.BuildDirectory)/.gdn
-        Contents: |
-          c
-          i
-      condition: succeededOrFailed()
-    - publish: $(Agent.BuildDirectory)/.gdn
-      artifact: GuardianConfiguration
-      displayName: Publish GuardianConfiguration
-      condition: succeededOrFailed()
+  - template: /eng/common/templates/steps/execute-sdl.yml
+    parameters:
+      overrideGuadianVersion: ${{ parameters.overrideGuardianVersion }}
+      executeAllSdlToolsScript: ${{ parameters.executeAllSdlToolsScript }}
+      overrideParameters: ${{ parameters.overrideParameters }}
+      additionalParameters: ${{ parameters.additionalParameters }}
+      publishGuardianDirectoryToPipeline: ${{ parameters.publishGuardianDirectoryToPipeline }}
+      sdlContinueOnError: ${{ parameters.sdlContinueOnError }}

--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -122,7 +122,7 @@ jobs:
   
   - template: /eng/common/templates/steps/execute-sdl.yml
     parameters:
-      overrideGuadianVersion: ${{ parameters.overrideGuardianVersion }}
+      overrideGuardianVersion: ${{ parameters.overrideGuardianVersion }}
       executeAllSdlToolsScript: ${{ parameters.executeAllSdlToolsScript }}
       overrideParameters: ${{ parameters.overrideParameters }}
       additionalParameters: ${{ parameters.additionalParameters }}

--- a/eng/common/templates/steps/execute-sdl.yml
+++ b/eng/common/templates/steps/execute-sdl.yml
@@ -1,5 +1,5 @@
 parameters:
-  overrideGuadianVersion: ''
+  overrideGuardianVersion: ''
   executeAllSdlToolsScript: ''
   overrideParameters: ''
   additionalParameters: ''

--- a/eng/common/templates/steps/execute-sdl.yml
+++ b/eng/common/templates/steps/execute-sdl.yml
@@ -1,0 +1,68 @@
+parameters:
+  overrideGuadianVersion: ''
+  executeAllSdlToolsScript: ''
+  overrideParameters: ''
+  additionalParameters: ''
+  publishGuardianDirectoryToPipeline: false
+  sdlContinueOnError: false
+  condition: ''
+
+steps:
+- ${{ if ne(parameters.overrideGuardianVersion, '') }}:
+  - powershell: |
+      $content = Get-Content $(GuardianPackagesConfigFile)
+
+      Write-Host "packages.config content was:`n$content"
+
+      $content = $content.Replace('$(DefaultGuardianVersion)', '$(GuardianVersion)')
+      $content | Set-Content $(GuardianPackagesConfigFile)
+
+      Write-Host "packages.config content updated to:`n$content"
+    displayName: Use overridden Guardian version ${{ parameters.overrideGuardianVersion }}
+
+- task: NuGetToolInstaller@1
+  displayName: 'Install NuGet.exe'
+  
+- task: NuGetCommand@2
+  displayName: 'Install Guardian'
+  inputs:
+    restoreSolution: $(Build.SourcesDirectory)\eng\common\sdl\packages.config
+    feedsToUse: config
+    nugetConfigPath: $(Build.SourcesDirectory)\eng\common\sdl\NuGet.config
+    externalFeedCredentials: GuardianConnect
+    restoreDirectory: $(Build.SourcesDirectory)\.packages
+
+- ${{ if ne(parameters.overrideParameters, '') }}:
+  - powershell: ${{ parameters.executeAllSdlToolsScript }} ${{ parameters.overrideParameters }}
+    displayName: Execute SDL
+    continueOnError: ${{ parameters.sdlContinueOnError }}
+    condition: ${{ parameters.condition }}
+
+- ${{ if eq(parameters.overrideParameters, '') }}:
+  - powershell: ${{ parameters.executeAllSdlToolsScript }}
+      -GuardianPackageName Microsoft.Guardian.Cli.$(GuardianVersion)
+      -NugetPackageDirectory $(Build.SourcesDirectory)\.packages
+      -AzureDevOpsAccessToken $(dn-bot-dotnet-build-rw-code-rw)
+      ${{ parameters.additionalParameters }}
+    displayName: Execute SDL
+    continueOnError: ${{ parameters.sdlContinueOnError }}
+    condition: ${{ parameters.condition }}
+
+- ${{ if ne(parameters.publishGuardianDirectoryToPipeline, 'false') }}:
+  # We want to publish the Guardian results and configuration for easy diagnosis. However, the
+  # '.gdn' dir is a mix of configuration, results, extracted dependencies, and Guardian default
+  # tooling files. Some of these files are large and aren't useful during an investigation, so
+  # exclude them by simply deleting them before publishing. (As of writing, there is no documented
+  # way to selectively exclude a dir from the pipeline artifact publish task.)
+  - task: DeleteFiles@1
+    displayName: Delete Guardian dependencies to avoid uploading
+    inputs:
+      SourceFolder: $(Agent.BuildDirectory)/.gdn
+      Contents: |
+        c
+        i
+    condition: succeededOrFailed()
+  - publish: $(Agent.BuildDirectory)/.gdn
+    artifact: GuardianConfiguration
+    displayName: Publish GuardianConfiguration
+    condition: succeededOrFailed()

--- a/eng/common/templates/variables/sdl-variables.yml
+++ b/eng/common/templates/variables/sdl-variables.yml
@@ -1,0 +1,7 @@
+variables:
+# The Guardian version specified in 'eng/common/sdl/packages.config'. This value must be kept in
+# sync with the packages.config file.
+- name: DefaultGuardianVersion
+  value: 0.109.0
+- name: GuardianPackagesConfigFile
+  value: $(Build.SourcesDirectory)\eng\common\sdl\packages.config


### PR DESCRIPTION
SDL Validation is done in both the repos and the staging/validation pipelines. Today, we have a large amount of the sdl job template duplicated for the staging/validation pipelines because we need to use different sources/we don't need all the artifact downloading (and if we did, we would want to get the artifacts from a different place). This duplication leads to issues like https://github.com/dotnet/arcade/issues/8243 (among others), where versions changed in arcade, but they weren't properly migrated to dotnet-release, and the validation pipeline started failing.

This change moves the duplicated steps to a steps template, and the duplicated variables to a variables template, so we can more easily share between these repos/pipelines.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation

This was tested in https://dev.azure.com/dnceng/internal/_build/results?buildId=1499177&view=results.
