### PR TITLE
Fix issues with dotnet-release publishing.

### DIFF
--- a/.vault-config/product-builds-dnceng-pipeline-secrets.yaml
+++ b/.vault-config/product-builds-dnceng-pipeline-secrets.yaml
@@ -41,6 +41,24 @@ secrets:
     type: text
     parameters:
       description: set to never expire
+      
+  dotnetclichecksumsmsrc-connection-string:
+    type: azure-storage-connection-string
+    parameters:
+      storageKeySecret: dotnetclichecksumsmsrc-storage-key
+      account: dotnetclichecksumsmsrc
+      
+  dotnetclichecksumsmsrc-dotnet-container-uri:
+    type: azure-storage-container-sas-uri
+    parameters:
+      connectionString: dotnetclichecksumsmsrc-connection-string
+      permissions: rlwc
+      container: dotnet
+
+  dotnetclichecksumsmsrc-dotnet-container-uri-base64:
+    type: base64-encoder
+    parameters:
+      secret: dotnetclichecksumsmsrc-dotnet-container-uri
 
   dotnetclimsrc-access-key:
     type: text
@@ -58,6 +76,18 @@ secrets:
       storageKeySecret: dotnetclimsrc-access-key
       account: dotnetclimsrc
 
+  dotnetclimsrc-read-uri-token:
+    type: azure-storage-container-sas-token
+    parameters:
+      connectionString: dotnetclimsrc-connection-string
+      permissions: rl
+      container: dotnet
+
+  dotnetclimsrc-read-sas-token-base64:
+    type: base64-encoder
+    parameters:
+      secret: dotnetclimsrc-read-sas-token
+      
   dotnetclimsrc-read-sas-token:
     type: azure-storage-container-sas-token
     parameters:
@@ -69,6 +99,18 @@ secrets:
     type: base64-encoder
     parameters:
       secret: dotnetclimsrc-read-sas-token
+      
+  dotnetclimsrc-dotnet-container-uri:
+    type: azure-storage-container-sas-uri
+    parameters:
+      connectionString: dotnetclimsrc-connection-string
+      permissions: rlwc
+      container: dotnet
+
+  dotnetclimsrc-dotnet-container-uri-base64:
+    type: base64-encoder
+    parameters:
+      secret: dotnetclimsrc-dotnet-container-uri
 
   dotnetfeedmsrc-private-feed-url:
     type: text

--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -17,6 +17,7 @@ stages:
         - group: DotNet-Symbol-Server-Pats
         - group: DotNetBuilds storage account tokens
         - group: AzureDevOps-Artifact-Feeds-Pats
+        - group: DotNet-MSRC-Storage
         - group: Publish-Build-Assets
           
         # Default Maestro++ API Endpoint and API Version

--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -173,12 +173,7 @@ stages:
               /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/'
               /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts/'
               /p:PublishInstallersAndChecksums=true
-              /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
-              /p:InternalInstallersAzureAccountKey=$(dotnetclimsrc-access-key)
-              /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-              /p:InternalChecksumsAzureAccountKey=$(dotnetclichecksumsmsrc-storage-key)
               /p:AzureDevOpsFeedsKey='$(dn-bot-all-orgs-artifact-feeds-rw)'
-              /p:AzureStorageTargetFeedPAT='$(dotnetfeed-storage-access-key-1)'
               /p:AkaMSClientId=$(akams-client-id)
               /p:AkaMSClientSecret=$(akams-client-secret)
               ${{ parameters.artifactsPublishingAdditionalParameters }}
@@ -200,6 +195,8 @@ stages:
               /p:DotNetBuildsPublicChecksumsUriBase64='$(dotnetbuilds-public-container-checksum-uri-base64)'
               /p:DotNetBuildsInternalUriBase64='$(dotnetbuilds-internal-container-uri-base64)'
               /p:DotNetBuildsInternalChecksumsUriBase64='$(dotnetbuilds-internal-container-checksum-uri-base64)'
