### PR TITLE
Fix evaluation of SourceBuildArcadeBuild.targets

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
@@ -133,7 +133,7 @@
     access to the git data, this also makes it easy to see what changes the source-build infra has
     made, for diagnosis or exploratory purposes.
   -->
-  <Target Name="CloneInnerSourceBuildRepoRoot" Condition=" '$(CopySrcInsteadOfClone)' != 'true' ">
+  <Target Name="CloneInnerSourceBuildRepoRoot" Condition=" '$(CopySrcInsteadOfClone)' != 'true'">
     <PropertyGroup>
       <!--
         By default, copy WIP. WIP copy helps with local machine dev work. Don't copy WIP if this is
@@ -183,7 +183,7 @@
       <CloneSubmodulesToInnerSourceBuildRepo Condition="'$(CloneSubmodulesToInnerSourceBuildRepo)' == ''">true</CloneSubmodulesToInnerSourceBuildRepo>
 
       <Error Text="Submodule cloning not available on Windows at this time"
-             Condition="'$(CloneSubmodulesToInnerSourceBuildRepo)' == 'true' and '$(OS)' == 'Windows_NT' />
+             Condition="'$(CloneSubmodulesToInnerSourceBuildRepo)' == 'true' and '$(OS)' == 'Windows_NT'" />
 
       <_GitSubmoduleCloneArgs />
       <_GitSubmoduleCloneArgs>$(_GitSubmoduleCloneArgs) --source .</_GitSubmoduleCloneArgs>


### PR DESCRIPTION
Missing quote. Regressed with https://github.com/dotnet/arcade/commit/9a643b7b15a044f249a1d569c1c170b88245a47c

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
