### PR TITLE
Remove (EOL 6/30/2022) Debian 9 usage

### DIFF
--- a/tests/UnitTests.proj
+++ b/tests/UnitTests.proj
@@ -16,6 +16,7 @@
     <TestRunNamePrefix>$(AGENT_JOBNAME)</TestRunNamePrefix>
 
     <EnableXUnitReporter>true</EnableXUnitReporter>
+    <FailOnMissingTargetQueue>false</FailOnMissingTargetQueue>
   </PropertyGroup>
 
   <ItemGroup>
@@ -58,7 +59,6 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(HelixAccessToken)' != '' ">
-    <HelixTargetQueue Include="Debian.9.Amd64"/>
     <HelixTargetQueue Include="RedHat.7.Amd64"/>
     <HelixTargetQueue Include="Windows.10.Amd64"/>
   </ItemGroup>
@@ -70,7 +70,6 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(HelixAccessToken)' == '' ">
-    <HelixTargetQueue Include="Debian.9.Amd64.Open"/>
     <HelixTargetQueue Include="RedHat.7.Amd64.Open"/>
     <HelixTargetQueue Include="Windows.10.Amd64.Open"/>
   </ItemGroup>


### PR DESCRIPTION
Add FailOnMissingTargetQueue property usage to keep working if target queue is removed as long as 1+ remains.

## Description

Remove Debian.9.Amd64* helix queues from test matrix for arcade CI

## Customer Impact

Once the relevant Helix queues are removed, folks still using them will start to see failures to send work (ETA 7/6/2022) 

## Regression

No

## Risk

Minimal: this is removing a row of the test matrix that already has coverage from RH 7 and the Debian 10 "docker" scenario.

## Workarounds

No