### PR TITLE
Reduce likelyhood that large containers cause OOMs when repacking

### DIFF
--- a/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
+++ b/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
@@ -214,7 +214,8 @@ namespace Microsoft.DotNet.SignTool
                 var repackList = files.Where(w => toRepackSet.Contains(w.FullPath)).ToList();
 
                 repackCount = repackList.Count();
-                if(repackCount == 0)
+
+                if (repackCount == 0)
                 {
                     return;
                 }
@@ -252,6 +253,11 @@ namespace Microsoft.DotNet.SignTool
                     repackContainer(file);
                     toRepackSet.Remove(file.FullPath);
                 });
+
+                if (largeRepackList.Count == 0)
+                {
+                    return;
+                }
 
                 _log.LogMessage(MessageImportance.High, $"Repacking {largeRepackList.Count} large containers in serial.");
 

--- a/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
+++ b/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
@@ -220,26 +220,64 @@ namespace Microsoft.DotNet.SignTool
                 }
                 _log.LogMessage(MessageImportance.High, $"Repacking {repackCount} containers.");
 
+                const int repackParallelism = 16;
                 ParallelOptions parallelOptions = new ParallelOptions();
-                parallelOptions.MaxDegreeOfParallelism = 16;
-                Parallel.ForEach(repackList, parallelOptions, file =>
+                parallelOptions.MaxDegreeOfParallelism = repackParallelism;
+
+                // It's possible that there are large containers within this set that, if
+                // repacked in parallel, could cause OOMs. To avoid this, we set a limit on the size of containers
+                // that we will repack in parallel based on the parallelism degree and a 2GB limit.
+                // Repack these in serial later.
+                var largeRepackList = new List<FileSignInfo>();
+                var smallRepackList = new List<FileSignInfo>();
+                const long parallelRepackLimitInBytes = (2 * 1024 / repackParallelism) * 1024 * 1024;
+
+                foreach (var file in repackList)
                 {
-                    if (file.IsZipContainer())
+                    FileInfo fileInfo = new FileInfo(file.FullPath);
+                    if (fileInfo.Length > parallelRepackLimitInBytes)
                     {
-                        _log.LogMessage($"Repacking container: '{file.FileName}'");
-                        _batchData.ZipDataMap[file.FileContentKey].Repack(_log);
-                    }
-                    else if (file.IsWixContainer())
-                    {
-                        _log.LogMessage($"Packing wix container: '{file.FileName}'");
-                        _batchData.ZipDataMap[file.FileContentKey].Repack(_log, _signTool.TempDir, _signTool.WixToolsPath);
+                        largeRepackList.Add(file);
                     }
                     else
                     {
-                        _log.LogError($"Don't know how to repack file '{file.FullPath}'");
+                        smallRepackList.Add(file);
                     }
+                }
+
+                _log.LogMessage(MessageImportance.High, $"Repacking {smallRepackList.Count} containers in parallel.");
+
+                Parallel.ForEach(smallRepackList, parallelOptions, file =>
+                {
+                    repackContainer(file);
                     toRepackSet.Remove(file.FullPath);
                 });
+
+                _log.LogMessage(MessageImportance.High, $"Repacking {largeRepackList.Count} large containers in serial.");
+
+                foreach (var file in largeRepackList)
+                {
+                    repackContainer(file);
+                    toRepackSet.Remove(file.FullPath);
+                }
+            }
+
+            void repackContainer(FileSignInfo file)
+            {
+                if (file.IsZipContainer())
+                {
+                    _log.LogMessage($"Repacking container: '{file.FileName}'");
+                    _batchData.ZipDataMap[file.FileContentKey].Repack(_log);
+                }
+                else if (file.IsWixContainer())
+                {
+                    _log.LogMessage($"Packing wix container: '{file.FileName}'");
+                    _batchData.ZipDataMap[file.FileContentKey].Repack(_log, _signTool.TempDir, _signTool.WixToolsPath);
+                }
+                else
+                {
+                    _log.LogError($"Don't know how to repack file '{file.FullPath}'");
+                }
             }
 
             // Is this file ready to be signed or repackaged? That is are all of the items that it depends on already

--- a/src/Microsoft.DotNet.SignTool/src/ZipData.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ZipData.cs
@@ -113,7 +113,8 @@ namespace Microsoft.DotNet.SignTool
         /// </summary>
         private void RepackRawZip(TaskLoggingHelper log)
         {
-            using (var archive = new ZipArchive(File.Open(FileSignInfo.FullPath, FileMode.Open), ZipArchiveMode.Update))
+            using (var zipStream = File.Open(FileSignInfo.FullPath, FileMode.Open))
+            using (var archive = new ZipArchive(zipStream, ZipArchiveMode.Update))
             {
                 foreach (ZipArchiveEntry entry in archive.Entries)
                 {


### PR DESCRIPTION
- 'Using' archive stream in ZipData.cs
- When repacking, make an initial pass over the container set to separate out large/small containers. Then repack small ones in parallel, and large ones in serial. Large and small are determined by a 2GB limit/max parallelism.

In the code, we could have used two loops instead of 3. Instead, I prioritized printing the correct number of containers being packed in parallel vs. serial.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
