### PR TITLE
add changes review request message

### DIFF
--- a/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/ValidateUsageAgainstBaseline.cs
+++ b/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/ValidateUsageAgainstBaseline.cs
@@ -40,9 +40,15 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
         private readonly string _preBuiltDocMessage = "See aka.ms/dotnet/prebuilts " +
             "for guidance on what pre-builts are and how to eliminate them.";
 
+        private readonly string _changesReviewRequestMessage = "Whenever altering this " +
+            "or other Source Build files, please make sure to include @dotnet/source-build-internal " +
+            "as a reviewer";
+
         public override bool Execute()
         {
+            string ChangesReviewRequestComment = $"<!-- {_changesReviewRequestMessage} -->\n";
             string PreBuiltDocXmlComment = $"<!-- {_preBuiltDocMessage} -->\n";
+            
             var used = UsageData.Parse(XElement.Parse(File.ReadAllText(DataFile)));
 
             string baselineText = string.IsNullOrEmpty(BaselineDataFile)
@@ -54,7 +60,7 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
             UsageValidationData data = GetUsageValidationData(baseline, used);
 
             Directory.CreateDirectory(Path.GetDirectoryName(OutputBaselineFile));
-            File.WriteAllText(OutputBaselineFile, PreBuiltDocXmlComment + data.ActualUsageData.ToXml().ToString());
+            File.WriteAllText(OutputBaselineFile, ChangesReviewRequestComment + PreBuiltDocXmlComment + data.ActualUsageData.ToXml().ToString());
 
             Directory.CreateDirectory(Path.GetDirectoryName(OutputReportFile));
             File.WriteAllText(OutputReportFile, PreBuiltDocXmlComment + data.Report.ToString());

--- a/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/ValidateUsageAgainstBaseline.cs
+++ b/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/ValidateUsageAgainstBaseline.cs
@@ -40,13 +40,13 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
         private readonly string _preBuiltDocMessage = "See aka.ms/dotnet/prebuilts " +
             "for guidance on what pre-builts are and how to eliminate them.";
 
-        private readonly string _changesReviewRequestMessage = "Whenever altering this " +
+        private readonly string _reviewRequestMessage = "Whenever altering this " +
             "or other Source Build files, please make sure to include @dotnet/source-build-internal " +
             "as a reviewer";
 
         public override bool Execute()
         {
-            string ChangesReviewRequestComment = $"<!-- {_changesReviewRequestMessage} -->\n";
+            string ReviewRequestComment = $"<!-- {_reviewRequestMessage} -->\n";
             string PreBuiltDocXmlComment = $"<!-- {_preBuiltDocMessage} -->\n";
             
             var used = UsageData.Parse(XElement.Parse(File.ReadAllText(DataFile)));
@@ -60,7 +60,7 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
             UsageValidationData data = GetUsageValidationData(baseline, used);
 
             Directory.CreateDirectory(Path.GetDirectoryName(OutputBaselineFile));
-            File.WriteAllText(OutputBaselineFile, ChangesReviewRequestComment + PreBuiltDocXmlComment + data.ActualUsageData.ToXml().ToString());
+            File.WriteAllText(OutputBaselineFile, ReviewRequestComment + PreBuiltDocXmlComment + data.ActualUsageData.ToXml().ToString());
 
             Directory.CreateDirectory(Path.GetDirectoryName(OutputReportFile));
             File.WriteAllText(OutputReportFile, PreBuiltDocXmlComment + data.Report.ToString());

--- a/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/ValidateUsageAgainstBaseline.cs
+++ b/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/ValidateUsageAgainstBaseline.cs
@@ -4,6 +4,7 @@
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using NuGet.Packaging.Core;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -42,12 +43,12 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
 
         private readonly string _reviewRequestMessage = "Whenever altering this " +
             "or other Source Build files, please make sure to include @dotnet/source-build-internal " +
-            "as a reviewer";
+            "as a reviewer.";
 
         public override bool Execute()
         {
-            string ReviewRequestComment = $"<!-- {_reviewRequestMessage} -->\n";
-            string PreBuiltDocXmlComment = $"<!-- {_preBuiltDocMessage} -->\n";
+            string ReviewRequestComment = $"<!-- {_reviewRequestMessage} -->{Environment.NewLine}";
+            string PreBuiltDocXmlComment = $"<!-- {_preBuiltDocMessage} -->{Environment.NewLine}";
             
             var used = UsageData.Parse(XElement.Parse(File.ReadAllText(DataFile)));
 
@@ -89,8 +90,8 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
                 tellUserToUpdateBaseline = true;
                 Log.LogError(
                     $"{diff.Added.Length} new pre-builts discovered! Detailed usage " +
-                    $"report can be found at {OutputReportFile}.\n{_preBuiltDocMessage}\n" +
-                    $"Package IDs are:\n" + string.Join("\n", diff.Added.Select(u => u.ToString())));
+                    $"report can be found at {OutputReportFile}.{Environment.NewLine}{_preBuiltDocMessage}{Environment.NewLine}" +
+                    $"Package IDs are:{Environment.NewLine}" + string.Join(Environment.NewLine, diff.Added.Select(u => u.ToString())));
 
                 // In the report, list full usage info, not only identity.
                 report.Add(


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/3435

In case a repo encounters pre-builts that cannot be resolved instantly, a repo maintainer could just replace the existing baseline with the generated one to silence the check until the underlying issue is resolved.

To account for this, added the review request to the generated baseline so it does not get lost in this case

@MichaelSimons not sure if this is a valid use-case, it was just cheap to do. Feel free to correct me here
