### PR TITLE
Add ability to generate workload components/pack authoring with out-o…

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
@@ -66,6 +66,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
                 ShortNames = shortNames,
                 WixToolsetPath = TestBase.WixToolsetPath,
                 WorkloadManifestPackageFiles = manifestsPackages,
+                IsOutOfSupportInVisualStudio = true
             };
 
             bool result = createWorkloadTask.Execute();
@@ -93,6 +94,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
 
             // Emscripten is an abstract workload so it should be a component group.
             Assert.Contains("vs.package.type=component", componentSwr);
+            Assert.Contains("vs.package.outOfSupport=yes", componentSwr);
             Assert.Contains("isUiGroup=yes", componentSwr);
             Assert.Contains("version=5.6.7.8", componentSwr);
 
@@ -106,9 +108,10 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             // Verify the SWIX authoring for the VS package wrapping the manifest MSI
             string manifestMsiSwr = File.ReadAllText(Path.Combine(baseIntermediateOutputPath, "src", "swix", "6.0.200", "Emscripten.Manifest-6.0.200", "x64", "msi.swr"));
             Assert.Contains("package name=Emscripten.Manifest-6.0.200", manifestMsiSwr);
-            Assert.Contains("vs.package.type=msi", manifestMsiSwr);
+            Assert.Contains("vs.package.type=msi", manifestMsiSwr);            
             Assert.Contains("vs.package.chip=x64", manifestMsiSwr);
             Assert.DoesNotContain("vs.package.machineArch", manifestMsiSwr);
+            Assert.DoesNotContain("vs.package.outOfSupport", manifestMsiSwr);
 
             // Verify that no arm64 MSI authoring for VS. EMSDK doesn't define RIDs for arm64, but manifests always generate
             // arm64 MSIs for the CLI based installs so we should not see that.
@@ -122,6 +125,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             string packMsiSwr = File.ReadAllText(Path.Combine(Path.GetDirectoryName(pythonPackSwixItem.ItemSpec), "msi.swr"));
             Assert.Contains("package name=Microsoft.Emscripten.Python.6.0.4", packMsiSwr);
             Assert.Contains("vs.package.chip=x64", packMsiSwr);
+            Assert.Contains("vs.package.outOfSupport=yes", packMsiSwr);
             Assert.DoesNotContain("vs.package.machineArch", packMsiSwr);
         }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
@@ -108,7 +108,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             // Verify the SWIX authoring for the VS package wrapping the manifest MSI
             string manifestMsiSwr = File.ReadAllText(Path.Combine(baseIntermediateOutputPath, "src", "swix", "6.0.200", "Emscripten.Manifest-6.0.200", "x64", "msi.swr"));
             Assert.Contains("package name=Emscripten.Manifest-6.0.200", manifestMsiSwr);
-            Assert.Contains("vs.package.type=msi", manifestMsiSwr);            
+            Assert.Contains("vs.package.type=msi", manifestMsiSwr);
             Assert.Contains("vs.package.chip=x64", manifestMsiSwr);
             Assert.DoesNotContain("vs.package.machineArch", manifestMsiSwr);
             Assert.DoesNotContain("vs.package.outOfSupport", manifestMsiSwr);
@@ -208,6 +208,8 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             Assert.Contains("vs.package.type=component", componentSwr);
             Assert.Contains("isUiGroup=yes", componentSwr);
             Assert.Contains("version=5.6.7.8", componentSwr);
