### PR TITLE
Properly handle template variable expansion

### DIFF
--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -101,7 +101,7 @@ jobs:
     # handle key-value variable syntax.
     # example:
     # - [key]: [value]
-    - ${{ if and(eq(variable.name, ''), eq(variable.group, '')) }}:
+    - ${{ if and(eq(variable.name, ''), eq(variable.group, ''), eq(variable.template, '')) }}:
       - ${{ each pair in variable }}:
         - name: ${{ pair.key }}
           value: ${{ pair.value }}


### PR DESCRIPTION
Something like

```
variables:
  - template: foo.yml
```
Would previously expand to 

```
variables:
  - template: foo.yml
  - name: template
    value: foo.yml
```

Also, all this custom handling is now unnecessary - all syntaxes are respected by AzDO. A possible solution is also to just push them down as-is.