### PR TITLE
Allow PublicSign=true even if full keys are available

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/StrongName.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/StrongName.targets
@@ -5,6 +5,12 @@
   <!--
     Reads variables:
       SignAssembly    "true" to sign the output assembly of the current project
+      FullAssemblySigningSupported    "false" to use public signing even when full signing is possible. This is useful
+                                      in environments where full signing is non-functional or not desired. For example,
+                                      in some Linux distributions RSA+SHA1 (required for full signing) is not
+                                      functional/availalbe, and trying to use full signing results in the runtime
+                                      throwing an exception. For more details and an example, see
+                                      https://github.com/dotnet/runtime/issues/65874.
       StrongNameKeyId The id of the key used for strong name generation
 
     Writes variables:
@@ -42,7 +48,7 @@
         <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)snk/AspNetCore.snk</AssemblyOriginatorKeyFile>
         <PublicKey>$(MicrosoftAspNetCorePublicKey)</PublicKey>
         <PublicKeyToken>adb9793829ddae60</PublicKeyToken>
-        <PublicSign>false</PublicSign> <!-- The MicrosoftAspNetCore strong name key is a full key -->
+        <PublicSign Condition="'$(FullAssemblySigningSupported)' != 'false'">false</PublicSign> <!-- The MicrosoftAspNetCore strong name key is a full key -->
       </PropertyGroup>
     </When>
     <When Condition="'$(StrongNameKeyId)' == 'ECMA'">
@@ -63,7 +69,7 @@
         <PublicKey>$(OpenPublicKey)</PublicKey>
         <PublicKeyToken>cc7b13ffcd2ddd51</PublicKeyToken>
         <DelaySign>false</DelaySign>
-        <PublicSign>false</PublicSign> <!-- The Open strong name key is a full key -->
+        <PublicSign Condition="'$(FullAssemblySigningSupported)' != 'false'">false</PublicSign> <!-- The Open strong name key is a full key -->
       </PropertyGroup>
     </When>
     <When Condition="'$(StrongNameKeyId)' == 'SilverlightPlatform'">

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/StrongName.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/StrongName.targets
@@ -8,7 +8,7 @@
       FullAssemblySigningSupported    "false" to use public signing even when full signing is possible. This is useful
                                       in environments where full signing is non-functional or not desired. For example,
                                       in some Linux distributions RSA+SHA1 (required for full signing) is not
-                                      functional/availalbe, and trying to use full signing results in the runtime
+                                      functional/available, and trying to use full signing results in the runtime
                                       throwing an exception. For more details and an example, see
                                       https://github.com/dotnet/runtime/issues/65874.
       StrongNameKeyId The id of the key used for strong name generation


### PR DESCRIPTION
In certain environments - such as RHEL 9 - full signing does not work. That's because full signing requires SHA1 which is considered weak and was disabled in OpenSSL. Trying to use full signing leads to a Interop+Crypto+OpenSslCryptographicException. For more details, see https://github.com/dotnet/runtime/issues/65874.

In contrast, public signing doesn't use SHA1 and works fine in these environments.

To make sure we can still build projects in those environments using arcade, allow arcade consumers to select public signing even when we have all the keys for full signing.

Fixes: #12515

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
