### PR TITLE
Add codename of riscv64 cross-build

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -153,6 +153,7 @@ while :; do
             __AlpinePackages="${__AlpinePackages// compiler-rt-static/}"
             __QEMUArch=riscv64
             __UbuntuArch=riscv64
+            __CodeName=sid
             __UbuntuRepo="http://deb.debian.org/debian-ports"
             __UbuntuPackages="${__UbuntuPackages// libunwind8-dev/}"
             unset __LLDB_Package


### PR DESCRIPTION
The ```__Codename``` is missing when cross-building ```riscv64``
```
runtime$ sudo ./eng/common/cross/build-rootfs.sh riscv64
W: qemu-debootstrap is deprecated. Please use regular debootstrap directly
I: Running command: debootstrap --arch riscv64 xenial /home/choi/git/github/runtime/.tools/rootfs/riscv64 http://deb.debian.org/debian-ports
I: Retrieving InRelease
I: Retrieving Release
E: Failed getting release file http://deb.debian.org/debian-ports/dists/xenial/Release
runtime$ 
```

https://github.com/dotnet/arcade/blob/39952f0f2dbd76699158d5f84fc3644602ad08c9/eng/common/cross/riscv64/sources.list.sid#L1

https://github.com/dotnet/arcade/blob/39952f0f2dbd76699158d5f84fc3644602ad08c9/eng/common/cross/build-rootfs.sh#L577-L579

```
runtime$ sudo ./eng/common/cross/build-rootfs.sh riscv64
W: qemu-debootstrap is deprecated. Please use regular debootstrap directly
I: Running command: debootstrap --arch riscv64 sid /home/choi/git/github/runtime/.tools/rootfs/riscv64 http://deb.debian.org/debian-ports
W: Cannot check Release signature; keyring file not available /usr/share/keyrings/debian-archive-keyring.gpg
I: Retrieving InRelease
I: Retrieving Packages
I: Validating Packages
...
```

Related PR: https://github.com/dotnet/arcade/pull/10154 (@am11)