### PR TITLE
Convert build.tasks.installer scripts to python3

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/deb-package-tool/scripts/config_template_generator.py
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/deb-package-tool/scripts/config_template_generator.py
@@ -47,7 +47,7 @@ def generate_and_write_all(config_data, template_dir, output_dir, package_name=N
         symlink_contents = generate_symlinks(config_data, package_name=package_name)
         rules_contents = generate_rules(config_data, template_dir)
     except Exception as exc:
-      print exc
+      print(exc)
       help_and_exit("Error: Generation Failed, check your config file.")
 
     write_file(changelog_contents, output_dir, FILE_CHANGELOG)
@@ -157,7 +157,7 @@ def generate_symlinks(config_data, package_name=None):
 
     symlink_data = config_data.get("symlinks", dict())
 
-    for package_rel_path, symlink_path in symlink_data.iteritems():
+    for package_rel_path, symlink_path in symlink_data.items():
 
         package_abs_path = os.path.join(package_root_path, package_rel_path)
 
@@ -222,11 +222,11 @@ def write_file(contents, output_dir, name):
 
 # Tool Functions
 def help_and_exit(msg):
-    print msg
+    print(msg)
     sys.exit(1)
 
 def print_usage():
-    print "Usage: config_template_generator.py [config file path] [template directory path] [output directory] (package name) (package version)"
+    print("Usage: config_template_generator.py [config file path] [template directory path] [output directory] (package name) (package version)")
 
 def parse_and_validate_args():
     if len(sys.argv) < 4:

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/deb-package-tool/scripts/extract_json_value.py
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/deb-package-tool/scripts/extract_json_value.py
@@ -12,13 +12,13 @@ import sys
 import json
 
 def print_usage():
-	print """
+	print("""
 		Usage: extract_json_value.py [json file path] [key of value to extract]
 		For nested keys, use . separator
-	"""
+	""")
 
 def help_and_exit(msg=None):
-	print msg
+	print(msg)
 	print_usage()
 	sys.exit(1)
 
@@ -60,5 +60,5 @@ def execute():
 	return value
 
 if __name__ == "__main__":
-	print execute()
+	print(execute())
 

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/deb-package-tool/scripts/manpage_generator.py
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/deb-package-tool/scripts/manpage_generator.py
@@ -271,8 +271,8 @@ def _option_string_helper(specifier_short, specifier_long, parameter, include_br
 
 
 def print_usage():
-    print "Usage: argv[1] = path to docs.json; argv[2] = output path"
-    print "Example: manpage_generator.py ../docs.json ./dotnet-1.0/debian"
+    print("Usage: argv[1] = path to docs.json; argv[2] = output path")
+    print("Example: manpage_generator.py ../docs.json ./dotnet-1.0/debian")
 
 def parse_args():
     doc_path = sys.argv[1]
@@ -296,7 +296,7 @@ def execute_command_line():
         generate_man_pages(doc_path, output_dir)
 
     except Exception as exc:
-        print "Error: ", exc
+        print("Error: ", exc)
         print_usage()
 
 if __name__ == "__main__":


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation

Python2 is no longer in support and may not be used.
