### PR TITLE
Relese 6.0 - Bump LZMA-SDK version to solve CG warning

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
+++ b/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
@@ -15,7 +15,7 @@
     <IsTool>true</IsTool>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="LZMA-SDK" Version="18.1.0" />
+    <PackageReference Include="LZMA-SDK" Version="19.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.OLE.Interop" Version="7.10.6071" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="NuGet.Common" Version="4.7.0" />


### PR DESCRIPTION
Port https://github.com/dotnet/arcade/pull/7976 to release 6.0 to solve CG warnings

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
