### PR TITLE
Updated UB roadmap

### DIFF
--- a/Documentation/UnifiedBuild/UB-Roadmap-Gantt.md
+++ b/Documentation/UnifiedBuild/UB-Roadmap-Gantt.md
@@ -21,8 +21,8 @@ gantt
 
     section Vertical Build
         Win VB PoC: after net8-ga, 6w
-        Linux VB PoC: after net8-ga, 6w
-        MacOS VB PoC: after net8-ga, 6w
+        Linux VB PoC: after net8-rc2, 11w
+        MacOS VB PoC: after net8-rc2, 11w
         Workloads PoC: after net8-ga, 6w
         Identify Join Points: after net8-ga, 6w
         Vertical Builds Design: after holiday, 7w
@@ -37,19 +37,147 @@ gantt
         Scenario tests in VMR: after net8-rc2, 10w
         PR Validation: after net9-p2, 4w
 
-    section Shared Infra
-        Signing Design: after holiday, 7w
-
     section Product Construction
+        Backflow design: after net8-rc2, 5w
         Backflow tooling: after net8-ga, 6w
         Dependency Flow Service: after holiday, 7w
         Maestro Integration: after net9-p1, 8w
+
         Multi-band SDKs: after net9-p4, 4w
         Dependency Flow Switch Preparation: after net9-p3, 8w
         Depenendency Flow Switch: after net9-p5, 4w
 
     section Release Infra
         Release infra investigation & design: after net8-ga, 6w
-        Staging / Release Pipeline Update: after net9-p3, 4w
+        Signing Design: after holiday, 7w
         Identify Repo Dependencies: after net9-p3, 4w
