### PR TITLE
Add `richCodeNavigationUploadArtifacts` option.

### DIFF
--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -140,6 +140,7 @@ jobs:
         languages: ${{ coalesce(parameters.richCodeNavigationLanguage, 'csharp') }}
         environment: ${{ coalesce(parameters.richCodeNavigationEnvironment, 'production') }}
         richNavLogOutputDirectory: $(Build.SourcesDirectory)/artifacts/bin
+        uploadRichNavArtifacts: ${{ parameters.richCodeNavigationUploadArtifacts }}
       continueOnError: true
 
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(parameters.disableComponentGovernance, 'true')) }}:

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -140,7 +140,7 @@ jobs:
         languages: ${{ coalesce(parameters.richCodeNavigationLanguage, 'csharp') }}
         environment: ${{ coalesce(parameters.richCodeNavigationEnvironment, 'production') }}
         richNavLogOutputDirectory: $(Build.SourcesDirectory)/artifacts/bin
-        uploadRichNavArtifacts: ${{ parameters.richCodeNavigationUploadArtifacts }}
+        uploadRichNavArtifacts: ${{ coalesce(parameters.richCodeNavigationUploadArtifacts, false) }}
       continueOnError: true
 
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(parameters.disableComponentGovernance, 'true')) }}:


### PR DESCRIPTION
- This new option correlates to the `RichCodeNavIndexer`'s `uploadRichNavArtifacts` input. Effectively it'll allow anyone to easily capture trace/debug level output from rich nav runs.
