### PR TITLE
Update Versions.props

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -63,9 +63,6 @@
     <SystemTextJsonVersion>7.0.2</SystemTextJsonVersion>
     <!-- sdk -->
     <MicrosoftNetSdkWorkloadManifestReaderVersion>8.0.100-preview.3.23178.3</MicrosoftNetSdkWorkloadManifestReaderVersion>
-    <!-- sourcelink -->
-    <MicrosoftSourceLinkGitHubVersion>8.0.0-beta.23361.2</MicrosoftSourceLinkGitHubVersion>
-    <MicrosoftSourceLinkAzureReposGitVersion>8.0.0-beta.23361.2</MicrosoftSourceLinkAzureReposGitVersion>
     <!-- symreader-converter -->
     <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta2-19575-01</MicrosoftDiaSymReaderPdb2PdbVersion>
     <!-- templating -->


### PR DESCRIPTION
These versions aren't used anymore now with an updated Arcade.Sdk.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
