### PR TITLE
Remove Special Casing of RemoteExecutor Detection for Single File

### DIFF
--- a/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs
@@ -109,8 +109,6 @@ namespace Microsoft.DotNet.RemoteExecutor
             !RuntimeInformation.IsOSPlatform(OSPlatform.Create("WATCHOS")) &&
             !RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")) &&
             !RuntimeInformation.IsOSPlatform(OSPlatform.Create("WASI")) &&
-            // The current RemoteExecutor design is not compatible with single file
-            !string.IsNullOrEmpty(typeof(RemoteExecutor).Assembly.Location) &&
             Environment.GetEnvironmentVariable("DOTNET_REMOTEEXECUTOR_SUPPORTED") != "0";
 
         /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>


### PR DESCRIPTION
This PR removes the special case of `RemoteExecutor` detection in `IsSupported()`. The reason for this is that in dotnet/runtime's PR #80946 (https://github.com/dotnet/runtime/pull/80946), we are setting the `DOTNET_REMOTEEXECUTOR_SUPPORTED` Environment Variable to 0, and since `IsSupported()` here looks for the aforementioned variable to be different from 0, then the RemoteExecutor detection became redundant.

This PR is expected to be merged after the one in dotnet/runtime.