### PR TITLE
Cherry-pick: Enable authenticated discovery of dotnet runtime packages (#8667)

### DIFF
--- a/src/Common/Microsoft.Arcade.Common/ArcadeHttpMessageHandler.cs
+++ b/src/Common/Microsoft.Arcade.Common/ArcadeHttpMessageHandler.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Arcade.Common
+{
+    public class ArcadeHttpMessageHandler : HttpMessageHandler
+    {
+        public virtual RequestResponseHelper [] RequestResponses { get; set; }
+
+        public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request) => SendAsync(request, CancellationToken.None);
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            foreach(var requestResponse in RequestResponses)
+            {
+                if(request.RequestUri.ToString().StartsWith(requestResponse.RequestMessage.RequestUri.ToString()) &&
+                    request.Method.Equals(requestResponse.RequestMessage.Method))
+                {
+                    return Task.FromResult(new HttpResponseMessage()
+                    {
+                        StatusCode = requestResponse.ResponseMessage.StatusCode,
+                        Content = requestResponse.ResponseMessage.Content
+                    });
+                }
+            }
+            return Task.FromResult(new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.InternalServerError,
+                Content = new StringContent($"No response specified in RequestResponses for '({request.Method}) {request.RequestUri}")
+            });
+        }
+    }
+}

