### PR TITLE
Backport ArPow infrastructure changes carried in source-build tarball

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
@@ -21,6 +21,9 @@
     <ItemGroup>
       <AllRestoredPackageFiles Include="$(CurrentRepoSourceBuildPackageCache)**/*.nupkg" />
       <SourceBuiltPackageFiles Include="$(CurrentRepoSourceBuiltNupkgCacheDir)**/*.nupkg" />
+      <SourceBuiltPackageFiles Include="$(AdditionalSourceBuiltNupkgCacheDir)**/*.nupkg" Condition=" '$(AdditionalSourceBuiltNupkgCacheDir)' != '' " />
+      <SourceBuiltPackageFiles Include="$(ReferencePackageNupkgCacheDir)**/*.nupkg" Condition=" '$(ReferencePackageNupkgCacheDir)' != '' " />
+      <SourceBuiltPackageFiles Include="$(PreviouslySourceBuiltNupkgCacheDir)**/*.nupkg" Condition=" '$(PreviouslySourceBuiltNupkgCacheDir)' != '' " />
 
       <!-- Add some other potential top-level project directories for a more specific report. -->
       <ProjectDirectories Include="$(CurrentRepoSourceBuildSourceDir)" />
@@ -147,7 +150,7 @@
         SourceBuildArcadeTargetsFile=$(MSBuildThisFileDirectory)SourceBuildArcade.targets;
         SourceBuildIntermediateNupkgLicenseFile=$(SourceBuildIntermediateNupkgLicenseFile);
         "
-      BuildInParallel="true"/>
+      BuildInParallel="false"/>
   </Target>
 
   <Import Project="SourceBuildArcade.targets" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
@@ -89,7 +89,7 @@
       <InnerBuildArgs>$(InnerBuildArgs) /p:EnableSourceControlManagerQueries=false</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) /p:EnableSourceLink=false</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) /p:DeterministicSourcePaths=false</InnerBuildArgs>
-      <InnerBuildArgs >$(InnerBuildArgs) /p:DotNetBuildOffline=true</InnerBuildArgs>
+      <InnerBuildArgs>$(InnerBuildArgs) /p:DotNetBuildOffline=true</InnerBuildArgs>
       <InnerBuildArgs Condition=" '$(DotNetPackageVersionPropsPath)' != '' ">$(InnerBuildArgs) /p:DotNetPackageVersionPropsPath=$(DotNetPackageVersionPropsPath)</InnerBuildArgs>
     </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
@@ -78,6 +78,8 @@
       <InnerBuildArgs>$(InnerBuildArgs) /p:ArtifactsDir=$(CurrentRepoSourceBuildArtifactsDir)</InnerBuildArgs>
       <!-- Set a custom binlog location to avoid clashing over the currenly specified file. -->
       <InnerBuildArgs>$(InnerBuildArgs) /bl:$(CurrentRepoSourceBuildBinlogFile)</InnerBuildArgs>
+      <!-- Flow ContinuousIntegrationBuild to the inner build. -->
+      <InnerBuildArgs Condition="'$(ContinuousIntegrationBuild)' == 'true'">$(InnerBuildArgs) /p:ContinuousIntegrationBuild=true</InnerBuildArgs>
 
       <!-- The inner build needs to reference the overall output dir for nupkg transport etc. -->
       <InnerBuildArgs>$(InnerBuildArgs) /p:SourceBuildOutputDir=$(SourceBuildOutputDir)</InnerBuildArgs>
@@ -87,6 +89,8 @@
       <InnerBuildArgs>$(InnerBuildArgs) /p:EnableSourceControlManagerQueries=false</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) /p:EnableSourceLink=false</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) /p:DeterministicSourcePaths=false</InnerBuildArgs>
+      <InnerBuildArgs >$(InnerBuildArgs) /p:DotNetBuildOffline=true</InnerBuildArgs>
+      <InnerBuildArgs Condition=" '$(DotNetPackageVersionPropsPath)' != '' ">$(InnerBuildArgs) /p:DotNetPackageVersionPropsPath=$(DotNetPackageVersionPropsPath)</InnerBuildArgs>
     </PropertyGroup>
 
     <ItemGroup>
@@ -96,13 +100,36 @@
   </Target>
 
   <!--
+    PrepareInnerSourceBuildRepoRoot either clones the source to the inner repo
+    or copies the source to the inner repo depending on CopySrcInsteadOfClone.
+    Repos take a dependency on PrepareInnerSourceBuildRepoRoot, so this target
+    exists to wait until either the source is cloned or copied.
+  -->
+  <Target Name="PrepareInnerSourceBuildRepoRoot"
+          DependsOnTargets="CopyInnerSourceBuildRepoRoot;CloneInnerSourceBuildRepoRoot">
+  </Target>
+
+  <Target Name="CopyInnerSourceBuildRepoRoot" Condition=" '$(CopySrcInsteadOfClone)' == 'true' ">
+    <ItemGroup>
+      <SourceBuildFilesToCopy Include="$(RepoRoot)/**/*" />
+      <SourceBuildFilesToCopy Include="$(RepoRoot)/**/.*" />
+      <SourceBuildFilesToCopy Remove="$(RepoRoot)/artifacts/**/*" />
+      <SourceBuildFilesToCopy Remove="$(RepoRoot)/artifacts/**/.*" />
+    </ItemGroup>
+
+    <Copy
+      SourceFiles="@(SourceBuildFilesToCopy)"
+      DestinationFolder="$(InnerSourceBuildRepoRoot)%(RecursiveDir)" />
+  </Target>
+
+  <!--
     Clone the repo to a new location. Source-build targets will change the source dynamically.
     Creating a fresh clone avoids overwriting existing work or making subtle changes that might
     accidentally get added to the user's existing work via a 'git add .'. Since the clone also has
     access to the git data, this also makes it easy to see what changes the source-build infra has
     made, for diagnosis or exploratory purposes.
   -->
-  <Target Name="PrepareInnerSourceBuildRepoRoot">
+  <Target Name="CloneInnerSourceBuildRepoRoot" Condition=" '$(CopySrcInsteadOfClone)' != 'true' ">
     <PropertyGroup>
       <!--
         By default, copy WIP. WIP copy helps with local machine dev work. Don't copy WIP if this is


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/2295

These changes are backporting the tarball's [ArcadeOverrides](https://github.com/dotnet/installer/tree/main/src/SourceBuild/tarball/content/ArcadeOverrides) back to Arcade.
