### PR TITLE
Add a trailing slash to $env:VSINSTALLDIR

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -399,7 +399,8 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
   # Locate Visual Studio installation or download x-copy msbuild.
   $vsInfo = LocateVisualStudio $vsRequirements
   if ($vsInfo -ne $null) {
-    $vsInstallDir = $vsInfo.installationPath
+    # Ensure vsInstallDir has a trailing slash
+    $vsInstallDir = Join-Path $vsInfo.installationPath "\"
     $vsMajorVersion = $vsInfo.installationVersion.Split('.')[0]
 
     InitializeVisualStudioEnvironmentVariables $vsInstallDir $vsMajorVersion


### PR DESCRIPTION
Without a trailing slash publishing NativeAOT projects no longer works.

See https://github.com/dotnet/runtime/issues/85737

cc @wtgodbe @missymessa @riarenas @agocke 