### PR TITLE
Handle BlobAlreadyExists errors more gracefully in Helix JobSender

### DIFF
--- a/src/Microsoft.DotNet.Helix/JobSender.Tests/Payloads/ArchivePayloadTests.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender.Tests/Payloads/ArchivePayloadTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Helix.JobSender.Test
             var archiveFile = Path.GetTempFileName();
             var blobContainer = new Mock<IBlobContainer>(MockBehavior.Strict);
             blobContainer
-                .Setup(bc => bc.UploadFileAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Setup(bc => bc.UploadFileAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<Action<string>>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new Uri("http://microsoft.com/blob")));
             var archivePayload = new ArchivePayload(archiveFile);
 

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -186,6 +186,7 @@ namespace Microsoft.DotNet.Helix.Client
             Uri jobListUri = await storageContainer.UploadTextAsync(
                 jobListJson,
                 $"job-list-{Guid.NewGuid()}.json",
+                log,
                 cancellationToken);
             // Don't log the sas, remove the query string.
             string jobListUriForLogging = jobListUri.ToString().Replace(jobListUri.Query, "");

--- a/src/Microsoft.DotNet.Helix/JobSender/Payloads/AdhocPayload.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/Payloads/AdhocPayload.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.Helix.Client
                     }
                 }
                 stream.Position = 0;
-                Uri zipUri = await payloadContainer.UploadFileAsync(stream, $"{Guid.NewGuid()}.zip", cancellationToken);
+                Uri zipUri = await payloadContainer.UploadFileAsync(stream, $"{Guid.NewGuid()}.zip", log, cancellationToken);
                 return zipUri.AbsoluteUri;
             }
         }

--- a/src/Microsoft.DotNet.Helix/JobSender/Payloads/ArchivePayload.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/Payloads/ArchivePayload.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Helix.Client
 
             using (var stream = File.OpenRead(Archive.FullName))
             {
-                Uri zipUri = await payloadContainer.UploadFileAsync(stream, $"{Archive.Name}", cancellationToken);
+                Uri zipUri = await payloadContainer.UploadFileAsync(stream, $"{Archive.Name}", log, cancellationToken);
                 File.WriteAllText(alreadyUploadedFile.FullName, zipUri.AbsoluteUri);
                 return zipUri.AbsoluteUri;
             }

--- a/src/Microsoft.DotNet.Helix/JobSender/Payloads/DirectoryPayload.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/Payloads/DirectoryPayload.cs
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.Helix.Client
                 }
 
                 stream.Position = 0;
-                Uri zipUri = await payloadContainer.UploadFileAsync(stream, $"{Guid.NewGuid()}.zip", cancellationToken);
+                Uri zipUri = await payloadContainer.UploadFileAsync(stream, $"{Guid.NewGuid()}.zip", log, cancellationToken);
                 File.WriteAllText(alreadyUploadedFile.FullName, zipUri.AbsoluteUri);
                 return zipUri.AbsoluteUri;
             }

--- a/src/Microsoft.DotNet.Helix/JobSender/Payloads/SingleFilePayload.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/Payloads/SingleFilePayload.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.Helix.Client
                     }
                 }
                 stream.Position = 0;
-                Uri zipUri = await payloadContainer.UploadFileAsync(stream, $"{Guid.NewGuid()}.zip", cancellationToken);
+                Uri zipUri = await payloadContainer.UploadFileAsync(stream, $"{Guid.NewGuid()}.zip", log, cancellationToken);
                 return zipUri.AbsoluteUri;
             }
         }

--- a/src/Microsoft.DotNet.Helix/JobSender/StorageHelpers/ContainerBase.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/StorageHelpers/ContainerBase.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Storage.Blobs;
 using Azure;