--- a/src/Common/Microsoft.Arcade.Common/Microsoft.Arcade.Common.csproj
+++ b/src/Common/Microsoft.Arcade.Common/Microsoft.Arcade.Common.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
+    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/src/Common/Microsoft.Arcade.Common/RequestResponseHelper.cs
+++ b/src/Common/Microsoft.Arcade.Common/RequestResponseHelper.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+
+namespace Microsoft.Arcade.Common
+{
+    public class RequestResponseHelper
+    {
+        public HttpRequestMessage RequestMessage { get; set; }
+        public HttpResponseMessage ResponseMessage { get; set;}
+    }
+}

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/FindDotNetCliPackageTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/FindDotNetCliPackageTests.cs
@@ -1,0 +1,267 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Microsoft.Arcade.Common;
+using Microsoft.Arcade.Test.Common;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.DotNet.Helix.Sdk.Tests
+{
+    public class FindDotNetCliPackageTests
+    {
+        [Fact]
+        public void InstallRuntimeSuccessfully()
+        {
+            List<RequestResponseHelper> requestResponseHelpers = new List<RequestResponseHelper>()
+            {
+                new RequestResponseHelper()
+                {
+                    RequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.102/runtime-productVersion.txt"),
+                    ResponseMessage = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("6.0.102")}
+                },
+                new RequestResponseHelper()
+                {
+                    RequestMessage= new HttpRequestMessage(HttpMethod.Head, "https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.102/dotnet-runtime-6.0.102-win-x86.zip"),
+                    ResponseMessage = new HttpResponseMessage(HttpStatusCode.NotFound)
+                },
+                new RequestResponseHelper()
+                {
+                    RequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://dotnetbuilds.azureedge.net/public/Runtime/6.0.102/runtime-productVersion.txt"),
+                    ResponseMessage = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("6.0.102")}
+                },
+                new RequestResponseHelper()
+                {
+                    RequestMessage = new HttpRequestMessage(HttpMethod.Head, "https://dotnetbuilds.azureedge.net/public/Runtime/6.0.102/dotnet-runtime-6.0.102-win-x86.zip"),
+                    ResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+                }
+            };
+
+            MockBuildEngine buildEngineMock = new MockBuildEngine();
+
+            FindDotNetCliPackage task = new FindDotNetCliPackage()
+            {
+                Channel = "Current",
+                Version = "6.0.102",
+                Runtime = "win-x86",
+                PackageType = "runtime",
+                BuildEngine = buildEngineMock
+            };
+
+            var collection = CreateMockServiceCollection(requestResponseHelpers.ToArray());
+            task.ConfigureServices(collection);
+
+            // Act
+            using var provider = collection.BuildServiceProvider();
+            task.InvokeExecute(provider).Should().BeTrue();
+
+            buildEngineMock.BuildMessageEvents.Should().Contain(x => x.Message.Contains("is valid."));
+        }
+
+        [Fact]
+        public void InstallAdditionalRuntimeSuccessfully()
+        {
+            List<RequestResponseHelper> requestResponseHelpers = new List<RequestResponseHelper>(GetDefaultRequestResponseHelpers());
+            requestResponseHelpers.AddRange(new [] {
+                new RequestResponseHelper()
+                {
+                    RequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://fakeazureaccount.blob.core.windows.net/Runtime/6.0.102/runtime-productVersion.txt"),
+                    ResponseMessage = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("6.0.102")}
+                },
+                new RequestResponseHelper()
+                {
+                    RequestMessage = new HttpRequestMessage(HttpMethod.Head, "https://fakeazureaccount.blob.core.windows.net/Runtime/6.0.102/dotnet-runtime-6.0.102-win-x86.zip"),
+                    ResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+                }
+            });
+
+            var collection = CreateMockServiceCollection(requestResponseHelpers.ToArray());
+            Dictionary<string, string> metadata = new Dictionary<string, string>()
+            {
+                { "SasToken", "bar" }
+            };
+            ITaskItem[] additionalFeed = new TaskItem[]
+            {
+                new TaskItem("https://fakeazureaccount.blob.core.windows.net", metadata)
+            };
+            MockBuildEngine buildEngineMock = new MockBuildEngine();
+
+            FindDotNetCliPackage task = new FindDotNetCliPackage()
+            {
+                Channel = "Current",
+                Version = "6.0.102",
+                Runtime = "win-x86",
+                PackageType = "runtime",
+                BuildEngine = buildEngineMock
+            };
+
+            task.AdditionalFeeds = additionalFeed;
+            task.ConfigureServices(collection);
+
+            // Act
+            using var provider = collection.BuildServiceProvider();
+            task.InvokeExecute(provider).Should().BeTrue();
+
+            // verify we didn't print the sas token 
+            buildEngineMock.BuildMessageEvents.Should().NotContain(x => Regex.IsMatch(x.Message, @"\?sv=[^ ]+"));
+
+            buildEngineMock.BuildMessageEvents.Should().Contain(x => x.Message.Contains("is valid."));
+        }
+
+        [Fact]
+        public void IfAuthenticatedFeedReturnsForbiddenFails()
+        {
+            List<RequestResponseHelper> requestResponseHelpers = new List<RequestResponseHelper>(GetDefaultRequestResponseHelpers());
+            requestResponseHelpers.AddRange(new[] {
+                new RequestResponseHelper()
+                {
+                    RequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://fakeazureaccount.blob.core.windows.net/Runtime/6.0.102/runtime-productVersion.txt"),
+                    ResponseMessage = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("6.0.102")}
+                },
+                new RequestResponseHelper()
+                {
+                    // If your sas token is invalid or missing, azure storage returns 403 (Forbidden)
+                    RequestMessage = new HttpRequestMessage(HttpMethod.Head, "https://fakeazureaccount.blob.core.windows.net/Runtime/6.0.102/dotnet-runtime-6.0.102-win-x86.zip"),
+                    ResponseMessage = new HttpResponseMessage(HttpStatusCode.Forbidden)
+                }
+            });
+
+            var collection = CreateMockServiceCollection(requestResponseHelpers.ToArray());
+            Dictionary<string, string> metadata = new Dictionary<string, string>()
+            {
+                { "SasToken", "bar" }
+            };
+            ITaskItem[] additionalFeed = new TaskItem[]
+            {
+                new TaskItem("https://fakeazureaccount.blob.core.windows.net", metadata)
+            };
+            MockBuildEngine buildEngineMock = new MockBuildEngine();
+
+            FindDotNetCliPackage task = new FindDotNetCliPackage()
+            {
+                Channel = "Current",
+                Version = "6.0.102",
+                Runtime = "win-x86",
+                PackageType = "runtime",
+                BuildEngine = buildEngineMock
+            };
+
+            task.AdditionalFeeds = additionalFeed;
+            task.ConfigureServices(collection);
+
+            // Act
+            using var provider = collection.BuildServiceProvider();
+            task.InvokeExecute(provider).Should().BeFalse();
+
+            // verify we reported being unable to access container
+            buildEngineMock.BuildMessageEvents.Should().Contain(x => x.Message.Contains("Response status code does not indicate success: 403 (Forbidden)."));
+            // verify we didn't print the sas token 
+            buildEngineMock.BuildMessageEvents.Should().NotContain(x => Regex.IsMatch(x.Message, @"\?sv=[^ ]+"));
+
+            buildEngineMock.BuildMessageEvents.Should().NotContain(x => x.Message.Contains("is valid."));
+        }
+
+        [Fact]
+        public void InstallRuntimeFailsIfNotFound()
+        {
+            List<RequestResponseHelper> requestResponseHelpers = new List<RequestResponseHelper>()
+            {
+                new RequestResponseHelper()
+                {
+                    RequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.102/runtime-productVersion.txt"),
+                    ResponseMessage = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("6.0.102")}
+                },
+                new RequestResponseHelper()
+                {
+                    RequestMessage= new HttpRequestMessage(HttpMethod.Head, "https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.102/dotnet-runtime-6.0.102-win-x86.zip"),
+                    ResponseMessage = new HttpResponseMessage(HttpStatusCode.NotFound)
+                },
+                new RequestResponseHelper()
+                {
+                    RequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://dotnetbuilds.azureedge.net/public/Runtime/6.0.102/runtime-productVersion.txt"),
+                    ResponseMessage = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("6.0.102")}
+                },
+                new RequestResponseHelper()
+                {
+                    RequestMessage = new HttpRequestMessage(HttpMethod.Head, "https://dotnetbuilds.azureedge.net/public/Runtime/6.0.102/dotnet-runtime-6.0.102-win-x86.zip"),
+                    ResponseMessage = new HttpResponseMessage(HttpStatusCode.NotFound)
+                }
+            };
+
+            var collection = CreateMockServiceCollection(requestResponseHelpers.ToArray());
+
+            MockBuildEngine buildEngineMock = new MockBuildEngine();
+
+            FindDotNetCliPackage task = new FindDotNetCliPackage()
+            {
+                Channel = "Current",
+                Version = "6.0.102",
+                Runtime = "win-x86",
+                PackageType = "runtime",
+                BuildEngine = buildEngineMock
+            };
+
+            task.ConfigureServices(collection);
+
+            // Act
+            using var provider = collection.BuildServiceProvider();
+            task.InvokeExecute(provider).Should().BeFalse();
+
+            // verify we didn't print the sas token 
+            buildEngineMock.BuildMessageEvents.Should().NotContain(x => Regex.IsMatch(x.Message, @"\?sv=[^ ]+"));
+
+            buildEngineMock.BuildMessageEvents.Should().NotContain(x => x.Message.Contains("is valid."));
+        }
+
+        private IServiceCollection CreateMockServiceCollection(RequestResponseHelper[] requestResponseHelpers)
+        {
+            var collection = new ServiceCollection();
+
+            // Our message has to be unique or we will get the failure 
+            // "The request message was already sent"
+            collection.AddScoped<HttpMessageHandler, ArcadeHttpMessageHandler>(mh =>
+            {
+                return new ArcadeHttpMessageHandler()
+                {
+                    RequestResponses = requestResponseHelpers
+                };
+            });
+            return collection;
+        }
+
+        private RequestResponseHelper[] GetDefaultRequestResponseHelpers()
+        {
+            var requestResponseHelpers = new RequestResponseHelper[] {
+                new RequestResponseHelper()
+                {
+                    RequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.102/runtime-productVersion.txt"),
+                    ResponseMessage = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("6.0.102") }
+                },
+                new RequestResponseHelper()
+                {
+                    RequestMessage = new HttpRequestMessage(HttpMethod.Head, "https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.102/dotnet-runtime-6.0.102-win-x86.zip"),
+                    ResponseMessage = new HttpResponseMessage(HttpStatusCode.NotFound)
+                },
+                new RequestResponseHelper()
+                {
+                    RequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://dotnetbuilds.azureedge.net/public/Runtime/6.0.102/runtime-productVersion.txt"),
+                    ResponseMessage = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("6.0.102") }
+                },
+                new RequestResponseHelper()
+                {
+                    RequestMessage = new HttpRequestMessage(HttpMethod.Head, "https://dotnetbuilds.azureedge.net/public/Runtime/6.0.102/dotnet-runtime-6.0.102-win-x86.zip"),
+                    ResponseMessage = new HttpResponseMessage(HttpStatusCode.NotFound)
+                }
+            };
+            return requestResponseHelpers;
+        }
+    }
+}
+

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelpersTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelpersTests.cs
@@ -55,6 +55,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             if (!exists)
             {
                 File.WriteAllText(target, "Test failed once");
+                exists = File.Exists(target);
             }
             
             Assert.True(exists, $"File should exist: {target}");

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests.csproj
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Moq" Version="4.8.3" />
     <!-- This is here so that we agree with the project's transitive references to NewtonSoft.Json -->
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="NuGet.Versioning" Version="6.1.0" />
     <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.Helix/Sdk/FindDotNetCliPackage.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/FindDotNetCliPackage.cs
