### PR TITLE
Port InstallDotNetCore workaround to release/7.0

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
@@ -138,8 +138,28 @@ namespace Microsoft.DotNet.Arcade.Sdk
                                         {
                                             FileName = DotNetInstallScript,
                                             Arguments = arguments,
-                                            UseShellExecute = false
+                                            UseShellExecute = false,
+                                            // Redirect to stdout/err. Addressing https://github.com/dotnet/msbuild/issues/7913
+                                            // Without it script execution was failing on Linux when run from
+                                            RedirectStandardOutput = true,
+                                            RedirectStandardError = true,
                                         });
+                                        process.OutputDataReceived += (sender, e) =>
+                                        {
+                                            if (!String.IsNullOrEmpty(e.Data))
+                                            {
+                                                Console.WriteLine(e.Data);
+                                            }
+                                        };
+                                        process.ErrorDataReceived += (sender, e) =>
+                                        {
+                                            if (!String.IsNullOrEmpty(e.Data))
+                                            {
+                                                Console.Error.WriteLine(e.Data);
+                                            }
+                                        };
+                                        process.BeginOutputReadLine();
+                                        process.BeginErrorReadLine();
                                         process.WaitForExit();
                                         if (process.ExitCode != 0)
                                         {


### PR DESCRIPTION
Cherry pick of "Fix for msbuild server - InstallDotNetCore task redirects its outputs (#10629)"

* Redirect InstallDotNetCore child processes stdout and stderr

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
