### PR TITLE
Update ArPow SourceBuild infra to fully work on Windows

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -1,6 +1,19 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
+  <!-- OS invariant helper properties for use in the repo's SourceBuild.props file and here. -->
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+    <ArchiveExtension>.zip</ArchiveExtension>
+    <FlagParameterPrefix>-</FlagParameterPrefix>
+    <ArcadeFalseBoolBuildArg>0</ArcadeFalseBoolBuildArg>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+    <ArchiveExtension>.tar.gz</ArchiveExtension>
+    <FlagParameterPrefix>--</FlagParameterPrefix>
+    <ArcadeFalseBoolBuildArg>false</ArcadeFalseBoolBuildArg>
+  </PropertyGroup>
+
   <!-- Repo extensibility point. -->
   <Import Project="$(RepositoryEngineeringDir)SourceBuild.props" Condition="Exists('$(RepositoryEngineeringDir)SourceBuild.props')" />
 
@@ -67,7 +80,7 @@
 
   <!--
     Get the list of nupkg contents, categorized into supplemental categories if necessary. By
-    default, all non-symbol-package nupkg files and tar.gz files in
+    default, all non-symbol-package nupkg files and archive files in
     'artifacts/packages/{configuration}' are packed in the intermediate nupkg.
 
     To configure this, add a target to eng/SourceBuild.props with
@@ -81,7 +94,7 @@
     <ItemGroup Condition="'$(EnableDefaultSourceBuildIntermediateItems)' == 'true'">
       <!-- Catch-all: anything not in a category gets packed in the 'main' intermediate nupkg. -->
       <IntermediateNupkgArtifactFile Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)**\*.nupkg" />
-      <IntermediateNupkgArtifactFile Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)**\*.tar.gz" />
+      <IntermediateNupkgArtifactFile Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)**\*$(ArchiveExtension)" />
       <!-- Don't pack any symbol packages: not needed for downstream source-build CI. -->
       <IntermediateNupkgArtifactFile Remove="$(CurrentRepoSourceBuildArtifactsPackagesDir)**\*.symbols.nupkg" />
     </ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
@@ -75,18 +75,17 @@
       <!-- Turn on DotNetBuildFromSource or DotNetBuildVertical in the inner build -->
       <InnerBuildArgs Condition="'$(ArcadeBuildFromSource)' == 'true'">$(InnerBuildArgs) /p:DotNetBuildFromSource=true</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(ArcadeBuildVertical)' == 'true'">$(InnerBuildArgs) /p:DotNetBuildVertical=true</InnerBuildArgs>
-      <!-- Use a fresh clone of the repo so that source-build modifications are isolated.
-           Don't trim the trailing directors separator for Windows as Arcade depends on it being pasesd in. -->
-      <InnerBuildArgs>$(InnerBuildArgs) /p:RepoRoot=$(InnerSourceBuildRepoRoot)</InnerBuildArgs>
-      <!-- Override the artifacts dir to cleanly separate the inner build from outer build. -->
-      <InnerBuildArgs>$(InnerBuildArgs) /p:ArtifactsDir="$(CurrentRepoSourceBuildArtifactsDir.TrimEnd('\'))"</InnerBuildArgs>
+      <!-- Use a fresh clone of the repo so that source-build modifications are isolated. -->
+      <InnerBuildArgs>$(InnerBuildArgs) /p:RepoRoot="$(InnerSourceBuildRepoRoot)\"</InnerBuildArgs>
+      <!-- Override the artifacts dir to cleanly separate the inner build from outer build.  -->
+      <InnerBuildArgs>$(InnerBuildArgs) /p:ArtifactsDir="$(CurrentRepoSourceBuildArtifactsDir)\"</InnerBuildArgs>
       <!-- Set a custom binlog location to avoid clashing over the currenly specified file. -->
       <InnerBuildArgs>$(InnerBuildArgs) /bl:"$(CurrentRepoSourceBuildBinlogFile)"</InnerBuildArgs>
       <!-- Flow ContinuousIntegrationBuild to the inner build. -->
       <InnerBuildArgs Condition="'$(ContinuousIntegrationBuild)' == 'true'">$(InnerBuildArgs) /p:ContinuousIntegrationBuild=true</InnerBuildArgs>
 
       <!-- The inner build needs to reference the overall output dir for nupkg transport etc. -->
