### PR TITLE
Add eng/common/build.cmd

### DIFF
--- a/eng/common/build.cmd
+++ b/eng/common/build.cmd
@@ -1,0 +1,3 @@
+@echo off
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0build.ps1""" %*"
+exit /b %ErrorLevel%


### PR DESCRIPTION
This allows VMR builds to directly invoke this script instead of the repo root build scripts that pass in different switches and arguments.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
