### PR TITLE
Update SWIX generation

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Arcade.Test.Common;
@@ -102,15 +104,120 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             Assert.Contains("vs.dependency id=Microsoft.Emscripten.Sdk.6.0.4", componentSwr);
 
             // Verify the SWIX authoring for the VS package wrapping the manifest MSI
-            string manifestMsiSwr = File.ReadAllText(Path.Combine(baseIntermediateOutputPath, "src", "swix", "Emscripten.Manifest-6.0.200", "x64", "msi.swr"));
+            string manifestMsiSwr = File.ReadAllText(Path.Combine(baseIntermediateOutputPath, "src", "swix", "6.0.200", "Emscripten.Manifest-6.0.200", "x64", "msi.swr"));
             Assert.Contains("package name=Emscripten.Manifest-6.0.200", manifestMsiSwr);
             Assert.Contains("vs.package.type=msi", manifestMsiSwr);
+            Assert.Contains("vs.package.chip=x64", manifestMsiSwr);
+            Assert.DoesNotContain("vs.package.machineArch", manifestMsiSwr);
+
+            // Verify that no arm64 MSI authoring for VS. EMSDK doesn't define RIDs for arm64, but manifests always generate
+            // arm64 MSIs for the CLI based installs so we should not see that.
+            string swixRootDirectory = Path.Combine(baseIntermediateOutputPath, "src", "swix", "6.0.200");
+            IEnumerable<string> arm64Directories = Directory.EnumerateDirectories(swixRootDirectory, "arm64", SearchOption.AllDirectories);
+            Assert.DoesNotContain(arm64Directories, s => s.Contains("arm64"));
 
             // Verify the SWIX authoring for one of the workload pack MSIs. Packs get assigned random sub-folders so we
             // need to filter out the SWIX project output items the task produced.
             ITaskItem pythonPackSwixItem = createWorkloadTask.SwixProjects.Where(s => s.ItemSpec.Contains(@"Microsoft.Emscripten.Python.6.0.4\x64")).FirstOrDefault();
             string packMsiSwr = File.ReadAllText(Path.Combine(Path.GetDirectoryName(pythonPackSwixItem.ItemSpec), "msi.swr"));
             Assert.Contains("package name=Microsoft.Emscripten.Python.6.0.4", packMsiSwr);
