### PR TITLE
Use IsTestUtilityProject and remove unnecessary ExcludeFrom* properties

### DIFF
--- a/src/Common/Microsoft.Arcade.Common.Tests/Microsoft.Arcade.Common.Tests.csproj
+++ b/src/Common/Microsoft.Arcade.Common.Tests/Microsoft.Arcade.Common.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <Nullable>enable</Nullable>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Common/Microsoft.Arcade.Test.Common/Microsoft.Arcade.Test.Common.csproj
+++ b/src/Common/Microsoft.Arcade.Test.Common/Microsoft.Arcade.Test.Common.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCurrent);$(NetFrameworkToolCurrent)</TargetFrameworks>
-    <IsTestProject>true</IsTestProject>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Tasks.Core" />
+    <PackageReference Include="xunit" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">

--- a/src/Microsoft.DotNet.Build.Tasks.Archives/Microsoft.DotNet.Build.Tasks.Archives.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Archives/Microsoft.DotNet.Build.Tasks.Archives.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
-    <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
     <IsPackable>true</IsPackable>
     <PackTasks>false</PackTasks>
     <Description>Targets for producing an archive of file outputs.</Description>

--- a/src/Microsoft.DotNet.Build.Tasks.VisualStudio/Microsoft.DotNet.Build.Tasks.VisualStudio.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.VisualStudio/Microsoft.DotNet.Build.Tasks.VisualStudio.csproj
@@ -6,7 +6,6 @@
     <PackageDescription>Arcade SDK build tasks for Visual Studio profile guided optimization training</PackageDescription>
     <PackageTags>Roslyn Build Task OptProf Optimization Training</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.RemoteExecutor/src/Microsoft.DotNet.RemoteExecutor.csproj
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/Microsoft.DotNet.RemoteExecutor.csproj
@@ -5,7 +5,7 @@
     <!-- The assembly is used as both a library and an executable. -->
     <OutputType>Exe</OutputType>
     <Description>This package provides support for running tests out-of-process.</Description>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
     <IsPackable>true</IsPackable>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PackBuildOutputs</TargetsForTfmSpecificContentInPackage>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/Microsoft.DotNet.VersionTools/tools/Microsoft.DotNet.VersionTools.Cli/Microsoft.DotNet.VersionTools.Cli.csproj
+++ b/src/Microsoft.DotNet.VersionTools/tools/Microsoft.DotNet.VersionTools.Cli/Microsoft.DotNet.VersionTools.Cli.csproj
@@ -5,7 +5,6 @@
     <OutputType>Exe</OutputType>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
     <RollForward>Major</RollForward>
     <Description>This package provides a CLI interface to the Microsoft.DotNet.VersionTools library.</Description>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.XUnitAssert/src/Microsoft.DotNet.XUnitAssert.csproj
+++ b/src/Microsoft.DotNet.XUnitAssert/src/Microsoft.DotNet.XUnitAssert.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <Description>This package is a fork of xunit.assert that is AOT-compatible.</Description>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
     <DefineConstants>$(DefineConstants);XUNIT_NULLABLE;XUNIT_SPAN;XUNIT_AOT</DefineConstants>
     <IsTrimmable>true</IsTrimmable>
     <EnableAotAnalyzer>true</EnableAotAnalyzer>

--- a/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
@@ -7,7 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>Xunit.ConsoleClient</RootNamespace>
     <RollForward>Major</RollForward>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
     <IsPackable>true</IsPackable>
     <PackageId>Microsoft.DotNet.XUnitConsoleRunner</PackageId>
     <VersionPrefix>2.6.1</VersionPrefix>

--- a/src/Microsoft.DotNet.XUnitExtensions/src/Microsoft.DotNet.XUnitExtensions.csproj
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/Microsoft.DotNet.XUnitExtensions.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <Description>This package provides things like various traits and discovers like OuterLoop/ActiveIssue that are used by .NET test projects.</Description>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
+++ b/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
@@ -10,7 +10,6 @@
     <!-- This assembly is bundled in the Microsoft.DotNet.SignCheck package and is not mean to be used as a class library package. -->
     <IsPackable>false</IsPackable>
     <IsTool>true</IsTool>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SignCheck/SignCheck/Microsoft.DotNet.SignCheck.csproj
+++ b/src/SignCheck/SignCheck/Microsoft.DotNet.SignCheck.csproj
@@ -14,7 +14,6 @@
     <Description>Build artifact signing validation tool</Description>
     <PackageTags>Arcade Signing Validation Tool</PackageTags>
     <RootNamespace>SignCheck</RootNamespace>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WinShimmer/WinShimmer.csproj
+++ b/src/WinShimmer/WinShimmer.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>$(NetFrameworkToolCurrent)</TargetFramework>
     <OutputType>Exe</OutputType>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**Requires https://github.com/dotnet/arcade/pull/14321**

TFM filtering already excludes .NET Framework targeting projects, so remove the ExcludeFromSourceBuild properties from them.

Set IsTestUtilityProject property in test utility projects, i.e. XUnitAssert, XUnitExtensions, XUnitConsoleRunner, RemoteExecutor, etc.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
