### PR TITLE
Update .NET Test SDK Version to 17.4.0-preview-20220707-01 

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -40,7 +40,7 @@
     <MicrosoftExtensionsLoggingConsoleVersion>2.1.1</MicrosoftExtensionsLoggingConsoleVersion>
     <MicrosoftNETCorePlatformsVersion>2.1.0</MicrosoftNETCorePlatformsVersion>
     <MicrosoftNetCompilersToolsetVersion>4.3.0-3.22371.17</MicrosoftNetCompilersToolsetVersion>
-    <MicrosoftNetTestSdkVersion>16.7.1</MicrosoftNetTestSdkVersion>
+    <MicrosoftNetTestSdkVersion>17.4.0-preview-20220707-01</MicrosoftNetTestSdkVersion>
     <MicrosoftNETILLinkTasksVersion>6.0.100-1.22103.2</MicrosoftNETILLinkTasksVersion>
     <MicrosoftSignedWixVersion>1.0.0-v3.14.0.5722</MicrosoftSignedWixVersion>
     <MoqVersion>4.8.3</MoqVersion>
@@ -49,7 +49,7 @@
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
     <SystemTextJsonVersion>4.7.0</SystemTextJsonVersion>
     <NuGetVersioningVersion>4.4.0</NuGetVersioningVersion>
-    <NuGetVersion>5.6.0-preview.2.6489</NuGetVersion>
+    <NuGetVersion>6.2.1</NuGetVersion>
     <OctokitVersion>0.32.0</OctokitVersion>
     <DotNetSleetLibVersion>2.2.143</DotNetSleetLibVersion>
     <SwashbuckleAspNetCoreSwaggerVersion>3.0.0</SwashbuckleAspNetCoreSwaggerVersion>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -82,7 +82,7 @@
     <MicroBuildPluginsSwixBuildVersion Condition="'$(MicroBuildPluginsSwixBuildVersion)' == ''">1.0.422</MicroBuildPluginsSwixBuildVersion>
     <MicroBuildCoreVersion Condition="'$(MicroBuildCoreVersion)' == ''">0.2.0</MicroBuildCoreVersion>
     <MicrosoftDotNetIBCMergeVersion Condition="'$(MicrosoftDotNetIBCMergeVersion)' == ''">5.1.0-beta.21356.1</MicrosoftDotNetIBCMergeVersion>
-    <MicrosoftNETTestSdkVersion Condition="'$(MicrosoftNETTestSdkVersion)' == ''">16.6.1</MicrosoftNETTestSdkVersion>
+    <MicrosoftNETTestSdkVersion Condition="'$(MicrosoftNETTestSdkVersion)' == ''">17.4.0-preview-20220707-01</MicrosoftNETTestSdkVersion>
     <MicrosoftVSSDKBuildToolsVersion Condition="'$(MicrosoftVSSDKBuildToolsVersion)' == ''">16.9.1050</MicrosoftVSSDKBuildToolsVersion>
     <MicrosoftDotnetNuGetRepackTasksVersion Condition="'$(MicrosoftDotnetNuGetRepackTasksVersion)' == ''">$(ArcadeSdkVersion)</MicrosoftDotnetNuGetRepackTasksVersion>
     <MicrosoftDotNetSignToolVersion Condition="'$(MicrosoftDotNetSignToolVersion)' == ''">$(ArcadeSdkVersion)</MicrosoftDotNetSignToolVersion>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetAssetResolver.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetAssetResolver.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         {
             RuntimeGraph runtimeGraph = null;
 
-            if (!String.IsNullOrEmpty(runtimeFile))
+            if (!string.IsNullOrEmpty(runtimeFile))
             {
                 runtimeGraph = JsonRuntimeFormat.ReadRuntimeGraph(runtimeFile);
             }

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetAssetResolver.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetAssetResolver.cs
@@ -270,6 +270,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             return resolvedAssets;
         }
 
+        [Obsolete]
         public IReadOnlyDictionary<string, IEnumerable<ContentItemGroup>> GetAllRuntimeItems()
         {
             Dictionary<string, IEnumerable<ContentItemGroup>> resolvedAssets = new Dictionary<string, IEnumerable<ContentItemGroup>>();


### PR DESCRIPTION
to pick up latest indirect dependencies, and some updates that fell out from this.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
