### PR TITLE
Change richCodeNavigationEnvironment to internal

### DIFF
--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -154,7 +154,7 @@ jobs:
       displayName: RichCodeNav Upload
       inputs:
         languages: ${{ coalesce(parameters.richCodeNavigationLanguage, 'csharp') }}
-        environment: ${{ coalesce(parameters.richCodeNavigationEnvironment, 'production') }}
+        environment: ${{ coalesce(parameters.richCodeNavigationEnvironment, 'internal') }}
         richNavLogOutputDirectory: $(Build.SourcesDirectory)/artifacts/bin
         uploadRichNavArtifacts: ${{ coalesce(parameters.richCodeNavigationUploadArtifacts, false) }}
       continueOnError: true


### PR DESCRIPTION
The RichCodeNav team reached out to me that they'd like to have the environment changed to `internal`.

/cc @ViktorHofer 