### PR TITLE
Improve duplicate asset error handling

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishToSymbolServerTest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishToSymbolServerTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -90,7 +91,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                 BuildEngine = buildEngine,
             };
             var path = TestInputs.GetFullPath("Symbol");
-            var buildAsset = new Dictionary<string, HashSet<Asset>>();
+            var buildAsset = new Dictionary<string, Asset>().AsReadOnly();
             await task.HandleSymbolPublishingAsync(path, MsdlToken, SymWebToken, "", false, buildAsset, null, path);
             Assert.True(task.Log.HasLoggedErrors);
         }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -92,7 +93,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 // of the assets being published so we can add a new location for them.
                 IMaestroApi client = ApiFactory.GetAuthenticated(MaestroApiEndpoint, BuildAssetRegistryToken);
                 Maestro.Client.Models.Build buildInformation = await client.Builds.GetBuildAsync(BARBuildId);
-                Dictionary<string, HashSet<Asset>> buildAssets = CreateBuildAssetDictionary(buildInformation);
+                ReadOnlyDictionary<string, Asset> buildAssets = CreateBuildAssetDictionary(buildInformation);
+
+                if (Log.HasLoggedErrors)
+                {
+                    return false;
+                }
 
                 foreach (var targetChannelId in targetChannelsIds.Distinct())
                 {


### PR DESCRIPTION
Right now it's possible for a build to contain a set of assets with duplicated names. This can occur in various places:
- Merged manifest contains dupes
- Maestro build asset list contains dupes

These may not be exact dupes. You could have two assets with the same name but different versions. However, I think this scenario should generally be disallowed. A Maestro build with multiple assets with the same name would not be able to successfully flow dependencies downstream. What is chosen to flow downstream would essentially be arbitrary, which is not desirable.

So, I think we should take steps to disallow this scenario and harden against it. Fully hardening against it will require changes at multiple levels:
- Manifest merging (disallow duplicate entries even with same name + version)
- Maestro build asset upload
- Arcade publishing.

It's important to harden in multiple locations to improve error handling and avoid missing some code paths (e.g. if the merging code was updated in some branches but not others).

This PR begins this process by hardening the publishing phase. In addition, some general code cleanup and refactoring was performed. Dead code was removed.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
