### PR TITLE
Make GenFacade reference assembly configure-able

### DIFF
--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenPartialFacadeSource.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenPartialFacadeSource.targets
@@ -6,6 +6,7 @@
 
   <PropertyGroup>
     <GenFacadesReferencePathItemName Condition="'$(GenFacadesReferencePathItemName)' == ''">ReferencePath</GenFacadesReferencePathItemName>
+    <GenFacadesReferenceAssemblyItemName Condition="'$(GenFacadesReferenceAssemblyItemName)' == ''">ResolvedMatchingContract</GenFacadesReferenceAssemblyItemName>
     <!-- Tell ResolveMatchingContract to run and resolve contract to project reference -->
     <ResolveMatchingContract>true</ResolveMatchingContract>
     <GeneratePartialFacadeSourceDependsOn>$(GeneratePartialFacadeSourceDependsOn);ResolveMatchingContract;_GetRoslynAssembliesPath</GeneratePartialFacadeSourceDependsOn>
@@ -14,33 +15,29 @@
     <TargetsTriggeredByCompilation Condition="'$(DesignTimeBuild)' != 'true' and '$(GenFacadesForceZeroVersionSeeds)' == 'true'">
       $(TargetsTriggeredByCompilation);ClearAssemblyReferenceVersions
     </TargetsTriggeredByCompilation>
-    <OutputSourcePath>$(IntermediateOutputPath)$(AssemblyTitle).Forwards.cs</OutputSourcePath>
+    <GenFacadesOutputSourcePath Condition="'$(GenFacadesOutputSourcePath)' == ''">$(IntermediateOutputPath)$(AssemblyTitle).Forwards.cs</GenFacadesOutputSourcePath>
   </PropertyGroup>
 
   <Target Name="GeneratePartialFacadeSource"
-          Inputs="$(MSBuildAllProjects);@(ResolvedMatchingContract);@($(GenFacadesReferencePathItemName));@(Compile)"
-          Outputs="$(OutputSourcePath)"
+          Inputs="$(MSBuildAllProjects);@($(GenFacadesReferenceAssemblyItemName));@($(GenFacadesReferencePathItemName));@(Compile)"
+          Outputs="$(GenFacadesOutputSourcePath)"
           DependsOnTargets="$(GeneratePartialFacadeSourceDependsOn)">
-    <PropertyGroup>
-      <ReferenceAssembly>%(ResolvedMatchingContract.Identity)</ReferenceAssembly>
-    </PropertyGroup>
-
     <GenPartialFacadeSource
       ReferencePaths="@($(GenFacadesReferencePathItemName))"
-      ReferenceAssembly="$(ReferenceAssembly)"
+      ReferenceAssembly="@($(GenFacadesReferenceAssemblyItemName))"
       CompileFiles="@(Compile)"
       DefineConstants="$(DefineConstants)"
       LangVersion="$(LangVersion)"
       IgnoreMissingTypes="$(GenFacadesIgnoreMissingTypes)"
       IgnoreMissingTypesList="@(GenFacadesIgnoreMissingType)"
       OmitTypes="@(GenFacadesOmitType)"
-      OutputSourcePath="$(OutputSourcePath)"
+      OutputSourcePath="$(GenFacadesOutputSourcePath)"
       SeedTypePreferences="@(SeedTypePreference)"
       RoslynAssembliesPath="$(RoslynAssembliesPath)" />
 
-    <ItemGroup Condition="Exists('$(OutputSourcePath)')">
-      <Compile Include="$(OutputSourcePath)" />
-      <FileWrites Include="$(OutputSourcePath)" />
+    <ItemGroup Condition="Exists('$(GenFacadesOutputSourcePath)')">
+      <Compile Include="$(GenFacadesOutputSourcePath)" />
+      <FileWrites Include="$(GenFacadesOutputSourcePath)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
... and apply code clean-up. Rename the OutputSourcePath property that could easily collide with other msbuild components. I verified that the property isn't used anywhere in the github.com/dotnet organization.

In dotnet/runtime when ProjectReferencing a source project, we want to compile against the contract project which is resolved via the `ResolvedMatchingContract` item. When we compile the shim projects, we want to preserve that behavior but pass a different reference assembly to GenFacades, i.e. https://github.com/dotnet/runtime/blob/ea4f2cc6190b1fbcc53e27e9b21a91eeea5b7736/src/libraries/shims/Directory.Build.targets#L6

By making the item to use configure-able, we don't need to work with overrides in the resolve contract logic in runtime.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
