### PR TITLE
Add TaskCanceledException to the reasons we retry in DownloadFile tas…

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs
@@ -160,7 +160,13 @@ namespace Microsoft.DotNet.Arcade.Sdk
 
                     return true;
                 }
-                catch (Exception e) when (e is HttpRequestException || e is IOException && !(e is DirectoryNotFoundException || e is PathTooLongException))
+                // Retry cases:
+                // 1. Plain Http error
+                // 2. IOExceptions that aren't definitely deterministic (such as antivirus was scanning the file)
+                // 3. HttpClient Timeouts - these surface as TaskCanceledExceptions that don't match our cancellation token source
+                catch (Exception e) when (e is HttpRequestException ||  
+                                          e is IOException && !(e is DirectoryNotFoundException || e is PathTooLongException) ||
+                                          e is Tasks.TaskCanceledException && ((Tasks.TaskCanceledException)e).CancellationToken != _cancellationSource.Token)
                 {
                     attempt++;
 


### PR DESCRIPTION
…k (#10542)

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
