### PR TITLE
Separate Helix and XHarness testing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,7 +120,7 @@ stages:
               Build_Debug:
                 _BuildConfig: Debug
           variables:
-            _Testing: Helix
+          - _Testing: Helix
           preSteps:
           - checkout: self
             clean: true
@@ -161,7 +161,7 @@ stages:
               Build_Debug:
                 _BuildConfig: Debug
           variables:
-            _Testing: Xharness
+          - _Testing: Xharness
           preSteps:
           - checkout: self
             clean: true
@@ -191,7 +191,7 @@ stages:
               Build_Release:
                 _BuildConfig: Release
           variables:
-            _Testing: Helix
+          - _Testing: Helix
           preSteps:
           - checkout: self
             clean: true
@@ -209,7 +209,7 @@ stages:
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''
-        - job: Linux_XHarness
+        - job: Linux_XHarness_Apple_Simulator
           timeoutInMinutes: 90
           container: LinuxContainer
           pool:
@@ -221,7 +221,7 @@ stages:
               Build_Release:
                 _BuildConfig: Release
           variables:
-            _Testing: Xharness
+          - _Testing: Xharness_Apple_Simulator
           preSteps:
           - checkout: self
             clean: true
@@ -239,6 +239,23 @@ stages:
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''
+        - job: Linux_XHarness_Apple_Device
+          timeoutInMinutes: 90
+          container: LinuxContainer
+          pool:
+            vmimage: ubuntu-latest
+          strategy:
+            matrix:
+              Build_Debug:
+                _BuildConfig: Debug
+              Build_Release:
+                _BuildConfig: Release
+          variables:
+          - _Testing: Xharness_Apple_Device
+          preSteps:
+          - checkout: self
+            clean: true
+          steps:
           - script: eng/common/build.sh
               -configuration $(_BuildConfig)
               -prepareMachine
@@ -252,6 +269,23 @@ stages:
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''
+        - job: Linux_XHarness
+          timeoutInMinutes: 90
+          container: LinuxContainer
+          pool:
+            vmimage: ubuntu-latest
+          strategy:
+            matrix:
+              Build_Debug:
+                _BuildConfig: Debug
+              Build_Release:
+                _BuildConfig: Release
+          variables:
+          - _Testing: Xharness
+          preSteps:
+          - checkout: self
+            clean: true
+          steps:
           - script: eng/common/build.sh
               -configuration $(_BuildConfig) 
               -prepareMachine

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -119,6 +119,8 @@ stages:
                 _BuildConfig: Release
               Build_Debug:
                 _BuildConfig: Debug
+          variables:
+            _Testing: Helix
           preSteps:
           - checkout: self
             clean: true
@@ -158,6 +160,8 @@ stages:
                 _BuildConfig: Release
               Build_Debug:
                 _BuildConfig: Debug
+          variables:
+            _Testing: Xharness
           preSteps:
           - checkout: self
             clean: true
@@ -186,6 +190,8 @@ stages:
                 _BuildConfig: Debug
               Build_Release:
                 _BuildConfig: Release
+          variables:
+            _Testing: Helix
           preSteps:
           - checkout: self
             clean: true
@@ -214,6 +220,8 @@ stages:
                 _BuildConfig: Debug
               Build_Release:
                 _BuildConfig: Release
+          variables:
+            _Testing: Xharness
           preSteps:
           - checkout: self
             clean: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,9 +102,9 @@ stages:
         artifacts:
           publish:
             artifacts:
-              name: Artifacts_Test_$(Agent.OS)_$(_BuildConfig)
+              name: Artifacts_Test_$(Agent.OS)_$(_BuildConfig)_$(_Testing)
             logs: 
-              name: Logs_Test_$(Agent.OS)_$(_BuildConfig)
+              name: Logs_Test_$(Agent.OS)_$(_BuildConfig)_$(_Testing)
           download: true
         workspace:
           clean: all

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -148,6 +148,20 @@ stages:
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''
+        - job: Windows_NT_XHarness
+          timeoutInMinutes: 90
+          pool:
+            vmimage: windows-latest
+          strategy:
+            matrix:
+              Build_Release:
+                _BuildConfig: Release
+              Build_Debug:
+                _BuildConfig: Debug
+          preSteps:
+          - checkout: self
+            clean: true
+          steps:
           - powershell: eng\common\build.ps1
               -configuration $(_BuildConfig) 
               -prepareMachine
@@ -189,6 +203,21 @@ stages:
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''
+        - job: Linux_XHarness
+          timeoutInMinutes: 90
+          container: LinuxContainer
+          pool:
+            vmimage: ubuntu-latest
+          strategy:
+            matrix:
+              Build_Debug:
+                _BuildConfig: Debug
+              Build_Release:
+                _BuildConfig: Release
+          preSteps:
+          - checkout: self
+            clean: true
+          steps:
           - script: eng/common/build.sh
               -configuration $(_BuildConfig)
               -prepareMachine


### PR DESCRIPTION
There are frequently intermittent failures in the XHarness testing that need to be retried due to timeouts or xharness flakiness. Because the XHarness tests are in the same job as the regular helix tests, we have rerun all of the testing just to rerun the xharness tests. This wastes resources and is frustrating for devs.

This change splits out the xharness tests into their own jobs so that when xharness reruns need to happen, we only have to rerun the xharness legs.

Fixes #8252.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
