### PR TITLE
Use 1ES pools in templates that run internally

### DIFF
--- a/azure-pipelines-code-mirror.yml
+++ b/azure-pipelines-code-mirror.yml
@@ -10,7 +10,8 @@ jobs:
     jobs:
     - job: Merge_GitHub_to_Azure_DevOps
       pool:
-        vmImage: 'windows-2019'
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals Build.Server.Amd64.VS2019
       variables:
       - name: WorkingDirectoryName
         value: repo-dir

--- a/azure-pipelines-codeql.yml
+++ b/azure-pipelines-codeql.yml
@@ -24,7 +24,8 @@ stages:
       - job: Windows_NT_CSharp
         timeoutInMinutes: 90
         pool:
-          vmImage: windows-2019
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals Build.Server.Amd64.VS2019
 
         steps:
         - checkout: self

--- a/azure-pipelines-merge-mirror.yml
+++ b/azure-pipelines-merge-mirror.yml
@@ -10,7 +10,8 @@ jobs:
     jobs:
     - job: Merge_GitHub_to_Azure_DevOps
       pool:
-        vmImage: 'windows-2019'
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals Build.Server.Amd64.VS2019
       variables:
       - name: WorkingDirectoryName
         value: repo-dir

--- a/azure-pipelines-weekly.yaml
+++ b/azure-pipelines-weekly.yaml
@@ -14,7 +14,9 @@ stages:
     jobs:
     - job: Synchronize
       pool:
-        vmImage: windows-2019
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals Build.Server.Amd64.VS2019
+
       steps:
       - task: UseDotNet@2
         displayName: Install Correct .NET Version

--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -29,14 +29,6 @@ parameters:
   # Optional: download a list of pipeline artifacts. 'downloadArtifacts' controls build artifacts,
   # not pipeline artifacts, so doesn't affect the use of this parameter.
   pipelineArtifactNames: []
-  # Optional: location and ID of the AzDO build that the build/pipeline artifacts should be
-  # downloaded from. By default, uses runtime expressions to decide based on the variables set by
-  # the 'setupMaestroVars' dependency. Overriding this parameter is necessary if SDL tasks are
-  # running without Maestro++/BAR involved, or to download artifacts from a specific existing build
-  # to iterate quickly on SDL changes.
-  AzDOProjectName: ''
-  AzDOPipelineId: ''
-  AzDOBuildId: ''
 
 jobs:
 - job: Run_SDL
@@ -60,6 +52,8 @@ jobs:
   steps:
   - checkout: self
     clean: true
+
+  - template: /eng/common/templates/post-build/setup-maestro-vars.yml
 
   - ${{ if ne(parameters.downloadArtifacts, 'false')}}:
     - ${{ if ne(parameters.artifactNames, '') }}:

--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -34,9 +34,9 @@ parameters:
   # the 'setupMaestroVars' dependency. Overriding this parameter is necessary if SDL tasks are
   # running without Maestro++/BAR involved, or to download artifacts from a specific existing build
   # to iterate quickly on SDL changes.
-  AzDOProjectName: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOProjectName'] ]
-  AzDOPipelineId: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOPipelineId'] ]
-  AzDOBuildId: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOBuildId'] ]
+  AzDOProjectName: ''
+  AzDOPipelineId: ''
+  AzDOBuildId: ''
 
 jobs:
 - job: Run_SDL
@@ -55,7 +55,8 @@ jobs:
     - name: GuardianVersion
       value: ${{ coalesce(parameters.overrideGuardianVersion, '$(DefaultGuardianVersion)') }}
   pool:
-    vmImage: windows-2019
+    name: NetCore1ESPool-Internal
+    demands: ImageOverride -equals Build.Server.Amd64.VS2019
   steps:
   - checkout: self
     clean: true

--- a/eng/common/templates/job/onelocbuild.yml
+++ b/eng/common/templates/job/onelocbuild.yml
@@ -4,7 +4,8 @@ parameters:
 
   # Optional: A defined YAML pool - https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=vsts&tabs=schema#pool
   pool:
