### PR TITLE
Allow ignoring directories for Component Governance/SBOM

### DIFF
--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -25,6 +25,7 @@ parameters:
   enablePublishTestResults: false
   enablePublishUsingPipelines: false
   disableComponentGovernance: false
+  componentGovernanceIgnoreDirectories: ''
   mergeTestResults: false
   testRunTitle: ''
   testResultsFormat: ''
@@ -146,6 +147,8 @@ jobs:
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(parameters.disableComponentGovernance, 'true')) }}:
       - task: ComponentGovernanceComponentDetection@0
         continueOnError: true
+        inputs:
+          ignoreDirectories: ${{ parameters.componentGovernanceIgnoreDirectories }}
 
   - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
     - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -223,4 +226,5 @@ jobs:
       parameters:
         PackageVersion: ${{ parameters.packageVersion}}
         BuildDropPath: ${{ parameters.buildDropPath }}
+        IgnoreDirectories: ${{ parameters.componentGovernanceIgnoreDirectories }}
 

--- a/eng/common/templates/steps/generate-sbom.yml
+++ b/eng/common/templates/steps/generate-sbom.yml
@@ -2,12 +2,14 @@
 # PackageName - The name of the package this SBOM represents.
 # PackageVersion - The version of the package this SBOM represents. 
 # ManifestDirPath - The path of the directory where the generated manifest files will be placed
+# IgnoreDirectories - Directories to ignore for SBOM generation. This will be passed through to the CG component detector.
 
 parameters:
   PackageVersion: 7.0.0
   BuildDropPath: '$(Build.SourcesDirectory)/artifacts'
   PackageName: '.NET'
   ManifestDirPath: $(Build.ArtifactStagingDirectory)/sbom
+  IgnoreDirectories: ''
   sbomContinueOnError: true
 
 steps:
@@ -34,6 +36,8 @@ steps:
       BuildDropPath: ${{ parameters.buildDropPath }}
       PackageVersion: ${{ parameters.packageVersion }}
       ManifestDirPath: ${{ parameters.manifestDirPath }}
+      ${{ if ne(parameters.IgnoreDirectories, '') }}:
+        AdditionalComponentDetectorArgs: '--IgnoreDirectories ${{ parameters.IgnoreDirectories }}'
 
 - task: PublishPipelineArtifact@1
   displayName: Publish SBOM manifest


### PR DESCRIPTION
We were hitting a warning in dotnet/runtime about a malformed package.json that was used as a test asset by the resolve npm module:

```
##[warning]Could not parse Jtokens from file /__w/1/s/src/mono/wasm/runtime/node_modules/resolve/test/resolver/malformed_package_json/package.json.
```

I emailed the CG owners and they said we should ignore the directory.

Allow passing in an option to the CG and SBOM tasks to ignore certain directories from scanning.

