### PR TITLE
Generate checksums after signing

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateChecksums.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateChecksums.targets
@@ -8,7 +8,7 @@
   -->
   <Target Name="GenerateChecksums"
           Condition="'@(GenerateChecksumItems)' != ''"
-          AfterTargets="Build">
+          AfterTargets="Sign">
 
     <Error Condition="'%(GenerateChecksumItems.DestinationPath)' == ''"
            Text="Item &quot;%(GenerateChecksumItems.Identity)&quot; does not define required metadata &quot;DestinationPath&quot;" />


### PR DESCRIPTION
Checksums for archives or msis that were signed are wrong if generated after build, rather than signing.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
