### PR TITLE
Backport more GDN / Policheck functionality from main to unbreak 3.x build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -215,4 +215,5 @@ stages:
         -TsaIterationPath $(_TsaIterationPath)
         -TsaRepositoryName "Arcade"
         -TsaCodebaseName "Arcade"
-        -TsaPublish $True'
+        -TsaPublish $True
+        -PoliCheckAdditionalRunConfigParams @("UserExclusionPath < $(Build.SourcesDirectory)/eng/PoliCheckExclusions.xml")'

--- a/eng/PoliCheckExclusions.xml
+++ b/eng/PoliCheckExclusions.xml
@@ -1,0 +1,5 @@
+<!-- See https://www.1eswiki.com/wiki/PoliCheck_Build_Task#Excluding_Files_or_folders_from_the_PoliCheck_scan for guidance -->
+<PoliCheckExclusions>
+  <!-- Can't be modified, contains appropriate usage of term for geographical location --> 
+  <Exclusion Type="FileName">MICROSOFTDOTNETLIBRARY.TXT</Exclusion>
+</PoliCheckExclusions>

--- a/eng/common/pipeline-logging-functions.ps1
+++ b/eng/common/pipeline-logging-functions.ps1
@@ -12,6 +12,7 @@ $script:loggingCommandEscapeMappings = @( # TODO: WHAT ABOUT "="? WHAT ABOUT "%"
 # TODO: BUG: Escape % ???
 # TODO: Add test to verify don't need to escape "=".
 
+# Specify "-Force" to force pipeline formatted output even if "$ci" is false or not set
 function Write-PipelineTelemetryError {
     [CmdletBinding()]
     param(
@@ -25,80 +26,101 @@ function Write-PipelineTelemetryError {
         [string]$SourcePath,
         [string]$LineNumber,
         [string]$ColumnNumber,
-        [switch]$AsOutput)
+        [switch]$AsOutput,
+        [switch]$Force)
 
-        $PSBoundParameters.Remove("Category") | Out-Null
+    $PSBoundParameters.Remove('Category') | Out-Null
 
+    if ($Force -Or ((Test-Path variable:ci) -And $ci)) {
         $Message = "(NETCORE_ENGINEERING_TELEMETRY=$Category) $Message"
-        $PSBoundParameters.Remove("Message") | Out-Null
-        $PSBoundParameters.Add("Message", $Message)
-
-        Write-PipelineTaskError @PSBoundParameters
+    }
+    $PSBoundParameters.Remove('Message') | Out-Null
+    $PSBoundParameters.Add('Message', $Message)
+    Write-PipelineTaskError @PSBoundParameters
 }
 
+# Specify "-Force" to force pipeline formatted output even if "$ci" is false or not set
 function Write-PipelineTaskError {
     [CmdletBinding()]
     param(
-      [Parameter(Mandatory = $true)]
-      [string]$Message,
-      [Parameter(Mandatory = $false)]
-      [string]$Type = 'error',
-      [string]$ErrCode,
-      [string]$SourcePath,
-      [string]$LineNumber,
-      [string]$ColumnNumber,
-      [switch]$AsOutput)
-  
-      if(!$ci) {
-        if($Type -eq 'error') {
-          Write-Host $Message -ForegroundColor Red
-          return
+        [Parameter(Mandatory = $true)]
+        [string]$Message,
+        [Parameter(Mandatory = $false)]
+        [string]$Type = 'error',
+        [string]$ErrCode,
+        [string]$SourcePath,
+        [string]$LineNumber,
+        [string]$ColumnNumber,
+        [switch]$AsOutput,
+        [switch]$Force
+    )
+
+    if (!$Force -And (-Not (Test-Path variable:ci) -Or !$ci)) {
+        if ($Type -eq 'error') {
+            Write-Host $Message -ForegroundColor Red
+            return
         }
         elseif ($Type -eq 'warning') {
-          Write-Host $Message -ForegroundColor Yellow
-          return
+            Write-Host $Message -ForegroundColor Yellow
+            return
         }
-      }
-  
-      if(($Type -ne 'error') -and ($Type -ne 'warning')) {
+    }
+
+    if (($Type -ne 'error') -and ($Type -ne 'warning')) {
         Write-Host $Message
         return
-      }
-      if(-not $PSBoundParameters.ContainsKey('Type')) {
+    }
+    $PSBoundParameters.Remove('Force') | Out-Null      
+    if (-not $PSBoundParameters.ContainsKey('Type')) {
         $PSBoundParameters.Add('Type', 'error')
-      }
-      Write-LogIssue @PSBoundParameters
-  }
+    }
+    Write-LogIssue @PSBoundParameters
+}
   
