### PR TITLE
Split DotNetBackgroundPngFile into WixInstallerBackgroundFile msbuild property.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets
@@ -177,6 +177,10 @@
     <Error Text="A bundle theme directory property must be specified with the BundleThemeDirectory property."
            Condition="'$(BundleThemeDirectory)' == ''" />
       
+    <PropertyGroup>
+      <WixInstallerBackgroundFile Condition="'$(WixInstallerBackgroundFile)' == ''">$(MSBuildThisFileDirectory)..\resources\dotnetbackground.png</WixInstallerBackgroundFile>
+    </PropertyGroup>
+
     <ItemGroup>
       <LocFile Include="$(BundleThemeDirectory)\theme\**\bundle.wxl" />
       <LocDirName Include="$([System.String]::new('%(LocFile.RecursiveDir)').TrimEnd('\'))" />
@@ -185,7 +189,7 @@
       <CandleVariables Include="LcidList" Value="@(LocDirName)" />
       <CandleVariables Include="BundleThmDir" Value="$(BundleThemeDirectory)" />
 
-      <CandleVariables Include="DotNetBackgroundPngFile" Value="$(MSBuildThisFileDirectory)..\resources\dotnetbackground.png" />
+      <CandleVariables Include="DotNetBackgroundPngFile" Value="$(WixInstallerBackgroundFile)" />
       <CandleVariables Include="DotNetDummyEulaFile" Value="$(MSBuildThisFileDirectory)bundle\dummyEula.rtf" />
     </ItemGroup>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/8352.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation