### PR TITLE
Unset platform vars in toolchain file for cmake3.25

### DIFF
--- a/eng/common/cross/toolchain.cmake
+++ b/eng/common/cross/toolchain.cmake
@@ -1,5 +1,12 @@
 set(CROSS_ROOTFS $ENV{ROOTFS_DIR})
 
+# reset platform variables (e.g. cmake 3.25 sets LINUX=1)
+unset(LINUX)
+unset(FREEBSD)
+unset(ILLUMOS)
+unset(ANDROID)
+unset(TIZEN)
+
 set(TARGET_ARCH_NAME $ENV{TARGET_BUILD_ARCH})
 if(EXISTS ${CROSS_ROOTFS}/bin/freebsd-version)
   set(CMAKE_SYSTEM_NAME FreeBSD)


### PR DESCRIPTION
In cmake 3.25, the toolchain file is called with context containing `LINUX` variable set. This causes problem for non-Linux platform. Fix is to unset platform variables which we use in the toolchain file.

Issue: https://github.com/dotnet/runtime/issues/78528