### PR TITLE
Set ExcludeFrom* properties for test projects in targets

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ExcludeFromBuild.BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ExcludeFromBuild.BeforeCommonTargets.targets
@@ -26,6 +26,13 @@
           where the BeforeCommonTargets hook is not used (see https://github.com/dotnet/arcade/issues/2676).
           In that case, Sdk.targets imports it explicitly. -->
 
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true' or '$(IsTestUtilityProject)' == 'true'">
+    <!-- Exclude test projects from source-build by default -->
+    <ExcludeFromSourceBuild Condition="'$(ExcludeFromSourceBuild)' == ''">true</ExcludeFromSourceBuild>
+    <!-- Vertical Build PoC. Exclude test projects. -->
+    <ExcludeFromVerticalBuild Condition="'$(ExcludeFromVerticalBuild)' == ''">true</ExcludeFromVerticalBuild>
+  </PropertyGroup>
+
   <!--
     If a project specifies ExcludeFromSourceBuild=true or ExcludeFromVerticalBuild=true during a source build/vertical
     build suppress all targets and emulate a no-op (empty common targets like Restore, Build, Pack, etc.).

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.props
@@ -33,9 +33,4 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" IsImplicitlyDefined="true" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
-    <!-- Treat test assemblies as non-shipping (do not publish or sign them). -->
-    <IsShipping Condition="'$(IsShipping)' == ''">false</IsShipping>
-  </PropertyGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.props
@@ -33,15 +33,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" IsImplicitlyDefined="true" />
   </ItemGroup>
 
-  <!-- The IsTestUtilityProject property is supposed to be set manually for test utility projects, there's no auto-detection. -->
-  <PropertyGroup Condition="'$(IsTestProject)' == 'true' or '$(IsTestUtilityProject)' == 'true'">
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
     <!-- Treat test assemblies as non-shipping (do not publish or sign them). -->
     <IsShipping Condition="'$(IsShipping)' == ''">false</IsShipping>
-
-    <!-- exclude test projects from source-build by default -->
-    <ExcludeFromSourceBuild Condition="'$(ExcludeFromSourceBuild)' == ''">true</ExcludeFromSourceBuild>
-    <!-- Vertical Build PoC. Exclude test projects. -->
-    <ExcludeFromVerticalBuild Condition="'$(ExcludeFromVerticalBuild)' == ''">true</ExcludeFromVerticalBuild>
   </PropertyGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
@@ -14,6 +14,8 @@
       if available for the kind of artifact they operate on.
   -->
   <PropertyGroup>
+    <!-- Treat test assemblies as non-shipping (do not publish or sign them). -->
+    <IsShipping Condition="'$(IsShipping)' == '' and '$(IsTestProject)' == 'true' or '$(IsTestUtilityProject)' == 'true'">false</IsShipping>
     <IsShipping Condition="'$(IsShipping)' == ''">true</IsShipping>
 
     <IsShippingAssembly Condition="'$(IsShippingAssembly)' == ''">$(IsShipping)</IsShippingAssembly>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
@@ -15,7 +15,7 @@
   -->
   <PropertyGroup>
     <!-- Treat test assemblies as non-shipping (do not publish or sign them). -->
-    <IsShipping Condition="'$(IsShipping)' == '' and '$(IsTestProject)' == 'true' or '$(IsTestUtilityProject)' == 'true'">false</IsShipping>
+    <IsShipping Condition="'$(IsShipping)' == '' and ('$(IsTestProject)' == 'true' or '$(IsTestUtilityProject)' == 'true')">false</IsShipping>
     <IsShipping Condition="'$(IsShipping)' == ''">true</IsShipping>
 
     <IsShippingAssembly Condition="'$(IsShippingAssembly)' == ''">$(IsShipping)</IsShippingAssembly>


### PR DESCRIPTION
Also set IsShipping default for test projects in targets.

This allows projects to set `<IsTestUtilityProject>true</...>` which will cause the project to be marked as non shipping and excluded from source build and the vertical build POC.

Unblocks https://github.com/dotnet/arcade/pull/14320

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
