### PR TITLE
Vs insertion Sbom generation (Roslyn,fSharp)

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.InsertionManifests.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.InsertionManifests.targets
@@ -11,23 +11,6 @@
     <GenerateSbom Condition="'$(GenerateSbom)' == ''">false</GenerateSbom>
   </PropertyGroup>
 
-  <Target Name ="GenerateSbomForVSInsertion" 
-          Condition="'$(GenerateSbom)' != 'false'">
-    <Message Text="Generating SBOM manifest" Importance="high"/>
-    <ItemGroup>
-     <VsixFile Include="$(ArtifactsDir)VSSetup\$(Configuration)\Insertion\*.vsix"></VsixFile>
-     <VsixFile Include="$(ArtifactsDir)VSSetup\$(Configuration)\Insertion\*.exe"></VsixFile>
-    </ItemGroup>
-     <MakeDir Directories="$(ArtifactsDir)sbom;$(ArtifactsDir)sbom\%(VsixFile.Filename);$(ArtifactsDir)Vsix;$(ArtifactsDir)Vsix\Unpacked\%(VsixFile.Filename)"/>
-     
-     <Unzip
-      SourceFiles="@(VsixFile)"
-      DestinationFolder="$(ArtifactsDir)Vsix\Unpacked\%(VsixFile.Filename)"
-      OverwriteReadOnlyFiles="true"/>
-
-    <Exec Command = "$(DotNetTool) $(NUGET_PACKAGES)microsoft.manifesttool.crossplatform\$(MicrosoftManifestToolCrossPlatformVersion)\Content\Microsoft.ManifestTool.dll generate -b $(ArtifactsDir)Vsix\Unpacked\%(VsixFile.Filename) -m $(ArtifactsDir)sbom\%(VsixFile.Filename) -pn VsInsertion -V Verbose"/>
-    <Message Text="Completed generating SBOM manifest for %(VsixFile.Filename)." Importance="high"/>
-  </Target>
   <!---
     This target is invoked in a separate phase after all input VSIX files are signed.
     This is important since the manifest contain hashes of the VSIX files.
@@ -35,8 +18,7 @@
   <Target Name="GenerateVisualStudioInsertionManifests"
           BeforeTargets="AfterPack"
           Outputs="%(_StubDirs.Identity)"
