### PR TITLE
Add net9.0 to default TFM filtering

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -38,7 +38,7 @@
       TFM filtering is enabled by default and can be disabled, at repo level, by setting NoTargetFrameworkFiltering property to true,
       in repo's root Directory.Build.props file.
     -->
-    <_DefaultNetFrameworkFilter>netstandard2.0%3bnetstandard2.1%3bnetcoreapp2.1%3bnetcoreapp3.1%3bnet5.0%3bnet6.0%3bnet7.0%3bnet8.0</_DefaultNetFrameworkFilter>
+    <_DefaultNetFrameworkFilter>netstandard2.0%3bnetstandard2.1%3bnetcoreapp2.1%3bnetcoreapp3.1%3bnet5.0%3bnet6.0%3bnet7.0%3bnet8.0%3bnet9.0</_DefaultNetFrameworkFilter>
     <SourceBuildTargetFrameworkFilter Condition="'$(SourceBuildTargetFrameworkFilter)' == ''">$(_DefaultNetFrameworkFilter)</SourceBuildTargetFrameworkFilter>
   </PropertyGroup>
 


### PR DESCRIPTION
Adds `net9.0` to the list of the `_DefaultNetFrameworkFilter`. This enables TFM filtering to work properly if `net9.0` is the only TFM of a project. Without this, such a project would skip being built.