### PR TITLE
Remove redundant SourceBuildTrimNetFrameworkTargets property

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -5,7 +5,6 @@
   <PropertyGroup>
     <GitHubRepositoryName>arcade</GitHubRepositoryName>
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
-    <SourceBuildTrimNetFrameworkTargets>true</SourceBuildTrimNetFrameworkTargets>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Part of https://github.com/dotnet/source-build/issues/3503