### PR TITLE
Fix TargetFramework package via multiTargeting and binplace import

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/BinPlace.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/BinPlace.targets
@@ -4,13 +4,12 @@
 
   <PropertyGroup>
     <BinPlaceUseHardlinksIfPossible Condition="'$(BinPlaceUseHardlinksIfPossible)' == ''">true</BinPlaceUseHardlinksIfPossible>
-    <EnableBinPlacing Condition="'$(EnableBinPlacing)' == '' and ('$(BinPlaceNative)' == 'true' or '$(BinPlaceRef)' == 'true' or '$(BinPlaceRuntime)' == 'true' or '$(BinPlaceTest)' == 'true')">true</EnableBinPlacing>
   </PropertyGroup>
 
   <Target Name="BinPlace"
           DependsOnTargets="GetBinPlaceTargetFramework;BinPlaceFiles;BinPlaceProps"
           AfterTargets="CopyFilesToOutputDirectory"
-          Condition="'$(EnableBinPlacing)' == 'true' or '@(BinPlaceDir)' != ''" />
+          Condition="'$(BinPlaceNative)' == 'true' or '$(BinPlaceRef)' == 'true' or '$(BinPlaceRuntime)' == 'true' or '$(BinPlaceTest)' == 'true' or '@(BinPlaceDir)' != ''" />
 
   <Target Name="BinPlaceFiles"
           Condition="'@(BinPlaceDir)' != ''"

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
@@ -85,5 +85,5 @@
     </ItemGroup>
   </Target>
 
-  <Import Project="BinPlace.targets" />
+  <Import Project="BinPlace.targets" Condition="'$(EnableBinPlacing)' != 'false'" />
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/buildMultiTargeting/Microsoft.DotNet.Build.Tasks.TargetFramework.props
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/buildMultiTargeting/Microsoft.DotNet.Build.Tasks.TargetFramework.props
@@ -1,0 +1,4 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Project>
+  <Import Project="..\build\$(MSBuildThisFile)" />
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/buildMultiTargeting/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/buildMultiTargeting/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
@@ -1,0 +1,4 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Project>
+  <Import Project="..\build\$(MSBuildThisFile)" />
+</Project>


### PR DESCRIPTION
Renaming and migrating the package from an msbuild sdk package to a normal nuget package broke the imports and the evaluation order which I'm fixing with this PR. Tested the change locally.

The package's props and targets files need to be imported in both the outer and the inner build. Hence, adding a buildMultiTargeting folder that redirects to the build folder.

Also the `EnableBinPlace` property is now evaluated sooner than expected and hence some properties in dotnet/runtime aren't yet set which this property depends on. Inline the condition into the target so that it runs later and condition the overall import of the BinPlace.targets file via the existing condition.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
