### PR TITLE
Update SDK to 9.0.100-alpha.1.23615.4

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "9.0.100-alpha.1.23613.1"
+    "dotnet": "9.0.100-alpha.1.23615.4"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.23612.2",


### PR DESCRIPTION
The previous SDK had a roslyn CodeAnalysis regression that was meanwhile reverted: https://github.com/dotnet/roslyn/pull/71173

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
