### PR TITLE
[release/6.0] Use SHA256 for RPM digest

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/BuildFPMToolPreReqs.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/BuildFPMToolPreReqs.cs
@@ -128,6 +128,7 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
             //      -a : architecture  --JSON
             //      -d : is for all dependent packages. This can be used multiple times to specify the dependencies of the package.   --JSON
             //      --rpm-os : the operating system to target this rpm  --Static
+            //      --rpm-digest : rpm digest algorithm  --Static
             //      --rpm-changelog : the changelog from FILEPATH contents  --ARG
             //      --rpm-summary : it is the RPM summary that shows in the Title   --JSON
             //      --description : it is the description for the package   --JSON
@@ -211,6 +212,7 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
             }
             
             parameters.Add("--rpm-os linux");
+            parameters.Add("--rpm-digest sha256");
             parameters.Add(string.Concat("--rpm-changelog ", EscapeArg(Path.Combine(InputDir, "templates", "changelog")))); // Changelog File
             parameters.Add(string.Concat("--rpm-summary ", EscapeArg(configJson.Short_Description)));
             parameters.Add(string.Concat("--description ", EscapeArg(configJson.Long_Description)));


### PR DESCRIPTION
Backport of https://github.com/dotnet/arcade/pull/14269

FIPS compliance blocks installation of RPM packages that use MD5 digest algorithm. We use `fpm` tool which defaults to MD5 digests. The fix is to specify SHA256 instead.

This is the same fix that was made by many other RPM package owners, for instance: https://github.com/influxdata/telegraf
