### PR TITLE
Fix M.DotNet.XUnitAssert package name

### DIFF
--- a/src/Microsoft.DotNet.XUnitAssert/src/Microsoft.DotNet.XUnitAssert.csproj
+++ b/src/Microsoft.DotNet.XUnitAssert/src/Microsoft.DotNet.XUnitAssert.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCurrent);$(NetMinimum)</TargetFrameworks>
     <AssemblyName>xunit.assert</AssemblyName>
+    <PackageId>$(MSBuildProjectName)</PackageId>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
When the assembly name change was reverted the package id changed as well which wasn't expected. Fixing that to unblock https://github.com/dotnet/arcade/pull/13675

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
