### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Users referenced in this file will automatically be requested as reviewers for PRs that modify the given paths.
+# See https://help.github.com/articles/about-code-owners/
+
+/eng/SourceBuild*                                                                 @dotnet/source-build-internal


### PR DESCRIPTION
Closes https://github.com/dotnet/arcade/issues/14273

Creates a codeowners file with source-build-internal as the owner of files `/eng/SourceBuild*`