### PR TITLE
Remove LCID from UpgradeTable

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/ManifestProduct.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/ManifestProduct.wxs
@@ -9,8 +9,8 @@
 
     <!-- MajorUpgrade element doesn't support setting the language attribute in the upgrade table -->
     <Upgrade Id="$(var.UpgradeCode)">
-      <UpgradeVersion Language="1033" Maximum="$(var.ProductVersion)" MigrateFeatures="yes" IncludeMinimum="no" Property="WIX_UPGRADE_DETECTED" />
-      <UpgradeVersion Language="1033" Minimum="$(var.ProductVersion)" IncludeMinimum="no" OnlyDetect="yes" Property="WIX_DOWNGRADE_DETECTED" />
+      <UpgradeVersion Maximum="$(var.ProductVersion)" MigrateFeatures="yes" IncludeMinimum="no" Property="WIX_UPGRADE_DETECTED" />
+      <UpgradeVersion Minimum="$(var.ProductVersion)" IncludeMinimum="no" OnlyDetect="yes" Property="WIX_DOWNGRADE_DETECTED" />
     </Upgrade>
 
     <!-- The new MSI is installed before the older version is removed. This is the fastest upgrade option. -->


### PR DESCRIPTION
## Description

Workload manifest installers currently configure the language column of the MSI upgrade table. When the MSI is included in a bundle and running under local SYSTEM, the bundle defaults to querying installed products against the user  unmanaged context first. The `INSTALLPROPERTY_LANGUAGE` cannot be queried in this context (see https://docs.microsoft.com/en-us/windows/win32/api/msi/nf-msi-msigetproductinfoexw)

The logic in the setup engine reports the failure, but doesn't query the machine context and plans the MSI package for execution. When the planned MSI is a lower version than what's already installed, the engine fails to detect this. By allowing the MSI to execute, it then triggers the downgrade launch condition. The MSI terminates with 1603 as expected, but then the bundle rolls back and fails the overall install.

## Fix

We don't need to set the language ID in the upgrade table and removing it will work around the error in Burn (bundle engine).