### PR TITLE
Allow passing AzDO build into job/execute-sdl.yml

### DIFF
--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -59,7 +59,9 @@ jobs:
   - checkout: self
     clean: true
 
-  - template: /eng/common/templates/post-build/setup-maestro-vars.yml
+  # If the template caller didn't provide an AzDO parameter, set them all up as Maestro vars.
+  - ${{ if not(and(parameters.AzDOProjectName, parameters.AzDOPipelineId, parameters.AzDOBuildId)) }}:
+    - template: /eng/common/templates/post-build/setup-maestro-vars.yml
 
   - ${{ if ne(parameters.downloadArtifacts, 'false')}}:
     - ${{ if ne(parameters.artifactNames, '') }}:


### PR DESCRIPTION
In https://github.com/dotnet/arcade/pull/7611, I added a way to pass `AzDOBuildId` etc. into `eng/common/templates/job/execute-sdl.yml` so the template works for non-BAR scenarios like mine (microsoft/go). It looks like this broke in some refactor PRs, and now the Maestro/BAR-based `setup-maestro-vars.yml` runs unconditionally.

The template still has these:

```yml
    - name: AzDOBuildId
      value: ${{ parameters.AzDOBuildId }}
```

So, all I had to do in this PR was make `setup-maestro-vars.yml` conditional. 🙂 

The change works in my build. I'm not sure if any more testing is necessary: nobody else sets these template parameters (I did some searching in `dotnet`), and the change is pretty simple.

@adiaaida, @garath, can you take a look, or loop in more people involved in Guardian/SDL currently?

---

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
