### PR TITLE
[release/3.x] use correctly named PAT for x-org publishing

### DIFF
--- a/eng/common/templates/post-build/channels/generic-internal-channel.yml
+++ b/eng/common/templates/post-build/channels/generic-internal-channel.yml
@@ -100,7 +100,7 @@ stages:
         displayName: Enable cross-org publishing
         inputs:
           filePath: eng\common\enable-cross-org-publishing.ps1
-          arguments: -token $(dn-bot-dnceng-artifact-feeds-rw)
+          arguments: -token $(dn-bot-all-orgs-artifact-feeds-rw)
 
       - task: PowerShell@2
         displayName: Publish Assets

--- a/eng/common/templates/post-build/channels/generic-public-channel.yml
+++ b/eng/common/templates/post-build/channels/generic-public-channel.yml
@@ -50,7 +50,7 @@ stages:
         displayName: Enable cross-org publishing
         inputs:
           filePath: eng\common\enable-cross-org-publishing.ps1
-          arguments: -token $(dn-bot-dnceng-artifact-feeds-rw)
+          arguments: -token $(dn-bot-all-orgs-artifact-feeds-rw)
 
       - task: PowerShell@2
         displayName: Publish
@@ -109,7 +109,7 @@ stages:
         displayName: Enable cross-org publishing
         inputs:
           filePath: eng\common\enable-cross-org-publishing.ps1
-          arguments: -token $(dn-bot-dnceng-artifact-feeds-rw)
+          arguments: -token $(dn-bot-all-orgs-artifact-feeds-rw)
 
       - task: PowerShell@2
         displayName: Publish Assets


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/5103

This changes the token we use to enable cross-org publishing, in order to have a more appropriately named token for this

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
