### PR TITLE
Update tooling versions to resolve secret-manager errors

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,13 +3,13 @@
   "isRoot": true,
   "tools": {
     "microsoft.dnceng.secretmanager": {
-      "version": "1.1.0-beta.21380.2",
+      "version": "1.1.0-beta.22166.1",
       "commands": [
         "secret-manager"
       ]
     },
     "microsoft.dnceng.patgeneratortool": {
-      "version": "1.1.0-beta.22102.6",
+      "version": "1.1.0-beta.22166.1",
       "commands": [
         "pat-generator"
       ]


### PR DESCRIPTION
The current vault config requires a newer tool that understands 'azure-storage-account-sas-token'

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
