### PR TITLE
Avoid alerting CG when an intermediate nupkg contains "vulnerable" dependencies

### DIFF
--- a/eng/common/templates/steps/source-build.yml
+++ b/eng/common/templates/steps/source-build.yml
@@ -121,6 +121,8 @@ steps:
 
 # Manually inject component detection so that we can ignore the source build upstream cache, which contains
 # a nupkg cache of input packages (a local feed).
+# This path must match the upstream cache path in property 'CurrentRepoSourceBuiltNupkgCacheDir'
+# in src\Microsoft.DotNet.Arcade.Sdk\tools\SourceBuild\SourceBuildArcade.targets
 - task: ComponentGovernanceComponentDetection@0
   displayName: Component Detection (Exclude upstream cache)
   inputs:

--- a/eng/common/templates/steps/source-build.yml
+++ b/eng/common/templates/steps/source-build.yml
@@ -118,3 +118,10 @@ steps:
     artifactName: BuildLogs_SourceBuild_${{ parameters.platform.name }}_Attempt$(System.JobAttempt)
   continueOnError: true
   condition: succeededOrFailed()
+
+# Manually inject component detection so that we can ignore the source build upstream cache, which contains
+# a nupkg cache of input packages (a local feed).
+- task: ComponentGovernanceComponentDetection@0
+  displayName: Component Detection (Exclude upstream cache)
+  inputs:
+    ignoreDirectories: '$(Build.SourcesDirectory)/artifacts/source-build/self/src/artifacts/obj/source-built-upstream-cache'

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -19,6 +19,8 @@
     <CurrentRepoSourceBuildArtifactsDir>$([MSBuild]::NormalizeDirectory('$(CurrentRepoSourceBuildSourceDir)', 'artifacts'))</CurrentRepoSourceBuildArtifactsDir>
     <CurrentRepoSourceBuildArtifactsPackagesDir>$([MSBuild]::NormalizeDirectory('$(CurrentRepoSourceBuildArtifactsDir)', 'packages', '$(Configuration)'))</CurrentRepoSourceBuildArtifactsPackagesDir>
 
+    <CurrentRepoSourceBuildNuGetSourceName>source-build-int-nupkg-cache</CurrentRepoSourceBuildNuGetSourceName>
+    <!-- If this path is updated, also update the component detection task in eng\common\templates\steps\source-build.yml -->
     <CurrentRepoSourceBuiltNupkgCacheDir>$([MSBuild]::NormalizeDirectory('$(CurrentRepoSourceBuildArtifactsDir)', 'obj', 'source-built-upstream-cache'))</CurrentRepoSourceBuiltNupkgCacheDir>
 
     <PrebuiltBaselineDataFileDefault>$(RepositoryEngineeringDir)SourceBuildPrebuiltBaseline.xml</PrebuiltBaselineDataFileDefault>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
@@ -36,11 +36,6 @@
             (('$(ArcadeBuildFromSource)' == 'true' and '$(ArcadeInnerBuildFromSource)' == 'true' and '@(SourceBuildIntermediateNupkgReference)' != '') or
               '$(SetUpSourceBuildIntermediateNupkgCache)' == 'true')"
           AfterTargets="Restore">
-    <PropertyGroup>
-      <SourceBuildNuGetSourceName>source-build-int-nupkg-cache</SourceBuildNuGetSourceName>
-      <SourceBuiltNupkgCacheDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsObjDir)', 'source-built-upstream-cache'))</SourceBuiltNupkgCacheDir>
-    </PropertyGroup>
-
     <ItemGroup>
       <IntermediateNupkgSourceDir Include="$([MSBuild]::NormalizeDirectory(
         '$(NuGetPackageRoot)',
@@ -56,7 +51,7 @@
 
     <Copy
       SourceFiles="@(SourceBuiltNupkgFile)"
