### PR TITLE
Enable template variables for Azure DevOps in Arcade-based jobs, try 2

### DIFF
--- a/azure-pipelines-code-mirror.yml
+++ b/azure-pipelines-code-mirror.yml
@@ -3,7 +3,7 @@ trigger: none
 
 variables:
   - group: Mirror-Credentials
-  - template: eng/common/templates/variables/pool-providers.yml
+  - template: /eng/common/templates/variables/pool-providers.yml
 
 # Moves code from GitHub into internal repos
 jobs:

--- a/azure-pipelines-codeql.yml
+++ b/azure-pipelines-codeql.yml
@@ -6,8 +6,8 @@ parameters:
   default: true
 
 variables:
-- template: eng/common-variables.yml
-- template: eng/common/templates/variables/pool-providers.yml
+- template: /eng/common-variables.yml
+- template: /eng/common/templates/variables/pool-providers.yml
   # CG is handled in the primary CI pipeline
 - name: skipComponentGovernanceDetection
   value: true

--- a/azure-pipelines-merge-mirror.yml
+++ b/azure-pipelines-merge-mirror.yml
@@ -3,7 +3,7 @@ trigger: none
 
 variables:
   - group: Mirror-Credentials
-  - template: eng/common/templates/variables/pool-providers.yml
+  - template: /eng/common/templates/variables/pool-providers.yml
 
 # Merges code from GitHub into internal branches in internal repos
 jobs:

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -9,8 +9,8 @@ trigger:
 pr: none
 
 variables:
-- template: eng/common-variables.yml
-- template: eng/common/templates/variables/pool-providers.yml
+- template: /eng/common-variables.yml
+- template: /eng/common/templates/variables/pool-providers.yml
 
 stages:
 - stage: build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,8 +18,8 @@ pr:
     - templates
 
 variables:
-- template: eng/common-variables.yml
-- template: eng/common/templates/variables/pool-providers.yml
+- template: /eng/common-variables.yml
+- template: /eng/common/templates/variables/pool-providers.yml
 
 resources:
   containers:

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -88,6 +88,15 @@ jobs:
     - ${{ if ne(variable.group, '') }}:
       - group: ${{ variable.group }}
 
+    # handle template variable syntax
+    # example:
+    # - template: path/to/template.yml
+    #   parameters:
+    #     [key]: [value]
+    - ${{ if ne(variable.template, '') }}:
+      - template: ${{ variable.template }}
+        parameters: ${{ variable.parameters }}
+
     # handle key-value variable syntax.
     # example:
     # - [key]: [value]

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -95,8 +95,8 @@ jobs:
     #     [key]: [value]
     - ${{ if ne(variable.template, '') }}:
       - template: ${{ variable.template }}
-      ${{ if ne(variable.parameters, '') }}:
-        parameters: ${{ variable.parameters }}
+        ${{ if ne(variable.parameters, '') }}:
+          parameters: ${{ variable.parameters }}
 
     # handle key-value variable syntax.
     # example:

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -95,6 +95,7 @@ jobs:
     #     [key]: [value]
     - ${{ if ne(variable.template, '') }}:
       - template: ${{ variable.template }}
+      ${{ if ne(variable.parameters, '') }}:
         parameters: ${{ variable.parameters }}
 
     # handle key-value variable syntax.

--- a/eng/common/templates/variables/pool-providers.yml
+++ b/eng/common/templates/variables/pool-providers.yml
@@ -16,7 +16,7 @@
 #  First, import the template in an arcade-ified repo to pick up the variables, e.g.:
 #
 #  variables:
-#  - template: eng/common/templates/variables/pool-providers.yml
+#  - template: /eng/common/templates/variables/pool-providers.yml
 #
 #  ... then anywhere specifying the pool provider use the runtime variables,
 #      $(DncEngInternalBuildPool) and $  (DncEngPublicBuildPool), e.g.:

--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -36,7 +36,7 @@ stages:
           name: VSEngSS-MicroBuild2022-1ES
           demands: Cmd
         # If it's not devdiv, it's dnceng: 
-        # Publishing cannot use eng/common/templates/variables/pool-providers.yml since it always runs from 'main',
+        # Publishing cannot use /eng/common/templates/variables/pool-providers.yml since it always runs from 'main',
         # including in the servicing build case.  Instead the 'useServicingBuildPools' parameter dictates this.
         # If useServicingBuildPools = false, it's a main branch. 
         ${{ if and(ne(variables['System.TeamProject'], 'DevDiv'), eq(parameters['useServicingBuildPools'], false)) }}:

--- a/eng/validate-sdk.yml
+++ b/eng/validate-sdk.yml
@@ -24,7 +24,7 @@ jobs:
     - _BuildConfig: ${{ parameters.buildConfig }}
     - _BuildArgs: ${{ parameters.buildArgs }}
     - _ValidateBlobFeedUrl: ${{ parameters.validateBlobFeedUrl }}
-    - template: eng/common/templates/variables/pool-providers.yml
+    - template: /eng/common/templates/variables/pool-providers.yml
     pool:
       name: $(DncEngInternalBuildPool)
       demands: ImageOverride -equals windows.vs2019.amd64


### PR DESCRIPTION
Add support for variable templates in Arcade.

Official build at https://dev.azure.com/dnceng/internal/_build/results?buildId=2081988&view=results

Unlike the last attempt, this time we explicitly handle the case where no parameters are passed to the template.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
