### PR TITLE
Pass cancellation token to each of the file download/save operations

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -953,12 +953,13 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         {
             string uri =
                 $"{AzureDevOpsBaseUrl}/{AzureDevOpsOrg}/_apis/resources/Containers/{containerId}?itemPath=/{artifactName}/{fileName}&isShallow=true&api-version={AzureApiVersionForFileDownload}";
-            Log.LogMessage(MessageImportance.Low, $"Download file uri = {uri}");
             Exception mostRecentlyCaughtException = null;
             bool success = await RetryHandler.RunAsync(async attempt =>
             {
                 try
                 {
+                    Log.LogMessage(MessageImportance.Low, $"Download file uri = {uri}");
+
                     CancellationTokenSource timeoutTokenSource =
                         new CancellationTokenSource(TimeSpan.FromMinutes(TimeoutInMinutes));
 
@@ -972,11 +973,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         FileMode.Create,
                         FileAccess.ReadWrite,
                         FileShare.ReadWrite);
-                    using var stream = await response.Content.ReadAsStreamAsync();
+                    using var stream = await response.Content.ReadAsStreamAsync(timeoutTokenSource.Token);
 
                     try
                     {
-                        await stream.CopyToAsync(fs);
+                        await stream.CopyToAsync(fs, timeoutTokenSource.Token);
                     }
                     finally
                     {


### PR DESCRIPTION
Because the GetAsync call returns after the headers are read, the time based cancellation token isn't currently covering the file download (or save, for that matter). So it's possible that if there is an issue downloading the file content, we're not timing out and hitting the normal retry loop.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
