### PR TITLE
Suppress downgrade failure

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/bundle/bundle.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/bundle/bundle.wxs
@@ -37,6 +37,7 @@
     <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.Foundation">
       <bal:WixStandardBootstrapperApplication
         LicenseFile="$(var.DotNetDummyEulaFile)"
+        SuppressDowngradeFailure="yes"
         ShowFilesInUse="yes"
         ShowVersion="yes" />
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/42764

Allows installation of earlier version of ASP.Net Hosting bundle package when newer runtime is installed on the machine.
