### PR TITLE
Don't evaluate outer build targets in inner build

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.props
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.props
@@ -8,7 +8,7 @@
   </ItemDefinitionGroup>
 
   <PropertyGroup>
-    <DotNetBuildTasksTargetFrameworkAssembly Condition="'$(DotNetBuildTasksTargetFrameworkAssembly)' == '' and '$(MSBuildRuntimeType)' == 'core'">..\tools\netcoreapp3.1\Microsoft.DotNet.Build.Tasks.TargetFramework.dll</DotNetBuildTasksTargetFrameworkAssembly>
-    <DotNetBuildTasksTargetFrameworkAssembly Condition="'$(DotNetBuildTasksTargetFrameworkAssembly)' == '' and '$(MSBuildRuntimeType)' != 'core'">..\tools\net472\Microsoft.DotNet.Build.Tasks.TargetFramework.dll</DotNetBuildTasksTargetFrameworkAssembly>
+    <DotNetBuildTasksTargetFrameworkAssembly Condition="'$(MSBuildRuntimeType)' == 'core'">..\tools\netcoreapp3.1\Microsoft.DotNet.Build.Tasks.TargetFramework.dll</DotNetBuildTasksTargetFrameworkAssembly>
+    <DotNetBuildTasksTargetFrameworkAssembly Condition="'$(MSBuildRuntimeType)' != 'core'">..\tools\net472\Microsoft.DotNet.Build.Tasks.TargetFramework.dll</DotNetBuildTasksTargetFrameworkAssembly>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
@@ -1,57 +1,7 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <UsingTask TaskName="ChooseBestP2PTargetFrameworkTask" AssemblyFile="$(DotNetBuildTasksTargetFrameworkAssembly)" />
-  <UsingTask TaskName="ChooseBestTargetFrameworksTask" AssemblyFile="$(DotNetBuildTasksTargetFrameworkAssembly)" />
-
-  <!-- We filter _InnerBuildProjects items during DispatchToInnerBuilds and Clean to only run for best target frameworks. -->
-  <Target Name="RunOnlyBestTargetFrameworks"
-          Condition="'$(IsCrossTargetingBuild)' == 'true' and '$(BuildTargetFramework)' != ''" 
-          BeforeTargets="DispatchToInnerBuilds;Clean"
-          DependsOnTargets="GetProjectWithBestTargetFrameworks">
-    <ItemGroup>
-      <_OriginalInnerBuildProjects Include="@(_InnerBuildProjects)" />
-      <_InnerBuildProjects Remove="@(_InnerBuildProjects)" />
-      <_InnerBuildProjects Include="@(InnerBuildProjectsWithBestTargetFramework)" />
-    </ItemGroup>
-  </Target>
-
-  <!-- As _InnerBuildProjects items are used in the GetTargetFrameworks path as well (>= .NET 5), we restore the item state. -->
-  <Target Name="RestoreInnerBuildProjects"
-          BeforeTargets="GetTargetFrameworksWithPlatformFromInnerBuilds"
-          AfterTargets="DispatchToInnerBuilds;Clean"
-          Condition="'@(_OriginalInnerBuildProjects)' != ''">
-    <ItemGroup>
-      <_InnerBuildProjects Remove="@(_InnerBuildProjects)" />
-      <_InnerBuildProjects Include="@(_OriginalInnerBuildProjects)" />
-    </ItemGroup>
-  </Target>
   
