### PR TITLE
Publish SARIF results to a separate container

### DIFF
--- a/azure-pipelines-codeql.yml
+++ b/azure-pipelines-codeql.yml
@@ -36,6 +36,7 @@ stages:
             executeAllSdlToolsScript: 'eng/common/sdl/execute-all-sdl-tools.ps1'
             buildCommands: 'eng\common\cibuild.cmd -configuration Release -prepareMachine /p:Test=false /p:Sign=false'
             language: csharp
+            publishGuardianDirectoryToPipeline: true
             additionalParameters: '-SourceToolsList @("semmle")
             -TsaInstanceURL $(_TsaInstanceURL)
             -TsaProjectName $(_TsaProjectName)

--- a/eng/common/templates/steps/execute-sdl.yml
+++ b/eng/common/templates/steps/execute-sdl.yml
@@ -62,7 +62,28 @@ steps:
         c
         i
     condition: succeededOrFailed()
+
   - publish: $(Agent.BuildDirectory)/.gdn
     artifact: GuardianConfiguration
     displayName: Publish GuardianConfiguration
+    condition: succeededOrFailed()
+
+  # Publish the SARIF files in a container named CodeAnalysisLogs to enable integration
+  # with the "SARIF SAST Scans Tab" Azure DevOps extension
+  - task: CopyFiles@2
+    displayName: Copy SARIF files
+    inputs:
+      flattenFolders: true
+      sourceFolder:  $(Agent.BuildDirectory)/.gdn/rc/
+      contents: '**/*.sarif'
+      targetFolder: $(Build.SourcesDirectory)/CodeAnalysisLogs
+    condition: succeededOrFailed()
+
+  # Use PublishBuildArtifacts because the SARIF extension only checks this case
+  # see microsoft/sarif-azuredevops-extension#4
+  - task: PublishBuildArtifacts@1
+    displayName: Publish SARIF files to CodeAnalysisLogs container
+    inputs:
+      pathToPublish:  $(Build.SourcesDirectory)/CodeAnalysisLogs
+      artifactName: CodeAnalysisLogs
     condition: succeededOrFailed()


### PR DESCRIPTION
Azure DevOps provides some [helpful integration](https://marketplace.visualstudio.com/items?itemName=sariftools.sarif-viewer-build-tab) for SARIF files, but those files must be published in an artifact named CodeAnalysisLogs. 

This adds a build step to capture and upload SARIF files into the CodeAnalysisLogs container for nice access.

Example plain Arcade build: [20220729.7](https://dev.azure.com/dnceng/internal/_build/results?buildId=1912467)
Example CodeQL build: [20220729.1](https://dev.azure.com/dnceng/internal/_build/results?buildId=1912468)

(check the "Scans" tab)

Resolves dotnet/arcade#9712.