### PR TITLE
Fix versioning errors in workloads

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/SwixPackageTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/SwixPackageTests.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Build.Utilities;
+using System.IO;
+using Microsoft.Arcade.Test.Common;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.DotNet.Build.Tasks.Workloads.Msi;
 using Microsoft.DotNet.Build.Tasks.Workloads.Swix;
+using Microsoft.NET.Sdk.WorkloadManifestReader;
 using Xunit;
 
 namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
@@ -29,6 +29,24 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             });
 
             Assert.Equal(@"Relative package path exceeds the maximum length (182): Microsoft.NET.Workload.Mono.ToolChain.Manifest-6.0.100,version=6.0.0.0,chip=x64,productarch=neutral\Microsoft.NET.Workload.Mono.ToolChain.Manifest-6.0.100.6.0.0-preview.7.21377.12-x64.msi.", e.Message);
+        }
+
+        [WindowsOnlyFact]
+        public void SwixPackageIdsIncludeThePackageVersion()
+        {
+            // Build to a different path to avoid any file read locks on the MSI from other tests
+            // that can open it.
+            string PackageRootDirectory = Path.Combine(BaseIntermediateOutputPath, Path.GetRandomFileName());
+            string packagePath = Path.Combine(TestAssetsPath, "microsoft.ios.templates.15.2.302-preview.14.122.nupkg");
+
+            WorkloadPack p = new(new WorkloadPackId("Microsoft.iOS.Templates"), "15.2.302-preview.14.122", WorkloadPackKind.Template, null);
+            TemplatePackPackage pkg = new(p, packagePath, new[] { "x64" }, PackageRootDirectory);
+            pkg.Extract();
+            WorkloadPackMsi msi = new(pkg, "x64", new MockBuildEngine(), WixToolsetPath, BaseIntermediateOutputPath);
+
+            ITaskItem item = msi.Build(MsiOutputPath);
+
+            Assert.Equal("Microsoft.iOS.Templates.15.2.302-preview.14.122", item.GetMetadata(Metadata.SwixPackageId));
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
         /// <summary>
         /// The version to assign to workload manifest installers.
         /// </summary>
-        public Version ManifestMsiVersion
+        public string ManifestMsiVersion
         {
             get;
             set;
@@ -162,7 +162,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                 foreach (ITaskItem workloadManifestPackageFile in WorkloadManifestPackageFiles)
                 {
                     // 1. Process the manifest package and create a set of installers.
-                    WorkloadManifestPackage manifestPackage = new(workloadManifestPackageFile, PackageRootDirectory, ManifestMsiVersion, ShortNames, Log);
+                    WorkloadManifestPackage manifestPackage = new(workloadManifestPackageFile, PackageRootDirectory, new Version(ManifestMsiVersion), ShortNames, Log);
                     manifestPackages.Add(manifestPackage);
 
                     foreach (string platform in SupportedPlatforms)

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/WorkloadPackageBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/WorkloadPackageBase.cs
@@ -185,7 +185,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
 
             PackageFileName = Path.GetFileNameWithoutExtension(packagePath);
             ShortName = PackageFileName.Replace(shortNames);
-            SwixPackageId = Id.Replace(shortNames);
+            SwixPackageId = $"{Id.Replace(shortNames)}.{Identity.Version}";
             Log = log;
         }
 

--- a/tests/UnitTests.proj
+++ b/tests/UnitTests.proj
@@ -27,6 +27,8 @@
     <AzurePipelinesExpectedTestFailure Include="HelixReporterTests.failure2"/>
   </ItemGroup>
 
+
+<!-- Disabled : see https://github.com/dotnet/arcade/issues/10358
   <ItemGroup>
     <HelixWorkItem Include="TrxTest">
       <Command>echo 'done!'</Command>
@@ -38,6 +40,7 @@
     <AzurePipelinesExpectedTestFailure Include="HelixReporter.TRXTests.HelixReporter.TRX.Fail2"/>
     <AzurePipelinesExpectedTestFailure Include="tests.UnitTest2.ExpectedFailureTheoryTest"/>
   </ItemGroup>
+-->
 
   <ItemGroup>
     <XUnitProject Include="..\src\**\*.Tests.csproj"/>


### PR DESCRIPTION
Address multiple versioning issues

- Manifest version task property should be a `string` and not `Version`
- MSI package IDs in VS manifests should include the pack version, otherwise the component dependencies won't match. We'd end up with
```
vs.dependency id=Microsoft.Maui.Essentials.Ref.android.6.0.400-preview.1.6511
```
and a package definition like
```
package name=Microsoft.Maui.Essentials.Ref.android
```
