### PR TITLE
add validation for non-empty SB intermediate

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -80,7 +80,7 @@
     </ItemGroup>
 
     <Error
-      Text="No source-build artifacts were produced and the resulting intermediate is empty." 
+      Text="No source-build artifacts were found and the resulting intermediate is empty." 
       Condition="'@(IntermediateNupkgArtifactFile)' == ''" />
     
     <ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -79,6 +79,10 @@
       <IntermediateNupkgArtifactFile Remove="$(CurrentRepoSourceBuildArtifactsPackagesDir)**\*.symbols.nupkg" />
     </ItemGroup>
 
+    <Error
+      Text="No source-build artifacts were produced and the resulting intermediate is empty." 
+      Condition="'@(IntermediateNupkgArtifactFile)' == ''" />
+    
     <ItemGroup>
       <IntermediateNupkgFile Include="@(IntermediateNupkgArtifactFile)" PackagePath="artifacts" />
 


### PR DESCRIPTION
Resolves https://github.com/dotnet/source-build/issues/3337

Resulting exception:
```
./SourceBuildArcade.targets(83,5): error : No source-build artifacts were produced and the resulting intermediate is empty.
```