### PR TITLE
Fix for msbuild server - InstallDotNetCore task outputs list of required dotnets to be installed

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
@@ -139,8 +139,8 @@ namespace Microsoft.DotNet.Arcade.Sdk
                                         }
 
                                         Log.LogMessage(MessageImportance.Low, $"To be installed: {DotNetInstallScript} {arguments}");
-                                        // As opposed to start installation process from here, we better just output 
-                                        // list of all required install script argumets, so it can be executed by Exec task on target level
+                                        // As opposed to start installation process from here, we output list of all required install script arguments, 
+                                        // so it can be executed by Exec task on msbuild Target level.
                                         // See https://github.com/dotnet/msbuild/issues/7913 for more info.
                                         toBeInstalled.Add(new TaskItem(arguments));
                                     }

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
@@ -4,7 +4,6 @@ using Microsoft.Build.Utilities;
 using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -35,8 +34,13 @@ namespace Microsoft.DotNet.Arcade.Sdk
         
         public string RuntimeSourceFeedKey { get; set; }
 
+        [Output]
+        public ITaskItem[] ToBeInstalled { get; set; }        
+
         public override bool Execute()
         {
+            ToBeInstalled = Array.Empty<ITaskItem>();
+
             if (!File.Exists(GlobalJsonPath))
             {
                 Log.LogWarning($"Unable to find global.json file '{GlobalJsonPath} exiting");
@@ -88,6 +92,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
                                 }
                             }
 
+                            var toBeInstalled = new List<ITaskItem>();
                             foreach (var runtimeItem in runtimeItems)
                             {
                                 foreach (var item in runtimeItem.Value)
@@ -133,21 +138,15 @@ namespace Microsoft.DotNet.Arcade.Sdk
                                             arguments += $" -runtimeSourceFeedKey {RuntimeSourceFeedKey}";
                                         }
 
-                                        Log.LogMessage(MessageImportance.Low, $"Executing: {DotNetInstallScript} {arguments}");
-                                        var process = Process.Start(new ProcessStartInfo()
-                                        {
-                                            FileName = DotNetInstallScript,
-                                            Arguments = arguments,
-                                            UseShellExecute = false
-                                        });
-                                        process.WaitForExit();
-                                        if (process.ExitCode != 0)
-                                        {
-                                            Log.LogError("dotnet-install failed");
-                                        }
+                                        Log.LogMessage(MessageImportance.Low, $"To be installed: {DotNetInstallScript} {arguments}");
+                                        // As opposed to start installation process from here, we better just output 
+                                        // list of all required install script argumets, so it can be executed by Exec task on target level
+                                        // See https://github.com/dotnet/msbuild/issues/7913 for more info.
+                                        toBeInstalled.Add(new TaskItem(arguments));
                                     }
                                 }
-                            }
+                            }                            
+                            ToBeInstalled = toBeInstalled.ToArray();
                         }
                     }
                 }

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/InstallDotNetCore.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/InstallDotNetCore.targets
@@ -23,7 +23,7 @@
       <Output TaskParameter="ToBeInstalled" ItemName="DotNetCoreToBeInstalled" />
     </InstallDotNetCore>
 
-    <Exec Command="$(_DotNetInstallScript) %(DotNetCoreToBeInstalled.Identity)" />
+    <Exec IgnoreStandardErrorWarningFormat="true" Command="$(_DotNetInstallScript) %(DotNetCoreToBeInstalled.Identity)" />
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/InstallDotNetCore.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/InstallDotNetCore.targets
@@ -18,7 +18,12 @@
       DotNetInstallScript="$(_DotNetInstallScript)"
       Platform="$(Platform)"
       RuntimeSourceFeed="$(DotNetRuntimeSourceFeed)"
-      RuntimeSourceFeedKey="$(DotNetRuntimeSourceFeedKey)"/>
+      RuntimeSourceFeedKey="$(DotNetRuntimeSourceFeedKey)">
+
+      <Output TaskParameter="ToBeInstalled" ItemName="DotNetCoreToBeInstalled" />
+    </InstallDotNetCore>
+
+    <Exec Command="$(_DotNetInstallScript) %(DotNetCoreToBeInstalled.Identity)" />
   </Target>
 
 </Project>


### PR DESCRIPTION
### Context
MSBuild server runs as long live process, similar to VBCSCompiler, as oppose to formal short living console application.
Custom Tasks which execute child process from might be broken, as output from child processes started from detached parent process are not redirected to parent process.

This PR addresses issue: https://github.com/dotnet/msbuild/issues/7913

### Unblocks
- It supposes to unblock https://github.com/dotnet/aspnetcore/pull/43028
