### PR TITLE
Remove mention of tier one repos in documentation

### DIFF
--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -2,7 +2,7 @@
 
 Arcade SDK is a set of msbuild props and targets files and packages that provide common build features used across multiple repos, such as CI integration, packaging, VSIX and VS setup authoring, testing, and signing via Microbuild.
 
-The infrastructure of each repository that contributes to .NET Core 3.0 stack is built on top of Arcade SDK. This allows us to orchestrate the build of the entire stack as well as build the stack from source. These repositories are expected to be on the latest version of the Arcade SDK.
+The infrastructure of most repositories that contribute to the .NET stack is built on top of Arcade SDK. This allows us to orchestrate the build of the entire stack as well as build the stack from source. These repositories are expected to be on the latest version of the Arcade SDK.
 
 Repositories that do not participate in .NET Core 3.0 build may also use Arcade SDK in order to take advantage of the common infrastructure.
 

--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -2,7 +2,7 @@
 
 Arcade SDK is a set of msbuild props and targets files and packages that provide common build features used across multiple repos, such as CI integration, packaging, VSIX and VS setup authoring, testing, and signing via Microbuild.
 
-The infrastructure of each [repository that contributes to .NET Core 3.0 stack](TierOneRepos.md) is built on top of Arcade SDK. This allows us to orchestrate the build of the entire stack as well as build the stack from source. These repositories are expected to be on the latest version of the Arcade SDK.
+The infrastructure of each repository that contributes to .NET Core 3.0 stack is built on top of Arcade SDK. This allows us to orchestrate the build of the entire stack as well as build the stack from source. These repositories are expected to be on the latest version of the Arcade SDK.
 
 Repositories that do not participate in .NET Core 3.0 build may also use Arcade SDK in order to take advantage of the common infrastructure.
 

--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -4,7 +4,7 @@ Arcade SDK is a set of msbuild props and targets files and packages that provide
 
 The infrastructure of most repositories that contribute to the .NET stack is built on top of Arcade SDK. This allows us to orchestrate the build of the entire stack as well as build the stack from source. These repositories are expected to be on the latest version of the Arcade SDK.
 
-Repositories that do not participate in .NET Core 3.0 build may also use Arcade SDK in order to take advantage of the common infrastructure.
+Repositories that do not contribute to the .NET stack may also use Arcade SDK in order to take advantage of the common infrastructure.
 
 The goals are
 

--- a/Documentation/CorePackages/PackagesRoadmap.md
+++ b/Documentation/CorePackages/PackagesRoadmap.md
@@ -1,6 +1,6 @@
 # Packages Roadmap
 The goal of this document is to provide guidance on the definition and implementation of the "Core" packages that should be in the
-Arcade SDK and that should be consumed by the [tier 1 repositories](..\TierOneRepos.md)
+Arcade SDK and that should be consumed by the repositories that make up .NET.
 
 ## Packages that should belong in the Arcade SDK
 The following list provides a summary of the state of each package. For more information, the work is being tracked under the Epic [Publish core "set" of shared packages](https://github.com/dotnet/arcade/issues/46) where every issue is marked according to the package it belongs.

--- a/Documentation/Overview.md
+++ b/Documentation/Overview.md
@@ -50,7 +50,7 @@ This approach publishes what amounts to “public surface area” for the shared
 
 ### What shared tools should be part of the Arcade SDK and which should not?
 
-- If a tool provides functionality which is meant to be used by all of the [Tier 1 Repos](TierOneRepos.md) then we should add it to the SDK. 
+- If a tool provides functionality which is meant to be used by most repositories in .NET, then we should add it to the SDK. 
 - If the provided functionality will only work for a couple of repos then these won't be part of the SDK and will have to be manually referenced in a project.
 - The SDK comes with props and targets files that are imported to any repository using the SDK, or invoked by common build infrastructure.
 - These files automatically import required packages via `PackageReference` (e.g. Microsoft.DotNet.SignTool, MicroBuild.Core, etc.)

--- a/Documentation/StartHere.md
+++ b/Documentation/StartHere.md
@@ -27,8 +27,7 @@ areas:
 
 ## Does my repository need to be involved?
 
-Generally, if your repo is shipping in .NET, yes.  For ['Tier
-1'](TierOneRepos.md) repos a full transition is required.  While there exist
+Generally, if your repo is shipping in .NET, yes.  For core functionality repos a full transition is required.  While there exist
 some special cases (e.g. repos used as submodules in aspnet/universe), we're
 striving to move as many people towards the new infrastructure as possible.
 - If you use .NET CI (ci.dot.net, ci2.dot.net, ci3.dot.net) you'll need to move


### PR DESCRIPTION
We no longer have a list of tier 1 repos.
fixes https://github.com/dotnet/dnceng/issues/1023

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
