### PR TITLE
Allow explicitly including symbol files in non-symbol packages

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
@@ -113,11 +113,11 @@
              Text="$(MSBuildProjectName) -> $(NuSpecPath)"
              Importance="high" />
 
-    <Message Condition="'$(ShouldCreatePackage)' != 'true' AND '$(ShouldGenerateNuSpec)' != 'true'" 
+    <Message Condition="'$(ShouldCreatePackage)' != 'true' AND '$(ShouldGenerateNuSpec)' != 'true'"
              Text="$(MSBuildProjectName) -> Skipping for this platform."
              Importance="high" />
   </Target>
-  
+
   <Target Name="Pack"
           DependsOnTargets="Build" />
 
@@ -251,7 +251,7 @@
 
     <ItemGroup>
       <_FilesToPackage Remove="@(_FilesToPackage)" Condition="'$(ExcludeReferenceAssets)' == 'true' AND '%(_FilesToPackage.IsReferenceAsset)' == 'true'" />
-      
+
       <!-- Some packages support legacy portable profiles where dependencies are provided by targeting pack -->
       <_FilesToPackage Condition="'%(_FilesToPackage.HarvestDependencies)' == '' AND !$([System.String]::Copy('%(_FilesToPackage.TargetFramework)').StartsWith('portable-'))">
         <!-- Only harvest files from ref/lib/runtimes dir-->
@@ -335,7 +335,7 @@
       <!-- PkgProj includes all Content, and None only when Pack=True-->
       <_additionalFiles Include="@(Content)" />
       <_additionalFiles Include="@(None)" Condition="'%(None.Pack)' == 'true'" />
-      
+
       <File Include="@(_additionalFiles)" Condition="'%(_additionalFiles.PackagePath)' != ''" TargetPath="%(_additionalFiles.PackagePath)" />
       <File Include="@(_additionalFiles)" Condition="'%(_additionalFiles.PackagePath)' == '' AND '%(_additionalFiles.Link)' != ''" TargetPath="%(_additionalFiles.Link)" />
       <File Include="@(_additionalFiles)" Condition="'%(_additionalFiles.PackagePath)' == '' AND '%(_additionalFiles.Link)' == ''" TargetPath="%(_additionalFiles.RelativeDir)" />
@@ -467,7 +467,7 @@
 
   <!--Target that will add the specified source files into the package.
       In order for this target to run, define SourcePackageFiles item by including
-      all source files that need to be packaged into it. Each source file must have the 
+      all source files that need to be packaged into it. Each source file must have the
       PackagePath metadata defined, which is the location of where the source file will
       end up in the package-->
   <Target Name="AddSourceToFilesToPackage" BeforeTargets="GetFiles"
@@ -1189,7 +1189,7 @@
       <RepositoryCommit Condition="'$(RepositoryCommit)' == ''">$(SourceRevisionId)</RepositoryCommit>
     </PropertyGroup>
   </Target>
-  
+
   <Target Name="GenerateNuSpec"
           DependsOnTargets="GetPackageDependencies;GetPackageFiles;GetPackageMetadata;GenerateRuntimeDependencies;EnsureEmptyPackage;_InitializeNuspecRepositoryInformationProperties">
 
@@ -1265,6 +1265,7 @@
                CreatePackedPackage="$(CreatePackedPackage)"
                IncludeSymbolsInPackage="$(IncludeSymbolsInPackage)"
                SymbolPackageOutputDirectory="$(SymbolPackageOutputPath)"
+               LibPackageExcludes="@(LibPackageExcludes)"
                AdditionalLibPackageExcludes="@(AdditionalLibPackageExcludes)"
                AdditionalSymbolPackageExcludes="@(AdditionalSymbolPackageExcludes)"
                PackedPackageNamePrefix="$(PackedPackageNamePrefix)"
@@ -1312,11 +1313,11 @@
     <!-- Set FrameworkListsFolder to the path to a set of directories containing framework lists, where the subdirectory name is the TFM.  These lists will determine what is inbox on that framework. -->
     <!-- Set FrameowrkLayout to folder identity with 'TargetFramework' metadata to consider files within that folder inbox on that framework.-->
     <!-- Set UpdateStablePackageInfo to true in order to go through all the package index and update the stable version information for all the packages in the index.-->
-    
+
     <ItemGroup>
       <PackageFolders Include="$(PackageFolders)" />
     </ItemGroup>
-      
+
     <UpdatePackageIndex PackageIndexFile="$(PackageIndexFile)"
                         PackageIds="@(PackageIds)"
                         PackageFolders="@(PackageFolders)"

--- a/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -24,7 +24,7 @@
     </PropertyGroup>
   </Target>
 
-  
+
   <Target Name="_RemoveSelfContainedAfterFrameworkReferenceResolution" AfterTargets="ProcessFrameworkReferences">
     <PropertyGroup>
       <SelfContained>false</SelfContained>
@@ -38,7 +38,7 @@
       <IsSymbolFile>true</IsSymbolFile>
     </_SymbolFilesToPackage>
   </ItemDefinitionGroup>
-  
+
   <Target Name="_FindSymbolFilesForSharedFrameworkFiles"
           DependsOnTargets="GetSharedFrameworkFilesForReadyToRun"
           Returns="@(_SymbolFilesToPackage)">
@@ -58,7 +58,7 @@
       <ResolvedFileToPublish Include="@(RuntimePackAsset)" ReferenceOnly="true" PostprocessAssembly="true" RelativePath="%(FileName)%(Extension)" />
       <ResolvedFileToPublish Include="@(ReferenceCopyLocalPaths)" Exclude="@(RuntimePackAsset)" PostprocessAssembly="true" RelativePath="%(FileName)%(Extension)" />
     </ItemGroup>
-    <!-- 
+    <!--
       The PrepareForReadyToRunCompilation task now requires the MainAssembly metadata to be set.
       It's only used in composite mode, which we do not use, so create a ficticous $(PackageId).dll
       to ensure we don't accidentally trigger any unexpected behavior.
@@ -106,7 +106,7 @@
       <FilesToPackage Include="@(NativeRuntimeAsset)" IsNative="true" />
     </ItemGroup>
     <ItemGroup Condition="'$(PlatformPackageType)' == 'RuntimePack' or '$(PlatformPackageType)' == 'AppHostPack'">
-      <!--- 
+      <!---
        Files for runtime packs will have already been added to FilesToPackage in _ReadyToRunSharedFramework.
        Files for AppHost packs have to be added manually anyway before this target.
       -->
@@ -141,7 +141,7 @@
         <TargetPath>PgoData</TargetPath>
       </FilesToPackage>
       <!-- Legacy crossgen perf map files. Supported by crossgen2 using perfmap-format-version:0. -->
-      <FilesToPackage Condition="$([System.String]::new('%(Filename)').Contains('.ni.{')) and 
+      <FilesToPackage Condition="$([System.String]::new('%(Filename)').Contains('.ni.{')) and
                                  $([System.String]::new('%(Filename)').EndsWith('}')) and
                                  '%(Extension)' == '.map'">
         <IsSymbolFile>true</IsSymbolFile>
@@ -253,20 +253,20 @@
      For shared frameworks with differing sets of files on various platforms
      and with no single platform that contains all of the files, this SDK provides support
      for creating a platform manifest from a templated list of items.
-     
+
      Assumptions:
      - All managed assemblies are either present in both the ref and runtime pack for the shared framework
          or have an easily calculatable assembly version and file version.
      - All native files have an easily calculatable file version.
-    
+
     To use, set UseTemplatedPlatformManifest to true and define a set of PlatformManifestFileEntry items
-    
+
     PlatformManifestFileEntry metadata:
     - ItemSpec/Identity: File name and extension of file in the shared framework.
     - IsNative: true when the file is a native file
     - FallbackAssemblyVersion: An assembly version for this file if it is not present in the ref-pack build.
     - FallbackFileVersion: A file version for this file if it is not present in the ref-pack build.
-    
+
     Properties for these targets:
     UseTemplatedPlatformManifest: Set to true to enable the templated platform manifest generation
     PlatformManifestFallbackAssemblyVersion: Fallback asssembly version when one is needed and there is no fallback on the entry.
