### PR TITLE
[release/6.0] import pipeline-logging-functions during sbom generation prep (#10082)

### DIFF
--- a/eng/common/generate-sbom-prep.ps1
+++ b/eng/common/generate-sbom-prep.ps1
@@ -2,6 +2,8 @@ Param(
     [Parameter(Mandatory=$true)][string] $ManifestDirPath    # Manifest directory where sbom will be placed
 )
 
+. $PSScriptRoot\pipeline-logging-functions.ps1
+
 Write-Host "Creating dir $ManifestDirPath"
 # create directory for sbom manifest to be placed
 if (!(Test-Path -path $ManifestDirPath))

--- a/eng/common/generate-sbom-prep.sh
+++ b/eng/common/generate-sbom-prep.sh
@@ -2,6 +2,18 @@
 
 source="${BASH_SOURCE[0]}"
 
+# resolve $SOURCE until the file is no longer a symlink
+while [[ -h $source ]]; do
+  scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+  source="$(readlink "$source")"
+
+  # if $source was a relative symlink, we need to resolve it relative to the path where the
+  # symlink file was located
+  [[ $source != /* ]] && source="$scriptroot/$source"
+done
+scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+. $scriptroot/pipeline-logging-functions.sh
+
 manifest_dir=$1
 
 if [ ! -d "$manifest_dir" ] ; then


### PR DESCRIPTION
## Description

Cherry-pick of https://github.com/dotnet/arcade/commit/cda764613f89280de6d5c5383ebded9ac01ebd00. This script uses functions that it doesn't import.

Test build that calls the scripts as PR validation doesn't: https://dev.azure.com/dnceng/internal/_build/results?buildId=1893006&view=results

## Customer Impact

When we re-enable automated arcade updates to arcade-services, these scripts will break. Suprisingly I haven't seen other repos fail in this step.

## Regression

No

## Risk

Low risk

## Workarounds

Currently we have a modified version of these scripts in arcade-services https://github.com/dotnet/arcade-services/blob/main/eng/common/generate-sbom-prep.ps1#L5 

