### PR TITLE
Automatically switch to -Svc pool provider for branch/ target-branch named 'release'

### DIFF
--- a/azure-pipelines-code-mirror.yml
+++ b/azure-pipelines-code-mirror.yml
@@ -3,6 +3,7 @@ trigger: none
 
 variables:
   - group: Mirror-Credentials
+  - template: eng/common/templates/variables/pool-providers.yml
 
 # Moves code from GitHub into internal repos
 jobs:
@@ -19,7 +20,7 @@ jobs:
           demands: Cmd
         # If it's not devdiv, it's dnceng
         ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
-          name: NetCore1ESPool-Internal
+          name: $(DncEngInternalBuildPool)
           demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
       variables:
       - name: WorkingDirectoryName

--- a/azure-pipelines-codeql.yml
+++ b/azure-pipelines-codeql.yml
@@ -7,6 +7,7 @@ parameters:
 
 variables:
 - template: eng/common-variables.yml
+- template: eng/common/templates/variables/pool-providers.yml
   # CG is handled in the primary CI pipeline
 - name: skipComponentGovernanceDetection
   value: true
@@ -40,7 +41,7 @@ jobs:
 - job: codeql
   displayName: CodeQL
   pool:
-    name: NetCore1ESPool-Internal
+    name: $(DncEngInternalBuildPool)
     demands: ImageOverride -equals 1es-windows-2022
   timeoutInMinutes: 90
 

--- a/azure-pipelines-merge-mirror.yml
+++ b/azure-pipelines-merge-mirror.yml
@@ -3,6 +3,7 @@ trigger: none
 
 variables:
   - group: Mirror-Credentials
+  - template: eng/common/templates/variables/pool-providers.yml
 
 # Merges code from GitHub into internal branches in internal repos
 jobs:
@@ -19,7 +20,7 @@ jobs:
           demands: Cmd
         # If it's not devdiv, it's dnceng
         ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
-          name: NetCore1ESPool-Internal
+          name: $(DncEngInternalBuildPool)
           demands: ImageOverride -equals windows.vs2019.amd64
       variables:
       - name: WorkingDirectoryName

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -10,6 +10,7 @@ pr: none
 
 variables:
 - template: eng/common-variables.yml
+- template: eng/common/templates/variables/pool-providers.yml
 
 stages:
 - stage: build
@@ -24,7 +25,7 @@ stages:
       - job: Windows_NT
         timeoutInMinutes: 90
         pool:
-          name: NetCore-Public
+          name: $(DncEngPublicBuildPool)
           demands: ImageOverride -equals windows.vs2019.amd64.open
         preSteps:
         - checkout: self

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,7 @@ pr:
 
 variables:
 - template: eng/common-variables.yml
+- template: eng/common/templates/variables/pool-providers.yml
 
 resources:
   containers:
@@ -55,7 +56,7 @@ stages:
           ${{ if eq(variables._RunAsPublic, True) }}:
             vmImage: windows-latest
           ${{ if eq(variables._RunAsInternal, True) }}:
-            name: NetCore1ESPool-Internal
+            name: $(DncEngInternalBuildPool)
             demands: ImageOverride -equals windows.vs2019.amd64
         strategy:
           matrix:

--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -46,6 +46,7 @@ jobs:
     - template: /eng/common/templates/variables/sdl-variables.yml
     - name: GuardianVersion
       value: ${{ coalesce(parameters.overrideGuardianVersion, '$(DefaultGuardianVersion)') }}
+    - template: /eng/common/templates/variables/pool-providers.yml
   pool:
     # We don't use the collection uri here because it might vary (.visualstudio.com vs. dev.azure.com)
     ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
@@ -53,7 +54,7 @@ jobs:
       demands: Cmd
     # If it's not devdiv, it's dnceng
     ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
-      name: NetCore1ESPool-Internal
+      name: $(DncEngInternalBuildPool)
       demands: ImageOverride -equals windows.vs2019.amd64
   steps:
   - checkout: self

--- a/eng/common/templates/job/onelocbuild.yml
+++ b/eng/common/templates/job/onelocbuild.yml
@@ -31,6 +31,17 @@ jobs:
 
   displayName: OneLocBuild${{ parameters.JobNameSuffix }}
 
