### PR TITLE
Upgrade SDK to 8.0.100-alpha.1.23061.8

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "8.0.100-alpha.1.23055.1"
+    "dotnet": "8.0.100-alpha.1.23061.8"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23059.1",

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <IncludeDotNetCli Condition=" '$(IncludeDotNetCli)' != 'true' ">false</IncludeDotNetCli>
-    <AspNetCoreRuntimeVersion>8.0.100-alpha.1.23055.1</AspNetCoreRuntimeVersion>
+    <AspNetCoreRuntimeVersion>8.0.100-alpha.1.23061.8</AspNetCoreRuntimeVersion>
     <DotNetCliPackageType Condition=" '$(DotNetCliPackageType)' == '' ">runtime</DotNetCliPackageType>
     <DotNetCliVersion Condition=" '$(DotNetCliVersion)' == '' AND '$(DotNetCliPackageType)' == 'runtime' ">$(BundledNETCoreAppPackageVersion)</DotNetCliVersion>
     <!-- TODO (https://github.com/dotnet/arcade/issues/7022): We are hardcoding this version to use the one tied to the SDK version from global.json -->


### PR DESCRIPTION
TL;DR: We found a severe issue with the previous chosen SDK that impacts single file applications that results in a `Failed to create CoreCLR, HRESULT: 0x80131524` error. Upgrading to `8.0.100-alpha.1.23061.8` which contains the necessary runtime fix: https://github.com/dotnet/runtime/commit/6c0c96ccc775cad4119e2d5d3a1797c4126b4533.

See https://github.com/dotnet/runtime/pull/80234#issuecomment-1379473810 for more details

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
