### PR TITLE
Force .NET rollforward for SBOM ManifestTool

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
@@ -101,7 +101,7 @@
     <Copy SourceFiles="%(_VsixFileInfo.VsixPath)" DestinationFolder="%(_VsixFileInfo.UnpackDir)" Condition = "'%(_VsixFileInfo.Extension)' == '.exe'" />
     <Unzip SourceFiles="%(_VsixFileInfo.VsixPath)" DestinationFolder="%(_VsixFileInfo.UnpackDir)" Condition = "'%(_VsixFileInfo.Extension)' != '.exe'"/>
 
-    <Exec Command='"$(DotNetTool)" "$(ManifestTool)" generate -BuildDropPath "%(_VsixFileInfo.UnpackDir)" -ManifestDirPath "%(_VsixFileInfo.SbomDir)" -PackageName "%(_VsixFileInfo.VsixFileName)" -PackageVersion "%(_VsixFileInfo.VsixVersion)" -Verbosity Verbose'/>
+    <Exec Command='"$(DotNetTool)" --roll-forward major "$(ManifestTool)" generate -BuildDropPath "%(_VsixFileInfo.UnpackDir)" -ManifestDirPath "%(_VsixFileInfo.SbomDir)" -PackageName "%(_VsixFileInfo.VsixFileName)" -PackageVersion "%(_VsixFileInfo.VsixVersion)" -Verbosity Verbose'/>
 
     <ItemGroup>
       <MergeManifest Include="%(_VsixFileInfo.ManifestJsonPath)" SBOMFileLocation="%(_VsixFileInfo.SbomJsonPath)" />


### PR DESCRIPTION
The ManifestTool targets .NET Core 3.1, which is not available in most Arcade repos. Adding it to global.json as a required "test" runtime breaks restore + build on ARM64 systems, which isn't ideal.

Instead, force rollforward to the latest major runtime even though the application's manifest doesn't specify that.

Works around microsoft/dropvalidator#454.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