-    vmImage: 'windows-2019'
+    name: NetCore1ESPool-Internal
+    demands: ImageOverride -equals Build.Server.Amd64.VS2019
 
   CeapexPat: $(dn-bot-ceapex-package-r) # PAT for the loc AzDO instance https://dev.azure.com/ceapex
   GithubPat: $(BotAccount-dotnet-bot-repo-PAT)

--- a/eng/common/templates/jobs/jobs.yml
+++ b/eng/common/templates/jobs/jobs.yml
@@ -83,7 +83,9 @@ jobs:
         - ${{ if eq(parameters.enableSourceBuild, true) }}:
           - Source_Build_Complete
         pool:
-          vmImage: 'windows-2019'
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals Build.Server.Amd64.VS2019
+
         runAsPublic: ${{ parameters.runAsPublic }}
         publishUsingPipelines: ${{ parameters.enablePublishUsingPipelines }}
         enablePublishBuildArtifacts: ${{ parameters.enablePublishBuildArtifacts }}

--- a/eng/common/templates/post-build/common-variables.yml
+++ b/eng/common/templates/post-build/common-variables.yml
@@ -4,54 +4,6 @@ variables:
   - group: DotNet-DotNetCli-Storage
   - group: DotNet-MSRC-Storage
   - group: Publish-Build-Assets
-    
-  # .NET Core 3.1 Dev
-  - name: PublicDevRelease_31_Channel_Id
-    value: 128
-
-  # .NET 5 Dev
-  - name: Net_5_Dev_Channel_Id
-    value: 131
-
-  # .NET Eng - Validation
-  - name: Net_Eng_Validation_Channel_Id
-    value: 9
-
-  # .NET Eng - Latest
-  - name: Net_Eng_Latest_Channel_Id
-    value: 2
-
-  # .NET 3 Eng - Validation
-  - name: NET_3_Eng_Validation_Channel_Id
-    value: 390
-
-  # .NET 3 Eng
-  - name: NetCore_3_Tools_Channel_Id
-    value: 344
-
-  # .NET Core 3.0 Internal Servicing
-  - name: InternalServicing_30_Channel_Id
-    value: 184
-
-  # .NET Core 3.0 Release
-  - name: PublicRelease_30_Channel_Id
-    value: 19
-
-  # .NET Core 3.1 Release
-  - name: PublicRelease_31_Channel_Id
-    value: 129
-
-  # General Testing
-  - name: GeneralTesting_Channel_Id
-    value: 529
-
-  # .NET Core 3.1 Blazor Features
-  - name: NetCore_31_Blazor_Features_Channel_Id
-    value: 531
-
-  # .NET Core Experimental
-  - name: NetCore_Experimental_Channel_Id
-    value: 562
 
   # Whether the build is internal or not
   - name: IsInternalBuild
@@ -69,27 +21,6 @@ variables:
     value: 3.0.0
   - name: SymbolToolVersion
     value: 1.0.1
-
-  # Feed Configurations
-  # These should include the suffix "/index.json"
-
-  # Default locations for Installers and checksums
-  # Public Locations
-  - name: ChecksumsBlobFeedUrl
-    value: https://dotnetclichecksums.blob.core.windows.net/dotnet/index.json
-  - name: InstallersBlobFeedUrl
-    value: https://dotnetcli.blob.core.windows.net/dotnet/index.json
-
-  # Private Locations
-  - name: InternalChecksumsBlobFeedUrl
-    value: https://dotnetclichecksumsmsrc.blob.core.windows.net/dotnet/index.json
-  - name: InternalChecksumsBlobFeedKey
-    value: $(dotnetclichecksumsmsrc-storage-key)
-
-  - name: InternalInstallersBlobFeedUrl
-    value: https://dotnetclimsrc.blob.core.windows.net/dotnet/index.json
-  - name: InternalInstallersBlobFeedKey
-    value: $(dotnetclimsrc-access-key)
 
   # Skip component governance and codesign validation for SDL. These jobs
   # create no content.

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -211,9 +211,6 @@ stages:
 
     - template: /eng/common/templates/job/execute-sdl.yml
       parameters:
