### PR TITLE
Disable flakey test

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/MsiTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/MsiTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             Assert.NotNull(msi604.GetMetadata(Metadata.WixObj));
         }
 
-        [WindowsOnlyFact]
+        [WindowsOnlyFact(Skip = "Flakey; see dotnet/arcade#14054")]
         public void ItCanBuildAManifestMsi()
         {
             string PackageRootDirectory = Path.Combine(BaseIntermediateOutputPath, "pkg");


### PR DESCRIPTION
Resolves dotnet/arcade#14054.

Related to dotnet/arcade#14047.

(Temporarily) disable flakey test ItCanBuildAManifestMsi that impacts customer productivity.