### PR TITLE
Return native tools installation locations to users

### DIFF
--- a/eng/common/init-tools-native.ps1
+++ b/eng/common/init-tools-native.ps1
@@ -87,6 +87,7 @@ try {
         $NativeTools.PSObject.Properties | ForEach-Object {
           $ToolName = $_.Name
           $ToolVersion = $_.Value
+          $InstalledTools = @{}
 
           if ((Get-Command "$ToolName" -ErrorAction SilentlyContinue) -eq $null) {
             if ($ToolVersion -eq "latest") {
@@ -111,9 +112,10 @@ try {
             $ToolPath = Convert-Path -Path $BinPath
             Write-Host "Adding $ToolName to the path ($ToolPath)..."
             Write-Host "##vso[task.prependpath]$ToolPath"
+            $InstalledTools += @{ $ToolName = $ToolDirectory }
           }
         }
-        exit 0
+        return $InstalledTools
       } else {
         $NativeTools.PSObject.Properties | ForEach-Object {
           $ToolName = $_.Name

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -635,7 +635,7 @@ function InitializeNativeTools() {
         InstallDirectory = "$ToolsDir"
       }
     }
-    if (Test-Path variable:NativeToolsOnMachine) {
+    if ($env:NativeToolsOnMachine) {
       Write-Host "Variable NativeToolsOnMachine detected, enabling native tool path promotion..."
       $nativeArgs += @{ PathPromotion = $true }
     }


### PR DESCRIPTION
This will allow them to be able to derive their own paths to executables or libraries if they need to.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
