### PR TITLE
Align Windows and non-Windows on _InitializeToolset variable

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -676,7 +676,7 @@ function Read-ArcadeSdkVersion() {
 }
 
 function InitializeToolset() {
-  # For Unified Build PoC/Source-build support, check whether the environment variable is
+  # For Unified Build/Source-build support, check whether the environment variable is
   # set. If it is, then use this as the toolset build project.
   if ($env:_InitializeToolset -ne $null) {
     return $global:_InitializeToolset = $env:_InitializeToolset

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -676,8 +676,14 @@ function Read-ArcadeSdkVersion() {
 }
 
 function InitializeToolset() {
-  if (Test-Path variable:global:_ToolsetBuildProj) {
-    return $global:_ToolsetBuildProj
+  # For Unified Build PoC/Source-build support, check whether the environment variable is
+  # set. If it is, then use this as the toolset build project.
+  if ($env:_InitializeToolset -ne $null) {
+    return $global:_InitializeToolset = $env:_InitializeToolset
+  }
+
+  if (Test-Path variable:global:_InitializeToolset) {
+    return $global:_InitializeToolset
   }
 
   $nugetCache = GetNuGetPackageCachePath
@@ -688,7 +694,7 @@ function InitializeToolset() {
   if (Test-Path $toolsetLocationFile) {
     $path = Get-Content $toolsetLocationFile -TotalCount 1
     if (Test-Path $path) {
-      return $global:_ToolsetBuildProj = $path
+      return $global:_InitializeToolset = $path
     }
   }
 
@@ -711,7 +717,7 @@ function InitializeToolset() {
     throw "Invalid toolset path: $path"
   }
 
-  return $global:_ToolsetBuildProj = $path
+  return $global:_InitializeToolset = $path
 }
 
 function ExitWithExitCode([int] $exitCode) {


### PR DESCRIPTION
In  the VMR PoC it was discovered that the SDK kept getting installed even when DOTNET_INSTALL_DIR was already specified. This was because SB was using _InitializeToolset to short circuit arcade and SDK initialization. This is a wider issue discussed in https://github.com/dotnet/source-build/issues/3785. For now, align the behavior of non-Windows with Windows by allowing setting of the _InitializeToolset environment variable (using this to set the global). In addition, align the global variable name with the Nix variants.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
