### PR TITLE
Non-determinism in publishing in presence of errors

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -413,11 +413,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             Log.LogMessage(MessageImportance.High,
                 $"Performing symbol publishing... \nExpirationInDays : {ExpirationInDays} \nConvertPortablePdbsToWindowsPdb : false \ndryRun: false ");
             var symbolCategory = TargetFeedContentType.Symbols;
+            TaskLoggingHelper _log;
 
             using HttpClient httpClient = CreateAzdoClient(AzureDevOpsOrg, false, AzureProject);
             string containerId = await GetContainerIdAsync(httpClient, ArtifactName.BlobArtifacts);
 
-            if (Log.HasLoggedErrors)
+            if (_log.HasLoggedErrors)
             {
                 return;
             }
@@ -1167,10 +1168,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             TargetFeedConfig feedConfig,
             SemaphoreSlim clientThrottle)
         {
+            TaskLoggingHelper _log;
             using HttpClient httpClient = CreateAzdoClient(AzureDevOpsOrg, false, AzureProject);
             string containerId = await GetContainerIdAsync(httpClient, ArtifactName.PackageArtifacts);
 
-            if (Log.HasLoggedErrors)
+            if (_log.HasLoggedErrors)
             {
                 return;
             }
@@ -1523,10 +1525,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             TargetFeedConfig feedConfig,
             SemaphoreSlim clientThrottle)
         {
+            TaskLoggingHelper _log;
             using HttpClient httpClient = CreateAzdoClient(AzureDevOpsOrg, false, AzureProject);
             string containerId = await GetContainerIdAsync(httpClient, ArtifactName.BlobArtifacts);
 
-            if (Log.HasLoggedErrors)
+            if (_log.HasLoggedErrors)
             {
                 return;
             }
@@ -1695,10 +1698,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             TargetFeedConfig feedConfig,
             SemaphoreSlim clientThrottle)
         {
+            TaskLoggingHelper _log;
             using HttpClient httpClient = CreateAzdoClient(AzureDevOpsOrg, false, AzureProject);
             string containerId = await GetContainerIdAsync(httpClient, ArtifactName.BlobArtifacts);
 
-            if (Log.HasLoggedErrors)
+            if (_log.HasLoggedErrors)
             {
                 return;
             }
@@ -1767,14 +1771,21 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 {
                     var fileName = Path.GetFileName(asset);
                     var localBlobPath = Path.Combine(BlobAssetsBasePath, fileName);
+                    TaskLoggingHelper _log;
+
                     if (!File.Exists(localBlobPath))
                     {
-                        Log.LogError($"Could not locate '{asset} at '{localBlobPath}'");
+                        _log.LogError($"Could not locate '{asset} at '{localBlobPath}'");
                     }
 
                     return (localBlobPath, id: asset);
                 })
                 .ToArray();
+
+            if (_log.HasLoggedErrors)
+            {
+                return;
+            }
 
             var pushOptions = new PushOptions
             {

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -410,7 +410,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             Dictionary<string, HashSet<Asset>> buildAssets,
             SemaphoreSlim clientThrottle)
         {
-            boolean failed = false;
+            bool failed = false;
             Log.LogMessage(MessageImportance.High,
                 $"Performing symbol publishing... \nExpirationInDays : {ExpirationInDays} \nConvertPortablePdbsToWindowsPdb : false \ndryRun: false ");
             var symbolCategory = TargetFeedContentType.Symbols;
@@ -1170,7 +1170,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             TargetFeedConfig feedConfig,
             SemaphoreSlim clientThrottle)
         {
-            boolean failed = false;
+            bool failed = false;
             using HttpClient httpClient = CreateAzdoClient(AzureDevOpsOrg, false, AzureProject);
             string containerId = await GetContainerIdAsync(httpClient, ArtifactName.PackageArtifacts);
 
@@ -1529,7 +1529,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             TargetFeedConfig feedConfig,
             SemaphoreSlim clientThrottle)
         {
-            boolean failed = false;
+            bool failed = false;
             using HttpClient httpClient = CreateAzdoClient(AzureDevOpsOrg, false, AzureProject);
             string containerId = await GetContainerIdAsync(httpClient, ArtifactName.BlobArtifacts);
 
@@ -1705,7 +1705,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             TargetFeedConfig feedConfig,
             SemaphoreSlim clientThrottle)
         {
-            boolean failed = false;
+            bool failed = false;
             using HttpClient httpClient = CreateAzdoClient(AzureDevOpsOrg, false, AzureProject);
             string containerId = await GetContainerIdAsync(httpClient, ArtifactName.BlobArtifacts);
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -1776,11 +1776,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 })
                 .ToArray();
 
-            if (Log.HasLoggedErrors)
-            {
-                return;
-            }
-
             var pushOptions = new PushOptions
             {
                 AllowOverwrite = feedConfig.AllowOverwrite,


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation

Issue -> https://github.com/dotnet/arcade/issues/10360

We should not read Log.HasLoggedErrors to determine what to do here. That way it will not PublishAssetsWithoutStreamingPublishingAsync will not stop when an error is logged here https://github.com/dotnet/arcade/blob/71994b4095bbd33fd1bab9aeee6f3104f78bc24f/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs#L1141. This will consider only the local state not the global state