### PR TITLE
Group Versions.props entries & nit clean-up

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -7,6 +7,7 @@
     <PackageReference Include="NETStandard.Library"
                       Version="$(NETStandardLibraryVersion)"
                       PrivateAssets="all"
+                      ExcludeAssets="runtime"
                       Condition="'$(TargetFrameworkIdentifier)' != '.NETStandard' and
                                  $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.0'))" />
   </ItemGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,14 +9,43 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- netstandard -->
-    <NETStandardLibraryVersion>2.0.3</NETStandardLibraryVersion>
+    <!-- arcade -->
+    <MicrosoftDotNetBuildTasksFeedVersion>8.0.0-beta.23219.2</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetSignToolVersion>8.0.0-beta.23219.2</MicrosoftDotNetSignToolVersion>
+    <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>8.0.0-beta.23219.2</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
+
+    <!-- arcade-services -->
+    <MicrosoftDotNetMaestroClientVersion>1.1.0-beta.21553.1</MicrosoftDotNetMaestroClientVersion>
+    <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.22076.4</MicrosoftDotNetMaestroTasksVersion>
+
+    <!-- corefx -->
+    <MicrosoftBclHashCodeVersion>1.1.1</MicrosoftBclHashCodeVersion>
+    <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
+    <SystemRuntimeInteropServicesRuntimeInformation>4.3.0</SystemRuntimeInteropServicesRuntimeInformation>
+
+    <!-- deployment-tools -->
+    <MicrosoftDeploymentDotNetReleasesVersion>1.0.0-preview6.1.23159.4</MicrosoftDeploymentDotNetReleasesVersion>
+
+    <!-- dotnet-symuploader -->
+    <MicrosoftSymbolUploaderBuildTaskVersion>2.0.0-preview.1.21526.15</MicrosoftSymbolUploaderBuildTaskVersion>
+    <MicrosoftSymbolUploaderVersion>2.0.0-preview.1.21526.15</MicrosoftSymbolUploaderVersion>
+
+    <!-- linker -->
+    <MicrosoftNETILLinkTasksVersion>6.0.100-1.22103.2</MicrosoftNETILLinkTasksVersion>
 
     <!-- msbuild -->
     <MicrosoftBuildFrameworkVersion>17.3.2</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildTasksCoreVersion>17.3.2</MicrosoftBuildTasksCoreVersion>
     <MicrosoftBuildUtilitiesCoreVersion>17.3.2</MicrosoftBuildUtilitiesCoreVersion>
     <MicrosoftBuildVersion>17.3.2</MicrosoftBuildVersion>
+
+    <!-- netstandard -->
+    <NETStandardLibraryVersion>2.0.3</NETStandardLibraryVersion>
+
+    <!-- nuget -->
+    <NuGetFrameworksVersion>6.2.2</NuGetFrameworksVersion>
+    <NuGetPackagingVersion>6.2.2</NuGetPackagingVersion>
+    <NuGetVersioningVersion>6.2.2</NuGetVersioningVersion>
 
     <!-- roslyn -->
     <MicrosoftCodeAnalysisCSharpVersion>4.4.0</MicrosoftCodeAnalysisCSharpVersion>
@@ -40,56 +69,27 @@
     <SystemTextEncodingsWebVersion>6.0.0</SystemTextEncodingsWebVersion>
     <SystemTextJsonVersion>7.0.2</SystemTextJsonVersion>
 
