### PR TITLE
Prepend native tool to the path for current build step

### DIFF
--- a/eng/common/init-tools-native.ps1
+++ b/eng/common/init-tools-native.ps1
@@ -113,6 +113,7 @@ try {
             $ToolPath = Convert-Path -Path $BinPath
             Write-Host "Adding $ToolName to the path ($ToolPath)..."
             Write-Host "##vso[task.prependpath]$ToolPath"
+            $env:PATH = "$ToolPath;$env:PATH"
             $InstalledTools += @{ $ToolName = $ToolDirectory.FullName }
           }
         }


### PR DESCRIPTION
Fixes a bug in prepending the native tools to the path. Previously, they were prepended to the path but only for the _next_ build step. This adds them to the current step as well.