### PR TITLE
Add HTML file support & more WiX file support to LocProject.json generation

### DIFF
--- a/eng/common/generate-locproject.ps1
+++ b/eng/common/generate-locproject.ps1
@@ -45,12 +45,12 @@ if (-not $wxlFiles) {
     }
 }
 
-$installerHtmlEnFiles = Get-ChildItem -Recurse -Path "$SourcesDirectory" | Where-Object { $_.FullName -Match "en\.lproj\\.+\.html" } # add installer HTML files
-$installerHtmlFiles = @()
-if ($installerHtmlEnFiles) {
-    $installerHtmlEnFiles | ForEach-Object {
+$macosHtmlEnFiles = Get-ChildItem -Recurse -Path "$SourcesDirectory" | Where-Object { $_.FullName -Match "en\.lproj\\.+\.html" } # add installer HTML files
+$macosHtmlFiles = @()
+if ($macosHtmlEnFiles) {
+    $macosHtmlEnFiles | ForEach-Object {
         $destinationFile = "$($_.Directory.Parent.FullName)\$($_.Name)"
-        $installerHtmlFiles += Copy-Item "$($_.FullName)" -Destination $destinationFile -PassThru
+        $macosHtmlFiles += Copy-Item "$($_.FullName)" -Destination $destinationFile -PassThru
     }
 }
 
@@ -138,7 +138,7 @@ $locJson = @{
             LanguageSet = $LanguageSet
             CloneLanguageSet = "VS_macOS_CloneLanguages"
             LocItems = @(
-                $installerHtmlFiles | ForEach-Object {
+                $macosHtmlFiles | ForEach-Object {
                     $outputPath = "$($_.Directory.FullName | Resolve-Path -Relative)\"
                     $continue = $true
                     foreach ($exclusion in $exclusions.Exclusions) {

--- a/eng/common/generate-locproject.ps1
+++ b/eng/common/generate-locproject.ps1
@@ -35,7 +35,7 @@ $jsonWinformsTemplateFiles = Get-ChildItem -Recurse -Path "$SourcesDirectory" | 
 
 $wxlFiles = Get-ChildItem -Recurse -Path "$SourcesDirectory" | Where-Object { $_.FullName -Match "\\.+\.wxl" -And -Not( $_.Directory.Name -Match "\d{4}" ) } # localized files live in four digit lang ID directories; this excludes them
 if (-not $wxlFiles) {
-    $wxlEnFiles = Get-ChildItem -Recurse -Path "$SourcesDirectory" | Where-Object { $_.FullName -Match "\\1033\\.+\.wxl" } # pick up en files specifically
+    $wxlEnFiles = Get-ChildItem -Recurse -Path "$SourcesDirectory" | Where-Object { $_.FullName -Match "\\1033\\.+\.wxl" } #  pick up en files (1033 = en) specifically so we can copy them to use as the neutral xlf files
     if ($wxlEnFiles) {
       $wxlFiles = @()
       $wxlEnFiles | ForEach-Object {

--- a/eng/common/generate-locproject.ps1
+++ b/eng/common/generate-locproject.ps1
@@ -35,6 +35,8 @@ $jsonWinformsTemplateFiles = Get-ChildItem -Recurse -Path "$SourcesDirectory" | 
 
 $wxlFiles = Get-ChildItem -Recurse -Path "$SourcesDirectory" | Where-Object { $_.FullName -Match "\\.+\.wxl" -And -Not( $_.Directory.Name -Match "\d{4}" ) } # localized files live in four digit lang ID directories; this excludes them
 
+$installerHtmlFiles = Get-ChildItem -Recurse -Path "$SourcesDirecotry" | Where-Object { $_.FullName -Match "en\.lproj\\.+\.html" } # add installer HTML files
+
 $xlfFiles = @()
 
 $allXlfFiles = Get-ChildItem -Recurse -Path "$SourcesDirectory\*\*.xlf"


### PR DESCRIPTION
Resolves #12090.

This adds code to the `generate-locproject.ps1` script to pick up macOS HTML files. Specifically, it finds the English version of these files and then copies it to the parent directory to act as a neutral language file for translators (which is the appropriate OneLocBuild process). Additionally, I noticed that some repos did not have neutral language wxl files checked in for their WiX files (like aspnetcore does which was the basis for this feature). So this also adds functionality to handle that.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
