### PR TITLE
[helix][ios] Emulate deep signing of iOS app bundles on helix in order to support library mode builds

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
@@ -114,9 +114,9 @@ function sign ()
       if [ "$file_extension" = "app" ] || [ "$file_extension" = "framework" ] || [ ! -z "${is_macho}" ]; then
         echo "Signing file $file_in_bundle"
         if [ "$file_extension" = "app" ]; then
-            /usr/bin/codesign -v --force --sign "$sign_identity" --keychain "$keychain_name" --entitlements entitlements.plist "$file_in_bundle"
+            /usr/bin/codesign -v --force --sign "Apple Development" --keychain "$keychain_name" --entitlements entitlements.plist "$file_in_bundle"
         else
-            /usr/bin/codesign -v --force --sign "$sign_identity" --keychain "$keychain_name" --preserve-metadata\=identifier,entitlements,flags "$file_in_bundle"
+            /usr/bin/codesign -v --force --sign "Apple Development" --keychain "$keychain_name" --preserve-metadata=identifier,entitlements,flags "$file_in_bundle"
         fi
       fi
     done

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.apple.sh
@@ -104,6 +104,12 @@ function sign ()
     security cms -D -i "$provisioning_profile" > provision.plist
     /usr/libexec/PlistBuddy -x -c 'Print :Entitlements' provision.plist > entitlements.plist
 
+    # Sign all embedded shared libs
+    for shared_lib in $(find "$1" -name "*.dylib" -o -name "*.framework" 2>/dev/null); do
+      echo "Signing shared library $shared_lib"
+      /usr/bin/codesign -v --force --sign "Apple Development" --keychain "$keychain_name" --entitlements entitlements.plist "$shared_lib"
+    done
+
     # Sign the app
     /usr/bin/codesign -v --force --sign "Apple Development" --keychain "$keychain_name" --entitlements entitlements.plist "$1"
 }


### PR DESCRIPTION
## Description

This PR adds support for properly signing iOS app bundles which include apps with shared libraries on Helix. 
This is required so we can execute library mode tests on Helix properly when we target ios devices with Mono and NativeAOT using library mode.

## Changes

In order to properly perform deep signing of iOS app bundles, I am adding a manual step which finds all:
- `Macho-O`
- `.app`
- `.framework`

files in the bundle and signs them by respecting the bundle hierarchy (deepest files are signed first). This is achieved by looking up all the files in the bundle with `find -d`. 

This manual signing step is required as the `--deep` argument on the `codesign` tool seems to be deprecated.
```
man codesign
...
     --deep  (DEPRECATED for signing as of macOS 13.0) When signing a bundle, specifies that nested code content such as helpers, frameworks, and plug-ins, should be recursively signed in turn.
             Beware:
```

## Validation

I have validated locally that the change properly signs the app, by signing and running the added tests in: https://github.com/dotnet/runtime/pull/93658

### Repro steps

1. Checkout the PR
```
gh pr checkout 93658
```
2. Build runtime and tests (as on build machine):
```
./build.sh -s mono+libs+libs.tests -os ios -arch arm64 -c Release /p:ArchiveTests=true /p:DevTeamProvisioning=- /p:RunAOTCompilation=true /p:RunSmokeTestsOnly=False /p:EnableAdditionalTimezoneChecks=true  /p:BuildDarwinFrameworks=true /p:IsManualOrRollingBuild=true /p:BuildTestsOnHelix=true /p:BuildDarwinFrameworks=true /p:UsePortableRuntimePack=true -binaryLog
```
3. Build build tasks:
```
./build.sh -s tasks -c Debug
```
4. Extract built test
```
cd artifacts/helix/tests/ios.AnyCPU.Release
mkdir iOS.Device.LibraryMode.Test
tar -xvf iOS.Device.LibraryMode.Test.zip -C iOS.Device.LibraryMode.Test
cd iOS.Device.LibraryMode.Test/publish
```
5. AOT compile the test (as on Helix):
```
../../../../../../dotnet.sh msbuild ProxyProjectForAOTOnHelix.proj /p:RuntimeSrcDir=/Users/ivan/repos/runtime-naot /p:RuntimeConfig=Release /p:RunAOTCompilation=true /p:UsePortableRuntimePack=true /p:TargetOS=ios /p:TargetArchitecture=arm64 /p:MonoEnableLLVM=true /p:DevTeamProvisioning=- /p:Configuration=Release /bl:test.binlog -p:BundlesResources=false -p:NativeLib=Shared -p:ForceLibraryModeGenerateAppBundle=true ; cd ..
```
6. Adjust `build-apple-app.sh` to invoke `sign` function with my local settings and changes from this PR
7. Run the app
```
../../../../../dotnet.sh xharness apple run --app publish/iOS.Device.LibraryMode.Test.app --output-directory /tmp/helix/testing --target ios-device --timeout 01:00:00 --xcode /Applications/Xcode_14.3.1.app -v --launch-timeout 00:05:00 --signal-app-end --expected-exit-code 42 --
```