### PR TITLE
Apply source build patches

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Microsoft.DotNet.Build.Tasks.Workloads.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Microsoft.DotNet.Build.Tasks.Workloads.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>Latest</LangVersion>
     <IsPackable>true</IsPackable>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Utils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Utils.cs
@@ -122,7 +122,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             Buffer.BlockCopy(nameBytes, 0, hashBuffer, 16, nameBytes.Length);
             byte[] hash;
 
-            using (SHA256 sha256 = new SHA256Managed())
+            using (SHA256 sha256 = SHA256.Create())
             {
                 hash = sha256.ComputeHash(hashBuffer);
             }

--- a/src/Microsoft.DotNet.SharedFramework.Sdk/sdk/Sdk.props
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/sdk/Sdk.props
@@ -10,6 +10,9 @@
   <PropertyGroup Condition="'$(DotNetSharedFrameworkTaskDir)' == ''">
     <DotNetSharedFrameworkTaskDir Condition="'$(MSBuildRuntimeType)' == 'core'">$(MSBuildThisFileDirectory)../tools/netcoreapp3.1/</DotNetSharedFrameworkTaskDir>
     <DotNetSharedFrameworkTaskDir Condition="'$(MSBuildRuntimeType)' != 'core'">$(MSBuildThisFileDirectory)../tools/net472/</DotNetSharedFrameworkTaskDir>
+
+    <!-- Workaround for https://github.com/dotnet/arcade/issues/7413 -->
+    <DotNetSharedFrameworkTaskDir Condition="'$(MSBuildRuntimeType)' == 'core' and '$(DotNetBuildFromSource)' == 'true'">$(MSBuildThisFileDirectory)../tools/net6.0/</DotNetSharedFrameworkTaskDir>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This PR applies two patches that source-build is currently using to build arcade, see https://github.com/dotnet/source-build/issues/2708.

Summary of changes:

- Use the net6.0 target framework for `Microsoft.DotNet.Build.Tasks.Workloads` during source build
    - This also required updating an obsolete managed SHA256 usage to avoid a [syslib0021](https://docs.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0021) error
- Override the hardcoded path for `DotNetSharedFrameworkTaskDir` during source build
    - This is a workaround for https://github.com/dotnet/arcade/issues/7413, and not a fix. The benefit of merging this patch now means that when/if this is fixed we won't still have to deal with a patch conflict in [dotnet/installer](https://github.com/dotnet/installer).
