### PR TITLE
Enable PDB archives for source-build

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
@@ -90,21 +90,22 @@
       <SymbolsArchiveLocation Condition="'$(GitHubRepositoryName)' == 'nuget-client'">$(PackageOutputPath)</SymbolsArchiveLocation>
       <SymbolsList>$(SymbolsArchiveLocation)\symbols.lst</SymbolsList>
       <SymbolsArchivePrefix>Symbols.</SymbolsArchivePrefix>
-      <SymbolsArchiveName>$(SymbolsArchiveLocation)$(SymbolsArchivePrefix)$(GitHubRepositoryName).tar.gz</SymbolsArchiveName>
+      <SymbolsArchiveSuffix>.$(Version).$(TargetRid)</SymbolsArchiveSuffix>
+      <SymbolsArchiveName>$(SymbolsArchiveLocation)$(SymbolsArchivePrefix)$(GitHubRepositoryName)$(SymbolsArchiveSuffix).tar.gz</SymbolsArchiveName>
     </PropertyGroup>
 
     <ItemGroup>
       <AbsoluteSymbolPath Include="$(SymbolsRoot)\**\obj\**\*.pdb" />
-      <RelativeSymbolPath Include="@(AbsoluteSymbolPath)" Condition="'@(AbsoluteSymbolPath)' != ''">
-        <RelativePath>$([MSBuild]::MakeRelative($(SymbolsRoot), %(AbsoluteSymbolPath.FullPath)))</RelativePath>
-      </RelativeSymbolPath>
+      <AbsoluteSymbolPath Update="@(AbsoluteSymbolPath)" Condition="'@(AbsoluteSymbolPath)' != ''">
+        <RelativePath>$([MSBuild]::MakeRelative($(SymbolsRoot), %(FullPath)))</RelativePath>
+      </AbsoluteSymbolPath>
     </ItemGroup>
 
     <WriteLinesToFile
       File="$(SymbolsList)"
-      Lines="@(RelativeSymbolPath->'%(RelativePath)')"
+      Lines="@(AbsoluteSymbolPath->'%(RelativePath)')"
       Overwrite="true"
-      Condition="'@(RelativeSymbolPath)' != ''" />
+      Condition="'@(AbsoluteSymbolPath)' != ''" />
 
     <Exec Command="tar --numeric-owner -czf $(SymbolsArchiveName) --files-from=$(SymbolsList)"
           WorkingDirectory="$(SymbolsRoot)" Condition="Exists($(SymbolsList))" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
@@ -54,9 +54,8 @@
           DependsOnTargets="
             GetCategorizedIntermediateNupkgContents;
             GetSupplementalIntermediateNupkgManifest;
-            CreateSymbolsList;
-            CreateSymbolsArchive;
-            CreateNonShippingNupkgList"
+            GetSymbolsArchive;
+            GetNonShippingNupkgList"
           BeforeTargets="_GetPackageFiles">
     <ItemGroup>
       <Content Include="@(IntermediatePackageFile->WithMetadataValue('Category', '$(SupplementalIntermediateNupkgCategory)'))" />
@@ -81,14 +80,16 @@
     </ItemGroup>
   </Target>
 
-  <!-- Discover all repo's symbols that match **\obj\**\*.pdb, to be included in the "main" intermediate nupkg. -->
-  <Target Name="CreateSymbolsList" Condition="'$(SupplementalIntermediateNupkgCategory)' == ''">
+  <!-- Create symbols archive and include it in the "main" intermediate nupkg. -->
+  <Target Name="GetSymbolsArchive" Condition="'$(SupplementalIntermediateNupkgCategory)' == ''">
     <PropertyGroup>
       <SymbolsRoot>$(CurrentRepoSourceBuildArtifactsDir)</SymbolsRoot>
       <!-- Fall back to repo root for source-build-externals or repos that don't have the regular SymbolsRoot as defined above -->
       <SymbolsRoot Condition="!Exists('$(SymbolsRoot)') or '$(GitHubRepositoryName)' != 'source-build-externals'">$(RepoRoot)</SymbolsRoot>
       <SymbolsArchiveLocation>$(CurrentRepoSourceBuildArtifactsPackagesDir)</SymbolsArchiveLocation>
       <SymbolsList>$(SymbolsArchiveLocation)\symbols.lst</SymbolsList>
