### PR TITLE
[release/7.0] Bump a few package versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,7 +17,7 @@
     <AzureIdentityVersion>1.8.0</AzureIdentityVersion>
     <AzureSecurityKeyVaultSecretsVersion>4.4.0</AzureSecurityKeyVaultSecretsVersion>
     <AzureStorageBlobsVersion>12.13.0</AzureStorageBlobsVersion>
-    <AzureDataTablesVersion>12.8.0</AzureDataTablesVersion>
+    <AzureDataTablesVersion>12.8.1</AzureDataTablesVersion>
     <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>
     <NETStandardLibraryVersion>1.6.1</NETStandardLibraryVersion>
     <MicrosoftApplicationInsightsVersion>2.16.0</MicrosoftApplicationInsightsVersion>
@@ -29,16 +29,13 @@
     <MicrosoftBuildFrameworkVersion>15.7.179</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildTasksCoreVersion>15.7.179</MicrosoftBuildTasksCoreVersion>
     <MicrosoftBuildUtilitiesCoreVersion>15.7.179</MicrosoftBuildUtilitiesCoreVersion>
-    <MicrosoftCodeAnalysisAnalyzersVersion>2.6.3</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisCSharpVersion>2.9.0</MicrosoftCodeAnalysisCSharpVersion>
     <MsbuildTaskMicrosoftCodeAnalysisCSharpVersion>3.8.0</MsbuildTaskMicrosoftCodeAnalysisCSharpVersion>
     <GenAPIMicrosoftCodeAnalysisVersion>4.3.0-3.final</GenAPIMicrosoftCodeAnalysisVersion>
-    <MicrosoftIdentityModelClientsActiveDirectoryVersion>3.17.2</MicrosoftIdentityModelClientsActiveDirectoryVersion>
-    <MicrosoftRestClientRuntimeVersion>2.3.13</MicrosoftRestClientRuntimeVersion>
+    <MicrosoftIdentityClientVersion>4.55.0</MicrosoftIdentityClientVersion>
     <MicrosoftExtensionsDependencyModelVersion>2.1.0</MicrosoftExtensionsDependencyModelVersion>
     <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>2.1.1</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
     <MicrosoftExtensionsDependencyInjectionVersion>2.1.1</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsFileSystemGlobbingVersion>2.0.0</MicrosoftExtensionsFileSystemGlobbingVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>2.1.1</MicrosoftExtensionsLoggingConsoleVersion>
     <MicrosoftNETCorePlatformsVersion>2.1.0</MicrosoftNETCorePlatformsVersion>
     <MicrosoftNetCompilersToolsetVersion>4.4.0-3.22472.2</MicrosoftNetCompilersToolsetVersion>
@@ -48,13 +45,12 @@
     <MoqVersion>4.8.3</MoqVersion>
     <MonoOptionsVersion>5.3.0.1</MonoOptionsVersion>
     <McMasterExtensionsCommandLineUtils>2.3.0</McMasterExtensionsCommandLineUtils>
-    <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
+    <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <SystemTextJsonVersion>4.7.0</SystemTextJsonVersion>
-    <NuGetVersioningVersion>4.4.0</NuGetVersioningVersion>
-    <NuGetVersion>6.2.2</NuGetVersion>
+    <NuGetVersioningVersion>6.7.0</NuGetVersioningVersion>
+    <NuGetVersion>$(NuGetVersioningVersion)</NuGetVersion>
     <OctokitVersion>0.32.0</OctokitVersion>
     <DotNetSleetLibVersion>2.2.143</DotNetSleetLibVersion>
-    <SwashbuckleAspNetCoreSwaggerVersion>3.0.0</SwashbuckleAspNetCoreSwaggerVersion>
     <SystemBuffersVersion>4.5.0</SystemBuffersVersion>
     <SystemCollectionsImmutableVersion>1.5.0</SystemCollectionsImmutableVersion>
     <SystemDiagnosticsTraceSourceVersion>4.0.0</SystemDiagnosticsTraceSourceVersion>
