### PR TITLE
Pass ICE suppressions to Light

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
@@ -241,7 +241,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                     _ = Parallel.ForEach(data.FeatureBands.Keys, platform =>
                     {
                         WorkloadPackMsi msi = new(data.Package, platform, BuildEngine, WixToolsetPath, BaseIntermediateOutputPath);
-                        ITaskItem msiOutputItem = msi.Build(MsiOutputPath);
+                        ITaskItem msiOutputItem = msi.Build(MsiOutputPath, IceSuppressions);
 
                         // Create the JSON manifest for CLI based installations.
                         string msiJsonPath = MsiProperties.Create(msiOutputItem.ItemSpec);


### PR DESCRIPTION
ICE suppressions weren't being passed to Light when building workload pack installers
