### PR TITLE
Remove test TFMs from PackageTesting

### DIFF
--- a/src/Microsoft.DotNet.PackageTesting/build/Microsoft.DotNet.PackageTesting.props
+++ b/src/Microsoft.DotNet.PackageTesting/build/Microsoft.DotNet.PackageTesting.props
@@ -8,24 +8,6 @@
 
   <UsingTask TaskName="GetCompatiblePackageTargetFrameworks" AssemblyFile="$(DotNetPackageTestingAssembly)" />
   <UsingTask TaskName="VerifyClosure" AssemblyFile="$(DotNetPackageTestingAssembly)" />
-  <UsingTask TaskName="VerifyTypes" AssemblyFile="$(DotNetPackageTestingAssembly)"/>
-
-  <ItemGroup>
-    <SupportedTestFramework Include="net6.0" />
-    <SupportedTestFramework Include="net7.0" />
-    <SupportedTestFramework Include="net8.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <SupportedTestFramework Include="netstandard2.0" />
-    <SupportedTestFramework Include="netstandard2.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <SupportedTestFramework Include="net462" />
-    <SupportedTestFramework Include="net471" />
-    <SupportedTestFramework Include="net472" />
-    <SupportedTestFramework Include="net48" />
-  </ItemGroup>
+  <UsingTask TaskName="VerifyTypes" AssemblyFile="$(DotNetPackageTestingAssembly)" />
 
 </Project>


### PR DESCRIPTION
Follow-up on https://github.com/dotnet/runtime/pull/90880

These listed TFMs are dotnet/runtime specific and shouldn't be hardcoded in arcade as they change every year.

Remove them form the props file and add them back directly in testPackages.proj in dotnet/runtime.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
