### PR TITLE
Set repo URL conditionally

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -260,21 +260,33 @@ while :; do
             ;;
         jessie) # Debian 8
             __CodeName=jessie
-            __UbuntuRepo="http://ftp.debian.org/debian/"
+
+            if [[ -z "$__UbuntuRepo" ]]; then
+                __UbuntuRepo="http://ftp.debian.org/debian/"
+            fi
             ;;
         stretch) # Debian 9
             __CodeName=stretch
-            __UbuntuRepo="http://ftp.debian.org/debian/"
             __LLDB_Package="liblldb-6.0-dev"
+
+            if [[ -z "$__UbuntuRepo" ]]; then
+                __UbuntuRepo="http://ftp.debian.org/debian/"
+            fi
             ;;
         buster) # Debian 10
             __CodeName=buster
-            __UbuntuRepo="http://ftp.debian.org/debian/"
             __LLDB_Package="liblldb-6.0-dev"
+
+            if [[ -z "$__UbuntuRepo" ]]; then
+                __UbuntuRepo="http://ftp.debian.org/debian/"
+            fi
             ;;
         bullseye) # Debian 11
             __CodeName=bullseye
-            __UbuntuRepo="http://ftp.debian.org/debian/"
+
+            if [[ -z "$__UbuntuRepo" ]]; then
+                __UbuntuRepo="http://ftp.debian.org/debian/"
+            fi
             ;;
         sid) # Debian sid
             __CodeName=sid

--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -278,7 +278,10 @@ while :; do
             ;;
         sid) # Debian sid
             __CodeName=sid
-            __UbuntuRepo="http://ftp.debian.org/debian/"
+
+            if [[ -z "$__UbuntuRepo" ]]; then
+                __UbuntuRepo="http://ftp.debian.org/debian/"
+            fi
             ;;
         tizen)
             __CodeName=


### PR DESCRIPTION
If repo URL is set by architecture branch, we don't need to override it.

This was breaking riscv64 on Debian sid (sets URL to `debian-ports` in its branch).

cc @janvorli 