### PR TITLE
update secret-manager tooling

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,13 +3,13 @@
   "isRoot": true,
   "tools": {
     "microsoft.dnceng.secretmanager": {
-      "version": "1.1.0-beta.22517.1",
+      "version": "1.1.0-beta.22580.1",
       "commands": [
         "secret-manager"
       ]
     },
     "microsoft.dnceng.patgeneratortool": {
-      "version": "1.1.0-beta.22166.1",
+      "version": "1.1.0-beta.22580.1",
       "commands": [
         "pat-generator"
       ]


### PR DESCRIPTION
Part of https://github.com/dotnet/arcade/issues/11745

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation

This updates secret-manager to a version that is able to automatically cycle azure devops tokens. The secret manifests in this repo already contain the scope and organizations information necessary for the tool to work. 