### PR TITLE
Make prebuilt detection docs links clickable

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,5 +1,5 @@
 <!-- Whenever altering this or other Source Build files, please include @dotnet/source-build-internal as a reviewer. -->
-<!-- See aka.ms/dotnet/prebuilts for guidance on what pre-builts are and how to eliminate them. -->
+<!-- See https://aka.ms/dotnet/prebuilts for guidance on what pre-builts are and how to eliminate them. -->
 
 <UsageData>
   <IgnorePatterns>

--- a/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/ValidateUsageAgainstBaseline.cs
+++ b/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/ValidateUsageAgainstBaseline.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
         [Required]
         public string OutputReportFile { get; set; }
 
-        private readonly string _preBuiltDocMessage = "See aka.ms/dotnet/prebuilts " +
+        private readonly string _preBuiltDocMessage = "See https://aka.ms/dotnet/prebuilts " +
             "for guidance on what pre-builts are and how to eliminate them.";
 
         private readonly string _reviewRequestMessage = "Whenever altering this " +


### PR DESCRIPTION
I noticed that you need copy the URL out but AzDO builds (and most terminals these days) make URLs clickable so it's a better UX.
