### PR TITLE
Fix collection of emulator boot logs

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-processor.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-processor.py
@@ -142,14 +142,14 @@ def analyze_operation(command: str, platform: str, device: str, is_device: bool,
                 if os.name != 'nt':
                     # This is where Azure stores logs from custom extension script runs
                     # More details here https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/custom-script-linux#troubleshooting
-                    boot_log_file = '/var/lib/waagent/custom-script/download'
+                    boot_log_location = '/var/lib/waagent/custom-script/download'
 
-                    print(f'    Collecting emulator boot logs from {boot_log_file}..')
+                    print(f'    Collecting emulator boot logs from {boot_log_location}..')
                     boot_log_destination = output_directory + '/emulator_logs'
 
                     # Only copy stdout/stderr files (however they might be in different folders based on how Azure executed extension scripts)
                     subprocess.call(['sudo', 'rsync', '--recursive', '--include', 'stdout', '--include', 'stderr', '--filter', '-! */',
-                        '/var/lib/waagent/custom-script/download', boot_log_destination])
+                        boot_log_location, boot_log_destination])
 
                     # The logs are sometimes owned by root
                     subprocess.call(['sudo', 'chmod', '-R', '777', boot_log_destination])

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-processor.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-processor.py
@@ -151,7 +151,7 @@ def analyze_operation(command: str, platform: str, device: str, is_device: bool,
                     subprocess.call(['sudo', 'rsync', '--recursive', '--include', 'stdout', '--include', 'stderr', '--filter', '-! */',
                         boot_log_location, boot_log_destination])
 
-                    # The logs are sometimes owned by root
+                    # The boot logs are owned by root, so make them readable for the Helix agent
                     subprocess.call(['sudo', 'chmod', '-R', '777', boot_log_destination])
 
             retry = True

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-processor.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-processor.py
@@ -129,8 +129,7 @@ def analyze_operation(command: str, platform: str, device: str, is_device: bool,
     reboot_message = 'This machine will reboot to heal.'
 
     if platform == "android":
-        # TODO (https://github.com/dotnet/xharness/pull/825): 85 is old code for ADB_DEVICE_ENUMERATION_FAILURE and will be removed after it has been flown everywhere
-        if exit_code == 81 or exit_code == 85: # DEVICE_NOT_FOUND
+        if exit_code == 81: # DEVICE_NOT_FOUND
             # This handles issues where emulators fail to start or devices go silent.
             print(f'    Encountered DEVICE_NOT_FOUND. {retry_message} {reboot_message}')
             print('    If this occurs repeatedly, please check for architectural mismatch, e.g. sending arm64_v8a APKs to an x86_64 / x86 only queue.')
@@ -138,13 +137,22 @@ def analyze_operation(command: str, platform: str, device: str, is_device: bool,
             if not is_device:
                 # For emulators it makes sense to reboot to try to heal the emulator
                 reboot = True
-                
-                if os.name != 'nt' and os.path.isdir('/var/lib/waagent/custom-script/download'):
-                    # We also attach logs from the emulator boot
-                    subprocess.call(['sudo', 'rsync', '--recursive', '--include', 'stdout', '--include', 'stderr', '--filter', "'-! */'",
-                        '/var/lib/waagent/custom-script/download',
-                        '$HELIX_WORKITEM_UPLOAD_ROOT/emulator_logs'])
-                    subprocess.call(['sudo', 'chmod', '-R', '777', '$HELIX_WORKITEM_UPLOAD_ROOT/emulator_logs'])
+
+                # We also attach logs from the emulator boot (which might tell us why there's no emulator)
+                if os.name != 'nt':
+                    # This is where Azure stores logs from custom extension script runs
+                    # More details here https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/custom-script-linux#troubleshooting
+                    boot_log_file = '/var/lib/waagent/custom-script/download'
+
+                    print(f'    Collecting emulator boot logs from {boot_log_file}..')
+                    boot_log_destination = output_directory + '/emulator_logs'
+
+                    # Only copy stdout/stderr files (however they might be in different folders based on how Azure executed extension scripts)
+                    subprocess.call(['sudo', 'rsync', '--recursive', '--include', 'stdout', '--include', 'stderr', '--filter', '-! */',
+                        '/var/lib/waagent/custom-script/download', boot_log_destination])
+
+                    # The logs are sometimes owned by root
+                    subprocess.call(['sudo', 'chmod', '-R', '777', boot_log_destination])
 
             retry = True
             return


### PR DESCRIPTION
This is a fix of #9211 where sometimes the whole path is owned by root and the `is_dir` fails so no logs are copied.

Also adds more comments to explain what is going on and why

Example result: https://helix.dot.net/api/jobs/d0e6441e-7edb-45de-a9b7-6f601704afc7/workitems/System.Buffers.Tests-x64?api-version=2019-06-17