-    <!-- corefx -->
-    <MicrosoftBclHashCodeVersion>1.1.1</MicrosoftBclHashCodeVersion>
-    <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
-    <SystemRuntimeInteropServicesRuntimeInformation>4.3.0</SystemRuntimeInteropServicesRuntimeInformation>
-
-    <!-- vstest -->
-    <MicrosoftNetTestSdkVersion>17.5.0</MicrosoftNetTestSdkVersion>
-
-    <!-- linker -->
-    <MicrosoftNETILLinkTasksVersion>6.0.100-1.22103.2</MicrosoftNETILLinkTasksVersion>
-
-    <!-- nuget -->
-    <NuGetFrameworksVersion>6.2.2</NuGetFrameworksVersion>
-    <NuGetPackagingVersion>6.2.2</NuGetPackagingVersion>
-    <NuGetVersioningVersion>6.2.2</NuGetVersioningVersion>
-
-    <!-- arcade -->
-    <MicrosoftDotNetBuildTasksFeedVersion>8.0.0-beta.23219.2</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetSignToolVersion>8.0.0-beta.23219.2</MicrosoftDotNetSignToolVersion>
-    <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>8.0.0-beta.23219.2</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
-
-    <!-- dotnet-symuploader -->
-    <MicrosoftSymbolUploaderBuildTaskVersion>2.0.0-preview.1.21526.15</MicrosoftSymbolUploaderBuildTaskVersion>
-    <MicrosoftSymbolUploaderVersion>2.0.0-preview.1.21526.15</MicrosoftSymbolUploaderVersion>
-
-    <!-- arcade-services -->
-    <MicrosoftDotNetMaestroClientVersion>1.1.0-beta.21553.1</MicrosoftDotNetMaestroClientVersion>
-    <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.22076.4</MicrosoftDotNetMaestroTasksVersion>
-
-    <!-- symreader-converter -->
-    <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta2-19575-01</MicrosoftDiaSymReaderPdb2PdbVersion>
+    <!-- sdk -->
+    <MicrosoftNetSdkWorkloadManifestReaderVersion>8.0.100-preview.3.23178.3</MicrosoftNetSdkWorkloadManifestReaderVersion>
 
     <!-- sourcelink -->
     <MicrosoftSourceLinkGitHubVersion>8.0.0-beta.23218.3</MicrosoftSourceLinkGitHubVersion>
     <MicrosoftSourceLinkAzureReposGitVersion>8.0.0-beta.23218.3</MicrosoftSourceLinkAzureReposGitVersion>
-  
-    <!-- xliff-tasks -->
-    <MicrosoftDotNetXliffTasksVersion>1.0.0-beta.23218.1</MicrosoftDotNetXliffTasksVersion>
+
+    <!-- symreader-converter -->
+    <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta2-19575-01</MicrosoftDiaSymReaderPdb2PdbVersion>
+
+    <!-- templating -->
+    <MicrosoftTemplateEngineAuthoringTasksVersion>8.0.100-preview.4.23224.3</MicrosoftTemplateEngineAuthoringTasksVersion>
+
+    <!-- vstest -->
+    <MicrosoftNetTestSdkVersion>17.5.0</MicrosoftNetTestSdkVersion>
 
     <!-- xharness -->
     <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.23212.1</MicrosoftDotNetXHarnessCLIVersion>
 
-    <!-- sdk -->
-    <MicrosoftNetSdkWorkloadManifestReaderVersion>8.0.100-preview.3.23178.3</MicrosoftNetSdkWorkloadManifestReaderVersion>
-
-    <!-- deployment-tools -->
-    <MicrosoftDeploymentDotNetReleasesVersion>1.0.0-preview6.1.23159.4</MicrosoftDeploymentDotNetReleasesVersion>
-
-    <!-- templating -->
-    <MicrosoftTemplateEngineAuthoringTasksVersion>8.0.100-preview.4.23224.3</MicrosoftTemplateEngineAuthoringTasksVersion>
+    <!-- xliff-tasks -->
+    <MicrosoftDotNetXliffTasksVersion>1.0.0-beta.23218.1</MicrosoftDotNetXliffTasksVersion>
 
     <!-- external -->
     <AzureCoreVersion>1.31.0</AzureCoreVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,85 +6,124 @@
     <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
     <!-- Opt-out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
-    <!-- Libs -->
-    <CommandLineParserVersion>2.5.0</CommandLineParserVersion>
-    <CredentialManagementVersion>1.0.2</CredentialManagementVersion>
-    <HandlebarsNetVersion>1.10.1</HandlebarsNetVersion>
-    <LibGit2SharpVersion>0.25.2</LibGit2SharpVersion>
-    <log4netVersion>2.0.10</log4netVersion>
-    <AzureCoreVersion>1.31.0</AzureCoreVersion>
-    <AzureIdentityVersion>1.8.0</AzureIdentityVersion>
-    <AzureSecurityKeyVaultSecretsVersion>4.4.0</AzureSecurityKeyVaultSecretsVersion>
-    <AzureStorageBlobsVersion>12.13.0</AzureStorageBlobsVersion>
-    <AzureDataTablesVersion>12.8.0</AzureDataTablesVersion>
-    <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- netstandard -->
     <NETStandardLibraryVersion>2.0.3</NETStandardLibraryVersion>
