### PR TITLE
Change ApiCompat back to executable

### DIFF
--- a/src/Microsoft.DotNet.ApiCompat/src/Microsoft.DotNet.ApiCompat.csproj
+++ b/src/Microsoft.DotNet.ApiCompat/src/Microsoft.DotNet.ApiCompat.csproj
@@ -2,8 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCurrent);$(NetFrameworkToolCurrent)</TargetFrameworks>
+    <OutputType>Exe</OutputType>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
     <IsPackable>true</IsPackable>
+    <NoWarn>$(NoWarn);0436</NoWarn>
+    <RollForward>Major</RollForward>
     <DefaultExcludesInProjectFolder>Microsoft.DotNet.ApiCompat.Core\**\*</DefaultExcludesInProjectFolder>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.ApiCompat/src/build/Microsoft.DotNet.ApiCompat.targets
+++ b/src/Microsoft.DotNet.ApiCompat/src/build/Microsoft.DotNet.ApiCompat.targets
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <ApiCompatAssembly Condition="'$(MSBuildRuntimeType)' == 'core'">$(MSBuildThisFileDirectory)..\tools\net8.0\Microsoft.DotNet.ApiCompat.dll</ApiCompatAssembly>
-    <ApiCompatAssembly Condition="'$(MSBuildRuntimeType)' != 'core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.DotNet.ApiCompat.dll</ApiCompatAssembly>
+    <ApiCompatAssembly Condition="'$(MSBuildRuntimeType)' != 'core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.DotNet.ApiCompat.exe</ApiCompatAssembly>
 
     <!-- By default, run API Compat if this package is referenced. -->
     <RunApiCompat Condition="'$(RunApiCompat)' == '' and '$(DesignTimeBuild)' != 'true'">true</RunApiCompat>


### PR DESCRIPTION
Fixes https://github.com/dotnet/wpf/pull/7774

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
