### PR TITLE
Pin SRM & SCI versions for msbuild compatibility

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,10 +56,12 @@
     <MicrosoftNETWorkloadMonoToolChainManifest_60200Version>6.0.3</MicrosoftNETWorkloadMonoToolChainManifest_60200Version>
     <MicrosoftNETWorkloadMonoToolChainManifest_60200Version_604>6.0.4</MicrosoftNETWorkloadMonoToolChainManifest_60200Version_604>
     <MicrosoftiOSTemplatesVersion>15.2.302-preview.14.122</MicrosoftiOSTemplatesVersion>
-    <SystemCollectionsImmutableVersion>8.0.0-preview.4.23259.5</SystemCollectionsImmutableVersion>
+    <!-- Keep this version in sync with what msbuild / VS ships with. -->
+    <SystemCollectionsImmutableVersion>7.0.0</SystemCollectionsImmutableVersion>
     <SystemCompositionVersion>8.0.0-preview.4.23259.5</SystemCompositionVersion>
     <SystemIOPackagingVersion>8.0.0-preview.4.23259.5</SystemIOPackagingVersion>
-    <SystemReflectionMetadataVersion>8.0.0-preview.4.23259.5</SystemReflectionMetadataVersion>
+    <!-- Keep this version in sync with what msbuild / VS ships with. -->
+    <SystemReflectionMetadataVersion>7.0.2</SystemReflectionMetadataVersion>
     <SystemTextEncodingsWebVersion>8.0.0-preview.4.23259.5</SystemTextEncodingsWebVersion>
     <SystemTextJsonVersion>8.0.0-preview.4.23259.5</SystemTextJsonVersion>
     <!-- sdk -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -61,7 +61,7 @@
     <SystemCompositionVersion>8.0.0-preview.4.23259.5</SystemCompositionVersion>
     <SystemIOPackagingVersion>8.0.0-preview.4.23259.5</SystemIOPackagingVersion>
     <!-- Keep this version in sync with what msbuild / VS ships with. -->
-    <SystemReflectionMetadataVersion>7.0.2</SystemReflectionMetadataVersion>
+    <SystemReflectionMetadataVersion>7.0.0</SystemReflectionMetadataVersion>
     <SystemTextEncodingsWebVersion>8.0.0-preview.4.23259.5</SystemTextEncodingsWebVersion>
     <SystemTextJsonVersion>8.0.0-preview.4.23259.5</SystemTextJsonVersion>
     <!-- sdk -->


### PR DESCRIPTION
Fixes https://github.com/dotnet/dnceng/issues/1004

Desktop MSBuild ships with these versions of S.R.M and S.C.I. If we move forward, tasks won't be able to be loaded.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
