### PR TITLE
Add compact console formatter

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -38,7 +38,7 @@
     <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>2.1.1</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
     <MicrosoftExtensionsDependencyInjectionVersion>2.1.1</MicrosoftExtensionsDependencyInjectionVersion>
     <MicrosoftExtensionsFileSystemGlobbingVersion>2.0.0</MicrosoftExtensionsFileSystemGlobbingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>2.1.1</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>6.0.0</MicrosoftExtensionsLoggingConsoleVersion>
     <MicrosoftNETCorePlatformsVersion>2.1.0</MicrosoftNETCorePlatformsVersion>
     <MicrosoftNetCompilersToolsetVersion>4.3.0-3.22453.1</MicrosoftNetCompilersToolsetVersion>
     <MicrosoftNetTestSdkVersion>17.4.0-preview-20220707-01</MicrosoftNetTestSdkVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -35,8 +35,8 @@
     <MicrosoftIdentityModelClientsActiveDirectoryVersion>3.17.2</MicrosoftIdentityModelClientsActiveDirectoryVersion>
     <MicrosoftRestClientRuntimeVersion>2.3.13</MicrosoftRestClientRuntimeVersion>
     <MicrosoftExtensionsDependencyModelVersion>2.1.0</MicrosoftExtensionsDependencyModelVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>2.1.1</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>2.1.1</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>6.0.0</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>6.0.0</MicrosoftExtensionsDependencyInjectionVersion>
     <MicrosoftExtensionsFileSystemGlobbingVersion>2.0.0</MicrosoftExtensionsFileSystemGlobbingVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>6.0.0</MicrosoftExtensionsLoggingConsoleVersion>
     <MicrosoftNETCorePlatformsVersion>2.1.0</MicrosoftNETCorePlatformsVersion>
@@ -48,26 +48,26 @@
     <MonoOptionsVersion>5.3.0.1</MonoOptionsVersion>
     <McMasterExtensionsCommandLineUtils>2.3.0</McMasterExtensionsCommandLineUtils>
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
-    <SystemTextJsonVersion>4.7.0</SystemTextJsonVersion>
+    <SystemTextJsonVersion>6.0.0</SystemTextJsonVersion>
     <NuGetVersioningVersion>4.4.0</NuGetVersioningVersion>
     <NuGetVersion>6.2.1</NuGetVersion>
     <OctokitVersion>0.32.0</OctokitVersion>
     <DotNetSleetLibVersion>2.2.143</DotNetSleetLibVersion>
     <SwashbuckleAspNetCoreSwaggerVersion>3.0.0</SwashbuckleAspNetCoreSwaggerVersion>
-    <SystemBuffersVersion>4.5.0</SystemBuffersVersion>
+    <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
     <SystemCollectionsImmutableVersion>1.5.0</SystemCollectionsImmutableVersion>
     <SystemDiagnosticsTraceSourceVersion>4.0.0</SystemDiagnosticsTraceSourceVersion>
     <SystemIOCompressionVersion>4.3.0</SystemIOCompressionVersion>
     <SystemIOPackagingVersion>4.5.0</SystemIOPackagingVersion>
     <SystemIOFileSystemPrimitivesVersion>4.3.0</SystemIOFileSystemPrimitivesVersion>
-    <SystemMemoryVersion>4.5.3</SystemMemoryVersion>
+    <SystemMemoryVersion>4.5.4</SystemMemoryVersion>
     <SystemNumericsVectorsVersion>4.5.0</SystemNumericsVectorsVersion>
     <SystemReflectionMetadataVersion>1.6.0</SystemReflectionMetadataVersion>
-    <SystemRuntimeCompilerServicesUnsafeVersion>4.7.0</SystemRuntimeCompilerServicesUnsafeVersion>
+    <SystemRuntimeCompilerServicesUnsafeVersion>6.0.0</SystemRuntimeCompilerServicesUnsafeVersion>
     <SystemRuntimeInteropServicesRuntimeInformation>4.3.0</SystemRuntimeInteropServicesRuntimeInformation>
     <SystemSecurityCryptographyX509CertificatesVersion>4.3.0</SystemSecurityCryptographyX509CertificatesVersion>