+              /p:DotNetCliMsrcDotNetUriBase64='$(dotnetclimsrc-dotnet-container-uri-base64)'
+              /p:DotNetCliChecksumsMsrcDotNetUriBase64='$(dotnetclichecksumsmsrc-dotnet-container-uri-base64)'
         - template: /eng/common/templates/steps/publish-logs.yml
           parameters:
             StageLabel: '${{ parameters.stageName }}'

--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -17,9 +17,6 @@ stages:
         - group: DotNet-Symbol-Server-Pats
         - group: DotNetBuilds storage account tokens
         - group: AzureDevOps-Artifact-Feeds-Pats
-        - group: DotNet-Blob-Feed
-        - group: DotNet-DotNetCli-Storage
-        - group: DotNet-MSRC-Storage
         - group: Publish-Build-Assets
           
         # Default Maestro++ API Endpoint and API Version

--- a/src/Microsoft.DotNet.ApiCompat/README.md
+++ b/src/Microsoft.DotNet.ApiCompat/README.md
@@ -1,4 +1,8 @@
-# Microsoft.DotNet.ApiCompat
+# Not maintained anymore
+
+:warning: Microsoft.DotNet.ApiCompat which is CCI based isn't maintained anymore and was never intended to be publicly used. Please switch to the Roslyn based ApiCompat & PackageValidation functionality that is part of the .NET SDK: https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/overview. This code base will be deleted in the future.
+
+## Microsoft.DotNet.ApiCompat
 
 APICompat is a tool which may be used to test API compatibility between a two .NET assemblies.
 
@@ -8,7 +12,7 @@ The *contract* represents the API that's expected : for example a reference asse
 
 The *implementation* represents the API that's provided : for example the current version of an assembly.
 
-## Usage
+### Usage
 
 API Compat can be used by referencing this Microsoft.DotNet.ApiCompat package from the *implementation* project, and providing the path to the *contract* via a single `@(ResolvedMatchingContract)` item.  Dependencies of `@(ResolvedMatchingContract)` must be specified in either `DependencyPaths` metadata on the items themselves or via the `$(ContractDependencyPaths)` property.
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
@@ -53,7 +53,6 @@
       - AzureStorageAccountKey
       - AzureDevOpsFeedsBaseUrl
       - ArtifactsCategory
-      - AzureStorageTargetFeedPAT               : PAT for accessing dotnetfeed Azure Storage
 
     Optional parameters for SetupTargetFeeds.proj
       - PublishInstallersAndChecksums   : This control whether installers & checksums should be published to public feeds on public builds
@@ -99,10 +98,6 @@
       <AkaMSGroupOwner Condition="'$(AkaMSGroupOwner)' == ''">ddfwlink</AkaMSGroupOwner>
       <PublishSpecialClrFiles Condition="'$(PublishSpecialClrFiles)' == ''">false</PublishSpecialClrFiles>
       <BuildQuality Condition="'$(BuildQuality)' == ''">daily</BuildQuality>
-      <InstallersFeedKey>$(InstallersAzureAccountKey)</InstallersFeedKey>
-      <InternalInstallersFeedKey>$(InternalInstallersAzureAccountKey)</InternalInstallersFeedKey>
-      <ChecksumsFeedKey>$(ChecksumsAzureAccountKey)</ChecksumsFeedKey>
-      <InternalChecksumsFeedKey>$(InternalChecksumsAzureAccountKey)</InternalChecksumsFeedKey>
       <AllowFeedOverrides Condition="'$(AllowFeedOverrides)' == ''">false</AllowFeedOverrides>
       <UseStreamingPublishing Condition="'$(UseStreamingPublishing)' == ''">false</UseStreamingPublishing>
       <ArtifactsBasePath Condition="'$(ArtifactsBasePath)' == ''">$(BlobBasePath)</ArtifactsBasePath>
@@ -111,13 +106,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <FeedKey Include="https://dotnetclichecksums.blob.core.windows.net/dotnet/index.json" Key="$(ChecksumsFeedKey)"/>
-      <FeedKey Include="https://dotnetcli.blob.core.windows.net/dotnet/index.json" Key="$(InstallersFeedKey)"/>
-      <FeedKey Include="https://dotnetclichecksumsmsrc.blob.core.windows.net/dotnet/index.json" Key="$(InternalChecksumsFeedKey)"/>
-      <FeedKey Include="https://dotnetclimsrc.blob.core.windows.net/dotnet/index.json" Key="$(InternalInstallersFeedKey)"/>
+      <!-- These stay for .NET 5 for now -->
       <FeedKey Include="https://pkgs.dev.azure.com/dnceng" Key="$(AzureDevOpsFeedsKey)"/>
