### PR TITLE
Don't overwrite `DeployExtension` if defined

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.VsixBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.VsixBuild.targets
@@ -34,7 +34,7 @@
     <TargetVsixContainerName Condition="'$(TargetVsixContainerName)' == ''">$(TargetName).vsix</TargetVsixContainerName>
     <TargetVsixContainer Condition="'$(TargetVsixContainer)' == ''">$(_TargetVsixContainerDir)$(TargetVsixContainerName)</TargetVsixContainer>
 
-    <DeployExtension Condition="'$(DeployExtension)' != '' and '$(DeployProjectOutput)' == 'true'">true</DeployExtension>
+    <DeployExtension Condition="'$(DeployExtension)' == '' and '$(DeployProjectOutput)' == 'true'">true</DeployExtension>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(VisualStudioInsertionComponent)' != ''">

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.VsixBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.VsixBuild.targets
@@ -34,7 +34,7 @@
     <TargetVsixContainerName Condition="'$(TargetVsixContainerName)' == ''">$(TargetName).vsix</TargetVsixContainerName>
     <TargetVsixContainer Condition="'$(TargetVsixContainer)' == ''">$(_TargetVsixContainerDir)$(TargetVsixContainerName)</TargetVsixContainer>
 
-    <DeployExtension Condition="'$(DeployProjectOutput)' == 'true'">true</DeployExtension>
+    <DeployExtension Condition="'$(DeployExtension)' != '' and '$(DeployProjectOutput)' == 'true'">true</DeployExtension>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(VisualStudioInsertionComponent)' != ''">


### PR DESCRIPTION
This breaks Roslyn local build and deploy scenario. We explicitly defined `DeployExtension` to `false` to prevent the visx targeting Arm64 to be deployed when building the solution.

https://github.com/dotnet/roslyn/blob/cca9495918b45f11e0abd4f56e55c8288e0b8554/src/VisualStudio/Setup.ServiceHub/arm64/Roslyn.VisualStudio.ServiceHub.Setup.arm64.csproj#L12