### PR TITLE
Revert "Azure Pipelines has added support for variable templates..." (broke build)

### DIFF
--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -88,15 +88,6 @@ jobs:
     - ${{ if ne(variable.group, '') }}:
       - group: ${{ variable.group }}
 
-    # handle template variable syntax
-    # example:
-    # - template: path/to/template.yml
-    #   parameters:
-    #     [key]: [value]
-    - ${{ if ne(variable.template, '') }}:
-      - template: ${{ variable.template }}
-        parameters: ${{ variable.parameters }}
-
     # handle key-value variable syntax.
     # example:
     # - [key]: [value]


### PR DESCRIPTION
This reverts commit 8760c92e5970c6ef67069aaed665f49a6c174f3e.

See https://dev.azure.com/dnceng/internal/_build/results?buildId=2081813&view=results for context

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