-      <FeedKey Include="$(ChecksumsFeedOverride)" Key="$(ChecksumsFeedKey)" Condition="'$(ChecksumsFeedOverride)' != ''"/>
-      <FeedKey Include="$(InstallersFeedOverride)" Key="$(InstallersFeedKey)" Condition="'$(InstallersFeedOverride)' != ''"/>
+      <FeedSasUri Include="$(ChecksumsFeedOverride)" Base64Uri="$(ChecksumsFeedBase64SasUri)" Condition="'$(ChecksumsFeedOverride)' != ''"/>
+      <FeedSasUri Include="$(InstallersFeedOverride)" Base64Uri="$(InstallersFeedBase64SasUri)" Condition="'$(InstallersFeedOverride)' != ''"/>
+      <FeedSasUri Include="https://dotnetclimsrc.blob.core.windows.net/dotnet" Key="$(DotNetCliMsrcDotNetUriBase64)"/>
+      <FeedSasUri Include="https://dotnetclichecksumsmsrc.blob.core.windows.net/dotnet" Key="$(DotNetCliChecksumsMsrcDotNetUriBase64)"/>
       <FeedSasUri Include="https://dotnetbuilds.blob.core.windows.net/public" Base64Uri="$(DotNetBuildsPublicUriBase64)"/>
       <FeedSasUri Include="https://dotnetbuilds.blob.core.windows.net/public-checksums" Base64Uri="$(DotNetBuildsPublicChecksumsUriBase64)"/>
       <FeedSasUri Include="https://dotnetbuilds.blob.core.windows.net/internal" Base64Uri="$(DotNetBuildsInternalUriBase64)"/>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/SetupTargetFeedConfigV3Tests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/SetupTargetFeedConfigV3Tests.cs
