### PR TITLE
Remove non needed xml tags

### DIFF
--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -144,7 +144,6 @@ By default, Arcade builds solutions in the root of the repo.  Overriding the def
   Example:
 
   ```xml
-  <?xml version="1.0" encoding="utf-8"?>
   <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup>
       <ProjectToBuild Include="$(MSBuildThisFileDirectory)..\MyProject.proj" />

--- a/Documentation/CorePackages/Publishing.md
+++ b/Documentation/CorePackages/Publishing.md
@@ -190,7 +190,6 @@ In order to use the new publishing mechanism, the easiest way to start is by tur
 
    Sample: 
      ```XML
-      <?xml version="1.0" encoding="utf-8"?>
         <Project>
            <PropertyGroup>
               <PublishingVersion>3</PublishingVersion>

--- a/Documentation/UnifiedBuild/TFM-Trimming-And-Targeting.md
+++ b/Documentation/UnifiedBuild/TFM-Trimming-And-Targeting.md
@@ -108,7 +108,6 @@ In `Imports.targets`, a new file `TargetFrameworkDefaults.targets` will be impor
 ```xml
 TargetFrameworkDefaults.targets
 
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <PropertyGroup>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
    <PropertyGroup>
       <PublishingVersion>3</PublishingVersion>

--- a/src/Microsoft.DotNet.Arcade.Sdk/sdk/Sdk.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/sdk/Sdk.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/BeforeCommonTargets.CrossTargeting.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/BeforeCommonTargets.CrossTargeting.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <Import Project="$(_ArcadeOverriddenCustomBeforeMicrosoftCommonCrossTargetingTargets)" Condition="Exists('$(_ArcadeOverriddenCustomBeforeMicrosoftCommonCrossTargetingTargets)')"/>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/BeforeCommonTargets.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <Import Project="$(_ArcadeOverriddenCustomBeforeMicrosoftCommonTargets)" Condition="Exists('$(_ArcadeOverriddenCustomBeforeMicrosoftCommonTargets)')"/>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Empty.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Empty.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project DefaultTargets="Build">
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/EmptyIsProjectRestoreSupportedTarget.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/EmptyIsProjectRestoreSupportedTarget.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project DefaultTargets="Build">
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ExcludeFromBuild.BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ExcludeFromBuild.BeforeCommonTargets.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateChecksums.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateChecksums.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GenerateChecksums" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateInternalsVisibleTo.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateInternalsVisibleTo.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateResxSource.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/GenerateResxSource.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <Import Project="ProjectDefaults.targets"/>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Localization.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Localization.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/MSTest/MSTest.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/MSTest/MSTest.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/NUnit/NUnit.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/NUnit/NUnit.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/NoRestore.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/NoRestore.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project DefaultTargets="Build">
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/OptimizationData.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Performance.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Performance.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <!-- The 'PerformanceTest' target is only viable for repos building their own performance-test harness. -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryValidation.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryValidation.proj
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project DefaultTargets="Validate">
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/StrongName.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/StrongName.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/TargetFrameworkFilters.BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/TargetFrameworkFilters.BeforeCommonTargets.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project InitialTargets="ErrorForMissingTestRunner">
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.ImportSdk.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.ImportSdk.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <Import Project="$(VSToolsPath)\vssdk\Microsoft.VsSDK.targets"/>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.VsixBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.VsixBuild.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <!-- 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Microsoft.DotNet.Build.Tasks.Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Microsoft.DotNet.Build.Tasks.Packaging.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
     <ImportPackagingTargets Condition="'$(ImportPackagingTargets)' == '' AND '$(MSBuildProjectExtension)' == '.pkgproj'">true</ImportPackagingTargets>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/PackageLibs.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/PackageLibs.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Condition="'$(_PackagingCommonTargetsImported)' != 'true'" Project="Packaging.common.targets"/>
 

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.common.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
     <_PackagingCommonTargetsImported>true</_PackagingCommonTargetsImported>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Condition="'$(_PackagingCommonTargetsImported)' != 'true'" Project="Packaging.common.targets"/>
 

--- a/src/Microsoft.DotNet.Helix/Sdk/build/Microsoft.DotNet.Helix.Sdk.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/build/Microsoft.DotNet.Helix.Sdk.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Project="$(MSBuildThisFileDirectory)..\tools\Microsoft.DotNet.Helix.Sdk.targets"/>
 </Project>

--- a/src/Microsoft.DotNet.Helix/Sdk/sdk/Sdk.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/sdk/Sdk.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Project="$(MSBuildThisFileDirectory)..\tools\Microsoft.DotNet.Helix.Sdk.targets"/>
 </Project>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
     <!-- Helix Queues which do not exist (deprecation, typos, or purposful removal for use reduction) will error by default. 

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MultiQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MultiQueue.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project InitialTargets="ValidateTargetQueues;ValidateOpenQueueUsage">
   <PropertyGroup>
     <!-- Split up HelixTargetQueues list

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
 


### PR DESCRIPTION
Those tags aren't required by msbuild anymore: https://github.com/dotnet/corefx/pull/35686#discussion_r261718230

We removed them from corefx (now dotnet/runtime) 4 years ago and didn't encounter any issues with tooling. Our samples don't include them either.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