@@ -1,16 +1,19 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Arcade.Common;
 using Microsoft.Build.Framework;
+using MSBuild = Microsoft.Build.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using NuGet.Versioning;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.Helix.Sdk
 {
-    public class FindDotNetCliPackage : BaseTask
+    public class FindDotNetCliPackage : MSBuildTaskBase
     {
         // Use lots of retries since an Http Client failure here means failure to send to Helix
         private ExponentialRetry _retry = new ExponentialRetry()
@@ -18,7 +21,6 @@ namespace Microsoft.DotNet.Helix.Sdk
             MaxAttempts = 10,
             DelayBase = 3.0
         };
-        private static readonly HttpClient _client = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true });
 
         /// <summary>
         ///   'LTS' or 'Current'
@@ -44,35 +46,57 @@ namespace Microsoft.DotNet.Helix.Sdk
         [Required]
         public string PackageType { get; set; }
 
+        public ITaskItem [] AdditionalFeeds { get; set; }
+
         [Output]
         public string PackageUri { get; set; }
 
-        public override bool Execute()
+        private static HttpClient _client;
+        private HttpMessageHandler _httpMessageHandler;
+
+        public override void ConfigureServices(IServiceCollection collection)
         {
-            ExecuteAsync().GetAwaiter().GetResult();
+            _httpMessageHandler = new HttpClientHandler {  CheckCertificateRevocationList = true };
+            collection.TryAddSingleton(_httpMessageHandler);
+            collection.TryAddSingleton(Log);
+        }
+
+        public bool ExecuteTask(HttpMessageHandler httpMessageHandler)
+        {
+            _httpMessageHandler = httpMessageHandler;
+            _client = new HttpClient(_httpMessageHandler);
+            FindCliPackage().GetAwaiter().GetResult();
             return !Log.HasLoggedErrors;
         }
 
