### PR TITLE
add pre-built doc link

### DIFF
--- a/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/ValidateUsageAgainstBaseline.cs
+++ b/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/ValidateUsageAgainstBaseline.cs
@@ -39,8 +39,12 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
 
         public bool AllowTestProjectUsage { get; set; }
 
+        private readonly string _preBuiltDocMessage = "Additional documentation " +
+            "on pre-built detection can be found at https://aka.ms/source-build/pre-built";
+
         public override bool Execute()
         {
+            string PreBuiltDocXmlComment = $"<!-- {_preBuiltDocMessage} -->\n";
             var used = UsageData.Parse(XElement.Parse(File.ReadAllText(DataFile)));
 
             string baselineText = string.IsNullOrEmpty(BaselineDataFile)
@@ -52,10 +56,10 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
             UsageValidationData data = GetUsageValidationData(baseline, used);
 
             Directory.CreateDirectory(Path.GetDirectoryName(OutputBaselineFile));
-            File.WriteAllText(OutputBaselineFile, data.ActualUsageData.ToXml().ToString());
+            File.WriteAllText(OutputBaselineFile, PreBuiltDocXmlComment + data.ActualUsageData.ToXml().ToString());
 
             Directory.CreateDirectory(Path.GetDirectoryName(OutputReportFile));
-            File.WriteAllText(OutputReportFile, data.Report.ToString());
+            File.WriteAllText(OutputReportFile, PreBuiltDocXmlComment + data.Report.ToString());
 
             return !Log.HasLoggedErrors;
         }
@@ -81,8 +85,8 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
                 tellUserToUpdateBaseline = true;
                 Log.LogError(
                     $"{diff.Added.Length} new packages used not in baseline! See report " +
-                    $"at {OutputReportFile} for more information. Package IDs are:\n" +
-                    string.Join("\n", diff.Added.Select(u => u.ToString())));
+                    $"at {OutputReportFile} for more information.\n{_preBuiltDocMessage}\n" +
+                    $"Package IDs are:\n" + string.Join("\n", diff.Added.Select(u => u.ToString())));
 
                 // In the report, list full usage info, not only identity.
                 report.Add(

--- a/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/ValidateUsageAgainstBaseline.cs
+++ b/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/ValidateUsageAgainstBaseline.cs
@@ -39,8 +39,8 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
 
         public bool AllowTestProjectUsage { get; set; }
 
-        private readonly string _preBuiltDocMessage = "Additional documentation " +
-            "on pre-built detection can be found at https://aka.ms/dotnet/prebuilts";
+        private readonly string _preBuiltDocMessage = "See aka.ms/dotnet/prebuilts " +
+            "for guidance on what pre-builts are and how to eliminate them.";
 
         public override bool Execute()
         {
@@ -84,8 +84,8 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
             {
                 tellUserToUpdateBaseline = true;
                 Log.LogError(
-                    $"{diff.Added.Length} new packages used not in baseline! See report " +
-                    $"at {OutputReportFile} for more information.\n{_preBuiltDocMessage}\n" +
+                    $"{diff.Added.Length} new pre-builts discovered! Detailed usage " +
+                    $"report can be found at {OutputReportFile}.\n{_preBuiltDocMessage}\n" +
                     $"Package IDs are:\n" + string.Join("\n", diff.Added.Select(u => u.ToString())));
 
                 // In the report, list full usage info, not only identity.

--- a/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/ValidateUsageAgainstBaseline.cs
+++ b/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/ValidateUsageAgainstBaseline.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
         public bool AllowTestProjectUsage { get; set; }
 
         private readonly string _preBuiltDocMessage = "Additional documentation " +
-            "on pre-built detection can be found at https://aka.ms/source-build/pre-built";
+            "on pre-built detection can be found at https://aka.ms/dotnet/prebuilts";
 
         public override bool Execute()
         {


### PR DESCRIPTION
Part of https://github.com/dotnet/source-build/issues/3054

New pre-built detection error message example:
```
3 new pre-builts discovered! Detailed usage report can be found at ./artifacts/source-build/self/prebuilt-report/baseline-comparison.xml.
See aka.ms/dotnet/prebuilts for guidance on what pre-builts are and how to eliminate them.
Package IDs are:
Microsoft.Bcl.AsyncInterfaces.8.0.0-alpha.1.22557.11
Microsoft.Build.16.7.0
Microsoft.Build.Framework.14.3.0
```

Generated new baseline example:
```xml
<!-- See aka.ms/dotnet/prebuilts for guidance on what pre-builts are and how to eliminate them -->
<UsageData>
  <Usages>
    <Usage Id="Microsoft.SourceBuild.Intermediate.arcade" Version="8.0.0-beta.22630.1" IsDirectDependency="true" />
    <Usage Id="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.22616.1" IsDirectDependency="true" />
  </Usages>
</UsageData>
```

New baseline comparison report:
```xml
<!-- See aka.ms/dotnet/prebuilts for guidance on what pre-builts are and how to eliminate them -->
<BaselineComparison>
  <New>
    <Usage Id="Microsoft.SourceBuild.Intermediate.arcade" Version="8.0.0-beta.22630.1" File="src/artifacts/toolset/Common/project.assets.json" IsDirectDependency="true" />
    <Usage Id="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.22616.1"
  </New>
</BaselineComparison>
```