### PR TITLE
Remove dotnet/linker from flow

### DIFF
--- a/scripts/create-preview-flow.ps1
+++ b/scripts/create-preview-flow.ps1
@@ -88,11 +88,10 @@ MakeDefaultChannel https://github.com/dotnet/runtime $RuntimeBranch $RuntimeChan
 MakeDefaultChannel https://github.com/dotnet/windowsdesktop $RuntimeBranch $RuntimeChannel
 MakeDefaultChannel https://github.com/dotnet/wpf $RuntimeBranch $RuntimeChannel
 MakeDefaultChannel https://github.com/dotnet/winforms $RuntimeBranch $RuntimeChannel
-MakeDefaultChannel https://github.com/dotnet/linker $RuntimeBranch $RuntimeChannel
 
 if ($AddInternalFlow) {
     # Because of where internal fixes tend to be, we eliminate some leaves in the graph
-    # and flow them through the normal public channels: emsdk, icu, linker.
+    # and flow them through the normal public channels: emsdk, icu.
     # wpf-int is flowed from the public channel (there is no internal branch or merge) due to
     # an issue in the staging pipeline where it will give the test feed for the public preview build
     # internal permissions in some cases because it sees the internal repo publishing locations before
@@ -139,7 +138,6 @@ AddArcadeFlow https://github.com/dotnet/runtime $RuntimeBranch
 AddArcadeFlow https://github.com/dotnet/windowsdesktop $RuntimeBranch
 AddArcadeFlow https://github.com/dotnet/wpf $RuntimeBranch
 AddArcadeFlow https://github.com/dotnet/winforms $RuntimeBranch
-AddArcadeFlow https://github.com/dotnet/linker $RuntimeBranch
 AddArcadeFlow https://github.com/dotnet/installer $SdkBranch
 AddArcadeFlow https://github.com/dotnet/sdk $SdkBranch
 AddArcadeFlow https://github.com/dotnet/roslyn-analyzers $SdkBranch
@@ -156,7 +154,6 @@ AddFlow https://github.com/dotnet/runtime $RuntimeChannel https://github.com/dot
 AddFlow https://github.com/dotnet/runtime $RuntimeChannel https://github.com/dotnet/winforms $RuntimeBranch EveryBuild
 AddFlow https://github.com/dotnet/winforms $RuntimeChannel https://github.com/dotnet/wpf $RuntimeBranch EveryBuild
 AddFlow https://github.com/dotnet/wpf $RuntimeChannel https://github.com/dotnet/windowsdesktop $RuntimeBranch EveryBuild
-AddFlow https://github.com/dotnet/linker $RuntimeChannel https://github.com/dotnet/runtime $RuntimeBranch EveryBuild
 
 if ($AddInternalFlow) {
     Write-Host "Adding internal runtime -> internal runtime flow"
@@ -176,7 +173,6 @@ AddFlow https://github.com/dotnet/aspnetcore $RuntimeChannel https://github.com/
 AddFlow https://github.com/dotnet/windowsdesktop $RuntimeChannel https://github.com/dotnet/sdk $SdkBranch EveryBuild
 AddFlow https://github.com/dotnet/runtime $RuntimeChannel https://github.com/dotnet/sdk $SdkBranch EveryBuild
 AddFlow https://github.com/dotnet/runtime $RuntimeChannel https://github.com/dotnet/templating $SdkBranch EveryBuild
-AddFlow https://github.com/dotnet/linker $RuntimeChannel https://github.com/dotnet/sdk $SdkBranch EveryBuild
 
 if ($AddInternalFlow) {
     Write-Host "Adding internal runtime->internal sdk flow"


### PR DESCRIPTION
This repo's functionality moved into the runtime

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
