### PR TITLE
Add variable to enable path promotion

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -636,6 +636,7 @@ function InitializeNativeTools() {
       }
     }
     if (Test-Path variable:NativeToolsOnMachine) {
+      Write-Host "Variable NativeToolsOnMachine detected, enabling native tool path promotion..."
       $nativeArgs += @{ PathPromotion = $true }
     }
     & "$PSScriptRoot/init-tools-native.ps1" @nativeArgs

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -635,6 +635,9 @@ function InitializeNativeTools() {
         InstallDirectory = "$ToolsDir"
       }
     }
+    if (Test-Path variable:NativeToolsOnMachine) {
+      $nativeArgs += @{ PathPromotion = $true }
+    }
     & "$PSScriptRoot/init-tools-native.ps1" @nativeArgs
   }
 }


### PR DESCRIPTION
Quick fix to be able to enable path promotion by simply setting a variable rather than having to call the script directly.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
