### PR TITLE
Allow modifying GenFacade's ReferencePaths input

### DIFF
--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenPartialFacadeSource.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenPartialFacadeSource.targets
@@ -5,6 +5,7 @@
   <UsingTask TaskName="GenPartialFacadeSource" AssemblyFile="$(GenFacadesTargetAssemblyPath)" />
 
   <PropertyGroup>
+    <GenFacadesReferencePathItemName Condition="'$(GenFacadesReferencePathItemName)' == ''">ReferencePath</GenFacadesReferencePathItemName>
     <!-- Tell ResolveMatchingContract to run and resolve contract to project reference -->
     <ResolveMatchingContract>true</ResolveMatchingContract>
     <GeneratePartialFacadeSourceDependsOn>$(GeneratePartialFacadeSourceDependsOn);ResolveMatchingContract</GeneratePartialFacadeSourceDependsOn>
@@ -17,7 +18,7 @@
   </PropertyGroup>
 
   <Target Name="GeneratePartialFacadeSource"
-          Inputs="$(MSBuildAllProjects);@(ResolvedMatchingContract);@(ReferencePath);@(Compile)"
+          Inputs="$(MSBuildAllProjects);@(ResolvedMatchingContract);@($(GenFacadesReferencePathItemName));@(Compile)"
           Outputs="$(OutputSourcePath)"
           DependsOnTargets="$(GeneratePartialFacadeSourceDependsOn)">
     <PropertyGroup>
@@ -25,7 +26,7 @@
     </PropertyGroup>
 
     <GenPartialFacadeSource
-      ReferencePaths="@(ReferencePath)"
+      ReferencePaths="@($(GenFacadesReferencePathItemName))"
       ReferenceAssembly="$(ReferenceAssembly)"
       CompileFiles="@(Compile)"
       DefineConstants="$(DefineConstants)"


### PR DESCRIPTION
There are cases where the ReferencePath item isn't the right input for GenFacades, i.e. a project's generated reference assembly might be a better candidate. Allow to override the default item to point to something different, i.e. to ReferencePathWithRefAssemblies.

Tested these changes locally by building the libraries subset with it.