### PR TITLE
Workloads: Add support for advertising packages in VS

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/SwixComponentTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/SwixComponentTests.cs
@@ -39,6 +39,36 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
         }
 
         [WindowsOnlyFact]
+        public void ItCanAdvertiseComponents()
+        {
+            ITaskItem[] componentResources = new[]
+            {
+                new TaskItem("microsoft-net-sdk-blazorwebassembly-aot").WithMetadata(Metadata.Version, "4.5.6")
+                .WithMetadata(Metadata.Description, "A long wordy description about Blazor.")
+                .WithMetadata(Metadata.Category, "WebAssembly")
+                .WithMetadata(Metadata.AdvertisePackage, "true")
+            };
+
+            WorkloadManifest manifest = Create("WorkloadManifest.json");
+            WorkloadDefinition workload = (WorkloadDefinition)manifest.Workloads.FirstOrDefault().Value;
+            SwixComponent component = SwixComponent.Create(new ReleaseVersion("6.0.300"), workload, manifest, packGroupId: null,
+                componentResources);
+
+            ComponentSwixProject project = new(component, BaseIntermediateOutputPath, BaseOutputPath);
+            string swixProj = project.Create();
+
+            string componentSwr = File.ReadAllText(Path.Combine(Path.GetDirectoryName(swixProj), "component.swr"));
+            Assert.Contains("package name=microsoft.net.sdk.blazorwebassembly.aot", componentSwr);
+            Assert.Contains("version=4.5.6", componentSwr);
+            Assert.Contains("isAdvertisedPackage=yes", componentSwr);
+
+            string componentResSwr = File.ReadAllText(Path.Combine(Path.GetDirectoryName(swixProj), "component.res.swr"));
+            Assert.Contains(@"title=""Blazor WebAssembly AOT workload""", componentResSwr);
+            Assert.Contains(@"description=""A long wordy description about Blazor.""", componentResSwr);
+            Assert.Contains(@"category=""WebAssembly""", componentResSwr);
+        }
+
+        [WindowsOnlyFact]
         public void ItPrefersComponentResourcesOverDefaults()
         {
             ITaskItem[] componentResources = new[] 
@@ -59,6 +89,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             string componentSwr = File.ReadAllText(Path.Combine(Path.GetDirectoryName(swixProj), "component.swr"));
             Assert.Contains("package name=microsoft.net.sdk.blazorwebassembly.aot", componentSwr);
             Assert.Contains("version=4.5.6", componentSwr);
+            Assert.Contains("isAdvertisedPackage=no", componentSwr);
 
             string componentResSwr = File.ReadAllText(Path.Combine(Path.GetDirectoryName(swixProj), "component.res.swr"));
             Assert.Contains(@"title=""Blazor WebAssembly AOT workload""", componentResSwr);

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Metadata.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Metadata.cs
@@ -44,6 +44,12 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
         /// </summary>
         public static readonly string SupportsMachineArch = nameof(SupportsMachineArch);
 
+        /// <summary>
+        /// Boolean value indicating that a new component should be advertised in VS when performing
+        /// an update.
+        /// </summary>
+        public static readonly string AdvertisePackage = nameof(AdvertisePackage);
+
         public static readonly string Title = nameof(Title);
         public static readonly string Version = nameof(Version);
 

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/ComponentSwixProject.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/ComponentSwixProject.cs
@@ -44,6 +44,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
             ReplacementTokens[SwixTokens.__VS_COMPONENT_CATEGORY__] = component.Category;
             ReplacementTokens[SwixTokens.__VS_IS_UI_GROUP__] = component.IsUiGroup ? "yes" : "no";
             ReplacementTokens[SwixTokens.__VS_PACKAGE_OUT_OF_SUPPORT__] = OutOfSupport ? "yes" : "no";
+            ReplacementTokens[SwixTokens.__VS_IS_ADVERTISED_PACKAGE__] = component.Advertise ? "yes" : "no";
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/SwixTokens.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/SwixTokens.cs
@@ -12,6 +12,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
         public static readonly string __VS_COMPONENT_DESCRIPTION__ = nameof(__VS_COMPONENT_DESCRIPTION__);
         public static readonly string __VS_COMPONENT_TITLE__ = nameof(__VS_COMPONENT_TITLE__);
         public static readonly string __VS_IS_UI_GROUP__ = nameof(__VS_IS_UI_GROUP__);
+        public static readonly string __VS_IS_ADVERTISED_PACKAGE__ = nameof(__VS_IS_ADVERTISED_PACKAGE__);
         public static readonly string __VS_PACKAGE_CHIP__ = nameof(__VS_PACKAGE_CHIP__);
         public static readonly string __VS_PACKAGE_INSTALL_SIZE_SYSTEM_DRIVE__ = nameof(__VS_PACKAGE_INSTALL_SIZE_SYSTEM_DRIVE__);
         public static readonly string __VS_PACKAGE_NAME__ = nameof(__VS_PACKAGE_NAME__);

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/SwixTemplate/component.swr
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/SwixTemplate/component.swr
@@ -7,5 +7,6 @@ package name=__VS_PACKAGE_NAME__
 
 vs.properties
   isUiGroup=__VS_IS_UI_GROUP__
+  isAdvertisedPackage=__VS_IS_ADVERTISED_PACKAGE__
 
 vs.dependencies


### PR DESCRIPTION
# Description

Visual Studio supports advertising new components being introduced during an upgrade that were not present in a previous release. This change allows workload authors to mark components for advertising and generate the appropriate SWIX authoring.

This is an opt-in feature and the property will default to "no" to maintain compatibility. To opt-in, simply add `AdvertisePackage="true"` into the component resource items for the specific component(s).

Verified SWIX output:

```json
  "packages": [
    {
      "id": "microsoft.net.sdk.emscripten.pre",
      "version": "15.16.17",
      "type": "Component",
      "isUiGroup": true,
      "ui": {
        "isAdvertisedPackage": true
      },
```