### PR TITLE
Allow passing in different compile items to GenFacades

### DIFF
--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.PartialFacadeSource.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.PartialFacadeSource.targets
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <Target Name="GeneratePartialFacadeSource"
-          Inputs="$(MSBuildAllProjects);@($(GenFacadesReferenceAssemblyItemName));@($(GenFacadesReferencePathItemName));@(Compile)"
+          Inputs="$(MSBuildAllProjects);@($(GenFacadesReferenceAssemblyItemName));@($(GenFacadesReferencePathItemName));@(GenFacadeCompile)"
           Outputs="$(GenFacadesOutputSourcePath)"
           DependsOnTargets="$(GeneratePartialFacadeSourceDependsOn)">
     <GenPartialFacadeSource

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.PartialFacadeSource.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.PartialFacadeSource.targets
@@ -12,6 +12,11 @@
     <CoreCompileDependsOn Condition="'$(DesignTimeBuild)' != 'true'">$(CoreCompileDependsOn);GeneratePartialFacadeSource</CoreCompileDependsOn>
     <GenFacadesOutputSourcePath Condition="'$(GenFacadesOutputSourcePath)' == ''">$(IntermediateOutputPath)$(AssemblyTitle).Forwards.cs</GenFacadesOutputSourcePath>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <!-- Allow passing in different compile items to GenFacades. -->
+    <GenFacadeCompile Include="@(Compile)" Condition="'@(GenFacadeCompile)' == ''" />
+  </ItemGroup>
 
   <Target Name="GeneratePartialFacadeSource"
           Inputs="$(MSBuildAllProjects);@($(GenFacadesReferenceAssemblyItemName));@($(GenFacadesReferencePathItemName));@(Compile)"
@@ -20,7 +25,7 @@
     <GenPartialFacadeSource
       ReferencePaths="@($(GenFacadesReferencePathItemName))"
       ReferenceAssembly="@($(GenFacadesReferenceAssemblyItemName))"
-      CompileFiles="@(Compile)"
+      CompileFiles="@(GenFacadeCompile)"
       DefineConstants="$(DefineConstants)"
       LangVersion="$(LangVersion)"
       IgnoreMissingTypes="$(GenFacadesIgnoreMissingTypes)"

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.PartialFacadeSource.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.PartialFacadeSource.targets
@@ -8,15 +8,17 @@
     <GenFacadesReferenceAssemblyItemName Condition="'$(GenFacadesReferenceAssemblyItemName)' == ''">ResolvedMatchingContract</GenFacadesReferenceAssemblyItemName>
     <!-- Tell ResolveMatchingContract to run and resolve contract to project reference -->
     <ResolveMatchingContract>true</ResolveMatchingContract>
-    <GeneratePartialFacadeSourceDependsOn>$(GeneratePartialFacadeSourceDependsOn);ResolveMatchingContract;_GetRoslynAssembliesPath</GeneratePartialFacadeSourceDependsOn>
+    <GeneratePartialFacadeSourceDependsOn>$(GeneratePartialFacadeSourceDependsOn);ResolveMatchingContract;_GetRoslynAssembliesPath;GetGenFacadeCompileItems</GeneratePartialFacadeSourceDependsOn>
     <CoreCompileDependsOn Condition="'$(DesignTimeBuild)' != 'true'">$(CoreCompileDependsOn);GeneratePartialFacadeSource</CoreCompileDependsOn>
     <GenFacadesOutputSourcePath Condition="'$(GenFacadesOutputSourcePath)' == ''">$(IntermediateOutputPath)$(AssemblyTitle).Forwards.cs</GenFacadesOutputSourcePath>
   </PropertyGroup>
   
-  <ItemGroup>
-    <!-- Allow passing in different compile items to GenFacades. -->
-    <GenFacadeCompile Include="@(Compile)" Condition="'@(GenFacadeCompile)' == ''" />
-  </ItemGroup>
+  <!-- Allow passing in different compile items to GenFacades. -->
+  <Target Name="GetGenFacadeCompileItems">
+    <ItemGroup>
+      <GenFacadeCompile Include="@(Compile)" Condition="'@(GenFacadeCompile)' == ''" />
+    </ItemGroup>
+  </Target>
 
   <Target Name="GeneratePartialFacadeSource"
           Inputs="$(MSBuildAllProjects);@($(GenFacadesReferenceAssemblyItemName));@($(GenFacadesReferencePathItemName));@(GenFacadeCompile)"


### PR DESCRIPTION
Non-breaking change that allows to pass in a different set of compile items to GenFacades.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
