### PR TITLE
Devdiv mirroring changes

### DIFF
--- a/azure-pipelines-code-mirror.yml
+++ b/azure-pipelines-code-mirror.yml
@@ -14,29 +14,52 @@ jobs:
     - job: Merge_GitHub_to_Azure_DevOps
       enableSBOM: false
       pool:
-        name: NetCore1ESPool-Internal
-        demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+        ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+          name: VSEngSS-MicroBuild2022-1ES
+          demands: Cmd
+        # If it's not devdiv, it's dnceng
+        ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
       variables:
       - name: WorkingDirectoryName
         value: repo-dir
       steps:
-      - powershell: |
-          $azDORepo = "$(GithubRepo)".Replace("/", "-");
-          # Check that the parameters look correct
-          if ($azDORepo -eq "" -or "$(BranchToMirror)" -eq "")
-          {
-            Write-Error "Expected valid branch and GitHub repo in the form of owner/repo"
-          }
-          Write-Host "##vso[task.setvariable variable=AzDORepoName]$azDORepo"
-          Write-Host "Mirroring branch '$(BranchToMirror)' from GitHub repo '$(GithubRepo)' to Azure DevOps repo '$azDORepo'."
-        displayName: Calculate Mirrored Branch Names
+      - ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
+        - powershell: |
+            $azDORepo = "$(GithubRepo)".Replace("/", "-");
+            # Check that the parameters look correct
+            if ($azDORepo -eq "" -or "$(BranchToMirror)" -eq "")
+            {
+              Write-Error "Expected valid branch and GitHub repo in the form of owner/repo"
+            }
+            Write-Host "##vso[task.setvariable variable=AzDORepoName]$azDORepo"
+            Write-Host "Mirroring branch '$(BranchToMirror)' from GitHub repo '$(GithubRepo)' to Azure DevOps repo '$azDORepo'."
+          displayName: Calculate Mirrored Branch Names (DncEng)
+      - ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+        - powershell: |
+            $azDORepo = "$(GithubRepo)".Replace("/", "-") + "-Trusted";
+            # Check that the parameters look correct
+            if ($azDORepo -eq "" -or "$(BranchToMirror)" -eq "")
+            {
+              Write-Error "Expected valid branch and GitHub repo in the form of owner/repo"
+            }
+            Write-Host "##vso[task.setvariable variable=AzDORepoName]$azDORepo"
+            Write-Host "Mirroring branch '$(BranchToMirror)' from GitHub repo '$(GithubRepo)' to Azure DevOps repo '$azDORepo'."
+          displayName: Calculate Mirrored Branch Names (DevDiv)
       - script: |
           git clone https://dotnet-maestro-bot:$(BotAccount-dotnet-maestro-bot-PAT)@github.com/$(GithubRepo) $(WorkingDirectoryName) -b $(BranchToMirror)
         displayName: Clone GitHub repo
-      - script: |
-          git remote add azdo-mirror https://dn-bot:$(dn-bot-dnceng-build-rw-code-rw)@dev.azure.com/dnceng/internal/_git/$(AzDORepoName)
-        displayName: Add Azure DevOps remote
-        workingDirectory: $(WorkingDirectoryName)
+      - ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+        - script: |
+            git remote add azdo-mirror https://dn-bot:$(dn-bot-devdiv-build-rw-code-rw)@dev.azure.com/devdiv/devdiv/_git/$(AzDORepoName)
+          displayName: Add Azure DevOps remote (DevDiv)
+          workingDirectory: $(WorkingDirectoryName)
+      - ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
+        - script: |
+            git remote add azdo-mirror https://dn-bot:$(dn-bot-dnceng-build-rw-code-rw)@dev.azure.com/dnceng/internal/_git/$(AzDORepoName)
+          displayName: Add Azure DevOps remote (DncEng)
+          workingDirectory: $(WorkingDirectoryName)
       - script: |
           git reset --hard origin/$(BranchToMirror)
         displayName: Hard reset local branch to GitHub branch
@@ -78,7 +101,7 @@ jobs:
         displayName: Push changes to Azure DevOps repo
         workingDirectory: $(WorkingDirectoryName)
 
-      - powershell: |         
+      - powershell: |
           $commit = (git rev-parse HEAD).Substring(0, 7)
           $target = "$(GithubRepo) $(BranchToMirror)".Replace('/', ' ')
 


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/10159

### To double check:

* [x] The right tests are in and/or the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation

### Validation: 

#### Here's an example of these changes:

##### Mirroring a DevDiv repo:
  https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6482554&view=logs

##### Mirroring a DncEng repo:
  https://dnceng.visualstudio.com/internal/_build/results?buildId=1909535&view=logs



