### PR TITLE
Upgrade NuGet packages from 6.2.2 to 6.2.4

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -33,11 +33,11 @@
     <!-- netstandard -->
     <NETStandardLibraryVersion>2.0.3</NETStandardLibraryVersion>
     <!-- nuget -->
-    <NuGetCommandsVersion>6.2.2</NuGetCommandsVersion>
-    <NuGetFrameworksVersion>6.2.2</NuGetFrameworksVersion>
-    <NuGetPackagingVersion>6.2.2</NuGetPackagingVersion>
-    <NuGetProjectModelVersion>6.2.2</NuGetProjectModelVersion>
-    <NuGetVersioningVersion>6.2.2</NuGetVersioningVersion>
+    <NuGetCommandsVersion>6.2.4</NuGetCommandsVersion>
+    <NuGetFrameworksVersion>6.2.4</NuGetFrameworksVersion>
+    <NuGetPackagingVersion>6.2.4</NuGetPackagingVersion>
+    <NuGetProjectModelVersion>6.2.4</NuGetProjectModelVersion>
+    <NuGetVersioningVersion>6.2.4</NuGetVersioningVersion>
     <!-- roslyn -->
     <MicrosoftCodeAnalysisCSharpVersion>4.6.0</MicrosoftCodeAnalysisCSharpVersion>
     <MicrosoftNetCompilersToolsetVersion>4.6.0</MicrosoftNetCompilersToolsetVersion>


### PR DESCRIPTION
This addresses the CG reports of CVE-2023-29337 by upgrading to version 6.2.4 of NuGet packages.

Related to https://github.com/dotnet/source-build-reference-packages/pull/740