### PR TITLE
Add basic doc for rollout-blocking etiquette

### DIFF
--- a/Documentation/TeamProcess/DevGuide/blockingetiquette.md
+++ b/Documentation/TeamProcess/DevGuide/blockingetiquette.md
@@ -1,0 +1,5 @@
+# Rollout-Blocking Etiquette
+
+When you check in a change that ends up breaking a service, post in the General teams channel
+to alert the team that you are aware of the build break and are actively working to remedy
+it.


### PR DESCRIPTION
Very simple doc (currently one sentence) describing etiquette for blocking a rollout. Can be rolled into an existing doc, but I couldn't find one that I thought fit -- if you have an idea, please let me know and I'll do that.
