### PR TITLE
Set vsMajorVersion when provided vs version is too low

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -413,6 +413,7 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
       if($vsMinVersion -lt $vsMinVersionReqd){
         Write-Host "Using xcopy-msbuild version of $defaultXCopyMSBuildVersion since VS version $vsMinVersionStr provided in global.json is not compatible"
         $xcopyMSBuildVersion = $defaultXCopyMSBuildVersion
+        $vsMajorVersion = $xcopyMSBuildVersion.Split('.')[0]
       }
       else{
         # If the VS version IS compatible, look for an xcopy msbuild package


### PR DESCRIPTION
In the "vs version provided in global.json is too low" case when initializing msbuild, we were failing to set the vsMajorVersion, resulting in the issue reported in https://github.com/dotnet/arcade/issues/11383. This change sets vsMajorVersion in that case so that the code path does not immediately fail.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
