### PR TITLE
Eliminate unnecessary legs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -227,8 +227,8 @@ stages:
             vmimage: ubuntu-latest
           strategy:
             matrix:
-              Build_Release:
-                _BuildConfig: Release
+              Build_Debug:
+                _BuildConfig: Debug
           variables:
           - _Testing: XHarness_Apple_Device_Tests
           preSteps:
@@ -257,8 +257,8 @@ stages:
             vmimage: ubuntu-latest
           strategy:
             matrix:
-              Build_Release:
-                _BuildConfig: Release
+              Build_Debug:
+                _BuildConfig: Debug
           variables:
           - _Testing: XHarness_Android_Simulator_Tests
           preSteps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -286,8 +286,8 @@ stages:
             vmimage: windows-latest
           strategy:
             matrix:
-              Build_Debug:
-                _BuildConfig: Debug
+              Build_Release:
+                _BuildConfig: Release
           variables:
           - _Testing: XHarness_Android_Device_Tests
           preSteps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,9 +61,6 @@ stages:
           matrix:
             Build_Release:
               _BuildConfig: Release
-            ${{ if eq(variables._RunAsPublic, True) }}:
-              Build_Debug:
-                _BuildConfig: Debug
         preSteps:
         - checkout: self
           clean: true
@@ -84,8 +81,6 @@ stages:
             matrix:
               Build_Debug:
                 _BuildConfig: Debug
-              Build_Release:
-                _BuildConfig: Release
           preSteps:
           - checkout: self
             clean: true
@@ -118,8 +113,6 @@ stages:
             matrix:
               Build_Release:
                 _BuildConfig: Release
-              Build_Debug:
-                _BuildConfig: Debug
           variables:
           - _Testing: Helix
           preSteps:
@@ -162,8 +155,6 @@ stages:
             matrix:
               Build_Debug:
                 _BuildConfig: Debug
-              Build_Release:
-                _BuildConfig: Release
           variables:
           - _Testing: Helix
           preSteps:


### PR DESCRIPTION
I took a look at the Kusto data for arcade, to try and see how correlated failures in some configurations are. It turns out the failure rates for our Debug/Release pairs for Linux and Windows fail at the same rate. That basically just means that we should be able to eliminate one without affecting quality. This should improve reliability and reduce VM/helix usage.

I left Windows_Release and Linux_Debug to cover the official build as well as Debug build configurations.

Raw data on main from last year (PR or otherwise)

```
Windows_NT Build_Debug	    succeeded	        1713
Windows_NT Build_Debug	    failed	            69
Windows_NT Build_Debug	    succeededWithIssues	8
Windows_NT Build_Debug	    canceled	        3
Windows_NT Build_Release	succeeded	        1706
Windows_NT Build_Release	succeededWithIssues	12
Windows_NT Build_Release	failed	            71
Windows_NT Build_Release	canceled	        4

Linux Build_Debug	        succeeded	        1678
Linux Build_Debug	        succeededWithIssues	26
Linux Build_Debug	        failed	            88
Linux Build_Debug	        canceled	        1
Linux Build_Release	        succeeded	        1691
Linux Build_Release	        succeededWithIssues	18
Linux Build_Release	        failed	            83
Linux Build_Release	        canceled	        1
```

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
