### PR TITLE
Add pull request information to infra issues template

### DIFF
--- a/.github/ISSUE_TEMPLATE/z-build-break-infrastructure-issue-template.yml
+++ b/.github/ISSUE_TEMPLATE/z-build-break-infrastructure-issue-template.yml
@@ -18,6 +18,11 @@ body:
       label: Build leg reported
       description: Enter the name of the stage/job where the build failed.
   - type: textarea
+    id: pr
+    attributes:
+      label: Pull Request
+      description: Enter link to one pull request in which the issue is observed
+  - type: textarea
     id: error-message
     attributes:
       label: Action required for the engineering services team

--- a/.github/ISSUE_TEMPLATE/z-build-break-infrastructure-issue-template.yml
+++ b/.github/ISSUE_TEMPLATE/z-build-break-infrastructure-issue-template.yml
@@ -17,7 +17,7 @@ body:
     attributes:
       label: Build leg reported
       description: Enter the name of the stage/job where the build failed.
-  - type: textarea
+  - type: input
     id: pr
     attributes:
       label: Pull Request


### PR DESCRIPTION
Add field of pull request to infrastructure issue template.

This was requested in: https://github.com/dotnet/core-eng/issues/15800
This information is going to be autofill when opened from the build analysis. 

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
