### PR TITLE
Ensure op_CheckedExplicit is correctly handled

### DIFF
--- a/src/Microsoft.Cci.Extensions/Extensions/CSharp/CSharpCciExtensions.cs
+++ b/src/Microsoft.Cci.Extensions/Extensions/CSharp/CSharpCciExtensions.cs
@@ -217,8 +217,13 @@ namespace Microsoft.Cci.Extensions.CSharp
 
         public static bool IsConversionOperator(this IMethodDefinition method)
         {
-            return (method.IsSpecialName &&
-                (method.Name.Value == "op_Explicit" || method.Name.Value == "op_Implicit"));
+            if (method.IsSpecialName)
+            {
+                return (method.Name.Value == "op_CheckedExplicit")
+                    || (method.Name.Value == "op_Explicit")
+                    || (method.Name.Value == "op_Implicit");
+            }
+            return false;
         }
 
         public static bool IsExplicitInterfaceMember(this ITypeDefinitionMember member)

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Cci.Writers.CSharp
                 case "op_CheckedSubtraction": return "operator checked -";
                 case "op_CheckedMultiply": return "operator checked *";
                 case "op_CheckedDivision": return "operator checked /";
-                case "op_CheckedExplicit": return "explicit checked operator";
+                case "op_CheckedExplicit": return "explicit operator checked";
                 default: return name.Value; // return just the name
             }
         }
@@ -178,7 +178,7 @@ namespace Microsoft.Cci.Writers.CSharp
                 WriteTypeName(method.Type, method.ContainingType, methodNullableContextValue: nullableContextValue);
             }
 
-            Contract.Assert(!(method is IGenericMethodInstance), "Currently don't support generic method instances");
+            Contract.Assert(method is not IGenericMethodInstance, "Currently don't support generic method instances");
             if (method.IsGeneric)
                 WriteGenericParameters(method.GenericParameters);
 


### PR DESCRIPTION
`IsConversionOperator` wasn't handled `op_CheckedExplicit` and the ordering of the keywords was incorrect.

CC. @ericstj, @ViktorHofer 