### PR TITLE
Switch to native tools images (release/6.0)

### DIFF
--- a/azure-pipelines-code-mirror.yml
+++ b/azure-pipelines-code-mirror.yml
@@ -12,7 +12,7 @@ jobs:
       enableSBOM: false
       pool:
         name: NetCore1ESPool-Internal
-        demands: ImageOverride -equals Build.Server.Amd64.VS2019
+        demands: ImageOverride -equals windows.vs2019.amd64
       variables:
       - name: WorkingDirectoryName
         value: repo-dir

--- a/azure-pipelines-codeql.yml
+++ b/azure-pipelines-codeql.yml
@@ -24,7 +24,7 @@ stages:
         timeoutInMinutes: 90
         pool:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals Build.Server.Amd64.VS2019
+          demands: ImageOverride -equals windows.vs2019.amd64
 
         steps:
         - checkout: self

--- a/azure-pipelines-merge-mirror.yml
+++ b/azure-pipelines-merge-mirror.yml
@@ -12,7 +12,7 @@ jobs:
       enableSBOM: false
       pool:
         name: NetCore1ESPool-Internal
-        demands: ImageOverride -equals Build.Server.Amd64.VS2019
+        demands: ImageOverride -equals windows.vs2019.amd64
       variables:
       - name: WorkingDirectoryName
         value: repo-dir

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -25,7 +25,7 @@ stages:
         timeoutInMinutes: 90
         pool:
           name: NetCore1ESPool-Svc-Public
-          demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
+          demands: ImageOverride -equals windows.vs2019.amd64.open
         preSteps:
         - checkout: self
           clean: true

--- a/azure-pipelines-weekly.yaml
+++ b/azure-pipelines-weekly.yaml
@@ -15,7 +15,7 @@ stages:
     - job: Synchronize
       pool:
         name: NetCore1ESPool-Internal
-        demands: ImageOverride -equals Build.Server.Amd64.VS2019
+        demands: ImageOverride -equals windows.amd64.vs2019
 
       steps:
       - task: UseDotNet@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,7 @@ stages:
             vmImage: windows-latest
           ${{ if eq(variables._RunAsInternal, True) }}:
             name: NetCore1ESPool-Svc-Internal
-            demands: ImageOverride -equals Build.Server.Amd64.VS2019
+            demands: ImageOverride -equals windows.vs2019.amd64
         strategy:
           matrix:
             Build_Release:


### PR DESCRIPTION
## Description

Switching to the native tools images as part of image consolidation.

## Customer Impact

6.0 will cease working when the images it's currently on are deleted.

## Regression

No

## Risk

Should be little to no risk as the images are essentially the same, but as always there's a risk that for some unforeseen reason the build fails.

## Workarounds

No.