+  variables:
+    - group: OneLocBuildVariables # Contains the CeapexPat and GithubPat
+    - name: _GenerateLocProjectArguments
+      value: -SourcesDirectory ${{ parameters.SourcesDirectory }}
+        -LanguageSet "${{ parameters.LanguageSet }}"
+        -CreateNeutralXlfs
+    - ${{ if eq(parameters.UseCheckedInLocProjectJson, 'true') }}:
+      - name: _GenerateLocProjectArguments
+        value: ${{ variables._GenerateLocProjectArguments }} -UseCheckedInLocProjectJson
+    - template: /eng/common/templates/variables/pool-providers.yml
+
   ${{ if ne(parameters.pool, '') }}:
     pool: ${{ parameters.pool }}
   ${{ if eq(parameters.pool, '') }}:
@@ -41,19 +52,8 @@ jobs:
         demands: Cmd
       # If it's not devdiv, it's dnceng
       ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
-        name: NetCore1ESPool-Internal
+        name: $(DncEngInternalBuildPool)
         demands: ImageOverride -equals windows.vs2019.amd64
-
-  variables:
-    - group: OneLocBuildVariables # Contains the CeapexPat and GithubPat
-    - name: _GenerateLocProjectArguments
-      value: -SourcesDirectory ${{ parameters.SourcesDirectory }}
-        -LanguageSet "${{ parameters.LanguageSet }}"
-        -CreateNeutralXlfs
-    - ${{ if eq(parameters.UseCheckedInLocProjectJson, 'true') }}:
-      - name: _GenerateLocProjectArguments
-        value: ${{ variables._GenerateLocProjectArguments }} -UseCheckedInLocProjectJson
-      
 
   steps:
     - task: Powershell@2

--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -40,9 +40,8 @@ jobs:
   ${{ else }}:
     displayName: Publish to Build Asset Registry
 
-  pool: ${{ parameters.pool }}
-
   variables:
+  - template: /eng/common/templates/variables/pool-providers.yml
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - group: Publish-Build-Assets
     - group: AzureDevOps-Artifact-Feeds-Pats
@@ -50,6 +49,16 @@ jobs:
       value: false
     - ${{ if eq(parameters.publishAssetsImmediately, 'true') }}:
       - template: /eng/common/templates/post-build/common-variables.yml
+
+  pool:
+    # We don't use the collection uri here because it might vary (.visualstudio.com vs. dev.azure.com)
+    ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+      name: VSEngSS-MicroBuild2022-1ES
+      demands: Cmd
+    # If it's not devdiv, it's dnceng
+    ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
+      name: $(DncEngInternalBuildPool)
+      demands: ImageOverride -equals windows.vs2019.amd64
 
   steps:
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/common/templates/job/source-build.yml
+++ b/eng/common/templates/job/source-build.yml
@@ -34,6 +34,8 @@ parameters:
 jobs:
 - job: ${{ parameters.jobNamePrefix }}_${{ parameters.platform.name }}
   displayName: Source-Build (${{ parameters.platform.name }})
+  variables:
+    - template: /eng/common/templates/variables/pool-providers.yml
 
   ${{ each property in parameters.platform.jobProperties }}:
     ${{ property.key }}: ${{ property.value }}
@@ -46,10 +48,10 @@ jobs:
     # source-build builds run in Docker, including the default managed platform.
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: NetCore-Public
+        name: $(DncEngPublicBuildPool)
         demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        name: NetCore1ESPool-Internal
+        name: $(DncEngInternalBuildPool)
         demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
   ${{ if ne(parameters.platform.pool, '') }}:
     pool: ${{ parameters.platform.pool }}

--- a/eng/common/templates/job/source-index-stage1.yml
+++ b/eng/common/templates/job/source-index-stage1.yml
@@ -22,16 +22,17 @@ jobs:
     value: ${{ parameters.binlogPath }}
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - group: source-dot-net stage1 variables
+  - template: /eng/common/templates/variables/pool-providers.yml
 
   ${{ if ne(parameters.pool, '') }}:
     pool: ${{ parameters.pool }}
   ${{ if eq(parameters.pool, '') }}:
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: NetCore-Public
+        name: $(DncEngPublicBuildPool)
         demands: ImageOverride -equals windows.vs2019.amd64.open
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        name: NetCore1ESPool-Internal
+        name: $(DncEngInternalBuildPool)
         demands: ImageOverride -equals windows.vs2019.amd64
 
   steps:

