### PR TITLE
Don't append TargetOS to .NETFramework tfms

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/buildMultiTargeting/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/buildMultiTargeting/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
@@ -26,16 +26,20 @@
   </Target>
   
   <Target Name="GetProjectWithBestTargetFrameworks">
-    <ItemGroup Condition="'$(BuildTargetFramework)' != ''">
-      <_BuildTargetFrameworkWithTargetOS Include="$(BuildTargetFramework)-$(TargetOS.ToLowerInvariant())" />
+    <ItemGroup>
+      <_BuildTargetFramework Include="$(BuildTargetFramework)"
+                             Condition="'$(BuildTargetFramework)' != ''" />
+      <_BuildTargetFramework Include="$([MSBuild]::Unescape($([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '(-[^;]+)', ''))))"
+                             Condition="'$(BuildTargetFramework)' == ''" />
     </ItemGroup>
-    <ItemGroup Condition="'$(BuildTargetFramework)' == ''">
-      <_BuildTargetFrameworkWithoutOS Include="$([MSBuild]::Unescape($([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '(-[^;]+)', ''))))" />
-      <!-- TODO: Find a better way to filter out non applicable TargetOS values for .NET Framework. -->
-      <_BuildTargetFrameworkWithTargetOS Include="@(_BuildTargetFrameworkWithoutOS->Distinct()->'%(Identity)-$(TargetOS.ToLowerInvariant())')"
-                                         Condition="'$(TargetOS)' == 'windows' or !$([System.String]::Copy('%(Identity)').StartsWith('net4'))" />
+
+    <ItemGroup>
+      <_BuildTargetFrameworkWithTargetOS Include="@(_BuildTargetFramework->Distinct()->'%(Identity)-$(TargetOS)')"
+                                         Condition="!$([System.String]::Copy('%(Identity)').StartsWith('net4'))" />
+      <_BuildTargetFrameworkWithTargetOS Include="@(_BuildTargetFramework->Distinct())"
+                                         Condition="$([System.String]::Copy('%(Identity)').StartsWith('net4'))" />
     </ItemGroup>
-    
+
     <ChooseBestTargetFrameworksTask BuildTargetFrameworks="@(_BuildTargetFrameworkWithTargetOS);$(AdditionalBuildTargetFrameworks)"
                                     SupportedTargetFrameworks="$(TargetFrameworks)"
                                     RuntimeGraph="$(BundledRuntimeIdentifierGraphFile)"


### PR DESCRIPTION
Regressed with https://github.com/dotnet/arcade/commit/e82404fca08383513e0b0b3c5308d4a9b18b7c7a

As .NET Framework tfms don't support TargetPlatform, the TargetOS property shouldn't be appended to such target frameworks when calculating the best compatible asset. In addition to that, .NETCoreApp (.NET 5+) is the only target framework family that is used when compiling runtime specific assets (i.e. in dotnet/runtime).

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