+            // Default setting should be off
+            Assert.Contains("vs.package.outOfSupport=no", componentSwr);
 
             // Verify pack dependencies. These should map to MSI packages. The VS package IDs should be the non-aliased
             // pack IDs and version from the workload manifest. The actual VS packages will point to the MSIs generated from the

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
@@ -449,7 +449,6 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                                 // Don't generate a SWIX package if the MSI targets arm64 and VS doesn't support machineArch
                                 if (_supportsMachineArch[manifestPackage.SdkFeatureBand] || !string.Equals(msiOutputItem.GetMetadata(Metadata.Platform), DefaultValues.arm64))
                                 {
-                                    // Do not flag manifest MSI packages for out-of-support. These are typically pulled in through .NET SDK components.
                                     MsiSwixProject swixProject = _supportsMachineArch[manifestPackage.SdkFeatureBand] ?
                                         new(msiOutputItem, BaseIntermediateOutputPath, BaseOutputPath, manifestPackage.SdkFeatureBand, chip: null, machineArch: msiOutputItem.GetMetadata(Metadata.Platform), outOfSupport: IsOutOfSupportInVisualStudio) :
                                         new(msiOutputItem, BaseIntermediateOutputPath, BaseOutputPath, manifestPackage.SdkFeatureBand, chip: msiOutputItem.GetMetadata(Metadata.Platform), outOfSupport: IsOutOfSupportInVisualStudio);
@@ -478,7 +477,8 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                     // Don't generate a SWIX package if the MSI targets arm64 and VS doesn't support machineArch
                     if (_supportsMachineArch[msi.Package.SdkFeatureBand] || !string.Equals(msiOutputItem.GetMetadata(Metadata.Platform), DefaultValues.arm64))
                     {
-                        // Generate SWIX authoring for the MSI package.
+                        // Generate SWIX authoring for the MSI package. Do not flag manifest MSI packages for out-of-support.
+                        // These are typically pulled in through .NET SDK components.
                         MsiSwixProject swixProject = _supportsMachineArch[msi.Package.SdkFeatureBand] ?
                             new(msiOutputItem, BaseIntermediateOutputPath, BaseOutputPath, msi.Package.SdkFeatureBand, chip: null, machineArch: msiOutputItem.GetMetadata(Metadata.Platform)) :
                             new(msiOutputItem, BaseIntermediateOutputPath, BaseOutputPath, msi.Package.SdkFeatureBand, chip: msiOutputItem.GetMetadata(Metadata.Platform));

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
@@ -72,6 +72,16 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
         }
 
         /// <summary>
+        /// Determines whether the component (and related packs) should be flagged as
+        /// out-of-support in Visual Studio.
+        /// </summary>
+        public bool IsOutOfSupportInVisualStudio
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// The version to assign to workload manifest installers.
         /// </summary>
         public string ManifestMsiVersion
@@ -263,7 +273,6 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                                 packGroupJsonList.Add(packGroupJson);
                             }
 
