### PR TITLE
Support byref fields in GenAPI

### DIFF
--- a/src/Microsoft.Cci.Extensions/Extensions/CSharp/CSharpCciExtensions.cs
+++ b/src/Microsoft.Cci.Extensions/Extensions/CSharp/CSharpCciExtensions.cs
@@ -155,8 +155,7 @@ namespace Microsoft.Cci.Extensions.CSharp
                 if (resolvedType.IsReferenceType)
                     return true;
 
-                // ByReference<T> is a special type understood by runtime to hold a ref T.
-                if (resolvedType.AreGenericTypeEquivalent(ByReferenceFullName))
+                if (resolvedType.IsByRef())
                     return true;
 
                 foreach (var field in resolvedType.Fields.Where(f => !f.IsStatic))
@@ -189,7 +188,7 @@ namespace Microsoft.Cci.Extensions.CSharp
                 if (typeToCheck.TypeCode != PrimitiveTypeCode.NotPrimitive && typeToCheck.TypeCode != PrimitiveTypeCode.Invalid)
                     return true;
 
-                if (resolvedType is Dummy || resolvedType.IsReferenceType || resolvedType.AreGenericTypeEquivalent(ByReferenceFullName))
+                if (resolvedType is Dummy || resolvedType.IsReferenceType || resolvedType.IsByRef())
                 {
                     if (node == 0)
                     {
@@ -392,6 +391,13 @@ namespace Microsoft.Cci.Extensions.CSharp
         public static bool IsUnsafeType(this ITypeReference type)
         {
             return type.TypeCode == PrimitiveTypeCode.Pointer;
+        }
+
+        public static bool IsByRef(this ITypeReference type)
+        {
+            // ByReference<T> is a special type understood by runtime to hold a ref T.
+            // ByReference<T> was removed in .NET 7 since support for ref T in C# 11 was introduced.
+            return type.TypeCode == PrimitiveTypeCode.Reference || type.AreGenericTypeEquivalent(ByReferenceFullName);
         }
 
         public static bool IsMethodUnsafe(this IMethodDefinition method)

--- a/src/Microsoft.Cci.Extensions/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.Cci.Extensions/Extensions/TypeExtensions.cs
@@ -413,7 +413,8 @@ namespace Microsoft.Cci.Extensions
                 || reference is INamespaceTypeReference
                 || reference is IGenericTypeParameterReference
                 || reference is IGenericMethodParameterReference
-                || reference is IFunctionPointerTypeReference,
+                || reference is IFunctionPointerTypeReference
+                || reference is IManagedPointerType,
                 string.Format("Unexpected type reference that we may need to unwrap {0}", (reference != null ? reference.GetType().FullName : "null")));
 
             return reference;

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Properties.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Properties.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Cci.Writers.CSharp
                     WriteKeyword("readonly");
             }
 
-            WriteTypeName(property.Type, attributes: property.Attributes);
+            WriteTypeName(property.Type, property.Attributes);
 
             if (property.IsExplicitInterfaceProperty() && _forCompilationIncludeGlobalprefix)
                 Write("global::");

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.cs
@@ -6,7 +6,6 @@ using Microsoft.Cci.Extensions.CSharp;
 using Microsoft.Cci.Filters;
 using Microsoft.Cci.Writers.Syntax;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
@@ -282,13 +281,20 @@ namespace Microsoft.Cci.Writers.CSharp
             }
 
             return (bool)dynamicAttributeArgument;
+        }
 
