### PR TITLE
Better trimming support + trimming fix

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/AfterSigning.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/AfterSigning.proj
@@ -1,5 +1,8 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
+  <PropertyGroup>
+    <NoTargetFrameworkFiltering>true</NoTargetFrameworkFiltering>
+  </PropertyGroup>
   <Import Project="BuildStep.props" />
 
   <Target Name="Rebuild" DependsOnTargets="Clean;Build" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/AfterSolutionBuild.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/AfterSolutionBuild.proj
@@ -1,5 +1,10 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
+  <PropertyGroup>
+    <!-- Disable target framework filtering for top level projects -->
+    <NoTargetFrameworkFiltering>true</NoTargetFrameworkFiltering>
+  </PropertyGroup>
+
   <Import Project="BuildStep.props" />
 
   <Target Name="Rebuild" DependsOnTargets="Clean;Build" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -34,6 +34,8 @@
 
   <PropertyGroup>
     <_OriginalProjectsValue>$(Projects)</_OriginalProjectsValue>
+    <!-- Disable target framework filtering for top level projects -->
+    <NoTargetFrameworkFiltering>true</NoTargetFrameworkFiltering>
   </PropertyGroup>
 
   <ItemDefinitionGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -1,5 +1,11 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project DefaultTargets="Publish">
+
+  <PropertyGroup>
+    <!-- Disable target framework filtering for top level projects -->
+    <NoTargetFrameworkFiltering>true</NoTargetFrameworkFiltering>
+  </PropertyGroup>
+
   <!--
     Documentation for publishing is available here:
       - https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Publishing.md

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryValidation.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryValidation.proj
@@ -2,6 +2,11 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project DefaultTargets="Validate">
 
+  <PropertyGroup>
+    <!-- Disable target framework filtering for top level projects -->
+    <NoTargetFrameworkFiltering>true</NoTargetFrameworkFiltering>
+  </PropertyGroup>
+  
   <Import Project="BuildTasks.props" />
 
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.ValidateLicense" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -1,5 +1,11 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project DefaultTargets="Sign">
+
+  <PropertyGroup>
+    <!-- Disable target framework filtering for top level projects -->
+    <NoTargetFrameworkFiltering>true</NoTargetFrameworkFiltering>
+  </PropertyGroup>
+
   <Import Project="BuildStep.props" />
 
   <Import Project="$(NuGetPackageRoot)microsoft.dotnet.signtool\$(MicrosoftDotNetSignToolVersion)\build\Microsoft.DotNet.SignTool.props" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -31,7 +31,7 @@
 
     <!-- This is fed into the inner source build as an environment variable (DotNetTargetFrameworkFilter) to enable filtering.
          The default target framework filter includes all recent netcoreapps in SBRP, as well as 8.0 (latest) and 7.0 (working to get rid of it -->
-    <_DefaultNetFrameworkFilter>netstandard2.0%3bnetstandard2.1%3bnetcoreapp2.1%3bnet5.0%3bnet6.0%3bnet7.0%3bnet8.0</_DefaultNetFrameworkFilter>
+    <_DefaultNetFrameworkFilter>netstandard2.0%3bnetstandard2.1%3bnetcoreapp2.1%3bnetcoreapp3.1%3bnet5.0%3bnet6.0%3bnet7.0%3bnet8.0</_DefaultNetFrameworkFilter>
     <SourceBuildTargetFrameworkFilter Condition="'$(SourceBuildTrimNetFrameworkTargets)' == 'true' and '$(SourceBuildTargetFrameworkFilter)' == ''">$(_DefaultNetFrameworkFilter)</SourceBuildTargetFrameworkFilter>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -28,6 +28,11 @@
     <DetectSourceBuildIntermediateNupkgLicense Condition="'$(DetectSourceBuildIntermediateNupkgLicense)' == ''">true</DetectSourceBuildIntermediateNupkgLicense>
 
     <EnableDefaultSourceBuildIntermediateItems Condition="'$(EnableDefaultSourceBuildIntermediateItems)' == ''">true</EnableDefaultSourceBuildIntermediateItems>
+
+    <!-- This is fed into the inner source build as an environment variable (DotNetTargetFrameworkFilter) to enable filtering.
+         The default target framework filter includes all recent netcoreapps in SBRP, as well as 8.0 (latest) and 7.0 (working to get rid of it -->
+    <_DefaultNetFrameworkFilter>netstandard2.0%3bnetstandard2.1%3bnetcoreapp2.1%3bnet5.0%3bnet6.0%3bnet7.0%3bnet8.0</_DefaultNetFrameworkFilter>
+    <SourceBuildTargetFrameworkFilter Condition="'$(SourceBuildTrimNetFrameworkTargets)' == 'true' and '$(SourceBuildTargetFrameworkFilter)' == ''">$(_DefaultNetFrameworkFilter)</SourceBuildTargetFrameworkFilter>
   </PropertyGroup>
 
   <Target Name="GetSourceBuildIntermediateNupkgNameConvention">

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
@@ -92,6 +92,7 @@
     <ItemGroup>
       <!-- Override package cache to separate source-built packages from upstream. -->
       <InnerBuildEnv Include="NUGET_PACKAGES=$(CurrentRepoSourceBuildPackageCache)" />
+      <InnerBuildEnv Include="DotNetTargetFrameworkFilter=$(SourceBuildTargetFrameworkFilter)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
- Allow for trimming to be set in SourceBuild.props. This enables use in repo SB legs. Includes a default set which is all netcoreapps + netstandards.
- Disable trimming for top level projects in Arcade, so that we don't accidentally skip things like publishing.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
