### PR TITLE
Make sbom generation optional in repos that insert to VS (PR builds)

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.InsertionManifests.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.InsertionManifests.targets
@@ -7,7 +7,12 @@
 <!--
   Before pack create the SBOM here
 -->
-  <Target Name ="GenerateSbomForVSInsertion">
+ <PropertyGroup>
+    <GenerateSbom Condition="'$(GenerateSbom)' == ''">false</GenerateSbom>
+  </PropertyGroup>
+
+  <Target Name ="GenerateSbomForVSInsertion" 
+          Condition="'$(GenerateSbom)' != 'false'">
     <Message Text="Generating SBOM manifest" Importance="high"/>
     <ItemGroup>
      <VsixFile Include="$(ArtifactsDir)VSSetup\$(Configuration)\Insertion\*.vsix"></VsixFile>


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation

Test build -> https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6140675&view=logs&j=4032467e-dc57-5727-0bde-0b3f32a19231&t=d467e7d5-e028-5fd4-b25f-2746de72cefc

(Here Build passed and created VS manifest and did not create SBOM)