### PR TITLE
[release/6.0] Update Maestro Tasks to fix stable publishing issues

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -81,7 +81,7 @@
     <MicrosoftSourceLinkAzureReposGitVersion>1.1.0-beta-21423-02</MicrosoftSourceLinkAzureReposGitVersion>
     <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>6.0.0-beta.21620.3</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
     <MicrosoftDotNetXliffTasksVersion>1.0.0-beta.21431.1</MicrosoftDotNetXliffTasksVersion>
-    <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.21615.11</MicrosoftDotNetMaestroTasksVersion>
+    <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.22076.4</MicrosoftDotNetMaestroTasksVersion>
     <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.21613.2</MicrosoftDotNetXHarnessCLIVersion>
     <MicrosoftSymbolUploaderBuildTaskVersion>2.0.0-preview.1.21466.7</MicrosoftSymbolUploaderBuildTaskVersion>
     <MicrosoftSymbolUploaderVersion>2.0.0-preview.1.21466.7</MicrosoftSymbolUploaderVersion>


### PR DESCRIPTION
## Description

release/6.0 fix for https://github.com/dotnet/arcade/issues/8393

## Customer Impact

Publishing will continue to fail for stable builds

## Regression

Yes, bug introduced in https://github.com/dotnet/arcade-services/pull/1782

## Risk

Low risk. Made this change in a branch using 6.0 arcade in MSBuild (where the bug was originally found): https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5679730&view=results. The merged manifest is now correctly reporting the build as stable. 

## Workarounds

None other than using an arcade SDK that doesn't include https://github.com/dotnet/arcade/commit/13f16f1c7ff352a5a4b2378a3ba668ceb769aec1
