### PR TITLE
Add Bcl.AsyncInterfaces dependency

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -74,6 +74,10 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>547c506abe05e510bd43330fc8f6d4c5961e9223</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0-preview.4.23259.5">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>547c506abe05e510bd43330fc8f6d4c5961e9223</Sha>
+    </Dependency>
     <!-- Latest preview version required by source-build. The dependency is loaded in during built-time
          by consumers of SharedFramework.Sdk (such as runtime), so we cannot use a ref pack for it -->
     <Dependency Name="Microsoft.Extensions.DependencyModel" Version="8.0.0-preview.4.23259.5">


### PR DESCRIPTION
Arcade has an implicit dependency on Microsoft.Bcl.AsyncInterfaces that is not declared in Version.Details. It also has a dependency on System.Text.Json which has a transitive dependency on Microsoft.Bcl.AsyncInterfaces. With source-build, it's possible to get a newer version of System.Text.Json that provides a newer version of Microsoft.Bcl.AsyncInterfaces than what arcade references. This would cause a conflict:

```
/vmr/src/arcade/artifacts/source-build/self/src/src/Common/Microsoft.Arcade.Common/Microsoft.Arcade.Common.csproj(0,0): error NU1109: (NETCORE_ENGINEERING_TELEMETRY=Restore) Detected package downgrade: Microsoft.Bcl.AsyncInterfaces from 8.0.0-rc.1.23381.3 to centrally defined 8.0.0-preview.4.23259.5. Update the centrally managed package version to a higher version. 
 Microsoft.Arcade.Common -> System.Text.Json 8.0.0-rc.1.23381.3 -> Microsoft.Bcl.AsyncInterfaces (>= 8.0.0-rc.1.23381.3) 
 Microsoft.Arcade.Common -> Microsoft.Bcl.AsyncInterfaces (>= 8.0.0-preview.4.23259.5)
```

By declaring the dependency in Version.Details.xml, it allows source-build to provide the newer version, overriding what arcade had originally declared for its Microsoft.Bcl.AsyncInterfaces version.