### PR TITLE
Additional fixes for workloads/multitargeting

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
@@ -100,8 +100,8 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             Assert.Contains("vs.dependency id=Microsoft.Emscripten.Sdk.6.0.4", componentSwr);
 
             // Verify the SWIX authoring for the VS package wrapping the manifest MSI
-            string manifestMsiSwr = File.ReadAllText(Path.Combine(baseIntermediateOutputPath, "src", "swix", "Emscripten.Manifest-6.0.200.6.0.4", "x64", "msi.swr"));
-            Assert.Contains("package name=Emscripten.Manifest-6.0.200.6.0.4", manifestMsiSwr);
+            string manifestMsiSwr = File.ReadAllText(Path.Combine(baseIntermediateOutputPath, "src", "swix", "Emscripten.Manifest-6.0.200", "x64", "msi.swr"));
+            Assert.Contains("package name=Emscripten.Manifest-6.0.200", manifestMsiSwr);
             Assert.Contains("vs.package.type=msi", manifestMsiSwr);
 
             // Verify the SWIX authoring for one of the workload pack MSIs. Packs get assigned random sub-folders so we

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
@@ -18,9 +18,9 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
         [WindowsOnlyFact]
         public static void ItCanCreateWorkloads()
         {
-            // Create intermediate outputs under Artifacts\obj to avoid path issues and make sure it's clean so we don't pick up
+            // Create intermediate outputs under %temp% to avoid path issues and make sure it's clean so we don't pick up
             // conflicting sources from previous runs.
-            string baseIntermediateOutputPath = Path.Combine(File.ReadAllLines(Path.Combine(AppContext.BaseDirectory, "ObjDir.txt"))[0], "WL");
+            string baseIntermediateOutputPath = Path.Combine(Path.GetTempPath(), "WL");
 
             if (Directory.Exists(baseIntermediateOutputPath))
             {

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
@@ -1,0 +1,114 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Arcade.Test.Common;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.Deployment.WindowsInstaller;
+using Microsoft.DotNet.Build.Tasks.Workloads.Msi;
+using Xunit;
+
+namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
+{
+    public class CreateVisualStudioWorkloadTests : TestBase
+    {
+        [WindowsOnlyFact]
+        public static void ItCanCreateWorkloads()
+        {
+            // Create intermediate outputs under Artifacts\obj to avoid path issues and make sure it's clean so we don't pick up
+            // conflicting sources from previous runs.
+            string baseIntermediateOutputPath = Path.Combine(File.ReadAllLines(Path.Combine(AppContext.BaseDirectory, "ObjDir.txt"))[0], "WL");
+
+            if (Directory.Exists(baseIntermediateOutputPath))
+            {
+                Directory.Delete(baseIntermediateOutputPath, recursive: true);
+            }
+
+            ITaskItem[] manifestsPackages = new[]
+            {
+                new TaskItem(Path.Combine(TestBase.TestAssetsPath, "microsoft.net.workload.emscripten.manifest-6.0.200.6.0.4.nupkg"))
+                .WithMetadata(Metadata.MsiVersion, "6.33.28")
+            };
+
+            ITaskItem[] componentResources = new[]
+            {
+                new TaskItem("microsoft-net-sdk-emscripten")
+                .WithMetadata(Metadata.Title, ".NET WebAssembly Build Tools (Emscripten)")
+                .WithMetadata(Metadata.Description, "Build tools for WebAssembly ahead-of-time (AoT) compilation and native linking.")
+            };
+
+            ITaskItem[] shortNames = new[]
+            {
+                new TaskItem("Microsoft.NET.Workload.Emscripten").WithMetadata("Replacement", "Emscripten"),
+                new TaskItem("microsoft.netcore.app.runtime").WithMetadata("Replacement", "Microsoft"),
+                new TaskItem("Microsoft.NETCore.App.Runtime").WithMetadata("Replacement", "Microsoft"),
+                new TaskItem("microsoft.net.runtime").WithMetadata("Replacement", "Microsoft"),
+                new TaskItem("Microsoft.NET.Runtime").WithMetadata("Replacement", "Microsoft")
+            };
+
+            IBuildEngine buildEngine = new MockBuildEngine();
+
+            CreateVisualStudioWorkload createWorkloadTask = new CreateVisualStudioWorkload()
+            {
+                AllowMissingPacks = true,
+                BaseOutputPath = TestBase.BaseOutputPath,
+                BaseIntermediateOutputPath = baseIntermediateOutputPath,
+                BuildEngine = buildEngine,
+                ComponentResources = componentResources,
+                ManifestMsiVersion = null,
+                PackageSource = TestBase.TestAssetsPath,
+                ShortNames = shortNames,
+                WixToolsetPath = TestBase.WixToolsetPath,
+                WorkloadManifestPackageFiles = manifestsPackages,
+            };
+
+            bool result = createWorkloadTask.Execute();
+
+            Assert.True(result);
+            ITaskItem manifestMsiItem = createWorkloadTask.Msis.Where(m => m.ItemSpec.ToLowerInvariant().Contains("microsoft.net.workload.emscripten.manifest-6.0.200.6.0.4-x64.msi")).FirstOrDefault();
+            Assert.NotNull(manifestMsiItem);
+
+            // Spot check one of the manifest MSIs. We have additional tests that cover MSI generation.
+            // The UpgradeCode is predictable/stable for manifest MSIs since they are upgradable withing an SDK feature band,
+            Assert.Equal("{C4F269D9-6B65-36C5-9556-75B78EFE9EDA}", MsiUtils.GetProperty(manifestMsiItem.ItemSpec, MsiProperty.UpgradeCode));
+            // The version should match the value passed to the build task. For actual builds like dotnet/runtiem, this value would
+            // be generated.
+            Assert.Equal("6.33.28", MsiUtils.GetProperty(manifestMsiItem.ItemSpec, MsiProperty.ProductVersion));
+            Assert.Equal("Microsoft.NET.Workload.Emscripten,6.0.200,x64", MsiUtils.GetProviderKeyName(manifestMsiItem.ItemSpec));
+
+            // Process the template in the summary information stream. This is the only way to verify the intended platform
+            // of the MSI itself.
+            using SummaryInfo si = new(manifestMsiItem.ItemSpec, enableWrite: false);
+            Assert.Equal("x64;1033", si.Template);
+
+            // Verify the SWIX authoring for the component representing the workload in VS.
+            string componentSwr = File.ReadAllText(Path.Combine(baseIntermediateOutputPath, "src", "swix", "6.0.200", "microsoft.net.sdk.emscripten.6.0.4", "component.swr"));
+            Assert.Contains("package name=microsoft.net.sdk.emscripten", componentSwr);
+
+            // Emscripten is an abstract workload so it should be a component group.
+            Assert.Contains("vs.package.type=component", componentSwr);
+            Assert.Contains("isUiGroup=yes", componentSwr);
+
+            // Verify pack dependencies. These should map to MSI packages. The VS package IDs should be the non-aliased
+            // pack IDs and version from the workload manifest. The actual VS packages will point to the MSIs generated from the
+            // aliased workload pack packages. 
+            Assert.Contains("vs.dependency id=Microsoft.Emscripten.Node.6.0.4", componentSwr);
+            Assert.Contains("vs.dependency id=Microsoft.Emscripten.Python.6.0.4", componentSwr);
+            Assert.Contains("vs.dependency id=Microsoft.Emscripten.Sdk.6.0.4", componentSwr);
+
+            // Verify the SWIX authoring for the VS package wrapping the manifest MSI
+            string manifestMsiSwr = File.ReadAllText(Path.Combine(baseIntermediateOutputPath, "src", "swix", "Emscripten.Manifest-6.0.200.6.0.4", "x64", "msi.swr"));
+            Assert.Contains("package name=Emscripten.Manifest-6.0.200.6.0.4", manifestMsiSwr);
+            Assert.Contains("vs.package.type=msi", manifestMsiSwr);
+
+            // Verify the SWIX authoring for one of the workload pack MSIs. Packs get assigned random sub-folders so we
+            // need to filter out the SWIX project output items the task produced.
+            ITaskItem pythonPackSwixItem = createWorkloadTask.SwixProjects.Where(s => s.ItemSpec.Contains(@"Microsoft.Emscripten.Python.6.0.4\x64")).FirstOrDefault();
+            string packMsiSwr = File.ReadAllText(Path.Combine(Path.GetDirectoryName(pythonPackSwixItem.ItemSpec), "msi.swr"));
+            Assert.Contains("package name=Microsoft.Emscripten.Python.6.0.4", packMsiSwr);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/Extensions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/Extensions.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
+{
+    public static class Extensions
+    {
+        public static TaskItem WithMetadata(this TaskItem item, string metadataName, string metadataValue)
+        {
+            item.SetMetadata(metadataName, metadataValue);
+            return item;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/Microsoft.DotNet.Build.Tasks.Workloads.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/Microsoft.DotNet.Build.Tasks.Workloads.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
@@ -15,21 +15,33 @@
     <PackageReference Include="Microsoft.NET.Sdk.WorkloadManifestReader" Version="$(MicrosoftNetSdkWorkloadManifestReaderVersion)" />
     <PackageReference Include="Microsoft.Deployment.DotNet.Releases" Version="$(MicrosoftDeploymentDotNetReleasesVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="NuGet.Packaging" Version="$(NuGetVersion)" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" Condition="'$(TargetFramework)' == 'net472'" />
+    <PackageReference Include="NuGet.Packaging" Version="$(NuGetVersion)" />    
 
-    <PackageReference Include="Microsoft.Signed.Wix" Version="$(MicrosoftSignedWixVersion)" GeneratePathProperty="true"/>
+    <PackageReference Include="Microsoft.Signed.Wix" Version="$(MicrosoftSignedWixVersion)" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Workload.Mono.ToolChain.Manifest-6.0.200" Version="6.0.3" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.iOS.Templates" Version="15.2.302-preview.14.122" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.iOS.Templates" Version="15.2.302-preview.14.122" GeneratePathProperty="true" />    
+
+    <!-- We can only test the task properly by building an actual workload end-to-end. EMSDK is the tiniest one available -->
+    <PackageReference Include="Microsoft.NET.Workload.Emscripten.Manifest-6.0.200" Version="6.0.4" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.NET.Runtime.Emscripten.2.0.23.Node.win-x64" Version="6.0.4" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.NET.Runtime.Emscripten.2.0.23.Python.win-x64" Version="6.0.4" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.NET.Runtime.Emscripten.2.0.23.Sdk.win-x64" Version="6.0.4" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup>
     <Content Include="testassets\**\*" CopyToOutputDirectory="PreserveNewest" />
-    <Content Include="$(PkgMicrosoft_Signed_Wix)\tools\**\*" Link="testassets\wix\%(RecursiveDir)%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false"/>
-    <Content Include="$(PkgMicrosoft_NET_Workload_Mono_ToolChain_Manifest-6_0_200)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false"/>
-    <Content Include="$(PkgMicrosoft_iOS_Templates)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false"/>
+    <Content Include="$(PkgMicrosoft_Signed_Wix)\tools\**\*" Link="testassets\wix\%(RecursiveDir)%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+    <Content Include="$(PkgMicrosoft_NET_Workload_Mono_ToolChain_Manifest-6_0_200)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+    <Content Include="$(PkgMicrosoft_iOS_Templates)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+    <Content Include="$(PkgMicrosoft_NET_Workload_Emscripten_Manifest-6_0_200)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+    <Content Include="$(PkgMicrosoft_NET_Runtime_Emscripten_2_0_23_Node_win-x64)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+    <Content Include="$(PkgMicrosoft_NET_Runtime_Emscripten_2_0_23_Python_win-x64)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+    <Content Include="$(PkgMicrosoft_NET_Runtime_Emscripten_2_0_23_Sdk_win-x64)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="testassets\AliasedPacks.json" />
     <None Remove="testassets\emsdkWorkloadManifest.json" />
     <None Remove="testassets\emsdkWorkloadManifest2.json" />
     <None Remove="testassets\mauiWorkloadManifest.json" />
@@ -42,4 +54,10 @@
     <Reference Include="$(WixInstallPath)\Microsoft.Deployment.WindowsInstaller.dll" />
     <Reference Include="$(WixInstallPath)\Microsoft.Deployment.WindowsInstaller.Package.dll" />
   </ItemGroup>
+
+  <Target Name="GenerateObjDirTxt" AfterTargets="Build">
+    <!-- Unit tests need to know the root obj folder since the default location where tests are executed is too
+         deep when extracting workload packs. -->
+    <WriteLinesToFile File="$(OutputPath)ObjDir.txt" Lines="$(ArtifactsObjDir)" Overwrite="true" />
+  </Target>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/Microsoft.DotNet.Build.Tasks.Workloads.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/Microsoft.DotNet.Build.Tasks.Workloads.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
@@ -54,10 +54,4 @@
     <Reference Include="$(WixInstallPath)\Microsoft.Deployment.WindowsInstaller.dll" />
     <Reference Include="$(WixInstallPath)\Microsoft.Deployment.WindowsInstaller.Package.dll" />
   </ItemGroup>
-
-  <Target Name="GenerateObjDirTxt" AfterTargets="Build">
-    <!-- Unit tests need to know the root obj folder since the default location where tests are executed is too
-         deep when extracting workload packs. -->
-    <WriteLinesToFile File="$(OutputPath)ObjDir.txt" Lines="$(ArtifactsObjDir)" Overwrite="true" />
-  </Target>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/TestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/TestBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
 {
@@ -17,5 +18,6 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
         public static readonly string WixToolsetPath = Path.Combine(TestAssetsPath, "wix");
 
         public static readonly string PackageRootDirectory = Path.Combine(BaseIntermediateOutputPath, "pkg");
+        
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/TestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/TestBase.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
 {
@@ -18,6 +17,5 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
         public static readonly string WixToolsetPath = Path.Combine(TestAssetsPath, "wix");
 
         public static readonly string PackageRootDirectory = Path.Combine(BaseIntermediateOutputPath, "pkg");
-        
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/testassets/AliasedPacks.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/testassets/AliasedPacks.json
@@ -1,0 +1,27 @@
+{
+  "version": "33.0.0-rc.1.132",
+  "workloads": {
+    "android": {
+      "description": ".NET SDK Workload for building Android applications.",
+      "packs": [
+        "Microsoft.Android.Sdk"
+      ],
+      "platforms": [ "win-x64", "win-arm64", "linux-x64", "osx-x64", "osx-arm64" ],
+      "extends": [ "microsoft-net-runtime-android", "microsoft-net-runtime-android-aot" ]
+    }
+  },
+  "packs": {
+    "Microsoft.Android.Sdk": {
+      "kind": "sdk",
+      "version": "33.0.0-rc.1.132",
+      "alias-to": {
+        "osx-x64": "Microsoft.Android.Sdk.Darwin",
+        "osx-arm64": "Microsoft.Android.Sdk.Darwin",
+        "win-x86": "Microsoft.Android.Sdk.Windows",
+        "win-x64": "Microsoft.Android.Sdk.Windows",
+        "win-arm64": "Microsoft.Android.Sdk.Windows",
+        "linux-x64": "Microsoft.Android.Sdk.Linux"
+      }
+    }
+  }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Metadata.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Metadata.cs
@@ -19,6 +19,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
         public static readonly string RelativeDir = nameof(RelativeDir);
         public static readonly string Replacement = nameof(Replacement);        
         public static readonly string PackageProject = nameof(PackageProject);
+        public static readonly string PackageType = nameof(PackageType);
         public static readonly string SdkFeatureBand = nameof(SdkFeatureBand);
         public static readonly string ShortName = nameof(ShortName);
         public static readonly string SourcePackage = nameof(SourcePackage);

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/ComponentSwixProject.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/ComponentSwixProject.cs
@@ -15,6 +15,9 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
     {
         private SwixComponent _component;
 
+        /// <inheritdoc />
+        public override string PackageType => "component";
+
         protected override string ProjectFile
         {
             get;

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/MsiSwixProject.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/MsiSwixProject.wix.cs
@@ -24,6 +24,9 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
         }
 
         /// <inheritdoc />
+        public override string PackageType => "Msi";
+
+        /// <inheritdoc />
         protected override string ProjectFile
         {
             get;

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/SwixProjectBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/SwixProjectBase.cs
@@ -29,6 +29,14 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
         }
 
         /// <summary>
+        /// The package type associated with the SWIX project.
+        /// </summary>
+        public abstract string PackageType
+        {
+            get;
+        }
+
+        /// <summary>
         /// The version of the SWIX package.
         /// </summary>
         public Version Version

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/WorkloadManifestPackage.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/WorkloadManifestPackage.wix.cs
@@ -86,6 +86,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
 
             SdkFeatureBand = GetSdkFeatureBandVersion(GetSdkVersion(Id));
             ManifestId = GetManifestId(Id);
+            SwixPackageId = $"{Id.Replace(shortNames)}";
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/WorkloadPackPackage.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/WorkloadPackPackage.wix.cs
@@ -41,6 +41,9 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             _pack = pack;
             Platforms = platforms;
             MsiVersion = Version;
+
+            // Override the SWIX ID for MSI packages to use the shortened, non-aliased ID with the pack version
+            SwixPackageId = $"{pack.Id.ToString().Replace(shortNames)}.{Identity.Version}";
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/WorkloadPackPackage.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/WorkloadPackPackage.wix.cs
@@ -42,7 +42,18 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             Platforms = platforms;
             MsiVersion = Version;
 
-            // Override the SWIX ID for MSI packages to use the shortened, non-aliased ID with the pack version
+            // Override the SWIX ID for MSI packages to use the shortened, non-aliased ID with the pack version. For example,
+            // if a the manifest defines a pack as 
+            //
+            // "Microsoft.NET.Runtime.Emscripten.Python.net7" : {
+            // "alias-to": {
+            //   "win-x64": "Microsoft.NET.Runtime.Emscripten.3.1.12.Python.win-x64",
+            //   "osx-x64": "Microsoft.NET.Runtime.Emscripten.3.1.12.Python.osx-x64",
+            //   "osx-arm64": "Microsoft.NET.Runtime.Emscripten.3.1.12.Python.osx-x64"
+            //  }
+            //
+            // We'll pick "Microsoft.NET.Runtime.Emscripten.Python.net7" as the SWIX ID + with the pack version, but the SWIX package
+            // will point to the MSI generated from the aliased pack, e.g. Microsoft.NET.Runtime.Emscripten.3.1.12.Python.win-x64
             SwixPackageId = $"{pack.Id.ToString().Replace(shortNames)}.{Identity.Version}";
         }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/WorkloadPackageBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/WorkloadPackageBase.cs
@@ -129,9 +129,13 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             get;
         }
 
+        /// <summary>
+        /// The SWIX identifier for the package in VS.
+        /// </summary>
         public string SwixPackageId
         {
             get;
+            protected set;
         }
 
         /// <summary>


### PR DESCRIPTION
Number of fixes

1. Fix the `ManifestMsiVersion` parameter requirement on `CreateVisualStudioWorkload`
2. Add metadata to SWIX output items that indicate the type of VS package it produces. This will make it easier to create batches, e.g. separating packages and components and publishing them separately to different VSDrop locations.
3. Fix the package dependencies being generated for workloads in VS and add a unit test to run the task end-to-end. This requires using an actual set of packages. For now, we're using EMSDK because it's the smallest workload and relies on using aliasing.
