### PR TITLE
Add source-build option to build scripts

### DIFF
--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -19,6 +19,9 @@ usage()
   echo "Actions:"
   echo "  --restore                  Restore dependencies (short: -r)"
   echo "  --build                    Build solution (short: -b)"
+  echo "  --source-build             Source-build the solution (short: -sb)"
+  echo "                             Will additionally trigger the following actions: --restore, --build, --pack"
+  echo "                             If --configuration is not set explicitly, will also set it to 'Release'"
   echo "  --rebuild                  Rebuild solution"
   echo "  --test                     Run all unit tests in the solution (short: -t)"
   echo "  --integrationTest          Run all integration tests in the solution"
@@ -55,6 +58,7 @@ scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 
 restore=false
 build=false
+source_build=false
 rebuild=false
 test=false
 integration_test=false
@@ -73,7 +77,7 @@ exclude_ci_binary_log=false
 pipelines_log=false
 
 projects=''
-configuration='Debug'
+configuration=''
 prepare_machine=false
 verbosity='minimal'
 runtime_source_feed=''
@@ -117,6 +121,12 @@ while [[ $# > 0 ]]; do
       rebuild=true
       ;;
     -pack)
+      pack=true
+      ;;
+    -sourcebuild|-sb)
+      build=true
+      source_build=true
+      restore=true
       pack=true
       ;;
     -test|-t)
@@ -168,6 +178,10 @@ while [[ $# > 0 ]]; do
   shift
 done
 
+if [[ -z "$configuration" ]]; then
+  if [[ "$source_build" = true ]]; then configuration="Release"; else configuration="Debug"; fi
+fi
+
 if [[ "$ci" == true ]]; then
   pipelines_log=true
   node_reuse=false
@@ -205,6 +219,7 @@ function Build {
     /p:RepoRoot="$repo_root" \
     /p:Restore=$restore \
     /p:Build=$build \
+    /p:ArcadeBuildFromSource=$source_build \
     /p:Rebuild=$rebuild \
     /p:Test=$test \
     /p:Pack=$pack \


### PR DESCRIPTION
Resolves https://github.com/dotnet/source-build/issues/2674

Resulting changes were tested by source-building the [xharness](https://github.com/dotnet/xharness/tree/7871eb473366b7246d628ba30bfc70dd84f8dbb9) repository on:
  - Microsoft's Built Tools image of Fedora 36 -> `mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:4a2bbece99ec3115754839f141f4ebb8077bec516fab55d3cd28824d2fdfc9b5`
  - Windows 10 Enterprise version `21H2` build `19044.1826`

CC: @tkapin @MichaelSimons @riarenas 
