### PR TITLE
[release/6.0] Downgrade NuGet packages to 6.0.5

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -35,7 +35,7 @@
     <McMasterExtensionsCommandLineUtils>2.3.0</McMasterExtensionsCommandLineUtils>
     <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <SystemTextJsonVersion>4.7.0</SystemTextJsonVersion>
-    <NuGetVersioningVersion>6.7.0</NuGetVersioningVersion>
+    <NuGetVersioningVersion>6.0.5</NuGetVersioningVersion>
     <NuGetVersion>$(NuGetVersioningVersion)</NuGetVersion>
     <OctokitVersion>0.32.0</OctokitVersion>
     <DotNetSleetLibVersion>2.2.143</DotNetSleetLibVersion>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetAssetResolver.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetAssetResolver.cs
@@ -276,9 +276,8 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
             foreach (var package in _packages.Keys)
             {
-                var contentItemGroups = new List<ContentItemGroup>();
-                _packages[package].PopulateItemGroups(_conventions.Patterns.RuntimeAssemblies, contentItemGroups);
-                resolvedAssets.Add(package, contentItemGroups);
+                resolvedAssets.Add(package,
+                    _packages[package].FindItemGroups(_conventions.Patterns.RuntimeAssemblies));
             }
 
             return resolvedAssets;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/NupkgVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/NupkgVerifier.cs
@@ -37,7 +37,6 @@ namespace Microsoft.SignCheck.Verification
             IEnumerable<ISignatureVerificationProvider> providers = new ISignatureVerificationProvider[] {
                 new IntegrityVerificationProvider(),
                 new SignatureTrustAndValidityVerificationProvider(allowUntrustedRootList: null),
-                new AllowListVerificationProvider(allowList: null),
             };
             var packageSignatureVerifier = new PackageSignatureVerifier(providers);
 


### PR DESCRIPTION
- see https://github.com/dotnet/installer/pull/17517
- need to maintain alignment w/ versions bundled in .NET SDK

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
