### PR TITLE
Enable support for workloads from multiple SDKs in Visual Studio

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             Assert.Equal("x64;1033", si.Template);
 
             // Verify the SWIX authoring for the component representing the workload in VS.
-            string componentSwr = File.ReadAllText(Path.Combine(baseIntermediateOutputPath, "src", "swix", "6.0.200", "microsoft.net.sdk.emscripten.5.6.7.8", "component.swr"));
+            string componentSwr = File.ReadAllText(Path.Combine(baseIntermediateOutputPath, "src", "swix", "6.0.200", "microsoft.net.sdk.emscripten.xyz.5.6.7.8", "component.swr"));
             Assert.Contains("package name=microsoft.net.sdk.emscripten.xyz", componentSwr);
 
             // Emscripten is an abstract workload so it should be a component group.

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
@@ -135,6 +135,12 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             Assert.Contains("package name=Microsoft.Emscripten.Python.6.0.4", packMsiSwr);
             Assert.Contains("vs.package.chip=x64", packMsiSwr);
             Assert.DoesNotContain("vs.package.machineArch", packMsiSwr);
+
+            // Verify the swix project items for components. The project files names always contain the major.minor suffix, so we'll end up
+            // with microsoft.net.sdk.emscripten.5.6.swixproj and microsoft.net.sdk.emscripten.pre.5.6.swixproj
+            IEnumerable<ITaskItem> swixComponentProjects = createWorkloadTask.SwixProjects.Where(s => s.GetMetadata(Metadata.PackageType).Equals(DefaultValues.PackageTypeComponent));
+            Assert.All(swixComponentProjects, c => Assert.True(c.ItemSpec.Contains(".pre.") && c.GetMetadata(Metadata.IsPreview) == "true" ||
+                !c.ItemSpec.Contains(".pre.") && c.GetMetadata(Metadata.IsPreview) == "false"));
         }
 
         [WindowsOnlyFact]

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
@@ -61,6 +61,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
                 BaseIntermediateOutputPath = baseIntermediateOutputPath,
                 BuildEngine = buildEngine,
                 ComponentResources = componentResources,
+                ComponentSuffix = "xyz",
                 ManifestMsiVersion = null,
                 PackageSource = TestBase.TestAssetsPath,
                 ShortNames = shortNames,
@@ -89,7 +90,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
 
             // Verify the SWIX authoring for the component representing the workload in VS.
             string componentSwr = File.ReadAllText(Path.Combine(baseIntermediateOutputPath, "src", "swix", "6.0.200", "microsoft.net.sdk.emscripten.5.6.7.8", "component.swr"));
-            Assert.Contains("package name=microsoft.net.sdk.emscripten", componentSwr);
+            Assert.Contains("package name=microsoft.net.sdk.emscripten.xyz", componentSwr);
 
             // Emscripten is an abstract workload so it should be a component group.
             Assert.Contains("vs.package.type=component", componentSwr);

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
@@ -515,6 +515,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                     ITaskItem swixProjectItem = new TaskItem(swixComponentProject.Create());
                     swixProjectItem.SetMetadata(Metadata.SdkFeatureBand, $"{swixComponent.SdkFeatureBand}");
                     swixProjectItem.SetMetadata(Metadata.PackageType, DefaultValues.PackageTypeComponent);
