### PR TITLE
Don't bundle NuGet assemblies in NETCoreApp tasks

### DIFF
--- a/eng/BuildTask.targets
+++ b/eng/BuildTask.targets
@@ -1,13 +1,15 @@
 <Project>
+
   <PropertyGroup>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IsPackable>true</IsPackable>
     <!-- Build Tasks should not include any dependencies -->
     <SuppressDependenciesWhenPacking Condition="'$(SuppressDependenciesWhenPacking)' == ''">true</SuppressDependenciesWhenPacking>
-    <PackTasks Condition="'$(PackTasks)' == ''">true</PackTasks>
     <!-- Build Tasks should have this set per https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md#recommended-settings -->
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
     <BuildTaskTargetFolder Condition="'$(BuildTaskTargetFolder)' == ''">tools</BuildTaskTargetFolder>
+    <PackTasks Condition="'$(PackTasks)' == ''">true</PackTasks>
+    <TargetsForTfmSpecificContentInPackage Condition="'$(PackTasks)' == 'true'">$(TargetsForTfmSpecificContentInPackage);_AddBuildOutputToPackageCore;_AddBuildOutputToPackageDesktop</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
   <!--
@@ -26,29 +28,52 @@
     <None Include="$(RepoRoot)THIRD-PARTY-NOTICES.txt" PackagePath="THIRD-PARTY-NOTICES.txt" Pack="true"/>
   </ItemGroup>
 
+  <!-- Don't include assemblies that MSBuild ships with. -->
   <ItemGroup>
-    <!-- 
-      Do not include assemblies that MSBuild ships with in the package.
-    -->
     <PackageReference Update="Microsoft.Build" Publish="false" />
     <PackageReference Update="Microsoft.Build.Framework" Publish="false" />
     <PackageReference Update="Microsoft.Build.Tasks.Core" Publish="false" />
     <PackageReference Update="Microsoft.Build.Utilities.Core" Publish="false" />
+    <PackageReference Update="Microsoft.NET.StringTools" Publish="false" />
     <PackageReference Update="System.Collections.Immutable" Publish="false" />
-    <PackageReference Update="System.Runtime.InteropServices.RuntimeInformation" Publish="false" />
+  </ItemGroup>
 
+  <!-- Don't include assemblies that are provided by the SDK, next to MSBuild. -->
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(SkipSDKInboxPublishExcludes)' != 'true'">
+    <PackageReference Update="Newtonsoft.Json" Publish="false" />
+    <PackageReference Update="NuGet.Commands" Publish="false" />
+    <PackageReference Update="NuGet.Common" Publish="false" />
+    <PackageReference Update="NuGet.Configuration" Publish="false" />
+    <PackageReference Update="NuGet.Frameworks" Publish="false" />
+    <PackageReference Update="NuGet.Packaging" Publish="false" />
+    <PackageReference Update="NuGet.ProjectModel" Publish="false" />
+    <PackageReference Update="NuGet.Versioning" Publish="false" />
+  </ItemGroup>
+
+  <!-- Don't include assemblies that are inbox in Desktop MSBuild -->
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <PackageReference Update="System.Buffers" Publish="false" />
+    <PackageReference Update="System.Memory" Publish="false" />
+    <PackageReference Update="System.Numerics.Vectors" Publish="false" />
+    <PackageReference Update="System.Reflection.Metadata" Publish="false" />
+    <PackageReference Update="System.Reflection.MetadataLoadContext" Publish="false" />
+    <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Publish="false" />
+    <PackageReference Update="System.Text.Encodings.Web" Publish="false" />
+    <PackageReference Update="System.Text.Json" Publish="false" />
+    <PackageReference Update="System.Threading.Tasks.Dataflow" Publish="false" />
+    <PackageReference Update="System.Threading.Tasks.Extensions" Publish="false" />
+    <PackageReference Update="System.ValueTuple" Publish="false" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!--
-      Update all PackageReference and ProjectReference Items to
-      default Publish to true.
+      Update all PackageReference items to default Publish to true.
       This forces the publish output to contain the dlls.
      -->
     <PackageReference Update="@(PackageReference)">
       <Publish Condition="'%(PackageReference.Publish)' == ''">true</Publish>
       <ExcludeAssets Condition="'%(PackageReference.Publish)' == 'false'">runtime</ExcludeAssets>
     </PackageReference>
