### PR TITLE
Generate fixed length names for MSIs

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             bool result = createWorkloadTask.Execute();
 
             Assert.True(result);
-            ITaskItem manifestMsiItem = createWorkloadTask.Msis.Where(m => m.ItemSpec.ToLowerInvariant().Contains("microsoft.net.workload.emscripten.manifest-6.0.200.6.0.4-x64.msi")).FirstOrDefault();
+            ITaskItem manifestMsiItem = createWorkloadTask.Msis.Where(m => m.ItemSpec.ToLowerInvariant().Contains("8611bf463c6ff41092008be7191ad949-x64.msi")).FirstOrDefault();
             Assert.NotNull(manifestMsiItem);
 
             // Spot check one of the manifest MSIs. We have additional tests that cover MSI generation.
@@ -180,7 +180,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             bool result = createWorkloadTask.Execute();
 
             Assert.True(result);
-            ITaskItem manifestMsiItem = createWorkloadTask.Msis.Where(m => m.ItemSpec.ToLowerInvariant().Contains("microsoft.net.workload.emscripten.manifest-6.0.200.6.0.4-arm64.msi")).FirstOrDefault();
+            ITaskItem manifestMsiItem = createWorkloadTask.Msis.Where(m => m.ItemSpec.ToLowerInvariant().Contains("8611bf463c6ff41092008be7191ad949-arm64.msi")).FirstOrDefault();
             Assert.NotNull(manifestMsiItem);
 
             // Spot check one of the manifest MSIs. We have additional tests that cover MSI generation.

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/MsiTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/MsiTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             // Generated MSI should return the path where the .wixobj files are located so
             // WiX packs can be created for post-build signing.
             Assert.NotNull(item.GetMetadata(Metadata.WixObj));
