### PR TITLE
Fix variable initialization error in source-build.yml

### DIFF
--- a/eng/common/templates/steps/source-build.yml
+++ b/eng/common/templates/steps/source-build.yml
@@ -23,7 +23,7 @@ steps:
     # In addition, add an msbuild argument to copy the WIP from the repo to the target build location.
     # This is because SetupNuGetSources.sh will alter the current NuGet.config file, and we need to preserve those
     # changes.
-    $internalRestoreArgs=
+    internalRestoreArgs=
     if [ '$(dn-bot-dnceng-artifact-feeds-rw)' != '$''(dn-bot-dnceng-artifact-feeds-rw)' ]; then
       # Temporarily work around https://github.com/dotnet/arcade/issues/7709
       chmod +x $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh


### PR DESCRIPTION
The dollar prefix isn't used when initializing a variable, this led to `line 9: =: command not found` messages in the build
