### PR TITLE
Add xcopy-msbuild scripts

### DIFF
--- a/eng/xcopy-msbuild/azure-pipelines-xcopy-msbuild.yml
+++ b/eng/xcopy-msbuild/azure-pipelines-xcopy-msbuild.yml
@@ -1,0 +1,48 @@
+parameters:
+- name: Sku
+  displayName: Visual Studio Build Tools Sku (ie, BuildTools, Enterprise, Professional, Community, etc...)
+  type: string
+  default: BuildTools
+- name: Channel
+  displayName: Visual Studio Build Tools Channel (ie, pre, etc...)
+  type: string
+  default: pre
+- name: Release
+  displayName: Visual Studio Build Tools Release (ie, 16, 17, etc...)
+  type: number
+
+
+trigger: none
+
+name: ${{ parameters.Sku }}_${{ parameters.Release }}_${{ parameters.Channel }}-$(Rev:r)
+
+jobs:
+- job: Build
+  displayName: Build xcopy-msbuild package
+  pool: 
+    vmImage: windows-latest
+  steps:
+    - task: PowerShell@2
+      displayName: Download Visual Studio Build Tools
+      inputs:
+        filePath: 'eng\xcopy-msbuild\build.ps1'
+        arguments: -sku "${{ parameters.sku }}" -channel "${{ parameters.channel }}" -release "${{ parameters.release }}" -outputDirectory "$(Build.ArtifactStagingDirectory)\install"
+
+    - task: PowerShell@2
+      displayName: Build Xcopy-MSBuild package
+      inputs:
+        filePath: 'eng\xcopy-msbuild\build-msbuild.ps1'
+        arguments: -buildToolsDir "$(Build.ArtifactStagingDirectory)\install" -outputDirectory "$(Build.ArtifactStagingDirectory)\package"
+
+    - task: CopyFiles@2
+      inputs:
+        SourceFolder: '$(Build.ArtifactStagingDirectory)\package'
+        Contents: '*.nupkg'
+        TargetFolder: '$(Build.ArtifactStagingDirectory)\publish'
+        OverWrite: true
+
+    - task: PublishBuildArtifacts@1
+      inputs:
+        PathtoPublish: '$(Build.ArtifactStagingDirectory)\publish'
+        ArtifactName: 'package'
+        publishLocation: 'Container'

