### PR TITLE
Remove (EOL 6/30/2022) Debian 9 usage.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -166,7 +166,7 @@ stages:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''
         - job: Linux
-          timeoutInMinutes: 90
+          timeoutInMinutes: 180
           container: LinuxContainer
           pool:
             vmimage: ubuntu-latest

--- a/tests/UnitTests.proj
+++ b/tests/UnitTests.proj
@@ -14,6 +14,7 @@
     <DotNetCliPackageType>sdk</DotNetCliPackageType>
 
     <TestRunNamePrefix>$(AGENT_JOBNAME)</TestRunNamePrefix>
+    <FailOnMissingTargetQueue>false</FailOnMissingTargetQueue>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/UnitTests.proj
+++ b/tests/UnitTests.proj
@@ -58,7 +58,6 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(HelixAccessToken)' != '' ">
-    <HelixTargetQueue Include="Debian.9.Amd64"/>
     <HelixTargetQueue Include="RedHat.7.Amd64"/>
     <HelixTargetQueue Include="Windows.10.Amd64"/>
     <HelixTargetQueue Include="(Debian.10.Amd64)ubuntu.1804.amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-10-helix-amd64-20210304164434-56c6673"/>
@@ -71,7 +70,6 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(HelixAccessToken)' == '' ">
-    <HelixTargetQueue Include="Debian.9.Amd64.Open"/>
     <HelixTargetQueue Include="RedHat.7.Amd64.Open"/>
     <HelixTargetQueue Include="Windows.10.Amd64.Open"/>
     <HelixTargetQueue Include="(Debian.10.Amd64.Open)ubuntu.1804.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-10-helix-amd64-20210304164434-56c6673"/>


### PR DESCRIPTION
## Description

Remove Debian.9.Amd64* helix queues from test matrix for arcade CI

## Customer Impact

Once the relevant Helix queues are removed, folks still using them will start to see failures to send work (ETA 7/6/2022) 

## Regression

No

## Risk

Minimal: this is removing a row of the test matrix that already has coverage from RH 7 and the Debian 10 "docker" scenario.

## Workarounds

No