+        private ref struct TypeNameRecursiveState
+        {
+            public object DynamicAttributeArgument;
+            public object NullableAttributeArgument;
+            public IEnumerable<ICustomAttribute> Attributes;
         }
 
         private int WriteTypeNameRecursive(ITypeReference type, NameFormattingOptions namingOptions,
-            string[] valueTupleNames, ref int valueTupleNameIndex, ref int nullableIndex, object nullableAttributeArgument, object dynamicAttributeArgument,
+            string[] valueTupleNames, ref int valueTupleNameIndex, ref int nullableIndex, ref TypeNameRecursiveState state,
             int typeDepth = 0, int genericParameterIndex = 0, bool isValueTupleParameter = false)
         {
+            object dynamicAttributeArgument = state.DynamicAttributeArgument;
             void WriteTypeNameInner(ITypeReference typeReference)
             {
                 if (IsDynamicType(dynamicAttributeArgument, typeDepth))
@@ -386,7 +392,7 @@ namespace Microsoft.Cci.Writers.CSharp
 
                     string valueTupleName = isValueTuple ? valueTupleNames?[valueTupleLocalIndex + i] : null;
                     int destinationTypeDepth = typeDepth + i + genericArgumentsInChildTypes + 1;
-                    genericArgumentsInChildTypes += WriteTypeNameRecursive(parameter, namingOptions, valueTupleNames, ref valueTupleNameIndex, ref nullableIndex, nullableAttributeArgument, dynamicAttributeArgument, destinationTypeDepth, i, isValueTuple);
+                    genericArgumentsInChildTypes += WriteTypeNameRecursive(parameter, namingOptions, valueTupleNames, ref valueTupleNameIndex, ref nullableIndex, ref state, destinationTypeDepth, i, isValueTuple);
 
                     if (valueTupleName != null)
                     {
@@ -426,7 +432,7 @@ namespace Microsoft.Cci.Writers.CSharp
                     nullableIndex++;
 
                 WriteTypeNameRecursive(arrayType.ElementType, namingOptions, valueTupleNames, ref valueTupleNameIndex, ref nullableIndex,
-                    nullableAttributeArgument, dynamicAttributeArgument, typeDepth + 1);
+                    ref state, typeDepth + 1);
                 WriteSymbol("[");
 
                 uint arrayDimension = arrayType.Rank - 1;
@@ -440,6 +446,10 @@ namespace Microsoft.Cci.Writers.CSharp
             else if (type.IsByRef())
             {
                 WriteSymbol("ref", addSpace: true);
+
+                if (state.Attributes.HasIsReadOnlyAttribute())
+                    WriteSymbol("readonly", addSpace: true);
+
                 WriteTypeNameInner(((IManagedPointerType)type).TargetType);
             }
             else
@@ -453,7 +463,7 @@ namespace Microsoft.Cci.Writers.CSharp
             }
             else if (!type.IsValueType)
             {
-                WriteNullableSymbolForReferenceType(nullableAttributeArgument, nullableLocalIndex);
+                WriteNullableSymbolForReferenceType(state.NullableAttributeArgument, nullableLocalIndex);
             }
 
             return genericArgumentsCount;
@@ -471,13 +481,13 @@ namespace Microsoft.Cci.Writers.CSharp
 
             object dynamicAttributeArgument = dynamicAttribute.GetAttributeArgumentValue<bool>(defaultValue: hasDynamicAttribute);
 
-            WriteTypeName(type, noSpace, useTypeKeywords, omitGenericTypeList, nullableAttributeArgument, dynamicAttributeArgument, attributes?.GetValueTupleNames());
+            WriteTypeName(type, noSpace, useTypeKeywords, omitGenericTypeList, nullableAttributeArgument, dynamicAttributeArgument, attributes);
         }
 
         private void WriteTypeName(ITypeReference type, bool noSpace = false, bool useTypeKeywords = true,
-            bool omitGenericTypeList = false, object nullableAttributeArgument = null, object dynamicAttributeArgument = null, string[] valueTupleNames = null)
+            bool omitGenericTypeList = false, object nullableAttributeArgument = null, object dynamicAttributeArgument = null, IEnumerable<ICustomAttribute> attributes = null)
         {
-            NameFormattingOptions namingOptions = NameFormattingOptions.TypeParameters | NameFormattingOptions.ContractNullable | NameFormattingOptions.OmitTypeArguments; ;
+            NameFormattingOptions namingOptions = NameFormattingOptions.TypeParameters | NameFormattingOptions.ContractNullable | NameFormattingOptions.OmitTypeArguments;
 
             if (useTypeKeywords)
                 namingOptions |= NameFormattingOptions.UseTypeKeywords;
@@ -493,7 +503,13 @@ namespace Microsoft.Cci.Writers.CSharp
 
             int valueTupleNameIndex = 0;
             int nullableIndex = 0;
-            WriteTypeNameRecursive(type, namingOptions, valueTupleNames, ref valueTupleNameIndex, ref nullableIndex, nullableAttributeArgument, dynamicAttributeArgument);
+            var state = new TypeNameRecursiveState()
+            {
+                DynamicAttributeArgument = dynamicAttributeArgument,
+                NullableAttributeArgument = nullableAttributeArgument,
+                Attributes = attributes,
+            };
+            WriteTypeNameRecursive(type, namingOptions, attributes?.GetValueTupleNames(), ref valueTupleNameIndex, ref nullableIndex, ref state);
 
             if (!noSpace) WriteSpace();
         }

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.cs
@@ -437,6 +437,11 @@ namespace Microsoft.Cci.Writers.CSharp
 
                 WriteSymbol("]");
             }