+        Staging / Release Pipeline: after net9-p3, 4w
 ```
+
+# Milestones
+
+The Unified Build milestones are aligned with the .NET9 lifecycle, specifically with the preview releases.
+
+**Holiday Break (end of Dec)**
+
+* Vertical Build (VB) Proof of Concepts (PoCs) for each of the major platforms completed.
+* The main join points are identified and most of the unforseen problems have surfaced as result of the PoC work.
+* The VMR scenario tests focused on the overall product functionality are running on the VMR for every PR.
+
+**.NET9 Preview 1**
+
+* High confidence in the PoCs. At this point, we expect to have uncovered and understood all problematic aspects of the Unified build designs, including the Vertical Buidls, their Join points, cross-compiled builds, and the full flow (forward flow + backflow) between the individual produt repos and the VMR. Differences between the current source-build and Linux vertical build are identified.
+
+**.NET9 Preview 3**
+
+* PoC Productization. At this point, we expect to have the Vertical Builds work completed, including setting up minimal set of join points.
+* The VMR tooling will support automated backflow and be fully integrated with the current dependency flow tooling (Maestro++).
+
+**.NET9 Preview 4**
+
+* Test release of VMR in parallel with existing build methodology.
+
+**.NET9 Preview 5**
+
+* Switch to release from VMR.
+* Start turning off the existing build methodology (for .NET9).
+
+**.NET9 Preview 7**
+
+* The latest possible time to move to the VMR based dependency flow with confidence to not introduce any risk for .NET9 release.
+
+# Individual Tasks
+
+## Vertical Build area
+
+**Windows, Linux, MacOS Vertical Build (VB) PoC**
+
+Initial vertical build efforts for each of the main platforms (Windows, Linux, MacOS). The goal of these efforts is to uncover hidden problems with building the product for each platform in a single build without requiring cross-platform build assets.
+        
+**Workloads PoC**
+
+SDK Workloads vertical build Proof of Concept. Similar to the platform VB PoCs, this effort is focused to identify and uncover all issues related to building the SDK workloads.
+
+**Identify Join Points**
+
+Identification and mapping of the current cross-platform build orchestration.
+
+**Vertical Builds Design**
+
+Leverage the finding of the vertical build PoC works to design vertical builds for each platform properly, with the minimal set of join points.
+
+**Enable Vertical Builds**
+
+Implementation of the vertical builds design with the new se of join points.
+
+**Crossbuilds Design**
+
+Design for cross-arch or cross-platform builds and determine how to define cross-build behavior.
+
+## Source-Build area
+
+**VMR UX Improvements**
+
+Improvements of the VMR user experience. This includes, but is not limited to:
+  * Updating source-build to not modify source-controlled files
+  * Design of appropriate controls and command line options
+  * Source-build inner clone removal
+
+**Multi-band SDKs**
+
+Implementing support for building multiple SDK bands sharing one binary copy of the runtime.
+
+## Product Validation area
+        
+**Scenario tests in VMR**
+
+End-to-end scenario tests (such as `dotnet new console` or a running a Stage 2 Linux source-build of the SDK) of the .NET product.
+
+**PR Validation**
+
+Definition and implementation of the set of tests that would be executed as part of the VMR PR validation.
+
+## Product Construction area
+
+**Backflow design**
+
+Design for the backflow from the VMR to the individual product repositories.
+
+**Backflow tooling**
+
+Implementation of the core functionality and CLI tooling for the VMR backflow in to the product repos.
+
+**Dependency Flow Service**
+
+Implementation of the new dependency flow service, that will be extending the current BAR design.
+
+**Maestro Integration**
+
+Integration of the new dependency flow service with Maestro++.
+
+**Dependency Flow Switch Preparation**
+
+Preparation for switching from the existing multi-leayered product dependency flow to the new flat dependency flow between VMR and product repos.
+
+**Depenendency Flow Switch**
+
+Swith to the new flat dependency flow between VMR and product repos.
+
+## Release Infra area
+
+**Release infra investigation & design**
+
+Design for changes necessary to enable releases off of the VMR.
+
+**Signing Design**
+
+Design for signing releases based off of the VMR.
+
+**Identify Repo Dependencies**
+
+Identification of the dependencies between product repos and the layout used to stage the product assets for release.
+
+**Staging / Release Pipeline**
+
+Updates to the current release infrastructure, namely the staging and release pipelines to be able to base releases both off the current dependency flow for ..NET8 and the VMR for .NET9.
+

--- a/Documentation/UnifiedBuild/UB-Roadmap-Gantt.md
+++ b/Documentation/UnifiedBuild/UB-Roadmap-Gantt.md
@@ -122,6 +122,7 @@ Improvements of the VMR user experience. This includes, but is not limited to:
   * Updating source-build to not modify source-controlled files
   * Design of appropriate controls and command line options
   * Source-build inner clone removal
+  * Incremental build improvements
 
 **Multi-band SDKs**
 

--- a/Documentation/UnifiedBuild/UB-Roadmap-Gantt.md
+++ b/Documentation/UnifiedBuild/UB-Roadmap-Gantt.md
@@ -179,5 +179,5 @@ Identification of the dependencies between product repos and the layout used to 
 
 **Staging / Release Pipeline**
 
-Updates to the current release infrastructure, namely the staging and release pipelines to be able to base releases both off the current dependency flow for ..NET8 and the VMR for .NET9.
+Updates to the current release infrastructure, namely the staging and release pipelines to be able to base releases both off the current dependency flow for .NET8 and the VMR for .NET9.
 

--- a/Documentation/UnifiedBuild/UB-Roadmap-Gantt.md
+++ b/Documentation/UnifiedBuild/UB-Roadmap-Gantt.md
@@ -53,4 +53,3 @@ gantt
         Release infra investigation & design: after net8-ga, 6w
         Staging / Release Pipeline: after net9-p3, 4w
 ```
-s

--- a/Documentation/UnifiedBuild/UB-Roadmap-Gantt.md
+++ b/Documentation/UnifiedBuild/UB-Roadmap-Gantt.md
@@ -161,7 +161,7 @@ Preparation for switching from the existing multi-leayered product dependency fl
 
 **Depenendency Flow Switch**
 
