### PR TITLE
Remove private feed url secrets from manifests

### DIFF
--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -176,11 +176,6 @@ secrets:
     type: text
     parameters:
       description: Also located in dnceng-pipeline-secrets keyvault.
-      
-  dotnetfeedmsrc-private-feed-url:
-    type: text
-    parameters:
-      description: created manually from SAS in the format https://dotnetfeedmsrc.azurewebsites.net/sig/{sig}/se{se}
 
   dotnetfeedmsrc-connection-string:
     type: azure-storage-connection-string
@@ -204,11 +199,6 @@ secrets:
     type: text
     parameters:
       description: Also located in dnceng-pipeline-secrets keyvault.
-
-  dotnetclimsrc-private-feed-url:
-    type: text
-    parameters:
-      description: created manually from SAS in the format https://dotnetclimsrc.azurewebsites.net/sig/{sig}/se{se}
 
   dotnetclimsrc-connection-string:
     type: azure-storage-connection-string


### PR DESCRIPTION
https://github.com/dotnet/dnceng/issues/1144

These secrets are not used anymore. We don't use private feed proxies any longer.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
