### PR TITLE
Fix issue where the folder that pkgbuild should output the pkg file to might not exist when it tries to output the pkg file.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
@@ -410,7 +410,9 @@
     
     <MakeDir Directories="$(_OutputPathRoot)" />
     <!-- avoid error where the root folder for the _InstallerFile does not exist: https://github.com/dotnet/arcade/issues/8603. -->
+    <MakeDir Directories="$(ArtifactsShippingPackagesDir)" Condition="!Exists($(ArtifactsShippingPackagesDir)) AND '$(IsShipping)' == 'true'" />
     <MakeDir Directories="$(ArtifactsNonShippingPackagesDir)" Condition="!Exists($(ArtifactsNonShippingPackagesDir)) AND '$(IsShipping)' == 'false'" />
+
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="PublishToDisk"
              Properties="OutputPath=$(_OutputPathRoot)"

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
@@ -410,7 +410,7 @@
     
     <MakeDir Directories="$(_OutputPathRoot)" />
     <!-- avoid error where the root folder for the _InstallerFile does not exist: https://github.com/dotnet/arcade/issues/8603. -->
-    <MakeDir Directories="$(PackageOutputPath)" Condition="!Exists($(PackageOutputPath))" />
+    <MakeDir Directories="$(ArtifactsNonShippingPackagesDir)" Condition="!Exists($(ArtifactsNonShippingPackagesDir)) AND '$(IsShipping)' == 'false'" />
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="PublishToDisk"
              Properties="OutputPath=$(_OutputPathRoot)"

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
@@ -409,7 +409,8 @@
     </PropertyGroup>
     
     <MakeDir Directories="$(_OutputPathRoot)" />
-
+    <!-- avoid error where the root folder for the _InstallerFile does not exist: https://github.com/dotnet/arcade/issues/8603. -->
+    <MakeDir Directories="$(PackageOutputPath)" Condition="!Exists($(PackageOutputPath))" />
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="PublishToDisk"
              Properties="OutputPath=$(_OutputPathRoot)"


### PR DESCRIPTION
Fixes: https://github.com/dotnet/arcade/issues/8603.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