+            Assert.Contains("vs.package.chip=x64", packMsiSwr);
+            Assert.DoesNotContain("vs.package.machineArch", packMsiSwr);
+        }
+
+        [WindowsOnlyFact]
+        public static void ItCanCreateWorkloadsThatSupportArm64InVisualStudio()
+        {
+            // Create intermediate outputs under %temp% to avoid path issues and make sure it's clean so we don't pick up
+            // conflicting sources from previous runs.
+            string baseIntermediateOutputPath = Path.Combine(Path.GetTempPath(), "WLa64");
+
+            if (Directory.Exists(baseIntermediateOutputPath))
+            {
+                Directory.Delete(baseIntermediateOutputPath, recursive: true);
+            }
+
+            ITaskItem[] manifestsPackages = new[]
+            {
+                new TaskItem(Path.Combine(TestBase.TestAssetsPath, "microsoft.net.workload.emscripten.manifest-6.0.200.6.0.4.nupkg"))
+                .WithMetadata(Metadata.MsiVersion, "6.33.28")
+                .WithMetadata(Metadata.SupportsMachineArch, "true")
+            };
+
+            ITaskItem[] componentResources = new[]
+            {
+                new TaskItem("microsoft-net-sdk-emscripten")
+                .WithMetadata(Metadata.Title, ".NET WebAssembly Build Tools (Emscripten)")
+                .WithMetadata(Metadata.Description, "Build tools for WebAssembly ahead-of-time (AoT) compilation and native linking.")
+                .WithMetadata(Metadata.Version, "5.6.7.8")
+            };
+
+            ITaskItem[] shortNames = new[]
+            {
+                new TaskItem("Microsoft.NET.Workload.Emscripten").WithMetadata("Replacement", "Emscripten"),
+                new TaskItem("microsoft.netcore.app.runtime").WithMetadata("Replacement", "Microsoft"),
+                new TaskItem("Microsoft.NETCore.App.Runtime").WithMetadata("Replacement", "Microsoft"),
+                new TaskItem("microsoft.net.runtime").WithMetadata("Replacement", "Microsoft"),
+                new TaskItem("Microsoft.NET.Runtime").WithMetadata("Replacement", "Microsoft")
+            };
+
+            IBuildEngine buildEngine = new MockBuildEngine();
+
+            CreateVisualStudioWorkload createWorkloadTask = new CreateVisualStudioWorkload()
+            {
+                AllowMissingPacks = true,
+                BaseOutputPath = TestBase.BaseOutputPath,
+                BaseIntermediateOutputPath = baseIntermediateOutputPath,
+                BuildEngine = buildEngine,
+                ComponentResources = componentResources,
+                ManifestMsiVersion = null,
+                PackageSource = TestBase.TestAssetsPath,
+                ShortNames = shortNames,
+                WixToolsetPath = TestBase.WixToolsetPath,
+                WorkloadManifestPackageFiles = manifestsPackages,
+            };
+
+            bool result = createWorkloadTask.Execute();
+
+            Assert.True(result);
+            ITaskItem manifestMsiItem = createWorkloadTask.Msis.Where(m => m.ItemSpec.ToLowerInvariant().Contains("microsoft.net.workload.emscripten.manifest-6.0.200.6.0.4-arm64.msi")).FirstOrDefault();
+            Assert.NotNull(manifestMsiItem);
+
+            // Spot check one of the manifest MSIs. We have additional tests that cover MSI generation.
+            // The UpgradeCode is predictable/stable for manifest MSIs since they are upgradable withing an SDK feature band,
+            Assert.Equal("{CBA7CF4A-F3C9-3B75-8F1F-0D08AF7CD7BE}", MsiUtils.GetProperty(manifestMsiItem.ItemSpec, MsiProperty.UpgradeCode));
+            // The version should match the value passed to the build task. For actual builds like dotnet/runtiem, this value would
+            // be generated.
+            Assert.Equal("6.33.28", MsiUtils.GetProperty(manifestMsiItem.ItemSpec, MsiProperty.ProductVersion));
+            Assert.Equal("Microsoft.NET.Workload.Emscripten,6.0.200,arm64", MsiUtils.GetProviderKeyName(manifestMsiItem.ItemSpec));
+
+            // Process the template in the summary information stream. This is the only way to verify the intended platform
+            // of the MSI itself.
+            using SummaryInfo si = new(manifestMsiItem.ItemSpec, enableWrite: false);
+            Assert.Equal("Arm64;1033", si.Template);
+
+            // Verify the SWIX authoring for the component representing the workload in VS.
+            string componentSwr = File.ReadAllText(Path.Combine(baseIntermediateOutputPath, "src", "swix", "6.0.200", "microsoft.net.sdk.emscripten.5.6.7.8", "component.swr"));
+            Assert.Contains("package name=microsoft.net.sdk.emscripten", componentSwr);
+
+            // Emscripten is an abstract workload so it should be a component group.
+            Assert.Contains("vs.package.type=component", componentSwr);
+            Assert.Contains("isUiGroup=yes", componentSwr);
+            Assert.Contains("version=5.6.7.8", componentSwr);
+
+            // Verify pack dependencies. These should map to MSI packages. The VS package IDs should be the non-aliased
+            // pack IDs and version from the workload manifest. The actual VS packages will point to the MSIs generated from the
+            // aliased workload pack packages. 
+            Assert.Contains("vs.dependency id=Microsoft.Emscripten.Node.6.0.4", componentSwr);
+            Assert.Contains("vs.dependency id=Microsoft.Emscripten.Python.6.0.4", componentSwr);
+            Assert.Contains("vs.dependency id=Microsoft.Emscripten.Sdk.6.0.4", componentSwr);
+
+            // Verify the SWIX authoring for the VS package wrapping the manifest MSI
+            string manifestMsiSwr = File.ReadAllText(Path.Combine(baseIntermediateOutputPath, "src", "swix", "6.0.200", "Emscripten.Manifest-6.0.200", "arm64", "msi.swr"));
+            Assert.Contains("package name=Emscripten.Manifest-6.0.200", manifestMsiSwr);
+            Assert.Contains("vs.package.type=msi", manifestMsiSwr);
+            Assert.DoesNotContain("vs.package.chip", manifestMsiSwr);
+            Assert.Contains("vs.package.machineArch=arm64", manifestMsiSwr);
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
@@ -23,7 +23,6 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             string baseIntermediateOutputPath = Path.Combine(Path.GetTempPath(), "WL");
 
             if (Directory.Exists(baseIntermediateOutputPath))
-            if (Directory.Exists(baseIntermediateOutputPath))
             {
                 Directory.Delete(baseIntermediateOutputPath, recursive: true);
             }

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
@@ -23,6 +23,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             string baseIntermediateOutputPath = Path.Combine(Path.GetTempPath(), "WL");
 
             if (Directory.Exists(baseIntermediateOutputPath))
+            if (Directory.Exists(baseIntermediateOutputPath))
             {
                 Directory.Delete(baseIntermediateOutputPath, recursive: true);
             }
@@ -38,6 +39,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
                 new TaskItem("microsoft-net-sdk-emscripten")
                 .WithMetadata(Metadata.Title, ".NET WebAssembly Build Tools (Emscripten)")
                 .WithMetadata(Metadata.Description, "Build tools for WebAssembly ahead-of-time (AoT) compilation and native linking.")
+                .WithMetadata(Metadata.Version, "5.6.7.8")
             };
 
             ITaskItem[] shortNames = new[]
@@ -85,12 +87,13 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             Assert.Equal("x64;1033", si.Template);
 
             // Verify the SWIX authoring for the component representing the workload in VS.
