### PR TITLE
Port https://github.com/dotnet/arcade/pull/10451 changes to rel/6.0

### DIFF
--- a/eng/common/sdl/sdl.ps1
+++ b/eng/common/sdl/sdl.ps1
@@ -1,0 +1,38 @@
+
+function Install-Gdn {
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$Path,
+
+        # If omitted, install the latest version of Guardian, otherwise install that specific version.
+        [string]$Version
+    )
+
+    $ErrorActionPreference = 'Stop'
+    Set-StrictMode -Version 2.0
+    $disableConfigureToolsetImport = $true
+    $global:LASTEXITCODE = 0
+
+    # `tools.ps1` checks $ci to perform some actions. Since the SDL
+    # scripts don't necessarily execute in the same agent that run the
+    # build.ps1/sh script this variable isn't automatically set.
+    $ci = $true
+    . $PSScriptRoot\..\tools.ps1
+
+    $argumentList = @("install", "Microsoft.Guardian.Cli", "-Source https://securitytools.pkgs.visualstudio.com/_packaging/Guardian/nuget/v3/index.json", "-OutputDirectory $Path", "-NonInteractive", "-NoCache")
+
+    if ($Version) {
+        $argumentList += "-Version $Version"
+    }
+    
+    Start-Process nuget -Verbose -ArgumentList $argumentList -NoNewWindow -Wait
+
+    $gdnCliPath = Get-ChildItem -Filter guardian.cmd -Recurse -Path $Path
+
+    if (!$gdnCliPath)
+    {
+        Write-PipelineTelemetryError -Category 'Sdl' -Message 'Failure installing Guardian'
+    }
+
+    return $gdnCliPath.FullName
+}

--- a/eng/common/templates/steps/execute-sdl.yml
+++ b/eng/common/templates/steps/execute-sdl.yml
@@ -8,29 +8,28 @@ parameters:
   condition: ''
 
 steps:
-- ${{ if ne(parameters.overrideGuardianVersion, '') }}:
-  - powershell: |
-      $content = Get-Content $(GuardianPackagesConfigFile)
-
-      Write-Host "packages.config content was:`n$content"
-
-      $content = $content.Replace('$(DefaultGuardianVersion)', '$(GuardianVersion)')
-      $content | Set-Content $(GuardianPackagesConfigFile)
-
-      Write-Host "packages.config content updated to:`n$content"
-    displayName: Use overridden Guardian version ${{ parameters.overrideGuardianVersion }}
+- task: NuGetAuthenticate@1
+  inputs:
+    nuGetServiceConnections: GuardianConnect
 
 - task: NuGetToolInstaller@1
   displayName: 'Install NuGet.exe'
   
-- task: NuGetCommand@2
-  displayName: 'Install Guardian'
-  inputs:
-    restoreSolution: $(Build.SourcesDirectory)\eng\common\sdl\packages.config
-    feedsToUse: config
-    nugetConfigPath: $(Build.SourcesDirectory)\eng\common\sdl\NuGet.config
-    externalFeedCredentials: GuardianConnect
-    restoreDirectory: $(Build.SourcesDirectory)\.packages
+- ${{ if ne(parameters.overrideGuardianVersion, '') }}:
+  - pwsh: |
+      Set-Location -Path $(Build.SourcesDirectory)\eng\common\sdl
+      . .\sdl.ps1
+      $guardianCliLocation = Install-Gdn -Path $(Build.SourcesDirectory)\.artifacts -Version ${{ parameters.overrideGuardianVersion }}
+      Write-Host "##vso[task.setvariable variable=GuardianCliLocation]$guardianCliLocation"
+    displayName: Install Guardian (Overridden)
+
+- ${{ if eq(parameters.overrideGuardianVersion, '') }}:
+  - pwsh: |
+      Set-Location -Path $(Build.SourcesDirectory)\eng\common\sdl
+      . .\sdl.ps1
+      $guardianCliLocation = Install-Gdn -Path $(Build.SourcesDirectory)\.artifacts
+      Write-Host "##vso[task.setvariable variable=GuardianCliLocation]$guardianCliLocation"
+    displayName: Install Guardian
 
 - ${{ if ne(parameters.overrideParameters, '') }}:
   - powershell: ${{ parameters.executeAllSdlToolsScript }} ${{ parameters.overrideParameters }}
@@ -40,7 +39,7 @@ steps:
 
 - ${{ if eq(parameters.overrideParameters, '') }}:
   - powershell: ${{ parameters.executeAllSdlToolsScript }}
-      -GuardianPackageName Microsoft.Guardian.Cli.$(GuardianVersion)
+      -GuardianCliLocation $(GuardianCliLocation)
       -NugetPackageDirectory $(Build.SourcesDirectory)\.packages
       -AzureDevOpsAccessToken $(dn-bot-dotnet-build-rw-code-rw)
       ${{ parameters.additionalParameters }}
@@ -62,7 +61,28 @@ steps:
         c
         i
     condition: succeededOrFailed()
+
   - publish: $(Agent.BuildDirectory)/.gdn
     artifact: GuardianConfiguration
     displayName: Publish GuardianConfiguration
+    condition: succeededOrFailed()
+
+  # Publish the SARIF files in a container named CodeAnalysisLogs to enable integration
+  # with the "SARIF SAST Scans Tab" Azure DevOps extension
+  - task: CopyFiles@2
+    displayName: Copy SARIF files
+    inputs:
+      flattenFolders: true
+      sourceFolder:  $(Agent.BuildDirectory)/.gdn/rc/
+      contents: '**/*.sarif'
+      targetFolder: $(Build.SourcesDirectory)/CodeAnalysisLogs
+    condition: succeededOrFailed()
+
+  # Use PublishBuildArtifacts because the SARIF extension only checks this case
+  # see microsoft/sarif-azuredevops-extension#4
+  - task: PublishBuildArtifacts@1
+    displayName: Publish SARIF files to CodeAnalysisLogs container
+    inputs:
+      pathToPublish:  $(Build.SourcesDirectory)/CodeAnalysisLogs
+      artifactName: CodeAnalysisLogs
     condition: succeededOrFailed()


### PR DESCRIPTION
### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation

Arcade Test run of these changes: https://dnceng.visualstudio.com/internal/_build/results?buildId=2029580&view=logs&j=7d9eef18-6720-5c1f-4d30-89d7b76728e9
Arcade-Services test run of these changes: https://dnceng.visualstudio.com/internal/_build/results?buildId=2029572&view=logs&j=7d9eef18-6720-5c1f-4d30-89d7b76728e9&t=66df1a84-4ac1-5ba1-6998-e011cc992fec