### PR TITLE
Use 11.00 AppleTV queue for XHarness PR tests

### DIFF
--- a/tests/XHarness.Apple.DeviceTests.proj
+++ b/tests/XHarness.Apple.DeviceTests.proj
@@ -10,7 +10,7 @@
   <!-- Test project which builds app bundle to run via XHarness -->
   <ItemGroup>
     <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)XHarness\XHarness.Apple.Device.Archived.proj" />
-    <HelixTargetQueue Include="osx.1015.amd64.appletv.open" />
+    <HelixTargetQueue Include="osx.1100.amd64.appletv.open" />
   </ItemGroup>
 
   <Target Name="Pack"/>


### PR DESCRIPTION
The 10.15 queue is getting deprecated soon and devices were already moved out of the queue.