### PR TITLE
Forward `--launch-timeout` for the `apple run` command

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
@@ -205,11 +205,10 @@ namespace Microsoft.DotNet.Helix.Sdk
             "--output-directory \"$output_directory\" " +
             "--target \"$target\" " +
             "--timeout \"$timeout\" " +
+            "--launch-timeout \"$launch_timeout\" " +
             "--xcode \"$xcode_path\" " +
             "-v " +
-            (includesTestRunner
-                ? $"--launch-timeout \"$launch_timeout\" "
-                : $"--expected-exit-code $expected_exit_code ") +
+            (!includesTestRunner ? "--expected-exit-code $expected_exit_code " : string.Empty) +
             (resetSimulator ? $"--reset-simulator " : string.Empty) +
             (!string.IsNullOrEmpty(AppArguments) ? "-- " + AppArguments : string.Empty);
 

--- a/tests/XHarness/XHarness.Apple.Simulator.CustomCommands.proj
+++ b/tests/XHarness/XHarness.Apple.Simulator.CustomCommands.proj
@@ -21,14 +21,14 @@
     <ItemGroup>
       <XHarnessAppBundleToTest Include="$(ArtifactsTmpDir)XHarness.CustomCommandsAppBundle/$(XHarnessAppBundleName).app">
         <TestTarget>ios-simulator-64</TestTarget>
-        <WorkItemTimeout>00:15:00</WorkItemTimeout>
+        <WorkItemTimeout>00:20:00</WorkItemTimeout>
         <TestTimeout>00:05:00</TestTimeout>
         <LaunchTimeout>00:03:30</LaunchTimeout>
         <CustomCommands>
           <![CDATA[
           set -ex
           deviceId=`xharness apple device $target`
-          xharness apple install -t=$target --device="$deviceId" -o="$output_directory" --app="$app" -v
+          xharness apple install -t=$target --device="$deviceId" -o="$output_directory" --app="$app" --timeout=$launch_timeout -v
           set +e
           result=0
           xharness apple just-test -t=$target --device="$deviceId" -o="$output_directory" --app="net.dot.$(XHarnessAppBundleName)" --launch-timeout=$launch_timeout --timeout=$timeout -v

--- a/tests/XHarness/XHarness.Apple.Simulator.Test.proj
+++ b/tests/XHarness/XHarness.Apple.Simulator.Test.proj
@@ -23,7 +23,7 @@
         <TestTarget>ios-simulator-64</TestTarget>
         <TestTimeout>00:05:00</TestTimeout>
         <LaunchTimeout>00:03:30</LaunchTimeout>
-        <WorkItemTimeout>00:15:00</WorkItemTimeout>
+        <WorkItemTimeout>00:12:00</WorkItemTimeout>
       </XHarnessAppBundleToTest>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
Previously, this parameter wasn't supported for both `apple test` and `apple run` but we actually need it now
