### PR TITLE
Disable SBOM generation in mirroring pipelines and remove parameters from jobs.yml

### DIFF
--- a/azure-pipelines-code-mirror.yml
+++ b/azure-pipelines-code-mirror.yml
@@ -12,6 +12,7 @@ jobs:
     helixRepo: dotnet/arcade
     jobs:
     - job: Merge_GitHub_to_Azure_DevOps
+      enableSBOM: false
       pool:
         name: NetCore1ESPool-Internal
         demands: ImageOverride -equals Build.Server.Amd64.VS2019

--- a/azure-pipelines-merge-mirror.yml
+++ b/azure-pipelines-merge-mirror.yml
@@ -12,6 +12,7 @@ jobs:
     helixRepo: dotnet/arcade
     jobs:
     - job: Merge_GitHub_to_Azure_DevOps
+      enableSBOM: false
       pool:
         name: NetCore1ESPool-Internal
         demands: ImageOverride -equals Build.Server.Amd64.VS2019

--- a/eng/common/templates/jobs/jobs.yml
+++ b/eng/common/templates/jobs/jobs.yml
@@ -37,11 +37,6 @@ parameters:
 # Internal resources (telemetry, microbuild) can only be accessed from non-public projects,
 # and some (Microbuild) should only be applied to non-PR cases for internal builds.
 
-# Sbom related params
-  enableSbom: true
-  PackageVersion: 7.0.0
-  BuildDropPath: '$(Build.SourcesDirectory)/artifacts'
-
 jobs:
 - ${{ each job in parameters.jobs }}:
   - template: ../job/job.yml


### PR DESCRIPTION
Fixes https://github.com/dotnet/core-eng/issues/15581

I'm also removing the SBOM parameters from the jobs.yml, because they are affected by the same YAML problem outlined in https://github.com/dotnet/arcade/issues/8470. This allows repos to configure things at the at the individual job level. 

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