-    <SystemTextEncodingsWebVersion>4.7.2</SystemTextEncodingsWebVersion>
-    <SystemThreadingTasksExtensionVersion>4.5.2</SystemThreadingTasksExtensionVersion>
+    <SystemTextEncodingsWebVersion>6.0.0</SystemTextEncodingsWebVersion>
+    <SystemThreadingTasksExtensionVersion>4.5.4</SystemThreadingTasksExtensionVersion>
     <SystemValueTupleVersion>4.5.0</SystemValueTupleVersion>
     <WindowsAzureStorageVersion>8.5.0</WindowsAzureStorageVersion>
     <XUnitVersion>2.4.2</XUnitVersion>

--- a/src/Common/Microsoft.Arcade.Common/CompactConsoleLoggerFormatter.cs
+++ b/src/Common/Microsoft.Arcade.Common/CompactConsoleLoggerFormatter.cs
@@ -1,0 +1,193 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Console;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Arcade.Common;
+
+/// <summary>
+/// Copied over from SimpleConsoleFormatter. Leaves out the logger name and new line, turning
+/// info: test[0]
+///     Log message
+///     Second line of the message
+///
+/// into
+///
+/// info: Log message
+///       Second line of the message
+///
+/// Only using SimpleConsoleFormatterOptions.SingleLine didn't help because multi-line messages
+/// were put together on a single line so things like stack traces of exceptions were unreadable.
+///
+/// See https://github.com/dotnet/runtime/blob/0817e748b7698bef1e812fd74c8a3558b7f86421/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
+/// </summary>
+public class CompactConsoleLoggerFormatter : ConsoleFormatter
+{
+    private const string LoglevelPadding = ": ";
+    private const string DefaultForegroundColor = "\x1B[39m\x1B[22m"; // reset to default foreground color
+    private const string DefaultBackgroundColor = "\x1B[49m"; // reset to the background color
+
+    public const string FormatterName = "compact";
+
+    private readonly SimpleConsoleFormatterOptions _options;
+    private readonly string _messagePadding;
+    private readonly string _newLineWithMessagePadding;
+
+    public CompactConsoleLoggerFormatter(IOptionsMonitor<SimpleConsoleFormatterOptions> options)
+        : base(FormatterName)
+    {
+        _options = options.CurrentValue;
+        _messagePadding = new string(' ', GetLogLevelString(LogLevel.Information).Length + LoglevelPadding.Length + (_options.TimestampFormat?.Length ?? 0));
+        _newLineWithMessagePadding = Environment.NewLine + _messagePadding;
+    }
+
+    public override void Write<TState>(in LogEntry<TState> logEntry, IExternalScopeProvider? scopeProvider, TextWriter textWriter)
+    {
+        if (logEntry.Formatter == null)
+        {
+            return;
+        }
+
+        var message = logEntry.Formatter(logEntry.State, logEntry.Exception);
+        if (logEntry.Exception == null && message == null)
+        {
+            return;
+        }
+
+        LogLevel logLevel = logEntry.LogLevel;
+        var logLevelColors = GetLogLevelConsoleColors(logLevel);
+        var logLevelString = GetLogLevelString(logLevel);
+
+        if (_options.TimestampFormat != null)
+        {
+            var timestamp = DateTimeOffset.Now.ToString(_options.TimestampFormat);
+            textWriter.Write(timestamp);
+        }
+
+        WriteColoredMessage(textWriter, logLevelString, logLevelColors.Background, logLevelColors.Foreground);
+
+        textWriter.Write(LoglevelPadding);
+
+        WriteMessage(textWriter, message, false);
+
+        // Example:
+        // System.InvalidOperationException
+        //    at Namespace.Class.Function() in File:line X
+        if (logEntry.Exception != null)
+        {
+            // exception message
+            WriteMessage(textWriter, logEntry.Exception.ToString());
+        }
+    }
+
+    private void WriteMessage(TextWriter textWriter, string message, bool includePadding = true)
+    {
+        if (message == null)
+        {
+            return;
+        }
+
+        if (includePadding)
+        {
+            textWriter.Write(_messagePadding);
+        }
+
+        textWriter.WriteLine(message.Replace(Environment.NewLine, _newLineWithMessagePadding));
+    }
+
+    private static string GetLogLevelString(LogLevel logLevel) => logLevel switch
+    {
+        LogLevel.Trace => "trce",
+        LogLevel.Debug => "dbug",
+        LogLevel.Information => "info",
+        LogLevel.Warning => "warn",
+        LogLevel.Error => "fail",
+        LogLevel.Critical => "crit",
+        _ => throw new ArgumentOutOfRangeException(nameof(logLevel))
+    };
+
+    private (ConsoleColor? Foreground, ConsoleColor? Background) GetLogLevelConsoleColors(LogLevel logLevel)
+    {
+        if (_options.ColorBehavior == LoggerColorBehavior.Disabled)
+        {
+            return (null, null);
+        }
+
+        // We must explicitly set the background color if we are setting the foreground color,
+        // since just setting one can look bad on the users console.
+        return logLevel switch
+        {
+            LogLevel.Trace => (ConsoleColor.Gray, ConsoleColor.Black),
+            LogLevel.Debug => (ConsoleColor.Gray, ConsoleColor.Black),
+            LogLevel.Information => (ConsoleColor.DarkGreen, ConsoleColor.Black),
+            LogLevel.Warning => (ConsoleColor.Yellow, ConsoleColor.Black),
+            LogLevel.Error => (ConsoleColor.Black, ConsoleColor.DarkRed),
+            LogLevel.Critical => (ConsoleColor.White, ConsoleColor.DarkRed),
+            _ => (null, null)
+        };
+    }
+
+    private static void WriteColoredMessage(TextWriter textWriter, string message, ConsoleColor? background, ConsoleColor? foreground)
+    {
+        // Order: backgroundcolor, foregroundcolor, Message, reset foregroundcolor, reset backgroundcolor
+        if (background.HasValue)
+        {
+            textWriter.Write(GetBackgroundColorEscapeCode(background.Value));
+        }
+
+        if (foreground.HasValue)
+        {
+            textWriter.Write(GetForegroundColorEscapeCode(foreground.Value));
+        }
+
+        textWriter.Write(message);
+
+        if (foreground.HasValue)
+        {
+            textWriter.Write(DefaultForegroundColor); // reset to default foreground color
+        }
+
+        if (background.HasValue)
+        {
+            textWriter.Write(DefaultBackgroundColor); // reset to the background color
+        }
+    }
+
+    private static string GetForegroundColorEscapeCode(ConsoleColor color) => color switch
+    {
+        ConsoleColor.Black => "\x1B[30m",
+        ConsoleColor.DarkRed => "\x1B[31m",
+        ConsoleColor.DarkGreen => "\x1B[32m",
+        ConsoleColor.DarkYellow => "\x1B[33m",
+        ConsoleColor.DarkBlue => "\x1B[34m",
+        ConsoleColor.DarkMagenta => "\x1B[35m",
+        ConsoleColor.DarkCyan => "\x1B[36m",
+        ConsoleColor.Gray => "\x1B[37m",
+        ConsoleColor.Red => "\x1B[1m\x1B[31m",
+        ConsoleColor.Green => "\x1B[1m\x1B[32m",
+        ConsoleColor.Yellow => "\x1B[1m\x1B[33m",
+        ConsoleColor.Blue => "\x1B[1m\x1B[34m",
+        ConsoleColor.Magenta => "\x1B[1m\x1B[35m",
+        ConsoleColor.Cyan => "\x1B[1m\x1B[36m",
+        ConsoleColor.White => "\x1B[1m\x1B[37m",
+        _ => DefaultForegroundColor // default foreground color
+    };
+
+    private static string GetBackgroundColorEscapeCode(ConsoleColor color) => color switch
+    {
+        ConsoleColor.Black => "\x1B[40m",
+        ConsoleColor.DarkRed => "\x1B[41m",
+        ConsoleColor.DarkGreen => "\x1B[42m",
+        ConsoleColor.DarkYellow => "\x1B[43m",
+        ConsoleColor.DarkBlue => "\x1B[44m",
+        ConsoleColor.DarkMagenta => "\x1B[45m",
+        ConsoleColor.DarkCyan => "\x1B[46m",
+        ConsoleColor.Gray => "\x1B[47m",
+        _ => DefaultBackgroundColor // Use default background color
+    };
+}

