### PR TITLE
Revert "Removing Dotnet-blob-feed from release/6.0 (#14198)"

### DIFF
--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -17,6 +17,13 @@ secrets:
     parameters:
       Name: dotnet-maestro-bot
 
+  #DotNet-Blob-Feed
+  dotnetfeed-storage-access-key-1:
+    type: azure-storage-key
+    parameters:
+      subscription: a4fc5514-21a9-4296-bfaf-5c7ee7fa35d1
+      account: dotnetfeed
+
   #Publish-Build-Assets
   MaestroAccessToken:
     type: maestro-access-token

--- a/Documentation/CorePackages/Publishing.md
+++ b/Documentation/CorePackages/Publishing.md
@@ -160,6 +160,9 @@ In order to use the new publishing mechanism, the easiest way to start is by tur
   ```YAML
     - _InternalBuildArgs: /p:DotNetSignType=$(_SignType) 
         /p:TeamName=$(_TeamName)
+        /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
+        /p:DotNetPublishBlobFeedUrl=$(_PublishBlobFeedUrl)
+        /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
         /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
         /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
         /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
@@ -173,6 +176,9 @@ In order to use the new publishing mechanism, the easiest way to start is by tur
   ```YAML
     - _InternalBuildArgs: /p:DotNetSignType=$(_SignType) 
         /p:TeamName=$(_TeamName)
+        /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
+        /p:DotNetPublishBlobFeedUrl=$(_PublishBlobFeedUrl)
+        /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
         /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
         /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
         /p:OfficialBuildId=$(BUILD.BUILDNUMBER)

--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -18,8 +18,10 @@ variables:
       value: True
     - name: _SignType
       value: real
+    # DotNet-Blob-Feed provides: dotnetfeed-storage-access-key-1
     # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
     # DotNet-HelixApi-Access provides: HelixApiAccessToken
+    - group: DotNet-Blob-Feed
     - group: Publish-Build-Assets
     - group: DotNet-HelixApi-Access
     - group: SDL_Settings

--- a/eng/common/templates/post-build/common-variables.yml
+++ b/eng/common/templates/post-build/common-variables.yml
@@ -1,5 +1,6 @@
 variables:
   - group: AzureDevOps-Artifact-Feeds-Pats
+  - group: DotNet-Blob-Feed
   - group: DotNet-DotNetCli-Storage
   - group: DotNet-MSRC-Storage
   - group: Publish-Build-Assets

--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -17,6 +17,7 @@ stages:
         - group: DotNet-Symbol-Server-Pats
         - group: DotNetBuilds storage account tokens
         - group: AzureDevOps-Artifact-Feeds-Pats
+        - group: DotNet-Blob-Feed
         - group: DotNet-DotNetCli-Storage
         - group: DotNet-MSRC-Storage
         - group: Publish-Build-Assets
@@ -175,6 +176,7 @@ stages:
               /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
               /p:InternalChecksumsAzureAccountKey=$(dotnetclichecksumsmsrc-storage-key)
               /p:AzureDevOpsFeedsKey='$(dn-bot-dnceng-artifact-feeds-rw)'
+              /p:AzureStorageTargetFeedPAT='$(dotnetfeed-storage-access-key-1)'
               /p:AkaMSClientId=$(akams-client-id)
               /p:AkaMSClientSecret=$(akams-client-secret)
               ${{ parameters.artifactsPublishingAdditionalParameters }}

--- a/eng/validate-sdk.yml
+++ b/eng/validate-sdk.yml
@@ -22,6 +22,7 @@ jobs:
       name: NetCore1ESPool-Svc-Internal
       demands: ImageOverride -equals windows.vs2019.amd64
     variables:
+    - group: DotNet-Blob-Feed
     - group: Publish-Build-Assets
     - _BuildConfig: ${{ parameters.buildConfig }}
     - _BuildArgs: ${{ parameters.buildArgs }}


### PR DESCRIPTION
This reverts commit d52698c9568995f16412ccb44dd4a7039de8a238.

This broke arcade validation 6.0 https://dev.azure.com/dnceng/internal/_build/results?buildId=2309431&view=results and is blocking https://github.com/dotnet/arcade/pull/14248