-
                             foreach (WorkloadPackId packId in wd.Packs)
                             {
                                 WorkloadPack pack = manifest.Packs[packId];
@@ -393,8 +402,8 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                             if (_supportsMachineArch[sdkFeatureBand] || !string.Equals(msiOutputItem.GetMetadata(Metadata.Platform), DefaultValues.arm64))
                             {
                                 MsiSwixProject swixProject = _supportsMachineArch[sdkFeatureBand] ?
-                                    new(msiOutputItem, BaseIntermediateOutputPath, BaseOutputPath, sdkFeatureBand, chip: null, machineArch: msiOutputItem.GetMetadata(Metadata.Platform)) :
-                                    new(msiOutputItem, BaseIntermediateOutputPath, BaseOutputPath, sdkFeatureBand, chip: msiOutputItem.GetMetadata(Metadata.Platform));
+                                    new(msiOutputItem, BaseIntermediateOutputPath, BaseOutputPath, sdkFeatureBand, chip: null, machineArch: msiOutputItem.GetMetadata(Metadata.Platform), outOfSupport: IsOutOfSupportInVisualStudio) :
+                                    new(msiOutputItem, BaseIntermediateOutputPath, BaseOutputPath, sdkFeatureBand, chip: msiOutputItem.GetMetadata(Metadata.Platform), outOfSupport: IsOutOfSupportInVisualStudio);
                                 string swixProj = swixProject.Create();
 
                                 ITaskItem swixProjectItem = new TaskItem(swixProj);
@@ -440,9 +449,10 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                                 // Don't generate a SWIX package if the MSI targets arm64 and VS doesn't support machineArch
                                 if (_supportsMachineArch[manifestPackage.SdkFeatureBand] || !string.Equals(msiOutputItem.GetMetadata(Metadata.Platform), DefaultValues.arm64))
                                 {
+                                    // Do not flag manifest MSI packages for out-of-support. These are typically pulled in through .NET SDK components.
                                     MsiSwixProject swixProject = _supportsMachineArch[manifestPackage.SdkFeatureBand] ?
-                                        new(msiOutputItem, BaseIntermediateOutputPath, BaseOutputPath, manifestPackage.SdkFeatureBand, chip: null, machineArch: msiOutputItem.GetMetadata(Metadata.Platform)) :
-                                        new(msiOutputItem, BaseIntermediateOutputPath, BaseOutputPath, manifestPackage.SdkFeatureBand, chip: msiOutputItem.GetMetadata(Metadata.Platform));
+                                        new(msiOutputItem, BaseIntermediateOutputPath, BaseOutputPath, manifestPackage.SdkFeatureBand, chip: null, machineArch: msiOutputItem.GetMetadata(Metadata.Platform), outOfSupport: IsOutOfSupportInVisualStudio) :
+                                        new(msiOutputItem, BaseIntermediateOutputPath, BaseOutputPath, manifestPackage.SdkFeatureBand, chip: msiOutputItem.GetMetadata(Metadata.Platform), outOfSupport: IsOutOfSupportInVisualStudio);
                                     string swixProj = swixProject.Create();
 
                                     ITaskItem swixProjectItem = new TaskItem(swixProj);
@@ -497,7 +507,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                 // artifacts.                
                 _ = Parallel.ForEach(swixComponents, swixComponent =>
                 {
-                    ComponentSwixProject swixComponentProject = new(swixComponent, BaseIntermediateOutputPath, BaseOutputPath);
+                    ComponentSwixProject swixComponentProject = new(swixComponent, BaseIntermediateOutputPath, BaseOutputPath, IsOutOfSupportInVisualStudio);
                     ITaskItem swixProjectItem = new TaskItem(swixComponentProject.Create());
                     swixProjectItem.SetMetadata(Metadata.SdkFeatureBand, $"{swixComponent.SdkFeatureBand}");
                     swixProjectItem.SetMetadata(Metadata.PackageType, DefaultValues.PackageTypeComponent);

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/ComponentSwixProject.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/ComponentSwixProject.cs
@@ -24,8 +24,8 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
             get;
         }
 
-        public ComponentSwixProject(SwixComponent component, string baseIntermediateOutputPath, string baseOutputPath) :
-            base(component.Name, component.Version, baseIntermediateOutputPath, baseOutputPath)
+        public ComponentSwixProject(SwixComponent component, string baseIntermediateOutputPath, string baseOutputPath, bool outOfSupport = false) :
+            base(component.Name, component.Version, baseIntermediateOutputPath, baseOutputPath, outOfSupport)
         {
             _component = component;
             ValidateRelativePackagePath(GetRelativePackagePath());
@@ -43,6 +43,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
             ReplacementTokens[SwixTokens.__VS_COMPONENT_DESCRIPTION__] = component.Description;
             ReplacementTokens[SwixTokens.__VS_COMPONENT_CATEGORY__] = component.Category;
             ReplacementTokens[SwixTokens.__VS_IS_UI_GROUP__] = component.IsUiGroup ? "yes" : "no";
+            ReplacementTokens[SwixTokens.__VS_PACKAGE_OUT_OF_SUPPORT__] = OutOfSupport ? "yes" : "no";
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/MsiSwixProject.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/MsiSwixProject.wix.cs
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
 
         public MsiSwixProject(ITaskItem msi, string baseIntermediateOutputPath, string baseOutputPath,
             ReleaseVersion sdkFeatureBand,
-            string chip = null, string machineArch = null, string productArch = null) : base(msi.GetMetadata(Metadata.SwixPackageId), new Version(msi.GetMetadata(Metadata.Version)), baseIntermediateOutputPath, baseOutputPath)
+            string chip = null, string machineArch = null, string productArch = null, bool outOfSupport = false) : base(msi.GetMetadata(Metadata.SwixPackageId), new Version(msi.GetMetadata(Metadata.Version)), baseIntermediateOutputPath, baseOutputPath, outOfSupport)
         {
             _msi = msi;
             Chip = chip;
@@ -133,6 +133,11 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
             if (!string.IsNullOrEmpty(MachineArch))
             {
                 msiWriter.WriteLine($"        vs.package.machineArch={MachineArch}");
+            }
+
+            if (OutOfSupport)
+            {
+                msiWriter.WriteLine($"        vs.package.outOfSupport=yes");
             }
 
             msiWriter.WriteLine($"        vs.package.type=msi");

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/SwixProjectBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/SwixProjectBase.cs
@@ -29,6 +29,15 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
         }
 
         /// <summary>
+        /// Determines whether the package is marked as out-of-support.
+        /// </summary>
+        public bool OutOfSupport
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// The version of the SWIX package.
         /// </summary>
         public Version Version
@@ -47,11 +56,12 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
         /// </summary>
         /// <param name="id">The SWIX package ID.</param>
         /// <param name="version">The package version.</param>
-        public SwixProjectBase(string id, Version version, string baseIntermediateOutputPath, string baseOutputPath) :
+        public SwixProjectBase(string id, Version version, string baseIntermediateOutputPath, string baseOutputPath, bool outOfSupport = false) :
             base(baseIntermediateOutputPath, baseOutputPath)
         {
             Id = id;
             Version = version;
+            OutOfSupport = outOfSupport;
 
             ReplacementTokens[SwixTokens.__VS_PACKAGE_NAME__] = Id;
             ReplacementTokens[SwixTokens.__VS_PACKAGE_VERSION__] = $"{Version}";

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/SwixTokens.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/SwixTokens.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
@@ -15,6 +15,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
         public static readonly string __VS_PACKAGE_CHIP__ = nameof(__VS_PACKAGE_CHIP__);
         public static readonly string __VS_PACKAGE_INSTALL_SIZE_SYSTEM_DRIVE__ = nameof(__VS_PACKAGE_INSTALL_SIZE_SYSTEM_DRIVE__);
         public static readonly string __VS_PACKAGE_NAME__ = nameof(__VS_PACKAGE_NAME__);
+        public static readonly string __VS_PACKAGE_OUT_OF_SUPPORT__ = nameof(__VS_PACKAGE_OUT_OF_SUPPORT__);
         public static readonly string __VS_PACKAGE_PRODUCT_ARCH__ = nameof(__VS_PACKAGE_PRODUCT_ARCH__);
         public static readonly string __VS_PAYLOAD_SIZE__ = nameof(__VS_PAYLOAD_SIZE__);
         public static readonly string __VS_PAYLOAD_SOURCE__ = nameof(__VS_PAYLOAD_SOURCE__);

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/SwixTemplate/component.swr
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/SwixTemplate/component.swr
@@ -3,6 +3,7 @@ use vs
 package name=__VS_PACKAGE_NAME__
         version=__VS_PACKAGE_VERSION__
         vs.package.type=component
+        vs.package.outOfSupport=__VS_PACKAGE_OUT_OF_SUPPORT__
 
 vs.properties
   isUiGroup=__VS_IS_UI_GROUP__


### PR DESCRIPTION
## Description

Visual Studio supports marking components and packages as out-of-support and allows removing these packages during installs/upgrades. This change allows workload authors to optionally generate the package property when creating a workload.