### PR TITLE
Add DotNetCoreESRP app secret to EngKv

### DIFF
--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -283,3 +283,8 @@ secrets:
       name: dn-bot-ceapex-package-r
       organizations: ceapex
       scopes: packaging
+
+  App-DotNetCoreESRP-Secret:
+    type: text
+    parameters:
+      description: Secret for the DotNetCoreESRP app. Used for the ESRP CodeSign service connection


### PR DESCRIPTION
The secret has expired and we didn't notice before the issue hit our customers. By adding it here, we'll be able to see when the arcade-weekly pipeline starts going red and take action before the secret actually expires