### PR TITLE
Fix nested submodule clone in inner source clone

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
@@ -167,7 +167,7 @@
 
       <_GitSubmoduleCloneArgs />
       <_GitSubmoduleCloneArgs>$(_GitSubmoduleCloneArgs) --source .</_GitSubmoduleCloneArgs>
-      <_GitSubmoduleCloneArgs>$(_GitSubmoduleCloneArgs) --dest &quot;%24(echo &quot;${toplevel}/&quot; | sed s+$(RepoRoot)+$(InnerSourceBuildRepoRoot)+)/${sm_path}&quot;</_GitSubmoduleCloneArgs>
+      <_GitSubmoduleCloneArgs>$(_GitSubmoduleCloneArgs) --dest &quot;%24(echo &quot;${toplevel}/&quot; | sed s+$(RepoRoot)+$(InnerSourceBuildRepoRoot)+)${sm_path}&quot;</_GitSubmoduleCloneArgs>
       <_GitSubmoduleCloneArgs Condition="'$(CopyWipIntoInnerSourceBuildRepo)' == 'true'">$(_GitSubmoduleCloneArgs) --copy-wip</_GitSubmoduleCloneArgs>
       <_GitSubmoduleCloneArgs Condition="'$(CleanInnerSourceBuildRepoRoot)' == 'true'">$(_GitSubmoduleCloneArgs) --clean</_GitSubmoduleCloneArgs>
     </PropertyGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
@@ -167,6 +167,18 @@
 
       <_GitSubmoduleCloneArgs />
       <_GitSubmoduleCloneArgs>$(_GitSubmoduleCloneArgs) --source .</_GitSubmoduleCloneArgs>
+      <!-- The destination is set using a bit of bash and msbuild logic that takes the root directory of innermost repository
+           containing the submodule (root of repo, or parent submodule), then replaces that root path with the inner source build root
+           location using sed, and then adds on the subpath of the submodule.
+
+           There are various escaped special characters here:
+           - %24 ensures that msbuild does not attempt to evaluate the whole bash statement as a variable
+           - &quot; ensures that the whole path is quoted.
+
+           We also use an atypical sed replacement delimiter (+), because the typical '/' would occur within paths
+
+           It is expected that when the inner clone goes away, this code goes away.
+      -->
       <_GitSubmoduleCloneArgs>$(_GitSubmoduleCloneArgs) --dest &quot;%24(echo &quot;${toplevel}/&quot; | sed s+$(RepoRoot)+$(InnerSourceBuildRepoRoot)+)${sm_path}&quot;</_GitSubmoduleCloneArgs>
       <_GitSubmoduleCloneArgs Condition="'$(CopyWipIntoInnerSourceBuildRepo)' == 'true'">$(_GitSubmoduleCloneArgs) --copy-wip</_GitSubmoduleCloneArgs>
       <_GitSubmoduleCloneArgs Condition="'$(CleanInnerSourceBuildRepoRoot)' == 'true'">$(_GitSubmoduleCloneArgs) --clean</_GitSubmoduleCloneArgs>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
@@ -177,7 +177,7 @@
 
            We also use an atypical sed replacement delimiter (+), because the typical '/' would occur within paths
 
-           It is expected that when the inner clone goes away, this code goes away.
+           It is expected that when the inner clone goes away, this code goes away (see https://github.com/dotnet/source-build/issues/3072).
       -->
       <_GitSubmoduleCloneArgs>$(_GitSubmoduleCloneArgs) --dest &quot;%24(echo &quot;${toplevel}/&quot; | sed s+$(RepoRoot)+$(InnerSourceBuildRepoRoot)+)${sm_path}&quot;</_GitSubmoduleCloneArgs>
       <_GitSubmoduleCloneArgs Condition="'$(CopyWipIntoInnerSourceBuildRepo)' == 'true'">$(_GitSubmoduleCloneArgs) --copy-wip</_GitSubmoduleCloneArgs>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
@@ -167,7 +167,7 @@
 
       <_GitSubmoduleCloneArgs />
       <_GitSubmoduleCloneArgs>$(_GitSubmoduleCloneArgs) --source .</_GitSubmoduleCloneArgs>
-      <_GitSubmoduleCloneArgs>$(_GitSubmoduleCloneArgs) --dest &quot;$(InnerSourceBuildRepoRoot)$sm_path&quot;</_GitSubmoduleCloneArgs>
+      <_GitSubmoduleCloneArgs>$(_GitSubmoduleCloneArgs) --dest &quot;%24(echo &quot;${toplevel}/&quot; | sed s+$(RepoRoot)+$(InnerSourceBuildRepoRoot)+)/${sm_path}&quot;</_GitSubmoduleCloneArgs>
       <_GitSubmoduleCloneArgs Condition="'$(CopyWipIntoInnerSourceBuildRepo)' == 'true'">$(_GitSubmoduleCloneArgs) --copy-wip</_GitSubmoduleCloneArgs>
       <_GitSubmoduleCloneArgs Condition="'$(CleanInnerSourceBuildRepoRoot)' == 'true'">$(_GitSubmoduleCloneArgs) --clean</_GitSubmoduleCloneArgs>
     </PropertyGroup>


### PR DESCRIPTION
When a submodule has submodules, $sm_path only refers to the subpath from the immediate submodule parent. Based on this, it meant that nested submodules got cloned at the top level repo root. Instead, use $toplevel, which is the full path to the immediate parent.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
