### PR TITLE
Bump Azure.Data.Tables and its dependency Azure.Core

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,11 +13,11 @@
     <LibGit2SharpVersion>0.25.2</LibGit2SharpVersion>
     <log4netVersion>2.0.10</log4netVersion>
     <SystemNetHttpVersion>4.3.4</SystemNetHttpVersion>
-    <AzureCoreVersion>1.25.0</AzureCoreVersion>
+    <AzureCoreVersion>1.31.0</AzureCoreVersion>
     <AzureIdentityVersion>1.8.0</AzureIdentityVersion>
     <AzureSecurityKeyVaultSecretsVersion>4.4.0</AzureSecurityKeyVaultSecretsVersion>
     <AzureStorageBlobsVersion>12.13.0</AzureStorageBlobsVersion>
-    <AzureDataTablesVersion>12.5.0</AzureDataTablesVersion>
+    <AzureDataTablesVersion>12.8.0</AzureDataTablesVersion>
     <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>
     <NETStandardLibraryVersion>1.6.1</NETStandardLibraryVersion>
     <MicrosoftApplicationInsightsVersion>2.20.0</MicrosoftApplicationInsightsVersion>


### PR DESCRIPTION
Part of resolving [dotnet/arcade#13190](https://github.com/dotnet/arcade/issues/13190).

Bump `Azure.Data.Tables` and its dependency `Azure.Core`.