### PR TITLE
Remove release notes section of issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/default-arcade-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/default-arcade-issue-template.md
@@ -12,13 +12,3 @@ assignees: ''
 - [ ] This issue is causing unreasonable pain
 
 <!-- Write your issue description below. -->
-
-<!-- DO NOT DELETE -->
-<!-- For internal use only; put release notes here. -->
-<!-- For guidance on writing good release notes, please see documentation here: https://dev.azure.com/dnceng/internal/_wiki/wikis/DNCEng%20Services%20Wiki/983/ReleaseNotesGuidance -->
-<!-- Additionally, please specify the note category below. -->
-### Release Note Category
-- [ ] Feature changes/additions 
-- [ ] Bug fixes
-- [ ] Internal Infrastructure Improvements
-### Release Note Description


### PR DESCRIPTION
Fixes https://github.com/dotnet/dnceng/issues/648

Remove the release notes section from the Arcade issue template. This repo no longer has the issues for the engineering services team so this is no longer needed.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