-        private async Task ExecuteAsync()
+        private string SanitizeString(string text)
+        {
+            return Regex.Replace(text, @"\?[^ ]+", "");
+        }
+
+        private async Task FindCliPackage()
         {
             NormalizeParameters();
-            var feeds = new List<string>
+            var feeds = new List<ITaskItem>();
+            feeds.Add(new MSBuild.TaskItem("https://dotnetcli.azureedge.net/dotnet"));
+            feeds.Add(new MSBuild.TaskItem("https://dotnetbuilds.azureedge.net/public"));
+            if (AdditionalFeeds != null)
             {
-                "https://dotnetcli.azureedge.net/dotnet",
-                "https://dotnetbuilds.azureedge.net/public",
-            };
+                feeds.AddRange(AdditionalFeeds);
+            }
 
             string finalDownloadUrl = null;
             foreach (var feed in feeds)
             {
                 string downloadUrl = await GetDownloadUrlAsync(feed);
+
                 if (downloadUrl == null)
                 {
                     Log.LogMessage($"Could not retrieve dotnet cli {PackageType} version {Version} package uri from feed {feed}");
                     continue;
                 }
 
-                Log.LogMessage($"Retrieved dotnet cli {PackageType} version {Version} package uri {downloadUrl} from feed {feed}, testing...");
+                Log.LogMessage($"Retrieved dotnet cli {PackageType} version {Version} package uri {SanitizeString(downloadUrl)} from feed {feed}, testing...");
 
                 try
                 {
@@ -86,11 +110,12 @@ namespace Microsoft.DotNet.Helix.Sdk
                     }
 
                     res.EnsureSuccessStatusCode();
+
                     finalDownloadUrl = downloadUrl;
                 }
                 catch (Exception ex)
                 {
-                    Log.LogMessage($"Unable to access dotnet cli {PackageType} version {Version} from feed {feed}, {ex.Message}");
+                    Log.LogMessage($"Unable to access dotnet cli {PackageType} version {Version} from feed {feed}, {SanitizeString(ex.Message)}");
                 }
             }
 
