### PR TITLE
Revert "add validation for non-empty SB intermediate (#12962)"

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -79,10 +79,6 @@
       <IntermediateNupkgArtifactFile Remove="$(CurrentRepoSourceBuildArtifactsPackagesDir)**\*.symbols.nupkg" />
     </ItemGroup>
 
-    <Error
-      Text="No source-build artifacts were found and the resulting intermediate is empty." 
-      Condition="'@(IntermediateNupkgArtifactFile)' == ''" />
-    
     <ItemGroup>
       <IntermediateNupkgFile Include="@(IntermediateNupkgArtifactFile)" PackagePath="artifacts" />
 


### PR DESCRIPTION
This reverts commit 09d0a87438a3b03412b02e1770310ba6b72fa567.

This new check breaks the product source-build because of NuGet.Client  (https://github.com/NuGet/Home/issues/11059).  Reverting this to unblock the arcade flow into installer - https://github.com/dotnet/installer/pull/15999/checks?check_run_id=12596916678