-Swith to the new flat dependency flow between VMR and product repos.
+Switch to the new flat dependency flow between VMR and product repos.
 
 ## Release Infra area
 

--- a/Documentation/UnifiedBuild/UB-Roadmap-Gantt.md
+++ b/Documentation/UnifiedBuild/UB-Roadmap-Gantt.md
@@ -125,7 +125,7 @@ Improvements of the VMR user experience. This includes, but is not limited to:
 
 **Multi-band SDKs**
 
-Implementing support for building multiple SDK bands sharing one binary copy of the runtime.
+Implementing support for building multiple SDK bands sharing one binary copy of shared components (e.g. runtime).
 
 ## Product Validation area
         

--- a/Documentation/UnifiedBuild/UB-Roadmap-Gantt.md
+++ b/Documentation/UnifiedBuild/UB-Roadmap-Gantt.md
@@ -19,7 +19,7 @@ gantt
     section Common
         UB Week: ub-week, 2023-10-02, 1w
 
-    section Product Teams
+    section Vertical Build
         Win VB PoC: after net8-ga, 6w
         Linux VB PoC: after net8-ga, 6w
         MacOS VB PoC: after net8-ga, 6w
@@ -29,21 +29,28 @@ gantt
         Enable Vertical Builds: after net9-p1, 8w
         Crossbuilds Design: after net8-ga, 13w
 
-    section A&D
+    section Source-Build
         VMR UX Improvements: after net8-ga, 13w
         Multi-band SDKs: after net9-p4, 4w
 
-    section DncEng
-        Signing Design: after holiday, 7w
+    section Product Validation
         Scenario tests in VMR: after net8-rc2, 10w
         PR Validation: after net9-p2, 4w
 
-    section ProdCon
+    section Shared Infra
+        Signing Design: after holiday, 7w
+
+    section Product Construction
         Backflow tooling: after net8-ga, 6w
-        Release infra repo dependency investigation: after net8-ga, 6w
-        Dependency Flow Service: after holiday, 8w
-        Staging / Release Pipeline: after net9-p3, 4w
+        Dependency Flow Service: after holiday, 7w
+        Maestro Integration: after net9-p1, 8w
         Identify Repo Dependencies: after net9-p3, 4w
         Multi-band SDKs: after net9-p4, 4w
+        Dependency Flow Switch Preparation: after net9-p3, 8w
         Depenendency Flow Switch: after net9-p5, 4w
+
+    section Release Infra
+        Release infra investigation & design: after net8-ga, 6w
+        Staging / Release Pipeline: after net9-p3, 4w
 ```
+s

--- a/Documentation/UnifiedBuild/UB-Roadmap-Gantt.md
+++ b/Documentation/UnifiedBuild/UB-Roadmap-Gantt.md
@@ -44,12 +44,12 @@ gantt
         Backflow tooling: after net8-ga, 6w
         Dependency Flow Service: after holiday, 7w
         Maestro Integration: after net9-p1, 8w
-        Identify Repo Dependencies: after net9-p3, 4w
         Multi-band SDKs: after net9-p4, 4w
         Dependency Flow Switch Preparation: after net9-p3, 8w
         Depenendency Flow Switch: after net9-p5, 4w
 
     section Release Infra
         Release infra investigation & design: after net8-ga, 6w
-        Staging / Release Pipeline: after net9-p3, 4w
+        Staging / Release Pipeline Update: after net9-p3, 4w
+        Identify Repo Dependencies: after net9-p3, 4w
 ```


### PR DESCRIPTION
This is a Markdown change only.

I made several changes to the roadmap, based on our morning discussion with Premek.

1) I've changed the sections to represent technical areas, rather than teams that might be responsible for the work. Although the initial split per teams had some benefits, decoupling the "what" from "who" brings cleaner view of what needs to be done without postulating early funding assumptions.
1) We've added two more chunks of work - Integration of the new Dep Flow Service with Maestro++ and Preparation for the Dependency Flow Switch (which includes necessary investigations, communication, planning of the actual execution, etc.)