-  function Write-PipelineSetVariable {
+function Write-PipelineSetVariable {
     [CmdletBinding()]
     param(
-      [Parameter(Mandatory = $true)]
-      [string]$Name,
-      [string]$Value,
-      [switch]$Secret,
-      [switch]$AsOutput,
-      [bool]$IsMultiJobVariable=$true)
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+        [string]$Value,
+        [switch]$Secret,
+        [switch]$AsOutput,
+        [bool]$IsMultiJobVariable = $true)
 
-      if($ci) {
+    if ((Test-Path variable:ci) -And $ci) {
         Write-LoggingCommand -Area 'task' -Event 'setvariable' -Data $Value -Properties @{
-          'variable' = $Name
-          'isSecret' = $Secret
-          'isOutput' = $IsMultiJobVariable
+            'variable' = $Name
+            'isSecret' = $Secret
+            'isOutput' = $IsMultiJobVariable
         } -AsOutput:$AsOutput
-      }
-  }
+    }
+}
   
-  function Write-PipelinePrependPath {
+function Write-PipelinePrependPath {
     [CmdletBinding()]
     param(
-      [Parameter(Mandatory=$true)]
-      [string]$Path,
-      [switch]$AsOutput)
-      if($ci) {
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+        [switch]$AsOutput)
+
+    if ((Test-Path variable:ci) -And $ci) {
         Write-LoggingCommand -Area 'task' -Event 'prependpath' -Data $Path -AsOutput:$AsOutput
-      }
-  }
+    }
+}
+
+function Write-PipelineSetResult {
+    [CmdletBinding()]
+    param(
+        [ValidateSet("Succeeded", "SucceededWithIssues", "Failed", "Cancelled", "Skipped")]
+        [Parameter(Mandatory = $true)]
+        [string]$Result,
+        [string]$Message)
+    if ((Test-Path variable:ci) -And $ci) {
+        Write-LoggingCommand -Area 'task' -Event 'complete' -Data $Message -Properties @{
+            'result' = $Result
+        }
+    }
+}
 
 <########################################
 # Private functions.
