### PR TITLE
[release/6.0] Fix DotnetSharedFrameworkTaskDir to not rely on DotnetBuildFromSource

### DIFF
--- a/src/Microsoft.DotNet.SharedFramework.Sdk/sdk/Sdk.props
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/sdk/Sdk.props
@@ -8,11 +8,10 @@
   -->
 
   <PropertyGroup Condition="'$(DotNetSharedFrameworkTaskDir)' == ''">
-    <DotNetSharedFrameworkTaskDir Condition="'$(MSBuildRuntimeType)' == 'core'">$(MSBuildThisFileDirectory)../tools/netcoreapp3.1/</DotNetSharedFrameworkTaskDir>
-    <DotNetSharedFrameworkTaskDir Condition="'$(MSBuildRuntimeType)' != 'core'">$(MSBuildThisFileDirectory)../tools/net472/</DotNetSharedFrameworkTaskDir>
-
     <!-- Workaround for https://github.com/dotnet/arcade/issues/7413 -->
-    <DotNetSharedFrameworkTaskDir Condition="'$(MSBuildRuntimeType)' == 'core' and '$(DotNetBuildFromSource)' == 'true'">$(MSBuildThisFileDirectory)../tools/net6.0/</DotNetSharedFrameworkTaskDir>
+    <DotNetSharedFrameworkTaskDir Condition="'$(MSBuildRuntimeType)' == 'core' and Exists('$(MSBuildThisFileDirectory)../tools/net6.0/')">$(MSBuildThisFileDirectory)../tools/net6.0/</DotNetSharedFrameworkTaskDir>
+    <DotNetSharedFrameworkTaskDir Condition="'$(MSBuildRuntimeType)' == 'core' and '$(DotNetSharedFrameworkTaskDir)' == ''">$(MSBuildThisFileDirectory)../tools/netcoreapp3.1/</DotNetSharedFrameworkTaskDir>
+    <DotNetSharedFrameworkTaskDir Condition="'$(MSBuildRuntimeType)' != 'core'">$(MSBuildThisFileDirectory)../tools/net472/</DotNetSharedFrameworkTaskDir>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Port of https://github.com/dotnet/arcade/pull/8355, working around https://github.com/dotnet/source-build/issues/2802

After https://github.com/dotnet/arcade/pull/8338 we saw a build error in a dotnet/runtime build job that tries to validate source-build but still uses the non-source-built arcade packages:

```
 /__w/1/s/artifacts/source-build/self/src/src/libraries/ref.proj(68,5): error MSB4062: The "CreateFrameworkListFile" task could not be loaded from the assembly /__w/1/s/artifacts/source-build/self/package-cache/microsoft.dotnet.sharedframework.sdk/7.0.0-beta.22064.25/sdk/../tools/net6.0/Microsoft.DotNet.SharedFramework.Sdk.dll. Could not load file or assembly '/__w/1/s/artifacts/source-build/self/package-cache/microsoft.dotnet.sharedframework.sdk/7.0.0-beta.22064.25/tools/net6.0/Microsoft.DotNet.SharedFramework.Sdk.dll'. The system cannot find the file specified.
```

This is because the non-source-built arcade packages use netcoreapp3.1 libraries instead of  net6.0, but we're still setting DotnetBuildFromSource=true in those builds.

Instead of using DotnetBuildFromSource to switch between libraries we can check for the existence of the net6.0 folder which works in both scenarios.