### PR TITLE
[AsmDiff] Upgrade csproj to net6.0, add PowerShell script to generate API-diff report

### DIFF
--- a/src/Microsoft.DotNet.AsmDiff/Microsoft.DotNet.AsmDiff.csproj
+++ b/src/Microsoft.DotNet.AsmDiff/Microsoft.DotNet.AsmDiff.csproj
@@ -1,10 +1,9 @@
-﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project Sdk="Microsoft.NET.Sdk">
-  
   <!-- Most of the code has been ported from https://devdiv.visualstudio.com/DevDiv/_git/CoreFxTools repo.-->
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-asmdiff</ToolCommandName>
@@ -12,18 +11,15 @@
     <StrongNameKeyId>Open</StrongNameKeyId>
     <UsingToolXliff>true</UsingToolXliff>
   </PropertyGroup>
-  
   <ItemGroup>
     <Compile Include="..\Common\Internal\DisposeAction.cs" Link="Internal\DisposeAction.cs" />
     <ProjectReference Include="..\Microsoft.Cci.Extensions\Microsoft.Cci.Extensions.csproj" />
   </ItemGroup>
-  
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="$(McMasterExtensionsCommandLineUtils)" />
     <!-- Arcade only makes shipping assemblies localizable by default, we'd like to localize this tool without treating it as "shipping". -->
     <PackageReference Include="Microsoft.DotNet.XliffTasks" Version="$(MicrosoftDotNetXliffTasksVersion)" PrivateAssets="all" />
   </ItemGroup>
-
   <ItemGroup>
     <EmbeddedResource Update="Resources.resx" GenerateSource="true" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.AsmDiff/README.md
+++ b/src/Microsoft.DotNet.AsmDiff/README.md
@@ -1,13 +1,15 @@
 # Microsoft.DotNet.AsmDiff
 
-AsmDiff is a command line tool which may be used to check the API changes between a two sets of .NET assemblies. 
+AsmDiff is a command line tool which may be used to check the API changes between a two sets of .NET assemblies.
 
-## Required Options
+## Usage
+
+### Required Options
 
 - `-os|--OldSet` - Provide path to an assembly or directory for an assembly set to gather the old set of types. These types will be the baseline for the compare.
 - `-ns|--NewSet` - Provide path to an assembly or directory for an assembly set to gather the new set of types. If this parameter is not provided the API's for the oldset will be printed instead of the diff.
 
-## Additional Options
+### Additional Options
 
 - `-nsn|--NewSetName` - Provide a name for the new set in output. If this parameter is not provided the file or directory name will be used.
 - `-osn|--OldSetName` - Provide a name for the old set in output. If this parameter is not provided the file or directory name will be used.
@@ -31,3 +33,58 @@ AsmDiff is a command line tool which may be used to check the API changes betwee
 - `-s|--SyntaxWriter` - Specific the syntax writer type. Only used if the writer is CSDecl
 - `-o|--OutFile` - Output file path. Default is the console.
 - `-l|--Language` - Provide a languagetag for localized content. Currently language specific content is only available in Markdown for en and de. If this parameter is not provided the environments default language will be used. If a specific language is not supported english is the default language.
