### PR TITLE
Install numa package in rootfs

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -48,12 +48,14 @@ __UbuntuPackages+=" symlinks"
 __UbuntuPackages+=" libicu-dev"
 __UbuntuPackages+=" liblttng-ust-dev"
 __UbuntuPackages+=" libunwind8-dev"
+__UbuntuPackages+=" libnuma-dev"
 
 __AlpinePackages+=" gettext-dev"
 __AlpinePackages+=" icu-dev"
 __AlpinePackages+=" libunwind-dev"
 __AlpinePackages+=" lttng-ust-dev"
 __AlpinePackages+=" compiler-rt-static"
+__AlpinePackages+=" numactl-dev"
 
 # runtime libraries' dependencies
 __UbuntuPackages+=" libcurl4-openssl-dev"


### PR DESCRIPTION
Without this installed, `NUMASupportInitialize()` on arm{64} platforms is skipping the initialization and directly going to `false` branch: https://github.com/dotnet/runtime/blob/a10ee9ec8edaae541f074a77474cf6c2d1ffc56f/src/coreclr/gc/unix/gcenv.unix.cpp#L333 (`HAVE_NUMA_H` is 0)