### PR TITLE
Fix build break because of missing metdata

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/ChooseBestTargetFrameworksTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/ChooseBestTargetFrameworksTask.cs
@@ -41,9 +41,7 @@ namespace Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk
                 }
             }
 
-            BestTargetFrameworks = new TaskItem[bestTargetFrameworkList.Count];
-            bestTargetFrameworkList.CopyTo(BestTargetFrameworks);
- 
+            BestTargetFrameworks = bestTargetFrameworkList.ToArray(); 
             return !Log.HasLoggedErrors;
         }
     }

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.targets
@@ -46,7 +46,8 @@
     
     <ChooseBestTargetFrameworksTask BuildTargetFrameworks="@(_BuildTargetFrameworkWithTargetOS);$(AdditionalBuildTargetFrameworks)"
                                     SupportedTargetFrameworks="$(TargetFrameworks)"
-                                    RuntimeGraph="$(RuntimeGraph)">
+                                    RuntimeGraph="$(RuntimeGraph)"
+                                    Distinct="true">
       <Output TaskParameter="BestTargetFrameworks" ItemName="_BestTargetFramework" />
     </ChooseBestTargetFrameworksTask>
 


### PR DESCRIPTION
In the previous change I didn't notice that the binplacing logic depends on metadata passing in being preserved in the items being returned. Because of that, I revert the collection change from List to HashSet and instead manually iterate through the list. The binplacing logic depends on duplicates being allowed versus the inner build project logic explicitly doesn't want duplicates to avoid unnecessary inner builds, hence adding a switch for it.

Tested this in dotnet/runtime for real this time. I didn't notice the break before as I tested a part of the libs subset in dotnet/runtime which wasn't affected.
