### PR TITLE
Fixes #9014 escape double quotes in Microsoft.DotNet.CMake.Sdk.targets

### DIFF
--- a/src/Microsoft.DotNet.CMake.Sdk/build/Microsoft.DotNet.CMake.Sdk.targets
+++ b/src/Microsoft.DotNet.CMake.Sdk/build/Microsoft.DotNet.CMake.Sdk.targets
@@ -39,7 +39,7 @@
     <Error Condition="'$(_VSNativeCompilerComponentArchName)' == ''" Text="Unable to determine if Visual Studio has MSVC tools installed for the '$(Platform)' architecture." />
 
     <Exec
-      Command="$(VSWherePath) -latest -prerelease -products * -version $(VSGeneratorVersionRange) -requires $(_VSNativeCompilerComponentName) -property installationVersion"
+      Command="&quot;$(VSWherePath)&quot; -latest -prerelease -products * -version $(VSGeneratorVersionRange) -requires $(_VSNativeCompilerComponentName) -property installationVersion"
       EchoOff="true"
       ConsoleToMsBuild="true"
       StandardOutputImportance="Low">


### PR DESCRIPTION
Fixes #9014

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
