### PR TITLE
Add an opt-in target to flag .NETStandard1.x dependencies

### DIFF
--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -1041,6 +1041,8 @@ If set to `true` calls to GetResourceString receive a default resource string va
 #### `GenerateResxSourceOmitGetResourceString` (bool)
 If set to `true` the GetResourceString method is not included in the generated class and must be specified in a separate source file.
 
+#### `FlagNetStandard1XDependencies` (bool)
+If set to `true` the `FlagNetStandard1xDependencies` target validates that the dependency graph doesn't contain any netstandard1.x packages.
 
 <!-- Begin Generated Content: Doc Feedback -->
 <sub>Was this helpful? [![Yes](https://helix.dot.net/f/ip/5?p=Documentation%5CArcadeSdk.md)](https://helix.dot.net/f/p/5?p=Documentation%5CArcadeSdk.md) [![No](https://helix.dot.net/f/in)](https://helix.dot.net/f/n/5?p=Documentation%5CArcadeSdk.md)</sub>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/TargetFrameworkFilters.BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/TargetFrameworkFilters.BeforeCommonTargets.targets
@@ -16,5 +16,68 @@
     <!-- If nothing left to build, exclude it! -->
     <ExcludeFromBuild Condition="'$(_FilteredTargetFrameworks)' == ''">true</ExcludeFromBuild>
   </PropertyGroup>
+  
+  <!-- Opt-in target to verify that a project doesn't bring in the .NET Standard 1.x dependency graph
+       (usually transitively) via old dependencies. -->        
+  <Target Name="FlagNetStandard1xDependencies"
+          Condition="'$(FlagNetStandard1xDependencies)' == 'true'"
+          AfterTargets="ResolvePackageAssets">
+    <ItemGroup>
+      <NetStandard1xPackage Include="
+        Microsoft.Win32.Primitives;
+        System.AppContext;
+        System.Collections;
+        System.Collections.Concurrent;
+        System.Console;
+        System.Diagnostics.Debug;
+        System.Diagnostics.Tools;
+        System.Diagnostics.Tracing;
+        System.Globalization;
+        System.Globalization.Calendars;
+        System.IO;
+        System.IO.Compression;
+        System.IO.Compression.ZipFile;
+        System.IO.FileSystem;
+        System.IO.FileSystem.Primitives;
+        System.Linq;
+        System.Linq.Expressions;
+        System.Net.Http;
+        System.Net.Primitives;
+        System.Net.Sockets;
+        System.ObjectModel;
+        System.Reflection;
+        System.Reflection.Extensions;
+        System.Reflection.Primitives;
+        System.Resources.ResourceManager;
+        System.Runtime;
+        System.Runtime.Extensions;
+        System.Runtime.Handles;
+        System.Runtime.InteropServices;
+        System.Runtime.InteropServices.RuntimeInformation;
+        System.Runtime.Numerics;
+        System.Security.Cryptography.Algorithms;
+        System.Security.Cryptography.Encoding;
+        System.Security.Cryptography.Primitives;
+        System.Security.Cryptography.X509Certificates;
+        System.Text.Encoding;
+        System.Text.Encoding.Extensions;
+        System.Text.RegularExpressions;
+        System.Threading;
+        System.Threading.Tasks;
+        System.Threading.Timer;
+        System.Xml.ReaderWriter;
+        System.Xml.XDocument" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <NonFoundNetStandard1xPackage Include="@(PackageDependencies)"
+                                    Exclude="@(NetStandard1xPackage)" />
+      <FoundNetStandard1xPackage Include="@(PackageDependencies)"
+                                 Exclude="@(NonFoundNetStandard1xPackage)" />
+    </ItemGroup>
+
+    <Error Text="The following .NET Standard 1.x packages are referenced and must be removed: %0D%0A- @(FoundNetStandard1xPackage, '%0D%0A- ')%0D%0AConsult the project.assets.json files to find the parent dependencies."
+           Condition="'@(FoundNetStandard1xPackage)' != ''" />
+  </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/TargetFrameworkFilters.BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/TargetFrameworkFilters.BeforeCommonTargets.targets
@@ -20,7 +20,7 @@
   <!-- Opt-in target to verify that a project doesn't bring in the .NET Standard 1.x dependency graph
        (usually transitively) via old dependencies. -->        
   <Target Name="FlagNetStandard1xDependencies"
-          Condition="'$(FlagNetStandard1xDependencies)' == 'true'"
+          Condition="'$(FlagNetStandard1XDependencies)' == 'true'"
           AfterTargets="ResolvePackageAssets">
     <ItemGroup>
       <NetStandard1xPackage Include="


### PR DESCRIPTION
The .NETStandard1.x dependency graph is extremely big and results in dependency scan utilities flagging the brought in packages (in case of vulnerabilities). All the .NETStandard1.x packages except for Microsoft.NETCore.Platforms haven't shipped for years anymore and are considered deprecated.

Provide an opt-in target that can be enabled either per project or per repository (usually the later). Tested this in dotnet/format and want to enable it in other repositories when cleaning up the repository's dependency graph, i.e. in https://github.com/dotnet/arcade/pull/13210

Example output:
```
C:\git\format>Build.cmd /bl /p:FlagNetStandard1XDependencies=true
C:\git\format\tests\dotnet-format.UnitTests.csproj(95,5): error : The following .NET Standard 1.x packages are referenced and must be removed:
C:\git\format\tests\dotnet-format.UnitTests.csproj(95,5): error : - System.Collections
C:\git\format\tests\dotnet-format.UnitTests.csproj(95,5): error : - System.Diagnostics.Debug
C:\git\format\tests\dotnet-format.UnitTests.csproj(95,5): error : - System.Globalization
C:\git\format\tests\dotnet-format.UnitTests.csproj(95,5): error : - System.IO
C:\git\format\tests\dotnet-format.UnitTests.csproj(95,5): error : - System.Linq
C:\git\format\tests\dotnet-format.UnitTests.csproj(95,5): error : - System.Linq.Expressions
C:\git\format\tests\dotnet-format.UnitTests.csproj(95,5): error : - System.ObjectModel
C:\git\format\tests\dotnet-format.UnitTests.csproj(95,5): error : - System.Reflection
C:\git\format\tests\dotnet-format.UnitTests.csproj(95,5): error : - System.Reflection.Extensions
C:\git\format\tests\dotnet-format.UnitTests.csproj(95,5): error : - System.Reflection.Primitives
C:\git\format\tests\dotnet-format.UnitTests.csproj(95,5): error : - System.Resources.ResourceManager
C:\git\format\tests\dotnet-format.UnitTests.csproj(95,5): error : - System.Runtime
C:\git\format\tests\dotnet-format.UnitTests.csproj(95,5): error : - System.Runtime.Extensions
C:\git\format\tests\dotnet-format.UnitTests.csproj(95,5): error : - System.Runtime.Handles
C:\git\format\tests\dotnet-format.UnitTests.csproj(95,5): error : - System.Runtime.InteropServices
C:\git\format\tests\dotnet-format.UnitTests.csproj(95,5): error : - System.Text.Encoding
C:\git\format\tests\dotnet-format.UnitTests.csproj(95,5): error : - System.Threading
C:\git\format\tests\dotnet-format.UnitTests.csproj(95,5): error : - System.Threading.Tasks
C:\git\format\tests\dotnet-format.UnitTests.csproj(95,5): error : Consult the project.assets.json files to find the parent dependency.
```

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
