### PR TITLE
Enable retries for `APP_CRASH` results on iOS/AppleTV devices

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-processor.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-processor.py
@@ -125,8 +125,8 @@ def analyze_operation(command: str, platform: str, device: str, is_device: bool,
 
     global retry, reboot, android_connectivity_verified
 
-    # Apps crashing can be infra failures, retry except on Apple devices where retries can be costly due to small queue size
-    if exit_code == 80 and not (platform == "apple" and is_device): # APP_CRASH
+    # Apps crashing can be infra failures too (this is a gray zone)
+    if exit_code == 80: # APP_CRASH
         print(f'    Application crashed - if persist, please investigate system logs from the run')
         retry = True
         reboot = True


### PR DESCRIPTION
Resolves https://github.com/dotnet/arcade/issues/11690

Original issue https://github.com/dotnet/arcade/issues/11683
