### PR TITLE
Rev FreeBSD from 12.3 to 12.4

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -70,7 +70,7 @@ __AlpinePackages+=" krb5-dev"
 __AlpinePackages+=" openssl-dev"
 __AlpinePackages+=" zlib-dev"
 
-__FreeBSDBase="12.3-RELEASE"
+__FreeBSDBase="12.4-RELEASE"
 __FreeBSDPkg="1.17.0"
 __FreeBSDABI="12"
 __FreeBSDPackages="libunwind"


### PR DESCRIPTION
FreeBSD 12.3 has reached EOL.

Refs:
1. https://www.freebsd.org/security/unsupported/
2. https://www.freebsd.org/releases/

cc @Thefrank, @janvorli, @mthalman

Fixes https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/855 