### PR TITLE
API Compat fixes

### DIFF
--- a/src/Microsoft.Cci.Extensions/HostEnvironment.cs
+++ b/src/Microsoft.Cci.Extensions/HostEnvironment.cs
@@ -244,6 +244,7 @@ namespace Microsoft.Cci.Extensions
         private AssemblyIdentity ResolveCoreAssemblyIdentity(IAssembly assembly)
         {
             AssemblyIdentity coreIdentity = assembly.CoreAssemblySymbolicIdentity;
+            HashSet<AssemblyIdentity> consideredIdentities = new HashSet<AssemblyIdentity>();
 
             // Try to find the assembly which believes itself is the core assembly
             while (!assembly.AssemblyIdentity.Equals(coreIdentity))
@@ -251,18 +252,25 @@ namespace Microsoft.Cci.Extensions
                 // CCI may not be able to identify the core assembly if no types are referenced
                 if (coreIdentity == Dummy.AssemblyIdentity)
                 {
-                    // try the first referenced assembly and walk down from there.
-                    coreIdentity = assembly.AssemblyReferences.FirstOrDefault()?.AssemblyIdentity;
+                    // try the first referenced assembly we haven't already checked and walk down from there.
+                    coreIdentity = assembly.AssemblyReferences
+                        .Select(ar => ar.AssemblyIdentity)
+                        .FirstOrDefault(ai => !consideredIdentities.Contains(ai));
                 }
 
-                if (coreIdentity == null)
+                // if we couldn't find a new identity to try, or we've already tried this identity, give up
+                if (coreIdentity == null || consideredIdentities.Contains(coreIdentity))
                 {
                     return null;
                 }
 
+                // track all considered identities, this will prevent us from entering a cycle
+                consideredIdentities.Add(coreIdentity);
+
+                // unify to the version of the identify found in our paths
                 coreIdentity = ProbeLibPaths(coreIdentity);
 
-                // push down until we can find an assembly that is the core assembly
+                // load it to see which assembly it believes to be the core
                 assembly = LoadAssembly(coreIdentity);
 
                 if (assembly == null || assembly == Dummy.Assembly)

--- a/src/Microsoft.Cci.Extensions/HostEnvironment.cs
+++ b/src/Microsoft.Cci.Extensions/HostEnvironment.cs
@@ -248,7 +248,14 @@ namespace Microsoft.Cci.Extensions
             // Try to find the assembly which believes itself is the core assembly
             while (!assembly.AssemblyIdentity.Equals(coreIdentity))
             {
-                if (coreIdentity == null || coreIdentity == Dummy.AssemblyIdentity)
+                // CCI may not be able to identify the core assembly if no types are referenced
+                if (coreIdentity == Dummy.AssemblyIdentity)
+                {
+                    // try the first referenced assembly and walk down from there.
+                    coreIdentity = assembly.AssemblyReferences.FirstOrDefault()?.AssemblyIdentity;
+                }
+
+                if (coreIdentity == null)
                 {
                     return null;
                 }

--- a/src/Microsoft.DotNet.ApiCompat/src/ApiCompatTask.cs
+++ b/src/Microsoft.DotNet.ApiCompat/src/ApiCompatTask.cs
@@ -207,6 +207,12 @@ namespace Microsoft.DotNet.ApiCompat
                 ExcludeAttributes,
                 AllowDefaultInterfaceMethods);
 
+            // If the tool exited cleanly, but logged errors then assign a failing exit code (-1)
+            if (ExitCode == 0 && Log.HasLoggedErrors)
+            {
+                ExitCode = -1;
+            }
+
             return IgnoreExitCode || ExitCode == 0;
         }
     }


### PR DESCRIPTION
This addresses two problems with API compat.  Fixes dotnet/runtime#68699

The first issue is that the task would never fail the build, even when it had errors.  This happened due to the task refactoring where it lost functionality provided by the exec task which would change the error code to -1 if the task logged errors but otherwise returned 0.  I just copied that from ToolTask:
https://github.com/dotnet/msbuild/blob/10dbde3bf1986251a5e958af8c7391ad0d9e7f11/src/Utilities/ToolTask.cs#L761-L765

The second issue is that the task failed when consuming the System.Runtime facade and running on .NETFramework.  Details are in the linked issue.  I considered actually looking for the System.Object typeforward and following that but resolving TypeForwards in CCI actually requires this same code-path, which caused this to be re-entrant.  I was able to workaround that by capturing state to determine when the method was re-entrant but that complicated the solution.  Instead I chose to go with a simpler heuristic -> just push down into the references of the assembly.  This will eventually find an assembly that defines System.Object.

There is the chance that this hits a cycle.  For example if someone had a `System.Runtime` facade with all typeforwards to `mscorlib` and an `mscorlib` with all typeforwards to `System.Runtime`.  Previously we'd just bail from this loop and fallback to corelib used by CCI (since CCI didn't understand full facades).  I didn't hit this in my testing but I can't abide leaving it since anyone hitting it would see a hang, so I also added a check for this and preserved the old behavior.