### PR TITLE
Remove dead code in SDL scripts

### DIFF
--- a/eng/common/sdl/execute-all-sdl-tools.ps1
+++ b/eng/common/sdl/execute-all-sdl-tools.ps1
@@ -74,7 +74,7 @@ try {
   }
 
   Exec-BlockVerbosely {
-    & $(Join-Path $PSScriptRoot 'init-sdl.ps1') -GuardianCliLocation $guardianCliLocation -Repository $RepoName -BranchName $BranchName -WorkingDirectory $workingDirectory -AzureDevOpsAccessToken $AzureDevOpsAccessToken -GuardianLoggerLevel $GuardianLoggerLevel
+    & $(Join-Path $PSScriptRoot 'init-sdl.ps1') -GuardianCliLocation $guardianCliLocation -WorkingDirectory $workingDirectory -GuardianLoggerLevel $GuardianLoggerLevel
   }
   $gdnFolder = Join-Path $workingDirectory '.gdn'
 

--- a/eng/common/sdl/init-sdl.ps1
+++ b/eng/common/sdl/init-sdl.ps1
@@ -1,6 +1,9 @@
 Param(
+  [Parameter(Mandatory)]
   [string] $GuardianCliLocation,
+  [Parameter(Mandatory)]
   [string] $WorkingDirectory,
+  [ValidateSet("Trace", "Verbose", "Standard", "Warning", "Error")]
   [string] $GuardianLoggerLevel='Standard'
 )
 

--- a/eng/common/sdl/init-sdl.ps1
+++ b/eng/common/sdl/init-sdl.ps1
@@ -1,9 +1,6 @@
 Param(
   [string] $GuardianCliLocation,
-  [string] $Repository,
-  [string] $BranchName='master',
   [string] $WorkingDirectory,
-  [string] $AzureDevOpsAccessToken,
   [string] $GuardianLoggerLevel='Standard'
 )
 
@@ -20,15 +17,6 @@ $ci = $true
 
 # Don't display the console progress UI - it's a huge perf hit
 $ProgressPreference = 'SilentlyContinue'
-
-# Construct basic auth from AzDO access token; construct URI to the repository's gdn folder stored in that repository; construct location of zip file
-$encodedPat = [Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$AzureDevOpsAccessToken"))
-$escapedRepository = [Uri]::EscapeDataString("/$Repository/$BranchName/.gdn")
-$uri = "https://dev.azure.com/dnceng/internal/_apis/git/repositories/sdl-tool-cfg/Items?path=$escapedRepository&versionDescriptor[versionOptions]=0&`$format=zip&api-version=5.0"
-$zipFile = "$WorkingDirectory/gdn.zip"
-
-Add-Type -AssemblyName System.IO.Compression.FileSystem
-$gdnFolder = (Join-Path $WorkingDirectory '.gdn')
 
 try {
   # if the folder does not exist, we'll do a guardian init and push it to the remote repository


### PR DESCRIPTION
Remove dead code from SDL scripts. Looks like init-sdl used to download the tooling, but now simply requires the tool be present.