### PR TITLE
Remove mention of code of conduct 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,10 +9,6 @@ When you submit a pull request, a CLA-bot will automatically determine whether y
 to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the
 instructions provided by the bot. You will only need to do this once across all repositories using our CLA.
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
-or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
-
 See [Arcade Contributor Guidance](Documentation/Policy/ArcadeContributorGuidance.md) for principles, expectations, and guidance around issues when contributing to this repo.
 
 See [the overview page](Documentation/Overview.md) for a more general overview of the repository.


### PR DESCRIPTION
Per https://github.com/dotnet/org-policy/blob/main/doc/PR15.md

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
