### PR TITLE
bump vs image for signing validation

### DIFF
--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -145,7 +145,7 @@ stages:
         # If it's not devdiv, it's dnceng
         ${{ else }}:
           name: $(DncEngInternalBuildPool)
-          demands: ImageOverride -equals windows.vs2019.amd64
+          demands: ImageOverride -equals windows.vs2022.amd64
       steps:
         - template: setup-maestro-vars.yml
           parameters:


### PR DESCRIPTION
Bumping VS image for Sign Validation job to VS2022

Needed for dealing with an issue in F#, where 7.0 RC2 requires a newer version of MSBuild

[Failing build log](https://dev.azure.com/dnceng/internal/_build/results?buildId=2036452&view=logs&j=b11b921d-8982-5bb3-754b-b114d42fd804&t=cdcedd1f-8008-523f-9da1-cc35fbfef9a3)
```
D:\a\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\8.0.0-beta.22524.5\tools\SdkTasks\SigningValidation.proj : error : Version 7.0.100-rc.2.22477.23 of the .NET SDK requires at least version 17.3.0 of MSBuild. The current available version of MSBuild is 17.2.1.25201. Change the .NET SDK specified in global.json to an older version that requires the MSBuild version currently available.
```

CC: @dkurepa 