### PR TITLE
Check if runtime toolsets exist before restoring

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -287,6 +287,25 @@ function InstallDotNet([string] $dotnetRoot,
   [string] $runtimeSourceFeedKey = '',
   [switch] $noPath) {
 
+  $dotnetVersionLabel = "'sdk v$version'"
+
+  if ($runtime -ne '' -and $runtime -ne 'sdk') {
+    $runtimePath = $dotnetRoot
+    $runtimePath = $runtimePath + "\shared"
+    if ($runtime -eq "dotnet") { $runtimePath = $runtimePath + "\Microsoft.NETCore.App" }
+    if ($runtime -eq "aspnetcore") { $runtimePath = $runtimePath + "\Microsoft.AspNetCore.App" }
+    if ($runtime -eq "windowsdesktop") { $runtimePath = $runtimePath + "\Microsoft.WindowsDesktop.App" }
+    $runtimePath = $runtimePath + "\" + $version
+  
+    $dotnetVersionLabel = "runtime toolset '$runtime/$architecture v$version'"
+
+    if (Test-Path $runtimePath) {
+      Write-Host "  Runtime toolset '$runtime/$architecture v$version' already installed."
+      $installSuccess = $true
+      Exit
+    }
+  }
+
   $installScript = GetDotNetInstallScript $dotnetRoot
   $installParameters = @{
     Version = $version
@@ -323,18 +342,18 @@ function InstallDotNet([string] $dotnetRoot,
     } else {
       $location = "public location";
     }
-    Write-Host "Attempting to install dotnet from $location."
+    Write-Host "  Attempting to install $dotnetVersionLabel from $location."
     try {
       & $installScript @variation
       $installSuccess = $true
       break
     }
     catch {
-      Write-Host "Failed to install dotnet from $location."
+      Write-Host "  Failed to install $dotnetVersionLabel from $location."
     }
   }
   if (-not $installSuccess) {
-    Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "Failed to install dotnet from any of the specified locations."
+    Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "Failed to install $dotnetVersionLabel from any of the specified locations."
     ExitWithExitCode 1
   }
 }

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -184,6 +184,35 @@ function InstallDotNetSdk {
 function InstallDotNet {
   local root=$1
   local version=$2
+  local runtime=$4
+
+  local dotnetVersionLabel="'$runtime v$version'"
+  if [[ -n "${4:-}" ]] && [ "$4" != 'sdk' ]; then
+    runtimePath="$root"
+    runtimePath="$runtimePath/shared"
+    case "$runtime" in
+      dotnet)
+        runtimePath="$runtimePath/Microsoft.NETCore.App"
+        ;;
+      aspnetcore)
+        runtimePath="$runtimePath/Microsoft.AspNetCore.App"
+        ;;
+      windowsdesktop)
+        runtimePath="$runtimePath/Microsoft.WindowsDesktop.App"
+        ;;
+      *)
+        ;;
+    esac
+    runtimePath="$runtimePath/$version"
+
+    dotnetVersionLabel="runtime toolset '$runtime/$architecture v$version'"
+
+    if [ -d "$runtimePath" ]; then
+      echo "  Runtime toolset '$runtime/$architecture v$version' already installed."
+      local installSuccess=1
+      return
+    fi
+  fi
 
   GetDotNetInstallScript "$root"
   local install_script=$_GetDotNetInstallScript
@@ -228,17 +257,17 @@ function InstallDotNet {
   for variationName in "${variations[@]}"; do
     local name="$variationName[@]"
     local variation=("${!name}")
-    echo "Attempting to install dotnet from $variationName."
+    echo "  Attempting to install $dotnetVersionLabel from $variationName."
     bash "$install_script" "${variation[@]}" && installSuccess=1
     if [[ "$installSuccess" -eq 1 ]]; then
       break
     fi
 
-    echo "Failed to install dotnet from $variationName."
+    echo "  Failed to install $dotnetVersionLabel from $variationName."
   done
 
   if [[ "$installSuccess" -eq 0 ]]; then
-    Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install dotnet SDK from any of the specified locations."
+    Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install $dotnetVersionLabel from any of the specified locations."
     ExitWithExitCode 1
   fi
 }


### PR DESCRIPTION
Check if runtime toolsets specfied in global.json under tools/runtimes node exist before attempting to restore those. This check removes unnecessary wait time and reduces the console "noise".

Resolves #13128

```json
{
  "sdk": {
    "version": "8.0.100-preview.4.23212.7"
  },
  "tools": {
    "dotnet": "8.0.100-preview.4.23212.7",
    "runtimes": {
      "dotnet/x64": [
        "3.1.32",
        "6.0.13",
        "7.0.2"
      ],
      "aspnetcore/x64": [
        "3.1.32",
        "6.0.13",
        "7.0.2"
      ]
    }
  }
}
```



# After

## Windows