@@ -75,10 +71,6 @@
     <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>
     <MicrosoftDotNetBuildTasksFeedVersion>7.0.0-beta.22426.8</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetSignToolVersion>7.0.0-beta.22426.8</MicrosoftDotNetSignToolVersion>
-    <MicrosoftAspNetCoreAllVersion>2.0.0</MicrosoftAspNetCoreAllVersion>
-    <MicrosoftDotNetGitHubIssueLabelerAssetsVersion>1.6.0</MicrosoftDotNetGitHubIssueLabelerAssetsVersion>
-    <MicrosoftMLVersion>1.0.0</MicrosoftMLVersion>
-    <MicrosoftVisualStudioWebCodeGenerationDesignVersion>2.0.4</MicrosoftVisualStudioWebCodeGenerationDesignVersion>
     <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta2-19575-01</MicrosoftDiaSymReaderPdb2PdbVersion>
     <MicrosoftDotNetMaestroClientVersion>1.1.0-beta.21553.1</MicrosoftDotNetMaestroClientVersion>
     <MicrosoftSourceLinkGitHubVersion>1.2.0-beta-22429-01</MicrosoftSourceLinkGitHubVersion>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetAssetResolver.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetAssetResolver.cs
@@ -277,8 +277,9 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
             foreach (var package in _packages.Keys)
             {
-                resolvedAssets.Add(package,
-                    _packages[package].FindItemGroups(_conventions.Patterns.RuntimeAssemblies));
+                var contentItemGroups = new List<ContentItemGroup>();
+                _packages[package].PopulateItemGroups(_conventions.Patterns.RuntimeAssemblies, contentItemGroups);
+                resolvedAssets.Add(package, contentItemGroups);
             }
 
             return resolvedAssets;

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/Microsoft.DotNet.Deployment.Tasks.Links.csproj
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/Microsoft.DotNet.Deployment.Tasks.Links.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="$(MicrosoftIdentityModelClientsActiveDirectoryVersion)" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="$(MicrosoftIdentityClientVersion)" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" Publish="false" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" Publish="false" ExcludeAssets="runtime" />
     <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" />

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksBase.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksBase.cs
@@ -1,11 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Net.Http;
-using System.Threading.Tasks;
 using Microsoft.Build.Framework;
-using Microsoft.IdentityModel.Clients.ActiveDirectory;
 
 namespace Microsoft.DotNet.Deployment.Tasks.Links
 {

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests.csproj
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Moq" Version="4.8.3" />
     <!-- This is here so that we agree with the project's transitive references to NewtonSoft.Json -->
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="NuGet.Versioning" Version="6.1.0" />
+    <PackageReference Include="NuGet.Versioning" Version="$(NuGetVersion)" />
     <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.Helix/Sdk/Microsoft.DotNet.Helix.Sdk.csproj
+++ b/src/Microsoft.DotNet.Helix/Sdk/Microsoft.DotNet.Helix.Sdk.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
     <PackageReference Include="Microsoft.Data.Services.Client" Version="$(MicrosoftDataServicesClientVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="NuGet.Versioning" Version="6.0.0-preview.4.230" />
+    <PackageReference Include="NuGet.Versioning" Version="$(NuGetVersion)" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 

--- a/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
+++ b/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
@@ -18,11 +18,11 @@
     <PackageReference Include="LZMA-SDK" Version="19.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.OLE.Interop" Version="7.10.6071" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="NuGet.Common" Version="4.7.0" />
-    <PackageReference Include="NuGet.Frameworks" Version="4.7.0" />
-    <PackageReference Include="NuGet.Packaging" Version="4.7.0" />
-    <PackageReference Include="NuGet.Packaging.Core" Version="4.7.0" />
-    <PackageReference Include="NuGet.Versioning" Version="4.7.0" />
+    <PackageReference Include="NuGet.Common" Version="$(NuGetVersioningVersion)" />
+    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetVersioningVersion)" />
+    <PackageReference Include="NuGet.Packaging" Version="$(NuGetVersioningVersion)" />
+    <PackageReference Include="NuGet.Packaging.Core" Version="$(NuGetVersioningVersion)" />
+    <PackageReference Include="NuGet.Versioning" Version="$(NuGetVersioningVersion)" />
     <PackageReference Include="System.IO.Packaging" Version="4.5.0" />
     <PackageReference Include="Microsoft.Signed.Wix" Version="$(MicrosoftSignedWixVersion)" />
   </ItemGroup>