-        AzDOProjectName: $(AzDOProjectName)
-        AzDOPipelineId: $(AzDOPipelineId)
-        AzDOBuildId: $(AzDOBuildId)
         enable: ${{ parameters.SDLValidationParameters.enable }}
         additionalParameters: ${{ parameters.SDLValidationParameters.params }}
         continueOnError: ${{ parameters.SDLValidationParameters.continueOnError }}

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -90,25 +90,19 @@ stages:
     variables:
       - template: common-variables.yml
     jobs:
-    - template: setup-maestro-vars.yml
-      parameters:
-        BARBuildId: ${{ parameters.BARBuildId }}
-        PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
-
     - job:
       displayName: NuGet Validation
-      dependsOn: setupMaestroVars
       condition: eq( ${{ parameters.enableNugetValidation }}, 'true')
       pool:
-        vmImage: 'windows-2019'
-      variables:
-        - name: AzDOProjectName
-          value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOProjectName'] ]
-        - name: AzDOPipelineId
-          value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOPipelineId'] ]
-        - name: AzDOBuildId
-          value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOBuildId'] ]
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals Build.Server.Amd64.VS2019
+
       steps:
+        - template: setup-maestro-vars.yml
+          parameters:
+            BARBuildId: ${{ parameters.BARBuildId }}
+            PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
+
         - task: DownloadBuildArtifacts@0
           displayName: Download Package Artifacts
           inputs:
@@ -129,19 +123,16 @@ stages:
 
     - job:
       displayName: Signing Validation
-      dependsOn: setupMaestroVars
       condition: and( eq( ${{ parameters.enableSigningValidation }}, 'true'), ne( variables['PostBuildSign'], 'true'))
-      variables:
-        - template: common-variables.yml
-        - name: AzDOProjectName
-          value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOProjectName'] ]
-        - name: AzDOPipelineId
-          value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOPipelineId'] ]
-        - name: AzDOBuildId
-          value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOBuildId'] ]
       pool:
-        vmImage: 'windows-2019'
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals Build.Server.Amd64.VS2019
       steps:
+        - template: setup-maestro-vars.yml
+          parameters:
+            BARBuildId: ${{ parameters.BARBuildId }}
+            PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
+
         - task: DownloadBuildArtifacts@0
           displayName: Download Package Artifacts
           inputs:
@@ -186,19 +177,16 @@ stages:
 
     - job:
       displayName: SourceLink Validation
-      dependsOn: setupMaestroVars
       condition: eq( ${{ parameters.enableSourceLinkValidation }}, 'true')
-      variables:
-        - template: common-variables.yml
-        - name: AzDOProjectName
-          value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOProjectName'] ]
-        - name: AzDOPipelineId
-          value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOPipelineId'] ]
-        - name: AzDOBuildId
-          value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOBuildId'] ]
       pool:
-        vmImage: 'windows-2019'
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals Build.Server.Amd64.VS2019
       steps:
+        - template: setup-maestro-vars.yml
+          parameters:
+            BARBuildId: ${{ parameters.BARBuildId }}
+            PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
+
         - task: DownloadBuildArtifacts@0
           displayName: Download Blob Artifacts
           inputs:
@@ -223,8 +211,10 @@ stages:
 
     - template: /eng/common/templates/job/execute-sdl.yml
       parameters:
+        AzDOProjectName: $(AzDOProjectName)
+        AzDOPipelineId: $(AzDOPipelineId)
+        AzDOBuildId: $(AzDOBuildId)
         enable: ${{ parameters.SDLValidationParameters.enable }}
-        dependsOn: setupMaestroVars
         additionalParameters: ${{ parameters.SDLValidationParameters.params }}
         continueOnError: ${{ parameters.SDLValidationParameters.continueOnError }}
         artifactNames: ${{ parameters.SDLValidationParameters.artifactNames }}
@@ -239,21 +229,18 @@ stages:
   variables:
     - template: common-variables.yml
   jobs:
-  - template: setup-maestro-vars.yml
-    parameters:
-      BARBuildId: ${{ parameters.BARBuildId }}
-      PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
-
   - job:
     displayName: Publish Using Darc
-    dependsOn: setupMaestroVars
     timeoutInMinutes: 120
