### PR TITLE
Drop explicit import in BuildIbcTrainingSettings

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/VisualStudio.BuildIbcTrainingSettings.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/VisualStudio.BuildIbcTrainingSettings.proj
@@ -17,7 +17,6 @@
   -->
 
   <Import Project="Directory.Build.props" />
-  <Import Project="Directory.Build.targets" />
 
   <PropertyGroup>
     <_VisualStudioBuildTasksAssembly>$(NuGetPackageRoot)microsoft.dotnet.build.tasks.visualstudio\$(MicrosoftDotNetBuildTasksVisualStudioVersion)\tools\net472\Microsoft.DotNet.Build.Tasks.VisualStudio.dll</_VisualStudioBuildTasksAssembly>


### PR DESCRIPTION
The file that was to be imported was deleted in 7e7bf28723, but
the import remained, causing an MSB4019 error.

Fixes #10939.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
