### PR TITLE
Remove unused argument from initDistroRidGlobal

### DIFF
--- a/eng/common/native/init-distro-rid.sh
+++ b/eng/common/native/init-distro-rid.sh
@@ -79,7 +79,6 @@ getNonPortableDistroRid()
 # Input:
 #   os: (str)
 #   arch: (str)
-#   isPortable: (int)
 #   rootfsDir?: (nullable:string)
 #
 # Return:
@@ -97,10 +96,9 @@ initDistroRidGlobal()
 {
     local targetOs="$1"
     local targetArch="$2"
-    local isPortable="$3"
     local rootfsDir=""
-    if [ "$#" -ge 4 ]; then
-        rootfsDir="$4"
+    if [ "$#" -ge 3 ]; then
+        rootfsDir="$3"
     fi
 
     if [ -n "${rootfsDir}" ]; then


### PR DESCRIPTION
This was just added in https://github.com/dotnet/arcade/pull/13947 and not consumed yet. While trying to make another repo use it, I realized the `isPortable` argument to `initDistroRidGlobal` was not used.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