-    <MicrosoftApplicationInsightsVersion>2.21.0</MicrosoftApplicationInsightsVersion>
-    <MicrosoftDataODataVersion>5.8.4</MicrosoftDataODataVersion>
-    <MicrosoftDataServicesClientVersion>5.8.5</MicrosoftDataServicesClientVersion>
-    <MicrosoftBuildVersion>17.3.2</MicrosoftBuildVersion>
+
+    <!-- msbuild -->
     <MicrosoftBuildFrameworkVersion>17.3.2</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildTasksCoreVersion>17.3.2</MicrosoftBuildTasksCoreVersion>
     <MicrosoftBuildUtilitiesCoreVersion>17.3.2</MicrosoftBuildUtilitiesCoreVersion>
+    <MicrosoftBuildVersion>17.3.2</MicrosoftBuildVersion>
+
+    <!-- roslyn -->
     <MicrosoftCodeAnalysisCSharpVersion>4.4.0</MicrosoftCodeAnalysisCSharpVersion>
-    <!-- TODO: This library is deprecated, brings in the entire .NET Standard 1.3 dependency graph (including vulnerable libraries)
-         and should be replaced with Microsoft.Identity.Client. -->
-    <MicrosoftIdentityModelClientsActiveDirectoryVersion>3.17.2</MicrosoftIdentityModelClientsActiveDirectoryVersion>
-    <MicrosoftExtensionsDependencyModelVersion>6.0.0</MicrosoftExtensionsDependencyModelVersion>
+    <MicrosoftNetCompilersToolsetVersion>4.5.2-3.23152.4</MicrosoftNetCompilersToolsetVersion>
+
+    <!-- runtime -->
     <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>6.0.0</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
     <MicrosoftExtensionsDependencyInjectionVersion>6.0.0</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyModelVersion>6.0.0</MicrosoftExtensionsDependencyModelVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>6.0.0</MicrosoftExtensionsLoggingConsoleVersion>
     <MicrosoftNETCorePlatformsVersion>5.0.0</MicrosoftNETCorePlatformsVersion>
