### PR TITLE
Set DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1 for any build.sh path

### DIFF
--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -417,12 +417,11 @@ function MSBuild {
       Write-PipelineSetVariable -name "NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS" -value "20"
       Write-PipelineSetVariable -name "NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS" -value "20"
 
-      export NUGET_ENABLE_EXPERIMENTAL_HTTP_RETRY=true
-      export NUGET_EXPERIMENTAL_MAX_NETWORK_TRY_COUNT=6
-      export NUGET_EXPERIMENTAL_NETWORK_RETRY_DELAY_MILLISECONDS=1000
-      Write-PipelineSetVariable -name "NUGET_ENABLE_EXPERIMENTAL_HTTP_RETRY" -value "true"
-      Write-PipelineSetVariable -name "NUGET_EXPERIMENTAL_MAX_NETWORK_TRY_COUNT" -value "6"
-      Write-PipelineSetVariable -name "NUGET_EXPERIMENTAL_NETWORK_RETRY_DELAY_MILLISECONDS" -value "1000"
+      # https://github.com/dotnet/arcade/issues/11369 - disable new MSBuild server feature on linux
+      # This feature is new and can result in build failures from connection timeout errors.
+      export DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1
+      Write-PipelineSetVariable -name "DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER" -value "1"
+
     fi
 
     local toolset_dir="${_InitializeToolset%/*}"


### PR DESCRIPTION
This feature is flaky and randomly breaks builds in its current form.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation (tested by PR code path)
