### PR TITLE
Exclude _.pdb files from BinSkim scan.

### DIFF
--- a/eng/common/sdl/configure-sdl-tool.ps1
+++ b/eng/common/sdl/configure-sdl-tool.ps1
@@ -93,7 +93,7 @@ try {
       }
       'binskim' {
         if ($targetDirectory) {
-          # There is an issue with Binskim related to scanning specific PDBs. GitHub issue: https://github.com/microsoft/binskim/issues/924.
+          # Binskim crashes due to specific PDBs. GitHub issue: https://github.com/microsoft/binskim/issues/924.
           # We are excluding all `_.pdb` files from the scan.
           $tool.Args += "`"Target < $TargetDirectory\**;-:file|$TargetDirectory\**\_.pdb`""
         }

--- a/eng/common/sdl/configure-sdl-tool.ps1
+++ b/eng/common/sdl/configure-sdl-tool.ps1
@@ -93,7 +93,9 @@ try {
       }
       'binskim' {
         if ($targetDirectory) {
-          $tool.Args += "`"Target < $TargetDirectory\**`""
+          # There is an issue with Binskim related to scanning specific PDBs. GitHub issue: https://github.com/microsoft/binskim/issues/924.
+          # We are excluding all `_.pdb` files from the scan.
+          $tool.Args += "`"Target < $TargetDirectory\**;-:file|$TargetDirectory\**\_.pdb`""
         }
         $tool.Args += $BinskimAdditionalRunConfigParams
       }


### PR DESCRIPTION
Certain PDBs causing Binskim to behave unexpectedly and crash with Out of memory exception. https://github.com/dotnet/arcade-services/issues/2744

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
