### PR TITLE
[release/7.0] Introduce targeting properties

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
-  <Import Project="$(RepositoryEngineeringDir)TargetFrameworkDefaults.props" />
+  
 
   <PropertyGroup>
     <Copyright>$(CopyrightNetFoundation)</Copyright>
@@ -11,6 +11,7 @@
     <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <LangVersion>Latest</LangVersion>
+    <TargetFrameworkForNETSDK>net7.0</TargetFrameworkForNETSDK>
 
     <!--
       Tools and packages produced by this repository support infrastructure and are not shipping on NuGet or via any other official channel.

--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -943,6 +943,15 @@ Set to `false` to override the default (uncommon).
 
 Set to `partial` or `full` in a shipping project to require IBC optimization data to be available for the project and embed them into the binary during official build. The value of `partial` indicates partial NGEN, whereas `full` means full NGEN optimization.
 
+### `NetCurrent/NetPrevious/NetMinimum/NetFrameworkMinimum`
+
+Properties that define TargetFramework for use by projects so their targeting easily aligns with the current .NET version in development as well as those that are supported. Arcade will update these properties to match the current supported .NET versions, as well as the release being currently developed.
+
+- NetCurrent - The TFM of the major release of .NET that the Arcade SDK aligns with.
+- NetPrevious - The previously released version of .NET (e.g. this would be net7 if NetCurrent is net8)
+- NetMinimum - Lowest supported version of .NET the time of the release of NetCurrent. E.g. if NetCurrent is net8, then NetMinimum is net6
+- NetFrameworkMinimum - Lowest supported version of .NET Framework the time of the release of NetCurrent. E.g. if NetCurrent is net8, then NetFrameworkMinimum is net462
+
 ### `SkipTests` (bool)
 
 Set to `true` in a test project to skip running tests.

--- a/eng/TargetFrameworkDefaults.props
+++ b/eng/TargetFrameworkDefaults.props
@@ -1,7 +1,0 @@
-<Project>
-
-  <PropertyGroup>
-    <TargetFrameworkForNETSDK>net7.0</TargetFrameworkForNETSDK>
-  </PropertyGroup>
-
-</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Settings.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Settings.props
@@ -19,6 +19,7 @@
   <Import Project="ProjectDefaults.props"/>
   <Import Project="Tests.props" Condition="'$(DisableArcadeTestFramework)' != 'true'" />
   <Import Project="Workarounds.props"/>
+  <Import Project="TargetFrameworkDefaults.props"/>
 
   <Import Project="Compiler.props" Condition="'$(UsingToolMicrosoftNetCompilers)' == 'true'" />
   <Import Project="Linker.props" Condition="'$(UsingToolMicrosoftNetILLinkTasks)' == 'true'" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/TargetFrameworkDefaults.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/TargetFrameworkDefaults.props
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Project>
+  <!-- Repositories using the arcade SDK can stay up to date with their target framework more easily using the properties in this file.
+       - NetCurrent - The TFM of the major release of .NET that the Arcade SDK aligns with.
+       - NetPrevious - The previously released version of .NET (e.g. this would be net7 if NetCurrent is net8)
+       - NetMinimum - Lowest supported version of .NET the time of the release of NetCurrent. E.g. if NetCurrent is net8, then NetMinimum is net6
+       - NetFrameworkMinimum - Lowest supported version of .NET Framework the time of the release of NetCurrent. E.g. if NetCurrent is net8, then NetFrameworkMinimum is net462
+
+       Examples:
+
+       <TargetFrameworks>$(NetCurrent)</TargetFrameworks>
+       <TargetFrameworks>$(NetCurrent);net472</TargetFrameworks>
+       <TargetFrameworks>$(NetCurrent);$(NetPrevious);$(NetFrameworkMinimum);net472</TargetFrameworks>
+  -->
+  <PropertyGroup>
+    <NetCurrent>net7.0</NetCurrent>
+    <NetPrevious>net6.0</NetPrevious>
+    <NetMinimum>net3.1</NetMinimum>
+    <NetFrameworkMinimum>net462</NetFrameworkMinimum>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Introduce targeting properties Targeting implementation of https://github.com/dotnet/arcade/pull/11903/files. Adds three properties to allow repos to defer some/all of their target framework maintenance to arcade. Arcade already had a file like this for its own purposes. I've removed that and hoisted arcade's targeting property into its Directory.Build.props.

This is a backport to 7.0 so that source-build components using older arcades (e.g. if they target VS) can utilize the properties and allow source build to transparently set the TFM.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
