### PR TITLE
Align TargetFramework pkg with NuGet Task

### DIFF
--- a/src/Common/Internal/AssemblyResolver.cs
+++ b/src/Common/Internal/AssemblyResolver.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 using System.IO;

--- a/src/Common/Internal/BuildTask.cs
+++ b/src/Common/Internal/BuildTask.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable disable
+
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System;

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/README.md
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/README.md
@@ -8,7 +8,7 @@ Supports copying to additional paths based on which `TargetFramework` among `Tar
 
 - BinPlaceItem
     - Typically computed by the BinPlacing targets to determine what assets to binplace.
-    - Identity: source of file to binplace.  For example: the built output dll, pdb, content files, etc.
+    - Identity: source of file to binplace. For example: the built output dll, pdb, content files, etc.
     - Metadata:
         - TargetPath: when specified can indicate the relative path, including filename, to place the item.
 
@@ -26,14 +26,10 @@ Supports copying to additional paths based on which `TargetFramework` among `Tar
         - RefPath: directory to copy `BinPlaceItem`s when `BinPlaceRef` is set to true.
         - RuntimePath: directory to copy `BinPlaceItem`s when `BinPlaceRuntime` is set to true.
         - TestPath: directory to copy `BinPlaceItem`s when `BinPlaceTest` is set to true.
-        - PackageFileNativePath: directory to write props file containing `BinPlaceItem`s when `BinPlaceNative` is set to true.
-        - PackageFileRefPath: directory to write props file containing `BinPlaceItem`s when `BinPlaceRef` is set to true.
-        - PackageFileRuntimePath: directory to write props file containing `BinPlaceItem`s when `BinPlaceRuntime` is set to true.
         - ItemName: An item name to use instead of `BinPlaceItem` for the source of items for this `BinPlaceTargetFramework`.
-        - SetProperties: Name=Value pairs of properties that should be set.
 
 ## BinPlacing Properties
-- BinPlaceNative: When set to true `BinPlaceItem`s are copied to the `NativePath` of active `BinPlaceTargetFramework`s. Props are written to the `PackageFileNativePath` directory.
-- BinPlaceRef: When set to true `BinPlaceItem`s are copied to the `RefPath` of active `BinPlaceTargetFramework`s.  Props are written to the `PackageFileRefPath` directory.
-- BinPlaceRuntime: When set to true `BinPlaceItem`s are copied to the `RuntimePath` of active `BinPlaceTargetFramework`s.  Props are written to the `PackageFileRuntimePath` directory.
+- BinPlaceNative: When set to true `BinPlaceItem`s are copied to the `NativePath` of active `BinPlaceTargetFramework`s.
+- BinPlaceRef: When set to true `BinPlaceItem`s are copied to the `RefPath` of active `BinPlaceTargetFramework`s.
+- BinPlaceRuntime: When set to true `BinPlaceItem`s are copied to the `RuntimePath` of active `BinPlaceTargetFramework`s.
 - BinPlaceTest:  When set to true `BinPlaceItem`s are copied to the `TestPath` of active `BinPlaceTargetFramework`s.

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/ChooseBestP2PTargetFrameworkTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/ChooseBestP2PTargetFrameworkTask.cs
@@ -1,87 +1,134 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Build.Framework;
+// Keep in sync with https://raw.githubusercontent.com/NuGet/NuGet.Client/dccbd304b11103e08b97abf4cf4bcc1499d9235a/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkUtility.cs
+
 using System;
 using System.Collections.Generic;
