### PR TITLE
Tweaks to codeQL pipeline for getting reporting turned on

### DIFF
--- a/azure-pipelines-codeql.yml
+++ b/azure-pipelines-codeql.yml
@@ -1,6 +1,6 @@
 parameters:
   # Optionally do not publish to TSA. Useful for e.g. verifying fixes before PR.
-- name: Codeql.TSAEnabled
+- name: TSAEnabled
   displayName: Publish results to TSA
   type: boolean
   default: true
@@ -16,6 +16,10 @@ variables:
   # Do not let CodeQL 3000 Extension gate scan frequency
 - name: Codeql.Cadence
   value: 0
+  # CodeQL needs this plumbed along as a variable to enable TSA
+- name: Codeql.TSAEnabled
+  value: ${{ parameters.TSAEnabled }}
+
   # Build variables
 - name: _BuildConfig
   value: Release


### PR DESCRIPTION
TSA reporting doesn't seem to honor the parameters.  From experimenting, setting the parameter into a variable works around this.

https://github.com/dotnet/arcade/issues/11151

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
