### PR TITLE
Add extra logging to DownloadFile after all retries fail

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs
@@ -183,6 +183,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
                     }
 
                     Log.LogMessage($"Retrying download of '{uri}' to '{DestinationPath}' due to failure: '{e.Message}' ({attempt}/{Retries})");
+                    Log.LogErrorFromException(e, true, true, null);
 
                     await Tasks.Task.Delay(RetryDelayMilliseconds).ConfigureAwait(false);
                     continue;


### PR DESCRIPTION
Add extra logging for https://github.com/dotnet/installer/issues/17588 

cc @wfurt 