### PR TITLE
Update known issues documentation to point to arcade repo

### DIFF
--- a/Documentation/Projects/Build Analysis/KnownIssues.md
+++ b/Documentation/Projects/Build Analysis/KnownIssues.md
@@ -74,7 +74,7 @@ After selecting the message, fill the "ErrorMessage";
 
 ## How to get onboard
 1. This feature is tightly related to the build analysis because of that it's necessary to have the `.NET Helix` GitHub application installed in the repo in which you intend to use known issues. </br>
-To get the application installed, you can contact the [.NET Core Engineering Services team](https://github.com/dotnet/core-eng/wiki/How-to-get-a-hold-of-Engineering-Servicing)
+To get the application installed, you can contact the [.NET Core Engineering Services team](https://dev.azure.com/dnceng/internal/_wiki/wikis/DNCEng%20Services%20Wiki/107/How-to-get-a-hold-of-Engineering-Servicing)
 1. For infrastructure issues there are not additional steps because this are part of dotnet/arcade.
 1. For the repository issues it's necessary to [Create a label](https://docs.github.com/en/enterprise-server@3.1/issues/using-labels-and-milestones-to-track-work/managing-labels#creating-a-label) on the repository in which you need to open the Repository issue. <br>
 The name of the label needs to be `Known Build Error`


### PR DESCRIPTION
We are moving the feature to arcade so updating the documentation.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
