### PR TITLE
Update .props with new task name

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/build/Microsoft.DotNet.Build.Tasks.Workloads.props
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/build/Microsoft.DotNet.Build.Tasks.Workloads.props
@@ -5,6 +5,5 @@
     <MicrosoftDotNetBuildTasksWorkloadsAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.DotNet.Build.Tasks.Workloads.dll</MicrosoftDotNetBuildTasksWorkloadsAssembly>
   </PropertyGroup>
 
-  <UsingTask TaskName="GenerateManifestMsi" AssemblyFile="$(MicrosoftDotNetBuildTasksWorkloadsAssembly)" />
-  <UsingTask TaskName="GenerateVisualStudioWorkload" AssemblyFile="$(MicrosoftDotNetBuildTasksWorkloadsAssembly)" />
+  <UsingTask TaskName="CreateVisualStudioWorkload" AssemblyFile="$(MicrosoftDotNetBuildTasksWorkloadsAssembly)" />
 </Project>


### PR DESCRIPTION
arcade/main introduced a props file that wasn't present in 6.0, so merges from release/6.0 won't work.