### PR TITLE
Fixes https://github.com/dotnet/arcade/issues/12740

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -33,7 +33,7 @@
     </ItemGroup>
 
     <Exec
-      Command="sed -i 's/netcoreapp3.1/$(TargetFrameworkForNETSDK)/g' '%(ToolMSBuildFileUsingTargetFramework.FullPath)'"
+      Command="sed -i 's/netcoreapp3.1/net6.0/g' '%(ToolMSBuildFileUsingTargetFramework.FullPath)'"
       WorkingDirectory="$(RepoRoot)"
       Condition="'@(ToolMSBuildFileUsingTargetFramework)' != ''" />
   </Target>


### PR DESCRIPTION
When I moved around properties to support NetCurrent, etc. in 6.0, the TFM replacement in arcade's build property files broke because the TFM property was not defined. Fix this by simply hardcoding the property value. It's not ever going to change.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
