### PR TITLE
Add platform moniker to workload pack MSI

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Msi/WorkloadPackMsi.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Msi/WorkloadPackMsi.wix.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.IO;
+using System.IO.Packaging;
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.Tasks.Workloads.Wix;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
@@ -71,12 +72,9 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Msi
                 throw new Exception(Strings.FailedToCompileMsi);
             }
 
-            // Add the platform to the MSI unless the package name already contains it.
-            string msiFileName = _package.PackageFileName.Contains(Platform) ?
-                Path.Combine(outputPath, _package.ShortName + ".msi") :
-                Path.Combine(outputPath, _package.ShortName + $"-{Platform}.msi");
-
-            ITaskItem msi = Link(candle.OutputPath, msiFileName, iceSuppressions);
+            ITaskItem msi = Link(candle.OutputPath,
+                Path.Combine(outputPath, _package.ShortName + $"-{Platform}.msi"),
+                iceSuppressions);
 
             AddDefaultPackageFiles(msi);
 


### PR DESCRIPTION
We should always add the platform moniker to the generated workload pack MSI. We previously avoided this if the package for the workload pack contained the platform to avoid repeating platform information multiple times.

However, when using aliasing, e.g. taking an x64 pack and repurposing it for arm64, etc. we now end up with duplicate file names that results in conflicts when generating the visual studio manifests.

For example, a manifest like

```json
  "workloads": {
    "microsoft-net-runtime-android-aot": {
      "description": "Android Mono AOT Workload",
      "packs": [
        "Microsoft.NETCore.App.Runtime.AOT.Cross.net6.android-arm64"
      ],
      "platforms": [ "win-x64", "win-arm64", "linux-x64", "osx-x64", "osx-arm64" ]
    }
  },
  "packs": {
    "Microsoft.NETCore.App.Runtime.AOT.Cross.net6.android-arm64": {
      "kind": "Sdk",
      "version": "6.0.11-mauiarm",
      "alias-to": {
        "win-x64": "Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-arm64",
        "win-arm64": "Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-arm64",
        "linux-x64": "Microsoft.NETCore.App.Runtime.AOT.linux-x64.Cross.android-arm64",
        "osx-x64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-arm64",
        "osx-arm64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-arm64"
      }
    }
```

would generate a single MSI named `Microsoft.AOT.win-x64.Cross.android-arm64.6.0.11-mauiarm.msi`. With this change, we'll generate two MSIs instead.

Microsoft.AOT.win-x64.Cross.android-arm64.6.0.11-mauiarm-arm64.msi
Microsoft.AOT.win-x64.Cross.android-arm64.6.0.11-mauiarm-x64.msi
