### PR TITLE
Make the backport-base workflow usable by third-party repositories.

### DIFF
--- a/.github/workflows/backport-base.yml
+++ b/.github/workflows/backport-base.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   cleanup:
-    if: ${{ contains(inputs.repository_owners, github.repository_owner) && github.event_name == 'schedule' }}
+    if: ${{ contains(format('{0},', inputs.repository_owners), format('{0},', github.repository_owner) && github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -62,7 +62,7 @@ jobs:
           }
 
   run_backport:
-    if: ${{ contains(inputs.repository_owners, github.repository_owner) && github.event.issue.pull_request != '' && contains(github.event.comment.body, '/backport to') }}
+    if: ${{ contains(format('{0},', inputs.repository_owners), format('{0},', github.repository_owner)) && github.event.issue.pull_request != '' && contains(github.event.comment.body, '/backport to') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/backport-base.yml
+++ b/.github/workflows/backport-base.yml
@@ -14,10 +14,15 @@ on:
           Backport of #%source_pr_number% to %target_branch%
 
           /cc %cc_users%
+      repository_owners:
+        description: 'A comma-separated list of repository owners where the workflow will run. Defaults to "dotnet,microsoft".'
+        required: false
+        type: string
+        default: 'dotnet,microsoft'
 
 jobs:
   cleanup:
-    if: ${{ (github.repository_owner == 'dotnet' || github.repository_owner == 'microsoft') && github.event_name == 'schedule' }}
+    if: ${{ contains(inputs.repository_owners, github.repository_owner) && github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -57,7 +62,7 @@ jobs:
           }
 
   run_backport:
-    if: ${{ (github.repository_owner == 'dotnet' || github.repository_owner == 'microsoft') && github.event.issue.pull_request != '' && contains(github.event.comment.body, '/backport to') }}
+    if: ${{ contains(inputs.repository_owners, github.repository_owner) && github.event.issue.pull_request != '' && contains(github.event.comment.body, '/backport to') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/backport-base.yml
+++ b/.github/workflows/backport-base.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   cleanup:
-    if: ${{ contains(format('{0},', inputs.repository_owners), format('{0},', github.repository_owner) && github.event_name == 'schedule' }}
+    if: ${{ contains(format('{0},', inputs.repository_owners), format('{0},', github.repository_owner)) && github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
     permissions:
       actions: write


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation

Having seen the backport workflow in action multiple times in `dotnet/runtime`, I would like to be able to use it in a non-dotnet repository. This PR modifies `backport-base.yml` to allow customizing the owners of the repositories in which it is allowed to run. They default to `dotnet` and `microsoft`, maintaining backwards compatibility.

A third-party repository can use the backport action by writing something like this:

```yml
jobs:
  backport:
    uses: dotnet/arcade/.github/workflows/backport-base.yml@main
    with:
      repository_owners: 'MyOrg'
```