### PR TITLE
Add DOTNET_REMOTEEXECUTOR_SUPPORTED check to RemoteExecutor.IsSupported

### DIFF
--- a/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
@@ -104,7 +104,8 @@ namespace Microsoft.DotNet.RemoteExecutor
             !RuntimeInformation.IsOSPlatform(OSPlatform.Create("WATCHOS")) &&
             !RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")) &&
             // The current RemoteExecutor design is not compatible with single file
-            !string.IsNullOrEmpty(typeof(RemoteExecutor).Assembly.Location);
+            !string.IsNullOrEmpty(typeof(RemoteExecutor).Assembly.Location) &&
+            Environment.GetEnvironmentVariable("DOTNET_REMOTEEXECUTOR_SUPPORTED") != "0";
 
         /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
         /// <param name="method">The method to invoke.</param>


### PR DESCRIPTION
Using an environment variable will allow us to skip adding new configurations to check when they come up.
