### PR TITLE
SDL Validation: add a --create-manifest-if-needed parameter to dotnet install

### DIFF
--- a/eng/common/sdl/trim-assets-version.ps1
+++ b/eng/common/sdl/trim-assets-version.ps1
@@ -23,9 +23,13 @@ function Install-VersionTools-Cli {
   )
 
   Write-Host "Installing the package '$CliToolName' with a version of '$version' ..."
+
+  $argumentList = @("new", "tool-manifest", "--ignore-if-exists")
+  Start-Process "$dotnet" -Verbose -ArgumentList $argumentList -NoNewWindow -Wait
+
   $feed = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json"
 
-  $argumentList = @("tool", "install", "--global", "$CliToolName", "--add-source $feed", "--no-cache", "--version $Version")
+  $argumentList = @("tool", "install", "$CliToolName", "--add-source $feed", "--no-cache", "--version $Version", "--ignore-if-installed")
   Start-Process "$dotnet" -Verbose -ArgumentList $argumentList -NoNewWindow -Wait
 }
 

--- a/eng/common/sdl/trim-assets-version.ps1
+++ b/eng/common/sdl/trim-assets-version.ps1
@@ -25,7 +25,7 @@ function Install-VersionTools-Cli {
   Write-Host "Installing the package '$CliToolName' with a version of '$version' ..."
   $feed = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json"
 
-  $argumentList = @("tool", "install", "--global", "$CliToolName", "--add-source $feed", "--no-cache", "--version $Version", "--create-manifest-if-needed")
+  $argumentList = @("tool", "install", "--local", "$CliToolName", "--add-source $feed", "--no-cache", "--version $Version", "--create-manifest-if-needed")
   Start-Process "$dotnet" -Verbose -ArgumentList $argumentList -NoNewWindow -Wait
 }
 

--- a/eng/common/sdl/trim-assets-version.ps1
+++ b/eng/common/sdl/trim-assets-version.ps1
@@ -23,7 +23,6 @@ function Install-VersionTools-Cli {
   )
 
   Write-Host "Installing the package '$CliToolName' with a version of '$version' ..."
-
   $feed = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json"
 
   $argumentList = @("tool", "install", "--global", "$CliToolName", "--add-source $feed", "--no-cache", "--version $Version", "--create-manifest-if-needed")

--- a/eng/common/sdl/trim-assets-version.ps1
+++ b/eng/common/sdl/trim-assets-version.ps1
@@ -24,12 +24,9 @@ function Install-VersionTools-Cli {
 
   Write-Host "Installing the package '$CliToolName' with a version of '$version' ..."
 
-  $argumentList = @("new", "tool-manifest", "--ignore-if-exists")
-  Start-Process "$dotnet" -Verbose -ArgumentList $argumentList -NoNewWindow -Wait
-
   $feed = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json"
 
-  $argumentList = @("tool", "install", "$CliToolName", "--add-source $feed", "--no-cache", "--version $Version", "--ignore-if-installed")
+  $argumentList = @("tool", "install", "--global", "$CliToolName", "--add-source $feed", "--no-cache", "--version $Version", "--create-manifest-if-needed")
   Start-Process "$dotnet" -Verbose -ArgumentList $argumentList -NoNewWindow -Wait
 }
 

--- a/eng/common/sdl/trim-assets-version.ps1
+++ b/eng/common/sdl/trim-assets-version.ps1
@@ -25,7 +25,7 @@ function Install-VersionTools-Cli {
   Write-Host "Installing the package '$CliToolName' with a version of '$version' ..."
   $feed = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json"
 
-  $argumentList = @("tool", "install", "--local", "$CliToolName", "--add-source $feed", "--no-cache", "--version $Version")
+  $argumentList = @("tool", "install", "--global", "$CliToolName", "--add-source $feed", "--no-cache", "--version $Version")
   Start-Process "$dotnet" -Verbose -ArgumentList $argumentList -NoNewWindow -Wait
 }
 


### PR DESCRIPTION
ref issue: https://github.com/dotnet/dnceng/issues/573
ref PR: https://github.com/dotnet/arcade-validation/pull/3926

`dotnet install --local` results in a failure of the dotnet-arcade-validation pipeline. Added a `--create-manifest-if-needed` parameter as described here https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools#install-a-local-tool

Tested: https://dev.azure.com/dnceng/internal/_build/results?buildId=2245622&view=logs&j=7d9eef18-6720-5c1f-4d30-89d7b76728e9&t=c49a855a-1eb9-5019-62bf-639a659fe361

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation

