### PR TITLE
import pipeline-logging-functions during sbom generation prep

### DIFF
--- a/eng/common/generate-sbom-prep.ps1
+++ b/eng/common/generate-sbom-prep.ps1
@@ -2,6 +2,8 @@ Param(
     [Parameter(Mandatory=$true)][string] $ManifestDirPath    # Manifest directory where sbom will be placed
 )
 
+. $PSScriptRoot\common\pipeline-logging-functions.ps1
+
 Write-Host "Creating dir $ManifestDirPath"
 # create directory for sbom manifest to be placed
 if (!(Test-Path -path $ManifestDirPath))

--- a/eng/common/generate-sbom-prep.ps1
+++ b/eng/common/generate-sbom-prep.ps1
@@ -2,7 +2,7 @@ Param(
     [Parameter(Mandatory=$true)][string] $ManifestDirPath    # Manifest directory where sbom will be placed
 )
 
-. $PSScriptRoot\common\pipeline-logging-functions.ps1
+. $PSScriptRoot\pipeline-logging-functions.ps1
 
 Write-Host "Creating dir $ManifestDirPath"
 # create directory for sbom manifest to be placed

--- a/eng/common/generate-sbom-prep.sh
+++ b/eng/common/generate-sbom-prep.sh
@@ -2,6 +2,18 @@
 
 source="${BASH_SOURCE[0]}"
 
+# resolve $SOURCE until the file is no longer a symlink
+while [[ -h $source ]]; do
+  scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+  source="$(readlink "$source")"
+
+  # if $source was a relative symlink, we need to resolve it relative to the path where the
+  # symlink file was located
+  [[ $source != /* ]] && source="$scriptroot/$source"
+done
+scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+. $scriptroot/pipeline-logging-functions.sh
+
 manifest_dir=$1
 
 if [ ! -d "$manifest_dir" ] ; then


### PR DESCRIPTION
Found this during testing of https://github.com/dotnet/arcade-services/pull/1951.

We use the telemetry logging functions in the scripts, but we never imported them and I think this has been working out of sheer luck that other steps in the build had imported these functions previously.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
