### PR TITLE
Do not import the windows desktop targets if all targets should be su…

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ExcludeFromBuild.BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ExcludeFromBuild.BeforeCommonTargets.targets
@@ -44,5 +44,8 @@
          execute. -->
     <DisableWarnForInvalidRestoreProjects Condition="'$(_SuppressAllTargets)' == 'true'">true</DisableWarnForInvalidRestoreProjects>
     <NuGetRestoreTargets Condition="'$(_SuppressAllTargets)' == 'true'">$(MSBuildThisFileDirectory)NoRestore.targets</NuGetRestoreTargets>
+    <!-- When a project is using the .NET SDK, but with the "UseWpf" property, there will be an attempt to import the windows desktop SDK targets.
+         These are not available in certain circumstances, like linux source build. -->
+    <ImportWindowsDesktopTargets Condition="'$(_SuppressAllTargets)' == 'true'">false</ImportWindowsDesktopTargets>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
…ppressed

In cases where UseWpf is true and the .NET SDK is in use (vs. WindowsDesktop SDK), the .NET SDK will attempt to import the Windows desktop targets. This presents no problems in most cases, but source build doesn't have these files available. Normally, when using the WindowsDesktop SDK (via the project SDK property), source build will resolve this to an empty SDK and no targets will be imported.

If a project is generally excluded from the build, we want to suppress any targets. We can piggy-pack on this concept to solve the source build issue by preventing the .NET SDK from importing the WD SDK targets when all targets should be suppressed.
