### PR TITLE
Add installation record keys for manifest MSI

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Msi/WorkloadManifestMsi.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Msi/WorkloadManifestMsi.wix.cs
@@ -105,7 +105,8 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Msi
             candle.AddSourceFiles(packageContentWxs,
                 EmbeddedTemplates.Extract("DependencyProvider.wxs", WixSourceDirectory),
                 EmbeddedTemplates.Extract("dotnethome_x64.wxs", WixSourceDirectory),
-                EmbeddedTemplates.Extract("ManifestProduct.wxs", WixSourceDirectory));
+                EmbeddedTemplates.Extract("ManifestProduct.wxs", WixSourceDirectory),
+                EmbeddedTemplates.Extract("Registry.wxs", WixSourceDirectory));
 
             if (IsSxS)
             {
@@ -142,6 +143,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Msi
             candle.AddPreprocessorDefinition(PreprocessorDefinitionNames.DependencyProviderKeyName, $"{providerKeyName}");
             candle.AddPreprocessorDefinition(PreprocessorDefinitionNames.SourceDir, $"{packageDataDirectory}");
             candle.AddPreprocessorDefinition(PreprocessorDefinitionNames.SdkFeatureBandVersion, $"{Package.SdkFeatureBand}");
+            candle.AddPreprocessorDefinition(PreprocessorDefinitionNames.InstallationRecordKey, $"InstalledManifests");
 
             // The temporary installer in the SDK (6.0) used lower invariants of the manifest ID.
             // We have to do the same to ensure the keypath generation produces stable GUIDs.

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/ManifestProduct.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiTemplate/ManifestProduct.wxs
@@ -57,6 +57,7 @@
     </Feature>
 
     <FeatureRef Id="F_DependencyProvider" />
+    <FeatureRef Id="F_RegistryKeys" />
 
     <WixVariable Id="WixUILicenseRtf" Value="$(var.EulaRtf)" />
     <UIRef Id="WixUI_Minimal"/>


### PR DESCRIPTION
# Description

In earlier versions of .NET, workload manifest MSIs were upgrade related within a feature band. In .NET 8, manifests are SxS to support workload sets. When the CLI needs to clean up workload sets, it may need to remove the manifest installer, however, we have no record so the CLI has to fall back to an expensive registry search to identify potential candidate installations. This includes potentially back tracing the installer database and linear search over large sets of registry entries.

This change adds an installation record that enables the CLI to directly look up and retrieve the relevant information it needs to remove a manifest MSI.

![image](https://github.com/dotnet/arcade/assets/7409981/f1f22708-7df2-42d9-81e4-c8754597ec04)
