### PR TITLE
Move from Guardian to CodeQL 3000 version of CodeQL execution

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,10 @@
+{  
+    "instanceUrl": "https://devdiv.visualstudio.com/",
+    "template": "TFSDEVDIV",
+    "projectName": "DEVDIV",
+    "areaPath": "DevDiv\\NET Fundamentals\\Infrastructure\\Arcade\\SDL",
+    "iterationPath": "DevDiv",
+    "notificationAliases": [ "dnceng@microsoft.com" ],
+    "repositoryName":"Arcade",
+    "codebaseName": "Arcade"
+}

--- a/azure-pipelines-codeql.yml
+++ b/azure-pipelines-codeql.yml
@@ -1,47 +1,63 @@
+parameters:
+  # Optionally do not publish to TSA. Useful for e.g. verifying fixes before PR.
+- name: TSAEnabled
+  displayName: Publish results to TSA
+  type: boolean
+  default: true
+
 variables:
-  - name: _TeamName
-    value: DotNetCore
-  - group: SDL_Settings
-    
+- template: eng/common-variables.yml
+  # CG is handled in the primary CI pipeline
+- name: skipComponentGovernanceDetection
+  value: true
+  # Force CodeQL enabled so it may be run on any branch
+- name: Codeql.Enabled
+  value: true
+  # Do not let CodeQL 3000 Extension gate scan frequency
+- name: Codeql.Cadence
+  value: 0
+  # CodeQL needs this plumbed along as a variable to enable TSA
+- name: Codeql.TSAEnabled
+  value: ${{ parameters.TSAEnabled }}
+
+  # Build variables
+- name: _BuildConfig
+  value: Release
+
 trigger: none
 
 schedules:
   - cron: 0 12 * * 1
-    displayName: Weekly Monday CodeQL/Semmle run
+    displayName: Weekly Monday CodeQL run
     branches:
       include:
+      - main
       - release/6.0
+      - release/7.0
     always: true
 
-stages:
-- stage: build
-  displayName: Build
-  jobs:
-  - template: /eng/common/templates/jobs/codeql-build.yml
-    parameters:
-      jobs:
-      - job: Windows_NT_CSharp
-        timeoutInMinutes: 90
-        pool:
-          name: NetCore1ESPool-Svc-Internal
-          demands: ImageOverride -equals windows.vs2019.amd64
+jobs:
+- job: codeql
+  displayName: CodeQL
+  pool:
+    name: NetCore1ESPool-Svc-Internal
+    demands: ImageOverride -equals 1es-windows-2022
+  timeoutInMinutes: 90
 
-        steps:
-        - checkout: self
-          clean: true
+  steps:
 
-        - template: /eng/common/templates/steps/execute-codeql.yml
-          parameters:
-            executeAllSdlToolsScript: 'eng/common/sdl/execute-all-sdl-tools.ps1'
-            buildCommands: 'eng\common\cibuild.cmd -configuration Release -prepareMachine /p:Test=false /p:Sign=false'
-            language: csharp
-            additionalParameters: '-SourceToolsList @("semmle")
-            -TsaInstanceURL $(_TsaInstanceURL)
-            -TsaProjectName $(_TsaProjectName)
-            -TsaNotificationEmail $(_TsaNotificationEmail)
-            -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
-            -TsaBugAreaPath $(_TsaBugAreaPath)
-            -TsaIterationPath $(_TsaIterationPath)
-            -TsaRepositoryName "Arcade"
-            -TsaCodebaseName "Arcade"
-            -TsaPublish $True'
+  - task: UseDotNet@2
+    inputs:
+      useGlobalJson: true
+
+  - task: CodeQL3000Init@0
+    displayName: CodeQL Initialize
+
+  - script: eng\common\cibuild.cmd
+      -configuration $(_BuildConfig)
+      -prepareMachine
+      /p:Test=false
+    displayName: Windows Build
+
+  - task: CodeQL3000Finalize@0
+    displayName: CodeQL Finalize


### PR DESCRIPTION

See https://github.com/dotnet/arcade/issues/11151 for context.  
### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
Test execution: https://dnceng.visualstudio.com/internal/_build/results?buildId=2016722&view=results