### PR TITLE
[release/6.0] Allow using non-default disableComponentGovernance value

### DIFF
--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -148,6 +148,8 @@ jobs:
           disableComponentGovernance: false
         ${{ else }}:
           disableComponentGovernance: true
+      ${{ else }}:
+        disableComponentGovernance: ${{ parameters.disableComponentGovernance }}
 
   - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
     - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
Manual backport of #13274 to `release/6.0`; difference is that `componentGovernanceIgnoreDirectories` template parameter doesn't exist.