@@ -102,31 +127,37 @@ namespace Microsoft.DotNet.Helix.Sdk
 
             if (!Log.HasLoggedErrors)
             {
-                Log.LogMessage($"Url {finalDownloadUrl} is valid.");
+                Log.LogMessage($"Url {SanitizeString(finalDownloadUrl)} is valid.");
                 PackageUri = finalDownloadUrl;
             }
         }
 
-        private async Task<string> GetDownloadUrlAsync(string feed)
+        private async Task<string> GetDownloadUrlAsync(ITaskItem feed)
         {
             var oldVersion = Version; // ResolveVersionAsync will adjust the Version property, but we need it set back for other feeds to see the same initial Version
             try
             {
                 var version = await ResolveVersionAsync(feed);
                 string extension = Runtime.StartsWith("win") ? "zip" : "tar.gz";
+
                 string effectiveVersion = await GetEffectiveVersion(feed, version);
+                feed.TryGetMetadata("SasToken", out string sasToken);
+                if (!string.IsNullOrEmpty(sasToken) && !sasToken.StartsWith("?"))
+                {
+                    sasToken = "?" + sasToken;
+                }
 
                 return PackageType switch
                 {
-                    "sdk" => $"{feed}/Sdk/{version}/dotnet-sdk-{effectiveVersion}-{Runtime}.{extension}",
+                    "sdk" => $"{feed.ItemSpec}/Sdk/{version}/dotnet-sdk-{effectiveVersion}-{Runtime}.{extension}{sasToken}",
                     "aspnetcore-runtime" =>
-                        $"{feed}/aspnetcore/Runtime/{version}/aspnetcore-runtime-{effectiveVersion}-{Runtime}.{extension}",
-                    _ => $"{feed}/Runtime/{version}/dotnet-runtime-{effectiveVersion}-{Runtime}.{extension}"
+                        $"{feed.ItemSpec}/aspnetcore/Runtime/{version}/aspnetcore-runtime-{effectiveVersion}-{Runtime}.{extension}{sasToken}",
+                    _ => $"{feed.ItemSpec}/Runtime/{version}/dotnet-runtime-{effectiveVersion}-{Runtime}.{extension}{sasToken}"
                 };
             }
             catch (Exception ex)
             {
-                Log.LogWarning($"Unable to resolve download link from feed {feed}; {ex.Message}");
+                Log.LogWarning($"Unable to resolve download link from feed {feed}; {SanitizeString(ex.Message)}");
                 return null;
             }
             finally
@@ -135,7 +166,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             }
         }
 
