### PR TITLE
Revert "Raise verbosity of publishing"

### DIFF
--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -161,10 +161,7 @@ stages:
           displayName: Publish packages, blobs and symbols
           inputs:
             filePath: $(Build.SourcesDirectory)/eng/common/sdk-task.ps1
-            arguments: -task PublishArtifactsInManifest
-              -restore
-              -msbuildEngine dotnet
-              -verbosity detailed
+            arguments: -task PublishArtifactsInManifest -restore -msbuildEngine dotnet
               /p:PublishingInfraVersion=3
               /p:BARBuildId=${{ parameters.BARBuildId }}
               /p:TargetChannels='${{ parameters.PromoteToChannelIds }}'

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/LatestLinksManager.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/LatestLinksManager.cs
@@ -118,6 +118,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 ShortUrl = GetLatestShortUrlForBlob(shortUrlPrefix, asset, flatten),
                 TargetUrl = actualTargetUrl
             };
+            Logger.LogMessage(MessageImportance.High, $"  {Path.GetFileName(asset)}");
 
             Logger.LogMessage(MessageImportance.High, $"  aka.ms/{newLink.ShortUrl} -> {newLink.TargetUrl}");
 


### PR DESCRIPTION
Reverts dotnet/arcade#11800. The original issue was fixed so we can go back to the nice looking log.