### PR TITLE
Update FreeBSD packages

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -7,7 +7,7 @@ usage()
     echo "Usage: $0 [BuildArch] [CodeName] [lldbx.y] [--skipunmount] --rootfsdir <directory>]"
     echo "BuildArch can be: arm(default), armel, arm64, x86"
     echo "CodeName - optional, Code name for Linux, can be: xenial(default), zesty, bionic, alpine, alpine3.13 or alpine3.14. If BuildArch is armel, LinuxCodeName is jessie(default) or tizen."
-    echo "                              for FreeBSD can be: freebsd11, freebsd12, freebsd13"
+    echo "                              for FreeBSD can be: freebsd12, freebsd13"
     echo "                              for illumos can be: illumos."
     echo "lldbx.y - optional, LLDB version, can be: lldb3.9(default), lldb4.0, lldb5.0, lldb6.0 no-lldb. Ignored for alpine and FreeBSD"
     echo "--skipunmount - optional, will skip the unmount of rootfs folder."
@@ -60,13 +60,13 @@ __AlpinePackages+=" krb5-dev"
 __AlpinePackages+=" openssl-dev"
 __AlpinePackages+=" zlib-dev"
 
-__FreeBSDBase="12.2-RELEASE"
-__FreeBSDPkg="1.12.0"
+__FreeBSDBase="12.3-RELEASE"
+__FreeBSDPkg="1.17.0"
 __FreeBSDABI="12"
 __FreeBSDPackages="libunwind"
 __FreeBSDPackages+=" icu"
 __FreeBSDPackages+=" libinotify"
-__FreeBSDPackages+=" lttng-ust"
+__FreeBSDPackages+=" openssl"
 __FreeBSDPackages+=" krb5"
 __FreeBSDPackages+=" terminfo-db"
 
@@ -206,10 +206,6 @@ while :; do
             __AlpineVersion=3.14
             __AlpinePackages+=" llvm11-libs"
             ;;
-        freebsd11)
-            __FreeBSDBase="11.3-RELEASE"
-            __FreeBSDABI="11"
-            ;&
         freebsd12)
             __CodeName=freebsd
             __BuildArch=x64


### PR DESCRIPTION
removes `lttng-ust` (already merged here https://github.com/dotnet/runtime/pull/63567) by @wfurt 
updates base version of `pkg` to 1.17
adds `openssl`
updates FreeBSD 12.2 to 12.3 
removes FreeBSD 11.x (EOL)