### PR TITLE
Make sure to emit the override header directive before the command and put spaces before each argument

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/deb-package-tool/scripts/config_template_generator.py
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/deb-package-tool/scripts/config_template_generator.py
@@ -69,8 +69,10 @@ def generate_rules(config_data, template_dir):
     ignored_libraries = config_data.get("debian_ignored_libraries", None)
     override_text = ""
 
-    if ignored_dependency_packages != None:
+    if ignored_dependency_packages != None or ignored_libraries != None:
         override_text = "override_dh_shlibdeps:\n\tdh_shlibdeps"
+
+    if ignored_dependency_packages != None:
         override_text += " --dpkg-shlibdeps-params=\""
 
         for package in ignored_dependency_packages:
@@ -80,7 +82,7 @@ def generate_rules(config_data, template_dir):
         
     if ignored_libraries != None:
         for library in ignored_libraries:
-            override_text += "-X{0} ".format(library)
+            override_text += " -X{0} ".format(library)
 
     return template.format(overrides=override_text)
 


### PR DESCRIPTION
I've validated this script in a build of dotnet/runtime (instead of trying to just match the script to well-known-good output) so this will be the last fix in this area for a while hopefully.
