### PR TITLE
Reset current directory

### DIFF
--- a/src/Microsoft.DotNet.RemoteExecutor/src/Program.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/Program.cs
@@ -95,6 +95,10 @@ namespace Microsoft.DotNet.RemoteExecutor
             }
             finally
             {
+                // We have seen cases where current directory holds a handle to a directory
+                // for a period after RemoteExecutor exits, preventing that directory being
+                // deleted. Tidy up by resetting it to the temp path.
+                Directory.SetCurrentDirectory(Path.GetTempPath());
                 (instance as IDisposable)?.Dispose();
             }
 


### PR DESCRIPTION
Reset current directory just before terminating the RemoteExecutor process, as we've seen cases where the handle to it isn't immediately released, which prevents deleting the test directory a moment later.

Context https://github.com/dotnet/runtime/pull/68522