### PR TITLE
Force import of the "right" version of X509Certificates

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,8 +27,8 @@
     <MsbuildTaskMicrosoftCodeAnalysisCSharpVersion>$(MicrosoftCodeAnalysisCSharpVersion)</MsbuildTaskMicrosoftCodeAnalysisCSharpVersion>
   </PropertyGroup>
 
-  <!-- Don't let it restore lower versions of this package, which can come transitively from NetStandard package restores -->
-  <ItemGroup>
+  <!-- Don't let it restore lower versions of this package, which can come transitively from NetStandard package restores (CSProj only) -->
+  <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'" >
     <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="$(SystemSecurityCryptographyX509CertificatesVersion)" />
   </ItemGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,4 +26,10 @@
     -->
     <MsbuildTaskMicrosoftCodeAnalysisCSharpVersion>$(MicrosoftCodeAnalysisCSharpVersion)</MsbuildTaskMicrosoftCodeAnalysisCSharpVersion>
   </PropertyGroup>
+
+  <!-- Don't let it restore lower versions of this package, which can come transitively from NetStandard package restores -->
+  <ItemGroup>
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="$(SystemSecurityCryptographyX509CertificatesVersion)" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
(we were restoring multiple before and this is undesirable for static analysis)

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation (verified locally)
