### PR TITLE
Use portable RID graph

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/BinPlace.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/build/BinPlace.targets
@@ -76,7 +76,7 @@
          for each binplace targetFramework. -->
     <ChooseBestTargetFrameworksTask BuildTargetFrameworks="@(BinPlaceTargetFrameworks)"
                                     SupportedTargetFrameworks="@(_supportedTargetFramework)"
-                                    RuntimeGraph="$(BundledRuntimeIdentifierGraphFile)">
+                                    RuntimeGraph="$([MSBuild]::ValueOrDefault('$(RuntimeIdentifierGraphPath)', '$(BundledRuntimeIdentifierGraphFile)'))">
       <Output TaskParameter="BestTargetFrameworks" ItemName="_bestBinPlaceTargetFrameworks" />
     </ChooseBestTargetFrameworksTask>
     

--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/buildMultiTargeting/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/buildMultiTargeting/Microsoft.DotNet.Build.Tasks.TargetFramework.targets
@@ -42,7 +42,7 @@
 
     <ChooseBestTargetFrameworksTask BuildTargetFrameworks="@(_BuildTargetFrameworkWithTargetOS);$(AdditionalBuildTargetFrameworks)"
                                     SupportedTargetFrameworks="$(TargetFrameworks)"
-                                    RuntimeGraph="$(BundledRuntimeIdentifierGraphFile)"
+                                    RuntimeGraph="$([MSBuild]::ValueOrDefault('$(RuntimeIdentifierGraphPath)', '$(BundledRuntimeIdentifierGraphFile)'))"
                                     Distinct="true">
       <Output TaskParameter="BestTargetFrameworks" ItemName="_BestTargetFramework" />
     </ChooseBestTargetFrameworksTask>

--- a/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -194,7 +194,7 @@
                                      Files="@(_FilesForDepsFile)"
                                      IntermediateOutputPath="$(IntermediateOutputPath)"
                                      SharedFrameworkDepsNameOverride="$(SharedFrameworkHostFileNameOverride)"
-                                     RuntimeIdentifierGraph="$(BundledRuntimeIdentifierGraphFile)"
+                                     RuntimeIdentifierGraph="$([MSBuild]::ValueOrDefault('$(RuntimeIdentifierGraphPath)', '$(BundledRuntimeIdentifierGraphFile)'))"
                                      IncludeFallbacksInDepsFile="$(IncludeFallbacksInDepsFile)">
       <Output TaskParameter="GeneratedDepsFile" ItemName="_SharedFrameworkDepsFile" />
     </GenerateSharedFrameworkDepsFile>


### PR DESCRIPTION
Continuation of 08a46d5d5fb05f3d55de3955535996a630d75e2a

cc @jkoritzinsky 

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
