### PR TITLE
Split XHarness tests into a separate stage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -196,36 +196,7 @@ stages:
         workspace:
           clean: all
         jobs:
-        - job: Windows_NT_XHarness
-          timeoutInMinutes: 90
-          pool:
-            vmimage: windows-latest
-          strategy:
-            matrix:
-              Build_Debug:
-                _BuildConfig: Debug
-          variables:
-          - _Testing: XHarness_Android_Device
-          preSteps:
-          - checkout: self
-            clean: true
-          steps:
-          - powershell: eng\common\build.ps1
-              -configuration $(_BuildConfig) 
-              -prepareMachine
-              -ci
-              -restore
-              -test
-              -warnAsError $false
-              -projects $(Build.SourcesDirectory)\tests\XHarness.Android.DeviceTests.proj
-              /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.XHarness.Android.Device.Tests.binlog
-              /p:RestoreUsingNuGetTargets=false
-            displayName: XHarness Android Helix Testing (Windows)
-            env:
-              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-              HelixAccessToken: ''
-
-        - job: Linux_XHarness_Apple_Simulator
+        - job: XHarness_Apple_Simulator
           timeoutInMinutes: 90
           container: LinuxContainer
           pool:
@@ -255,7 +226,7 @@ stages:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''
 
-        - job: Linux_XHarness_Apple_Device
+        - job: XHarness_Apple_Device
           timeoutInMinutes: 90
           container: LinuxContainer
           pool:
@@ -285,7 +256,7 @@ stages:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''
 
-        - job: Linux_XHarness
+        - job: XHarness_Android_Simulator
           timeoutInMinutes: 90
           container: LinuxContainer
           pool:
@@ -311,6 +282,35 @@ stages:
               /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.XHarness.Android.Simulator.Tests.binlog
               /p:RestoreUsingNuGetTargets=false
             displayName: XHarness Android Helix Testing (Linux)
+            env:
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+              HelixAccessToken: ''
+
+        - job: XHarness_Android_Device
+          timeoutInMinutes: 90
+          pool:
+            vmimage: windows-latest
+          strategy:
+            matrix:
+              Build_Debug:
+                _BuildConfig: Debug
+          variables:
+          - _Testing: XHarness_Android_Device
+          preSteps:
+          - checkout: self
+            clean: true
+          steps:
+          - powershell: eng\common\build.ps1
+              -configuration $(_BuildConfig) 
+              -prepareMachine
+              -ci
+              -restore
+              -test
+              -warnAsError $false
+              -projects $(Build.SourcesDirectory)\tests\XHarness.Android.DeviceTests.proj
+              /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.XHarness.Android.Device.Tests.binlog
+              /p:RestoreUsingNuGetTargets=false
+            displayName: XHarness Android Helix Testing (Windows)
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -206,7 +206,7 @@ stages:
               Build_Debug:
                 _BuildConfig: Debug
           variables:
-          - _Testing: XHarness_Apple_Simulator
+          - _Testing: Apple_Simulator_Tests
           preSteps:
           - checkout: self
             clean: true
@@ -236,7 +236,7 @@ stages:
               Build_Release:
                 _BuildConfig: Release
           variables:
-          - _Testing: XHarness_Apple_Device
+          - _Testing: Apple_Device_Tests
           preSteps:
           - checkout: self
             clean: true
@@ -266,7 +266,7 @@ stages:
               Build_Release:
                 _BuildConfig: Release
           variables:
-          - _Testing: XHarness_Android_Simulator
+          - _Testing: Android_Simulator_Tests
           preSteps:
           - checkout: self
             clean: true
@@ -295,7 +295,7 @@ stages:
               Build_Debug:
                 _BuildConfig: Debug
           variables:
-          - _Testing: XHarness_Android_Device
+          - _Testing: Android_Device_Tests
           preSteps:
           - checkout: self
             clean: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -149,36 +149,7 @@ stages:
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''
-        - job: Windows_NT_XHarness
-          timeoutInMinutes: 90
-          pool:
-            vmimage: windows-latest
-          strategy:
-            matrix:
-              Build_Release:
-                _BuildConfig: Release
-              Build_Debug:
-                _BuildConfig: Debug
-          variables:
-          - _Testing: Xharness
-          preSteps:
-          - checkout: self
-            clean: true
-          steps:
-          - powershell: eng\common\build.ps1
-              -configuration $(_BuildConfig) 
-              -prepareMachine
-              -ci
-              -restore
-              -test
-              -warnAsError $false
-              -projects $(Build.SourcesDirectory)\tests\XHarness.Android.DeviceTests.proj
-              /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.XHarness.Android.Device.Tests.binlog
-              /p:RestoreUsingNuGetTargets=false
-            displayName: XHarness Android Helix Testing (Windows)
-            env:
-              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-              HelixAccessToken: ''
+
         - job: Linux
           timeoutInMinutes: 90
           container: LinuxContainer
