### PR TITLE
[Release/5.0] Work around lack of 6.0 sdk in 2019 build images

### DIFF
--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -266,7 +266,7 @@ stages:
         # If it's not devdiv, it's dnceng
         ${{ else }}:
           name: NetCore1ESPool-Svc-Internal
-          demands: ImageOverride -equals windows.vs2019.amd64
+          demands: ImageOverride -equals 1es-windows-2022
       steps:
         - task: PowerShell@2
           displayName: Publish Using Darc

--- a/eng/update-packagesource.ps1
+++ b/eng/update-packagesource.ps1
@@ -66,7 +66,8 @@ try {
   $DarcExe = "$dotnetRoot\tools"
   Create-Directory $DarcExe
   $DarcExe = Resolve-Path $DarcExe
-  . .\common\darc-init.ps1 -toolpath $DarcExe
+  # TODO: remove hardcoded darc version once The build machines have a 6.0 sdk: https://github.com/dotnet/arcade/issues/10748
+  . .\common\darc-init.ps1 -toolpath $DarcExe -darcVersion "1.1.0-beta.22220.1"
   CheckExitCode "Running darc-init"
 
   $Env:dotnet_root = $dotnetRoot


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/10748

Use an older darc version during the dependency update in the sdk validation stage of the build, and move the publish-using-darc stage to use a vs2022 image that has a 6.0 sdk while we install it in our vs2019 images to unblock flow of arcade in the 5.0 branch.

Test build with these changes: 
https://dev.azure.com/dnceng/internal/_build/results?buildId=2012439&view=results

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation

