### PR TITLE
Fix project build exclusion logic in the face of static graph

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/sdk/Sdk.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/sdk/Sdk.targets
@@ -2,18 +2,15 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <!--
-    If a project specifies ExcludeFromSourceBuild=true during a source build suppress all targets and emulate a no-op
-    (empty common targets like Restore, Build, Pack, etc.).
-    
-    It's also possible to set ExcludeFromBuild prior to importing the Sdk.targets
-    to skip building as desired in non-source build scenarios. This might be done to
-    avoid building tests in certain product build scenarios.
+    Some projects do not import Common targets, so BeforeCommonTargets.targets doesn't get imported. 
+    (https://github.com/dotnet/arcade/issues/2676).
   -->
   <PropertyGroup>
-    <_SuppressAllTargets>false</_SuppressAllTargets>
-    <_SuppressAllTargets Condition="'$(DotNetBuildFromSource)' == 'true' and '$(ExcludeFromSourceBuild)' == 'true'">true</_SuppressAllTargets>
-    <_SuppressAllTargets Condition="'$(ExcludeFromBuild)' == 'true'">true</_SuppressAllTargets>
+    <_BeforeCommonTargetsHookUsed>true</_BeforeCommonTargetsHookUsed>
+    <_BeforeCommonTargetsHookUsed Condition="'$(_ArcadeBeforeCommonTargetsImported)' != 'true'">false</_BeforeCommonTargetsHookUsed>
   </PropertyGroup>
+  <Import Project="BeforeCommonTargets.targets" Condition="'$(_ArcadeBeforeCommonTargetsImported)' != 'true' and '$(IsCrossTargetingBuild)' != 'true'"/>
+  <Import Project="BeforeCommonTargets.CrossTargeting.targets" Condition="'$(_ArcadeBeforeCommonTargetsImported)' != 'true' and '$(IsCrossTargetingBuild)' == 'true'"/>
 
   <!-- 
     Output the location of the Build.proj so that the build driver can find where it was restored.

--- a/src/Microsoft.DotNet.Arcade.Sdk/sdk/Sdk.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/sdk/Sdk.targets
@@ -9,8 +9,8 @@
     <_BeforeCommonTargetsHookUsed>true</_BeforeCommonTargetsHookUsed>
     <_BeforeCommonTargetsHookUsed Condition="'$(_ArcadeBeforeCommonTargetsImported)' != 'true'">false</_BeforeCommonTargetsHookUsed>
   </PropertyGroup>
-  <Import Project="BeforeCommonTargets.targets" Condition="'$(_ArcadeBeforeCommonTargetsImported)' != 'true' and '$(IsCrossTargetingBuild)' != 'true'"/>
-  <Import Project="BeforeCommonTargets.CrossTargeting.targets" Condition="'$(_ArcadeBeforeCommonTargetsImported)' != 'true' and '$(IsCrossTargetingBuild)' == 'true'"/>
+  <Import Project="..\tools\BeforeCommonTargets.targets" Condition="'$(_ArcadeBeforeCommonTargetsImported)' != 'true' and '$(IsCrossTargetingBuild)' != 'true'"/>
+  <Import Project="..\tools\BeforeCommonTargets.CrossTargeting.targets" Condition="'$(_ArcadeBeforeCommonTargetsImported)' != 'true' and '$(IsCrossTargetingBuild)' == 'true'"/>
 
   <!-- 
     Output the location of the Build.proj so that the build driver can find where it was restored.

--- a/src/Microsoft.DotNet.Arcade.Sdk/sdk/Sdk.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/sdk/Sdk.targets
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
+  <!--
+    Some projects do not import Common targets, so BeforeCommonTargets.targets doesn't get imported. 
+    (https://github.com/dotnet/arcade/issues/2676).
+  -->
+  <PropertyGroup>
+    <_BeforeCommonTargetsHookUsed>true</_BeforeCommonTargetsHookUsed>
+    <_BeforeCommonTargetsHookUsed Condition="'$(_ArcadeBeforeCommonTargetsImported)' != 'true'">false</_BeforeCommonTargetsHookUsed>
+  </PropertyGroup>
+
+  <Import Project="..\tools\BeforeCommonTargets.targets" Condition="!$(_SuppressSdkImports) and '$(_ArcadeBeforeCommonTargetsImported)' != 'true' and '$(IsCrossTargetingBuild)' != 'true'"/>
+  <Import Project="..\tools\BeforeCommonTargets.CrossTargeting.targets" Condition="!$(_SuppressSdkImports) and '$(_ArcadeBeforeCommonTargetsImported)' != 'true' and '$(IsCrossTargetingBuild)' == 'true'"/>
 
   <!-- 
     Output the location of the Build.proj so that the build driver can find where it was restored.
@@ -12,17 +23,6 @@
       <FileWrites Include="$(__ToolsetLocationOutputFile)" />
     </ItemGroup>
   </Target>
-
-  <!--
-    Some projects do not import Common targets, so BeforeCommonTargets.targets doesn't get imported. 
-    (https://github.com/dotnet/arcade/issues/2676).
-  -->
-  <PropertyGroup>
-    <_BeforeCommonTargetsHookUsed>true</_BeforeCommonTargetsHookUsed>
-    <_BeforeCommonTargetsHookUsed Condition="'$(_ArcadeBeforeCommonTargetsImported)' != 'true'">false</_BeforeCommonTargetsHookUsed>
-  </PropertyGroup>
-  <Import Project="..\tools\BeforeCommonTargets.targets" Condition="'$(_ArcadeBeforeCommonTargetsImported)' != 'true' and '$(IsCrossTargetingBuild)' != 'true'"/>
-  <Import Project="..\tools\BeforeCommonTargets.CrossTargeting.targets" Condition="'$(_ArcadeBeforeCommonTargetsImported)' != 'true' and '$(IsCrossTargetingBuild)' == 'true'"/>
 
   <Import Project="..\tools\Imports.targets" Condition="!$(_SuppressSdkImports) and !$(_SuppressAllTargets)" />
   <Import Project="..\tools\Empty.targets" Condition="!$(_SuppressSdkImports) and $(_SuppressAllTargets)"/>

--- a/src/Microsoft.DotNet.Arcade.Sdk/sdk/Sdk.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/sdk/Sdk.targets
@@ -1,16 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
-  <!--
-    Some projects do not import Common targets, so BeforeCommonTargets.targets doesn't get imported. 
-    (https://github.com/dotnet/arcade/issues/2676).
-  -->
-  <PropertyGroup>
-    <_BeforeCommonTargetsHookUsed>true</_BeforeCommonTargetsHookUsed>
-    <_BeforeCommonTargetsHookUsed Condition="'$(_ArcadeBeforeCommonTargetsImported)' != 'true'">false</_BeforeCommonTargetsHookUsed>
-  </PropertyGroup>
-  <Import Project="..\tools\BeforeCommonTargets.targets" Condition="'$(_ArcadeBeforeCommonTargetsImported)' != 'true' and '$(IsCrossTargetingBuild)' != 'true'"/>
-  <Import Project="..\tools\BeforeCommonTargets.CrossTargeting.targets" Condition="'$(_ArcadeBeforeCommonTargetsImported)' != 'true' and '$(IsCrossTargetingBuild)' == 'true'"/>
 
   <!-- 
     Output the location of the Build.proj so that the build driver can find where it was restored.
@@ -22,6 +12,17 @@
       <FileWrites Include="$(__ToolsetLocationOutputFile)" />
     </ItemGroup>
   </Target>
+
+  <!--
+    Some projects do not import Common targets, so BeforeCommonTargets.targets doesn't get imported. 
+    (https://github.com/dotnet/arcade/issues/2676).
+  -->
+  <PropertyGroup>
+    <_BeforeCommonTargetsHookUsed>true</_BeforeCommonTargetsHookUsed>
+    <_BeforeCommonTargetsHookUsed Condition="'$(_ArcadeBeforeCommonTargetsImported)' != 'true'">false</_BeforeCommonTargetsHookUsed>
+  </PropertyGroup>
+  <Import Project="..\tools\BeforeCommonTargets.targets" Condition="'$(_ArcadeBeforeCommonTargetsImported)' != 'true' and '$(IsCrossTargetingBuild)' != 'true'"/>
+  <Import Project="..\tools\BeforeCommonTargets.CrossTargeting.targets" Condition="'$(_ArcadeBeforeCommonTargetsImported)' != 'true' and '$(IsCrossTargetingBuild)' == 'true'"/>
 
   <Import Project="..\tools\Imports.targets" Condition="!$(_SuppressSdkImports) and !$(_SuppressAllTargets)" />
   <Import Project="..\tools\Empty.targets" Condition="!$(_SuppressSdkImports) and $(_SuppressAllTargets)"/>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/BeforeCommonTargets.CrossTargeting.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/BeforeCommonTargets.CrossTargeting.targets
@@ -3,6 +3,15 @@
 <Project>
   <Import Project="$(_ArcadeOverriddenCustomBeforeMicrosoftCommonCrossTargetingTargets)" Condition="Exists('$(_ArcadeOverriddenCustomBeforeMicrosoftCommonCrossTargetingTargets)')"/>
 
+  <PropertyGroup>
+    <_ArcadeBeforeCommonTargetsImported>true</_ArcadeBeforeCommonTargetsImported>
+  </PropertyGroup>
+
   <Import Project="Version.BeforeCommonTargets.targets"/>
   <Import Project="TargetFrameworkFilters.BeforeCommonTargets.targets"/>
+
+  <!-- Import the logic to determine whether a project should not build.
+       This is done at this point because we need to exclude the import of some standard Microsoft restore targets (NuGet)
+       that are loaded before the import of Arcade's Sdk.targets. See info in ExcludeFromBuild -->
+  <Import Project="ExcludeFromBuild.BeforeCommonTargets.targets"/>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/BeforeCommonTargets.targets
@@ -9,4 +9,9 @@
 
   <Import Project="Version.BeforeCommonTargets.targets"/>
   <Import Project="TargetFrameworkFilters.BeforeCommonTargets.targets"/>
+
+  <!-- Import the logic to determine whether a project should not build.
+       This is done at this point because we need to exclude the import of some standard Microsoft restore targets (NuGet)
+       that are loaded before the import of Arcade's Sdk.targets. See info in ExcludeFromBuild -->
+  <Import Project="ExcludeFromBuild.BeforeCommonTargets.targets"/>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Empty.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Empty.targets
@@ -13,7 +13,10 @@
     <ImportNuGetBuildTasksPackTargetsFromSdk>false</ImportNuGetBuildTasksPackTargetsFromSdk>
   </PropertyGroup>
 
-  <Target Name="_IsProjectRestoreSupported"/>
+  <!-- We don't want to create this target if the before common targets hook is in use.
+       If we are using the hook, then we avoid creation of the target altogether, which is more
+       compatible with static graph restores -->
+  <Import Project="..\tools\EmptyIsProjectRestoreSupportedTarget.targets" Condition="!$(_BeforeCommonTargetsHookUsed)"/>
   <Target Name="Restore"/>
   <Target Name="Build"/>
   <Target Name="Test"/>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/EmptyIsProjectRestoreSupportedTarget.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/EmptyIsProjectRestoreSupportedTarget.targets
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Project DefaultTargets="Build">
+  <!--
+    Import this file to suppress all _IsProjectRestoreSupported when the BeforeCommonTargets hook isn't in 
+    use while allowing the project to participate in the build.
+    Workaround for https://github.com/dotnet/sdk/issues/2071.
+    
+    The targets defined here are not sufficient for the project to be open in Visual Studio without issues though.    
+  -->
+
+  <Target Name="_IsProjectRestoreSupported"/>
+
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ExcludeFromBuild.BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ExcludeFromBuild.BeforeCommonTargets.targets
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Project>
+
+  <!--  This file sets properties that enable skipping of a project build if desired.
+        Cases where we might skip include:
+        - Source-build mode and "ExcludeFromSourceBuild" is set.
+        - Non source-build mode and "ExcludeFromBuild" is set
+        - Target filtering is used and the target filters set "ExcludeFromBuild".
+
+        To exclude a project from building, Arcade must do two things:
+        - Create/override the standard targets (Build, Restore, Sign, etc.) with empty ones.
+        - Keep the .NET SDK from importing the standard NuGet restore targets - NuGet uses the
+          '_IsProjectRestoreSupported target' to determine whether a project can be restored. If the project shouldn't be built,
+          it shouldn't be restored either. This could be done two ways:
+            - Override the _IsProjectRestoreSupported target to an empty target, or one that returns false.
+            - Avoid import of the _IsProjectRestoreSupported target altogether.
+          The first approach is more consistent with the rest of Arcade's approach to skipping a build.
+          However is does **not** work with msbuild static graph. Static graph uses the *existence* of the
+          target to determine whether a project should be restored, so overriding with an empty target will
+          only avoid building a project, but it will still get restored. This could cause issues with target
+          framework filtering, or introduce unexpected prebuilts.
+
+          So to achieve the desired affect, Arcade must reset NuGetRestoreTargets to an empty file. Because
+          this import is done early, the BeforeCommonTargets hook must be used. There is a case
+          where the BeforeCommonTargets hook is not used (see https://github.com/dotnet/arcade/issues/2676).
+          In that case, Sdk.targets imports it explicitly. -->
+
+  <!--
+    If a project specifies ExcludeFromSourceBuild=true during a source build suppress all targets and emulate a no-op
+    (empty common targets like Restore, Build, Pack, etc.).
+
+    It's also possible to set ExcludeFromBuild prior to importing the Sdk.targets
+    to skip building as desired in non-source build scenarios. This might be done to
+    avoid building tests in certain product build scenarios.
+  -->
+  <PropertyGroup>
+    <_SuppressAllTargets>false</_SuppressAllTargets>
+    <_SuppressAllTargets Condition="'$(DotNetBuildFromSource)' == 'true' and '$(ExcludeFromSourceBuild)' == 'true'">true</_SuppressAllTargets>
+    <_SuppressAllTargets Condition="'$(ExcludeFromBuild)' == 'true'">true</_SuppressAllTargets>
+
+    <!-- If excluding, then disable a restore warning, which will fire on newer SDKs, as well as set the NuGetRestoreTargets property to empty,
+         which will avoid importing the restore targets inside the .NET SDK. If the restore targets exist, then static graph restore will attempt tpo
+         execute. -->
+    <DisableWarnForInvalidRestoreProjects Condition="'$(_SuppressAllTargets)' == 'true'">true</DisableWarnForInvalidRestoreProjects>
+    <NuGetRestoreTargets Condition="'$(_SuppressAllTargets)' == 'true'">$(MSBuildThisFileDirectory)NoRestore.targets</NuGetRestoreTargets>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
-  <!-- 
-    Some projects do not import Common targets, so BeforeCommonTargets.targets doesn't get imported. 
-    (https://github.com/dotnet/arcade/issues/2676).
-  -->
-  <Import Project="BeforeCommonTargets.targets" Condition="'$(_ArcadeBeforeCommonTargetsImported)' != 'true' and '$(IsCrossTargetingBuild)' != 'true'"/>
-
   <Import Project="ProjectDefaults.targets"/>
   <Import Project="StrongName.targets"/>
   <Import Project="GenerateChecksums.targets" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/NoRestore.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/NoRestore.targets
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Project DefaultTargets="Build">
+  <!--
+    Set this file as property NuGetRestoreTargets to avoid msbuild attempting a restore in static graph mode. It probes
+    for _IsProjectRestoreSupported to determine whether restore should be performed, rather than evaluating the target, because
+    it assumes that this target will always return true.
+  -->
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/TargetFrameworkFilters.BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/TargetFrameworkFilters.BeforeCommonTargets.targets
@@ -15,8 +15,6 @@
     <TargetFramework Condition="'$(TargetFramework)' != ''">$(_FilteredTargetFrameworks)</TargetFramework>
     <!-- If nothing left to build, exclude it! -->
     <ExcludeFromBuild Condition="'$(_FilteredTargetFrameworks)' == ''">true</ExcludeFromBuild>
-    <!-- If excluding, then disable a restore warning, which will fire on newer SDKs-->
-    <DisableWarnForInvalidRestoreProjects Condition="'$(_FilteredTargetFrameworks)' == ''">true</DisableWarnForInvalidRestoreProjects>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
While working on filtering, I discovered that static graph and target filtering do not play nicely together. After some help from the msbuild team, the problem was identified. Arcade typically uses a series of empty targets that override standard targets (or its own) to avoid executing a project build or restore. Static graph, however, uses the existence of the _IsProjectRestoreSupported target, rather than its return value to determine whether restore is supported. This means that any excluded project still gets restored in static graph mode.

The fix (or workaround, depending on how you look at it) for this is to set the NuGetRestoreTargets file to an empty stub early enough in the build (in the BeforeCommonTargets hook) so that this target is never loaded at all. This requires determining whether a build will be skipped earlier than we do today, in BeforeCommonTargets rather than in Sdk.targets.

The code has been refactored so that we determine whether a build should be skipped in ExcludeFromBuild.BeforeCommonTargets.targets, which is imported in the BeforeCommonTargets files. I've also moved the import of these files earlier so that in cases where the BeforeCommonTargets SDK hook is **not** used (see https://github.com/dotnet/arcade/issues/2676), we will still compute the exclusion properties early enough to import "Empty.targets". In that case, we also create the target.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
