### PR TITLE
Avoid doing extra work in the RemoteExecutor static ctor

### DIFF
--- a/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
@@ -46,6 +46,11 @@ namespace Microsoft.DotNet.RemoteExecutor
 
         static RemoteExecutor()
         {
+            if (!IsSupported)
+            {
+                return;
+            }
+
             string processFileName = Process.GetCurrentProcess().MainModule?.FileName;
             if (processFileName == null)
             {


### PR DESCRIPTION
Exit the static ctor instead of throwing an exception on some platforms when IsSupported is false

Invoke already throws under the same condition but this way you can check IsSupported on wasm without getting a PNSE from Process like is commonly done in ConditionalFact