### PR TITLE
Remove all runtime properties from frameworks

### DIFF
--- a/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -215,6 +215,12 @@
       <ProjectRuntimeConfigFilePath>$(IntermediateOutputPath)$(SharedFrameworkName).runtimeconfig.json</ProjectRuntimeConfigFilePath>
       <ProjectRuntimeConfigFilePath Condition="'$(SharedFrameworkHostFileNameOverride)' != ''">$(IntermediateOutputPath)$(SharedFrameworkHostFileNameOverride).runtimeconfig.json</ProjectRuntimeConfigFilePath>
     </PropertyGroup>
+
+    <!-- Remove all runtime config options. SDK sets some of these by default, but those defaults are meant
+         for applications. We don't want any of these to be part of the framework. -->
+    <ItemGroup>
+      <RuntimeHostConfigurationOption Remove="@(RuntimeHostConfigurationOption)" />
+    </ItemGroup>
   </Target>
 
   <Target Name="_GenerateSharedFrameworkRuntimeConfigFile"


### PR DESCRIPTION
The way we produce a shared framework is by simulating a build of an application (to certain degree), running lot of the code from SDK which is meant to build apps.

This includes the part which generates `.runtimeconfig.json` for the framework.

Starting with .NET 6, SDK sets some runtime config options by default of console apps. Because of this process these options became part of the `.runtimeconfig.json` for the framework. In .NET 6 we shipped with one such property (`System.Reflection.Metadata.MetadataUpdater.IsSupported`). In .NET 8 we've added another one `System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization`).

The problem with these options is that the SDK sets them to different values based on which type of app it builds. For example, the `System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization` should be `false` for console apps, but it should be `true` for WindowsDesktop apps (at least for now).

The shared framework is common to all application types though, and so it should not set any values for these options as it can't know the appropriate default.

This change removes all runtime options before we generate the `.runtimeconfig.json`. If we ever need to include a runtime option in a shared framework, it will have to be added after this removal - this change doesn't introduce any such mechanism for now.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation

As far as I can tell there is no existing framework to test shared framework creation, and this change seems small enough to warrant adding an entire infra for it.

I validated that building the `Microsoft.NETCore.App` framework in dotnet/runtime with this change applied locally doesn't produce any runtime options into the `.runtimeconfig.json.

This should resolve the problem in https://github.com/dotnet/sdk/issues/32969 (once it flows to runtime and from runtime to sdk/installer).