### PR TITLE
Multi-target Microsoft.DotNet.Tar package to .NET FX to allow restore from Tools.proj

### DIFF
--- a/src/Microsoft.DotNet.Tar/Microsoft.DotNet.Tar.csproj
+++ b/src/Microsoft.DotNet.Tar/Microsoft.DotNet.Tar.csproj
@@ -1,15 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);$(NetFrameworkToolCurrent)</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>true</IsPackable>
     <Description>Tar</Description>
     <PackageTags>Arcade Build Tool Tar</PackageTags>
     <DevelopmentDependency>false</DevelopmentDependency>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == '$(NetCurrent)'">
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-tar</ToolCommandName>
   </PropertyGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.Tar/Program.cs
+++ b/src/Microsoft.DotNet.Tar/Program.cs
@@ -1,6 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if NETFRAMEWORK
+
+System.Console.Error.WriteLine("Not supported on .NET Framework");
+return 1;
+
+#else
+
 using System;
 using System.Formats.Tar;
 using System.IO;
@@ -42,3 +49,5 @@ catch (Exception e)
 }
 
 return 0;
+
+#endif


### PR DESCRIPTION
Workaround for restore issue: https://github.com/dotnet/arcade-validation/pull/3945

Probably want Tools.proj to target .NET Core instead, but that would be a bigger change.