### PR TITLE
Avoid Microsoft.Cci transitive dependencies & clean-up code

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -64,6 +64,7 @@
     <MicrosoftNETWorkloadMonoToolChainManifest_60200Version>6.0.3</MicrosoftNETWorkloadMonoToolChainManifest_60200Version>
     <MicrosoftiOSTemplatesVersion>15.2.302-preview.14.122</MicrosoftiOSTemplatesVersion>
     <SystemCollectionsImmutableVersion>1.5.0</SystemCollectionsImmutableVersion>
+    <SystemCompositionVersion>7.0.0</SystemCompositionVersion>
     <SystemIOPackagingVersion>4.5.0</SystemIOPackagingVersion>
     <SystemReflectionMetadataVersion>6.0.1</SystemReflectionMetadataVersion>
     <SystemTextEncodingsWebVersion>6.0.0</SystemTextEncodingsWebVersion>
@@ -106,6 +107,7 @@
     <LibGit2SharpVersion>0.25.2</LibGit2SharpVersion>
     <McMasterExtensionsCommandLineUtils>2.3.0</McMasterExtensionsCommandLineUtils>
     <MicrosoftApplicationInsightsVersion>2.21.0</MicrosoftApplicationInsightsVersion>
+    <MicrosoftCciVersion>4.0.0-rc3-24214-00</MicrosoftCciVersion>
     <MicrosoftDataODataVersion>5.8.4</MicrosoftDataODataVersion>
     <MicrosoftDataServicesClientVersion>5.8.5</MicrosoftDataServicesClientVersion>
     <!-- TODO: This library is deprecated, brings in the entire .NET Standard 1.3 dependency graph (including vulnerable libraries)

--- a/src/Microsoft.Cci.Extensions/Differs/ElementDifferenceFactory.cs
+++ b/src/Microsoft.Cci.Extensions/Differs/ElementDifferenceFactory.cs
@@ -5,16 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
-using Microsoft.Cci.Mappings;
-
-#if COREFX
 using System.Reflection;
 using System.Composition;
 using System.Composition.Hosting;
 using CompositionContainer = System.Composition.Hosting.CompositionHost;
-#else
-using System.ComponentModel.Composition.Hosting;
-#endif
+using Microsoft.Cci.Mappings;
 
 namespace Microsoft.Cci.Differs
 {
@@ -46,21 +41,12 @@ namespace Microsoft.Cci.Differs
 
             if (_diffRules == null)
             {
-#if COREFX
                 var rules = _container.GetExports<ExportFactory<IDifferenceRule, DifferenceRuleMetadata>>();
                 if (_ruleFilter != null)
                 {
                     rules = rules.Where(r => _ruleFilter(r.Metadata));
                 }
                 _diffRules = rules.Select(r => r.CreateExport().Value).ToArray();
-#else
-                IEnumerable<Lazy<IDifferenceRule, IDifferenceRuleMetadata>> lazyRules = _container.GetExports<IDifferenceRule, IDifferenceRuleMetadata>();
-                if (_ruleFilter != null)
-                {
-                    lazyRules = lazyRules.Where(l => _ruleFilter(l.Metadata));
-                }
-                _diffRules = lazyRules.Select(l => l.Value).ToArray();
-#endif
             }
 
             return _diffRules;
@@ -70,12 +56,9 @@ namespace Microsoft.Cci.Differs
         {
             if (_container != null)
                 return;
-#if COREFX
+
             var configuration = new ContainerConfiguration().WithAssembly(typeof(ElementDifferenceFactory).GetTypeInfo().Assembly);
             _container = configuration.CreateContainer();
-#else
-            _container = new CompositionContainer(new AssemblyCatalog(typeof(ElementDifferenceFactory).Assembly));
-#endif
         }
     }
 }

--- a/src/Microsoft.Cci.Extensions/Differs/ExportDifferenceRuleAttribute.cs
+++ b/src/Microsoft.Cci.Extensions/Differs/ExportDifferenceRuleAttribute.cs
@@ -5,11 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-#if COREFX
 using System.Composition;
-#else
-using System.ComponentModel.Composition;
-#endif
 
 namespace Microsoft.Cci.Differs
 {

--- a/src/Microsoft.Cci.Extensions/Differs/IDifferenceRule.cs
+++ b/src/Microsoft.Cci.Extensions/Differs/IDifferenceRule.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Cci.Differs
         bool OptionalRule { get; }
     }
 
