### PR TITLE
Update infrastructure issue template to accept include build retry setting as part of known issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/z-build-break-infrastructure-issue-template.yml
+++ b/.github/ISSUE_TEMPLATE/z-build-break-infrastructure-issue-template.yml
@@ -38,7 +38,8 @@ body:
 
          ```json
          {
-            "ErrorMessage" : ""
+            "ErrorMessage" : "",
+            "BuildRetry": false
          }
          ```
   - type: textarea


### PR DESCRIPTION
Update infrastructure issue template to accept include build retry setting as part of known issues.
As part of: https://github.com/dotnet/arcade/issues/8973

DNM until helix-service has been rolled out and it is stable. Probably until Thursday (06/23)