### PR TITLE
Set explicit default value for sdlContinueOnError

### DIFF
--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -53,6 +53,7 @@ parameters:
       params: ''
       artifactNames: ''
       downloadArtifacts: true
+      sdlContinueOnError: false
 
   # These parameters let the user customize the call to sdk-task.ps1 for publishing
   # symbols & general artifacts as well as for signing validation


### PR DESCRIPTION
Arcade-validation build [20220727.18](https://dev.azure.com/dnceng/internal/_build/results?buildId=1908410&view=results) failed because changes #10141 mean more `SDLValidationParameters` in `post-build.yml` need explicit defaults set (the parameters-as-an-object method does not allow template defaults to come into play). 

This fixes that by setting an explicit default for `sdlContinueOnError`. This should be the only parameter affected as the others are checked for the "null or empty" value.

Fixes #10172.