### PR TITLE
Fix missing script property and only allow submodule cloning on non-win

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
@@ -145,22 +145,24 @@
       <_GitCloneToDirArgs />
     </PropertyGroup>
 
-    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform(Windows))">
+    <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
       <_GitCloneToDirArgs>$(_GitCloneToDirArgs) -Source "$(RepoRoot)$(_DirSeparatorEscapedCharForExecArg)"</_GitCloneToDirArgs>
       <_GitCloneToDirArgs>$(_GitCloneToDirArgs) -Dest "$(InnerSourceBuildRepoRoot)$(_DirSeparatorEscapedCharForExecArg)"</_GitCloneToDirArgs>
       <_GitCloneToDirArgs Condition="'$(CopyWipIntoInnerSourceBuildRepo)' == 'true'">$(_GitCloneToDirArgs) -CopyWip</_GitCloneToDirArgs>
       <_GitCloneToDirArgs Condition="'$(CleanInnerSourceBuildRepoRoot)' == 'true'">$(_GitCloneToDirArgs) -Clean</_GitCloneToDirArgs>
 
-      <_GitCloneToDirScriptCommand>powershell -ExecutionPolicy Unrestricted -NoProfile -command "&amp; $(MSBuildThisFileDirectory)git-clone-to-dir.ps1 $(_GitCloneToDirArgs)"</_GitCloneToDirScriptCommand>
+      <_GitCloneToDirScriptFile>$(MSBuildThisFileDirectory)git-clone-to-dir.ps1</_GitCloneToDirScriptFile>
+      <_GitCloneToDirScriptCommand>powershell -ExecutionPolicy Unrestricted -NoProfile -command "&amp; $(_GitCloneToDirScriptFile) $(_GitCloneToDirArgs)"</_GitCloneToDirScriptCommand>
     </PropertyGroup>
 
-    <PropertyGroup Condition="!$([MSBuild]::IsOSPlatform(Windows))">
+    <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
       <_GitCloneToDirArgs>$(_GitCloneToDirArgs) --source "$(RepoRoot)"</_GitCloneToDirArgs>
       <_GitCloneToDirArgs>$(_GitCloneToDirArgs) --dest "$(InnerSourceBuildRepoRoot)"</_GitCloneToDirArgs>
       <_GitCloneToDirArgs Condition="'$(CopyWipIntoInnerSourceBuildRepo)' == 'true'">$(_GitCloneToDirArgs) --copy-wip</_GitCloneToDirArgs>
       <_GitCloneToDirArgs Condition="'$(CleanInnerSourceBuildRepoRoot)' == 'true'">$(_GitCloneToDirArgs) --clean</_GitCloneToDirArgs>
 
-      <_GitCloneToDirScriptCommand>$(MSBuildThisFileDirectory)git-clone-to-dir.sh $(_GitCloneToDirArgs)</_GitCloneToDirScriptCommand>
+      <_GitCloneToDirScriptFile>$(MSBuildThisFileDirectory)git-clone-to-dir.sh</_GitCloneToDirScriptFile>
+      <_GitCloneToDirScriptCommand>$(_GitCloneToDirScriptFile) $(_GitCloneToDirArgs)</_GitCloneToDirScriptCommand>
     </PropertyGroup>
 
     <Exec Command="$(_GitCloneToDirScriptCommand)" />
@@ -179,6 +181,9 @@
     -->
     <PropertyGroup>
       <CloneSubmodulesToInnerSourceBuildRepo Condition="'$(CloneSubmodulesToInnerSourceBuildRepo)' == ''">true</CloneSubmodulesToInnerSourceBuildRepo>
+
+      <Error Text="Submodule cloning not available on Windows at this time"
+             Condition="'$(CloneSubmodulesToInnerSourceBuildRepo)' == 'true' and '$(OS)' == 'Windows_NT' />
 
       <_GitSubmoduleCloneArgs />
       <_GitSubmoduleCloneArgs>$(_GitSubmoduleCloneArgs) --source .</_GitSubmoduleCloneArgs>
@@ -201,7 +206,7 @@
 
     <Exec
       Condition="'$(CloneSubmodulesToInnerSourceBuildRepo)' == 'true'"
-      Command="git submodule foreach --recursive '$(_gitCloneToDirScriptFile) $(_GitSubmoduleCloneArgs)'"
+      Command="git submodule foreach --recursive '$(_GitCloneToDirScriptFile) $(_GitSubmoduleCloneArgs)'"
       WorkingDirectory="$(RepoRoot)" />
   </Target>
 


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
