### PR TITLE
Fix some bugs with the new XunitAssert

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
@@ -5,7 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="$(XUnitVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true"/>
+    <PackageReference Include="xunit.core" Version="$(XUnitVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true" />
+    <PackageReference Include="xunit.analyzers" Version="$(XUnitVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true" />
+    <PackageReference Include="xunit.assert" Version="$(XUnitVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true" Condition="'$(UseDotNetXUnitAssert)' != 'true'" />
+    <PackageReference Include="Microsoft.DotNet.XUnitAssert" Version="$(MicrosoftDotNetXUnitAssertVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true" Condition="'$(UseDotNetXUnitAssert)' == 'true'" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true"/>
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.XUnitAssert/src/Microsoft.DotNet.XUnitAssert.csproj
+++ b/src/Microsoft.DotNet.XUnitAssert/src/Microsoft.DotNet.XUnitAssert.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCurrent);$(NetMinimum)</TargetFrameworks>
+    <AssemblyName>xunit.assert</AssemblyName>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>

--- a/src/Microsoft.DotNet.XUnitAssert/tests/Directory.Build.targets
+++ b/src/Microsoft.DotNet.XUnitAssert/tests/Directory.Build.targets
@@ -3,7 +3,6 @@
 
   <!-- This project provides xunit.assert, so we can't bring the package in, as it would conflict. -->
   <ItemGroup>
-    <PackageReference Remove="xunit" />
     <PackageReference Include="xunit.core" Version="$(XUnitVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true"/>
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.XUnitAssert/tests/Directory.Build.targets
+++ b/src/Microsoft.DotNet.XUnitAssert/tests/Directory.Build.targets
@@ -1,8 +1,0 @@
-<Project>
-  <Import Project="..\..\..\Directory.Build.targets" />
-
-  <!-- This project provides xunit.assert, so we can't bring the package in, as it would conflict. -->
-  <ItemGroup>
-    <PackageReference Include="xunit.core" Version="$(XUnitVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true"/>
-  </ItemGroup>
-</Project>

--- a/src/Microsoft.DotNet.XUnitAssert/tests/Microsoft.DotNet.XUnitAssert.Tests.csproj
+++ b/src/Microsoft.DotNet.XUnitAssert/tests/Microsoft.DotNet.XUnitAssert.Tests.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <Nullable>enable</Nullable>
+    <!-- Baselining tests from imported sources -->
+    <NoWarn>$(NoWarn);xUnit2000;xUnit2003;xUnit2005;xUnit2007;xUnit2011;xUnit2015;xUnit2017</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.XUnitAssert/tests/Microsoft.DotNet.XUnitAssert.Tests.csproj
+++ b/src/Microsoft.DotNet.XUnitAssert/tests/Microsoft.DotNet.XUnitAssert.Tests.csproj
@@ -3,8 +3,9 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <Nullable>enable</Nullable>
-    <!-- Baselining tests from imported sources -->
+    <!-- Baseline analyzer warnings. These warnings are present in the upstream xunit.assert tests. -->
     <NoWarn>$(NoWarn);xUnit2000;xUnit2003;xUnit2005;xUnit2007;xUnit2011;xUnit2015;xUnit2017</NoWarn>
+    <UseDotNetXUnitAssert>true</UseDotNetXUnitAssert>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I found a few bugs in trying to enable https://github.com/dotnet/runtime/pull/86193. One is that there's no way to flip Arcade to pull in the fork package instead of xunit.assert. The second is that when both are pulled in, because the fork has a different assembly name, the references are ambiguous and produce compile-time breaks. Matching names seems like it will get rid of that problem, and it also has the side-effect of letting the analyzer work properly against the fork.