### PR TITLE
Add osx-arm64 to dotnet-cli when helix queue is osx-arm64

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
@@ -40,6 +40,11 @@
         <DotNetCliRuntime>osx-x64</DotNetCliRuntime>
       </PropertyGroup>
     </When>
+    <When Condition="$(HelixTargetQueue.ToLowerInvariant().Contains('osx')) AND $(HelixTargetQueue.ToLowerInvariant().Contains('arm64'))">
+      <PropertyGroup>
+        <DotNetCliRuntime>osx-arm64</DotNetCliRuntime>
+      </PropertyGroup>
+    </When>
     <When Condition="$(HelixTargetQueue.ToLowerInvariant().Contains('alpine')) AND $(HelixTargetQueue.ToLowerInvariant().Contains('arm64'))">
       <PropertyGroup>
         <DotNetCliRuntime>linux-musl-arm64</DotNetCliRuntime>


### PR DESCRIPTION
Normally, an x64 SDK should be fine, but we have been running into some weird Rosetta assertions that will hopefully go away with a proper arm64 SDK.
