### PR TITLE
Update Guardian CLI version to latest 

### DIFF
--- a/eng/common/sdl/packages.config
+++ b/eng/common/sdl/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Guardian.Cli" version="0.109.0"/>
+  <package id="Microsoft.Guardian.Cli" version="0.130.0"/>
 </packages>

--- a/eng/common/templates/variables/sdl-variables.yml
+++ b/eng/common/templates/variables/sdl-variables.yml
@@ -2,6 +2,6 @@ variables:
 # The Guardian version specified in 'eng/common/sdl/packages.config'. This value must be kept in
 # sync with the packages.config file.
 - name: DefaultGuardianVersion
-  value: 0.109.0
+  value: 0.130.0
 - name: GuardianPackagesConfigFile
   value: $(Build.SourcesDirectory)\eng\common\sdl\packages.config


### PR DESCRIPTION
(the certificate it uses for communication expired 10/8/2022)

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
