### PR TITLE
Fix vswhere PackageReference in Microsoft.DotNet.CMake.Sdk.targets

### DIFF
--- a/src/Microsoft.DotNet.CMake.Sdk/build/Microsoft.DotNet.CMake.Sdk.targets
+++ b/src/Microsoft.DotNet.CMake.Sdk/build/Microsoft.DotNet.CMake.Sdk.targets
@@ -4,7 +4,7 @@
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
   <ItemGroup>
-    <PackageReference Include="vswhere" IsImplicitlyDefined="true" GeneratePathProperty="true" />
+    <PackageReference Include="vswhere" Version="$(VSWhereVersion)" IsImplicitlyDefined="true" GeneratePathProperty="true" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This version is not defined by CPM but usually by src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
Regressed with https://github.com/dotnet/arcade/pull/14074 which resulted in a _very_ old vswhere package getting restored which caused a build error in https://github.com/dotnet/installer/pull/17473