-            string componentSwr = File.ReadAllText(Path.Combine(baseIntermediateOutputPath, "src", "swix", "6.0.200", "microsoft.net.sdk.emscripten.6.0.4", "component.swr"));
+            string componentSwr = File.ReadAllText(Path.Combine(baseIntermediateOutputPath, "src", "swix", "6.0.200", "microsoft.net.sdk.emscripten.5.6.7.8", "component.swr"));
             Assert.Contains("package name=microsoft.net.sdk.emscripten", componentSwr);
 
             // Emscripten is an abstract workload so it should be a component group.
             Assert.Contains("vs.package.type=component", componentSwr);
             Assert.Contains("isUiGroup=yes", componentSwr);
+            Assert.Contains("version=5.6.7.8", componentSwr);
 
             // Verify pack dependencies. These should map to MSI packages. The VS package IDs should be the non-aliased
             // pack IDs and version from the workload manifest. The actual VS packages will point to the MSIs generated from the

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/SwixComponentTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/SwixComponentTests.cs
@@ -30,11 +30,40 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
 
             string componentSwr = File.ReadAllText(Path.Combine(Path.GetDirectoryName(swixProj), "component.swr"));
             Assert.Contains("package name=microsoft.net.sdk.blazorwebassembly.aot", componentSwr);
+            Assert.Contains("version=1.0.0", componentSwr);
 
             string componentResSwr = File.ReadAllText(Path.Combine(Path.GetDirectoryName(swixProj), "component.res.swr"));
             Assert.Contains(@"title=""Blazor WebAssembly AOT workload""", componentResSwr);
             Assert.Contains(@"description=""Blazor WebAssembly AOT workload""", componentResSwr);
             Assert.Contains(@"category="".NET""", componentResSwr);
+        }
+
+        [WindowsOnlyFact]
+        public void ItPrefersComponentResourcesOverDefaults()
+        {
+            ITaskItem[] componentResources = new[] 
+            {
+                new TaskItem("microsoft-net-sdk-blazorwebassembly-aot").WithMetadata(Metadata.Version, "4.5.6")
+                .WithMetadata(Metadata.Description, "A long wordy description about Blazor.")
+                .WithMetadata(Metadata.Category, "WebAssembly")
+            };
+
+            WorkloadManifest manifest = Create("WorkloadManifest.json");
+            WorkloadDefinition workload = (WorkloadDefinition)manifest.Workloads.FirstOrDefault().Value;
+            SwixComponent component = SwixComponent.Create(new ReleaseVersion("6.0.300"), workload, manifest, packGroupId: null,
+                componentResources);
+
+            ComponentSwixProject project = new(component, BaseIntermediateOutputPath, BaseOutputPath);
+            string swixProj = project.Create();
+
+            string componentSwr = File.ReadAllText(Path.Combine(Path.GetDirectoryName(swixProj), "component.swr"));
+            Assert.Contains("package name=microsoft.net.sdk.blazorwebassembly.aot", componentSwr);
+            Assert.Contains("version=4.5.6", componentSwr);
+
+            string componentResSwr = File.ReadAllText(Path.Combine(Path.GetDirectoryName(swixProj), "component.res.swr"));
+            Assert.Contains(@"title=""Blazor WebAssembly AOT workload""", componentResSwr);
+            Assert.Contains(@"description=""A long wordy description about Blazor.""", componentResSwr);
+            Assert.Contains(@"category=""WebAssembly""", componentResSwr);
         }
 
         [WindowsOnlyFact]

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/SwixPackageTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/SwixPackageTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using Microsoft.Arcade.Test.Common;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using Microsoft.Deployment.DotNet.Releases;
 using Microsoft.DotNet.Build.Tasks.Workloads.Msi;
 using Microsoft.DotNet.Build.Tasks.Workloads.Swix;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
@@ -26,6 +27,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             Exception e = Assert.Throws<Exception>(() =>
             {
                 MsiSwixProject swixProject = new(msiItem, BaseIntermediateOutputPath, BaseOutputPath,
+                    new ReleaseVersion("6.0.100"),
                     chip: "x64", machineArch: "x64", productArch: "neutral");
             });
 
@@ -68,7 +70,9 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
 
             Assert.Equal("Microsoft.iOS.Templates.15.2.302-preview.14.122", msiItem.GetMetadata(Metadata.SwixPackageId));
 
