### PR TITLE
Add correct number of RemoteExecutor.Invoke overloads for Func

### DIFF
--- a/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
@@ -118,6 +118,7 @@ namespace Microsoft.DotNet.RemoteExecutor
 
         /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
         /// <param name="method">The method to invoke.</param>
+        /// <param name="arg">The argument to pass to the method.</param>
         /// <param name="options">Options to use for the invocation.</param>
         public static RemoteInvokeHandle Invoke(Action<string> method, string arg, RemoteInvokeOptions options = null)
         {
@@ -126,6 +127,8 @@ namespace Microsoft.DotNet.RemoteExecutor
 
         /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
         /// <param name="method">The method to invoke.</param>
+        /// <param name="arg1">The first argument to pass to the method.</param>
+        /// <param name="arg2">The second argument to pass to the method.</param>
         /// <param name="options">Options to use for the invocation.</param>
         public static RemoteInvokeHandle Invoke(Action<string, string> method, string arg1, string arg2,
             RemoteInvokeOptions options = null)
@@ -135,6 +138,9 @@ namespace Microsoft.DotNet.RemoteExecutor
 
         /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
         /// <param name="method">The method to invoke.</param>
+        /// <param name="arg1">The first argument to pass to the method.</param>
+        /// <param name="arg2">The second argument to pass to the method.</param>
+        /// <param name="arg3">The third argument to pass to the method.</param>
         /// <param name="options">Options to use for the invocation.</param>
         public static RemoteInvokeHandle Invoke(Action<string, string, string> method, string arg1, string arg2,
             string arg3, RemoteInvokeOptions options = null)
@@ -144,11 +150,29 @@ namespace Microsoft.DotNet.RemoteExecutor
 
         /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
         /// <param name="method">The method to invoke.</param>
+        /// <param name="arg1">The first argument to pass to the method.</param>
+        /// <param name="arg2">The second argument to pass to the method.</param>
+        /// <param name="arg3">The third argument to pass to the method.</param>
+        /// <param name="arg4">The fourth argument to pass to the method.</param>
         /// <param name="options">Options to use for the invocation.</param>
         public static RemoteInvokeHandle Invoke(Action<string, string, string, string> method, string arg1,
             string arg2, string arg3, string arg4, RemoteInvokeOptions options = null)
         {
             return Invoke(GetMethodInfo(method), new[] { arg1, arg2, arg3, arg4 }, options);
+        }
+
+        /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
+        /// <param name="method">The method to invoke.</param>
+        /// <param name="arg1">The first argument to pass to the method.</param>
+        /// <param name="arg2">The second argument to pass to the method.</param>
+        /// <param name="arg3">The third argument to pass to the method.</param>
+        /// <param name="arg4">The fourth argument to pass to the method.</param>
+        /// <param name="arg5">The fifth argument to pass to the method.</param>
+        /// <param name="options">Options to use for the invocation.</param>
+        public static RemoteInvokeHandle Invoke(Action<string, string, string, string, string> method, string arg1,
+            string arg2, string arg3, string arg4, string arg5, RemoteInvokeOptions options = null)
+        {
+            return Invoke(GetMethodInfo(method), new[] { arg1, arg2, arg3, arg4, arg5 }, options);
         }
 
         /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
@@ -194,6 +218,33 @@ namespace Microsoft.DotNet.RemoteExecutor
 
         /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
         /// <param name="method">The method to invoke.</param>
+        /// <param name="arg1">The first argument to pass to the method.</param>
+        /// <param name="arg2">The second argument to pass to the method.</param>
+        /// <param name="arg3">The third argument to pass to the method.</param>
+        /// <param name="arg4">The fourth argument to pass to the method.</param>
+        /// <param name="options">Options to use for the invocation.</param>
+        public static RemoteInvokeHandle Invoke(Func<string, string, string, string, Task<int>> method, string arg1,
+            string arg2, string arg3, string arg4, RemoteInvokeOptions options = null)
+        {
+            return Invoke(GetMethodInfo(method), new[] { arg1, arg2, arg3, arg4 }, options);
+        }
+
+        /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
+        /// <param name="method">The method to invoke.</param>
+        /// <param name="arg1">The first argument to pass to the method.</param>
+        /// <param name="arg2">The second argument to pass to the method.</param>
+        /// <param name="arg3">The third argument to pass to the method.</param>
+        /// <param name="arg4">The fourth argument to pass to the method.</param>
+        /// <param name="arg5">The fifth argument to pass to the method.</param>
+        /// <param name="options">Options to use for the invocation.</param>
+        public static RemoteInvokeHandle Invoke(Func<string, string, string, string, string, Task<int>> method, string arg1,
+            string arg2, string arg3, string arg4, string arg5, RemoteInvokeOptions options = null)
+        {
+            return Invoke(GetMethodInfo(method), new[] { arg1, arg2, arg3, arg4, arg5 }, options);
+        }
+
+        /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
+        /// <param name="method">The method to invoke.</param>
         /// <param name="options">Options to use for the invocation.</param>
         public static RemoteInvokeHandle Invoke(Func<Task> method, RemoteInvokeOptions options = null)
         {
@@ -231,6 +282,33 @@ namespace Microsoft.DotNet.RemoteExecutor
             string arg2, string arg3, RemoteInvokeOptions options = null)
         {
             return Invoke(GetMethodInfo(method), new[] { arg1, arg2, arg3 }, options);
+        }
+
+        /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
+        /// <param name="method">The method to invoke.</param>
+        /// <param name="arg1">The first argument to pass to the method.</param>
+        /// <param name="arg2">The second argument to pass to the method.</param>
+        /// <param name="arg3">The third argument to pass to the method.</param>
+        /// <param name="arg4">The fourth argument to pass to the method.</param>
+        /// <param name="options">Options to use for the invocation.</param>
+        public static RemoteInvokeHandle Invoke(Func<string, string, string, string, Task> method, string arg1,
+            string arg2, string arg3, string arg4, RemoteInvokeOptions options = null)
+        {
+            return Invoke(GetMethodInfo(method), new[] { arg1, arg2, arg3, arg4 }, options);
+        }
+
+        /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
+        /// <param name="method">The method to invoke.</param>
+        /// <param name="arg1">The first argument to pass to the method.</param>
+        /// <param name="arg2">The second argument to pass to the method.</param>
+        /// <param name="arg3">The third argument to pass to the method.</param>
+        /// <param name="arg4">The fourth argument to pass to the method.</param>
+        /// <param name="arg5">The fifth argument to pass to the method.</param>
+        /// <param name="options">Options to use for the invocation.</param>
+        public static RemoteInvokeHandle Invoke(Func<string, string, string, string, string, Task> method, string arg1,
+            string arg2, string arg3, string arg4, string arg5, RemoteInvokeOptions options = null)
+        {
+            return Invoke(GetMethodInfo(method), new[] { arg1, arg2, arg3, arg4, arg5 }, options);
         }
 
         /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>

--- a/src/Microsoft.DotNet.RemoteExecutor/tests/RemoteExecutorTests.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/tests/RemoteExecutorTests.cs
@@ -59,6 +59,18 @@ namespace Microsoft.DotNet.RemoteExecutor.Tests
         }
 
         [Fact]
+        public void AsyncFuncFiveArgs_ThrowException()
+        {
+            Assert.Throws<RemoteExecutionException>(() =>
+                RemoteExecutor.Invoke(async (a, b, c, d, e) =>
+                {
+                    Assert.True(false);
+                    await Task.Delay(1);
+                }, "a", "b", "c", "d", "e", new RemoteInvokeOptions { RollForward = "Major" }).Dispose()
+            );
+        }
+
+        [Fact]
         public void AsyncFunc_InvalidReturnCode()
         {
             Assert.Throws<TrueException>(() =>


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/74994 we hit an issue because a test was inadvertently using `RemoteExecutor.Invoke(Action<string, string, string, string> method, ...)` since there was no overload that takes `Func<string, string, string, string, Task>` (only one with three strings) and that means it's becoming an async void (bad!).

This PR makes sure we have a matching number of overloads that take Func with the same number of arguments as the one that takes Action.

Since there was a bit of a mismatch (one overload took five arguments), I made the overloads consistent so that everyone takes five args.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