+
 namespace Microsoft.DotNet.Helix.Client
 {
     internal abstract class ContainerBase : IBlobContainer

--- a/src/Microsoft.DotNet.Helix/JobSender/StorageHelpers/ContainerBase.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/StorageHelpers/ContainerBase.cs
@@ -7,28 +7,35 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Storage.Blobs;
-
+using Azure;
 namespace Microsoft.DotNet.Helix.Client
 {
-
     internal abstract class ContainerBase : IBlobContainer
     {
         protected abstract (BlobClient blob, string sasToken) GetBlob(string blobName);
 
-        public async Task<Uri> UploadFileAsync(Stream stream, string blobName, CancellationToken cancellationToken)
+        public async Task<Uri> UploadFileAsync(Stream stream, string blobName, Action<string> log, CancellationToken cancellationToken)
         {
             var (pageBlob, sasToken) = GetBlob(blobName);
-            await pageBlob.UploadAsync(stream, cancellationToken);
+
+            try
+            {
+                await pageBlob.UploadAsync(stream, cancellationToken);
+            }
+            catch (RequestFailedException e) when (e.Status == 409)
+            {
+                log?.Invoke($"warning : Upload failed because the blob already exists.");
+            }
 
             return new UriBuilder(pageBlob.Uri) { Query = sasToken }.Uri;
         }
 
-        public async Task<Uri> UploadTextAsync(string text, string blobName, CancellationToken cancellationToken)
+        public async Task<Uri> UploadTextAsync(string text, string blobName, Action<string> log, CancellationToken cancellationToken)
         {
             var (pageBlob, sasToken) = GetBlob(blobName);
             byte[] bytes = Encoding.UTF8.GetBytes(text);
 
-            return await UploadFileAsync(new MemoryStream(bytes), blobName, cancellationToken);
+            return await UploadFileAsync(new MemoryStream(bytes), blobName, log, cancellationToken);
         }
 
         public abstract string Uri { get; }

--- a/src/Microsoft.DotNet.Helix/JobSender/StorageHelpers/ContainerBase.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/StorageHelpers/ContainerBase.cs
@@ -6,8 +6,8 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Storage.Blobs;
 using Azure;
+using Azure.Storage.Blobs;
 
 namespace Microsoft.DotNet.Helix.Client
 {

--- a/src/Microsoft.DotNet.Helix/JobSender/StorageHelpers/ContainerBase.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/StorageHelpers/ContainerBase.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.Helix.Client
                 }
                 else
                 {
-                    log?.Invoke($"warning : Upload of {pageBlob.Uri} failures with {e.ErrorCode}. The blob exists, continuing");
+                    log?.Invoke($"warning : Upload of {pageBlob.Uri} failed with {e.ErrorCode}. The blob exists, continuing");
                 }
             }
 

--- a/src/Microsoft.DotNet.Helix/JobSender/StorageHelpers/ContainerBase.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/StorageHelpers/ContainerBase.cs
@@ -25,7 +25,15 @@ namespace Microsoft.DotNet.Helix.Client
             }
             catch (RequestFailedException e) when (e.Status == 409)
             {
-                log?.Invoke($"warning : Upload failed because the blob already exists.");
+                if (!pageBlob.Exists())
+                {
+                    log?.Invoke($"error : Upload of {pageBlob.Uri} failed with {e.ErrorCode}, but the blob does not exist.");
+                    throw;
+                }
+                else
+                {
+                    log?.Invoke($"warning : Upload of {pageBlob.Uri} failures with {e.ErrorCode}. The blob exists, continuing");
+                }
             }
 
             return new UriBuilder(pageBlob.Uri) { Query = sasToken }.Uri;

--- a/src/Microsoft.DotNet.Helix/JobSender/StorageHelpers/IBlobContainer.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/StorageHelpers/IBlobContainer.cs
@@ -11,8 +11,8 @@ namespace Microsoft.DotNet.Helix.Client
 
     internal interface IBlobContainer
     {
-        Task<Uri> UploadFileAsync(Stream stream, string blobName, CancellationToken cancellationToken);
-        Task<Uri> UploadTextAsync(string text, string blobName, CancellationToken cancellationToken);
+        Task<Uri> UploadFileAsync(Stream stream, string blobName, Action<string> log, CancellationToken cancellationToken);
+        Task<Uri> UploadTextAsync(string text, string blobName, Action<string> log, CancellationToken cancellationToken);
         string Uri { get; }
         string ReadSas { get; }
         string WriteSas { get; }


### PR DESCRIPTION
On occassion, on retry, we will end up with an 409 BlobAlreadyExists error when uploading a blob, because the original upload already succeeded, but a retry had been triggered. This would throw in UploadAsync. This change catches the 409 error, logs a warning, and then continues on (since the blob does exist).

Fixes https://github.com/dotnet/arcade/issues/8622

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
