### PR TITLE
Update TargetFrameworkFilters.BeforeCommonTargets.targets

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/TargetFrameworkFilters.BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/TargetFrameworkFilters.BeforeCommonTargets.targets
@@ -66,6 +66,9 @@
         System.Threading.Timer;
         System.Xml.ReaderWriter;
         System.Xml.XDocument" />
+      <!-- That package doesn't bring any dependencies in on .NET Framework and is fine to use. -->
+      <NetStandard1xPackage Remove="System.Runtime.InteropServices.RuntimeInformation"
+                            Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
It's fine to reference the `System.Runtime.InteropServices.RuntimeInformation` package on .NET Framework (still, not ideal as the package is already quite old) as it doesn't bring in any dependencies. While references to all the other netstandard1.x era packages can be avoided, this reference is still required on .NET Framework for runtime OS conditions.

Combined with https://github.com/dotnet/arcade/pull/14036, we can finally enable the `FlagNetStandard1XDependencies` opt-in target in Arcade. That means we are finally netstandard1.x assets free and have validation to not regress.

Can't enable that switch yet as these changes aren't reflected in the live build because Arcade uses a prebuilt Arcade.Sdk.