### PR TITLE
add workaround for https://github.com/dotnet/arcade/issues/8461 during linux sbom preparation

### DIFF
--- a/eng/common/templates/steps/generate-sbom.yml
+++ b/eng/common/templates/steps/generate-sbom.yml
@@ -18,7 +18,9 @@ steps:
     filePath: ./eng/common/generate-sbom-prep.ps1
     arguments: ${{parameters.manifestDirPath}}
 
+# Chmodding is a workaround for https://github.com/dotnet/arcade/issues/8461
 - script: |
+    chmod +x ./eng/common/generate-sbom-prep.sh
     ./eng/common/generate-sbom-prep.sh ${{parameters.manifestDirPath}}
   displayName: Prep for SBOM generation in (Linux)
   condition: eq(variables['Agent.Os'], 'Linux')


### PR DESCRIPTION
workaround for https://github.com/dotnet/arcade/issues/8461 while we fix file permission propagation in Maestro

Tested this same change in: https://dev.azure.com/dnceng/internal/_build/results?buildId=1607895&view=results

### To double check:

* [X] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
