### PR TITLE
[release/6.0] Port XHarness SDK from main

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -39,9 +39,9 @@
       <Uri>https://github.com/dotnet/arcade-services</Uri>
       <Sha>a5f3ed9d5f560555ff6d26b286acdcfbb7ce3b14</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="1.0.0-prerelease.21613.2">
+    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="1.0.0-prerelease.22327.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>d5affc0d0361de14aa1ccbf5cad268d5873e3113</Sha>
+      <Sha>d86d851e6f769397f03e6c5fe720ed5cf12eb4ec</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.0.0-4.21427.11">
       <Uri>https://github.com/dotnet/roslyn</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -82,7 +82,7 @@
     <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>6.0.0-beta.21620.3</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
     <MicrosoftDotNetXliffTasksVersion>1.0.0-beta.21431.1</MicrosoftDotNetXliffTasksVersion>
     <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.22076.4</MicrosoftDotNetMaestroTasksVersion>
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.21613.2</MicrosoftDotNetXHarnessCLIVersion>
+    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.22327.1</MicrosoftDotNetXHarnessCLIVersion>
     <MicrosoftSymbolUploaderBuildTaskVersion>2.0.0-preview.1.21466.7</MicrosoftSymbolUploaderBuildTaskVersion>
     <MicrosoftSymbolUploaderVersion>2.0.0-preview.1.21466.7</MicrosoftSymbolUploaderVersion>
     <MicrosoftNetSdkWorkloadManifestReaderVersion>6.0.100-rtm.21515.10</MicrosoftNetSdkWorkloadManifestReaderVersion>

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAndroidWorkItemsTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAndroidWorkItemsTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 });
 
             _task = new CreateXHarnessAndroidWorkItems()
-            {
+            {                
                 BuildEngine = new MockBuildEngine(),
             };
         }
@@ -76,7 +76,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             var workItem = _task.WorkItems.First();
             workItem.GetMetadata("Identity").Should().Be("System.Foo");
-            workItem.GetMetadata("Timeout").Should().Be("00:16:02");
+            workItem.GetMetadata("Timeout").Should().Be("00:17:42");
 
             var payloadArchive = workItem.GetMetadata("PayloadArchive");
             payloadArchive.Should().NotBeNullOrEmpty();
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             var workItem = _task.WorkItems.Last();
             workItem.GetMetadata("Identity").Should().Be("System.Bar");
-
+            
             workItem = _task.WorkItems.First();
             workItem.GetMetadata("Identity").Should().Be("System.Foo");
 
@@ -178,7 +178,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             var workItem = _task.WorkItems.First();
             workItem.GetMetadata("Identity").Should().Be("System.Foo");
-            workItem.GetMetadata("Timeout").Should().Be("00:16:02");
+            workItem.GetMetadata("Timeout").Should().Be("00:17:42");
 
             var payloadArchive = workItem.GetMetadata("PayloadArchive");
             payloadArchive.Should().NotBeNullOrEmpty();

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAppleWorkItemsTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/CreateXHarnessAppleWorkItemsTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             var workItem = _task.WorkItems.First();
             workItem.GetMetadata("Identity").Should().Be("System.Foo");
-            workItem.GetMetadata("Timeout").Should().Be("00:16:02");
+            workItem.GetMetadata("Timeout").Should().Be("00:17:42");
 
             var payloadArchive = workItem.GetMetadata("PayloadArchive");
             payloadArchive.Should().NotBeNullOrEmpty();
@@ -135,7 +135,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             _fileSystem.RemovedFiles.Should().Contain(payloadArchive);
 
             var command = workItem.GetMetadata("Command");
-            command.Should().Contain("--launch-timeout \"00:03:00\"");
+            command.Should().Contain("--launch-timeout \"00:06:00\"");
         }
 
         [Fact]
@@ -205,7 +205,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             command = workItem2.GetMetadata("Command");
             command.Should().Contain("--target \"ios-simulator-64_13.6\"");
-            command.Should().Contain("--launch-timeout \"00:03:00\"");
+            command.Should().Contain("--launch-timeout \"00:06:00\"");
         }
 
         [Fact]
@@ -230,7 +230,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
 
             var workItem = _task.WorkItems.First();
             workItem.GetMetadata("Identity").Should().Be("System.Foo");
-            workItem.GetMetadata("Timeout").Should().Be("00:16:02");
+            workItem.GetMetadata("Timeout").Should().Be("00:17:42");
 
             var payloadArchive = workItem.GetMetadata("PayloadArchive");
             payloadArchive.Should().NotBeNullOrEmpty();

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAndroidWorkItems.cs
@@ -102,8 +102,7 @@ namespace Microsoft.DotNet.Helix.Sdk
             }
 
             string apkName = Path.GetFileName(apkPath);
