### PR TITLE
Replace MD5 with SHA2

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             bool result = createWorkloadTask.Execute();
 
             Assert.True(result);
-            ITaskItem manifestMsiItem = createWorkloadTask.Msis.Where(m => m.ItemSpec.ToLowerInvariant().Contains("8611bf463c6ff41092008be7191ad949-x64.msi")).FirstOrDefault();
+            ITaskItem manifestMsiItem = createWorkloadTask.Msis.Where(m => m.ItemSpec.ToLowerInvariant().Contains("ff575e3118bd60fedcf654569551f4b2-x64.msi")).FirstOrDefault();
             Assert.NotNull(manifestMsiItem);
 
             // Spot check one of the manifest MSIs. We have additional tests that cover MSI generation.
@@ -202,7 +202,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             bool result = createWorkloadTask.Execute();
 
             Assert.True(result);
-            ITaskItem manifestMsiItem = createWorkloadTask.Msis.Where(m => m.ItemSpec.ToLowerInvariant().Contains("8611bf463c6ff41092008be7191ad949-arm64.msi")).FirstOrDefault();
+            ITaskItem manifestMsiItem = createWorkloadTask.Msis.Where(m => m.ItemSpec.ToLowerInvariant().Contains("ff575e3118bd60fedcf654569551f4b2-arm64.msi")).FirstOrDefault();
             Assert.NotNull(manifestMsiItem);
 
             // Spot check one of the manifest MSIs. We have additional tests that cover MSI generation.

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             bool result = createWorkloadTask.Execute();
 
             Assert.True(result);
-            ITaskItem manifestMsiItem = createWorkloadTask.Msis.Where(m => m.ItemSpec.ToLowerInvariant().Contains("ff575e3118bd60fedcf654569551f4b2-x64.msi")).FirstOrDefault();
+            ITaskItem manifestMsiItem = createWorkloadTask.Msis.Where(m => m.ItemSpec.ToLowerInvariant().Contains("d96ba8044ad35589f97716ecbf2732fb-x64.msi")).FirstOrDefault();
             Assert.NotNull(manifestMsiItem);
 
             // Spot check one of the manifest MSIs. We have additional tests that cover MSI generation.
@@ -202,7 +202,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             bool result = createWorkloadTask.Execute();
 
             Assert.True(result);
-            ITaskItem manifestMsiItem = createWorkloadTask.Msis.Where(m => m.ItemSpec.ToLowerInvariant().Contains("ff575e3118bd60fedcf654569551f4b2-arm64.msi")).FirstOrDefault();
+            ITaskItem manifestMsiItem = createWorkloadTask.Msis.Where(m => m.ItemSpec.ToLowerInvariant().Contains("d96ba8044ad35589f97716ecbf2732fb-arm64.msi")).FirstOrDefault();
             Assert.NotNull(manifestMsiItem);
 
             // Spot check one of the manifest MSIs. We have additional tests that cover MSI generation.

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Msi/MsiBase.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Msi/MsiBase.wix.cs
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Msi
         /// <summary>
         /// The filename of the MSI file to generate.
         /// </summary>
-        protected string OutputName => $"{Utils.GetHash(BaseOutputName, HashAlgorithmName.MD5)}-{Platform}.msi";
+        protected string OutputName => $"{Utils.GetHash(BaseOutputName, HashAlgorithmName.SHA256)}-{Platform}.msi";
 
         /// <summary>
         /// The directory where the WiX source code will be generated.

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Msi/MsiBase.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Msi/MsiBase.wix.cs
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Msi
         /// <summary>
         /// The filename of the MSI file to generate.
         /// </summary>
-        protected string OutputName => $"{Utils.GetHash(BaseOutputName, HashAlgorithmName.SHA256)}-{Platform}.msi";
+        protected string OutputName => $"{Utils.GetTruncatedHash(BaseOutputName, HashAlgorithmName.SHA256)}-{Platform}.msi";
 
         /// <summary>
         /// The directory where the WiX source code will be generated.

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/MsiSwixProject.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/MsiSwixProject.wix.cs
@@ -87,7 +87,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
             // For drop publishing all the JSON manifests and payloads must reside in the same folder so we shorten the project names
             // and use a hashed filename to avoid path too long errors.
             string hashInputs = $"{Id},{Version.ToString(3)},{sdkFeatureBand},{Platform},{Chip},{machineArch}";
-            ProjectFile = $"{Utils.GetHash(hashInputs, HashAlgorithmName.SHA256)}.swixproj";
+            ProjectFile = $"{Utils.GetTruncatedHash(hashInputs, HashAlgorithmName.SHA256)}.swixproj";
 
             ReplacementTokens[SwixTokens.__VS_PAYLOAD_SOURCE__] = msi.GetMetadata(Metadata.FullPath);
         }

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/MsiSwixProject.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/MsiSwixProject.wix.cs
@@ -87,7 +87,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
             // For drop publishing all the JSON manifests and payloads must reside in the same folder so we shorten the project names
             // and use a hashed filename to avoid path too long errors.
             string hashInputs = $"{Id},{Version.ToString(3)},{sdkFeatureBand},{Platform},{Chip},{machineArch}";
-            ProjectFile = $"{Utils.GetHash(hashInputs, HashAlgorithmName.MD5)}.swixproj";
+            ProjectFile = $"{Utils.GetHash(hashInputs, HashAlgorithmName.SHA256)}.swixproj";
 
             ReplacementTokens[SwixTokens.__VS_PAYLOAD_SOURCE__] = msi.GetMetadata(Metadata.FullPath);
         }

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Utils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Utils.cs
@@ -32,7 +32,9 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                 sb.Append(b.ToString("x2"));
             }
 
-            return sb.ToString();
+            string result = sb.ToString();
+
+            return result.Substring(result.Length / 2);
         }
 
         /// <summary>
@@ -51,7 +53,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
         /// <param name="id">The identifier to convert to a safe identifier</param>
         /// <returns>The safe identifier.</returns>
         internal static string ToSafeId(string id, string suffix = null) =>
-            id.Replace("-", ".").Replace(" ", ".").Replace("_", ".")+
+            id.Replace("-", ".").Replace(" ", ".").Replace("_", ".") +
             (string.IsNullOrWhiteSpace(suffix) ? null : $".{suffix}");
 
         /// <summary>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Utils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Utils.cs
@@ -14,12 +14,12 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
     public class Utils
     {
         /// <summary>
-        /// Generate a hash for a string value using a given hash algorithm.
+        /// Generate a truncated hash (first 16 bytes) for a string value using a given hash algorithm.
         /// </summary>
         /// <param name="value">The value to hash.</param>
         /// <param name="hashName">The name of the <see cref="HashAlgorithm"/> to use.</param>
         /// <returns>A string containing the hash result.</returns>
-        public static string GetHash(string value, HashAlgorithmName hashName)
+        public static string GetTruncatedHash(string value, HashAlgorithmName hashName)
         {
             byte[] bytes = Encoding.UTF8.GetBytes(value);
 #pragma warning disable SYSLIB0045 // Cryptographic factory methods accepting an algorithm name are obsolete. Use the parameterless Create factory method on the algorithm type instead.
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
 
             string result = sb.ToString();
 
-            return result.Substring(result.Length / 2);
+            return result.Substring(0, 32);
         }
 
         /// <summary>


### PR DESCRIPTION
Use SHA256 when generating workload MSI names.
