### PR TITLE
Create ParallelTheory type for running theory cases in parallel instead of sequentially

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ParallelTheoryAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Attributes/ParallelTheoryAttribute.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Microsoft.DotNet.XUnitExtensions.Attributes
+{
+    [XunitTestCaseDiscoverer("Microsoft.DotNet.XUnitExtensions.ParallelTheoryDiscoverer", "Microsoft.DotNet.XUnitExtensions")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public sealed class ParallelTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ParallelTheoryDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Discoverers/ParallelTheoryDiscoverer.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.DotNet.XUnitExtensions
+{
+    public class ParallelTheoryDiscoverer : TheoryDiscoverer
+    {
+        public ParallelTheoryDiscoverer(IMessageSink diagnosticMessageSink) : base(diagnosticMessageSink)
+        {
+        }
+
+        protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
+        {
+            return new[] { new XunitParallelTheoryTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod) };
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XUnitExtensions/src/XunitParallelTheoryTestCase.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/XunitParallelTheoryTestCase.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.DotNet.XUnitExtensions
+{
+    internal sealed class XunitParallelTheoryTestCase : XunitTheoryTestCase
+    {
+        public XunitParallelTheoryTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod)
+            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod)
+        {
+        }
+
+        public override Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink, IMessageBus messageBus, object[] constructorArguments, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
+            => new XunitParallelTheoryTestCaseRunner(this, DisplayName, SkipReason, constructorArguments, diagnosticMessageSink, messageBus, aggregator, cancellationTokenSource).RunAsync();
+    }
+}

--- a/src/Microsoft.DotNet.XUnitExtensions/src/XunitParallelTheoryTestCaseRunner.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/XunitParallelTheoryTestCaseRunner.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.DotNet.XUnitExtensions
+{
+    internal sealed class XunitParallelTheoryTestCaseRunner : XunitTheoryTestCaseRunner
+    {
+        readonly ExceptionAggregator _cleanupAggregator = new();
+
+        public XunitParallelTheoryTestCaseRunner(IXunitTestCase testCase, string displayName, string skipReason, object[] constructorArguments, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
+            : base(testCase, displayName, skipReason, constructorArguments, diagnosticMessageSink, messageBus, aggregator, cancellationTokenSource)
+        {
+            // We want to use the same data discovery functionality of the base type, but the results are not exposed to subclasses.
+            // Use reflection to get the data. Not the best, but it works.
+            DataDiscoveryException = (Func<Exception>)typeof(XunitTheoryTestCaseRunner)
+                .GetProperty("dataDiscoveryException", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+                .GetGetMethod(true)
+                .CreateDelegate(typeof(Func<Exception>), this);
+            TestRunners = (Func<List<XunitTestRunner>>)typeof(XunitTheoryTestCaseRunner)
+                .GetProperty("testRunners", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+                .GetGetMethod(true)
+                .CreateDelegate(typeof(Func<List<XunitTestRunner>>), this);
+            ToDispose = (Func<List<IDisposable>>)typeof(XunitTheoryTestCaseRunner)
+                .GetProperty("toDispose", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+                .GetGetMethod(true)
+                .CreateDelegate(typeof(Func<List<IDisposable>>), this);
+        }
+
+        private Func<Exception> DataDiscoveryException { get; }
+
+        private Func<List<XunitTestRunner>> TestRunners { get; }
+
+        private Func<List<IDisposable>> ToDispose { get; }
+
+        /// <inheritdoc/>
+        protected override async Task<RunSummary> RunTestAsync()
+        {
+            if (DataDiscoveryException() != null)
+                return await base.RunTestAsync();
+
+            var runningTests = new List<Task<RunSummary>>(TestRunners().Count);
+            foreach (var testRunner in TestRunners())
+                runningTests.Add(testRunner.RunAsync());
+
+            var results = await Task.WhenAll(runningTests);
+            var runSummary = new RunSummary();
+            foreach (var result in results)
+            {
+                runSummary.Aggregate(result);
+            }
+            // Run the cleanup here so we can include cleanup time in the run summary,
+            // but save any exceptions so we can surface them during the cleanup phase,
+            // so they get properly reported as test case cleanup failures.
+            var timer = new ExecutionTimer();
+            foreach (var disposable in ToDispose())
+                timer.Aggregate(() => _cleanupAggregator.Run(disposable.Dispose));
+
+            runSummary.Time += timer.Total;
+            return runSummary;
+        }
+
+        /// <inheritdoc/>
+        protected override Task BeforeTestCaseFinishedAsync()
+        {
+            Aggregator.Aggregate(_cleanupAggregator);
+            return base.BeforeTestCaseFinishedAsync();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XUnitExtensions/src/XunitParallelTheoryTestCaseRunner.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/XunitParallelTheoryTestCaseRunner.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,67 +13,168 @@ using Xunit.Sdk;
 
 namespace Microsoft.DotNet.XUnitExtensions
 {
-    internal sealed class XunitParallelTheoryTestCaseRunner : XunitTheoryTestCaseRunner
+    /// <summary>
+    /// This class uses the code from <see cref="XunitTheoryTestCaseRunner"/> with some slight modifications to run tests non-sequentially in <see cref="RunTestAsync"/>.
+    /// </summary>
+    internal sealed class XunitParallelTheoryTestCaseRunner : XunitTestCaseRunner
     {
-        readonly ExceptionAggregator _cleanupAggregator = new();
+        private static readonly object[] s_noArguments = new object[0];
+        private readonly ExceptionAggregator _cleanupAggregator = new();
+        private Exception _dataDiscoveryException;
+        private readonly List<XunitTestRunner> _testRunners = new();
+        private readonly List<IDisposable> _toDispose = new();
 
-        public XunitParallelTheoryTestCaseRunner(IXunitTestCase testCase, string displayName, string skipReason, object[] constructorArguments, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
-            : base(testCase, displayName, skipReason, constructorArguments, diagnosticMessageSink, messageBus, aggregator, cancellationTokenSource)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XunitParallelTheoryTestCaseRunner"/> class.
+        /// </summary>
+        /// <param name="testCase">The test case to be run.</param>
+        /// <param name="displayName">The display name of the test case.</param>
+        /// <param name="skipReason">The skip reason, if the test is to be skipped.</param>
+        /// <param name="constructorArguments">The arguments to be passed to the test class constructor.</param>
+        /// <param name="diagnosticMessageSink">The message sink used to send diagnostic messages</param>
+        /// <param name="messageBus">The message bus to report run status to.</param>
+        /// <param name="aggregator">The exception aggregator used to run code and collect exceptions.</param>
+        /// <param name="cancellationTokenSource">The task cancellation token source, used to cancel the test run.</param>
+        public XunitParallelTheoryTestCaseRunner(IXunitTestCase testCase,
+                                         string displayName,
+                                         string skipReason,
+                                         object[] constructorArguments,
+                                         IMessageSink diagnosticMessageSink,
+                                         IMessageBus messageBus,
+                                         ExceptionAggregator aggregator,
+                                         CancellationTokenSource cancellationTokenSource)
+            : base(testCase, displayName, skipReason, constructorArguments, s_noArguments, messageBus, aggregator, cancellationTokenSource)
         {
-            // We want to use the same data discovery functionality of the base type, but the results are not exposed to subclasses.
-            // Use reflection to get the data. Not the best, but it works.
-            DataDiscoveryException = (Func<Exception>)typeof(XunitTheoryTestCaseRunner)
-                .GetProperty("dataDiscoveryException", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
-                .GetGetMethod(true)
-                .CreateDelegate(typeof(Func<Exception>), this);
-            TestRunners = (Func<List<XunitTestRunner>>)typeof(XunitTheoryTestCaseRunner)
-                .GetProperty("testRunners", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
-                .GetGetMethod(true)
-                .CreateDelegate(typeof(Func<List<XunitTestRunner>>), this);
-            ToDispose = (Func<List<IDisposable>>)typeof(XunitTheoryTestCaseRunner)
-                .GetProperty("toDispose", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
-                .GetGetMethod(true)
-                .CreateDelegate(typeof(Func<List<IDisposable>>), this);
+            DiagnosticMessageSink = diagnosticMessageSink;
         }
 
-        private Func<Exception> DataDiscoveryException { get; }
-
-        private Func<List<XunitTestRunner>> TestRunners { get; }
-
-        private Func<List<IDisposable>> ToDispose { get; }
+        private IMessageSink DiagnosticMessageSink { get; }
 
         /// <inheritdoc/>
-        protected override async Task<RunSummary> RunTestAsync()
+        protected override async Task AfterTestCaseStartingAsync()
         {
-            if (DataDiscoveryException() != null)
-                return await base.RunTestAsync();
+            await base.AfterTestCaseStartingAsync();
 
-            var runningTests = new List<Task<RunSummary>>(TestRunners().Count);
-            foreach (var testRunner in TestRunners())
-                runningTests.Add(testRunner.RunAsync());
-
-            var results = await Task.WhenAll(runningTests);
-            var runSummary = new RunSummary();
-            foreach (var result in results)
+            try
             {
-                runSummary.Aggregate(result);
-            }
-            // Run the cleanup here so we can include cleanup time in the run summary,
-            // but save any exceptions so we can surface them during the cleanup phase,
-            // so they get properly reported as test case cleanup failures.
-            var timer = new ExecutionTimer();
-            foreach (var disposable in ToDispose())
-                timer.Aggregate(() => _cleanupAggregator.Run(disposable.Dispose));
+                IEnumerable<IAttributeInfo> dataAttributes = TestCase.TestMethod.Method.GetCustomAttributes(typeof(DataAttribute));
 
-            runSummary.Time += timer.Total;
-            return runSummary;
+                foreach (IAttributeInfo dataAttribute in dataAttributes)
+                {
+                    IAttributeInfo discovererAttribute = dataAttribute.GetCustomAttributes(typeof(DataDiscovererAttribute)).First();
+
+                    IDataDiscoverer discoverer;
+                    try
+                    {
+                        discoverer = ExtensibilityPointFactory.GetDataDiscoverer(DiagnosticMessageSink, discovererAttribute);
+                    }
+                    catch (InvalidCastException)
+                    {
+                        if (dataAttribute is IReflectionAttributeInfo reflectionAttribute)
+                            Aggregator.Add(new InvalidOperationException($"Data discoverer specified for {reflectionAttribute.Attribute.GetType()} on {TestCase.TestMethod.TestClass.Class.Name}.{TestCase.TestMethod.Method.Name} does not implement IDataDiscoverer."));
+                        else
+                            Aggregator.Add(new InvalidOperationException($"A data discoverer specified on {TestCase.TestMethod.TestClass.Class.Name}.{TestCase.TestMethod.Method.Name} does not implement IDataDiscoverer."));
+
+                        continue;
+                    }
+
+                    IEnumerable<object[]> data = discoverer.GetData(dataAttribute, TestCase.TestMethod.Method);
+                    if (data == null)
+                    {
+                        Aggregator.Add(new InvalidOperationException($"Test data returned null for {TestCase.TestMethod.TestClass.Class.Name}.{TestCase.TestMethod.Method.Name}. Make sure it is statically initialized before this test method is called."));
+                        continue;
+                    }
+
+                    foreach (object[] dataRow in data)
+                    {
+                        _toDispose.AddRange(dataRow.OfType<IDisposable>());
+
+                        ITypeInfo[] resolvedTypes = null;
+                        MethodInfo methodToRun = TestMethod;
+                        object[] convertedDataRow = methodToRun.ResolveMethodArguments(dataRow);
+
+                        if (methodToRun.IsGenericMethodDefinition)
+                        {
+                            resolvedTypes = TestCase.TestMethod.Method.ResolveGenericTypes(convertedDataRow);
+                            methodToRun = methodToRun.MakeGenericMethod(resolvedTypes.Select(t => ((IReflectionTypeInfo)t).Type).ToArray());
+                        }
+
+                        Type[] parameterTypes = methodToRun.GetParameters().Select(p => p.ParameterType).ToArray();
+                        convertedDataRow = Reflector.ConvertArguments(convertedDataRow, parameterTypes);
+
+                        string theoryDisplayName = TestCase.TestMethod.Method.GetDisplayNameWithArguments(DisplayName, convertedDataRow, resolvedTypes);
+                        ITest test = CreateTest(TestCase, theoryDisplayName);
+                        string skipReason = SkipReason ?? dataAttribute.GetNamedArgument<string>("Skip");
+                        _testRunners.Add(CreateTestRunner(test, MessageBus, TestClass, ConstructorArguments, methodToRun, convertedDataRow, skipReason, BeforeAfterAttributes, Aggregator, CancellationTokenSource));
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // Stash the exception so we can surface it during RunTestAsync
+                _dataDiscoveryException = ex;
+            }
         }
 
         /// <inheritdoc/>
         protected override Task BeforeTestCaseFinishedAsync()
         {
             Aggregator.Aggregate(_cleanupAggregator);
+
             return base.BeforeTestCaseFinishedAsync();
+        }
+
+        /// <inheritdoc/>
+        protected override async Task<RunSummary> RunTestAsync()
+        {
+            if (_dataDiscoveryException != null)
+                return RunTest_DataDiscoveryException();
+
+            var runningTests = new List<Task<RunSummary>>(_testRunners.Count);
+            foreach (XunitTestRunner testRunner in _testRunners)
+                runningTests.Add(testRunner.RunAsync());
+
+            RunSummary[] results = await Task.WhenAll(runningTests);
+            var runSummary = new RunSummary();
+            foreach (RunSummary result in results)
+            {
+                runSummary.Aggregate(result);
+            }
+
+            // Run the cleanup here so we can include cleanup time in the run summary,
+            // but save any exceptions so we can surface them during the cleanup phase,
+            // so they get properly reported as test case cleanup failures.
+            var timer = new ExecutionTimer();
+            foreach (IDisposable disposable in _toDispose)
+                timer.Aggregate(() => _cleanupAggregator.Run(disposable.Dispose));
+
+            runSummary.Time += timer.Total;
+            return runSummary;
+        }
+
+        private RunSummary RunTest_DataDiscoveryException()
+        {
+            var test = new XunitTest(TestCase, DisplayName);
+
+            if (!MessageBus.QueueMessage(new TestStarting(test)))
+                CancellationTokenSource.Cancel();
+            else if (!MessageBus.QueueMessage(new TestFailed(test, 0, null, Unwrap(_dataDiscoveryException))))
+                CancellationTokenSource.Cancel();
+            if (!MessageBus.QueueMessage(new TestFinished(test, 0, null)))
+                CancellationTokenSource.Cancel();
+
+            return new RunSummary { Total = 1, Failed = 1 };
+        }
+
+        private static Exception Unwrap(Exception ex)
+        {
+            while (true)
+            {
+                if (ex is not TargetInvocationException tiex)
+                    return ex;
+
+                ex = tiex.InnerException;
+            }
         }
     }
 }


### PR DESCRIPTION
Add a new `ParallelTheory` attribute to our xunit extensions to enable running different theory cases in parallel. In dotnet/runtime and in the diagnostic tests space, we have many `Theory`-based tests that have hundreds of cases that also have no dependencies on the containing type, test collections, etc. These tests can run in parallel, but are currently limited to running sequentially.

For example, the `Compiles.ValidateSnippets` tests for `LibraryImportGenerator` could run the separate cases fully in parallel instead of sequentially and would execute significantly quicker (the test run generally takes a minute and a half on my machine for just this test, whereas the rest of the test suite is very quick in comparison). This attribute would allow us to selectively parallelize theories that we know can run in parallel.

### To double check

* [ ] The right tests are in and and the right validation has happened.  Guidance:  <https://github.com/dotnet/arcade/tree/main/Documentation/Validation>
