### PR TITLE
[release/6.0] Add native tools to path for current build step

### DIFF
--- a/eng/common/init-tools-native.ps1
+++ b/eng/common/init-tools-native.ps1
@@ -112,6 +112,7 @@ try {
             $ToolPath = Convert-Path -Path $BinPath
             Write-Host "Adding $ToolName to the path ($ToolPath)..."
             Write-Host "##vso[task.prependpath]$ToolPath"
+            $env:PATH = "$ToolPath;$env:PATH"
             $InstalledTools += @{ $ToolName = $ToolDirectory.FullName }
           }
         }


### PR DESCRIPTION
## Description

Backporting https://github.com/dotnet/arcade/pull/11030.

## Customer Impact

Fixes a bug in native tools.

## Regression

No

## Risk

None.

## Workarounds

No.