### PR TITLE
Add ability to trigger Tools.proj SetUpSourceBuildIntermediateNupkgCache target

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
@@ -12,8 +12,9 @@
 
   <Target Name="CollectSourceBuildIntermediateNupkgDependencies"
           Condition="
-            '$(ArcadeBuildFromSource)' == 'true' and
-            '$(ArcadeInnerBuildFromSource)' == 'true'"
+            ('$(ArcadeBuildFromSource)' == 'true' and
+              '$(ArcadeInnerBuildFromSource)' == 'true') or
+            '$(SetUpSourceBuildIntermediateNupkgCache)' == 'true'"
           DependsOnTargets="GetSourceBuildIntermediateNupkgNameConvention"
           BeforeTargets="CollectPackageReferences">
     <ReadSourceBuildIntermediateNupkgDependencies
@@ -30,9 +31,10 @@
 
   <Target Name="SetUpSourceBuildIntermediateNupkgCache"
           Condition="
-            '$(ArcadeBuildFromSource)' == 'true' and
-            '$(ArcadeInnerBuildFromSource)' == 'true' and
-            '@(SourceBuildIntermediateNupkgReference)' != ''"
+            ('$(ArcadeBuildFromSource)' == 'true' and
+              '$(ArcadeInnerBuildFromSource)' == 'true' and
+              '@(SourceBuildIntermediateNupkgReference)' != '') or
+            '$(SetUpSourceBuildIntermediateNupkgCache)' == 'true'"
           AfterTargets="Restore">
     <PropertyGroup>
       <SourceBuiltNupkgCacheDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsObjDir)', 'source-built-upstream-cache'))</SourceBuiltNupkgCacheDir>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -51,7 +51,7 @@
     <Exec Command='"$(DotNetTool)" tool restore' WorkingDirectory="$(RepoRoot)" />
   </Target>
 
-  <Import Project="SourceBuild/SourceBuildArcadeTools.targets" Condition="'$(ArcadeBuildFromSource)' == 'true'" />
+  <Import Project="SourceBuild/SourceBuildArcadeTools.targets" Condition="'$(ArcadeBuildFromSource)' == 'true' or '$(SetUpSourceBuildIntermediateNupkgCache)' == 'true'" />
 
   <!-- Repository extensibility point -->
   <Import Project="$(RepositoryEngineeringDir)Tools.props" Condition="Exists('$(RepositoryEngineeringDir)Tools.props')" />


### PR DESCRIPTION
This is needed for dotnet/source-build-reference-packages to be able trigger the SetUpSourceBuildIntermediateNupkgCache explicitly in order to fix https://github.com/dotnet/source-build/issues/2840.
