### PR TITLE
Set proper packageSourceMapping when installing Guardian

### DIFF
--- a/eng/common/sdl/NuGet.config
+++ b/eng/common/sdl/NuGet.config
@@ -7,6 +7,11 @@
     <clear />
     <add key="guardian" value="https://securitytools.pkgs.visualstudio.com/_packaging/Guardian/nuget/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="guardian">
+      <package pattern="microsoft.guardian.cli" />
+    </packageSource>
+  </packageSourceMapping>
   <disabledPackageSources>
     <clear />
   </disabledPackageSources>

--- a/eng/common/sdl/sdl.ps1
+++ b/eng/common/sdl/sdl.ps1
@@ -1,6 +1,7 @@
 
 function Install-Gdn {
     param(
+        [Parameter(Mandatory=$true)]
         [string]$Path,
 
         # If omitted, install the latest version of Guardian, otherwise install that specific version.

--- a/eng/common/templates/steps/execute-sdl.yml
+++ b/eng/common/templates/steps/execute-sdl.yml
@@ -17,14 +17,16 @@ steps:
   
 - ${{ if ne(parameters.overrideGuardianVersion, '') }}:
   - pwsh: |
-      . $(Build.SourcesDirectory)\eng\common\sdl\sdl.ps1
+      Set-Location -Path $(Build.SourcesDirectory)\eng\common\sdl
+      . sdl.ps1
       $guardianCliLocation = Install-Gdn -Path $(Build.SourcesDirectory)\.artifacts -Version ${{ parameters.overrideGuardianVersion }}
       Write-Host "##vso[task.setvariable variable=GuardianCliLocation]$guardianCliLocation"
     displayName: Install Guardian (Overridden)
 
 - ${{ if eq(parameters.overrideGuardianVersion, '') }}:
   - pwsh: |
-      . $(Build.SourcesDirectory)\eng\common\sdl\sdl.ps1
+      Set-Location -Path $(Build.SourcesDirectory)\eng\common\sdl
+      . sdl.ps1
       $guardianCliLocation = Install-Gdn -Path $(Build.SourcesDirectory)\.artifacts
       Write-Host "##vso[task.setvariable variable=GuardianCliLocation]$guardianCliLocation"
     displayName: Install Guardian


### PR DESCRIPTION
NuGet's new Package Source Mapping feature requires that all package IDs be specifically matched to a service feed. The effect rolls "up" the repo. #10755 discovered that if the repository root enables packageSourceMapping, any NuGet operation within the repository must comply, including the manual restoration of the Guardian CLI. 

This PR adds proper packageSourceMapping to the SDL-specific NuGet.Config and modifies YAML to ensure it gets picked as the priority config.

Testing done locally using all combinations of enabling and disabling packageSourceMapping in the repository root NuGet.Config and the SDL-specific `eng\common\sdl\NuGet.Config`. 