### PR TITLE
Suppress a couple warnings coming from automated scans

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/MsiSwixProject.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/MsiSwixProject.wix.cs
@@ -87,7 +87,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
             // For drop publishing all the JSON manifests and payloads must reside in the same folder so we shorten the project names
             // and use a hashed filename to avoid path too long errors.
             string hashInputs = $"{Id},{Version.ToString(3)},{sdkFeatureBand},{Platform},{Chip},{machineArch}";
-            ProjectFile = $"{Utils.GetHash(hashInputs, HashAlgorithmName.MD5)}.swixproj";
+            ProjectFile = $"{Utils.GetHash(hashInputs, HashAlgorithmName.MD5)}.swixproj"; // lgtm [cs/weak-crypto] Hash algorithm used only for determining file uniqueness
 
             ReplacementTokens[SwixTokens.__VS_PAYLOAD_SOURCE__] = msi.GetMetadata(Metadata.FullPath);
         }

--- a/src/Microsoft.DotNet.Helix/Sdk/FindDotNetCliPackage.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/FindDotNetCliPackage.cs
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.Helix.Sdk
         public bool ExecuteTask(HttpMessageHandler httpMessageHandler)
         {
             _httpMessageHandler = httpMessageHandler;
-            _client = new HttpClient(_httpMessageHandler);
+            _client = new HttpClient(_httpMessageHandler); // lgtm [cs/httpclient-checkcertrevlist-disabled] False positive; see above in ConfigureServices(); this is always created with CheckCertificateRevocationList = true
             FindCliPackage().GetAwaiter().GetResult();
             return !Log.HasLoggedErrors;
         }


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
