### PR TITLE
Use portable RID graph for builds

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
@@ -55,7 +55,7 @@
     <ChooseBestP2PTargetFrameworkTask AnnotatedProjectReferences="@(_ProjectReferenceWithTargetFrameworks)"
                                       CurrentProjectTargetFramework="$(ReferringTargetFrameworkForProjectReferences)"
                                       CurrentProjectTargetPlatform="$(TargetPlatformMoniker)"
-                                      RuntimeGraph="$(BundledRuntimeIdentifierGraphFile)"
+                                      RuntimeGraph="$([MSBuild]::ValueOrDefault('$(RuntimeIdentifierGraphPath)', '$(BundledRuntimeIdentifierGraphFile)'))"
                                       OmitIncompatibleProjectReferences="$(OmitIncompatibleProjectReferences)">
       <Output TaskParameter="AssignedProjects" ItemName="AnnotatedProjects" />
     </ChooseBestP2PTargetFrameworkTask>


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