-        }       
+        }
 
         [WindowsOnlyFact]
         public void ItCanBuildATemplatePackMsi()

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/WorkloadManifestTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/WorkloadManifestTests.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Deployment.DotNet.Releases;
+using Xunit;
+
+namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
+{
+    public class WorkloadManifestTests : TestBase
+    {
+        [WindowsOnlyTheory]
+        [InlineData("Microsoft.NET.Workload.Emscripten.net6.Manifest-8.0.100-alpha.1", "8.0.100-alpha.1")]
+        [InlineData("Microsoft.NET.Workload.Emscripten.Manifest-8.0.100-alpha.1.23062.6", "8.0.100-alpha.1.23062.6")]
+        public static void ItExtractsTheSdkVersionFromTheManifestPackageId(string packageId, string expectedVersion)
+        {
+            string actualSdkVersion = WorkloadManifestPackage.GetSdkVersion(packageId);
+
+            Assert.Equal(expectedVersion, actualSdkVersion);
+        }
+
+        [WindowsOnlyTheory]
+        [InlineData("8.0.100-alpha.1", "8.0.100-alpha.1")]
+        [InlineData("8.0.100-preview.1", "8.0.100-preview.1")]
+        [InlineData("8.0.100-dev.1", "8.0.100")]
+        [InlineData("8.0.100-alpha.1.23062.6", "8.0.100-alpha.1")]
+        [InlineData("8.0.101-alpha.1.23062.6", "8.0.100-alpha.1")]
+        public static void ItConvertsTheManifestSdkVersionToAFeatureBandVersion(string sdkVersion, string expectedVersion)
+        {
+            ReleaseVersion actualFeatureBandVersion = WorkloadManifestPackage.GetSdkFeatureBandVersion(sdkVersion);
+
+            Assert.Equal(expectedVersion, $"{actualFeatureBandVersion}");
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/WorkloadManifestTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/WorkloadManifestTests.cs
@@ -22,13 +22,14 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
         [InlineData("8.0.100-alpha.1", "8.0.100-alpha.1")]
         [InlineData("8.0.100-preview.1", "8.0.100-preview.1")]
         [InlineData("8.0.100-dev.1", "8.0.100")]
+        [InlineData("7.0.203", "7.0.200")]
         [InlineData("8.0.100-alpha.1.23062.6", "8.0.100-alpha.1")]
         [InlineData("8.0.101-alpha.1.23062.6", "8.0.100-alpha.1")]
         public static void ItConvertsTheManifestSdkVersionToAFeatureBandVersion(string sdkVersion, string expectedVersion)
         {
             ReleaseVersion actualFeatureBandVersion = WorkloadManifestPackage.GetSdkFeatureBandVersion(sdkVersion);
 
-            Assert.Equal(expectedVersion, actualFeatureBandVersion);
+            Assert.Equal(expectedVersion, $"{actualFeatureBandVersion}");
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/WorkloadManifestTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/WorkloadManifestTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
         {
             ReleaseVersion actualFeatureBandVersion = WorkloadManifestPackage.GetSdkFeatureBandVersion(sdkVersion);
 
-            Assert.Equal(expectedVersion, $"{actualFeatureBandVersion}");
+            Assert.Equal(expectedVersion, actualFeatureBandVersion);
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
@@ -195,7 +195,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                 // TODO: trim out duplicate manifests.
                 List<WorkloadManifestPackage> manifestPackages = new();
                 List<WorkloadManifestMsi> manifestMsisToBuild = new();
-                List<SwixComponent> swixComponents = new();
+                HashSet<SwixComponent> swixComponents = new();
                 Dictionary<string, BuildData> buildData = new();
                 Dictionary<string, WorkloadPackGroupPackage> packGroupPackages = new();
 
@@ -358,6 +358,14 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                             // Finally, add a component for the workload in Visual Studio.
                             SwixComponent component = SwixComponent.Create(manifestPackage.SdkFeatureBand, workload, manifest, packGroupId,
                                 ComponentResources, ShortNames);
+
+                            // Check for duplicates, e.g. manifests that were copied without changing workload definition IDs and
+                            // provide a more usable error message so users can track down the duplication.
+                            if (swixComponents.Contains(component))
+                            {
+                                Log.LogError($"Duplicate workload ID: {workload.Id}. A SWIX component with the same workload ID already exists.");
+                            }
+
                             swixComponents.Add(component);
                         }
                     }

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Msi/WorkloadManifestMsi.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Msi/WorkloadManifestMsi.wix.cs
@@ -27,9 +27,11 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Msi
 
         public List<WorkloadPackGroupJson> WorkloadPackGroups { get; } = new();
 
+        /// <inheritdoc />
+        protected override string BaseOutputName => Path.GetFileNameWithoutExtension(Package.PackagePath);
 
         public WorkloadManifestMsi(WorkloadManifestPackage package, string platform, IBuildEngine buildEngine, string wixToolsetPath,
-            string baseIntermediateOutputPath) : 
+            string baseIntermediateOutputPath) :
             base(MsiMetadata.Create(package), buildEngine, wixToolsetPath, platform, baseIntermediateOutputPath)
         {
             Package = package;
@@ -136,15 +138,12 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Msi
                 throw new Exception(Strings.FailedToCompileMsi);
             }
 
-            ITaskItem msi = Link(candle.OutputPath, 
-                Path.Combine(outputPath, Path.GetFileNameWithoutExtension(Package.PackagePath) + $"-{Platform}.msi"),
-                iceSuppressions);
+            ITaskItem msi = Link(candle.OutputPath, Path.Combine(outputPath, OutputName), iceSuppressions);
 
             AddDefaultPackageFiles(msi);
-                        
+
             return msi;
         }
-
 
         public class WorkloadPackGroupJson
         {

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Msi/WorkloadPackGroupMsi.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Msi/WorkloadPackGroupMsi.wix.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.Tasks.Workloads.Wix;
@@ -17,6 +15,9 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Msi
     internal class WorkloadPackGroupMsi : MsiBase
     {
         WorkloadPackGroupPackage _package;
+
+        /// <inheritdoc />
+        protected override string BaseOutputName => Metadata.Id;
 
         public WorkloadPackGroupMsi(WorkloadPackGroupPackage package, string platform, IBuildEngine buildEngine, string wixToolsetPath,
             string baseIntermediatOutputPath)
@@ -139,14 +140,13 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Msi
                 throw new Exception(Strings.FailedToCompileMsi);
             }
 
-            string msiFileName = Path.Combine(outputPath, Metadata.Id + $"-{Platform}.msi");
+            string msiFileName = Path.Combine(outputPath, OutputName);
 
             ITaskItem msi = Link(candle.OutputPath, msiFileName, iceSuppressions);
 
             AddDefaultPackageFiles(msi);
 
             return msi;
-
         }
 
         class MsiDirectory

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Msi/WorkloadPackMsi.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Msi/WorkloadPackMsi.wix.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.IO;
-using System.IO.Packaging;
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.Tasks.Workloads.Wix;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
@@ -15,6 +14,9 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Msi
     internal class WorkloadPackMsi : MsiBase
     {
         private WorkloadPackPackage _package;
+
+        /// <inheritdoc />
+        protected override string BaseOutputName => _package.ShortName;
 
         public WorkloadPackMsi(WorkloadPackPackage package, string platform, IBuildEngine buildEngine, string wixToolsetPath,
             string baseIntermediatOutputPath) :
@@ -72,9 +74,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Msi
                 throw new Exception(Strings.FailedToCompileMsi);
             }
 
-            ITaskItem msi = Link(candle.OutputPath,
-                Path.Combine(outputPath, _package.ShortName + $"-{Platform}.msi"),
-                iceSuppressions);
+            ITaskItem msi = Link(candle.OutputPath, Path.Combine(outputPath, OutputName), iceSuppressions);
 
             AddDefaultPackageFiles(msi);
 

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/MsiSwixProject.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/MsiSwixProject.wix.cs
@@ -2,12 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Text;
 using System.IO;
 using System.Security.Cryptography;
+using System.Text;
 using Microsoft.Build.Framework;
-using Microsoft.DotNet.Build.Tasks.Workloads.Msi;
 using Microsoft.Deployment.DotNet.Releases;
+using Microsoft.DotNet.Build.Tasks.Workloads.Msi;
 
 namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
 {
@@ -87,7 +87,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
             // For drop publishing all the JSON manifests and payloads must reside in the same folder so we shorten the project names
             // and use a hashed filename to avoid path too long errors.
             string hashInputs = $"{Id},{Version.ToString(3)},{sdkFeatureBand},{Platform},{Chip},{machineArch}";
-            ProjectFile = $"{Utils.GetHash(hashInputs, HashAlgorithmName.MD5)}.swixproj"; // lgtm [cs/weak-crypto] Hash algorithm used only for determining file uniqueness
+            ProjectFile = $"{Utils.GetHash(hashInputs, HashAlgorithmName.MD5)}.swixproj";
 
             ReplacementTokens[SwixTokens.__VS_PAYLOAD_SOURCE__] = msi.GetMetadata(Metadata.FullPath);
         }

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/SwixComponent.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/SwixComponent.cs
@@ -152,6 +152,17 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
             _dependencies.Add(new SwixDependency($"{pack.Id.ToString().Replace(ShortNames)}.{pack.Version}", new NuGetVersion(pack.Version).Version, maxVersion: null));
         }
 
+        /// <inheritdoc/>
+        public override int GetHashCode() => Name.GetHashCode();
+
+        /// <inheritdoc/>
+        public override bool Equals(object? obj)
+        {
+            SwixComponent? c = obj as SwixComponent;
+
+            return c != null && c.Name.Equals(Name);
+        }
+
         /// <summary>
         /// Creates a SWIX component representing a workload definition.
         /// </summary>


### PR DESCRIPTION
## Description

Package cache validation for VS restricts the full path to 182 characters. In some cases, NuGet reports errors when creating packages that wrap the workload MSI installers. 

## Changes
- Generate fixed length filenames for workload MSIs. The filenames are based on the MD5 hash of the full MSI name along with a platform identifier. The original MSI name depends on the type of workload package (manifest, pack, pack group). Test cases are updated to reflect this change. Flat containers, both in Arcade artifacts and VSDROP require that we have unique filenames.
- Detect duplicate workload IDs when building multiple manifests and generate a proper error message
- Additional unit tests to verify the extraction of the SDK feature band from manifest packages

