### PR TITLE
Allow DownloadFile task to handle multiple local URIs

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs
@@ -104,9 +104,15 @@ namespace Microsoft.DotNet.Arcade.Sdk
             if (uri.StartsWith(FileUriProtocol, StringComparison.Ordinal))
             {
                 var filePath = uri.Substring(FileUriProtocol.Length);
-                Log.LogMessage($"Copying '{filePath}' to '{DestinationPath}'");
-                File.Copy(filePath, DestinationPath, overwrite: true);
-                return true;
+
+                if (File.Exists(filePath)) {
+                    Log.LogMessage($"Copying '{filePath}' to '{DestinationPath}'");
+                    File.Copy(filePath, DestinationPath, overwrite: true);
+                    return true;
+                } else {
+                    Log.LogMessage($"'{filePath}' does not exist.");
+                    return false;
+                }
             }
 
             Log.LogMessage($"Downloading '{uri}' to '{DestinationPath}'");


### PR DESCRIPTION
If a potential URI for DownloadFile is a local URI, and that local URI does not exist, then the task outright fails, rather than moving onto the next URI. This results in a poor error message and an inability to utilize multiple local sources.