+
+## Script
+
+The [`RunApiDiff.ps1`](./RunApiDiff.ps1) script can generate an API comparison report for two specified .NET previews, in the format expected for publishing in the dotnet/core repo.
+
+Instructions:
+
+1. Clone this repo. Let's assume you clone it into `D:\arcade`.
+2. Clone the dotnet/core repo. Let's assume you clone it into `D:\core`.
+3. Create a temporary directory. Let's assume you create it in `D:\tmp`.
+4. Inside the temporary directory, create 6 subdirectories (one pair for each SDK):
+
+   - `Microsoft.AspNetCore.App.Before`
+   - `Microsoft.AspNetCore.App.After`
+   - `Microsoft.NETCore.App.Before`
+   - `Microsoft.NETCore.App.After`
+   - `Microsoft.WindowsDesktop.App.Before`
+   - `Microsoft.WindowsDesktop.App.After`
+
+5. For each one of the above SDKs, you will need to download the two nuget packages that contain the ref assemblies of the .NET versions you want to compare. For example, let's assume you want to compare `7.0-preview1` vs `7.0-preview2`. Then you have to open each one of these links:
+
+    - https://www.nuget.org/packages/Microsoft.AspNetCore.App.Ref/
+    - https://www.nuget.org/packages/Microsoft.WindowsDesktop.App.Ref/
+    - https://www.nuget.org/packages/Microsoft.NETCore.App.Ref/
+
+6. Inside each link, you have to click on the `Versions` tab, select the desired preview from the list, then click on `Download package` on the sidebar on the right. Do this for each pair of versions.
+7. Change the extension of the files to zip. Open them with File Explorer. Navigate to the folder `ref\net7.0\`, select all the contents, then copy them and paste them into the appropriate `*.Before` or `*.After` directory. For example, the `7.0-preview1` nupkg for AspNet should go into `Microsoft.AspNetCore.App.Before` and the `7.0-preview2` nupkg should go into `Microsoft.AspNetCore.App.After`. Similar with the other two SDKs.
+8. Run the script, specifying the desired value for the mandatory arguments:
+    - `PreviousDotNetVersion`: Indicates the .NET version of the `Before` folders, in the `N.N` format. For this example, it's `7.0`.
+    - `PreviousPreviewVersion`: Indicates the preview name of the `Before` folders, and it can be in the `previewN` or `RCN` formats. For this example, it's `preview1`.
+    - `CurrentDotNetversion`: Indicates the .NET version of the `After` folders, in the `N.N` format. For this example, it's `7.0` as well.
+    - `CurrentPreviewVersion`: Indicates the preview name of the `After` folders, in the `previewN` or `RCN` formats. For this example, it's `preview2`.
+    - `CurrentDotNetNumberAndPreviewFriendlyName`: Indicates the friendly name of the current .NET version and preview name, without dashes, and without ".NET". This string will be printed as the header of the main `*.md` output readme file. For this example, we want this value to be `7.0 Preview 2`.
+    - `CoreRepo`: The absolute path of the cloned core repo. For this example: `D:\core`.
+    - `ArcadeRepo`: The absolute path of the cloned arcade repo. For this example: `D:\arcade`.
+    - `TmpFolder`: The absolute path of the temporary directory containing the `Before` and `After` folders. For this example: `D:\tmp`.
+
+Execution example:
+
+```powershell
+.\RunApiDiff.ps1 `
+    -PreviousDotNetVersion 7.0 `
+    -PreviousPreviewVersion preview1 `
+    -CurrentDotNetVersion 7.0 `
+    -CurrentPreviewVersion preview2 `
+    -CurrentDotNetNumberAndPreviewFriendlyName "7.0 Preview 2" `
+    -CoreRepo D:\core `
+    -ArcadeRepo D:\arcade `
+    -TmpFolder D:\tmp
+```
+
+Examples of what this script generates:
+
+- PR comparing .NET 6.0 vs .NET 7.0 Preview1: https://github.com/dotnet/core/pull/7211
+- PR comparing .NET 7.0 Preview1 vs Preview2: https://github.com/dotnet/core/pull/7307

--- a/src/Microsoft.DotNet.AsmDiff/RunApiDiff.ps1
+++ b/src/Microsoft.DotNet.AsmDiff/RunApiDiff.ps1
@@ -1,0 +1,406 @@
+# This script allows running API-diff to generate the dotnet/core report that compares the APIs introduced between two previews, in the format expected for publishing in the dotnet/core repo.
+
+Param (
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [ValidatePattern("\d+\.\d")]
+        [string]
+        $PreviousDotNetVersion # 7.0, 8.0, 9.0, ...
+    ,
+        [Parameter(Mandatory=$true)]
+        [string]
+        $PreviousPreviewVersion # preview1, preview2, RC1, RC2, or even " "
+    ,
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [ValidatePattern("\d+\.\d")]
+        [string]
+        $CurrentDotNetVersion # 7.0, 8.0, 9.0, ...
+    ,
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $CurrentPreviewVersion # preview1, preview2, rc1, rc2
+    ,
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $CurrentDotNetNumberAndPreviewFriendlyName # "7.0 Preview 1", "7.0 RC1"
+    ,
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $CoreRepo #"D:\\core"
+    ,
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $ArcadeRepo #"D:\\arcade"
+    ,
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $TmpFolder #"D:\tmp"
+    ,
+        [Parameter(Mandatory=$false)]
+        [boolean]
+        $Debugging = $false
+)
+
+### Functions
+
+Function VerifyPathOrExit
+{
+    Param
+    (
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $path
+    )
+
+    If (-Not (Test-Path -Path $path))
+    {
+        Write-Color red "The path does not exist: $path"
+        Exit
+    }
+}
+
+Function RemoveFolder
+{
+    Param
+    (
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $path
+    ,
+        [Parameter(Mandatory=$false)]
+        [boolean]
+        $Debugging = $false
+    )
+
+    If (Test-Path -Path $path)
+    {
+        Write-Color yellow "Removing existing folder: $path"
+
+        If (-Not $Debugging)
+        {
+            Remove-Item -Recurse -Path $path
+        }
+    }
+}
+Function CreateFolder
+{
+    Param
+    (
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $path
+    ,
+        [Parameter(Mandatory=$false)]
+        [boolean]
+        $Debugging = $false
+    )
+
+    RemoveFolder $path $Debugging
+
+    Write-Color white "Creating new folder: $path"
+    If (-Not $Debugging)
+    {
+        New-Item -ItemType Directory -Path $path
+    }
+}
+
+Function VerifyCountDlls
+{
+    Param
+    (
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $path
+    ,
+        [Parameter(Mandatory=$false)]
+        [boolean]
+        $Debugging = $false
+    )
+
+    VerifyPathOrExit $path
+
+    If (-Not $Debugging)
+    {
+       $count=(Get-ChildItem -Path $path -Filter "*.dll" | Measure-Object).Count
+        If ($count -eq 0)
+        {
+            Write-Color red "There are no DLL files inside the folder."
+            Exit
+        }
+    }
+}
+
+Function RunAsmDiff
+{
+    Param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $AsmDiffExe
+    ,
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $TableOfContentsFilePath
+    ,
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $BeforeFolder
+    ,
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $AfterFolder
+    ,
+        [Parameter(Mandatory=$false)]
+        [boolean]
+        $Debugging = $false
+    )
+
+    VerifyPathOrExit $AsmDiffExe
+    VerifyPathOrExit $BeforeFolder
+    VerifyPathOrExit $AfterFolder
+
+    If (Test-Path -Path $TableOfContentsFilePath)
+    {
+        Write-Color yellow "Deleting existing table of contents file..."
+        If (-Not $Debugging)
+        {
+            Remove-Item -Path $TableOfContentsFilePath
+        }
+    }
+    # Arguments currently used:
+    # -r: Include members, types, and namespaces that were removed.
+    # -a: Include members, types and namespaces that were added.
+    # -c: Included members, types and namespaces that were changed.
+    # -itc: Include table of contents.
+    # -cfn: Create files per namespace.
+    # -adm: Forces showing all members of a type that was added or removed.
+    # -hbm: Highlight members that are interface implementations or overrides of a base member.
+    # -da: Enables diffing of the attributes as well.
+    # -w markdown: Type of diff writer to use.
+    # -o <path>: Output file path.
+    # -os <path>: Path to the old assembly set (baseline).
+    # -ns <path>: Path to the new assembly set.
+
+    # All arguments:
+    # https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.AsmDiff/Program.cs
+
+    $Command="$AsmDiffExe -r -a -c -itc -cfn -adm -hbm -da -w markdown -o $TableOfContentsFilePath -os $BeforeFolder -ns $AfterFolder"
+
+    Run-Command -Command $Command -Debugging $Debugging
+}
+
+Function ReplaceTitle
+{
+    Param
+    (
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $PreviousDotNetVersion
+    ,
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $CurrentDotNetVersion
+    ,
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $TableOfContentsFilePath
+    ,
+        [Parameter(Mandatory=$false)]
+        [boolean]
+        $Debugging = $false
+    )
+
+    VerifyPathOrExit $TableOfContentsFilePath
+
+    $CorrectTitle="# API Difference ${PreviousDotNetVersion} vs ${CurrentDotNetVersion}"
+
+    Write-Color white "Replacing title of table of contents with correct one: $TableOfContentsFilePath"
+    $UpdatedTableOfContents = .{
+        $CorrectTitle
+        Get-Content $TableOfContentsFilePath | Select-Object -Skip 1
+    }
+    If (-Not $Debugging)
+    {
+        Set-Content -Path $TableOfContentsFilePath -Value $UpdatedTableOfContents
+    }
+}
+
+Function CreateReadme
+{
+    Param
+    (
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $PreviewFolderPath
+    ,
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $CurrentDotNetVersion
+    ,
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $CurrentPreviewVersion
+    ,
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $CurrentDotNetNumberAndPreviewFriendlyName
+    ,
+        [Parameter(Mandatory=$false)]
+        [boolean]
+        $Debugging = $false
+    )
+
+    If (-Not $Debugging)
+    {
+        $ReadmePath=[IO.Path]::Combine($PreviewFolderPath, "README.md")
+        If (Test-Path -Path $ReadmePath)
+        {
+            Remove-Item -Path $ReadmePath
+        }
+        New-Item -ItemType File $ReadmePath
+
+        $DotNetNumberAndPreview="$CurrentDotNetVersion-$CurrentPreviewVersion"
+
+        $FullCurrentDotNetVersionFile="$DotNetNumberAndPreview.md"
+
+        Add-Content $ReadmePath "# .NET $CurrentDotNetNumberAndPreviewFriendlyName API Changes"
+        Add-Content $ReadmePath ""
+        Add-Content $ReadmePath "The following API changes were made in .NET $($CurrentDotNetNumberAndPreviewFriendlyName):"
+        Add-Content $ReadmePath ""
+        Add-Content $ReadmePath "- [Microsoft.NETCore.App](./Microsoft.NETCore.App/$FullCurrentDotNetVersionFile)"
+        Add-Content $ReadmePath "- [Microsoft.AspNetCore.App](./Microsoft.AspNetCore.App/$FullCurrentDotNetVersionFile)"
+        Add-Content $ReadmePath "- [Microsoft.WindowsDesktop.App](./Microsoft.WindowsDesktop.App/$FullCurrentDotNetVersionFile)"
+    }
+}
+
+### Execution
+
+## Check folders passed as parameters
+
+VerifyPathOrExit $CoreRepo
+VerifyPathOrExit $ArcadeRepo
+VerifyPathOrExit $TmpFolder
+
+
+## Check that the before and after folders exist and they have DLLs inside
+
+# NETCore
+$NETCoreBeforeFolder = [IO.Path]::Combine($TmpFolder, "Microsoft.NETCore.App.Before")
+VerifyCountDlls $NETCoreBeforeFolder $Debugging
+
+$NETCoreAfterFolder = [IO.Path]::Combine($TmpFolder, "Microsoft.NETCore.App.After")
+VerifyCountDlls $NETCoreAfterFolder $Debugging
+
+# AspNetCore
+$AspNetCoreBeforeFolder = [IO.Path]::Combine($TmpFolder, "Microsoft.AspNetCore.App.Before")
+VerifyCountDlls $AspNetCoreBeforeFolder $Debugging
+
+$AspNetCoreAfterFolder = [IO.Path]::Combine($TmpFolder, "Microsoft.AspNetCore.App.After")
+VerifyCountDlls $AspNetCoreAfterFolder $Debugging
+
+# WindowsDesktop
+$WindowsDesktopBeforeFolder = [IO.Path]::Combine($TmpFolder, "Microsoft.WindowsDesktop.App.Before")
+VerifyCountDlls $WindowsDesktopBeforeFolder $Debugging
+
+$WindowsDesktopAfterFolder = [IO.Path]::Combine($TmpFolder, "Microsoft.WindowsDesktop.App.After")
+VerifyCountDlls $WindowsDesktopAfterFolder $Debugging
+
+
+# Verify the AsmDiff project folder exists
+
+$AsmDiffProjectPath = [IO.Path]::Combine($ArcadeRepo, "src", "Microsoft.DotNet.AsmDiff", "Microsoft.DotNet.AsmDiff.csproj")
+VerifyPathOrExit $AsmDiffProjectPath
+
+
+## Build the AsmDiff project if it hasn't been built yet
+
+$AsmDiffArtifactsPath = [IO.Path]::Combine($ArcadeRepo ,"artifacts", "bin", "Microsoft.DotNet.AsmDiff")
+$AsmDiffExe = [IO.Path]::Combine($AsmDiffArtifactsPath, "Release", "net6.0", "Microsoft.DotNet.AsmDiff.exe")
+If (-Not (Test-Path -Path $AsmDiffExe))
+{
+    # Building the AsmDiff project
+
+    Write-Color white "Building AsmDiff project"
+
+    $BuildCommand="dotnet build -c release $AsmDiffProjectPath"
+    Run-Command -Command $BuildCommand -Debugging $Debugging
+
+    # Verifying expected output from building
+    VerifyPathOrExit $AsmDiffArtifactsPath
+    VerifyPathOrExit $AsmDiffExe
+}
+
+
+## Re-creating api-diff folder in core repo folder
+
+$PreviewFolderPath = [IO.Path]::Combine($CoreRepo, "release-notes", $CurrentDotNetVersion, "preview", "api-diff", $CurrentPreviewVersion)
+Write-Color white "Checking existing diff folder: $PreviewFolderPath"
+CreateFolder $PreviewFolderPath $Debugging
+
+
+## Creating subfolders
+
+# NETCore
+$NETCoreTargetFolder = [IO.Path]::Combine($PreviewFolderPath, "Microsoft.NETCore.App")
+CreateFolder $NETCoreTargetFolder $Debugging
+
+#AspNetCore
+$AspNetCoreTargetFolder = [IO.Path]::Combine($PreviewFolderPath, "Microsoft.AspNetCore.App")
+CreateFolder $AspNetCoreTargetFolder $Debugging
+
+# WindowsDesktop
+$WindowsDesktopTargetFolder = [IO.Path]::Combine($PreviewFolderPath, "Microsoft.WindowsDesktop.App")
+CreateFolder $WindowsDesktopTargetFolder $Debugging
+
+
+## Run the Asm-Diff commands
+
+$TableOfContentsFile = "$CurrentDotNetVersion-$CurrentPreviewVersion.md"
+
+$TableOfContentsFilePathNETCore = [IO.Path]::Combine($NETCoreTargetFolder, $TableOfContentsFile)
+$TableOfContentsFilePathAspNetCore = [IO.Path]::Combine($AspNetCoreTargetFolder, $TableOfContentsFile)
+$TableOfContentsFilePathWindowsDesktop = [IO.Path]::Combine($WindowsDesktopTargetFolder, $TableOfContentsFile)
+
+RunAsmDiff $AsmDiffExe $TableOfContentsFilePathNETCore $NETCoreBeforeFolder $NETCoreAfterFolder $Debugging
+RunAsmDiff $AsmDiffExe $TableOfContentsFilePathAspNetCore $AspNetCoreBeforeFolder $AspNetCoreAfterFolder $Debugging
+RunAsmDiff $AsmDiffExe $TableOfContentsFilePathWindowsDesktop $WindowsDesktopBeforeFolder $WindowsDesktopAfterFolder $Debugging
+
+
+## Replace the first line of the summmary files with the correct title
+
+$FullPreviousDotNetVersion=$PreviousDotNetVersion
+If (-Not [System.String]::IsNullOrWhiteSpace($PreviousPreviewVersion))
+{
+    $FullPreviousDotNetVersion="$PreviousDotNetVersion-$PreviousPreviewVersion"
+}
+$FullCurrentDotNetVersion=$CurrentDotNetVersion
+If (-Not [System.String]::IsNullOrWhiteSpace($CurrentPreviewVersion))
+{
+    $FullCurrentDotNetVersion="$CurrentDotNetVersion-$CurrentPreviewVersion"
+}
+
+ReplaceTitle $FullPreviousDotNetVersion $FullCurrentDotNetVersion $TableOfContentsFilePathNETCore $Debugging
+ReplaceTitle $FullPreviousDotNetVersion $FullCurrentDotNetVersion $TableOfContentsFilePathAspNetCore $Debugging
+ReplaceTitle $FullPreviousDotNetVersion $FullCurrentDotNetVersion $TableOfContentsFilePathWindowsDesktop $Debugging
+
+CreateReadme $PreviewFolderPath $CurrentDotNetVersion $CurrentPreviewVersion $CurrentDotNetNumberAndPreviewFriendlyName $Debugging


### PR DESCRIPTION
I used the [.NET Upgrade Assistant](https://dotnet.microsoft.com/en-us/platform/upgrade-assistant/tutorial/install-upgrade-assistant) to upgrade `Microsoft.DotNet.AsmDiff.csproj` to `net6.0`. No issues found.

I added a PowerShell script that automates the process of generating the ApiDiff report we publish on every preview in dotnet/core.

I updated the readme with instructions on how to use the script.