### PR TITLE
Dedupe workload packs 

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/GenerateVisualStudioWorkloadTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/GenerateVisualStudioWorkloadTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
     {
         public string IntermediateBaseOutputPath = Path.Combine(AppContext.BaseDirectory, "obj");
 
-        public string TestAssetsPath = Path.Combine(AppContext.BaseDirectory, "testassets");
+        public static readonly string TestAssetsPath = Path.Combine(AppContext.BaseDirectory, "testassets");
 
         public string TestIntermediateBaseOutputPath => Path.Combine(IntermediateBaseOutputPath, Path.GetFileNameWithoutExtension(Path.GetTempFileName()));
 

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/GenerateWorkloadMsisTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/GenerateWorkloadMsisTests.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Utilities;
+using Xunit;
+
+namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
+{
+    public class GenerateWorkloadMsisTests
+    {
+        public string TestAssetsPath = Path.Combine(AppContext.BaseDirectory, "testassets");
+
+        [Fact]
+        public void ItRemovesDuplicateWorkloadPacks()
+        {
+            TaskItem[] manifests = new[]
+            {
+                new TaskItem(Path.Combine(TestAssetsPath, "emsdkWorkloadManifest.json")),
+                new TaskItem(Path.Combine(TestAssetsPath, "emsdkWorkloadManifest2.json")),
+            };
+
+            var packs = GenerateWorkloadMsis.GetWorkloadPacks(manifests).ToArray();
+
+            Assert.Equal(4, packs.Length);
+            Assert.Equal("Microsoft.NET.Runtime.Emscripten.Node", packs[0].Id.ToString());
+            Assert.Equal("7.0.0-alpha.2.22078.1", packs[0].Version);
+            Assert.Equal("Microsoft.NET.Runtime.Emscripten.Node", packs[3].Id.ToString());
+            Assert.Equal("7.0.0-alpha.2.22079.1", packs[3].Version);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/Microsoft.DotNet.Build.Tasks.Workloads.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/Microsoft.DotNet.Build.Tasks.Workloads.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk"> 
 
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
@@ -22,6 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="testassets\emsdkWorkloadManifest.json" />
+    <None Remove="testassets\emsdkWorkloadManifest2.json" />
     <None Remove="testassets\mauiWorkloadManifest.json" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/testassets/emsdkWorkloadManifest.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/testassets/emsdkWorkloadManifest.json
@@ -1,0 +1,46 @@
+{
+  "version": "7.0.0-alpha.2.22078.1",
+  "workloads": {
+    "microsoft-net-sdk-emscripten": {
+      "abstract": true,
+      "description": "Emscripten SDK compiler tooling",
+      "packs": [
+        "Microsoft.NET.Runtime.Emscripten.Node",
+        "Microsoft.NET.Runtime.Emscripten.Python",
+        "Microsoft.NET.Runtime.Emscripten.Sdk"
+      ],
+      "platforms": [ "win-x64", "linux-x64", "osx-x64", "osx-arm64" ]
+    }
+  },
+  "packs": {
+    "Microsoft.NET.Runtime.Emscripten.Node" : {
+      "kind": "Sdk",
+      "version": "7.0.0-alpha.2.22078.1",
+      "alias-to": {
+        "win-x64": "Microsoft.NET.Runtime.Emscripten.2.0.34.Node.win-x64",
+        "linux-x64": "Microsoft.NET.Runtime.Emscripten.2.0.34.Node.linux-x64",
+        "osx-x64": "Microsoft.NET.Runtime.Emscripten.2.0.34.Node.osx-x64",
+        "osx-arm64": "Microsoft.NET.Runtime.Emscripten.2.0.34.Node.osx-x64"
+      }
+    },
+    "Microsoft.NET.Runtime.Emscripten.Python" : {
+      "kind": "Sdk",
+      "version": "7.0.0-alpha.2.22078.1",
+      "alias-to": {
+        "win-x64": "Microsoft.NET.Runtime.Emscripten.2.0.34.Python.win-x64",
+        "osx-x64": "Microsoft.NET.Runtime.Emscripten.2.0.34.Python.osx-x64",
+        "osx-arm64": "Microsoft.NET.Runtime.Emscripten.2.0.34.Python.osx-x64"
+      }
+    },
+    "Microsoft.NET.Runtime.Emscripten.Sdk" : {
+      "kind": "Sdk",
+      "version": "7.0.0-alpha.2.22078.1",
+      "alias-to": {
+        "win-x64": "Microsoft.NET.Runtime.Emscripten.2.0.34.Sdk.win-x64",
+        "linux-x64": "Microsoft.NET.Runtime.Emscripten.2.0.34.Sdk.linux-x64",
+        "osx-x64": "Microsoft.NET.Runtime.Emscripten.2.0.34.Sdk.osx-x64",
+        "osx-arm64": "Microsoft.NET.Runtime.Emscripten.2.0.34.Sdk.osx-x64"
+      }
+    }
+  }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/testassets/emsdkWorkloadManifest2.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/testassets/emsdkWorkloadManifest2.json
@@ -1,0 +1,46 @@
+{
+  "version": "7.0.0-alpha.2.22078.1",
+  "workloads": {
+    "microsoft-net-sdk-emscripten": {
+      "abstract": true,
+      "description": "Emscripten SDK compiler tooling",
+      "packs": [
+        "Microsoft.NET.Runtime.Emscripten.Node",
+        "Microsoft.NET.Runtime.Emscripten.Python",
+        "Microsoft.NET.Runtime.Emscripten.Sdk"
+      ],
+      "platforms": [ "win-x64", "linux-x64", "osx-x64", "osx-arm64" ]
+    }
+  },
+  "packs": {
+    "Microsoft.NET.Runtime.Emscripten.Node" : {
+      "kind": "Sdk",
+      "version": "7.0.0-alpha.2.22079.1",
+      "alias-to": {
+        "win-x64": "Microsoft.NET.Runtime.Emscripten.2.0.34.Node.win-x64",
+        "linux-x64": "Microsoft.NET.Runtime.Emscripten.2.0.34.Node.linux-x64",
+        "osx-x64": "Microsoft.NET.Runtime.Emscripten.2.0.34.Node.osx-x64",
+        "osx-arm64": "Microsoft.NET.Runtime.Emscripten.2.0.34.Node.osx-x64"
+      }
+    },
+    "Microsoft.NET.Runtime.Emscripten.Python" : {
+      "kind": "Sdk",
+      "version": "7.0.0-alpha.2.22078.1",
+      "alias-to": {
+        "win-x64": "Microsoft.NET.Runtime.Emscripten.2.0.34.Python.win-x64",
+        "osx-x64": "Microsoft.NET.Runtime.Emscripten.2.0.34.Python.osx-x64",
+        "osx-arm64": "Microsoft.NET.Runtime.Emscripten.2.0.34.Python.osx-x64"
+      }
+    },
+    "Microsoft.NET.Runtime.Emscripten.Sdk" : {
+      "kind": "Sdk",
+      "version": "7.0.0-alpha.2.22078.1",
+      "alias-to": {
+        "win-x64": "Microsoft.NET.Runtime.Emscripten.2.0.34.Sdk.win-x64",
+        "linux-x64": "Microsoft.NET.Runtime.Emscripten.2.0.34.Sdk.linux-x64",
+        "osx-x64": "Microsoft.NET.Runtime.Emscripten.2.0.34.Sdk.osx-x64",
+        "osx-arm64": "Microsoft.NET.Runtime.Emscripten.2.0.34.Sdk.osx-x64"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Porting change from release/6.0 (#8423) to dedupe workload packs when processing multiple manifests.
