### PR TITLE
Migrate to Microsoft.Identity.Client for creating aka.ms links

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
@@ -100,6 +100,7 @@
       <ArtifactsBasePath Condition="'$(ArtifactsBasePath)' == ''">$(BlobBasePath)</ArtifactsBasePath>
       <NonStreamingPublishingMaxClients Condition="'$(NonStreamingPublishingMaxClients)' == ''">12</NonStreamingPublishingMaxClients>
       <StreamingPublishingMaxClients Condition="'$(UseStreamingPublishing)' == 'true' and '$(StreamingPublishingMaxClients)' == ''">16</StreamingPublishingMaxClients>
+      <UseIdentityClientLibrary Condition="'$(UseIdentityClientLibrary)' == ''">false</UseIdentityClientLibrary>
     </PropertyGroup>
 
     <ItemGroup>
@@ -168,6 +169,7 @@
       FeedKeys="@(FeedKey)"
       FeedSasUris="@(FeedSasUri)"
       FeedOverrides="@(FeedOverride)"
+      UseIdentityClientLibrary="$(UseIdentityClientLibrary)"
       />
   </Target>
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -185,7 +185,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public int NonStreamingPublishingMaxClients {get; set;}
 
         /// <summary>
-        /// Feature flag for switching to the Microsoft.Identity.Client library https://github.com/dotnet/arcade/pull/13316
+        /// Feature flag for switching to the Microsoft.Identity.Client library
+        /// TODO (https://github.com/dotnet/arcade/issues/13318): Remove the switch and use the new library
         /// </summary>
         private bool UseIdentityClientLibrary { get; set; } = false;
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -184,6 +184,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public int NonStreamingPublishingMaxClients {get; set;}
 
+        /// <summary>
+        /// Feature flag for switching to the Microsoft.Identity.Client library https://github.com/dotnet/arcade/pull/13316
+        /// </summary>
         private bool UseIdentityClientLibrary { get; set; } = false;
 
         /// <summary>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -184,6 +184,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public int NonStreamingPublishingMaxClients {get; set;}
 
+        private bool UseIdentityClientLibrary { get; set; } = false;
+
         /// <summary>
         /// Just an internal flag to keep track whether we published assets via a V3 manifest or not.
         /// </summary>
@@ -343,6 +345,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 UseStreamingPublishing = this.UseStreamingPublishing,
                 StreamingPublishingMaxClients = this.StreamingPublishingMaxClients,
                 NonStreamingPublishingMaxClients = this.NonStreamingPublishingMaxClients,
+                UseIdentityClientLibrary = this.UseIdentityClientLibrary,
             };
         }
     }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -192,6 +192,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         /// </summary>
         public int RetryDelayMilliseconds { get; set; } = 5000;
 
+        public bool UseIdentityClientLibrary { get; set; }
+
         public ExponentialRetry RetryHandler = new ExponentialRetry
         {
             MaxAttempts = 5,
@@ -1689,6 +1691,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         AkaMSGroupOwner,
                         AkaMSCreatedBy,
                         AkaMsOwners,
+                        UseIdentityClientLibrary,
                         Log);
                 }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/LatestLinksManager.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/LatestLinksManager.cs
@@ -25,6 +25,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         private string AkaMSCreatedBy { get; }
         private string AkaMSGroupOwner { get; }
 
