### PR TITLE
Bump binlogtool

### DIFF
--- a/eng/common/templates/post-build/common-variables.yml
+++ b/eng/common/templates/post-build/common-variables.yml
@@ -18,7 +18,7 @@ variables:
   - name: SymbolToolVersion
     value: 1.0.1
   - name: BinlogToolVersion
-    value: 1.0.9
+    value: 1.0.11
 
   - name: runCodesignValidationInjection
     value: false

--- a/eng/common/templates/steps/publish-logs.yml
+++ b/eng/common/templates/steps/publish-logs.yml
@@ -3,7 +3,7 @@ parameters:
   JobLabel: ''
   CustomSensitiveDataList: ''
   # A default - in case value from eng/common/templates/post-build/common-variables.yml is not passed
-  BinlogToolVersion: '1.0.9'
+  BinlogToolVersion: '1.0.11'
 
 steps:
 - task: Powershell@2


### PR DESCRIPTION
FYI @KirillOsenkov 


### Context

This is update to the latest version of binlogtool, that contains the forward compatibility reading support.
The initial MSBuild change to forward compatible logs reading is **breaking** (log data format needs to be adjusted in order to allow forward compatibile reading for the future) - hence updating the reading code ahead of MSBuild pushing the updated version of binlog writing (https://github.com/dotnet/msbuild/pull/9307) is advisable.
Once on this version - it should be possible to process future revisions of binlogs without need to upgrade the tool (unless a major cahnge is performed).


Job pushing the required package to the dnceng feed:
https://dev.azure.com/dnceng/internal/_build/results?buildId=2351197&view=results