### PR TITLE
fix name of dotnet-core-internal-tooling feed

### DIFF
--- a/eng/common/internal/NuGet.config
+++ b/eng/common/internal/NuGet.config
@@ -2,6 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="dotnet-core-internal" value="https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal/nuget/v3/index.json" />
+    <add key="dotnet-core-internal-tooling" value="https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Part of https://github.com/dotnet/arcade/issues/8144

I distinctly remember having this bug and then fixing it in my test builds, but I clearly didn't port it to the original PR branch 👎 
I'll also add a step in arcade-validation to restore from these feeds, so that a mistake like this one can't happen again.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
