### PR TITLE
Avoid dependencies and upgrade X509Certificates

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,11 +51,12 @@
     <MicrosoftNETWorkloadEmscriptenManifest_60200Version>6.0.4</MicrosoftNETWorkloadEmscriptenManifest_60200Version>
     <MicrosoftNETWorkloadMonoToolChainManifest_60200Version>6.0.3</MicrosoftNETWorkloadMonoToolChainManifest_60200Version>
     <MicrosoftiOSTemplatesVersion>15.2.302-preview.14.122</MicrosoftiOSTemplatesVersion>
-    <SystemCollectionsImmutableVersion>1.5.0</SystemCollectionsImmutableVersion>
+    <SystemCollectionsImmutableVersion>7.0.0</SystemCollectionsImmutableVersion>
     <SystemCompositionVersion>7.0.0</SystemCompositionVersion>
-    <SystemIOPackagingVersion>4.5.0</SystemIOPackagingVersion>
-    <SystemReflectionMetadataVersion>6.0.1</SystemReflectionMetadataVersion>
-    <SystemTextEncodingsWebVersion>6.0.0</SystemTextEncodingsWebVersion>
+    <SystemIOPackagingVersion>7.0.0</SystemIOPackagingVersion>
+    <SystemReflectionMetadataVersion>7.0.0</SystemReflectionMetadataVersion>
+    <SystemSecurityCryptographyX509CertificatesVersion>4.3.2</SystemSecurityCryptographyX509CertificatesVersion>
+    <SystemTextEncodingsWebVersion>7.0.0</SystemTextEncodingsWebVersion>
     <SystemTextJsonVersion>7.0.2</SystemTextJsonVersion>
     <!-- sdk -->
     <MicrosoftNetSdkWorkloadManifestReaderVersion>8.0.100-preview.3.23178.3</MicrosoftNetSdkWorkloadManifestReaderVersion>
@@ -75,36 +76,40 @@
     <!-- external -->
     <AzureCoreVersion>1.31.0</AzureCoreVersion>
     <AzureDataTablesVersion>12.8.0</AzureDataTablesVersion>
-    <AzureIdentityVersion>1.8.0</AzureIdentityVersion>
+    <AzureIdentityVersion>1.9.0-beta.3</AzureIdentityVersion>
     <AzureSecurityKeyVaultSecretsVersion>4.4.0</AzureSecurityKeyVaultSecretsVersion>
-    <AzureStorageBlobsVersion>12.13.0</AzureStorageBlobsVersion>
+    <AzureStorageBlobsVersion>12.16.0</AzureStorageBlobsVersion>
     <CommandLineParserVersion>2.5.0</CommandLineParserVersion>
     <CoverletCollectorVersion>1.0.1</CoverletCollectorVersion>
     <CredentialManagementVersion>1.0.2</CredentialManagementVersion>
     <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>
-    <HandlebarsNetVersion>1.10.1</HandlebarsNetVersion>
+    <HandlebarsNetVersion>1.11.5</HandlebarsNetVersion>
     <JetBrainsAnnotationsVersion>2018.2.1</JetBrainsAnnotationsVersion>
     <LibGit2SharpVersion>0.25.2</LibGit2SharpVersion>
+    <LZMA_SDKVersion>19.0.0</LZMA_SDKVersion>
     <McMasterExtensionsCommandLineUtils>2.3.0</McMasterExtensionsCommandLineUtils>
     <MicrosoftApplicationInsightsVersion>2.21.0</MicrosoftApplicationInsightsVersion>
     <MicrosoftCciVersion>4.0.0-rc3-24214-00</MicrosoftCciVersion>
     <MicrosoftDataODataVersion>5.8.4</MicrosoftDataODataVersion>
-    <MicrosoftDataServicesClientVersion>5.8.5</MicrosoftDataServicesClientVersion>
+    <!-- Keep Microsoft.Data.Services.Client package version in sync with Microsoft.Data.OData -->
+    <MicrosoftDataServicesClientVersion>5.8.4</MicrosoftDataServicesClientVersion>
     <!-- TODO: This library is deprecated, brings in the entire .NET Standard 1.3 dependency graph (including vulnerable libraries)
