### PR TITLE
Disable CG in non-prod branches

### DIFF
--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -163,7 +163,6 @@ jobs:
         ${{ else }}:
           disableComponentGovernance: true
       componentGovernanceIgnoreDirectories: ${{ parameters.componentGovernanceIgnoreDirectories }}
-      runAsPublic: ${{ parameters.runAsPublic }}
 
   - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
     - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -25,7 +25,7 @@ parameters:
   enablePublishTestResults: false
   enablePublishUsingPipelines: false
   enableBuildRetry: false
-  disableComponentGovernance: false
+  disableComponentGovernance: ''
   componentGovernanceIgnoreDirectories: ''
   mergeTestResults: false
   testRunTitle: ''
@@ -74,9 +74,6 @@ jobs:
       value: '$(Build.Repository.Uri)'
   - ${{ if eq(parameters.enableRichCodeNavigation, 'true') }}:
     - name: EnableRichCodeNavigation
-      value: 'true'
-  - ${{ if eq(parameters.disableComponentGovernance, 'true') }}:
-    - name: skipComponentGovernanceDetection
       value: 'true'
   - ${{ each variable in parameters.variables }}:
     # handle name-value variable syntax
@@ -158,11 +155,15 @@ jobs:
         uploadRichNavArtifacts: ${{ coalesce(parameters.richCodeNavigationUploadArtifacts, false) }}
       continueOnError: true
 
-  - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(parameters.disableComponentGovernance, 'true')) }}:
-      - task: ComponentGovernanceComponentDetection@0
-        continueOnError: true
-        inputs:
-          ignoreDirectories: ${{ parameters.componentGovernanceIgnoreDirectories }}
+  - template: /eng/common/templates/steps/component-governance.yml
+    parameters:
+      ${{ if eq(parameters.disableComponentGovernance, '') }}:
+        ${{ if and(ne(variables['System.TeamProject'], 'public'), or(contains(variables['Build.SourceBranch'], 'internal/release'), eq(variables['Build.SourceBranch'], 'main'))) }}:
+          disableComponentGovernance: false
+        ${{ else }}:
+          disableComponentGovernance: true
+      componentGovernanceIgnoreDirectories: ${{ parameters.componentGovernanceIgnoreDirectories }}
+      runAsPublic: ${{ parameters.runAsPublic }}
 
   - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
     - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -158,7 +158,7 @@ jobs:
   - template: /eng/common/templates/steps/component-governance.yml
     parameters:
       ${{ if eq(parameters.disableComponentGovernance, '') }}:
-        ${{ if and(ne(variables['System.TeamProject'], 'public'), or(contains(variables['Build.SourceBranch'], 'internal/release'), eq(variables['Build.SourceBranch'], 'main'))) }}:
+        ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(parameters.runAsPublic, 'false'), or(contains(variables['Build.SourceBranch'], 'internal/release'), eq(variables['Build.SourceBranch'], 'main'))) }}:
           disableComponentGovernance: false
         ${{ else }}:
           disableComponentGovernance: true

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -75,6 +75,9 @@ jobs:
   - ${{ if eq(parameters.enableRichCodeNavigation, 'true') }}:
     - name: EnableRichCodeNavigation
       value: 'true'
+  - ${{ if eq(parameters.disableComponentGovernance, 'true') }}:
+    - name: skipComponentGovernanceDetection
+      value: 'true'
   - ${{ each variable in parameters.variables }}:
     # handle name-value variable syntax
     # example:

--- a/eng/common/templates/jobs/jobs.yml
+++ b/eng/common/templates/jobs/jobs.yml
@@ -59,6 +59,11 @@ jobs:
           ${{ property.key }}: ${{ property.value }}
 
       name: ${{ job.job }}
+      ${{ if eq(parameters.disableComponentGovernance, '') }}:
+        ${{ if and(ne(variables['System.TeamProject'], 'public'), or(contains(variables['Build.SourceBranch'], 'internal/release'), eq(variables['Build.SourceBranch'], 'main'))) }}:
+          disableComponentGovernance: false
+        ${{ else }}:
+          disableComponentGovernance: true
 
 - ${{ if eq(parameters.enableSourceBuild, true) }}:
   - template: /eng/common/templates/jobs/source-build.yml

--- a/eng/common/templates/jobs/jobs.yml
+++ b/eng/common/templates/jobs/jobs.yml
@@ -59,11 +59,6 @@ jobs:
           ${{ property.key }}: ${{ property.value }}
 
       name: ${{ job.job }}
