### PR TITLE
[release/5.0] Remove disableComponentGovernance parameter from jobs.yml (#8471)

### DIFF
--- a/eng/common/templates/jobs/jobs.yml
+++ b/eng/common/templates/jobs/jobs.yml
@@ -8,10 +8,6 @@ parameters:
   # Optional: Enable publishing using release pipelines
   enablePublishUsingPipelines: false
 
-  # Optional: Disable component governance detection. In general, component governance
-  # should be on for all jobs. Use only in the event of issues.
-  disableComponentGovernance: false
-
   graphFileGeneration:
     # Optional: Enable generating the graph files at the end of the build
     enabled: false


### PR DESCRIPTION
## Description

Remove disableComponentGovernance parameter from jobs.yml in release/5.0
cherry-pick of https://github.com/dotnet/arcade/commit/64a726863440a7f45c8327cf64c9ebc0a269e823
## Customer Impact

Customers are not able to disable the component governance step in individual jobs because this property conflicts

## Regression

No

## Risk

Low. This change has been in main for a week now

## Workarounds

Customers can change their usage of `jobs.yml` to make multiple, individual calls to `job.yml` to disable these steps. 