+      <SymbolsArchivePrefix>Symbols.</SymbolsArchivePrefix>
+      <SymbolsArchiveName>$(SymbolsArchiveLocation)$(SymbolsArchivePrefix)$(GitHubRepositoryName).tar.gz</SymbolsArchiveName>
     </PropertyGroup>
 
     <ItemGroup>
@@ -103,28 +104,20 @@
       Lines="@(RelativeSymbolPath->'%(RelativePath)')"
       Overwrite="true"
       Condition="'@(RelativeSymbolPath)' != ''" />
-  </Target>
-
-  <Target Name="CreateSymbolsArchive" Condition="Exists($(SymbolsList))">
-    <PropertyGroup>
-      <SymbolsArchivePrefix>Symbols.</SymbolsArchivePrefix>
-      <SymbolsArchiveName>$(SymbolsArchiveLocation)$(SymbolsArchivePrefix)$(GitHubRepositoryName).tar.gz</SymbolsArchiveName>
-    </PropertyGroup>
 
     <Exec Command="tar --numeric-owner -czf $(SymbolsArchiveName) --files-from=$(SymbolsList)"
-          WorkingDirectory="$(SymbolsRoot)" />
-    <Message Importance="High" Text="Packaged symbols to $(SymbolsArchiveName)" />
+          WorkingDirectory="$(SymbolsRoot)" Condition="Exists($(SymbolsList))" />
+    <Message Importance="High" Text="Packaged symbols to $(SymbolsArchiveName)" Condition="Exists($(SymbolsArchiveName))" />
 
-    <ItemGroup>
-      <!-- Symbols archive goes into the "main" intermediate nupkg. -->
+    <ItemGroup Condition="Exists($(SymbolsArchiveName))">
       <Content Include="$(SymbolsArchiveName)" PackagePath="artifacts" />
     </ItemGroup>
 
-    <Delete Files="$(SymbolsList)" />
+    <Delete Files="$(SymbolsList)" Condition="Exists($(SymbolsList))" />
   </Target>
 
   <!-- Create a list of non-shipping packages and include it in the intermediate package. -->
-  <Target Name="CreateNonShippingNupkgList"
+  <Target Name="GetNonShippingNupkgList"
           Condition="'@(IntermediateNonShippingNupkgFile)' != ''">
     <PropertyGroup>
       <!-- The prefix needs to match what's defined in tarball source-build infra. Consider using a single property, in the future. -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
@@ -54,6 +54,8 @@
           DependsOnTargets="
             GetCategorizedIntermediateNupkgContents;
             GetSupplementalIntermediateNupkgManifest;
+            CreateSymbolsList;
+            CreateSymbolsArchive;
             CreateNonShippingNupkgList"
           BeforeTargets="_GetPackageFiles">
     <ItemGroup>
@@ -77,6 +79,48 @@
       <!-- The list of supplemental package ids goes into the "main" intermediate nupkg. -->
       <Content Include="$(SupplementalIntermediateNupkgManifestFile)" PackagePath="." />
     </ItemGroup>
