### PR TITLE
Add bash version of `Get-Darc` to `tools.sh`

### DIFF
--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -497,11 +497,11 @@ function GetDarc {
     darc_path="$temp_dir/darc"
     version="$1"
 
-    if [[ -z "$version" ]]; then
-      "$eng_root/common/darc-init.sh" --toolpath "$darc_path"
-    else
-      "$eng_root/common/darc-init.sh" --toolpath "$darc_path" -darcversion "$version"
+    if [[ -n "$version" ]]; then
+      version="--darcversion $version"
     fi
+
+    "$eng_root/common/darc-init.sh" --toolpath "$darc_path" $version
 }
 
 ResolvePath "${BASH_SOURCE[0]}"

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -493,6 +493,17 @@ function MSBuild-Core {
   RunBuildTool "$_InitializeBuildToolCommand" /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse $warnaserror_switch /p:TreatWarningsAsErrors=$warn_as_error /p:ContinuousIntegrationBuild=$ci "$@"
 }
 
+function GetDarc {
+    darc_path="$temp_dir/darc"
+    version="$1"
+
+    if [[ -z "$version" ]]; then
+      "$eng_root/common/darc-init.sh" --toolpath "$darc_path"
+    else
+      "$eng_root/common/darc-init.sh" --toolpath "$darc_path" -darcversion "$version"
+    fi
+}
+
 ResolvePath "${BASH_SOURCE[0]}"
 _script_dir=`dirname "$_ResolvePath"`
 


### PR DESCRIPTION
I will need to also use `darc` on Linux

Windows version is already there: https://github.com/dotnet/arcade/blob/32f13f8a8af8085ca09fbf93513ac848582c4a41/eng/common/tools.ps1#L858-L866