### PR TITLE
Persist FPU variables across try_compile passes

### DIFF
--- a/eng/common/cross/toolchain.cmake
+++ b/eng/common/cross/toolchain.cmake
@@ -298,6 +298,9 @@ if(TARGET_ARCH_NAME MATCHES "^(arm|armel)$")
 
   add_definitions (-DCLR_ARM_FPU_CAPABILITY=${CLR_ARM_FPU_CAPABILITY})
 
+  # persist variables across multiple try_compile passes
+  list(APPEND CMAKE_TRY_COMPILE_PLATFORM_VARIABLES CLR_ARM_FPU_TYPE CLR_ARM_FPU_CAPABILITY)
+
   if(TARGET_ARCH_NAME STREQUAL "armel")
     add_compile_options(-mfloat-abi=softfp)
   endif()


### PR DESCRIPTION
When `-cmakeargs -DCLR_ARM_FPU_TYPE=vfpv4` is passed from command-line, the first pass to toolchain was failing the condition `if (NOT DEFINED CLR_ARM_FPU_TYPE)` as expected, but the second and subsequent passes were satisfying the condition. This is because how cmake invokes the toolchain file.

Append variables that we must persist across the passes to [`CMAKE_TRY_COMPILE_PLATFORM_VARIABLES`](https://cmake.org/cmake/help/latest/variable/CMAKE_TRY_COMPILE_PLATFORM_VARIABLES.html) to override this behavior.

Contributes to https://github.com/dotnet/runtime/issues/83170.

cc @janvorli