-        private async Task<string> GetEffectiveVersion(string feed, string version)
+        private async Task<string> GetEffectiveVersion(ITaskItem feed, string version)
         {
             if (NuGetVersion.TryParse(version, out NuGetVersion semanticVersion))
             {
@@ -147,11 +178,12 @@ namespace Microsoft.DotNet.Helix.Sdk
                 // Do nothing for older runtimes; the file won't exist
                 if (semanticVersion >= new NuGetVersion("5.0.0"))
                 {
+                    feed.TryGetMetadata("sasToken", out string sasToken);
                     var productVersionText = PackageType switch
                     {
-                        "sdk" => await GetMatchingProductVersionTxtContents($"{feed}/Sdk/{version}", "sdk-productVersion.txt"),
-                        "aspnetcore-runtime" => await GetMatchingProductVersionTxtContents($"{feed}/aspnetcore/Runtime/{version}", "aspnetcore-productVersion.txt"),
-                        _ => await GetMatchingProductVersionTxtContents($"{feed}/Runtime/{version}", "runtime-productVersion.txt")
+                        "sdk" => await GetMatchingProductVersionTxtContents($"{feed.ItemSpec}/Sdk/{version}", "sdk-productVersion.txt", sasToken),
+                        "aspnetcore-runtime" => await GetMatchingProductVersionTxtContents($"{feed.ItemSpec}/aspnetcore/Runtime/{version}", "aspnetcore-productVersion.txt", sasToken),
+                        _ => await GetMatchingProductVersionTxtContents($"{feed.ItemSpec}/Runtime/{version}", "runtime-productVersion.txt", sasToken)
                     };
 
                     if (!productVersionText.Equals(version))
@@ -165,14 +197,15 @@ namespace Microsoft.DotNet.Helix.Sdk
 
             throw new ArgumentException($"'{version}' is not a valid semantic version.");
         }
-        private async Task<string> GetMatchingProductVersionTxtContents(string baseUri, string customVersionTextFileName)
+        private async Task<string> GetMatchingProductVersionTxtContents(string baseUri, string customVersionTextFileName, string sasToken = null)
         {
             Log.LogMessage(MessageImportance.Low, $"Checking for productVersion.txt files under {baseUri}");
 
-            using HttpResponseMessage specificResponse = await GetAsyncWithRetry($"{baseUri}/{customVersionTextFileName}");
+            using HttpResponseMessage specificResponse = await GetAsyncWithRetry($"{baseUri}/{customVersionTextFileName}", sasToken);
+
             if (specificResponse.StatusCode == HttpStatusCode.NotFound)
             {
-                using HttpResponseMessage genericResponse = await GetAsyncWithRetry($"{baseUri}/productVersion.txt");
+                using HttpResponseMessage genericResponse = await GetAsyncWithRetry($"{baseUri}/productVersion.txt", sasToken);
                 if (genericResponse.StatusCode != HttpStatusCode.NotFound)
                 {
                     genericResponse.EnsureSuccessStatusCode();
@@ -180,7 +213,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                 }
                 else
                 {
-                    Log.LogMessage(MessageImportance.Low, $"No *productVersion.txt files found for {Version} under {baseUri}");
+                    Log.LogMessage(MessageImportance.Low, $"No *productVersion.txt files found for {Version} under {SanitizeString(baseUri)}");
                 }
             }
             else
@@ -191,25 +224,31 @@ namespace Microsoft.DotNet.Helix.Sdk
             return Version;
         }
 
-        private async Task<HttpResponseMessage> GetAsyncWithRetry(string uri)
+        private async Task<HttpResponseMessage> GetAsyncWithRetry(string uri, string sasToken = null)
         {
             HttpResponseMessage response = null;
+            if (!string.IsNullOrEmpty(sasToken) && !sasToken.StartsWith("?"))
+            {
+                sasToken = "?" + sasToken;
+            }
+
             await _retry.RunAsync(async attempt =>
             {
                 try
                 {
-                    response = await _client.GetAsync(uri);
+                    response = await _client.GetAsync($"{uri}{sasToken}");
+
                     return true;
                 }
                 catch (Exception toLog)
                 {
-                    Log.LogMessage(MessageImportance.Low, $"Hit exception in GetAsync(); will retry up to 10 times ({toLog.Message})");
+                    Log.LogMessage(MessageImportance.Low, $"Hit exception in GetAsync(); will retry up to 10 times ({SanitizeString(toLog.Message)})");
                     return false;
                 }
             });
             if (response == null)  // All retries failed
             {
-                throw new Exception($"Failed to GET from {uri}, even after retrying");
+                throw new Exception($"Failed to GET from {SanitizeString(uri)}, even after retrying");
             }
             return response;
         }
@@ -227,13 +266,13 @@ namespace Microsoft.DotNet.Helix.Sdk
                 }
                 catch (Exception toLog)
                 {
-                    Log.LogMessage(MessageImportance.Low, $"Hit exception in SendAsync(); will retry up to 10 times ({toLog.Message})");
+                    Log.LogMessage(MessageImportance.Low, $"Hit exception in SendAsync(); will retry up to 10 times ({SanitizeString(toLog.Message)})");
                     return false;
                 }
             });
             if (response == null) // All retries failed
             {
-                throw new Exception($"Failed to make HEAD request to {uri}, even after retrying");
+                throw new Exception($"Failed to make HEAD request to {SanitizeString(uri)}, even after retrying");
             }
             return response;
         }
