### PR TITLE
Improve error handling when a key is missing

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
@@ -107,10 +107,10 @@ namespace Microsoft.DotNet.Arcade.Sdk
                                         var propertyName = item.Key.Trim('$', '(', ')');
 
                                         // Unable to parse version, try to find the corresponding identifier from the MSBuild loaded MSBuild properties
-                                        string evaluatedValue = properties[propertyName].First().EvaluatedValue;
-                                        if (!SemanticVersion.TryParse(evaluatedValue, out version))
+                                        ProjectProperty property = properties[propertyName].FirstOrDefault();
+                                        if (property == null || !SemanticVersion.TryParse(property.EvaluatedValue, out version))
                                         {
-                                            Log.LogError($"Unable to parse '{item.Key}' from properties defined in '{VersionsPropsPath}'");
+                                            Log.LogError($"Unable to find '{item.Key}' in properties defined in '{VersionsPropsPath}'");
                                         }
                                     }
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
@@ -108,9 +108,13 @@ namespace Microsoft.DotNet.Arcade.Sdk
 
                                         // Unable to parse version, try to find the corresponding identifier from the MSBuild loaded MSBuild properties
                                         ProjectProperty property = properties[propertyName].FirstOrDefault();
-                                        if (property == null || !SemanticVersion.TryParse(property.EvaluatedValue, out version))
+                                        if (property == null)
                                         {
                                             Log.LogError($"Unable to find '{item.Key}' in properties defined in '{VersionsPropsPath}'");
+                                        }
+                                        else if (!SemanticVersion.TryParse(property.EvaluatedValue, out version))
+                                        {
+                                            Log.LogError($"Unable to parse '{item.Key}' from properties defined in '{VersionsPropsPath}'");
                                         }
                                     }
 


### PR DESCRIPTION
This pr is to avoid

```
.packages\microsoft.dotnet.arcade.sdk\8.0.0-beta.23428.2\tools\InstallDotNetCore.targets(15,5): error MSB4018: (NETCORE_ENGINEERING_TELEMETRY=Restore) The "InstallDotNetCore" task failed unexpectedly.
System.InvalidOperationException: Sequence contains no elements
   at System.Linq.ThrowHelper.ThrowNoElementsException()
   at System.Linq.Enumerable.First[TSource](IEnumerable`1 source)
   at Microsoft.DotNet.Arcade.Sdk.InstallDotNetCore.Execute() in /_/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs:line 110
   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
   at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(ITaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask)
```
when the property doesn't exist.

cc @mmitche 