### PR TITLE
Fix GetTargetFrameworks MSBuild invoc

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
@@ -46,7 +46,7 @@
     <MSBuild Projects="@(ProjectReference)"
              Targets="GetTargetFrameworks"
              BuildInParallel="$(BuildInParallel)"
-             RemoveProperties="%(ProjectReference.GlobalPropertiesToRemove);TargetFramework;RuntimeIdentifier;SelfContained;Platform;Configuration;$(_GlobalPropertiesToRemoveFromProjectReferences)"
+             RemoveProperties="%(ProjectReference.GlobalPropertiesToRemove);TargetFramework;RuntimeIdentifier;SelfContained;$(_GlobalPropertiesToRemoveFromProjectReferences)"
              Condition="'%(ProjectReference.SkipGetTargetFrameworkProperties)' != 'true'">
       <Output TaskParameter="TargetOutputs" ItemName="_ProjectReferenceWithTargetFrameworks" />
     </MSBuild>

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
@@ -46,6 +46,7 @@
     <MSBuild Projects="@(ProjectReference)"
              Targets="GetTargetFrameworks"
              BuildInParallel="$(BuildInParallel)"
+             Properties="%(ProjectReference.SetConfiguration);%(ProjectReference.SetPlatform)"
              RemoveProperties="%(ProjectReference.GlobalPropertiesToRemove);TargetFramework;RuntimeIdentifier;SelfContained;$(_GlobalPropertiesToRemoveFromProjectReferences)"
              Condition="'%(ProjectReference.SkipGetTargetFrameworkProperties)' != 'true'">
       <Output TaskParameter="TargetOutputs" ItemName="_ProjectReferenceWithTargetFrameworks" />


### PR DESCRIPTION
The `Platform` and `Configuration` properties must not be undefined when invoking the GetTargetFrameworks target. Unblocks https://github.com/dotnet/runtime/pull/80074

Mimics the existing `GetTargetFrameworks` target: https://github.com/dotnet/msbuild/blob/a6f6699d1f70bf79db82030938d2c5e52d1e4d2e/src/Tasks/Microsoft.Common.CurrentVersion.targets#L1779-L1795

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
