### PR TITLE
Add a timeout to WiX download

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/acquisition/acquire-wix/acquire-wix.proj
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/acquisition/acquire-wix/acquire-wix.proj
@@ -22,7 +22,8 @@
     <DownloadFile
       Uri="$(WixDownloadUrl)"
       DestinationPath="$(WixDestinationPath)"
-      Overwrite="true" />
+      Overwrite="true"
+      TimeoutInSeconds="9999" />
 
     <Unzip
       SourceFiles="$(WixDestinationPath)"


### PR DESCRIPTION
The WiX download is huge and for some reason it goes slowly on my otherwise 80 Mbps connection. The default timeout is causing an unnecessary build break that I keep hitting.

I filed this as #8301 originally (for the root cause) but since that one was closed and I hit it again and lost time on this, I'm proposing this workaround. This has worked for me locally.