### PR TITLE
Fix APICompat for attributes on properties, events, and enum values

### DIFF
--- a/src/Microsoft.DotNet.ApiCompat/src/Microsoft.DotNet.ApiCompat.Core/Rules/Compat/AttributeDifference.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/Microsoft.DotNet.ApiCompat.Core/Rules/Compat/AttributeDifference.cs
@@ -78,24 +78,27 @@ namespace Microsoft.Cci.Differs.Rules
 
         public override DifferenceType Diff(IDifferences differences, ITypeDefinitionMember impl, ITypeDefinitionMember contract)
         {
-            var implMethod = impl as IMethodDefinition;
-            var contractMethod = contract as IMethodDefinition;
-            if (implMethod == null || contractMethod == null)
+            if (impl == null || contract == null)
                 return DifferenceType.Unknown;
 
-            bool changed = CheckAttributeDifferences(differences, implMethod, implMethod.Attributes, contractMethod.Attributes);
+            bool changed = CheckAttributeDifferences(differences, impl, impl.Attributes, contract.Attributes);
 
-            IParameterDefinition[] method1Params = implMethod.Parameters.ToArray();
-            IParameterDefinition[] method2Params = contractMethod.Parameters.ToArray();
-            for (int i = 0; i < implMethod.ParameterCount; i++)
-                changed |= CheckAttributeDifferences(differences, method1Params[i], method1Params[i].Attributes, method2Params[i].Attributes, member: implMethod);
-
-            if (implMethod.IsGeneric)
+            var implMethod = impl as IMethodDefinition;
+            var contractMethod = contract as IMethodDefinition;
+            if (implMethod != null && contractMethod != null)
             {
-                IGenericParameter[] method1GenParams = implMethod.GenericParameters.ToArray();
-                IGenericParameter[] method2GenParam = contractMethod.GenericParameters.ToArray();
-                for (int i = 0; i < implMethod.GenericParameterCount; i++)
-                    changed |= CheckAttributeDifferences(differences, method1GenParams[i], method1GenParams[i].Attributes, method2GenParam[i].Attributes, member: implMethod);
+                IParameterDefinition[] method1Params = implMethod.Parameters.ToArray();
+                IParameterDefinition[] method2Params = contractMethod.Parameters.ToArray();
+                for (int i = 0; i < implMethod.ParameterCount; i++)
+                    changed |= CheckAttributeDifferences(differences, method1Params[i], method1Params[i].Attributes, method2Params[i].Attributes, member: implMethod);
+
+                if (implMethod.IsGeneric)
+                {
+                    IGenericParameter[] method1GenParams = implMethod.GenericParameters.ToArray();
+                    IGenericParameter[] method2GenParam = contractMethod.GenericParameters.ToArray();
+                    for (int i = 0; i < implMethod.GenericParameterCount; i++)
+                        changed |= CheckAttributeDifferences(differences, method1GenParams[i], method1GenParams[i].Attributes, method2GenParam[i].Attributes, member: implMethod);
+                }
             }
 
             return changed ? DifferenceType.Changed : DifferenceType.Unchanged;

--- a/src/Microsoft.DotNet.ApiCompat/tests/AttributeDifferenceTests.cs
+++ b/src/Microsoft.DotNet.ApiCompat/tests/AttributeDifferenceTests.cs
@@ -21,12 +21,14 @@ namespace Microsoft.DotNet.ApiCompat.Tests
 
             Assert.Contains("CannotRemoveAttribute : Attribute 'System.ComponentModel.DesignerAttribute' exists on 'AttributeDifference.AttributeDifferenceClass1' in the implementation but not the contract.", runOutput);
             Assert.Contains("CannotRemoveAttribute : Attribute 'AttributeDifference.FooAttribute' exists on 'AttributeDifference.AttributeDifferenceClass1' in the implementation but not the contract.", runOutput);
+            Assert.Contains("CannotRemoveAttribute : Attribute 'AttributeDifference.FooAttribute' exists on 'AttributeDifference.AttributeDifferenceClass1.PropertyWithAttribute' in the implementation but not the contract.", runOutput);
+            Assert.Contains("CannotRemoveAttribute : Attribute 'AttributeDifference.FooAttribute' exists on 'AttributeDifference.AttributeDifferenceClass1.EventWithAttribute' in the implementation but not the contract.", runOutput);
             Assert.Contains("CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on generic param 'T' on member 'AttributeDifference.AttributeDifferenceClass1.GenericMethodWithAttribute<T>()' in the implementation but not the contract.", runOutput);
             Assert.Contains("CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on generic param 'T' on member 'AttributeDifference.AttributeDifferenceClass1.GenericMethodWithAttribute<T>()' in the implementation but not the contract.", runOutput);
             Assert.Contains("CannotRemoveAttribute : Attribute 'AttributeDifference.FooAttribute' exists on 'AttributeDifference.AttributeDifferenceClass1.MethodWithAttribute()' in the implementation but not the contract.", runOutput);
             Assert.Contains("CannotRemoveAttribute : Attribute 'AttributeDifference.FooAttribute' exists on parameter 'myParameter' on member 'AttributeDifference.AttributeDifferenceClass1.MethodWithAttribute(System.String, System.Object)' in the implementation but not the contract.", runOutput);
             Assert.Contains("CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on generic param 'TOne' on member 'AttributeDifference.AttributeDifferenceGenericCLass<TOne, TTwo>' in the implementation but not the contract.", runOutput);
-            Assert.Contains("Total Issues: 6", runOutput);
+            Assert.Contains("Total Issues: 8", runOutput);
         }
 
         [Theory]

--- a/src/Microsoft.DotNet.ApiCompat/tests/TestProjects/AttributeDifference/Contract/AttributeDifference.cs
+++ b/src/Microsoft.DotNet.ApiCompat/tests/TestProjects/AttributeDifference/Contract/AttributeDifference.cs
@@ -11,6 +11,8 @@ namespace AttributeDifference
         public string MethodWithAttribute(string myParameter, [DefaultValue("myObject")] object myObject) => throw null;
         public T GenericMethodWithAttribute<T>() => throw null;
         public void MethodWithAttribute() { }
+        public string PropertyWithAttribute { get; set; }
+        public event System.EventHandler EventWithAttribute { add { } remove { } }
     }
     public class AttributeDifferenceGenericCLass<TOne, [DefaultValue("TTwo")] TTwo>
     {

--- a/src/Microsoft.DotNet.ApiCompat/tests/TestProjects/AttributeDifference/Implementation/AttributeDifferenceClass1.cs
+++ b/src/Microsoft.DotNet.ApiCompat/tests/TestProjects/AttributeDifference/Implementation/AttributeDifferenceClass1.cs
@@ -15,6 +15,10 @@ namespace AttributeDifference
         public T GenericMethodWithAttribute<[DefaultValue("T")] T>() => default(T);
         [Foo]
         public void MethodWithAttribute() { }
+        [Foo]
+        public string PropertyWithAttribute { get; set; }
+        [Foo]
+        public event System.EventHandler EventWithAttribute { add { } remove { } }
     }
 
     public class AttributeDifferenceGenericCLass<[DefaultValue("TOne")] TOne, [DefaultValue("TTwo")] TTwo>


### PR DESCRIPTION
This appears to have regressed with https://github.com/dotnet/arcade/commit/45a923c53b4a297dd42fc2f112a1917fa3c96032