### PR TITLE
Remove `testResults.xml` when infra retry requested from CWD

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-processor.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-processor.py
@@ -355,9 +355,13 @@ if retry:
     # TODO https://github.com/dotnet/core-eng/issues/15059
     # We need to remove testResults.xml so that it is not uploaded since this run will be discarded
     # This is a workaround until we make AzDO reporter not upload test results
-    test_results = os.path.join(output_directory, "testResults.xml")
+    file_name = "testResults.xml"
+    test_results = os.path.join(output_directory, file_name)
     if os.path.exists(test_results):
         os.remove(test_results)
+
+    if os.path.exists(file_name):
+        os.remove(file_name)
 
 if reboot:
     send_metric(REBOOT_METRIC_NAME, reboot_exit_code, reboot_dimensions, event_type=EVENT_TYPE)


### PR DESCRIPTION
This is rather a hotfix for dotnet/runtime failures where we know the file is in CWD. We can think about a better scan later.

More details: https://github.com/dotnet/arcade/issues/8804