-  <Target Name="GetProjectWithBestTargetFrameworks">
-    <ItemGroup Condition="'$(BuildTargetFramework)' != ''">
-      <_BuildTargetFrameworkWithTargetOS Include="$(BuildTargetFramework)-$(TargetOS)" />
-    </ItemGroup>
-    <ItemGroup Condition="'$(BuildTargetFramework)' == ''">
-      <_BuildTargetFrameworkWithoutOS Include="$([MSBuild]::Unescape($([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '(-[^;]+)', ''))))" />
-      <!-- TODO: Find a better way to filter out non applicable TargetOS values for .NET Framework. -->
-      <_BuildTargetFrameworkWithTargetOS Include="@(_BuildTargetFrameworkWithoutOS->Distinct()->'%(Identity)-$(TargetOS)')"
-                                         Condition="'$(TargetOS)' == 'windows' or !$([System.String]::Copy('%(Identity)').StartsWith('net4'))" />
-    </ItemGroup>
-    
-    <ChooseBestTargetFrameworksTask BuildTargetFrameworks="@(_BuildTargetFrameworkWithTargetOS);$(AdditionalBuildTargetFrameworks)"
-                                    SupportedTargetFrameworks="$(TargetFrameworks)"
-                                    RuntimeGraph="$(RuntimeGraph)"
-                                    Distinct="true">
-      <Output TaskParameter="BestTargetFrameworks" ItemName="_BestTargetFramework" />
-    </ChooseBestTargetFrameworksTask>
-
-    <!-- Create inner build project nodes with the TargetFramework supplied via AdditionalProperties. -->
-    <ItemGroup>
-      <_BestTargetFramework Project="$(MSBuildProjectFile)" />
-      <InnerBuildProjectsWithBestTargetFramework Include="%(_BestTargetFramework.Project)"
-                                                 AdditionalProperties="TargetFramework=%(Identity)" />
-    </ItemGroup>
-  </Target>
-
   <!--
     Runs in a leaf project (csproj) to determine best configuration for ProjectReferences.
     Make sure to run late enough for transitive dependencies which runs before AssignProjectConfiguration.

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/buildMultiTargeting/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/buildMultiTargeting/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
@@ -1,4 +1,53 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
-  <Import Project="..\build\$(MSBuildThisFile)" />
+  <UsingTask TaskName="ChooseBestTargetFrameworksTask" AssemblyFile="$(DotNetBuildTasksTargetFrameworkAssembly)" />
+
+  <!-- We filter _InnerBuildProjects items during DispatchToInnerBuilds and Clean to only run for best target frameworks. -->
+  <Target Name="RunOnlyBestTargetFrameworks"
+          Condition="'$(BuildTargetFramework)' != ''" 
+          BeforeTargets="DispatchToInnerBuilds;Clean"
+          DependsOnTargets="GetProjectWithBestTargetFrameworks">
+    <ItemGroup>
+      <_OriginalInnerBuildProjects Include="@(_InnerBuildProjects)" />
+      <_InnerBuildProjects Remove="@(_InnerBuildProjects)" />
+      <_InnerBuildProjects Include="@(InnerBuildProjectsWithBestTargetFramework)" />
+    </ItemGroup>
+  </Target>
+  
+  <!-- As _InnerBuildProjects items are used in the GetTargetFrameworks path as well (>= .NET 5), we restore the item state. -->
+  <Target Name="RestoreInnerBuildProjects"
+          BeforeTargets="GetTargetFrameworksWithPlatformFromInnerBuilds"
+          AfterTargets="DispatchToInnerBuilds;Clean"
+          Condition="'@(_OriginalInnerBuildProjects)' != ''">
+    <ItemGroup>
+      <_InnerBuildProjects Remove="@(_InnerBuildProjects)" />
+      <_InnerBuildProjects Include="@(_OriginalInnerBuildProjects)" />
+    </ItemGroup>
+  </Target>
+  
+  <Target Name="GetProjectWithBestTargetFrameworks">
+    <ItemGroup Condition="'$(BuildTargetFramework)' != ''">
+      <_BuildTargetFrameworkWithTargetOS Include="$(BuildTargetFramework)-$(TargetOS)" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(BuildTargetFramework)' == ''">
+      <_BuildTargetFrameworkWithoutOS Include="$([MSBuild]::Unescape($([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '(-[^;]+)', ''))))" />
+      <!-- TODO: Find a better way to filter out non applicable TargetOS values for .NET Framework. -->
+      <_BuildTargetFrameworkWithTargetOS Include="@(_BuildTargetFrameworkWithoutOS->Distinct()->'%(Identity)-$(TargetOS)')"
+                                         Condition="'$(TargetOS)' == 'windows' or !$([System.String]::Copy('%(Identity)').StartsWith('net4'))" />
+    </ItemGroup>
+    
+    <ChooseBestTargetFrameworksTask BuildTargetFrameworks="@(_BuildTargetFrameworkWithTargetOS);$(AdditionalBuildTargetFrameworks)"
+                                    SupportedTargetFrameworks="$(TargetFrameworks)"
+                                    RuntimeGraph="$(RuntimeGraph)"
+                                    Distinct="true">
+      <Output TaskParameter="BestTargetFrameworks" ItemName="_BestTargetFramework" />
+    </ChooseBestTargetFrameworksTask>
+
+    <!-- Create inner build project nodes with the TargetFramework supplied via AdditionalProperties. -->
+    <ItemGroup>
+      <_BestTargetFramework Project="$(MSBuildProjectFile)" />
+      <InnerBuildProjectsWithBestTargetFramework Include="%(_BestTargetFramework.Project)"
+                                                 AdditionalProperties="TargetFramework=%(Identity)" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
This is a nit change but it showed up in an msbuild binlog and hence I felt like cleaning this up, now that we already split between inner and outer build via nuget conventions.

This change has minor, probably not noticeable performance improvements. I would expect that this saves less than a second in the evaluation of an allconfigurations libraries build. Still it felt right to clean this up by doing the following:
- BinPlace.targets isn't evaluated in outer builds
- Two outer build targets aren't evaluated in inner builds.

These are the information messages that were logged before:
```
The target "DispatchToInnerBuilds" listed in a BeforeTargets attribute at "C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.targetframework\7.0.0-beta.22102.1\build\Microsoft.DotNet.Build.Tasks.TargetFramework.targets (9,11)" does not exist in the project, and will be ignored.
The target "GetTargetFrameworksWithPlatformFromInnerBuilds" listed in a BeforeTargets attribute at "C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.targetframework\7.0.0-beta.22102.1\build\Microsoft.DotNet.Build.Tasks.TargetFramework.targets (20,11)" does not exist in the project, and will be ignored.
The target "DispatchToInnerBuilds" listed in an AfterTargets attribute at "C:\Users\vihofer\.nuget\packages\microsoft.dotnet.build.tasks.targetframework\7.0.0-beta.22102.1\build\Microsoft.DotNet.Build.Tasks.TargetFramework.targets (21,11)" does not exist in the project, and will be ignored.
```