-    <MicrosoftNetCompilersToolsetVersion>4.5.2-3.23152.4</MicrosoftNetCompilersToolsetVersion>
-    <MicrosoftNetTestSdkVersion>17.5.0</MicrosoftNetTestSdkVersion>
-    <MicrosoftNETILLinkTasksVersion>6.0.100-1.22103.2</MicrosoftNETILLinkTasksVersion>
-    <MicrosoftSignedWixVersion>1.0.0-v3.14.0.5722</MicrosoftSignedWixVersion>
-    <MoqVersion>4.18.4</MoqVersion>
-    <MonoOptionsVersion>5.3.0.1</MonoOptionsVersion>
-    <McMasterExtensionsCommandLineUtils>2.3.0</McMasterExtensionsCommandLineUtils>
-    <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
-    <SystemTextJsonVersion>7.0.2</SystemTextJsonVersion>
-    <NuGetFrameworksVersion>6.2.2</NuGetFrameworksVersion>
-    <NuGetPackagingVersion>6.2.2</NuGetPackagingVersion>
-    <NuGetVersioningVersion>6.2.2</NuGetVersioningVersion>
-    <OctokitVersion>0.41.0</OctokitVersion>
-    <SystemCollectionsImmutableVersion>1.5.0</SystemCollectionsImmutableVersion>
-    <SystemIOPackagingVersion>4.5.0</SystemIOPackagingVersion>
-    <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
-    <SystemReflectionMetadataVersion>6.0.1</SystemReflectionMetadataVersion>
-    <SystemRuntimeInteropServicesRuntimeInformation>4.3.0</SystemRuntimeInteropServicesRuntimeInformation>
-    <SystemTextEncodingsWebVersion>6.0.0</SystemTextEncodingsWebVersion>
-    <!-- TODO: This library is deprecated, brings in the entire .NET Standard 1.3 dependency graph (including vulnerable libraries)
-         and should be replaced with Azure.Storage.Common. -->
-    <WindowsAzureStorageVersion>8.5.0</WindowsAzureStorageVersion>
-    <XUnitVersion>2.4.2</XUnitVersion>
-    <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>8.0.0-beta.23219.2</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetSignToolVersion>8.0.0-beta.23219.2</MicrosoftDotNetSignToolVersion>
-    <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta2-19575-01</MicrosoftDiaSymReaderPdb2PdbVersion>
-    <MicrosoftDotNetMaestroClientVersion>1.1.0-beta.21553.1</MicrosoftDotNetMaestroClientVersion>
-    <MicrosoftSourceLinkGitHubVersion>8.0.0-beta.23218.3</MicrosoftSourceLinkGitHubVersion>
-    <MicrosoftSourceLinkAzureReposGitVersion>8.0.0-beta.23218.3</MicrosoftSourceLinkAzureReposGitVersion>
-    <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>8.0.0-beta.23219.2</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
-    <MicrosoftDotNetXliffTasksVersion>1.0.0-beta.23218.1</MicrosoftDotNetXliffTasksVersion>
-    <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.22076.4</MicrosoftDotNetMaestroTasksVersion>
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.23212.1</MicrosoftDotNetXHarnessCLIVersion>
-    <MicrosoftSymbolUploaderBuildTaskVersion>2.0.0-preview.1.21526.15</MicrosoftSymbolUploaderBuildTaskVersion>
-    <MicrosoftSymbolUploaderVersion>2.0.0-preview.1.21526.15</MicrosoftSymbolUploaderVersion>
-    <MicrosoftNetSdkWorkloadManifestReaderVersion>8.0.100-preview.3.23178.3</MicrosoftNetSdkWorkloadManifestReaderVersion>
-    <MicrosoftDeploymentDotNetReleasesVersion>1.0.0-preview6.1.23159.4</MicrosoftDeploymentDotNetReleasesVersion>
-    <MicrosoftTemplateEngineAuthoringTasksVersion>8.0.100-preview.4.23224.3</MicrosoftTemplateEngineAuthoringTasksVersion>
-    <MicrosoftNETWorkloadMonoToolChainManifest_60200Version>6.0.3</MicrosoftNETWorkloadMonoToolChainManifest_60200Version>
-    <MicrosoftiOSTemplatesVersion>15.2.302-preview.14.122</MicrosoftiOSTemplatesVersion>
-    <MicrosoftNETWorkloadEmscriptenManifest_60200Version>6.0.4</MicrosoftNETWorkloadEmscriptenManifest_60200Version>
     <MicrosoftNETRuntimeEmscripten2023Nodewin_x64>6.0.4</MicrosoftNETRuntimeEmscripten2023Nodewin_x64>
     <MicrosoftNETRuntimeEmscripten2023Pythonwin_x64>6.0.4</MicrosoftNETRuntimeEmscripten2023Pythonwin_x64>
     <MicrosoftNETRuntimeEmscripten2023Sdkwin_x64>6.0.4</MicrosoftNETRuntimeEmscripten2023Sdkwin_x64>
-    <CoverletCollectorVersion>1.0.1</CoverletCollectorVersion>
-    <MicrosoftOpenApiVersion>1.1.4</MicrosoftOpenApiVersion>
-    <MicrosoftOpenApiReadersVersion>1.1.4</MicrosoftOpenApiReadersVersion>
+    <MicrosoftNETWorkloadEmscriptenManifest_60200Version>6.0.4</MicrosoftNETWorkloadEmscriptenManifest_60200Version>
+    <MicrosoftNETWorkloadMonoToolChainManifest_60200Version>6.0.3</MicrosoftNETWorkloadMonoToolChainManifest_60200Version>
+    <MicrosoftiOSTemplatesVersion>15.2.302-preview.14.122</MicrosoftiOSTemplatesVersion>
+    <SystemCollectionsImmutableVersion>1.5.0</SystemCollectionsImmutableVersion>
+    <SystemIOPackagingVersion>4.5.0</SystemIOPackagingVersion>
+    <SystemReflectionMetadataVersion>6.0.1</SystemReflectionMetadataVersion>
+    <SystemTextEncodingsWebVersion>6.0.0</SystemTextEncodingsWebVersion>
+    <SystemTextJsonVersion>7.0.2</SystemTextJsonVersion>
+
+    <!-- corefx -->
     <MicrosoftBclHashCodeVersion>1.1.1</MicrosoftBclHashCodeVersion>
