### PR TITLE
Add override option to force using tar on Windows.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Archives/README.md
+++ b/src/Microsoft.DotNet.Build.Tasks.Archives/README.md
@@ -13,5 +13,5 @@ Additionally, if a `ProjectServicingConfiguration` item is provided with the ide
 # Creating tar.gz archives on Windows
 
 There is an override that you can use to opt into generating tar.gz archives instead of zip archives on Windows to get an consistent experience as with linux and macos.
-That opt-in is setting ``ArchiveFormat`` to ``.tar.gz`` on a project that uses this package when building for Windows.
-This can also be used on Linux and MacOS to override creating ``.tar.gz`` to ``.zip`` as well based on preferences for the project.
+That opt-in is setting ``ArchiveFormat`` to ``tar.gz`` on a project that uses this package when building for Windows.
+This can also be used on Linux and MacOS to force creating ``zip`` archives as well.

--- a/src/Microsoft.DotNet.Build.Tasks.Archives/README.md
+++ b/src/Microsoft.DotNet.Build.Tasks.Archives/README.md
@@ -14,3 +14,4 @@ Additionally, if a `ProjectServicingConfiguration` item is provided with the ide
 
 There is an override that you can use to opt into generating tar.gz archives instead of zip archives on Windows to get an consistent experience as with linux and macos.
 That opt-in is setting ``ArchiveFormat`` to ``.tar.gz`` on a project that uses this package when building for Windows.
+This can also be used on Linux and MacOS to override creating ``.tar.gz`` to ``.zip`` as well based on preferences for the project.

--- a/src/Microsoft.DotNet.Build.Tasks.Archives/README.md
+++ b/src/Microsoft.DotNet.Build.Tasks.Archives/README.md
@@ -13,4 +13,4 @@ Additionally, if a `ProjectServicingConfiguration` item is provided with the ide
 # Creating tar.gz archives on Windows
 
 There is an override that you can use to opt into generating tar.gz archives instead of zip archives on Windows to get an consistent experience as with linux and macos.
-That opt-in is setting ``UseTarOnWindows`` to ``true`` on a project that uses this package.
+That opt-in is setting ``ArchiveFormat`` to ``.tar.gz`` on a project that uses this package when building for Windows.

--- a/src/Microsoft.DotNet.Build.Tasks.Archives/README.md
+++ b/src/Microsoft.DotNet.Build.Tasks.Archives/README.md
@@ -10,3 +10,7 @@ This SDK also supports automatically skipping builds on unsupported platforms or
 
 Additionally, if a `ProjectServicingConfiguration` item is provided with the identity of the project name and the `PatchVersion` metadata on the item is not equal to the current `PatchVersion`, the build will be skipped. This support enables a repository to disable building targeting packs in servicing releases if that is desired.
 
+# Creating tar.gz archives on Windows
+
+There is an override that you can use to opt into generating tar.gz archives instead of zip archives on Windows to get an consistent experience as with linux and macos.
+That opt-in is setting ``UseTarOnWindows`` to ``true`` on a project that uses this package.

--- a/src/Microsoft.DotNet.Build.Tasks.Archives/build/Microsoft.DotNet.Build.Tasks.Archives.props
+++ b/src/Microsoft.DotNet.Build.Tasks.Archives/build/Microsoft.DotNet.Build.Tasks.Archives.props
@@ -1,0 +1,8 @@
+<Project>
+
+  <PropertyGroup>
+    <ArchiveFormat Condition="$([MSBuild]::IsOSPlatform(Windows)) AND '$(ArchiveFormat)' == ''">.zip</ArchiveFormat>
+    <ArchiveFormat Condition="!$([MSBuild]::IsOSPlatform(Windows)) AND '$(ArchiveFormat)' == ''">.tar.gz</ArchiveFormat>
+  </PropertyGroup>
+
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Archives/build/Microsoft.DotNet.Build.Tasks.Archives.props
+++ b/src/Microsoft.DotNet.Build.Tasks.Archives/build/Microsoft.DotNet.Build.Tasks.Archives.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <ArchiveFormat Condition="$([MSBuild]::IsOSPlatform(Windows)) AND '$(ArchiveFormat)' == ''">.zip</ArchiveFormat>
-    <ArchiveFormat Condition="!$([MSBuild]::IsOSPlatform(Windows)) AND '$(ArchiveFormat)' == ''">.tar.gz</ArchiveFormat>
+    <ArchiveFormat Condition="$([MSBuild]::IsOSPlatform(Windows)) AND '$(ArchiveFormat)' == ''">zip</ArchiveFormat>
+    <ArchiveFormat Condition="!$([MSBuild]::IsOSPlatform(Windows)) AND '$(ArchiveFormat)' == ''">tar.gz</ArchiveFormat>
   </PropertyGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Archives/build/archives.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Archives/build/archives.targets
