### PR TITLE
Bump to Ubuntu 22.04 image in azure-pipelines-code-mirror.yml

### DIFF
--- a/azure-pipelines-code-mirror.yml
+++ b/azure-pipelines-code-mirror.yml
@@ -21,7 +21,7 @@ jobs:
         # If it's not devdiv, it's dnceng
         ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
           name: $(DncEngInternalBuildPool)
-          demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+          demands: ImageOverride -equals Build.Ubuntu.2204.Amd64
       variables:
       - name: WorkingDirectoryName
         value: repo-dir


### PR DESCRIPTION
I noticed this warning in the code-mirror job:

```
/usr/local/vss-agent/3.232.0/externals/node20_1/bin/node -v
/usr/local/vss-agent/3.232.0/externals/node20_1/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /usr/local/vss-agent/3.232.0/externals/node20_1/bin/node)
##[warning]The agent operating system doesn't support Node20. Using Node16 instead. Please upgrade the operating system of the agent to remain compatible with future updates of tasks: https://github.com/nodesource/distributions
```

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
