### PR TITLE
Updated outdated comment

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -51,7 +51,7 @@
     <UsingToolXUnit Condition="'$(UsingToolXUnit)' == ''">true</UsingToolXUnit>
 
     <!--
-      Use compilers from the Microsoft.Net.Compilers/Microsoft.NETCore.Compilers package.
+      Use compilers from the Microsoft.Net.Compilers.Toolset package.
       Repo can set this property to true if it needs to use a different version of the compiler than the one in the dotnet SDK.
     -->
     <UsingToolMicrosoftNetCompilers Condition="'$(UsingToolMicrosoftNetCompilers)' == ''">false</UsingToolMicrosoftNetCompilers>


### PR DESCRIPTION
This property uses `Microsoft.Net.Compilers.Toolset` starting from https://github.com/dotnet/arcade/pull/2131. Comment was outdated.

https://github.com/dotnet/arcade/blob/0b5e6fc8489539f9a9a63bb547729722042c001b/src/Microsoft.DotNet.Arcade.Sdk/tools/Settings.props#L23

https://github.com/dotnet/arcade/blob/0b5e6fc8489539f9a9a63bb547729722042c001b/src/Microsoft.DotNet.Arcade.Sdk/tools/Compiler.props#L5

