### PR TITLE
Add a way to exclude Microsoft.NET.Test.Sdk reference

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.props
@@ -27,7 +27,9 @@
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
     <!-- VS TestExplorer uses this to identify a test project -->
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 
+  <ItemGroup Condition="'$(IsTestProject)' == 'true' and '$(ExcludeMicrosoftNetTestSdk)' != 'true'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" IsImplicitlyDefined="true" />
   </ItemGroup>
 


### PR DESCRIPTION
Change is to add a way to exclude Microsoft.NET.Test.Sdk from a test project. There are some other frameworks (for example C++ UT) where this reference is not needed.

### To double check:

[X] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