-            if (isAlreadyArchived)
-            {
+            if (isAlreadyArchived) {
                 apkName = apkName.Replace(".zip", ".apk");
             }
 

--- a/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateXHarnessAppleWorkItems.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Helix.Sdk
 
         // We have a more aggressive timeout towards simulators which tend to slow down until installation takes 20 minutes and the machine needs a reboot
         // For this reason, it's better to be aggressive and detect a slower machine sooner
-        private static readonly TimeSpan s_defaultSimulatorLaunchTimeout = TimeSpan.FromMinutes(3);
+        private static readonly TimeSpan s_defaultSimulatorLaunchTimeout = TimeSpan.FromMinutes(6);
         private static readonly TimeSpan s_defaultDeviceLaunchTimeout = TimeSpan.FromMinutes(5);
 
         /// <summary>
@@ -205,11 +205,10 @@ namespace Microsoft.DotNet.Helix.Sdk
             "--output-directory \"$output_directory\" " +
             "--target \"$target\" " +
             "--timeout \"$timeout\" " +
+            "--launch-timeout \"$launch_timeout\" " +
             "--xcode \"$xcode_path\" " +
             "-v " +
-            (includesTestRunner
-                ? $"--launch-timeout \"$launch_timeout\" "
-                : $"--expected-exit-code $expected_exit_code ") +
+            (!includesTestRunner ? "--expected-exit-code $expected_exit_code " : string.Empty) +
             (resetSimulator ? $"--reset-simulator " : string.Empty) +
             (!string.IsNullOrEmpty(AppArguments) ? "-- " + AppArguments : string.Empty);
 

--- a/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/XharnessTaskBase.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Helix.Sdk
     {
         private static readonly TimeSpan s_defaultWorkItemTimeout = TimeSpan.FromMinutes(20);
         private static readonly TimeSpan s_defaultTestTimeout = TimeSpan.FromMinutes(12);
-        protected static readonly TimeSpan s_telemetryBuffer = TimeSpan.FromSeconds(20); // extra time to send the XHarness telemetry
+        private static readonly TimeSpan s_telemetryBuffer = TimeSpan.FromMinutes(2); // extra time to send the XHarness telemetry
 
         public class MetadataName
         {

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/Readme.md
@@ -124,14 +124,28 @@ You can configure the execution further via MSBuild properties:
 
 #### Targeting real iOS/tvOS devices
 
-To deploy an app bundle to a real device, the app bundle needs to be signed before the deployment.
-The Helix machines, that have devices attached to them, already contain the signing certificates and a provisioning profile will be downloaded as part of the job prepartion.
+When you are not using `CustomCommands` and you point the SDK to an app bundle, signing will be taken care of for you and you can skip this section.
 
-When using the Helix SDK and targeting real devices:
-- You have to ideally supply a non-signed app bundle - the app will be signed for you on the Helix machine where your job gets executed
-- Only the basic set of app permissions are supported at the moment and we cannot re-sign an app that was already signed with a different set of permissions
+Otherwise, to deploy an app bundle to a real device, the app bundle needs to be signed before it is installed.
+To sign an app bundle you need to make sure that:
+
+1. The bundle contains a *provisioning profile*. This is a file called **embedded.mobileprovision** that needs to be in the root of the app bundle folder (`[PATH TO BUNDLE]/embedded.mobileprovision`).
+2. The `sign [PATH TO BUNDLE]` bash command is called. This method is available for you when using `CustomCommands`.
+
+The provisioning profile will be injected into your Helix payload as part of the job preparation and you need to copy it into the app bundle's root:
+- If you point the SDK to an app bundle directory, the profile will be injected in that folder automatically (in this case you don't control the payload creation).
+- If you give the SDK a custom already zipped payload (you control the payload more), the profile is:
+  - Either placed into any `.app` ending folder from the root of the zip archive (assumed app bundle),
+  - or placed in the root of the zip archive otherwise.
+
+> Take away: If you provide your own zipped payload that doesn't contain an `.app` ending directory, make sure you copy `embedded.mobileprovision` from `$HELIX_WORKITEM_ROOT` into your app bundle.
+
+Couple more notes:
+- Only the basic set of app permissions is supported at the moment (e.g. no GPS control...)
+- We cannot re-sign an app that was already signed with a different set of permissions
 - App bundle identifier has to start with `net.dot.` since we only support those application IDs at the moment (restrictions by Apple)
-- In case you don't supply the app bundle but for example build the app on the Helix agent as part of the job, use the `sign [path to app]` bash function to perform the signing. In this case, make sure the provisioning profile is part of the app bundle present at `[app]/embedded.mobileprovision`.
+- When signing succeeds, you should see something like this in the logs:  
+    `/tmp/helix/working/A74A0921/w/A5C2095E/e/System.Buffers.Tests.app: signed app bundle with Mach-O thin (arm64) [net.dot.System.Buffers.Tests]`
 
 ### Android .apk payloads
 

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup Condition=" '$(IncludeXHarnessCli)' == 'true' ">
     <IncludeDotNetCli>true</IncludeDotNetCli>
-    <XHarnessTargetFramework Condition=" '$(XHarnessTargetFramework)' == '' ">net7.0</XHarnessTargetFramework>
+    <XHarnessTargetFramework Condition=" '$(XHarnessTargetFramework)' == '' ">net6.0</XHarnessTargetFramework>
     <DotNetCliVersion Condition=" '$(XHarnessTargetFramework)' == 'net7.0' ">7.0.100-preview.2.22153.17</DotNetCliVersion>
     <DotNetCliVersion Condition=" '$(XHarnessTargetFramework)' == 'net6.0' ">6.0.202</DotNetCliVersion>
     <DotNetCliPackageType>sdk</DotNetCliPackageType>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
@@ -1,12 +1,10 @@
 <Project>
   <PropertyGroup Condition=" '$(IncludeXHarnessCli)' == 'true' ">
-    <!-- We then invoke the CLI DLL directly using .NET runtime without the need for .NET SDK -->
     <IncludeDotNetCli>true</IncludeDotNetCli>
-    <IncludeXHarnessCli>true</IncludeXHarnessCli>
-    <XHarnessTargetFramework Condition=" '$(XHarnessTargetFramework)' == '' ">net6.0</XHarnessTargetFramework>
-    <DotNetCliVersion Condition=" '$(DotNetCliVersion)' == '' ">6.0.100</DotNetCliVersion>
-    <DotNetCliPackageType Condition=" '$(DotNetCliPackageType)' != 'sdk' ">aspnetcore-runtime</DotNetCliPackageType>
-    <DotNetCliVersion Condition=" '$(DotNetCliVersion)' == '$(NETCoreSdkVersion)' AND '$(DotNetCliPackageType)' == 'aspnetcore-runtime' ">$(AspNetCoreRuntimeVersion)</DotNetCliVersion>
+    <XHarnessTargetFramework Condition=" '$(XHarnessTargetFramework)' == '' ">net7.0</XHarnessTargetFramework>
+    <DotNetCliVersion Condition=" '$(XHarnessTargetFramework)' == 'net7.0' ">7.0.100-preview.2.22153.17</DotNetCliVersion>
+    <DotNetCliVersion Condition=" '$(XHarnessTargetFramework)' == 'net6.0' ">6.0.202</DotNetCliVersion>
+    <DotNetCliPackageType>sdk</DotNetCliPackageType>
   </PropertyGroup>
 
   <Target Name="AddXHarnessCli"
@@ -64,21 +62,21 @@
       <HelixPreCommands>$(HelixPreCommands);export PATH=$HELIX_CORRELATION_PAYLOAD/xharness-cli:$PATH</HelixPreCommands>
       <HelixPreCommands>$(HelixPreCommands);export XHARNESS_DISABLE_COLORED_OUTPUT=true</HelixPreCommands>
       <HelixPreCommands>$(HelixPreCommands);export XHARNESS_LOG_WITH_TIMESTAMPS=true</HelixPreCommands>
-      <HelixPreCommands>$(HelixPreCommands);export XHARNESS_CLI_PATH=$HELIX_CORRELATION_PAYLOAD/microsoft.dotnet.xharness.cli/$(_XHarnessPackageVersion)/tools/net6.0/any/Microsoft.DotNet.XHarness.CLI.dll</HelixPreCommands>
+      <HelixPreCommands>$(HelixPreCommands);export XHARNESS_CLI_PATH=$HELIX_CORRELATION_PAYLOAD/microsoft.dotnet.xharness.cli/$(_XHarnessPackageVersion)/tools/$(XHarnessTargetFramework)/any/Microsoft.DotNet.XHarness.CLI.dll</HelixPreCommands>
 
       <HelixPreCommands Condition=" '$(EnableXHarnessTelemetry)' == 'true' ">$(HelixPreCommands);export XHARNESS_DIAGNOSTICS_PATH=$HELIX_WORKITEM_ROOT/diagnostics.json</HelixPreCommands>
-      <HelixPostCommands Condition=" '$(EnableXHarnessTelemetry)' == 'true' ">"$HELIX_PYTHONPATH" "$HELIX_WORKITEM_PAYLOAD/xharness-event-processor.py";$(HelixPostCommands)</HelixPostCommands>
+      <HelixPostCommands Condition=" '$(EnableXHarnessTelemetry)' == 'true' ">"$HELIX_PYTHONPATH" -u "$HELIX_WORKITEM_PAYLOAD/xharness-event-processor.py";$(HelixPostCommands)</HelixPostCommands>
     </PropertyGroup>
 
     <PropertyGroup Condition="!$(IsPosixShell)">
       <HelixPreCommands>$(HelixPreCommands);set PATH=%HELIX_CORRELATION_PAYLOAD%\xharness-cli%3B%PATH%</HelixPreCommands>
       <HelixPreCommands>$(HelixPreCommands);set XHARNESS_DISABLE_COLORED_OUTPUT=true</HelixPreCommands>
       <HelixPreCommands>$(HelixPreCommands);set XHARNESS_LOG_WITH_TIMESTAMPS=true</HelixPreCommands>
-      <HelixPreCommands>$(HelixPreCommands);set XHARNESS_CLI_PATH=%HELIX_CORRELATION_PAYLOAD%\microsoft.dotnet.xharness.cli\$(_XHarnessPackageVersion)\tools\net6.0\any\Microsoft.DotNet.XHarness.CLI.dll</HelixPreCommands>
+      <HelixPreCommands>$(HelixPreCommands);set XHARNESS_CLI_PATH=%HELIX_CORRELATION_PAYLOAD%\microsoft.dotnet.xharness.cli\$(_XHarnessPackageVersion)\tools\$(XHarnessTargetFramework)\any\Microsoft.DotNet.XHarness.CLI.dll</HelixPreCommands>
       <HelixPreCommands>$(HelixPreCommands);doskey xharness="dotnet exec %XHARNESS_CLI_PATH%"</HelixPreCommands>
 
       <HelixPreCommands Condition=" '$(EnableXHarnessTelemetry)' == 'true' ">$(HelixPreCommands);set XHARNESS_DIAGNOSTICS_PATH=%HELIX_WORKITEM_ROOT%\diagnostics.json</HelixPreCommands>
-      <HelixPostCommands Condition=" '$(EnableXHarnessTelemetry)' == 'true' ">"%HELIX_PYTHONPATH%" "%HELIX_WORKITEM_PAYLOAD%\xharness-event-processor.py";$(HelixPostCommands)</HelixPostCommands>
+      <HelixPostCommands Condition=" '$(EnableXHarnessTelemetry)' == 'true' ">"%HELIX_PYTHONPATH%" -u "%HELIX_WORKITEM_PAYLOAD%\xharness-event-processor.py";$(HelixPostCommands)</HelixPostCommands>
     </PropertyGroup>
   </Target>
 

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-processor.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-processor.py
@@ -3,19 +3,21 @@ import json
 import os
 import subprocess
 import sys
+from typing import Tuple
 
-from helix.appinsights import app_insights
-from helix.public import request_reboot, request_infra_retry
+from helix.public import request_reboot, request_infra_retry, send_metric, send_metrics
 
 ### This script's purpose is to parse the diagnostics.json file produced by XHarness, evaluate it and send it to AppInsights
 ### The diagnostics.json file contains information about each XHarness command executed during the job
 ### In case of events that suggest infrastructure issues, we request a retry and for some reboot the agent
 
-# Name of metrics we send to Helix
-OPERATION_METRIC_NAME = 'XHarnessOperation'
-DURATION_METRIC_NAME = 'XHarnessOperationDuration'
-RETRY_METRIC_NAME = 'XHarnessRetry'
-REBOOT_METRIC_NAME = 'XHarnessReboot'
+# Name of metrics we send (to Kusto)
+EVENT_TYPE = 'MobileDeviceOperation'
+OPERATION_METRIC_NAME = 'ExitCode'
+DURATION_METRIC_NAME = 'Duration'
+RETRY_METRIC_NAME = 'Retry'
+REBOOT_METRIC_NAME = 'Reboot'
+NETWORK_CONNECTIVITY_METRIC_NAME = 'NoInternet'
 
 opts, args = getopt.gnu_getopt(sys.argv[1:], 'd:', ['diagnostics-data='])
 opt_dict = dict(opts)
@@ -43,27 +45,63 @@ output_directory = os.getenv('HELIX_WORKITEM_UPLOAD_ROOT')
 # Retry/reboot can be also asked for by the client (by creating .retry/.reboot files)
 retry = False
 reboot = False
-retry_dimensions = None
-reboot_dimensions = None
+retry_dimensions = dict()
+reboot_dimensions = dict()
 retry_exit_code = -1
 reboot_exit_code = -1
+android_connectivity_verified = False
+
+class AdditionalTelemetryRequired(Exception):
+    """Exception raised when we need to send additional telemetry during analysis
+
+    Attributes:
+        metric_name -- name of the event
+        metric_value -- value of the metric event
+    """
+
+    def __init__(self, metric_name, metric_value):
+        self.metric_name = metric_name
+        self.metric_value = metric_value
+        super().__init__("Additional telemetry required")
+
+def call_xharness(args: list, capture_output: bool = False) -> Tuple[int, str]:
+    """ Calls the XHarness CLI with given arguments
+    """
+
+    xharness_cli_path = os.getenv('XHARNESS_CLI_PATH')
+    args = ['dotnet', 'exec', xharness_cli_path] + args
+
+    if capture_output:
+        process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        stdout = process.communicate()[0].decode("utf-8")
+        return process.returncode, stdout
+    else:
+        return subprocess.run(args, stdout=None, stderr=None, text=True).returncode, None
+
+def call_adb(args: list, capture_output: bool = False):
+    """ Calls the XHarness CLI with `android adb` command and given arguments
+    """
+
+    return call_xharness(['android', 'adb', '--'] + args, capture_output)
 
 def remove_android_apps(device: str = None):
     """ Removes all Android applications from the target device/emulator
     """
 
-    print(f'    Removing installed apps after unsuccessful run' + (' from ' + device if device else ""))
-
-    xharness_cli_path = os.getenv('XHARNESS_CLI_PATH')
-    adb_args = ['dotnet', 'exec', xharness_cli_path, 'android', 'adb', '--']
+    print('    Removing installed apps after unsuccessful run' + (' from ' + device if device else ""))
 
     # Get list of installed apps
     args = ['shell', 'pm', 'list', 'packages', 'net.dot']
     if device:
         args = ['-s', device] + args
 
-    installed_apps = subprocess.check_output(adb_args + args).decode('utf-8').splitlines()
-    installed_apps = [app.split(':')[1] for app in installed_apps if app]
+    exit_code, output = call_adb(args, capture_output=True)
+    if exit_code != 0:
+        print(f'    Failed to get list of installed apps: {output}')
+        return
+
+    installed_apps = output.splitlines()
+    installed_apps = [app.split(':')[1] for app in installed_apps if app and app.startswith('package:')]
 
     # Remove all installed apps
     for app in installed_apps:
@@ -73,12 +111,10 @@ def remove_android_apps(device: str = None):
         if device:
             args = ['-s', device] + args
 
-        try:
-            result = subprocess.run(adb_args + args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-            output = result.stdout.decode('utf8')
-            print(f'            {output}')
-        except Exception as e:
-            print(f'            Failed to remove app {app}: {e}')
+        exit_code, _ = call_adb(args)
+
+        if exit_code != 0:
+            print(f'            Failed to remove app {app}')
 
 def analyze_operation(command: str, platform: str, device: str, is_device: bool, target: str, exit_code: int):
     """ Analyzes the result and requests retry/reboot in case of an infra failure
@@ -87,27 +123,85 @@ def analyze_operation(command: str, platform: str, device: str, is_device: bool,
 
     print(f'Analyzing {platform}/{command}@{target} ({exit_code})')
 
-    global retry, reboot
+    global retry, reboot, android_connectivity_verified
+
+    # Kill the simulator when we fail to launch the app
+    if exit_code == 80: # APP_CRASH
+        print(f'    Application crashed - if persist, please investigate system logs from the run')
+        retry = True
+        reboot = True
+        return
+
+    # Simulators are known to slow down which results in installation taking several minutes
+    # Retry+reboot usually resolves this
+    if exit_code == 86: # APP_INSTALLATION_TIMEOUT
+        print(f'    Installation timed out')
+        reboot = True
+        retry = True
+        return
+
+    # Simulators are known to slow/break down and a reboot usually helps
+    # This manifest by us not being able to launch the simulator
+    if exit_code == 88: # SIMULATOR_FAILURE
+        print(f'    Failed to launch the emulator')
+        reboot = True
+        retry = True
+        return
+
+    # Devices can be locked or in a corrupted state, in this case we only retry the work item
+    if exit_code == 89: # DEVICE_FAILURE
+        print(f'    Failed to talk to the device')
+        retry = True
+        return
+
+    if exit_code == 90: # APP_LAUNCH_TIMEOUT
+        print(f'    Failed to launch the app in alloted time')
+        if not is_device:
+            reboot = True
+        retry = True
+        return
 
     if platform == "android":
-        if exit_code == 85: # ADB_DEVICE_ENUMERATION_FAILURE
-            # This handles issues where devices or emulators fail to start.
-            # The only solution is to reboot the machine, so we request a work item retry + agent reboot when this happens
-            print('    Encountered ADB_DEVICE_ENUMERATION_FAILURE. This is typically not a failure of the work item. It will be run again. This machine will reboot to help its devices')
-            print('    If this occurs repeatedly, please check for architectural mismatch, e.g. sending arm64_v8a APKs to an x86_64 / x86 only queue.')
-
-            if not is_device and os.name != 'nt':
-                # Copy emulator log
-                subprocess.call(['cp', '/tmp/*-logcat.log', output_directory])
-
-            reboot = True
+        if exit_code == 81: # DEVICE_NOT_FOUND
+            # This handles issues where emulators fail to start or devices go silent.
+            print(f'    Encountered DEVICE_NOT_FOUND')
+            print('    If this occurs repeatedly, please check for architectural mismatch, e.g. sending arm64_v8a APKs to an x86_64 / x86 only queue')
             retry = True
+
+            if not is_device:
+                # For emulators it makes sense to reboot to try to heal the emulator
+                reboot = True
+
+                # We also attach logs from the emulator boot (which might tell us why there's no emulator)
+                if os.name != 'nt':
+                    # This is where Azure stores logs from custom extension script runs
+                    # More details here https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/custom-script-linux#troubleshooting
+                    boot_log_location = '/var/lib/waagent/custom-script/download'
+
+                    print(f'    Collecting emulator boot logs from {boot_log_location}..')
+                    boot_log_destination = output_directory + '/emulator_logs'
+
+                    # Only copy stdout/stderr files (however they might be in different folders based on how Azure executed extension scripts)
+                    subprocess.call(['sudo', 'rsync', '--recursive', '--include', 'stdout', '--include', 'stderr', '--filter', '-! */',
+                        boot_log_location, boot_log_destination])
+
+                    # The boot logs are owned by root, so make them readable for the Helix agent
+                    subprocess.call(['sudo', 'chmod', '-R', '777', boot_log_destination])
+
+            return
+
+        if exit_code == 82 and not is_device: # RETURN_CODE_NOT_SET - this happens when emulator crashes halfway through
+            print(f'    Failed to read the instrumentation result')
+            retry = True
+            reboot = True
+            return
 
         if exit_code == 78: # PACKAGE_INSTALLATION_FAILURE
             # This handles issues where APKs fail to install.
             # We already reboot a device inside XHarness and now request a work item retry when this happens
-            print('    Encountered PACKAGE_INSTALLATION_FAILURE. This is typically not a failure of the work item. We will try it again on another Helix agent')
-            print('    If this occurs repeatedly, please check for architectural mismatch, e.g. requesting installation on arm64_v8a-only queue for x86 or x86_64 APKs.')
+            print(f'    Encountered PACKAGE_INSTALLATION_FAILURE')
+            print('    If this occurs repeatedly, please check for architectural mismatch, e.g. requesting installation on arm64_v8a-only queue for x86 or x86_64 APKs')
+            retry = True
 
             if is_device:
                 try:
@@ -115,67 +209,95 @@ def analyze_operation(command: str, platform: str, device: str, is_device: bool,
                 except Exception as e:
                     print(f'    Failed to remove installed apps from device: {e}')
 
+            return
+
+        if exit_code == 91: # ADB_FAILURE
+            # This handles issues where we have problems with ADB
+            # The only solution is to reboot the machine, so we request a work item retry + agent reboot when this happens
+            print(f'    Encountered ADB_FAILURE')
+            print('    If this occurs repeatedly, please check for architectural mismatch, e.g. sending arm64_v8a APKs to an x86_64 / x86 only queue')
+
+            if not is_device and os.name != 'nt':
+                # Copy emulator log
+                subprocess.call(['cp', '/tmp/*-logcat.log', output_directory])
+
+            reboot = True
             retry = True
+            return
+
+        if exit_code != 0 and is_device and not android_connectivity_verified:
+            # Any issue can also be caused by network connectivity problems (devices sometimes lose the WiFi connection)
+            # In those cases, we want a retry and we want to report this
+            print('    Encountered non-zero exit code. Checking network connectivity...')
+            android_connectivity_verified = True
+
+            exitcode, _ = call_adb(['shell', 'ping', '-i', '0.2', '-c', '3', 'www.microsoft.com'])
+
+            if exitcode != 0:
+                retry = True
+                print(f'    Detected network connectivity issue')
+                raise AdditionalTelemetryRequired(NETWORK_CONNECTIVITY_METRIC_NAME, 1)
 
     elif platform == "apple":
-        retry_message = 'This is typically not a failure of the work item. It will be run again. '
-        reboot_message = 'This machine will reboot to heal.'
+        # This code should only be retried for Apple as in Android this can mean failed tests or app crash
+        if exit_code == 82: # RETURN_CODE_NOT_SET
+            # See https://github.com/dotnet/xharness/issues/812
+            print(f'    Failed to detect app\'s exit code')
+            retry = True
+            return
+
+        # If we have a launch failure on simulators, we want a reboot+retry
+        # We want retry only on devices (it happens quite rarely)
+        if exit_code == 83: # APP_LAUNCH_FAILURE
+            print(f'    Encountered APP_LAUNCH_FAILURE')
+            if not is_device:
+                reboot = True
+            retry = True
+            return
 
         if is_device:
             # If we fail to find a real device, it is unexpected as device queues should have one
-            # It can often be fixed with a reboot
             if exit_code == 81: # DEVICE_NOT_FOUND
-                print(f'    Requested tethered Apple device not found. {retry_message}{reboot_message}')
+                print(f'    Requested tethered Apple device not found')
                 reboot = True
                 retry = True
+                return
 
-            # Devices can be locked or in a corrupted state, in this case we only retry the work item
-            if exit_code == 89: # DEVICE_FAILURE
-                print(f'    Failed to launch the simulator. {retry_message}')
-                retry = True
         else:
-            # Kill the simulator when we fail to launch the app
-            if exit_code == 80: # APP_CRASH
-                simulator_app = os.getenv('SIMULATOR_APP')
-                subprocess.call(['sudo', 'pkill', '-9', '-f', simulator_app])
-
-            # If we have a launch failure on simulators, we want a reboot+retry
-            if exit_code == 83: # APP_LAUNCH_FAILURE
-                print(f'    Encountered APP_LAUNCH_FAILURE. {retry_message}{reboot_message}')
-                reboot = True
+            if exit_code == 78: # PACKAGE_INSTALLATION_FAILURE
+                print(f'    Encountered PACKAGE_INSTALLATION_FAILURE. This might be caused by a corrupt simulator')
                 retry = True
+                reboot = True
+                return
 
             # If we fail to find a simulator and we are not targeting a specific version (e.g. `ios-simulator_13.5`),
             # it is probably an issue because Xcode should always have at least one runtime version inside
             if exit_code == 81 and '_' not in target: # DEVICE_NOT_FOUND
-                print(f'    No simulator runtime found. {retry_message}')
+                print(f'    No simulator runtime found')
                 retry = True
-
-            # Simulators are known to slow down which results in installation taking several minutes
-            # Retry+reboot usually resolves this
-            if exit_code == 86: # APP_INSTALLATION_TIMEOUT
-                print(f'    Installation timed out. {retry_message}{reboot_message}')
                 reboot = True
-                retry = True
-
-            # Simulators are known to slow/break down and a reboot usually helps
-            # This manifest by us not being able to launch the simulator
-            if exit_code == 88: # SIMULATOR_FAILURE
-                print(f'    Failed to launch the simulator. {retry_message}{reboot_message}')
-                reboot = True
-                retry = True
-
-            # Simulators are known to slow/break down and a reboot usually helps
-            # This manifest by us not being able to launch the simulator/start the test run in time
-            if exit_code == 90: # APP_LAUNCH_TIMEOUT
-                print(f'    Failed to start the test execution in time. {retry_message}{reboot_message}')
-                reboot = True
-                retry = True
+                return
 
 # The JSON should be an array of objects (one per each executed XHarness command)
-operations = json.load(open(diagnostics_file))
+try:
+    operations = json.load(open(diagnostics_file))
+except Exception as e:
+    print(f'    Failed to load the diagnostics file: {e}')
+    print('Diagnostics file contents:')
+    with open(diagnostics_file) as f:
+        print(f.read())
+    exit(1)
+
+if len(operations) == 0:
+    print('    No operations found in the diagnostics file')
+    exit(0)
 
 print(f"Reporting {len(operations)} events from diagnostics file `{diagnostics_file}`")
+
+# Example version: 1.0.0-prerelease.22269.1+6e87004b51c89c59ac4a34536e9bc22da0124f39
+# We remove the commit SHA
+_, version = call_xharness(['version'], capture_output=True)
+version = version.strip().split("+")[0]
 
 # Parse operations, analyze them and send them to Application Insights
 for operation in operations:
@@ -186,25 +308,30 @@ for operation in operations:
     device = operation.get('device')
     target = operation.get('target')
     target_os = operation.get('targetOS')
-    is_device = operation.get('isDevice', False)
-
-    try:
-        analyze_operation(command, platform, device, is_device, target, exit_code)
-    except Exception as e:
-        print(f'    Failed to analyze operation: {e}')
+    is_device = operation.get('isDevice', None)
 
     custom_dimensions = dict()
-    custom_dimensions['command'] = operation['command']
-    custom_dimensions['platform'] = operation['platform']
-    custom_dimensions['isDevice'] = 'true' if operation['isDevice'] else 'false'
+    custom_dimensions['command'] = command
+    custom_dimensions['platform'] = platform
+    custom_dimensions['version'] = version
+
+    if is_device is not None:
+        custom_dimensions['isDevice'] = 'true' if str(is_device).lower() == 'true' else 'false'
 
     if 'target' in operation:
         if 'targetOS' in operation:
-            custom_dimensions['target'] = target + '_' + target_os
+            custom_dimensions['target'] = target + ':' + target_os
         else:
             custom_dimensions['target'] = target
     elif 'targetOS' in operation:
         custom_dimensions['target'] = target_os
+
+    try:
+        analyze_operation(command, platform, device, is_device, target, exit_code)
+    except AdditionalTelemetryRequired as e:
+        send_metric(e.metric_name, e.metric_value, custom_dimensions, event_type=EVENT_TYPE)
+    except Exception as e:
+        print(f'    Failed to analyze operation: {e}')
 
     # Note down the dimensions that caused retry/reboot
     if retry and retry_dimensions is None:
@@ -214,8 +341,11 @@ for operation in operations:
     if reboot and reboot_dimensions is None:
         reboot_dimensions = custom_dimensions
 
-    app_insights.send_metric(OPERATION_METRIC_NAME, exit_code, properties=custom_dimensions)
-    app_insights.send_metric(DURATION_METRIC_NAME, duration, properties=custom_dimensions)
+    kusto_metrics = dict()
+    kusto_metrics[OPERATION_METRIC_NAME] = exit_code
+    kusto_metrics[DURATION_METRIC_NAME] = duration
+
+    send_metrics(kusto_metrics, custom_dimensions, event_type=EVENT_TYPE)
 
 # Retry / reboot is handled here
 script_dir = os.getenv('HELIX_WORKITEM_ROOT')
@@ -227,16 +357,20 @@ if os.path.exists(os.path.join(script_dir, '.reboot')):
     reboot = True
 
 if retry:
-    app_insights.send_metric(RETRY_METRIC_NAME, retry_exit_code, properties=retry_dimensions)
+    send_metric(RETRY_METRIC_NAME, retry_exit_code, retry_dimensions, event_type=EVENT_TYPE)
     request_infra_retry('Requesting work item retry because an infrastructure issue was detected on this machine')
 
     # TODO https://github.com/dotnet/core-eng/issues/15059
     # We need to remove testResults.xml so that it is not uploaded since this run will be discarded
     # This is a workaround until we make AzDO reporter not upload test results
-    test_results = os.path.join(output_directory, "testResults.xml")
+    file_name = "testResults.xml"
+    test_results = os.path.join(output_directory, file_name)
     if os.path.exists(test_results):
         os.remove(test_results)
 
+    if os.path.exists(file_name):
+        os.remove(file_name)
+
 if reboot:
-    app_insights.send_metric(REBOOT_METRIC_NAME, reboot_exit_code, properties=reboot_dimensions)
+    send_metric(REBOOT_METRIC_NAME, reboot_exit_code, reboot_dimensions, event_type=EVENT_TYPE)
     request_reboot('Requesting machine reboot as an infrastructure issue was detected on this machine')

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.ps1
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.android.ps1
@@ -46,13 +46,11 @@ if ($ev) {
     Write-Output "User command timed out after $command_timeout seconds!"
 
     Write-Output "Removing installed apps after unsuccessful run"
-    $adb_path = & dotnet exec $Env:XHARNESS_CLI_PATH android state --adb
-    $packages = & $adb_path shell pm list packages net.dot
+    $packages = dotnet exec $Env:XHARNESS_CLI_PATH android adb -- shell pm list packages net.dot
     $split_packages = $packages.split(':')
     For ($i = 1; $i -lt $split_packages.Length; $i += 2) {
         Write-Output "    Uninstalling $($split_packages[$i])"
-        $output = & $adb_path uninstall $split_packages[$i]
-        Write-Output "        $output"
+        dotnet exec $Env:XHARNESS_CLI_PATH android adb -- uninstall $split_packages[$i]
     }
 
     exit -3

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-helix-job.apple.sh
@@ -49,7 +49,7 @@ if [ -f "$HELIX_WORKITEM_ROOT/.retry" ]; then
     retry_message=$(cat "$HELIX_WORKITEM_ROOT/.retry" | tr -d "'\\\\")
 
     if [ -z "$retry_message" ]; then
-        retry_message='Retrying because we could not enumerate all Android devices'
+        retry_message='Infrastructural problem reported by the user, requesting retry'
     fi
 
     "$HELIX_PYTHONPATH" -c "from helix.workitemutil import request_infra_retry; request_infra_retry('$retry_message')"
@@ -59,7 +59,7 @@ if [ -f "$HELIX_WORKITEM_ROOT/.reboot" ]; then
     reboot_message=$(cat "$HELIX_WORKITEM_ROOT/.reboot" | tr -d "'\\\\")
 
     if [ -z "$reboot_message" ]; then
-        reboot_message='Rebooting to allow Android emulator to restart'
+        reboot_message='Infrastructural problem reported by the user, requesting reboot'
     fi
 
     "$HELIX_PYTHONPATH" -c "from helix.workitemutil import request_reboot; request_reboot('$reboot_message')"

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
@@ -167,7 +167,7 @@ exit_code=$?
 
 # In case of issues, include the syslog (last 2 MB from the time this work item has been running)
 if [ $exit_code -ne 0 ]; then
-    sudo log show --style syslog --start "$start_time" --end "$(date '+%Y-%m-%d %H:%M:%S')" | tail -c 2097152 > "$output_directory/system.log"
+    sudo log show --style syslog --start "$start_time" --end "$(date '+%Y-%m-%d %H:%M:%S')" | tail -c 2097152 > "$output_directory/macos.system.log"
 fi
 
 echo "Removing empty log files:"


### PR DESCRIPTION
This should improve reliability of the 6.0 builds by bringing over some work we've done there when running mobile device tests. This is needed also because the HW is shared between `main` and `release/6.0`

Related to #9828 