### PR TITLE
Governance compliance 3.x - Remove Microsoft.VisualStudio.Web.CodeGeneration.Design dependency

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -73,7 +73,6 @@
     <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>2.1.30</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
     <MicrosoftDotNetGitHubIssueLabelerAssetsVersion>1.4.0</MicrosoftDotNetGitHubIssueLabelerAssetsVersion>
     <MicrosoftMLVersion>1.0.0</MicrosoftMLVersion>
-    <MicrosoftVisualStudioWebCodeGenerationDesignVersion>2.1.10</MicrosoftVisualStudioWebCodeGenerationDesignVersion>
     <MicrosoftDiaSymReaderConverterVersion>1.1.0-beta2-19521-03</MicrosoftDiaSymReaderConverterVersion>
     <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta2-19521-03</MicrosoftDiaSymReaderPdb2PdbVersion>
     <MicrosoftDiaSymReaderNativeVersion>1.7.0</MicrosoftDiaSymReaderNativeVersion>

--- a/src/Microsoft.DotNet.Github.IssueLabeler/Microsoft.DotNet.Github.IssueLabeler.csproj
+++ b/src/Microsoft.DotNet.Github.IssueLabeler/Microsoft.DotNet.Github.IssueLabeler.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="$(MicrosoftIdentityModelClientsActiveDirectoryVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCoreAuthenticationJwtBearerVersion)" />
     <PackageReference Include="Microsoft.ML" Version="$(MicrosoftMLVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="$(MicrosoftVisualStudioWebCodeGenerationDesignVersion)" />
     <PackageReference Include="Octokit" Version="$(OctokitVersion)" />
     <PackageReference Include="Microsoft.DotNet.GitHubIssueLabeler.Assets" Version="$(MicrosoftDotNetGitHubIssueLabelerAssetsVersion)" />
     <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/9076

Fixing: https://dev.azure.com/dnceng/internal/_componentGovernance/dotnet-arcade?_a=alerts&typeId=10530823&alerts-view-option=active

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
