### PR TITLE
Pass the ignored libraries parameter to dh_shlibdeps directly, not with the dpkg-shlibdeps-params parameter.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/deb-package-tool/scripts/config_template_generator.py
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/deb-package-tool/scripts/config_template_generator.py
@@ -69,19 +69,19 @@ def generate_rules(config_data, template_dir):
     ignored_libraries = config_data.get("debian_ignored_libraries", None)
     override_text = ""
 
-    if ignored_dependency_packages != None or ignored_libraries != None:
+    if ignored_dependency_packages != None:
         override_text = "override_dh_shlibdeps:\n\tdh_shlibdeps"
         override_text += " --dpkg-shlibdeps-params=\""
 
-        if ignored_dependency_packages != None:
-            for package in ignored_dependency_packages:
-                override_text += "-x{0} ".format(package)
-        
-        if ignored_libraries != None:
-            for library in ignored_libraries:
-                override_text += "-X{0} ".format(library)
+        for package in ignored_dependency_packages:
+            override_text += "-x{0} ".format(package)
 
         override_text += "\""
+        
+    if ignored_libraries != None:
+        for library in ignored_libraries:
+            override_text += "-X{0} ".format(library)
+
     return template.format(overrides=override_text)
 
 def generate_changelog(config_data, template_dir, package_version=None, package_name=None):


### PR DESCRIPTION
### To double check:

* [X] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation

This parameter needs to be passed directly, not wrapped in a command to go down to dpkg-shlibdeps.