### PR TITLE
Let default(TargetChannelConfig) equal itself

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/GeneralTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/GeneralTests.cs
@@ -3,15 +3,16 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.DotNet.Arcade.Test.Common;
 using Microsoft.DotNet.Build.Tasks.Feed.Model;
 using Microsoft.DotNet.Build.Tasks.Feed.Tests.TestDoubles;
 using Xunit;
 using static Microsoft.DotNet.Build.Tasks.Feed.GeneralUtils;
-using FluentAssertions;
-using Microsoft.DotNet.Arcade.Test.Common;
 
 namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
 {
@@ -171,6 +172,92 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                 retryHandler);
 
             retryHandler.ActualAttempts.Should().Be(expectedAttemptCount);
+        }
+
+        [Fact]
+        public void TargetChannelConfig_DefaultAreEqual_Test()
+        {
+            // Remember:
+            //      default(TargetChannelConfig)
+            // is not the same as
+            //      new TargetChannelConfig(default, default, ...)
+            // The latter uses the constructor, the former does not.
+
+            TargetChannelConfig defaultLeft = default;
+            TargetChannelConfig defaultRight = default;
+
+            Func<bool> action = () => defaultLeft.Equals(defaultRight);
+
+            action.Should().NotThrow();
+
+            bool actualResult = action();
+
+            actualResult.Should().BeTrue();
+        }
+
+        [Fact]
+        public void TargetChannelConfig_TargetFeeds_EqualTest()
+        {
+            TargetChannelConfig left = new(
+                id: default,
+                isInternal: default,
+                publishingInfraVersion: default,
+                akaMSChannelNames: default,
+                targetFeeds: new TargetFeedSpecification[]
+                {
+                    new (new[] { TargetFeedContentType.Deb }, dummyFeedUrl, AssetSelection.ShippingOnly)  
+                },
+                symbolTargetType: default,
+                filenamesToExclude: default,
+                flatten: default);
+
+            TargetChannelConfig right = new(
+                id: default,
+                isInternal: default,
+                publishingInfraVersion: default,
+                akaMSChannelNames: default,
+                targetFeeds: new TargetFeedSpecification[]
+                {
+                    new (new[] { TargetFeedContentType.Deb }, dummyFeedUrl, AssetSelection.ShippingOnly) 
+                },
+                symbolTargetType: default,
+                filenamesToExclude: default,
+                flatten: default);
+
+            bool actualResult = left.Equals(right);
+
+            actualResult.Should().BeTrue();
+        }
+
+        [Fact]
+        public void TargetChannelConfig_TargetFeeds_UnequalTest()
+        {
+            TargetChannelConfig left = new(
+                id: default,
+                isInternal: default,
+                publishingInfraVersion: default,
+                akaMSChannelNames: default,
+                targetFeeds: new TargetFeedSpecification[]
+                {
+                    new (new[] { TargetFeedContentType.Deb }, dummyFeedUrl, AssetSelection.ShippingOnly)
+                },
+                symbolTargetType: default,
+                filenamesToExclude: default,
+                flatten: default);
+
+            TargetChannelConfig right = new(
+                id: default,
+                isInternal: default,
+                publishingInfraVersion: default,
+                akaMSChannelNames: default,
+                targetFeeds: Enumerable.Empty<TargetFeedSpecification>(),
+                symbolTargetType: default,
+                filenamesToExclude: default,
+                flatten: default);
+
+            bool actualResult = left.Equals(right);
+
+            actualResult.Should().BeFalse();
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetChannelConfig.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetChannelConfig.cs
@@ -83,24 +83,36 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
         public override bool Equals(object other)
         {
             if (other is TargetChannelConfig config &&
+                NullAcceptingSequencesEqual(TargetFeeds, config.TargetFeeds) &&
+                NullAcceptingSequencesEqual(AkaMSChannelNames, config.AkaMSChannelNames) &&
+                NullAcceptingSequencesEqual(FilenamesToExclude, config.FilenamesToExclude) &&
                 PublishingInfraVersion == config.PublishingInfraVersion &&
                 Id == config.Id &&
-                AkaMSChannelNames.SequenceEqual(config.AkaMSChannelNames) &&
-                TargetFeeds.Count == config.TargetFeeds.Count &&
-                TargetFeeds.Zip(config.TargetFeeds, (l, r) => l.Equals(r)).All(b => b) &&
                 IsInternal == config.IsInternal &&
                 Flatten == config.Flatten)
             {
-                if (FilenamesToExclude is null)
-                    return config.FilenamesToExclude is null;
-                
-                if (config.FilenamesToExclude is null)
-                    return false;
-                
-                return FilenamesToExclude.SequenceEqual(config.FilenamesToExclude);
+                return true;
             }
             
             return false;
+
+
+            static bool NullAcceptingSequencesEqual<T>(IEnumerable<T> left, IEnumerable<T> right)
+            {
+                if (left is not null && right is not null)
+                {
+                    if (!left.SequenceEqual(right))
+                    {
+                        return false;
+                    }
+                }
+                else if ((left is null) ^ (right is null))
+                {
+                    return false;
+                }
+
+                return true;
+            }
         }
 
         public override int GetHashCode()
@@ -162,7 +174,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
 
             if (assets == AssetSelection.All && contentTypes.Contains(TargetFeedContentType.Package))
             {
-                throw new ArgumentException($"Target feed specification for {feedUrl} must have a separated asset selection 'ShippingOnly' and 'NonShippingOnly packages");
+                throw new ArgumentException($"Target feed specification for {feedUrl} must have a separated asset selection 'ShippingOnly' and 'NonShippingOnly' packages");
             }
 
             ContentTypes = contentTypes.ToImmutableList();


### PR DESCRIPTION
There are checks expecting that `default(TargetChannelConfig).Equals(default(TargetChannelConfig))` be true, but the Equals method does not expect the reference types to be (their default) null. Currently, putting `default(TargetChannelConfig)` on either side of the equality results in a `ArgumentNullException` from various paths trying to deference a null type.

This PR teaches the Equals method to handle null reference types with acceptance and understanding. 

Validation was done using new unit tests. 

Resolves dotnet/arcade#9908 by letting the `.FirstOrDefault()` check happen as expected and thus print the helpful error message.