+    <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
+    <SystemRuntimeInteropServicesRuntimeInformation>4.3.0</SystemRuntimeInteropServicesRuntimeInformation>
+
+    <!-- vstest -->
+    <MicrosoftNetTestSdkVersion>17.5.0</MicrosoftNetTestSdkVersion>
+
+    <!-- linker -->
+    <MicrosoftNETILLinkTasksVersion>6.0.100-1.22103.2</MicrosoftNETILLinkTasksVersion>
+
+    <!-- nuget -->
+    <NuGetFrameworksVersion>6.2.2</NuGetFrameworksVersion>
+    <NuGetPackagingVersion>6.2.2</NuGetPackagingVersion>
+    <NuGetVersioningVersion>6.2.2</NuGetVersioningVersion>
+
+    <!-- arcade -->
+    <MicrosoftDotNetBuildTasksFeedVersion>8.0.0-beta.23219.2</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetSignToolVersion>8.0.0-beta.23219.2</MicrosoftDotNetSignToolVersion>
+    <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>8.0.0-beta.23219.2</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
+
+    <!-- dotnet-symuploader -->
+    <MicrosoftSymbolUploaderBuildTaskVersion>2.0.0-preview.1.21526.15</MicrosoftSymbolUploaderBuildTaskVersion>
+    <MicrosoftSymbolUploaderVersion>2.0.0-preview.1.21526.15</MicrosoftSymbolUploaderVersion>
+
+    <!-- arcade-services -->
+    <MicrosoftDotNetMaestroClientVersion>1.1.0-beta.21553.1</MicrosoftDotNetMaestroClientVersion>
+    <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.22076.4</MicrosoftDotNetMaestroTasksVersion>
+
+    <!-- symreader-->
+    <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta2-19575-01</MicrosoftDiaSymReaderPdb2PdbVersion>
+
+    <!-- sourcelink-->
+    <MicrosoftSourceLinkGitHubVersion>8.0.0-beta.23218.3</MicrosoftSourceLinkGitHubVersion>
+    <MicrosoftSourceLinkAzureReposGitVersion>8.0.0-beta.23218.3</MicrosoftSourceLinkAzureReposGitVersion>
+  
+    <!-- xliff-tasks -->
+    <MicrosoftDotNetXliffTasksVersion>1.0.0-beta.23218.1</MicrosoftDotNetXliffTasksVersion>
+
+    <!-- xharness -->
+    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.23212.1</MicrosoftDotNetXHarnessCLIVersion>
+
+    <!-- sdk -->
+    <MicrosoftNetSdkWorkloadManifestReaderVersion>8.0.100-preview.3.23178.3</MicrosoftNetSdkWorkloadManifestReaderVersion>
+
+    <!-- deployment-tools -->
+    <MicrosoftDeploymentDotNetReleasesVersion>1.0.0-preview6.1.23159.4</MicrosoftDeploymentDotNetReleasesVersion>
+
+    <!-- templating -->
+    <MicrosoftTemplateEngineAuthoringTasksVersion>8.0.100-preview.4.23224.3</MicrosoftTemplateEngineAuthoringTasksVersion>
+
+    <!-- external -->
+    <AzureCoreVersion>1.31.0</AzureCoreVersion>
+    <AzureDataTablesVersion>12.8.0</AzureDataTablesVersion>
+    <AzureIdentityVersion>1.8.0</AzureIdentityVersion>
+    <AzureSecurityKeyVaultSecretsVersion>4.4.0</AzureSecurityKeyVaultSecretsVersion>
+    <AzureStorageBlobsVersion>12.13.0</AzureStorageBlobsVersion>
+    <CommandLineParserVersion>2.5.0</CommandLineParserVersion>
+    <CoverletCollectorVersion>1.0.1</CoverletCollectorVersion>
+    <CredentialManagementVersion>1.0.2</CredentialManagementVersion>
+    <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>
+    <HandlebarsNetVersion>1.10.1</HandlebarsNetVersion>
     <JetBrainsAnnotationsVersion>2018.2.1</JetBrainsAnnotationsVersion>
