### PR TITLE
Revert "Use 1ES pool for secret rotation"

### DIFF
--- a/azure-pipelines-weekly.yaml
+++ b/azure-pipelines-weekly.yaml
@@ -8,40 +8,32 @@ schedules:
     - main
   always: true
 
-variables:
-- template: eng/common/templates/variables/pool-providers.yml
-
 name: $(Date:yyyMMdd)$(Rev:rr)
 stages:
-- stage: SynchronizeSecrets
-  displayName: Synchronize secrets
-  jobs:
-  - job: SynchronizeSecrets
-    displayName: Synchronize secrets
-    pool:
-      name: $(DncEngInternalBuildPool)
-      demands: ImageOverride -equals 1es-windows-2022
+  - stage: SynchronizeSecrets
+    jobs:
+    - job: Synchronize
+      pool:
+        vmImage: windows-latest
 
-    steps:
-    - task: UseDotNet@2
-      displayName: Install .NET
-      inputs:
-        useGlobalJson: true
+      steps:
+      - task: UseDotNet@2
+        displayName: Install Correct .NET Version
+        inputs:
+          useGlobalJson: true
 
-    - task: UseDotNet@2
-      displayName: Install .NET 3.1 runtime
-      inputs:
-        packageType: runtime
-        version: 3.1.x
+      - task: UseDotNet@2
+        displayName: Install .NET 3.1 runtime
+        inputs:
+          packageType: runtime
+          version: 3.1.x
 
-    - script: dotnet tool restore
-      displayName: Install .NET tools
+      - script: dotnet tool restore
 
-    - task: AzureCLI@2
-      displayName: Synchronize secrets
-      inputs:
-        azureSubscription: DotNet Eng Services Secret Manager
-        scriptType: ps
-        scriptLocation: inlineScript
-        inlineScript: |
-          Get-ChildItem .vault-config/*.yaml |% { dotnet secret-manager synchronize $_}
+      - task: AzureCLI@2
+        inputs:
+          azureSubscription: DotNet Eng Services Secret Manager
+          scriptType: ps
+          scriptLocation: inlineScript
+          inlineScript: |
+            Get-ChildItem .vault-config/*.yaml |% { dotnet secret-manager synchronize $_}


### PR DESCRIPTION
Reverts dotnet/arcade#13381

After this change we have been unable to rotate secrets on dotnet/arcade: https://dev.azure.com/dnceng/internal/_build?definitionId=1020

the underlying reason is that with this change we are using a different application for authentication (1ESHostedPoolManagedIdentity ) instead of the secret manager application which has all the necessary permissions to update the secrets

we can chat about a different way to approach this but we need to rotate some secrets and this is blocking us right now