### PR TITLE
Make it easier to use BenchmarkDotNet

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.props
@@ -29,7 +29,8 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(IsTestProject)' == 'true' and '$(ExcludeMicrosoftNetTestSdk)' != 'true'">
+  <!-- BenchmarkDotNet doesn't need the Microsoft.NET.Test.Sdk -->
+  <ItemGroup Condition="'$(IsTestProject)' == 'true' and ('$(ExcludeMicrosoftNetTestSdk)' != 'true' or '$(TestRunnerName)' != 'BenchmarkDotNet')">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" IsImplicitlyDefined="true" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.props
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <!-- BenchmarkDotNet doesn't need the Microsoft.NET.Test.Sdk -->
-  <ItemGroup Condition="'$(IsTestProject)' == 'true' and ('$(ExcludeMicrosoftNetTestSdk)' != 'true' or '$(TestRunnerName)' != 'BenchmarkDotNet')">
+  <ItemGroup Condition="'$(IsTestProject)' == 'true' and '$(ExcludeMicrosoftNetTestSdk)' != 'true' and '$(TestRunnerName)' != 'BenchmarkDotNet'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" IsImplicitlyDefined="true" />
   </ItemGroup>
 


### PR DESCRIPTION
Perf test projects can use Arcade's test infrastructure with BenchmarkDotNet by specifying: `<TestRunnerName>BenchmarkDotNet</BenchmarkDotNet>` and creating a `BenchmarkDotNet.targets` file under their `eng` folder that then defines the custom test target.

BenchmarkDotNet doesn't need the Microsoft.NET.Test.Sdk so condition it out for that mode.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