-#if COREFX
     /// <summary>
     /// Metadata views must be concrete types rather than interfaces.
     /// </summary>
@@ -29,5 +28,4 @@ namespace Microsoft.Cci.Differs
 
         public bool OptionalRule { get; set; }
     }
-#endif
 }

--- a/src/Microsoft.Cci.Extensions/Differs/Rules/TokenListDiffer.cs
+++ b/src/Microsoft.Cci.Extensions/Differs/Rules/TokenListDiffer.cs
@@ -3,11 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-#if COREFX
 using System.Composition;
-#else
-using System.ComponentModel.Composition;
-#endif
 using System.Linq;
 using Microsoft.Cci.Writers;
 using Microsoft.Cci.Writers.Syntax;

--- a/src/Microsoft.Cci.Extensions/Extensions/AssemblyIdentityHelpers.cs
+++ b/src/Microsoft.Cci.Extensions/Extensions/AssemblyIdentityHelpers.cs
@@ -14,14 +14,8 @@ namespace Microsoft.Cci.Extensions
         {
             var name = new System.Reflection.AssemblyName();
             name.Name = assemblyIdentity.Name.Value;
-#if !COREFX
-            name.CultureInfo = new CultureInfo(assemblyIdentity.Culture);
-#endif
             name.Version = assemblyIdentity.Version;
             name.SetPublicKeyToken(assemblyIdentity.PublicKeyToken.ToArray());
-#if !COREFX
-            name.CodeBase = assemblyIdentity.Location;
-#endif
             return name.ToString();
         }
 
@@ -32,11 +26,7 @@ namespace Microsoft.Cci.Extensions
                                         name.CultureName,
                                         name.Version,
                                         name.GetPublicKeyToken(),
-#if COREFX
                                         "");
-#else
-                                        name.CodeBase);
-#endif
         }
     }
 }

--- a/src/Microsoft.Cci.Extensions/Microsoft.Cci.Extensions.csproj
+++ b/src/Microsoft.Cci.Extensions/Microsoft.Cci.Extensions.csproj
@@ -1,14 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <DisableImplicitAssetTargetFallback>true</DisableImplicitAssetTargetFallback>
-    <AssetTargetFallback>$(PackageTargetFallback)portable-net45+win8;</AssetTargetFallback>
+    <TargetFrameworks>$(NetCurrent);netstandard2.0</TargetFrameworks>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
     <IsPackable>true</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <NoWarn>NU1701</NoWarn>
-    <DefineConstants>$(DefineConstants);COREFX</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,14 +12,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Don't change these versions as they rely on Microsoft.Cci which is already deprecated. -->
-    <PackageReference Include="Microsoft.Cci" Version="4.0.0-rc3-24214-00" />
-    <PackageReference Include="Microsoft.Composition" Version="1.0.30" />
-    <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" />
+    <!-- Manually reference Microsoft.Cci.dll via a PackageDownload+Reference item instead of
+         using a PackageReference to avoid bringing in the old dependency graph. -->
+    <PackageDownload Include="Microsoft.Cci" Version="[$(MicrosoftCciVersion)]" />
+    <Reference Include="$(NuGetPackageRoot)microsoft.cci\$(MicrosoftCciVersion)\lib\netstandard1.3\Microsoft.Cci.dll" />
+    <PackageReference Include="System.Composition" Version="$(SystemCompositionVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
-    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Cci.Extensions/README.md
+++ b/src/Microsoft.Cci.Extensions/README.md
@@ -1,0 +1,3 @@
+# Not maintained anymore
+
+:warning: Microsoft.Cci.Extensions isn't maintained anymore and shouldn't be used. Please switch to the Roslyn based Microsoft.CodeAnalysis API. This code base will be deleted in the future.

--- a/src/Microsoft.DotNet.ApiCompat/src/Microsoft.DotNet.ApiCompat.Core/Microsoft.DotNet.ApiCompat.Core.csproj
+++ b/src/Microsoft.DotNet.ApiCompat/src/Microsoft.DotNet.ApiCompat.Core/Microsoft.DotNet.ApiCompat.Core.csproj
@@ -9,4 +9,11 @@
     <ProjectReference Include="..\..\..\Microsoft.Cci.Extensions\Microsoft.Cci.Extensions.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Manually reference Microsoft.Cci.dll via a PackageDownload+Reference item instead of