@@ -72,8 +72,8 @@
       <_OutputPathRoot>$(IntermediateOutputPath)output/</_OutputPathRoot>
       <_ArchiveFileName>$(ArchiveName)-$(Version)</_ArchiveFileName>
       <_ArchiveFileName Condition="'$(RuntimeIdentifier)' != ''">$(ArchiveName)-$(Version)-$(RuntimeIdentifier)</_ArchiveFileName>
-      <_DestinationFileName Condition="$([MSBuild]::IsOSPlatform(Windows))">$(PackageOutputPath)/$(_ArchiveFileName).zip</_DestinationFileName>
-      <_DestinationFileName Condition="!$([MSBuild]::IsOSPlatform(Windows))">$(PackageOutputPath)/$(_ArchiveFileName).tar.gz</_DestinationFileName>
+      <_DestinationFileName Condition="$([MSBuild]::IsOSPlatform(Windows)) AND '$(UseTarOnWindows)' != 'true'">$(PackageOutputPath)/$(_ArchiveFileName).zip</_DestinationFileName>
+      <_DestinationFileName Condition="!$([MSBuild]::IsOSPlatform(Windows)) OR '$(UseTarOnWindows)' == 'true'">$(PackageOutputPath)/$(_ArchiveFileName).tar.gz</_DestinationFileName>
     </PropertyGroup>
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="PublishToDisk"
@@ -83,11 +83,11 @@
     <ZipDirectory SourceDirectory="$(_OutputPathRoot)"
                   Overwrite="true"
                   DestinationFile="$(_DestinationFileName)"
-                  Condition="$([MSBuild]::IsOSPlatform(Windows))"/>
+                  Condition="$([MSBuild]::IsOSPlatform(Windows)) AND '$(UseTarOnWindows)' != 'true'"/>
     <Exec Command="tar -C '$(_OutputPathRoot)' -czf $(_DestinationFileName) ."
           IgnoreExitCode="true"
           IgnoreStandardErrorWarningFormat="true"
-          Condition="!$([MSBuild]::IsOSPlatform(Windows))"/>
+          Condition="!$([MSBuild]::IsOSPlatform(Windows)) OR '$(UseTarOnWindows)' == 'true'"/>
 
     <Message Text="$(_OutputPathRoot) -> $(_DestinationFileName)" Importance="high" />
   </Target>
@@ -98,8 +98,8 @@
       <_SymbolsOutputPathRoot>$(IntermediateOutputPath)symbols/</_SymbolsOutputPathRoot>
       <_ArchiveFileName>$(SymbolsArchiveName)-$(Version)</_ArchiveFileName>
       <_ArchiveFileName Condition="'$(RuntimeIdentifier)' != ''">$(SymbolsArchiveName)-$(RuntimeIdentifier)-$(Version)</_ArchiveFileName>
-      <_DestinationFileName Condition="$([MSBuild]::IsOSPlatform(Windows))">$(PackageOutputPath)/$(_ArchiveFileName).zip</_DestinationFileName>
-      <_DestinationFileName Condition="!$([MSBuild]::IsOSPlatform(Windows))">$(PackageOutputPath)/$(_ArchiveFileName).tar.gz</_DestinationFileName>
+      <_DestinationFileName Condition="$([MSBuild]::IsOSPlatform(Windows)) AND '$(UseTarOnWindows)' != 'true'">$(PackageOutputPath)/$(_ArchiveFileName).zip</_DestinationFileName>
+      <_DestinationFileName Condition="!$([MSBuild]::IsOSPlatform(Windows)) OR '$(UseTarOnWindows)' == 'true'">$(PackageOutputPath)/$(_ArchiveFileName).tar.gz</_DestinationFileName>
     </PropertyGroup>
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="PublishSymbolsToDisk"
@@ -109,11 +109,11 @@
     <ZipDirectory SourceDirectory="$(_SymbolsOutputPathRoot)"
                   Overwrite="true"
                   DestinationFile="$(_DestinationFileName)"
