### PR TITLE
Downgrade S.R.Metadata version in SignTool

### DIFF
--- a/src/Microsoft.DotNet.SignTool/Microsoft.DotNet.SignTool.csproj
+++ b/src/Microsoft.DotNet.SignTool/Microsoft.DotNet.SignTool.csproj
@@ -28,7 +28,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
+    <!-- TODO: Change version back to repo defined $(SystemReflectionMetadataVersion) when VS used is >= 17.6. -->
+    <PackageReference Include="System.Reflection.Metadata" Version="6.0.1" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/13648

As reported in https://github.com/dotnet/arcade/issues/13648, not all consumers of Arcade already use a VS >= 17.6 which is required to load S.R.Metadata and S.C.Immutable 7.0.x.

This commit will be reverted soon when VMs use VS 17.6.
