### PR TITLE
Allow trimming out incompatible ProjectReferences

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/ChooseBestP2PTargetFrameworkTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/ChooseBestP2PTargetFrameworkTask.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Build.Tasks.TargetFramework
         [Required]
         public string TargetFramework { get; set; }
 
-        public bool TrimIncompatibleProjectReferencesWithoutRaisingAnError { get; set; }
+        public bool TrimIncompatibleProjectReferences { get; set; }
 
         [Output]
         public ITaskItem[] AnnotatedProjectReferencesWithSetTargetFramework { get; set; }
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.Build.Tasks.TargetFramework
                     string bestTargetFramework = targetFrameworkResolver.GetBestSupportedTargetFramework(targetFrameworks, referringTargetFramework);
                     if (bestTargetFramework == null)
                     {
-                        if (TrimIncompatibleProjectReferencesWithoutRaisingAnError)
+                        if (TrimIncompatibleProjectReferences)
                         {
                             continue;
                         }

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/ChooseBestP2PTargetFrameworkTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/ChooseBestP2PTargetFrameworkTask.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Build.Tasks.TargetFramework
         [Required]
         public string TargetFramework { get; set; }
 
-        public bool TrimIncompatibleProjectReferences { get; set; }
+        public bool OmitIncompatibleProjectReferences { get; set; }
 
         [Output]
         public ITaskItem[] AnnotatedProjectReferencesWithSetTargetFramework { get; set; }
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.Build.Tasks.TargetFramework
                     string bestTargetFramework = targetFrameworkResolver.GetBestSupportedTargetFramework(targetFrameworks, referringTargetFramework);
                     if (bestTargetFramework == null)
                     {
-                        if (TrimIncompatibleProjectReferences)
+                        if (OmitIncompatibleProjectReferences)
                         {
                             continue;
                         }

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.props
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.props
@@ -1,12 +1,5 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
-  <!-- Add unparsed TargetFrameworks property to GetTargetFrameworks return item metadata to read from it later. -->
-  <ItemDefinitionGroup>
-    <_ThisProjectBuildMetadata>
-      <RawTargetFrameworks>$(TargetFrameworks)</RawTargetFrameworks>
-    </_ThisProjectBuildMetadata>
-  </ItemDefinitionGroup>
-
   <PropertyGroup>
     <DotNetBuildTasksTargetFrameworkAssembly Condition="'$(MSBuildRuntimeType)' == 'core'">..\tools\netcoreapp3.1\Microsoft.DotNet.Build.Tasks.TargetFramework.dll</DotNetBuildTasksTargetFrameworkAssembly>
     <DotNetBuildTasksTargetFrameworkAssembly Condition="'$(MSBuildRuntimeType)' != 'core'">..\tools\net472\Microsoft.DotNet.Build.Tasks.TargetFramework.dll</DotNetBuildTasksTargetFrameworkAssembly>

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
@@ -26,7 +26,7 @@
     <ChooseBestP2PTargetFrameworkTask ProjectReferencesWithTargetFrameworks="@(_ProjectReferenceWithTargetFrameworks)"
                                       RuntimeGraph="$(RuntimeGraph)"
                                       TargetFramework="$(TargetFramework)"
-                                      TrimIncompatibleProjectReferences="$(TrimIncompatibleProjectReferences)">
+                                      OmitIncompatibleProjectReferences="$(OmitIncompatibleProjectReferences)">
       <Output TaskParameter="AnnotatedProjectReferencesWithSetTargetFramework" ItemName="_ProjectReferenceWithBestTargetFramework" />
     </ChooseBestP2PTargetFrameworkTask>
     

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
@@ -23,9 +23,10 @@
       <_ProjectReferenceWithTargetFrameworks Include="@(ProjectReference->WithMetadataValue('SkipGetTargetFrameworkProperties', 'true'))" />
     </ItemGroup>
 
-    <ChooseBestP2PTargetFrameworkTask TargetFramework="$(TargetFramework)"
-                                      ProjectReferencesWithTargetFrameworks="@(_ProjectReferenceWithTargetFrameworks)"
-                                      RuntimeGraph="$(RuntimeGraph)">
+    <ChooseBestP2PTargetFrameworkTask ProjectReferencesWithTargetFrameworks="@(_ProjectReferenceWithTargetFrameworks)"
+                                      RuntimeGraph="$(RuntimeGraph)"
+                                      TargetFramework="$(TargetFramework)"
+                                      TrimIncompatibleProjectReferencesWithoutRaisingAnError="$(TrimIncompatibleProjectReferencesWithoutRaisingAnError)">
       <Output TaskParameter="AnnotatedProjectReferencesWithSetTargetFramework" ItemName="_ProjectReferenceWithBestTargetFramework" />
     </ChooseBestP2PTargetFrameworkTask>
     

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
@@ -26,7 +26,7 @@
     <ChooseBestP2PTargetFrameworkTask ProjectReferencesWithTargetFrameworks="@(_ProjectReferenceWithTargetFrameworks)"
                                       RuntimeGraph="$(RuntimeGraph)"
                                       TargetFramework="$(TargetFramework)"
-                                      TrimIncompatibleProjectReferencesWithoutRaisingAnError="$(TrimIncompatibleProjectReferencesWithoutRaisingAnError)">
+                                      TrimIncompatibleProjectReferences="$(TrimIncompatibleProjectReferences)">
       <Output TaskParameter="AnnotatedProjectReferencesWithSetTargetFramework" ItemName="_ProjectReferenceWithBestTargetFramework" />
     </ChooseBestP2PTargetFrameworkTask>
     


### PR DESCRIPTION
Filtering out incompatible inner builds in traversal builds happens in outer builds via hooking onto the DispatchToInnerBuild target. This works well when the project multi-targets and actually has an outer-build but which isn't true for single target framework projects. Instead during traversal builds (i.e. which are orchestrated by the ref.proj, src.proj and tests.proj projects in dotnet/runtime), filter via the ResolveP2PReferences target.

Also removing the `RawTargetFrameworks` attribute on ProjectReferences as it isn't required anymore as the TargetFrameworks attribute contains everything needed for the best target framework selection.