### PR TITLE
Merge-on-Red: Implemented YAML log reader alongside the XML ones

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/formats/__init__.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/formats/__init__.py
@@ -3,10 +3,12 @@ from .result_format import ResultFormat
 from .xunit import XUnitFormat
 from .junit import JUnitFormat
 from .trx import TRXFormat
+from .yaml import YAMLFormat
 
 
 all_formats = [
     XUnitFormat(),
     JUnitFormat(),
-    TRXFormat()
+    TRXFormat(),
+    YAMLFormat()
 ]  # type: List[ResultFormat]

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/formats/yaml.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/formats/yaml.py
@@ -1,0 +1,60 @@
+import yaml
+
+from .result_format import ResultFormat
+from helix.public import TestResult, TestResultAttachment
+
+class YAMLFormat(ResultFormat):
+
+    def __init__(self):
+        super(YAMLFormat, self).__init__()
+        pass
+
+    @property
+    def name(self):
+        return 'yaml'
+
+    @property
+    def acceptable_file_suffixes(self):
+        yield 'testResults.yml'
+        yield 'test-results.yml'
+        yield 'test_results.yml'
+
+    # Work in Progress :)
+    def read_results(self, path):
+        contents = None
+        with open(path) as fh:
+            contents = yaml.safe_load(fh)
+
+        results = contents.get("assemblies").get("assembly").get("collection").get("tests")
+
+        for test in results:
+            name = test.get("name")
+            type_name = test.get("type")
+            method = test.get("method")
+            time = float(test.get("time"))
+            result = test.get("result")
+            exception_type = None
+            failure_message = None
+            stack_trace = None
+            skip_reason = None
+            attachments = []
+
+        failure_element = test.find("failure")
+
+        if failure_element is not None:
+            exception_type = failure_element.get("exception-type")
+            failure_message = failure_element.find("message")
+            stack_trace = failure_element.find("stack-trace")
+
+        output_element = test.find("output")
+
+        if output_element is not None:
+            attachments.append(TestResultAttachment(
+                name=u"Console_Output.log",
+                text=output_element,
+            ))
+
+        skip_reason = test.find("reason")
+        res = TestResult(name, u'yaml', type_name, method, time, result, exception_type,
+                         failure_message, stack_trace, skip_reason, attachments)
+        yield res


### PR DESCRIPTION
Follow up to issue #11559. Now that the Helix machines have the `PyYaml` dependency installed, we can proceed with the next stage, which is processing the YAML test logs.

For context, our current test logs written in XML format. The problem with this is that if a there's a fatal hang/freeze or crash, then the log will end up incomplete, and therefore unreadable later on. This led to the motivation to add another log based in YAML format. Even if it's "incomplete", it's perfectly readable thanks to YAML's lack of closing indicators.

The full project can be found in the following links, for further information:

- Merge-on-Red is thoroughly explained here: https://github.com/dotnet/runtime/issues/75243
- As for this particular work item, we are tracking it here: https://github.com/dotnet/runtime/issues/77735 (This one is also linked in the Merge-on-Red issue specified above)

The goal of this PR is to update Helix's scripts, so that they can process the YAML logs, alongside to their existing XML counterparts.