### PR TITLE
Fix HelixResultsDestinationDir default

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/download-results/DownloadFromResultsContainer.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/download-results/DownloadFromResultsContainer.targets
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <HelixResultsDestinationDir Condition="'$(HelixResultsDestinationDir)' == '' AND '$(BUILD_SOURCESDIRECTORY)' != ''">$([MSBuild]::NormalizeDirectory($(BUILD_SOURCESDIRECTORY), 'artifacts', helixresults'))</HelixResultsDestinationDir>
+      <HelixResultsDestinationDir Condition="'$(HelixResultsDestinationDir)' == '' AND '$(BUILD_SOURCESDIRECTORY)' != ''">$([MSBuild]::NormalizeDirectory($(BUILD_SOURCESDIRECTORY), 'artifacts', 'helixresults'))</HelixResultsDestinationDir>
 
       <_shouldDownloadResults>false</_shouldDownloadResults>
       <_shouldDownloadResults Condition="'@(_workItemsWithDownloadMetadata)' != '' AND '$(HelixResultsDestinationDir)' != ''">true</_shouldDownloadResults>


### PR DESCRIPTION
Without this, the expression appears as-is; no path is computed.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
