### PR TITLE
Avoid project evaluations for single tfms

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/ChooseBestP2PTargetFrameworkTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/ChooseBestP2PTargetFrameworkTask.cs
@@ -52,7 +52,25 @@ namespace Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk
                         Log.LogError($"Not able to find a compatible supported target framework for {referringTargetFramework} in Project {Path.GetFileName(projectReference.ItemSpec)}. The Supported Configurations are {string.Join(", ", targetFrameworks)}");
                     }
 
-                    projectReference.SetMetadata("SetTargetFramework", "TargetFramework=" + bestTargetFramework);
+                    // Mimic msbuild's Common.targets behavior: https://github.com/dotnet/msbuild/blob/3c8fb11a080a5a15199df44fabf042a22e9ad4da/src/Tasks/Microsoft.Common.CurrentVersion.targets#L1842-L1853
+                    if (projectReference.GetMetadata("HasSingleTargetFramework") != "true")
+                    {
+                        projectReference.SetMetadata("SetTargetFramework", "TargetFramework=" + bestTargetFramework);
+                    }
+                    else
+                    {
+                        // If the project has a single TargetFramework, we need to Undefine TargetFramework to avoid another project evaluation.
+                        string undefineProperties = projectReference.GetMetadata("UndefineProperties");
+                        projectReference.SetMetadata("UndefineProperties", undefineProperties + ";TargetFramework");
+                    }
+
+                    if (projectReference.GetMetadata("IsRidAgnostic") == "true")
+                    {
+                        // If the project is RID agnostic, undefine the RuntimeIdentifier property to avoid another evaluation. -->
+                        string undefineProperties = projectReference.GetMetadata("UndefineProperties");
+                        projectReference.SetMetadata("UndefineProperties", undefineProperties + ";RuntimeIdentifier");
+                    }
+
                     projectReference.SetMetadata("SkipGetTargetFrameworkProperties", "true");
                 }
 

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/BinPlace.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/BinPlace.targets
@@ -117,10 +117,16 @@
   </Target>
 
   <Target Name="GetBinPlaceTargetFramework">
-    <!-- find which, if any, supported target framework of this project is best
-         for each binplace targetFramework -->     
+    <ItemGroup>
+      <!-- This needs to be a separate item as batching doesn't work when passing in the ValueOrDefault result directly. -->
+      <_supportedTargetFramework Include="$(TargetFrameworks)" Condition="'$(TargetFrameworks)' != ''" />
+      <_supportedTargetFramework Include="$(TargetFramework)" Condition="'@(_supportedTargetFramework)' == '' and '$(TargetFramework)' != ''" />
+    </ItemGroup>
+
+    <!-- Find which, if any, supported target framework of this project is best
+         for each binplace targetFramework. -->
     <ChooseBestTargetFrameworksTask BuildTargetFrameworks="@(BinPlaceTargetFrameworks)"
-                                    SupportedTargetFrameworks="$([MSBuild]::ValueOrDefault('$(TargetFrameworks)', '$(TargetFramework)'))"
+                                    SupportedTargetFrameworks="@(_supportedTargetFramework)"
                                     RuntimeGraph="$(RuntimeGraph)">
       <Output TaskParameter="BestTargetFrameworks" ItemName="_bestBinPlaceTargetFrameworks" />
     </ChooseBestTargetFrameworksTask>

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/BinPlace.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk/src/build/BinPlace.targets
@@ -9,13 +9,13 @@
   <Target Name="BinPlace"
           DependsOnTargets="GetBinPlaceTargetFramework;BinPlaceFiles;BinPlaceProps"
           AfterTargets="CopyFilesToOutputDirectory"
-          Condition="'$(EnableBinPlacing)' == 'true' OR '@(BinPlaceDir)' != ''" />
+          Condition="'$(EnableBinPlacing)' == 'true' or '@(BinPlaceDir)' != ''" />
 
   <Target Name="BinPlaceFiles"
           Condition="'@(BinPlaceDir)' != ''"
           DependsOnTargets="GetBinPlaceItems"
           Inputs="@(BinPlaceDir);%(BinPlaceDir.ItemName);%(BinPlaceDir.Identity)"
-          Outputs="unused" >
+          Outputs="unused">
 
     <PropertyGroup>
       <_BinPlaceItemName>%(BinPlaceDir.ItemName)</_BinPlaceItemName>
@@ -120,8 +120,8 @@
     <!-- find which, if any, supported target framework of this project is best
          for each binplace targetFramework -->     
     <ChooseBestTargetFrameworksTask BuildTargetFrameworks="@(BinPlaceTargetFrameworks)"
-                                   SupportedTargetFrameworks="$(TargetFrameworks)"
-                                   RuntimeGraph="$(RuntimeGraph)" >
+                                    SupportedTargetFrameworks="$([MSBuild]::ValueOrDefault('$(TargetFrameworks)', '$(TargetFramework)'))"
+                                    RuntimeGraph="$(RuntimeGraph)">
       <Output TaskParameter="BestTargetFrameworks" ItemName="_bestBinPlaceTargetFrameworks" />
     </ChooseBestTargetFrameworksTask>
 


### PR DESCRIPTION
To avoid additional project evaluations when a project doesn't multi-target, don't set the SetTargetFramework property and undefine the TargetFramework property. For consistency also undefine the RuntimeIdentifier property when a project is RID agnostic. This mimics the msbuild's Common.targets behavior which is disabled because the SkipGetTargetFrameworkProperties attribute is set to the annotated P2Ps.

## Change

Without this change, projects like System.Runtime or System.Linq.Expressions which don't multi-target, are evaluated twice. Once without TargetFramework being passed in globally and once with it being passed in.

This change shows a drastic speed improvement when building the libs.ref projects in dotnet/runtime and changing the projects to use the TargetFramework property instead of TargetFrameworks when the project doesn't multi-target. That's because additional project evaluations are avoided:

![image](https://user-images.githubusercontent.com/7412651/150622122-dc4e8c3e-7a12-4718-b71f-c032b91cfc52.png)

42s instead of 55s in a no-op incremental build.