### PR TITLE
Allow filtering GenFacades compile items

### DIFF
--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.PartialFacadeSource.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.PartialFacadeSource.targets
@@ -14,13 +14,13 @@
   </PropertyGroup>
 
   <Target Name="GeneratePartialFacadeSource"
-          Inputs="$(MSBuildAllProjects);@($(GenFacadesReferenceAssemblyItemName));@($(GenFacadesReferencePathItemName));@(Compile)"
+          Inputs="$(MSBuildAllProjects);@($(GenFacadesReferenceAssemblyItemName));@($(GenFacadesReferencePathItemName));@(Compile->WithMetadataValue('ExcludeFromGenFacades', ''))"
           Outputs="$(GenFacadesOutputSourcePath)"
           DependsOnTargets="$(GeneratePartialFacadeSourceDependsOn)">
     <GenPartialFacadeSource
       ReferencePaths="@($(GenFacadesReferencePathItemName))"
       ReferenceAssembly="@($(GenFacadesReferenceAssemblyItemName))"
-      CompileFiles="@(Compile)"
+      CompileFiles="@(Compile->WithMetadataValue('ExcludeFromGenFacades', ''))"
       DefineConstants="$(DefineConstants)"
       LangVersion="$(LangVersion)"
       IgnoreMissingTypes="$(GenFacadesIgnoreMissingTypes)"


### PR DESCRIPTION
Opened https://github.com/dotnet/msbuild/issues/8205 to be able to also respect "false" metadata values without the need of a separate target. In this use-case here, it's probably fine to just support "true" and "" metadata values.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