-    <ProjectReference Update="@(ProjectReference)">
-      <Publish Condition="'%(ProjectReference.Publish)' == ''">true</Publish>
-    </ProjectReference>
 
     <!--
       Update all Reference items to have Pack="false"
@@ -57,23 +82,20 @@
     <Reference Update="@(Reference)"
                Pack="false" />
   </ItemGroup>
-
-  <PropertyGroup Condition="'$(PackTasks)' == 'true'">
-    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddBuildOutputToPackageCore;_AddBuildOutputToPackageDesktop</TargetsForTfmSpecificContentInPackage>
-  </PropertyGroup>
   
+  <!-- Publish .NET Core assets and include them in the package under $(BuildTaskTargetFolder) directory. -->
   <Target Name="_AddBuildOutputToPackageCore" DependsOnTargets="Publish" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <ItemGroup>
-      <!-- Publish .NET Core assets and include them in the package under $(BuildTaskTargetFolder) directory. -->
       <TfmSpecificPackageFile Include="$(PublishDir)**" 
                               PackagePath="$(BuildTaskTargetFolder)/$(TargetFramework)/%(RecursiveDir)%(FileName)%(Extension)"/>
     </ItemGroup>
   </Target>
 
+  <!-- Include .NET Framework build outputs in the package under $(BuildTaskTargetFolder) directory. -->
   <Target Name="_AddBuildOutputToPackageDesktop" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <ItemGroup>
-      <!-- Include .NET Framework build outputs in the package under $(BuildTaskTargetFolder) directory. -->
       <TfmSpecificPackageFile Include="$(OutputPath)**" PackagePath="$(BuildTaskTargetFolder)/$(TargetFramework)/%(RecursiveDir)%(FileName)%(Extension)"/>
     </ItemGroup>
   </Target>
+
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -33,8 +33,10 @@
     <!-- netstandard -->
     <NETStandardLibraryVersion>2.0.3</NETStandardLibraryVersion>
     <!-- nuget -->
+    <NuGetCommandsVersion>6.2.2</NuGetCommandsVersion>
     <NuGetFrameworksVersion>6.2.2</NuGetFrameworksVersion>
     <NuGetPackagingVersion>6.2.2</NuGetPackagingVersion>
+    <NuGetProjectModelVersion>6.2.2</NuGetProjectModelVersion>
     <NuGetVersioningVersion>6.2.2</NuGetVersioningVersion>
     <!-- roslyn -->
     <MicrosoftCodeAnalysisCSharpVersion>4.4.0</MicrosoftCodeAnalysisCSharpVersion>
@@ -94,6 +96,7 @@
     <MicrosoftIdentityClientVersion>4.53.0</MicrosoftIdentityClientVersion>
     <!-- Keep Microsoft.Data.Services.Client package version in sync with Microsoft.Data.OData -->
     <MicrosoftDataServicesClientVersion>5.8.4</MicrosoftDataServicesClientVersion>
+    <MicrosoftDiagnosticsRuntimeVersion>1.0.5</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftOpenApiReadersVersion>1.3.2</MicrosoftOpenApiReadersVersion>
     <MicrosoftOpenApiVersion>1.3.2</MicrosoftOpenApiVersion>
     <MicrosoftSignedWixVersion>1.0.0-v3.14.0.5722</MicrosoftSignedWixVersion>

--- a/src/Microsoft.DotNet.ApiCompat/src/Microsoft.DotNet.ApiCompat.csproj
+++ b/src/Microsoft.DotNet.ApiCompat/src/Microsoft.DotNet.ApiCompat.csproj
@@ -2,12 +2,14 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCurrent);$(NetFrameworkToolCurrent)</TargetFrameworks>
-    <OutputType>Exe</OutputType>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
     <IsPackable>true</IsPackable>
     <NoWarn>$(NoWarn);0436</NoWarn>
     <RollForward>Major</RollForward>
     <DefaultExcludesInProjectFolder>Microsoft.DotNet.ApiCompat.Core\**\*</DefaultExcludesInProjectFolder>
