### PR TITLE
[Workloads] Allow missing workload packs

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
@@ -172,6 +172,14 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             get;
             set;
         }
+        /// <summary>
+        /// Allow VS workload generation to proceed if any nupkgs declared in the manifest are not found on disk.
+        /// </summary>
+        public bool AllowMissingPacks
+        {
+            get;
+            set;
+        } = false;
 
         public override bool Execute()
         {
@@ -227,7 +235,12 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                                 {
                                     if (!File.Exists(sourcePackage))
                                     {
-                                        throw new FileNotFoundException(message: null, fileName: sourcePackage);
+                                        if (AllowMissingPacks) {
+                                            Log.LogMessage($"Pack {sourcePackage} - {string.Join(",", platforms)} could not be found, it will be skipped.");
+                                            continue;
+                                        } else {
+                                            throw new FileNotFoundException(message: null, fileName: sourcePackage);
+                                        }
                                     }
 
                                     // Create new build data and add the pack if we haven't seen it previously.
@@ -239,6 +252,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
 
                                     foreach (string platform in platforms)
                                     {
+                                        Log.LogMessage($"Processing {sourcePackage} - {platform}...");
                                         // If we haven't seen the platform, create a new entry, then add
                                         // the current feature band. This allows us to track platform specific packs
                                         // across multiple feature bands and manifests.


### PR DESCRIPTION
Commit f8c0d511 introduced a change that breaks MSI generation for the
Android workload.  Previously, workload packs that were declared in the
WorkloadManifest.json but not present on disk would be skipped.

The .NET 7 Android workload manifest [now declares SDK packs][0] that
have already shipped in order to support .NET 6 projects.  We do not
want to regenerate MSI installers for these packs, and we should be able
to continue shipping them in VS by keeping the .NET 6 workload authoring
in VS alongside new .NET 7 workload authoring.

A new `AllowMissingPacks` task parameter has been added to let workload
owners skip MSI and setup authoring generation for packs that are not
present when the tooling runs.

[0]: https://github.com/xamarin/xamarin-android/blob/ac5bb6b910a5d9e72f38b9df4528dd308e5000d6/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.json#L45