### PR TITLE
remove retain-build.ps1's dependency on tools.ps1

### DIFF
--- a/eng/common/retain-build.ps1
+++ b/eng/common/retain-build.ps1
@@ -8,8 +8,6 @@ Param(
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
-. $PSScriptRoot\tools.ps1
-
 
 function Get-AzDOHeaders(
     [string] $token)
@@ -38,10 +36,10 @@ function Update-BuildRetention(
         Write-Host "Updated retention settings for build ${buildId}."
     }
     catch {
-        Write-PipelineTelemetryError -Category "Build" -Message "Failed to update retention settings for build: $_.Exception.Response.StatusDescription"
-        ExitWithExitCode 1
+        Write-Error "Failed to update retention settings for build: $_.Exception.Response.StatusDescription"
+        exit 1
     }
 }
 
 Update-BuildRetention -azdoOrgUri $azdoOrgUri -azdoProject $azdoProject -buildId $buildId -token $token
-ExitWithExitCode 0
+exit 0

--- a/eng/configure-toolset.ps1
+++ b/eng/configure-toolset.ps1
@@ -2,7 +2,8 @@
 function Test-FilesUseTelemetryOutput {
     $requireTelemetryExcludeFiles = @(
         "enable-cross-org-publishing.ps1",
-        "performance-setup.ps1" )
+        "performance-setup.ps1",
+        "retain-build.ps1" )
 
     $filesMissingTelemetry = Get-ChildItem -File -Recurse -Path "$PSScriptRoot\common" -Include "*.ps1" -Exclude $requireTelemetryExcludeFiles |
         Where-Object { -Not( $_ | Select-String -Pattern "Write-PipelineTelemetryError" )}


### PR DESCRIPTION
https://github.com/dotnet/core-eng/issues/15697

This removes the dependency on tools.ps1 so that this script can be used in non-arcade repos. Also adds the script to the list of scripts exempt from having telemetry, or we get errors such as https://dev.azure.com/dnceng/internal/_build/results?buildId=1637962&view=results 

Test builds: 

* successful build: https://dev.azure.com/dnceng/internal/_build/results?buildId=1637946&view=results
* this is how an error in the script would now show up without the telemetry cateogorization: https://dev.azure.com/dnceng/internal/_build/results?buildId=1637974&view=results

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/core-eng/tree/master/Documentation/Validation
