### PR TITLE
Add support for linux-musl-{s390x,ppc64le,risv64}

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -6,10 +6,11 @@ usage()
 {
     echo "Usage: $0 [BuildArch] [CodeName] [lldbx.y] [llvmx[.y]] [--skipunmount] --rootfsdir <directory>]"
     echo "BuildArch can be: arm(default), arm64, armel, armv6, ppc64le, riscv64, s390x, x64, x86"
-    echo "CodeName - optional, Code name for Linux, can be: xenial(default), zesty, bionic, alpine, alpine3.13 or alpine3.14. If BuildArch is armel, LinuxCodeName is jessie(default) or tizen."
-    echo "                              for FreeBSD can be: freebsd12, freebsd13"
-    echo "                              for illumos can be: illumos"
-    echo "                                for Haiku can be: haiku."
+    echo "CodeName - optional, Code name for Linux, can be: xenial(default), zesty, bionic, alpine"
+    echo "                               for alpine can be specified with version: alpineX.YY or alpineedge"
+    echo "                               for FreeBSD can be: freebsd12, freebsd13"
+    echo "                               for illumos can be: illumos"
+    echo "                               for Haiku can be: haiku."
     echo "lldbx.y - optional, LLDB version, can be: lldb3.9(default), lldb4.0, lldb5.0, lldb6.0 no-lldb. Ignored for alpine and FreeBSD"
     echo "llvmx[.y] - optional, LLVM version for LLVM related packages."
     echo "--skipunmount - optional, will skip the unmount of rootfs folder."
@@ -145,35 +146,54 @@ while :; do
                 __Keyring="--keyring /usr/share/keyrings/raspbian-archive-keyring.gpg"
             fi
             ;;
-        ppc64le)
-            __BuildArch=ppc64le
-            __UbuntuArch=ppc64el
-            __UbuntuRepo="http://ports.ubuntu.com/ubuntu-ports/"
-            __UbuntuPackages="${__UbuntuPackages// libunwind8-dev/}"
-            __UbuntuPackages="${__UbuntuPackages// libomp-dev/}"
-            __UbuntuPackages="${__UbuntuPackages// libomp5/}"
-            unset __LLDB_Package
-            ;;
         riscv64)
             __BuildArch=riscv64
+            __AlpineArch=riscv64
+            __AlpinePackages="${__AlpinePackages// lldb-dev/}"
+            __AlpinePackages="${__AlpinePackages// compiler-rt-static/}"
+            __QEMUArch=riscv64
             __UbuntuArch=riscv64
             __UbuntuRepo="http://deb.debian.org/debian-ports"
-            __CodeName=sid
             __UbuntuPackages="${__UbuntuPackages// libunwind8-dev/}"
             unset __LLDB_Package
 
             if [[ -e "/usr/share/keyrings/debian-ports-archive-keyring.gpg" ]]; then
                 __Keyring="--keyring /usr/share/keyrings/debian-ports-archive-keyring.gpg --include=debian-ports-archive-keyring"
             fi
+
+            if [[ "$version" != "edge" && ( -z "$__AlpineVersion" || -z "$__AlpineMajorVersion" )]]; then
+                __AlpineVersion=edge # minimum version with APKINDEX.tar.gz (packages archive)
+            fi
+            ;;
+        ppc64le)
+            __BuildArch=ppc64le
+            __AlpineArch=ppc64le
+            __QEMUArch=ppc64le
+            __UbuntuArch=ppc64el
+            __UbuntuRepo="http://ports.ubuntu.com/ubuntu-ports/"
+            __UbuntuPackages="${__UbuntuPackages// libunwind8-dev/}"
+            __UbuntuPackages="${__UbuntuPackages// libomp-dev/}"
+            __UbuntuPackages="${__UbuntuPackages// libomp5/}"
+            unset __LLDB_Package
+
+            if [[ "$version" != "edge" && ( -z "$__AlpineVersion" || -z "$__AlpineMajorVersion" )]]; then
+                __AlpineVersion=3.15 # minimum version that supports compiler-rt
+            fi
             ;;
         s390x)
             __BuildArch=s390x
+            __AlpineArch=s390x
+            __QEMUArch=s390x
             __UbuntuArch=s390x
             __UbuntuRepo="http://ports.ubuntu.com/ubuntu-ports/"
             __UbuntuPackages="${__UbuntuPackages// libunwind8-dev/}"
             __UbuntuPackages="${__UbuntuPackages// libomp-dev/}"
             __UbuntuPackages="${__UbuntuPackages// libomp5/}"
             unset __LLDB_Package
+
+            if [[ "$version" != "edge" && ( -z "$__AlpineVersion" || -z "$__AlpineMajorVersion" )]]; then
+                __AlpineVersion=3.15 # minimum version that supports compiler-rt
+            fi
             ;;
         x64)
             __BuildArch=x64
@@ -252,22 +272,53 @@ while :; do
             __UbuntuRepo="http://ftp.debian.org/debian/"
             __LLDB_Package="liblldb-6.0-dev"
             ;;
+        bullseye) # Debian 11
+            __CodeName=bullseye
+            __UbuntuRepo="http://ftp.debian.org/debian/"
+            ;;
+        sid) # Debian sid
+            __CodeName=sid
+            __UbuntuRepo="http://ftp.debian.org/debian/"
+            ;;
         tizen)
             __CodeName=
             __UbuntuRepo=
             __Tizen=tizen
             ;;
-        alpine|alpine3.13)
+        alpine*)
             __CodeName=alpine
             __UbuntuRepo=
