### PR TITLE
Make Arcade CodeQL clean

### DIFF
--- a/src/Common/Microsoft.Arcade.Test.Common/FakeHttpClient.cs
+++ b/src/Common/Microsoft.Arcade.Test.Common/FakeHttpClient.cs
@@ -11,8 +11,9 @@ namespace Microsoft.DotNet.Arcade.Test.Common
 {
     public static class FakeHttpClient
     {
+        
         public static HttpClient WithResponses(params HttpResponseMessage[] responses)
-            => new HttpClient(
+            => new HttpClient( // lgtm [cs/httpclient-checkcertrevlist-disabled] HttpClient used in unit tests
                 new FakeHttpMessageHandler(responses));
 
         private class FakeHttpMessageHandler : HttpMessageHandler

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/AzureStorageExtensions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/AzureStorageExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
     {
         public static string CalculateMD5(string filename)
         {
-            using var md5 = MD5.Create();
+            using var md5 = MD5.Create(); // lgtm [cs/weak-crypto] Azure Storage specifies use of MD5
             using var stream = File.OpenRead(filename);
             byte[] hash = md5.ComputeHash(stream);
             return Convert.ToBase64String(hash);

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/ExecWithRetriesForNuGetPush.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/ExecWithRetriesForNuGetPush.cs
@@ -202,7 +202,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     $"Downloading package from '{packageUrl}' " +
                     $"to check if identical to '{PackageFile}'");
 
-                using (var client = new HttpClient
+                using (var client = new HttpClient (new HttpClientHandler() { CheckCertificateRevocationList = true })
                 {
                     Timeout = TimeSpan.FromMinutes(10)
                 })

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
@@ -38,7 +38,14 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
 
         public BlobContainerClient Container { get; set; }
 
-        private static readonly HttpClient s_httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(300) };
+        private static readonly HttpClient s_httpClient = new HttpClient(
+            new HttpClientHandler() 
+            { 
+                CheckCertificateRevocationList = true 
+            })
+        { 
+            Timeout = TimeSpan.FromSeconds(300) 
+        };
         private static readonly BlobClientOptions s_clientOptions = new BlobClientOptions()
         {
             Transport = new HttpClientTransport(s_httpClient)
@@ -60,7 +67,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
 
         public static string CalculateMD5(string filename)
         {
-            using (var md5 = MD5.Create())
+            using (var md5 = MD5.Create())  // lgtm [cs/weak-crypto] Azure Storage specifies use of MD5
             {
                 using (var stream = File.OpenRead(filename))
                 {

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateGuidFromName.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateGuidFromName.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
             // Any fixed GUID will do for a namespace.
             Guid namespaceId = new Guid("28F1468D-672B-489A-8E0C-7C5B3030630C");
 
-            using (SHA1 hasher = SHA1.Create())
+            using (SHA1 hasher = SHA1.Create()) // lgtm [cs/weak-crypto] Algorithm is required by UUIDv5 spec
             {
                 var nameBytes = System.Text.Encoding.UTF8.GetBytes(Name ?? string.Empty);
                 var namespaceBytes = namespaceId.ToByteArray();

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/GitHubAuth.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/GitHubAuth.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.VersionTools.Automation
             }
             AuthToken = authToken;
             User = user ?? "dotnet-bot";
-            Email = email ?? "dotnet-bot@microsoft.com";
+            Email = email ?? "dotnet-bot@microsoft.com"; // lgtm [cs/hard-coded-id] This default is correct for this tool's narrow use
         }
     }
 }

--- a/src/SignCheck/Microsoft.SignCheck/Verification/ArchiveVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/ArchiveVerifier.cs
@@ -37,13 +37,13 @@ namespace Microsoft.SignCheck.Verification
                         // Generate an alias for the actual file that has the same extension. We do this to avoid path too long errors so that
                         // containers can be flattened.
                         string directoryName = Path.GetDirectoryName(archiveEntry.FullName);
-                        string hashedPath = String.IsNullOrEmpty(directoryName) ? Utils.GetHash(@".\", HashAlgorithmName.MD5.Name) :
-                            Utils.GetHash(directoryName, HashAlgorithmName.MD5.Name);
+                        string hashedPath = String.IsNullOrEmpty(directoryName) ? Utils.GetHash(@".\", HashAlgorithmName.SHA256.Name) :
+                            Utils.GetHash(directoryName, HashAlgorithmName.SHA256.Name);
                         string extension = Path.GetExtension(archiveEntry.FullName);
 
                         // CAB files cannot be aliased since they're referred to from the Media table inside the MSI
                         string aliasFileName = String.Equals(extension.ToLowerInvariant(), ".cab") ? Path.GetFileName(archiveEntry.FullName) :
-                            Utils.GetHash(archiveEntry.FullName, HashAlgorithmName.MD5.Name) + Path.GetExtension(archiveEntry.FullName);
+                            Utils.GetHash(archiveEntry.FullName, HashAlgorithmName.SHA256.Name) + Path.GetExtension(archiveEntry.FullName);
                         string aliasFullName = Path.Combine(tempPath, hashedPath, aliasFileName);
 
                         if (File.Exists(aliasFullName))

--- a/src/SignCheck/Microsoft.SignCheck/Verification/Jar/JarSignatureFile.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Jar/JarSignatureFile.cs
@@ -209,7 +209,7 @@ namespace Microsoft.SignCheck.Verification.Jar
             byte[] signatureBlockBytes = JarUtils.ReadBytes(ArchivePath, SignatureBlockFilePath);
             byte[] signatureFileBytes = JarUtils.ReadBytes(ArchivePath, SignatureFilePath);
 
-            SHA1Managed sha = new SHA1Managed();
+            SHA1Managed sha = new SHA1Managed(); // lgtm [cs/weak-crypto] Hash algorithm specified by signature algorithm
             byte[] hash = sha.ComputeHash(signatureFileBytes);
 
             ContentInfo ci = new ContentInfo(signatureFileBytes);

--- a/src/SignCheck/SignCheck/SignCheck.cs
+++ b/src/SignCheck/SignCheck/SignCheck.cs
@@ -462,6 +462,8 @@ namespace SignCheck
         {
             try
             {
+                ServicePointManager.CheckCertificateRevocationList = true;
+
                 using (var wc = new WebClient())
                 {
                     string downloadPath = Path.Combine(_appData, Path.GetFileName(uri.LocalPath));


### PR DESCRIPTION
All CodeQL errors (Under the "SDLRequired" plan) are either resolved via a code change or silenced with inline comment. 

All instances of type "Check CSRL" were resolved with code changes. 

Most instances of "weak crypto" are hashes and were silenced as they're used according to other specifications. To properly resolve this, use of those standards should be stopped. 