+  </Target>
+
+  <!-- Discover all repo's symbols that match **\obj\**\*.pdb, to be included in the "main" intermediate nupkg. -->
+  <Target Name="CreateSymbolsList" Condition="'$(SupplementalIntermediateNupkgCategory)' == ''">
+    <PropertyGroup>
+      <SymbolsRoot>$(CurrentRepoSourceBuildArtifactsDir)</SymbolsRoot>
+      <!-- Fall back to repo root for source-build-externals or repos that don't have the regular SymbolsRoot as defined above -->
+      <SymbolsRoot Condition="!Exists('$(SymbolsRoot)') or '$(GitHubRepositoryName)' != 'source-build-externals'">$(RepoRoot)</SymbolsRoot>
+      <SymbolsArchiveLocation>$(CurrentRepoSourceBuildArtifactsPackagesDir)</SymbolsArchiveLocation>
+      <SymbolsList>$(SymbolsArchiveLocation)\symbols.lst</SymbolsList>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <AbsoluteSymbolPath Include="$(SymbolsRoot)\**\obj\**\*.pdb" />
+      <RelativeSymbolPath Include="@(AbsoluteSymbolPath)" Condition="'@(AbsoluteSymbolPath)' != ''">
+        <RelativePath>$([MSBuild]::MakeRelative($(SymbolsRoot), %(AbsoluteSymbolPath.FullPath)))</RelativePath>
+      </RelativeSymbolPath>
+    </ItemGroup>
+
+    <WriteLinesToFile
+      File="$(SymbolsList)"
+      Lines="@(RelativeSymbolPath->'%(RelativePath)')"
+      Overwrite="true"
+      Condition="'@(RelativeSymbolPath)' != ''" />
+  </Target>
+
+  <Target Name="CreateSymbolsArchive" Condition="Exists($(SymbolsList))">
+    <PropertyGroup>
+      <SymbolsArchivePrefix>Symbols.</SymbolsArchivePrefix>
+      <SymbolsArchiveName>$(SymbolsArchiveLocation)$(SymbolsArchivePrefix)$(GitHubRepositoryName).tar.gz</SymbolsArchiveName>
+    </PropertyGroup>
+
+    <Exec Command="tar --numeric-owner -czf $(SymbolsArchiveName) --files-from=$(SymbolsList)"
+          WorkingDirectory="$(SymbolsRoot)" />
+    <Message Importance="High" Text="Packaged symbols to $(SymbolsArchiveName)" />
+
+    <ItemGroup>
+      <!-- Symbols archive goes into the "main" intermediate nupkg. -->
+      <Content Include="$(SymbolsArchiveName)" PackagePath="artifacts" />
+    </ItemGroup>
+
+    <Delete Files="$(SymbolsList)" />
   </Target>
 
   <!-- Create a list of non-shipping packages and include it in the intermediate package. -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
@@ -85,8 +85,9 @@
     <PropertyGroup>
       <SymbolsRoot>$(CurrentRepoSourceBuildArtifactsDir)</SymbolsRoot>
       <!-- Fall back to repo root for source-build-externals or repos that don't have the regular SymbolsRoot as defined above -->
-      <SymbolsRoot Condition="!Exists('$(SymbolsRoot)') or '$(GitHubRepositoryName)' != 'source-build-externals'">$(RepoRoot)</SymbolsRoot>
+      <SymbolsRoot Condition="!Exists('$(SymbolsRoot)') or '$(GitHubRepositoryName)' == 'source-build-externals'">$(RepoRoot)</SymbolsRoot>
       <SymbolsArchiveLocation>$(CurrentRepoSourceBuildArtifactsPackagesDir)</SymbolsArchiveLocation>
+      <SymbolsArchiveLocation Condition="'$(GitHubRepositoryName)' == 'nuget-client'">$(PackageOutputPath)</SymbolsArchiveLocation>
       <SymbolsList>$(SymbolsArchiveLocation)\symbols.lst</SymbolsList>
       <SymbolsArchivePrefix>Symbols.</SymbolsArchivePrefix>
       <SymbolsArchiveName>$(SymbolsArchiveLocation)$(SymbolsArchivePrefix)$(GitHubRepositoryName).tar.gz</SymbolsArchiveName>


### PR DESCRIPTION
Resolves: https://github.com/dotnet/source-build/issues/3547, https://github.com/dotnet/source-build/issues/3609 and https://github.com/dotnet/source-build/issues/3610