-            MsiSwixProject swixProject = new(msiItem, BaseIntermediateOutputPath, BaseOutputPath, chip: msiItem.GetMetadata(Metadata.Platform),
+            MsiSwixProject swixProject = new(msiItem, BaseIntermediateOutputPath, BaseOutputPath,
+                new ReleaseVersion("6.0.100"),
+                chip: msiItem.GetMetadata(Metadata.Platform),                
                 machineArch: DefaultValues.x64);
             string swixProj = swixProject.Create();
             string msiSwr = File.ReadAllText(Path.Combine(Path.GetDirectoryName(swixProj), "msi.swr"));

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/SwixPackageTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/SwixPackageTests.cs
@@ -66,13 +66,13 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             WorkloadPackMsi msi = new(pkg, "x64", new MockBuildEngine(), WixToolsetPath, BaseIntermediateOutputPath);
 
             ITaskItem msiItem = msi.Build(MsiOutputPath);
-            msiItem.SetMetadata(Metadata.Platform, "x64");            
+            msiItem.SetMetadata(Metadata.Platform, "x64");
 
             Assert.Equal("Microsoft.iOS.Templates.15.2.302-preview.14.122", msiItem.GetMetadata(Metadata.SwixPackageId));
 
             MsiSwixProject swixProject = new(msiItem, BaseIntermediateOutputPath, BaseOutputPath,
                 new ReleaseVersion("6.0.100"),
-                chip: msiItem.GetMetadata(Metadata.Platform),                
+                chip: msiItem.GetMetadata(Metadata.Platform),
                 machineArch: DefaultValues.x64);
             string swixProj = swixProject.Create();
             string msiSwr = File.ReadAllText(Path.Combine(Path.GetDirectoryName(swixProj), "msi.swr"));

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/BuildData.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/BuildData.wix.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
         /// <summary>
         /// For each platform, the set of feature bands that include contain a reference to this pack.
         /// </summary>
-        public Dictionary<string, HashSet<ReleaseVersion>> FeatureBands = new();
+        public Dictionary<string, HashSet<ReleaseVersion>> FeatureBands = new();        
 
         public BuildData(WorkloadPackPackage package)
         {

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
@@ -399,6 +399,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
 
                                 ITaskItem swixProjectItem = new TaskItem(swixProj);
                                 swixProjectItem.SetMetadata(Metadata.SdkFeatureBand, $"{sdkFeatureBand}");
+                                swixProjectItem.SetMetadata(Metadata.PackageType, DefaultValues.PackageTypeMsiPack);
 
                                 lock (swixProjectItems)
                                 {
@@ -446,6 +447,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
 
                                     ITaskItem swixProjectItem = new TaskItem(swixProj);
                                     swixProjectItem.SetMetadata(Metadata.SdkFeatureBand, $"{manifestPackage.SdkFeatureBand}");
+                                    swixProjectItem.SetMetadata(Metadata.PackageType, DefaultValues.PackageTypeMsiPack);
 
                                     lock (swixProjectItems)
                                     {
@@ -457,8 +459,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                     }
                 });
 
-                // Generate MSIs for the workload manifests along with
-                // a .csproj to package the MSI and a SWIX project for
+                // Generate MSIs for the workload manifests along with a .csproj to package the MSI and a SWIX project for
                 // Visual Studio.
                 _ = Parallel.ForEach(manifestMsisToBuild, msi =>
                 {
@@ -473,7 +474,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                             new(msiOutputItem, BaseIntermediateOutputPath, BaseOutputPath, msi.Package.SdkFeatureBand, chip: msiOutputItem.GetMetadata(Metadata.Platform));
                         ITaskItem swixProjectItem = new TaskItem(swixProject.Create());
                         swixProjectItem.SetMetadata(Metadata.SdkFeatureBand, $"{((WorkloadManifestPackage)msi.Package).SdkFeatureBand}");
-                        swixProjectItem.SetMetadata(Metadata.PackageType, swixProject.PackageType);
+                        swixProjectItem.SetMetadata(Metadata.PackageType, DefaultValues.PackageTypeMsiManifest);
 
                         lock (swixProjectItems)
                         {
@@ -499,7 +500,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                     ComponentSwixProject swixComponentProject = new(swixComponent, BaseIntermediateOutputPath, BaseOutputPath);
                     ITaskItem swixProjectItem = new TaskItem(swixComponentProject.Create());
                     swixProjectItem.SetMetadata(Metadata.SdkFeatureBand, $"{swixComponent.SdkFeatureBand}");
-                    swixProjectItem.SetMetadata(Metadata.PackageType, swixComponentProject.PackageType);
+                    swixProjectItem.SetMetadata(Metadata.PackageType, DefaultValues.PackageTypeComponent);
 
                     lock (swixProjectItems)
                     {

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/DefaultValues.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/DefaultValues.cs
@@ -23,5 +23,20 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
         public static readonly string x64 = "x64";
         public static readonly string arm64 = "arm64";
         public static readonly string Neutral = "neutral";
+
+        /// <summary>
+        /// A value indicating that the SWIX project creates an MSI package for a workload manifest. 
+        /// </summary>
+        public static readonly string PackageTypeMsiManifest = "msi-manifest";
+
+        /// <summary>
+        /// A value indicating that the SWIX project creates an MSI package for a workload pack. 
+        /// </summary>
+        public static readonly string PackageTypeMsiPack = "msi-pack";
+
+        /// <summary>
+        /// A value indicating that the SWIX project creates a component package for a workload. 
+        /// </summary>
+        public static readonly string PackageTypeComponent = "component";
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/DefaultValues.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/DefaultValues.cs
@@ -18,5 +18,10 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
         /// The default value to assign to the Manufacturer property of an MSI.
         /// </summary>
         public static readonly string Manufacturer = "Microsoft Corporation";
+
+        public static readonly string x86 = "x64";
+        public static readonly string x64 = "x64";
+        public static readonly string arm64 = "arm64";
+        public static readonly string Neutral = "neutral";
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Extensions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Extensions.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Build.Tasks.Workloads
+{
+    public static class Extensions
+    {
+        /// <summary>
+        /// Determines if the item contains a the specified metadata.
+        /// </summary>
+        /// <param name="item">The item to evaluate.</param>
+        /// <param name="metadataName">The name of the metadata to check.</param>
+        /// <returns><see langword="true"/> if the metadata exists; <see langword="false"/> otherwise.</returns>
+        public static bool HasMetadata(this ITaskItem item, string metadataName)
+        {
+            foreach (string name in item.MetadataNames)
+            {
+                if (string.Equals(metadataName, name, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Metadata.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Metadata.cs
@@ -37,6 +37,12 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
         public static readonly string SourcePackage = nameof(SourcePackage);
         public static readonly string SwixPackageId = nameof(SwixPackageId);
         public static readonly string SwixProject = nameof(SwixProject);
+
+        /// <summary>
+        /// Metadata describing whether the VS authoring supports the machineArch SWIX property.
+        /// </summary>
+        public static readonly string SupportsMachineArch = nameof(SupportsMachineArch);
+
         public static readonly string Title = nameof(Title);
         public static readonly string Version = nameof(Version);
 

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Metadata.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Metadata.cs
@@ -10,16 +10,28 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
     {
         public static readonly string AliasTo = nameof(AliasTo);
         public static readonly string Category = nameof(Category);
+        public static readonly string Chip = nameof(Chip);
         public static readonly string Description = nameof(Description);
         public static readonly string Filename = nameof(Filename);
         public static readonly string FullPath = nameof(FullPath);
         public static readonly string JsonProperties = nameof(JsonProperties);
+
+        /// <summary>
+        /// Metadata describing the native machine architecture of an installation
+        /// package for VS.
+        /// </summary>
+        public static readonly string MachineArch = nameof(MachineArch);
         public static readonly string MsiVersion = nameof(MsiVersion);
+
+        /// <summary>
+        /// Metadata describing the platform of the MSI itself.
+        /// </summary>
         public static readonly string Platform = nameof(Platform);
         public static readonly string RelativeDir = nameof(RelativeDir);
         public static readonly string Replacement = nameof(Replacement);        
         public static readonly string PackageProject = nameof(PackageProject);
         public static readonly string PackageType = nameof(PackageType);
+        public static readonly string ProductArch = nameof(ProductArch);
         public static readonly string SdkFeatureBand = nameof(SdkFeatureBand);
         public static readonly string ShortName = nameof(ShortName);
         public static readonly string SourcePackage = nameof(SourcePackage);

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Strings.Designer.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Strings.Designer.cs
@@ -88,6 +88,24 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to At least one of the following properties must contain a valid value: Chip, MachineArch..
+        /// </summary>
+        internal static string ChipOrMachineArchRequired {
+            get {
+                return ResourceManager.GetString("ChipOrMachineArchRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Components must have define at lease on category..
+        /// </summary>
+        internal static string ComponentCategoryCannotBeNull {
+            get {
+                return ResourceManager.GetString("ComponentCategoryCannotBeNull", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Components cannot have a null description. Either provide a custom resource or add a description to the workload definition..
         /// </summary>
         internal static string ComponentDescriptionCannotBeNull {

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Strings.resx
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Strings.resx
@@ -130,7 +130,7 @@
     <value>At least one of the following properties must contain a valid value: Chip, MachineArch.</value>
   </data>
   <data name="ComponentCategoryCannotBeNull" xml:space="preserve">
-    <value>Components must have define at lease on category.</value>
+    <value>Components must define at least one category.</value>
   </data>
   <data name="ComponentDescriptionCannotBeNull" xml:space="preserve">
     <value>Components cannot have a null description. Either provide a custom resource or add a description to the workload definition.</value>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Strings.resx
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Strings.resx
@@ -126,6 +126,12 @@
   <data name="CannotExtractSdkVersionFromPackageId" xml:space="preserve">
     <value>Unable to extract the SDK version from the package ID: {0}.</value>
   </data>
+  <data name="ChipOrMachineArchRequired" xml:space="preserve">
+    <value>At least one of the following properties must contain a valid value: Chip, MachineArch.</value>
+  </data>
+  <data name="ComponentCategoryCannotBeNull" xml:space="preserve">
+    <value>Components must have define at lease on category.</value>
+  </data>
   <data name="ComponentDescriptionCannotBeNull" xml:space="preserve">
     <value>Components cannot have a null description. Either provide a custom resource or add a description to the workload definition.</value>
   </data>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/ComponentSwixProject.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/ComponentSwixProject.cs
@@ -13,9 +13,6 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
     {
         private SwixComponent _component;
 
-        /// <inheritdoc />
-        public override string PackageType => "component";
-
         protected override string ProjectFile
         {
             get;

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/ComponentSwixProject.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/ComponentSwixProject.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
 {
@@ -33,7 +31,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
             base(component.Name, component.Version, baseIntermediateOutputPath, baseOutputPath)
         {
             _component = component;
-            ValidateRelativePackagePath($@"{component.Name},version={component.Version}\_package.json");
+            ValidateRelativePackagePath(GetRelativePackagePath());
 
             // Components must have 1 or more dependencies.
             if (!component.HasDependencies)
@@ -41,7 +39,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
                 throw new ArgumentException(string.Format(Strings.ComponentMustHaveAtLeastOneDependency, component.Name));
             }
 
-            ProjectSourceDirectory = Path.Combine(SwixDirectory, $"{component.SdkFeatureBand}", 
+            ProjectSourceDirectory = Path.Combine(SwixDirectory, $"{component.SdkFeatureBand}",
                 $"{component.Name}.{component.Version}");
 
             ReplacementTokens[SwixTokens.__VS_COMPONENT_TITLE__] = component.Title;
@@ -76,5 +74,9 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
 
             return swixProj;
         }
+
+        /// <inheritdoc />
+        protected override string GetRelativePackagePath() =>
+            Path.Combine(base.GetRelativePackagePath(), "_package.json");
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/MsiSwixProject.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/MsiSwixProject.wix.cs
@@ -34,9 +34,6 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
             get;
         }
 
-        /// <inheritdoc />
-        public override string PackageType => "Msi";
-
         /// <summary>
         /// The platform associated with the MSI.
         /// </summary>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/MsiSwixProject.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/MsiSwixProject.wix.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using System.Security.Cryptography;
-using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.Tasks.Workloads.Msi;
 
@@ -15,6 +14,8 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
     /// </summary>
     public class MsiSwixProject : SwixProjectBase
     {
+        ITaskItem _msi;
+
         /// <summary>
         /// The target platform of the package.
         /// </summary>
@@ -23,8 +24,32 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
             get;
         }
 
+        /// <summary>
+        /// The machine architecture of the package.
+        /// </summary>
+        protected string MachineArch
+        {
+            get;
+        }
+
         /// <inheritdoc />
         public override string PackageType => "Msi";
+
+        /// <summary>
+        /// The platform associated with the MSI.
+        /// </summary>
+        protected string Platform
+        {
+            get;
+        }
+
+        /// <summary>
+        /// The product architecture of Visual Studio.
+        /// </summary>
+        protected string ProductArch
+        {
+            get;
+        }
 
         /// <inheritdoc />
         protected override string ProjectFile
@@ -38,36 +63,92 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
             get;
         }
 
-        public MsiSwixProject(ITaskItem msi, string baseIntermediateOutputPath, string baseOutputPath, 
-            string visualStudioProductArchitecture = "neutral") : base(msi.GetMetadata(Metadata.SwixPackageId), new Version(msi.GetMetadata(Metadata.Version)), baseIntermediateOutputPath, baseOutputPath)
+        public MsiSwixProject(ITaskItem msi, string baseIntermediateOutputPath, string baseOutputPath,
+            string chip = null, string machineArch = null, string productArch = null) : base(msi.GetMetadata(Metadata.SwixPackageId), new Version(msi.GetMetadata(Metadata.Version)), baseIntermediateOutputPath, baseOutputPath)
         {
-            Chip = msi.GetMetadata(Metadata.Platform);
-            ProjectSourceDirectory = Path.Combine(SwixDirectory, Id, Chip);
+            _msi = msi;
+            Chip = chip;
+            MachineArch = machineArch;
+            ProductArch = productArch;
+            Platform = msi.GetMetadata(Metadata.Platform);
 
-            ValidateRelativePackagePath($@"{Id},version={Version},chip={Chip},productarch={visualStudioProductArchitecture}\{Path.GetFileName(msi.ItemSpec)}");
+            // At least one of Chip or MachineArch should have a value, otherwise we cannot generate valid SWIX.
+            if (string.IsNullOrWhiteSpace(Chip) && string.IsNullOrWhiteSpace(MachineArch))
+            {
+                throw new ArgumentOutOfRangeException(Strings.ChipOrMachineArchRequired);
+            }
+
+            // We need to always use the platform as an output folder because the chip value will be x64 for both arm64/x64 MSIs
+            // and machineArch is not guaranteed to be applicable. 
+            ProjectSourceDirectory = Path.Combine(SwixDirectory, Id, Platform);
+            ValidateRelativePackagePath(GetRelativePackagePath());
 
             // The name of the .swixproj file is used to create the JSON manifest that will be merged into the .vsman file later.
             // For drop publishing all the JSON manifests and payloads must reside in the same folder so we shorten the project names
             // and use a hashed filename to avoid path too long errors.
-            string projectName = $"{Id}.{Version.ToString(3)}.{Chip}";
+            string projectName = $"{Id}.{Version.ToString(3)}.{Platform}";
             ProjectFile = $"{Utils.GetHash(projectName, HashAlgorithmName.MD5)}.swixproj";
+        }
 
-            FileInfo fileInfo = new(msi.ItemSpec);
+        /// <inheritdoc />
+        protected override string GetRelativePackagePath()
+        {
+            string relativePath = base.GetRelativePackagePath();
 
-            ReplacementTokens[SwixTokens.__VS_PACKAGE_CHIP__] = Chip;
-            ReplacementTokens[SwixTokens.__VS_PACKAGE_INSTALL_SIZE_SYSTEM_DRIVE__] = $"{MsiUtils.GetInstallSize(msi.ItemSpec)}";
-            ReplacementTokens[SwixTokens.__VS_PACKAGE_PRODUCT_ARCH__] = visualStudioProductArchitecture;
-            ReplacementTokens[SwixTokens.__VS_PAYLOAD_SIZE__] = $"{fileInfo.Length}";
-            ReplacementTokens[SwixTokens.__VS_PAYLOAD_SOURCE__] = msi.GetMetadata(Metadata.FullPath);
+            relativePath += !string.IsNullOrEmpty(Chip) ? $",chip={Chip}" : string.Empty;
+            relativePath += !string.IsNullOrEmpty(ProductArch) ? $",productarch={ProductArch}" : string.Empty;
+            relativePath += !string.IsNullOrEmpty(Chip) ? $",machinearch={MachineArch}" : string.Empty;
+
+            return Path.Combine(relativePath, Path.GetFileName(_msi.ItemSpec));
         }
 
         /// <inheritdoc />
         public override string Create()
         {
             string swixProj = EmbeddedTemplates.Extract("msi.swixproj", ProjectSourceDirectory, ProjectFile);
+            FileInfo fileInfo = new(_msi.ItemSpec);
 
-            Utils.StringReplace(swixProj, ReplacementTokens, Encoding.UTF8);
-            Utils.StringReplace(EmbeddedTemplates.Extract("msi.swr", ProjectSourceDirectory), ReplacementTokens, Encoding.UTF8);
+            // Since we can't use preprocessor directives in the source, we'll do the conditional authoring inline instead.
+            using StreamWriter msiWriter = File.CreateText(Path.Combine(ProjectSourceDirectory, "msi.swr"));
+
+            msiWriter.WriteLine($"use vs");
+            msiWriter.WriteLine();
+            msiWriter.WriteLine($"package name={Id}");
+            msiWriter.WriteLine($"        version={Version}");
+
+            if (!string.IsNullOrWhiteSpace(Chip))
+            {
+                msiWriter.WriteLine($"        vs.package.chip={Chip}");
+            }
+
+            if (!string.IsNullOrWhiteSpace(ProductArch))
+            {
+                msiWriter.WriteLine($"        vs.package.productArch={ProductArch}");
+            }
+
+            if (!string.IsNullOrEmpty(MachineArch))
+            {
+                msiWriter.WriteLine($"        vs.package.machineArch={MachineArch}");
+            }
+
+            msiWriter.WriteLine($"        vs.package.type=msi");
+            msiWriter.WriteLine();
+            msiWriter.WriteLine($"vs.installSize");
+            msiWriter.WriteLine($"  SystemDrive={MsiUtils.GetInstallSize(_msi.ItemSpec)}");
+            msiWriter.WriteLine($"  TargetDrive=0");
+            msiWriter.WriteLine($"  SharedDrive=0");
+            msiWriter.WriteLine();
+            msiWriter.WriteLine($"vs.logFiles");
+            msiWriter.WriteLine($"  vs.logFile pattern=\"dd_setup*{Id}*.log\"");
+            msiWriter.WriteLine();
+            msiWriter.WriteLine($"vs.msiProperties");
+            msiWriter.WriteLine($"  vs.msiProperty name=\"MSIFASTINSTALL\" value=\"7\"");
+            msiWriter.WriteLine($"  vs.msiProperty name=\"VSEXTUI\" value=\"1\"");
+            msiWriter.WriteLine();
+            msiWriter.WriteLine($"vs.payloads");
+            msiWriter.WriteLine($"  vs.payload source=$(PayloadSource)");
+            msiWriter.WriteLine($"             size={fileInfo.Length}");
+            msiWriter.WriteLine();
 
             return swixProj;
         }

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/SwixComponent.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/SwixComponent.cs
@@ -176,12 +176,12 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
                 new Version((new ReleaseVersion(manifest.Version)).ToString(3));
 
             // Since workloads only define a description, if no custom resources were provided, both the title and description of
-            // the SWIX component will default to the workload description.
-            SwixComponent component = new(sdkFeatureBand, Utils.ToSafeId(workload.Id), 
-                resourceItem?.GetMetadata(Metadata.Title) ?? workload.Description ?? throw new Exception(Strings.ComponentTitleCannotBeNull),
-                resourceItem?.GetMetadata(Metadata.Description) ?? workload.Description ?? throw new Exception(Strings.ComponentDescriptionCannotBeNull), 
+            // the SWIX component will default to the workload description. 
+            SwixComponent component = new(sdkFeatureBand, Utils.ToSafeId(workload.Id),
+                resourceItem != null && !string.IsNullOrEmpty(resourceItem.GetMetadata(Metadata.Title)) ? resourceItem.GetMetadata(Metadata.Title) : workload.Description ?? throw new Exception(Strings.ComponentTitleCannotBeNull),
+                resourceItem != null && !string.IsNullOrEmpty(resourceItem.GetMetadata(Metadata.Description)) ? resourceItem.GetMetadata(Metadata.Description) : workload.Description ?? throw new Exception(Strings.ComponentDescriptionCannotBeNull),
                 componentVersion, workload.IsAbstract,
-                resourceItem?.GetMetadata(Metadata.Category) ?? DefaultValues.ComponentCategory,
+                resourceItem != null && !string.IsNullOrEmpty(resourceItem.GetMetadata(Metadata.Category)) ? resourceItem.GetMetadata(Metadata.Category) : DefaultValues.ComponentCategory ?? throw new Exception(Strings.ComponentCategoryCannotBeNull),
                 shortNames);
 
             // If the workload extends other workloads, we add those as component dependencies before

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/SwixProjectBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/SwixProjectBase.cs
@@ -29,14 +29,6 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
         }
 
         /// <summary>
-        /// The package type associated with the SWIX project.
-        /// </summary>
-        public abstract string PackageType
-        {
-            get;
-        }
-
-        /// <summary>
         /// The version of the SWIX package.
         /// </summary>
         public Version Version

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/SwixProjectBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/SwixProjectBase.cs
@@ -75,14 +75,20 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
         }
 
         /// <summary>
+        /// Compute the relative path of the package within the Visual Studio package cache.
+        /// </summary>
+        /// <returns>The relative path of the package.</returns>
+        protected virtual string GetRelativePackagePath() => $"{Id},version={Version}";
+
+        /// <summary>
         /// Validates that the length of the relative package path does not execeed the maximum limit allowed by Visual Studio. The length
         /// accounts for the location of the Visual Studio installer package cache.
         /// </summary>
         /// <exception cref="Exception" />
         internal static void ValidateRelativePackagePath(string relativePackagePath)
         {
-            _ = relativePackagePath ?? throw new ArgumentNullException(nameof(relativePackagePath));            
- 
+            _ = relativePackagePath ?? throw new ArgumentNullException(nameof(relativePackagePath));
+
             // Visual Studio will verify this as part of its manifest validation logic during PR builds, but
             // any error would require rebuilding workloads and effectively reset .NET builds. 
             if (relativePackagePath.Length > MaxRelativePackagePath)

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Utils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Utils.cs
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
         /// </summary>
         /// <param name="name">The name of the parameter to check.</param>
         /// <param name="value">The value of the parameter.</param>
-        internal static void CheckNullOrEmpty(string name, string value)
+        internal static string CheckNullOrEmpty(string name, string value)
         {
             if (value is null)
             {
@@ -90,6 +90,8 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             {
                 throw new ArgumentException($"Parameter cannot be empty: ${name}");
             }
+
+            return value;
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/WorkloadManifestPackage.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/WorkloadManifestPackage.wix.cs
@@ -54,6 +54,15 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
         }
 
         /// <summary>
+        /// Returns <see langword="true" /> if the Visual Studio version targeted by the feature band supports the machineArch property;
+        /// <see langword="false" /> otherwise.
+        /// </summary>
+        public bool SupportsMachineArch
+        {
+            get;
+        }
+
+        /// <summary>
         /// Creates a new instance of a <see cref="WorkloadManifestPackage"/>.
         /// </summary>
         /// <param name="package">A task item for the workload manifest NuGet package.</param>
@@ -87,7 +96,8 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             SdkFeatureBand = GetSdkFeatureBandVersion(GetSdkVersion(Id));
             ManifestId = GetManifestId(Id);
             SwixPackageId = $"{Id.Replace(shortNames)}";
-        }
+            SupportsMachineArch = bool.TryParse(package.GetMetadata(Metadata.SupportsMachineArch), out bool supportsMachineArch) ? supportsMachineArch : false; 
+         }
 
         /// <summary>
         /// Gets the path of the workload manifest file. 

--- a/tests/UnitTests.proj
+++ b/tests/UnitTests.proj
@@ -15,6 +15,7 @@
 
     <TestRunNamePrefix>$(AGENT_JOBNAME)</TestRunNamePrefix>
     <FailOnMissingTargetQueue>false</FailOnMissingTargetQueue>
+    <XUnitWorkitemTimeout>300</XUnitWorkitemTimeout>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Various fixes for SWIX projects for workloads. 
- Ensure relative package paths only include properties that are defined
- Add `machineArch` property and support for arm64. Manifests that do not support arm64 will no longer generate SWIX packages for the arm64 MSI. Previously we always set `chip` to the MSI platform, generating invalid SWIX: `vs.package.chip=arm64`
- Don't set the  `productArch` property for SWIX projects. It's unnecessary for workloads and increases the relative path for the package cache.
- Add more tests
