### PR TITLE
Use normal message importance for the send to helix call

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
@@ -264,7 +264,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                 Log.LogMessage(MessageImportance.High, $"Sending Job to {TargetQueue}...");
                 cancellationToken.ThrowIfCancellationRequested();
                 // LogMessageFromText will take any string formatted as a canonical error or warning and convert the type of log to this
-                ISentJob job = await def.SendAsync(msg => Log.LogMessageFromText(msg, MessageImportance.High), cancellationToken);
+                ISentJob job = await def.SendAsync(msg => Log.LogMessageFromText(msg, MessageImportance.Normal), cancellationToken);
                 JobCorrelationId = job.CorrelationId;
                 JobCancellationToken = job.HelixCancellationToken;
                 ResultsContainerUri = job.ResultsContainerUri;


### PR DESCRIPTION
Follow up from https://github.com/dotnet/arcade/pull/8426 .   We didn't need the high importance, we just need to translate errors and warnings to the right type. 

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