@@ -210,6 +181,51 @@ stages:
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''
+
+  - stage: Test_XHarness
+    displayName: Test XHarness (Helix SDK)
+    dependsOn: build
+    jobs:
+    - template: /eng/common/templates/jobs/jobs.yml
+      parameters:
+        artifacts:
+          publish:
+            logs:
+              name: Logs_Test_$(Agent.OS)_$(_BuildConfig)_$(_Testing)
+          download: true
+        workspace:
+          clean: all
+        jobs:
+
+        - job: Windows_NT_XHarness
+          timeoutInMinutes: 90
+          pool:
+            vmimage: windows-latest
+          strategy:
+            matrix:
+              Build_Debug:
+                _BuildConfig: Debug
+          variables:
+          - _Testing: XHarness_Android_Device
+          preSteps:
+          - checkout: self
+            clean: true
+          steps:
+          - powershell: eng\common\build.ps1
+              -configuration $(_BuildConfig) 
+              -prepareMachine
+              -ci
+              -restore
+              -test
+              -warnAsError $false
+              -projects $(Build.SourcesDirectory)\tests\XHarness.Android.DeviceTests.proj
+              /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.XHarness.Android.Device.Tests.binlog
+              /p:RestoreUsingNuGetTargets=false
+            displayName: XHarness Android Helix Testing (Windows)
+            env:
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+              HelixAccessToken: ''
+
         - job: Linux_XHarness_Apple_Simulator
           timeoutInMinutes: 90
           container: LinuxContainer
@@ -219,10 +235,8 @@ stages:
             matrix:
               Build_Debug:
                 _BuildConfig: Debug
-              Build_Release:
-                _BuildConfig: Release
           variables:
-          - _Testing: Xharness_Apple_Simulator
+          - _Testing: XHarness_Apple_Simulator
           preSteps:
           - checkout: self
             clean: true
@@ -241,6 +255,7 @@ stages:
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''
+
         - job: Linux_XHarness_Apple_Device
           timeoutInMinutes: 90
           container: LinuxContainer
@@ -248,12 +263,10 @@ stages:
             vmimage: ubuntu-latest
           strategy:
             matrix:
-              Build_Debug:
-                _BuildConfig: Debug
               Build_Release:
                 _BuildConfig: Release
           variables:
-          - _Testing: Xharness_Apple_Device
+          - _Testing: XHarness_Apple_Device
           preSteps:
           - checkout: self
             clean: true
@@ -272,6 +285,7 @@ stages:
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''
+
         - job: Linux_XHarness
           timeoutInMinutes: 90
           container: LinuxContainer
@@ -279,12 +293,10 @@ stages:
             vmimage: ubuntu-latest
           strategy:
             matrix:
-              Build_Debug:
-                _BuildConfig: Debug
               Build_Release:
                 _BuildConfig: Release
           variables:
-          - _Testing: Xharness
+          - _Testing: XHarness_Android_Simulator
           preSteps:
           - checkout: self
             clean: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -196,7 +196,7 @@ stages:
         workspace:
           clean: all
         jobs:
-        - job: XHarness_Apple_Simulator
+        - job: Apple_Simulators
           timeoutInMinutes: 90
           container: LinuxContainer
           pool:
@@ -206,7 +206,7 @@ stages:
               Build_Debug:
                 _BuildConfig: Debug
           variables:
-          - _Testing: Apple_Simulator_Tests
+          - _Testing: XHarness_Apple_Simulator_Tests
           preSteps:
           - checkout: self
             clean: true
@@ -226,7 +226,7 @@ stages:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''
 
-        - job: XHarness_Apple_Device
+        - job: Apple_Devices
           timeoutInMinutes: 90
           container: LinuxContainer
           pool:
@@ -236,7 +236,7 @@ stages:
               Build_Release:
                 _BuildConfig: Release
           variables:
-          - _Testing: Apple_Device_Tests
+          - _Testing: XHarness_Apple_Device_Tests
           preSteps:
           - checkout: self
             clean: true
@@ -256,7 +256,7 @@ stages:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''
 
-        - job: XHarness_Android_Simulator
+        - job: Android_Simulators
           timeoutInMinutes: 90
           container: LinuxContainer
           pool:
@@ -266,7 +266,7 @@ stages:
               Build_Release:
                 _BuildConfig: Release
           variables:
-          - _Testing: Android_Simulator_Tests
+          - _Testing: XHarness_Android_Simulator_Tests
           preSteps:
           - checkout: self
             clean: true
@@ -286,7 +286,7 @@ stages:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''
 
-        - job: XHarness_Android_Device
+        - job: Android_Devices
           timeoutInMinutes: 90
           pool:
             vmimage: windows-latest
@@ -295,7 +295,7 @@ stages:
               Build_Debug:
                 _BuildConfig: Debug
           variables:
-          - _Testing: Android_Device_Tests
+          - _Testing: XHarness_Android_Device_Tests
           preSteps:
           - checkout: self
             clean: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -183,7 +183,7 @@ stages:
               HelixAccessToken: ''
 
   - stage: Test_XHarness
-    displayName: Test XHarness (Helix SDK)
+    displayName: Test XHarness SDK
     dependsOn: build
     jobs:
     - template: /eng/common/templates/jobs/jobs.yml
@@ -196,7 +196,6 @@ stages:
         workspace:
           clean: all
         jobs:
-
         - job: Windows_NT_XHarness
           timeoutInMinutes: 90
           pool:


### PR DESCRIPTION
- Splits the tests into a separate stage so it's easier to tell from the build overview which stage failed
- Build Debug and Release only once but in different jobs to cross validate both (less Helix jobs, same coverage)
- Fix artifact/stage names