+         using a PackageReference to avoid bringing in the old dependency graph. -->
+    <PackageDownload Include="Microsoft.Cci" Version="[$(MicrosoftCciVersion)]" />
+    <Reference Include="$(NuGetPackageRoot)microsoft.cci\$(MicrosoftCciVersion)\lib\netstandard1.3\Microsoft.Cci.dll" />
+  </ItemGroup>
+
 </Project>

--- a/src/Microsoft.DotNet.AsmDiff/Microsoft.DotNet.AsmDiff.csproj
+++ b/src/Microsoft.DotNet.AsmDiff/Microsoft.DotNet.AsmDiff.csproj
@@ -14,6 +14,13 @@
   
   <ItemGroup>
     <Compile Include="..\Common\Internal\DisposeAction.cs" Link="Internal\DisposeAction.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="Resources.resx" GenerateSource="true" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Microsoft.Cci.Extensions\Microsoft.Cci.Extensions.csproj" />
   </ItemGroup>
   
@@ -21,10 +28,11 @@
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="$(McMasterExtensionsCommandLineUtils)" />
     <!-- Arcade only makes shipping assemblies localizable by default, we'd like to localize this tool without treating it as "shipping". -->
     <PackageReference Include="Microsoft.DotNet.XliffTasks" Version="$(MicrosoftDotNetXliffTasksVersion)" PrivateAssets="all" />
-  </ItemGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Update="Resources.resx" GenerateSource="true" />
+    <!-- Manually reference Microsoft.Cci.dll via a PackageDownload+Reference item instead of
+         using a PackageReference to avoid bringing in the old dependency graph. -->
+    <PackageDownload Include="Microsoft.Cci" Version="[$(MicrosoftCciVersion)]" />
+    <Reference Include="$(NuGetPackageRoot)microsoft.cci\$(MicrosoftCciVersion)\lib\netstandard1.3\Microsoft.Cci.dll" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.GenAPI/Microsoft.DotNet.GenAPI.csproj
+++ b/src/Microsoft.DotNet.GenAPI/Microsoft.DotNet.GenAPI.csproj
@@ -15,6 +15,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
+
+    <!-- Manually reference Microsoft.Cci.dll via a PackageDownload+Reference item instead of
+         using a PackageReference to avoid bringing in the old dependency graph. -->
+    <PackageDownload Include="Microsoft.Cci" Version="[$(MicrosoftCciVersion)]" />
+    <Reference Include="$(NuGetPackageRoot)microsoft.cci\$(MicrosoftCciVersion)\lib\netstandard1.3\Microsoft.Cci.dll" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.GenAPI/README.md
+++ b/src/Microsoft.DotNet.GenAPI/README.md
@@ -1,12 +1,3 @@
-Microsoft.DotNet.GenAPI
-===============================
+# Not maintained anymore
 
-Contains GenAPITask - MSBuild task that allows to synthesize C# source tree out of a dll.
-The project is build on top of Microsoft.CCI and Microsoft.CCI.Extensions.
-
-Currently, new Roslyn-based GenAPIv2 is in development in folders:
-* Shared - common library for Tool and Tasks.
-* Tasks - MSBuild tasks for GenAPIv2.
-* Tool - CLI tool used to generate reference assemblies out of executable and produce output in console or to file.
-
-We'll remove the original CCI-based implementation after GenAPIv2 is ready.
+:warning: Microsoft.DotNet.GenAPI which is CCI based isn't maintained anymore and shouldn't be used. Please switch to the Roslyn based GenAPI that is part of the .NET SDK repository: https://github.com/dotnet/sdk/tree/main/src/GenAPI. This code base will be deleted in the future.


### PR DESCRIPTION
1. Avoid Microsoft.Cci transitive package dependencies by using PackageDownload instead. We can't yet delete Microsoft.Cci.Extensions as AsmDiff, GenAPI and ApiCompat depend on it but we are planning to eventually replace them with the Roslyn based tools that live in the sdk repository.
2. Remove the COREFX ifdef
3. Add READMEs for GenAPI and Cci.Extensions to indicate that those libraries aren't maintained anymore.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
