### PR TITLE
Switch to Microsoft.Identity.Client library for managing aka.ms links

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -91,6 +91,7 @@
     <MicrosoftApplicationInsightsVersion>2.21.0</MicrosoftApplicationInsightsVersion>
     <MicrosoftCciVersion>4.0.0-rc3-24214-00</MicrosoftCciVersion>
     <MicrosoftDataODataVersion>5.8.4</MicrosoftDataODataVersion>
+    <MicrosoftIdentityClientVersion>4.53.0</MicrosoftIdentityClientVersion>
     <!-- Keep Microsoft.Data.Services.Client package version in sync with Microsoft.Data.OData -->
     <MicrosoftDataServicesClientVersion>5.8.4</MicrosoftDataServicesClientVersion>
     <!-- TODO: This library is deprecated, brings in the entire .NET Standard 1.3 dependency graph (including vulnerable libraries)

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -94,10 +94,6 @@
     <MicrosoftIdentityClientVersion>4.53.0</MicrosoftIdentityClientVersion>
     <!-- Keep Microsoft.Data.Services.Client package version in sync with Microsoft.Data.OData -->
     <MicrosoftDataServicesClientVersion>5.8.4</MicrosoftDataServicesClientVersion>
-    <!-- TODO: This library is deprecated, brings in the entire .NET Standard 1.3 dependency graph (including vulnerable libraries)
-         and should be replaced with Microsoft.Identity.Client.
-         Meanwhile make sure that the version is in sync with the version used by symboluploader. -->
-    <MicrosoftIdentityModelClientsActiveDirectoryVersion>3.17.2</MicrosoftIdentityModelClientsActiveDirectoryVersion>
     <MicrosoftOpenApiReadersVersion>1.3.2</MicrosoftOpenApiReadersVersion>
     <MicrosoftOpenApiVersion>1.3.2</MicrosoftOpenApiVersion>
     <MicrosoftSignedWixVersion>1.0.0-v3.14.0.5722</MicrosoftSignedWixVersion>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
@@ -100,7 +100,6 @@
       <ArtifactsBasePath Condition="'$(ArtifactsBasePath)' == ''">$(BlobBasePath)</ArtifactsBasePath>
       <NonStreamingPublishingMaxClients Condition="'$(NonStreamingPublishingMaxClients)' == ''">12</NonStreamingPublishingMaxClients>
       <StreamingPublishingMaxClients Condition="'$(UseStreamingPublishing)' == 'true' and '$(StreamingPublishingMaxClients)' == ''">16</StreamingPublishingMaxClients>
-      <UseIdentityClientLibrary Condition="'$(UseIdentityClientLibrary)' == ''">false</UseIdentityClientLibrary>
     </PropertyGroup>
 
     <ItemGroup>
@@ -169,7 +168,6 @@
       FeedKeys="@(FeedKey)"
       FeedSasUris="@(FeedSasUri)"
       FeedOverrides="@(FeedOverride)"
-      UseIdentityClientLibrary="$(UseIdentityClientLibrary)"
       />
   </Target>
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -185,12 +185,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public int NonStreamingPublishingMaxClients {get; set;}
 
         /// <summary>
-        /// Feature flag for switching to the Microsoft.Identity.Client library
-        /// TODO (https://github.com/dotnet/arcade/issues/13318): Remove the switch and use the new library
-        /// </summary>
-        public bool UseIdentityClientLibrary { get; set; } = false;
-
-        /// <summary>
         /// Just an internal flag to keep track whether we published assets via a V3 manifest or not.
         /// </summary>
         private static bool PublishedV3Manifest { get; set; }
@@ -348,8 +342,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 AzureDevOpsOrg = this.AzureDevOpsOrg,
                 UseStreamingPublishing = this.UseStreamingPublishing,
                 StreamingPublishingMaxClients = this.StreamingPublishingMaxClients,
-                NonStreamingPublishingMaxClients = this.NonStreamingPublishingMaxClients,
-                UseIdentityClientLibrary = this.UseIdentityClientLibrary,
+                NonStreamingPublishingMaxClients = this.NonStreamingPublishingMaxClients
             };
         }
     }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -192,8 +192,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         /// </summary>
         public int RetryDelayMilliseconds { get; set; } = 5000;
 
