### PR TITLE
Update credentials for mirror jobs to use explicit group

### DIFF
--- a/azure-pipelines-code-mirror.yml
+++ b/azure-pipelines-code-mirror.yml
@@ -1,6 +1,9 @@
 # Disable CI triggers, only called using Maestro
 trigger: none
 
+variables:
+  - group: Mirror-Credentials
+
 # Moves code from GitHub into internal repos
 jobs:
 - template: /eng/common/templates/jobs/jobs.yml

--- a/azure-pipelines-merge-mirror.yml
+++ b/azure-pipelines-merge-mirror.yml
@@ -1,6 +1,9 @@
 # Disable CI triggers, only called using Maestro
 trigger: none
 
+variables:
+  - group: Mirror-Credentials
+
 # Merges code from GitHub into internal branches in internal repos
 jobs:
 - template: /eng/common/templates/jobs/jobs.yml


### PR DESCRIPTION
Update the credentials for the merge and code mirror jobs to use an explicit variable group

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
