### PR TITLE
Add resources section to job template.

### DIFF
--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -15,6 +15,7 @@ parameters:
   timeoutInMinutes: ''
   variables: []
   workspace: ''
+  resources: []
 
 # Job base template specific parameters
   # See schema documentation - https://github.com/dotnet/arcade/blob/master/Documentation/AzureDevOps/TemplateSchema.md
@@ -100,6 +101,11 @@ jobs:
 
   ${{ if ne(parameters.workspace, '') }}:
     workspace: ${{ parameters.workspace }}
+
+  ${{ if ne(parameters.resources, '') }}:
+    resources:
+      - ${{ each resource in parameters.resources }}:
+        - ${{ resource }}
 
   steps:
   - ${{ if ne(parameters.preSteps, '') }}:


### PR DESCRIPTION
This section can be used by the dotnet/runtime repo to use the "step targets" feature to simplify some of our build jobs that currently use multiple docker containers

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
