### PR TITLE
Enable correct Linux package architecture

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
@@ -459,6 +459,9 @@
     <PropertyGroup>
       <FullLicenseText>$([System.IO.File]::ReadAllText('$(LicenseFile)').Replace('%0A', '\n').Replace('"', '\"'))</FullLicenseText>
       <LinuxInstallRoot Condition="'$(LinuxInstallRoot)' == ''">/usr/share/dotnet</LinuxInstallRoot>
+      <LinuxPackageArchitecture>$(InstallerTargetArchitecture)</LinuxPackageArchitecture>
+      <!-- Linux packaging requires 'amd64' for x64 packages -->
+      <LinuxPackageArchitecture Condition="'$(LinuxPackageArchitecture)' == 'x64'">amd64</LinuxPackageArchitecture>
     </PropertyGroup>
 
     <ItemGroup>
@@ -469,7 +472,7 @@
 
       <_LinuxPackageControlProperty Include="priority" String="standard" />
       <_LinuxPackageControlProperty Include="section" String="libs" />
-      <_LinuxPackageControlProperty Include="architecture" String="amd64" />
+      <_LinuxPackageControlProperty Include="architecture" String="$(LinuxPackageArchitecture)" />
 
       <_LinuxPackageLicenseProperty Include="type" String="MIT and ASL 2.0 and BSD" />
       <_LinuxPackageLicenseProperty Include="full_text" String="$(FullLicenseText)" />

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.targets
@@ -87,7 +87,9 @@
     <PropertyGroup>
       <TargetRuntimeOS>$(InstallerRuntimeIdentifier.Substring(0, $(InstallerRuntimeIdentifier.LastIndexOf('-'))))</TargetRuntimeOS>
       <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">$(InstallerRuntimeIdentifier.Substring($(InstallerRuntimeIdentifier.LastIndexOf('-'))).TrimStart('-'))</TargetArchitecture>
-      <InstallerTargetArchitecture Condition="'$(InstallerTargetArchitecture)' == ''">$(TargetArchitecture)</InstallerTargetArchitecture>
+      <_TargetArch>$(TargetArchitecture)</_TargetArch>
+      <_TargetArch Condition="'$(BuildRpmPackage)' == 'true' and '$(TargetArchitecture)' == 'arm64'">aarch64</_TargetArch>
+      <InstallerTargetArchitecture Condition="'$(InstallerTargetArchitecture)' == ''">$(_TargetArch)</InstallerTargetArchitecture>
     </PropertyGroup>
     <ItemGroup>
       <CrossArchMsiToBuild Include="@(CrossArchSdkMsiInstallerArch)" Exclude="$(TargetArchitecture)" />


### PR DESCRIPTION
Package architecture was hard-coded to `amd64`. We need to enable other architectures, as a prerequisite for https://github.com/dotnet/runtime/issues/64755

We currently only build amd64 packages. `InstallerTargetArchitecture` property is `x64` - this is used in constructing the package filename. Package architecture is `amd64` This is not changing.

We enable other architectures like arm64.

For DEBs, both `InstallerTargetArchitecture` and package architecture values are `arm64`.

For RPMs, both `InstallerTargetArchitecture` and package architecture values are `aarch64`.

## Testing

Built and tested private x64 and aarch64 RPM packages.