### PR TITLE
Increase default launch timeout for Apple Simulators

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAppleWorkItemsTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAppleWorkItemsTests.cs
@@ -135,7 +135,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             _fileSystem.RemovedFiles.Should().Contain(payloadArchive);
 
             var command = workItem.GetMetadata("Command");
-            command.Should().Contain("--launch-timeout \"00:03:00\"");
+            command.Should().Contain("--launch-timeout \"00:06:00\"");
         }
 
         [Fact]
@@ -205,7 +205,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             command = workItem2.GetMetadata("Command");
             command.Should().Contain("--target \"ios-simulator-64_13.6\"");
-            command.Should().Contain("--launch-timeout \"00:03:00\"");
+            command.Should().Contain("--launch-timeout \"00:06:00\"");
         }
 
         [Fact]

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Helix.Sdk
 
         // We have a more aggressive timeout towards simulators which tend to slow down until installation takes 20 minutes and the machine needs a reboot
         // For this reason, it's better to be aggressive and detect a slower machine sooner
-        private static readonly TimeSpan s_defaultSimulatorLaunchTimeout = TimeSpan.FromMinutes(3);
+        private static readonly TimeSpan s_defaultSimulatorLaunchTimeout = TimeSpan.FromMinutes(6);
         private static readonly TimeSpan s_defaultDeviceLaunchTimeout = TimeSpan.FromMinutes(5);
 
         /// <summary>


### PR DESCRIPTION
As older machines were added into the pool (https://github.com/dotnet/arcade/issues/9780) they do not run fast enough and hit the aggressive timeouts we set even when running OK

Should also help with https://github.com/dotnet/arcade/issues/9274