### PR TITLE
Use CodeQL 3000 instead of Guardian

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,10 @@
+{  
+    "instanceUrl": "https://devdiv.visualstudio.com/",
+    "template": "TFSDEVDIV",
+    "projectName": "DEVDIV",
+    "areaPath": "DevDiv\\NET Fundamentals\\Infrastructure\\Arcade\\SDL",
+    "iterationPath": "DevDiv",
+    "notificationAliases": [ "dnceng@microsoft.com" ],
+    "repositoryName":"Arcade",
+    "codebaseName": "Arcade"
+}

--- a/azure-pipelines-codeql.yml
+++ b/azure-pipelines-codeql.yml
@@ -1,49 +1,55 @@
+parameters:
+  # Optionally do not publish to TSA. Useful for e.g. verifying fixes before PR.
+- name: Codeql.TSAEnabled
+  displayName: Publish results to TSA
+  type: boolean
+  default: true
+
 variables:
-  - name: _TeamName
-    value: DotNetCore
-  - group: SDL_Settings
-    
+- template: eng/common-variables.yml
+  # CG is handled in the primary CI pipeline
+- name: skipComponentGovernanceDetection
+  value: true
+  # Force CodeQL enabled so it may be run on any branch
+- name: Codeql.Enabled
+  value: true
+- name: Codeql.Cadence
+  value: 0
+
 trigger: none
 
 schedules:
   - cron: 0 12 * * 1
-    displayName: Weekly Monday CodeQL/Semmle run
+    displayName: Weekly Monday CodeQL run
     branches:
       include:
       - main
     always: true
 
-stages:
-- stage: build
-  displayName: Build
-  # Three phases for each of the three OSes we want to run on
-  jobs:
-  - template: /eng/common/templates/jobs/codeql-build.yml
-    parameters:
-      jobs:
-      - job: Windows_NT_CSharp
-        timeoutInMinutes: 90
-        pool:
-          name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals windows.vs2019.amd64
+jobs:
+- job: codeql_windows
+  displayName: CodeQL (Windows)
+  pool:
+    name: NetCore1ESPool-Internal
+    demands: ImageOverride -equals 1es-windows-2022
+  timeoutInMinutes: 90
 
-        steps:
-        - checkout: self
-          clean: true
+  steps:
 
-        - template: /eng/common/templates/steps/execute-codeql.yml
-          parameters:
-            executeAllSdlToolsScript: 'eng/common/sdl/execute-all-sdl-tools.ps1'
-            buildCommands: 'eng\common\cibuild.cmd -configuration Release -prepareMachine /p:Test=false /p:Sign=false'
-            language: csharp
-            publishGuardianDirectoryToPipeline: true
-            additionalParameters: '-SourceToolsList @("semmle")
-            -TsaInstanceURL $(_TsaInstanceURL)
-            -TsaProjectName $(_TsaProjectName)
-            -TsaNotificationEmail $(_TsaNotificationEmail)
-            -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
-            -TsaBugAreaPath $(_TsaBugAreaPath)
-            -TsaIterationPath $(_TsaIterationPath)
-            -TsaRepositoryName "Arcade"
-            -TsaCodebaseName "Arcade"
-            -TsaPublish $True'
+  - task: UseDotNet@2
+    inputs:
+      useGlobalJson: true
+
+  - task: CodeQL3000Init@0
+    displayName: CodeQL Initialize
+
+  - script: eng\common\cibuild.cmd
+      -configuration $(_BuildConfig)
+      -prepareMachine
+      $(_InternalBuildArgs)
+      /p:Test=false
+    displayName: Windows Build
+
+
+  - task: CodeQL3000Finalize@0
+    displayName: CodeQL Finalize

--- a/azure-pipelines-codeql.yml
+++ b/azure-pipelines-codeql.yml
@@ -13,6 +13,7 @@ variables:
   # Force CodeQL enabled so it may be run on any branch
 - name: Codeql.Enabled
   value: true
+  # Do not let CodeQL 3000 Extension gate scan frequency
 - name: Codeql.Cadence
   value: 0
 

--- a/azure-pipelines-codeql.yml
+++ b/azure-pipelines-codeql.yml
@@ -50,7 +50,6 @@ jobs:
   - script: eng\common\cibuild.cmd
       -configuration $(_BuildConfig)
       -prepareMachine
-      $(_InternalBuildArgs)
       /p:Test=false
     displayName: Windows Build
 

--- a/azure-pipelines-codeql.yml
+++ b/azure-pipelines-codeql.yml
@@ -28,6 +28,8 @@ schedules:
     branches:
       include:
       - main
+      - release/6.0
+      - release/7.0
     always: true
 
 jobs:

--- a/azure-pipelines-codeql.yml
+++ b/azure-pipelines-codeql.yml
@@ -16,6 +16,9 @@ variables:
   # Do not let CodeQL 3000 Extension gate scan frequency
 - name: Codeql.Cadence
   value: 0
+  # Build variables
+- name: _BuildConfig
+  value: Release
 
 trigger: none
 
@@ -28,8 +31,8 @@ schedules:
     always: true
 
 jobs:
-- job: codeql_windows
-  displayName: CodeQL (Windows)
+- job: codeql
+  displayName: CodeQL
   pool:
     name: NetCore1ESPool-Internal
     demands: ImageOverride -equals 1es-windows-2022
@@ -50,7 +53,6 @@ jobs:
       $(_InternalBuildArgs)
       /p:Test=false
     displayName: Windows Build
-
 
   - task: CodeQL3000Finalize@0
     displayName: CodeQL Finalize


### PR DESCRIPTION
Swap Guardian for CodeQL 3000 Azure DevOps extension for CodeQL static code analysis.

Successful test build (minus TSA publish): [Pipelines - Run 2012728](https://dev.azure.com/dnceng/internal/_build/results?buildId=2012728&view=results)

Part of [dotnet/arcade#11151](https://github.com/dotnet/arcade/issues/11151)