### PR TITLE
Add initial binlogs redacting functionality

### DIFF
--- a/eng/common/post-build/redact-logs.ps1
+++ b/eng/common/post-build/redact-logs.ps1
@@ -1,0 +1,68 @@
+param(
+  [Parameter(Mandatory=$true)][string] $InputPath,
+  [Parameter(ValueFromRemainingArguments=$true)][String[]]$tokensToRedact
+)
+
+try {
+  . $PSScriptRoot\post-build-utils.ps1
+
+  $packageName = 'MSBuild.BinlogRedactor.CLI'
+
+  $dotnetRoot = InitializeDotNetCli -install:$true
+  $dotnet = "$dotnetRoot\dotnet.exe"
+  $toolList = & "$dotnet" tool list -g
+
+  if ($toolList -like "*$packageName*") {
+    & "$dotnet" tool uninstall $packageName -g
+  }
+
+  $packageFeed = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json'
+
+  $toolPath  = "$TempDir\logredactor\$(New-Guid)"
+  $verbosity = 'minimal'
+  
+  New-Item -ItemType Directory -Force -Path $toolPath
+  
+  Push-Location -Path $toolPath
+
+  try {
+    Write-Host "Installing Binlog redactor CLI..."
+    Write-Host "'$dotnet' new tool-manifest"
+    & "$dotnet" new tool-manifest
+    Write-Host "'$dotnet' tool install $packageName --prerelease --add-source '$packageFeed' -v $verbosity"
+    & "$dotnet" tool install $packageName --local --prerelease --add-source "$packageFeed" -v $verbosity
+  
+
+    $optionalParams = [System.Collections.ArrayList]::new()
+  
+    Foreach ($p in $tokensToRedact)
+    {
+	  if($p -match '^\$\(.*\)$')
+	  {
+		Write-Host ("Ignoring token {0} as it is probably unexpanded AzDO variable"  -f $p)
+	  }		  
+	  elseif($p)
+	  {
+        $optionalParams.Add("-p") | Out-Null
+	    $optionalParams.Add($p) | Out-Null
+	  }
+    }
+
+    & $dotnet redact-binlog -f -r -i $InputPath `
+	  @optionalParams
+
+    if ($LastExitCode -ne 0) {
+      Write-Host "Problems using Redactor tool. But ingoring them now."
+    }
+  }
+  finally {
+    Pop-Location
+  }
+
+  Write-Host 'done.'
+} 
+catch {
+  Write-Host $_
+  Write-PipelineTelemetryError -Category 'Redactor' -Message "There was an error while trying to redact logs."
+  ExitWithExitCode 1
+}

--- a/eng/common/templates/steps/publish-logs.yml
+++ b/eng/common/templates/steps/publish-logs.yml
@@ -12,7 +12,25 @@ steps:
       Move-Item -Path $(Build.SourcesDirectory)/artifacts/log/Debug/* $(Build.SourcesDirectory)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
   continueOnError: true
   condition: always()
-
+  
+- task: PowerShell@2
+  displayName: Redact Logs
+  inputs:
+    filePath: $(Build.SourcesDirectory)/eng/common/post-build/redact-logs.ps1
+    # For now this needs to have explicit list of all sensitive data. Taken from eng/publishing/v3/publish.yml
+    arguments: -InputPath '$(Build.SourcesDirectory)/PostBuildLogs'
+      '$(publishing-dnceng-devdiv-code-r-build-re)'
+      '$(MaestroAccessToken)'
+      '$(dn-bot-all-orgs-artifact-feeds-rw)'
+      '$(akams-client-id)'
+      '$(akams-client-secret)'
+      '$(nonexistent)'
+      '$(microsoft-symbol-server-pat)'
+      '$(symweb-symbol-server-pat)'
+      '$(dn-bot-all-orgs-build-rw-code-rw)'
+  continueOnError: true
+  condition: always()
+      
 - task: PublishBuildArtifacts@1
   displayName: Publish Logs
   inputs:


### PR DESCRIPTION

### Motivation
Binlogs can (and do) contain sensitive data - including binlogs from our pipelines
MSBuild team is working on redacting functionality as part of https://github.com/dotnet/msbuild/issues/8400 - and we want to pilot the initial PoC within arcade - which will provide removing a way of spilling sensitive data from pipelines runs.

### Test runs

Tested on MSBuild CI pipeline here: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=8283720&view=logs&j=d17d50ef-afac-5d4b-95a6-3014ce5cf7a4&t=494cebad-6f4c-572d-253c-6aabdd2e1073
The results are as expected - all binlogs are preserved, only sensitive data is removed:

![image](https://github.com/dotnet/arcade/assets/3809076/9fa8f9b2-74dd-44f0-9e18-f8adac20172a)

The error that occured is caused by unrelated MSBuild bug: https://github.com/dotnet/msbuild/issues/9146, that influences producing of the binlogs - as a result the redacting is skiped. That will be addressed independetly


### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
