### PR TITLE
Avoid setting source control properties during design-time build

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets
@@ -13,7 +13,7 @@
   <Import Project="GenerateInternalsVisibleTo.targets" />
   <Import Project="GenerateResxSource.targets" />
   <Import Project="Workarounds.targets"/>
-  <Import Project="RepositoryInfo.targets" />
+  <Import Project="RepositoryInfo.targets"/>
   <Import Project="Version.targets"/>
   <Import Project="Tests.targets" Condition="'$(DisableArcadeTestFramework)' != 'true'" />
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets
@@ -13,7 +13,7 @@
   <Import Project="GenerateInternalsVisibleTo.targets" />
   <Import Project="GenerateResxSource.targets" />
   <Import Project="Workarounds.targets"/>
-  <Import Project="RepositoryInfo.targets"/>
+  <Import Project="RepositoryInfo.targets" />
   <Import Project="Version.targets"/>
   <Import Project="Tests.targets" Condition="'$(DisableArcadeTestFramework)' != 'true'" />
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
@@ -17,26 +17,27 @@
   </PropertyGroup>
 
   <!--
-    Set the SourceRoot to repo root to facilitate deterministic source paths when SCM queries are disabled.
+    Set the SourceRoot to repo root to facilitate deterministic source paths when SCM queries are disabled, unless during design-time build.
     Set the RepositoryUrl to the Build.Repository.Uri Azure DevOps build variable if on CI, otherwise to local repo path.
+    Do not set these properties during design-time build to avoid differences between design-time and reuglar builds.
   -->
 
-  <ItemGroup Condition="'$(EnableSourceControlManagerQueries)' != 'true'">
+  <ItemGroup Condition="'$(EnableSourceControlManagerQueries)' != 'true' and '$(DesignTimeBuild)' != 'true'">
     <SourceRoot Include="$(RepoRoot)" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(EnableSourceControlManagerQueries)' != 'true' and '$(RepositoryUrl)' == ''">
+  <PropertyGroup Condition="'$(EnableSourceControlManagerQueries)' != 'true' and '$(DesignTimeBuild)' != 'true' and '$(RepositoryUrl)' == ''">
     <RepositoryUrl Condition="'$(BUILD_REPOSITORY_URI)' != '' and '$(DisableSourceLinkUrlTranslation)' != 'true'">$([System.Text.RegularExpressions.Regex]::Replace($(BUILD_REPOSITORY_URI), $(_TranslateUrlPattern), $(_TranslateUrlReplacement)))</RepositoryUrl>
     <RepositoryUrl Condition="'$(BUILD_REPOSITORY_URI)' != '' and '$(DisableSourceLinkUrlTranslation)' == 'true'">$(BUILD_REPOSITORY_URI)</RepositoryUrl>
     <RepositoryUrl Condition="'$(BUILD_REPOSITORY_URI)' == ''">file://$(RepoRoot)</RepositoryUrl>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(EnableSourceControlManagerQueries)' != 'true' and '$(RepositoryCommit)' == ''">
+  <PropertyGroup Condition="'$(EnableSourceControlManagerQueries)' != 'true' and '$(DesignTimeBuild)' != 'true' and '$(RepositoryCommit)' == ''">
     <RepositoryCommit Condition="'$(BUILD_SOURCEVERSION)' != ''">$(BUILD_SOURCEVERSION)</RepositoryCommit>
     <RepositoryCommit Condition="'$(BUILD_SOURCEVERSION)' == ''">0000000000000000000000000000000000000000</RepositoryCommit>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(EnableSourceControlManagerQueries)' != 'true' and '$(RepositoryType)' == ''">
+  <PropertyGroup Condition="'$(EnableSourceControlManagerQueries)' != 'true' and '$(DesignTimeBuild)' != 'true' and '$(RepositoryType)' == ''">
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 


### PR DESCRIPTION
`RepositoryInfo.targets` sets properties/items when Source Link is disabled. Since Source Link is disabled during design-time build, setting these properties/items results in undesirable changes to build outputs (e.g. to the content of generated AssemblyInfo.cs files). These changes may break Hot Reload if the design-time build happens to run during debugging, as the changes made to the generated files are (correctly) detected by Hot Reload and attempted to be applied to the running application.
