### PR TITLE
Don't include intermediates in prebuilt detection

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -3,8 +3,6 @@
 
 <UsageData>
   <IgnorePatterns>
-    <UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*/*" />
-
     <!-- TODO: Ignore needed until https://github.com/NuGet/Home/issues/11059 is addressed. -->
     <UsagePattern IdentityGlob="Nuget.*/*" />
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
@@ -26,7 +26,7 @@
       <SourceBuiltPackageFiles Include="$(PreviouslySourceBuiltNupkgCacheDir)**/*.nupkg" Condition=" '$(PreviouslySourceBuiltNupkgCacheDir)' != '' " />
 
       <!-- Exclude intermediate packages. See https://github.com/dotnet/source-build/issues/3010 -->
-      <SourceBuiltPackageFiles Remove="@(SourceBuiltPackageFiles)" Condition="$([System.String]::Copy(%(SourceBuiltPackageFiles.Filename)).Contains('Microsoft.SourceBuild.Intermediate'))" />
+      <SourceBuiltPackageFiles Remove="@(SourceBuiltPackageFiles)" Condition="$([System.String]::Copy(%(SourceBuiltPackageFiles.Filename)).Contains('Microsoft.SourceBuild.Intermediate.'))" />
 
       <!-- Add some other potential top-level project directories for a more specific report. -->
       <ProjectDirectories Include="$(CurrentRepoSourceBuildSourceDir)" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
@@ -25,6 +25,9 @@
       <SourceBuiltPackageFiles Include="$(ReferencePackageNupkgCacheDir)**/*.nupkg" Condition=" '$(ReferencePackageNupkgCacheDir)' != '' " />
       <SourceBuiltPackageFiles Include="$(PreviouslySourceBuiltNupkgCacheDir)**/*.nupkg" Condition=" '$(PreviouslySourceBuiltNupkgCacheDir)' != '' " />
 
+      <!-- Exclude intermediate packages. See https://github.com/dotnet/source-build/issues/3010 -->
+      <SourceBuiltPackageFiles Remove="@(SourceBuiltPackageFiles)" Condition="$([System.String]::Copy(%(SourceBuiltPackageFiles.Filename)).Contains('Microsoft.SourceBuild.Intermediate'))" />
+
       <!-- Add some other potential top-level project directories for a more specific report. -->
       <ProjectDirectories Include="$(CurrentRepoSourceBuildSourceDir)" />
       <!-- Finally, scan entire source-build, in case project.assets.json ends up in an unexpected place. -->


### PR DESCRIPTION
Addresses https://github.com/dotnet/source-build/issues/3010

This PR eliminates the need for `Microsoft.SourceBuild.Intermediate` in the repo level prebuilt baselines by removing these packages from being flagged as prebuilts by the prebuilt detection.

It also removes the `<UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*/*" />` for this repo, but this will have to be done in every repo's `SouceBuildPrebuiltBaseline.xml`