### PR TITLE
Temporary disable trimming the version from the NuGet packages for the SDL validation stage.

### DIFF
--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -105,11 +105,6 @@ jobs:
         downloadPath: $(Build.ArtifactStagingDirectory)\artifacts
         checkDownloadedFiles: true
 
-  - powershell: eng/common/sdl/trim-assets-version.ps1
-      -InputPath $(Build.ArtifactStagingDirectory)\artifacts
-    displayName: Trim the version from the NuGet packages
-    continueOnError: ${{ parameters.sdlContinueOnError }}
-
   - powershell: eng/common/sdl/extract-artifact-packages.ps1
       -InputPath $(Build.ArtifactStagingDirectory)\artifacts\BlobArtifacts
       -ExtractPath $(Build.ArtifactStagingDirectory)\artifacts\BlobArtifacts

--- a/src/Microsoft.DotNet.VersionTools/tools/Microsoft.DotNet.VersionTools.Cli/ConsoleLogger.cs
+++ b/src/Microsoft.DotNet.VersionTools/tools/Microsoft.DotNet.VersionTools.Cli/ConsoleLogger.cs
@@ -16,7 +16,7 @@ internal class ConsoleLogger : ILogger
     {
         var fgColor = Console.ForegroundColor;
         Console.ForegroundColor = ConsoleColor.Red;
-        Console.Error.WriteLine(message);
+        Console.Error.WriteLine(String.Format(message, values));
         Console.ForegroundColor = fgColor;
     }
 }

--- a/src/Microsoft.DotNet.VersionTools/tools/Microsoft.DotNet.VersionTools.Cli/VersionTrimmingOperation.cs
+++ b/src/Microsoft.DotNet.VersionTools/tools/Microsoft.DotNet.VersionTools.Cli/VersionTrimmingOperation.cs
@@ -56,7 +56,7 @@ public class VersionTrimmingOperation : IOperation
             {
                 info = _context.NupkgInfoFactory.CreateNupkgInfo(assetFileName);
             }
-            catch (InvalidDataException e)
+            catch (Exception e)
             {
                 _context.Logger.WriteError($"Asset {assetFileName} in not a valid nuget package: {e.Message}");
                 continue;


### PR DESCRIPTION
Ref https://github.com/dotnet/arcade/issues/13939

The arcade-official-ci pipeline is failing https://dev.azure.com/dnceng/internal/_build/results?buildId=2242647&view=results as we have an incorrect (without nuspec file) nuget package merged in the repo [ContainerOne.1.0.0.nupkg](https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.SignTool.Tests/Resources/ContainerOne.1.0.0.nupkg)

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
