### PR TITLE
Don't retry/reboot for Apple device app crashes

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-processor.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-processor.py
@@ -126,7 +126,7 @@ def analyze_operation(command: str, platform: str, device: str, is_device: bool,
     global retry, reboot, android_connectivity_verified
 
     # Kill the simulator when we fail to launch the app
-    if exit_code == 80: # APP_CRASH
+    if exit_code == 80 and not is_device: # APP_CRASH
         print(f'    Application crashed - if persist, please investigate system logs from the run')
         retry = True
         reboot = True

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-processor.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-processor.py
@@ -126,7 +126,8 @@ def analyze_operation(command: str, platform: str, device: str, is_device: bool,
     global retry, reboot, android_connectivity_verified
 
     # Kill the simulator when we fail to launch the app
-    if exit_code == 80 and not is_device: # APP_CRASH
+    # Apps crashing can be infra failures apart form Apple devices where retries can be costly
+    if exit_code == 80 and platform != "apple" and is_device: # APP_CRASH
         print(f'    Application crashed - if persist, please investigate system logs from the run')
         retry = True
         reboot = True


### PR DESCRIPTION
When the app exit code is 80 and running on an iOS device, do not reboot or retry the app.  This is a trade off given we don't have a large amount of devices in the testing queue.
