### PR TITLE
Enable SxS support for preview workload manifests

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -86,7 +86,7 @@
     <MicrosoftSymbolUploaderBuildTaskVersion>2.0.0-preview.1.21526.15</MicrosoftSymbolUploaderBuildTaskVersion>
     <MicrosoftSymbolUploaderVersion>2.0.0-preview.1.21526.15</MicrosoftSymbolUploaderVersion>
     <MicrosoftNetSdkWorkloadManifestReaderVersion>6.0.100-rtm.21515.10</MicrosoftNetSdkWorkloadManifestReaderVersion>
-    <MicrosoftDeploymentDotNetReleasesVersion>1.0.0-preview1.1.21116.1</MicrosoftDeploymentDotNetReleasesVersion>
+    <MicrosoftDeploymentDotNetReleasesVersion>1.0.0-preview2.6.21561.1</MicrosoftDeploymentDotNetReleasesVersion>
     <!-- Used to flow Source Link version through Arcade SDK -->
     <MicrosoftSourceLinkVersion>$(MicrosoftSourceLinkGitHubVersion)</MicrosoftSourceLinkVersion>
     <MicrosoftTemplateEngineTasksVersion>7.0.100-alpha.1.21601.1</MicrosoftTemplateEngineTasksVersion>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/GenerateManifestMsiTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/GenerateManifestMsiTests.cs
@@ -68,8 +68,5 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
 
             Assert.Equal(expectedManifestId, actual);
         }
-
-        //Microsoft.NET.Workload.Emscripten.Manifest-6.0.100
-
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/GenerateManifestMsiTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/GenerateManifestMsiTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Microsoft.Deployment.DotNet.Releases;
 using Xunit;
 
 namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
@@ -18,5 +19,57 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
                 "Microsoft.NET.Workload.Mono.ToolChain.Manifest-6.0.100", "x64"));
             Assert.Equal(@"Payload relative path exceeds max length (182): Microsoft.NET.Workload.Mono.ToolChain.Manifest-6.0.100,version=1.2.3,chip=x64,productarch=neutral\Microsoft.NET.Workload.Mono.ToolChain.Manifest-6.0.100.6.0.0-preview.7.21377.12-x64.msi", e.Message);
         }
+
+        [WindowsOnlyTheory]
+        [InlineData("a.b.c", "6.0.100", "x86", "{1c857c83-6584-3c77-ab20-7c77f4fdc097}")]
+        [InlineData("a.b.c", "6.0.105", "x86", "{1c857c83-6584-3c77-ab20-7c77f4fdc097}")]
+        [InlineData("a.b.c", "7.0.105-preview.3.5.6.7.8.9", "x86", "{ca8c5ba1-6937-3237-99d5-cbae7b2b8868}")]
+        [InlineData("a.b.c", "7.0.105-preview.3.5.6.7.8.9", "x64", "{da611d31-8a65-3eea-8949-13bcf2a99950}")]
+        [InlineData("a.b.c", "7.0.105-preview.4.5.6.7.8.9", "x86", "{e6c1ec79-16d9-3cef-ad7b-0bcefa9636b1}")]
+        public void ItGeneratesStableUpgradeCodes(string manifestId, string sdkVersion, string platform, string expectedUpgradeCode)
+        {
+            ReleaseVersion sdkFeatureBandVersion = GenerateManifestMsi.GetSdkFeatureBandVersion(sdkVersion);
+            Guid upgradeCode = GenerateManifestMsi.GenerateUpgradeCode(manifestId, sdkFeatureBandVersion, platform);
+
+            Assert.Equal(expectedUpgradeCode.ToLowerInvariant(), upgradeCode.ToString("B"));
+        }
+
+        [WindowsOnlyTheory]
+        [InlineData("6.0.100", "6.0.100")]
+        [InlineData("6.0.103", "6.0.100")]
+        [InlineData("6.0.103-ci", "6.0.100")]
+        [InlineData("7.0.1243-preview.8+12345", "7.0.1200-preview.8")]
+        public void ItIncludesPrereleasePartsInFeatureBandVersion(string sdkVersion, string expectedFeatureBandVersion)
+        {
+            ReleaseVersion actual = GenerateManifestMsi.GetSdkFeatureBandVersion(sdkVersion);
+            ReleaseVersion expected = new ReleaseVersion(expectedFeatureBandVersion);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [WindowsOnlyTheory]
+        [InlineData("Microsoft.NET.Workload.Emscripten.Manifest-6.0.100", "6.0.100")]
+        [InlineData("Microsoft.NET.Workload.Emscripten-7.0.100", null)]
+        [InlineData(null, null)]
+        [InlineData("Microsoft.NET.Workload.Emscripten.Manifest-7.3.504-preview.9", "7.3.504-preview.9")]
+        public void ItCanExtractTheSdkVersionFromTheManifestPackageId(string packageId, string expectedSdkVersion)
+        {
+            string actual = GenerateManifestMsi.GetSdkVersionFromPackageId(packageId);
+
+            Assert.Equal(expectedSdkVersion, actual);
+        }
+
+        [WindowsOnlyTheory]
+        [InlineData("Microsoft.NET.Workload.Emscripten.Manifest-6.0.100", "Microsoft.NET.Workload.Emscripten")]
+        [InlineData("Microsoft.NET.Workload.Emscripten-6.0.100", null)]
+        public void ItCanExtractTheManifestIdFromTheManifestPackageId(string packageId, string expectedManifestId)
+        {
+            string actual = GenerateManifestMsi.GetManifestIdFromPackageId(packageId);
+
+            Assert.Equal(expectedManifestId, actual);
+        }
+
+        //Microsoft.NET.Workload.Emscripten.Manifest-6.0.100
+
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/Microsoft.DotNet.Build.Tasks.Workloads.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/Microsoft.DotNet.Build.Tasks.Workloads.Tests.csproj
@@ -12,8 +12,9 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
+    <PackageReference Include="Microsoft.Deployment.DotNet.Releases" Version="$(MicrosoftDeploymentDotNetReleasesVersion)" />
     <PackageReference Include="Microsoft.NET.Sdk.WorkloadManifestReader" Version="$(MicrosoftNetSdkWorkloadManifestReaderVersion)" />
-    <PackageReference Include="NuGet.Packaging" Version="$(NuGetVersion)" />
+    <PackageReference Include="NuGet.Packaging" Version="$(NuGetVersion)" />    
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/TestHelper.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/TestHelper.cs
@@ -16,4 +16,15 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             }
         }
     }
+
+    public class WindowsOnlyTheoryAttribute : TheoryAttribute
+    {
+        public WindowsOnlyTheoryAttribute()
+        {
+            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+            {
+                Skip = "Not running on Windows";
+            }
+        }
+    }
 }


### PR DESCRIPTION
Enable SxS installs of different previews for workload manifests within the same feature band. Previously, manifest installers within the same band were upgradeable.

Manifest packages can now include prerelease information in the package ID, e.g. `Microsoft.NET.Workload.Emscripten.Manifest-6.0.100-preview.1` and `Microsoft.NET.Workload.Emscripten.Manifest-6.0.100-preview.2` will generate installers that are not upgrade related. 


