### PR TITLE
Unblock Fsharp and Roslyn to consume arcade updates

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.InsertionManifests.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.InsertionManifests.targets
@@ -55,6 +55,7 @@
       <_Args Include="SwixBuildPath=$(NuGetPackageRoot)microsoft.visualstudioeng.microbuild.plugins.swixbuild\$(MicrosoftVisualStudioEngMicroBuildPluginsSwixBuildVersion)\"/>
       <_Args Include="VisualStudioDropName=$(VisualStudioDropName)" />
       <_Args Include="ArtifactsDir=$(ArtifactsDir)" />
+      <_Args Include="GenerateSbom=$(GenerateSbom)" />
     </ItemGroup>
 
     <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
@@ -40,7 +40,10 @@
 
   <ItemGroup>
     <_PackageStubFiles Include="$(ComponentIntermediateOutputPath)*.stub"/>
-    <MergeManifest condition="'$(GenerateSbom)' == 'false'" Include="@(_PackageStubFiles->'$(SetupOutputPath)%(Filename).json')"/>
+  </ItemGroup>
+
+  <ItemGroup condition="'$(GenerateSbom)' == 'false'">
+    <MergeManifest Include="@(_PackageStubFiles->'$(SetupOutputPath)%(Filename).json')"/>
   </ItemGroup>
 
   <Import Project="$(SwixBuildPath)build\Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild.targets" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
@@ -31,7 +31,7 @@
     <OutputPath>$(SetupOutputPath)</OutputPath>
     <IntermediateOutputPath>$(ComponentIntermediateOutputPath)</IntermediateOutputPath>
     <ArtifactsDir>$(ArtifactsDir)</ArtifactsDir>
-    <GenerateSbom>$(GenerateSbom)<GenerateSbom>
+    <GenerateSbom>$(GenerateSbom)</GenerateSbom>
 
     <!-- Note that the url is expected to end with ';' (%3B) -->
     <ManifestPublishUrl Condition="'$(VisualStudioDropName)' != ''">https://vsdrop.corp.microsoft.com/file/v1/$(VisualStudioDropName)%3B</ManifestPublishUrl>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
@@ -31,6 +31,7 @@
     <OutputPath>$(SetupOutputPath)</OutputPath>
     <IntermediateOutputPath>$(ComponentIntermediateOutputPath)</IntermediateOutputPath>
     <ArtifactsDir>$(ArtifactsDir)</ArtifactsDir>
+    <GenerateSbom>$(GenerateSbom)<GenerateSbom>
 
     <!-- Note that the url is expected to end with ';' (%3B) -->
     <ManifestPublishUrl Condition="'$(VisualStudioDropName)' != ''">https://vsdrop.corp.microsoft.com/file/v1/$(VisualStudioDropName)%3B</ManifestPublishUrl>
@@ -39,6 +40,7 @@
 
   <ItemGroup>
     <_PackageStubFiles Include="$(ComponentIntermediateOutputPath)*.stub"/>
+    <MergeManifest condition="'$(GenerateSbom)' == 'false'" Include="@(_PackageStubFiles->'$(SetupOutputPath)%(Filename).json')"/>
   </ItemGroup>
 
   <Import Project="$(SwixBuildPath)build\Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild.targets" />
@@ -77,7 +79,7 @@
       <ManifestBuildVersion>@(_VsixVersionNoDuplicates)</ManifestBuildVersion>
       <ManifestVsixName>@(_VsixVersionNoDuplicates->'%(Name)')</ManifestVsixName>
     </PropertyGroup>
-    <ItemGroup>
+    <ItemGroup Condition= "'$(GenerateSbom)' == 'true'">
     <MergeManifest Include="$(SetupOutputPath)$(ComponentName).json">
       <SBOMFileLocation>$(ArtifactsDir)sbom\$(ManifestVsixName.Substring(0, $(ManifestVsixName.LastIndexOf('.'))))\spdx_2.2\manifest.spdx.json</SBOMFileLocation>
       </MergeManifest>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
@@ -42,7 +42,7 @@
     <_PackageStubFiles Include="$(ComponentIntermediateOutputPath)*.stub"/>
   </ItemGroup>
 
-  <ItemGroup condition="'$(GenerateSbom)' == 'false'">
+  <ItemGroup Condition="'$(GenerateSbom)' == 'false'">
     <MergeManifest Include="@(_PackageStubFiles->'$(SetupOutputPath)%(Filename).json')"/>
   </ItemGroup>
 


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation

Fsharp and Roslyn repos have a different way of generating vs manifest. For public builds Vs manifest generation is failing here https://github.com/dotnet/arcade/blob/e960dbff8e9aea4c423bf9fc9e039b46fc92cead/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj#L81

So till we figure what we should do for repos like Fsharp and Roslyn, I reverted the part where we generate VS manifest to what it used to before we added SBOM generation feature. 

Fsharp test build -> https://dev.azure.com/dnceng/public/_build/results?buildId=1803949&view=results

This should not cause any problem for repos who have sbom generation working, cos that part will still work. 