### PR TITLE
Cause build warnings when sending to impending-removal Helix queues (release/6.0)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -143,6 +143,7 @@ stages:
               -ci
               -restore
               -test
+              -warnAsError $false
               -projects $(Build.SourcesDirectory)\tests\UnitTests.proj
               /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.binlog
               /p:RestoreUsingNuGetTargets=false
@@ -156,6 +157,7 @@ stages:
               -ci
               -restore
               -test
+              -warnAsError $false
               -projects $(Build.SourcesDirectory)\tests\XHarness.Android.DeviceTests.proj
               /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.XHarness.Android.Device.Tests.binlog
               /p:RestoreUsingNuGetTargets=false
@@ -184,6 +186,7 @@ stages:
               --ci
               --restore
               --test
+              --warnAsError false
               --projects $(Build.SourcesDirectory)/tests/UnitTests.proj
               /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.binlog
               /p:RestoreUsingNuGetTargets=false
@@ -197,6 +200,7 @@ stages:
               -ci
               -restore
               -test
+              -warnAsError false
               -projects $(Build.SourcesDirectory)/tests/XHarness.Apple.SimulatorTests.proj
               /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/XHarness.Apple.Simulator.Tests.binlog
               /p:RestoreUsingNuGetTargets=false
@@ -210,6 +214,7 @@ stages:
               -ci
               -restore
               -test
+              -warnAsError false
               -projects $(Build.SourcesDirectory)/tests/XHarness.Apple.DeviceTests.proj
               /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.XHarness.Apple.Device.Tests.binlog
               /p:RestoreUsingNuGetTargets=false
@@ -223,6 +228,7 @@ stages:
               -ci
               -restore
               -test
+              -warnAsError false
               -projects $(Build.SourcesDirectory)/tests/XHarness.Android.SimulatorTests.proj
               /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.XHarness.Android.Simulator.Tests.binlog
               /p:RestoreUsingNuGetTargets=false

--- a/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
@@ -264,7 +264,8 @@ namespace Microsoft.DotNet.Helix.Sdk
                 Log.LogMessage(MessageImportance.High, $"Sending Job to {TargetQueue}...");
 
                 cancellationToken.ThrowIfCancellationRequested();
-                ISentJob job = await def.SendAsync(msg => Log.LogMessage(msg), cancellationToken);
+                // LogMessageFromText will take any string formatted as a canonical error or warning and convert the type of log to this
+                ISentJob job = await def.SendAsync(msg => Log.LogMessageFromText(msg, MessageImportance.High), cancellationToken);
                 JobCorrelationId = job.CorrelationId;
                 JobCancellationToken = job.HelixCancellationToken;
                 ResultsContainerUri = job.ResultsContainerUri;


### PR DESCRIPTION
Follow-on from https://github.com/dotnet/core-eng/issues/15080 .  This version of the fix wouldn't actually cause a warning if verbosity was set low enough, and most actual users of the Arcade Helix SDK set their verbosity low.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation (this codepath is exercised by the PR)

## Description

We now need to remove Helix test queues on a faster cadence when the OSes life cycle expires. This change brings a warning into builds that send to Helix if the queue is scheduled to be removed in the next 10 days with some guidance, so that users have a chance to remove usage or update to a different queue.

## Customer Impact

Without this change, Helix consumers won't know about the deprecation of their queues (except from various dncpartners emails weeks before hand) until they are gone.

## Regression

No

## Risk

Very low: Tested in this PR validation.

## Workarounds

None:  The alternative is to just react when things are already broken
