### PR TITLE
Add a secret for Guardian CLI service connections

### DIFF
--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -283,3 +283,18 @@ secrets:
       name: dn-bot-ceapex-package-r
       organizations: ceapex
       scopes: packaging
+
+  # Token used for installing the Guardian CLI from the securitytools AzDO org
+  # The PAT is in the Guardian service connections in dnceng and devdiv:
+  # https://devdiv.visualstudio.com/DevDiv/_settings/adminservices?resourceId=e002c3af-b8a4-4ebe-816b-d4908648a66a
+  # https://dev.azure.com/dnceng/internal/_settings/adminservices?resourceId=d2604fd5-04f1-4957-afe3-3d3ea81a665b
+  dn-bot-securitytools-packaging-r:
+    type: azure-devops-access-token
+    parameters:
+      domainAccountName: dn-bot
+      domainAccountSecret:
+          location: helixkv
+          name: dn-bot-account-redmond
+      name: dn-bot-securitytools-packaging-r
+      organizations: securitytools
+      scopes: packaging


### PR DESCRIPTION
The PAT needs to have packaging read for the securitytools AzDO org (we don't have a secret for that org in the manifest yet).

The PAT needs to be put in the service connections listed in the Arcade PR (in the manifest):
https://dev.azure.com/dnceng/internal/_settings/adminservices?resourceId=d2604fd5-04f1-4957-afe3-3d3ea81a665b
https://devdiv.visualstudio.com/DevDiv/_settings/adminservices?resourceId=e002c3af-b8a4-4ebe-816b-d4908648a66a