@@ -115,7 +137,8 @@ function Format-LoggingCommandData {
         foreach ($mapping in $script:loggingCommandEscapeMappings) {
             $Value = $Value.Replace($mapping.Token, $mapping.Replacement)
         }
-    } else {
+    }
+    else {
         for ($i = $script:loggingCommandEscapeMappings.Length - 1 ; $i -ge 0 ; $i--) {
             $mapping = $script:loggingCommandEscapeMappings[$i]
             $Value = $Value.Replace($mapping.Replacement, $mapping.Token)
@@ -148,7 +171,8 @@ function Format-LoggingCommand {
                 if ($first) {
                     $null = $sb.Append(' ')
                     $first = $false
-                } else {
+                }
+                else {
                     $null = $sb.Append(';')
                 }
 
@@ -185,7 +209,8 @@ function Write-LoggingCommand {
     $command = Format-LoggingCommand -Area $Area -Event $Event -Data $Data -Properties $Properties
     if ($AsOutput) {
         $command
-    } else {
+    }
+    else {
         Write-Host $command
     }
 }
@@ -204,12 +229,12 @@ function Write-LogIssue {
         [switch]$AsOutput)
 
     $command = Format-LoggingCommand -Area 'task' -Event 'logissue' -Data $Message -Properties @{
-            'type' = $Type
-            'code' = $ErrCode
-            'sourcepath' = $SourcePath
-            'linenumber' = $LineNumber
-            'columnnumber' = $ColumnNumber
-        }
+        'type'         = $Type
+        'code'         = $ErrCode
+        'sourcepath'   = $SourcePath
+        'linenumber'   = $LineNumber
+        'columnnumber' = $ColumnNumber
+    }
     if ($AsOutput) {
         return $command
     }
@@ -221,7 +246,8 @@ function Write-LogIssue {
             $foregroundColor = [System.ConsoleColor]::Red
             $backgroundColor = [System.ConsoleColor]::Black
         }
-    } else {
+    }
+    else {
         $foregroundColor = $host.PrivateData.WarningForegroundColor
         $backgroundColor = $host.PrivateData.WarningBackgroundColor
         if ($foregroundColor -isnot [System.ConsoleColor] -or $backgroundColor -isnot [System.ConsoleColor]) {

--- a/eng/common/sdl/configure-sdl-tool.ps1
+++ b/eng/common/sdl/configure-sdl-tool.ps1
@@ -1,0 +1,109 @@
+Param(
+  [string] $GuardianCliLocation,
+  [string] $WorkingDirectory,
+  [string] $TargetDirectory,
+  [string] $GdnFolder,
+  # The list of Guardian tools to configure. For each object in the array:
+  # - If the item is a [hashtable], it must contain these entries:
+  #   - Name = The tool name as Guardian knows it.
+  #   - Scenario = (Optional) Scenario-specific name for this configuration entry. It must be unique
+  #     among all tool entries with the same Name.
+  #   - Args = (Optional) Array of Guardian tool configuration args, like '@("Target > C:\temp")'
+  # - If the item is a [string] $v, it is treated as '@{ Name="$v" }'
+  [object[]] $ToolsList,
+  [string] $GuardianLoggerLevel='Standard',
+  # Optional: Additional params to add to any tool using CredScan.
+  [string[]] $CrScanAdditionalRunConfigParams,
+  # Optional: Additional params to add to any tool using PoliCheck.
+  [string[]] $PoliCheckAdditionalRunConfigParams
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+$disableConfigureToolsetImport = $true
+$global:LASTEXITCODE = 0
+
+try {
+  # `tools.ps1` checks $ci to perform some actions. Since the SDL
+  # scripts don't necessarily execute in the same agent that run the
+  # build.ps1/sh script this variable isn't automatically set.
+  $ci = $true
+  . $PSScriptRoot\..\tools.ps1
+
+  # Normalize tools list: all in [hashtable] form with defined values for each key.
+  $ToolsList = $ToolsList |
+    ForEach-Object {
+      if ($_ -is [string]) {
+        $_ = @{ Name = $_ }
+      }
+
+      if (-not ($_['Scenario'])) { $_.Scenario = "" }
+      if (-not ($_['Args'])) { $_.Args = @() }
+      $_
+    }
+  
+  Write-Host "List of tools to configure:"
+  $ToolsList | ForEach-Object { $_ | Out-String | Write-Host }
+
+  # We store config files in the r directory of .gdn
+  $gdnConfigPath = Join-Path $GdnFolder 'r'
+  $ValidPath = Test-Path $GuardianCliLocation
+
+  if ($ValidPath -eq $False)
+  {
+    Write-PipelineTelemetryError -Force -Category 'Sdl' -Message "Invalid Guardian CLI Location."
+    ExitWithExitCode 1
+  }
+
+  foreach ($tool in $ToolsList) {
+    # Put together the name and scenario to make a unique key.
+    $toolConfigName = $tool.Name
+    if ($tool.Scenario) {
+      $toolConfigName += "_" + $tool.Scenario
+    }
+
+    Write-Host "=== Configuring $toolConfigName..."
+
+    $gdnConfigFile = Join-Path $gdnConfigPath "$toolConfigName-configure.gdnconfig"
+
+    # For some tools, add default and automatic args.
+    if ($tool.Name -eq 'credscan') {
+      if ($targetDirectory) {
+        $tool.Args += "`"TargetDirectory < $TargetDirectory`""
+      }
+      $tool.Args += "`"OutputType < pre`""
+      $tool.Args += $CrScanAdditionalRunConfigParams
+    } elseif ($tool.Name -eq 'policheck') {
+      if ($targetDirectory) {
+        $tool.Args += "`"Target < $TargetDirectory`""
+      }
+      $tool.Args += $PoliCheckAdditionalRunConfigParams
+    }
+
+    # Create variable pointing to the args array directly so we can use splat syntax later.
+    $toolArgs = $tool.Args
+
+    # Configure the tool. If args array is provided or the current tool has some default arguments
+    # defined, add "--args" and splat each element on the end. Arg format is "{Arg id} < {Value}",
+    # one per parameter. Doc page for "guardian configure":
+    # https://dev.azure.com/securitytools/SecurityIntegration/_wiki/wikis/Guardian/1395/configure
+    Exec-BlockVerbosely {
+      & $GuardianCliLocation configure `
+        --working-directory $WorkingDirectory `
+        --tool $tool.Name `
+        --output-path $gdnConfigFile `
+        --logger-level $GuardianLoggerLevel `
+        --noninteractive `
+        --force `
+        $(if ($toolArgs) { "--args" }) @toolArgs
+      Exit-IfNZEC "Sdl"
+    }
+
+    Write-Host "Created '$toolConfigName' configuration file: $gdnConfigFile"
+  }
+}
+catch {
+  Write-Host $_.ScriptStackTrace
+  Write-PipelineTelemetryError -Force -Category 'Sdl' -Message $_
+  ExitWithExitCode 1
+}

--- a/eng/common/sdl/extract-artifact-archives.ps1
+++ b/eng/common/sdl/extract-artifact-archives.ps1
@@ -1,0 +1,63 @@
+# This script looks for each archive file in a directory and extracts it into the target directory.
+# For example, the file "$InputPath/bin.tar.gz" extracts to "$ExtractPath/bin.tar.gz.extracted/**".
+# Uses the "tar" utility added to Windows 10 / Windows 2019 that supports tar.gz and zip.
+param(
+  # Full path to directory where archives are stored.
+  [Parameter(Mandatory=$true)][string] $InputPath,
+  # Full path to directory to extract archives into. May be the same as $InputPath.
+  [Parameter(Mandatory=$true)][string] $ExtractPath
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$disableConfigureToolsetImport = $true
+
+try {
+  # `tools.ps1` checks $ci to perform some actions. Since the SDL
+  # scripts don't necessarily execute in the same agent that run the
+  # build.ps1/sh script this variable isn't automatically set.
+  $ci = $true
+  . $PSScriptRoot\..\tools.ps1
+
+  Measure-Command {
+    $jobs = @()
+
+    # Find archive files for non-Windows and Windows builds.
+    $archiveFiles = @(
+      Get-ChildItem (Join-Path $InputPath "*.tar.gz")
+      Get-ChildItem (Join-Path $InputPath "*.zip")
+    )
+
+    foreach ($targzFile in $archiveFiles) {
+      $jobs += Start-Job -ScriptBlock {
+        $file = $using:targzFile
+        $fileName = [System.IO.Path]::GetFileName($file)
+        $extractDir = Join-Path $using:ExtractPath "$fileName.extracted"
+
+        New-Item $extractDir -ItemType Directory -Force | Out-Null
+
+        Write-Host "Extracting '$file' to '$extractDir'..."
+
+        # Pipe errors to stdout to prevent PowerShell detecting them and quitting the job early.
+        # This type of quit skips the catch, so we wouldn't be able to tell which file triggered the
+        # error. Save output so it can be stored in the exception string along with context.
+        $output = tar -xf $file -C $extractDir 2>&1
+        # Handle NZEC manually rather than using Exit-IfNZEC: we are in a background job, so we
+        # don't have access to the outer scope.
+        if ($LASTEXITCODE -ne 0) {
+          throw "Error extracting '$file': non-zero exit code ($LASTEXITCODE). Output: '$output'"
+        }
+
+        Write-Host "Extracted to $extractDir"
+      }
+    }
+
+    Receive-Job $jobs -Wait
+  }
+}
+catch {
+  Write-Host $_
+  Write-PipelineTelemetryError -Force -Category 'Sdl' -Message $_
+  ExitWithExitCode 1
+}

--- a/eng/common/sdl/extract-artifact-packages.ps1
+++ b/eng/common/sdl/extract-artifact-packages.ps1
@@ -3,54 +3,12 @@ param(
   [Parameter(Mandatory=$true)][string] $ExtractPath            # Full path to directory where the packages will be extracted
 )
 
-$ErrorActionPreference = "Stop"
+$ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
 
-# `tools.ps1` checks $ci to perform some actions. Since the post-build
-# scripts don't necessarily execute in the same agent that run the
-# build.ps1/sh script this variable isn't automatically set.
-$ci = $true
-. $PSScriptRoot\..\tools.ps1
+$disableConfigureToolsetImport = $true
 
-$ExtractPackage = {
-  param( 
-    [string] $PackagePath                                 # Full path to a NuGet package
-  )
-  
-  if (!(Test-Path $PackagePath)) {
-    Write-PipelineTaskError "Input file does not exist: $PackagePath"
-    ExitWithExitCode 1
-  }
-  
-  $RelevantExtensions = @(".dll", ".exe", ".pdb")
-  Write-Host -NoNewLine "Extracting" ([System.IO.Path]::GetFileName($PackagePath)) "... "
-
-  $PackageId = [System.IO.Path]::GetFileNameWithoutExtension($PackagePath)
-  $ExtractPath = Join-Path -Path $using:ExtractPath -ChildPath $PackageId
-
-  Add-Type -AssemblyName System.IO.Compression.FileSystem
-
-  [System.IO.Directory]::CreateDirectory($ExtractPath);
-
-  try {
-    $zip = [System.IO.Compression.ZipFile]::OpenRead($PackagePath)
-
-    $zip.Entries | 
-    Where-Object {$RelevantExtensions -contains [System.IO.Path]::GetExtension($_.Name)} |
-      ForEach-Object {
-          $TargetFile = Join-Path -Path $ExtractPath -ChildPath $_.Name
-
-          [System.IO.Compression.ZipFileExtensions]::ExtractToFile($_, $TargetFile, $true)
-        }
-  }
-  catch {
-  
-  }
-  finally {
-    $zip.Dispose() 
-  }
- }
- function ExtractArtifacts {
+function ExtractArtifacts {
   if (!(Test-Path $InputPath)) {
     Write-Host "Input Path does not exist: $InputPath"
     ExitWithExitCode 0
@@ -67,11 +25,56 @@ $ExtractPackage = {
 }
 
 try {
+  # `tools.ps1` checks $ci to perform some actions. Since the SDL
+  # scripts don't necessarily execute in the same agent that run the
+  # build.ps1/sh script this variable isn't automatically set.
+  $ci = $true
+  . $PSScriptRoot\..\tools.ps1
+
+  $ExtractPackage = {
+    param( 
+      [string] $PackagePath                                 # Full path to a NuGet package
+    )
+    
+    if (!(Test-Path $PackagePath)) {
+      Write-PipelineTelemetryError -Category 'Build' -Message "Input file does not exist: $PackagePath"
+      ExitWithExitCode 1
+    }
+    
+    $RelevantExtensions = @('.dll', '.exe', '.pdb')
+    Write-Host -NoNewLine 'Extracting ' ([System.IO.Path]::GetFileName($PackagePath)) '...'
+  
+    $PackageId = [System.IO.Path]::GetFileNameWithoutExtension($PackagePath)
+    $ExtractPath = Join-Path -Path $using:ExtractPath -ChildPath $PackageId
+  
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+  
+    [System.IO.Directory]::CreateDirectory($ExtractPath);
+  
+    try {
+      $zip = [System.IO.Compression.ZipFile]::OpenRead($PackagePath)
+  
+      $zip.Entries | 
+      Where-Object {$RelevantExtensions -contains [System.IO.Path]::GetExtension($_.Name)} |
+        ForEach-Object {
+            $TargetFile = Join-Path -Path $ExtractPath -ChildPath $_.Name
+  
+            [System.IO.Compression.ZipFileExtensions]::ExtractToFile($_, $TargetFile, $true)
+          }
+    }
+    catch {
+      Write-Host $_
+      Write-PipelineTelemetryError -Force -Category 'Sdl' -Message $_
+      ExitWithExitCode 1
+    }
+    finally {
+      $zip.Dispose() 
+    }
+  }
   Measure-Command { ExtractArtifacts }
 }
 catch {
   Write-Host $_
-  Write-Host $_.Exception
-  Write-Host $_.ScriptStackTrace
+  Write-PipelineTelemetryError -Force -Category 'Sdl' -Message $_
   ExitWithExitCode 1
 }

--- a/eng/common/sdl/run-sdl.ps1
+++ b/eng/common/sdl/run-sdl.ps1
@@ -1,59 +1,49 @@
 Param(
   [string] $GuardianCliLocation,
   [string] $WorkingDirectory,
-  [string] $TargetDirectory,
   [string] $GdnFolder,
-  [string[]] $ToolsList,
   [string] $UpdateBaseline,
-  [string] $GuardianLoggerLevel="Standard",
-  [string[]] $CrScanAdditionalRunConfigParams,
-  [string[]] $PoliCheckAdditionalRunConfigParams
+  [string] $GuardianLoggerLevel='Standard'
 )
 
-$ErrorActionPreference = "Stop"
+$ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
+$disableConfigureToolsetImport = $true
 $global:LASTEXITCODE = 0
 
-# We store config files in the r directory of .gdn
-Write-Host $ToolsList
-$gdnConfigPath = Join-Path $GdnFolder "r"
-$ValidPath = Test-Path $GuardianCliLocation
+try {
+  # `tools.ps1` checks $ci to perform some actions. Since the SDL
+  # scripts don't necessarily execute in the same agent that run the
+  # build.ps1/sh script this variable isn't automatically set.
+  $ci = $true
+  . $PSScriptRoot\..\tools.ps1
 
-if ($ValidPath -eq $False)
-{
-  Write-Error "Invalid Guardian CLI Location."
-  exit 1
-}
+  # We store config files in the r directory of .gdn
+  $gdnConfigPath = Join-Path $GdnFolder 'r'
+  $ValidPath = Test-Path $GuardianCliLocation
 
-$configParam = @("--config")
-
-foreach ($tool in $ToolsList) {
-  $gdnConfigFile = Join-Path $gdnConfigPath "$tool-configure.gdnconfig"
-  Write-Host $tool
-  # We have to manually configure tools that run on source to look at the source directory only
-  if ($tool -eq "credscan") {
-    Write-Host "$GuardianCliLocation configure --working-directory $WorkingDirectory --tool $tool --output-path $gdnConfigFile --logger-level $GuardianLoggerLevel --noninteractive --force --args `" TargetDirectory < $TargetDirectory `" `" OutputType < pre `" $(If ($CrScanAdditionalRunConfigParams) {$CrScanAdditionalRunConfigParams})"
-    & $GuardianCliLocation configure --working-directory $WorkingDirectory --tool $tool --output-path $gdnConfigFile --logger-level $GuardianLoggerLevel --noninteractive --force --args " TargetDirectory < $TargetDirectory " "OutputType < pre" $(If ($CrScanAdditionalRunConfigParams) {$CrScanAdditionalRunConfigParams})
-    if ($LASTEXITCODE -ne 0) {
-      Write-Error "Guardian configure for $tool failed with exit code $LASTEXITCODE."
-      exit $LASTEXITCODE
-    }
-  }
-  if ($tool -eq "policheck") {
-    Write-Host "$GuardianCliLocation configure --working-directory $WorkingDirectory --tool $tool --output-path $gdnConfigFile --logger-level $GuardianLoggerLevel --noninteractive --force --args `" Target < $TargetDirectory `" $(If ($PoliCheckAdditionalRunConfigParams) {$PoliCheckAdditionalRunConfigParams})"
-    & $GuardianCliLocation configure --working-directory $WorkingDirectory --tool $tool --output-path $gdnConfigFile --logger-level $GuardianLoggerLevel --noninteractive --force --args " Target < $TargetDirectory " $(If ($PoliCheckAdditionalRunConfigParams) {$PoliCheckAdditionalRunConfigParams})
-    if ($LASTEXITCODE -ne 0) {
-      Write-Error "Guardian configure for $tool failed with exit code $LASTEXITCODE."
-      exit $LASTEXITCODE
-    }
+  if ($ValidPath -eq $False)
+  {
+    Write-PipelineTelemetryError -Force -Category 'Sdl' -Message "Invalid Guardian CLI Location."
+    ExitWithExitCode 1
   }
 
-  $configParam+=$gdnConfigFile
-}
+  $gdnConfigFiles = Get-ChildItem $gdnConfigPath -Recurse -Include '*.gdnconfig'
+  Write-Host "Discovered Guardian config files:"
+  $gdnConfigFiles | Out-String | Write-Host
 
-Write-Host "$GuardianCliLocation run --working-directory $WorkingDirectory --baseline mainbaseline --update-baseline $UpdateBaseline --logger-level $GuardianLoggerLevel $configParam"
-& $GuardianCliLocation run --working-directory $WorkingDirectory --tool $tool --baseline mainbaseline --update-baseline $UpdateBaseline --logger-level $GuardianLoggerLevel $configParam
-if ($LASTEXITCODE -ne 0) {
-  Write-Error "Guardian run for $ToolsList using $configParam failed with exit code $LASTEXITCODE."
-  exit $LASTEXITCODE
+  Exec-BlockVerbosely {
+    & $GuardianCliLocation run `
+      --working-directory $WorkingDirectory `
+      --baseline mainbaseline `
+      --update-baseline $UpdateBaseline `
+      --logger-level $GuardianLoggerLevel `
+      --config @gdnConfigFiles
+    Exit-IfNZEC "Sdl"
+  }
+}
+catch {
+  Write-Host $_.ScriptStackTrace
+  Write-PipelineTelemetryError -Force -Category 'Sdl' -Message $_
+  ExitWithExitCode 1
 }

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -96,6 +96,46 @@ function Exec-Process([string]$command, [string]$commandArgs) {
   }
 }
 
+# Take the given block, print it, print what the block probably references from the current set of
+# variables using low-effort string matching, then run the block.
+#
+# This is intended to replace the pattern of manually copy-pasting a command, wrapping it in quotes,
+# and printing it using "Write-Host". The copy-paste method is more readable in build logs, but less
+# maintainable and less reliable. It is easy to make a mistake and modify the command without
+# properly updating the "Write-Host" line, resulting in misleading build logs. The probability of
+# this mistake makes the pattern hard to trust when it shows up in build logs. Finding the bug in
+# existing source code can also be difficult, because the strings are not aligned to each other and
+# the line may be 300+ columns long.
+#
+# By removing the need to maintain two copies of the command, Exec-BlockVerbosely avoids the issues.
+#
+# In Bash (or any posix-like shell), "set -x" prints usable verbose output automatically.
+# "Set-PSDebug" appears to be similar at first glance, but unfortunately, it isn't very useful: it
+# doesn't print any info about the variables being used by the command, which is normally the
+# interesting part to diagnose.
+function Exec-BlockVerbosely([scriptblock] $block) {
+  Write-Host "--- Running script block:"
+  $blockString = $block.ToString().Trim()
+  Write-Host $blockString
+
+  Write-Host "--- List of variables that might be used:"
+  # For each variable x in the environment, check the block for a reference to x via simple "$x" or
+  # "@x" syntax. This doesn't detect other ways to reference variables ("${x}" nor "$variable:x",
+  # among others). It only catches what this function was originally written for: simple
+  # command-line commands.
+  $variableTable = Get-Variable |
+    Where-Object {
+      $blockString.Contains("`$$($_.Name)") -or $blockString.Contains("@$($_.Name)")
+    } |
+    Format-Table -AutoSize -HideTableHeaders -Wrap |
+    Out-String
+  Write-Host $variableTable.Trim()
+
+  Write-Host "--- Executing:"
+  & $block
+  Write-Host "--- Done running script block!"
+}
+
 function InitializeDotNetCli([bool]$install, [string] $runtimeSourceFeed, [string] $runtimeSourceFeedKey) {
   if (Test-Path variable:global:_DotNetInstallDir) {
     return $global:_DotNetInstallDir
@@ -577,6 +617,17 @@ function ExitWithExitCode([int] $exitCode) {
     Stop-Processes
   }
   exit $exitCode
+}
+
+# Check if $LASTEXITCODE is a nonzero exit code (NZEC). If so, print a Azure Pipeline error for
+# diagnostics, then exit the script with the $LASTEXITCODE.
+function Exit-IfNZEC([string] $category = "General") {
+  Write-Host "Exit code $LASTEXITCODE"
+  if ($LASTEXITCODE -ne 0) {
+    $message = "Last command failed with exit code $LASTEXITCODE."
+    Write-PipelineTelemetryError -Force -Category $category -Message $message
+    ExitWithExitCode $LASTEXITCODE
+  }
 }
 
 function Stop-Processes() {

--- a/src/Microsoft.Cci.Extensions/Filters/DocIdExcludeListFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/DocIdExcludeListFilter.cs
@@ -2,13 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using Microsoft.Cci.Extensions;
+using Microsoft.Cci.Extensions.CSharp;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Microsoft.Cci.Extensions;
-using System.IO;
-using Microsoft.Cci.Extensions.CSharp;
 
 namespace Microsoft.Cci.Filters
 {
@@ -23,9 +20,9 @@ namespace Microsoft.Cci.Filters
             _excludeMembers = excludeMembers;
         }
 
-        public DocIdExcludeListFilter(string whiteListFilePath, bool excludeMembers)
+        public DocIdExcludeListFilter(string allowListFilePath, bool excludeMembers)
         {
-            _docIds = DocIdExtensions.ReadDocIds(whiteListFilePath);
+            _docIds = DocIdExtensions.ReadDocIds(allowListFilePath);
             _excludeMembers = excludeMembers;
         }
 

--- a/src/Microsoft.Cci.Extensions/Filters/DocIdIncludeListFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/DocIdIncludeListFilter.cs
@@ -20,9 +20,9 @@ namespace Microsoft.Cci.Filters
             _docIds = new HashSet<string>(docIds);
         }
 
-        public DocIdIncludeListFilter(string whiteListFilePath)
+        public DocIdIncludeListFilter(string allowListFilePath)
         {
-            _docIds = DocIdExtensions.ReadDocIds(whiteListFilePath);
+            _docIds = DocIdExtensions.ReadDocIds(allowListFilePath);
         }
 
         public bool AlwaysIncludeNonEmptyTypes { get; set; }


### PR DESCRIPTION
Addresses dotnet/core-eng#15253, but previous change was insufficient.  This change copies over the full 'SDL' folder from main and adds a couple helper functions to tools.ps1, and cleans up one policheck violation ("allow List") and add exclusion for other.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation

https://dev.azure.com/dnceng/internal/_build/results?buildId=1535775&view=results