### PR TITLE
Retry TCP Failures and stop retring APP_CRASH for apple devices

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-processor.py
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-event-processor.py
@@ -125,8 +125,8 @@ def analyze_operation(command: str, platform: str, device: str, is_device: bool,
 
     global retry, reboot, android_connectivity_verified
 
-    # Apps crashing can be infra failures too (this is a gray zone)
-    if exit_code == 80: # APP_CRASH
+    # Apps crashing can be infra failures, retry except on Apple devices where retries can be costly due to small queue size
+    if exit_code == 80 and not (platform == "apple" and is_device): # APP_CRASH
         print(f'    Application crashed - if persist, please investigate system logs from the run')
         retry = True
         reboot = True
@@ -159,6 +159,12 @@ def analyze_operation(command: str, platform: str, device: str, is_device: bool,
         if not is_device:
             reboot = True
         retry = True
+        return
+
+    if exit_code == 92: # TCP_CONNECTION_FAILED
+        print(f'    Failed to communicate using TCP connection')
+        retry = True
+        reboot = True
         return
 
     if platform == "android":


### PR DESCRIPTION
Reverting: https://github.com/dotnet/arcade/commit/c4cc09bef379e3450b851cd730eaedd9288c1851#diff-b9ee7ec50f4418cea65dd2ce6903edabcda042c9e83b1bd18b62874771bc50e1

and adding retries TCP_CONNECTION_FAILED.

This is linked to: https://github.com/dotnet/xharness/pull/987 
