### PR TITLE
Added tests for `ActiveIssue` feature, fix mono-debugger tests

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
@@ -35,10 +35,12 @@ namespace Microsoft.DotNet.XUnitExtensions
                 (platforms.HasFlag(TestPlatforms.Windows) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
 
         public static bool TestRuntimeApplies(TestRuntimes runtimes) =>
+                (runtimes.HasFlag(TestPlatforms.Any)) ||
                 (runtimes.HasFlag(TestRuntimes.Mono) && IsMonoRuntime) ||
                 (runtimes.HasFlag(TestRuntimes.CoreCLR) && !IsMonoRuntime); // assume CoreCLR if it's not Mono
 
         public static bool TestFrameworkApplies(TargetFrameworkMonikers frameworks) =>
+                (frameworks.HasFlag(TestPlatforms.Any)) ||
                 (frameworks.HasFlag(TargetFrameworkMonikers.Netcoreapp) && IsRunningOnNetCoreApp) ||
                 (frameworks.HasFlag(TargetFrameworkMonikers.NetFramework) && IsRunningOnNetFramework);
 

--- a/src/Microsoft.DotNet.XUnitExtensions/tests/ActiveIssueTests.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/tests/ActiveIssueTests.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+using Xunit.Sdk;
+
+namespace Microsoft.DotNet.XUnitExtensions.Tests
+{
+    [TestCaseOrderer("Microsoft.DotNet.XUnitExtensions.Tests.AlphabeticalOrderer", "Microsoft.DotNet.XUnitExtensions.Tests")]
+    public class ActiveIssueTests
+    {
+        [Fact]
+        [ActiveIssue("https://github.com/repo/123")]
+        public void CheckIfSkipsFact()
+        {
+            Assert.False(true, "Should have been skipped.");
+        }
+
+        [Fact]
+        [ActiveIssue("https://github.com/repo/456")]
+        public void CheckIfSkipsConditionalFact()
+        {
+            Assert.False(true, "Should have been skipped.");
+        }
+    }
+}


### PR DESCRIPTION
Reason for the change:
- We had no tests for `ActiveIssue` feature.
- Applying `ActiveIssue` to mono-debugger tests does not work.
- Applying `ActiveIssue` to XUnit sample template on net 8 does not work:
![image](https://github.com/dotnet/arcade/assets/32700855/872d2291-e82f-4f30-8baf-6b47bd5ac9c4)

I do not understand what is the motivation behind limiting `ActiveIssue` functionality by checking `TestRuntimeApplies` and `TestFrameworkApplies`, so this change might be wrong. The local tests enter with arguments: ["https://github.com/repo/123", Any, Any, Any], that's why adding `.HasFlag(TestPlatforms.Any)` was necessary.

Debugger tests and template tests are fixed after these changes.
I don't know what labels to attach.