+    <!-- APICompat is used as both a CLI tool and an msbuild task via the same assembly. -->
+    <OutputType>Exe</OutputType>
+    <SkipSDKInboxPublishExcludes>true</SkipSDKInboxPublishExcludes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
@@ -49,9 +49,9 @@
     <PackageDownload Include="Microsoft.NETCore.Platforms" Version="[$(MicrosoftNETCorePlatformsVersion)]" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="NuGet.Commands" Version="$(NuGetPackagingVersion)" />
+    <PackageReference Include="NuGet.Commands" Version="$(NuGetCommandsVersion)" />
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagingVersion)" />
-    <PackageReference Include="NuGet.ProjectModel" Version="$(NuGetPackagingVersion)" />
+    <PackageReference Include="NuGet.ProjectModel" Version="$(NuGetProjectModelVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/Microsoft.DotNet.Build.Tasks.Workloads.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/Microsoft.DotNet.Build.Tasks.Workloads.Tests.csproj
@@ -15,6 +15,11 @@
     <PackageReference Include="Microsoft.Signed.Wix" Version="$(MicrosoftSignedWixVersion)" />
   </ItemGroup>
 
+  <!-- The tests reference the MSBuild task assembly directly and therefore we need to add references that would normally be provided by MSBuild. -->
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+    <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagingVersion)" />
+  </ItemGroup>
+
   <!-- Sample packages -->
   <ItemGroup>
     <PackageDownload Include="Microsoft.Signed.Wix" Version="[$(MicrosoftSignedWixVersion)]" />

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/Microsoft.DotNet.Deployment.Tasks.Links.csproj
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/Microsoft.DotNet.Deployment.Tasks.Links.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client" Version="$(MicrosoftIdentityClientVersion)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" Publish="false" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.GenFacades/Microsoft.DotNet.GenFacades.csproj
+++ b/src/Microsoft.DotNet.GenFacades/Microsoft.DotNet.GenFacades.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" Publish="false" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpVersion)" ExcludeAssets="analyzers" Publish="false" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests.csproj
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests.csproj
@@ -12,6 +12,11 @@
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
   </ItemGroup>
 
+  <!-- The tests reference the MSBuild task assembly directly and therefore we need to add references that would normally be provided by MSBuild. -->
+  <ItemGroup>
+    <PackageReference Include="NuGet.Versioning" Version="$(NuGetVersioningVersion)" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\Common\Microsoft.Arcade.Common\Microsoft.Arcade.Common.csproj" />
     <ProjectReference Include="..\..\..\Common\Microsoft.Arcade.Test.Common\Microsoft.Arcade.Test.Common.csproj" />

--- a/src/Microsoft.DotNet.NuGetRepack/tasks/Microsoft.DotNet.NuGetRepack.Tasks.csproj
+++ b/src/Microsoft.DotNet.NuGetRepack/tasks/Microsoft.DotNet.NuGetRepack.Tasks.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.Versioning" Version="$(NuGetPackagingVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
+    <PackageReference Include="NuGet.Versioning" Version="$(NuGetVersioningVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">

--- a/src/Microsoft.DotNet.NuGetRepack/tests/Microsoft.DotNet.NuGetRepack.Tests.csproj
+++ b/src/Microsoft.DotNet.NuGetRepack/tests/Microsoft.DotNet.NuGetRepack.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.Versioning" Version="$(NuGetPackagingVersion)" />
+    <PackageReference Include="NuGet.Versioning" Version="$(NuGetVersioningVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.PackageTesting.Tests/Microsoft.DotNet.PackageTesting.Tests.csproj
+++ b/src/Microsoft.DotNet.PackageTesting.Tests/Microsoft.DotNet.PackageTesting.Tests.csproj
@@ -6,7 +6,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
-    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetPackagingVersion)" />
+    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetFrameworksVersion)" />
+  </ItemGroup>
+
+  <!-- The tests reference the MSBuild task assembly directly and therefore we need to add references that would normally be provided by MSBuild. -->
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+    <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagingVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.PackageTesting/Microsoft.DotNet.PackageTesting.csproj
+++ b/src/Microsoft.DotNet.PackageTesting/Microsoft.DotNet.PackageTesting.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" Publish="false" />
-    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetPackagingVersion)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
+    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetFrameworksVersion)" />
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagingVersion)" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.RemoteExecutor/src/Microsoft.DotNet.RemoteExecutor.csproj
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/Microsoft.DotNet.RemoteExecutor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
-    <!-- On .NET Framework and .NET Core we use this assembly as both a library and as an executable. -->
+    <!-- The assembly is used as both a library and an executable. -->
     <OutputType>Exe</OutputType>
     <Description>This package provides support for running tests out-of-process.</Description>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="1.0.5" />
