### PR TITLE
Move from Microsoft.Azure.KeyVault to Azure.Security.KeyVault libraries (release/3.x)

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,13 +14,14 @@
     <HandlebarsNetVersion>1.9.5</HandlebarsNetVersion>
     <LibGit2SharpVersion>0.25.2</LibGit2SharpVersion>
     <log4netVersion>2.0.10</log4netVersion>
+    <AzureIdentityVersion>1.8.0</AzureIdentityVersion>
+    <AzureSecurityKeyVaultSecretsVersion>4.4.0</AzureSecurityKeyVaultSecretsVersion>
     <AzureDataTablesVersion>12.5.0</AzureDataTablesVersion>
     <SystemNetHttpVersion>4.3.3</SystemNetHttpVersion>
     <MicrosoftApplicationInsightsAspNetCoreVersion>2.7.1</MicrosoftApplicationInsightsAspNetCoreVersion>
     <MicrosoftAspNetCoreHostingVersion>2.1.1</MicrosoftAspNetCoreHostingVersion>
     <MicrosoftAspNetCoreHttpVersion>2.1.22</MicrosoftAspNetCoreHttpVersion>
     <MicrosoftAzureStorageBlobVersion>10.0.2</MicrosoftAzureStorageBlobVersion>
-    <MicrosoftAzureKeyVaultVersion>3.0.0</MicrosoftAzureKeyVaultVersion>
     <MicrosoftBuildVersion>15.7.179</MicrosoftBuildVersion>
     <MicrosoftBuildFrameworkVersion>15.7.179</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildTasksCoreVersion>15.7.179</MicrosoftBuildTasksCoreVersion>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "tools": {
-    "dotnet": "3.1.425"
+    "dotnet": "3.1.425",
+    "runtimes" : { } 
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.22558.6",

--- a/src/Microsoft.DotNet.GitSync/Microsoft.DotNet.GitSync.csproj
+++ b/src/Microsoft.DotNet.GitSync/Microsoft.DotNet.GitSync.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="CredentialManagement" Version="$(CredentialManagementVersion)" />
     <PackageReference Include="LibGit2Sharp" Version="$(LibGit2SharpVersion)" />
     <PackageReference Include="log4net" Version="$(log4netVersion)" />
-    <PackageReference Include="Microsoft.Azure.KeyVault" Version="$(MicrosoftAzureKeyVaultVersion)" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="$(MicrosoftIdentityModelClientsActiveDirectoryVersion)" />
+    <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="$(AzureSecurityKeyVaultSecretsVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)"/>
     <PackageReference Include="Octokit" Version="$(OctokitVersion)" />
   </ItemGroup>


### PR DESCRIPTION
Same changes as https://github.com/dotnet/arcade/pull/11763 (release/3.x version)

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
