### PR TITLE
Update sourceIndexpackageVersion to latest

### DIFF
--- a/eng/common/templates/job/source-index-stage1.yml
+++ b/eng/common/templates/job/source-index-stage1.yml
@@ -1,6 +1,6 @@
 parameters:
   runAsPublic: false
-  sourceIndexPackageVersion: 1.0.1-20221220.2
+  sourceIndexPackageVersion: 1.0.1-20230228.2
   sourceIndexPackageSource: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
   sourceIndexBuildCommand: powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "eng/common/build.ps1 -restore -build -binarylog -ci"
   preSteps: []


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/12735
Updates the source indexing tooling to understand binlog version 16.

Package is available here: https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-tools/NuGet/BinLogToSln/overview/1.0.1-20230228.2

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
