### PR TITLE
Add some extra logging to Helix runs

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/StopAzurePipelinesTestRun.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/StopAzurePipelinesTestRun.cs
@@ -1,9 +1,9 @@
-using Microsoft.Build.Framework;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.DotNet.Helix.AzureDevOps
 {
@@ -12,11 +12,16 @@ namespace Microsoft.DotNet.Helix.AzureDevOps
         [Required]
         public int TestRunId { get; set; }
 
+        [Required]
+        public string TestRunName { get; set; }
+
         protected override async Task ExecuteCoreAsync(HttpClient client)
         {
             await RetryAsync(
                 async () =>
                 {
+                    Log.LogMessage(MessageImportance.High, $"Stopping Azure Pipelines Test Run {TestRunName} (Results: {CollectionUri}{TeamProject}/_build/results?buildId={BuildId}&view=ms.vss-test-web.build-test-results-tab )");
+
                     using (var req =
                         new HttpRequestMessage(
                             new HttpMethod("PATCH"),

--- a/src/Microsoft.DotNet.Helix/Sdk/WaitForHelixJobCompletion.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/WaitForHelixJobCompletion.cs
@@ -1,11 +1,10 @@
-using Microsoft.Build.Framework;
-using Microsoft.DotNet.Helix.Client;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.DotNet.Helix.Client;
 
 namespace Microsoft.DotNet.Helix.Sdk
 {
@@ -35,7 +34,12 @@ namespace Microsoft.DotNet.Helix.Sdk
         {
             await Task.Yield();
             cancellationToken.ThrowIfCancellationRequested();
-            Log.LogMessage(MessageImportance.High, $"Waiting for completion of job {jobName} on {queueName}");
+
+            // Only include the link to the Helix API "Details" page if we're using anonymous access.
+            // If a user must manually edit the URL with an Access Token, there is limited value in including it in build logging.
+            string detailsUrlWhereApplicable = HelixApi.Options.Credentials == null ? $" (Details: {HelixApi.Options.BaseUri}api/jobs/{jobName}/details?api-version=2019-06-17 )" : string.Empty;
+
+            Log.LogMessage(MessageImportance.High, $"Waiting for completion of job {jobName} on {queueName}{detailsUrlWhereApplicable}");
 
             int iterationCount = 0;
             try

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/AzurePipelines.MultiQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/AzurePipelines.MultiQueue.targets
@@ -33,8 +33,7 @@
   <Target Name="StopTestRuns"
           AfterTargets="CoreTest"
           Outputs="%(HelixTargetQueue.Identity)">
-    <Message Text="Stopping Azure Pipelines Test Run %(HelixTargetQueue.TestRunName)" Importance="High"/>
-    <StopAzurePipelinesTestRun TestRunId="%(HelixTargetQueue.TestRunId)"/>
+    <StopAzurePipelinesTestRun TestRunId="%(HelixTargetQueue.TestRunId)" TestRunName="%(HelixTargetQueue.TestRunName)"/>
   </Target>
 
   <Target Name="CheckTestResults"


### PR DESCRIPTION
Changes as requested in https://github.com/dotnet/arcade/issues/10375:

- When anonymous, log the job Details API URL in the `Waiting for completion of job {jobName} on {queueName}` messages
- Add link to test run URL when stopping test runs (`Stopping Azure Pipelines Test Run...`)

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
