### PR TITLE
Ensure "starts with llvm" in latest version detection

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -487,7 +487,7 @@ if [[ "$__CodeName" == "alpine" ]]; then
             -X "http://dl-cdn.alpinelinux.org/alpine/$version/main" \
             -X "http://dl-cdn.alpinelinux.org/alpine/$version/community" \
             -U $__ApkSignatureArg --root "$__RootfsDir" --arch "$__AlpineArch" \
-            search 'llvm*-libs' | sort | tail -1 | sed 's/-[^-]*//2g')"
+            search 'llvm*-libs' | grep -E '^llvm' | sort | tail -1 | sed 's/-[^-]*//2g')"
     fi
 
     # install all packages in one go


### PR DESCRIPTION
This filter is now necessary because a package called `spirv-llvm-translator-libs-15.0.0-r4` is sorted on the top and we fail to auto-detect the latest llvm version with edge repository. The (unclear/cryptic) error looks like this:

```
23:29:40.5572832Z /tmp/tmp.hiZtMmvWIm/apk.static: OK
2023-09-21T23:29:40.5634883Z '/usr/bin/qemu-riscv64-static' -> '/rootfs/riscv64/usr/bin/qemu-riscv64-static'
2023-09-21T23:29:40.5668497Z fetch http://dl-cdn.alpinelinux.org/alpine/edge/community/riscv64/APKINDEX.tar.gz
2023-09-21T23:29:40.8399372Z fetch http://dl-cdn.alpinelinux.org/alpine/edge/main/riscv64/APKINDEX.tar.gz
2023-09-21T23:29:41.3253585Z OK: 0 MiB in 0 packages
2023-09-21T23:29:41.8163826Z ERROR: unable to select packages:
2023-09-21T23:29:41.8164270Z   spirv-llvm (no such package):
2023-09-21T23:29:41.8568951Z     required by: world[spirv-llvm]
```

This fixes riscv64 error blocking https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/915.

cc @lbussell