### Fresh repo

```powershell
GET https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1
  Attempting to install 'sdk v8.0.100-preview.4.23212.7' from public location.
dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.

dotnet-install: Extracting the archive.
dotnet-install: Adding to current process PATH: ....
dotnet-install: Note that the script does not resolve dependencies during installation.
dotnet-install: To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install/windows#dependencies
dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.
dotnet-install: Extracting the archive.
dotnet-install: Note that the script does not resolve dependencies during installation.
dotnet-install: To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install/windows#dependencies
dotnet-install: Installed version is 6.0.13
dotnet-install: Installation finished
  Attempting to install runtime toolset 'dotnet/x64 v7.0.2' from public location.
dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.
dotnet-install: Extracting the archive.
dotnet-install: Note that the script does not resolve dependencies during installation.
dotnet-install: To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install/windows#dependencies
dotnet-install: Installed version is 7.0.2
dotnet-install: Installation finished
GET https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1
  Attempting to install runtime toolset 'dotnet/x86 v3.1.32' from public location.
dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.
dotnet-install: Extracting the archive.
dotnet-install: Adding to current process PATH: ...
dotnet-install: Note that the script does not resolve dependencies during installation.
dotnet-install: To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install/windows#dependencies
dotnet-install: Installed version is 3.1.32
dotnet-install: Installation finished
  Attempting to install runtime toolset 'aspnetcore/x64 v3.1.32' from public location.
dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.
dotnet-install: Extracting the archive.
dotnet-install: Note that the script does not resolve dependencies during installation.
dotnet-install: To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install/windows#dependencies
dotnet-install: Installed version is 3.1.32
dotnet-install: Installation finished
  Attempting to install runtime toolset 'aspnetcore/x64 v6.0.13' from public location.
dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.
dotnet-install: Extracting the archive.
dotnet-install: Note that the script does not resolve dependencies during installation.
dotnet-install: To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install/windows#dependencies
dotnet-install: Installed version is 6.0.13
dotnet-install: Installation finished
  Attempting to install runtime toolset 'aspnetcore/x64 v7.0.2' from public location.
dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.
dotnet-install: Extracting the archive.
dotnet-install: Note that the script does not resolve dependencies during installation.
dotnet-install: To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install/windows#dependencies
dotnet-install: Installed version is 7.0.2
dotnet-install: Installation finished
  Determining projects to restore...
  All projects are up-to-date for restore.

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:01:16.21
```

### Restored repo

```powershell
  Determining projects to restore...
  
  Restore was successful.
  All projects are up-to-date for restore.
  Runtime toolset 'dotnet/x64 v3.1.32' already installed.
  Runtime toolset 'dotnet/x64 v6.0.13' already installed.
  Runtime toolset 'dotnet/x64 v7.0.2' already installed.
  Runtime toolset 'dotnet/x86 v3.1.32' already installed.
  Runtime toolset 'aspnetcore/x64 v3.1.32' already installed.
  Runtime toolset 'aspnetcore/x64 v6.0.13' already installed.
  Runtime toolset 'aspnetcore/x64 v7.0.2' already installed.
  Determining projects to restore...
  All projects are up-to-date for restore.

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:10.21
```

## Linux

### Fresh repo


