### PR TITLE
Add llvm-17 detection

### DIFF
--- a/eng/common/native/init-compiler.sh
+++ b/eng/common/native/init-compiler.sh
@@ -63,7 +63,7 @@ if [ -z "$CLR_CC" ]; then
     # Set default versions
     if [ -z "$majorVersion" ]; then
         # note: gcc (all versions) and clang versions higher than 6 do not have minor version in file name, if it is zero.
-        if [ "$compiler" = "clang" ]; then versions="16 15 14 13 12 11 10 9 8 7 6.0 5.0 4.0 3.9 3.8 3.7 3.6 3.5"
+        if [ "$compiler" = "clang" ]; then versions="17 16 15 14 13 12 11 10 9 8 7 6.0 5.0 4.0 3.9 3.8 3.7 3.6 3.5"
         elif [ "$compiler" = "gcc" ]; then versions="13 12 11 10 9 8 7 6 5 4.9"; fi
 
         for version in $versions; do


### PR DESCRIPTION
Currently v17 is at RC2 (https://llvm.org/), final version will be released on Sep. 5. Tested on linux-x64 and runtime build was clean (since https://github.com/dotnet/runtime/pull/90068).

cc @janvorli

On Ubuntu, this command come handy for runtime dependencies installation, when testing with llvm release candidates:

> sudo -c 'rm -rf /usr/lib/llvm-*; apt install -y curl libssl-dev cmake liblttng-ust-dev libkrb5-dev libz-dev libssl-dev lsb-release wget software-properties-common gnupg; curl -sSL https://apt.llvm.org/llvm.sh | bash -s - 17 all'
