### PR TITLE
Stop publishing pipeline artifacts from test stages

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,8 +101,6 @@ stages:
       parameters:
         artifacts:
           publish:
-            artifacts:
-              name: Artifacts_Test_$(Agent.OS)_$(_BuildConfig)_$(_Testing)
             logs: 
               name: Logs_Test_$(Agent.OS)_$(_BuildConfig)_$(_Testing)
           download: true


### PR DESCRIPTION
During the test stage of Arcade PR builds, we upload built artifacts as pipeline artifacts for no reason - they are not used in any way. After we have added even more jobs, we needlessly upload >10 GB:

![image](https://user-images.githubusercontent.com/7013027/145788371-5c46ffe2-a735-4a73-bdf1-829347010397.png)

This PR disables this upload which also saves about 6-10 minutes of build time.

Related #7979