### PR TITLE
Remove manually pinned package references

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/Microsoft.DotNet.Build.Tasks.TargetFramework.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.TargetFramework/src/Microsoft.DotNet.Build.Tasks.TargetFramework.csproj
@@ -19,8 +19,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Tasks.Core" />
-    <!-- Pinning transitive version -->
-    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NuGet.Packaging" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Microsoft.DotNet.Build.Tasks.Workloads.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Microsoft.DotNet.Build.Tasks.Workloads.csproj
@@ -26,8 +26,6 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
     <PackageReference Include="Microsoft.Deployment.DotNet.Releases" />
     <PackageReference Include="Microsoft.NET.Sdk.WorkloadManifestReader" />
-    <!-- Pinning transitive version -->
-    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NuGet.Packaging" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.NuGetRepack/tasks/Microsoft.DotNet.NuGetRepack.Tasks.csproj
+++ b/src/Microsoft.DotNet.NuGetRepack/tasks/Microsoft.DotNet.NuGetRepack.Tasks.csproj
@@ -11,8 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Tasks.Core" />
-    <!-- Pinning transitive version -->
-    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NuGet.Versioning" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.PackageTesting/Microsoft.DotNet.PackageTesting.csproj
+++ b/src/Microsoft.DotNet.PackageTesting/Microsoft.DotNet.PackageTesting.csproj
@@ -8,8 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Tasks.Core" />
-    <!-- Pinning transitive version -->
-    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NuGet.Frameworks" />
     <PackageReference Include="NuGet.Packaging" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.SharedFramework.Sdk/Microsoft.DotNet.SharedFramework.Sdk.csproj
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/Microsoft.DotNet.SharedFramework.Sdk.csproj
@@ -12,8 +12,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" />
-    <!-- Pinning transitive version -->
-    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NuGet.Packaging" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.SignTool/Microsoft.DotNet.SignTool.csproj
+++ b/src/Microsoft.DotNet.SignTool/Microsoft.DotNet.SignTool.csproj
@@ -24,8 +24,6 @@
     <PackageReference Include="Microsoft.ApplicationInsights" />
     <PackageReference Include="Microsoft.Build.Framework" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
-    <!-- Pinning transitive version -->
-    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NuGet.Packaging" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.SourceBuild/tasks/Microsoft.DotNet.SourceBuild.Tasks.csproj
+++ b/src/Microsoft.DotNet.SourceBuild/tasks/Microsoft.DotNet.SourceBuild.Tasks.csproj
@@ -11,8 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Tasks.Core" />
-    <!-- Pinning transitive version -->
-    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NuGet.Frameworks" />
     <PackageReference Include="NuGet.Packaging" />
     <PackageReference Include="NuGet.Versioning" />


### PR DESCRIPTION
See https://github.com/dotnet/arcade/pull/13998#discussion_r1338619007 for context

[CPM - Central Package Management takes care of pinning transitives](https://github.com/dotnet/arcade/blob/822f095b8c815dd7b9161140a9ff8151de593f82/Directory.Packages.props#L5). Remove the package references that were added for that purpose before CPM was enabled in the repository.

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
