### PR TITLE
AsmDiff fixes for Api-Diff

### DIFF
--- a/src/Microsoft.Cci.Extensions/Extensions/CSharp/CSharpCciExtensions.cs
+++ b/src/Microsoft.Cci.Extensions/Extensions/CSharp/CSharpCciExtensions.cs
@@ -41,13 +41,13 @@ namespace Microsoft.Cci.Extensions.CSharp
             (byte)'S', (byte)'e', (byte)'r', (byte)'v', (byte)'i', (byte)'c', (byte)'e', (byte)'s'
         };
 
-        public static string GetCSharpDeclaration(this IDefinition definition, bool includeAttributes = false)
+        public static string GetCSharpDeclaration(this IDefinition definition, ICciFilter filter)
         {
             using (var stringWriter = new StringWriter())
             {
                 using (var syntaxWriter = new TextSyntaxWriter(stringWriter))
                 {
-                    var writer = new CSDeclarationWriter(syntaxWriter, new AttributesFilter(includeAttributes), false, true);
+                    var writer = new CSDeclarationWriter(syntaxWriter, filter, false, true);
 
                     var nsp = definition as INamespaceDefinition;
                     var typeDefinition = definition as ITypeDefinition;

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
@@ -134,7 +134,6 @@ namespace Microsoft.Cci.Writers.CSharp
 
                 WriteTypeName(methodImplementation.ImplementedMethod.ContainingType, noSpace: true, nullableAttributeArgument: nullableAttributeArgument);
                 WriteSymbol(".");
-
                 WriteIdentifier(GetNormalizedMethodName(methodImplementation.ImplementedMethod.Name));
             }
             else

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
@@ -131,13 +131,11 @@ namespace Microsoft.Cci.Writers.CSharp
             {
                 IMethodImplementation methodImplementation = method.GetMethodImplementation();
                 object nullableAttributeArgument = methodImplementation.GetExplicitInterfaceMethodNullableAttributeArgument(_metadataReaderCache);
-                if (nullableAttributeArgument is int iNullableAttributeArgument && iNullableAttributeArgument > 0)
-                {
-                    WriteTypeName(methodImplementation.ImplementedMethod.ContainingType, noSpace: true, nullableAttributeArgument: nullableAttributeArgument);
-                    WriteSymbol(".");
-                    WriteIdentifier(methodImplementation.ImplementedMethod.Name);
-                    return;
-                }
+
+                WriteTypeName(methodImplementation.ImplementedMethod.ContainingType, noSpace: true, nullableAttributeArgument: nullableAttributeArgument);
+                WriteSymbol(".");
+
+                WriteIdentifier(GetNormalizedMethodName(methodImplementation.ImplementedMethod.Name));
             }
             else
             {

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Cci.Writers.CSharp
             {
                 writeVisibility = false;
             }
-            
+
             if (method.IsExplicitInterfaceMethod() || method.IsStaticConstructor)
             {
                 writeVisibility = false;
@@ -131,10 +131,13 @@ namespace Microsoft.Cci.Writers.CSharp
             {
                 IMethodImplementation methodImplementation = method.GetMethodImplementation();
                 object nullableAttributeArgument = methodImplementation.GetExplicitInterfaceMethodNullableAttributeArgument(_metadataReaderCache);
-
-                WriteTypeName(methodImplementation.ImplementedMethod.ContainingType, noSpace: true, nullableAttributeArgument: nullableAttributeArgument);
-                WriteSymbol(".");
-                WriteIdentifier(GetNormalizedMethodName(methodImplementation.ImplementedMethod.Name));
+                if (nullableAttributeArgument is int iNullableAttributeArgument && iNullableAttributeArgument > 0)
+                {
+                    WriteTypeName(methodImplementation.ImplementedMethod.ContainingType, noSpace: true, nullableAttributeArgument: nullableAttributeArgument);
+                    WriteSymbol(".");
+                    WriteIdentifier(methodImplementation.ImplementedMethod.Name);
+                    return;
+                }
             }
             else
             {

--- a/src/Microsoft.DotNet.AsmDiff/DiffCSharpWriter.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffCSharpWriter.cs
@@ -51,14 +51,16 @@ namespace Microsoft.DotNet.AsmDiff
 
         public DiffCSharpWriter(IStyleSyntaxWriter writer, MappingSettings settings)
             : this(writer, settings, null, false)
-        {          
+        {
         }
 
         public bool IncludeSpaceBetweenMemberGroups { get; set; }
 
         public bool IncludeMemberGroupHeadings { get; set; }
 
-        public bool HighlightBaseMembers { get; set; }
+        public bool HighlightMemberOverrides { get; set; }
+
+        public bool HighlightInterfaceImplementations { get; set; }
 
         public bool IncludeAssemblyProperties { get; set; }
 
@@ -237,7 +239,7 @@ namespace Microsoft.DotNet.AsmDiff
                 foreach (var comment in commentSet)
                 {
                     reviewCommentWriter.WriteReviewComment(comment.Author, comment.Text);
-                    _syntaxWriter.WriteLine();    
+                    _syntaxWriter.WriteLine();
                 }
             }
         }

--- a/src/Microsoft.DotNet.AsmDiff/DiffCSharpWriter.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffCSharpWriter.cs
@@ -58,6 +58,16 @@ namespace Microsoft.DotNet.AsmDiff
 
         public bool IncludeMemberGroupHeadings { get; set; }
 
+        public bool HighlightBaseMembers
+        {
+            get => HighlightMemberOverrides && HighlightInterfaceImplementations;
+            set
+            {
+                HighlightMemberOverrides = true;
+                HighlightInterfaceImplementations = true;
+            }
+        }
+
         public bool HighlightMemberOverrides { get; set; }
 
         public bool HighlightInterfaceImplementations { get; set; }

--- a/src/Microsoft.DotNet.AsmDiff/DiffCSharpWriter.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffCSharpWriter.cs
@@ -199,11 +199,11 @@ namespace Microsoft.DotNet.AsmDiff
             {
                 IDisposable style = null;
 
-                if (this.HighlightBaseMembers)
+                if (HighlightMemberOverrides || HighlightInterfaceImplementations)
                 {
-                    if (member.Representative.IsInterfaceImplementation())
+                    if (HighlightInterfaceImplementations && member.Representative.IsInterfaceImplementation())
                         style = _syntaxWriter.StartStyle(SyntaxStyle.InterfaceMember);
-                    else if (member.Representative.IsOverride())
+                    else if (HighlightMemberOverrides && member.Representative.IsOverride())
                         style = _syntaxWriter.StartStyle(SyntaxStyle.InheritedMember);
                 }
 

--- a/src/Microsoft.DotNet.AsmDiff/DiffCSharpWriter.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffCSharpWriter.cs
@@ -31,11 +31,6 @@ namespace Microsoft.DotNet.AsmDiff
         private bool _firstMemberGroup = false;
         private readonly IEnumerable<DiffComment> _diffComments;
 
-        public DiffCSharpWriter(IStyleSyntaxWriter writer, MappingSettings settings, IEnumerable<DiffComment> diffComments)
-            : this(writer, settings, diffComments, includePseudoCustomAttributes:false)
-        {
-        }
-
         public DiffCSharpWriter(IStyleSyntaxWriter writer, MappingSettings settings, IEnumerable<DiffComment> diffComments, bool includePseudoCustomAttributes)
             : base (settings)
         {

--- a/src/Microsoft.DotNet.AsmDiff/DiffCciFilter.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffCciFilter.cs
@@ -10,6 +10,32 @@ namespace Microsoft.DotNet.AsmDiff
 {
     internal sealed class DiffCciFilter : ICciFilter
     {
+        private readonly string[] _skippableAttributes = new[]
+        {
+            "System.AttributeUsageAttribute",
+            "System.ComponentModel.DefaultEventAttribute",
+            "System.ComponentModel.DefaultPropertyAttribute",
+            "System.ComponentModel.DesignerAttribute",
+            "System.ComponentModel.DesignerCategoryAttribute",
+            "System.ComponentModel.DesignerSerializationVisibilityAttribute",
+            "System.ComponentModel.DesignTimeVisibleAttribute",
+            "System.ComponentModel.EditorAttribute",
+            "System.ComponentModel.EditorBrowsableAttribute",
+            "System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute",
+            "System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute",
+            "System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute",
+            "System.Diagnostics.DebuggerDisplayAttribute",
+            "System.Diagnostics.DebuggerHiddenAttribute",
+            "System.Diagnostics.DebuggerStepThroughAttribute",
+            "System.Runtime.CompilerServices.AsyncStateMachineAttribute",
+            "System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute",
+            "System.Runtime.CompilerServices.CompilerGeneratedAttribute",
+            "System.Runtie.CompilerServices.InterpolatedStringHandlerAttribute",
+            "System.Runtime.CompilerServices.NullableAttribute",
+            "System.Runtime.CompilerServices.NullableContextAttribute",
+            "System.Runtime.InteropServices.StructLayoutAttribute",
+        };
+
         public DiffCciFilter(bool includeAttributes = false, bool includeInternals = false, bool includePrivates = false, bool includeGenerated = false)
         {
             IncludeAttributes = includeAttributes;
@@ -27,10 +53,16 @@ namespace Microsoft.DotNet.AsmDiff
                 return false;
 
             if (attribute.Type == null)
-                return true;
+                return false;
 
             var resolvedType = attribute.Type.ResolvedType;
-            return resolvedType is Dummy || Include(resolvedType);
+            string name = resolvedType.ToString();
+            bool isNull = name != null;
+            bool contains = _skippableAttributes.Contains(name);
+            bool dummy = resolvedType is Dummy;
+            bool include = Include(resolvedType);
+            bool result = isNull && !contains && (dummy || include);
+            return result;
         }
 
         public bool Include(INamespaceDefinition ns)
@@ -129,9 +161,9 @@ namespace Microsoft.DotNet.AsmDiff
         }
 
         public bool IncludeAttributes { get; set; }
-        
+
         public bool IncludeInternals { get; set; }
-        
+
         public bool IncludePrivates { get; set; }
 
         public bool IncludeGenerated { get; set; }

--- a/src/Microsoft.DotNet.AsmDiff/DiffConfiguration.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffConfiguration.cs
@@ -15,7 +15,8 @@ namespace Microsoft.DotNet.AsmDiff
                       DiffConfigurationOptions.IncludeUnchanged |
                       DiffConfigurationOptions.IncludeAddedTypes |
                       DiffConfigurationOptions.IncludeRemovedTypes |
-                      DiffConfigurationOptions.HighlightBaseMembers;
+                      DiffConfigurationOptions.HightlightMemberOverrides |
+                      DiffConfigurationOptions.HighlightInterfaceImplementations;
         }
 
         public DiffConfiguration(AssemblySet left, AssemblySet right, DiffConfigurationOptions options)

--- a/src/Microsoft.DotNet.AsmDiff/DiffConfigurationOptions.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffConfigurationOptions.cs
@@ -21,10 +21,13 @@ namespace Microsoft.DotNet.AsmDiff
         GroupByAssembly = 0x400,
         FlattenTypes = 0x800,
         TypesOnly = 0x1000,
-        HighlightBaseMembers = 0x2000,
         AlwaysDiffMembers = 0x4000,
         IncludeAddedTypes = 0x8000,
         IncludeRemovedTypes = 0x10000,
-        StrikeRemoved = 0x20000 
+        StrikeRemoved = 0x20000,
+        HightlightMemberOverrides = 0x40000,
+        HighlightInterfaceImplementations = 0x80000,
+
+        HighlightBasesMembers = HightlightMemberOverrides | HighlightInterfaceImplementations,
     }
 }

--- a/src/Microsoft.DotNet.AsmDiff/DiffConfigurationOptions.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffConfigurationOptions.cs
@@ -28,6 +28,6 @@ namespace Microsoft.DotNet.AsmDiff
         HightlightMemberOverrides = 0x40000,
         HighlightInterfaceImplementations = 0x80000,
 
-        HighlightBasesMembers = HightlightMemberOverrides | HighlightInterfaceImplementations,
+        HighlightBaseMembers = HightlightMemberOverrides | HighlightInterfaceImplementations,
     }
 }

--- a/src/Microsoft.DotNet.AsmDiff/DiffEngine.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffEngine.cs
@@ -60,16 +60,18 @@ namespace Microsoft.DotNet.AsmDiff
                     return new DiffCSharpWriter(writer, mappingSettings, diffComments, includeAttributes)
                     {
                         IncludeAssemblyProperties = configuration.IsOptionSet(DiffConfigurationOptions.DiffAssemblyInfo),
-                        HighlightBaseMembers = configuration.IsOptionSet(DiffConfigurationOptions.HighlightBaseMembers)
+                        HighlightMemberOverrides = configuration.IsOptionSet(DiffConfigurationOptions.HightlightMemberOverrides) || configuration.IsOptionSet(DiffConfigurationOptions.HighlightBasesMembers),
+                        HighlightInterfaceImplementations = configuration.IsOptionSet(DiffConfigurationOptions.HighlightInterfaceImplementations) || configuration.IsOptionSet(DiffConfigurationOptions.HighlightBasesMembers),
                     };
                 case DiffFormat.WordXml:
                 case DiffFormat.Text:
                 case DiffFormat.UnifiedDiff:
                     return new DiffCSharpWriter(writer, mappingSettings, diffComments, includeAttributes)
-                               {
-                                   IncludeAssemblyProperties = configuration.IsOptionSet(DiffConfigurationOptions.DiffAssemblyInfo),
-                                   HighlightBaseMembers = configuration.IsOptionSet(DiffConfigurationOptions.HighlightBaseMembers)
-                               };
+                    {
+                        IncludeAssemblyProperties = configuration.IsOptionSet(DiffConfigurationOptions.DiffAssemblyInfo),
+                        HighlightMemberOverrides = configuration.IsOptionSet(DiffConfigurationOptions.HightlightMemberOverrides) || configuration.IsOptionSet(DiffConfigurationOptions.HighlightBasesMembers),
+                        HighlightInterfaceImplementations = configuration.IsOptionSet(DiffConfigurationOptions.HighlightInterfaceImplementations) || configuration.IsOptionSet(DiffConfigurationOptions.HighlightBasesMembers),
+                    };
                 default:
                     throw new ArgumentOutOfRangeException("format");
             }
@@ -164,7 +166,8 @@ namespace Microsoft.DotNet.AsmDiff
             var writer = new ApiRecordingCSharpDiffWriter(diffRecorder, mappingSettings, includeAttributes)
             {
                 IncludeAssemblyProperties = configuration.IsOptionSet(DiffConfigurationOptions.DiffAssemblyInfo),
-                HighlightBaseMembers = configuration.IsOptionSet(DiffConfigurationOptions.HighlightBaseMembers)
+                HighlightMemberOverrides = configuration.IsOptionSet(DiffConfigurationOptions.HightlightMemberOverrides) || configuration.IsOptionSet(DiffConfigurationOptions.HighlightBasesMembers),
+                HighlightInterfaceImplementations = configuration.IsOptionSet(DiffConfigurationOptions.HighlightInterfaceImplementations) || configuration.IsOptionSet(DiffConfigurationOptions.HighlightBasesMembers),
             };
 
             WriteDiff(configuration, writer);

--- a/src/Microsoft.DotNet.AsmDiff/DiffEngine.cs
+++ b/src/Microsoft.DotNet.AsmDiff/DiffEngine.cs
@@ -60,8 +60,8 @@ namespace Microsoft.DotNet.AsmDiff
                     return new DiffCSharpWriter(writer, mappingSettings, diffComments, includeAttributes)
                     {
                         IncludeAssemblyProperties = configuration.IsOptionSet(DiffConfigurationOptions.DiffAssemblyInfo),
-                        HighlightMemberOverrides = configuration.IsOptionSet(DiffConfigurationOptions.HightlightMemberOverrides) || configuration.IsOptionSet(DiffConfigurationOptions.HighlightBasesMembers),
-                        HighlightInterfaceImplementations = configuration.IsOptionSet(DiffConfigurationOptions.HighlightInterfaceImplementations) || configuration.IsOptionSet(DiffConfigurationOptions.HighlightBasesMembers),
+                        HighlightMemberOverrides = configuration.IsOptionSet(DiffConfigurationOptions.HightlightMemberOverrides) || configuration.IsOptionSet(DiffConfigurationOptions.HighlightBaseMembers),
+                        HighlightInterfaceImplementations = configuration.IsOptionSet(DiffConfigurationOptions.HighlightInterfaceImplementations) || configuration.IsOptionSet(DiffConfigurationOptions.HighlightBaseMembers),
                     };
                 case DiffFormat.WordXml:
                 case DiffFormat.Text:
@@ -69,8 +69,8 @@ namespace Microsoft.DotNet.AsmDiff
                     return new DiffCSharpWriter(writer, mappingSettings, diffComments, includeAttributes)
                     {
                         IncludeAssemblyProperties = configuration.IsOptionSet(DiffConfigurationOptions.DiffAssemblyInfo),
-                        HighlightMemberOverrides = configuration.IsOptionSet(DiffConfigurationOptions.HightlightMemberOverrides) || configuration.IsOptionSet(DiffConfigurationOptions.HighlightBasesMembers),
-                        HighlightInterfaceImplementations = configuration.IsOptionSet(DiffConfigurationOptions.HighlightInterfaceImplementations) || configuration.IsOptionSet(DiffConfigurationOptions.HighlightBasesMembers),
+                        HighlightMemberOverrides = configuration.IsOptionSet(DiffConfigurationOptions.HightlightMemberOverrides) || configuration.IsOptionSet(DiffConfigurationOptions.HighlightBaseMembers),
+                        HighlightInterfaceImplementations = configuration.IsOptionSet(DiffConfigurationOptions.HighlightInterfaceImplementations) || configuration.IsOptionSet(DiffConfigurationOptions.HighlightBaseMembers),
                     };
                 default:
                     throw new ArgumentOutOfRangeException("format");
@@ -166,8 +166,8 @@ namespace Microsoft.DotNet.AsmDiff
             var writer = new ApiRecordingCSharpDiffWriter(diffRecorder, mappingSettings, includeAttributes)
             {
                 IncludeAssemblyProperties = configuration.IsOptionSet(DiffConfigurationOptions.DiffAssemblyInfo),
-                HighlightMemberOverrides = configuration.IsOptionSet(DiffConfigurationOptions.HightlightMemberOverrides) || configuration.IsOptionSet(DiffConfigurationOptions.HighlightBasesMembers),
-                HighlightInterfaceImplementations = configuration.IsOptionSet(DiffConfigurationOptions.HighlightInterfaceImplementations) || configuration.IsOptionSet(DiffConfigurationOptions.HighlightBasesMembers),
+                HighlightMemberOverrides = configuration.IsOptionSet(DiffConfigurationOptions.HightlightMemberOverrides) || configuration.IsOptionSet(DiffConfigurationOptions.HighlightBaseMembers),
+                HighlightInterfaceImplementations = configuration.IsOptionSet(DiffConfigurationOptions.HighlightInterfaceImplementations) || configuration.IsOptionSet(DiffConfigurationOptions.HighlightBaseMembers),
             };
 
             WriteDiff(configuration, writer);

--- a/src/Microsoft.DotNet.AsmDiff/MarkdownDiffExporter.cs
+++ b/src/Microsoft.DotNet.AsmDiff/MarkdownDiffExporter.cs
@@ -235,6 +235,15 @@ namespace Microsoft.DotNet.AsmDiff
         private readonly string[] _skippableAttributes = new[]
         {
             "System.AttributeUsageAttribute",
+            "System.ComponentModel.DefaultEventAttribute",
+            "System.ComponentModel.DefaultPropertyAttribute",
+            "System.ComponentModel.DesignerAttribute",
+            "System.ComponentModel.DesignTimeVisibleAttribute",
+            "System.ComponentModel.EditorAttribute",
+            "System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute",
+            "System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute",
+            "System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute",
+            "System.Runtime.CompilerServices.AsyncStateMachineAttribute",
             "System.Runtime.CompilerServices.CompilerGeneratedAttribute",
             "System.Runtime.CompilerServices.NullableAttribute",
             "System.Runtime.CompilerServices.NullableContextAttribute"
@@ -247,13 +256,13 @@ namespace Microsoft.DotNet.AsmDiff
         public bool Include(ITypeDefinitionMember member) => true;
         public bool Include(ICustomAttribute attribute)
         {
-            if (!_includeAttributes)
+            if (!_includeAttributes || attribute == null || attribute.Type == null)
             {
                 return false;
             }
 
             string name = attribute.Type.ToString();
-            return !_skippableAttributes.Contains(name);
+            return name != null && !_skippableAttributes.Contains(name);
         }
     }
 }

