### PR TITLE
Update trim-assets-version.ps1

### DIFF
--- a/eng/common/sdl/trim-assets-version.ps1
+++ b/eng/common/sdl/trim-assets-version.ps1
@@ -61,8 +61,9 @@ try {
     ExitWithExitCode 1
   }
 
+  # Remove the ROLL FORWARD env var with a future Arcade.Sdk update in Arcade.
   Exec-BlockVerbosely {
-    & "$dotnet" $CliToolName trim-assets-version `
+    & set "DOTNET_ROLL_FORWARD=Major" && "$dotnet" $CliToolName trim-assets-version `
       --assets-path $InputPath `
       --recursive $Recursive
     Exit-IfNZEC "Sdl"


### PR DESCRIPTION
For https://github.com/dotnet/arcade/issues/14287

https://github.com/dotnet/arcade/commit/8bf81f58a5fbc7ee9c8b4a53b109d8d2876bbd2a fixed this for the future but right now we need to make the current prebuilt compatible with the 9.0 SDK.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
