### PR TITLE
Fix NotSupported assembly metadata

### DIFF
--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacadesNotSupported.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacadesNotSupported.targets
@@ -12,7 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <AssemblyMetadata Include="NotSupported" Value="True" />
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadata">
+      <_Parameter1>NotSupported</_Parameter1>
+      <_Parameter2>True</_Parameter2>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup Condition="'$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">


### PR DESCRIPTION
With https://github.com/dotnet/runtime/commit/4c2ea7e9010e9c71bfba332e430e92f00e19c04e the dotnet/runtime custom AssemblyMetadata item isn't recognized anymore. Instead use the AssemblyAttribute item which is exposed by the sdk and a documented extension point.