### PR TITLE
Add FR / Ops work backlog guidance

### DIFF
--- a/Documentation/Policy/FirstRespondersOpsGuidance.md
+++ b/Documentation/Policy/FirstRespondersOpsGuidance.md
@@ -1,0 +1,42 @@
+# Clarifying First Responders and Operations Epics
+
+Work organized in three backlogs:
+
+## FR Backlog
+
+This is unchanged and operates as today. It prioritizes work that is
+
+- Customer facing
+- Existing service functionality broken
+- Critical Priority "P0"
+
+Its purpose is to unblock customers. That's it.
+
+Work is expected to be short and randomizing. The FR Lead is empowered to reprioritize issues according to need.
+
+## Operations Backlog
+
+Operations handles ongoing work around keeping services up and running ("keeping the trains running"), including
+
+- Important priority "P2"
+- Ensure compliance with company policies, specifically 
+- Implementing features to improve service maintainability
+- Reducing service technical debt
+
+Work is expected to be more "epic style" chunks that are regularly planned. 
+
+## FR / Ops Shared Backlog (aka "FROps")
+
+This backlog provides a home for tasks that are not immediately urgent but must still be completed with a timeframe that would be disruptive for typical epic work. 
+
+FR draws tasks from this backlog after the regular FR backlog is empty. 
+
+Operations draws tasks from this backlog before working on the regular Operations backlog. This means that Operations epics may be more "randomized" than regular epics.
+
+- Customer-impacting but not critical
+- High priority "P1"
+
+Examples:
+
+- New queues
+- Resolving Component Governance issues


### PR DESCRIPTION
Adding doc clarifying work organization between the First Responder and the Operations epics. 