-      ${{ if eq(parameters.disableComponentGovernance, '') }}:
-        ${{ if and(ne(variables['System.TeamProject'], 'public'), or(contains(variables['Build.SourceBranch'], 'internal/release'), eq(variables['Build.SourceBranch'], 'main'))) }}:
-          disableComponentGovernance: false
-        ${{ else }}:
-          disableComponentGovernance: true
 
 - ${{ if eq(parameters.enableSourceBuild, true) }}:
   - template: /eng/common/templates/jobs/source-build.yml

--- a/eng/common/templates/steps/component-governance.yml
+++ b/eng/common/templates/steps/component-governance.yml
@@ -5,7 +5,7 @@ parameters:
 
 steps:
 - ${{ if eq(parameters.disableComponentGovernance, 'true') }}:
-    script: "echo ##vso[task.setvariable variable=skipComponentGovernanceDetection]true"
+  - script: "echo ##vso[task.setvariable variable=skipComponentGovernanceDetection]true"
     displayName: Set skipComponentGovernanceDetection variable
 - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(parameters.disableComponentGovernance, 'true')) }}:
   - task: ComponentGovernanceComponentDetection@0

--- a/eng/common/templates/steps/component-governance.yml
+++ b/eng/common/templates/steps/component-governance.yml
@@ -1,7 +1,6 @@
 parameters:
   disableComponentGovernance: false
   componentGovernanceIgnoreDirectories: ''
-  runAsPublic: false
 
 steps:
 - ${{ if eq(parameters.disableComponentGovernance, 'true') }}:

--- a/eng/common/templates/steps/component-governance.yml
+++ b/eng/common/templates/steps/component-governance.yml
@@ -7,7 +7,7 @@ steps:
 - ${{ if eq(parameters.disableComponentGovernance, 'true') }}:
   - script: "echo ##vso[task.setvariable variable=skipComponentGovernanceDetection]true"
     displayName: Set skipComponentGovernanceDetection variable
-- ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(parameters.disableComponentGovernance, 'true')) }}:
+- ${{ if ne(parameters.disableComponentGovernance, 'true')) }}:
   - task: ComponentGovernanceComponentDetection@0
     continueOnError: true
     inputs:

--- a/eng/common/templates/steps/component-governance.yml
+++ b/eng/common/templates/steps/component-governance.yml
@@ -7,7 +7,7 @@ steps:
 - ${{ if eq(parameters.disableComponentGovernance, 'true') }}:
   - script: "echo ##vso[task.setvariable variable=skipComponentGovernanceDetection]true"
     displayName: Set skipComponentGovernanceDetection variable
-- ${{ if ne(parameters.disableComponentGovernance, 'true')) }}:
+- ${{ if ne(parameters.disableComponentGovernance, 'true') }}:
   - task: ComponentGovernanceComponentDetection@0
     continueOnError: true
     inputs:

--- a/eng/common/templates/steps/component-governance.yml
+++ b/eng/common/templates/steps/component-governance.yml
@@ -5,8 +5,7 @@ parameters:
 
 steps:
 - ${{ if eq(parameters.disableComponentGovernance, 'true') }}:
-  - pwsh: |
-      Write-Host "##vso[task.setvariable variable=skipComponentGovernanceDetection]true"
+    script: "echo ##vso[task.setvariable variable=skipComponentGovernanceDetection]true"
     displayName: Set skipComponentGovernanceDetection variable
 - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(parameters.disableComponentGovernance, 'true')) }}:
   - task: ComponentGovernanceComponentDetection@0

--- a/eng/common/templates/steps/component-governance.yml
+++ b/eng/common/templates/steps/component-governance.yml
@@ -1,0 +1,15 @@
+parameters:
+  disableComponentGovernance: false
+  componentGovernanceIgnoreDirectories: ''
+  runAsPublic: false
+
+steps:
+- ${{ if eq(parameters.disableComponentGovernance, 'true') }}:
+  - pwsh: |
+      Write-Host "##vso[task.setvariable variable=skipComponentGovernanceDetection]true"
+    displayName: Set skipComponentGovernanceDetection variable
+- ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(parameters.disableComponentGovernance, 'true')) }}:
+  - task: ComponentGovernanceComponentDetection@0
+    continueOnError: true
+    inputs:
+      ignoreDirectories: ${{ parameters.componentGovernanceIgnoreDirectories }}


### PR DESCRIPTION
Disables Component Governance except in internal builds of branches named `main` or `internal/release/*`. Repos who want to opt in to other branches running CG can set the `disableComponentGovernance` parameter in their .yml file (Same with dev branches). I tested this in EFCore and all the scenarios I tried worked. Note that repos like aspnetcore that use the `job.yml` template instead of `jobs.yml` will also have to manually set the `disableComponentGovernance` param. We should backport this to 6 and 7 once approved