### PR TITLE
Log the XHarness diagnostics file content when failed to parse

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-processor.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-processor.py
@@ -251,7 +251,13 @@ def analyze_operation(command: str, platform: str, device: str, is_device: bool,
                 retry = True
 
 # The JSON should be an array of objects (one per each executed XHarness command)
-operations = json.load(open(diagnostics_file))
+try:
+    operations = json.load(open(diagnostics_file))
+except Exception as e:
+    print(f'    Failed to load the diagnostics file: {e}')
+    print('Diagnostics file contents:')
+    print(open(diagnostics_file))
+    exit(1)
 
 print(f"Reporting {len(operations)} events from diagnostics file `{diagnostics_file}`")
 


### PR DESCRIPTION
I have seen following error in the logs:
```
Traceback (most recent call last):
  File "/datadisks/disk1/work/ACE10989/w/9CD40882/u/xharness-event-processor.py", line 249, in <module>
    operations = json.load(open(diagnostics_file))
  File "/usr/lib/python3.6/json/__init__.py", line 299, in load
    parse_constant=parse_constant, object_pairs_hook=object_pairs_hook, **kw)
  File "/usr/lib/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.6/json/decoder.py", line 355, in raw_decode
    obj, end = self.scan_once(s, idx)
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 1 column 3 (char 2)
```

I don't understand how the file can be invalid since it is produced by C# serializer.