### PR TITLE
Do not fail backport if commenting fails

### DIFF
--- a/.github/workflows/backport-base.yml
+++ b/.github/workflows/backport-base.yml
@@ -80,6 +80,7 @@ jobs:
           return target_branch[1];
     - name: Post backport started comment to pull request
       uses: actions/github-script@v6
+      continue-on-error: true
       with:
         script: |
           const target_branch = '${{ steps.target-branch-extractor.outputs.result }}';


### PR DESCRIPTION
When trying to backport an old PR where github already locked the conversation, the commenting step will fail. It's an odd reason to fail backport.

Example of a failed backport: https://github.com/dotnet/runtime/actions/runs/3468792216
