### PR TITLE
Feed overrides were swapped for shipping and non-shipping

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigV3.cs
@@ -145,13 +145,13 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     var oldFeed = spec.FeedUrl;
                     var feed = GetFeedOverride(oldFeed);
                     if (type is TargetFeedContentType.Package &&
-                        spec.Assets == AssetSelection.ShippingOnly &&
+                        spec.Assets == AssetSelection.NonShippingOnly &&
                         FeedOverrides.TryGetValue("transport-packages", out string newFeed))
                     {
                         feed = newFeed;
                     }
                     else if (type is TargetFeedContentType.Package &&
-                        spec.Assets == AssetSelection.NonShippingOnly &&
+                        spec.Assets == AssetSelection.ShippingOnly &&
                         FeedOverrides.TryGetValue("shipping-packages", out newFeed))
                     {
                         feed = newFeed;


### PR DESCRIPTION
There was a bug in the setup for feed overrides where nonshipping feeds were using the shipping package override and shipping feeds were using the transport package override. This change swaps that to be correct.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