-        public bool UseIdentityClientLibrary { get; set; }
-
         public ExponentialRetry RetryHandler = new ExponentialRetry
         {
             MaxAttempts = 5,
@@ -1691,7 +1689,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         AkaMSGroupOwner,
                         AkaMSCreatedBy,
                         AkaMsOwners,
-                        UseIdentityClientLibrary,
                         Log);
                 }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/LatestLinksManager.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/LatestLinksManager.cs
@@ -25,8 +25,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         private string AkaMSCreatedBy { get; }
         private string AkaMSGroupOwner { get; }
 
-        private bool UseIdentityClientLibrary { get; }
-
         private static HashSet<string> AccountsWithCdns { get; } = new()
         {
             "dotnetcli.blob.core.windows.net", "dotnetbuilds.blob.core.windows.net",
@@ -39,7 +37,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             string akaMSGroupOwner,
             string akaMSCreatedBy,
             string akaMsOwners,
-            bool useIdentityClientLibrary,
             TaskLoggingHelper logger)
         {
             Logger = logger;
@@ -49,8 +46,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             AkaMSGroupOwner = akaMSGroupOwner;
             AkaMSCreatedBy = akaMSCreatedBy;
             AkaMsOwners = akaMsOwners;
-            UseIdentityClientLibrary = useIdentityClientLibrary;
-            LinkManager = new AkaMSLinkManager(AkaMSClientId, AkaMSClientSecret, AkaMSTenant, Logger, UseIdentityClientLibrary);
+            LinkManager = new AkaMSLinkManager(AkaMSClientId, AkaMSClientSecret, AkaMSTenant, Logger);
         }
 
         public async System.Threading.Tasks.Task CreateOrUpdateLatestLinksAsync(

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/Microsoft.DotNet.Deployment.Tasks.Links.csproj
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/Microsoft.DotNet.Deployment.Tasks.Links.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.53.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="$(MicrosoftIdentityClientVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" Publish="false" ExcludeAssets="runtime" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/Microsoft.DotNet.Deployment.Tasks.Links.csproj
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/Microsoft.DotNet.Deployment.Tasks.Links.csproj
@@ -15,15 +15,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>
 
-  <!-- Reference Microsoft.IdentityModel.Clients.ActiveDirectory on .NETCoreApp directly via PackageDownload+Reference to avoid its netstandard1.x dependencies. -->
-  <ItemGroup>
-    <PackageDownload Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="[$(MicrosoftIdentityModelClientsActiveDirectoryVersion)]" />
-    <Reference Include="$(NuGetPackageRoot)microsoft.identitymodel.clients.activedirectory\$(MicrosoftIdentityModelClientsActiveDirectoryVersion)\lib\netstandard1.3\*.dll"
-               Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
-    <Reference Include="$(NuGetPackageRoot)microsoft.identitymodel.clients.activedirectory\$(MicrosoftIdentityModelClientsActiveDirectoryVersion)\lib\net45\*.dll"
-               Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksBase.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksBase.cs
@@ -5,7 +5,6 @@ using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
-using Microsoft.IdentityModel.Clients.ActiveDirectory;
 
 namespace Microsoft.DotNet.Deployment.Tasks.Links
 {

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksBase.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksBase.cs
@@ -19,7 +19,5 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links
         public string ClientSecret { get; set; }
         [Required]
         public string Tenant { get; set; }
-
-        public bool UseIdentityClientLibrary { get; set; } = false;
     }
 }

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksManager.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksManager.cs
@@ -432,11 +432,10 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links.src
         // using the new Microsoft.Identity.Client library
         private async Task<HttpClient> CreateClientUsingMSAL()
         {
-            //_log.LogMessage(MessageImportance.High, "Creating a client using MSAL.NET");
+            _log.LogMessage(MessageImportance.High, "Creating a client using MSAL.NET");
 
             Identity.Client.AuthenticationResult token = await _akamsLinksApp.Value
                 .AcquireTokenForClient(new[] { $"{Endpoint}/.default" })
-                .WithTenantId(_tenant)
                 .ExecuteAsync()
                 .ConfigureAwait(false);
 

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksManager.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksManager.cs
@@ -41,23 +41,16 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links.src
         private string ApiTargeturl { get => $"{ApiBaseUrl}/1/{_tenant}"; }
         private ExponentialRetry RetryHandler;
 
-        /// <summary>
-        /// Feature flag for switching to the Microsoft.Identity.Client library
-        /// TODO (https://github.com/dotnet/arcade/issues/13318): Remove the switch and use the new library
-        /// </summary>
-        private bool _useIdentityClientLibrary;
-
         private Microsoft.Build.Utilities.TaskLoggingHelper _log;
         private Lazy<IConfidentialClientApplication> _akamsLinksApp;
 
 
-        public AkaMSLinkManager(string clientId, string clientSecret, string tenant, Microsoft.Build.Utilities.TaskLoggingHelper log, bool useIdentityClientLibrary)
+        public AkaMSLinkManager(string clientId, string clientSecret, string tenant, Microsoft.Build.Utilities.TaskLoggingHelper log)
         {
             _clientId = clientId;
             _clientSecret = clientSecret;
             _tenant = tenant;
             _log = log;
-            _useIdentityClientLibrary = useIdentityClientLibrary;
             _akamsLinksApp = new Lazy<IConfidentialClientApplication>(() => 
                 ConfidentialClientApplicationBuilder
                     .Create(_clientId)
@@ -403,11 +396,21 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links.src
             }
         }
 
+        private async Task<HttpClient> CreateClient()
+        {
+            _log.LogMessage("Creating a client using MSAL.NET");
 
-        // TODO (https://github.com/dotnet/arcade/issues/13318) Remove feature switch
-        private async Task<HttpClient> CreateClient() => _useIdentityClientLibrary
-            ? await CreateClientUsingMSAL()
-            : await CreateClientUsingADAL();
+            Identity.Client.AuthenticationResult token = await _akamsLinksApp.Value
+                .AcquireTokenForClient(new[] { $"{Endpoint}/.default" })
+                .WithTenantId(_tenant)
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            HttpClient httpClient = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true });
+            httpClient.DefaultRequestHeaders.Add("Authorization", token.CreateAuthorizationHeader());
+
+            return httpClient;
+        }
 
         // using the old Microsoft.IdentityModel.Clients.ActiveDirectory library
         private async Task<HttpClient> CreateClientUsingADAL()
