### PR TITLE
Fix duplicated PropertyGroup items

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/TargetFrameworkDefaults.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/TargetFrameworkDefaults.props
@@ -14,11 +14,9 @@
        <TargetFrameworks>$(NetCurrent);$(NetPrevious);$(NetFrameworkMinimum);net472</TargetFrameworks>
   -->
   <PropertyGroup>
-    <PropertyGroup>
-      <NetCurrent>net8.0</NetCurrent>
-      <NetPrevious>net7.0</NetPrevious>
-      <NetMinimum>net6.0</NetMinimum>
-      <NetFrameworkMinimum>net462</NetFrameworkMinimum>
-    </PropertyGroup>
+    <NetCurrent>net8.0</NetCurrent>
+    <NetPrevious>net7.0</NetPrevious>
+    <NetMinimum>net6.0</NetMinimum>
+    <NetFrameworkMinimum>net462</NetFrameworkMinimum>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Regressed with https://github.com/dotnet/arcade/commit/9a4d4f5144eeee047c94f4bc3e0dba532eb47f34

Error:
```
C:\Users\vikto\.nuget\packages\microsoft.dotnet.arcade.sdk\8.0.0-beta.23061.3\tools\TargetFrameworkDefaults.props(17,5)
: error MSB4004: The "PropertyGroup" property is reserved, and cannot be modified. [C:\git\sourcelink2\src\Microsoft.Bu
ild.Tasks.Git\Microsoft.Build.Tasks.Git.csproj]
```

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
