### PR TITLE
Fix warnings on Helix EOL queues

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -141,6 +141,7 @@ stages:
               -ci
               -restore
               -test
+              -warnAsError $false
               -projects $(Build.SourcesDirectory)\tests\UnitTests.proj
               /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.binlog
               /p:RestoreUsingNuGetTargets=false
@@ -170,6 +171,7 @@ stages:
               -ci
               -restore
               -test
+              -warnAsError $false
               -projects $(Build.SourcesDirectory)\tests\XHarness.Android.DeviceTests.proj
               /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.XHarness.Android.Device.Tests.binlog
               /p:RestoreUsingNuGetTargets=false
@@ -200,6 +202,7 @@ stages:
               --ci
               --restore
               --test
+              --warnAsError false
               --projects $(Build.SourcesDirectory)/tests/UnitTests.proj
               /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.binlog
               /p:RestoreUsingNuGetTargets=false
@@ -230,6 +233,7 @@ stages:
               -ci
               -restore
               -test
+              -warnAsError false
               -projects $(Build.SourcesDirectory)/tests/XHarness.Apple.SimulatorTests.proj
               /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/XHarness.Apple.Simulator.Tests.binlog
               /p:RestoreUsingNuGetTargets=false
@@ -260,6 +264,7 @@ stages:
               -ci
               -restore
               -test
+              -warnAsError false
               -projects $(Build.SourcesDirectory)/tests/XHarness.Apple.DeviceTests.proj
               /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.XHarness.Apple.Device.Tests.binlog
               /p:RestoreUsingNuGetTargets=false
@@ -290,6 +295,7 @@ stages:
               -ci
               -restore
               -test
+              -warnAsError false
               -projects $(Build.SourcesDirectory)/tests/XHarness.Android.SimulatorTests.proj
               /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.XHarness.Android.Simulator.Tests.binlog
               /p:RestoreUsingNuGetTargets=false

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -238,31 +238,23 @@ namespace Microsoft.DotNet.Helix.Client
 
         private void WarnForImpendingRemoval(Action<string> log, QueueInfo queueInfo) 
         {
-            bool azDoVariableDefined = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SYSTEM_TEAMPROJECT"));
             DateTime whenItExpires = DateTime.MaxValue;
 
             if (DateTime.TryParseExact(queueInfo.EstimatedRemovalDate, "yyyy-MM-dd", null, DateTimeStyles.AssumeUniversal, out DateTime dtIso))
             {
                 whenItExpires = dtIso;
             }
-            // This branch can be removed once the strings start coming in in ISO-8601 format
-            // Currently the API provides values in this format though and they are unlikely to get confused with each other.
-            else if (DateTime.TryParseExact(queueInfo.EstimatedRemovalDate, "M/d/yyyy", null, DateTimeStyles.AssumeUniversal, out DateTime dtUsa))
-            {
-                whenItExpires = dtUsa;
-            }
-
             if (whenItExpires != DateTime.MaxValue) // We recognized a date from the string
             {
                 TimeSpan untilRemoved = whenItExpires.ToUniversalTime().Subtract(DateTime.UtcNow);
                 if (untilRemoved.TotalDays <= 21)
                 {
-                    log?.Invoke($"{(azDoVariableDefined ? "##vso[task.logissue type=warning]" : "")}Helix queue {queueInfo.QueueId} {(untilRemoved.TotalDays < 0 ? "was" : "is")} slated for removal on {queueInfo.EstimatedRemovalDate}. Please discontinue usage.  Contact dnceng for questions / concerns ");
+                    log?.Invoke($"warning : Helix queue {queueInfo.QueueId} {(untilRemoved.TotalDays < 0 ? "was" : "is")} slated for removal on {queueInfo.EstimatedRemovalDate}. Please discontinue usage.  Contact dnceng for questions / concerns ");
                 }
             }
             else
             {
-                log?.Invoke($"{(azDoVariableDefined ? "##vso[task.logissue type=warning]" : "")}Unable to parse estimated removal date '{queueInfo.EstimatedRemovalDate}' for queue '{queueInfo.QueueId}' (please contact dnceng with this information)");
+                log?.Invoke($"error : Unable to parse estimated removal date '{queueInfo.EstimatedRemovalDate}' for queue '{queueInfo.QueueId}' (please contact dnceng with this information)");
             }
         }
 

--- a/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
@@ -262,9 +262,9 @@ namespace Microsoft.DotNet.Helix.Sdk
                 }
 
                 Log.LogMessage(MessageImportance.High, $"Sending Job to {TargetQueue}...");
-
                 cancellationToken.ThrowIfCancellationRequested();
-                ISentJob job = await def.SendAsync(msg => Log.LogMessage(msg), cancellationToken);
+                // LogMessageFromText will take any string formatted as a canonical error or warning and convert the type of log to this
+                ISentJob job = await def.SendAsync(msg => Log.LogMessageFromText(msg, MessageImportance.High), cancellationToken);
                 JobCorrelationId = job.CorrelationId;
                 JobCancellationToken = job.HelixCancellationToken;
                 ResultsContainerUri = job.ResultsContainerUri;


### PR DESCRIPTION
Warnings were getting buried in binlogs; promote ALL SendAsync logging to Important (it's brief) and produce warnings for missing queues.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation (tested by this PR)