--- a/eng/common/templates/jobs/jobs.yml
+++ b/eng/common/templates/jobs/jobs.yml
@@ -88,15 +88,6 @@ jobs:
             - ${{ job.job }}
         - ${{ if eq(parameters.enableSourceBuild, true) }}:
           - Source_Build_Complete
-        pool:
-          # We don't use the collection uri here because it might vary (.visualstudio.com vs. dev.azure.com)
-          ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
-            name: VSEngSS-MicroBuild2022-1ES
-            demands: Cmd
-          # If it's not devdiv, it's dnceng
-          ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
-            name: NetCore1ESPool-Internal
-            demands: ImageOverride -equals windows.vs2019.amd64
 
         runAsPublic: ${{ parameters.runAsPublic }}
         publishUsingPipelines: ${{ parameters.enablePublishUsingPipelines }}

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -95,6 +95,7 @@ stages:
     displayName: Validate Build Assets
     variables:
       - template: common-variables.yml
+      - template: /eng/common/templates/variables/pool-providers.yml
     jobs:
     - job:
       displayName: NuGet Validation
@@ -106,7 +107,7 @@ stages:
           demands: Cmd
         # If it's not devdiv, it's dnceng
         ${{ else }}:
-          name: NetCore1ESPool-Internal
+          name: $(DncEngInternalBuildPool)
           demands: ImageOverride -equals windows.vs2019.amd64
 
       steps:
@@ -143,7 +144,7 @@ stages:
           demands: Cmd
         # If it's not devdiv, it's dnceng
         ${{ else }}:
-          name: NetCore1ESPool-Internal
+          name: $(DncEngInternalBuildPool)
           demands: ImageOverride -equals windows.vs2019.amd64
       steps:
         - template: setup-maestro-vars.yml
@@ -203,7 +204,7 @@ stages:
           demands: Cmd
         # If it's not devdiv, it's dnceng
         ${{ else }}:
-          name: NetCore1ESPool-Internal
+          name: $(DncEngInternalBuildPool)
           demands: ImageOverride -equals windows.vs2019.amd64
       steps:
         - template: setup-maestro-vars.yml
@@ -262,7 +263,7 @@ stages:
           demands: Cmd
         # If it's not devdiv, it's dnceng
         ${{ else }}:
-          name: NetCore1ESPool-Internal
+          name: $(DncEngInternalBuildPool)
           demands: ImageOverride -equals windows.vs2019.amd64
       steps:
         - template: setup-maestro-vars.yml

--- a/eng/common/templates/variables/pool-providers.yml
+++ b/eng/common/templates/variables/pool-providers.yml
@@ -1,0 +1,48 @@
+# Select a pool provider based off branch name. Anything with branch name containing 'release' must go into an -Svc pool, 
+# otherwise it should go into the "normal" pools. This separates out the queueing and billing of released branches.
+
+# Motivation: 
+#   Once a given branch of a repository's output has been officially "shipped" once, it is then considered to be COGS
+#   (Cost of goods sold) and should be moved to a servicing pool provider. This allows both separation of queueing
+#   (allowing release builds and main PR builds to not intefere with each other) and billing (required for COGS.
+#   Additionally, the pool provider name itself may be subject to change when the .NET Core Engineering Services 
+#   team needs to move resources around and create new and potentially differently-named pools. Using this template 
+#   file from an Arcade-ified repo helps guard against both having to update one's release/* branches and renaming.
+
+# How to use: 
+#  This yaml assumes your shipped product branches use the naming convention "release/..." (which many do).
+#  If we find alternate naming conventions in broad usage it can be added to the condition below.
+#
+#  First, import the template in an arcade-ified repo to pick up the variables, e.g.:
+#
+#  variables:
+#  - template: eng/common/templates/variables/pool-providers.yml
+#
+#  ... then anywhere specifying the pool provider use the runtime variables,
+#      $(DncEngInternalBuildPool) and $  (DncEngPublicBuildPool), e.g.:
+#
+#        pool:
+#           name: $(DncEngInternalBuildPool)
+#           demands: ImageOverride -equals windows.vs2019.amd64
+
+variables:
+# Coalesce the target and source branches so we know when a PR targets a release branch
+# If these variables are somehow missing, fall back to main (tends to have more capacity)
+- name: BranchNameForPoolSelection
+  value: ${{ coalesce(variables['System.PullRequest.TargetBranch'], variables['Build.SourceBranch'], 'refs/heads/main') }}
+
+# Any new -Svc alternative pools should have variables added here to allow for splitting work
+
+# Main branch pools
+- ${{ if ne(contains(variables['BranchNameForPoolSelection'], 'release'), true) }}:
+  - name: DncEngPublicBuildPool
+    value: NetCore-Public
+  - name: DncEngInternalBuildPool
+    value: NetCore1ESPool-Internal
+
+# Release branch pools
+- ${{ if contains(variables['BranchNameForPoolSelection'], 'release') }}:
+  - name: DncEngPublicBuildPool
+    value: NetCore-Svc-Public
+  - name: DncEngInternalBuildPool
+    value: NetCore1ESPool-Svc-Internal

