### PR TITLE
Retry for failed iOS Simulator installations

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-processor.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-processor.py
@@ -218,6 +218,11 @@ def analyze_operation(command: str, platform: str, device: str, is_device: bool,
                 print(f'    Failed to launch the simulator. {retry_message}')
                 retry = True
         else:
+            if exit_code == 78: # PACKAGE_INSTALLATION_FAILURE
+                print(f'    Encountered PACKAGE_INSTALLATION_FAILURE. This might be caused by a corrupt simulator. {retry_message} {reboot_message}')
+                retry = True
+                reboot = True
+
             # Kill the simulator when we fail to launch the app
             if exit_code == 80: # APP_CRASH
                 simulator_app = os.getenv('SIMULATOR_APP')


### PR DESCRIPTION
Happened here: https://helix.dot.net/api/2019-06-17/jobs/7448eb3a-3bd7-4144-963a-e849ed8eb9b3/workitems/ios-simulator-64-System.Numerics.Vectors.Tests.app/console