-            __AlpineVersion=3.13
-            __AlpinePackages+=" llvm10-libs"
-            ;;
-        alpine3.14)
-            __CodeName=alpine
-            __UbuntuRepo=
-            __AlpineVersion=3.14
-            __AlpinePackages+=" llvm11-libs"
+            version="${lowerI/alpine/}"
+
+            if [[ "$version" == "edge" ]]; then
+                __AlpineVersion=edge
+            else
+                parts=(${version//./ })
+                __AlpineMajorVersion="${parts[0]}"
+                __AlpineMinoVersion="${parts[1]}"
+
+                if [[ -z "$__AlpineVersion" ]]; then
+                    __AlpineVersion="$__AlpineMajorVersion.$__AlpineMinoVersion"
+                fi
+            fi
+
+            case "$__AlpineVersion" in
+                3.14) __AlpinePackages+=" llvm11-libs" ;;
+                3.15) __AlpinePackages+=" llvm12-libs" ;;
+                3.16) __AlpinePackages+=" llvm13-libs" ;;
+                3.17) __AlpinePackages+=" llvm15-libs" ;;
+                edge) __AlpineLlvmLibsLookup=1 ;;
+                *)
+                    if [[ "$__AlpineArch" =~ "s390x|ppc64le" ]]; then
+                        __AlpineVersion=3.15 # minimum version that supports compiler-rt
+                        __AlpinePackages+=" llvm12-libs"
+                    elif [[ "$__AlpineArch" == "riscv64" ]]; then
+                        __AlpineLlvmLibsLookup=1
+                        __AlpineVersion=edge # minimum version with APKINDEX.tar.gz (packages archive)
+                    else
+                        __AlpineVersion=3.13 # 3.13 to maximize compatibility
+                    fi
+            esac
             ;;
         freebsd12)
             __CodeName=freebsd
@@ -341,18 +392,40 @@ mkdir -p "$__RootfsDir"
 __RootfsDir="$( cd "$__RootfsDir" && pwd )"
 
 if [[ "$__CodeName" == "alpine" ]]; then
-    __ApkToolsVersion=2.9.1
+    __ApkToolsVersion=2.12.11
     __ApkToolsDir="$(mktemp -d)"
-    wget "https://github.com/alpinelinux/apk-tools/releases/download/v$__ApkToolsVersion/apk-tools-$__ApkToolsVersion-x86_64-linux.tar.gz" -P "$__ApkToolsDir"
-    tar -xf "$__ApkToolsDir/apk-tools-$__ApkToolsVersion-x86_64-linux.tar.gz" -C "$__ApkToolsDir"
+
+    wget "https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic//v$__ApkToolsVersion/x86_64/apk.static" -P "$__ApkToolsDir"
+    chmod +x "$__ApkToolsDir/apk.static"
+
     mkdir -p "$__RootfsDir"/usr/bin
     cp -v "/usr/bin/qemu-$__QEMUArch-static" "$__RootfsDir/usr/bin"
 
-    "$__ApkToolsDir/apk-tools-$__ApkToolsVersion/apk" \
-      -X "http://dl-cdn.alpinelinux.org/alpine/v$__AlpineVersion/main" \
-      -X "http://dl-cdn.alpinelinux.org/alpine/v$__AlpineVersion/community" \
-      -U --allow-untrusted --root "$__RootfsDir" --arch "$__AlpineArch" --initdb \
-      add $__AlpinePackages
+    if [[ "$__AlpineVersion" == "edge" ]]; then
+        version=edge
+    else
+        version="v$__AlpineVersion"
+    fi
+
+    "$__ApkToolsDir/apk.static" \
+        -X "http://dl-cdn.alpinelinux.org/alpine/$version/main" \
+        -X "http://dl-cdn.alpinelinux.org/alpine/$version/community" \
+        -U --allow-untrusted --root "$__RootfsDir" --arch "$__AlpineArch" --initdb \
+        add $__AlpinePackages
+
+    if [[ "$__AlpineLlvmLibsLookup" == 1 ]]; then
+        "$__ApkToolsDir/apk.static" \
+            -X "http://dl-cdn.alpinelinux.org/alpine/$version/main" \
+            -X "http://dl-cdn.alpinelinux.org/alpine/$version/community" \
+            -U --allow-untrusted --root "$__RootfsDir" --arch "$__AlpineArch" \
+            search 'llvm*-libs' | sort | tail -1 | while IFS=- read name rest; do
+                "$__ApkToolsDir/apk.static" \
+                    -X "http://dl-cdn.alpinelinux.org/alpine/$version/main" \
+                    -X "http://dl-cdn.alpinelinux.org/alpine/$version/community" \
+                    -U --allow-untrusted --root "$__RootfsDir" --arch "$__AlpineArch" \
+                    add "$name-libs"
+            done
+    fi
 
     rm -r "$__ApkToolsDir"
 elif [[ "$__CodeName" == "freebsd" ]]; then


### PR DESCRIPTION
This is to complement @ayakael's toolchain changes https://github.com/dotnet/arcade/pull/11608.

* Set minimum versions to 3.15 for s390x and ppc64le architectures which provides all packages we need.
* `riscv64` doesn't provide compiler-rt-static and lldb-dev; skip those two packages.
* `riscv64` requires (the bleeding) `edge` version atm. The bleeding edge version can have any latest version of llvmXY-libs package, which is unfortunately version specific. To accommodate that, add a lookup step. 
* Restructure case-esac flow for alpine to support future versions and `edge`.
* Update apk-tool for riscv64. The new versions are provided from gitlab as `apk.static`.

cc @janvorli