### PR TITLE
[release/6.0] When publishing symbols, only publish symbol packages (#12664)

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs
@@ -123,7 +123,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     else
                     {
                         ITaskItem[] symbolItems = itemsToPushNoExcludes
-                            .Where(i => i.ItemSpec.Contains("symbols.nupkg"))
+                            .Where(i => i.ItemSpec.EndsWith("symbols.nupkg"))
                             .Select(i =>
                             {
                                 string fileName = Path.GetFileName(i.ItemSpec);


### PR DESCRIPTION
We were including checksums in addition to symbols.nupkgs by using Contains instead of EndsWith

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
