### PR TITLE
Update Microsoft.DotNet.XUnitAssert version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,8 @@
     <!-- Keep Microsoft.Data.Services.Client package version in sync with Microsoft.Data.OData -->
     <MicrosoftDataServicesClientVersion>5.8.4</MicrosoftDataServicesClientVersion>
     <MicrosoftSignedWixVersion>1.0.0-v3.14.0.5722</MicrosoftSignedWixVersion>
+    <!-- Overwrite XUnitVersion that comes from the Arcade SDK to be in sync as Arcade doesn't use a live Arcade SDK. -->
+    <XUnitVersion>2.6.1</XUnitVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,8 @@
     <!-- Keep Microsoft.Data.Services.Client package version in sync with Microsoft.Data.OData -->
     <MicrosoftDataServicesClientVersion>5.8.4</MicrosoftDataServicesClientVersion>
     <MicrosoftSignedWixVersion>1.0.0-v3.14.0.5722</MicrosoftSignedWixVersion>
-    <!-- Overwrite XUnitVersion that comes from the Arcade SDK to be in sync as Arcade doesn't use a live Arcade SDK. -->
+    <!-- Overwrite XUnitVersion that comes from the Arcade SDK to be in sync as Arcade doesn't use a live Arcade SDK.
+         Keep in sync with XUnitVersion in DefaultVersions.props. -->
     <XUnitVersion>2.6.1</XUnitVersion>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -81,10 +81,13 @@
     <MicrosoftDotNetSignToolVersion Condition="'$(MicrosoftDotNetSignToolVersion)' == ''">$(ArcadeSdkVersion)</MicrosoftDotNetSignToolVersion>
     <MicrosoftDotNetTarVersion Condition="'$(MicrosoftDotNetTarVersion)' == ''">$(ArcadeSdkVersion)</MicrosoftDotNetTarVersion>
     <MicrosoftTestPlatformVersion Condition="'$(MicrosoftTestPlatformVersion)' == ''">16.5.0</MicrosoftTestPlatformVersion>
+
+    <!-- Follow the instructions on how to update any of the below xunit versions: https://github.com/dotnet/arcade/blob/main/Documentation/update-xunit.md. -->
     <XUnitVersion Condition="'$(XUnitVersion)' == ''">2.6.1</XUnitVersion>
     <XUnitAnalyzersVersion Condition="'$(XUnitAnalyzersVersion)' == ''">1.4.0</XUnitAnalyzersVersion>
     <XUnitRunnerConsoleVersion Condition="'$(XUnitRunnerConsoleVersion)' == ''">$(XUnitVersion)</XUnitRunnerConsoleVersion>
     <XUnitRunnerVisualStudioVersion Condition="'$(XUnitRunnerVisualStudioVersion)' == ''">2.5.5</XUnitRunnerVisualStudioVersion>
+
     <MSTestVersion Condition="'$(MSTestVersion)' == ''">2.0.0</MSTestVersion>
     <MSTestTestAdapterVersion Condition="'$(MSTestTestAdapterVersion)' == ''">$(MSTestVersion)</MSTestTestAdapterVersion>
     <MSTestTestFrameworkVersion Condition="'$(MSTestTestFrameworkVersion)' == ''">$(MSTestVersion)</MSTestTestFrameworkVersion>

--- a/src/Microsoft.DotNet.XUnitAssert/src/Microsoft.DotNet.XUnitAssert.csproj
+++ b/src/Microsoft.DotNet.XUnitAssert/src/Microsoft.DotNet.XUnitAssert.csproj
@@ -17,6 +17,7 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)xunit.snk</AssemblyOriginatorKeyFile>
     <PublicKey>0024000004800000940000000602000000240000525341310004000001000100252e049addea87f30f99d6ed8ebc189bc05b8c9168765df08f86e0214471dc89844f1f4b9c4a26894d029465848771bc758fed20371280eda223a9f64ae05f48b320e4f0e20c4282dd701e985711bc33b5b9e6ab3fafab6cb78e220ee2b8e1550573e03f8ad665c051c63fbc5359d495d4b1c61024ef76ed9c1ebb471fed59c9</PublicKey>
     <PublicKeyToken>8d05b1bb7a6fdb6c</PublicKeyToken>
+    <VersionPrefix>$(XUnitVersion)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.XUnitAssert/src/Microsoft.DotNet.XUnitAssert.csproj
+++ b/src/Microsoft.DotNet.XUnitAssert/src/Microsoft.DotNet.XUnitAssert.csproj
@@ -17,7 +17,7 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)xunit.snk</AssemblyOriginatorKeyFile>
     <PublicKey>0024000004800000940000000602000000240000525341310004000001000100252e049addea87f30f99d6ed8ebc189bc05b8c9168765df08f86e0214471dc89844f1f4b9c4a26894d029465848771bc758fed20371280eda223a9f64ae05f48b320e4f0e20c4282dd701e985711bc33b5b9e6ab3fafab6cb78e220ee2b8e1550573e03f8ad665c051c63fbc5359d495d4b1c61024ef76ed9c1ebb471fed59c9</PublicKey>
     <PublicKeyToken>8d05b1bb7a6fdb6c</PublicKeyToken>
-    <VersionPrefix>$(XUnitVersion)</VersionPrefix>
+    <VersionPrefix>2.6.1</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.XUnitAssert/src/Microsoft.DotNet.XUnitAssert.csproj
+++ b/src/Microsoft.DotNet.XUnitAssert/src/Microsoft.DotNet.XUnitAssert.csproj
@@ -17,7 +17,7 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)xunit.snk</AssemblyOriginatorKeyFile>
     <PublicKey>0024000004800000940000000602000000240000525341310004000001000100252e049addea87f30f99d6ed8ebc189bc05b8c9168765df08f86e0214471dc89844f1f4b9c4a26894d029465848771bc758fed20371280eda223a9f64ae05f48b320e4f0e20c4282dd701e985711bc33b5b9e6ab3fafab6cb78e220ee2b8e1550573e03f8ad665c051c63fbc5359d495d4b1c61024ef76ed9c1ebb471fed59c9</PublicKey>
     <PublicKeyToken>8d05b1bb7a6fdb6c</PublicKeyToken>
-    <VersionPrefix>2.6.1</VersionPrefix>
+    <VersionPrefix>$(XUnitVersion)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
@@ -10,7 +10,7 @@
     <IsTestUtilityProject>true</IsTestUtilityProject>
     <IsPackable>true</IsPackable>
     <PackageId>Microsoft.DotNet.XUnitConsoleRunner</PackageId>
-    <VersionPrefix>2.6.1</VersionPrefix>
+    <VersionPrefix>$(XUnitVersion)</VersionPrefix>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddBuildOutputToPackage</TargetsForTfmSpecificContentInPackage>

--- a/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
@@ -10,7 +10,7 @@
     <IsTestUtilityProject>true</IsTestUtilityProject>
     <IsPackable>true</IsPackable>
     <PackageId>Microsoft.DotNet.XUnitConsoleRunner</PackageId>
-    <VersionPrefix>$(XUnitVersion)</VersionPrefix>
+    <VersionPrefix>2.6.1</VersionPrefix>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddBuildOutputToPackage</TargetsForTfmSpecificContentInPackage>


### PR DESCRIPTION
VersionPrefix also controls the assembly version and we want to keep them in sync with upstream because of other assemblies referencing xunit.assert.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
