### PR TITLE
Update secret-manager to use newer azure auth libraries

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "microsoft.dnceng.secretmanager": {
-      "version": "1.1.0-beta.23219.2",
+      "version": "1.1.0-beta.23451.13",
       "commands": [
         "secret-manager"
       ]


### PR DESCRIPTION
https://github.com/dotnet/dnceng/issues/740

Validated this by running the weekly synchronization build: https://dnceng.visualstudio.com/internal/_build/results?buildId=2257992&view=logs&j=df0a3355-897e-53ae-288d-2f16ccab2822&t=78db2542-c627-4140-8a7a-d06178fff4e4

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
