### PR TITLE
Delete DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER workaround

### DIFF
--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -416,12 +416,6 @@ function MSBuild {
       export NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS=20
       Write-PipelineSetVariable -name "NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS" -value "20"
       Write-PipelineSetVariable -name "NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS" -value "20"
-
-      # https://github.com/dotnet/arcade/issues/11369 - disable new MSBuild server feature on linux
-      # This feature is new and can result in build failures from connection timeout errors.
-      export DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1
-      Write-PipelineSetVariable -name "DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER" -value "1"
-
     fi
 
     local toolset_dir="${_InitializeToolset%/*}"


### PR DESCRIPTION
This workaround is no longer needed with .NET SDK 7 GA