### PR TITLE
Cause build warnings when sending to impending-removal Helix queues (release/5.0)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,6 +123,7 @@ stages:
               -ci
               -restore
               -test
+              -warnAsError $false
               -projects $(Build.SourcesDirectory)\tests\UnitTests.proj
               /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.binlog
               /p:RestoreUsingNuGetTargets=false
@@ -136,6 +137,7 @@ stages:
               -ci
               -restore
               -test
+              -warnAsError $false
               -projects $(Build.SourcesDirectory)\tests\UnitTests.XHarness.Android.proj
               /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.XHarness.Android.binlog
               /p:RestoreUsingNuGetTargets=false
@@ -165,6 +167,7 @@ stages:
               --ci
               --restore
               --test
+              --warnAsError false
               --projects $(Build.SourcesDirectory)/tests/UnitTests.proj
               /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.binlog
               /p:RestoreUsingNuGetTargets=false
@@ -178,6 +181,7 @@ stages:
               -ci
               -restore
               -test
+              -warnAsError false
               -projects $(Build.SourcesDirectory)/tests/UnitTests.XHarness.iOS.proj
               /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.XHarness.iOS.binlog
               /p:RestoreUsingNuGetTargets=false
@@ -191,6 +195,7 @@ stages:
               -ci
               -restore
               -test
+              -warnAsError false
               -projects $(Build.SourcesDirectory)/tests/UnitTests.XHarness.iOS.IncludeCliOnly.proj
               /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.XHarness.CLI.binlog
               /p:RestoreUsingNuGetTargets=false

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.Helix.Client
             _properties = new Dictionary<string, string>();
             Properties = new ReadOnlyDictionary<string, string>(_properties);
             JobApi = jobApi;
-            HelixApi = ((IServiceOperations<HelixApi>) JobApi).Client;
+            HelixApi = ((IServiceOperations<HelixApi>)JobApi).Client;
         }
 
         public IHelixApi HelixApi { get; }
@@ -206,7 +206,7 @@ namespace Microsoft.DotNet.Helix.Client
 
                 // ResultContainerPrefix will be <Repository Name>-<BranchName>
                 ResultContainerPrefix = $"{repoName}-{branchName}-".Replace("/", "-").ToLower();
-                ResultContainerPrefix  = multipleDashes.Replace(illegalCharacters.Replace(ResultContainerPrefix, ""), "-");
+                ResultContainerPrefix = multipleDashes.Replace(illegalCharacters.Replace(ResultContainerPrefix, ""), "-");
             }
 
             var creationRequest = new JobCreationRequest(Type, jobListUri.ToString(), queueId)
@@ -237,31 +237,23 @@ namespace Microsoft.DotNet.Helix.Client
 
         private void WarnForImpendingRemoval(Action<string> log, QueueInfo queueInfo)
         {
-            bool azDoVariableDefined = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SYSTEM_TEAMPROJECT"));
             DateTime whenItExpires = DateTime.MaxValue;
 
             if (DateTime.TryParseExact(queueInfo.EstimatedRemovalDate, "yyyy-MM-dd", null, DateTimeStyles.AssumeUniversal, out DateTime dtIso))
             {
                 whenItExpires = dtIso;
             }
-            // This branch can be removed once the strings start coming in in ISO-8601 format
-            // Currently the API provides values in this format though and they are unlikely to get confused with each other.
-            else if (DateTime.TryParseExact(queueInfo.EstimatedRemovalDate, "M/d/yyyy", null, DateTimeStyles.AssumeUniversal, out DateTime dtUsa))
-            {
-                whenItExpires = dtUsa;
-            }
-
             if (whenItExpires != DateTime.MaxValue) // We recognized a date from the string
             {
                 TimeSpan untilRemoved = whenItExpires.ToUniversalTime().Subtract(DateTime.UtcNow);
-                if (untilRemoved.TotalDays <= 21)
+                if (untilRemoved.TotalDays <= 10)
                 {
-                    log?.Invoke($"{(azDoVariableDefined ? "##vso[task.logissue type=warning]" : "")}Helix queue {queueInfo.QueueId} {(untilRemoved.TotalDays < 0 ? "was" : "is")} slated for removal on {queueInfo.EstimatedRemovalDate}. Please discontinue usage.  Contact dnceng for questions / concerns ");
+                    log?.Invoke($"warning : Helix queue {queueInfo.QueueId} {(untilRemoved.TotalDays < 0 ? "was" : "is")} set for estimated removal date of {queueInfo.EstimatedRemovalDate}. In most cases the queue will be removed permanently due to end-of-life; please contact dnceng for any questions or concerns, and we can help you decide how to proceed and discuss other options.");
                 }
             }
             else
             {
-                log?.Invoke($"{(azDoVariableDefined ? "##vso[task.logissue type=warning]" : "")}Unable to parse estimated removal date '{queueInfo.EstimatedRemovalDate}' for queue '{queueInfo.QueueId}' (please contact dnceng with this information)");
+                log?.Invoke($"error : Unable to parse estimated removal date '{queueInfo.EstimatedRemovalDate}' for queue '{queueInfo.QueueId}' (please contact dnceng with this information)");
             }
         }
 

--- a/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
@@ -233,7 +233,8 @@ namespace Microsoft.DotNet.Helix.Sdk
                 Log.LogMessage(MessageImportance.High, $"Sending Job to {TargetQueue}...");
 
                 cancellationToken.ThrowIfCancellationRequested();
-                ISentJob job = await def.SendAsync(msg => Log.LogMessage(msg), cancellationToken);
+                // LogMessageFromText will take any string formatted as a canonical error or warning and convert the type of log to this
+                ISentJob job = await def.SendAsync(msg => Log.LogMessageFromText(msg, MessageImportance.High), cancellationToken);
                 JobCorrelationId = job.CorrelationId;
                 ResultsContainerUri = job.ResultsContainerUri;
                 ResultsContainerReadSAS = job.ResultsContainerReadSAS;


### PR DESCRIPTION

Follow-on from https://github.com/dotnet/core-eng/issues/15080 .  This version of the fix wouldn't actually cause a warning if verbosity was set low enough, and most actual users of the Arcade Helix SDK set their verbosity low.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation (this codepath is exercised by the PR)


