### PR TITLE
Changed `MicrosoftTemplateEngineTasksVersion` to `MicrosoftTemplateEngineAuthoringTasksVersion` in Arcade.Sdk csproj

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
@@ -84,7 +84,7 @@
     <MicrosoftDotNetXliffTasksVersion>$(MicrosoftDotNetXliffTasksVersion)</MicrosoftDotNetXliffTasksVersion>
     <MicrosoftDotNetMaestroTasksVersion>$(MicrosoftDotNetMaestroTasksVersion)</MicrosoftDotNetMaestroTasksVersion>
     <MicrosoftSymbolUploaderBuildTaskVersion>$(MicrosoftSymbolUploaderBuildTaskVersion)</MicrosoftSymbolUploaderBuildTaskVersion>
-    <MicrosoftTemplateEngineTasksVersion>$(MicrosoftTemplateEngineTasksVersion)</MicrosoftTemplateEngineTasksVersion>
+    <MicrosoftTemplateEngineAuthoringTasksVersion>$(MicrosoftTemplateEngineAuthoringTasksVersion)</MicrosoftTemplateEngineAuthoringTasksVersion>
   </PropertyGroup>
 </Project>]]>
   </_SdkVersionPropsContent>


### PR DESCRIPTION
Follow up: https://github.com/dotnet/arcade/pull/11866

Changed `MicrosoftTemplateEngineTasksVersion` to `MicrosoftTemplateEngineAuthoringTasksVersion` in Arcade.Sdk csproj
