### PR TITLE
Update to new images on release/5.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,10 +44,10 @@ stages:
         pool:
           ${{ if eq(variables._RunAsPublic, True) }}:
             name: NetCore1ESPool-Svc-Public
-            demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
+            demands: ImageOverride -equals windows.vs2019.amd64.open
           ${{ if eq(variables._RunAsInternal, True) }}:
             name: NetCore1ESPool-Svc-Internal
-            demands: ImageOverride -equals Build.Server.Amd64.VS2019
+            demands: ImageOverride -equals windows.vs2019.amd64
         strategy:
           matrix:
             Build_Release:

--- a/eng/validate-sdk.yml
+++ b/eng/validate-sdk.yml
@@ -20,7 +20,7 @@ jobs:
     timeoutInMinutes: 90
     pool:
       name: NetCore1ESPool-Svc-Internal
-      demands: ImageOverride -equals Build.Server.Amd64.VS2019
+      demands: ImageOverride -equals windows.vs2019.amd64
     variables:
     - group: DotNet-Blob-Feed
     - group: Publish-Build-Assets


### PR DESCRIPTION
## Description

release/5.0 is still releasing apparently so this needs to be done.

## Customer Impact

5.0 will cease working when the images it's currently on are deleted.

## Regression

No

## Risk

Should be little to no risk as the images are essentially the same, but as always there's a risk that for some unforeseen reason the build fails.

## Workarounds

No.