### PR TITLE
Add base classes for assembly symbols traversal.

### DIFF
--- a/src/Microsoft.DotNet.GenAPI/Shared/AssemblySymbolLoader.cs
+++ b/src/Microsoft.DotNet.GenAPI/Shared/AssemblySymbolLoader.cs
@@ -6,33 +6,32 @@ using System.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 
-namespace Microsoft.DotNet.GenAPI.Shared
+namespace Microsoft.DotNet.GenAPI.Shared;
+
+internal class AssemblySymbolLoader : IAssemblySymbolLoader
 {
-    internal class AssemblySymbolLoader : IAssemblySymbolLoader
+    public IAssemblySymbol? LoadAssembly(string path)
     {
-        public IAssemblySymbol? LoadAssembly(string path)
+        using var stream = File.OpenRead(path);
+        return LoadAssembly(stream);
+    }
+
+    public IAssemblySymbol? LoadAssembly(Stream stream)
+    {
+        PortableExecutableReference reference;
+
+        using (var memoryStream = new MemoryStream())
         {
-            using var stream = File.OpenRead(path);
-            return LoadAssembly(stream);
+            stream.CopyTo(memoryStream);
+            memoryStream.Position = 0;
+
+            // MetadataReference.CreateFromStream closes the stream
+            reference = MetadataReference.CreateFromStream(memoryStream);
         }
 
-        public IAssemblySymbol? LoadAssembly(Stream stream)
-        {
-            PortableExecutableReference reference;
+        var compilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable);
+        var compilation = CSharpCompilation.Create($"AssemblyLoader_{DateTime.Now:MM_dd_yy_HH_mm_ss_FFF}", options: compilationOptions);
 
-            using (var memoryStream = new MemoryStream())
-            {
-                stream.CopyTo(memoryStream);
-                memoryStream.Position = 0;
-
-                // MetadataReference.CreateFromStream closes the stream
-                reference = MetadataReference.CreateFromStream(memoryStream);
-            }
-
-            var compilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable);
-            var compilation = CSharpCompilation.Create($"AssemblyLoader_{DateTime.Now:MM_dd_yy_HH_mm_ss_FFF}", options: compilationOptions);
-
-            return compilation.GetAssemblyOrModuleSymbol(reference) as IAssemblySymbol;
-        }
+        return compilation.GetAssemblyOrModuleSymbol(reference) as IAssemblySymbol;
     }
 }

