### PR TITLE
Reenable "TRX" tests 

### DIFF
--- a/tests/UnitTests.proj
+++ b/tests/UnitTests.proj
@@ -27,8 +27,6 @@
     <AzurePipelinesExpectedTestFailure Include="HelixReporterTests.failure2"/>
   </ItemGroup>
 
-
-<!-- Disabled : see https://github.com/dotnet/arcade/issues/10358
   <ItemGroup>
     <HelixWorkItem Include="TrxTest">
       <Command>echo 'done!'</Command>
@@ -40,7 +38,6 @@
     <AzurePipelinesExpectedTestFailure Include="HelixReporter.TRXTests.HelixReporter.TRX.Fail2"/>
     <AzurePipelinesExpectedTestFailure Include="tests.UnitTest2.ExpectedFailureTheoryTest"/>
   </ItemGroup>
--->
 
   <ItemGroup>
     <XUnitProject Include="..\src\**\*.Tests.csproj"/>


### PR DESCRIPTION
Turn these tests back on; if the PR build is green, then the Azure DevOps issue with test results & attachments is mitigated for our org.

This reverts commit 7ebced53d2346641dc3105fbb8d8911658ca76ee.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
