### PR TITLE
Add UsingMicrosoftDotNetSharedFrameworkSdk marker

### DIFF
--- a/src/Microsoft.DotNet.SharedFramework.Sdk/sdk/Sdk.props
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/sdk/Sdk.props
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <UsingMicrosoftDotNetSharedFrameworkSdk>true</UsingMicrosoftDotNetSharedFrameworkSdk>
     <DotNetSharedFrameworkTaskFile>$(DotNetSharedFrameworkTaskDir)Microsoft.DotNet.SharedFramework.Sdk.dll</DotNetSharedFrameworkTaskFile>
   </PropertyGroup>
 


### PR DESCRIPTION
Similar to the Microsoft.Build.NoTargets/Traversal SDK, adding a property marker to identify projects that use the shared framework SDK. Intentionally not using the sfxproj file extension as that isn't a great indicator.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
