### PR TITLE
[release/7.0] Allow file protocol in source-build Git clones

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/git-clone-to-dir.sh
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/git-clone-to-dir.sh
@@ -124,12 +124,12 @@ fi
       # * '--no-local' allows a shallow clone from a git dir on the same filesystem. This means the
       #   clone will not use hard links and takes up more space. However, since we're doing a shallow
       #   clone anyway, the difference is probably not significant. (This has not been measured.)
-      git clone --depth=1 --no-local --no-checkout "$sourceDir" "$destDir"
+      git clone -c protocol.file.allow=always --depth=1 --no-local --no-checkout "$sourceDir" "$destDir"
 
       # Put the 'shallow' file back so operations on the outer Git repo continue to work normally.
       printf "%s" "$shallowContent" > "$shallowFile"
     else
-      git clone --no-checkout "$sourceDir" "$destDir"
+      git clone -c protocol.file.allow=always --no-checkout "$sourceDir" "$destDir"
     fi
 
     (

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/git-clone-to-dir.sh
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/git-clone-to-dir.sh
@@ -124,6 +124,8 @@ fi
       # * '--no-local' allows a shallow clone from a git dir on the same filesystem. This means the
       #   clone will not use hard links and takes up more space. However, since we're doing a shallow
       #   clone anyway, the difference is probably not significant. (This has not been measured.)
+      # * '-c protocol.file.allow=alwyas allows cloning from the local filesystem even on newer versions
+      #   of git which have disabled this for security reasons.
       git clone -c protocol.file.allow=always --depth=1 --no-local --no-checkout "$sourceDir" "$destDir"
 
       # Put the 'shallow' file back so operations on the outer Git repo continue to work normally.


### PR DESCRIPTION
Port of https://github.com/dotnet/arcade/pull/12297 to 7.0.