### PR TITLE
Updates to enable PVP flow

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -95,6 +95,12 @@
       <Uri>https://github.com/dotnet/deployment-tools</Uri>
       <Sha>b60c95e1ce736630d17e16626c59e3dd85ebae2b</Sha>
     </Dependency>
+    <!-- Necessary for source-build. This allows the package to be retrieved from previously-source-built artifacts
+         and flow in as dependencies of the packages produced by arcade. -->
+    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="6.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>8470979eb44c2218025515234d3e01138bd74afb</Sha>
+    </Dependency>
     <!-- Explicit dependency because Microsoft.Deployment.DotNet.Releases has different versioning
          than the SB intermediate -->
     <Dependency Name="Microsoft.SourceBuild.Intermediate.deployment-tools" Version="8.0.0-preview.1.23159.4" CoherentParentDependency="Microsoft.NET.Sdk.WorkloadManifestReader">
@@ -106,6 +112,12 @@
       <Uri>https://github.com/dotnet/sdk</Uri>
       <Sha>39aef81ec6cffa06da9964b46d4b9e3bf2fc9979</Sha>
       <SourceBuild RepoName="sdk" ManagedOnly="true" />
+    </Dependency>
+    <!-- Necessary for source-build. This allows the package to be retrieved from previously-source-built artifacts
+         and flow in as dependencies of the packages produced by arcade. -->
+    <Dependency Name="System.IO.Packaging" Version="4.5.0">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>30ab651fcb4354552bd4891619a0bdd81e0ebdbf</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/src/Microsoft.DotNet.CodeAnalysis/Microsoft.DotNet.CodeAnalysis.csproj
+++ b/src/Microsoft.DotNet.CodeAnalysis/Microsoft.DotNet.CodeAnalysis.csproj
@@ -12,16 +12,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpVersion)" ExcludeAssets="analyzers" />
   </ItemGroup>
 
-  <!--
-    In the source-build tarball build, Microsoft.CodeAnalysis.CSharp has dependencies on old
-    versions of these packages due to repo build order. Override to lift them to the versions passed
-    in via DotNetPackageVersionPropsPath.
-  -->
-  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
-    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
-    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
-  </ItemGroup>
-
   <ItemGroup>
     <Content Include="build/*.*" PackagePath="build" />
     <Content Include="content/*.*" PackagePath="content" />

--- a/src/Microsoft.DotNet.GenFacades/Microsoft.DotNet.GenFacades.csproj
+++ b/src/Microsoft.DotNet.GenFacades/Microsoft.DotNet.GenFacades.csproj
@@ -14,11 +14,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MsbuildTaskMicrosoftCodeAnalysisCSharpVersion)" ExcludeAssets="analyzers" Publish="false" />
   </ItemGroup>
 
-  <!-- When building offline we need to bump the version of System.Reflection.Metadata that CodeAnalysis package depends on to match what the source build tarball expects. -->
-  <ItemGroup Condition="'$(DotNetBuildOffline)' == 'true'">
-    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Compile Include="..\Common\Internal\AssemblyResolver.cs" />
     <Compile Include="..\Common\Internal\BuildTask.Desktop.cs" />


### PR DESCRIPTION
In order to enable PVP flow for the arcade repo, it's necessary to remove some workarounds that were added to explicitly bump up the referenced version of the `System.Collections.Immutable` and `System.Reflection.Metadata` packages for source-build since it uses a higher version in that build than it does in the arcade repo. PVP flow now allows the package versions defined by the repo to be used directly.

It was also necessary to add the following two packages to Version.Details.xml:

* Microsoft.Extensions.DependencyModel.6.0.0
* System.IO.Packaging.4.5.0

Defining them here enables them, with PVP flow, to be retrieved from previously-source-built artifacts instead of SBRP. Both of these packages are needed at build-time; they are literally executed during the build. Since they need to be executed, retrieving the package from SBRP is not desired since that only contains ref assemblies.

In the case of System.IO.Packaging, it is a dependency of Microsoft.DotNet.NuGetRepack.Tasks. But since the System.IO.Packaging.dll is a ref assembly, it doesn't get included in the lib directory of the Microsoft.DotNet.NuGetRepack.Tasks package. Then downstream, the symreader repo had a dependency on Microsoft.DotNet.NuGetRepack.Tasks and when attempting to load Microsoft.DotNet.NuGetRepack.Tasks.dll, it failed because System.IO.Packaging.dll did not exist. Using the non-ref assembly from previously-source-built artifacts solves this issue.

Similarly, Microsoft.Extensions.DependencyModel ends up being used during the build and fails in the build of the runtime repo, as described by https://github.com/dotnet/runtime/issues/84925, because it's attempting to execute a ref assembly.

Related: https://github.com/dotnet/arcade/pull/6837, https://github.com/dotnet/arcade/pull/6971

Contributes to https://github.com/dotnet/source-build/issues/3043