### PR TITLE
Define TestPlatforms.LinuxBionic, for headless Android use

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
@@ -28,6 +28,7 @@ namespace Microsoft.DotNet.XUnitExtensions
                 (platforms.HasFlag(TestPlatforms.iOS) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS")) && !RuntimeInformation.IsOSPlatform(OSPlatform.Create("MACCATALYST"))) ||
                 (platforms.HasFlag(TestPlatforms.tvOS) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS"))) ||
                 (platforms.HasFlag(TestPlatforms.MacCatalyst) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("MACCATALYST"))) ||
+                (platforms.HasFlag(TestPlatforms.LinuxBionic) && RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) && !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("ANDROID_STORAGE")) ||
                 (platforms.HasFlag(TestPlatforms.Android) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"))) ||
                 (platforms.HasFlag(TestPlatforms.Browser) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"))) ||
                 (platforms.HasFlag(TestPlatforms.Windows) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows));

--- a/src/Microsoft.DotNet.XUnitExtensions/src/TestPlatforms.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/TestPlatforms.cs
@@ -20,7 +20,8 @@ namespace Xunit
         Android = 512,
         Browser = 1024,
         MacCatalyst = 2048,
-        AnyUnix = FreeBSD | Linux | NetBSD | OSX | illumos | Solaris | iOS | tvOS | MacCatalyst | Android | Browser,
+        LinuxBionic = 4096,
+        AnyUnix = FreeBSD | Linux | NetBSD | OSX | illumos | Solaris | iOS | tvOS | MacCatalyst | Android | Browser | LinuxBionic,
         Any = ~0
     }
 }


### PR DESCRIPTION
We have an internal custom who needs support for devices with an Android kernel and libc, but no Android UI (and no Android JNI). We need to be able to treat this as Linux in most cases, but Android in a few edge cases.

We're claiming to be Linux in RuntimeInformation (since we mostly are), so here we check "if you claim to be Linux, but also have this Android-only environment variable set, then that probably means you're Linux Bionic" - which enables us to skip tests on this configuration without skipping Linux entirely.