### PR TITLE
Make all RemoteExecutor.Invoke overloads check exit code by default

### DIFF
--- a/src/Microsoft.DotNet.RemoteExecutor/src/Program.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/Program.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.RemoteExecutor
             Type t = null;
             MethodInfo mi = null;
             object instance = null;
-            int exitCode = 0;
+            int exitCode = RemoteExecutor.SuccessExitCode;
             try
             {
                 // Create the test class if necessary

--- a/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
@@ -111,10 +111,6 @@ namespace Microsoft.DotNet.RemoteExecutor
         /// <param name="options">Options to use for the invocation.</param>
         public static RemoteInvokeHandle Invoke(Action method, RemoteInvokeOptions options = null)
         {
-            // There's no exit code to check
-            options = options ?? new RemoteInvokeOptions();
-            options.CheckExitCode = false;
-
             return Invoke(GetMethodInfo(method), Array.Empty<string>(), options);
         }
 
@@ -124,10 +120,6 @@ namespace Microsoft.DotNet.RemoteExecutor
         /// <param name="options">Options to use for the invocation.</param>
         public static RemoteInvokeHandle Invoke(Action<string> method, string arg, RemoteInvokeOptions options = null)
         {
-            // There's no exit code to check
-            options = options ?? new RemoteInvokeOptions();
-            options.CheckExitCode = false;
-
             return Invoke(GetMethodInfo(method), new[] { arg }, options);
         }
 
@@ -137,10 +129,6 @@ namespace Microsoft.DotNet.RemoteExecutor
         public static RemoteInvokeHandle Invoke(Action<string, string> method, string arg1, string arg2,
             RemoteInvokeOptions options = null)
         {
-            // There's no exit code to check
-            options = options ?? new RemoteInvokeOptions();
-            options.CheckExitCode = false;
-
             return Invoke(GetMethodInfo(method), new[] { arg1, arg2 }, options);
         }
 
@@ -150,10 +138,6 @@ namespace Microsoft.DotNet.RemoteExecutor
         public static RemoteInvokeHandle Invoke(Action<string, string, string> method, string arg1, string arg2,
             string arg3, RemoteInvokeOptions options = null)
         {
-            // There's no exit code to check
-            options = options ?? new RemoteInvokeOptions();
-            options.CheckExitCode = false;
-
             return Invoke(GetMethodInfo(method), new[] { arg1, arg2, arg3 }, options);
         }
 
@@ -163,10 +147,6 @@ namespace Microsoft.DotNet.RemoteExecutor
         public static RemoteInvokeHandle Invoke(Action<string, string, string, string> method, string arg1,
             string arg2, string arg3, string arg4, RemoteInvokeOptions options = null)
         {
-            // There's no exit code to check
-            options = options ?? new RemoteInvokeOptions();
-            options.CheckExitCode = false;
-
             return Invoke(GetMethodInfo(method), new[] { arg1, arg2, arg3, arg4 }, options);
         }
 
@@ -216,10 +196,6 @@ namespace Microsoft.DotNet.RemoteExecutor
         /// <param name="options">Options to use for the invocation.</param>
         public static RemoteInvokeHandle Invoke(Func<Task> method, RemoteInvokeOptions options = null)
         {
-            // There's no exit code to check
-            options = options ?? new RemoteInvokeOptions();
-            options.CheckExitCode = false;
-
             return Invoke(GetMethodInfo(method), Array.Empty<string>(), options);
         }
 
@@ -230,10 +206,6 @@ namespace Microsoft.DotNet.RemoteExecutor
         public static RemoteInvokeHandle Invoke(Func<string, Task> method, string arg,
             RemoteInvokeOptions options = null)
         {
-            // There's no exit code to check
-            options = options ?? new RemoteInvokeOptions();
-            options.CheckExitCode = false;
-
             return Invoke(GetMethodInfo(method), new[] { arg }, options);
         }
 
@@ -245,10 +217,6 @@ namespace Microsoft.DotNet.RemoteExecutor
         public static RemoteInvokeHandle Invoke(Func<string, string, Task> method, string arg1, string arg2,
             RemoteInvokeOptions options = null)
         {
-            // There's no exit code to check
-            options = options ?? new RemoteInvokeOptions();
-            options.CheckExitCode = false;
-
             return Invoke(GetMethodInfo(method), new[] { arg1, arg2 }, options);
         }
 
@@ -261,10 +229,6 @@ namespace Microsoft.DotNet.RemoteExecutor
         public static RemoteInvokeHandle Invoke(Func<string, string, string, Task> method, string arg1,
             string arg2, string arg3, RemoteInvokeOptions options = null)
         {
-            // There's no exit code to check
-            options = options ?? new RemoteInvokeOptions();
-            options.CheckExitCode = false;
-
             return Invoke(GetMethodInfo(method), new[] { arg1, arg2, arg3 }, options);
         }
 

--- a/src/Microsoft.DotNet.RemoteExecutor/tests/Microsoft.DotNet.RemoteExecutor.Tests.csproj
+++ b/src/Microsoft.DotNet.RemoteExecutor/tests/Microsoft.DotNet.RemoteExecutor.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <LangVersion>Latest</LangVersion>
     <SignAssembly>false</SignAssembly>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\Microsoft.DotNet.RemoteExecutor.csproj" />

--- a/src/Microsoft.DotNet.RemoteExecutor/tests/RemoteExecutorTests.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/tests/RemoteExecutorTests.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
+using System;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Sdk;
@@ -10,6 +10,16 @@ namespace Microsoft.DotNet.RemoteExecutor.Tests
 {
     public class RemoteExecutorTests
     {
+        [Fact]
+        public void Action()
+        {
+            RemoteInvokeHandle h = RemoteExecutor.Invoke(() => { }, new RemoteInvokeOptions { RollForward = "Major" });
+            using (h)
+            {
+                Assert.Equal(RemoteExecutor.SuccessExitCode, h.ExitCode);
+            }
+        }
+
         [Fact]
         public void AsyncAction_ThrowException()
         {
@@ -25,10 +35,14 @@ namespace Microsoft.DotNet.RemoteExecutor.Tests
         [Fact]
         public void AsyncAction()
         {
-            RemoteExecutor.Invoke(async () =>
+            RemoteInvokeHandle h = RemoteExecutor.Invoke(async () =>
             {
                 await Task.Delay(1);
-            }, new RemoteInvokeOptions { RollForward = "Major" }).Dispose();
+            }, new RemoteInvokeOptions { RollForward = "Major" });
+            using (h)
+            {
+                Assert.Equal(RemoteExecutor.SuccessExitCode, h.ExitCode);
+            }
         }
 
         [Fact]
@@ -64,6 +78,73 @@ namespace Microsoft.DotNet.RemoteExecutor.Tests
                 await Task.Delay(1);
                 return RemoteExecutor.SuccessExitCode;
             }, new RemoteInvokeOptions { RollForward = "Major" }).Dispose();
+        }
+
+        [Fact]
+        public static void AsyncAction_FatalError_AV()
+        {
+            // Invocation should report as failing on AV
+            Assert.Throws<TrueException>(() =>
+                RemoteExecutor.Invoke(async () =>
+                {
+                    await Task.Delay(1);
+                    unsafe
+                    {
+                        *(int*)0x10000 = 0;
+                    }
+                }, new RemoteInvokeOptions { RollForward = "Major" }).Dispose()
+            );
+        }
+
+        [Fact]
+        public static void AsyncAction_FatalError_Runtime()
+        {
+            // Invocation should report as failing on fatal runtime error
+            Assert.Throws<TrueException>(() =>
+                RemoteExecutor.Invoke(async () =>
+                {
+                    await Task.Delay(1);
+                    System.Runtime.InteropServices.Marshal.StructureToPtr(1, new IntPtr(1), true);
+                }, new RemoteInvokeOptions { RollForward = "Major" }).Dispose()
+            );
+        }
+
+        [Fact]
+        public static unsafe void FatalError_AV()
+        {
+            // Invocation should report as failing on AV
+            Assert.Throws<TrueException>(() =>
+                RemoteExecutor.Invoke(() =>
+                {
+                    *(int*)0x10000 = 0;
+                }, new RemoteInvokeOptions { RollForward = "Major" }).Dispose()
+            );
+        }
+
+        [Fact]
+        public static void FatalError_Runtime()
+        {
+            // Invocation should report as failing on fatal runtime error
+            Assert.Throws<TrueException>(() =>
+                RemoteExecutor.Invoke(() =>
+                {
+                    System.Runtime.InteropServices.Marshal.StructureToPtr(1, new IntPtr(1), true);
+                }, new RemoteInvokeOptions { RollForward = "Major" }).Dispose()
+            );
+        }
+
+        [Fact]
+        public static void IgnoreExitCode()
+        {
+            int exitCode = 1;
+            RemoteInvokeHandle h = RemoteExecutor.Invoke(
+                s => int.Parse(s),
+                exitCode.ToString(),
+                new RemoteInvokeOptions { RollForward = "Major", CheckExitCode = false, ExpectedExitCode = 0 });
+            using(h)
+            {
+                Assert.Equal(exitCode, h.ExitCode);
+            }
         }
     }
 }


### PR DESCRIPTION
Currently, only the overloads where the invoked method returns an `int` or `Task<int>` check for an expected exit code. This meant that crashes (not caught as a managed exception) would not be detected when those overloads were used. This changes all the overloads to check the exit code by default.

Resolves https://github.com/dotnet/arcade/issues/5865

cc @stephentoub 