### PR TITLE
Retry/reboot when app installation fails on Apple devices

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-processor.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-processor.py
@@ -263,6 +263,12 @@ def analyze_operation(command: str, platform: str, device: str, is_device: bool,
                 retry = True
                 return
 
+            if exit_code == 78: # PACKAGE_INSTALLATION_FAILURE
+                print(f'    Encountered PACKAGE_INSTALLATION_FAILURE. This might be a transient issue with the device')
+                retry = True
+                reboot = True
+                return
+
         else:
             if exit_code == 78: # PACKAGE_INSTALLATION_FAILURE
                 print(f'    Encountered PACKAGE_INSTALLATION_FAILURE. This might be caused by a corrupt simulator')


### PR DESCRIPTION
We have seen new kind of issue with Apple devices where the app fails to install (mlaunch fails):
```
[14:07:58] dbug: Running /private/tmp/helix/working/B2A309AE/p/microsoft.dotnet.xharness.cli/1.0.0-prerelease.22612.1/tools/net7.0/any/../../../runtimes/any/native/mlaunch/bin/mlaunch --sdkroot /Applications/Xcode124.app --devname dba7ff12af20a0269eca1e15db8bb896f3bdb00c --installdev /tmp/helix/working/B2A309AE/w/A5E70950/e/System.Diagnostics.StackTrace.Tests.app -v -v
[14:07:58] dbug: Using Xcode 12.4 found in /Applications/Xcode124.app
[14:07:58] dbug: Xamarin.Hosting: Xamarin.Hosting
[14:07:58] dbug: Xamarin.Hosting:     Version: 75a03ccbfc (refs/heads/xcode14)
[14:07:58] dbug: Xamarin.Hosting:     Xcode: /Applications/Xcode124.app
[14:07:58] dbug: Xamarin.Hosting:     Xcode Version: 12.4
[14:07:58] dbug: Xamarin.Hosting:     Verbosity: 2
[14:07:59] dbug: Xamarin.Hosting: Device discovery started
[14:07:59] dbug: Xamarin.Hosting: Device discovery event: Connected (fff44:c6:5d:82:ac:e7fff)
[14:07:59] dbug: 2022-12-14 14:07:59.230 mlaunch[47084:1747590]
[14:07:59] dbug: Unhandled Exception:
[14:07:59] dbug: Xamarin.Hosting.MobileDeviceException: Read Error (error: 0xe8000004)
[14:07:59] dbug: at Xamarin.Hosting.RealDevice.Connect () [0x00021] in /Users/builder/azdo/_work/2/s/tools/mlaunch/Xamarin.Hosting/Xamarin.Hosting/RealDevice.cs:57
[14:07:59] dbug: at Xamarin.Hosting.RealDevice..ctor (System.IntPtr am_device) [0x00022] in /Users/builder/azdo/_work/2/s/tools/mlaunch/Xamarin.Hosting/Xamarin.Hosting/RealDevice.cs:40
[14:07:59] dbug: at Xamarin.Hosting.DeviceDiscovery+<>c__DisplayClass23_1.<DiscoverNotificationCallback>b__0 () [0x00007] in /Users/builder/azdo/_work/2/s/tools/mlaunch/Xamarin.Hosting/Xamarin.Hosting/DeviceDiscovery.cs:225
[14:07:59] dbug: at System.Threading.ThreadHelper.ThreadStart_Context (System.Object state) [0x00014] in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/mcs/class/referencesource/mscorlib/system/threading/thread.cs:74
[14:07:59] dbug: at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00071] in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:968
[14:07:59] dbug: at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:910
[14:07:59] dbug: at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state) [0x0002b] in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:899
[14:07:59] dbug: at System.Threading.ThreadHelper.ThreadStart () [0x00008] in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/mcs/class/referencesource/mscorlib/system/threading/thread.cs:111
[14:07:59] dbug: [ERROR] FATAL UNHANDLED EXCEPTION: Xamarin.Hosting.MobileDeviceException: Read Error (error: 0xe8000004)
[14:07:59] dbug: at Xamarin.Hosting.RealDevice.Connect () [0x00021] in /Users/builder/azdo/_work/2/s/tools/mlaunch/Xamarin.Hosting/Xamarin.Hosting/RealDevice.cs:57
[14:07:59] dbug: at Xamarin.Hosting.RealDevice..ctor (System.IntPtr am_device) [0x00022] in /Users/builder/azdo/_work/2/s/tools/mlaunch/Xamarin.Hosting/Xamarin.Hosting/RealDevice.cs:40
[14:07:59] dbug: at Xamarin.Hosting.DeviceDiscovery+<>c__DisplayClass23_1.<DiscoverNotificationCallback>b__0 () [0x00007] in /Users/builder/azdo/_work/2/s/tools/mlaunch/Xamarin.Hosting/Xamarin.Hosting/DeviceDiscovery.cs:225
[14:07:59] dbug: at System.Threading.ThreadHelper.ThreadStart_Context (System.Object state) [0x00014] in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/mcs/class/referencesource/mscorlib/system/threading/thread.cs:74
[14:07:59] dbug: at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00071] in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:968
[14:07:59] dbug: at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:910
[14:07:59] dbug: at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state) [0x0002b] in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:899
[14:07:59] dbug: at System.Threading.ThreadHelper.ThreadStart () [0x00008] in /Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/mcs/class/referencesource/mscorlib/system/threading/thread.cs:111
```

Reported here: https://github.com/dotnet/runtime/pull/79675