@@ -17,7 +17,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
 {
     public class SetupTargetFeedConfigV3Tests
     {
-        private const string AzureStorageTargetFeedPAT = "AzureStorageTargetFeedPAT";
         private const string LatestLinkShortUrlPrefix = "LatestLinkShortUrlPrefix";
         private const string BuildQuality = "quality";
         private const string AzureDevOpsFeedsKey = "AzureDevOpsFeedsKey";

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/AssetPublisherFactory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/AssetPublisherFactory.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 case FeedType.AzDoNugetFeed:
                     return new AzureDevOpsNugetFeedAssetPublisher(_log, feedConfig.TargetURL, feedConfig.Token, task);
                 case FeedType.AzureStorageContainer:
-                    return new AzureStorageContainerAssetPublisher(new Uri(feedConfig.TargetURL), _log);
+                    return new AzureStorageContainerAssetPublisher(new Uri(feedConfig.TargetURL), new Uri(feedConfig.Token), _log);
                 default:
                     throw new NotImplementedException();
             }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/AzureStorageContainerAssetPublisher.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/AzureStorageContainerAssetPublisher.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Azure.Storage.Blobs;
+using Azure;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.Build.Tasks.Feed
@@ -10,15 +11,18 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
     public class AzureStorageContainerAssetPublisher : AzureStorageAssetPublisher
     {
         private readonly Uri _containerUri;
+        private readonly Uri _sasUri;
 
-        public AzureStorageContainerAssetPublisher(Uri containerUri, TaskLoggingHelper log) : base(log)
+        public AzureStorageContainerAssetPublisher(Uri containerUri, Uri sasUri, TaskLoggingHelper log) : base(log)
         {
             _containerUri = containerUri;
+            _sasUri = sasUri;
         }
 
         public override BlobClient CreateBlobClient(string blobPath)
         {
-            var containerClient = new BlobContainerClient(_containerUri); 
+            // When creating the blob client from the URI, only utilize the query parameters for the SAS uri (excluding the leading ?)
+            var containerClient = new BlobContainerClient(_containerUri, new AzureSasCredential(_sasUri.Query));
             return containerClient.GetBlobClient(blobPath);
         }
     }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -590,7 +590,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                             treatPdbConversionIssuesAsInfo: false,
                             dryRun: false,
                             timer: false,
-                            verboseLogging: true);
+                            verboseLogging: false);
                     }
                     catch (Exception ex)
                     {
@@ -719,7 +719,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                             treatPdbConversionIssuesAsInfo: false,
                             dryRun: false,
                             timer: false,
-                            verboseLogging: true);
+                            verboseLogging: false);
                     }
                     catch (Exception ex)
                     {

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigBase.cs
@@ -12,7 +12,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         protected bool IsStableBuild { get; set; }
         protected string RepositoryName { get; set; }
         protected string CommitSha { get; set; }
-        protected string AzureStorageTargetFeedPAT { get; set; }
         protected bool PublishInstallersAndChecksums { get; set; }
         protected string InstallersTargetStaticFeed { get; set; }
         protected string InstallersAzureAccountKey { get; set; }
@@ -28,7 +27,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             bool isStableBuild,
             string repositoryName,
             string commitSha,
-            string azureStorageTargetFeedPAT,
             bool publishInstallersAndChecksums,
             string installersTargetStaticFeed,
             string installersAzureAccountKey,
@@ -44,7 +42,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             IsStableBuild = isStableBuild;
             RepositoryName = repositoryName;
             CommitSha = commitSha;
-            AzureStorageTargetFeedPAT = azureStorageTargetFeedPAT;
             PublishInstallersAndChecksums = publishInstallersAndChecksums;
             InstallersTargetStaticFeed = installersTargetStaticFeed;
             InstallersAzureAccountKey = installersAzureAccountKey;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigV3.cs
@@ -170,7 +170,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         type,
                         feed,
                         feedType,
-                        sasUri ?? key
+                        sasUri ?? key,
                         LatestLinkShortUrlPrefixes,
                         spec.Assets,
                         false,

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigV3.cs
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             ImmutableList<string> filesToExclude = null,
             bool flatten = true,
             TaskLoggingHelper log = null) 
-            : base(isInternalBuild, isStableBuild, repositoryName, commitSha, null, publishInstallersAndChecksums, null, null, null, null, null, null, null, latestLinkShortUrlPrefixes, null)
+            : base(isInternalBuild, isStableBuild, repositoryName, commitSha, publishInstallersAndChecksums, null, null, null, null, null, null, null, latestLinkShortUrlPrefixes, null)
         {
             _targetChannelConfig = targetChannelConfig;
             BuildEngine = buildEngine;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigV3.cs
@@ -158,18 +158,19 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     }
                     var key = GetFeedKey(feed);
                     var sasUri = GetFeedSasUri(feed);
-                    if (feed != oldFeed && string.IsNullOrEmpty(key) && string.IsNullOrEmpty(sasUri))
+                    if (string.IsNullOrEmpty(key) && string.IsNullOrEmpty(sasUri))
                     {
-                        Log?.LogWarning($"No keys found for {feed}, unable to publish to it.");
+                        Log?.LogError($"No keys found for {feed}, unable to publish to it.");
                         continue;
                     }
+
                     var feedType = feed.StartsWith("https://pkgs.dev.azure.com")
                         ? FeedType.AzDoNugetFeed : FeedType.AzureStorageContainer;
                     yield return new TargetFeedConfig(
                         type,
-                        sasUri ?? feed,
+                        feed,
                         feedType,
-                        sasUri == null ? key : null,
+                        sasUri == null ? key : sasUri,
                         LatestLinkShortUrlPrefixes,
                         spec.Assets,
                         false,


### PR DESCRIPTION
When I removed sleet publishing, I removed the ability to publish via a key. dotnet-release was relying on this. However, it's not required. dotnet-release's publishing can use SAS based auth just fine. Tweak publishing to enable this:
- When constructing the blob storage client, pass the SAS separately.
- Remove feed tokens from PublishArtifactsInManifest.proj. Replace with FeedSasUris
- Turn off verbose logging for symbol uplods
- Ensure an error when a feed or SAS token is not available for a given target location.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
