### PR TITLE
Change code-mirror to use Ubuntu build agent (#8449)

### DIFF
--- a/azure-pipelines-code-mirror.yml
+++ b/azure-pipelines-code-mirror.yml
@@ -15,27 +15,21 @@ jobs:
       enableSBOM: false
       pool:
         name: NetCore1ESPool-Internal
-        demands: ImageOverride -equals Build.Server.Amd64.VS2019
+        demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
       variables:
       - name: WorkingDirectoryName
         value: repo-dir
       steps:
-      - task: PowerShell@1
+      - powershell: |
+          $azDORepo = "$(GithubRepo)".Replace("/", "-");
+          # Check that the parameters look correct
+          if ($azDORepo -eq "" -or "$(BranchToMirror)" -eq "")
+          {
+            Write-Error "Expected valid branch and GitHub repo in the form of owner/repo"
+          }
+          Write-Host "##vso[task.setvariable variable=AzDORepoName]$azDORepo"
+          Write-Host "Mirroring branch '$(BranchToMirror)' from GitHub repo '$(GithubRepo)' to Azure DevOps repo '$azDORepo'."
         displayName: Calculate Mirrored Branch Names
-        inputs:
-          scriptType: inlineScript
-          arguments: '$(GithubRepo) $(BranchToMirror)'
-          inlineScript: |
-            param([string]$repo, [string]$branch)
-          
-            $azDORepo = $repo.Replace("/", "-");
-            # Check that the parameters look correct
-            if ($azDORepo -eq "" -or $branch -eq "")
-            {
-              Write-Error "Expected valid branch and GitHub repo in the form of owner/repo"
-            }
-            Write-Host "##vso[task.setvariable variable=AzDORepoName]$azDORepo"
-            Write-Host "Mirroring branch '$branch' from GitHub repo '$repo' to Azure DevOps repo '$azDORepo'."
       - script: |
           git clone https://dotnet-maestro-bot:$(BotAccount-dotnet-maestro-bot-PAT)@github.com/$(GithubRepo) $(WorkingDirectoryName) -b $(BranchToMirror)
         displayName: Clone GitHub repo
@@ -47,59 +41,50 @@ jobs:
           git reset --hard origin/$(BranchToMirror)
         displayName: Hard reset local branch to GitHub branch
         workingDirectory: $(WorkingDirectoryName)
-      - task: PowerShell@2
-        displayName: Push changes to Azure DevOps repo
-        inputs:
-          targetType: inline
-          workingDirectory: $(WorkingDirectoryName)
-          script: |
-            git push azdo-mirror $(BranchToMirror) --tags $(ExtraPushArgs)
+      - powershell: |
+          git push azdo-mirror $(BranchToMirror) --tags $(ExtraPushArgs)
 
+          if ($LASTEXITCODE -EQ 0) {
+            Write-Host "Push was successful"
+            exit
+          }
+
+          git fetch azdo-mirror
+          git fetch origin
+          $commits = (git --no-pager rev-list origin/$(BranchToMirror)..azdo-mirror/$(BranchToMirror) | Measure-Object -line).Lines
+          if ($commits -NE 0) {
+            Write-Host "##vso[task.LogIssue type=error;]Mirror repository $(AzDORepoName) has unexpected commits"
+            git --no-pager log origin/$(BranchToMirror)..azdo-mirror/$(BranchToMirror)
+            exit 1
+          }
+
+          Write-Host "##vso[task.LogIssue type=warning;]Push failed for unknown reason"
+
+          $retryattempt=0
+          while ($retryattempt -LT 3) {
+            $retryattempt+=1
+            Write-Host "Retry attempt $retryattempt of 3 in 5 seconds..."
+            Start-Sleep -Seconds 5
+
+            git push azdo-mirror $(BranchToMirror) $(ExtraPushArgs)
             if ($LASTEXITCODE -EQ 0) {
-              Write-Host "Push was successful"
+              Write-Host "Push successful"
               exit
             }
+          }
 
-            git fetch azdo-mirror
-            git fetch origin
-            $commits = (git --no-pager rev-list origin/$(BranchToMirror)..azdo-mirror/$(BranchToMirror) | Measure-Object -line).Lines
-            if ($commits -NE 0) {
-              Write-Host "##vso[task.LogIssue type=error;]Mirror repository $(AzDORepoName) has unexpected commits"
-              git --no-pager log origin/$(BranchToMirror)..azdo-mirror/$(BranchToMirror)
-              exit 1
-            }
+          Write-Host "##vso[task.LogIssue type=error;]git failed to push to Azure DevOps mirror"
+          exit 1
+        displayName: Push changes to Azure DevOps repo
+        workingDirectory: $(WorkingDirectoryName)
 
-            Write-Host "##vso[task.LogIssue type=warning;]Push failed for unknown reason"
+      - powershell: |         
+          $commit = (git rev-parse HEAD).Substring(0, 7)
+          $target = "$(GithubRepo) $(BranchToMirror)".Replace('/', ' ')
 
-            $retryattempt=0
-            while ($retryattempt -LT 3) {
-              $retryattempt+=1
-              Write-Host "Retry attempt $retryattempt of 3 in 5 seconds..."
-              Start-Sleep -Seconds 5
-
-              git push azdo-mirror $(BranchToMirror) $(ExtraPushArgs)
-              if ($LASTEXITCODE -EQ 0) {
-                Write-Host "Push successful"
-                exit
-              }
-            }
-
-            Write-Host "##vso[task.LogIssue type=error;]git failed to push to Azure DevOps mirror"
-            exit 1
-
-      - task: PowerShell@1
+          Write-Host "##vso[build.updatebuildnumber]$target $commit"
+          Write-Host "##vso[build.addbuildtag]$target"
         displayName: Broadcast target, branch, commit in metadata
         continueOnError: true
         condition: always()
-        inputs:
-          scriptType: inlineScript
-          arguments: '$(GithubRepo) $(BranchToMirror)'
-          workingDirectory: $(WorkingDirectoryName)
-          inlineScript: |
-            param([string]$repo, [string]$branch)
-
-            $commit = (git rev-parse HEAD).Substring(0, 7)
-            $target = "$repo $branch".Replace('/', ' ')
-
-            Write-Host "##vso[build.updatebuildnumber]$target $commit"
-            Write-Host "##vso[build.addbuildtag]$target"
+        workingDirectory: $(WorkingDirectoryName)


### PR DESCRIPTION
* Change code-mirror to use Ubuntu build agent

The idea here is to improve throughput of code-mirror runs by switching from a Windows-based agent to a Linux-based agent. Linux-based agents provision faster. So this should reduce the overall time for a GitHub commit to reach the AzDO repo.

I haven't tested this change since I don't have the necessary permissions or git understanding to fix something that might get screwed up.

Fixes https://github.com/dotnet/core-eng/issues/15402

* Update PowerShell tasks to use PowerShell Core

Co-authored-by: Matt Mitchell <mmitche@microsoft.com>

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