-    variables:
-      - name: BARBuildId
-        value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
     pool:
-      vmImage: 'windows-2019'
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals Build.Server.Amd64.VS2019
     steps:
+      - template: setup-maestro-vars.yml
+        parameters:
+          BARBuildId: ${{ parameters.BARBuildId }}
+          PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
+
       - task: PowerShell@2
         displayName: Publish Using Darc
         inputs:

--- a/eng/common/templates/post-build/setup-maestro-vars.yml
+++ b/eng/common/templates/post-build/setup-maestro-vars.yml
@@ -2,77 +2,68 @@ parameters:
   BARBuildId: ''
   PromoteToChannelIds: ''
 
-jobs:
-- job: setupMaestroVars
-  displayName: Setup Maestro Vars
-  variables:
-    - template: common-variables.yml
-  pool:
-    vmImage: 'windows-2019'
-  steps:
-    - checkout: none
-
-    - ${{ if eq(coalesce(parameters.PromoteToChannelIds, 0), 0) }}:
-      - task: DownloadBuildArtifacts@0
-        displayName: Download Release Configs
-        inputs:
-          buildType: current
-          artifactName: ReleaseConfigs
-          checkDownloadedFiles: true
-
-    - task: PowerShell@2
-      name: setReleaseVars
-      displayName: Set Release Configs Vars
+steps:
+  - ${{ if eq(coalesce(parameters.PromoteToChannelIds, 0), 0) }}:
+    - task: DownloadBuildArtifacts@0
+      displayName: Download Release Configs
       inputs:
-        targetType: inline
-        script: |
-          try {
-            if (!$Env:PromoteToMaestroChannels -or $Env:PromoteToMaestroChannels.Trim() -eq '') {
-              $Content = Get-Content $(Build.StagingDirectory)/ReleaseConfigs/ReleaseConfigs.txt
+        buildType: current
+        artifactName: ReleaseConfigs
+        checkDownloadedFiles: true
 
-              $BarId = $Content | Select -Index 0
-              $Channels = $Content | Select -Index 1             
-              $IsStableBuild = $Content | Select -Index 2
+  - task: PowerShell@2
+    name: setReleaseVars
+    displayName: Set Release Configs Vars
+    inputs:
+      targetType: inline
+      script: |
+        try {
+          if (!$Env:PromoteToMaestroChannels -or $Env:PromoteToMaestroChannels.Trim() -eq '') {
+            $Content = Get-Content $(Build.StagingDirectory)/ReleaseConfigs/ReleaseConfigs.txt
 
-              $AzureDevOpsProject = $Env:System_TeamProject
-              $AzureDevOpsBuildDefinitionId = $Env:System_DefinitionId
-              $AzureDevOpsBuildId = $Env:Build_BuildId
-            }
-            else {
-              $buildApiEndpoint = "${Env:MaestroApiEndPoint}/api/builds/${Env:BARBuildId}?api-version=${Env:MaestroApiVersion}"
+            $BarId = $Content | Select -Index 0
+            $Channels = $Content | Select -Index 1             
+            $IsStableBuild = $Content | Select -Index 2
 
-              $apiHeaders = New-Object 'System.Collections.Generic.Dictionary[[String],[String]]'
-              $apiHeaders.Add('Accept', 'application/json')
-              $apiHeaders.Add('Authorization',"Bearer ${Env:MAESTRO_API_TOKEN}")
-
-              $buildInfo = try { Invoke-WebRequest -Method Get -Uri $buildApiEndpoint -Headers $apiHeaders | ConvertFrom-Json } catch { Write-Host "Error: $_" }
-             
-              $BarId = $Env:BARBuildId
-              $Channels = $Env:PromoteToMaestroChannels -split ","
-              $Channels = $Channels -join "]["
-              $Channels = "[$Channels]"
-
-              $IsStableBuild = $buildInfo.stable
-              $AzureDevOpsProject = $buildInfo.azureDevOpsProject
-              $AzureDevOpsBuildDefinitionId = $buildInfo.azureDevOpsBuildDefinitionId
-              $AzureDevOpsBuildId = $buildInfo.azureDevOpsBuildId
-            }
-
-            Write-Host "##vso[task.setvariable variable=BARBuildId;isOutput=true]$BarId"
-            Write-Host "##vso[task.setvariable variable=TargetChannels;isOutput=true]$Channels"
-            Write-Host "##vso[task.setvariable variable=IsStableBuild;isOutput=true]$IsStableBuild"
-
-            Write-Host "##vso[task.setvariable variable=AzDOProjectName;isOutput=true]$AzureDevOpsProject"
-            Write-Host "##vso[task.setvariable variable=AzDOPipelineId;isOutput=true]$AzureDevOpsBuildDefinitionId"
-            Write-Host "##vso[task.setvariable variable=AzDOBuildId;isOutput=true]$AzureDevOpsBuildId"
+            $AzureDevOpsProject = $Env:System_TeamProject
+            $AzureDevOpsBuildDefinitionId = $Env:System_DefinitionId
+            $AzureDevOpsBuildId = $Env:Build_BuildId
           }
-          catch {
-            Write-Host $_
-            Write-Host $_.Exception
-            Write-Host $_.ScriptStackTrace
-            exit 1
+          else {
+            $buildApiEndpoint = "${Env:MaestroApiEndPoint}/api/builds/${Env:BARBuildId}?api-version=${Env:MaestroApiVersion}"
+
+            $apiHeaders = New-Object 'System.Collections.Generic.Dictionary[[String],[String]]'
+            $apiHeaders.Add('Accept', 'application/json')
+            $apiHeaders.Add('Authorization',"Bearer ${Env:MAESTRO_API_TOKEN}")
+
+            $buildInfo = try { Invoke-WebRequest -Method Get -Uri $buildApiEndpoint -Headers $apiHeaders | ConvertFrom-Json } catch { Write-Host "Error: $_" }
+            
+            $BarId = $Env:BARBuildId
+            $Channels = $Env:PromoteToMaestroChannels -split ","
+            $Channels = $Channels -join "]["
+            $Channels = "[$Channels]"
+
+            $IsStableBuild = $buildInfo.stable
+            $AzureDevOpsProject = $buildInfo.azureDevOpsProject
+            $AzureDevOpsBuildDefinitionId = $buildInfo.azureDevOpsBuildDefinitionId
+            $AzureDevOpsBuildId = $buildInfo.azureDevOpsBuildId
           }
-      env:
-        MAESTRO_API_TOKEN: $(MaestroApiAccessToken)
-        BARBuildId: ${{ parameters.BARBuildId }}
-        PromoteToMaestroChannels: ${{ parameters.PromoteToChannelIds }}
+
+          Write-Host "##vso[task.setvariable variable=BARBuildId]$BarId"
+          Write-Host "##vso[task.setvariable variable=TargetChannels]$Channels"
+          Write-Host "##vso[task.setvariable variable=IsStableBuild]$IsStableBuild"
+
+          Write-Host "##vso[task.setvariable variable=AzDOProjectName]$AzureDevOpsProject"
+          Write-Host "##vso[task.setvariable variable=AzDOPipelineId]$AzureDevOpsBuildDefinitionId"
+          Write-Host "##vso[task.setvariable variable=AzDOBuildId]$AzureDevOpsBuildId"
+        }
+        catch {
+          Write-Host $_
+          Write-Host $_.Exception
+          Write-Host $_.ScriptStackTrace
+          exit 1
+        }
+    env:
+      MAESTRO_API_TOKEN: $(MaestroApiAccessToken)
+      BARBuildId: ${{ parameters.BARBuildId }}
+      PromoteToMaestroChannels: ${{ parameters.PromoteToChannelIds }}

--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -30,7 +30,9 @@ stages:
           value: "2020-02-20"
 
       pool:
-        vmImage: 'windows-2019'
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals Build.Server.Amd64.VS2019
+
       steps:
         - task: PowerShell@2
           displayName: Validate and Locate Build


### PR DESCRIPTION
- Use the 1ES pools in our templates, jobs, etc.
- To reduce some of the cost of this, remove the "Setup Maestro Vars" job and replace with a step so that we don't end up with an additional allocation in those cases.
- Clean up some unused variables from the common variables.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
