### PR TITLE
Publish the gdn folder when running Guardian

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -341,6 +341,7 @@ stages:
       # This is to enable SDL runs part of Post-Build Validation Stage
       SDLValidationParameters:
         enable: true
+        publishGdn: true
         continueOnError: false
         params: ' -SourceToolsList @("policheck","credscan")
         -TsaInstanceURL $(_TsaInstanceURL)

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -49,6 +49,7 @@ parameters:
     type: object
     default:
       enable: false
+      publishGdn: false
       continueOnError: false
       params: ''
       artifactNames: ''
@@ -235,6 +236,7 @@ stages:
     - template: /eng/common/templates/job/execute-sdl.yml
       parameters:
         enable: ${{ parameters.SDLValidationParameters.enable }}
+        publishGuardianDirectoryToPipeline: ${{ parameters.SDLValidationParameters.publishGdn }}
         additionalParameters: ${{ parameters.SDLValidationParameters.params }}
         continueOnError: ${{ parameters.SDLValidationParameters.continueOnError }}
         artifactNames: ${{ parameters.SDLValidationParameters.artifactNames }}


### PR DESCRIPTION
Sets up the option to publish Guardian results through the `post-build.yml` template and enables that in arcade. This will allow us to audit results manually which will make SDL passes easier.

[Sample build](https://dev.azure.com/dnceng/internal/_build/results?buildId=1907766&view=artifacts&pathAsName=false&type=publishedArtifacts).