### PR TITLE
updated `Microsoft.TemplateEngine.Authoring.Tasks` version

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,9 +9,9 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-symuploader</Uri>
       <Sha>62ceb439e80bf0814d0ffa17f022d4624ea4aa6c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-alpha.1.21601.1">
+    <Dependency Name="Microsoft.TemplateEngine.Authoring.Tasks" Version="8.0.100-alpha.1.22607.1">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>9b8b780bf233907ae5d38aaf8c8b769782322735</Sha>
+      <Sha>e245efe31114b3e273af54969c45266350569d17</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -94,6 +94,6 @@
     <MicrosoftDeploymentDotNetReleasesVersion>1.0.0-preview5.1.22263.1</MicrosoftDeploymentDotNetReleasesVersion>
     <!-- Used to flow Source Link version through Arcade SDK -->
     <MicrosoftSourceLinkVersion>$(MicrosoftSourceLinkGitHubVersion)</MicrosoftSourceLinkVersion>
-    <MicrosoftTemplateEngineTasksVersion>7.0.100-preview.2.22075.3</MicrosoftTemplateEngineTasksVersion>
+    <MicrosoftTemplateEngineAuthoringTasksVersion>8.0.100-alpha.1.22607.1</MicrosoftTemplateEngineAuthoringTasksVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Localization.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Localization.targets
@@ -34,7 +34,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.TemplateEngine.Tasks" Version="$(MicrosoftTemplateEngineTasksVersion)" PrivateAssets="all" IsImplicitlyDefined="true" Condition="'$(UsingToolTemplateLocalizer)' == 'true'" />
+    <PackageReference Include="Microsoft.TemplateEngine.Authoring.Tasks" Version="$(MicrosoftTemplateEngineAuthoringTasksVersion)" PrivateAssets="all" IsImplicitlyDefined="true" Condition="'$(UsingToolTemplateLocalizer)' == 'true'" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Problem: 

1. `Microsoft.TemplateEngine.Tasks` `7.0.100-preview.2.22075.3` is not available in `dotnet8` feed. Those repos which don't have `dotnet7` feed enabled start to fail when using `UsingToolTemplateLocalizer` property. Example: https://dev.azure.com/dnceng-public/public/_build/results?buildId=104630&view=logs&j=fa59fe4e-195c-56fa-189b-58fd241f10dd
2. Recently `Microsoft.TemplateEngine.Tasks` was renamed to `Microsoft.TemplateEngine.Authoring.Tasks

Solution

Updated dependency to use new package and its latest version. `dotnet7` feed is no longer need when using `UsingToolTemplateLocalizer` property.