--- a/src/SignCheck/Microsoft.SignCheck/Verification/NupkgVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/NupkgVerifier.cs
@@ -1,12 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SignCheck.Logging;
-using NuGet.Common;
 using NuGet.Packaging;
 using NuGet.Packaging.Signing;
 
@@ -14,12 +12,12 @@ namespace Microsoft.SignCheck.Verification
 {
     public class NupkgVerifier : ArchiveVerifier
     {
-        public NupkgVerifier(Log log, Exclusions exclusions, SignatureVerificationOptions options) : base(log, exclusions, options, fileExtension: ".nupkg")
+        public NupkgVerifier(Log log, Exclusions exclusions, SignatureVerificationOptions options) :
+            base(log, exclusions, options, fileExtension: ".nupkg")
         {
-
         }
 
-        public override SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath) 
+        public override SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath)
         {
             SignatureVerificationResult svr = new SignatureVerificationResult(path, parent, virtualPath);
             string fullPath = svr.FullPath;
@@ -31,20 +29,25 @@ namespace Microsoft.SignCheck.Verification
             return svr;
         }
 
+        // This method and SignatureVerificationResult.IsSigned are slightly misnamed. Signature validity is just as
+        // important as signature existence. The new VerifySignatureResult.IsSigned property would _not_ be correct
+        // to use here.
         private bool IsSigned(string path)
         {
-            IEnumerable<ISignatureVerificationProvider> providers = SignatureVerificationProviderFactory.GetSignatureVerificationProviders();
+            IEnumerable<ISignatureVerificationProvider> providers = new ISignatureVerificationProvider[] {
+                new IntegrityVerificationProvider(),
+                new SignatureTrustAndValidityVerificationProvider(allowUntrustedRootList: null),
+                new AllowListVerificationProvider(allowList: null),
+            };
             var packageSignatureVerifier = new PackageSignatureVerifier(providers);
 
             var verifierSettings = SignedPackageVerifierSettings.GetVerifyCommandDefaultPolicy();
-            IEnumerable<ISignatureVerificationProvider> verificationProviders = SignatureVerificationProviderFactory.GetSignatureVerificationProviders();
-            var verifier = new PackageSignatureVerifier(verificationProviders);
 
             using (var pr = new PackageArchiveReader(path))
             {
                 Task<VerifySignaturesResult> verifySignatureResult = packageSignatureVerifier.VerifySignaturesAsync(pr, verifierSettings, CancellationToken.None);
 
-                return verifySignatureResult.Result.Valid;
+                return verifySignatureResult.Result.IsValid;
             }
         }
     }


### PR DESCRIPTION
- small part of https://github.com/dotnet/dnceng/issues/345
- bump Azure.Data.Tables to v12.8.1
- replace Microsoft.IdentityModel.Clients.ActiveDirectory with Microsoft.Identity.Client
  - part of https://github.com/dotnet/dnceng/issues/629
- bump NuGet.* to v6.7.0
  - part of https://dev.azure.com/dnceng/internal/_workitems/edit/5127
  - part of https://dev.azure.com/dnceng/internal/_workitems/edit/5128
  - part of https://dev.azure.com/dnceng/internal/_workitems/edit/5129
  - part of https://dev.azure.com/dnceng/internal/_workitems/edit/5137
  - left both `$(NuGetVersioningVersion)` and `$(NuGetVersion)` to minimize disruption
    - see #12333 change in 'main' for a counter-example
  - react to deprecation of `ContentItemCollection.FindItemGroups(...)`
  - react to removal of `SignatureVerificationProviderFactory`
  - react to `VerifySignaturesResult` API changes (`Valid` to `IsValid`)
- bump NewtonSoft.Json to v13.0.3
- nits:
  - remove unused `$(...Version)` properties
  - remove a bit of dead code and unused `using`s in changed files

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