```bash
Downloading 'https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh'
  Attempting to install runtime toolset 'sdk v8.0.100-preview.4.23212.7' from public_location.
dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.

dotnet-install: Attempting to download using primary link https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.100-preview.4.23212.7/dotnet-sdk-8.0.100-preview.4.23212.7-linux-x64.tar.gz
curl: (22) The requested URL returned error: 404
dotnet-install: The resource at primary link 'https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.100-preview.4.23212.7/dotnet-sdk-8.0.100-preview.4.23212.7-linux-x64.tar.gz' is not available.
dotnet-install: Attempting to download using primary link https://dotnetbuilds.azureedge.net/public/Sdk/8.0.100-preview.4.23212.7/dotnet-sdk-8.0.100-preview.4.23212.7-linux-x64.tar.gz
dotnet-install: Extracting zip from https://dotnetbuilds.azureedge.net/public/Sdk/8.0.100-preview.4.23212.7/dotnet-sdk-8.0.100-preview.4.23212.7-linux-x64.tar.gz
dotnet-install: Installed version is 8.0.100-preview.4.23212.7
dotnet-install: Adding to current process PATH: ....
dotnet-install: Note that the script does not resolve dependencies during installation.
dotnet-install: To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install, select your operating system and check the "Dependencies" section.
dotnet-install: Installation finished successfully.
  Determining projects to restore...
  
  Restore was successful.
  All projects are up-to-date for restore.
  Attempting to install runtime toolset 'dotnet/x64 v3.1.32' from public_location.
dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.
dotnet-install: Attempting to download using primary link https://dotnetcli.azureedge.net/dotnet/Runtime/3.1.32/dotnet-runtime-3.1.32-linux-x64.tar.gz
dotnet-install: Extracting zip from https://dotnetcli.azureedge.net/dotnet/Runtime/3.1.32/dotnet-runtime-3.1.32-linux-x64.tar.gz
dotnet-install: Installed version is 3.1.32
dotnet-install: Adding to current process PATH: ...
dotnet-install: Note that the script does not resolve dependencies during installation.
dotnet-install: To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install, select your operating system and check the "Dependencies" section.
dotnet-install: Installation finished successfully.
  Attempting to install runtime toolset 'dotnet/x64 v6.0.13' from public_location.
dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.
dotnet-install: Attempting to download using primary link https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.13/dotnet-runtime-6.0.13-linux-x64.tar.gz
dotnet-install: Extracting zip from https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.13/dotnet-runtime-6.0.13-linux-x64.tar.gz
dotnet-install: Installed version is 6.0.13
dotnet-install: Adding to current process PATH: ...
dotnet-install: Note that the script does not resolve dependencies during installation.
dotnet-install: To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install, select your operating system and check the "Dependencies" section.
dotnet-install: Installation finished successfully.
  Attempting to install runtime toolset 'dotnet/x64 v7.0.2' from public_location.
dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.
dotnet-install: Attempting to download using primary link https://dotnetcli.azureedge.net/dotnet/Runtime/7.0.2/dotnet-runtime-7.0.2-linux-x64.tar.gz
dotnet-install: Extracting zip from https://dotnetcli.azureedge.net/dotnet/Runtime/7.0.2/dotnet-runtime-7.0.2-linux-x64.tar.gz
dotnet-install: Installed version is 7.0.2
dotnet-install: Adding to current process PATH: ...
dotnet-install: Note that the script does not resolve dependencies during installation.
dotnet-install: To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install, select your operating system and check the "Dependencies" section.
dotnet-install: Installation finished successfully.
  Attempting to install runtime toolset 'aspnetcore/x64 v3.1.32' from public_location.
dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.
dotnet-install: Attempting to download using primary link https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/3.1.32/aspnetcore-runtime-3.1.32-linux-x64.tar.gz
dotnet-install: Extracting zip from https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/3.1.32/aspnetcore-runtime-3.1.32-linux-x64.tar.gz
dotnet-install: Installed version is 3.1.32
dotnet-install: Adding to current process PATH: ...
dotnet-install: Note that the script does not resolve dependencies during installation.
dotnet-install: To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install, select your operating system and check the "Dependencies" section.
dotnet-install: Installation finished successfully.
  Attempting to install runtime toolset 'aspnetcore/x64 v6.0.13' from public_location.
dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.
dotnet-install: Attempting to download using primary link https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/6.0.13/aspnetcore-runtime-6.0.13-linux-x64.tar.gz
dotnet-install: Extracting zip from https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/6.0.13/aspnetcore-runtime-6.0.13-linux-x64.tar.gz
dotnet-install: Installed version is 6.0.13
dotnet-install: Adding to current process PATH: ...
dotnet-install: Note that the script does not resolve dependencies during installation.
dotnet-install: To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install, select your operating system and check the "Dependencies" section.
dotnet-install: Installation finished successfully.
  Attempting to install runtime toolset 'aspnetcore/x64 v7.0.2' from public_location.
dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.
dotnet-install: Attempting to download using primary link https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/7.0.2/aspnetcore-runtime-7.0.2-linux-x64.tar.gz
dotnet-install: Extracting zip from https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/7.0.2/aspnetcore-runtime-7.0.2-linux-x64.tar.gz
dotnet-install: Installed version is 7.0.2
dotnet-install: Adding to current process PATH: ...
dotnet-install: Note that the script does not resolve dependencies during installation.
dotnet-install: To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install, select your operating system and check the "Dependencies" section.
dotnet-install: Installation finished successfully.
  Determining projects to restore...
  All projects are up-to-date for restore.

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:01:08.08
```

### Restored repo

```bash
  Determining projects to restore...
  
  Restore was successful.
  All projects are up-to-date for restore.
  Runtime toolset 'dotnet/x64 v3.1.32' already installed.
  Runtime toolset 'dotnet/x64 v6.0.13' already installed.
  Runtime toolset 'dotnet/x64 v7.0.2' already installed.
  Runtime toolset 'aspnetcore/x64 v3.1.32' already installed.
  Runtime toolset 'aspnetcore/x64 v6.0.13' already installed.
  Runtime toolset 'aspnetcore/x64 v7.0.2' already installed.
  Determining projects to restore...
  All projects are up-to-date for restore.

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:12.37
```


Note, I'm badly waiting for https://github.com/dotnet/install-scripts/pull/356 to be made public as it would reduce this console noise even further. /cc: @baronfel 