--- a/src/Microsoft.DotNet.AsmDiff/MarkdownDiffExporter.cs
+++ b/src/Microsoft.DotNet.AsmDiff/MarkdownDiffExporter.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.AsmDiff
         private readonly string _path;
         private readonly bool _includeTableOfContents;
         private readonly bool _createFilePerNamespace;
-        private readonly MarkdownDiffExporterAttributesFilter _attributesFilter;
+        private readonly ICciFilter _attributesFilter;
 
         public MarkdownDiffExporter(DiffDocument diffDocument, string path, bool includeTableOfContents, bool createFilePerNamespace, bool includeAttributes)
         {
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.AsmDiff
             _path = path;
             _includeTableOfContents = includeTableOfContents;
             _createFilePerNamespace = createFilePerNamespace;
-            _attributesFilter = new MarkdownDiffExporterAttributesFilter(includeAttributes);
+            _attributesFilter = new DiffCciFilter(includeAttributes);
         }
 
         public void Export()
@@ -229,40 +229,25 @@ namespace Microsoft.DotNet.AsmDiff
         }
     }
 
-    internal sealed class MarkdownDiffExporterAttributesFilter : ICciFilter
-    {
-        private readonly bool _includeAttributes;
-        private readonly string[] _skippableAttributes = new[]
-        {
-            "System.AttributeUsageAttribute",
-            "System.ComponentModel.DefaultEventAttribute",
-            "System.ComponentModel.DefaultPropertyAttribute",
-            "System.ComponentModel.DesignerAttribute",
-            "System.ComponentModel.DesignTimeVisibleAttribute",
-            "System.ComponentModel.EditorAttribute",
-            "System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute",
-            "System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute",
-            "System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute",
-            "System.Runtime.CompilerServices.AsyncStateMachineAttribute",
-            "System.Runtime.CompilerServices.CompilerGeneratedAttribute",
-            "System.Runtime.CompilerServices.NullableAttribute",
-            "System.Runtime.CompilerServices.NullableContextAttribute"
-        };
+    //internal sealed class MarkdownDiffExporterAttributesFilter : ICciFilter
+    //{
+    //    private readonly bool _includeAttributes;
+        
 
-        internal MarkdownDiffExporterAttributesFilter(bool includeAttributes) => _includeAttributes = includeAttributes;
+    //    internal MarkdownDiffExporterAttributesFilter(bool includeAttributes) => _includeAttributes = includeAttributes;
 
-        public bool Include(INamespaceDefinition ns) => true;
-        public bool Include(ITypeDefinition type) => true;
-        public bool Include(ITypeDefinitionMember member) => true;
-        public bool Include(ICustomAttribute attribute)
-        {
-            if (!_includeAttributes || attribute == null || attribute.Type == null)
-            {
-                return false;
-            }
+    //    public bool Include(INamespaceDefinition ns) => true;
+    //    public bool Include(ITypeDefinition type) => true;
+    //    public bool Include(ITypeDefinitionMember member) => true;
+    //    public bool Include(ICustomAttribute attribute)
+    //    {
+    //        if (!_includeAttributes || attribute == null || attribute.Type == null)
+    //        {
+    //            return false;
+    //        }
 
-            string name = attribute.Type.ToString();
-            return name != null && !_skippableAttributes.Contains(name);
-        }
-    }
+    //        string name = attribute.Type.ToString();
+    //        return name != null && !_skippableAttributes.Contains(name);
+    //    }
+    //}
 }

