### PR TITLE
set content type and no-cache headers to blob publishing

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/AzureStorageAssetPublisher.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/AzureStorageAssetPublisher.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
 using Microsoft.Build.Utilities;
 using Microsoft.DotNet.Build.CloudTestTasks;
 #if !NET472_OR_GREATER
@@ -53,8 +54,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                 try
                 {
-                    await blobClient.SetHttpHeadersAsync(AzureStorageUtils.GetBlobHeadersByExtension(file));
-                    await blobClient.UploadAsync(file);
+                    BlobUploadOptions blobUploadOptions = new()
+                    {
+                        HttpHeaders = AzureStorageUtils.GetBlobHeadersByExtension(file)
+                    };
+                    await blobClient.UploadAsync(file, blobUploadOptions);
                 }
                 catch (Exception e)
                 {

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/AzureStorageAssetPublisher.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/AzureStorageAssetPublisher.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using Azure.Storage.Blobs;
 using Microsoft.Build.Utilities;
+using Microsoft.DotNet.Build.CloudTestTasks;
 #if !NET472_OR_GREATER
 using Microsoft.DotNet.Maestro.Client.Models;
 #endif
@@ -52,6 +53,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                 try
                 {
+                    await blobClient.SetHttpHeadersAsync(AzureStorageUtils.GetBlobHeadersByExtension(file));
                     await blobClient.UploadAsync(file);
                 }
                 catch (Exception e)

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
@@ -22,13 +22,13 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
 {
     public class AzureStorageUtils
     {
-        private readonly Dictionary<string, string> MimeMappings = new Dictionary<string, string>()
+        private static readonly Dictionary<string, string> MimeMappings = new Dictionary<string, string>()
         {
             {".svg", "image/svg+xml"},
             {".version", "text/plain"}
         };
 
-        private readonly Dictionary<string, string> CacheMappings = new Dictionary<string, string>()
+        private static readonly Dictionary<string, string> CacheMappings = new Dictionary<string, string>()
         {
             {".svg", "no-cache"}
         };
@@ -138,7 +138,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             await GetBlob(blobPath).ExistsAsync().ConfigureAwait(false);
 
 
-        private BlobHttpHeaders GetBlobHeadersByExtension(string filePath)
+        public static BlobHttpHeaders GetBlobHeadersByExtension(string filePath)
         {
             if (string.IsNullOrWhiteSpace(filePath))
             {


### PR DESCRIPTION
https://github.com/dotnet/core-eng/issues/15377

We lost the headers we used to set when moving to the new publisher for blobs, so badges are getting the wrong content type when being uploaded. 

I'm reusing the logic we previously had in place for this. Let me know if you'd rather I copy these functions to some other utility class. 

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
