### PR TITLE
Set more aggressive timeouts for XHarness E2E tests

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAndroidWorkItemsTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAndroidWorkItemsTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             var workItem = _task.WorkItems.First();
             workItem.GetMetadata("Identity").Should().Be("System.Foo");
-            workItem.GetMetadata("Timeout").Should().Be("00:16:02");
+            workItem.GetMetadata("Timeout").Should().Be("00:16:42");
 
             var payloadArchive = workItem.GetMetadata("PayloadArchive");
             payloadArchive.Should().NotBeNullOrEmpty();
@@ -178,7 +178,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             var workItem = _task.WorkItems.First();
             workItem.GetMetadata("Identity").Should().Be("System.Foo");
-            workItem.GetMetadata("Timeout").Should().Be("00:16:02");
+            workItem.GetMetadata("Timeout").Should().Be("00:16:42");
 
             var payloadArchive = workItem.GetMetadata("PayloadArchive");
             payloadArchive.Should().NotBeNullOrEmpty();

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAppleWorkItemsTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAppleWorkItemsTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             var workItem = _task.WorkItems.First();
             workItem.GetMetadata("Identity").Should().Be("System.Foo");
-            workItem.GetMetadata("Timeout").Should().Be("00:16:02");
+            workItem.GetMetadata("Timeout").Should().Be("00:16:42");
 
             var payloadArchive = workItem.GetMetadata("PayloadArchive");
             payloadArchive.Should().NotBeNullOrEmpty();
@@ -230,7 +230,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             var workItem = _task.WorkItems.First();
             workItem.GetMetadata("Identity").Should().Be("System.Foo");
-            workItem.GetMetadata("Timeout").Should().Be("00:16:02");
+            workItem.GetMetadata("Timeout").Should().Be("00:16:42");
 
             var payloadArchive = workItem.GetMetadata("PayloadArchive");
             payloadArchive.Should().NotBeNullOrEmpty();

--- a/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Helix.Sdk
     {
         private static readonly TimeSpan s_defaultWorkItemTimeout = TimeSpan.FromMinutes(20);
         private static readonly TimeSpan s_defaultTestTimeout = TimeSpan.FromMinutes(12);
-        protected static readonly TimeSpan s_telemetryBuffer = TimeSpan.FromSeconds(20); // extra time to send the XHarness telemetry
+        protected static readonly TimeSpan s_telemetryBuffer = TimeSpan.FromSeconds(60); // extra time to send the XHarness telemetry
 
         public class MetadataName
         {

--- a/tests/XHarness/XHarness.Apple.Simulator.CustomCommands.proj
+++ b/tests/XHarness/XHarness.Apple.Simulator.CustomCommands.proj
@@ -23,7 +23,7 @@
         <TestTarget>ios-simulator-64</TestTarget>
         <WorkItemTimeout>00:15:00</WorkItemTimeout>
         <TestTimeout>00:05:00</TestTimeout>
-        <LaunchTimeout>00:05:00</LaunchTimeout>
+        <LaunchTimeout>00:03:30</LaunchTimeout>
         <CustomCommands>
           <![CDATA[
           set -ex

--- a/tests/XHarness/XHarness.Apple.Simulator.Run.proj
+++ b/tests/XHarness/XHarness.Apple.Simulator.Run.proj
@@ -22,7 +22,8 @@
       <XHarnessAppBundleToTest Include="$(ArtifactsTmpDir)XHarness.RunAppBundle/$(XHarnessRunAppBundleName)">
         <TestTarget>ios-simulator-64</TestTarget>
         <WorkItemTimeout>00:12:00</WorkItemTimeout>
-        <TestTimeout>00:08:00</TestTimeout>
+        <TestTimeout>00:05:00</TestTimeout>
+        <LaunchTimeout>00:03:30</LaunchTimeout>
         <IncludesTestRunner>false</IncludesTestRunner>
         <ExpectedExitCode>200</ExpectedExitCode>
       </XHarnessAppBundleToTest>

--- a/tests/XHarness/XHarness.Apple.Simulator.Test.proj
+++ b/tests/XHarness/XHarness.Apple.Simulator.Test.proj
@@ -22,6 +22,7 @@
       <XHarnessAppBundleToTest Include="$(ArtifactsTmpDir)XHarness.TestAppBundle/$(XHarnessTestAppBundleName)">
         <TestTarget>ios-simulator-64</TestTarget>
         <TestTimeout>00:05:00</TestTimeout>
+        <LaunchTimeout>00:03:30</LaunchTimeout>
         <WorkItemTimeout>00:15:00</WorkItemTimeout>
       </XHarnessAppBundleToTest>
     </ItemGroup>


### PR DESCRIPTION
Same as https://github.com/dotnet/xharness/pull/880