### PR TITLE
Revert  #10585

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
@@ -4,6 +4,7 @@ using Microsoft.Build.Utilities;
 using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -34,13 +35,8 @@ namespace Microsoft.DotNet.Arcade.Sdk
         
         public string RuntimeSourceFeedKey { get; set; }
 
-        [Output]
-        public ITaskItem[] ToBeInstalled { get; set; }        
-
         public override bool Execute()
         {
-            ToBeInstalled = Array.Empty<ITaskItem>();
-
             if (!File.Exists(GlobalJsonPath))
             {
                 Log.LogWarning($"Unable to find global.json file '{GlobalJsonPath} exiting");
@@ -92,7 +88,6 @@ namespace Microsoft.DotNet.Arcade.Sdk
                                 }
                             }
 
-                            var toBeInstalled = new List<ITaskItem>();
                             foreach (var runtimeItem in runtimeItems)
                             {
                                 foreach (var item in runtimeItem.Value)
@@ -138,15 +133,21 @@ namespace Microsoft.DotNet.Arcade.Sdk
                                             arguments += $" -runtimeSourceFeedKey {RuntimeSourceFeedKey}";
                                         }
 
-                                        Log.LogMessage(MessageImportance.Low, $"To be installed: {DotNetInstallScript} {arguments}");
-                                        // As opposed to start installation process from here, we output list of all required install script arguments, 
-                                        // so it can be executed by Exec task on msbuild Target level.
-                                        // See https://github.com/dotnet/msbuild/issues/7913 for more info.
-                                        toBeInstalled.Add(new TaskItem(arguments));
+                                        Log.LogMessage(MessageImportance.Low, $"Executing: {DotNetInstallScript} {arguments}");
+                                        var process = Process.Start(new ProcessStartInfo()
+                                        {
+                                            FileName = DotNetInstallScript,
+                                            Arguments = arguments,
+                                            UseShellExecute = false
+                                        });
+                                        process.WaitForExit();
+                                        if (process.ExitCode != 0)
+                                        {
+                                            Log.LogError("dotnet-install failed");
+                                        }
                                     }
                                 }
-                            }                            
-                            ToBeInstalled = toBeInstalled.ToArray();
+                            }
                         }
                     }
                 }

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/InstallDotNetCore.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/InstallDotNetCore.targets
@@ -18,12 +18,7 @@
       DotNetInstallScript="$(_DotNetInstallScript)"
       Platform="$(Platform)"
       RuntimeSourceFeed="$(DotNetRuntimeSourceFeed)"
-      RuntimeSourceFeedKey="$(DotNetRuntimeSourceFeedKey)">
-
-      <Output TaskParameter="ToBeInstalled" ItemName="DotNetCoreToBeInstalled" />
-    </InstallDotNetCore>
-
-    <Exec IgnoreStandardErrorWarningFormat="true" Command="$(_DotNetInstallScript) %(DotNetCoreToBeInstalled.Identity)" />
+      RuntimeSourceFeedKey="$(DotNetRuntimeSourceFeedKey)"/>
   </Target>
 
 </Project>


### PR DESCRIPTION
@rokonec FYI; this is seemingly causing contention and failure in the arcade-validation tests when trying to clean up the dotnet.exes they unpack.

Reverts "Fix for msbuild server - InstallDotNetCore task outputs list of required dotnets to be installed (#10585)"

This reverts commit b084bccb9a1930cf8536173df680cb68df9802af.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
