### PR TITLE
Add support for required keyword

### DIFF
--- a/src/Microsoft.Cci.Extensions/Extensions/CSharp/CSharpCciExtensions.cs
+++ b/src/Microsoft.Cci.Extensions/Extensions/CSharp/CSharpCciExtensions.cs
@@ -805,6 +805,11 @@ namespace Microsoft.Cci.Extensions.CSharp
             return attributes.HasAttributeOfType("System.Runtime.CompilerServices.NativeIntegerAttribute");
         }
 
+        public static bool HasRequiredMemberAttribute(this IEnumerable<ICustomAttribute> attributes)
+        {
+            return attributes.HasAttributeOfType("System.Runtime.CompilerServices.RequiredMemberAttribute");
+        }
+
         public static string[] GetValueTupleNames(this IEnumerable<ICustomAttribute> attributes)
         {
             string[] names = null;

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Attributes.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Attributes.cs
@@ -376,7 +376,6 @@ namespace Microsoft.Cci.Writers.CSharp
 
             switch (typeName)
             {
-                case "System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute": return true;
                 case "System.ParamArrayAttribute": return true;
                 case "System.Reflection.AssemblyDelaySignAttribute": return true;
                 case "System.Reflection.AssemblyKeyFileAttribute": return true;
@@ -396,8 +395,8 @@ namespace Microsoft.Cci.Writers.CSharp
                         if (arg?.Value is string)
                         {
                             string argValue = (string)arg.Value;
-                            if (argValue == "Types with embedded references are not supported in this version of your compiler." ||
-                                argValue == "Constructors of types with required members are not supported in this version of your compiler.")
+                            if (argValue is "Types with embedded references are not supported in this version of your compiler."
+                                         or "Constructors of types with required members are not supported in this version of your compiler.")
                             {
                                 return true;
                             }

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Attributes.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Attributes.cs
@@ -376,15 +376,18 @@ namespace Microsoft.Cci.Writers.CSharp
 
             switch (typeName)
             {
-                case "System.Runtime.CompilerServices.FixedBufferAttribute": return true;
+                case "System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute": return true;
                 case "System.ParamArrayAttribute": return true;
-                case "System.Reflection.DefaultMemberAttribute": return true;
-                case "System.Reflection.AssemblyKeyFileAttribute": return true;
                 case "System.Reflection.AssemblyDelaySignAttribute": return true;
-                case "System.Runtime.CompilerServices.ExtensionAttribute": return true;
+                case "System.Reflection.AssemblyKeyFileAttribute": return true;
+                case "System.Reflection.DefaultMemberAttribute": return true;
+                case "System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute": return true;
                 case "System.Runtime.CompilerServices.DynamicAttribute": return true;
+                case "System.Runtime.CompilerServices.ExtensionAttribute": return true;
+                case "System.Runtime.CompilerServices.FixedBufferAttribute": return true;
                 case "System.Runtime.CompilerServices.IsByRefLikeAttribute": return true;
                 case "System.Runtime.CompilerServices.IsReadOnlyAttribute": return true;
+                case "System.Runtime.CompilerServices.RequiredMemberAttribute": return true;
                 case "System.Runtime.CompilerServices.TupleElementNamesAttribute": return true;
                 case "System.ObsoleteAttribute":
                     {

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Attributes.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Attributes.cs
@@ -396,7 +396,8 @@ namespace Microsoft.Cci.Writers.CSharp
                         if (arg?.Value is string)
                         {
                             string argValue = (string)arg.Value;
-                            if (argValue == "Types with embedded references are not supported in this version of your compiler.")
+                            if (argValue == "Types with embedded references are not supported in this version of your compiler." ||
+                                argValue == "Constructors of types with required members are not supported in this version of your compiler.")
                             {
                                 return true;
                             }

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Fields.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Fields.cs
@@ -30,6 +30,11 @@ namespace Microsoft.Cci.Writers.CSharp
                 WriteVisibility(field.Visibility);
                 WriteCustomModifiers(field.CustomModifiers);
 
+                if (field.Attributes.HasRequiredMemberAttribute())
+                {
+                    WriteKeyword("required");
+                }
+
                 if (field.Type.IsUnsafeType())
                     WriteKeyword("unsafe");
 

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Properties.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Properties.cs
@@ -74,6 +74,11 @@ namespace Microsoft.Cci.Writers.CSharp
                 WriteVisibility(property.Visibility);
             }
 
+            if (property.Attributes.HasRequiredMemberAttribute())
+            {
+                WriteKeyword("required");
+            }
+
             // Getter and Setter modifiers should be the same
             WriteMethodModifiers(accessor);
 

--- a/src/Microsoft.DotNet.GenFacades/GenPartialFacadeSource.cs
+++ b/src/Microsoft.DotNet.GenFacades/GenPartialFacadeSource.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 namespace Microsoft.DotNet.GenFacades
 {
-    public class GenPartialFacadeSource : BuildTask
+    public class GenPartialFacadeSource : RoslynBuildTask
     {
         [Required]
         public ITaskItem[] ReferencePaths { get; set; }
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.GenFacades
         [Required]
         public string OutputSourcePath { get; set; }
         
-        public override bool Execute()
+        public override bool ExecuteCore()
         {
             bool result = true;
             try

--- a/src/Microsoft.DotNet.GenFacades/GenPartialFacadeSource.cs
+++ b/src/Microsoft.DotNet.GenFacades/GenPartialFacadeSource.cs
@@ -21,6 +21,8 @@ namespace Microsoft.DotNet.GenFacades
 
         public string DefineConstants { get; set; }
 
+        public string LangVersion { get; set; }
+
         public bool IgnoreMissingTypes { get; set; }
 
         public string[] IgnoreMissingTypesList { get; set; }
@@ -42,6 +44,7 @@ namespace Microsoft.DotNet.GenFacades
                     ReferenceAssembly,
                     CompileFiles?.Select(item => item.ItemSpec).ToArray(),
                     DefineConstants,
+                    LangVersion,
                     OutputSourcePath,
                     Log,
                     IgnoreMissingTypes,

--- a/src/Microsoft.DotNet.GenFacades/GenPartialFacadeSourceGenerator.cs
+++ b/src/Microsoft.DotNet.GenFacades/GenPartialFacadeSourceGenerator.cs
@@ -21,6 +21,7 @@ namespace Microsoft.DotNet.GenFacades
             string contractAssembly,
             string[] compileFiles,
             string defineConstants,
+            string langVersion,
             string outputSourcePath,
             ILog logger,
             bool ignoreMissingTypes = false,
@@ -52,7 +53,7 @@ namespace Microsoft.DotNet.GenFacades
                 referenceTypes = referenceTypes.Where(type => !OmitTypes.Contains(type));
 
             var sourceGenerator = new SourceGenerator(referenceTypes, seedTypes, seedTypePreferences, outputSourcePath, ignoreMissingTypesList, logger);
-            return sourceGenerator.GenerateSource(compileFiles, ParseDefineConstants(defineConstants), ignoreMissingTypes);
+            return sourceGenerator.GenerateSource(compileFiles, ParseDefineConstants(defineConstants), langVersion, ignoreMissingTypes);
         }
 
         private static IEnumerable<string> ParseDefineConstants(string defineConstants)

--- a/src/Microsoft.DotNet.GenFacades/Microsoft.DotNet.GenFacades.csproj
+++ b/src/Microsoft.DotNet.GenFacades/Microsoft.DotNet.GenFacades.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" Publish="false" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" Publish="false" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MsbuildTaskMicrosoftCodeAnalysisCSharpVersion)" ExcludeAssets="analyzers" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MsbuildTaskMicrosoftCodeAnalysisCSharpVersion)" ExcludeAssets="analyzers" Publish="false" />
   </ItemGroup>
 
   <!-- When building offline we need to bump the version of System.Reflection.Metadata that CodeAnalysis package depends on to match what the source build tarball expects. -->

--- a/src/Microsoft.DotNet.GenFacades/NotSupportedAssemblyGenerator.cs
+++ b/src/Microsoft.DotNet.GenFacades/NotSupportedAssemblyGenerator.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.GenFacades
     /// <summary>
     /// The class generates an NotSupportedAssembly from the reference sources.
     /// </summary>
-    public class NotSupportedAssemblyGenerator : BuildTask
+    public class NotSupportedAssemblyGenerator : RoslynBuildTask
     {
         [Required]
         public ITaskItem[] SourceFiles { get; set; }
@@ -25,9 +25,10 @@ namespace Microsoft.DotNet.GenFacades
         public string Message { get; set; }
 
         public string LangVersion { get; set; }
+
         public string ApiExclusionListPath { get; set; }
 
-        public override bool Execute()
+        public override bool ExecuteCore()
         {
             if (SourceFiles == null || SourceFiles.Length == 0)
             {

--- a/src/Microsoft.DotNet.GenFacades/NotSupportedAssemblyGenerator.cs
+++ b/src/Microsoft.DotNet.GenFacades/NotSupportedAssemblyGenerator.cs
@@ -24,6 +24,7 @@ namespace Microsoft.DotNet.GenFacades
         [Required]
         public string Message { get; set; }
 
+        public string LangVersion { get; set; }
         public string ApiExclusionListPath { get; set; }
 
         public override bool Execute()
@@ -68,7 +69,13 @@ namespace Microsoft.DotNet.GenFacades
 
             try
             {
-                syntaxTree = CSharpSyntaxTree.ParseText(File.ReadAllText(sourceFile));
+                LanguageVersion languageVersion = LanguageVersion.Default;
+                if (!String.IsNullOrEmpty(LangVersion) && !LanguageVersionFacts.TryParse(LangVersion, out languageVersion))
+                {
+                    Log.LogError($"Invalid LangVersion value '{LangVersion}'");
+                    return;
+                }
+                syntaxTree = CSharpSyntaxTree.ParseText(File.ReadAllText(sourceFile), new CSharpParseOptions(languageVersion));
             }
             catch(Exception ex)
             {

--- a/src/Microsoft.DotNet.GenFacades/RoslynBuildTask.cs
+++ b/src/Microsoft.DotNet.GenFacades/RoslynBuildTask.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.IO;
+using System.Reflection;
+#if NETCOREAPP
+using System.Runtime.Loader;
+#endif
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public abstract partial class RoslynBuildTask : BuildTask
+    {
+        [Required]
+        public string RoslynAssembliesPath { get; set; }
+
+        public override bool Execute()
+        {
+#if NETCOREAPP
+            AssemblyLoadContext currentContext = AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly())!;
+            currentContext.Resolving += ResolverForRoslyn;
+#else
+            AppDomain.CurrentDomain.AssemblyResolve += ResolverForRoslyn;
+#endif
+            try
+            {
+                return ExecuteCore();
+            }
+            finally
+            {
+#if NETCOREAPP
+                currentContext.Resolving -= ResolverForRoslyn;
+#else
+                AppDomain.CurrentDomain.AssemblyResolve -= ResolverForRoslyn;
+#endif
+            }
+        }
+
+        public abstract bool ExecuteCore();
+        
+#if NETCOREAPP
+        private Assembly ResolverForRoslyn(AssemblyLoadContext context, AssemblyName assemblyName)
+        {
+            return LoadRoslyn(assemblyName, path => context.LoadFromAssemblyPath(path));
+        }
+#else
+        private Assembly ResolverForRoslyn(object sender, ResolveEventArgs args)
+        {
+            AssemblyName name = new(args.Name);
+            return LoadRoslyn(name, path => Assembly.LoadFrom(path));
+        }
+#endif
+
+        private Assembly LoadRoslyn(AssemblyName name, Func<string, Assembly> loadFromPath)
+        {
+            const string codeAnalysisName = "Microsoft.CodeAnalysis";
+            const string codeAnalysisCsharpName = "Microsoft.CodeAnalysis.CSharp";
+            if (name.Name == codeAnalysisName || name.Name == codeAnalysisCsharpName)
+            {
+                Assembly asm = loadFromPath(Path.Combine(RoslynAssembliesPath!, $"{name.Name}.dll"));
+                Version resolvedVersion = asm.GetName().Version;
+                if (resolvedVersion < name.Version)
+                {
+                    throw new Exception($"The minimum version required of Roslyn is '{name.Version}' and you are using '{resolvedVersion}' version of the Roslyn. You can update the sdk to get the latest version.");
+                }
+
+                // Being extra defensive but we want to avoid that we accidentally load two different versions of either
+                // of the roslyn assemblies from a different location, so let's load them both on the first request.
+                Assembly _ = name.Name == codeAnalysisName ?
+                    loadFromPath(Path.Combine(RoslynAssembliesPath!, $"{codeAnalysisCsharpName}.dll")) :
+                    loadFromPath(Path.Combine(RoslynAssembliesPath!, $"{codeAnalysisName}.dll"));
+
+                return asm;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.GenFacades/SourceGenerator.cs
+++ b/src/Microsoft.DotNet.GenFacades/SourceGenerator.cs
@@ -41,6 +41,7 @@ namespace Microsoft.DotNet.GenFacades
         public bool GenerateSource(
             IEnumerable<string> compileFiles,
             IEnumerable<string> constants,
+            string langVersion,
             bool ignoreMissingTypes)
         {
             List<string> externAliases = new List<string>();
@@ -51,7 +52,7 @@ namespace Microsoft.DotNet.GenFacades
 
             bool result = true;
 
-            HashSet<string> existingTypes = compileFiles != null ? TypeParser.GetAllPublicTypes(compileFiles, constants) : null;
+            HashSet<string> existingTypes = compileFiles != null ? TypeParser.GetAllPublicTypes(compileFiles, constants, langVersion) : null;
             IEnumerable<string> typesToForward = compileFiles == null ? _referenceTypes : _referenceTypes.Where(id => !existingTypes.Contains(id));
 
             foreach (string type in typesToForward.OrderBy(s => s))

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.targets
@@ -6,6 +6,17 @@
     <GenFacadesTargetAssemblyPath Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.DotNet.GenFacades.dll</GenFacadesTargetAssemblyPath>
   </PropertyGroup>
 
+  <Target Name="_GetRoslynAssembliesPath">
+    <PropertyGroup Condition="'$(RoslynAssembliesPath)' == ''">
+      <RoslynAssembliesPath>$(RoslynTargetsPath)</RoslynAssembliesPath>
+      <_packageReferenceList>@(PackageReference)</_packageReferenceList>
+      <!-- CSharpCoreTargetsPath and VisualBasicCoreTargetsPath point to the same location, Microsoft.CodeAnalysis.CSharp and Microsoft.CodeAnalysis.VisualBasic
+      are on the same directory as Microsoft.CodeAnalysis. So there is no need to distinguish between csproj or vbproj. -->
+      <RoslynAssembliesPath Condition="$(_packageReferenceList.Contains('Microsoft.Net.Compilers.Toolset'))">$([System.IO.Path]::GetDirectoryName($(CSharpCoreTargetsPath)))</RoslynAssembliesPath>
+      <RoslynAssembliesPath Condition="'$(MSBuildRuntimeType)' == 'Core'">$([System.IO.Path]::Combine('$(RoslynAssembliesPath)', bincore))</RoslynAssembliesPath>
+    </PropertyGroup>
+  </Target>
+
   <Import Project="Microsoft.DotNet.GenPartialFacadeSource.targets" Condition="'$(IsPartialFacadeAssembly)' == 'true'" />
   <Import Project="Microsoft.DotNet.GenFacadesNotSupported.targets" Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' or
                                                                                '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''" />

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacadesNotSupported.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacadesNotSupported.targets
@@ -47,7 +47,7 @@
   </Target>
 
   <Target Name="AddGenFacadeNotSupportedCompileItem"
-          DependsOnTargets="_GetGenFacadeNotSupportedCompileInputs"
+          DependsOnTargets="_GetGenFacadeNotSupportedCompileInputs;_GetRoslynAssembliesPath"
           AfterTargets="ResolveProjectReferences"
           Condition="'$(GeneratePlatformNotSupportedAssemblyMessage)' != ''"
           Inputs="@(GenFacadeNotSupportedCompileInput)"
@@ -57,7 +57,8 @@
       SourceFiles="@(GenFacadeNotSupportedCompileInput)"
       LangVersion="$(LangVersion)"
       Message="$(GeneratePlatformNotSupportedAssemblyMessage)"
-      ApiExclusionListPath="$(ApiExclusionListPath)" />
+      ApiExclusionListPath="$(ApiExclusionListPath)"
+      RoslynAssembliesPath="$(RoslynAssembliesPath)" />
 
     <ItemGroup>
       <Compile Include="@(GenFacadeNotSupportedCompileInput->'%(OutputPath)')" />

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacadesNotSupported.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacadesNotSupported.targets
@@ -55,6 +55,7 @@
 
     <NotSupportedAssemblyGenerator
       SourceFiles="@(GenFacadeNotSupportedCompileInput)"
+      LangVersion="$(LangVersion)"
       Message="$(GeneratePlatformNotSupportedAssemblyMessage)"
       ApiExclusionListPath="$(ApiExclusionListPath)" />
 

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenPartialFacadeSource.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenPartialFacadeSource.targets
@@ -8,7 +8,7 @@
     <GenFacadesReferencePathItemName Condition="'$(GenFacadesReferencePathItemName)' == ''">ReferencePath</GenFacadesReferencePathItemName>
     <!-- Tell ResolveMatchingContract to run and resolve contract to project reference -->
     <ResolveMatchingContract>true</ResolveMatchingContract>
-    <GeneratePartialFacadeSourceDependsOn>$(GeneratePartialFacadeSourceDependsOn);ResolveMatchingContract</GeneratePartialFacadeSourceDependsOn>
+    <GeneratePartialFacadeSourceDependsOn>$(GeneratePartialFacadeSourceDependsOn);ResolveMatchingContract;_GetRoslynAssembliesPath</GeneratePartialFacadeSourceDependsOn>
     <CoreCompileDependsOn Condition="'$(DesignTimeBuild)' != 'true'">$(CoreCompileDependsOn);GeneratePartialFacadeSource</CoreCompileDependsOn>
     <!-- Support zero version seeds by rewriting the output of the compiler. -->
     <TargetsTriggeredByCompilation Condition="'$(DesignTimeBuild)' != 'true' and '$(GenFacadesForceZeroVersionSeeds)' == 'true'">
@@ -35,7 +35,8 @@
       IgnoreMissingTypesList="@(GenFacadesIgnoreMissingType)"
       OmitTypes="@(GenFacadesOmitType)"
       OutputSourcePath="$(OutputSourcePath)"
-      SeedTypePreferences="@(SeedTypePreference)" />
+      SeedTypePreferences="@(SeedTypePreference)"
+      RoslynAssembliesPath="$(RoslynAssembliesPath)" />
 
     <ItemGroup Condition="Exists('$(OutputSourcePath)')">
       <Compile Include="$(OutputSourcePath)" />

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenPartialFacadeSource.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenPartialFacadeSource.targets
@@ -30,6 +30,7 @@
       ReferenceAssembly="$(ReferenceAssembly)"
       CompileFiles="@(Compile)"
       DefineConstants="$(DefineConstants)"
+      LangVersion="$(LangVersion)"
       IgnoreMissingTypes="$(GenFacadesIgnoreMissingTypes)"
       IgnoreMissingTypesList="@(GenFacadesIgnoreMissingType)"
       OmitTypes="@(GenFacadesOmitType)"


### PR DESCRIPTION
Best reviewed commit-by-commit.

This adds support for the `required` keyword into GenApi and then also makes `GenFacades` honor `LangVersion` and use the compiler version that the project is already using (similar to what we do for new API Compat).

This should fix https://github.com/dotnet/runtime/issues/71559