+    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="$(MicrosoftDiagnosticsRuntimeVersion)" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="$(SystemRuntimeInteropServicesRuntimeInformation)" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.SourceBuild/tasks/Microsoft.DotNet.SourceBuild.Tasks.csproj
+++ b/src/Microsoft.DotNet.SourceBuild/tasks/Microsoft.DotNet.SourceBuild.Tasks.csproj
@@ -11,9 +11,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
-    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetPackagingVersion)" />
+    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetFrameworksVersion)" />
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagingVersion)" />
-    <PackageReference Include="NuGet.Versioning" Version="$(NuGetPackagingVersion)" />
+    <PackageReference Include="NuGet.Versioning" Version="$(NuGetVersioningVersion)" />
   </ItemGroup>
 
   <Import Project="$(RepositoryEngineeringDir)BuildTask.targets" />

--- a/src/Microsoft.DotNet.SourceBuild/tests/Microsoft.DotNet.SourceBuild.Tasks.Tests.csproj
+++ b/src/Microsoft.DotNet.SourceBuild/tests/Microsoft.DotNet.SourceBuild.Tasks.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagingVersion)" />
-    <PackageReference Include="NuGet.Versioning" Version="$(NuGetPackagingVersion)" />
+    <PackageReference Include="NuGet.Versioning" Version="$(NuGetVersioningVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.VersionTools.Tasks.Tests/Microsoft.DotNet.VersionTools.Tasks.Tests.csproj
+++ b/src/Microsoft.DotNet.VersionTools.Tasks.Tests/Microsoft.DotNet.VersionTools.Tasks.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
     <!-- This unifies the transitive references coming from Microsoft.DotNet.VersionTools.csproj and Microsoft.TestPlatform.ObjectModel/17.5.0. -->
-    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetPackagingVersion)" />
+    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetFrameworksVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
@@ -2,16 +2,25 @@
 
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
-    <PackageId>Microsoft.DotNet.XUnitConsoleRunner</PackageId>
+    <OutputType>Exe</OutputType>
     <AssemblyName>xunit.console</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <OutputType>Exe</OutputType>
     <RootNamespace>Xunit.ConsoleClient</RootNamespace>
-    <IsPackable>true</IsPackable>
-    <VersionPrefix>2.5.1</VersionPrefix>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
     <RollForward>Major</RollForward>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <IsPackable>true</IsPackable>
+    <PackageId>Microsoft.DotNet.XUnitConsoleRunner</PackageId>
+    <VersionPrefix>2.5.1</VersionPrefix>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddBuildOutputToPackage</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="build\Microsoft.DotNet.XUnitConsoleRunner.props" Pack="true" PackagePath="build" />
+    <None Include="$(RepoRoot)LICENSE.txt" PackagePath="LICENSE.txt" Pack="true"/>
+    <None Include="$(RepoRoot)THIRD-PARTY-NOTICES.txt" PackagePath="THIRD-PARTY-NOTICES.txt" Pack="true"/>
+  </ItemGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="HTML.xslt" />
@@ -34,6 +43,12 @@
     <Reference Include="$(NuGetPackageRoot)xunit.runner.utility\$(XUnitVersion)\lib\netcoreapp1.0\xunit.runner.utility.netcoreapp10.dll" />
   </ItemGroup>
 
-  <Import Project="$(RepositoryEngineeringDir)BuildTask.targets" />
+  <!-- Publish publish build assets and include them in the package under the tools directory. -->
+  <Target Name="_AddBuildOutputToPackage" DependsOnTargets="Publish">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="$(PublishDir)**" 
+                              PackagePath="tools/$(TargetFramework)/%(RecursiveDir)%(FileName)%(Extension)"/>
+    </ItemGroup>
+  </Target>
 
 </Project>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build-reference-packages/pull/673#issuecomment-1550077968

NuGet assemblies are alread bundled into the SDK and therefore don't need to be included in .NETCoreApp msbuild task packages.

They need to be kept on .NET Framework which doesn't bundle NuGet along MSBuild.

Also fix a version package references using an incorrect NuGet version property.