--- a/src/Common/Microsoft.Arcade.Common/CompactConsoleLoggerFormatter.cs
+++ b/src/Common/Microsoft.Arcade.Common/CompactConsoleLoggerFormatter.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.Extensions.Options;
 
+#nullable enable
 namespace Microsoft.Arcade.Common;
 
 /// <summary>

--- a/src/Common/Microsoft.Arcade.Common/Microsoft.Arcade.Common.csproj
+++ b/src/Common/Microsoft.Arcade.Common/Microsoft.Arcade.Common.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
     <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
 
     <!-- This is here so that we agree with the project's transitive references to NewtonSoft.Json -->
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests.csproj
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests.csproj
@@ -6,14 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.7.179" />
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
-    <PackageReference Include="Moq" Version="4.8.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
+    <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <!-- This is here so that we agree with the project's transitive references to NewtonSoft.Json -->
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="NuGet.Versioning" Version="6.1.0" />
+    <PackageReference Include="NuGet.Versioning" Version="$(NuGetVersion)" />
     <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
Adds a custom console formatter that turns this:
```
info: Microsoft.DotNet.DarcLib.VirtualMonoRepo.VmrUpdater[0]
      Synchronizing installer from fdc96a7d0f3780df1aaee687692ba4145bb61d85 to https://github.com/dotnet/installer@HEAD
info: Microsoft.DotNet.DarcLib.VirtualMonoRepo.VmrUpdater[0]
      Clone of https://github.com/dotnet/installer found, pulling new changes...
info: Microsoft.DotNet.DarcLib.VirtualMonoRepo.VmrUpdater[0]
      Creating diff in /data/tmp/installer.patch..
info: Microsoft.DotNet.DarcLib.VirtualMonoRepo.VmrUpdater[0]
      Diff created at /data/tmp/installer.patch - 0 commits, 355.058 KB
info: Microsoft.DotNet.DarcLib.VirtualMonoRepo.VmrUpdater[0]
      Applying patch /data/tmp/installer.patch to src/installer...
info: Microsoft.DotNet.DarcLib.VirtualMonoRepo.VmrUpdater[0]
      Committing..
info: Microsoft.DotNet.DarcLib.VirtualMonoRepo.VmrUpdater[0]
      Created 764adb0 in 4 seconds
```

into this

```
info: Synchronizing installer from fdc96a7d0f3780df1aaee687692ba4145bb61d85 to https://github.com/dotnet/installer@HEAD
info: Clone of https://github.com/dotnet/installer found, pulling new changes...
info: Creating diff in /data/tmp/installer.patch..
info: Diff created at /data/tmp/installer.patch - 0 commits, 355.058 KB
info: Applying patch /data/tmp/installer.patch to src/installer...
info: Committing..
info: Created 764adb0 in 4 seconds
```

The update of the Logging library triggered a small avalanche so I had to update few more things. Hopefully this won't break anyone down the line?