-         and should be replaced with Microsoft.Identity.Client. -->
+         and should be replaced with Microsoft.Identity.Client.
+         Meanwhile make sure that the version is in sync with the version used by symboluploader. -->
     <MicrosoftIdentityModelClientsActiveDirectoryVersion>3.17.2</MicrosoftIdentityModelClientsActiveDirectoryVersion>
-    <MicrosoftOpenApiReadersVersion>1.1.4</MicrosoftOpenApiReadersVersion>
-    <MicrosoftOpenApiVersion>1.1.4</MicrosoftOpenApiVersion>
+    <MicrosoftOpenApiReadersVersion>1.3.2</MicrosoftOpenApiReadersVersion>
+    <MicrosoftOpenApiVersion>1.3.2</MicrosoftOpenApiVersion>
     <MicrosoftSignedWixVersion>1.0.0-v3.14.0.5722</MicrosoftSignedWixVersion>
+    <MicrosoftVisualStudioOLEInteropVersion>7.10.6071</MicrosoftVisualStudioOLEInteropVersion>
     <MonoOptionsVersion>5.3.0.1</MonoOptionsVersion>
     <MoqVersion>4.18.4</MoqVersion>
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
     <OctokitVersion>0.41.0</OctokitVersion>
     <!-- TODO: This library is deprecated, brings in the entire .NET Standard 1.3 dependency graph (including vulnerable libraries)
          and should be replaced with Azure.Storage.Common. -->
-    <WindowsAzureStorageVersion>8.5.0</WindowsAzureStorageVersion>
+    <WindowsAzureStorageVersion>9.3.3</WindowsAzureStorageVersion>
     <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>
     <XUnitVersion>2.4.2</XUnitVersion>
