### PR TITLE
Add mechanism to disable shlibs discovery for particular shared libraries

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/deb-package-tool/scripts/config_template_generator.py
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/deb-package-tool/scripts/config_template_generator.py
@@ -66,15 +66,22 @@ def generate_rules(config_data, template_dir):
     template = get_template(template_dir, FILE_RULES)
 
     ignored_dependency_packages = config_data.get("debian_ignored_dependencies", None)
+    ignored_libraries = config_data.get("debian_ignored_libraries", None)
     override_text = ""
 
-    if ignored_dependency_packages != None:
-        override_text = "override_dh_shlibdeps:\n\tdh_shlibdeps --dpkg-shlibdeps-params=\""
+    if ignored_dependency_packages != None or ignored_libraries != None:
+        override_text = "override_dh_shlibdeps:\n\tdh_shlibdeps"
 
-        for package in ignored_dependency_packages:
-            override_text += "-x{0} ".format(package)
+        if ignored_dependency_packages != None:
+            override_text += " --dpkg-shlibdeps-params=\""
+            for package in ignored_dependency_packages:
+                override_text += "-x{0} ".format(package)
 
-        override_text += "\""
+            override_text += "\""
+        
+        if ignored_libraries != None:
+            for library in ignored_libraries:
+                override_text += "-X{0} ".format(library)
 
     return template.format(overrides=override_text)
 


### PR DESCRIPTION
### To double check:

* [X] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation

Add an override mechanism for dotnet/runtime to exclude libraries from dh_shlibs so we can build our deb packages on Ubuntu 22.04.