### PR TITLE
Add cm.2 packages

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
@@ -154,10 +154,16 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(CreateRPMForCblMariner)' == 'true'">
+      <!-- CBL-Mariner 1.0 -->
       <_CblMarinerVersionSuffix>cm.1</_CblMarinerVersionSuffix>
       <_InstallerBuildPartCblMariner>$(Version)-$(_CblMarinerVersionSuffix)-$(InstallerTargetArchitecture)</_InstallerBuildPartCblMariner>
       <_InstallerFileNameWithoutExtensionCblMariner>$(InstallerName)-$(_InstallerBuildPartCblMariner)$(CrossArchContentsBuildPart)</_InstallerFileNameWithoutExtensionCblMariner>
       <_InstallerFileCblMariner>$(PackageOutputPath)$(_InstallerFileNameWithoutExtensionCblMariner)$(InstallerExtension)</_InstallerFileCblMariner>
+      <!-- CBL-Mariner 2.0 -->
+      <_CblMariner2VersionSuffix>cm.2</_CblMariner2VersionSuffix>
+      <_InstallerBuildPartCblMariner2>$(Version)-$(_CblMariner2VersionSuffix)-$(InstallerTargetArchitecture)</_InstallerBuildPartCblMariner2>
+      <_InstallerFileNameWithoutExtensionCblMariner2>$(InstallerName)-$(_InstallerBuildPartCblMariner2)$(CrossArchContentsBuildPart)</_InstallerFileNameWithoutExtensionCblMariner2>
+      <_InstallerFileCblMariner2>$(PackageOutputPath)$(_InstallerFileNameWithoutExtensionCblMariner2)$(InstallerExtension)</_InstallerFileCblMariner2>
     </PropertyGroup>
   </Target>
   
@@ -322,6 +328,7 @@
 
     <Message Text="$(MSBuildProjectName) -> $(_InstallerFile)" Importance="high" />
 
+    <!-- CBL-Mariner 1.0 -->
     <Copy Condition="'$(CreateRPMForCblMariner)' == 'true'"
           SourceFiles="@(GeneratedRpmFiles)"
           DestinationFiles="$(_InstallerFileCblMariner)"
@@ -330,6 +337,16 @@
           UseHardlinksIfPossible="False" />
 
     <Message Text="$(MSBuildProjectName) -> $(_InstallerFileCblMariner)" Importance="high" />
+
+    <!-- CBL-Mariner 2.0 -->
+    <Copy Condition="'$(CreateRPMForCblMariner)' == 'true'"
+          SourceFiles="@(GeneratedRpmFiles)"
+          DestinationFiles="$(_InstallerFileCblMariner2)"
+          OverwriteReadOnlyFiles="True"
+          SkipUnchangedFiles="False"
+          UseHardlinksIfPossible="False" />
+
+    <Message Text="$(MSBuildProjectName) -> $(_InstallerFileCblMariner2)" Importance="high" />
   </Target>
 
   <Target Name="GetRpmInstallerJsonProperties"


### PR DESCRIPTION
Add new copy of RPM packages for CBL-Mariner 2.0

This is a pre-requisite for CBL-Mariner 2.0 support: https://github.com/dotnet/runtime/issues/64756

Keeping implementation simpler and distinct from Mariner 1.0 packages (cm.1) which will eventually be removed.

## Testing

Private build and installation of RPM packages.