### PR TITLE
Update AsmDiff to fix ignored cmdline options and errors in markdown and text output.

### DIFF
--- a/src/Microsoft.Cci.Extensions/Extensions/MemberExtensions.cs
+++ b/src/Microsoft.Cci.Extensions/Extensions/MemberExtensions.cs
@@ -105,19 +105,19 @@ namespace Microsoft.Cci.Extensions
             var name = methodDefinition.GetNameWithoutExplicitType();
             if (name.StartsWith("get_"))
             {
-                return AccessorType.EventAdder;
+                return AccessorType.PropertyGetter;
             }
             else if (name.StartsWith("set_"))
             {
-                return AccessorType.PropertyGetter;
+                return AccessorType.PropertySetter;
             }
             else if (name.StartsWith("add_"))
             {
-                return AccessorType.EventRemover;
+                return AccessorType.EventAdder;
             }
             else if (name.StartsWith("remove_"))
             {
-                return AccessorType.PropertySetter;
+                return AccessorType.EventRemover;
             }
 
             return AccessorType.None;

--- a/src/Microsoft.DotNet.AsmDiff/DiffCSharpWriter.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffCSharpWriter.cs
@@ -183,7 +183,7 @@ namespace Microsoft.DotNet.AsmDiff
 
         public override void Visit(IEnumerable<MemberMapping> members)
         {
-            MemberMapping mapping = members.FirstOrDefault(DiffFilter.Include);
+            MemberMapping mapping = members.FirstOrDefault(m => DiffFilter.Include(m) && !IsPropertyOrEventAccessor(m.Representative));
 
             if (mapping != null)
                 WriteMemberGroupHeader(mapping.Representative);
@@ -193,23 +193,36 @@ namespace Microsoft.DotNet.AsmDiff
 
         public override void Visit(MemberMapping member)
         {
-            IDisposable style = null;
-
-            if (this.HighlightBaseMembers)
+            if (!IsPropertyOrEventAccessor(member.Representative))
             {
-                if (member.Representative.IsInterfaceImplementation())
-                    style = _syntaxWriter.StartStyle(SyntaxStyle.InterfaceMember);
-                else if (member.Representative.IsOverride())
-                    style = _syntaxWriter.StartStyle(SyntaxStyle.InheritedMember);
+                IDisposable style = null;
+
+                if (this.HighlightBaseMembers)
+                {
+                    if (member.Representative.IsInterfaceImplementation())
+                        style = _syntaxWriter.StartStyle(SyntaxStyle.InterfaceMember);
+                    else if (member.Representative.IsOverride())
+                        style = _syntaxWriter.StartStyle(SyntaxStyle.InheritedMember);
+                }
+
+                WriteHeader(member);
+                if (style != null)
+                    style.Dispose();
+
+                _syntaxWriter.WriteLine();
+                WriteComments(member);
             }
 
-            WriteHeader(member);
-            if (style != null)
-                style.Dispose();
-
-            _syntaxWriter.WriteLine();
-            WriteComments(member);
             base.Visit(member);
+        }
+
+        private static bool IsPropertyOrEventAccessor(ITypeDefinitionMember representative)
+        {
+            var methodDefinition = representative as IMethodDefinition;
+            if (methodDefinition == null)
+                return false;
+
+            return methodDefinition.IsPropertyOrEventAccessor();
         }
 
         private void WriteHeader<T>(ElementMapping<T> element) where T : class, IDefinition

--- a/src/Microsoft.DotNet.AsmDiff/DiffCSharpWriter.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffCSharpWriter.cs
@@ -206,8 +206,7 @@ namespace Microsoft.DotNet.AsmDiff
                 }
 
                 WriteHeader(member);
-                if (style != null)
-                    style.Dispose();
+                    style?.Dispose();
 
                 _syntaxWriter.WriteLine();
                 WriteComments(member);
@@ -218,11 +217,7 @@ namespace Microsoft.DotNet.AsmDiff
 
         private static bool IsPropertyOrEventAccessor(ITypeDefinitionMember representative)
         {
-            var methodDefinition = representative as IMethodDefinition;
-            if (methodDefinition == null)
-                return false;
-
-            return methodDefinition.IsPropertyOrEventAccessor();
+            return (representative is IMethodDefinition methodDefinition) && methodDefinition.IsPropertyOrEventAccessor();
         }
 
         private void WriteHeader<T>(ElementMapping<T> element) where T : class, IDefinition

--- a/src/Microsoft.DotNet.AsmDiff/MarkdownDiffExporter.cs
+++ b/src/Microsoft.DotNet.AsmDiff/MarkdownDiffExporter.cs
@@ -138,18 +138,21 @@ namespace Microsoft.DotNet.AsmDiff
                     diff = DifferenceType.Unchanged;
             }
 
-            if (diff == DifferenceType.Added)
+            switch (diff)
             {
-                WriteDiff(writer, "+", indent, suffix, api.Right);
-            }
-            else if (diff == DifferenceType.Changed || diff == DifferenceType.Removed)
-            {
-                WriteDiff(writer, "-", indent, suffix, api.Left);
-                WriteDiff(writer, "+", indent, suffix, api.Right);
-            }
-            else
-            {
-                WriteDiff(writer, " ", indent, suffix, api.Definition);
+                case DifferenceType.Added:
+                    WriteDiff(writer, "+", indent, suffix, api.Right);
+                    break;
+                case DifferenceType.Removed:
+                    WriteDiff(writer, "-", indent, suffix, api.Left);
+                    break;
+                case DifferenceType.Changed:
+                    WriteDiff(writer, "-", indent, suffix, api.Left);
+                    WriteDiff(writer, "+", indent, suffix, api.Right);
+                    break;
+                default:
+                    WriteDiff(writer, " ", indent, suffix, api.Definition);
+                    break;
             }
 
             if (hasChildren)

--- a/src/Microsoft.DotNet.AsmDiff/Program.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Program.cs
@@ -155,6 +155,9 @@ namespace Microsoft.DotNet.AsmDiff
             if (StrikeRemoved)
                 result |= DiffConfigurationOptions.StrikeRemoved;
 
+            if (DiffAttributes)
+                result |= DiffConfigurationOptions.DiffAttributes;
+
             if (ExcludeAddedTypes)
                 result &= ~DiffConfigurationOptions.IncludeAddedTypes;
 


### PR DESCRIPTION
Update AsmDiff
- Fix ignored DiffAttributes option: The `-da|--DiffAttributes` option wasn't added into `DiffConfigurationOptions` before and therefore had no effect.
- MarkdownDiffExporter: Separate handling of `DifferenceType.Removed`/`Changed` to avoid extra empty lines in diffing block.
- DiffCSharpWriter: Filter out property and event accessors during `Visit(MemberMapping)` to avoid extra lines in with empty diff brackets `[1  1]`/ `[2  2]` in text output.

Update Microsoft.Cci.Extensions
- Fix GetAccessorType() to return correct AccessorType.