--- a/src/Microsoft.DotNet.GenAPI/Shared/AssemblySymbolTraverser.cs
+++ b/src/Microsoft.DotNet.GenAPI/Shared/AssemblySymbolTraverser.cs
@@ -1,0 +1,89 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.DotNet.GenAPI.Shared
+{
+    public abstract class AssemblySymbolTraverser
+    {
+        private IAssemblySymbolOrderProvider _orderProvider;
+        private IAssemblySymbolFilter _filter;
+
+        public AssemblySymbolTraverser(IAssemblySymbolOrderProvider orderProvider, IAssemblySymbolFilter filter)
+        {
+            _orderProvider = orderProvider;
+            _filter = filter;
+        }
+
+        public void Visit(IAssemblySymbol assembly)
+        {
+            var namespaces = EnumerateNamespaces(assembly).Where(_filter.Include);
+
+            foreach (var namespaceSymbol in _orderProvider.Order(namespaces))
+            {
+                doProcess(namespaceSymbol);
+                Visit(namespaceSymbol);
+            }
+        }
+
+        public void Visit(INamespaceSymbol namespaceSymbol)
+        {
+            var typeMembers = namespaceSymbol.GetTypeMembers().Where(_filter.Include);
+
+            foreach (var typeMember in _orderProvider.Order(typeMembers))
+            {
+                foreach (var attribute in typeMember.GetAttributes().Where(_filter.Include))
+                {
+                    doProcess(attribute);
+                }
+
+                doProcess(typeMember);
+                Visit(typeMember);
+            }
+        }
+
+        public void Visit(INamedTypeSymbol typeMember)
+        {
+            var members = typeMember.GetMembers().Where(_filter.Include);
+
+            foreach (var member in _orderProvider.Order(members))
+            {
+                foreach (var attribute in member.GetAttributes().Where(_filter.Include))
+                {
+                    doProcess(attribute);
+                }
+
+                doProcess(member);
+            }
+        }
+
+        protected abstract void doProcess(INamespaceSymbol namespaceSymbol);
+        protected abstract void doProcess(INamedTypeSymbol typeMember);
+        protected abstract void doProcess(ISymbol member);
+        protected abstract void doProcess(AttributeData attribute);
+
+        private IEnumerable<INamespaceSymbol> EnumerateNamespaces(IAssemblySymbol assembly)
+        {
+            var stack = new Stack<INamespaceSymbol>();
+            stack.Push(assembly.GlobalNamespace);
+
+            while (stack.TryPop(out var current))
+            {
+                yield return current;
+
+                foreach (var subNamespace in current.GetNamespaceMembers())
+                {
+                    stack.Push(subNamespace);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.GenAPI/Shared/CSharpWriter.cs
+++ b/src/Microsoft.DotNet.GenAPI/Shared/CSharpWriter.cs
@@ -4,43 +4,26 @@
 using System;
 using Microsoft.CodeAnalysis;
 
-namespace Microsoft.DotNet.GenAPI.Shared
+namespace Microsoft.DotNet.GenAPI.Shared;
+
+public abstract class CSharpWriter : AssemblySymbolTraverser, IWriter, IDisposable
 {
-    public class CSharpWriter : AssemblySymbolTraverser, IWriter, IDisposable
+    private readonly ISyntaxWriter _syntaxWriter;
+
+    public CSharpWriter(IAssemblySymbolOrderProvider orderProvider,
+        IAssemblySymbolFilter filter, ISyntaxWriter syntaxWriter)
+        : base(orderProvider, filter)
     {
-        ISyntaxWriter _syntaxWriter;
+        _syntaxWriter = syntaxWriter;
+    }
 
-        public CSharpWriter(IAssemblySymbolOrderProvider orderProvider,
-            IAssemblySymbolFilter filter, ISyntaxWriter syntaxWriter)
-            : base(orderProvider, filter)
-        {
-            _syntaxWriter = syntaxWriter;
-        }
+    public void WriteAssemblies(IAssemblySymbol assembly)
+    {
+        Visit(assembly);
+    }
 
-        public void WriteAssemblies(IAssemblySymbol assembly)
-        {
-            Visit(assembly);
-        }
-
-        protected override void doProcess(INamespaceSymbol namespaceSymbol)
-        {
-        }
-
-        protected override void doProcess(INamedTypeSymbol typeMember)
-        {
-        }
-
-        protected override void doProcess(ISymbol member)
-        {
-        }
-
-        protected override void doProcess(AttributeData attribute)
-        {
-        }
-
-        public void Dispose()
-        {
-            _syntaxWriter.Dispose();
-        }
+    public void Dispose()
+    {
+        _syntaxWriter.Dispose();
     }
 }

--- a/src/Microsoft.DotNet.GenAPI/Shared/CSharpWriter.cs
+++ b/src/Microsoft.DotNet.GenAPI/Shared/CSharpWriter.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.DotNet.GenAPI.Shared
+{
+    public class CSharpWriter : AssemblySymbolTraverser, IWriter, IDisposable
+    {
+        ISyntaxWriter _syntaxWriter;
+
+        public CSharpWriter(IAssemblySymbolOrderProvider orderProvider,
+            IAssemblySymbolFilter filter, ISyntaxWriter syntaxWriter)
+            : base(orderProvider, filter)
+        {
+            _syntaxWriter = syntaxWriter;
+        }
+
+        public void WriteAssemblies(IAssemblySymbol assembly)
+        {
+            Visit(assembly);
+        }
+
+        protected override void doProcess(INamespaceSymbol namespaceSymbol)
+        {
+        }
+
+        protected override void doProcess(INamedTypeSymbol typeMember)
+        {
+        }
+
+        protected override void doProcess(ISymbol member)
+        {
+        }
+
+        protected override void doProcess(AttributeData attribute)
+        {
+        }
+
+        public void Dispose()
+        {
+            _syntaxWriter.Dispose();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.GenAPI/Shared/IAssemblySymbolFilter.cs
+++ b/src/Microsoft.DotNet.GenAPI/Shared/IAssemblySymbolFilter.cs
@@ -3,39 +3,38 @@
 
 using Microsoft.CodeAnalysis;
 
-namespace Microsoft.DotNet.GenAPI.Shared
+namespace Microsoft.DotNet.GenAPI.Shared;
+
+/// <summary>
+/// Interface responsible for filtering attributes, namespaces, types and members.
+/// </summary>
+public interface IAssemblySymbolFilter
 {
     /// <summary>
-    /// Interface responsible for filtering attributes, namespaces, types and members.
+    /// Including/fitlering out namespace symbol and it's types, members.
     /// </summary>
-    public interface IAssemblySymbolFilter
-    {
-        /// <summary>
-        /// Including/fitlering out namespace symbol and it's types, members.
-        /// </summary>
-        /// <param name="ns">Object of <cref="INamespaceSymbol"/>.</param>
-        /// <returns>Returns boolean value.</returns>
-        bool Include(INamespaceSymbol ns);
+    /// <param name="ns">Object of <cref="INamespaceSymbol"/>.</param>
+    /// <returns>Returns boolean value.</returns>
+    bool Include(INamespaceSymbol ns);
 
-        /// <summary>
-        /// Including/fitlering out attribute data.
-        /// </summary>
-        /// <param name="ns">Object of <cref="AttributeData"/>.</param>
-        /// <returns>Returns boolean value.</returns>
-        bool Include(AttributeData at);
+    /// <summary>
+    /// Including/fitlering out attribute data.
+    /// </summary>
+    /// <param name="ns">Object of <cref="AttributeData"/>.</param>
+    /// <returns>Returns boolean value.</returns>
+    bool Include(AttributeData at);
 
-        /// <summary>
-        /// Including/fitlering out type symbol and it's members .
-        /// </summary>
-        /// <param name="ns">Object of <cref="ITypeSymbol"/>.</param>
-        /// <returns>Returns boolean value.</returns>
-        bool Include(ITypeSymbol ts);
+    /// <summary>
+    /// Including/fitlering out type symbol and it's members .
+    /// </summary>
+    /// <param name="ns">Object of <cref="ITypeSymbol"/>.</param>
+    /// <returns>Returns boolean value.</returns>
+    bool Include(ITypeSymbol ts);
 
-        /// <summary>
-        /// Including/fitlering out member symbol.
-        /// </summary>
-        /// <param name="ns">Object of <cref="ISymbol"/>.</param>
-        /// <returns>Returns boolean value.</returns>
-        bool Include(ISymbol member);
-    }
+    /// <summary>
+    /// Including/fitlering out member symbol.
+    /// </summary>
+    /// <param name="ns">Object of <cref="ISymbol"/>.</param>
+    /// <returns>Returns boolean value.</returns>
+    bool Include(ISymbol member);
 }

--- a/src/Microsoft.DotNet.GenAPI/Shared/IAssemblySymbolLoader.cs
+++ b/src/Microsoft.DotNet.GenAPI/Shared/IAssemblySymbolLoader.cs
@@ -4,26 +4,24 @@
 using System.IO;
 using Microsoft.CodeAnalysis;
 
-namespace Microsoft.DotNet.GenAPI.Shared
+namespace Microsoft.DotNet.GenAPI.Shared;
+
+/// <summary>
+/// Interface responsible for creating Compilation Factory and loading <see cref="IAssemblySymbol"/> out of binaries.
+/// </summary>
+public interface IAssemblySymbolLoader
 {
+    /// <summary>
+    /// Loads an assembly from the provided path.
+    /// </summary>
+    /// <param name="path">The full path to the assembly.</param>
+    /// <returns><see cref="IAssemblySymbol"/> representing the loaded assembly.</returns>
+    IAssemblySymbol? LoadAssembly(string path);
 
     /// <summary>
-    /// Interface responsible for creating Compilation Factory and loading <see cref="IAssemblySymbol"/> out of binaries.
+    /// Loads an assembly from a given <see cref="Stream"/>.
     /// </summary>
-    public interface IAssemblySymbolLoader
-    {
-        /// <summary>
-        /// Loads an assembly from the provided path.
-        /// </summary>
-        /// <param name="path">The full path to the assembly.</param>
-        /// <returns><see cref="IAssemblySymbol"/> representing the loaded assembly.</returns>
-        IAssemblySymbol? LoadAssembly(string path);
-
-        /// <summary>
-        /// Loads an assembly from a given <see cref="Stream"/>.
-        /// </summary>
-        /// <param name="stream">The stream to read the metadata from.</param>
-        /// <returns><see cref="IAssemblySymbol"/> respresenting the given <paramref name="stream"/>.</returns>
-        IAssemblySymbol? LoadAssembly(Stream stream);
-    }
+    /// <param name="stream">The stream to read the metadata from.</param>
+    /// <returns><see cref="IAssemblySymbol"/> respresenting the given <paramref name="stream"/>.</returns>
+    IAssemblySymbol? LoadAssembly(Stream stream);
 }

--- a/src/Microsoft.DotNet.GenAPI/Shared/IAssemblySymbolOrderProvider.cs
+++ b/src/Microsoft.DotNet.GenAPI/Shared/IAssemblySymbolOrderProvider.cs
@@ -9,27 +9,27 @@ namespace Microsoft.DotNet.GenAPI.Shared
     /// <summary>
     /// Interface provides ordering for namespaces, types and members.
     /// </summary>
-    internal interface IAssemblySymbolOrderProvider
+    public  interface IAssemblySymbolOrderProvider
     {
         /// <summary>
         /// Sorts the elements of a INamespaceSymbol.
         /// </summary>
         /// <param name="namespaces">List of namespaces to be sorted.</param>
         /// <returns>Returns namespaces in sorted order.</returns>
-        IEnumerable<INamespaceSymbol> OrderNamespaces(IEnumerable<INamespaceSymbol> namespaces);
+        IEnumerable<INamespaceSymbol> Order(IEnumerable<INamespaceSymbol> namespaces);
 
         /// <summary>
         /// Sorts the elements of a ITypeSymbol.
         /// </summary>
         /// <param name="namespaces">List of TypeMembers to be sorted.</param>
         /// <returns>Returns TypeMembers in sorted order.</returns>
-        IEnumerable<T> OrderTypes<T>(IEnumerable<T> symbols) where T : ITypeSymbol;
+        IEnumerable<T> Order<T>(IEnumerable<T> symbols) where T : ITypeSymbol;
 
         /// <summary>
         /// Sorts the elements of a ISymbol.
         /// </summary>
         /// <param name="namespaces">List of Members to be sorted.</param>
         /// <returns>Returns Members in sorted order.</returns>
-        IEnumerable<ISymbol> OrderMembers(IEnumerable<ISymbol> members);
+        IEnumerable<ISymbol> Order(IEnumerable<ISymbol> members);
     }
 }

--- a/src/Microsoft.DotNet.GenAPI/Shared/IAssemblySymbolOrderProvider.cs
+++ b/src/Microsoft.DotNet.GenAPI/Shared/IAssemblySymbolOrderProvider.cs
@@ -4,32 +4,31 @@
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 
-namespace Microsoft.DotNet.GenAPI.Shared
+namespace Microsoft.DotNet.GenAPI.Shared;
+
+/// <summary>
+/// Interface provides ordering for namespaces, types and members.
+/// </summary>
+public  interface IAssemblySymbolOrderProvider
 {
     /// <summary>
-    /// Interface provides ordering for namespaces, types and members.
+    /// Sorts the elements of a INamespaceSymbol.
     /// </summary>
-    public  interface IAssemblySymbolOrderProvider
-    {
-        /// <summary>
-        /// Sorts the elements of a INamespaceSymbol.
-        /// </summary>
-        /// <param name="namespaces">List of namespaces to be sorted.</param>
-        /// <returns>Returns namespaces in sorted order.</returns>
-        IEnumerable<INamespaceSymbol> Order(IEnumerable<INamespaceSymbol> namespaces);
+    /// <param name="namespaces">List of namespaces to be sorted.</param>
+    /// <returns>Returns namespaces in sorted order.</returns>
+    IEnumerable<INamespaceSymbol> Order(IEnumerable<INamespaceSymbol> namespaces);
 
-        /// <summary>
-        /// Sorts the elements of a ITypeSymbol.
-        /// </summary>
-        /// <param name="namespaces">List of TypeMembers to be sorted.</param>
-        /// <returns>Returns TypeMembers in sorted order.</returns>
-        IEnumerable<T> Order<T>(IEnumerable<T> symbols) where T : ITypeSymbol;
+    /// <summary>
+    /// Sorts the elements of a ITypeSymbol.
+    /// </summary>
+    /// <param name="namespaces">List of TypeMembers to be sorted.</param>
+    /// <returns>Returns TypeMembers in sorted order.</returns>
+    IEnumerable<T> Order<T>(IEnumerable<T> symbols) where T : ITypeSymbol;
 
-        /// <summary>
-        /// Sorts the elements of a ISymbol.
-        /// </summary>
-        /// <param name="namespaces">List of Members to be sorted.</param>
-        /// <returns>Returns Members in sorted order.</returns>
-        IEnumerable<ISymbol> Order(IEnumerable<ISymbol> members);
-    }
+    /// <summary>
+    /// Sorts the elements of a ISymbol.
+    /// </summary>
+    /// <param name="namespaces">List of Members to be sorted.</param>
+    /// <returns>Returns Members in sorted order.</returns>
+    IEnumerable<ISymbol> Order(IEnumerable<ISymbol> members);
 }

--- a/src/Microsoft.DotNet.GenAPI/Shared/ISyntaxWriter.cs
+++ b/src/Microsoft.DotNet.GenAPI/Shared/ISyntaxWriter.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Microsoft.DotNet.GenAPI.Shared
+{
+    /// <summary>
+    /// Interface responsible for writing C# code in various formats: code file, xml, etc.
+    /// </summary>
+    public interface ISyntaxWriter : IDisposable
+    {
+        void WriteSymbol(string str);
+        void WriteKeyword(SyntaxKind sk);
+        void WriteLine();
+    }
+}

--- a/src/Microsoft.DotNet.GenAPI/Shared/ISyntaxWriter.cs
+++ b/src/Microsoft.DotNet.GenAPI/Shared/ISyntaxWriter.cs
@@ -4,15 +4,14 @@
 using System;
 using Microsoft.CodeAnalysis.CSharp;
 
-namespace Microsoft.DotNet.GenAPI.Shared
+namespace Microsoft.DotNet.GenAPI.Shared;
+
+/// <summary>
+/// Interface responsible for writing C# code in various formats: code file, xml, etc.
+/// </summary>
+public interface ISyntaxWriter : IDisposable
 {
-    /// <summary>
-    /// Interface responsible for writing C# code in various formats: code file, xml, etc.
-    /// </summary>
-    public interface ISyntaxWriter : IDisposable
-    {
-        void WriteSymbol(string str);
-        void WriteKeyword(SyntaxKind sk);
-        void WriteLine();
-    }
+    void WriteSymbol(string str);
+    void WriteKeyword(SyntaxKind sk);
+    void WriteLine();
 }

--- a/src/Microsoft.DotNet.GenAPI/Shared/IWriter.cs
+++ b/src/Microsoft.DotNet.GenAPI/Shared/IWriter.cs
@@ -3,13 +3,12 @@
 
 using Microsoft.CodeAnalysis;
 
-namespace Microsoft.DotNet.GenAPI.Shared
+namespace Microsoft.DotNet.GenAPI.Shared;
+
+/// <summary>
+/// Interface incapsulates logic for processing symbol assemblies.
+/// </summary>
+public interface IWriter
 {
-    /// <summary>
-    /// Interface incapsulates logic for processing symbol assemblies.
-    /// </summary>
-    public interface IWriter
-    {
-        void WriteAssemblies(IAssemblySymbol assembly);
-    }
+    void WriteAssemblies(IAssemblySymbol assembly);
 }

--- a/src/Microsoft.DotNet.GenAPI/Shared/IWriter.cs
+++ b/src/Microsoft.DotNet.GenAPI/Shared/IWriter.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.DotNet.GenAPI.Shared
+{
+    /// <summary>
+    /// Interface incapsulates logic for processing symbol assemblies.
+    /// </summary>
+    public interface IWriter
+    {
+        void WriteAssemblies(IAssemblySymbol assembly);
+    }
+}

--- a/src/Microsoft.DotNet.GenAPI/Tasks/GenAPITask.cs
+++ b/src/Microsoft.DotNet.GenAPI/Tasks/GenAPITask.cs
@@ -5,13 +5,12 @@ using System;
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.Tasks;
 
-namespace Microsoft.DotNet.GenAPI.Tasks
+namespace Microsoft.DotNet.GenAPI.Tasks;
+
+public class GenAPITask : BuildTask
 {
-    public class GenAPITask : BuildTask
+    public override bool Execute()
     {
-        public override bool Execute()
-        {
-            return false;
-        }
+        return false;
     }
 }

--- a/src/Microsoft.DotNet.GenAPI/Tool/Program.cs
+++ b/src/Microsoft.DotNet.GenAPI/Tool/Program.cs
@@ -3,13 +3,12 @@
 
 using System;
 
-namespace Microsoft.DotNet.GenAPI.Tool
+namespace Microsoft.DotNet.GenAPI.Tool;
+
+class Program
 {
-    class Program
+    static int Main(string[] args)
     {
-        static int Main(string[] args)
-        {
-            return 0;
-        }
+        return 0;
     }
 }


### PR DESCRIPTION
#10411
* Add base class for assembly symbol traversal: namespaces, named types, attributes, members
* Add base class for writing assemblies to file/console