@@ -311,7 +311,7 @@
       the present files in the runtime pack.
 
       This is enabled when UseTemplatedPlatformManifest is not set to true.
-      
+
       Set the RuntimePackProjectPath to the path to the runtime pack shared framework project.
 
       If you only want to use one RID to generate the platform manifest, you can set
@@ -527,7 +527,7 @@
           Returns="@(FilesToPackage)" />
 
   <Target Name="_AddFilesToNuGetPackage" BeforeTargets="_GetPackageFiles">
-    
+
     <MSBuild Projects="$(MSBuildProjectFullPath)"
           Targets="_GetAllSharedFrameworkFiles"
           RemoveProperties="NoBuild">
@@ -539,14 +539,15 @@
       <IncludeBuildOutput>true</IncludeBuildOutput>
     </PropertyGroup>
     <ItemGroup>
-      <_PackageFiles Include="@(_FilesToPackage)" PackagePath="%(_FilesToPackage.TargetPath)" Condition="'%(_FilesToPackage.IsSymbolFile)' != 'true' and '%(_FilesToPackage.PublishOnly)' != 'true'" />
-      <!-- 
+      <_PackageFiles Include="@(_FilesToPackage)" PackagePath="%(_FilesToPackage.TargetPath)"
+                    Condition="('%(_FilesToPackage.IsSymbolFile)' != 'true' and '%(_FilesToPackage.PublishOnly)' != 'true') or '%(_FilesToPackage.IncludeAlways)' == 'true'" />
+      <!--
            We need to handle symbol files specially so they get correctly filtered out of the implementation package.
            The base of the TargetPath attribute is $(BuildOutputTargetFolder)/%(TargetFramework), so we have to
            modify the TargetPath metadata with that base path in mind.
       -->
       <_TargetPathsToSymbols Include="@(_FilesToPackage)"
-                             Condition="'%(_FilesToPackage.IsSymbolFile)' == 'true' and '%(_FilesToPackage.PublishOnly)' != 'true'"
+                             Condition="'%(_FilesToPackage.IsSymbolFile)' == 'true' and '%(_FilesToPackage.PublishOnly)' != 'true' and '%(_FilesToPackage.IncludeAlways)' != 'true'"
                              TargetFramework="$(TargetFramework)"
                              TargetPath="$([MSBuild]::MakeRelative($([MSBuild]::NormalizePath('$(BuildOutputTargetFolder)/$(TargetFramework)')), $([MSBuild]::NormalizePath('%(_FilesToPackage.TargetPath)', '%(Filename)%(Extension)'))))"/>
     </ItemGroup>
@@ -565,7 +566,7 @@
           RemoveProperties="OutputPath;SymbolsOutputPath">
       <Output TaskParameter="TargetOutputs" ItemName="_FilesToPackage" />
     </MSBuild>
-      
+
     <ItemGroup>
       <_PackagedFilesToPublish Include="@(_FilesToPackage)" Condition="'%(_FilesToPackage.PackOnly)' != 'true'" />
     </ItemGroup>
@@ -587,7 +588,7 @@
     <Copy
       SourceFiles="@(FilesToPublish)"
       DestinationFolder="$(OutputPath)%(FilesToPublish.TargetPath)%(FilesToPublish.Culture)"
-      Condition="'%(FilesToPublish.IsSymbolFile)' != 'true'"
+      Condition="'%(FilesToPublish.IsSymbolFile)' != 'true' or '%(FilesToPublish.IncludeAlways)' == 'true'"
       OverwriteReadOnlyFiles="true"
       SkipUnchangedFiles="true" />
 


### PR DESCRIPTION
- Add mechanism for always including a file in a framework pack
  - `IncludeAlways` metadata can be specified on a file to package such that
it will always be included even if it is a symbol file.
- Allow custom definition of lib package excludes in `NuGetPack` task
  - `LibPackageExclude` parameter lets consumers explicitly set
the excludes instead of always using the defaults.

Example usage: https://github.com/elinor-fung/runtime/commit/a3b5315072420df537e13657e029fbe737caec23

Fixes https://github.com/dotnet/arcade/issues/8374

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
