### PR TITLE
Modify SymStore.targets to Handle Runtime Identifiers

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SymStore.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SymStore.targets
@@ -28,6 +28,7 @@
       <_SymStoreTargetFramework>$(TargetFramework)</_SymStoreTargetFramework>
       <_SymStoreOutputDir>$(ArtifactsSymStoreDirectory)$(OutDirName)\$(_SymStoreTargetFramework)\</_SymStoreOutputDir>
       <_SymStoreOutputDir Condition="'$(PlatformName)' != 'AnyCPU'">$(_SymStoreOutputDir)$(PlatformName)\</_SymStoreOutputDir>
+      <_SymStoreOutputDir Condition="'$(RuntimeIdentifier)' != ''">$(_SymStoreOutputDir)$(RuntimeIdentifier)\</_SymStoreOutputDir>
 
       <_SymStorePdbPath>$(_SymStoreOutputDir)$(TargetName).pdb</_SymStorePdbPath>
 


### PR DESCRIPTION
Allows the tool pdb2pdb.exe to use a different output path depending on the runtime identifier.

This change is aimed at preventing conflicts that arise during parallelism when multiple runtimes attempt to write to the same output file. Prior to this modification, such conflicts would cause pipelines to fail with the error message "file '.pdb' cannot be accessed by the process because it's being used by another process".

By allowing pdb2pdb.exe to use a different output path for each runtime, we can avoid these conflicts and ensure smoother operation of our pipelines.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
