### PR TITLE
use the internal pool for the weekly synchronization jobs

### DIFF
--- a/azure-pipelines-weekly.yaml
+++ b/azure-pipelines-weekly.yaml
@@ -14,7 +14,8 @@ stages:
     jobs:
     - job: Synchronize
       pool:
-        vmImage: windows-latest
+        name: NetCore1ESPool-Internal-NoMSI
+        demands: ImageOverride -equals 1es-windows-2022
 
       steps:
       - task: UseDotNet@2


### PR DESCRIPTION
Use the internal build pools to fix authentication issues during the weekly runs. 

I tested this change by running an internal build of my branch: https://dev.azure.com/dnceng/internal/_build/results?buildId=2254218&view=results

Fixes https://github.com/dotnet/dnceng/issues/723

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
