### PR TITLE
Fix BuildIbcTrainingSettings proj evaluation

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/VisualStudio.BuildIbcTrainingSettings.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/VisualStudio.BuildIbcTrainingSettings.proj
@@ -17,7 +17,6 @@
   -->
 
   <Import Project="Directory.Build.props" />
-  <Import Project="Directory.Build.targets" />
 
   <PropertyGroup>
     <_VisualStudioBuildTasksAssembly>$(NuGetPackageRoot)microsoft.dotnet.build.tasks.visualstudio\$(MicrosoftDotNetBuildTasksVisualStudioVersion)\tools\net472\Microsoft.DotNet.Build.Tasks.VisualStudio.dll</_VisualStudioBuildTasksAssembly>


### PR DESCRIPTION
Reported in https://github.com/dotnet/arcade/issues/10939.

https://github.com/dotnet/arcade/commit/7e7bf28723dd354839b89f56556713c9d1533677 forgot to remove the Directory.Builds.targets import in the VisualStudio.BuildIbcTrainingSettings.proj project.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
