### PR TITLE
MSI Bundle generator should honor msbuild Authors property when setting the authors value of the resulting msi file.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/variables.wxi
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/variables.wxi
@@ -4,7 +4,9 @@
   <?define Dotnet_ProductVersion = "$(var.BuildVersion)" ?>
   <?define Dotnet_BuildVersion = "$(var.BuildVersion)" ?>
 
+<?ifndef Manufacturer?>
   <?define Manufacturer     =   "Microsoft Corporation" ?>
+<?endif?>
   <?define ProductName      =   "$(var.ProductMoniker) ($(var.TargetArchitectureDescription))" ?>
   <?define ProductLanguage  =   "1033" ?>
   <?define ProductVersion   =   "$(var.Dotnet_ProductVersion)" ?>


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/8260.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation

Note: I tested this change manually with an msi and exe bundle and it works for both.