--- a/eng/xcopy-msbuild/build-msbuild.ps1
+++ b/eng/xcopy-msbuild/build-msbuild.ps1
@@ -1,0 +1,130 @@
+[CmdletBinding(PositionalBinding=$false)]
+param (
+    [Parameter(Mandatory=$true)][string]$buildToolsDir,
+    [Parameter(Mandatory=$true)][string]$outputDirectory,
+    [string]$packageName = "RoslynTools.MSBuild"
+)
+
+Set-StrictMode -version 2.0
+$ErrorActionPreference="Stop"
+
+function Print-Usage() {
+    Write-Host "build-msbuild.ps1"
+    Write-Host "`t-buildToolsDir path       Path to Build Tools Installation"
+    Write-Host "`t-packageName              Name of the nuget package (RoslynTools.MSBuild)"
+}
+
+function Get-MSBuildFileInfo() {
+    $fileInfo = New-Object IO.FileInfo $msbuildExe
+    return $fileInfo
+}
+function Get-Description() {
+    $fileInfo = Get-MSBuildFileInfo
+    $sha = & git show-ref HEAD -s
+    $text =
+"
+This is an xcopy version of MSBuild with the following version:
+
+- Product Version: $($fileInfo.VersionInfo.ProductVersion)
+- File Version: $($fileInfo.VersionInfo.FileVersion)
+
+This is built using the following tool:
+
+- Repo: https://github.com/dotnet/dnceng/eng/xcopy-msbuild
+- Source: https://github.com/dotnet/dnceng/eng/xcopy-msbuild/commit/$($sha)
+"
+    return $text
+}
+
+function Create-ReadMe() {
+    Write-Host "Creating README.md"
+    $text = Get-Description
+    $text | Out-File (Join-Path $outputDirectory "README.md")
+}
+
+function Create-Packages() {
+    
+    $text = Get-Description
+    $nuget = Ensure-NuGet
+    $fileInfo = Get-MSBuildFileInfo
+    $packageVersion = $fileInfo.VersionInfo.FileVersion
+    # Split the file version by '.' and take the first 3 components
+    $buildNumber = $Env:BUILD_BUILDNUMBER
+    if($buildNumber -ne $null)
+    {
+        $revision = $buildNumber.Substring($buildNumber.LastIndexOf('-') + 1)
+    }
+    else {
+        $revision = '1'
+    }
+    $packageVersion = $packageVersion.Split('.')[0..2] -join '.'
+    $packageVersion = "$packageVersion-$revision"
+    Write-Host "Packing $packageName, version $packageVersion"
+    & $nuget pack msbuild.nuspec -ExcludeEmptyDirectories -OutputDirectory $outputDirectory -Properties name=$packageName`;version=$packageVersion`;filePath=$outputBuildToolsDirectory`;description=$text
+}
+
+function Create-Directory([string]$dir) {
+    New-Item $dir -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
+}
+
+function Ensure-NuGet() {
+    $nuget = Join-Path $outputDirectory "nuget.exe"
+    if (-not (Test-Path $nuget)) {
+        Create-Directory (Split-Path -parent $nuget)
+        $version = "4.7.0"
+        Write-Host "Downloading NuGet.exe $version"
+        $webClient = New-Object -TypeName "System.Net.WebClient"
+        $webClient.DownloadFile("https://dist.nuget.org/win-x86-commandline/v$version/NuGet.exe", $nuget)
+    }
+
+    return $nuget
+}
+
+function Get-PackagesDir() {
+    $d = $null
+    if ($env:NUGET_PACKAGES -ne $null) {
+        $d = $env:NUGET_PACKAGES
+    }
+    else {
+        $d = Join-Path $env:UserProfile ".nuget\packages\"
+    }
+
+    Create-Directory $d
+    return $d
+}
+
+Push-Location $PSScriptRoot
+try {
+    $repoDir = $PSScriptRoot
+    
+    $msbuildDir = Join-Path $buildToolsDir "MSBuild\Current\Bin"
+    $msbuildExe = Join-Path $msbuildDir "msbuild.exe"
+
+    if (-not (Test-Path $buildToolsDir)) { 
+        New-Item -Path $buildToolsDir -ItemType Directory -Force| Out-Null
+    }
+
+    if (-not (Test-Path $msbuildExe)) { 
+        Write-Host "Did not find msbuild at $msbuildExe"
+        exit 1
+    }
+
+    $outputBuildToolsDirectory = Join-Path $outputDirectory "BuildTools"
+    Create-Directory $outputBuildToolsDirectory -ErrorAction SilentlyContinue | Out-Null
+    Remove-Item -re -fo "$outputBuildToolsDirectory\*"
+    Write-Host "Copying Build Tools"
+    Copy-Item -re "$buildToolsDir\*" $outputBuildToolsDirectory
+    Create-ReadMe
+    Create-Packages
+
+    exit 0
+}
+catch [exception] {
+    Write-Host $_
+    Write-Host $_.Exception
+    Write-Host $_.ScriptStackTrace
+    exit 1
+}
+finally {
+    Pop-Location
+}

--- a/eng/xcopy-msbuild/build.ps1
+++ b/eng/xcopy-msbuild/build.ps1
@@ -1,0 +1,42 @@
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+  [Parameter(Mandatory=$true)][String][Alias('s')]$sku,
+  [Parameter(Mandatory=$true)][String][Alias('c')]$channel,
+  [Parameter(Mandatory=$true)][String][Alias('r')]$release,
+  [Parameter(Mandatory=$true)][String][Alias('o')]$outputDirectory
+)
+# sku: BuildTools, Enterprise, Professional, Community
+# channel: pre, etc..
+# release: 16, 17, etc..
+$downloadUrl = "https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=$sku&ch=$channel&rel=$release"
+
+$folderName = "$sku-$channel-$release"
+$destinationDir = [System.IO.Path]::Combine("$PSScriptRoot", '.download', "$folderName")
+$installerFilename = "vs_installer.exe"
+$installerPath = "$destinationDir\$InstallerFilename"
+
+if(-Not (Test-Path $destinationDir))
+{
+    New-Item -ItemType 'Directory' -Path "$destinationDir" -Force | Out-Null
+}
+# Query the page to get the download link
+$response = Invoke-WebRequest $downloadUrl # -OutFile "$installerPath"
+
+$regex = "downloadUrl: '(?<downloadUrl>[^']+)'"
+$response.Content -Match $regex | Out-Null
+$downloadLink = $Matches['downloadUrl']
+
+Write-Host "download link: $downloadLink"
+$response = Invoke-WebRequest $downloadLink  -OutFile "$installerPath"
+
+if(-Not (Test-Path $outputDirectory))
+{
+    New-Item -ItemType 'Directory' -Path "$outputDirectory" -Force | Out-Null
+}
+
+# Install
+Write-Host "Installing..."
+Write-Host "Start-Process -FilePath $installerPath -ArgumentList install, --installPath, $outputDirectory, --quiet, --norestart, --force, --add, 'Microsoft.VisualStudio.Workload.ManagedDesktopBuildTools;includeRecommended' -Verb RunAs -Wait"
+Start-Process  -FilePath $installerPath -ArgumentList install, --installPath, $outputDirectory, --quiet, --norestart, --force, --add, 'Microsoft.VisualStudio.Workload.ManagedDesktopBuildTools;includeRecommended' -Verb RunAs -Wait
+
+Write-Host "Installation complete."

--- a/eng/xcopy-msbuild/msbuild.nuspec
+++ b/eng/xcopy-msbuild/msbuild.nuspec
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>$name$</id>
+    <version>$version$</version>
+    <title>$name$</title>
+    <authors>Microsoft</authors>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkID=614949</licenseUrl>
+    <projectUrl>http://aka.ms/vsextensibility</projectUrl>
+    <iconUrl>http://aka.ms/vsextensibilityicon</iconUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>$description$</description>
+    <summary>Roslyn xcopy msbuild</summary>
+    <releaseNotes>https://www.visualstudio.com/news/vs2015-vs</releaseNotes>
+    <copyright>Copyright © Microsoft</copyright>
+    <tags></tags>
+  </metadata>
+  <files>
+    <file src="$filePath$\**" target="tools\" />
+  </files>
+</package>


### PR DESCRIPTION
Adds code to produce an xcopy-able version of MSBuild.

Validated with https://dnceng-public.visualstudio.com/public/_build/results?buildId=440256&view=logs&j=ca395085-040a-526b-2ce8-bdc85f692774&t=ca395085-040a-526b-2ce8-bdc85f692774

To be clear:
- the pipeline I setup does not actually publish the package, it just produces a package which is valid (without tests) that can be used or that someone can take and publish to Azure Artifact Feeds as needed
- This is taking a subset of the code we use from https://github.com/jaredpar/xcopy-msbuild
- I'll update docs after this PR is merged

I'll schedule a follow-up meeting for 10/18, so that I can gather any additional feedback before potentially adding this code to Arcade.  

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
