### PR TITLE
[release/6.0] Use `NuGetAuthenticate@1` instead of `@0`

### DIFF
--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -123,7 +123,7 @@ jobs:
         continueOnError: ${{ parameters.continueOnError }}
         condition: and(succeeded(), in(variables['_SignType'], 'real', 'test'), eq(variables['Agent.Os'], 'Windows_NT'))
 
-    - task: NuGetAuthenticate@0
+    - task: NuGetAuthenticate@1
 
   - ${{ if or(eq(parameters.artifacts.download, 'true'), ne(parameters.artifacts.download, '')) }}:
     - task: DownloadPipelineArtifact@2

--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -53,7 +53,7 @@ jobs:
       continueOnError: ${{ parameters.continueOnError }}
     
     - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - task: NuGetAuthenticate@0
+      - task: NuGetAuthenticate@1
 
       - task: PowerShell@2 
         displayName: Enable cross-org NuGet feed authentication 

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -162,7 +162,7 @@ stages:
         # This is necessary whenever we want to publish/restore to an AzDO private feed
         # Since sdk-task.ps1 tries to restore packages we need to do this authentication here
         # otherwise it'll complain about accessing a private feed.
-        - task: NuGetAuthenticate@0
+        - task: NuGetAuthenticate@1
           displayName: 'Authenticate to AzDO Feeds'
 
         - task: PowerShell@2

--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -146,7 +146,7 @@ stages:
           displayName: 'Install NuGet.exe'
 
         # This is necessary whenever we want to publish/restore to an AzDO private feed
-        - task: NuGetAuthenticate@0
+        - task: NuGetAuthenticate@1
           displayName: 'Authenticate to AzDO Feeds'
 
         - task: PowerShell@2


### PR DESCRIPTION
Backport of https://github.com/dotnet/arcade/pull/14314