### PR TITLE
Use raspbian key optionally 

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -112,6 +112,10 @@ while :; do
             __CodeName=buster
             __LLDB_Package="liblldb-6.0-dev"
             __Keyring="--keyring /usr/share/keyrings/raspbian-archive-keyring.gpg"
+
+            if [[ ! -e "$__Keyring" ]]; then
+                __Keyring=
+            fi
             ;;
         arm64)
             __BuildArch=arm64

--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -111,10 +111,9 @@ while :; do
             __UbuntuRepo="http://raspbian.raspberrypi.org/raspbian/"
             __CodeName=buster
             __LLDB_Package="liblldb-6.0-dev"
-            __Keyring="--keyring /usr/share/keyrings/raspbian-archive-keyring.gpg"
 
-            if [[ ! -e "/usr/share/keyrings/raspbian-archive-keyring.gpg" ]]; then
-                __Keyring=
+            if [[ -e "/usr/share/keyrings/raspbian-archive-keyring.gpg" ]]; then
+                __Keyring="--keyring /usr/share/keyrings/raspbian-archive-keyring.gpg"
             fi
             ;;
         arm64)

--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -113,7 +113,7 @@ while :; do
             __LLDB_Package="liblldb-6.0-dev"
             __Keyring="--keyring /usr/share/keyrings/raspbian-archive-keyring.gpg"
 
-            if [[ ! -e “/usr/share/keyrings/raspbian-archive-keyring.gpg" ]]; then
+            if [[ ! -e "/usr/share/keyrings/raspbian-archive-keyring.gpg" ]]; then
                 __Keyring=
             fi
             ;;

--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -113,7 +113,7 @@ while :; do
             __LLDB_Package="liblldb-6.0-dev"
             __Keyring="--keyring /usr/share/keyrings/raspbian-archive-keyring.gpg"
 
-            if [[ ! -e “ /usr/share/keyrings/raspbian-archive-keyring.gpg" ]]; then
+            if [[ ! -e “/usr/share/keyrings/raspbian-archive-keyring.gpg" ]]; then
                 __Keyring=
             fi
             ;;

--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -113,7 +113,7 @@ while :; do
             __LLDB_Package="liblldb-6.0-dev"
             __Keyring="--keyring /usr/share/keyrings/raspbian-archive-keyring.gpg"
 
-            if [[ ! -e "$__Keyring" ]]; then
+            if [[ ! -e “ /usr/share/keyrings/raspbian-archive-keyring.gpg" ]]; then
                 __Keyring=
             fi
             ;;


### PR DESCRIPTION
Fallout from previous refactoring, it was causing failures downstream: https://dev.azure.com/dnceng/public/_build/results?buildId=1908557&view=logs&jobId=1bc45e3f-6287-5a42-b140-ca49e7cdf8b7&j=1bc45e3f-6287-5a42-b140-ca49e7cdf8b7&t=eaaa761e-30a0-5df4-5d27-935bf8944a6d

cc @directhex @akoeplinger