### PR TITLE
Begin removal of MicrosoftSourceLinkVersion

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -92,8 +92,6 @@
     <MicrosoftSymbolUploaderVersion>2.0.0-preview.1.21526.15</MicrosoftSymbolUploaderVersion>
     <MicrosoftNetSdkWorkloadManifestReaderVersion>7.0.100-preview.5.22273.2</MicrosoftNetSdkWorkloadManifestReaderVersion>
     <MicrosoftDeploymentDotNetReleasesVersion>1.0.0-preview5.1.22263.1</MicrosoftDeploymentDotNetReleasesVersion>
-    <!-- Used to flow Source Link version through Arcade SDK -->
-    <MicrosoftSourceLinkVersion>$(MicrosoftSourceLinkGitHubVersion)</MicrosoftSourceLinkVersion>
     <MicrosoftTemplateEngineAuthoringTasksVersion>8.0.100-alpha.1.23056.28</MicrosoftTemplateEngineAuthoringTasksVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
@@ -79,7 +79,10 @@
     <ArcadeSdkVersion>$(PackageVersion)</ArcadeSdkVersion>
     <MicrosoftNetCompilersToolsetVersion>$(MicrosoftNetCompilersToolsetVersion)</MicrosoftNetCompilersToolsetVersion>
     <MicrosoftNetILLinkTasksVersion>$(MicrosoftNetILLinkTasksVersion)</MicrosoftNetILLinkTasksVersion>
-    <MicrosoftSourceLinkVersion>$(MicrosoftSourceLinkVersion)</MicrosoftSourceLinkVersion>
+    <MicrosoftSourceLinkGitHubVersion>$(MicrosoftSourceLinkGitHubVersion)</MicrosoftSourceLinkGitHubVersion>
+    <MicrosoftSourceLinkAzureReposGitVersion$(MicrosoftSourceLinkAzureReposGitVersion)</MicrosoftSourceLinkAzureReposGitVersion>
+    <!-- This property will be removed as part of https://github.com/dotnet/arcade/issues/12196 and all dependencies on it should be removed -->
+    <MicrosoftSourceLinkVersion>$(MicrosoftSourceLinkGitHubVersion)</MicrosoftSourceLinkGitVersion>
     <MicrosoftDiaSymReaderPdb2PdbVersion>$(MicrosoftDiaSymReaderPdb2PdbVersion)</MicrosoftDiaSymReaderPdb2PdbVersion>
     <MicrosoftDotNetXliffTasksVersion>$(MicrosoftDotNetXliffTasksVersion)</MicrosoftDotNetXliffTasksVersion>
     <MicrosoftDotNetMaestroTasksVersion>$(MicrosoftDotNetMaestroTasksVersion)</MicrosoftDotNetMaestroTasksVersion>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
@@ -5,8 +5,8 @@
     Include both GitHub and Azure DevOps packages to enable SourceLink in repositories that mirror to Azure DevOps.
   -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
-    <PackageReference Include="Microsoft.SourceLink.AzureRepos.Git" Version="$(MicrosoftSourceLinkVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
+    <PackageReference Include="Microsoft.SourceLink.AzureRepos.Git" Version="$(MicrosoftSourceLinkAzureReposGitVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
 
   <!-- Opt-in switch to disable source link (i.e. for local builds). -->


### PR DESCRIPTION
This property is a proxy for the versions of the source link packages. Proxy properties do not generally play well with source build. Source build must explictly set this property to be equal to the version of one of the other packages (GitHub or AzureRepos.Git) in order to properly override sourcelink to the incoming version. This is very awkward and also not at all compatible with PVP flow.

Fixing this will happen in three stages:
- This PR: Change internal package references to reference the dependency flow properties for each individual package (GitHub and AzureRepos.Git). Add these properties to the generated sdk versions. Retain the original property name, but set it off of the GitHub package version.
- Future PRs: Remove usages of MicrosoftSourceLinkVersion in repos. Where this property is used in repos, instead use the correct individual properties.
- Final PR: Remove MicrosoftSourceLinkVersion.

Some repos today set MicrosoftSourceLinkVersion (usually to an ancient version) but do not use it. This overrides Arcade's version. I believe most of these cases are in error, where repo owners expected dependency flow, but are not getting it. In these cases, this change will transparently upgrade them to Arcade's default.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
