### PR TITLE
Avoid creating a new logging helper

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -211,7 +211,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         protected PublishArtifactsInManifestBase(AssetPublisherFactory assetPublisherFactory = null)
         {
-            AssetPublisherFactory = assetPublisherFactory ?? new AssetPublisherFactory(new MsBuildUtils.TaskLoggingHelper(this));
+            AssetPublisherFactory = assetPublisherFactory ?? new AssetPublisherFactory(Log);
         }
 
         public override bool Execute()


### PR DESCRIPTION
Creating a new logging helper doesn't share the "HasLoggedErrors" state.

https://github.com/dotnet/arcade/issues/12401