@@ -276,7 +315,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             }
         }
 
-        private async Task<string> ResolveVersionAsync(string feed)
+        private async Task<string> ResolveVersionAsync(ITaskItem feed)
         {
             string version = Version;
             if (Version == "latest")
@@ -284,14 +323,15 @@ namespace Microsoft.DotNet.Helix.Sdk
                 Log.LogMessage(MessageImportance.Low, "Resolving latest dotnet cli version.");
                 string latestVersionUrl = PackageType switch
                 {
-                    "sdk" => $"{feed}/Sdk/{Channel}/latest.version",
-                    "aspnetcore-runtime" => $"{feed}/aspnetcore/Runtime/{Channel}/latest.version",
-                    _ => $"{feed}/Runtime/{Channel}/latest.version"
+                    "sdk" => $"{feed.ItemSpec}/Sdk/{Channel}/latest.version",
+                    "aspnetcore-runtime" => $"{feed.ItemSpec}/aspnetcore/Runtime/{Channel}/latest.version",
+                    _ => $"{feed.ItemSpec}/Runtime/{Channel}/latest.version"
                 };
 
                 Log.LogMessage(MessageImportance.Low, $"Resolving latest version from url {latestVersionUrl}");
 
-                using HttpResponseMessage versionResponse = await GetAsyncWithRetry(latestVersionUrl);
+                feed.TryGetMetadata("sasToken", out string sasToken);
+                using HttpResponseMessage versionResponse = await GetAsyncWithRetry(latestVersionUrl, sasToken);
                 versionResponse.EnsureSuccessStatusCode();
                 string latestVersionContent = await versionResponse.Content.ReadAsStringAsync();
                 string[] versionData = latestVersionContent.Split(Array.Empty<char>(), StringSplitOptions.RemoveEmptyEntries);

--- a/src/Microsoft.DotNet.Helix/Sdk/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/Readme.md
@@ -163,6 +163,11 @@ Given a local folder `$(TestFolder)` containing `runtests.cmd`, this will run `r
     </AdditionalDotNetPackage>
     <!-- Includes the 6.0.0-preview.4.21175.1 version, using the default runtime packageType, DotNetCliRuntime, and Current channel  -->
     <AdditionalDotNetPackage Include="6.0.0-preview.4.21175.1" />
+
+    <!-- if the above package was not available from a public feed, you can specify a private feed like this -->
+    <AdditionalDotNetPackageFeed Include="https://someprivatefeed.blob.azure.com/internal">
+      <SasToken>$(SasTokenValueForSomePrivateFeed)</SasToken>
+    </AdditionalDotNetPackageFeed>
   </ItemGroup>
   
   <!--

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.targets
@@ -35,7 +35,7 @@
     </PropertyGroup>
 
     <Message Text = "Adding correlation payload for additional .NET Core package: Version: '%(AdditionalDotNetPackage.Identity)'  Runtime: '$(DotNetCliRuntime)' PackageType: '$(_packageType)' Channel: '$(_channel)' "/>
-    <FindDotNetCliPackage Version="%(AdditionalDotNetPackage.Identity)" Runtime="$(DotNetCliRuntime)" PackageType="$(_packageType)" Channel="$(_channel)">
+    <FindDotNetCliPackage Version="%(AdditionalDotNetPackage.Identity)" Runtime="$(DotNetCliRuntime)" PackageType="$(_packageType)" Channel="$(_channel)" AdditionalFeeds="@(AdditionalDotNetPackageFeed)">
       <Output TaskParameter="PackageUri" PropertyName="DotNetCliPackageUri"/>
     </FindDotNetCliPackage>
     <ItemGroup>


### PR DESCRIPTION
* Enable authenticated discovery of dotnet runtime packages

* PR feedback: code cleanup

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation

Cherry-pick https://github.com/dotnet/arcade/pull/8667