### PR TITLE
Increase the timeout for publish using darc

### DIFF
--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -34,6 +34,7 @@ jobs:
 - job: Asset_Registry_Publish
 
   dependsOn: ${{ parameters.dependsOn }}
+  timeoutInMinutes: 150
 
   ${{ if eq(parameters.publishAssetsImmediately, 'true') }}:
     displayName: Publish Assets


### PR DESCRIPTION
The timeout for the actual publishing pipeline job for publish using darc is 120 minutes, where as the pipelines waiting for the publishing job were set to the default (60 minutes). This change increases the timeout of the waiting job to 150 minutes, to account for publishing as well as any communication lag.

In response to https://github.com/dotnet/arcade/issues/11694. This doesn't necessarily fix the issue, but it should mitigate any weirdness where publishing completes successfully, but takes "too long" from the eyes of the waiting pipelines.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
