### PR TITLE
Allow override of build tool framework version

### DIFF
--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -1043,6 +1043,9 @@ If set to `true` the GetResourceString method is not included in the generated c
 #### `FlagNetStandard1XDependencies` (bool)
 If set to `true` the `FlagNetStandard1xDependencies` target validates that the dependency graph doesn't contain any netstandard1.x packages.
 
+#### `_OverrideArcadeInitializeBuildToolFramework` (string)
+If this environment variable is set, the value will be used to override the default Build Tools Framework version.
+
 <!-- Begin Generated Content: Doc Feedback -->
 <sub>Was this helpful? [![Yes](https://helix.dot.net/f/ip/5?p=Documentation%5CArcadeSdk.md)](https://helix.dot.net/f/p/5?p=Documentation%5CArcadeSdk.md) [![No](https://helix.dot.net/f/in)](https://helix.dot.net/f/n/5?p=Documentation%5CArcadeSdk.md)</sub>
 <!-- End Generated Content-->

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -341,7 +341,12 @@ function InitializeBuildTool {
   # return values
   _InitializeBuildTool="$_InitializeDotNetCli/dotnet"
   _InitializeBuildToolCommand="msbuild"
-  _InitializeBuildToolFramework="net8.0"
+  # use override if it exists - commonly set by source-build
+  if [[ -z "${_OverrideArcadeInitializeBuildToolFramework}" ]]; then
+    _InitializeBuildToolFramework="net8.0"
+  else
+    _InitializeBuildToolFramework="${_OverrideArcadeInitializeBuildToolFramework}"
+  fi
 }
 
 # Set RestoreNoCache as a workaround for https://github.com/NuGet/Home/issues/3116

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -342,7 +342,7 @@ function InitializeBuildTool {
   _InitializeBuildTool="$_InitializeDotNetCli/dotnet"
   _InitializeBuildToolCommand="msbuild"
   # use override if it exists - commonly set by source-build
-  if [[ -z "${_OverrideArcadeInitializeBuildToolFramework}" ]]; then
+  if [[ "${_OverrideArcadeInitializeBuildToolFramework:-x}" == "x" ]]; then
     _InitializeBuildToolFramework="net8.0"
   else
     _InitializeBuildToolFramework="${_OverrideArcadeInitializeBuildToolFramework}"


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/3171

As discussed in https://github.com/dotnet/command-line-api/pull/2283 this is a backport to Arcade of a change that allows source-build (and others) to override build tool framework version.