### PR TITLE
[release/3.x] Use netcoreapp3.1 darc for running update-dependencies during validate-sdk steps

### DIFF
--- a/eng/validate-sdk.ps1
+++ b/eng/validate-sdk.ps1
@@ -92,7 +92,7 @@ try {
 
   Write-Host "Updating Dependencies using Darc..."
 
-  . .\common\darc-init.ps1
+  . .\common\darc-init.ps1 -darcVersion "1.1.0-beta.22220.1"
   CheckExitCode "Running darc-init"
 
   $DarcExe = "$env:USERPROFILE\.dotnet\tools"


### PR DESCRIPTION
This is a workaround to unblock flow of the 3.x arcade while we install a 6.0 sdk in the vs 2019 images.

https://github.com/dotnet/arcade/issues/10748

Test build for this change: https://dev.azure.com/dnceng/internal/_build/results?buildId=2012432&view=results

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