This change enables creation of repo-specific PDB archives, named `Symbols.<repo-name>.tar.gz`. Archives get included in `main` source-build intermediate package, and eventually extracted to `artifacts/<chip>/<flavor>` i.e. `artifacts/x64/Release`.

New infra collects all PDBs using `**\obj\**\*.pdb` pattern.

File hierarchy is preserved, which enables archive to contain multiple files with the same name. File hierarchy is rooted in `$(CurrentRepoSourceBuildArtifactsDir)` except for `source-build-externals` repo, which uses `$(RepoRoot)`.

Validation VMR build is in progress: https://dev.azure.com/dnceng/internal/_build/results?buildId=2261578&view=results

Example content, from `Symbols.sourcelink.tar.gz`:
```
obj/dotnet-sourcelink/Release/net8.0/dotnet-sourcelink.pdb
obj/Microsoft.Build.Tasks.Git/Release/net8.0/Microsoft.Build.Tasks.Git.pdb
obj/Microsoft.SourceLink.AzureDevOpsServer.Git/Release/net8.0/Microsoft.SourceLink.AzureDevOpsServer.Git.pdb
obj/Microsoft.SourceLink.AzureRepos.Git/Release/net8.0/Microsoft.SourceLink.AzureRepos.Git.pdb
obj/Microsoft.SourceLink.Bitbucket.Git/Release/net8.0/Microsoft.SourceLink.Bitbucket.Git.pdb
obj/Microsoft.SourceLink.Common/Release/net8.0/Microsoft.SourceLink.Common.pdb
obj/Microsoft.SourceLink.Gitea/Release/net8.0/Microsoft.SourceLink.Gitea.pdb
obj/Microsoft.SourceLink.Gitee/Release/net8.0/Microsoft.SourceLink.Gitee.pdb
obj/Microsoft.SourceLink.GitHub/Release/net8.0/Microsoft.SourceLink.GitHub.pdb
obj/Microsoft.SourceLink.GitLab/Release/net8.0/Microsoft.SourceLink.GitLab.pdb
obj/Microsoft.SourceLink.GitWeb/Release/net8.0/Microsoft.SourceLink.GitWeb.pdb
```

Here are some numbers:

Repo | Previous intermediate size (MB) | Symbols archive (MB) | New intermediate size (MB)
-- | -- | -- | --
arcade | 6 | 0 | 6
aspnetcore | 94 | 7 | 101
cecil | 0.6 | 0.3 | 0.9
command-line-api | 0.6 | 0.3 | 0.9
deplyment-tools | 0.1 | 0.03 | 0.13
diagnostics | 0.06 | 0.06 | 0.12
emsdk | 0.04 | 0 | 0.04
format | 14.4 | 0.07 | 14.5
fsharp | 109 | 0 | 109
installer | 203 | 0 | 203
msbuild | 8.4 | 3.4 | 11.8
nuget-client | 5.3 | 1.4 | 6.7
razor | 1 | 1 | 2
roslyn | 78 | 41 | 119
roslyn-analyzers | 18.3 | 3 | 21.3
runtime - crossgen | 256 | 0 | 256
runtime - ilcompiler | 79 | 0 | 79
runtime - main | 177 | 128 | 305
runtime - runtime | 139 | 0 | 139
sdk | 74.7 | 2.2 | 76.9
source-build-externals | 3 | 3 | 6
source-build-reference-packages | 23.5 | 0 | 23.5
sourcelink | 0.7 | 0.1 | 0.8
symreader | 0.3 | 0.06 | 0.4
templating | 1.3 | 0.6 | 2
test-templates | 0.2 | 0.004 | 0.2
vstest | 3 | 0 | 3
xdt | 0.2 | 0.1 | 0.3
xliff-tasks | 0.1 | 0.04 | 0.15
Totals | 1297 | 192 | 1489
