### PR TITLE
Update archs in dotnet-install based on runtime

### DIFF
--- a/eng/common/dotnet-install.sh
+++ b/eng/common/dotnet-install.sh
@@ -52,7 +52,7 @@ done
 # Use uname to determine what the CPU is, see https://en.wikipedia.org/wiki/Uname#Examples
 cpuname=$(uname -m)
 case $cpuname in
-  aarch64)
+  arm64|aarch64)
     buildarch=arm64
     ;;
   loongarch64)
@@ -64,7 +64,7 @@ case $cpuname in
   armv*l)
     buildarch=arm
     ;;
-  i686)
+  i[3-6]86)
     buildarch=x86
     ;;
   *)


### PR DESCRIPTION
Handle "arm64", which is used by macOS on M1. This fixes dotnet-install
to work on M1 (untested).

Also handle i386, i486 and i585.

We could also take two other changes from dotnet/runtime, but neither of these are available as prebuilt SDKs that we can download and run directly.

- armv6l for Raspberry Pi, see https://github.com/dotnet/runtime/pull/62594. The current dotnet-install.sh script mistakenly uses the `arm` RID for this (not the more appropriate `armv6`), which may not work, depending on which exact version of Raspberry Pi you have.

- s390x, for IBM Z. See https://github.com/dotnet/runtime/pull/52840

So I am leaving these two out.

This fixes the error reported at https://github.com/dotnet/aspnetcore/issues/40109

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
