### PR TITLE
Setting GlobalNugetCache to false

### DIFF
--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -27,6 +27,7 @@ Param(
   [string] $runtimeSourceFeedKey = '',
   [switch] $excludePrereleaseVS,
   [switch] $nativeToolsOnMachine,
+  [switch] $useGlobalNuGetCache = $false,
   [switch] $help,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation

By default, this has to be set to false. We are experiencing errors in some repos like Fsharp, VS-Debugger during SBOM generation. 

We cannot set this value when we call the CIBuild.cmd

This is where we set the value https://github.com/dotnet/arcade/blob/1dc30c0321a8c97f1dae05829fb78138575ef163/eng/common/tools.ps1#L49

but for some reason the GlobalNugetCache is not set to false. 