+    <LibGit2SharpVersion>0.25.2</LibGit2SharpVersion>
+    <McMasterExtensionsCommandLineUtils>2.3.0</McMasterExtensionsCommandLineUtils>
+    <MicrosoftApplicationInsightsVersion>2.21.0</MicrosoftApplicationInsightsVersion>
+    <MicrosoftDataODataVersion>5.8.4</MicrosoftDataODataVersion>
+    <MicrosoftDataServicesClientVersion>5.8.5</MicrosoftDataServicesClientVersion>
+    <!-- TODO: This library is deprecated, brings in the entire .NET Standard 1.3 dependency graph (including vulnerable libraries)
+         and should be replaced with Microsoft.Identity.Client. -->
+    <MicrosoftIdentityModelClientsActiveDirectoryVersion>3.17.2</MicrosoftIdentityModelClientsActiveDirectoryVersion>
+    <MicrosoftOpenApiReadersVersion>1.1.4</MicrosoftOpenApiReadersVersion>
+    <MicrosoftOpenApiVersion>1.1.4</MicrosoftOpenApiVersion>
+    <MicrosoftSignedWixVersion>1.0.0-v3.14.0.5722</MicrosoftSignedWixVersion>
+    <MonoOptionsVersion>5.3.0.1</MonoOptionsVersion>
+    <MoqVersion>4.18.4</MoqVersion>
+    <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
+    <OctokitVersion>0.41.0</OctokitVersion>
+    <!-- TODO: This library is deprecated, brings in the entire .NET Standard 1.3 dependency graph (including vulnerable libraries)
+         and should be replaced with Azure.Storage.Common. -->
+    <WindowsAzureStorageVersion>8.5.0</WindowsAzureStorageVersion>
+    <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>
+    <XUnitVersion>2.4.2</XUnitVersion>
+    <log4netVersion>2.0.10</log4netVersion>
   </PropertyGroup>
 
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -69,7 +69,7 @@
     <MicrosoftDotNetMaestroClientVersion>1.1.0-beta.21553.1</MicrosoftDotNetMaestroClientVersion>
     <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.22076.4</MicrosoftDotNetMaestroTasksVersion>
 
-    <!-- symreader -->
+    <!-- symreader-converter -->
     <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta2-19575-01</MicrosoftDiaSymReaderPdb2PdbVersion>
 
     <!-- sourcelink -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -69,10 +69,10 @@
     <MicrosoftDotNetMaestroClientVersion>1.1.0-beta.21553.1</MicrosoftDotNetMaestroClientVersion>
     <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.22076.4</MicrosoftDotNetMaestroTasksVersion>
 
-    <!-- symreader-->
+    <!-- symreader -->
     <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta2-19575-01</MicrosoftDiaSymReaderPdb2PdbVersion>
 
-    <!-- sourcelink-->
+    <!-- sourcelink -->
     <MicrosoftSourceLinkGitHubVersion>8.0.0-beta.23218.3</MicrosoftSourceLinkGitHubVersion>
     <MicrosoftSourceLinkAzureReposGitVersion>8.0.0-beta.23218.3</MicrosoftSourceLinkAzureReposGitVersion>
   

--- a/src/Microsoft.Cci.Extensions/Microsoft.Cci.Extensions.csproj
+++ b/src/Microsoft.Cci.Extensions/Microsoft.Cci.Extensions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <DisableImplicitAssetTargetFallback>true</DisableImplicitAssetTargetFallback>
     <AssetTargetFallback>$(PackageTargetFallback)portable-net45+win8;</AssetTargetFallback>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>


### PR DESCRIPTION
1. Group Versions.props version entries by the source-repository. We do the same in other repositories which helped quickly identifying which dependencies are used from which repositories. **No versions are changed.**
3. Small clean-up in Cci.Extensions & NETStandard package-reference.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
