### PR TITLE
Allow override test logs default location

### DIFF
--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -963,6 +963,10 @@ If not specified by the project defaults to the value of `PlatformTarget` proper
 
 For example, a project that targets `AnyCPU` can opt-into running tests using both 32-bit and 64-bit test runners on .NET Framework by setting `TestArchitectures` to `x64;x86`.
 
+### `TestResultsLogDir` (string)
+
+An alternative path where to save test standard output logs (e.g., `MyProject.Tests_tfm_arch.log`). If not specified, these logs will be saved under the path specified in `$(ArtifactsLogDir)` variable.
+
 ### `TestTargetFrameworks` (list of strings)
 
 By default, the test runner will run tests for all frameworks a test project targets. Use `TestTargetFrameworks` to reduce the set of frameworks to run against.
@@ -1006,7 +1010,7 @@ Timeout to apply to an individual invocation of the test runner (e.g. `xunit.con
 
 ### `GenerateResxSource` (bool)
 
-When set to true, Arcade will generate a class source for all embedded .resx files.
+When set to `true`, Arcade will generate a class source for all embedded .resx files.
 
 If source should only be generated for some .resx files, this can be turned on for individual files like this:
 
@@ -1032,10 +1036,10 @@ class Resources
 ```
 
 #### `GenerateResxSourceIncludeDefaultValues` (bool)
-If set to true calls to GetResourceString receive a default resource string value.
+If set to `true` calls to GetResourceString receive a default resource string value.
 
 #### `GenerateResxSourceOmitGetResourceString` (bool)
-If set to true the GetResourceString method is not included in the generated class and must be specified in a separate source file.
+If set to `true` the GetResourceString method is not included in the generated class and must be specified in a separate source file.
 
 
 <!-- Begin Generated Content: Doc Feedback -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.targets
@@ -51,6 +51,9 @@
     <PropertyGroup>
       <_TestArchitecture>%(_TestArchitectureItems.Identity)</_TestArchitecture>
       <_ResultFileNameNoExt>$(MSBuildProjectName)_$(TargetFramework)_$(_TestArchitecture)</_ResultFileNameNoExt>
+
+      <!-- Send the logs into the default location, unless overriden by the consumer -->
+      <TestResultsLogDir Condition=" '$(TestResultsLogDir)' == '' ">$(ArtifactsLogDir)</TestResultsLogDir>
     </PropertyGroup>
 
     <ItemGroup>
@@ -66,7 +69,7 @@
         <ResultsXmlPath>$(ArtifactsTestResultsDir)$(_ResultFileNameNoExt).xml</ResultsXmlPath>
         <ResultsTrxPath>$(ArtifactsTestResultsDir)$(_ResultFileNameNoExt).trx</ResultsTrxPath>
         <ResultsHtmlPath>$(ArtifactsTestResultsDir)$(_ResultFileNameNoExt).html</ResultsHtmlPath>
-        <ResultsStdOutPath>$(ArtifactsLogDir)$(_ResultFileNameNoExt).log</ResultsStdOutPath>
+        <ResultsStdOutPath>$(TestResultsLogDir)$(_ResultFileNameNoExt).log</ResultsStdOutPath>
         <TestRunnerAdditionalArguments>$(TestRunnerAdditionalArguments)</TestRunnerAdditionalArguments>
       </TestToRun>
     </ItemGroup>


### PR DESCRIPTION
By default test logs are written under `$(ArtifactsLogDir)`. However, in situations where there are too many test projects, the logs folder gets innundated with files, making it difficult to explore (especially in CI).

Resolves #12485

Here are the test results with [8.0.0-beta.23120.2](https://dnceng.visualstudio.com/public/_artifacts/feed/general-testing/NuGet/Microsoft.DotNet.Arcade.Sdk/overview/8.0.0-beta.23120.2):
```diff
diff --git a/eng/ArcadeSdkImports.props b/eng/ArcadeSdkImports.props
index 31789da..a3df407 100644
--- a/eng/ArcadeSdkImports.props
+++ b/eng/ArcadeSdkImports.props
@@ -40,6 +40,12 @@
 
+    <!-- Redirect test logs into a subfolder -->
+    <TestResultsLogDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsLogDir)', 'TestLogs'))</TestResultsLogDir>
   </PropertyGroup>
```

![image](https://user-images.githubusercontent.com/4403806/220529534-b7921d86-109c-4ee3-b975-b17ff6852cbc.png)