--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -36,7 +36,9 @@ stages:
           name: VSEngSS-MicroBuild2022-1ES
           demands: Cmd
         # If it's not devdiv, it's dnceng: 
-        # If useServicingBuildPools = false, it's a main branch:
+        # Publishing cannot use eng/common/templates/variables/pool-providers.yml since it always runs from 'main',
+        # including in the servicing build case.  Instead the 'useServicingBuildPools' parameter dictates this.
+        # If useServicingBuildPools = false, it's a main branch. 
         ${{ if and(ne(variables['System.TeamProject'], 'DevDiv'), eq(parameters['useServicingBuildPools'], false)) }}:
           name: NetCore1ESPool-Internal
           demands: ImageOverride -equals windows.vs2019.amd64

--- a/eng/validate-sdk.yml
+++ b/eng/validate-sdk.yml
@@ -18,15 +18,16 @@ jobs:
         logs:
           name: Logs_ValidateSdk_Windows_NT_Release
     timeoutInMinutes: 90
-    pool:
-      name: NetCore1ESPool-Internal
-      demands: ImageOverride -equals windows.vs2019.amd64
     variables:
     - group: DotNet-Blob-Feed
     - group: Publish-Build-Assets
     - _BuildConfig: ${{ parameters.buildConfig }}
     - _BuildArgs: ${{ parameters.buildArgs }}
     - _ValidateBlobFeedUrl: ${{ parameters.validateBlobFeedUrl }}
+    - template: eng/common/templates/variables/pool-providers.yml
+    pool:
+      name: $(DncEngInternalBuildPool)
+      demands: ImageOverride -equals windows.vs2019.amd64
     preSteps:
     - checkout: self
       clean: true


### PR DESCRIPTION
See https://github.com/dotnet/arcade/issues/10839 for context.  This should prevent having to change these values in the future, or at a minimum make it so we only change them in one place.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation (see below)

## Testing scenarios:

I have endeavored to try out these changes everywhere arcade builds to prevent surprises.

### Main pipelines:
public
- [x] main named branch - (this PR) : https://dev.azure.com/dnceng-public/public/_build/results?buildId=57366&view=logs&j=a42fc470-5bd4-55f5-67d4-2dbd2090fa57
- [x] release/ named branch - Can't really test this before .NET 8 branches without setting up a PR flow for a fake branch; not porting this to older branches as it's not needed there.

internal
- [x] main named branch -  https://dnceng.visualstudio.com/internal/_build/results?buildId=2025106&view=results
- [x] release/ named branch - https://dnceng.visualstudio.com/internal/_build/results?buildId=2025102&view=results

### Custom pipelines: (all using main-named branches)

- [x] code-mirror - https://dnceng.visualstudio.com/internal/_build/results?buildId=2025115&view=results
- [x] codeql - https://dnceng.visualstudio.com/internal/_build/results?buildId=2025117&view=results
- [x] merge-mirror - https://dnceng.visualstudio.com/internal/_build/results?buildId=2025119&view=results
- [x] richnav - N/A: does not appear to have a pipeline associated with it