--- a/src/Microsoft.DotNet.AsmDiff/MarkdownDiffExporter.cs
+++ b/src/Microsoft.DotNet.AsmDiff/MarkdownDiffExporter.cs
@@ -91,19 +91,19 @@ namespace Microsoft.DotNet.AsmDiff
                 {
                     string fileName = GetFileNameForNamespace(topLevelApi.Name);
                     using (var nestedWriter = new StreamWriter(fileName))
-                        WriteDiffForNamespace(nestedWriter, topLevelApi, isStandalone: true);
+                        WriteDiffForNamespace(nestedWriter, topLevelApi);
                 }
             }
             else
             {
                 foreach (DiffApiDefinition topLevelApi in _diffDocument.ApiDefinitions)
                 {
-                    WriteDiffForNamespace(writer, topLevelApi, isStandalone: false);
+                    WriteDiffForNamespace(writer, topLevelApi);
                 }
             }
         }
 
-        private void WriteDiffForNamespace(StreamWriter writer, DiffApiDefinition topLevelApi, bool isStandalone)
+        private void WriteDiffForNamespace(StreamWriter writer, DiffApiDefinition topLevelApi)
         {
             string heading = _createFilePerNamespace ? "#" : "##";
             writer.WriteLine(heading + " " + topLevelApi.Name);

--- a/src/Microsoft.DotNet.AsmDiff/Program.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Program.cs
@@ -42,6 +42,10 @@ namespace Microsoft.DotNet.AsmDiff
         public bool AlwaysDiffMembers { get; set; }
         [Option("-hbm|--HighlightBaseMembers", "Highlight members that are interface implementations or overrides of a base member.", CommandOptionType.NoValue)]
         public bool HighlightBaseMembers { get; set; }
+        [Option("-hmo|--HighlightMemberOverrides", "Highlight members that are overrides of a base member.", CommandOptionType.NoValue)]
+        public bool HighlightMemberOverrides { get; set; }
+        [Option("-hii|--HighlightInterfaceImplementations", "Highlight members that are explicit interface implementations.", CommandOptionType.NoValue)]
+        public bool HighlightInterfaceImplementations { get; set; }
 
         [Option("-ft|--FlattenTypes", "Will flatten types so that all members available on the type show on the type not just the implemented ones.", CommandOptionType.NoValue)]
         public bool FlattenTypes { get; set; }
@@ -54,7 +58,7 @@ namespace Microsoft.DotNet.AsmDiff
         [Option("-iia|--IncludeInternalApis", "Include internal types and members as part of the diff.", CommandOptionType.NoValue)]
         public bool IncludeInternalApis { get; set; }
         [Option("-ipa|--IncludePrivateApis", "Include private types and members as part of the diff.", CommandOptionType.NoValue)]
-        public bool IncludePrivateApis { get; set; }        
+        public bool IncludePrivateApis { get; set; }
         
         [Option("-itc|--IncludeTableOfContents", "Include table of contents as part of the diff.", CommandOptionType.NoValue)]
         public bool IncludeTableOfContents { get; set; }
@@ -147,7 +151,18 @@ namespace Microsoft.DotNet.AsmDiff
                 result |= DiffConfigurationOptions.GroupByAssembly;
 
             if (HighlightBaseMembers)
-                result |= DiffConfigurationOptions.HighlightBaseMembers;
+            {
+                result |= DiffConfigurationOptions.HightlightMemberOverrides;
+                result |= DiffConfigurationOptions.HighlightInterfaceImplementations;
+            }
+            else
+            {
+                if (HighlightMemberOverrides)
+                    result |= DiffConfigurationOptions.HightlightMemberOverrides;
+
+                if (HighlightInterfaceImplementations)
+                    result |= DiffConfigurationOptions.HighlightInterfaceImplementations;
+            }
 
             if (DiffAssemblyInfo)
                 result |= DiffConfigurationOptions.DiffAssemblyInfo;

--- a/src/Microsoft.DotNet.AsmDiff/Program.cs
+++ b/src/Microsoft.DotNet.AsmDiff/Program.cs
@@ -110,7 +110,8 @@ namespace Microsoft.DotNet.AsmDiff
             if (diffFormat == DiffFormat.Md)
             {
                 DiffDocument diffDocument = DiffEngine.BuildDiffDocument(diffConfiguration);
-                var markdownDiffExporter = new MarkdownDiffExporter(diffDocument, OutFile, IncludeTableOfContents, CreateFilePerNamespace);
+                bool includeAttributes = diffConfiguration.IsOptionSet(DiffConfigurationOptions.DiffAttributes);
+                var markdownDiffExporter = new MarkdownDiffExporter(diffDocument, OutFile, IncludeTableOfContents, CreateFilePerNamespace, includeAttributes);
                 markdownDiffExporter.Export();
             }
             else

--- a/src/Microsoft.DotNet.AsmDiff/README.md
+++ b/src/Microsoft.DotNet.AsmDiff/README.md
@@ -21,6 +21,8 @@ AsmDiff is a command line tool which may be used to check the API changes betwee
 - `-dai|--DiffAssemblyInfo` - Enables diffing of the assembly level information like version, key, etc.
 - `-adm|--AlwaysDiffMembers` - By default if an entire class is added or removed we don't show the members, setting this option forces all the members to be shown instead.
 - `-hbm|--HighlightBaseMembers` - Highlight members that are interface implementations or overrides of a base member.
+- `-hmo|--HighlightMemberOverrides` - Highlight members that are overrides of a base member.
+- `-hii|--HighlightInterfaceImplementations` - Highlight members that are explicit interface implementations.
 - `-ft|--FlattenTypes` - Will flatten types so that all members available on the type show on the type not just the implemented ones.
 - `-gba|--GroupByAssembly` - Group the differences by assembly instead of flattening the namespaces.
 - `-eat|--ExcludeAddedTypes` - Do not show types that have been added to the new set of types.


### PR DESCRIPTION
- Explicit Interface Implementations were unnecessarily showing up as diffs, because the tool was printing the full name of return types and variables on one side, but not on the other, specifically affecting nullable types. ~This was fixed by checking that the return value for `GetExplicitInterfaceMethodNullableAttributeArgument`, which was being stored as an `object`, could be successfully casted to an `int`.~ Tanner's latest changes fixed this.
-  One CLI argument that grouping two options that should be separate, into a single one: Highlighting base member overrides, and highlighting explicit interface implementations. This was fixed by splitting this option into two, but at the same time preserving the old CLI argument, to prevent breaking any users of that option. With this change, we could ignore EIIs in the API diff, but still show base member override changes.
- Added a commit to fix the bug preventing attribute decorators from showing up in the diff.
- Added some minor fixes for unused stuff and ambiguous type names.