### PR TITLE
Fix UsingTask in Microsoft.DotNet.Build.Tasks.Workloads.props

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/build/Microsoft.DotNet.Build.Tasks.Workloads.props
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/build/Microsoft.DotNet.Build.Tasks.Workloads.props
@@ -6,6 +6,6 @@
     <MicrosoftDotNetBuildTasksWorkloadsAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.DotNet.Build.Tasks.Workloads.dll</MicrosoftDotNetBuildTasksWorkloadsAssembly>
   </PropertyGroup>
 
-  <UsingTask Include="GenerateManifestMsi" AssemblyFile="$(MicrosoftDotNetBuildTasksWorkloadsAssembly)" />
-  <UsingTask Include="GenerateVisualStudioWorkload" AssemblyFile="$(MicrosoftDotNetBuildTasksWorkloadsAssembly)" />
+  <UsingTask TaskName="GenerateManifestMsi" AssemblyFile="$(MicrosoftDotNetBuildTasksWorkloadsAssembly)" />
+  <UsingTask TaskName="GenerateVisualStudioWorkload" AssemblyFile="$(MicrosoftDotNetBuildTasksWorkloadsAssembly)" />
 </Project>


### PR DESCRIPTION
Include doesn't work there, it should be TaskName. Broken in https://github.com/dotnet/arcade/pull/9355