+                    swixProjectItem.SetMetadata(Metadata.IsPreview, swixComponent.Name.EndsWith(".pre").ToString().ToLowerInvariant());
 
                     lock (swixProjectItems)
                     {

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
@@ -414,6 +414,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                                 ITaskItem swixProjectItem = new TaskItem(swixProj);
                                 swixProjectItem.SetMetadata(Metadata.SdkFeatureBand, $"{sdkFeatureBand}");
                                 swixProjectItem.SetMetadata(Metadata.PackageType, DefaultValues.PackageTypeMsiPack);
+                                swixProjectItem.SetMetadata(Metadata.IsPreview, "false");
 
                                 lock (swixProjectItems)
                                 {
@@ -462,6 +463,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                                     ITaskItem swixProjectItem = new TaskItem(swixProj);
                                     swixProjectItem.SetMetadata(Metadata.SdkFeatureBand, $"{manifestPackage.SdkFeatureBand}");
                                     swixProjectItem.SetMetadata(Metadata.PackageType, DefaultValues.PackageTypeMsiPack);
+                                    swixProjectItem.SetMetadata(Metadata.IsPreview, "false");
 
                                     lock (swixProjectItems)
                                     {
@@ -489,6 +491,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                         ITaskItem swixProjectItem = new TaskItem(swixProject.Create());
                         swixProjectItem.SetMetadata(Metadata.SdkFeatureBand, $"{((WorkloadManifestPackage)msi.Package).SdkFeatureBand}");
                         swixProjectItem.SetMetadata(Metadata.PackageType, DefaultValues.PackageTypeMsiManifest);
+                        swixProjectItem.SetMetadata(Metadata.IsPreview, "false");
 
                         lock (swixProjectItems)
                         {

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
@@ -67,6 +67,16 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
         /// multiple copies of the same workload need to be inserted. The suffix is appended to
         /// all components, including external dependencies.
         /// </summary>
+        /// <remarks>
+        /// For example, given a suffix such as "abc" and a workload named "wasm-tools" that extends "microsoft-net-runtime-mono-tooling",
+        /// the generated SWIX component for Visual Studio would be
+        /// <code>
+        /// package name=wasm.tools.abc
+        /// 
+        /// vs.dependencies
+        ///   vs.dependency id=microsoft.net.runtime.mono.tooling.abc
+        /// </code>
+        /// </remarks>
         public string ComponentSuffix
         {
             get;

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
@@ -63,6 +63,17 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
         }
 
         /// <summary>
+        /// A suffix appeneded to component IDs for Visual Studio to allow SxS support when
+        /// multiple copies of the same workload need to be inserted. The suffix is appended to
+        /// all components, including external dependencies.
+        /// </summary>
+        public string ComponentSuffix
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// A set of Internal Consistency Evaluators (ICEs) to suppress.
         /// </summary>
         public ITaskItem[] IceSuppressions
@@ -357,7 +368,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
 
                             // Finally, add a component for the workload in Visual Studio.
                             SwixComponent component = SwixComponent.Create(manifestPackage.SdkFeatureBand, workload, manifest, packGroupId,
-                                ComponentResources, ShortNames);
+                                ComponentResources, ShortNames, ComponentSuffix);
 
                             // Check for duplicates, e.g. manifests that were copied without changing workload definition IDs and
                             // provide a more usable error message so users can track down the duplication.

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Metadata.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Metadata.cs
@@ -14,6 +14,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
         public static readonly string Description = nameof(Description);
         public static readonly string Filename = nameof(Filename);
         public static readonly string FullPath = nameof(FullPath);
+        public static readonly string IsPreview = nameof(IsPreview);
         public static readonly string JsonProperties = nameof(JsonProperties);
 
         /// <summary>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Strings.Designer.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Strings.Designer.cs
@@ -97,7 +97,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Components must have define at lease on category..
+        ///   Looks up a localized string similar to Components must define at least one category..
         /// </summary>
         internal static string ComponentCategoryCannotBeNull {
             get {
@@ -219,6 +219,15 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads {
         internal static string UnknownWorkloadKind {
             get {
                 return ResourceManager.GetString("UnknownWorkloadKind", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Duplicate workload ID: {0}. A SWIX component, {1}, with the same workload ID already exists..
+        /// </summary>
+        internal static string WorkloadComponentExists {
+            get {
+                return ResourceManager.GetString("WorkloadComponentExists", resourceCulture);
             }
         }
         

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Strings.resx
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Strings.resx
@@ -171,6 +171,9 @@
   <data name="UnknownWorkloadKind" xml:space="preserve">
     <value>Unknown workload kind: {0}.</value>
   </data>
+  <data name="WorkloadComponentExists" xml:space="preserve">
+    <value>Duplicate workload ID: {0}. A SWIX component, {1}, with the same workload ID already exists.</value>
+  </data>
   <data name="WorkloadDefinitionDoesNotSupportWindows" xml:space="preserve">
     <value>{0} does not support any Windows platforms and will be skipped. Supported platforms: {1}.</value>
   </data>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/SwixComponent.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/SwixComponent.cs
@@ -176,7 +176,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
         /// <returns>A SWIX component.</returns>
         public static SwixComponent Create(ReleaseVersion sdkFeatureBand, WorkloadDefinition workload, WorkloadManifest manifest,
             string? packGroupId,
-            ITaskItem[]? componentResources = null, ITaskItem[]? shortNames = null)
+            ITaskItem[]? componentResources = null, ITaskItem[]? shortNames = null, string? componentSuffix = null)
         {
             ITaskItem? resourceItem = componentResources?.Where(r => string.Equals(r.ItemSpec, workload.Id)).FirstOrDefault();
 
@@ -188,7 +188,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
 
             // Since workloads only define a description, if no custom resources were provided, both the title and description of
             // the SWIX component will default to the workload description. 
-            SwixComponent component = new(sdkFeatureBand, Utils.ToSafeId(workload.Id),
+            SwixComponent component = new(sdkFeatureBand, Utils.ToSafeId(workload.Id, componentSuffix),
                 resourceItem != null && !string.IsNullOrEmpty(resourceItem.GetMetadata(Metadata.Title)) ? resourceItem.GetMetadata(Metadata.Title) : workload.Description ?? throw new Exception(Strings.ComponentTitleCannotBeNull),
                 resourceItem != null && !string.IsNullOrEmpty(resourceItem.GetMetadata(Metadata.Description)) ? resourceItem.GetMetadata(Metadata.Description) : workload.Description ?? throw new Exception(Strings.ComponentDescriptionCannotBeNull),
                 componentVersion, workload.IsAbstract,
@@ -199,7 +199,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
             // processing direct pack dependencies.
             foreach (WorkloadId dependency in workload.Extends ?? Enumerable.Empty<WorkloadId>())
             {
-                component.AddDependency(Utils.ToSafeId(dependency), s_v1);
+                component.AddDependency(Utils.ToSafeId(dependency, componentSuffix), s_v1);
             }
 
             // TODO: Check for missing packs

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Utils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Utils.cs
@@ -50,8 +50,9 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
         /// </summary>
         /// <param name="id">The identifier to convert to a safe identifier</param>
         /// <returns>The safe identifier.</returns>
-        internal static string ToSafeId(string id) =>
-            id.Replace("-", ".").Replace(" ", ".").Replace("_", ".");
+        internal static string ToSafeId(string id, string suffix = null) =>
+            id.Replace("-", ".").Replace(" ", ".").Replace("_", ".")+
+            (string.IsNullOrWhiteSpace(suffix) ? null : $".{suffix}");
 
         /// <summary>
         /// Replaces all the tokens in a file using the provided dictionary. The dictionary keys define the tokens and


### PR DESCRIPTION
## Description

Inserting multiple .NET SDKs in Visual Studio creates a conflict because .NET workloads share the same IDs that are used to generate the corresponding SWIX components in Visual Studio. For example, both .NET 7 and .NET 8 produces a workload called `wasm-tools`. In Visual Studio, this is represented by a component named `wasm.tools`. If both .NET 7 and .NET 8 are inserted into Visual Studio, the merge manifests would contain duplicate component IDs.

## Solution

When generating a workload, the tooling will automatically generate a preview version of the components for Visual Studio. The components will contain a ".pre" suffix. Since Visual Studio will trim unused package references, during insertions, authors can decide to use none, one, or both sets of components.

## Example

Given the following workload

```json
 "workloads": {
    "wasm-tools": {
      "extends": [ "microsoft-net-runtime-mono-tooling", "microsoft-net-sdk-emscripten-net7" ],
    },
  }
```    

Two SWIX projects will be generated

```
package name=wasm.tools

vs.dependencies
  vs.dependency id=microsoft.net.runtime.mono.tooling
  vs.dependency id=microsoft.net.sdk.emscripten.net7
```

```
package name=wasm.tools.pre

vs.dependencies
  vs.dependency id=microsoft.net.runtime.mono.tooling.pre
  vs.dependency id=microsoft.net.sdk.emscripten.net7.pre
```