### PR TITLE
Switch to native tools images (release/3.x)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,10 +56,10 @@ stages:
           # Will eventually change this to two BYOC pools.
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
             name: NetCore1ESPool-Svc-Public
-            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
+            demands: ImageOverride -equals windows.vs2019.amd64.open
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
             name: NetCore1ESPool-Svc-Internal
-            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
+            demands: ImageOverride -equals windows.vs2019.amd64
         variables:
         - _Script: eng\common\cibuild.cmd
         - _ValidateSdkArgs: ''


### PR DESCRIPTION
## Description

Switching to the native tools images as part of image consolidation.

## Customer Impact

3.x will cease working when the images it's currently on are deleted.

## Regression

No

## Risk

Should be little to no risk as the images are essentially the same, but as always there's a risk that for some unforeseen reason the build fails.

## Workarounds

No.