### PR TITLE
add System.IO.Packaging to Version.Details

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -81,9 +81,11 @@
       <Uri>https://github.com/dotnet/xliff-tasks</Uri>
       <Sha>8fd12314c3e648c03a4189ba0bd1c3b09f5d6a01</Sha>
     </Dependency>
-    <Dependency Name="NuGet.Packaging" Version="6.2.2">
-      <Uri>https://github.com/NuGet/NuGet.Client</Uri>
-      <Sha>027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d</Sha>
+    <!-- Necessary for source-build. This allows the package to be retrieved from previously-source-built artifacts
+         and flow in as dependencies of the packages produced by arcade. -->
+    <Dependency Name="System.IO.Packaging" Version="7.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
     </Dependency>
     <!-- Live version required by source-build. It is loaded in during built-time by
       consumers of SharedFramework.Sdk (such as runtime), so we cannot use a ref pack for it -->


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/3043

Declaring the `System.IO.Packaging` dependency in `Version.Details.xml` will allow source-build to replace the currently used `7.0.0` version with the `n-1` version coming from previously source-built artifacts in the product / VMR build.

Without this change, once repo PvP is enabled for `runtime`, a ref pack of `System.IO.Packaging` would be loaded in, failing the build

Additionally, removed `Nuget.Packaging` from `Version.Details` as an SBRP for the package can now be used - https://github.com/dotnet/source-build-reference-packages/pull/673#issuecomment-1569508658