### PR TITLE
Port fix for https://github.com/dotnet/arcade/issues/9864 to release/3.x

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
@@ -73,7 +73,7 @@
         Redirect std output of the runner.
         Note that xUnit outputs failure info to both STDOUT (stack trace, message) and STDERR (failed test name) 
       -->
-      <_TestRunnerCommand Condition="'$(TestCaptureOutput)' != 'false'">$(_TestRunnerCommand) > "%(TestToRun.ResultsStdOutPath)" 2>&amp;1</_TestRunnerCommand>
+      <_TestRunnerCommand Condition="'$(TestCaptureOutput)' != 'false'">$(_TestRunnerCommand) >> "%(TestToRun.ResultsStdOutPath)" 2>&amp;1</_TestRunnerCommand>
     </PropertyGroup>
 
     <ItemGroup>
@@ -86,17 +86,16 @@
     <Delete Files="@(_OutputFiles)" />
 
     <Message Text="Running tests: $(_TestAssembly) [$(_TestEnvironment)]" Importance="high"/>
-    <Exec Command='$(_TestRunnerCommand)' LogStandardErrorAsError="false" WorkingDirectory="$(_TargetDir)" IgnoreExitCode="true">
-      <Output TaskParameter="ExitCode" PropertyName="_TestErrorCode" />
-    </Exec>
 
     <!--
       Add command line to the log.
     -->
-    <WriteLinesToFile File="%(TestToRun.ResultsStdOutPath)" 
-                      Overwrite="false" 
-                      Lines=";=== COMMAND LINE ===;$(_TestRunnerCommand)"
-                      Condition="'$(TestCaptureOutput)' != 'false'" />
+    <Exec Command="echo === COMMAND LINE === > %(TestToRun.ResultsStdOutPath)
+                   echo $(_TestRunnerCommand) >> %(TestToRun.ResultsStdOutPath)" />
+
+    <Exec Command='$(_TestRunnerCommand)' LogStandardErrorAsError="false" WorkingDirectory="$(_TargetDir)" IgnoreExitCode="true">
+      <Output TaskParameter="ExitCode" PropertyName="_TestErrorCode" />
+    </Exec>
 
     <!--
       Report test status.


### PR DESCRIPTION
Prevent file handle problems by removing usage of "WriteLinesToFile" and instead using echo commands from before test starts

https://github.com/dotnet/arcade/issues/9864 is the original issue. 

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
