### PR TITLE
fix invalid job url in logs

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
@@ -74,9 +74,10 @@
     <PropertyGroup>
       <_AccessTokenSuffix />
       <_AccessTokenSuffix Condition=" '$(HelixAccessToken)' != '' ">&amp;access_token={Get this from helix.dot.net}</_AccessTokenSuffix>
+      <TrimmedHelixBaseUri>[System.String]::Copy('$(HelixBaseUri)').TrimEnd('/')</TrimmedHelixBaseUri>
     </PropertyGroup>
-    <Message Condition=" '$(HelixBaseUri)' == '' " Text="Sent Helix Job; see work items at https://helix.dot.net/api/jobs/$(HelixJobId)/workitems?api-version=2019-06-17$(_AccessTokenSuffix)" Importance="High" />
-    <Message Condition=" '$(HelixBaseUri)' != '' " Text="Sent Helix Job; see work items at $(HelixBaseUri)/api/jobs/$(HelixJobId)/workitems?api-version=2019-06-17$(_AccessTokenSuffix)" Importance="High" />
+    <Message Condition=" '$(TrimmedHelixBaseUri)' == '' " Text="Sent Helix Job; see work items at https://helix.dot.net/api/jobs/$(HelixJobId)/workitems?api-version=2019-06-17$(_AccessTokenSuffix)" Importance="High" />
+    <Message Condition=" '$(TrimmedHelixBaseUri)' != '' " Text="Sent Helix Job; see work items at $(TrimmedHelixBaseUri)/api/jobs/$(HelixJobId)/workitems?api-version=2019-06-17$(_AccessTokenSuffix)" Importance="High" />
   </Target>
 
   <Target Name="Test"


### PR DESCRIPTION
Fix double slash in Helix URL in logs. 

Example of invalid URL can be found [here](https://dev.azure.com/dnceng-public/public/_build/results?buildId=29342&view=logs&j=60adcdc4-a9f0-5668-20f7-b72181c68fb2&t=c0c6b89d-5226-5436-b2c2-753d1b85eca3&s=6884a131-87da-5381-61f3-d7acc3b91d76)
