### PR TITLE
Remove `Write-Verbose` from `ForEach-Object -Parallel` as it is not supported

### DIFF
--- a/scripts/list-dotnet-install-versions.ps1
+++ b/scripts/list-dotnet-install-versions.ps1
@@ -82,8 +82,6 @@ $productVersions += $queries | ForEach-Object -Parallel {
     $quality = $_.quality
     $component = $_.component
 
-    Write-Verbose "Querying $channel $quality $component" -Verbose:$using:PSBoundParameters.Verbose
-
     @{channel = $channel; quality = $quality; component = $component; version = $(DoLookup $channel $quality $component) }
 }
 


### PR DESCRIPTION
Remove the usage of Write-Verbose from the parallel block as it is not supported.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