-          Condition="'@(_StubDirs)' != ''"
-          DependsOnTargets="GenerateSbomForVSInsertion">
+          Condition="'@(_StubDirs)' != ''">
     <PropertyGroup>
       <_ComponentDir>%(_StubDirs.Identity)</_ComponentDir>
       <_ComponentName>$(_ComponentDir.TrimEnd('\'))</_ComponentName>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.InsertionManifests.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.InsertionManifests.targets
@@ -4,13 +4,7 @@
     <_StubFiles Include="$(VisualStudioSetupIntermediateOutputPath)**\*.stub"/>
     <_StubDirs Include="@(_StubFiles->'%(RecursiveDir)')"/>
   </ItemGroup>
-<!--
-  Before pack create the SBOM here
--->
- <PropertyGroup>
-    <GenerateSbom Condition="'$(GenerateSbom)' == ''">false</GenerateSbom>
-  </PropertyGroup>
-
+  
   <!---
     This target is invoked in a separate phase after all input VSIX files are signed.
     This is important since the manifest contain hashes of the VSIX files.
@@ -36,8 +30,8 @@
       <_Args Include="ComponentIntermediateOutputPath=$(VisualStudioSetupIntermediateOutputPath)$(_ComponentName)\"/>
       <_Args Include="SwixBuildPath=$(NuGetPackageRoot)microsoft.visualstudioeng.microbuild.plugins.swixbuild\$(MicrosoftVisualStudioEngMicroBuildPluginsSwixBuildVersion)\"/>
       <_Args Include="VisualStudioDropName=$(VisualStudioDropName)" />
-      <_Args Include="ArtifactsDir=$(ArtifactsDir)" />
-      <_Args Include="GenerateSbom=$(GenerateSbom)" />
+      <_Args Include="DotNetTool=$(DotNetTool)" />
+      <_Args Include="ManifestTool=$(NUGET_PACKAGES)microsoft.manifesttool.crossplatform\$(MicrosoftManifestToolCrossPlatformVersion)\Content\Microsoft.ManifestTool.dll"/>
     </ItemGroup>
 
     <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
@@ -12,6 +12,8 @@
                                       "Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)"
                                       The manifest will be published with URI
                                       https://vsdrop.corp.microsoft.com/file/v1/$(VisualStudioDropName)
+      DotNetTool                      Path to dotnet.exe.
+      ManifestTool                    Path to Microsoft.ManifestTool.dll
   -->
 
   <PropertyGroup>
@@ -30,8 +32,6 @@
     <TargetName>$(ComponentName)</TargetName>
     <OutputPath>$(SetupOutputPath)</OutputPath>
     <IntermediateOutputPath>$(ComponentIntermediateOutputPath)</IntermediateOutputPath>
-    <ArtifactsDir>$(ArtifactsDir)</ArtifactsDir>
-    <GenerateSbom>$(GenerateSbom)</GenerateSbom>
 
     <!-- Note that the url is expected to end with ';' (%3B) -->
     <ManifestPublishUrl Condition="'$(VisualStudioDropName)' != ''">https://vsdrop.corp.microsoft.com/file/v1/$(VisualStudioDropName)%3B</ManifestPublishUrl>
@@ -42,68 +42,66 @@
     <_PackageStubFiles Include="$(ComponentIntermediateOutputPath)*.stub"/>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(GenerateSbom)' == 'false'">
-    <MergeManifest Include="@(_PackageStubFiles->'$(SetupOutputPath)%(Filename).json')"/>
-  </ItemGroup>
-
   <Import Project="$(SwixBuildPath)build\Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild.targets" />
 
-  <Target Name="_BuildManifest" DependsOnTargets="_GetVsixFileVersions;GenerateSbomForVSInsertion;GenerateVSManifest;GenerateSetupManifest" />
+  <Target Name="_BuildManifest" DependsOnTargets="_GetVsixFileInfo;_GenerateSbomForVsixAndAddManifestItem;GenerateSetupManifest" />
 
-  <Target Name="_GetVsixFileVersions">
-
+  <Target Name="_GetVsixFileInfo">
     <ReadLinesFromFile File="%(_PackageStubFiles.Identity)">
       <Output TaskParameter="Lines" ItemName="_StubLine"/>
     </ReadLinesFromFile>
-    <ItemGroup>
-      <_VsixFileInfo Include="@(_StubLine)"
-      Name="$([MSBuild]::ValueOrDefault('%(_StubLine.Identity)', '').Split('/')[0])"
-      Version="$([MSBuild]::ValueOrDefault('%(_StubLine.Identity)', '').Split('/')[1])" />
-     </ItemGroup>
 
     <ItemGroup>
-      <_VsixVersion Include="%(_VsixFileInfo.Version)" Name="%(_VsixFileInfo.Name)" />
+      <_ParsedLine Include="@(_StubLine)"
+                   VsixId="$([MSBuild]::ValueOrDefault('%(_StubLine.Identity)', '').Split('/')[0])"
+                   VsixFileName="$([MSBuild]::ValueOrDefault('%(_StubLine.Identity)', '').Split('/')[1])"
+                   VsixVersion="$([MSBuild]::ValueOrDefault('%(_StubLine.Identity)', '').Split('/')[2])" />
+
+      <_VsixFileInfo Include="@(_ParsedLine->'%(VsixFileName)')">
+        <ManifestJsonPath>$(SetupOutputPath)%(VsixId).json</ManifestJsonPath>
+        <VsixPath>$(SetupOutputPath)%(VsixFileName)</VsixPath>
+        <UnpackDir>$(ComponentIntermediateOutputPath)%(VsixFileName)\unpack</UnpackDir>
+        <SbomDir>$(ComponentIntermediateOutputPath)%(VsixFileName)\sbom</SbomDir>
+        <SbomJsonPath>$(ComponentIntermediateOutputPath)%(VsixFileName)\sbom\spdx_2.2\manifest.spdx.json</SbomJsonPath>
+      </_VsixFileInfo>
+    </ItemGroup>
+
+    <ItemGroup>
+      <_VsixVersion Include="%(_VsixFileInfo.VsixVersion)" VsixFileName="%(_VsixFileInfo.Identity)" />
     </ItemGroup>
 
     <RemoveDuplicates Inputs="@(_VsixVersion)">
       <Output TaskParameter="Filtered" ItemName="_VsixVersionNoDuplicates"/>
     </RemoveDuplicates>
 
-    <Error Text="Visual Studio component '$(ComponentName)' contains multiple VSIX files with different versions: @(_VsixVersionNoDuplicates->'%(Name) (version %(Identity))', ', ')"
+    <!--
+      Each stub file contains VSIX version of the respective VSIX file.
+      We require that all VSIXes included in a single VS insertion component have the same version.
+      This version will be set to ManifestBuildVersion.
+    -->
+    <Error Text="Visual Studio component '$(ComponentName)' contains multiple VSIX files with different versions: @(_VsixVersionNoDuplicates->'%(VsixFileName) (version %(Identity))', ', ')"
            Condition="@(_VsixVersionNoDuplicates->Count()) != 1"/>
-  </Target>
 
-  <Target Name="GenerateSbomForVSInsertion"
-        Inputs="@(_VsixFileInfo->'$(ArtifactsDir)VSSetup\$(Configuration)\Insertion\%(Name)')"
-        Outputs="@(_VsixFileInfo->'$(ArtifactsDir)VSSetup\$(Configuration)\Insertion\$(ComponentName)\%(Name)')"
-        DependsOnTargets="_GetVsixFileVersions"
-        Condition="'$(GenerateSbom)' != 'false'">
-    <Message Text="Generating SBOM manifest" Importance="high"/>
-    <MakeDir Directories="$(ComponentIntermediateOutputPath)$(ComponentName)\Sbom;$(ComponentIntermediateOutputPath)$(ComponentName)\unpacked"/>
-    <Unzip
-      SourceFiles="@(_VsixFileInfo->'$(ArtifactsDir)VSSetup\$(Configuration)\Insertion\%(Name)')"
-      DestinationFolder="$(ComponentIntermediateOutputPath)$(ComponentName)\unpacked"
-      OverwriteReadOnlyFiles="true"/>
-
-    <Exec Command = "$(DotNetTool) $(NUGET_PACKAGES)microsoft.manifesttool.crossplatform\$(MicrosoftManifestToolCrossPlatformVersion)\Content\Microsoft.ManifestTool.dll generate -b $(ComponentIntermediateOutputPath)$(ComponentName)\unpacked -m $(ComponentIntermediateOutputPath)$(ComponentName)\Sbom -pn VsInsertion -V Verbose"/>
-    <Message Text="Completed generating SBOM manifest for %(VsixFile.Filename)." Importance="high"/>
-  </Target>
-
-  <!--
-    Each stub file contains VSIX version of the respective VSIX file.
-    We require that all VSIXes included in a single VS insertion component have the same version.
-    This version will be set to ManifestBuildVersion.
-  -->
-
-  <Target Name= "GenerateVSManifest" DependsOnTargets="GenerateSbomForVSInsertion">
     <PropertyGroup>
       <ManifestBuildVersion>@(_VsixVersionNoDuplicates)</ManifestBuildVersion>
-      <ManifestVsixName>@(_VsixVersionNoDuplicates->'%(Name)')</ManifestVsixName>
     </PropertyGroup>
-    <ItemGroup Condition= "'$(GenerateSbom)' == 'true'">
-    <MergeManifest Include="$(SetupOutputPath)$(ComponentName).json">
-      <SBOMFileLocation>$(ArtifactsDir)sbom\$(ManifestVsixName.Substring(0, $(ManifestVsixName.LastIndexOf('.'))))\spdx_2.2\manifest.spdx.json</SBOMFileLocation>
-      </MergeManifest>
-  </ItemGroup>
+  </Target>
+
+  <Target Name="_GenerateSbomForVsixAndAddManifestItem"
+          Inputs="@(_VsixFileInfo->'%(VsixPath)')"
+          Outputs="@(_VsixFileInfo->'%(SbomJsonPath)')"
+          DependsOnTargets="_GetVsixFileInfo">
+    <Message Text="Generating SBOM manifest for '%(_VsixFileInfo.Identity)'" Importance="high"/>
+
+    <MakeDir Directories="%(_VsixFileInfo.SbomDir);%(_VsixFileInfo.UnpackDir)"/>
+    <Unzip SourceFiles="%(_VsixFileInfo.VsixPath)" DestinationFolder="%(_VsixFileInfo.UnpackDir)"/>
+
+    <Exec Command='"$(DotNetTool)" "$(ManifestTool)" generate -BuildDropPath "%(_VsixFileInfo.UnpackDir)" -ManifestDirPath "%(_VsixFileInfo.SbomDir)" -PackageName "%(_VsixFileInfo.VsixFileName)" -PackageVersion "%(_VsixFileInfo.VsixVersion)" -Verbosity Verbose'/>
+
+    <ItemGroup>
+      <MergeManifest Include="%(_VsixFileInfo.ManifestJsonPath)" SBOMFileLocation="%(_VsixFileInfo.SbomJsonPath)" />
+    </ItemGroup>
+
+    <Message Text="Completed generating SBOM manifest for %(_VsixFileInfo.Identity)." Importance="high"/>
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
@@ -51,6 +51,10 @@
       <Output TaskParameter="Lines" ItemName="_StubLine"/>
     </ReadLinesFromFile>
    <!--Parse the stub file to get the details of VsixId, VsixFileName and VsxiVersion-->
+   <!--Eg: _StubLine = Microsoft.FSharp.VSIX.Templates/VisualFSharpTemplates.vsix/17.0.0.2231309
+          VsixId = Microsoft.FSharp.VSIX.Templates
+          VsixFileName = VisualFSharpTemplates.vsix
+          VsixVersion = 17.0.0.2231309-->
     <ItemGroup>
       <_ParsedLine Include="@(_StubLine)"
                    VsixId="$([MSBuild]::ValueOrDefault('%(_StubLine.Identity)', '').Split('/')[0])"
@@ -79,7 +83,7 @@
       We require that all VSIXes included in a single VS insertion component have the same version.
       This version will be set to ManifestBuildVersion.
     -->
-    <Error Text="Visual Studio component '$(ComponentName)' contains multiple VSIX files with different versions: @(_VsixVersionNoDuplicates->'%(VsixFileName) (version %(Identity))', ', ')"
+    <Error Text="Cannot generate VS manifest because Visual Studio component '$(ComponentName)' contains multiple VSIX files with different versions: @(_VsixVersionNoDuplicates->'%(VsixFileName) (version %(Identity))', ', ')"
            Condition="@(_VsixVersionNoDuplicates->Count()) != 1"/>
 
     <PropertyGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
@@ -50,13 +50,13 @@
     <ReadLinesFromFile File="%(_PackageStubFiles.Identity)">
       <Output TaskParameter="Lines" ItemName="_StubLine"/>
     </ReadLinesFromFile>
-
+   <!--Parse the stub file to get the details of VsixId, VsixFileName and VsxiVersion-->
     <ItemGroup>
       <_ParsedLine Include="@(_StubLine)"
                    VsixId="$([MSBuild]::ValueOrDefault('%(_StubLine.Identity)', '').Split('/')[0])"
                    VsixFileName="$([MSBuild]::ValueOrDefault('%(_StubLine.Identity)', '').Split('/')[1])"
                    VsixVersion="$([MSBuild]::ValueOrDefault('%(_StubLine.Identity)', '').Split('/')[2])" />
-
+    <!--Set the VSmanifest name, Vsix path, Vsix unpacking path, Directory to generate SBOM and Path to generated SBOM manifest-->
       <_VsixFileInfo Include="@(_ParsedLine->'%(VsixFileName)')">
         <ManifestJsonPath>$(SetupOutputPath)%(VsixId).json</ManifestJsonPath>
         <VsixPath>$(SetupOutputPath)%(VsixFileName)</VsixPath>
@@ -95,9 +95,9 @@
 
     <MakeDir Directories="%(_VsixFileInfo.SbomDir);%(_VsixFileInfo.UnpackDir)"/>
     <Unzip SourceFiles="%(_VsixFileInfo.VsixPath)" DestinationFolder="%(_VsixFileInfo.UnpackDir)"/>
-
+    <!-- Generate SBOM -->
     <Exec Command='"$(DotNetTool)" "$(ManifestTool)" generate -BuildDropPath "%(_VsixFileInfo.UnpackDir)" -ManifestDirPath "%(_VsixFileInfo.SbomDir)" -PackageName "%(_VsixFileInfo.VsixFileName)" -PackageVersion "%(_VsixFileInfo.VsixVersion)" -Verbosity Verbose'/>
-
+    <!-- Generate VS manifest with link to the SBOM manifest-->
     <ItemGroup>
       <MergeManifest Include="%(_VsixFileInfo.ManifestJsonPath)" SBOMFileLocation="%(_VsixFileInfo.SbomJsonPath)" />
     </ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
@@ -74,18 +74,18 @@
   </Target>
 
   <Target Name="GenerateSbomForVSInsertion"
-        Inputs="@(_VsixFileInfo->'$(ComponentIntermediateOutputPath)\%(Name)')"
-        Outputs="@(_VsixFileInfo->'$(ComponentIntermediateOutputPath)\$(ComponentName)\%(Name)')"
+        Inputs="@(_VsixFileInfo->'$(ComponentIntermediateOutputPath)%(Name)')"
+        Outputs="@(_VsixFileInfo->'$(ComponentIntermediateOutputPath)$(ComponentName)\%(Name)')"
         DependsOnTargets="_GetVsixFileVersions"
         Condition="'$(GenerateSbom)' != 'false'">
     <Message Text="Generating SBOM manifest" Importance="high"/>
-    <MakeDir Directories="$(ComponentIntermediateOutputPath)\$(ComponentName)\Sbom"/>
+    <MakeDir Directories="$(ComponentIntermediateOutputPath)$(ComponentName)\Sbom;$(ComponentIntermediateOutputPath)$(ComponentName)\unpacked"/>
     <Unzip
       SourceFiles="@(_VsixFileInfo->'$(VisualStudioSetupInsertionPath)\%(Name)')"
-      DestinationFolder="@(_VsixFileInfo->'$(ComponentIntermediateOutputPath)\$(ComponentName)\%(Name)')"
+      DestinationFolder="$(ComponentIntermediateOutputPath)$(ComponentName)\unpacked"
       OverwriteReadOnlyFiles="true"/>
 
-    <Exec Command = "$(DotNetTool) $(NUGET_PACKAGES)microsoft.manifesttool.crossplatform\$(MicrosoftManifestToolCrossPlatformVersion)\Content\Microsoft.ManifestTool.dll generate -b @(_VsixFileInfo->'$(ComponentIntermediateOutputPath)\$(ComponentName)\%(Name)') -m $(ComponentIntermediateOutputPath)\$(ComponentName)\Sbom -pn VsInsertion -V Verbose"/>
+    <Exec Command = "$(DotNetTool) $(NUGET_PACKAGES)microsoft.manifesttool.crossplatform\$(MicrosoftManifestToolCrossPlatformVersion)\Content\Microsoft.ManifestTool.dll generate -b $(ComponentIntermediateOutputPath)$(ComponentName)\unpacked -m $(ComponentIntermediateOutputPath)$(ComponentName)\Sbom -pn VsInsertion -V Verbose"/>
     <Message Text="Completed generating SBOM manifest for %(VsixFile.Filename)." Importance="high"/>
   </Target>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
@@ -48,27 +48,21 @@
 
   <Import Project="$(SwixBuildPath)build\Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild.targets" />
 
-  <Target Name="_BuildManifest" DependsOnTargets="_SetManifestBuildVersion;GenerateSetupManifest" />
+  <Target Name="_BuildManifest" DependsOnTargets="_GetVsixFileVersions;GenerateSbomForVSInsertion;GenerateVSManifest;GenerateSetupManifest" />
 
-  <!--
-    Each stub file contains VSIX version of the respective VSIX file.
-    We require that all VSIXes included in a single VS insertion component have the same version.
-    This version will be set to ManifestBuildVersion.
-  -->
-  <Target Name="_SetManifestBuildVersion">
+  <Target Name="_GetVsixFileVersions">
 
     <ReadLinesFromFile File="%(_PackageStubFiles.Identity)">
       <Output TaskParameter="Lines" ItemName="_StubLine"/>
     </ReadLinesFromFile>
+    <ItemGroup>
+      <_VsixFileInfo Include="@(_StubLine)"
+      Name="$([MSBuild]::ValueOrDefault('%(_StubLine.Identity)', '').Split('/')[0])"
+      Version="$([MSBuild]::ValueOrDefault('%(_StubLine.Identity)', '').Split('/')[1])" />
+     </ItemGroup>
 
     <ItemGroup>
-      <_StubLineSplit Include="@(_StubLine)" 
-                      Name="$([MSBuild]::ValueOrDefault('%(_StubLine.Identity)', '').Split('/')[0])" 
-                      Version="$([MSBuild]::ValueOrDefault('%(_StubLine.Identity)', '').Split('/')[1])" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <_VsixVersion Include="%(_StubLineSplit.Version)" Name="%(_StubLineSplit.Name)" />
+      <_VsixVersion Include="%(_VsixFileInfo.Version)" Name="%(_VsixFileInfo.Name)" />
     </ItemGroup>
 
     <RemoveDuplicates Inputs="@(_VsixVersion)">
@@ -77,7 +71,31 @@
 
     <Error Text="Visual Studio component '$(ComponentName)' contains multiple VSIX files with different versions: @(_VsixVersionNoDuplicates->'%(Name) (version %(Identity))', ', ')"
            Condition="@(_VsixVersionNoDuplicates->Count()) != 1"/>
+  </Target>
 
+  <Target Name="GenerateSbomForVSInsertion"
+        Inputs="@(_VsixFileInfo->'$(VisualStudioSetupInsertionPath)\%(Name)')"
+        Outputs="@(_VsixFileInfo->'$(VisualStudioSetupIntermediateOutputPath\$(ComponentName)\%(Name)')"
+        DependsOnTargets="_GetVsixFileVersions"
+        Condition="'$(GenerateSbom)' != 'false'">
+    <Message Text="Generating SBOM manifest" Importance="high"/>
+    <MakeDir Directories="$(VisualStudioSetupIntermediateOutputPath\$(ComponentName)\Sbom"/>
+    <Unzip
+      SourceFiles="@(_VsixFileInfo->'$(VisualStudioSetupInsertionPath)\%(Name)')"
+      DestinationFolder="@(_VsixFileInfo->'$(VisualStudioSetupIntermediateOutputPath\$(ComponentName)\%(Name)')"
+      OverwriteReadOnlyFiles="true"/>
+
+    <Exec Command = "$(DotNetTool) $(NUGET_PACKAGES)microsoft.manifesttool.crossplatform\$(MicrosoftManifestToolCrossPlatformVersion)\Content\Microsoft.ManifestTool.dll generate -b @(_VsixFileInfo->'$(VisualStudioSetupIntermediateOutputPath\$(ComponentName)\%(Name)') -m $(VisualStudioSetupIntermediateOutputPath\$(ComponentName)\Sbom -pn VsInsertion -V Verbose"/>
+    <Message Text="Completed generating SBOM manifest for %(VsixFile.Filename)." Importance="high"/>
+  </Target>
+
+  <!--
+    Each stub file contains VSIX version of the respective VSIX file.
+    We require that all VSIXes included in a single VS insertion component have the same version.
+    This version will be set to ManifestBuildVersion.
+  -->
+
+  <Target Name= "GenerateVSManifest" DependsOnTargets="GenerateSbomForVSInsertion">
     <PropertyGroup>
       <ManifestBuildVersion>@(_VsixVersionNoDuplicates)</ManifestBuildVersion>
       <ManifestVsixName>@(_VsixVersionNoDuplicates->'%(Name)')</ManifestVsixName>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
@@ -81,7 +81,7 @@
     <Message Text="Generating SBOM manifest" Importance="high"/>
     <MakeDir Directories="$(ComponentIntermediateOutputPath)$(ComponentName)\Sbom;$(ComponentIntermediateOutputPath)$(ComponentName)\unpacked"/>
     <Unzip
-      SourceFiles="@(_VsixFileInfo->'$(ComponentIntermediateOutputPath)\%(Name)')"
+      SourceFiles="@(_VsixFileInfo->'$(ComponentIntermediateOutputPath)%(Name)')"
       DestinationFolder="$(ComponentIntermediateOutputPath)$(ComponentName)\unpacked"
       OverwriteReadOnlyFiles="true"/>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
@@ -75,17 +75,17 @@
 
   <Target Name="GenerateSbomForVSInsertion"
         Inputs="@(_VsixFileInfo->'$(VisualStudioSetupInsertionPath)\%(Name)')"
-        Outputs="@(_VsixFileInfo->'$(VisualStudioSetupIntermediateOutputPath\$(ComponentName)\%(Name)')"
+        Outputs="@(_VsixFileInfo->'$(VisualStudioSetupIntermediateOutputPath)\$(ComponentName)\%(Name)')"
         DependsOnTargets="_GetVsixFileVersions"
         Condition="'$(GenerateSbom)' != 'false'">
     <Message Text="Generating SBOM manifest" Importance="high"/>
-    <MakeDir Directories="$(VisualStudioSetupIntermediateOutputPath\$(ComponentName)\Sbom"/>
+    <MakeDir Directories="$(VisualStudioSetupIntermediateOutputPath)\$(ComponentName)\Sbom"/>
     <Unzip
       SourceFiles="@(_VsixFileInfo->'$(VisualStudioSetupInsertionPath)\%(Name)')"
-      DestinationFolder="@(_VsixFileInfo->'$(VisualStudioSetupIntermediateOutputPath\$(ComponentName)\%(Name)')"
+      DestinationFolder="@(_VsixFileInfo->'$(VisualStudioSetupIntermediateOutputPath)\$(ComponentName)\%(Name)')"
       OverwriteReadOnlyFiles="true"/>
 
-    <Exec Command = "$(DotNetTool) $(NUGET_PACKAGES)microsoft.manifesttool.crossplatform\$(MicrosoftManifestToolCrossPlatformVersion)\Content\Microsoft.ManifestTool.dll generate -b @(_VsixFileInfo->'$(VisualStudioSetupIntermediateOutputPath\$(ComponentName)\%(Name)') -m $(VisualStudioSetupIntermediateOutputPath\$(ComponentName)\Sbom -pn VsInsertion -V Verbose"/>
+    <Exec Command = "$(DotNetTool) $(NUGET_PACKAGES)microsoft.manifesttool.crossplatform\$(MicrosoftManifestToolCrossPlatformVersion)\Content\Microsoft.ManifestTool.dll generate -b @(_VsixFileInfo->'$(VisualStudioSetupIntermediateOutputPath)\$(ComponentName)\%(Name)') -m $(VisualStudioSetupIntermediateOutputPath)\$(ComponentName)\Sbom -pn VsInsertion -V Verbose"/>
     <Message Text="Completed generating SBOM manifest for %(VsixFile.Filename)." Importance="high"/>
   </Target>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
@@ -74,18 +74,18 @@
   </Target>
 
   <Target Name="GenerateSbomForVSInsertion"
-        Inputs="@(_VsixFileInfo->'$(VisualStudioSetupInsertionPath)\%(Name)')"
-        Outputs="@(_VsixFileInfo->'$(VisualStudioSetupIntermediateOutputPath)\$(ComponentName)\%(Name)')"
+        Inputs="@(_VsixFileInfo->'$(ComponentIntermediateOutputPath)\%(Name)')"
+        Outputs="@(_VsixFileInfo->'$(ComponentIntermediateOutputPath)\$(ComponentName)\%(Name)')"
         DependsOnTargets="_GetVsixFileVersions"
         Condition="'$(GenerateSbom)' != 'false'">
     <Message Text="Generating SBOM manifest" Importance="high"/>
-    <MakeDir Directories="$(VisualStudioSetupIntermediateOutputPath)\$(ComponentName)\Sbom"/>
+    <MakeDir Directories="$(ComponentIntermediateOutputPath)\$(ComponentName)\Sbom"/>
     <Unzip
       SourceFiles="@(_VsixFileInfo->'$(VisualStudioSetupInsertionPath)\%(Name)')"
-      DestinationFolder="@(_VsixFileInfo->'$(VisualStudioSetupIntermediateOutputPath)\$(ComponentName)\%(Name)')"
+      DestinationFolder="@(_VsixFileInfo->'$(ComponentIntermediateOutputPath)\$(ComponentName)\%(Name)')"
       OverwriteReadOnlyFiles="true"/>
 
-    <Exec Command = "$(DotNetTool) $(NUGET_PACKAGES)microsoft.manifesttool.crossplatform\$(MicrosoftManifestToolCrossPlatformVersion)\Content\Microsoft.ManifestTool.dll generate -b @(_VsixFileInfo->'$(VisualStudioSetupIntermediateOutputPath)\$(ComponentName)\%(Name)') -m $(VisualStudioSetupIntermediateOutputPath)\$(ComponentName)\Sbom -pn VsInsertion -V Verbose"/>
+    <Exec Command = "$(DotNetTool) $(NUGET_PACKAGES)microsoft.manifesttool.crossplatform\$(MicrosoftManifestToolCrossPlatformVersion)\Content\Microsoft.ManifestTool.dll generate -b @(_VsixFileInfo->'$(ComponentIntermediateOutputPath)\$(ComponentName)\%(Name)') -m $(ComponentIntermediateOutputPath)\$(ComponentName)\Sbom -pn VsInsertion -V Verbose"/>
     <Message Text="Completed generating SBOM manifest for %(VsixFile.Filename)." Importance="high"/>
   </Target>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
@@ -74,14 +74,14 @@
   </Target>
 
   <Target Name="GenerateSbomForVSInsertion"
-        Inputs="@(_VsixFileInfo->'$(ComponentIntermediateOutputPath)%(Name)')"
-        Outputs="@(_VsixFileInfo->'$(ComponentIntermediateOutputPath)$(ComponentName)\%(Name)')"
+        Inputs="@(_VsixFileInfo->'$(ArtifactsDir)VSSetup\$(Configuration)\Insertion\%(Name)')"
+        Outputs="@(_VsixFileInfo->'$(ArtifactsDir)VSSetup\$(Configuration)\Insertion\$(ComponentName)\%(Name)')"
         DependsOnTargets="_GetVsixFileVersions"
         Condition="'$(GenerateSbom)' != 'false'">
     <Message Text="Generating SBOM manifest" Importance="high"/>
     <MakeDir Directories="$(ComponentIntermediateOutputPath)$(ComponentName)\Sbom;$(ComponentIntermediateOutputPath)$(ComponentName)\unpacked"/>
     <Unzip
-      SourceFiles="@(_VsixFileInfo->'$(ComponentIntermediateOutputPath)%(Name)')"
+      SourceFiles="@(_VsixFileInfo->'$(ArtifactsDir)VSSetup\$(Configuration)\Insertion\%(Name)')"
       DestinationFolder="$(ComponentIntermediateOutputPath)$(ComponentName)\unpacked"
       OverwriteReadOnlyFiles="true"/>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
@@ -81,7 +81,7 @@
     <Message Text="Generating SBOM manifest" Importance="high"/>
     <MakeDir Directories="$(ComponentIntermediateOutputPath)$(ComponentName)\Sbom;$(ComponentIntermediateOutputPath)$(ComponentName)\unpacked"/>
     <Unzip
-      SourceFiles="@(_VsixFileInfo->'$(VisualStudioSetupInsertionPath)\%(Name)')"
+      SourceFiles="@(_VsixFileInfo->'$(ComponentIntermediateOutputPath)\%(Name)')"
       DestinationFolder="$(ComponentIntermediateOutputPath)$(ComponentName)\unpacked"
       OverwriteReadOnlyFiles="true"/>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.VsixBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.VsixBuild.targets
@@ -115,7 +115,7 @@
     <Error Text="VisualStudioInsertionComponent property must only be set for projects with extension.vsixmanifest or SWR files." Condition="'$(_PackageStubFile)' == ''"/>
 
     <MakeDir Directories="$(_ComponentIntermediateDir)" />
-    <WriteLinesToFile File="$(_PackageStubFile)" Lines="$(TargetVsixContainerName)/$(VsixVersion)" Overwrite="true" />
+    <WriteLinesToFile File="$(_PackageStubFile)" Lines="$(_VsixPackageId)/$(TargetVsixContainerName)/$(VsixVersion)" Overwrite="true" />
 
     <ItemGroup>
       <FileWrites Include="$(_PackageStubFile)"/>


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
* [ ] Issue -> https://github.com/dotnet/arcade/issues/9325

Repos like Roslyn, vs-code-coverage and Fsharp have multiple VSIXs per VS component. Previously when we created the feature for sbom generation, we assumed that we have one VSIX per VS component but then we hit some corner case, since there are many vsix per component, the build used to error saying that the sbom has already been generated for the VS component. Here in this fix, I have made sure that no matter how many vsix the vs component has, it will unpack all the vsix and generate sbom for them individually and it will be linked to the vs manifest file. 