### PR TITLE
Fix the target framework in the msi.proj now that net5.0 is unsupported by the sdk

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Misc/msi.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Misc/msi.csproj
@@ -20,7 +20,7 @@
     <PackageType>DotnetPlatform</PackageType>
     <PackageVersion>__PACKAGE_VERSION__</PackageVersion>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
See the failures in https://github.com/dotnet/emsdk/pull/238/checks?check_run_id=8896780677

cc @mmitche 