### PR TITLE
remove private feed proxy secrets from manifests

### DIFF
--- a/.vault-config/product-builds-dnceng-pipeline-secrets.yaml
+++ b/.vault-config/product-builds-dnceng-pipeline-secrets.yaml
@@ -65,11 +65,6 @@ secrets:
     parameters:
       description: set to never expire
 
-  dotnetclimsrc-private-feed-url:
-    type: text
-    parameters:
-      description: created manually from SAS in the format https://dotnetclimsrc.azurewebsites.net/sig/{sig}/se{se}
-
   dotnetclimsrc-connection-string:
     type: azure-storage-connection-string
     parameters:
@@ -111,11 +106,6 @@ secrets:
     type: base64-encoder
     parameters:
       secret: dotnetclimsrc-dotnet-container-uri
-
-  dotnetfeedmsrc-private-feed-url:
-    type: text
-    parameters:
-      description: created manually from SAS in the format https://dotnetfeedmsrc.azurewebsites.net/sig/{sig}/se{se}
 
   dotnetfeedmsrc-storage-access-key-1:
     type: text


### PR DESCRIPTION
More removals related to https://github.com/dotnet/dnceng/issues/1144

We no longer use the private feed proxies, so these secrets can be retired.

### To double check:
* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
