### PR TITLE
Fix DevDiv promotion job

### DIFF
--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -30,14 +30,21 @@ stages:
           value: "2020-02-20"
 
       pool:
-        name: NetCore1ESPool-Internal
-        demands: ImageOverride -equals Build.Server.Amd64.VS2019
+        # We don't use the collection uri here because it might vary (.visualstudio.com vs. dev.azure.com)
+        ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+          name: VSEngSS-MicroBuild2022-1ES
+          demands: Cmd
+        # If it's not devdiv, it's dnceng
+        ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals Build.Server.Amd64.VS2019
 
       steps:
         - task: PowerShell@2
           displayName: Validate and Locate Build
           inputs:
             targetType: inline
+            pwsh: true
             script: |
               # Keeping this script inline so that we don't need to checkout the whole repo to use just one file
               try {


### PR DESCRIPTION
- Ensure devdiv promotion job uses devdiv pools
- Use powershell core (the pools don't have IE initialized so we have to use basic parsing, which is default on powershell core)

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
