### PR TITLE
Update create-net7-preview-flow.ps1 for new ICU branch names

### DIFF
--- a/scripts/create-net7-preview-flow.ps1
+++ b/scripts/create-net7-preview-flow.ps1
@@ -122,7 +122,7 @@ AddFlow https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int $RuntimeChanne
 AddBatchedFlow https://github.com/dotnet/efcore $RuntimeChannel https://github.com/dotnet/aspnetcore $RuntimeBranch EveryBuild
 AddBatchedFlow https://github.com/dotnet/emsdk $RuntimeChannel https://github.com/dotnet/aspnetcore $RuntimeBranch EveryBuild
 AddFlow https://github.com/dotnet/emsdk $RuntimeChannel https://github.com/dotnet/runtime $RuntimeBranch EveryBuild
-AddFlow https://github.com/dotnet/icu $RuntimeChannel https://github.com/dotnet/runtime "dotnet/$RuntimeBranch" EveryBuild
+AddFlow https://github.com/dotnet/icu $RuntimeChannel https://github.com/dotnet/runtime $RuntimeBranch EveryBuild
 AddBatchedFlow https://github.com/dotnet/runtime $RuntimeChannel https://github.com/dotnet/aspnetcore $RuntimeBranch EveryBuild
 AddFlow https://github.com/dotnet/runtime $RuntimeChannel https://github.com/dotnet/efcore $RuntimeBranch EveryBuild
 AddFlow https://github.com/dotnet/runtime $RuntimeChannel https://github.com/dotnet/winforms $RuntimeBranch EveryBuild

--- a/scripts/create-net7-preview-flow.ps1
+++ b/scripts/create-net7-preview-flow.ps1
@@ -53,7 +53,7 @@ MakeDefaultChannel https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int $Ru
 MakeDefaultChannel https://github.com/dotnet/aspnetcore $RuntimeBranch $RuntimeChannel
 MakeDefaultChannel https://github.com/dotnet/efcore $RuntimeBranch $RuntimeChannel
 MakeDefaultChannel https://github.com/dotnet/emsdk $RuntimeBranch $RuntimeChannel
-MakeDefaultChannel https://github.com/dotnet/icu $RuntimeBranch $RuntimeChannel
+MakeDefaultChannel https://github.com/dotnet/icu "dotnet/$RuntimeBranch" $RuntimeChannel
 MakeDefaultChannel https://github.com/dotnet/runtime $RuntimeBranch $RuntimeChannel
 MakeDefaultChannel https://github.com/dotnet/windowsdesktop $RuntimeBranch $RuntimeChannel
 MakeDefaultChannel https://github.com/dotnet/wpf $RuntimeBranch $RuntimeChannel
@@ -105,7 +105,7 @@ AddArcadeFlow https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int $Runtime
 AddArcadeFlow https://github.com/dotnet/aspnetcore $RuntimeBranch
 AddArcadeFlow https://github.com/dotnet/efcore $RuntimeBranch
 AddArcadeFlow https://github.com/dotnet/emsdk $RuntimeBranch
-AddArcadeFlow https://github.com/dotnet/icu $RuntimeBranch
+AddArcadeFlow https://github.com/dotnet/icu "dotnet/$RuntimeBranch"
 AddArcadeFlow https://github.com/dotnet/runtime $RuntimeBranch
 AddArcadeFlow https://github.com/dotnet/windowsdesktop $RuntimeBranch
 AddArcadeFlow https://github.com/dotnet/wpf $RuntimeBranch
@@ -122,7 +122,7 @@ AddFlow https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int $RuntimeChanne
 AddBatchedFlow https://github.com/dotnet/efcore $RuntimeChannel https://github.com/dotnet/aspnetcore $RuntimeBranch EveryBuild
 AddBatchedFlow https://github.com/dotnet/emsdk $RuntimeChannel https://github.com/dotnet/aspnetcore $RuntimeBranch EveryBuild
 AddFlow https://github.com/dotnet/emsdk $RuntimeChannel https://github.com/dotnet/runtime $RuntimeBranch EveryBuild
-AddFlow https://github.com/dotnet/icu $RuntimeChannel https://github.com/dotnet/runtime $RuntimeBranch EveryBuild
+AddFlow https://github.com/dotnet/icu $RuntimeChannel https://github.com/dotnet/runtime "dotnet/$RuntimeBranch" EveryBuild
 AddBatchedFlow https://github.com/dotnet/runtime $RuntimeChannel https://github.com/dotnet/aspnetcore $RuntimeBranch EveryBuild
 AddFlow https://github.com/dotnet/runtime $RuntimeChannel https://github.com/dotnet/efcore $RuntimeBranch EveryBuild
 AddFlow https://github.com/dotnet/runtime $RuntimeChannel https://github.com/dotnet/winforms $RuntimeBranch EveryBuild


### PR DESCRIPTION
ICU branches now have a `dotnet/` prefix to distinguish them from upstream branches.

/cc @mmitche 