### PR TITLE
[release/3.x] Just use default machine dotnet

### DIFF
--- a/eng/common/darc-init.ps1
+++ b/eng/common/darc-init.ps1
@@ -10,8 +10,7 @@ param (
 function InstallDarcCli ($darcVersion, $toolpath) {
   $darcCliPackageName = 'microsoft.dotnet.darc'
 
-  $dotnetRoot = InitializeDotNetCli -install:$true
-  $dotnet = "$dotnetRoot\dotnet.exe"
+  $dotnet = "dotnet"
   $toolList = & "$dotnet" tool list -g
 
   if ($toolList -like "*$darcCliPackageName*") {


### PR DESCRIPTION
Use the default machine dotnet when installing darc. This dotnet should be a newer host and can install darc targeted at 6.0
