### PR TITLE
Allow backport workflow to be reusable

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,5 +1,6 @@
 name: Backport PR to branch
 on:
+  workflow_call:
   issue_comment:
     types: [created]
   schedule:


### PR DESCRIPTION
This makes it possible to use the workflow from other repos, allowing us to consolidate the workflows.
