### PR TITLE
OneLocBuild: Ensure AutoCompletePr setting is respected

### DIFF
--- a/eng/common/templates/job/onelocbuild.yml
+++ b/eng/common/templates/job/onelocbuild.yml
@@ -72,8 +72,8 @@ jobs:
         lclSource: ${{ parameters.LclSource }}
         lclPackageId: ${{ parameters.LclPackageId }}
         isCreatePrSelected: ${{ parameters.CreatePr }}
+        isAutoCompletePrSelected: ${{ parameters.AutoCompletePr }}
         ${{ if eq(parameters.CreatePr, true) }}:
-          isAutoCompletePrSelected: ${{ parameters.AutoCompletePr }}
           isUseLfLineEndingsSelected: ${{ parameters.UseLfLineEndings }}
           ${{ if eq(parameters.RepoType, 'gitHub') }}:
             isShouldReusePrSelected: ${{ parameters.ReusePr }}


### PR DESCRIPTION
When `CreatePr` is false, `isCreatePrSelected` is set but `isAutoCompletePrSelected` is left unset. The build task interprets the unset value as true, which causes the task to try to auto complete the PR even if the behavior is unwanted. This change moves the setting outside of the conditional gated by `CreatePr` so that the `AutoCompletePr` setting will always be passed into the task.

See #9048

/cc @AbhitejJohn @jonfortescue 