+        private bool UseIdentityClientLibrary { get; }
+
         private static HashSet<string> AccountsWithCdns { get; } = new()
         {
             "dotnetcli.blob.core.windows.net", "dotnetbuilds.blob.core.windows.net",
@@ -37,6 +39,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             string akaMSGroupOwner,
             string akaMSCreatedBy,
             string akaMsOwners,
+            bool useIdentityClientLibrary,
             TaskLoggingHelper logger)
         {
             Logger = logger;
@@ -46,7 +49,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             AkaMSGroupOwner = akaMSGroupOwner;
             AkaMSCreatedBy = akaMSCreatedBy;
             AkaMsOwners = akaMsOwners;
-            LinkManager = new AkaMSLinkManager(AkaMSClientId, AkaMSClientSecret, AkaMSTenant, Logger);
+            UseIdentityClientLibrary = useIdentityClientLibrary;
+            LinkManager = new AkaMSLinkManager(AkaMSClientId, AkaMSClientSecret, AkaMSTenant, Logger, UseIdentityClientLibrary);
         }
 
         public async System.Threading.Tasks.Task CreateOrUpdateLatestLinksAsync(

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/Microsoft.DotNet.Deployment.Tasks.Links.csproj
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/Microsoft.DotNet.Deployment.Tasks.Links.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.53.0" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" Publish="false" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="$(MicrosoftIdentityModelClientsActiveDirectoryVersion)" />

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksBase.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksBase.cs
@@ -19,5 +19,7 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links
         public string ClientSecret { get; set; }
         [Required]
         public string Tenant { get; set; }
+
+        public bool UseIdentityClientLibrary { get; set; } = false;
     }
 }

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksManager.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksManager.cs
@@ -395,6 +395,8 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links.src
 
         private async Task<HttpClient> CreateClient()
         {
+            //TODO remove feature switch: https://github.com/dotnet/arcade/issues/13318
+
             if (_useIdentityClientLibrary)
             {
                 _log.LogMessage(MessageImportance.High, "Creating a client using MSAL Library");

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksManager.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksManager.cs
@@ -41,19 +41,19 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links.src
         private string ApiTargeturl { get => $"{ApiBaseUrl}/1/{_tenant}"; }
         private ExponentialRetry RetryHandler;
 
-        private bool _useNewLibrary;
+        private bool _useIdentityClientLibrary;
 
         private Microsoft.Build.Utilities.TaskLoggingHelper _log;
         private IConfidentialClientApplication _akamsLinksApp;
 
 
-        public AkaMSLinkManager(string clientId, string clientSecret, string tenant, Microsoft.Build.Utilities.TaskLoggingHelper log, bool useNewLibrary)
+        public AkaMSLinkManager(string clientId, string clientSecret, string tenant, Microsoft.Build.Utilities.TaskLoggingHelper log, bool UseIdentityClientLibrary)
         {
             _clientId = clientId;
             _clientSecret = clientSecret;
             _tenant = tenant;
             _log = log;
-            _useNewLibrary = useNewLibrary;
+            _useIdentityClientLibrary = UseIdentityClientLibrary;
 
             RetryHandler = new ExponentialRetry
             {
@@ -395,8 +395,10 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links.src
 
         private async Task<HttpClient> CreateClient()
         {
-            if (_useNewLibrary)
+            if (_useIdentityClientLibrary)
             {
+                _log.LogMessage(MessageImportance.High, "Creating a client using MSAL Library");
+                
                 if (_akamsLinksApp == null)
                 {
                     _akamsLinksApp = ConfidentialClientApplicationBuilder.Create(_clientId)

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksManager.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksManager.cs
@@ -41,19 +41,23 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links.src
         private string ApiTargeturl { get => $"{ApiBaseUrl}/1/{_tenant}"; }
         private ExponentialRetry RetryHandler;
 
+        /// <summary>
+        /// Feature flag for switching to the Microsoft.Identity.Client library
+        /// TODO (https://github.com/dotnet/arcade/issues/13318): Remove the switch and use the new library
+        /// </summary>
         private bool _useIdentityClientLibrary;
 
         private Microsoft.Build.Utilities.TaskLoggingHelper _log;
         private IConfidentialClientApplication _akamsLinksApp;
 
 
-        public AkaMSLinkManager(string clientId, string clientSecret, string tenant, Microsoft.Build.Utilities.TaskLoggingHelper log, bool UseIdentityClientLibrary)
+        public AkaMSLinkManager(string clientId, string clientSecret, string tenant, Microsoft.Build.Utilities.TaskLoggingHelper log, bool useIdentityClientLibrary)
         {
             _clientId = clientId;
             _clientSecret = clientSecret;
             _tenant = tenant;
             _log = log;
-            _useIdentityClientLibrary = UseIdentityClientLibrary;
+            _useIdentityClientLibrary = useIdentityClientLibrary;
 
             RetryHandler = new ExponentialRetry
             {
@@ -394,7 +398,7 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links.src
         }
 
 
-        //TODO remove feature switch: https://github.com/dotnet/arcade/issues/13318
+        // TODO (https://github.com/dotnet/arcade/issues/13318) Remove feature switch
         private async Task<HttpClient> CreateClient() => _useIdentityClientLibrary
             ? await CreateClientUsingMSAL()
             : await CreateClientUsingADAL();
@@ -427,13 +431,13 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links.src
             if (_akamsLinksApp == null)
             {
                 _akamsLinksApp = ConfidentialClientApplicationBuilder.Create(_clientId)
-                .WithClientSecret(_clientSecret)
-                .WithAuthority(Authority)
-                .Build();
+                    .WithClientSecret(_clientSecret)
+                    .WithAuthority(Authority)
+                    .Build();
             }
 
-            Identity.Client.AuthenticationResult token = await _akamsLinksApp.AcquireTokenForClient(
-                new[] { $"{Endpoint}/.default" })
+            Identity.Client.AuthenticationResult token = await _akamsLinksApp
+                .AcquireTokenForClient(new[] { $"{Endpoint}/.default" })
                 .WithTenantId(_tenant)
                 .ExecuteAsync()
                 .ConfigureAwait(false);

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/CreateAkaMSLinks.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/CreateAkaMSLinks.cs
@@ -91,7 +91,7 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links
                     string descriptionString = !string.IsNullOrEmpty(link.Description) ? $" ({link.Description})" : "";
                     Log.LogMessage(MessageImportance.High, $"Creating link aka.ms/{link.ShortUrl} -> {link.TargetUrl}{descriptionString}");
                 }
-                AkaMSLinkManager manager = new AkaMSLinkManager(ClientId, ClientSecret, Tenant, Log);
+                AkaMSLinkManager manager = new AkaMSLinkManager(ClientId, ClientSecret, Tenant, Log, UseIdentityClientLibrary);
                 await manager.CreateOrUpdateLinksAsync(linksToCreate, Owners, CreatedBy, GroupOwner, Overwrite);
             }
             catch (Exception e)

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/DeleteAkaMSLinks.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/DeleteAkaMSLinks.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links
         {
             try
             {
-                AkaMSLinkManager manager = new AkaMSLinkManager(ClientId, ClientSecret, Tenant, Log);
+                AkaMSLinkManager manager = new AkaMSLinkManager(ClientId, ClientSecret, Tenant, Log, UseIdentityClientLibrary);
                 await manager.DeleteLinksAsync(new List<string>(ShortUrls));
             }
             catch (Exception e)


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/13287

Migrating from `Microsoft.IdentityModel.Clients.ActiveDirectory` to `Microsoft.Identity.Client` for authenticating with Azure Active Directory and creating aka.ms links, because `Microsoft.IdentityModel.Clients.ActiveDirectory` is deprecated.
Adding a feature switch so that the change can get to the Stage-DotNet-Test pipeline without breaking arcade and we can make sure publishing works with the new library.
Once it's validated by running the staging pipeline we'll remove the switch and leave the code that uses the new library. https://github.com/dotnet/arcade/issues/13318

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
