### PR TITLE
Define dependencies of ApiCompat targets

### DIFF
--- a/src/Microsoft.DotNet.ApiCompat/src/build/Microsoft.DotNet.ApiCompat.targets
+++ b/src/Microsoft.DotNet.ApiCompat/src/build/Microsoft.DotNet.ApiCompat.targets
@@ -4,6 +4,9 @@
     <ApiCompatAssembly Condition="'$(MSBuildRuntimeType)' == 'core'">$(MSBuildThisFileDirectory)..\tools\netcoreapp3.1\Microsoft.DotNet.ApiCompat.dll</ApiCompatAssembly>
     <ApiCompatAssembly Condition="'$(MSBuildRuntimeType)' != 'core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.DotNet.ApiCompat.exe</ApiCompatAssembly>
 
+    <!-- For calculating dependencies, ApiCompat reads from the ReferencePath. -->
+    <ApiCompatDependsOn>$(ApiCompatDependsOn);ResolveAssemblyReferences</ApiCompatDependsOn>
+
     <!-- By default, run API Compat if this package is referenced. -->
     <RunApiCompat Condition="'$(RunApiCompat)' == '' and '$(DesignTimeBuild)' != 'true'">true</RunApiCompat>
     <RunApiCompatForSrc Condition="'$(RunApiCompatForSrc)' == ''">$(RunApiCompat)</RunApiCompatForSrc>

--- a/src/Microsoft.DotNet.ApiCompat/src/build/Microsoft.DotNet.ApiCompat.targets
+++ b/src/Microsoft.DotNet.ApiCompat/src/build/Microsoft.DotNet.ApiCompat.targets
@@ -4,8 +4,8 @@
     <ApiCompatAssembly Condition="'$(MSBuildRuntimeType)' == 'core'">$(MSBuildThisFileDirectory)..\tools\netcoreapp3.1\Microsoft.DotNet.ApiCompat.dll</ApiCompatAssembly>
     <ApiCompatAssembly Condition="'$(MSBuildRuntimeType)' != 'core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.DotNet.ApiCompat.exe</ApiCompatAssembly>
 
-    <!-- For calculating dependencies, ApiCompat reads from the ReferencePath. -->
-    <ApiCompatDependsOn>$(ApiCompatDependsOn);ResolveAssemblyReferences</ApiCompatDependsOn>
+    <!-- For calculating dependencies, ApiCompat reads from the ReferencePath and uses the compiler output. -->
+    <ApiCompatDependsOn>$(ApiCompatDependsOn);ResolveAssemblyReferences;CoreCompile</ApiCompatDependsOn>
 
     <!-- By default, run API Compat if this package is referenced. -->
     <RunApiCompat Condition="'$(RunApiCompat)' == '' and '$(DesignTimeBuild)' != 'true'">true</RunApiCompat>


### PR DESCRIPTION
When invoking ApiCompat targets directly, the ReferencePath item isn't available and the targets fail to resolve the dependencies which are passed to the ApiCompatTask. To avoid that, declare a dependency on the ResolveAssemblyReferences target.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
