### PR TITLE
Use the correct feed to restore for internal builds 

### DIFF
--- a/eng/common/internal/NuGet.config
+++ b/eng/common/internal/NuGet.config
@@ -2,6 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="dotnet-core-internal" value="https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal/nuget/v3/index.json" />
+    <add key="dotnet-core-internal-tooling" value="https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation

The feed dotnet-core-internal does not exists. This is causing build error in msbuild and not able to generate sboms for VS insertions. So updated the correct feed. 