### PR TITLE
Annotate Conditional attributes for trimmability

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ConditionalClassAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ConditionalClassAttribute.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Xunit.Sdk;
 
 namespace Xunit
@@ -10,10 +11,14 @@ namespace Xunit
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     public sealed class ConditionalClassAttribute : Attribute, ITraitAttribute
     {
+        [DynamicallyAccessedMembers(StaticReflectionConstants.ConditionalMemberKinds)]
         public Type CalleeType { get; private set; }
         public string[] ConditionMemberNames { get; private set; }
 
-        public ConditionalClassAttribute(Type calleeType, params string[] conditionMemberNames)
+        public ConditionalClassAttribute(
+            [DynamicallyAccessedMembers(StaticReflectionConstants.ConditionalMemberKinds)]
+            Type calleeType,
+            params string[] conditionMemberNames)
         {
             CalleeType = calleeType;
             ConditionMemberNames = conditionMemberNames;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ConditionalFactAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ConditionalFactAttribute.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Xunit.Sdk;
 
 namespace Xunit
@@ -10,10 +11,14 @@ namespace Xunit
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
     public sealed class ConditionalFactAttribute : FactAttribute
     {
+        [DynamicallyAccessedMembers(StaticReflectionConstants.ConditionalMemberKinds)]
         public Type CalleeType { get; private set; }
         public string[] ConditionMemberNames { get; private set; }
 
-        public ConditionalFactAttribute(Type calleeType, params string[] conditionMemberNames)
+        public ConditionalFactAttribute(
+            [DynamicallyAccessedMembers(StaticReflectionConstants.ConditionalMemberKinds)]
+            Type calleeType,
+            params string[] conditionMemberNames)
         {
             CalleeType = calleeType;
             ConditionMemberNames = conditionMemberNames;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ConditionalTheoryAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ConditionalTheoryAttribute.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Xunit.Sdk;
 
 namespace Xunit
@@ -10,10 +11,14 @@ namespace Xunit
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
     public sealed class ConditionalTheoryAttribute : TheoryAttribute
     {
+        [DynamicallyAccessedMembers(StaticReflectionConstants.ConditionalMemberKinds)]
         public Type     CalleeType { get; private set; }
         public string[] ConditionMemberNames { get; private set; }
 
-        public ConditionalTheoryAttribute(Type calleeType, params string[] conditionMemberNames)
+        public ConditionalTheoryAttribute(
+            [DynamicallyAccessedMembers(StaticReflectionConstants.ConditionalMemberKinds)]
+            Type calleeType,
+            params string[] conditionMemberNames)
         {
             CalleeType = calleeType;
             ConditionMemberNames = conditionMemberNames;

--- a/src/Microsoft.DotNet.XUnitExtensions/src/StaticReflectionConstants.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/StaticReflectionConstants.cs
@@ -7,9 +7,8 @@ namespace Xunit
 {
     internal static class StaticReflectionConstants
     {
-        internal const DynamicallyAccessedMemberTypes ConditionalMemberKinds = DynamicallyAccessedMemberTypes.PublicFields |
-            DynamicallyAccessedMemberTypes.PublicMethods |
-            DynamicallyAccessedMemberTypes.PublicProperties;
+        // ConditionalTestDiscoverer looks at all fields/methods/properties, recursively.
+        internal const DynamicallyAccessedMemberTypes ConditionalMemberKinds = DynamicallyAccessedMemberTypes.All;
     }
 }
 

--- a/src/Microsoft.DotNet.XUnitExtensions/src/StaticReflectionConstants.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/StaticReflectionConstants.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Xunit
+{
+    internal static class StaticReflectionConstants
+    {
+        internal const DynamicallyAccessedMemberTypes ConditionalMemberKinds = DynamicallyAccessedMemberTypes.PublicFields |
+            DynamicallyAccessedMemberTypes.PublicMethods |
+            DynamicallyAccessedMemberTypes.PublicProperties;
+    }
+}
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    // This is a copy of the attribute from CoreLib. The attribute shipped in .NET 5.
+    // The tooling looks for the attribute by name, so we can define a local copy.
+    // This copy can be deleted once we stop supporting anything below .NET 5.
+    internal sealed class DynamicallyAccessedMembersAttribute : Attribute
+    {
+        public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes) => MemberTypes = memberTypes;
+        public DynamicallyAccessedMemberTypes MemberTypes { get; }
+    }
+
+    internal enum DynamicallyAccessedMemberTypes
+    {
+        None = 0,
+        PublicParameterlessConstructor = 0x0001,
+        PublicConstructors = 0x0002 | PublicParameterlessConstructor,
+        NonPublicConstructors = 0x0004,
+        PublicMethods = 0x0008,
+        NonPublicMethods = 0x0010,
+        PublicFields = 0x0020,
+        NonPublicFields = 0x0040,
+        PublicNestedTypes = 0x0080,
+        NonPublicNestedTypes = 0x0100,
+        PublicProperties = 0x0200,
+        NonPublicProperties = 0x0400,
+        PublicEvents = 0x0800,
+        NonPublicEvents = 0x1000,
+        Interfaces = 0x2000,
+        All = ~None
+    }
+}


### PR DESCRIPTION
This should ensure the target members are kept when we're running the tests with trimming enabled.

Some tests use these attributes with framework types and framework is always considered trimmable. Example: https://github.com/dotnet/runtime/blob/aafe4d465f97fa3a0ae61b18c2887cf84085d25d/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Cancellation.cs#L15

Cc @dotnet/ilc-contrib 