### PR TITLE
Add native tools build.ps1 switch on release/6.0

### DIFF
--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -26,6 +26,7 @@ Param(
   [string] $runtimeSourceFeed = '',
   [string] $runtimeSourceFeedKey = '',
   [switch] $excludePrereleaseVS,
+  [switch] $nativeToolsOnMachine,
   [switch] $help,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
@@ -67,6 +68,7 @@ function Print-Usage() {
   Write-Host "  -warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
   Write-Host "  -msbuildEngine <value>  Msbuild engine to use to run build ('dotnet', 'vs', or unspecified)."
   Write-Host "  -excludePrereleaseVS    Set to exclude build engines in prerelease versions of Visual Studio"
+  Write-Host "  -nativeToolsOnMachine   Sets the native tools on machine environment variable (indicating that the script should use native tools on machine)"
   Write-Host ""
 
   Write-Host "Command line arguments not listed above are passed thru to msbuild."
@@ -146,6 +148,9 @@ try {
     $nodeReuse = $false
   }
 
+  if ($nativeToolsOnMachine) {
+    $env:NativeToolsOnMachine = $true
+  }
   if ($restore) {
     InitializeNativeTools
   }


### PR DESCRIPTION
## Description

Per https://github.com/dotnet/arcade/issues/10951.

## Customer Impact

Various customers need this in their servicing branches; it just makes it easier to use the new native tools on machine.

## Regression

No

## Risk

None.

## Workarounds

No.