### PR TITLE
Workload Sets - minor fixes/cleanup

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadSetTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadSetTests.cs
@@ -39,7 +39,6 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
                 BaseOutputPath = BaseOutputPath,
                 BaseIntermediateOutputPath = baseIntermediateOutputPath,
                 BuildEngine = buildEngine,
-                PackageSource = TestAssetsPath,
                 WixToolsetPath = WixToolsetPath,
                 WorkloadSetPackageFiles = workloadSetPackages
             };

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
@@ -90,6 +90,16 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             set;
         }
 
+        /// <summary>
+        /// The directory to use for locating workload pack packages.
+        /// </summary>
+        [Required]
+        public string PackageSource
+        {
+            get;
+            set;
+        }
+
         public bool UseWorkloadPackGroupsForVS
         {
             get;

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/VisualStudioWorkloadTaskBase.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/VisualStudioWorkloadTaskBase.wix.cs
@@ -2,15 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using Microsoft.Deployment.DotNet.Releases;
-using Microsoft.DotNet.Build.Tasks.Workloads.Msi;
-using Microsoft.DotNet.Build.Tasks.Workloads.Swix;
 
 namespace Microsoft.DotNet.Build.Tasks.Workloads
 {
@@ -76,16 +70,6 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
         /// Root directory where packages are extracted.
         /// </summary>
         protected string PackageRootDirectory => Path.Combine(BaseIntermediateOutputPath, "pkg");
-
-        /// <summary>
-        /// The directory to use for locating workload pack packages.
-        /// </summary>
-        [Required]
-        public string PackageSource
-        {
-            get;
-            set;
-        }
 
         /// <summary>
         /// A set of items containing .swixproj files that can be build to generate

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/build/Microsoft.DotNet.Build.Tasks.Workloads.props
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/build/Microsoft.DotNet.Build.Tasks.Workloads.props
@@ -7,5 +7,6 @@
   </PropertyGroup>
 
   <UsingTask TaskName="CreateVisualStudioWorkload" AssemblyFile="$(MicrosoftDotNetBuildTasksWorkloadsAssembly)" />
+  <UsingTask TaskName="CreateVisualStudioWorkloadSet" AssemblyFile="$(MicrosoftDotNetBuildTasksWorkloadsAssembly)" />
 
 </Project>


### PR DESCRIPTION
* Initial PR did not include updating the .props file referencing the build task so other repos need to explicitly declare `<UsingTask.../>`
* Moved `PackageSource` parameter back to `CreateVisualStudioWorkload`. This is only required for workloads to resolve workload pack packages. Workload sets do not have additional package sources that need to be processed.
* Updated unit tests
* Removed unnecessary usings
