### PR TITLE
Add Service Principal secrets to help with some Guardian tasks

### DIFF
--- a/.vault-config/product-builds-dnceng-pipeline-secrets.yaml
+++ b/.vault-config/product-builds-dnceng-pipeline-secrets.yaml
@@ -82,3 +82,7 @@ secrets:
     type: base64-encoder
     parameters:
       secret: dotnetfeedmsrc-read-sas-token
+
+  # Service Principal used by the Guardian APIScan build task
+  apiscan-service-principal:
+    type: ad-application


### PR DESCRIPTION
Add a new service principal to the vault manifest.