### PR TITLE
Add a GitHub PAT with no scopes to secrets manifest

### DIFF
--- a/.vault-config/product-builds-dnceng-pipeline-secrets.yaml
+++ b/.vault-config/product-builds-dnceng-pipeline-secrets.yaml
@@ -4,7 +4,22 @@ storageLocation:
     subscription: a4fc5514-21a9-4296-bfaf-5c7ee7fa35d1
     name: dnceng-pipeline-secrets
 
+references:
+  engKeyVault:
+    type: azure-key-vault
+    parameters:
+      subscription: a4fc5514-21a9-4296-bfaf-5c7ee7fa35d1
+      name: EngKeyVault
+
 secrets:
+  BotAccount-dotnet-maestro-bot-no-scopes-PAT:
+    type: github-access-token
+    parameters:
+      gitHubBotAccountSecret:
+        location: engKeyVault
+        name: BotAccount-dotnet-maestro-bot
+      gitHubBotAccountName: dotnet-maestro-bot
+
   #DotNet-DotNetCli-Storage
   dotnetcli-storage-key:
     type: text


### PR DESCRIPTION
For https://github.com/dotnet/arcade/issues/12323 we need a GitHub PAT with public access that will be used for querying GraphQL api and validating that all commits in the VMR can be found in public repos
The PAT is generated, this is adding it to the manifest file
