### PR TITLE
Update default source-build managed container to centos-stream8

### DIFF
--- a/eng/common/templates/jobs/source-build.yml
+++ b/eng/common/templates/jobs/source-build.yml
@@ -14,7 +14,7 @@ parameters:
   # This is the default platform provided by Arcade, intended for use by a managed-only repo.
   defaultManagedPlatform:
     name: 'Managed'
-    container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343'
+    container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8-20220809204800-17a4aab'
 
   # Defines the platforms on which to run build jobs. One job is created for each platform, and the
   # object in this array is sent to the job template as 'platform'. If no platforms are specified,


### PR DESCRIPTION
Default managed container was centos-7, which is deprecated and does not support some required features or environment configurations, i.e. Git v2.

Updating to the preferred container, per this: https://github.com/dotnet/installer/blob/0600c205ab64abf7caecc6dee9d89514aeddb458/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml#L15