### PR TITLE
Fix casing of RC version name

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.targets
@@ -122,6 +122,7 @@
 
       <ReleaseBrandSuffix>$(PreReleaseVersionLabel.Substring(0,1).ToUpperInvariant())</ReleaseBrandSuffix>
       <ReleaseBrandSuffix>$(ReleaseBrandSuffix)$(PreReleaseVersionLabel.Substring(1))</ReleaseBrandSuffix>
+      <ReleaseBrandSuffix Condition="'$(PreReleaseVersionLabel.ToUpperInvariant())' == 'RC'">RC</ReleaseBrandSuffix>
       <ReleaseBrandSuffix>$(ReleaseBrandSuffix) $(PreReleaseVersionIteration)</ReleaseBrandSuffix>
     </PropertyGroup>
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/60093

RC version name should be specified as "RC" not "Rc".
