### PR TITLE
Continue a verbose attempt even when openssl returns non-zero

### DIFF
--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -310,7 +310,7 @@ function GetDotNetInstallScript {
       curl "$install_script_url" -sSL --retry 10 --create-dirs -o "$install_script" || {
         if command -v openssl &> /dev/null; then
           echo "Curl failed; dumping some information about dotnet.microsoft.com for later investigation"
-          echo | openssl s_client -showcerts -servername dotnet.microsoft.com  -connect dotnet.microsoft.com:443
+          echo | openssl s_client -showcerts -servername dotnet.microsoft.com  -connect dotnet.microsoft.com:443 || true
         fi
         echo "Will now retry the same URL with verbose logging."
         with_retries curl "$install_script_url" -sSL --verbose --retry 10 --create-dirs -o "$install_script" || {


### PR DESCRIPTION
When executed with `set -e` (as happens in build.sh which sources this file) The extended retry logic here will not run if openssl has a non-zero exit code unless we handle the error, so handle it.