### PR TITLE
Switch to new images on release/3.x

### DIFF
--- a/azure-pipelines-code-mirror.yml
+++ b/azure-pipelines-code-mirror.yml
@@ -11,7 +11,7 @@ jobs:
     - job: Merge_GitHub_to_Azure_DevOps
       pool:
         name: NetCore1ESPool-Svc-Internal
-        demands: ImageOverride -equals Build.Server.Amd64.VS2019
+        demands: ImageOverride -equals windows.vs2019.amd64
       variables:
       - name: WorkingDirectoryName
         value: repo-dir

--- a/azure-pipelines-merge-mirror.yml
+++ b/azure-pipelines-merge-mirror.yml
@@ -11,7 +11,7 @@ jobs:
     - job: Merge_GitHub_to_Azure_DevOps
       pool:
         name: NetCore1ESPool-Svc-Internal
-        demands: ImageOverride -equals Build.Server.Amd64.VS2019
+        demands: ImageOverride -equals windows.vs2019.amd64
       variables:
       - name: WorkingDirectoryName
         value: repo-dir

--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -20,7 +20,7 @@ jobs:
     - group: DotNet-VSTS-Bot
   pool:
     name: NetCore1ESPool-Svc-Internal
-    demands: ImageOverride -equals Build.Server.Amd64.VS2019
+    demands: ImageOverride -equals windows.vs2019.amd64
   steps:
   - checkout: self
     clean: true

--- a/eng/common/templates/job/onelocbuild.yml
+++ b/eng/common/templates/job/onelocbuild.yml
@@ -5,7 +5,7 @@ parameters:
   # Optional: A defined YAML pool - https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=vsts&tabs=schema#pool
   pool:
     name: NetCore1ESPool-Svc-Internal
-    demands: ImageOverride -equals Build.Server.Amd64.VS2019
+    demands: ImageOverride -equals windows.vs2019.amd64
 
   CeapexPat: $(dn-bot-ceapex-package-r) # PAT for the loc AzDO instance https://dev.azure.com/ceapex
   GithubPat: $(BotAccount-dotnet-bot-repo-PAT)

--- a/eng/common/templates/jobs/jobs.yml
+++ b/eng/common/templates/jobs/jobs.yml
@@ -75,7 +75,7 @@ jobs:
           - ${{ job.job }}
       pool:
         name: NetCore1ESPool-Svc-Internal
-        demands: ImageOverride -equals Build.Server.Amd64.VS2019
+        demands: ImageOverride -equals windows.vs2019.amd64
       runAsPublic: ${{ parameters.runAsPublic }}
       publishUsingPipelines: ${{ parameters.enablePublishUsingPipelines }}
       enablePublishBuildArtifacts: ${{ parameters.enablePublishBuildArtifacts }}
@@ -89,4 +89,4 @@ jobs:
         - Asset_Registry_Publish
       pool:
         name: NetCore1ESPool-Svc-Internal
-        demands: ImageOverride -equals Build.Server.Amd64.VS2019
+        demands: ImageOverride -equals windows.vs2019.amd64

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -29,7 +29,7 @@ stages:
       displayName: NuGet Validation
       pool:
         name: NetCore1ESPool-Svc-Internal
-        demands: ImageOverride -equals Build.Server.Amd64.VS2019
+        demands: ImageOverride -equals windows.vs2019.amd64
       steps:
         - task: DownloadBuildArtifacts@0
           displayName: Download Package Artifacts
@@ -49,7 +49,7 @@ stages:
       displayName: Signing Validation
       pool:
         name: NetCore1ESPool-Svc-Internal
-        demands: ImageOverride -equals Build.Server.Amd64.VS2019
+        demands: ImageOverride -equals windows.vs2019.amd64
       steps:
         # This is necessary whenever we want to publish/restore to an AzDO private feed
         # Since sdk-task.ps1 tries to restore packages we need to do this authentication here
@@ -80,7 +80,7 @@ stages:
         - template: common-variables.yml
       pool:
         name: NetCore1ESPool-Svc-Internal
-        demands: ImageOverride -equals Build.Server.Amd64.VS2019
+        demands: ImageOverride -equals windows.vs2019.amd64
       steps:
         - task: DownloadBuildArtifacts@0
           displayName: Download Blob Artifacts


### PR DESCRIPTION
## Description

Switching to the native tools images as part of image consolidation. Internal test build [here](https://dev.azure.com/dnceng/internal/_build/results?buildId=1921654&view=results).

## Customer Impact

3.x will cease working when the images it's currently on are deleted.

## Regression

No

## Risk

Should be little to no risk as the images are essentially the same, but as always there's a risk that for some unforeseen reason the build fails.

## Workarounds

No.