### PR TITLE
Don't skip ProjectReferences silently in TFM.SDK

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
@@ -14,8 +14,7 @@
              Targets="GetTargetFrameworks"
              BuildInParallel="$(BuildInParallel)"
              RemoveProperties="TargetFramework;RuntimeIdentifier"
-             Condition="'%(ProjectReference.SkipGetTargetFrameworkProperties)' != 'true'"
-             SkipNonexistentTargets="true">
+             Condition="'%(ProjectReference.SkipGetTargetFrameworkProperties)' != 'true'">
       <Output TaskParameter="TargetOutputs" ItemName="_ProjectReferenceWithTargetFrameworks" />
     </MSBuild>
 


### PR DESCRIPTION
ProjectReferences that don't have the `GetTargetFrameworks` target shouldn't be silently skipped. Instead an error should be thrown if the target doesn't exist. Helps with avoiding issues like https://github.com/dotnet/runtime/issues/69139 in the future. I tested this on top of a dotnet/runtime build and it works as expected with the libraries linker change that I'm making to fix the tests.