-                  Condition="$([MSBuild]::IsOSPlatform(Windows))"/>
+                  Condition="$([MSBuild]::IsOSPlatform(Windows)) AND '$(UseTarOnWindows)' != 'true'"/>
     <Exec Command="tar -C '$(_SymbolsOutputPathRoot)' -czf $(_DestinationFileName) ."
           IgnoreExitCode="true"
           IgnoreStandardErrorWarningFormat="true"
-          Condition="!$([MSBuild]::IsOSPlatform(Windows))"/>
+          Condition="!$([MSBuild]::IsOSPlatform(Windows)) OR '$(UseTarOnWindows)' == 'true'"/>
 
     <Message Text="$(_SymbolsOutputPathRoot) -> $(_DestinationFileName)" Importance="high" />
   </Target>

--- a/src/Microsoft.DotNet.Build.Tasks.Archives/build/archives.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Archives/build/archives.targets
@@ -72,8 +72,7 @@
       <_OutputPathRoot>$(IntermediateOutputPath)output/</_OutputPathRoot>
       <_ArchiveFileName>$(ArchiveName)-$(Version)</_ArchiveFileName>
       <_ArchiveFileName Condition="'$(RuntimeIdentifier)' != ''">$(ArchiveName)-$(Version)-$(RuntimeIdentifier)</_ArchiveFileName>
-      <_DestinationFileName Condition="$([MSBuild]::IsOSPlatform(Windows)) AND '$(UseTarOnWindows)' != 'true'">$(PackageOutputPath)/$(_ArchiveFileName).zip</_DestinationFileName>
-      <_DestinationFileName Condition="!$([MSBuild]::IsOSPlatform(Windows)) OR '$(UseTarOnWindows)' == 'true'">$(PackageOutputPath)/$(_ArchiveFileName).tar.gz</_DestinationFileName>
+      <_DestinationFileName>$(PackageOutputPath)/$(_ArchiveFileName)$(ArchiveFormat)</_DestinationFileName>
     </PropertyGroup>
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="PublishToDisk"
@@ -83,11 +82,11 @@
     <ZipDirectory SourceDirectory="$(_OutputPathRoot)"
                   Overwrite="true"
                   DestinationFile="$(_DestinationFileName)"
-                  Condition="$([MSBuild]::IsOSPlatform(Windows)) AND '$(UseTarOnWindows)' != 'true'"/>
+                  Condition="'$(ArchiveFormat)' == '.zip'"/>
     <Exec Command="tar -C '$(_OutputPathRoot)' -czf $(_DestinationFileName) ."
           IgnoreExitCode="true"
           IgnoreStandardErrorWarningFormat="true"
-          Condition="!$([MSBuild]::IsOSPlatform(Windows)) OR '$(UseTarOnWindows)' == 'true'"/>
+          Condition="'$(ArchiveFormat)' == '.tar.gz'"/>
 
     <Message Text="$(_OutputPathRoot) -> $(_DestinationFileName)" Importance="high" />
   </Target>
@@ -98,8 +97,7 @@
       <_SymbolsOutputPathRoot>$(IntermediateOutputPath)symbols/</_SymbolsOutputPathRoot>
       <_ArchiveFileName>$(SymbolsArchiveName)-$(Version)</_ArchiveFileName>
       <_ArchiveFileName Condition="'$(RuntimeIdentifier)' != ''">$(SymbolsArchiveName)-$(RuntimeIdentifier)-$(Version)</_ArchiveFileName>
-      <_DestinationFileName Condition="$([MSBuild]::IsOSPlatform(Windows)) AND '$(UseTarOnWindows)' != 'true'">$(PackageOutputPath)/$(_ArchiveFileName).zip</_DestinationFileName>
-      <_DestinationFileName Condition="!$([MSBuild]::IsOSPlatform(Windows)) OR '$(UseTarOnWindows)' == 'true'">$(PackageOutputPath)/$(_ArchiveFileName).tar.gz</_DestinationFileName>
+      <_DestinationFileName>$(PackageOutputPath)/$(_ArchiveFileName)$(ArchiveFormat)</_DestinationFileName>
     </PropertyGroup>
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="PublishSymbolsToDisk"
@@ -109,11 +107,11 @@
     <ZipDirectory SourceDirectory="$(_SymbolsOutputPathRoot)"
                   Overwrite="true"
                   DestinationFile="$(_DestinationFileName)"
