### PR TITLE
Use min VS version in tools.ps1 InitializeVisualStudioMSBuild if global.json doesn't provide it

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -373,7 +373,7 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
       $vsRequirements = $GlobalJson.tools.vs
     }
     else {
-      $vsRequirements = ConvertFrom-Json "{ `"version`": `"$vsMinVersionReqdStr`" }"
+      $vsRequirements = New-Object PSObject -Property @{ version = $vsMinVersionReqdStr }
     }
   }
   $vsMinVersionStr = if ($vsRequirements.version) { $vsRequirements.version } else { $vsMinVersionReqdStr }

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -368,7 +368,14 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
   # https://dev.azure.com/dnceng/public/_packaging?_a=package&feed=dotnet-eng&package=RoslynTools.MSBuild&protocolType=NuGet&version=17.1.0&view=overview
   $defaultXCopyMSBuildVersion = '17.1.0'
 
-  if (!$vsRequirements) { $vsRequirements = $GlobalJson.tools.vs }
+  if (!$vsRequirements) {
+    if (Get-Member -InputObject $GlobalJson.tools -Name 'vs') {
+      $vsRequirements = $GlobalJson.tools.vs
+    }
+    else {
+      $vsRequirements = ConvertFrom-Json "{ `"version`": `"$vsMinVersionReqdStr`" }"
+    }
+  }
   $vsMinVersionStr = if ($vsRequirements.version) { $vsRequirements.version } else { $vsMinVersionReqdStr }
   $vsMinVersion = [Version]::new($vsMinVersionStr)
 


### PR DESCRIPTION
Otherwise running `eng\common\build.ps1 -msbuildEngine vs` results in an error if the global.json doesn't have a `vs` key (like we do in dotnet/runtime):

```
The property 'vs' cannot be found on this object. Verify that the property exists.
```

This is similar to what we do in https://github.com/dotnet/arcade/blob/b2dad1fa64b4b80f7f4480782cf4ebf2f5fbbcda/eng/common/sdk-task.ps1#L63-L65
