### PR TITLE
Avoid duplicate BestTargetFrameworks in TargetFramework.Sdk

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/ChooseBestTargetFrameworksTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/ChooseBestTargetFrameworksTask.cs
@@ -4,7 +4,6 @@
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk
 {

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/ChooseBestTargetFrameworksTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/ChooseBestTargetFrameworksTask.cs
@@ -9,7 +9,7 @@ using System.Linq;
 namespace Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk
 {
     public class ChooseBestTargetFrameworksTask : BuildTask
-    {       
+    {
         [Required]
         public string[] BuildTargetFrameworks { get; set; }
 

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/ChooseBestTargetFrameworksTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/ChooseBestTargetFrameworksTask.cs
@@ -9,36 +9,36 @@ using System.Linq;
 namespace Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk
 {
     public class ChooseBestTargetFrameworksTask : BuildTask
-    {
+    {       
         [Required]
-        public ITaskItem[] SupportedTargetFrameworks { get; set; }
-        
-        [Required]
-        public ITaskItem[] BuildTargetFrameworks { get; set; }
+        public string[] BuildTargetFrameworks { get; set; }
 
         [Required]
         public string RuntimeGraph { get; set; }
 
+        [Required]
+        public string[] SupportedTargetFrameworks { get; set; }
+
         [Output]
-        public ITaskItem[] BestTargetFrameworks { get; set; }
+        public string[] BestTargetFrameworks { get; set; }
 
         public override bool Execute()
         {
-            var bestTargetFrameworkList = new List<ITaskItem>();
+            var bestTargetFrameworkList = new HashSet<string>(BuildTargetFrameworks.Length);
             var targetframeworkResolver = new TargetFrameworkResolver(RuntimeGraph);
-            
-            foreach (ITaskItem buildTargetFramework in BuildTargetFrameworks)
+ 
+            foreach (string buildTargetFramework in BuildTargetFrameworks)
             {
-                string bestTargetFramework = targetframeworkResolver.GetBestSupportedTargetFramework(SupportedTargetFrameworks.Select(t => t.ItemSpec), buildTargetFramework.ItemSpec);
+                string bestTargetFramework = targetframeworkResolver.GetBestSupportedTargetFramework(SupportedTargetFrameworks, buildTargetFramework);
                 if (bestTargetFramework != null)
-                {                    
-                    TaskItem item = new TaskItem(SupportedTargetFrameworks.First(t => t.ItemSpec == bestTargetFramework));
-                    buildTargetFramework.CopyMetadataTo(item);
-                    bestTargetFrameworkList.Add(item);
+                {
+                    bestTargetFrameworkList.Add(bestTargetFramework);
                 }
             }
 
-            BestTargetFrameworks = bestTargetFrameworkList.ToArray();
+            BestTargetFrameworks = new string[bestTargetFrameworkList.Count];
+            bestTargetFrameworkList.CopyTo(BestTargetFrameworks);
+ 
             return !Log.HasLoggedErrors;
         }
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7412651/150197164-8b008662-ceff-4fad-aca8-6d9a7c7583ce.png)

Avoid duplicates being returned by the ChooseBestTargetFrameworks task which leads to unnecessary inner project builds.
Also using string[] property types instead of ITaskItem[] as metadata isn't used.

Noticed that while inspecting the inner builds that are triggered in dotnet/runtime libs subset. Tested locally.

