### PR TITLE
Remove NuGet.Packaging.Core usage from arcade, use NuGet.Packaging instead

### DIFF
--- a/src/Microsoft.DotNet.SignTool/Microsoft.DotNet.SignTool.csproj
+++ b/src/Microsoft.DotNet.SignTool/Microsoft.DotNet.SignTool.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
-    <PackageReference Include="NuGet.Packaging.Core" Version="$(NuGetPackagingVersion)" />
+    <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagingVersion)" />
     <!-- This is here so that we agree with the project's transitive references to NewtonSoft.Json -->
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.VersionTools/lib/Microsoft.DotNet.VersionTools.csproj
+++ b/src/Microsoft.DotNet.VersionTools/lib/Microsoft.DotNet.VersionTools.csproj
@@ -16,7 +16,6 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagingVersion)" />
-    <PackageReference Include="NuGet.Packaging.Core" Version="$(NuGetPackagingVersion)" />
     <PackageReference Include="NuGet.Versioning" Version="$(NuGetPackagingVersion)" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="$(SystemDiagnosticsTraceSourceVersion)" />
   </ItemGroup>

--- a/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
+++ b/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
@@ -18,10 +18,10 @@
     <PackageReference Include="LZMA-SDK" Version="19.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.OLE.Interop" Version="7.10.6071" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="NuGet.Common" Version="5.0" />
-    <PackageReference Include="NuGet.Frameworks" Version="5.0" />
-    <PackageReference Include="NuGet.Packaging" Version="5.0" />
-    <PackageReference Include="NuGet.Versioning" Version="5.0" />
+    <PackageReference Include="NuGet.Common" Version="5.0.2" />
+    <PackageReference Include="NuGet.Frameworks" Version="5.0.2" />
+    <PackageReference Include="NuGet.Packaging" Version="5.0.2" />
+    <PackageReference Include="NuGet.Versioning" Version="5.0.2" />
     <PackageReference Include="System.IO.Packaging" Version="4.5.0" />
     <PackageReference Include="Microsoft.Signed.Wix" Version="$(MicrosoftSignedWixVersion)" />
   </ItemGroup>

--- a/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
+++ b/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
@@ -18,11 +18,10 @@
     <PackageReference Include="LZMA-SDK" Version="19.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.OLE.Interop" Version="7.10.6071" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="NuGet.Common" Version="4.7.0" />
-    <PackageReference Include="NuGet.Frameworks" Version="4.7.0" />
-    <PackageReference Include="NuGet.Packaging" Version="4.7.0" />
-    <PackageReference Include="NuGet.Packaging.Core" Version="4.7.0" />
-    <PackageReference Include="NuGet.Versioning" Version="4.7.0" />
+    <PackageReference Include="NuGet.Common" Version="5.0" />
+    <PackageReference Include="NuGet.Frameworks" Version="5.0" />
+    <PackageReference Include="NuGet.Packaging" Version="5.0" />
+    <PackageReference Include="NuGet.Versioning" Version="5.0" />
     <PackageReference Include="System.IO.Packaging" Version="4.5.0" />
     <PackageReference Include="Microsoft.Signed.Wix" Version="$(MicrosoftSignedWixVersion)" />
   </ItemGroup>

--- a/src/SignCheck/Microsoft.SignCheck/Verification/NupkgVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/NupkgVerifier.cs
@@ -33,7 +33,7 @@ namespace Microsoft.SignCheck.Verification
 
         private bool IsSigned(string path)
         {
-            IEnumerable<ISignatureVerificationProvider> providers = new List<ISignatureVerificationProvider>()
+            List<ISignatureVerificationProvider> providers = new()
             {
                 new IntegrityVerificationProvider(),
                 new SignatureTrustAndValidityVerificationProvider(),

--- a/src/SignCheck/Microsoft.SignCheck/Verification/NupkgVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/NupkgVerifier.cs
@@ -33,18 +33,19 @@ namespace Microsoft.SignCheck.Verification
 
         private bool IsSigned(string path)
         {
-            IEnumerable<ISignatureVerificationProvider> providers = SignatureVerificationProviderFactory.GetSignatureVerificationProviders();
-            var packageSignatureVerifier = new PackageSignatureVerifier(providers);
-
+            IEnumerable<ISignatureVerificationProvider> providers = new List<ISignatureVerificationProvider>()
+            {
+                new IntegrityVerificationProvider(),
+                new SignatureTrustAndValidityVerificationProvider(),
+            };
             var verifierSettings = SignedPackageVerifierSettings.GetVerifyCommandDefaultPolicy();
-            IEnumerable<ISignatureVerificationProvider> verificationProviders = SignatureVerificationProviderFactory.GetSignatureVerificationProviders();
-            var verifier = new PackageSignatureVerifier(verificationProviders);
+            var packageSignatureVerifier = new PackageSignatureVerifier(providers);
 
             using (var pr = new PackageArchiveReader(path))
             {
                 Task<VerifySignaturesResult> verifySignatureResult = packageSignatureVerifier.VerifySignaturesAsync(pr, verifierSettings, CancellationToken.None);
 
-                return verifySignatureResult.Result.Valid;
+                return verifySignatureResult.Result.IsValid;
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/12906

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
