### PR TITLE
Make sure that projects in packages don't import repository local settings.

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Directory.Build.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Directory.Build.props
@@ -2,6 +2,8 @@
 <Project>
   <!-- This is an empty Directory.Build.props file to prevent projects which reside
        under this directory to use any of the repository local settings. -->
-  <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
-  <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+  <PropertyGroup>
+    <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+  </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Directory.Build.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Directory.Build.props
@@ -1,5 +1,7 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
-  <!-- This is an empty Directory.Build.props file to prevent the Directory.Build.props file from the repo from being used
-       if the toolset package is restored to a subdirectory in the repo -->
+  <!-- This is an empty Directory.Build.props file to prevent projects which reside
+       under this directory to use any of the repository local settings. -->
+  <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
+  <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Directory.Build.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Directory.Build.targets
@@ -1,5 +1,0 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
-<Project>
-  <!-- This is an empty Directory.Build.targets file to prevent the Directory.Build.targets file from the repo from being used
-       if the toolset package is restored to a subdirectory in the repo -->
-</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Directory.Build.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Directory.Build.props
@@ -4,6 +4,7 @@
     <RepoRoot>$([System.IO.Path]::GetFullPath('$(RepoRoot)/'))</RepoRoot>
   </PropertyGroup>
 
+  <Import Project="../Directory.Build.props" />
   <Import Project="../RepoLayout.props"/>
   <Import Project="Versions.props"/>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Directory.Build.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Directory.Build.targets
@@ -1,3 +1,0 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
-<Project>
-</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
@@ -3,6 +3,7 @@
 
   <!-- Shield this project from nonstandard Directory.Build.props/targets. -->
   <PropertyGroup>
+    <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
     <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
     <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
@@ -16,6 +16,7 @@
 
   <PropertyGroup>
     <ResolveNuGetPackages>false</ResolveNuGetPackages>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
     <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
     <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
@@ -16,7 +16,7 @@
 
   <PropertyGroup>
     <ResolveNuGetPackages>false</ResolveNuGetPackages>
-    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+    <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
     <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
     <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/acquisition/Directory.Build.props
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/acquisition/Directory.Build.props
@@ -1,7 +1,11 @@
 <Project>
 
   <!-- Set up build infra for the acquire-* projects. -->
-
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
+  <PropertyGroup>
+    <!--  Prevent projects which reside under this directory to use any of the repository local settings. -->
+    <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
+  </PropertyGroup> 
+  
 </Project>


### PR DESCRIPTION
Replaces https://github.com/dotnet/arcade/pull/9361. For more context see the discussion in https://github.com/dotnet/arcade-services/pull/1892#issuecomment-1126495688.

The Arcade.Sdk and the Installer projects were the only ones that ship projects inside their package. 

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