+            else if (type.IsByRef())
+            {
+                WriteSymbol("ref", addSpace: true);
+                WriteTypeNameInner(((IManagedPointerType)type).TargetType);
+            }
             else
             {
                 WriteTypeNameInner(type);

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSharpWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSharpWriter.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Cci.Writers
                 // For compile-time compat, the following rules should work for producing a reference assembly. We drop all private fields,
                 // but add back certain synthesized private fields for a value type (struct) as follows:
 
-                // 1. If there is a reference type field in the struct or within the fields' type closure,
+                // 1. If there is a ref field or reference type field in the struct or within the fields' type closure,
                 //    it should emit a reference type and a value type dummy field.
                 //    - The reference type dummy field is needed in order to inform the compiler to block
                 //      taking pointers to this struct because the GC will not track updating those references.
@@ -184,7 +184,9 @@ namespace Microsoft.Cci.Writers
                 // this blog is helpful as well http://blog.paranoidcoding.com/2016/02/15/are-private-members-api-surface.html
 
                 List<IFieldDefinition> newFields = new List<IFieldDefinition>();
-                var includedVisibleFields = fields.Where(f => _cciFilter.Include(f));
+
+                // Do not include ByRef fields as they would introduce metadata that some compiler may find troublesome (e.g., C++/CLI).
+                var includedVisibleFields = fields.Where(f => _cciFilter.Include(f) && !f.Type.IsByRef());
                 includedVisibleFields = includedVisibleFields.OrderBy(GetMemberKey, StringComparer.OrdinalIgnoreCase);
 
                 var excludedFields = fields.Except(includedVisibleFields).Where(f => !f.IsStatic);

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSharpWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSharpWriter.cs
@@ -184,9 +184,7 @@ namespace Microsoft.Cci.Writers
                 // this blog is helpful as well http://blog.paranoidcoding.com/2016/02/15/are-private-members-api-surface.html
 
                 List<IFieldDefinition> newFields = new List<IFieldDefinition>();
-
-                // Do not include ByRef fields as they would introduce metadata that some compiler may find troublesome (e.g., C++/CLI).
-                var includedVisibleFields = fields.Where(f => _cciFilter.Include(f) && !f.Type.IsByRef());
+                var includedVisibleFields = fields.Where(f => _cciFilter.Include(f));
                 includedVisibleFields = includedVisibleFields.OrderBy(GetMemberKey, StringComparer.OrdinalIgnoreCase);
 
                 var excludedFields = fields.Except(includedVisibleFields).Where(f => !f.IsStatic);


### PR DESCRIPTION
Support for ref fields is being added in .NET 7 / C# 11.0.
This will impact reference assembly generation as ref fields impact
how C# consumes types that contain them. A ref field represents a
change to the metadata format and that can cause issues with tool
chains that are not updated to understand this metadata change.
A concrete example is C++/CLI which will likely error if it consumes
a ref field. If the ref field is public, it will be by GenAPI - we are required
to expose the real public API surface.

The following invariants must be preserved when not exposing private 
ref fields:
- The containing type can never be considered unmanaged
- The type of the field, sans ref, is still important for generic
  expansion calculations

Fixes https://github.com/dotnet/runtime/issues/63751

/cc @jaredpar @ericstj @carlossanlop @jkoritzinsky 