### PR TITLE
Revert "Disabling binlog redaction"

### DIFF
--- a/eng/common/templates/steps/publish-logs.yml
+++ b/eng/common/templates/steps/publish-logs.yml
@@ -15,31 +15,30 @@ steps:
       Move-Item -Path $(Build.SourcesDirectory)/artifacts/log/Debug/* $(Build.SourcesDirectory)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
   continueOnError: true
   condition: always()
-
-# TODO: Disabled - https://github.com/dotnet/dnceng/issues/1675
-# - task: PowerShell@2
-#   displayName: Redact Logs
-#   inputs:
-#     filePath: $(Build.SourcesDirectory)/eng/common/post-build/redact-logs.ps1
-#     # For now this needs to have explicit list of all sensitive data. Taken from eng/publishing/v3/publish.yml
-#     # Sensitive data can as well be added to $(Build.SourcesDirectory)/eng/BinlogSecretsRedactionFile.txt'
-#     #  If the file exists - sensitive data for redaction will be sourced from it
-#     #  (single entry per line, lines starting with '# ' are considered comments and skipped)
-#     arguments: -InputPath '$(Build.SourcesDirectory)/PostBuildLogs' 
-#       -BinlogToolVersion ${{parameters.BinlogToolVersion}}
-#       -TokensFilePath '$(Build.SourcesDirectory)/eng/BinlogSecretsRedactionFile.txt'
-#       '$(publishing-dnceng-devdiv-code-r-build-re)'
-#       '$(MaestroAccessToken)'
-#       '$(dn-bot-all-orgs-artifact-feeds-rw)'
-#       '$(akams-client-id)'
-#       '$(akams-client-secret)'
-#       '$(microsoft-symbol-server-pat)'
-#       '$(symweb-symbol-server-pat)'
-#       '$(dn-bot-all-orgs-build-rw-code-rw)'
-#       ${{parameters.CustomSensitiveDataList}}
-#   continueOnError: true
-#   condition: always()
-
+    
+- task: PowerShell@2
+  displayName: Redact Logs
+  inputs:
+    filePath: $(Build.SourcesDirectory)/eng/common/post-build/redact-logs.ps1
+    # For now this needs to have explicit list of all sensitive data. Taken from eng/publishing/v3/publish.yml
+    # Sensitive data can as well be added to $(Build.SourcesDirectory)/eng/BinlogSecretsRedactionFile.txt'
+    #  If the file exists - sensitive data for redaction will be sourced from it
+    #  (single entry per line, lines starting with '# ' are considered comments and skipped)
+    arguments: -InputPath '$(Build.SourcesDirectory)/PostBuildLogs' 
+      -BinlogToolVersion ${{parameters.BinlogToolVersion}}
+      -TokensFilePath '$(Build.SourcesDirectory)/eng/BinlogSecretsRedactionFile.txt'
+      '$(publishing-dnceng-devdiv-code-r-build-re)'
+      '$(MaestroAccessToken)'
+      '$(dn-bot-all-orgs-artifact-feeds-rw)'
+      '$(akams-client-id)'
+      '$(akams-client-secret)'
+      '$(microsoft-symbol-server-pat)'
+      '$(symweb-symbol-server-pat)'
+      '$(dn-bot-all-orgs-build-rw-code-rw)'
+      ${{parameters.CustomSensitiveDataList}}
+  continueOnError: true
+  condition: always()
+      
 - task: PublishBuildArtifacts@1
   displayName: Publish Logs
   inputs:


### PR DESCRIPTION
Reverts dotnet/arcade#14300
Fixes: https://github.com/dotnet/dnceng/issues/1675

### Background

The regression in bilogtool was fixed via https://github.com/KirillOsenkov/MSBuildStructuredLog/commit/83a97d05a5e02af24ad0e418d83b27840cdd8c14 and the tool was bumped in the pipeline via https://github.com/dotnet/arcade/pull/14313 - so we can now reintroduce the redaction step