### PR TITLE
Haiku: Update arcade support

### DIFF
--- a/eng/common/cross/toolchain.cmake
+++ b/eng/common/cross/toolchain.cmake
@@ -207,6 +207,7 @@ elseif(ILLUMOS)
     set(CMAKE_CXX_STANDARD_LIBRARIES "${CMAKE_CXX_STANDARD_LIBRARIES} -lssp")
 elseif(HAIKU)
     set(CMAKE_SYSROOT "${CROSS_ROOTFS}")
+    set(CMAKE_PROGRAM_PATH "${CMAKE_PROGRAM_PATH};${CROSS_ROOTFS}/cross-tools-x86_64/bin")
 
     set(TOOLSET_PREFIX ${TOOLCHAIN}-)
     function(locate_toolchain_exec exec var)
@@ -217,7 +218,6 @@ elseif(HAIKU)
         endif()
 
         find_program(EXEC_LOCATION_${exec}
-            PATHS "${CROSS_ROOTFS}/cross-tools-x86_64/bin"
             NAMES
             "${TOOLSET_PREFIX}${exec}${CLR_CMAKE_COMPILER_FILE_NAME_VERSION}"
             "${TOOLSET_PREFIX}${exec}")

--- a/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/DiscovererHelpers.cs
@@ -32,6 +32,7 @@ namespace Microsoft.DotNet.XUnitExtensions
                 (platforms.HasFlag(TestPlatforms.Android) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"))) ||
                 (platforms.HasFlag(TestPlatforms.Browser) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"))) ||
                 (platforms.HasFlag(TestPlatforms.Wasi) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("WASI"))) ||
+                (platforms.HasFlag(TestPlatforms.Haiku) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("HAIKU"))) ||
                 (platforms.HasFlag(TestPlatforms.Windows) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
 
         public static bool TestRuntimeApplies(TestRuntimes runtimes) =>
@@ -70,7 +71,7 @@ namespace Microsoft.DotNet.XUnitExtensions
             TestRuntimes runtimes = TestRuntimes.Any;
             Type calleeType = null;
             string[] conditionMemberNames = null;
-            
+
             foreach (object arg in ctorArgs.Skip(skipFirst)) // First argument is the issue number or reason.
             {
                 if (arg is TestPlatforms)

--- a/src/Microsoft.DotNet.XUnitExtensions/src/TestPlatforms.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/TestPlatforms.cs
@@ -22,7 +22,8 @@ namespace Xunit
         MacCatalyst = 2048,
         LinuxBionic = 4096,
         Wasi = 8192,
-        AnyUnix = FreeBSD | Linux | NetBSD | OSX | illumos | Solaris | iOS | tvOS | MacCatalyst | Android | Browser | LinuxBionic | Wasi,
+        Haiku = 16384,
+        AnyUnix = FreeBSD | Linux | NetBSD | OSX | illumos | Solaris | iOS | tvOS | MacCatalyst | Android | Browser | LinuxBionic | Wasi | Haiku,
         Any = ~0
     }
 }


### PR DESCRIPTION
- Fix Haiku toolchain detection code.
- Register Haiku to XUnit test platforms as mentioned in [this comment](https://github.com/dotnet/arcade/pull/13437#issuecomment-1549589332).

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