-                  Condition="$([MSBuild]::IsOSPlatform(Windows)) AND '$(UseTarOnWindows)' != 'true'"/>
+                  Condition="'$(ArchiveFormat)' == '.zip'"/>
     <Exec Command="tar -C '$(_SymbolsOutputPathRoot)' -czf $(_DestinationFileName) ."
           IgnoreExitCode="true"
           IgnoreStandardErrorWarningFormat="true"
-          Condition="!$([MSBuild]::IsOSPlatform(Windows)) OR '$(UseTarOnWindows)' == 'true'"/>
+          Condition="'$(ArchiveFormat)' == '.tar.gz'"/>
 
     <Message Text="$(_SymbolsOutputPathRoot) -> $(_DestinationFileName)" Importance="high" />
   </Target>

--- a/src/Microsoft.DotNet.Build.Tasks.Archives/build/archives.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Archives/build/archives.targets
@@ -72,7 +72,7 @@
       <_OutputPathRoot>$(IntermediateOutputPath)output/</_OutputPathRoot>
       <_ArchiveFileName>$(ArchiveName)-$(Version)</_ArchiveFileName>
       <_ArchiveFileName Condition="'$(RuntimeIdentifier)' != ''">$(ArchiveName)-$(Version)-$(RuntimeIdentifier)</_ArchiveFileName>
-      <_DestinationFileName>$(PackageOutputPath)/$(_ArchiveFileName)$(ArchiveFormat)</_DestinationFileName>
+      <_DestinationFileName>$(PackageOutputPath)/$(_ArchiveFileName).$(ArchiveFormat)</_DestinationFileName>
     </PropertyGroup>
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="PublishToDisk"
@@ -82,11 +82,11 @@
     <ZipDirectory SourceDirectory="$(_OutputPathRoot)"
                   Overwrite="true"
                   DestinationFile="$(_DestinationFileName)"
-                  Condition="'$(ArchiveFormat)' == '.zip'"/>
+                  Condition="'$(ArchiveFormat)' == 'zip'"/>
     <Exec Command="tar -C '$(_OutputPathRoot)' -czf $(_DestinationFileName) ."
           IgnoreExitCode="true"
           IgnoreStandardErrorWarningFormat="true"
-          Condition="'$(ArchiveFormat)' == '.tar.gz'"/>
+          Condition="'$(ArchiveFormat)' == 'tar.gz'"/>
 
     <Message Text="$(_OutputPathRoot) -> $(_DestinationFileName)" Importance="high" />
   </Target>
@@ -97,7 +97,7 @@
       <_SymbolsOutputPathRoot>$(IntermediateOutputPath)symbols/</_SymbolsOutputPathRoot>
       <_ArchiveFileName>$(SymbolsArchiveName)-$(Version)</_ArchiveFileName>
       <_ArchiveFileName Condition="'$(RuntimeIdentifier)' != ''">$(SymbolsArchiveName)-$(RuntimeIdentifier)-$(Version)</_ArchiveFileName>
-      <_DestinationFileName>$(PackageOutputPath)/$(_ArchiveFileName)$(ArchiveFormat)</_DestinationFileName>
+      <_DestinationFileName>$(PackageOutputPath)/$(_ArchiveFileName).$(ArchiveFormat)</_DestinationFileName>
     </PropertyGroup>
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="PublishSymbolsToDisk"
@@ -107,11 +107,11 @@
     <ZipDirectory SourceDirectory="$(_SymbolsOutputPathRoot)"
                   Overwrite="true"
                   DestinationFile="$(_DestinationFileName)"
-                  Condition="'$(ArchiveFormat)' == '.zip'"/>
+                  Condition="'$(ArchiveFormat)' == 'zip'"/>
     <Exec Command="tar -C '$(_SymbolsOutputPathRoot)' -czf $(_DestinationFileName) ."
           IgnoreExitCode="true"
           IgnoreStandardErrorWarningFormat="true"
-          Condition="'$(ArchiveFormat)' == '.tar.gz'"/>
+          Condition="'$(ArchiveFormat)' == 'tar.gz'"/>
 
     <Message Text="$(_SymbolsOutputPathRoot) -> $(_DestinationFileName)" Importance="high" />
   </Target>


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/11020.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation (Not sure if any tests can be made for these msbuild changes.)