-    <log4netVersion>2.0.10</log4netVersion>
+    <log4netVersion>2.0.15</log4netVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj
@@ -6,14 +6,9 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
-    <PackageReference Include="Microsoft.DotNet.Maestro.Client" Version="$(MicrosoftDotNetMaestroClientVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
-
-    <!-- Required to unify version from dependencies. -->
-    <PackageReference Include="Azure.Core" Version="$(AzureCoreVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -27,6 +27,9 @@
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <PackageReference Include="Microsoft.Bcl.HashCode" Version="$(MicrosoftBclHashCodeVersion)" />
+
+    <!-- Upgrade System.Security.Cryptography.X509Certificates/4.3.0 which is transitively referenced by Azure.Core. -->
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="$(SystemSecurityCryptographyX509CertificatesVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/Microsoft.DotNet.Deployment.Tasks.Links.csproj
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/Microsoft.DotNet.Deployment.Tasks.Links.csproj
@@ -11,9 +11,17 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client" Version="4.53.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" Publish="false" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="$(MicrosoftIdentityModelClientsActiveDirectoryVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+  </ItemGroup>
+
+  <!-- Reference Microsoft.IdentityModel.Clients.ActiveDirectory on .NETCoreApp directly via PackageDownload+Reference to avoid its netstandard1.x dependencies. -->
+  <ItemGroup>
+    <PackageDownload Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="[$(MicrosoftIdentityModelClientsActiveDirectoryVersion)]" />
+    <Reference Include="$(NuGetPackageRoot)microsoft.identitymodel.clients.activedirectory\$(MicrosoftIdentityModelClientsActiveDirectoryVersion)\lib\netstandard1.3\*.dll"
+               Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
+    <Reference Include="$(NuGetPackageRoot)microsoft.identitymodel.clients.activedirectory\$(MicrosoftIdentityModelClientsActiveDirectoryVersion)\lib\net45\*.dll"
+               Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">

--- a/src/Microsoft.DotNet.GitSync.CommitManager/Microsoft.DotNet.GitSync.CommitManager.csproj
+++ b/src/Microsoft.DotNet.GitSync.CommitManager/Microsoft.DotNet.GitSync.CommitManager.csproj
@@ -7,11 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Upgrade Azure.Data.Table's transitive Azure.Core dependendency. -->
+    <PackageReference Include="Azure.Core" Version="$(AzureCoreVersion)" />
     <PackageReference Include="Azure.Data.Tables" Version="$(AzureDataTablesVersion)" />
     <PackageReference Include="CommandLineParser" Version="$(CommandLineParserVersion)" />
     <PackageReference Include="log4net" Version="$(log4netVersion)" />
-    <PackageReference Include="Microsoft.Data.OData" Version="$(MicrosoftDataODataVersion)" />
-    <PackageReference Include="WindowsAzure.Storage" Version="$(WindowsAzureStorageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Reference WindowsAzure.Storage directly via PackageDownload+Reference to avoid its netstandard1.x dependencies. -->
+    <PackageDownload Include="WindowsAzure.Storage" Version="[$(WindowsAzureStorageVersion)]" />
+    <Reference Include="$(NuGetPackageRoot)windowsazure.storage\$(WindowsAzureStorageVersion)\lib\netstandard1.3\Microsoft.WindowsAzure.Storage.dll" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.GitSync/Microsoft.DotNet.GitSync.csproj
+++ b/src/Microsoft.DotNet.GitSync/Microsoft.DotNet.GitSync.csproj
@@ -8,6 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Upgrade Azure.Data.Table's transitive Azure.Core dependendency. -->
+    <PackageReference Include="Azure.Core" Version="$(AzureCoreVersion)" />
     <PackageReference Include="Azure.Data.Tables" Version="$(AzureDataTablesVersion)" />
     <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="$(AzureSecurityKeyVaultSecretsVersion)" />
@@ -16,6 +18,9 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="Octokit" Version="$(OctokitVersion)" />
     <PackageReference Include="log4net" Version="$(log4netVersion)" />
+
+    <!-- Upgrade System.Security.Cryptography.X509Certificates/4.3.0 which is transitively referenced by Azure.Core. -->
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="$(SystemSecurityCryptographyX509CertificatesVersion)" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/Microsoft.DotNet.Helix.Client.csproj
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/Microsoft.DotNet.Helix.Client.csproj
@@ -11,11 +11,13 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="$(AzureCoreVersion)" />
+    <PackageReference Include="Microsoft.DotNet.SwaggerGenerator.MSBuild" Version="$(MicrosoftDotNetSwaggerGeneratorMSBuildVersion)" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
 
-    <PackageReference Include="Microsoft.DotNet.SwaggerGenerator.MSBuild" Version="$(MicrosoftDotNetSwaggerGeneratorMSBuildVersion)" PrivateAssets="all" />
+    <!-- Upgrade System.Security.Cryptography.X509Certificates/4.3.0 which is transitively referenced by Azure.Core. -->
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="$(SystemSecurityCryptographyX509CertificatesVersion)" PrivateAssets="all" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Helix/Sdk/Microsoft.DotNet.Helix.Sdk.csproj
+++ b/src/Microsoft.DotNet.Helix/Sdk/Microsoft.DotNet.Helix.Sdk.csproj
@@ -10,21 +10,26 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
-    <PackageReference Include="Microsoft.Data.Services.Client" Version="$(MicrosoftDataServicesClientVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="NuGet.Versioning" Version="$(NuGetVersioningVersion)" />
 
+    <!-- Upgrade System.Security.Cryptography.X509Certificates/4.3.0 which is transitively referenced by Azure.Core. -->
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="$(SystemSecurityCryptographyX509CertificatesVersion)" PrivateAssets="all" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
+  </ItemGroup>
 
+  <!-- Reference Microsoft.Data.Services.Client directly via PackageDownload+Reference to avoid its netstandard1.x dependencies. -->
+  <ItemGroup>
+    <PackageDownload Include="Microsoft.Data.Services.Client" Version="[$(MicrosoftDataServicesClientVersion)]" />
+    <Reference Include="$(NuGetPackageRoot)microsoft.data.services.client\$(MicrosoftDataServicesClientVersion)\lib\net40\Microsoft.Data.Services.Client.dll"
+               Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
+    <Reference Include="$(NuGetPackageRoot)microsoft.data.services.client\$(MicrosoftDataServicesClientVersion)\lib\netstandard1.1\Microsoft.Data.Services.Client.dll"
+               Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
+    <PackageReference Include="Microsoft.Data.OData" Version="$(MicrosoftDataODataVersion)" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Client\CSharp\Microsoft.DotNet.Helix.Client.csproj" />
     <ProjectReference Include="..\JobSender\Microsoft.DotNet.Helix.JobSender.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
-    <!-- Upgrade the transitive dependencies that are brought in by Microsoft.Data.Services.Client. -->
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CmdLine/Microsoft.DotNet.SwaggerGenerator.CmdLine.csproj
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CmdLine/Microsoft.DotNet.SwaggerGenerator.CmdLine.csproj
@@ -11,9 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- TODO: Upgrade dependencies to repo defined version. -->
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
     <PackageReference Include="Mono.Options" Version="$(MonoOptionsVersion)" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CmdLine/Program.cs
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CmdLine/Program.cs
@@ -77,7 +77,7 @@ namespace Microsoft.DotNet.SwaggerGenerator.CmdLine
                 MissingArgument(nameof(output));
             }
 
