### PR TITLE
manage the loc pat in secret-manager

### DIFF
--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -281,3 +281,15 @@ secrets:
         location: dotnetbuildskeys
       permissions: rl
       container: public-checksums
+
+  #OneLocBuildVariables
+  dn-bot-ceapex-package-r:
+    type: azure-devops-access-token
+    parameters:
+      domainAccountName: dn-bot
+      domainAccountSecret:
+          location: helixkv
+          name: dn-bot-account-redmond
+      name: dn-bot-ceapex-package-r
+      organizations: ceapex
+      scopes: packaging


### PR DESCRIPTION

fixes https://github.com/dotnet/arcade/issues/14176
I have run this locally to cycle the existing PAT.

This is slightly different from the old PR, as I decided not to move the PAT to a different vault. The variable groups in devdiv and dnceng are connected to engkeyvault, and the ROI is not there to shake things up by using a different key vault for this.

We will eventually need to move this as part of sweeping and cleaning the secrets anyways.

### To double check:
* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
