### PR TITLE
Only set BuildTaskOutputFolder if not set

### DIFF
--- a/eng/BuildTask.targets
+++ b/eng/BuildTask.targets
@@ -7,7 +7,7 @@
     <PackTasks Condition="'$(PackTasks)' == ''">true</PackTasks>
     <!-- Build Tasks should have this set per https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md#recommended-settings -->
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
-    <BuildTaskTargetFolder>tools</BuildTaskTargetFolder>
+    <BuildTaskTargetFolder Condition="'$(BuildTaskTargetFolder)' == ''">tools</BuildTaskTargetFolder>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
If a project sets this, the targets file would have overritten their selection.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
