### PR TITLE
Rename `system.log` to not overwrite XHarness logs

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
@@ -167,7 +167,7 @@ exit_code=$?
 
 # In case of issues, include the syslog (last 2 MB from the time this work item has been running)
 if [ $exit_code -ne 0 ]; then
-    sudo log show --style syslog --start "$start_time" --end "$(date '+%Y-%m-%d %H:%M:%S')" | tail -c 2097152 > "$output_directory/system.log"
+    sudo log show --style syslog --start "$start_time" --end "$(date '+%Y-%m-%d %H:%M:%S')" | tail -c 2097152 > "$output_directory/macos.system.log"
 fi
 
 echo "Removing empty log files:"


### PR DESCRIPTION
The new XHarness can produce `system.log` too