-      DestinationFiles="@(SourceBuiltNupkgFile -> '$(SourceBuiltNupkgCacheDir)%(Filename)%(Extension)')" />
+      DestinationFiles="@(SourceBuiltNupkgFile -> '$(CurrentRepoSourceBuiltNupkgCacheDir)%(Filename)%(Extension)')" />
 
     <!-- Remove the original source build intermediate directory. The extracted cached remains.
          This ensures that all sources of intermediates are in the nupkg cache dir, and tooling like CG can
@@ -66,12 +61,12 @@
 
     <AddSourceToNuGetConfig
       NuGetConfigFile="$(RestoreConfigFile)"
-      SourceName="$(SourceBuildNuGetSourceName)"
-      SourcePath="$(SourceBuiltNupkgCacheDir)" />
+      SourceName="$(CurrentRepoSourceBuildNuGetSourceName)"
+      SourcePath="$(CurrentRepoSourceBuiltNupkgCacheDir)" />
 
     <AddSourceMappingToNugetConfig
       NuGetConfigFile="$(RestoreConfigFile)"
-      SourceName="$(SourceBuildNuGetSourceName)" />
+      SourceName="$(CurrentRepoSourceBuildNuGetSourceName)" />
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
@@ -45,15 +45,24 @@
       <IntermediateNupkgSourceDir Include="$([MSBuild]::NormalizeDirectory(
         '$(NuGetPackageRoot)',
         '$([System.String]::new(`%(SourceBuildIntermediateNupkgReference.Identity)`).ToLowerInvariant())',
-        '$([System.String]::new(`%(SourceBuildIntermediateNupkgReference.ExactVersion)`).ToLowerInvariant())',
+        '$([System.String]::new(`%(SourceBuildIntermediateNupkgReference.ExactVersion)`).ToLowerInvariant())'))" />
+
+      <IntermediateNupkgSourceArtifactsDir Include="$([MSBuild]::NormalizeDirectory(
+        '$([System.String]::new(`%(IntermediateNupkgSourceDir.Identity)`).ToLowerInvariant())',
         'artifacts'))" />
 
-      <SourceBuiltNupkgFile Include="%(IntermediateNupkgSourceDir.Identity)**\*.nupkg" />
+      <SourceBuiltNupkgFile Include="%(IntermediateNupkgSourceArtifactsDir.Identity)**\*.nupkg" />
     </ItemGroup>
 
     <Copy
       SourceFiles="@(SourceBuiltNupkgFile)"
       DestinationFiles="@(SourceBuiltNupkgFile -> '$(SourceBuiltNupkgCacheDir)%(Filename)%(Extension)')" />
+
+    <!-- Remove the original source build intermediate directory. The extracted cached remains.
+         This ensures that all sources of intermediates are in the nupkg cache dir, and tooling like CG can
+         exclude scanning of these directories, instead focusing on whether the packages are utilized rather
+         than simply available. -->
+    <RemoveDir Directories="@(IntermediateNupkgSourceDir)" />
 
     <AddSourceToNuGetConfig
       NuGetConfigFile="$(RestoreConfigFile)"


### PR DESCRIPTION
This change resolves https://github.com/dotnet/source-build/issues/3559.

When a repo restores the source build intermediates and places them in the package cache, it's essentially populating a local nuget feed. This feed should as a set of packages that _may_ be used, but are not necessarily used. When a package is restored from this feed, it is extracted and appears in the package root. Component Detection, unfortunately, picks up any .nupkg file that exists under the source or artifacts directories, which picks up the local package cache, even if those packages are not used by the repo. This tends to generate noise for repos because of SBRP's contents.

To fix this issue, we apply two changes:
- Delete the intermediate nupkg's extracted location after populating cache - The PackageReferences used to obtain the source build intermediates populate the nuget package root. We then copy the nupkg contents (nupkgs themselves) into the package cache. At this point, the original extracted nupkg is of no use. Deleting it removes one location where CG may detect .nupkgs that are available, but not necessarily used, by the repo.
- Use an explicit CG scanning step that excludes the package cache - Alter the source-build template to exclude the package cache (local feed).

This leaves the nuget package root "cleaner" as it should contain only .nupkg files that are actually utilized by the repo, and detection will include only the packages that are actually used by the repo.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
