### PR TITLE
Flip When osx and osx-arm64 condition in dotnet-cli.props

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
@@ -35,14 +35,14 @@
         <DotNetCliRuntime>win-x64</DotNetCliRuntime>
       </PropertyGroup>
     </When>
-    <When Condition="$(HelixTargetQueue.ToLowerInvariant().Contains('osx'))">
-      <PropertyGroup>
-        <DotNetCliRuntime>osx-x64</DotNetCliRuntime>
-      </PropertyGroup>
-    </When>
     <When Condition="$(HelixTargetQueue.ToLowerInvariant().Contains('osx')) AND $(HelixTargetQueue.ToLowerInvariant().Contains('arm64'))">
       <PropertyGroup>
         <DotNetCliRuntime>osx-arm64</DotNetCliRuntime>
+      </PropertyGroup>
+    </When>
+    <When Condition="$(HelixTargetQueue.ToLowerInvariant().Contains('osx'))">
+      <PropertyGroup>
+        <DotNetCliRuntime>osx-x64</DotNetCliRuntime>
       </PropertyGroup>
     </When>
     <When Condition="$(HelixTargetQueue.ToLowerInvariant().Contains('alpine')) AND $(HelixTargetQueue.ToLowerInvariant().Contains('arm64'))">


### PR DESCRIPTION
Fixes the problem that results in osx-x64 always winning