### PR TITLE
Update Newtonsoft.Json from 13.0.1 to 13.0.3

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -17,6 +17,11 @@
       to the corresponding entry in Version.Details.xml -->
     <UsagePattern IdentityGlob="Microsoft.CodeAnalysis.*/*" />
 
+    <!-- This version is brought in transitively from NuGet.Packaging.6.2.4.
+         Once a newer version of NuGet.Packaging is referenced which has a
+         dependency on 13.0.3, this can be removed. -->
+    <UsagePattern IdentityGlob="Newtonsoft.Json/13.0.1" />
+
      <!-- This package is upgraded to latest versions in product build and can be baselined for 
       the repo build. -->
     <UsagePattern IdentityGlob="System.IO.Packaging/*7.0.0*" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -90,9 +90,9 @@
       <Sha>93c23409e630c4f267234540b0e3557b76a53ef4</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="8.0.0-alpha.1.23424.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="8.0.0-alpha.1.23468.1">
       <Uri>https://github.com/dotnet/source-build-externals</Uri>
-      <Sha>e3cc6c792114ebdfe6627742d2820dbe1ae5bc47</Sha>
+      <Sha>e9d6489787a5ea5400a31dfa34aa6ad6b590de9b</Sha>
       <SourceBuild RepoName="source-build-externals" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.Deployment.DotNet.Releases" Version="1.0.0-preview6.1.23159.4" CoherentParentDependency="Microsoft.NET.Sdk.WorkloadManifestReader">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -98,7 +98,7 @@
     <MicrosoftVisualStudioOLEInteropVersion>7.10.6071</MicrosoftVisualStudioOLEInteropVersion>
     <MonoOptionsVersion>5.3.0.1</MonoOptionsVersion>
     <MoqVersion>4.18.4</MoqVersion>
-    <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
+    <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <OctokitVersion>0.41.0</OctokitVersion>
     <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>
     <XUnitVersion>2.4.2</XUnitVersion>


### PR DESCRIPTION
.NET repos currently have a mix of Newtonsoft.Json versions that we're trying to get consolidated into the latest version. This is particularly necessary for the .NET's [source-build](https://github.com/dotnet/source-build) which can only reference one version of a dependency.

This was missed as part of the initial set of work to update all repos to 13.0.3.

Related to https://github.com/dotnet/source-build-externals/pull/195