@@ -422,22 +425,6 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links.src
             AuthenticationContext authContext = new AuthenticationContext(Authority);
             IdentityModel.Clients.ActiveDirectory.ClientCredential credential = new IdentityModel.Clients.ActiveDirectory.ClientCredential(_clientId, _clientSecret);
             IdentityModel.Clients.ActiveDirectory.AuthenticationResult token = await authContext.AcquireTokenAsync(Endpoint, credential);
-
-            HttpClient httpClient = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true });
-            httpClient.DefaultRequestHeaders.Add("Authorization", token.CreateAuthorizationHeader());
-
-            return httpClient;
-        }
-
-        // using the new Microsoft.Identity.Client library
-        private async Task<HttpClient> CreateClientUsingMSAL()
-        {
-            _log.LogMessage(MessageImportance.High, "Creating a client using MSAL.NET");
-
-            Identity.Client.AuthenticationResult token = await _akamsLinksApp.Value
-                .AcquireTokenForClient(new[] { $"{Endpoint}/.default" })
-                .ExecuteAsync()
-                .ConfigureAwait(false);
 
             HttpClient httpClient = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true });
             httpClient.DefaultRequestHeaders.Add("Authorization", token.CreateAuthorizationHeader());

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksManager.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksManager.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Arcade.Common;
 using Microsoft.Build.Framework;
-using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.Identity.Client;
 using Newtonsoft.Json;
 using System;
@@ -405,26 +404,6 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links.src
                 .WithTenantId(_tenant)
                 .ExecuteAsync()
                 .ConfigureAwait(false);
