### PR TITLE
Revert "fix invalid job url in logs"

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
@@ -74,10 +74,9 @@
     <PropertyGroup>
       <_AccessTokenSuffix />
       <_AccessTokenSuffix Condition=" '$(HelixAccessToken)' != '' ">&amp;access_token={Get this from helix.dot.net}</_AccessTokenSuffix>
-      <TrimmedHelixBaseUri>[System.String]::Copy('$(HelixBaseUri)').TrimEnd('/')</TrimmedHelixBaseUri>
     </PropertyGroup>
-    <Message Condition=" '$(TrimmedHelixBaseUri)' == '' " Text="Sent Helix Job; see work items at https://helix.dot.net/api/jobs/$(HelixJobId)/workitems?api-version=2019-06-17$(_AccessTokenSuffix)" Importance="High" />
-    <Message Condition=" '$(TrimmedHelixBaseUri)' != '' " Text="Sent Helix Job; see work items at $(TrimmedHelixBaseUri)/api/jobs/$(HelixJobId)/workitems?api-version=2019-06-17$(_AccessTokenSuffix)" Importance="High" />
+    <Message Condition=" '$(HelixBaseUri)' == '' " Text="Sent Helix Job; see work items at https://helix.dot.net/api/jobs/$(HelixJobId)/workitems?api-version=2019-06-17$(_AccessTokenSuffix)" Importance="High" />
+    <Message Condition=" '$(HelixBaseUri)' != '' " Text="Sent Helix Job; see work items at $(HelixBaseUri)/api/jobs/$(HelixJobId)/workitems?api-version=2019-06-17$(_AccessTokenSuffix)" Importance="High" />
   </Target>
 
   <Target Name="Test"


### PR DESCRIPTION
Reverts dotnet/arcade#11041

as per https://github.com/dotnet/arcade/pull/11041#issuecomment-1264086485