### PR TITLE
Reenable "TRX" tests

### DIFF
--- a/tests/UnitTests.proj
+++ b/tests/UnitTests.proj
@@ -27,20 +27,17 @@
     <AzurePipelinesExpectedTestFailure Include="HelixReporterTests.failure2"/>
   </ItemGroup>
 
-
-<!-- Disabled : see https://github.com/dotnet/arcade/issues/10358
   <ItemGroup>
     <HelixWorkItem Include="TrxTest">
       <Command>echo 'done!'</Command>
       <PayloadDirectory>$(MSBuildThisFileDirectory)Trx</PayloadDirectory>
     </HelixWorkItem>
-  </ItemGroup>
+  </ItemGroup>  
   <ItemGroup>
     <AzurePipelinesExpectedTestFailure Include="HelixReporter.TRXTests.HelixReporter.TRXTests.Fail1"/>
     <AzurePipelinesExpectedTestFailure Include="HelixReporter.TRXTests.HelixReporter.TRX.Fail2"/>
     <AzurePipelinesExpectedTestFailure Include="tests.UnitTest2.ExpectedFailureTheoryTest"/>
   </ItemGroup>
--->
 
   <ItemGroup>
     <XUnitProject Include="..\src\**\*.Tests.csproj"/>


### PR DESCRIPTION
these have been disabled for some time due to an Azure Devops bug, this should be fixed now (if the PR is green it is)

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
