### PR TITLE
Update Guardian to Latest

### DIFF
--- a/eng/common/sdl/sdl.ps1
+++ b/eng/common/sdl/sdl.ps1
@@ -1,0 +1,37 @@
+
+function Install-Gdn {
+    param(
+        [string]$Path,
+
+        # If omitted, install the latest version of Guardian, otherwise install that specific version.
+        [string]$Version
+    )
+
+    $ErrorActionPreference = 'Stop'
+    Set-StrictMode -Version 2.0
+    $disableConfigureToolsetImport = $true
+    $global:LASTEXITCODE = 0
+
+    # `tools.ps1` checks $ci to perform some actions. Since the SDL
+    # scripts don't necessarily execute in the same agent that run the
+    # build.ps1/sh script this variable isn't automatically set.
+    $ci = $true
+    . $PSScriptRoot\..\tools.ps1
+
+    $argumentList = @("install", "Microsoft.Guardian.Cli", "-Source https://securitytools.pkgs.visualstudio.com/_packaging/Guardian/nuget/v3/index.json", "-OutputDirectory $Path", "-NonInteractive", "-NoCache")
+
+    if ($Version) {
+        $argumentList += "-Version $Version"
+    }
+    
+    Start-Process nuget -Verbose -ArgumentList $argumentList -NoNewWindow -Wait
+
+    $gdnCliPath = Get-ChildItem -Filter guardian.cmd -Recurse -Path $Path
+
+    if (!$gdnCliPath)
+    {
+        Write-PipelineTelemetryError -Category 'Sdl' -Message 'Failure installing Guardian'
+    }
+
+    return $gdnCliPath.FullName
+}

--- a/eng/common/templates/steps/execute-sdl.yml
+++ b/eng/common/templates/steps/execute-sdl.yml
@@ -8,29 +8,26 @@ parameters:
   condition: ''
 
 steps:
-- ${{ if ne(parameters.overrideGuardianVersion, '') }}:
-  - powershell: |
-      $content = Get-Content $(GuardianPackagesConfigFile)
-
-      Write-Host "packages.config content was:`n$content"
-
-      $content = $content.Replace('$(DefaultGuardianVersion)', '$(GuardianVersion)')
-      $content | Set-Content $(GuardianPackagesConfigFile)
-
-      Write-Host "packages.config content updated to:`n$content"
-    displayName: Use overridden Guardian version ${{ parameters.overrideGuardianVersion }}
+- task: NuGetAuthenticate@1
+  inputs:
+    nuGetServiceConnections: GuardianConnect
 
 - task: NuGetToolInstaller@1
   displayName: 'Install NuGet.exe'
   
-- task: NuGetCommand@2
-  displayName: 'Install Guardian'
-  inputs:
-    restoreSolution: $(Build.SourcesDirectory)\eng\common\sdl\packages.config
-    feedsToUse: config
-    nugetConfigPath: $(Build.SourcesDirectory)\eng\common\sdl\NuGet.config
-    externalFeedCredentials: GuardianConnect
-    restoreDirectory: $(Build.SourcesDirectory)\.packages
+- ${{ if ne(parameters.overrideGuardianVersion, '') }}:
+  - pwsh: |
+      . $(Build.SourcesDirectory)\eng\common\sdl\sdl.ps1
+      $guardianCliLocation = Install-Gdn -Path $(Build.SourcesDirectory)\.artifacts -Version ${{ parameters.overrideGuardianVersion }}
+      Write-Host "##vso[task.setvariable variable=GuardianCliLocation]$guardianCliLocation"
+    displayName: Install Guardian (Overridden)
+
+- ${{ if eq(parameters.overrideGuardianVersion, '') }}:
+  - pwsh: |
+      . $(Build.SourcesDirectory)\eng\common\sdl\sdl.ps1
+      $guardianCliLocation = Install-Gdn -Path $(Build.SourcesDirectory)\.artifacts
+      Write-Host "##vso[task.setvariable variable=GuardianCliLocation]$guardianCliLocation"
+    displayName: Install Guardian
 
 - ${{ if ne(parameters.overrideParameters, '') }}:
   - powershell: ${{ parameters.executeAllSdlToolsScript }} ${{ parameters.overrideParameters }}
@@ -40,7 +37,7 @@ steps:
 
 - ${{ if eq(parameters.overrideParameters, '') }}:
   - powershell: ${{ parameters.executeAllSdlToolsScript }}
-      -GuardianPackageName Microsoft.Guardian.Cli.$(GuardianVersion)
+      -GuardianCliLocation $(GuardianCliLocation)
       -NugetPackageDirectory $(Build.SourcesDirectory)\.packages
       -AzureDevOpsAccessToken $(dn-bot-dotnet-build-rw-code-rw)
       ${{ parameters.additionalParameters }}


### PR DESCRIPTION
Update Arcade to always use latest Guardian unless specified elsewhere. 

Resolves dotnet/arcade#8075.

This is an iteration of dotnet/arcade#10141 (which failed in arcade-validation and was reverted), simplified a bit to avoid causing problems with YAML configuration blobs.

successful tested in Arcade's CI pipeline at [build 1944921](https://dev.azure.com/dnceng/internal/_build/results?buildId=1944921&view=results)
Successfully tested in Arcade Validation's pipeline at [build 1945489](https://dev.azure.com/dnceng/internal/_build/results?buildId=1945489&view=results)

Special thanks to @missymessa for help in testing. 