### PR TITLE
Enable ForceNoAlign for msbuild based builds

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -805,7 +805,7 @@ function MSBuild-Core() {
 
   $buildTool = InitializeBuildTool
 
-  $cmdArgs = "$($buildTool.Command) /m /nologo /clp:Summary /v:$verbosity /nr:$nodeReuse /p:ContinuousIntegrationBuild=$ci"
+  $cmdArgs = "$($buildTool.Command) /m /nologo /clp:Summary;ForceNoAlign /v:$verbosity /nr:$nodeReuse /p:ContinuousIntegrationBuild=$ci"
 
   if ($warnAsError) {
     $cmdArgs += ' /warnaserror /p:TreatWarningsAsErrors=true'

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -516,7 +516,7 @@ function MSBuild-Core {
     }
   }
 
-  RunBuildTool "$_InitializeBuildToolCommand" /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse $warnaserror_switch /p:TreatWarningsAsErrors=$warn_as_error /p:ContinuousIntegrationBuild=$ci "$@"
+  RunBuildTool "$_InitializeBuildToolCommand" /m /nologo /clp:Summary;ForceNoAlign /v:$verbosity /nr:$node_reuse $warnaserror_switch /p:TreatWarningsAsErrors=$warn_as_error /p:ContinuousIntegrationBuild=$ci "$@"
 }
 
 function GetDarc {


### PR DESCRIPTION
- This enhances the ability to copy a command line or error message out of the console log without needing to either reconstruct the message across multiple lines, or to use the binlog files to get the data