-using System.IO;
+using System.Globalization;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NuGet.Common;
+using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.Build.Tasks.TargetFramework
 {
     public class ChooseBestP2PTargetFrameworkTask : BuildTask
     {
-        [Required]
-        public ITaskItem[] ProjectReferencesWithTargetFrameworks { get; set; }
+        private const string NEAREST_TARGET_FRAMEWORK = "NearestTargetFramework";
+        private const string TARGET_FRAMEWORKS = "TargetFrameworks";
 
         [Required]
-        public string RuntimeGraph { get; set; }
+        public string? RuntimeGraph { get; set; }
 
+        /// <summary>
+        /// The current project's target framework.
+        /// </summary>
         [Required]
-        public string TargetFramework { get; set; }
+        public string? CurrentProjectTargetFramework { get; set; }
+
+        /// <summary>
+        /// Optional TargetPlatformMoniker
+        /// </summary>
+        public string? CurrentProjectTargetPlatform { get; set; }
 
         public bool OmitIncompatibleProjectReferences { get; set; }
 
+        /// <summary>
+        /// The project references for property lookup.
+        /// </summary>
+        public ITaskItem[]? AnnotatedProjectReferences { get; set; }
+
+        /// <summary>
+        /// The project references with assigned properties.
+        /// </summary>
         [Output]
-        public ITaskItem[] AnnotatedProjectReferencesWithSetTargetFramework { get; set; }
+        public ITaskItem[]? AssignedProjects { get; set; }
 
         public override bool Execute()
         {
-            var annotatedProjectReferencesWithSetTargetFramework = new List<ITaskItem>(ProjectReferencesWithTargetFrameworks.Length);
-            var targetFrameworkResolver = new TargetFrameworkResolver(RuntimeGraph);
-
-            for (int i = 0; i < ProjectReferencesWithTargetFrameworks.Length; i++)
+            if (AnnotatedProjectReferences == null)
             {
-                ITaskItem projectReference = ProjectReferencesWithTargetFrameworks[i];
-                string targetFrameworksValue = projectReference.GetMetadata("TargetFrameworks");
-
-                // Allow referencing projects with TargetFrameworks explicitely cleared out, i.e. Microsoft.Build.Traversal.
-                if (!string.IsNullOrWhiteSpace(targetFrameworksValue))
-                {
-                    string[] targetFrameworks = targetFrameworksValue.Split(';');
-
-                    string referringTargetFramework = projectReference.GetMetadata("ReferringTargetFramework");
-                    if (string.IsNullOrWhiteSpace(referringTargetFramework))
-                    {
-                        referringTargetFramework = TargetFramework;
-                    }
-
-                    string bestTargetFramework = targetFrameworkResolver.GetBestSupportedTargetFramework(targetFrameworks, referringTargetFramework);
-                    if (bestTargetFramework == null)
-                    {
-                        if (OmitIncompatibleProjectReferences)
-                        {
-                            continue;
-                        }
-                        Log.LogError($"Not able to find a compatible supported target framework for {referringTargetFramework} in Project {Path.GetFileName(projectReference.ItemSpec)}. The Supported Configurations are {string.Join(", ", targetFrameworks)}");
-                    }
-
-                    // Mimic msbuild's Common.targets behavior: https://github.com/dotnet/msbuild/blob/3c8fb11a080a5a15199df44fabf042a22e9ad4da/src/Tasks/Microsoft.Common.CurrentVersion.targets#L1842-L1853
-                    if (projectReference.GetMetadata("HasSingleTargetFramework") != "true")
-                    {
-                        projectReference.SetMetadata("SetTargetFramework", "TargetFramework=" + bestTargetFramework);
-                    }
-                    else
-                    {
-                        // If the project has a single TargetFramework, we need to Undefine TargetFramework to avoid another project evaluation.
-                        string undefineProperties = projectReference.GetMetadata("UndefineProperties");
-                        projectReference.SetMetadata("UndefineProperties", undefineProperties + ";TargetFramework");
-                    }
-
-                    if (projectReference.GetMetadata("IsRidAgnostic") == "true")
-                    {
-                        // If the project is RID agnostic, undefine the RuntimeIdentifier property to avoid another evaluation. -->
-                        string undefineProperties = projectReference.GetMetadata("UndefineProperties");
-                        projectReference.SetMetadata("UndefineProperties", undefineProperties + ";RuntimeIdentifier");
-                    }
-
-                    projectReference.SetMetadata("SkipGetTargetFrameworkProperties", "true");
-                }
-
-                annotatedProjectReferencesWithSetTargetFramework.Add(projectReference);
+                return !Log.HasLoggedErrors;
             }
 
-            AnnotatedProjectReferencesWithSetTargetFramework = annotatedProjectReferencesWithSetTargetFramework.ToArray();
+            // validate current project framework
+            string errorMessage = string.Format(CultureInfo.CurrentCulture, "The project target framework '{0}' is not a supported target framework.", $"TargetFrameworkMoniker: {CurrentProjectTargetFramework}, TargetPlatformMoniker:{CurrentProjectTargetPlatform}");
+            if (!TryParseFramework(CurrentProjectTargetFramework!, CurrentProjectTargetPlatform, errorMessage, Log, out var projectNuGetFramework))
+            {
+                return false;
+            }
+
+            TargetFrameworkResolver targetFrameworkResolver = TargetFrameworkResolver.CreateOrGet(RuntimeGraph!);
+            List<ITaskItem> assignedProjects = new(AnnotatedProjectReferences.Length);
+
+            foreach (ITaskItem annotatedProjectReference in AnnotatedProjectReferences)
+            {
+                ITaskItem? assignedProject = AssignNearestFrameworkForSingleReference(annotatedProjectReference, projectNuGetFramework, targetFrameworkResolver);
+                if (assignedProject != null)
+                {
+                    assignedProjects.Add(assignedProject);
+                }
+            }
+
+            AssignedProjects = assignedProjects.ToArray();
             return !Log.HasLoggedErrors;
-        }        
+        }
+
+        private ITaskItem? AssignNearestFrameworkForSingleReference(ITaskItem project,
+            NuGetFramework projectNuGetFramework,
+            TargetFrameworkResolver targetFrameworkResolver)
+        {
+            TaskItem itemWithProperties = new(project);
+            string referencedProjectFrameworkString = project.GetMetadata(TARGET_FRAMEWORKS);
+
+            if (string.IsNullOrEmpty(referencedProjectFrameworkString))
+            {
+                // No target frameworks set, nothing to do.
+                return itemWithProperties;
+            }
+
+            string[] referencedProjectFrameworks = MSBuildStringUtility.Split(referencedProjectFrameworkString!);
+
+            // try project framework
+            string? nearestNuGetFramework = targetFrameworkResolver.GetNearest(referencedProjectFrameworks, projectNuGetFramework);
+            if (nearestNuGetFramework != null)
+            {
+                itemWithProperties.SetMetadata(NEAREST_TARGET_FRAMEWORK, nearestNuGetFramework);
+                return itemWithProperties;
+            }
+
+            if (OmitIncompatibleProjectReferences)
+            {
+                return null;
+            }
+
+            // no match found
+            Log.LogError(string.Format(CultureInfo.CurrentCulture, "Project '{0}' targets '{1}'. It cannot be referenced by a project that targets '{2}{3}'.", project.ItemSpec, referencedProjectFrameworkString, projectNuGetFramework.DotNetFrameworkName, projectNuGetFramework.HasPlatform ? "-" + projectNuGetFramework.DotNetPlatformName : string.Empty));
+            return itemWithProperties;
+        }
+
+        private static bool TryParseFramework(string targetFrameworkMoniker, string? targetPlatformMoniker, string errorMessage, Log logger, out NuGetFramework nugetFramework)
+        {
+            // Check if we have a long name.
+#if NETFRAMEWORK || NETSTANDARD
+            nugetFramework = targetFrameworkMoniker.Contains(",")
+                ? NuGetFramework.ParseComponents(targetFrameworkMoniker, targetPlatformMoniker)
+                : NuGetFramework.Parse(targetFrameworkMoniker);
+#else
+            nugetFramework = targetFrameworkMoniker.Contains(',', System.StringComparison.Ordinal)
+               ? NuGetFramework.ParseComponents(targetFrameworkMoniker, targetPlatformMoniker)
+               : NuGetFramework.Parse(targetFrameworkMoniker);
+#endif
+
+            // validate framework
+            if (nugetFramework.IsUnsupported)
+            {
+                logger.LogError(errorMessage);
+                return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/Microsoft.DotNet.Build.Tasks.TargetFramework.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/Microsoft.DotNet.Build.Tasks.TargetFramework.csproj
@@ -8,6 +8,7 @@
     <Title>Configuration system for cross-targeting projects.</Title>
     <PackageDescription>This package provides the following MSBuild tasks: ChooseBestTargetFrameworksTask and ChooseBestP2PTargetFrameworkTask.</PackageDescription>
     <DefaultItemExcludes Condition="'$(TargetFramework)' != 'net472'">**/*.Desktop.*</DefaultItemExcludes>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
@@ -24,7 +25,7 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
     <PackageReference Include="NuGet.Packaging" Version="$(NugetVersion)" />
 
-    <!-- This is here so that we agree with the project's transitive references to NewtonSoft.Json -->
+    <!-- This is here so that we agree with the project's transitive references to Newtonsoft.Json -->
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/BinPlace.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/BinPlace.targets
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <Target Name="BinPlace"
-          DependsOnTargets="GetBinPlaceTargetFramework;BinPlaceFiles;BinPlaceProps"
+          DependsOnTargets="GetBinPlaceTargetFramework;BinPlaceFiles"
           AfterTargets="CopyFilesToOutputDirectory"
           Condition="'$(BinPlaceNative)' == 'true' or '$(BinPlaceRef)' == 'true' or '$(BinPlaceRuntime)' == 'true' or '$(BinPlaceTest)' == 'true' or '@(BinPlaceDir)' != ''" />
 
@@ -45,57 +45,6 @@
     </Copy>
   </Target>
 
-  <UsingTask TaskName="SaveItems" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)"/>
-  <Target Name="BinPlaceProps"
-          Condition="'@(PackageFileDir)' != ''"
-          DependsOnTargets="GetBinPlaceItems"
-          Inputs="%(PackageFileDir.Identity);%(PackageFileDir.ItemName)"
-          Outputs="unused">
-    <ItemGroup>
-      <!-- in the case of an overlapping batch (eg: multiple configurations using same directory)
-           use the first -->
-      <_packageFileDir Include="@(PackageFileDir->Distinct())" />
-    </ItemGroup>
-
-    <!-- This filename is chosen so that each build of every project has a uniquie filename.-->
-    <PropertyGroup>
-      <_propsFilename>$(TargetName).$(TargetFramework)</_propsFilename>
-      <_propsFilename Condition="'$(TargetName)' == ''">$(MSBuildProjectName).$(TargetFramework)</_propsFilename>
-      <_projectDirLength>$(ProjectDir.Length)</_projectDirLength>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <_BinPlaceItemName>%(_packageFileDir.ItemName)</_BinPlaceItemName>
-      <_BinPlaceItemName Condition="'$(_BinPlaceItemName)' == ''">BinPlaceItem</_BinPlaceItemName>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <_itemsToSave Include="@($(_BinPlaceItemName))">
-        <!-- intentionally empty: to be set by pkgproj -->
-        <TargetPath />
-        <TargetFramework>%(_packageFileDir.BuildConfiguration_NuGetTargetMonikerShort)</TargetFramework>
-      </_itemsToSave>
-
-      <!-- Include doc files. -->
-      <_docFiles Condition="'$(BinPlaceRef)' == 'true'" Include="$(XmlDocDir)/**/$(TargetName).xml" />
-      <_docFiles>
-        <SubFolder Condition="'%(RecursiveDir)' != ''">/$([System.String]::new('%(RecursiveDir)').TrimEnd('\').TrimEnd('/'))</SubFolder>
-      </_docFiles>
-      <_docFiles>
-        <TargetFramework>%(_packageFileDir.BuildConfiguration_NuGetTargetMonikerShort)</TargetFramework>
-      </_docFiles>
-      <_itemsToSave Include="@(_docFiles)"/>
-    </ItemGroup>
-
-    <Message Importance="low" Text="PackageFileDir: @(PackageFileDir)" />
-
-    <SaveItems ItemName="%(_packageFileDir.SaveItemName)"
-               Items="@(_itemsToSave)"
-               File="%(_packageFileDir.Identity)\$(_propsFilename).props">
-      <Output TaskParameter="File" ItemName="FileWrites" />
-    </SaveItems>
-  </Target>
-
   <PropertyGroup>
     <GetBinPlaceItemsDependsOn>
       $(GetBinPlaceItemsDependsOn);
@@ -127,7 +76,7 @@
          for each binplace targetFramework. -->
     <ChooseBestTargetFrameworksTask BuildTargetFrameworks="@(BinPlaceTargetFrameworks)"
                                     SupportedTargetFrameworks="@(_supportedTargetFramework)"
-                                    RuntimeGraph="$(RuntimeGraph)">
+                                    RuntimeGraph="$(BundledRuntimeIdentifierGraphFile)">
       <Output TaskParameter="BestTargetFrameworks" ItemName="_bestBinPlaceTargetFrameworks" />
     </ChooseBestTargetFrameworksTask>
     
@@ -138,30 +87,7 @@
       <BinPlaceDir Condition="'$(BinPlaceRef)' == 'true'" Include="@(_currentBinPlaceTargetFrameworks->'%(RefPath)')" />
       <BinPlaceDir Condition="'$(BinPlaceRuntime)' == 'true'" Include="@(_currentBinPlaceTargetFrameworks->'%(RuntimePath)')" />
       <BinPlaceDir Condition="'$(BinPlaceTest)' == 'true'" Include="@(_currentBinPlaceTargetFrameworks->'%(TestPath)')" />
-
-      <PackageFileDir Condition="'$(BinPlaceNative)' == 'true'" Include="@(_currentBinPlaceTargetFrameworks->'%(PackageFileNativePath)')">
-        <SaveItemName Condition="'%(_currentBinPlaceTargetFrameworks.SaveItemName)' == ''">NativeFile</SaveItemName>
-      </PackageFileDir>
-      <PackageFileDir Condition="'$(BinPlaceRef)' == 'true'" Include="@(_currentBinPlaceTargetFrameworks->'%(PackageFileRefPath)')">
-        <SaveItemName Condition="'%(_currentBinPlaceTargetFrameworks.SaveItemName)' == ''">RefFile</SaveItemName>
-      </PackageFileDir>
-      <PackageFileDir Condition="'$(BinPlaceRuntime)' == 'true'" Include="@(_currentBinPlaceTargetFrameworks->'%(PackageFileRuntimePath)')">
-        <SaveItemName Condition="'%(_currentBinPlaceTargetFrameworks.SaveItemName)' == ''">LibFile</SaveItemName>
-      </PackageFileDir>
-
-      <!-- permit BinplaceConfigurations to define SetProperties metadata,
-           set those properties when BinplaceConfiguration is active -->
-      <_binplacePropertyTuples Include="%(_currentBinPlaceTargetFrameworks.SetProperties)" />
-
-      <_binplaceSetProperty Condition="'%(_binplacePropertyTuples.Identity)' != ''"
-                            Include="$([System.String]::new('%(_binplacePropertyTuples.Identity)').Split('=')[0])">
-        <Value>$([System.String]::new('%(_binplacePropertyTuples.Identity)').Split('=')[1])</Value>
-      </_binplaceSetProperty>
     </ItemGroup>
-
-    <CreateProperty Value="%(_binplaceSetProperty.Value)" Condition="'@(_binplaceSetProperty)' != ''" >
-      <Output TaskParameter="Value" PropertyName="%(_binplaceSetProperty.Identity)" />
-    </CreateProperty>
   </Target>
 
   <!-- IncrementalClean and CoreClean only clean paths under Intermediate or OutDir, handle additional paths -->
@@ -169,9 +95,6 @@
     <AdditionalCleanDirectories Include="@(BinPlaceTargetFrameworks->'%(NativePath)')" />
     <AdditionalCleanDirectories Include="@(BinPlaceTargetFrameworks->'%(RefPath)')" />
     <AdditionalCleanDirectories Include="@(BinPlaceTargetFrameworks->'%(RuntimePath)')" />
-    <AdditionalCleanDirectories Include="@(BinPlaceTargetFrameworks->'%(PackageFileNativePath)')" />
-    <AdditionalCleanDirectories Include="@(BinPlaceTargetFrameworks->'%(PackageFileRefPath)')" />
-    <AdditionalCleanDirectories Include="@(BinPlaceTargetFrameworks->'%(PackageFileRuntimePath)')" />
     <AdditionalCleanDirectories Include="@(BinPlaceTargetFrameworks->'%(TestPath)')" />
     <AdditionalCleanDirectories Include="@(BinPlaceDir)" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
@@ -5,33 +5,100 @@
   <!--
     Runs in a leaf project (csproj) to determine best configuration for ProjectReferences.
     Make sure to run late enough for transitive dependencies which runs before AssignProjectConfiguration.
+    Keep target in sync with SDK's _GetProjectReferenceTargetFrameworkProperties target.
   -->
   <Target Name="ResolveP2PReferences"
           Condition="'@(ProjectReference)' != ''"
           BeforeTargets="AssignProjectConfiguration"
-          DependsOnTargets="ResolvePackageDependenciesForBuild">
+          DependsOnTargets="ResolvePackageDependenciesForBuild;_AddOutputPathToGlobalPropertiesToRemove">
+    <!--
+      Select the moniker to send to each project reference  if not already set. NugetTargetMoniker (NTM) is preferred by default over
+      TargetFrameworkMoniker (TFM) because it is required to disambiguate the UWP case where TFM is fixed at .NETCore,Version=v5.0 and
+      has floating NTM=UAP,Version=vX.Y.Z. However, in other cases (classic PCLs), NTM contains multiple values and that will cause the MSBuild
+      invocation below to fail by passing invalid properties. Therefore we do not use the NTM if it contains a semicolon.
+    -->
+    <PropertyGroup Condition="'$(ReferringTargetFrameworkForProjectReferences)' == ''">
+      <ReferringTargetFrameworkForProjectReferences Condition="'$(NuGetTargetMoniker)' != '' and !$(NuGetTargetMoniker.Contains(';'))">$(NuGetTargetMoniker)</ReferringTargetFrameworkForProjectReferences>
+      <ReferringTargetFrameworkForProjectReferences Condition="'$(NuGetTargetMoniker)' == ''">$(TargetFrameworkMoniker)</ReferringTargetFrameworkForProjectReferences>
+    </PropertyGroup>
+
+    <!--
+       Allow project references to specify which target framework properties to set and their values
+       without consulting the referenced project. This has two use cases:
+
+       1. A caller may wish to pick a compatible but sub-optimal target framework. For example,
+          to unit test the .NETStandard implementation using a .NETFramework caller even though
+          there is also a .NETFramework implementation.
+
+       2. As an escape hatch for cases where the compatibility check performed by
+          GetTargetFrameworkProperties is faulty.
+    -->
+    <ItemGroup>
+      <ProjectReference Condition="'%(ProjectReference.SetTargetFramework)' != ''">
+        <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+      </ProjectReference>
+    </ItemGroup>
+
+    <!--
+       SetPlatform negotiation requires the 'GetTargetFrameworks' MSBuild call to NOT pass global properties. This is to verify
+       whether or not the referenced project would build as the same platform as the current project by default.
+    -->
     <MSBuild Projects="@(ProjectReference)"
              Targets="GetTargetFrameworks"
              BuildInParallel="$(BuildInParallel)"
-             RemoveProperties="TargetFramework;RuntimeIdentifier"
+             RemoveProperties="%(ProjectReference.GlobalPropertiesToRemove);TargetFramework;RuntimeIdentifier;SelfContained;Platform;Configuration;$(_GlobalPropertiesToRemoveFromProjectReferences)"
              Condition="'%(ProjectReference.SkipGetTargetFrameworkProperties)' != 'true'">
       <Output TaskParameter="TargetOutputs" ItemName="_ProjectReferenceWithTargetFrameworks" />
     </MSBuild>
 
-    <ItemGroup>
-      <_ProjectReferenceWithTargetFrameworks Include="@(ProjectReference->WithMetadataValue('SkipGetTargetFrameworkProperties', 'true'))" />
-    </ItemGroup>
-
-    <ChooseBestP2PTargetFrameworkTask ProjectReferencesWithTargetFrameworks="@(_ProjectReferenceWithTargetFrameworks)"
-                                      RuntimeGraph="$(RuntimeGraph)"
-                                      TargetFramework="$(TargetFramework)"
+    <ChooseBestP2PTargetFrameworkTask AnnotatedProjectReferences="@(_ProjectReferenceWithTargetFrameworks)"
+                                      CurrentProjectTargetFramework="$(ReferringTargetFrameworkForProjectReferences)"
+                                      CurrentProjectTargetPlatform="$(TargetPlatformMoniker)"
+                                      RuntimeGraph="$(BundledRuntimeIdentifierGraphFile)"
                                       OmitIncompatibleProjectReferences="$(OmitIncompatibleProjectReferences)">
-      <Output TaskParameter="AnnotatedProjectReferencesWithSetTargetFramework" ItemName="_ProjectReferenceWithBestTargetFramework" />
+      <Output TaskParameter="AssignedProjects" ItemName="AnnotatedProjects" />
     </ChooseBestP2PTargetFrameworkTask>
+
+    <!-- IsRidAgnostic metadata is used to determine whether global properties such as RuntimeIdentifier and SelfContained flow to a referenced project.
+         However, for multi-targeted projects there may be a different IsRidAgnostic value for each TargetFramework.  In that case, this task selects
+         the IsRidAgnostic value for the NearestTargetFramework for the project. -->
+    <SetRidAgnosticValueForProjects Projects="@(AnnotatedProjects)">
+      <Output ItemName="UpdatedAnnotatedProjects" TaskParameter="UpdatedProjects" />
+    </SetRidAgnosticValueForProjects>
     
     <ItemGroup>
-      <ProjectReference Remove="@(ProjectReference)" />
-      <ProjectReference Include="@(_ProjectReferenceWithBestTargetFramework)" />
+      <AnnotatedProjects Remove="@(AnnotatedProjects)" />
+      <AnnotatedProjects Include="@(UpdatedAnnotatedProjects)" />
+      <UpdatedAnnotatedProjects Remove="@(UpdatedAnnotatedProjects)" />
+
+      <!-- If the NearestTargetFramework property was set and the project multi-targets, SetTargetFramework must be set. -->
+      <AnnotatedProjects Condition="'%(AnnotatedProjects.NearestTargetFramework)' != '' and '%(AnnotatedProjects.HasSingleTargetFramework)' != 'true'">
+        <SetTargetFramework>TargetFramework=%(AnnotatedProjects.NearestTargetFramework)</SetTargetFramework>
+      </AnnotatedProjects>
+
+      <!--
+         If the NearestTargetFramework property was not set or the project has a single TargetFramework, we need to Undefine
+         TargetFramework to avoid another project evaluation.
+      -->
+      <AnnotatedProjects Condition="'%(AnnotatedProjects.NearestTargetFramework)' == '' or '%(AnnotatedProjects.HasSingleTargetFramework)' == 'true'">
+        <UndefineProperties>%(AnnotatedProjects.UndefineProperties);TargetFramework</UndefineProperties>
+      </AnnotatedProjects>
+
+      <!-- Add RuntimeIdentifier and SelfContained to the list of global properties that should not flow to the referenced project,
+           unless the project is expecting those properties to flow. -->
+      <AnnotatedProjects Condition="'%(AnnotatedProjects.IsRidAgnostic)' != 'false'">
+        <UndefineProperties>%(AnnotatedProjects.UndefineProperties);RuntimeIdentifier;SelfContained</UndefineProperties>
+      </AnnotatedProjects>
+
+      <!--
+         Remove the items we've touched from _MSBuildProjectReferenceExistent. This will leave all projects where
+         SkipGetTargetFrameworkProperties was set. Then add all AnnotatedProjects back and mark them with
+         SkipGetTargetFrameworkProperties so that the SDK's _GetProjectReferenceTargetFrameworkProperties target doesn't
+         retrieve the target framework properties again.
+      -->
+      <ProjectReference Remove="@(ProjectReference)" Condition="'%(ProjectReference.SkipGetTargetFrameworkProperties)' != 'true'" />
+      <ProjectReference Include="@(AnnotatedProjects)" SkipGetTargetFrameworkProperties="true" />
+      <AnnotatedProjects Remove="@(AnnotatedProjects)" />
     </ItemGroup>
   </Target>
 

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/buildMultiTargeting/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/buildMultiTargeting/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
@@ -27,18 +27,18 @@
   
   <Target Name="GetProjectWithBestTargetFrameworks">
     <ItemGroup Condition="'$(BuildTargetFramework)' != ''">
-      <_BuildTargetFrameworkWithTargetOS Include="$(BuildTargetFramework)-$(TargetOS)" />
+      <_BuildTargetFrameworkWithTargetOS Include="$(BuildTargetFramework)-$(TargetOS.ToLowerInvariant())" />
     </ItemGroup>
     <ItemGroup Condition="'$(BuildTargetFramework)' == ''">
       <_BuildTargetFrameworkWithoutOS Include="$([MSBuild]::Unescape($([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '(-[^;]+)', ''))))" />
       <!-- TODO: Find a better way to filter out non applicable TargetOS values for .NET Framework. -->
-      <_BuildTargetFrameworkWithTargetOS Include="@(_BuildTargetFrameworkWithoutOS->Distinct()->'%(Identity)-$(TargetOS)')"
+      <_BuildTargetFrameworkWithTargetOS Include="@(_BuildTargetFrameworkWithoutOS->Distinct()->'%(Identity)-$(TargetOS.ToLowerInvariant())')"
                                          Condition="'$(TargetOS)' == 'windows' or !$([System.String]::Copy('%(Identity)').StartsWith('net4'))" />
     </ItemGroup>
     
     <ChooseBestTargetFrameworksTask BuildTargetFrameworks="@(_BuildTargetFrameworkWithTargetOS);$(AdditionalBuildTargetFrameworks)"
                                     SupportedTargetFrameworks="$(TargetFrameworks)"
-                                    RuntimeGraph="$(RuntimeGraph)"
+                                    RuntimeGraph="$(BundledRuntimeIdentifierGraphFile)"
                                     Distinct="true">
       <Output TaskParameter="BestTargetFrameworks" ItemName="_BestTargetFramework" />
     </ChooseBestTargetFrameworksTask>


### PR DESCRIPTION
- Align the ChooseBestP2PTargetFrameworkTask more closely with the NuGet task that is used in the SDK to resolve best matching project references.
- Enable nullable reference type warnings
- Remove logic from BinPlace.targets that isn't needed anymore
- Make the TargetFramework msbuild files pick up the SDK's runtime graph instead of passing it in explicitly.

Tested thoroughly offline and will submit a follow-up change in dotnet/runtime when this got merged.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
