### PR TITLE
Fix option casing

### DIFF
--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -105,7 +105,7 @@ while [[ $# > 0 ]]; do
     -binarylog|-bl)
       binary_log=true
       ;;
-    -excludeCIBinarylog|-nobl)
+    -excludecibinarylog|-nobl)
       exclude_ci_binary_log=true
       ;;
     -pipelineslog|-pl)


### PR DESCRIPTION
The option casing is normalized to all lower case by the `tr` utility. That means the `--excluedCIBinaryLog` option can never be validly matched.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
