### PR TITLE
Add artifacts pattern to SDL tool arguments

### DIFF
--- a/eng/common/sdl/configure-sdl-tool.ps1
+++ b/eng/common/sdl/configure-sdl-tool.ps1
@@ -92,9 +92,6 @@ try {
         $tool.Args += $CodeQLAdditionalRunConfigParams
       }
       'binskim' {
-        if ($targetDirectory) {
-          $tool.Args += "`"Target < $TargetDirectory`""
-        }
         $tool.Args += $BinskimAdditionalRunConfigParams
       }
     }

--- a/eng/common/sdl/configure-sdl-tool.ps1
+++ b/eng/common/sdl/configure-sdl-tool.ps1
@@ -92,6 +92,9 @@ try {
         $tool.Args += $CodeQLAdditionalRunConfigParams
       }
       'binskim' {
+        if ($targetDirectory) {
+          $tool.Args += "`"Target < $TargetDirectory\**`""
+        }
         $tool.Args += $BinskimAdditionalRunConfigParams
       }
     }

--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -129,7 +129,6 @@ jobs:
       overrideGuardianVersion: ${{ parameters.overrideGuardianVersion }}
       executeAllSdlToolsScript: ${{ parameters.executeAllSdlToolsScript }}
       overrideParameters: ${{ parameters.overrideParameters }}
-      additionalParameters: -ArtifactsDirectory '$(Build.ArtifactStagingDirectory)\artifacts\**'
-        ${{ parameters.additionalParameters }}
+      additionalParameters: ${{ parameters.additionalParameters }}
       publishGuardianDirectoryToPipeline: ${{ parameters.publishGuardianDirectoryToPipeline }}
       sdlContinueOnError: ${{ parameters.sdlContinueOnError }}

--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -129,6 +129,7 @@ jobs:
       overrideGuardianVersion: ${{ parameters.overrideGuardianVersion }}
       executeAllSdlToolsScript: ${{ parameters.executeAllSdlToolsScript }}
       overrideParameters: ${{ parameters.overrideParameters }}
-      additionalParameters: ${{ parameters.additionalParameters }}
+      additionalParameters: -ArtifactsDirectory '$(Build.ArtifactStagingDirectory)\artifacts\**'
+        ${{ parameters.additionalParameters }}
       publishGuardianDirectoryToPipeline: ${{ parameters.publishGuardianDirectoryToPipeline }}
       sdlContinueOnError: ${{ parameters.sdlContinueOnError }}


### PR DESCRIPTION
Passing the path to the artifacts folder as a pattern suitable for BinSkim
We're enabling the BinSkim tool in the repos that run SDL checks in their CI builds as described in [Automate BinSkim runs over official builds issue](https://github.com/dotnet/arcade-services/issues/2647) 


### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