-
-            HttpClient httpClient = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true });
-            httpClient.DefaultRequestHeaders.Add("Authorization", token.CreateAuthorizationHeader());
-
-            return httpClient;
-        }
-
-        // using the old Microsoft.IdentityModel.Clients.ActiveDirectory library
-        private async Task<HttpClient> CreateClientUsingADAL()
-        {
-#if NETCOREAPP
-            var platformParameters = new PlatformParameters();
-#elif NETFRAMEWORK
-                var platformParameters = new PlatformParameters(PromptBehavior.Auto);
-#else
-#error "Unexpected TFM"
-#endif
-            AuthenticationContext authContext = new AuthenticationContext(Authority);
-            IdentityModel.Clients.ActiveDirectory.ClientCredential credential = new IdentityModel.Clients.ActiveDirectory.ClientCredential(_clientId, _clientSecret);
-            IdentityModel.Clients.ActiveDirectory.AuthenticationResult token = await authContext.AcquireTokenAsync(Endpoint, credential);
 
             HttpClient httpClient = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true });
             httpClient.DefaultRequestHeaders.Add("Authorization", token.CreateAuthorizationHeader());

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksManager.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksManager.cs
@@ -39,10 +39,9 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links.src
         private string _tenant;
         private string ApiTargeturl { get => $"{ApiBaseUrl}/1/{_tenant}"; }
         private ExponentialRetry RetryHandler;
-
         private Microsoft.Build.Utilities.TaskLoggingHelper _log;
         private Lazy<IConfidentialClientApplication> _akamsLinksApp;
-
+       
 
         public AkaMSLinkManager(string clientId, string clientSecret, string tenant, Microsoft.Build.Utilities.TaskLoggingHelper log)
         {
@@ -397,11 +396,8 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links.src
 
         private async Task<HttpClient> CreateClient()
         {
-            _log.LogMessage("Creating a client using MSAL.NET");
-
-            Identity.Client.AuthenticationResult token = await _akamsLinksApp.Value
+            AuthenticationResult token = await _akamsLinksApp.Value
                 .AcquireTokenForClient(new[] { $"{Endpoint}/.default" })
-                .WithTenantId(_tenant)
                 .ExecuteAsync()
                 .ConfigureAwait(false);
 

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/CreateAkaMSLinks.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/CreateAkaMSLinks.cs
@@ -91,7 +91,7 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links
                     string descriptionString = !string.IsNullOrEmpty(link.Description) ? $" ({link.Description})" : "";
                     Log.LogMessage(MessageImportance.High, $"Creating link aka.ms/{link.ShortUrl} -> {link.TargetUrl}{descriptionString}");
                 }
-                AkaMSLinkManager manager = new AkaMSLinkManager(ClientId, ClientSecret, Tenant, Log, UseIdentityClientLibrary);
+                AkaMSLinkManager manager = new AkaMSLinkManager(ClientId, ClientSecret, Tenant, Log);
                 await manager.CreateOrUpdateLinksAsync(linksToCreate, Owners, CreatedBy, GroupOwner, Overwrite);
             }
             catch (Exception e)

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/DeleteAkaMSLinks.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/DeleteAkaMSLinks.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links
         {
             try
             {
-                AkaMSLinkManager manager = new AkaMSLinkManager(ClientId, ClientSecret, Tenant, Log, UseIdentityClientLibrary);
+                AkaMSLinkManager manager = new AkaMSLinkManager(ClientId, ClientSecret, Tenant, Log);
                 await manager.DeleteLinksAsync(new List<string>(ShortUrls));
             }
             catch (Exception e)


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/13287

- Fixing a [error](https://dev.azure.com/dnceng/internal/_build/results?buildId=2176572&view=logs&j=8667c75e-c9c8-5a72-3326-7d35d151733c&t=41b4432a-9419-55ab-5d23-b5f87d53db66&l=7776) that appeared when testing the changes from https://github.com/dotnet/arcade/pull/13316 in the staging pipeline
- Moving the version of `Microsoft.Identity.Client` into `Versions.props`

Changes were tested as described in this [doc](https://github.com/dotnet/arcade/blob/main/Documentation/Policy/TestingMSBuildGuidance.md#how-to-validate-a-private-build)
Test run of Stage-DotNet-Test pipeline with the new arcade:
https://dev.azure.com/dnceng/internal/_build/results?buildId=2178541&view=results
Test run of the `Publish CTI Validated Asset` stage:
 https://dev.azure.com/dnceng/internal/_build/results?buildId=2178486&view=logs&j=8667c75e-c9c8-5a72-3326-7d35d151733c&t=41b4432a-9419-55ab-5d23-b5f87d53db66


### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
