### PR TITLE
Add DotNetBuildInnerRepo switch

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -41,7 +41,7 @@
     
     <!-- If `AutoGenerateSymbolPackages` is not set we default it to true. -->
     <!-- Do not generate symbol packages if in outer source build mode, to avoid creating copies of the SB intermediates. -->
-    <AutoGenerateSymbolPackages Condition="'$(AutoGenerateSymbolPackages)' == '' and ('$(ArcadeBuildFromSource)' != 'true' or '$(ArcadeInnerBuildFromSource)' == 'true')">true</AutoGenerateSymbolPackages>
+    <AutoGenerateSymbolPackages Condition="'$(AutoGenerateSymbolPackages)' == '' and ('$(ArcadeBuildFromSource)' != 'true' or '$(ArcadeInnerBuildFromSource)' == 'true' or '$(DotNetBuildInnerRepo)' == 'true')">true</AutoGenerateSymbolPackages>
 
     <AssetManifestOS Condition="'$(AssetManifestOS)' == ''">$(OS)</AssetManifestOS>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
@@ -12,7 +12,7 @@
   <Import Project="$(MicrosoftDotNetSourceBuildTasksBuildDir)Microsoft.DotNet.SourceBuild.Tasks.props" />
 
   <Target Name="AfterSourceBuild"
-          Condition="'$(ArcadeInnerBuildFromSource)' != 'true'"
+          Condition="'$(ArcadeInnerBuildFromSource)' != 'true' and '$(DotNetBuildInnerRepo)' != 'true'"
           DependsOnTargets="
             ReportPrebuiltUsage;
             PackSourceBuildIntermediateNupkgs" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/README.md
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/README.md
@@ -27,7 +27,7 @@ call an inner build after some setup. The targets work roughly like this:
     * [Hook] Before **Outer Execute**:
       * Clone the source into `artifacts/sb/src`
       * Assemble a build command by appending to the `dotnet msbuild` call.
-      * Run `dotnet msbuild ... Build.proj /p:ArcadeBuildFromSource=true ... /p:ArcadeInnerBuildFromSource=true`
+      * Run `dotnet msbuild ... Build.proj /p:ArcadeBuildFromSource=true ... /p:ArcadeInnerBuildFromSource=true /p:DotNetBuildInnerRepo=true`
         * [Hook] Before **Inner Execute**:
           * Compile source-build MSBuild tasks. (Temporary, should migrate to Arcade task DLL.)
         * During **Inner Execute**:

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
@@ -28,7 +28,7 @@
             PackSourceBuildTarball"
           Condition="
             ('$(ArcadeBuildFromSource)' == 'true' or '$(ArcadeBuildVertical)' == 'true') and
-            '$(ArcadeInnerBuildFromSource)' != 'true'"
+            '$(ArcadeInnerBuildFromSource)' != 'true' and '$(DotNetBuildInnerRepo)' != 'true'"
           BeforeTargets="Execute" />
 
   <!--
@@ -44,7 +44,7 @@
   <Target Name="HookExecuteInnerSourceBuild"
           Condition="
             ('$(ArcadeBuildFromSource)' == 'true' or '$(ArcadeBuildVertical)' == 'true') and
-            '$(ArcadeInnerBuildFromSource)' == 'true'"
+            ('$(ArcadeInnerBuildFromSource)' == 'true' or '$(DotNetBuildInnerRepo)' == 'true')"
           DependsOnTargets="ExecuteInnerSourceBuild"
           BeforeTargets="Execute"/>
 
@@ -74,7 +74,7 @@
   <Target Name="GetSourceBuildCommandConfiguration">
     <PropertyGroup>
       <!-- Track that this is the inner build to prevent infinite recursion. -->
-      <InnerBuildArgs>$(InnerBuildArgs) /p:ArcadeInnerBuildFromSource=true</InnerBuildArgs>
+      <InnerBuildArgs>$(InnerBuildArgs) /p:ArcadeInnerBuildFromSource=true /p:DotNetBuildInnerRepo=true</InnerBuildArgs>
       <!-- Turn on DotNetBuildFromSource or DotNetBuildVertical in the inner build -->
       <InnerBuildArgs Condition="'$(ArcadeBuildFromSource)' == 'true'">$(InnerBuildArgs) /p:DotNetBuildFromSource=true</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(ArcadeBuildVertical)' == 'true'">$(InnerBuildArgs) /p:DotNetBuildVertical=true</InnerBuildArgs>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadePublish.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadePublish.targets
@@ -13,7 +13,7 @@
     template. Publish may need to be disabled in eng/SourceBuild.props.
   -->
   <Target Name="EnsureSourceBuildInnerBuildDoesNotPublish"
-          Condition="'$(ArcadeInnerBuildFromSource)' == 'true'"
+          Condition="'$(ArcadeInnerBuildFromSource)' == 'true' or '$(DotNetBuildInnerRepo)' == 'true'"
           BeforeTargets="
             Publish;
             PublishSymbols;

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
@@ -14,7 +14,7 @@
   <Target Name="CollectSourceBuildIntermediateNupkgDependencies"
           Condition="
             '$(DotNetBuildFromSourceFlavor)' != 'Product' and
-            (('$(ArcadeBuildFromSource)' == 'true' and '$(ArcadeInnerBuildFromSource)' == 'true') or
+            (('$(ArcadeBuildFromSource)' == 'true' and ('$(ArcadeInnerBuildFromSource)' == 'true' or '$(DotNetBuildInnerRepo)' == 'true')) or
               '$(SetUpSourceBuildIntermediateNupkgCache)' == 'true')"
           DependsOnTargets="GetSourceBuildIntermediateNupkgNameConvention"
           BeforeTargets="CollectPackageReferences">
@@ -33,7 +33,7 @@
   <Target Name="SetUpSourceBuildIntermediateNupkgCache"
           Condition="
             '$(DotNetBuildFromSourceFlavor)' != 'Product' and
-            (('$(ArcadeBuildFromSource)' == 'true' and '$(ArcadeInnerBuildFromSource)' == 'true' and '@(SourceBuildIntermediateNupkgReference)' != '') or
+            (('$(ArcadeBuildFromSource)' == 'true' and ('$(ArcadeInnerBuildFromSource)' == 'true' or '$(DotNetBuildInnerRepo)' == 'true') and '@(SourceBuildIntermediateNupkgReference)' != '') or
               '$(SetUpSourceBuildIntermediateNupkgCache)' == 'true')"
           AfterTargets="Restore">
     <ItemGroup>


### PR DESCRIPTION
This is the exact equivalent as ArcadeBuildFromSource today, just removing the Source Build terminology. ArcadeBuildFromSource will be removed at a later point.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
