### PR TITLE
Cause build warnings when sending to impending-removal Helix queues (release/3.x) 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -124,6 +124,7 @@ stages:
             -prepareMachine
             -ci
             -test
+            -warnAsError $false
             -projects $(Build.SourcesDirectory)/tests/UnitTests.proj
             /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.binlog
           displayName: Run Helix Tests
@@ -136,6 +137,7 @@ stages:
             -prepareMachine
             -ci
             -test
+            -warnAsError $false
             -projects $(Build.SourcesDirectory)/tests/UnitTests.proj
             /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.binlog
             /p:HelixBaseUri=https://helix.int-dot.net/
@@ -184,6 +186,7 @@ stages:
               --prepareMachine
               --ci
               --test
+              --warnAsError false
               --projects $(Build.SourcesDirectory)/tests/UnitTests.proj
               /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.binlog
             displayName: Run Helix Tests

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -237,31 +237,23 @@ namespace Microsoft.DotNet.Helix.Client
 
         private void WarnForImpendingRemoval(Action<string> log, QueueInfo queueInfo)
         {
-            bool azDoVariableDefined = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SYSTEM_TEAMPROJECT"));
             DateTime whenItExpires = DateTime.MaxValue;
 
             if (DateTime.TryParseExact(queueInfo.EstimatedRemovalDate, "yyyy-MM-dd", null, DateTimeStyles.AssumeUniversal, out DateTime dtIso))
             {
                 whenItExpires = dtIso;
             }
-            // This branch can be removed once the strings start coming in in ISO-8601 format
-            // Currently the API provides values in this format though and they are unlikely to get confused with each other.
-            else if (DateTime.TryParseExact(queueInfo.EstimatedRemovalDate, "M/d/yyyy", null, DateTimeStyles.AssumeUniversal, out DateTime dtUsa))
-            {
-                whenItExpires = dtUsa;
-            }
-
             if (whenItExpires != DateTime.MaxValue) // We recognized a date from the string
             {
                 TimeSpan untilRemoved = whenItExpires.ToUniversalTime().Subtract(DateTime.UtcNow);
-                if (untilRemoved.TotalDays <= 21)
+                if (untilRemoved.TotalDays <= 10)
                 {
-                    log?.Invoke($"{(azDoVariableDefined ? "##vso[task.logissue type=warning]" : "")}Helix queue {queueInfo.QueueId} {(untilRemoved.TotalDays < 0 ? "was" : "is")} slated for removal on {queueInfo.EstimatedRemovalDate}. Please discontinue usage.  Contact dnceng for questions / concerns ");
+                    log?.Invoke($"warning : Helix queue {queueInfo.QueueId} {(untilRemoved.TotalDays < 0 ? "was" : "is")} set for estimated removal date of {queueInfo.EstimatedRemovalDate}. In most cases the queue will be removed permanently due to end-of-life; please contact dnceng for any questions or concerns, and we can help you decide how to proceed and discuss other options.");
                 }
             }
             else
             {
-                log?.Invoke($"{(azDoVariableDefined ? "##vso[task.logissue type=warning]" : "")}Unable to parse estimated removal date '{queueInfo.EstimatedRemovalDate}' for queue '{queueInfo.QueueId}' (please contact dnceng with this information)");
+                log?.Invoke($"error : Unable to parse estimated removal date '{queueInfo.EstimatedRemovalDate}' for queue '{queueInfo.QueueId}' (please contact dnceng with this information)");
             }
         }
 

--- a/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
@@ -230,7 +230,8 @@ namespace Microsoft.DotNet.Helix.Sdk
                 Log.LogMessage(MessageImportance.High, $"Sending Job to {TargetQueue}...");
 
                 cancellationToken.ThrowIfCancellationRequested();
-                ISentJob job = await def.SendAsync(msg => Log.LogMessage(msg));
+                // LogMessageFromText will take any string formatted as a canonical error or warning and convert the type of log to this
+                ISentJob job = await def.SendAsync(msg => Log.LogMessageFromText(msg, MessageImportance.High));
                 JobCorrelationId = job.CorrelationId;
                 ResultsContainerUri = job.ResultsContainerUri;
                 ResultsContainerReadSAS = job.ResultsContainerReadSAS;


### PR DESCRIPTION
### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation

## Description

We now need to remove Helix test queues on a faster cadence when the OSes life cycle expires. This change brings a warning into builds that send to Helix if the queue is scheduled to be removed in the next 10 days with some guidance, so that users have a chance to remove usage or update to a different queue.

## Customer Impact

Without this change, Helix consumers won't know about the deprecation of their queues (except from various dncpartners emails weeks before hand) until they are gone.

## Regression

No

## Risk

Very low: Tested in this PR validation.

## Workarounds

None:  The alternative is to just react when things are already broken