### PR TITLE
Expose task assembly when consuming workloads package

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Microsoft.DotNet.Build.Tasks.Workloads.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Microsoft.DotNet.Build.Tasks.Workloads.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>Latest</LangVersion>
     <IsPackable>true</IsPackable>
     <Description>Workload pack installer generation task package</Description>
     <PackageTags>Arcade Build Tool Installer Workloads</PackageTags>
@@ -52,14 +51,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="build/**/*.*" Pack="true">
-      <PackagePath>build</PackagePath>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Remove="obj\**" />
-    <EmbeddedResource Remove="obj\**" />
+    <None Include="build\**\*" Pack="true" PackagePath="%(Identity)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IncludeWiX)' != 'true'">

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/build/Microsoft.DotNet.Build.Tasks.Workloads.props
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/build/Microsoft.DotNet.Build.Tasks.Workloads.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <!-- Workaround for https://github.com/dotnet/arcade/issues/7413 -->
+    <MicrosoftDotNetBuildTasksWorkloadsAssembly Condition="'$(MSBuildRuntimeType)' == 'Core' and Exists('$(MSBuildThisFileDirectory)..\tools\net6.0\')">$(MSBuildThisFileDirectory)..\tools\net6.0\Microsoft.DotNet.Build.Tasks.Workloads.dll</MicrosoftDotNetBuildTasksWorkloadsAssembly>
+    <MicrosoftDotNetBuildTasksWorkloadsAssembly Condition="'$(MSBuildRuntimeType)' == 'Core' and '$(MicrosoftDotNetBuildTasksWorkloadsAssembly)' == ''">$(MSBuildThisFileDirectory)..\tools\netcoreapp3.1\Microsoft.DotNet.Build.Tasks.Workloads.dll</MicrosoftDotNetBuildTasksWorkloadsAssembly>
+    <MicrosoftDotNetBuildTasksWorkloadsAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.DotNet.Build.Tasks.Workloads.dll</MicrosoftDotNetBuildTasksWorkloadsAssembly>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/build/Microsoft.DotNet.Build.Tasks.Workloads.props
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/build/Microsoft.DotNet.Build.Tasks.Workloads.props
@@ -5,4 +5,7 @@
     <MicrosoftDotNetBuildTasksWorkloadsAssembly Condition="'$(MSBuildRuntimeType)' == 'Core' and '$(MicrosoftDotNetBuildTasksWorkloadsAssembly)' == ''">$(MSBuildThisFileDirectory)..\tools\netcoreapp3.1\Microsoft.DotNet.Build.Tasks.Workloads.dll</MicrosoftDotNetBuildTasksWorkloadsAssembly>
     <MicrosoftDotNetBuildTasksWorkloadsAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.DotNet.Build.Tasks.Workloads.dll</MicrosoftDotNetBuildTasksWorkloadsAssembly>
   </PropertyGroup>
+
+  <UsingTask Include="GenerateManifestMsi" AssemblyFile="$(MicrosoftDotNetBuildTasksWorkloadsAssembly)" />
+  <UsingTask Include="GenerateVisualStudioWorkload" AssemblyFile="$(MicrosoftDotNetBuildTasksWorkloadsAssembly)" />
 </Project>


### PR DESCRIPTION
Avoids the hardcoded paths in consuming repositories, i.e. https://github.com/dotnet/runtime/blob/4ecd06037d7dfc5a039911c262ab792d6575d7fc/src/workloads/workloads.csproj#L11-L12

Created the package offline and validated that the contents are in it, as expected. Also cleaned-up unnecessary items/props in the project file.