-      <InnerBuildArgs>$(InnerBuildArgs) /p:SourceBuildOutputDir=$(SourceBuildOutputDir.TrimEnd('\'))</InnerBuildArgs>
+      <InnerBuildArgs>$(InnerBuildArgs) /p:SourceBuildOutputDir="$(SourceBuildOutputDir)\"</InnerBuildArgs>
 
       <InnerBuildArgs Condition="'$(ArcadeBuildVertical)' != 'true'">$(InnerBuildArgs) /p:DotNetBuildOffline=true</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(DotNetPackageVersionPropsPath)' != ''">$(InnerBuildArgs) /p:DotNetPackageVersionPropsPath="$(DotNetPackageVersionPropsPath)"</InnerBuildArgs>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
@@ -16,8 +16,8 @@
 
     <FullAssemblySigningSupported Condition="'$(FullAssemblySigningSupported)' == ''">false</FullAssemblySigningSupported>
 
-    <_DirectorySeparatorEscapedCharForExecArgument Condition="'$(OS)' == 'Windows_NT'">\</_DirectorySeparatorEscapedCharForExecArgument>
-    <_DirectorySeparatorEscapedCharForExecArgument Condition="'$(OS)' != 'Windows_NT'" />
+    <_DirSeparatorEscapedCharForExecArg Condition="'$(OS)' == 'Windows_NT'">\</_DirSeparatorEscapedCharForExecArg>
+    <_DirSeparatorEscapedCharForExecArg Condition="'$(OS)' != 'Windows_NT'" />
   </PropertyGroup>
 
   <Target Name="ExecuteWithSourceBuiltTooling"
@@ -79,16 +79,16 @@
       <InnerBuildArgs Condition="'$(ArcadeBuildFromSource)' == 'true'">$(InnerBuildArgs) /p:DotNetBuildFromSource=true</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(ArcadeBuildVertical)' == 'true'">$(InnerBuildArgs) /p:DotNetBuildVertical=true</InnerBuildArgs>
       <!-- Use a fresh clone of the repo so that source-build modifications are isolated. -->
-      <InnerBuildArgs>$(InnerBuildArgs) /p:RepoRoot="$(InnerSourceBuildRepoRoot)$(_DirectorySeparatorEscapedCharForExecArgument)"</InnerBuildArgs>
+      <InnerBuildArgs>$(InnerBuildArgs) /p:RepoRoot="$(InnerSourceBuildRepoRoot)$(_DirSeparatorEscapedCharForExecArg)"</InnerBuildArgs>
       <!-- Override the artifacts dir to cleanly separate the inner build from outer build.  -->
-      <InnerBuildArgs>$(InnerBuildArgs) /p:ArtifactsDir="$(CurrentRepoSourceBuildArtifactsDir)$(_DirectorySeparatorEscapedCharForExecArgument)"</InnerBuildArgs>
+      <InnerBuildArgs>$(InnerBuildArgs) /p:ArtifactsDir="$(CurrentRepoSourceBuildArtifactsDir)$(_DirSeparatorEscapedCharForExecArg)"</InnerBuildArgs>
       <!-- Set a custom binlog location to avoid clashing over the currenly specified file. -->
       <InnerBuildArgs>$(InnerBuildArgs) /bl:"$(CurrentRepoSourceBuildBinlogFile)"</InnerBuildArgs>
       <!-- Flow ContinuousIntegrationBuild to the inner build. -->
       <InnerBuildArgs Condition="'$(ContinuousIntegrationBuild)' == 'true'">$(InnerBuildArgs) /p:ContinuousIntegrationBuild=true</InnerBuildArgs>
 
       <!-- The inner build needs to reference the overall output dir for nupkg transport etc. -->
-      <InnerBuildArgs>$(InnerBuildArgs) /p:SourceBuildOutputDir="$(SourceBuildOutputDir)$(_DirectorySeparatorEscapedCharForExecArgument)"</InnerBuildArgs>
+      <InnerBuildArgs>$(InnerBuildArgs) /p:SourceBuildOutputDir="$(SourceBuildOutputDir)$(_DirSeparatorEscapedCharForExecArg)"</InnerBuildArgs>
 
       <InnerBuildArgs Condition="'$(ArcadeBuildVertical)' != 'true'">$(InnerBuildArgs) /p:DotNetBuildOffline=true</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(DotNetPackageVersionPropsPath)' != ''">$(InnerBuildArgs) /p:DotNetPackageVersionPropsPath="$(DotNetPackageVersionPropsPath)"</InnerBuildArgs>
@@ -146,8 +146,8 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="$([MSBuild]::IsOSPlatform(Windows))">
-      <_GitCloneToDirArgs>$(_GitCloneToDirArgs) -Source "$(RepoRoot)$(_DirectorySeparatorEscapedCharForExecArgument)"</_GitCloneToDirArgs>
-      <_GitCloneToDirArgs>$(_GitCloneToDirArgs) -Dest "$(InnerSourceBuildRepoRoot)$(_DirectorySeparatorEscapedCharForExecArgument)"</_GitCloneToDirArgs>
+      <_GitCloneToDirArgs>$(_GitCloneToDirArgs) -Source "$(RepoRoot)$(_DirSeparatorEscapedCharForExecArg)"</_GitCloneToDirArgs>
+      <_GitCloneToDirArgs>$(_GitCloneToDirArgs) -Dest "$(InnerSourceBuildRepoRoot)$(_DirSeparatorEscapedCharForExecArg)"</_GitCloneToDirArgs>
       <_GitCloneToDirArgs Condition="'$(CopyWipIntoInnerSourceBuildRepo)' == 'true'">$(_GitCloneToDirArgs) -CopyWip</_GitCloneToDirArgs>
       <_GitCloneToDirArgs Condition="'$(CleanInnerSourceBuildRepoRoot)' == 'true'">$(_GitCloneToDirArgs) -Clean</_GitCloneToDirArgs>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
@@ -80,7 +80,7 @@
       <InnerBuildArgs Condition="'$(ArcadeBuildVertical)' == 'true'">$(InnerBuildArgs) /p:DotNetBuildVertical=true</InnerBuildArgs>
       <!-- Use a fresh clone of the repo so that source-build modifications are isolated. -->
       <InnerBuildArgs>$(InnerBuildArgs) /p:RepoRoot="$(InnerSourceBuildRepoRoot)$(_DirSeparatorEscapedCharForExecArg)"</InnerBuildArgs>
-      <!-- Override the artifacts dir to cleanly separate the inner build from outer build.  -->
+      <!-- Override the artifacts dir to cleanly separate the inner build from outer build. -->
       <InnerBuildArgs>$(InnerBuildArgs) /p:ArtifactsDir="$(CurrentRepoSourceBuildArtifactsDir)$(_DirSeparatorEscapedCharForExecArg)"</InnerBuildArgs>
       <!-- Set a custom binlog location to avoid clashing over the currenly specified file. -->
       <InnerBuildArgs>$(InnerBuildArgs) /bl:"$(CurrentRepoSourceBuildBinlogFile)"</InnerBuildArgs>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
@@ -15,6 +15,9 @@
     <CleanInnerSourceBuildRepoRoot Condition="'$(CleanInnerSourceBuildRepoRoot)' == ''">true</CleanInnerSourceBuildRepoRoot>
 
     <FullAssemblySigningSupported Condition="'$(FullAssemblySigningSupported)' == ''">false</FullAssemblySigningSupported>
+
+    <_DirectorySeparatorEscapedCharForExecArgument Condition="'$(OS)' == 'Windows_NT'">\</_DirectorySeparatorEscapedCharForExecArgument>
+    <_DirectorySeparatorEscapedCharForExecArgument Condition="'$(OS)' != 'Windows_NT'" />
   </PropertyGroup>
 
   <Target Name="ExecuteWithSourceBuiltTooling"
@@ -76,16 +79,16 @@
       <InnerBuildArgs Condition="'$(ArcadeBuildFromSource)' == 'true'">$(InnerBuildArgs) /p:DotNetBuildFromSource=true</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(ArcadeBuildVertical)' == 'true'">$(InnerBuildArgs) /p:DotNetBuildVertical=true</InnerBuildArgs>
       <!-- Use a fresh clone of the repo so that source-build modifications are isolated. -->
-      <InnerBuildArgs>$(InnerBuildArgs) /p:RepoRoot="$(InnerSourceBuildRepoRoot)\"</InnerBuildArgs>
+      <InnerBuildArgs>$(InnerBuildArgs) /p:RepoRoot="$(InnerSourceBuildRepoRoot)$(_DirectorySeparatorEscapedCharForExecArgument)"</InnerBuildArgs>
       <!-- Override the artifacts dir to cleanly separate the inner build from outer build.  -->
-      <InnerBuildArgs>$(InnerBuildArgs) /p:ArtifactsDir="$(CurrentRepoSourceBuildArtifactsDir)\"</InnerBuildArgs>
+      <InnerBuildArgs>$(InnerBuildArgs) /p:ArtifactsDir="$(CurrentRepoSourceBuildArtifactsDir)$(_DirectorySeparatorEscapedCharForExecArgument)"</InnerBuildArgs>
       <!-- Set a custom binlog location to avoid clashing over the currenly specified file. -->
       <InnerBuildArgs>$(InnerBuildArgs) /bl:"$(CurrentRepoSourceBuildBinlogFile)"</InnerBuildArgs>
       <!-- Flow ContinuousIntegrationBuild to the inner build. -->
       <InnerBuildArgs Condition="'$(ContinuousIntegrationBuild)' == 'true'">$(InnerBuildArgs) /p:ContinuousIntegrationBuild=true</InnerBuildArgs>
 
       <!-- The inner build needs to reference the overall output dir for nupkg transport etc. -->
-      <InnerBuildArgs>$(InnerBuildArgs) /p:SourceBuildOutputDir="$(SourceBuildOutputDir)\"</InnerBuildArgs>
+      <InnerBuildArgs>$(InnerBuildArgs) /p:SourceBuildOutputDir="$(SourceBuildOutputDir)$(_DirectorySeparatorEscapedCharForExecArgument)"</InnerBuildArgs>
 
       <InnerBuildArgs Condition="'$(ArcadeBuildVertical)' != 'true'">$(InnerBuildArgs) /p:DotNetBuildOffline=true</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(DotNetPackageVersionPropsPath)' != ''">$(InnerBuildArgs) /p:DotNetPackageVersionPropsPath="$(DotNetPackageVersionPropsPath)"</InnerBuildArgs>
@@ -143,8 +146,8 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="$([MSBuild]::IsOSPlatform(Windows))">
-      <_GitCloneToDirArgs>$(_GitCloneToDirArgs) -Source '$(RepoRoot)'</_GitCloneToDirArgs>
-      <_GitCloneToDirArgs>$(_GitCloneToDirArgs) -Dest '$(InnerSourceBuildRepoRoot)'</_GitCloneToDirArgs>
+      <_GitCloneToDirArgs>$(_GitCloneToDirArgs) -Source "$(RepoRoot)$(_DirectorySeparatorEscapedCharForExecArgument)"</_GitCloneToDirArgs>
+      <_GitCloneToDirArgs>$(_GitCloneToDirArgs) -Dest "$(InnerSourceBuildRepoRoot)$(_DirectorySeparatorEscapedCharForExecArgument)"</_GitCloneToDirArgs>
       <_GitCloneToDirArgs Condition="'$(CopyWipIntoInnerSourceBuildRepo)' == 'true'">$(_GitCloneToDirArgs) -CopyWip</_GitCloneToDirArgs>
       <_GitCloneToDirArgs Condition="'$(CleanInnerSourceBuildRepoRoot)' == 'true'">$(_GitCloneToDirArgs) -Clean</_GitCloneToDirArgs>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
@@ -76,20 +76,19 @@
       <InnerBuildArgs Condition="'$(ArcadeBuildFromSource)' == 'true'">$(InnerBuildArgs) /p:DotNetBuildFromSource=true</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(ArcadeBuildVertical)' == 'true'">$(InnerBuildArgs) /p:DotNetBuildVertical=true</InnerBuildArgs>
       <!-- Use a fresh clone of the repo so that source-build modifications are isolated. -->
-      <InnerBuildArgs>$(InnerBuildArgs) /p:RepoRoot=$(InnerSourceBuildRepoRoot)</InnerBuildArgs>
+      <InnerBuildArgs>$(InnerBuildArgs) /p:RepoRoot="$(InnerSourceBuildRepoRoot.TrimEnd('\'))"</InnerBuildArgs>
       <!-- Override the artifacts dir to cleanly separate the inner build from outer build. -->
-      <InnerBuildArgs>$(InnerBuildArgs) /p:ArtifactsDir=$(CurrentRepoSourceBuildArtifactsDir)</InnerBuildArgs>
+      <InnerBuildArgs>$(InnerBuildArgs) /p:ArtifactsDir="$(CurrentRepoSourceBuildArtifactsDir.TrimEnd('\'))"</InnerBuildArgs>
       <!-- Set a custom binlog location to avoid clashing over the currenly specified file. -->
-      <InnerBuildArgs>$(InnerBuildArgs) /bl:$(CurrentRepoSourceBuildBinlogFile)</InnerBuildArgs>
+      <InnerBuildArgs>$(InnerBuildArgs) /bl:"$(CurrentRepoSourceBuildBinlogFile)"</InnerBuildArgs>
       <!-- Flow ContinuousIntegrationBuild to the inner build. -->
       <InnerBuildArgs Condition="'$(ContinuousIntegrationBuild)' == 'true'">$(InnerBuildArgs) /p:ContinuousIntegrationBuild=true</InnerBuildArgs>
 
       <!-- The inner build needs to reference the overall output dir for nupkg transport etc. -->
-      <InnerBuildArgs>$(InnerBuildArgs) /p:SourceBuildOutputDir=$(SourceBuildOutputDir)</InnerBuildArgs>
-      <InnerBuildArgs>$(InnerBuildArgs) /p:SourceBuiltBlobFeedDir=$(SourceBuiltBlobFeedDir)</InnerBuildArgs>
+      <InnerBuildArgs>$(InnerBuildArgs) /p:SourceBuildOutputDir=$(SourceBuildOutputDir.TrimEnd('\'))</InnerBuildArgs>
 
       <InnerBuildArgs Condition="'$(ArcadeBuildVertical)' != 'true'">$(InnerBuildArgs) /p:DotNetBuildOffline=true</InnerBuildArgs>
-      <InnerBuildArgs Condition=" '$(DotNetPackageVersionPropsPath)' != '' ">$(InnerBuildArgs) /p:DotNetPackageVersionPropsPath=$(DotNetPackageVersionPropsPath)</InnerBuildArgs>
+      <InnerBuildArgs Condition="'$(DotNetPackageVersionPropsPath)' != ''">$(InnerBuildArgs) /p:DotNetPackageVersionPropsPath="$(DotNetPackageVersionPropsPath)"</InnerBuildArgs>
 
       <InnerBuildArgs>$(InnerBuildArgs) /p:FullAssemblySigningSupported=$(FullAssemblySigningSupported)</InnerBuildArgs>
     </PropertyGroup>
@@ -144,8 +143,8 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="$([MSBuild]::IsOSPlatform(Windows))">
-      <_GitCloneToDirArgs>$(_GitCloneToDirArgs) -Source '$(RepoRoot)'</_GitCloneToDirArgs>
-      <_GitCloneToDirArgs>$(_GitCloneToDirArgs) -Dest '$(InnerSourceBuildRepoRoot)'</_GitCloneToDirArgs>
+      <_GitCloneToDirArgs>$(_GitCloneToDirArgs) -Source "$(RepoRoot.TrimEnd('\'))"</_GitCloneToDirArgs>
+      <_GitCloneToDirArgs>$(_GitCloneToDirArgs) -Dest "$(InnerSourceBuildRepoRoot.TrimEnd('\'))"</_GitCloneToDirArgs>
       <_GitCloneToDirArgs Condition="'$(CopyWipIntoInnerSourceBuildRepo)' == 'true'">$(_GitCloneToDirArgs) -CopyWip</_GitCloneToDirArgs>
       <_GitCloneToDirArgs Condition="'$(CleanInnerSourceBuildRepoRoot)' == 'true'">$(_GitCloneToDirArgs) -Clean</_GitCloneToDirArgs>
 
@@ -153,8 +152,8 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="!$([MSBuild]::IsOSPlatform(Windows))">
-      <_GitCloneToDirArgs>$(_GitCloneToDirArgs) --source &quot;$(RepoRoot)&quot;</_GitCloneToDirArgs>
-      <_GitCloneToDirArgs>$(_GitCloneToDirArgs) --dest &quot;$(InnerSourceBuildRepoRoot)&quot;</_GitCloneToDirArgs>
+      <_GitCloneToDirArgs>$(_GitCloneToDirArgs) --source "$(RepoRoot)"</_GitCloneToDirArgs>
+      <_GitCloneToDirArgs>$(_GitCloneToDirArgs) --dest "$(InnerSourceBuildRepoRoot)"</_GitCloneToDirArgs>
       <_GitCloneToDirArgs Condition="'$(CopyWipIntoInnerSourceBuildRepo)' == 'true'">$(_GitCloneToDirArgs) --copy-wip</_GitCloneToDirArgs>
       <_GitCloneToDirArgs Condition="'$(CleanInnerSourceBuildRepoRoot)' == 'true'">$(_GitCloneToDirArgs) --clean</_GitCloneToDirArgs>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
@@ -75,8 +75,9 @@
       <!-- Turn on DotNetBuildFromSource or DotNetBuildVertical in the inner build -->
       <InnerBuildArgs Condition="'$(ArcadeBuildFromSource)' == 'true'">$(InnerBuildArgs) /p:DotNetBuildFromSource=true</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(ArcadeBuildVertical)' == 'true'">$(InnerBuildArgs) /p:DotNetBuildVertical=true</InnerBuildArgs>
-      <!-- Use a fresh clone of the repo so that source-build modifications are isolated. -->
-      <InnerBuildArgs>$(InnerBuildArgs) /p:RepoRoot="$(InnerSourceBuildRepoRoot.TrimEnd('\'))"</InnerBuildArgs>
+      <!-- Use a fresh clone of the repo so that source-build modifications are isolated.
+           Don't trim the trailing directors separator for Windows as Arcade depends on it being pasesd in. -->
+      <InnerBuildArgs>$(InnerBuildArgs) /p:RepoRoot=$(InnerSourceBuildRepoRoot)</InnerBuildArgs>
       <!-- Override the artifacts dir to cleanly separate the inner build from outer build. -->
       <InnerBuildArgs>$(InnerBuildArgs) /p:ArtifactsDir="$(CurrentRepoSourceBuildArtifactsDir.TrimEnd('\'))"</InnerBuildArgs>
       <!-- Set a custom binlog location to avoid clashing over the currenly specified file. -->
@@ -143,8 +144,8 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="$([MSBuild]::IsOSPlatform(Windows))">
-      <_GitCloneToDirArgs>$(_GitCloneToDirArgs) -Source "$(RepoRoot.TrimEnd('\'))"</_GitCloneToDirArgs>
-      <_GitCloneToDirArgs>$(_GitCloneToDirArgs) -Dest "$(InnerSourceBuildRepoRoot.TrimEnd('\'))"</_GitCloneToDirArgs>
+      <_GitCloneToDirArgs>$(_GitCloneToDirArgs) -Source '$(RepoRoot)'</_GitCloneToDirArgs>
+      <_GitCloneToDirArgs>$(_GitCloneToDirArgs) -Dest '$(InnerSourceBuildRepoRoot)'</_GitCloneToDirArgs>
       <_GitCloneToDirArgs Condition="'$(CopyWipIntoInnerSourceBuildRepo)' == 'true'">$(_GitCloneToDirArgs) -CopyWip</_GitCloneToDirArgs>
       <_GitCloneToDirArgs Condition="'$(CleanInnerSourceBuildRepoRoot)' == 'true'">$(_GitCloneToDirArgs) -Clean</_GitCloneToDirArgs>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
@@ -85,9 +85,12 @@
 
     Repos can select a different intermediate nupkg by defining 'SymbolsIntermediateNupkgCategory'
     property in eng/SourceBuild.props.
+
+    Conditioning out for Windows as the tar execution below doesn't work cross-plat.
   -->
   <Target Name="GetSymbolsArchive"
-    Condition="'$(SupplementalIntermediateNupkgCategory)' == '$(SymbolsIntermediateNupkgCategory)'">
+    Condition="'$(SupplementalIntermediateNupkgCategory)' == '$(SymbolsIntermediateNupkgCategory)' and
+               '$(OS)' != 'Windows_NT'">
     <PropertyGroup>
       <SymbolsRoot>$(CurrentRepoSourceBuildArtifactsDir)</SymbolsRoot>
       <!-- Fall back to repo root for source-build-externals or repos that don't have the regular SymbolsRoot as defined above -->
@@ -97,7 +100,7 @@
       <SymbolsList>$(SymbolsArchiveLocation)\symbols.lst</SymbolsList>
       <SymbolsArchivePrefix>Symbols.</SymbolsArchivePrefix>
       <SymbolsArchiveSuffix>.$(Version).$(TargetRid)</SymbolsArchiveSuffix>
-      <SymbolsArchiveName>$(SymbolsArchiveLocation)$(SymbolsArchivePrefix)$(GitHubRepositoryName)$(SymbolsArchiveSuffix).tar.gz</SymbolsArchiveName>
+      <SymbolsArchiveName>$(SymbolsArchiveLocation)$(SymbolsArchivePrefix)$(GitHubRepositoryName)$(SymbolsArchiveSuffix)$(ArchiveExtension)</SymbolsArchiveName>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
1. Remove the trailing directory separator in properties when those are being passed to an exec task so that they don't escape the subsequent `"` quote character on Windows.
2. Quote the path arguments that are passed to exec paths so that the commands work on a user path with a whitespace in it.
3. Define common properties to be used in the repo's SourceBuild.props and in the ArPow infra for the archive extension, the flag parameter prefix and the arcade false boolean arg.
4. Remove the dead `SourceBuiltBlobFeedDir` property. I verified that it isn't used anywhere in the product or in the repo's builds. It's always passed in as empty and never used.
5. Condition out the `GetSymbolsArchive` optional target on Windows as it invokes `tar` with arguments that aren't supported on Windows.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
