### PR TITLE
Port main branch changes for UseServicingBuildPool

### DIFF
--- a/eng/promote-build.yml
+++ b/eng/promote-build.yml
@@ -7,7 +7,7 @@ parameters:
     default: 3
     values:
       - 3
-      
+
   - name: BARBuildId
     displayName: "Maestro ID of the build to be promoted:"
     type: number
@@ -16,6 +16,11 @@ parameters:
     displayName: Which Maestro channels' IDs should the build be promoted to? (comma separated)
     type: string 
     default: ' '
+
+  - name: UseServicingBuildPool
+    displayName: If true, use the assigned 'Servicing' pool for publishing jobs
+    type: boolean
+    default: false
 
   - name: SymbolPublishingAdditionalParameters
     displayName: Additional (MSBuild) properties for symbol publishing
@@ -35,22 +40,22 @@ parameters:
     displayName: Should Sourcelink validation be performed?
     type: boolean 
     default: false
-    
+
   - name: EnableNugetValidation
     displayName: Should NuGet metadata validation be performed?
     type: boolean 
     default: false
-    
+
   - name: EnableSigningValidation
     displayName: Should signing validation be performed?
     type: boolean 
     default: false
-       
+
   - name: PublishInstallersAndChecksums
     displayName: Should installers and checksums be published?
     type: boolean 
     default: true
-    
+
   - name: SigningValidationAdditionalParameters
     displayName: Additional (MSBuild) properties for signing validation
     type: string 
@@ -65,3 +70,4 @@ stages:
     BARBuildId: ${{ parameters.BARBuildId }}
     symbolPublishingAdditionalParameters: ${{ parameters.SymbolPublishingAdditionalParameters }}
     artifactsPublishingAdditionalParameters: ${{ parameters.ArtifactsPublishingAdditionalParameters }}
+    useServicingBuildPools : ${{ parameters.UseServicingBuildPool }}

--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -4,6 +4,7 @@ parameters:
   BARBuildId: ''
   symbolPublishingAdditionalParameters: ''
   buildQuality: 'daily'
+  useServicingBuildPools: false
 
 stages:
   - stage: publish
@@ -34,8 +35,13 @@ stages:
         ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
           name: VSEngSS-MicroBuild2022-1ES
           demands: Cmd
-        # If it's not devdiv, it's dnceng
-        ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
+        # If it's not devdiv, it's dnceng: 
+        # If useServicingBuildPools = false, it's a main branch:
+        ${{ if and(ne(variables['System.TeamProject'], 'DevDiv'), eq(parameters['useServicingBuildPools'], false)) }}:
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals windows.vs2019.amd64
+        # If useServicingBuildPools = true, it's a release branch:
+        ${{ if and(ne(variables['System.TeamProject'], 'DevDiv'), eq(parameters['useServicingBuildPools'], true)) }}:
           name: NetCore1ESPool-Svc-Internal
           demands: ImageOverride -equals windows.vs2019.amd64
 


### PR DESCRIPTION
See https://github.com/dotnet/arcade/issues/10769.  Arcade-validation uses test branches off the release branch. While they shouldn't do this, it's less disruptive to just add new parameters to old branches.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
