### PR TITLE
Allow custom OneLocBuild name suffix

### DIFF
--- a/Documentation/OneLocBuild.md
+++ b/Documentation/OneLocBuild.md
@@ -193,5 +193,6 @@ The parameters that can be passed to the template are as follows:
 | `LclSource` | `LclFilesInRepo` | This passes the `LclSource` input to the OneLocBuild task as described in [its documentation](https://ceapex.visualstudio.com/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task?anchor=languageset%2C-languages-(required)). For most repos, this should be set to `LclFilesfromPackage`. |
 | `LclPackageId` | `''` | When `LclSource` is set to `LclFilesfromPackage`, this passes in the package ID as described in the [OneLocBuild task documentation](https://ceapex.visualstudio.com/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task?anchor=scenario-2%3A-lcl-files-from-a-package). |
 | `condition` | `''` | Allows for conditionalizing the template's steps on build-time variables. |
+| `JobNameSuffix` | `''` | Allows for custom job name suffix. This is helpful for disambiguation in case of need for more then one OneLocBuild job run - e.g. as a way to set multiple package IDs. |
 
 It is recommended that you set `LclSource` and `LclPackageId` as shown in the example above.

--- a/eng/common/templates/job/onelocbuild.yml
+++ b/eng/common/templates/job/onelocbuild.yml
@@ -22,13 +22,14 @@ parameters:
   MirrorRepo: ''
   MirrorBranch: main
   condition: ''
+  JobNameSuffix: ''
 
 jobs:
-- job: OneLocBuild
+- job: OneLocBuild${{ parameters.JobNameSuffix }}
   
   dependsOn: ${{ parameters.dependsOn }}
 
-  displayName: OneLocBuild
+  displayName: OneLocBuild${{ parameters.JobNameSuffix }}
 
   ${{ if ne(parameters.pool, '') }}:
     pool: ${{ parameters.pool }}


### PR DESCRIPTION
Adding optional OneLocBuild job name suffix - to make it possible to have it apper more than once in a pipeline. E.g. when having more then one `LclPackageId`.


### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
