### PR TITLE
Use empty project collection inside Project.FromFile()

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
@@ -83,7 +83,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
                                 }
                                 else
                                 {
-                                    var proj = Project.FromFile(VersionsPropsPath, new Build.Definition.ProjectOptions());
+                                    var proj = Project.FromFile(VersionsPropsPath, new Build.Definition.ProjectOptions() { ProjectCollection = new ProjectCollection() });
                                     properties = proj.AllEvaluatedProperties.ToLookup(p => p.Name, StringComparer.OrdinalIgnoreCase);
                                 }
                             }


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation

Testing ongoing; my first attempt used a Warning() call and I'm having trouble treating warnings as warnings in the ASP build
When this publishes I can try it: https://dnceng.visualstudio.com/internal/_build/results?buildId=1926170&view=results