### PR TITLE
Enable fail on prebuilt baseline errors

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
@@ -52,7 +52,7 @@
   <Target Name="ReportPrebuiltUsage"
           DependsOnTargets="WritePrebuiltUsageData">
     <PropertyGroup>
-      <FailOnPrebuiltBaselineError Condition="'$(FailOnPrebuiltBaselineError)' == ''">false</FailOnPrebuiltBaselineError>
+      <FailOnPrebuiltBaselineError Condition="'$(FailOnPrebuiltBaselineError)' == ''">true</FailOnPrebuiltBaselineError>
     </PropertyGroup>
 
     <WriteUsageReports


### PR DESCRIPTION
Fixes #14022

This ensures the existence of SB prebuilts will cause repo builds to fail even if they don't treat warnings as errors.