### PR TITLE
Package debs with xz compression

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/deb-package-tool/templates/debian/rules
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/deb-package-tool/templates/debian/rules
@@ -6,6 +6,9 @@
 
 {overrides}
 
+override_dh_builddeb:
+	dh_builddeb -- -Zxz
+
 %:
 	dh $@
 


### PR DESCRIPTION
zstd compression is the new default, but it doesn't work downlevel where we still support .NET. Use xz compression so we can build one deb for all debian-based targets.

I've built dotnet/installer with these changes and validated that all of the debs are built with xz compression.

### To double check:

* [X] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