-            ILogger logger = new LoggerFactory().AddConsole().CreateLogger("dotnet-swaggergen");
+            ILogger logger = LoggerFactory.Create(builder => builder.AddSimpleConsole()).CreateLogger("dotnet-swaggergen");
 
             var (diagnostic, document) = await GetSwaggerDocument(input);
             if (diagnostic.Errors.Any())

--- a/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
@@ -21,9 +21,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.runner.reporters" Version="$(XUnitVersion)" />
-    <PackageReference Include="xunit.runner.utility" Version="$(XUnitVersion)" />
     <PackageReference Include="xunit.abstractions" Version="$(XUnitAbstractionsVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Reference xunit.runner.reporters directly via PackageDownload+Reference to avoid its netstandard1.x dependencies. -->
+    <PackageDownload Include="xunit.runner.reporters" Version="[$(XUnitVersion)]" />
+    <Reference Include="$(NuGetPackageRoot)xunit.runner.reporters\$(XUnitVersion)\lib\netcoreapp1.0\xunit.runner.reporters.netcoreapp10.dll" />
+
+    <!-- Reference xunit.runner.utility directly via PackageDownload+Reference to avoid its netstandard1.x dependencies. -->
+    <PackageDownload Include="xunit.runner.utility" Version="[$(XUnitVersion)]" />
+    <Reference Include="$(NuGetPackageRoot)xunit.runner.utility\$(XUnitVersion)\lib\netcoreapp1.0\xunit.runner.utility.netcoreapp10.dll" />
   </ItemGroup>
 
   <Import Project="$(RepositoryEngineeringDir)BuildTask.targets" />

--- a/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
+++ b/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
@@ -14,12 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LZMA-SDK" Version="19.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.OLE.Interop" Version="7.10.6071" />
-    <!-- TODO: Update dependencies to repo defined versions. -->
-    <PackageReference Include="NuGet.Common" Version="5.0.2" />
-    <PackageReference Include="NuGet.Frameworks" Version="5.0.2" />
-    <PackageReference Include="NuGet.Packaging" Version="5.0.2" />
+    <PackageReference Include="LZMA-SDK" Version="$(LZMA_SDKVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.OLE.Interop" Version="$(MicrosoftVisualStudioOLEInteropVersion)" />
+    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetFrameworksVersion)" />
+    <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagingVersion)" />
     <PackageReference Include="System.IO.Packaging" Version="$(SystemIOPackagingVersion)" />
     <PackageReference Include="Microsoft.Signed.Wix" Version="$(MicrosoftSignedWixVersion)" />
   </ItemGroup>


### PR DESCRIPTION
- Upgrade the transitive x509Certificates dependency until Azure.Core is upgraded to not bring in old libraries like System.Net.Http on .NET Framework.
- Upgrade other dependencies and use PackageDownload for libraries which don't ship anymore but still bring in netstandard1.x dependencies.

Fixes https://github.com/dotnet/arcade/issues/13326
Replaces https://github.com/dotnet/arcade/pull/13331