### PR TITLE
Update XUnit and Microsoft.DotNet.XUnitAssert to 2.6.6

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,9 +13,11 @@
     <!-- Keep Microsoft.Data.Services.Client package version in sync with Microsoft.Data.OData -->
     <MicrosoftDataServicesClientVersion>5.8.4</MicrosoftDataServicesClientVersion>
     <MicrosoftSignedWixVersion>1.0.0-v3.14.0.5722</MicrosoftSignedWixVersion>
-    <!-- Overwrite XUnitVersion that comes from the Arcade SDK to be in sync as Arcade doesn't use a live Arcade SDK.
-         Keep in sync with XUnitVersion in DefaultVersions.props. -->
-    <XUnitVersion>2.6.1</XUnitVersion>
+    <!-- Overwrite XUnitVersion/XUnitAnalyzersVersion/XUnitAnalyzersVersion that comes from the Arcade SDK to be in sync as Arcade doesn't use a live Arcade SDK.
+         Keep in sync with DefaultVersions.props. -->
+    <XUnitVersion>2.6.6</XUnitVersion>
+    <XUnitAnalyzersVersion>1.10.0</XUnitAnalyzersVersion>
+    <XUnitRunnerVisualStudioVersion>2.5.6</XUnitRunnerVisualStudioVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -92,6 +94,7 @@
     <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
     <PackageVersion Include="xunit.extensibility.core" Version="$(XUnitVersion)" />
     <PackageVersion Include="xunit.extensibility.execution" Version="$(XUnitVersion)" />
+    <PackageVersion Include="xunit.runner.reporters" Version="$(XUnitVersion)" />
     <PackageVersion Include="nsubstitute" Version="5.1.0" />
   </ItemGroup>
 

--- a/Documentation/AzureDevOps/SendingJobsToHelix.md
+++ b/Documentation/AzureDevOps/SendingJobsToHelix.md
@@ -83,7 +83,7 @@ The simplest Helix use-case is zipping up a single folder containing your projec
 Simply specify the xUnit project(s) you wish to run (semicolon delimited) with the `XUnitProjects` parameter. Then, specify:
 * the `XUnitPublishTargetFramework` &ndash; this is the framework your **test projects are targeting**, e.g. `netcoreapp3.1`.
 * the `XUnitRuntimeTargetFramework` &ndash; this is the framework version of xUnit you want to use from the xUnit NuGet package, e.g. `netcoreapp2.0`. Notably, the xUnit console runner only supports up to netcoreapp2.0 as of 14 March 2018, so this is the target that should be specified for running against any higher version test projects.
-* the `XUnitRunnerVersion` (the version of the xUnit nuget package you want to use, e.g. `2.6.1`).
+* the `XUnitRunnerVersion` (the version of the xUnit nuget package you want to use, e.g. `2.6.6`).
 
 Finally, set `IncludeDotNetCli` to true and specify which `DotNetCliPackageType` (`sdk`, `runtime` or `aspnetcore-runtime`) and `DotNetCliVersion` you wish to use. (For a full list of .NET CLI versions/package types, see these links: [3.0](https://dotnet.microsoft.com/download/dotnet-core/3.0), [2.1](https://dotnet.microsoft.com/download/dotnet-core/2.1), [2.2](https://dotnet.microsoft.com/download/dotnet-core/2.2).)
 
@@ -104,7 +104,7 @@ The list of available Helix queues can be found on the [Helix homepage](https://
       # XUnitWorkItemTimeout: '00:05:00' -- a timeout (specified as a System.TimeSpan string) for all work items created from XUnitProjects
       XUnitPublishTargetFramework: netcoreapp3.1 # specify your publish target framework here
       XUnitRuntimeTargetFramework: netcoreapp2.0 # specify the framework you want to use for the xUnit runner
-      XUnitRunnerVersion: 2.6.1 # specify the version of xUnit runner you wish to use here
+      XUnitRunnerVersion: 2.6.6 # specify the version of xUnit runner you wish to use here
       # WorkItemDirectory: '' -- payload directory to zip up and send to Helix; requires WorkItemCommand; incompatible with XUnitProjects
       # WorkItemCommand: '' -- a command to execute on the payload; requires WorkItemDirectory; incompatible with XUnitProjects
       # WorkItemTimeout: '' -- a timeout (specified as a System.TimeSpan string) for the work item command; requires WorkItemDirectory; incompatible with XUnitProjects

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -83,10 +83,10 @@
     <MicrosoftTestPlatformVersion Condition="'$(MicrosoftTestPlatformVersion)' == ''">16.5.0</MicrosoftTestPlatformVersion>
 
     <!-- Follow the instructions on how to update any of the below xunit versions: https://github.com/dotnet/arcade/blob/main/Documentation/update-xunit.md. -->
-    <XUnitVersion Condition="'$(XUnitVersion)' == ''">2.6.1</XUnitVersion>
-    <XUnitAnalyzersVersion Condition="'$(XUnitAnalyzersVersion)' == ''">1.4.0</XUnitAnalyzersVersion>
+    <XUnitVersion Condition="'$(XUnitVersion)' == ''">2.6.6</XUnitVersion>
+    <XUnitAnalyzersVersion Condition="'$(XUnitAnalyzersVersion)' == ''">1.10.0</XUnitAnalyzersVersion>
     <XUnitRunnerConsoleVersion Condition="'$(XUnitRunnerConsoleVersion)' == ''">$(XUnitVersion)</XUnitRunnerConsoleVersion>
-    <XUnitRunnerVisualStudioVersion Condition="'$(XUnitRunnerVisualStudioVersion)' == ''">2.5.5</XUnitRunnerVisualStudioVersion>
+    <XUnitRunnerVisualStudioVersion Condition="'$(XUnitRunnerVisualStudioVersion)' == ''">2.5.6</XUnitRunnerVisualStudioVersion>
 
     <MSTestVersion Condition="'$(MSTestVersion)' == ''">2.0.0</MSTestVersion>
     <MSTestTestAdapterVersion Condition="'$(MSTestTestAdapterVersion)' == ''">$(MSTestVersion)</MSTestTestAdapterVersion>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
@@ -13,6 +13,11 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true"/>
   </ItemGroup>
 
+  <!-- Workaround for https://github.com/xunit/xunit/issues/1651 -->
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <None Remove="$(NuGetPackageRoot)xunit.runner.visualstudio\$(XUnitRunnerVisualStudioVersion)\build\net462\xunit.abstractions.dll" />
+  </ItemGroup>
+
   <PropertyGroup>
     <XUnitDesktopSettingsFile Condition="'$(XUnitDesktopSettingsFile)' == ''">$(MSBuildThisFileDirectory)xunit.runner.json</XUnitDesktopSettingsFile>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets
@@ -13,11 +13,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true"/>
   </ItemGroup>
 
-  <!-- Workaround for https://github.com/xunit/xunit/issues/1651 -->
-  <ItemGroup>
-    <None Remove="$(NuGetPackageRoot)xunit.runner.visualstudio\$(XUnitRunnerVisualStudioVersion)\build\net20\..\_common\xunit.abstractions.dll" />
-  </ItemGroup>
-
   <PropertyGroup>
     <XUnitDesktopSettingsFile Condition="'$(XUnitDesktopSettingsFile)' == ''">$(MSBuildThisFileDirectory)xunit.runner.json</XUnitDesktopSettingsFile>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Helix/Sdk/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/Readme.md
@@ -228,7 +228,7 @@ Given a local folder `$(TestFolder)` containing `runtests.cmd`, this will run `r
     <!-- TargetFramework of the xunit.runner.dll to use when running the tests -->
     <XUnitRuntimeTargetFramework>netcoreapp2.0</XUnitRuntimeTargetFramework>
     <!-- PackageVersion of xunit.runner.console to use -->
-    <XUnitRunnerVersion>2.6.1</XUnitRunnerVersion>
+    <XUnitRunnerVersion>2.6.6</XUnitRunnerVersion>
     <!-- Additional command line arguments to pass to xunit.console.exe -->
     <XUnitArguments></XUnitArguments>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xunit-runner/XUnitRunner.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xunit-runner/XUnitRunner.targets
@@ -5,7 +5,7 @@
     <XUnitPublishTargetFramework Condition="'$(XUnitPublishTargetFramework)' == ''">net9.0</XUnitPublishTargetFramework>
     <XUnitRuntimeTargetFramework Condition="'$(XUnitRuntimeTargetFramework)' == ''">netcoreapp2.0</XUnitRuntimeTargetFramework>
 
-    <XUnitRunnerVersion Condition="'$(XUnitRunnerVersion)' == ''">2.6.1</XUnitRunnerVersion>
+    <XUnitRunnerVersion Condition="'$(XUnitRunnerVersion)' == ''">2.6.6</XUnitRunnerVersion>
 
     <_XUnitPublishTargetsPath>$(MSBuildThisFileDirectory)XUnitPublish.targets</_XUnitPublishTargetsPath>
 

--- a/src/Microsoft.DotNet.XUnitAssert/src/.editorconfig
+++ b/src/Microsoft.DotNet.XUnitAssert/src/.editorconfig
@@ -227,4 +227,5 @@ dotnet_diagnostic.CA1200.severity = none  # Avoid using cref tags with a prefix
 dotnet_diagnostic.CA1707.severity = none  # Remove the underscores from type name
 dotnet_diagnostic.CA1720.severity = none  # Identifier contains type name
 dotnet_diagnostic.CA1810.severity = none  # Do not use static constructors
+dotnet_diagnostic.CA1859.severity = none  # Use concrete types when possible for improved performance
 dotnet_diagnostic.CA2007.severity = none  # Consider calling ConfigureAwait on the awaited task

--- a/src/Microsoft.DotNet.XUnitAssert/src/Comparers.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/src/Comparers.cs
@@ -20,10 +20,6 @@ namespace Xunit
 #endif
 	partial class Assert
 	{
-		static IComparer<T> GetComparer<T>()
-			where T : IComparable =>
-				new AssertComparer<T>();
-
 #if XUNIT_NULLABLE
 		static IEqualityComparer<T?> GetEqualityComparer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces |
 				DynamicallyAccessedMemberTypes.PublicFields |
@@ -41,5 +37,9 @@ namespace Xunit
 				DynamicallyAccessedMemberTypes.PublicMethods)] T>(IEqualityComparer innerComparer = null) =>
 			new AssertEqualityComparer<T>(innerComparer);
 #endif
+
+		static IComparer<T> GetRangeComparer<T>()
+			where T : IComparable =>
+				new AssertRangeComparer<T>();
 	}
 }

--- a/src/Microsoft.DotNet.XUnitAssert/src/EqualityAsserts.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/src/EqualityAsserts.cs
@@ -196,7 +196,15 @@ namespace Xunit
 					{
 						try
 						{
-							if (CollectionTracker.AreCollectionsEqual(expectedTracker, actualTracker, itemComparer, itemComparer == AssertEqualityComparer<T>.DefaultInnerComparer, out mismatchedIndex))
+							bool result;
+
+							// Call AssertEqualityComparer.Equals because it checks for IEquatable<> before using CollectionTracker
+							if (aec != null)
+								result = aec.Equals(expected, expectedTracker, actual, actualTracker, out mismatchedIndex);
+							else
+								result = CollectionTracker.AreCollectionsEqual(expectedTracker, actualTracker, itemComparer, itemComparer == AssertEqualityComparer<T>.DefaultInnerComparer, out mismatchedIndex);
+
+							if (result)
 								return;
 						}
 						catch (Exception ex)
@@ -709,7 +717,15 @@ namespace Xunit
 					{
 						try
 						{
-							if (!CollectionTracker.AreCollectionsEqual(expectedTracker, actualTracker, itemComparer, itemComparer == AssertEqualityComparer<T>.DefaultInnerComparer, out mismatchedIndex))
+							bool result;
+
+							// Call AssertEqualityComparer.Equals because it checks for IEquatable<> before using CollectionTracker
+							if (aec != null)
+								result = aec.Equals(expected, expectedTracker, actual, actualTracker, out mismatchedIndex);
+							else
+								result = CollectionTracker.AreCollectionsEqual(expectedTracker, actualTracker, itemComparer, itemComparer == AssertEqualityComparer<T>.DefaultInnerComparer, out mismatchedIndex);
+
+							if (!result)
 								return;
 
 							// For NotEqual that doesn't throw, pointers are irrelevant, because

--- a/src/Microsoft.DotNet.XUnitAssert/src/Microsoft.DotNet.XUnitAssert.csproj
+++ b/src/Microsoft.DotNet.XUnitAssert/src/Microsoft.DotNet.XUnitAssert.csproj
@@ -9,7 +9,7 @@
     <IsPackable>true</IsPackable>
     <Description>This package is a fork of xunit.assert that is AOT-compatible.</Description>
     <IsTestUtilityProject>true</IsTestUtilityProject>
-    <DefineConstants>$(DefineConstants);XUNIT_NULLABLE;XUNIT_SPAN;XUNIT_AOT</DefineConstants>
+    <DefineConstants>$(DefineConstants);XUNIT_NULLABLE;XUNIT_SPAN;XUNIT_IMMUTABLE_COLLECTIONS;XUNIT_AOT</DefineConstants>
     <IsTrimmable>true</IsTrimmable>
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>

--- a/src/Microsoft.DotNet.XUnitAssert/src/RangeAsserts.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/src/RangeAsserts.cs
@@ -31,7 +31,7 @@ namespace Xunit
 			T low,
 			T high)
 				where T : IComparable =>
-					InRange(actual, low, high, GetComparer<T>());
+					InRange(actual, low, high, GetRangeComparer<T>());
 
 		/// <summary>
 		/// Verifies that a value is within a given range, using a comparer.
@@ -70,7 +70,7 @@ namespace Xunit
 			T low,
 			T high)
 				where T : IComparable =>
-					NotInRange(actual, low, high, GetComparer<T>());
+					NotInRange(actual, low, high, GetRangeComparer<T>());
 
 		/// <summary>
 		/// Verifies that a value is not within a given range, using a comparer.

--- a/src/Microsoft.DotNet.XUnitAssert/src/Sdk/ArgumentFormatter.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/src/Sdk/ArgumentFormatter.cs
@@ -557,8 +557,15 @@ namespace Xunit.Sdk
 			return value != null;
 		}
 
-		static Exception UnwrapException(Exception ex)
+#if XUNIT_NULLABLE
+		internal static Exception? UnwrapException(Exception? ex)
+#else
+		internal static Exception UnwrapException(Exception ex)
+#endif
 		{
+			if (ex == null)
+				return null;
+
 			while (true)
 			{
 				var tiex = ex as TargetInvocationException;

--- a/src/Microsoft.DotNet.XUnitAssert/src/Sdk/AssertEqualityComparer.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/src/Sdk/AssertEqualityComparer.cs
@@ -15,6 +15,8 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using System.Reflection;
 
 #if XUNIT_NULLABLE
@@ -23,6 +25,86 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Xunit.Sdk
 {
+	static class AssertEqualityComparer
+	{
+#if !XUNIT_AOT // not supported on AOT due to MakeGenericType
+		static readonly ConcurrentDictionary<Type, IEqualityComparer> cachedDefaultComparers = new ConcurrentDictionary<Type, IEqualityComparer>();
+		static readonly ConcurrentDictionary<Type, IEqualityComparer> cachedDefaultInnerComparers = new ConcurrentDictionary<Type, IEqualityComparer>();
+#if XUNIT_NULLABLE
+		static readonly object?[] singleNullObject = new object?[] { null };
+#else
+		static readonly object[] singleNullObject = new object[] { null };
+#endif
+
+		/// <summary>
+		/// Gets the default comparer to be used for the provided <paramref name="type"/> when a custom one
+		/// has not been provided. Creates an instance of <see cref="AssertEqualityComparer{T}"/> wrapped
+		/// by <see cref="AssertEqualityComparerAdapter{T}"/>.
+		/// </summary>
+		/// <param name="type">The type to be compared</param>
+		internal static IEqualityComparer GetDefaultComparer(Type type) =>
+			cachedDefaultComparers.GetOrAdd(type, itemType =>
+			{
+				var comparerType = typeof(AssertEqualityComparer<>).MakeGenericType(itemType);
+				var comparer = Activator.CreateInstance(comparerType, singleNullObject);
+				if (comparer == null)
+					throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "Could not create instance of AssertEqualityComparer<{0}>", itemType.FullName ?? itemType.Name));
+
+				var wrapperType = typeof(AssertEqualityComparerAdapter<>).MakeGenericType(itemType);
+				var result = Activator.CreateInstance(wrapperType, new object[] { comparer }) as IEqualityComparer;
+				if (result == null)
+					throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "Could not create instance of AssertEqualityComparerAdapter<{0}>", itemType.FullName ?? itemType.Name));
+
+				return result;
+			});
+
+		/// <summary>
+		/// Gets the default comparer to be used as an inner comparer for the provided <paramref name="type"/>
+		/// when a custom one has not been provided. For non-collections, this defaults to an <see cref="object"/>-based
+		/// comparer; for collections, this creates an inner comparer based on the item type in the collection.
+		/// </summary>
+		/// <param name="type">The type to create an inner comparer for</param>
+		internal static IEqualityComparer GetDefaultInnerComparer<T>() =>
+			cachedDefaultInnerComparers.GetOrAdd(typeof(T), ([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type t) =>
+			{
+				var innerType = typeof(object);
+
+				// string is enumerable, but we don't treat it like a collection
+				if (t != typeof(string))
+				{
+					var enumerableOfT =
+						t.GetTypeInfo()
+							.ImplementedInterfaces
+							.Select(i => i.GetTypeInfo())
+							.FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+
+					if (enumerableOfT != null)
+						innerType = enumerableOfT.GenericTypeArguments[0];
+				}
+
+				return GetDefaultComparer(innerType);
+			});
+#endif // !XUNIT_AOT
+
+		/// <summary>
+		/// This exception is thrown when an operation failure has occured during equality comparison operations.
+		/// This generally indicates that a necessary pre-condition was not met for comparison operations to succeed.
+		/// </summary>
+		public sealed class OperationalFailureException : Exception
+		{
+			OperationalFailureException(string message) :
+				base(message)
+			{ }
+
+			/// <summary>
+			/// Gets an exception that indicates that GetHashCode was called on <see cref="AssertEqualityComparer{T}.FuncEqualityComparer"/>
+			/// which usually indicates that an item comparison function was used to try to compare two hash sets.
+			/// </summary>
+			public static OperationalFailureException ForIllegalGetHashCode() =>
+				new OperationalFailureException("During comparison of two collections, GetHashCode was called, but only a comparison function was provided. This typically indicates trying to compare two sets with an item comparison function, which is not supported. For more information, see https://xunit.net/docs/hash-sets-vs-linear-containers");
+		}
+	}
+
 	/// <summary>
 	/// Default implementation of <see cref="IEqualityComparer{T}"/> used by the xUnit.net equality assertions.
 	/// </summary>
@@ -35,7 +117,11 @@ namespace Xunit.Sdk
 				DynamicallyAccessedMemberTypes.NonPublicProperties |
 				DynamicallyAccessedMemberTypes.PublicMethods)] T> : IEqualityComparer<T>
 	{
+#if XUNIT_AOT
 		internal static readonly IEqualityComparer DefaultInnerComparer = new AssertEqualityComparerAdapter<object>(new AssertEqualityComparer<object>());
+#else
+		internal static readonly IEqualityComparer DefaultInnerComparer = AssertEqualityComparer.GetDefaultInnerComparer<T>();
+#endif
 
 		static readonly ConcurrentDictionary<Type, TypeInfo> cacheOfIComparableOfT = new ConcurrentDictionary<Type, TypeInfo>();
 		static readonly ConcurrentDictionary<Type, TypeInfo> cacheOfIEquatableOfT = new ConcurrentDictionary<Type, TypeInfo>();
@@ -69,23 +155,46 @@ namespace Xunit.Sdk
 			T y)
 #endif
 		{
+			int? _;
+
+#if XUNIT_FRAMEWORK
+			return Equals(x, y, out _);
+#else
+			using (var xTracker = x.AsNonStringTracker())
+			using (var yTracker = y.AsNonStringTracker())
+				return Equals(x, xTracker, y, yTracker, out _);
+#endif
+		}
+
+		internal bool Equals(
+#if XUNIT_NULLABLE
+			[AllowNull] T x,
+#if !XUNIT_FRAMEWORK
+			CollectionTracker? xTracker,
+#endif
+			[AllowNull] T y,
+#if !XUNIT_FRAMEWORK
+			CollectionTracker? yTracker,
+#endif
+#else
+			T x,
+#if !XUNIT_FRAMEWORK
+			CollectionTracker xTracker,
+#endif
+			T y,
+#if !XUNIT_FRAMEWORK
+			CollectionTracker yTracker,
+#endif
+#endif
+			out int? mismatchedIndex)
+		{
+			mismatchedIndex = null;
+
 			// Null?
 			if (x == null && y == null)
 				return true;
 			if (x == null || y == null)
 				return false;
-
-#if !XUNIT_FRAMEWORK
-			// Collections?
-			using (var xTracker = x.AsNonStringTracker())
-			using (var yTracker = y.AsNonStringTracker())
-			{
-				int? _;
-
-				if (xTracker != null && yTracker != null)
-					return CollectionTracker.AreCollectionsEqual(xTracker, yTracker, InnerComparer, InnerComparer == DefaultInnerComparer, out _);
-			}
-#endif
 
 			// Implements IEquatable<T>?
 			var equatable = x as IEquatable<T>;
@@ -116,6 +225,12 @@ namespace Xunit.Sdk
 				}
 			}
 #endif // !XUNIT_AOT
+
+#if !XUNIT_FRAMEWORK
+			// Special case collections (before IStructuralEquatable because arrays implement that in a way we don't want to call)
+			if (xTracker != null && yTracker != null)
+				return CollectionTracker.AreCollectionsEqual(xTracker, yTracker, InnerComparer, InnerComparer == DefaultInnerComparer, out mismatchedIndex);
+#endif
 
 			// Implements IStructuralEquatable?
 			var structuralEquatable = x as IStructuralEquatable;
@@ -188,9 +303,53 @@ namespace Xunit.Sdk
 			if (typeof(T).IsConstructedGenericType &&
 				typeof(T).GetGenericTypeDefinition() == typeKeyValuePair)
 			{
-				return
-					innerComparer.Value.Equals(typeof(T).GetRuntimeProperty("Key")?.GetValue(x), typeof(T).GetRuntimeProperty("Key")?.GetValue(y)) &&
-					innerComparer.Value.Equals(typeof(T).GetRuntimeProperty("Value")?.GetValue(x), typeof(T).GetRuntimeProperty("Value")?.GetValue(y));
+#if XUNIT_AOT
+				var xKey = typeof(T).GetRuntimeProperty("Key")?.GetValue(x);
+				var yKey = typeof(T).GetRuntimeProperty("Key")?.GetValue(y);
+#else
+				var xKey = xType.GetRuntimeProperty("Key")?.GetValue(x);
+				var yKey = yType.GetRuntimeProperty("Key")?.GetValue(y);
+#endif
+
+				if (xKey == null)
+				{
+					if (yKey != null)
+						return false;
+				}
+				else
+				{
+					var xKeyType = xKey.GetType();
+					var yKeyType = yKey?.GetType();
+
+#if XUNIT_AOT
+					var keyComparer = innerComparer.Value;
+#else
+					var keyComparer = AssertEqualityComparer.GetDefaultComparer(xKeyType == yKeyType ? xKeyType : typeof(object));
+#endif
+					if (!keyComparer.Equals(xKey, yKey))
+						return false;
+				}
+
+#if XUNIT_AOT
+				var xValue = typeof(T).GetRuntimeProperty("Value")?.GetValue(x);
+				var yValue = typeof(T).GetRuntimeProperty("Value")?.GetValue(y);
+#else
+				var xValue = xType.GetRuntimeProperty("Value")?.GetValue(x);
+				var yValue = yType.GetRuntimeProperty("Value")?.GetValue(y);
+#endif
+
+				if (xValue == null)
+					return yValue == null;
+
+				var xValueType = xValue.GetType();
+				var yValueType = yValue?.GetType();
+
+#if XUNIT_AOT
+				var valueComparer = innerComparer.Value;
+#else
+				var valueComparer = AssertEqualityComparer.GetDefaultComparer(xValueType == yValueType ? xValueType : typeof(object));
+#endif
+				return valueComparer.Equals(xValue, yValue);
 			}
 
 			// Last case, rely on object.Equals
@@ -243,11 +402,13 @@ namespace Xunit.Sdk
 			}
 
 #if XUNIT_NULLABLE
-			public int GetHashCode(T? obj) =>
+			public int GetHashCode(T? obj)
 #else
-			public int GetHashCode(T obj) =>
+			public int GetHashCode(T obj)
 #endif
-				GuardArgumentNotNull(nameof(obj), obj).GetHashCode();
+			{
+				throw AssertEqualityComparer.OperationalFailureException.ForIllegalGetHashCode();
+			}
 		}
 
 		sealed class TypeErasedEqualityComparer : IEqualityComparer

--- a/src/Microsoft.DotNet.XUnitAssert/src/Sdk/AssertRangeComparer.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/src/Sdk/AssertRangeComparer.cs
@@ -18,7 +18,7 @@ namespace Xunit.Sdk
 	/// Default implementation of <see cref="IComparer{T}"/> used by the xUnit.net range assertions.
 	/// </summary>
 	/// <typeparam name="T">The type that is being compared.</typeparam>
-	sealed class AssertComparer<T> : IComparer<T>
+	sealed class AssertRangeComparer<T> : IComparer<T>
 		where T : IComparable
 	{
 		/// <inheritdoc/>

--- a/src/Microsoft.DotNet.XUnitAssert/src/Sdk/CollectionTracker.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/src/Sdk/CollectionTracker.cs
@@ -86,7 +86,11 @@ namespace Xunit.Sdk
 			mismatchedIndex = null;
 
 			return
+#if XUNIT_AOT
 				CheckIfDictionariesAreEqual(x, y, itemComparer) ??
+#else
+				CheckIfDictionariesAreEqual(x, y) ??
+#endif
 				CheckIfSetsAreEqual(x, y, isDefaultItemComparer ? null : itemComparer) ??
 				CheckIfArraysAreEqual(x, y, itemComparer, isDefaultItemComparer, out mismatchedIndex) ??
 				CheckIfEnumerablesAreEqual(x, y, itemComparer, isDefaultItemComparer, out mismatchedIndex);
@@ -150,12 +154,16 @@ namespace Xunit.Sdk
 		static bool? CheckIfDictionariesAreEqual(
 #if XUNIT_NULLABLE
 			CollectionTracker? x,
-			CollectionTracker? y,
+			CollectionTracker? y
 #else
 			CollectionTracker x,
-			CollectionTracker y,
+			CollectionTracker y
 #endif
-			IEqualityComparer itemComparer)
+#if XUNIT_AOT
+			, IEqualityComparer itemComparer)
+#else
+		)
+#endif
 		{
 			if (x == null || y == null)
 				return null;
@@ -171,6 +179,11 @@ namespace Xunit.Sdk
 
 			var dictionaryYKeys = new HashSet<object>(dictionaryY.Keys.Cast<object>());
 
+#if !XUNIT_AOT
+			// We don't pass along the itemComparer from AreCollectionsEqual because we aren't directly
+			// comparing the KeyValuePair<> objects. Instead we rely on Contains() on the dictionary to
+			// match up keys, and then create type-appropriate comparers for the values.
+#endif
 			foreach (var key in dictionaryX.Keys.Cast<object>())
 			{
 				if (!dictionaryYKeys.Contains(key))
@@ -179,8 +192,26 @@ namespace Xunit.Sdk
 				var valueX = dictionaryX[key];
 				var valueY = dictionaryY[key];
 
-				if (!itemComparer.Equals(valueX, valueY))
+				if (valueX == null)
+				{
+					if (valueY != null)
+						return false;
+				}
+				else if (valueY == null)
 					return false;
+				else
+				{
+					var valueXType = valueX.GetType();
+					var valueYType = valueY.GetType();
+
+#if XUNIT_AOT
+					var comparer = itemComparer;
+#else
+					var comparer = AssertEqualityComparer.GetDefaultComparer(valueXType == valueYType ? valueXType : typeof(object));
+#endif
+					if (!comparer.Equals(valueX, valueY))
+						return false;
+				}
 
 				dictionaryYKeys.Remove(key);
 			}

--- a/src/Microsoft.DotNet.XUnitAssert/src/Sdk/Exceptions/CollectionException.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/src/Sdk/Exceptions/CollectionException.cs
@@ -18,6 +18,8 @@ namespace Xunit.Sdk
 #endif
 	partial class CollectionException : XunitException
 	{
+		static readonly char[] crlfSeparators = new[] { '\r', '\n' };
+
 		CollectionException(string message) :
 			base(message)
 		{ }
@@ -27,7 +29,7 @@ namespace Xunit.Sdk
 			var lines =
 				innerException
 					.Message
-					.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+					.Split(crlfSeparators, StringSplitOptions.RemoveEmptyEntries)
 					.Select((value, idx) => idx > 0 ? "            " + value : value);
 
 			return string.Join(Environment.NewLine, lines);

--- a/src/Microsoft.DotNet.XUnitAssert/src/Sdk/Exceptions/EqualException.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/src/Sdk/Exceptions/EqualException.cs
@@ -102,6 +102,10 @@ namespace Xunit.Sdk
 		{
 			Assert.GuardArgumentNotNull(nameof(actual), actual);
 
+			error = ArgumentFormatter.UnwrapException(error);
+			if (error is AssertEqualityComparer.OperationalFailureException)
+				return new EqualException("Assert.Equal() Failure: " + error.Message);
+
 			var message =
 				error == null
 					? string.Format(CultureInfo.CurrentCulture, "Assert.Equal() Failure: {0} differ", collectionDisplay ?? "Collections")

--- a/src/Microsoft.DotNet.XUnitAssert/src/Sdk/Exceptions/NotEqualException.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/src/Sdk/Exceptions/NotEqualException.cs
@@ -79,6 +79,10 @@ namespace Xunit.Sdk
 			Assert.GuardArgumentNotNull(nameof(expected), expected);
 			Assert.GuardArgumentNotNull(nameof(actual), actual);
 
+			error = ArgumentFormatter.UnwrapException(error);
+			if (error is AssertEqualityComparer.OperationalFailureException)
+				return new NotEqualException("Assert.NotEqual() Failure: " + error.Message);
+
 			var message =
 				error == null
 					? string.Format(CultureInfo.CurrentCulture, "Assert.NotEqual() Failure: {0} are equal", collectionDisplay ?? "Collections")

--- a/src/Microsoft.DotNet.XUnitAssert/src/SetAsserts.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/src/SetAsserts.cs
@@ -83,6 +83,18 @@ namespace Xunit
 			HashSet<T> set) =>
 				Contains(expected, (ISet<T>)set);
 
+		/// <summary>
+		/// Verifies that the sorted hashset contains the given object.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="expected">The object expected to be in the set</param>
+		/// <param name="set">The set to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the set</exception>
+		public static void Contains<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
+			T expected,
+			SortedSet<T> set) =>
+				Contains(expected, (ISet<T>)set);
+
 #if XUNIT_IMMUTABLE_COLLECTIONS
 		/// <summary>
 		/// Verifies that the immutable hashset contains the given object.
@@ -91,9 +103,21 @@ namespace Xunit
 		/// <param name="expected">The object expected to be in the set</param>
 		/// <param name="set">The set to be inspected</param>
 		/// <exception cref="ContainsException">Thrown when the object is not present in the set</exception>
-		public static void Contains<T>(
+		public static void Contains<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
 			T expected,
 			ImmutableHashSet<T> set) =>
+				Contains(expected, (ISet<T>)set);
+
+		/// <summary>
+		/// Verifies that the immutable sorted hashset contains the given object.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="expected">The object expected to be in the set</param>
+		/// <param name="set">The set to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the set</exception>
+		public static void Contains<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
+			T expected,
+			ImmutableSortedSet<T> set) =>
 				Contains(expected, (ISet<T>)set);
 #endif
 
@@ -161,6 +185,18 @@ namespace Xunit
 			HashSet<T> set) =>
 				DoesNotContain(expected, (ISet<T>)set);
 
+		/// <summary>
+		/// Verifies that the sorted hashset does not contain the given item.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="expected">The object expected to be in the set</param>
+		/// <param name="set">The set to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the set</exception>
+		public static void DoesNotContain<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
+			T expected,
+			SortedSet<T> set) =>
+				DoesNotContain(expected, (ISet<T>)set);
+
 #if XUNIT_IMMUTABLE_COLLECTIONS
 		/// <summary>
 		/// Verifies that the immutable hashset does not contain the given item.
@@ -177,6 +213,18 @@ namespace Xunit
 					| DynamicallyAccessedMemberTypes.PublicMethods)]T>(
 			T expected,
 			ImmutableHashSet<T> set) =>
+				DoesNotContain(expected, (ISet<T>)set);
+
+		/// <summary>
+		/// Verifies that the immutable sorted hashset does not contain the given item.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="expected">The object expected to be in the set</param>
+		/// <param name="set">The set to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the set</exception>
+		public static void DoesNotContain<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
+			T expected,
+			ImmutableSortedSet<T> set) =>
 				DoesNotContain(expected, (ISet<T>)set);
 #endif
 

--- a/src/Microsoft.DotNet.XUnitAssert/tests/BooleanAssertsTests.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/tests/BooleanAssertsTests.cs
@@ -43,7 +43,9 @@ public class BooleanAssertsTests
 		[Fact]
 		public static void UserSuppliedMessage()
 		{
-			var ex = Record.Exception(() => Assert.Fail("Custom User Message"));
+#pragma warning disable xUnit2020 // Do not use always-failing boolean assertions
+			var ex = Record.Exception(() => Assert.False(true, "Custom User Message"));
+#pragma warning restore xUnit2020 // Do not use always-failing boolean assertions
 
 			Assert.NotNull(ex);
 			Assert.Equal("Custom User Message", ex.Message);
@@ -89,7 +91,9 @@ public class BooleanAssertsTests
 		[Fact]
 		public static void UserSuppliedMessage()
 		{
-			var ex = Record.Exception(() => Assert.Fail("Custom User Message"));
+#pragma warning disable xUnit2020 // Do not use always-failing boolean assertions
+			var ex = Record.Exception(() => Assert.True(false, "Custom User Message"));
+#pragma warning restore xUnit2020 // Do not use always-failing boolean assertions
 
 			Assert.NotNull(ex);
 			Assert.Equal("Custom User Message", ex.Message);

--- a/src/Microsoft.DotNet.XUnitAssert/tests/CollectionAssertsTests.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/tests/CollectionAssertsTests.cs
@@ -3,13 +3,11 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 using NSubstitute;
 using Xunit;
 using Xunit.Sdk;
-
-#if XUNIT_VALUETASK
-using System.Threading.Tasks;
-#endif
 
 public class CollectionAssertsTests
 {
@@ -65,19 +63,18 @@ public class CollectionAssertsTests
 		}
 	}
 
-#if XUNIT_VALUETASK
 	public class AllAsync
 	{
 		[Fact]
-		public static async ValueTask GuardClauses()
+		public static async Task GuardClauses()
 		{
 			await Assert.ThrowsAsync<ArgumentNullException>("collection", () => Assert.AllAsync<object>(null!, async _ => await Task.Yield()));
-			await Assert.ThrowsAsync<ArgumentNullException>("action", () => Assert.AllAsync(Array.Empty<object>(), (Func<object, ValueTask>)null!));
-			await Assert.ThrowsAsync<ArgumentNullException>("action", () => Assert.AllAsync(Array.Empty<object>(), (Func<object, int, ValueTask>)null!));
+			await Assert.ThrowsAsync<ArgumentNullException>("action", () => Assert.AllAsync(new object[0], (Func<object, Task>)null!));
+			await Assert.ThrowsAsync<ArgumentNullException>("action", () => Assert.AllAsync(new object[0], (Func<object, int, Task>)null!));
 		}
 
 		[Fact]
-		public static async ValueTask Success()
+		public static async Task Success()
 		{
 			var items = new[] { 1, 1, 1, 1, 1, 1 };
 
@@ -107,7 +104,7 @@ public class CollectionAssertsTests
 		}
 
 		[Fact]
-		public static async ValueTask ActionCanReceiveIndex()
+		public static async Task ActionCanReceiveIndex()
 		{
 			var items = new[] { 1, 1, 2, 2, 1, 1 };
 			var indices = new List<int>();
@@ -117,7 +114,6 @@ public class CollectionAssertsTests
 			Assert.Equal(new[] { 0, 1, 2, 3, 4, 5 }, indices);
 		}
 	}
-#endif
 
 	public class Collection
 	{
@@ -126,7 +122,9 @@ public class CollectionAssertsTests
 		{
 			var list = new List<int>();
 
+#pragma warning disable xUnit2011 // Do not use empty collection check
 			Assert.Collection(list);
+#pragma warning restore xUnit2011 // Do not use empty collection check
 		}
 
 		[Fact]
@@ -187,11 +185,10 @@ public class CollectionAssertsTests
 		}
 	}
 
-#if XUNIT_VALUETASK
 	public class CollectionAsync
 	{
 		[Fact]
-		public static async ValueTask EmptyCollection()
+		public static async Task EmptyCollection()
 		{
 			var list = new List<int>();
 
@@ -199,7 +196,7 @@ public class CollectionAssertsTests
 		}
 
 		[Fact]
-		public static async ValueTask MismatchedElementCountAsync()
+		public static async Task MismatchedElementCountAsync()
 		{
 			var list = new List<int>();
 
@@ -221,7 +218,7 @@ public class CollectionAssertsTests
 		}
 
 		[Fact]
-		public static async ValueTask NonEmptyCollectionAsync()
+		public static async Task NonEmptyCollectionAsync()
 		{
 			var list = new List<int> { 42, 2112 };
 
@@ -240,7 +237,7 @@ public class CollectionAssertsTests
 		}
 
 		[Fact]
-		public static async ValueTask MismatchedElementAsync()
+		public static async Task MismatchedElementAsync()
 		{
 			var list = new List<int> { 42, 2112 };
 
@@ -271,7 +268,6 @@ public class CollectionAssertsTests
 			);
 		}
 	}
-#endif
 
 	public class Contains
 	{
@@ -756,7 +752,7 @@ public class CollectionAssertsTests
 			{
 				string message = "Assert.Equal() Failure: Collections differ";
 
-				if (expectedPointer != null)
+				if (expectedPointer is not null)
 					message += Environment.NewLine + "           " + expectedPointer;
 
 				var (expectedType, actualType) = (expected, actual) switch
@@ -770,7 +766,7 @@ public class CollectionAssertsTests
 					Environment.NewLine + "Expected: " + expectedType + ArgumentFormatter.Format(expected) +
 					Environment.NewLine + "Actual:   " + actualType + ArgumentFormatter.Format(actual);
 
-				if (actualPointer != null)
+				if (actualPointer is not null)
 					message += Environment.NewLine + "           " + actualPointer;
 
 				var ex = Record.Exception(() => Assert.Equal(expected, actual));
@@ -831,14 +827,14 @@ public class CollectionAssertsTests
 			{
 				var message = "Assert.Equal() Failure: Collections differ";
 
-				if (expectedPointer != null)
+				if (expectedPointer is not null)
 					message += Environment.NewLine + "           " + expectedPointer;
 
 				message +=
 					Environment.NewLine + "Expected: " + expectedDisplay +
 					Environment.NewLine + "Actual:   " + actualDisplay;
 
-				if (actualPointer != null)
+				if (actualPointer is not null)
 					message += Environment.NewLine + "           " + actualPointer;
 
 				var ex = Record.Exception(() => Assert.Equal(expected, actual));
@@ -861,6 +857,63 @@ public class CollectionAssertsTests
 					"                 ↑ (pos 2, type System.Int64)",
 					ex.Message
 				);
+			}
+		}
+
+		public class ArraysWithComparer
+		{
+			// https://github.com/xunit/xunit/issues/2795
+			[Fact]
+			public void CollectionItemIsEnumerable()
+			{
+				var actual = new EnumerableItem[] { new(0), new(2) };
+				var expected = new EnumerableItem[] { new(1), new(3) };
+
+				Assert.Equal(expected, actual, new EnumerableItemComparer());
+			}
+
+			public class EnumerableItemComparer : IEqualityComparer<EnumerableItem>
+			{
+				public bool Equals(EnumerableItem? x, EnumerableItem? y) =>
+					x?.Value / 2 == y?.Value / 2;
+
+				public int GetHashCode(EnumerableItem obj) =>
+					throw new NotImplementedException();
+			}
+
+			public sealed class EnumerableItem : IEnumerable<string>
+			{
+				public int Value { get; }
+
+				public EnumerableItem(int value) => Value = value;
+
+				public IEnumerator<string> GetEnumerator() => Enumerable.Repeat("", Value).GetEnumerator();
+
+				IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+			}
+		}
+
+		public class ArraysWithFunc
+		{
+			// https://github.com/xunit/xunit/issues/2795
+			[Fact]
+			public void CollectionItemIsEnumerable()
+			{
+				var actual = new EnumerableItem[] { new(0), new(2) };
+				var expected = new EnumerableItem[] { new(1), new(3) };
+
+				Assert.Equal(expected, actual, (x, y) => x.Value / 2 == y.Value / 2);
+			}
+
+			public sealed class EnumerableItem : IEnumerable<string>
+			{
+				public int Value { get; }
+
+				public EnumerableItem(int value) => Value = value;
+
+				public IEnumerator<string> GetEnumerator() => Enumerable.Repeat("", Value).GetEnumerator();
+
+				IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 			}
 		}
 
@@ -925,17 +978,17 @@ public class CollectionAssertsTests
 				string actualDisplay,
 				string? actualPointer)
 			{
-				var actual = actualArray == null ? null : new List<int>(actualArray);
+				var actual = actualArray is null ? null : new List<int>(actualArray);
 				var message = "Assert.Equal() Failure: Collections differ";
 
-				if (expectedPointer != null)
+				if (expectedPointer is not null)
 					message += Environment.NewLine + "          " + expectedPointer;
 
 				message +=
 					Environment.NewLine + "Expected: " + expectedDisplay +
 					Environment.NewLine + "Actual:   " + actualDisplay;
 
-				if (actualPointer != null)
+				if (actualPointer is not null)
 					message += Environment.NewLine + "          " + actualPointer;
 
 				var ex = Record.Exception(() => Assert.Equal(expected, actual));
@@ -988,6 +1041,105 @@ public class CollectionAssertsTests
 
 				public int GetHashCode(int obj) => throw new NotImplementedException();
 			}
+
+			// https://github.com/xunit/xunit/issues/2795
+			[Fact]
+			public void CollectionItemIsEnumerable()
+			{
+				List<EnumerableItem> actual = new List<EnumerableItem> { new(0), new(2) };
+				List<EnumerableItem> expected = new List<EnumerableItem> { new(1), new(3) };
+
+				Assert.Equal(expected, actual, new EnumerableItemComparer());
+			}
+
+			public class EnumerableItemComparer : IEqualityComparer<EnumerableItem>
+			{
+				public bool Equals(EnumerableItem? x, EnumerableItem? y) =>
+					x?.Value / 2 == y?.Value / 2;
+
+				public int GetHashCode(EnumerableItem obj) =>
+					throw new NotImplementedException();
+			}
+
+			public sealed class EnumerableItem : IEnumerable<string>
+			{
+				public int Value { get; }
+
+				public EnumerableItem(int value) => Value = value;
+
+				public IEnumerator<string> GetEnumerator() => Enumerable.Repeat("", Value).GetEnumerator();
+
+				IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+			}
+
+			[Fact]
+			public void WithThrow_PrintsPointerWhereThrowOccurs_RecordsInnerException()
+			{
+				var ex = Record.Exception(() => Assert.Equal(new[] { 1, 2 }, new[] { 1, 3 }, new ThrowingComparer()));
+
+				Assert.IsType<EqualException>(ex);
+				Assert.Equal(
+					"Assert.Equal() Failure: Exception thrown during comparison" + Environment.NewLine +
+					"           ↓ (pos 0)" + Environment.NewLine +
+					"Expected: [1, 2]" + Environment.NewLine +
+					"Actual:   [1, 3]" + Environment.NewLine +
+					"           ↑ (pos 0)",
+					ex.Message
+				);
+				Assert.IsType<DivideByZeroException>(ex.InnerException);
+			}
+
+			public class ThrowingComparer : IEqualityComparer<int>
+			{
+				public bool Equals(int x, int y) =>
+					throw new DivideByZeroException();
+
+				public int GetHashCode(int obj) =>
+					throw new NotImplementedException();
+			}
+		}
+
+		public class CollectionsWithEquatable
+		{
+#if XUNIT_AOT
+			[Fact(Skip = "Not supported with AOT")]
+#else
+			[Fact]
+#endif
+			public void Equal()
+			{
+				var expected = new[] { new EquatableObject { Char = 'a' } };
+				var actual = new[] { new EquatableObject { Char = 'a' } };
+
+				Assert.Equal(expected, actual);
+			}
+
+			[Fact]
+			public void NotEqual()
+			{
+				var expected = new[] { new EquatableObject { Char = 'a' } };
+				var actual = new[] { new EquatableObject { Char = 'b' } };
+
+				var ex = Record.Exception(() => Assert.Equal(expected, actual));
+
+				Assert.IsType<EqualException>(ex);
+				Assert.Equal(
+					"Assert.Equal() Failure: Collections differ" + Environment.NewLine +
+					"           ↓ (pos 0)" + Environment.NewLine +
+					"Expected: [EquatableObject { Char = 'a' }]" + Environment.NewLine +
+					"Actual:   [EquatableObject { Char = 'b' }]" + Environment.NewLine +
+					"           ↑ (pos 0)",
+					ex.Message
+				);
+			}
+
+			public class EquatableObject : IEquatable<EquatableObject>
+			{
+				public char Char { get; set; }
+
+				public bool Equals(EquatableObject? other) =>
+					other != null && other.Char == Char;
+			}
 		}
 
 		public class CollectionsWithFunc
@@ -1018,6 +1170,50 @@ public class CollectionAssertsTests
 				var actual = new List<int>(new int[] { 0, 0, 0, 0, 0 });
 
 				Assert.Equal(expected, actual, (x, y) => true);
+			}
+
+			// https://github.com/xunit/xunit/issues/2795
+			[Fact]
+			public void CollectionItemIsEnumerable()
+			{
+				List<EnumerableItem> actual = new List<EnumerableItem> { new(0), new(2) };
+				List<EnumerableItem> expected = new List<EnumerableItem> { new(1), new(3) };
+
+				Assert.Equal(expected, actual, (x, y) => x.Value / 2 == y.Value / 2);
+			}
+
+			public sealed class EnumerableItem : IEnumerable<string>
+			{
+				public int Value { get; }
+
+				public EnumerableItem(int value) => Value = value;
+
+				public IEnumerator<string> GetEnumerator() => Enumerable.Repeat("", Value).GetEnumerator();
+
+				IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+			}
+
+			[Fact]
+			public void WithThrow_PrintsPointerWhereThrowOccurs_RecordsInnerException()
+			{
+				var ex = Record.Exception(() =>
+					Assert.Equal(
+						new[] { 1, 2 },
+						new[] { 1, 3 },
+						(int e, int a) => throw new DivideByZeroException()
+					)
+				);
+
+				Assert.IsType<EqualException>(ex);
+				Assert.Equal(
+					"Assert.Equal() Failure: Exception thrown during comparison" + Environment.NewLine +
+					"           ↓ (pos 0)" + Environment.NewLine +
+					"Expected: [1, 2]" + Environment.NewLine +
+					"Actual:   [1, 3]" + Environment.NewLine +
+					"           ↑ (pos 0)",
+					ex.Message
+				);
+				Assert.IsType<DivideByZeroException>(ex.InnerException);
 			}
 		}
 
@@ -1106,6 +1302,277 @@ public class CollectionAssertsTests
 					$"Actual:   [[\"a\"] = 1, [\"ba\"] = 2, [\"c\"] = 3, [\"d\"] = 4, [\"e\"] = 5, {ArgumentFormatter.Ellipsis}]",
 					ex.Message
 				);
+			}
+
+			[Fact]
+			public static void WithCollectionValues_Equal()
+			{
+				// Different concrete collection types in the value slot, per https://github.com/xunit/xunit/issues/2850
+				var expected = new Dictionary<string, IEnumerable<string>>
+				{
+					["toAddresses"] = new List<string> { "test1@example.com" },
+					["ccAddresses"] = new List<string> { "test2@example.com" },
+				};
+				var actual = new Dictionary<string, IEnumerable<string>>
+				{
+					["toAddresses"] = new string[] { "test1@example.com" },
+					["ccAddresses"] = new string[] { "test2@example.com" },
+				};
+
+				Assert.Equal(expected, actual);
+			}
+
+			[Fact]
+			public static void WithCollectionValues_NotEqual()
+			{
+				// Different concrete collection types in the value slot, per https://github.com/xunit/xunit/issues/2850
+				var expected = new Dictionary<string, IEnumerable<string>>
+				{
+					["toAddresses"] = new List<string> { "test1@example.com" },
+					["ccAddresses"] = new List<string> { "test2@example.com" },
+				};
+				var actual = new Dictionary<string, IEnumerable<string>>
+				{
+					["toAddresses"] = new string[] { "test1@example.com" },
+					["ccAddresses"] = new string[] { "test3@example.com" },
+				};
+
+				var ex = Record.Exception(() => Assert.Equal(expected, actual));
+
+				Assert.IsType<EqualException>(ex);
+				Assert.Equal(
+					"Assert.Equal() Failure: Dictionaries differ" + Environment.NewLine +
+					"Expected: [[\"toAddresses\"] = [\"test1@example.com\"], [\"ccAddresses\"] = [\"test2@example.com\"]]" + Environment.NewLine +
+					"Actual:   [[\"toAddresses\"] = [\"test1@example.com\"], [\"ccAddresses\"] = [\"test3@example.com\"]]",
+					ex.Message
+				);
+			}
+
+#if XUNIT_AOT
+			[Fact(Skip = "Not supported with AOT")]
+#else
+			[Fact]
+#endif
+			public void EquatableValues_Equal()
+			{
+				var expected = new Dictionary<string, EquatableObject> { { "Key1", new() { Char = 'a' } } };
+				var actual = new Dictionary<string, EquatableObject> { { "Key1", new() { Char = 'a' } } };
+
+				Assert.Equal(expected, actual);
+			}
+
+			[Fact]
+			public void EquatableValues_NotEqual()
+			{
+				var expected = new Dictionary<string, EquatableObject> { { "Key1", new() { Char = 'a' } } };
+				var actual = new Dictionary<string, EquatableObject> { { "Key1", new() { Char = 'b' } } };
+
+				var ex = Record.Exception(() => Assert.Equal(expected, actual));
+
+				Assert.IsType<EqualException>(ex);
+				Assert.Equal(
+					"Assert.Equal() Failure: Dictionaries differ" + Environment.NewLine +
+					"Expected: [[\"Key1\"] = EquatableObject { Char = 'a' }]" + Environment.NewLine +
+					"Actual:   [[\"Key1\"] = EquatableObject { Char = 'b' }]",
+					ex.Message
+				);
+			}
+
+			public class EquatableObject : IEquatable<EquatableObject>
+			{
+				public char Char { get; set; }
+
+				public bool Equals(EquatableObject? other) =>
+					other != null && other.Char == Char;
+			}
+
+			[Fact]
+			public void ComplexEmbeddedValues_Equal()
+			{
+				var expected = new Dictionary<string, object>()
+				{
+					["key"] = new Dictionary<string, object>()
+					{
+						["key"] = new List<Dictionary<string, object>>()
+						{
+							new Dictionary<string, object>()
+							{
+								["key"] = new List<object> { "value" }
+							}
+						}
+					}
+				};
+				var actual = new Dictionary<string, object>()
+				{
+					["key"] = new Dictionary<string, object>()
+					{
+						["key"] = new List<Dictionary<string, object>>()
+						{
+							new Dictionary<string, object>()
+							{
+								["key"] = new List<object> { "value" }
+							}
+						}
+					}
+				};
+
+				Assert.Equal(expected, actual);
+			}
+
+			[Fact]
+			public void ComplexEmbeddedValues_NotEqual()
+			{
+				var expected = new Dictionary<string, object>()
+				{
+					["key"] = new Dictionary<string, object>()
+					{
+						["key"] = new List<Dictionary<string, object>>()
+						{
+							new Dictionary<string, object>()
+							{
+								["key"] = new List<object> { "value1" }
+							}
+						}
+					}
+				};
+				var actual = new Dictionary<string, object>()
+				{
+					["key"] = new Dictionary<string, object>()
+					{
+						["key"] = new List<Dictionary<string, object>>()
+						{
+							new Dictionary<string, object>()
+							{
+								["key"] = new List<object> { "value2" }
+							}
+						}
+					}
+				};
+
+				var ex = Record.Exception(() => Assert.Equal(expected, actual));
+
+				Assert.IsType<EqualException>(ex);
+				Assert.Equal(
+					"Assert.Equal() Failure: Dictionaries differ" + Environment.NewLine +
+					"Expected: [[\"key\"] = [[\"key\"] = [[[\"key\"] = [\"value1\"]]]]]" + Environment.NewLine +
+					"Actual:   [[\"key\"] = [[\"key\"] = [[[\"key\"] = [\"value2\"]]]]]",
+					ex.Message
+				);
+			}
+		}
+
+		public class Sets
+		{
+			[Fact]
+			public void Equal()
+			{
+				var expected = new HashSet<int> { 42, 2112 };
+				var actual = new HashSet<int> { 2112, 42 };
+
+				Assert.Equal(expected, actual);
+			}
+
+#if XUNIT_AOT
+			[Fact(Skip = "Not supported with AOT")]
+#else
+			[Fact]
+#endif
+			public void Equal_WithInternalComparer()
+			{
+				var comparer = new BitArrayComparer();
+				var expected = new HashSet<BitArray>(comparer) { new BitArray(new[] { true, false }) };
+				var actual = new HashSet<BitArray>(comparer) { new BitArray(new[] { true, false }) };
+
+				Assert.Equal(expected, actual);
+			}
+
+#if XUNIT_AOT
+			[Fact(Skip = "Not supported with AOT")]
+#else
+			[Fact]
+#endif
+			public void Equal_WithExternalComparer()
+			{
+				var expected = new HashSet<BitArray> { new BitArray(new[] { true, false }) };
+				var actual = new HashSet<BitArray> { new BitArray(new[] { true, false }) };
+
+				Assert.Equal(expected, actual, new BitArrayComparer());
+			}
+
+			[Fact]
+			public void NotEqual()
+			{
+				var expected = new HashSet<int> { 42, 2112 };
+				var actual = new HashSet<int> { 2600, 42 };
+
+				var ex = Record.Exception(() => Assert.Equal(expected, actual));
+
+				Assert.IsType<EqualException>(ex);
+				Assert.Equal(
+					"Assert.Equal() Failure: HashSets differ" + Environment.NewLine +
+					"Expected: [42, 2112]" + Environment.NewLine +
+					"Actual:   [2600, 42]",
+					ex.Message
+				);
+			}
+
+			[Fact]
+			public void NotEqual_WithInternalComparer()
+			{
+				var comparer = new BitArrayComparer();
+				var expected = new HashSet<BitArray>(comparer) { new BitArray(new[] { true, false }) };
+				var actual = new HashSet<BitArray>(comparer) { new BitArray(new[] { true, true }) };
+
+				var ex = Record.Exception(() => Assert.Equal(expected, actual));
+
+				Assert.IsType<EqualException>(ex);
+				Assert.Equal(
+					"Assert.Equal() Failure: HashSets differ" + Environment.NewLine +
+					"Expected: [[True, False]]" + Environment.NewLine +
+					"Actual:   [[True, True]]",
+					ex.Message
+				);
+			}
+
+			[Fact]
+			public void NotEqual_WithExternalComparer()
+			{
+				var expected = new HashSet<BitArray> { new BitArray(new[] { true, false }) };
+				var actual = new HashSet<BitArray> { new BitArray(new[] { true, true }) };
+
+				var ex = Record.Exception(() => Assert.Equal(expected, actual, new BitArrayComparer()));
+
+				Assert.IsType<EqualException>(ex);
+				Assert.Equal(
+					"Assert.Equal() Failure: HashSets differ" + Environment.NewLine +
+					"Expected: [[True, False]]" + Environment.NewLine +
+					"Actual:   [[True, True]]",
+					ex.Message
+				);
+			}
+
+			public class BitArrayComparer : IEqualityComparer<BitArray>
+			{
+				public bool Equals(
+					BitArray? x,
+					BitArray? y) =>
+						ToBitString(x) == ToBitString(y);
+
+				public int GetHashCode(BitArray obj) =>
+					ToBitString(obj).GetHashCode();
+
+				static string ToBitString(BitArray? bitArray)
+				{
+					if (bitArray is null)
+						return string.Empty;
+
+					var sb = new StringBuilder(bitArray.Length);
+
+					for (int idx = 0; idx < bitArray.Length; ++idx)
+						sb.Append(bitArray[idx] ? '1' : '0');
+
+					return sb.ToString();
+				}
 			}
 		}
 	}
@@ -1304,6 +1771,73 @@ public class CollectionAssertsTests
 
 				public int GetHashCode(int obj) => throw new NotImplementedException();
 			}
+
+			[Fact]
+			public void WithThrow_PrintsPointerWhereThrowOccurs_RecordsInnerException()
+			{
+				var ex = Record.Exception(() => Assert.NotEqual(new[] { 1, 2 }, new[] { 1, 2 }, new ThrowingComparer()));
+
+				Assert.IsType<NotEqualException>(ex);
+				Assert.Equal(
+					"Assert.NotEqual() Failure: Exception thrown during comparison" + Environment.NewLine +
+					"               ↓ (pos 0)" + Environment.NewLine +
+					"Expected: Not [1, 2]" + Environment.NewLine +
+					"Actual:       [1, 2]" + Environment.NewLine +
+					"               ↑ (pos 0)",
+					ex.Message
+				);
+				Assert.IsType<DivideByZeroException>(ex.InnerException);
+			}
+
+			public class ThrowingComparer : IEqualityComparer<int>
+			{
+				public bool Equals(int x, int y) =>
+					throw new DivideByZeroException();
+
+				public int GetHashCode(int obj) =>
+					throw new NotImplementedException();
+			}
+		}
+
+		public class CollectionsWithEquatable
+		{
+#if XUNIT_AOT
+			[Fact(Skip = "Not supported with AOT")]
+#else
+			[Fact]
+#endif
+			public void Equal()
+			{
+				var expected = new[] { new EquatableObject { Char = 'a' } };
+				var actual = new[] { new EquatableObject { Char = 'a' } };
+
+				var ex = Record.Exception(() => Assert.NotEqual(expected, actual));
+
+				Assert.IsType<NotEqualException>(ex);
+				Assert.Equal(
+					"Assert.NotEqual() Failure: Collections are equal" + Environment.NewLine +
+					"Expected: Not [EquatableObject { Char = 'a' }]" + Environment.NewLine +
+					"Actual:       [EquatableObject { Char = 'a' }]",
+					ex.Message
+				);
+			}
+
+			[Fact]
+			public void NotEqual()
+			{
+				var expected = new[] { new EquatableObject { Char = 'a' } };
+				var actual = new[] { new EquatableObject { Char = 'b' } };
+
+				Assert.NotEqual(expected, actual);
+			}
+
+			public class EquatableObject : IEquatable<EquatableObject>
+			{
+				public char Char { get; set; }
+
+				public bool Equals(EquatableObject? other) =>
+					other != null && other.Char == Char;
+			}
 		}
 
 		public class CollectionsWithFunc
@@ -1332,6 +1866,29 @@ public class CollectionAssertsTests
 					"Actual:       List<int> [0, 0, 0, 0, 0]",
 					ex.Message
 				);
+			}
+
+			[Fact]
+			public void WithThrow_PrintsPointerWhereThrowOccurs_RecordsInnerException()
+			{
+				var ex = Record.Exception(() =>
+					Assert.NotEqual(
+						new[] { 1, 2 },
+						new[] { 1, 2 },
+						(int e, int a) => throw new DivideByZeroException()
+					)
+				);
+
+				Assert.IsType<NotEqualException>(ex);
+				Assert.Equal(
+					"Assert.NotEqual() Failure: Exception thrown during comparison" + Environment.NewLine +
+					"               ↓ (pos 0)" + Environment.NewLine +
+					"Expected: Not [1, 2]" + Environment.NewLine +
+					"Actual:       [1, 2]" + Environment.NewLine +
+					"               ↑ (pos 0)",
+					ex.Message
+				);
+				Assert.IsType<DivideByZeroException>(ex.InnerException);
 			}
 		}
 
@@ -1412,6 +1969,277 @@ public class CollectionAssertsTests
 				};
 
 				Assert.NotEqual(expected, actual);
+			}
+
+			[Fact]
+			public static void WithCollectionValues_Equal()
+			{
+				// Different concrete collection types in the value slot, per https://github.com/xunit/xunit/issues/2850
+				var expected = new Dictionary<string, IEnumerable<string>>
+				{
+					["toAddresses"] = new List<string> { "test1@example.com" },
+					["ccAddresses"] = new List<string> { "test2@example.com" },
+				};
+				var actual = new Dictionary<string, IEnumerable<string>>
+				{
+					["toAddresses"] = new string[] { "test1@example.com" },
+					["ccAddresses"] = new string[] { "test2@example.com" },
+				};
+
+				var ex = Record.Exception(() => Assert.NotEqual(expected, actual));
+
+				Assert.IsType<NotEqualException>(ex);
+				Assert.Equal(
+					"Assert.NotEqual() Failure: Dictionaries are equal" + Environment.NewLine +
+					"Expected: Not [[\"toAddresses\"] = [\"test1@example.com\"], [\"ccAddresses\"] = [\"test2@example.com\"]]" + Environment.NewLine +
+					"Actual:       [[\"toAddresses\"] = [\"test1@example.com\"], [\"ccAddresses\"] = [\"test2@example.com\"]]",
+					ex.Message
+				);
+			}
+
+			[Fact]
+			public static void WithCollectionValues_NotEqual()
+			{
+				// Different concrete collection types in the value slot, per https://github.com/xunit/xunit/issues/2850
+				var expected = new Dictionary<string, IEnumerable<string>>
+				{
+					["toAddresses"] = new List<string> { "test1@example.com" },
+					["ccAddresses"] = new List<string> { "test2@example.com" },
+				};
+				var actual = new Dictionary<string, IEnumerable<string>>
+				{
+					["toAddresses"] = new string[] { "test1@example.com" },
+					["ccAddresses"] = new string[] { "test3@example.com" },
+				};
+
+				Assert.NotEqual(expected, actual);
+			}
+
+#if XUNIT_AOT
+			[Fact(Skip = "Not supported with AOT")]
+#else
+			[Fact]
+#endif
+			public void EquatableValues_Equal()
+			{
+				var expected = new Dictionary<string, EquatableObject> { { "Key1", new() { Char = 'a' } } };
+				var actual = new Dictionary<string, EquatableObject> { { "Key1", new() { Char = 'a' } } };
+
+				var ex = Record.Exception(() => Assert.NotEqual(expected, actual));
+
+				Assert.IsType<NotEqualException>(ex);
+				Assert.Equal(
+					"Assert.NotEqual() Failure: Dictionaries are equal" + Environment.NewLine +
+					"Expected: Not [[\"Key1\"] = EquatableObject { Char = 'a' }]" + Environment.NewLine +
+					"Actual:       [[\"Key1\"] = EquatableObject { Char = 'a' }]",
+					ex.Message
+				);
+			}
+
+			[Fact]
+			public void EquatableValues_NotEqual()
+			{
+				var expected = new Dictionary<string, EquatableObject> { { "Key1", new() { Char = 'a' } } };
+				var actual = new Dictionary<string, EquatableObject> { { "Key1", new() { Char = 'b' } } };
+
+				Assert.NotEqual(expected, actual);
+			}
+
+			public class EquatableObject : IEquatable<EquatableObject>
+			{
+				public char Char { get; set; }
+
+				public bool Equals(EquatableObject? other) =>
+					other != null && other.Char == Char;
+			}
+
+			[Fact]
+			public void ComplexEmbeddedValues_Equal()
+			{
+				var expected = new Dictionary<string, object>()
+				{
+					["key"] = new Dictionary<string, object>()
+					{
+						["key"] = new List<Dictionary<string, object>>()
+						{
+							new Dictionary<string, object>()
+							{
+								["key"] = new List<object> { "value" }
+							}
+						}
+					}
+				};
+				var actual = new Dictionary<string, object>()
+				{
+					["key"] = new Dictionary<string, object>()
+					{
+						["key"] = new List<Dictionary<string, object>>()
+						{
+							new Dictionary<string, object>()
+							{
+								["key"] = new List<object> { "value" }
+							}
+						}
+					}
+				};
+
+				var ex = Record.Exception(() => Assert.NotEqual(expected, actual));
+
+				Assert.IsType<NotEqualException>(ex);
+				Assert.Equal(
+					"Assert.NotEqual() Failure: Dictionaries are equal" + Environment.NewLine +
+					"Expected: Not [[\"key\"] = [[\"key\"] = [[[\"key\"] = [\"value\"]]]]]" + Environment.NewLine +
+					"Actual:       [[\"key\"] = [[\"key\"] = [[[\"key\"] = [\"value\"]]]]]",
+					ex.Message
+				);
+			}
+
+			[Fact]
+			public void ComplexEmbeddedValues_NotEqual()
+			{
+				var expected = new Dictionary<string, object>()
+				{
+					["key"] = new Dictionary<string, object>()
+					{
+						["key"] = new List<Dictionary<string, object>>()
+						{
+							new Dictionary<string, object>()
+							{
+								["key"] = new List<object> { "value1" }
+							}
+						}
+					}
+				};
+				var actual = new Dictionary<string, object>()
+				{
+					["key"] = new Dictionary<string, object>()
+					{
+						["key"] = new List<Dictionary<string, object>>()
+						{
+							new Dictionary<string, object>()
+							{
+								["key"] = new List<object> { "value2" }
+							}
+						}
+					}
+				};
+
+				Assert.NotEqual(expected, actual);
+			}
+		}
+
+		public class Sets
+		{
+			[Fact]
+			public void Equal()
+			{
+				var expected = new HashSet<int> { 42, 2112 };
+				var actual = new HashSet<int> { 2112, 42 };
+
+				var ex = Record.Exception(() => Assert.NotEqual(expected, actual));
+
+				Assert.IsType<NotEqualException>(ex);
+				Assert.Equal(
+					"Assert.NotEqual() Failure: HashSets are equal" + Environment.NewLine +
+					"Expected: Not [42, 2112]" + Environment.NewLine +
+					"Actual:       [2112, 42]",
+					ex.Message
+				);
+			}
+
+#if XUNIT_AOT
+			[Fact(Skip = "Not supported with AOT")]
+#else
+			[Fact]
+#endif
+			public void Equal_WithInternalComparer()
+			{
+				var comparer = new BitArrayComparer();
+				var expected = new HashSet<BitArray>(comparer) { new BitArray(new[] { true, false }) };
+				var actual = new HashSet<BitArray>(comparer) { new BitArray(new[] { true, false }) };
+
+				var ex = Record.Exception(() => Assert.NotEqual(expected, actual));
+
+				Assert.IsType<NotEqualException>(ex);
+				Assert.Equal(
+					"Assert.NotEqual() Failure: HashSets are equal" + Environment.NewLine +
+					"Expected: Not [[True, False]]" + Environment.NewLine +
+					"Actual:       [[True, False]]",
+					ex.Message
+				);
+			}
+
+#if XUNIT_AOT
+			[Fact(Skip = "Not supported with AOT")]
+#else
+			[Fact]
+#endif
+			public void Equal_WithExternalComparer()
+			{
+				var expected = new HashSet<BitArray> { new BitArray(new[] { true, false }) };
+				var actual = new HashSet<BitArray> { new BitArray(new[] { true, false }) };
+
+				var ex = Record.Exception(() => Assert.NotEqual(expected, actual, new BitArrayComparer()));
+
+				Assert.IsType<NotEqualException>(ex);
+				Assert.Equal(
+					"Assert.NotEqual() Failure: HashSets are equal" + Environment.NewLine +
+					"Expected: Not [[True, False]]" + Environment.NewLine +
+					"Actual:       [[True, False]]",
+					ex.Message
+				);
+			}
+
+			[Fact]
+			public void NotEqual()
+			{
+				var expected = new HashSet<int> { 42, 2112 };
+				var actual = new HashSet<int> { 2600, 42 };
+
+				Assert.NotEqual(expected, actual);
+			}
+
+			[Fact]
+			public void NotEqual_WithInternalComparer()
+			{
+				var comparer = new BitArrayComparer();
+				var expected = new HashSet<BitArray>(comparer) { new BitArray(new[] { true, false }) };
+				var actual = new HashSet<BitArray>(comparer) { new BitArray(new[] { true, true }) };
+
+				Assert.NotEqual(expected, actual);
+			}
+
+			[Fact]
+			public void NotEqual_WithExternalComparer()
+			{
+				var expected = new HashSet<BitArray> { new BitArray(new[] { true, false }) };
+				var actual = new HashSet<BitArray> { new BitArray(new[] { true, true }) };
+
+				Assert.NotEqual(expected, actual, new BitArrayComparer());
+			}
+
+			public class BitArrayComparer : IEqualityComparer<BitArray>
+			{
+				public bool Equals(
+					BitArray? x,
+					BitArray? y) =>
+						ToBitString(x) == ToBitString(y);
+
+				public int GetHashCode(BitArray obj) =>
+					ToBitString(obj).GetHashCode();
+
+				static string ToBitString(BitArray? bitArray)
+				{
+					if (bitArray is null)
+						return string.Empty;
+
+					var sb = new StringBuilder(bitArray.Length);
+
+					for (int idx = 0; idx < bitArray.Length; ++idx)
+						sb.Append(bitArray[idx] ? '1' : '0');
+
+					return sb.ToString();
+				}
 			}
 		}
 	}
@@ -1609,6 +2437,31 @@ public class CollectionAssertsTests
 				ex.Message
 			);
 		}
+
+		[Fact]
+		public static void StringAsCollection_Match()
+		{
+			var collection = "H";
+
+			var value = Assert.Single(collection);
+
+			Assert.Equal('H', value);
+		}
+
+		[Fact]
+		public static void StringAsCollection_NoMatch()
+		{
+			var collection = "Hello";
+
+			var ex = Record.Exception(() => Assert.Single(collection));
+
+			Assert.IsType<SingleException>(ex);
+			Assert.Equal(
+				"Assert.Single() Failure: The collection contained 5 items" + Environment.NewLine +
+				"Collection: ['H', 'e', 'l', 'l', 'o']",
+				ex.Message
+			);
+		}
 	}
 
 	public class Single_Generic_WithPredicate
@@ -1679,6 +2532,32 @@ public class CollectionAssertsTests
 				ex.Message
 			);
 		}
+
+		[Fact]
+		public static void StringAsCollection_Match()
+		{
+			var collection = "H";
+
+			var value = Assert.Single(collection, c => c != 'Q');
+
+			Assert.Equal('H', value);
+		}
+
+		[Fact]
+		public static void StringAsCollection_NoMatch()
+		{
+			var collection = "H";
+
+			var ex = Record.Exception(() => Assert.Single(collection, c => c == 'Q'));
+
+			Assert.IsType<SingleException>(ex);
+			Assert.Equal(
+				"Assert.Single() Failure: The collection did not contain any matching items" + Environment.NewLine +
+				"Expected:   (predicate expression)" + Environment.NewLine +
+				"Collection: ['H']",
+				ex.Message
+			);
+		}
 	}
 
 	sealed class SpyEnumerator<T> : IEnumerable<T>, IEnumerator<T>
@@ -1696,7 +2575,7 @@ public class CollectionAssertsTests
 		object? IEnumerator.Current =>
 			GuardNotNull("Tried to get Current on a disposed enumerator", innerEnumerator).Current;
 
-		public bool IsDisposed => innerEnumerator == null;
+		public bool IsDisposed => innerEnumerator is null;
 
 		public IEnumerator<T> GetEnumerator() => this;
 
@@ -1719,7 +2598,7 @@ public class CollectionAssertsTests
 			[NotNull] T2? value)
 				where T2 : class
 		{
-			if (value == null)
+			if (value is null)
 				throw new InvalidOperationException(message);
 
 			return value;

--- a/src/Microsoft.DotNet.XUnitAssert/tests/ExceptionAssertsTests.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/tests/ExceptionAssertsTests.cs
@@ -5,6 +5,7 @@ using Xunit.Sdk;
 
 public class ExceptionAssertsTests
 {
+#pragma warning disable xUnit2015 // Do not use typeof expression to check the exception type
 	public class Throws_NonGeneric
 	{
 		public class WithAction
@@ -101,19 +102,6 @@ public class ExceptionAssertsTests
 				Assert.Equal("You must call Assert.ThrowsAsync when testing async code", ex.Message);
 			}
 
-#if XUNIT_VALUETASK
-			[Fact]
-			public static void ProtectsAgainstAccidentalValueTask()
-			{
-				static object testCode() => default(ValueTask);
-
-				var ex = Record.Exception(() => Assert.Throws(typeof(Exception), testCode));
-
-				Assert.IsType<InvalidOperationException>(ex);
-				Assert.Equal("You must call Assert.ThrowsAsync when testing async code", ex.Message);
-			}
-#endif
-
 			[Fact]
 			public static void NoExceptionThrown()
 			{
@@ -175,6 +163,7 @@ public class ExceptionAssertsTests
 			}
 		}
 	}
+#pragma warning restore xUnit2015 // Do not use typeof expression to check the exception type
 
 	public class Throws_Generic
 	{
@@ -265,19 +254,6 @@ public class ExceptionAssertsTests
 				Assert.IsType<InvalidOperationException>(ex);
 				Assert.Equal("You must call Assert.ThrowsAsync when testing async code", ex.Message);
 			}
-
-#if XUNIT_VALUETASK
-			[Fact]
-			public static void ProtectsAgainstAccidentalValueTask()
-			{
-				static object testCode() => default(ValueTask);
-
-				var ex = Record.Exception(() => Assert.Throws<Exception>(testCode));
-
-				Assert.IsType<InvalidOperationException>(ex);
-				Assert.Equal("You must call Assert.ThrowsAsync when testing async code", ex.Message);
-			}
-#endif
 
 			[Fact]
 			public static void NoExceptionThrown()
@@ -596,19 +572,6 @@ public class ExceptionAssertsTests
 				Assert.Equal("You must call Assert.ThrowsAnyAsync when testing async code", ex.Message);
 			}
 
-#if XUNIT_VALUETASK
-			[Fact]
-			public static void ProtectsAgainstAccidentalValueTask()
-			{
-				static object testCode() => default(ValueTask);
-
-				var ex = Record.Exception(() => Assert.ThrowsAny<Exception>(testCode));
-
-				Assert.IsType<InvalidOperationException>(ex);
-				Assert.Equal("You must call Assert.ThrowsAnyAsync when testing async code", ex.Message);
-			}
-#endif
-
 			[Fact]
 			public static void NoExceptionThrown()
 			{
@@ -663,459 +626,215 @@ public class ExceptionAssertsTests
 
 	public class ThrowsAnyAsync
 	{
-		public class WithTask
+		[Fact]
+		public static async Task GuardClause()
 		{
-			[Fact]
-			public static async Task GuardClause()
-			{
-				await Assert.ThrowsAsync<ArgumentNullException>("testCode", () => Assert.ThrowsAnyAsync<ArgumentException>(default(Func<Task>)!));
-			}
-
-			[Fact]
-			public static async Task NoExceptionThrown()
-			{
-				Task testCode() => Task.FromResult(42);
-
-				var ex = await Record.ExceptionAsync(() => Assert.ThrowsAnyAsync<ArgumentException>(testCode));
-
-				Assert.IsType<ThrowsAnyException>(ex);
-				Assert.Equal(
-					"Assert.ThrowsAny() Failure: No exception was thrown" + Environment.NewLine +
-					"Expected: typeof(System.ArgumentException)",
-					ex.Message
-				);
-				Assert.Null(ex.InnerException);
-			}
-
-			[Fact]
-			public static async Task CorrectExceptionThrown()
-			{
-				Task testCode() => throw new ArgumentException();
-
-				await Assert.ThrowsAnyAsync<ArgumentException>(testCode);
-			}
-
-			[Fact]
-			public static async Task IncorrectExceptionThrown()
-			{
-				var thrown = new DivideByZeroException();
-				Task testCode() => throw thrown;
-
-				var ex = await Record.ExceptionAsync(() => Assert.ThrowsAnyAsync<ArgumentException>(testCode));
-
-				Assert.IsType<ThrowsAnyException>(ex);
-				Assert.Equal(
-					"Assert.ThrowsAny() Failure: Exception type was not compatible" + Environment.NewLine +
-					"Expected: typeof(System.ArgumentException)" + Environment.NewLine +
-					"Actual:   typeof(System.DivideByZeroException)",
-					ex.Message
-				);
-				Assert.Same(thrown, ex.InnerException);
-			}
-
-			[Fact]
-			public static async Task DerivedExceptionThrown()
-			{
-				Task testCode() => throw new ArgumentNullException();
-
-				await Assert.ThrowsAnyAsync<ArgumentException>(testCode);
-			}
+			await Assert.ThrowsAsync<ArgumentNullException>("testCode", () => Assert.ThrowsAnyAsync<ArgumentException>(default(Func<Task>)!));
 		}
 
-#if XUNIT_VALUETASK
-		public class WithValueTask
+		[Fact]
+		public static async Task NoExceptionThrown()
 		{
-			[Fact]
-			public static async ValueTask GuardClause()
-			{
-				async ValueTask testCode()
-				{
-					await Assert.ThrowsAnyAsync<ArgumentException>(default(Func<ValueTask>)!);
-				}
+			Task testCode() => Task.FromResult(42);
 
-				await Assert.ThrowsAsync<ArgumentNullException>("testCode", testCode);
-			}
+			var ex = await Record.ExceptionAsync(() => Assert.ThrowsAnyAsync<ArgumentException>(testCode));
 
-			[Fact]
-			public static async ValueTask NoExceptionThrown()
-			{
-				ValueTask testCode() => default(ValueTask);
-
-				var ex = await Record.ExceptionAsync(() => Assert.ThrowsAnyAsync<ArgumentException>(testCode));
-
-				Assert.IsType<ThrowsAnyException>(ex);
-				Assert.Equal(
-					"Assert.ThrowsAny() Failure: No exception was thrown" + Environment.NewLine +
-					"Expected: typeof(System.ArgumentException)",
-					ex.Message
-				);
-				Assert.Null(ex.InnerException);
-			}
-
-			[Fact]
-			public static async ValueTask CorrectExceptionThrown()
-			{
-				ValueTask testCode() => throw new ArgumentException();
-
-				await Assert.ThrowsAnyAsync<ArgumentException>(testCode);
-			}
-
-			[Fact]
-			public static async ValueTask IncorrectExceptionThrown()
-			{
-				var thrown = new DivideByZeroException();
-				ValueTask testCode() => throw thrown;
-
-				var ex = await Record.ExceptionAsync(() => Assert.ThrowsAnyAsync<ArgumentException>(testCode));
-
-				Assert.IsType<ThrowsAnyException>(ex);
-				Assert.Equal(
-					"Assert.ThrowsAny() Failure: Exception type was not compatible" + Environment.NewLine +
-					"Expected: typeof(System.ArgumentException)" + Environment.NewLine +
-					"Actual:   typeof(System.DivideByZeroException)",
-					ex.Message
-				);
-				Assert.Same(thrown, ex.InnerException);
-			}
-
-			[Fact]
-			public static async ValueTask DerivedExceptionThrown()
-			{
-				ValueTask testCode() => throw new ArgumentNullException();
-
-				await Assert.ThrowsAnyAsync<ArgumentException>(testCode);
-			}
+			Assert.IsType<ThrowsAnyException>(ex);
+			Assert.Equal(
+				"Assert.ThrowsAny() Failure: No exception was thrown" + Environment.NewLine +
+				"Expected: typeof(System.ArgumentException)",
+				ex.Message
+			);
+			Assert.Null(ex.InnerException);
 		}
-#endif
+
+		[Fact]
+		public static async Task CorrectExceptionThrown()
+		{
+			Task testCode() => throw new ArgumentException();
+
+			await Assert.ThrowsAnyAsync<ArgumentException>(testCode);
+		}
+
+		[Fact]
+		public static async Task IncorrectExceptionThrown()
+		{
+			var thrown = new DivideByZeroException();
+			Task testCode() => throw thrown;
+
+			var ex = await Record.ExceptionAsync(() => Assert.ThrowsAnyAsync<ArgumentException>(testCode));
+
+			Assert.IsType<ThrowsAnyException>(ex);
+			Assert.Equal(
+				"Assert.ThrowsAny() Failure: Exception type was not compatible" + Environment.NewLine +
+				"Expected: typeof(System.ArgumentException)" + Environment.NewLine +
+				"Actual:   typeof(System.DivideByZeroException)",
+				ex.Message
+			);
+			Assert.Same(thrown, ex.InnerException);
+		}
+
+		[Fact]
+		public static async Task DerivedExceptionThrown()
+		{
+			Task testCode() => throw new ArgumentNullException();
+
+			await Assert.ThrowsAnyAsync<ArgumentException>(testCode);
+		}
 	}
 
 	public class ThrowsAsync
 	{
-		public class WithTask
+		[Fact]
+		public static async Task GuardClause()
 		{
-			[Fact]
-			public static async Task GuardClause()
-			{
-				await Assert.ThrowsAsync<ArgumentNullException>("testCode", () => Assert.ThrowsAsync<ArgumentException>(default(Func<Task>)!));
-			}
-
-			[Fact]
-			public static async Task NoExceptionThrown()
-			{
-				Task testCode() => Task.FromResult(42);
-
-				var ex = await Record.ExceptionAsync(() => Assert.ThrowsAsync<ArgumentException>(testCode));
-
-				Assert.IsType<ThrowsException>(ex);
-				Assert.Equal(
-					"Assert.Throws() Failure: No exception was thrown" + Environment.NewLine +
-					"Expected: typeof(System.ArgumentException)",
-					ex.Message
-				);
-				Assert.Null(ex.InnerException);
-			}
-
-			[Fact]
-			public static async Task CorrectExceptionThrown()
-			{
-				Task testCode() => throw new ArgumentException();
-
-				await Assert.ThrowsAsync<ArgumentException>(testCode);
-			}
-
-			[Fact]
-			public static async Task IncorrectExceptionThrown()
-			{
-				var thrown = new DivideByZeroException();
-				Task testCode() => throw thrown;
-
-				var ex = await Record.ExceptionAsync(() => Assert.ThrowsAsync<ArgumentException>(testCode));
-
-				Assert.IsType<ThrowsException>(ex);
-				Assert.Equal(
-					"Assert.Throws() Failure: Exception type was not an exact match" + Environment.NewLine +
-					"Expected: typeof(System.ArgumentException)" + Environment.NewLine +
-					"Actual:   typeof(System.DivideByZeroException)",
-					ex.Message
-				);
-				Assert.Same(thrown, ex.InnerException);
-			}
-
-			[Fact]
-			public static async Task DerivedExceptionThrown()
-			{
-				var thrown = new ArgumentNullException();
-				Task testCode() => throw thrown;
-
-				var ex = await Record.ExceptionAsync(() => Assert.ThrowsAsync<ArgumentException>(testCode));
-
-				Assert.IsType<ThrowsException>(ex);
-				Assert.Equal(
-					"Assert.Throws() Failure: Exception type was not an exact match" + Environment.NewLine +
-					"Expected: typeof(System.ArgumentException)" + Environment.NewLine +
-					"Actual:   typeof(System.ArgumentNullException)",
-					ex.Message
-				);
-				Assert.Same(thrown, ex.InnerException);
-			}
+			await Assert.ThrowsAsync<ArgumentNullException>("testCode", () => Assert.ThrowsAsync<ArgumentException>(default(Func<Task>)!));
 		}
 
-#if XUNIT_VALUETASK
-		public class WithValueTask
+		[Fact]
+		public static async Task NoExceptionThrown()
 		{
-			[Fact]
-			public static async ValueTask GuardClause()
-			{
-				async ValueTask testCode()
-				{
-					await Assert.ThrowsAsync<ArgumentException>(default(Func<ValueTask>)!);
-				}
+			Task testCode() => Task.FromResult(42);
 
-				await Assert.ThrowsAsync<ArgumentNullException>("testCode", testCode);
-			}
+			var ex = await Record.ExceptionAsync(() => Assert.ThrowsAsync<ArgumentException>(testCode));
 
-			[Fact]
-			public static async ValueTask NoExceptionThrown()
-			{
-				ValueTask testCode() => default(ValueTask);
-
-				var ex = await Record.ExceptionAsync(() => Assert.ThrowsAsync<ArgumentException>(testCode));
-
-				Assert.IsType<ThrowsException>(ex);
-				Assert.Equal(
-					"Assert.Throws() Failure: No exception was thrown" + Environment.NewLine +
-					"Expected: typeof(System.ArgumentException)",
-					ex.Message
-				);
-				Assert.Null(ex.InnerException);
-			}
-
-			[Fact]
-			public static async ValueTask CorrectExceptionThrown()
-			{
-				ValueTask testCode() => throw new ArgumentException();
-
-				await Assert.ThrowsAsync<ArgumentException>(testCode);
-			}
-
-			[Fact]
-			public static async ValueTask IncorrectExceptionThrown()
-			{
-				var thrown = new DivideByZeroException();
-				ValueTask testCode() => throw thrown;
-
-				var ex = await Record.ExceptionAsync(() => Assert.ThrowsAsync<ArgumentException>(testCode));
-
-				Assert.IsType<ThrowsException>(ex);
-				Assert.Equal(
-					"Assert.Throws() Failure: Exception type was not an exact match" + Environment.NewLine +
-					"Expected: typeof(System.ArgumentException)" + Environment.NewLine +
-					"Actual:   typeof(System.DivideByZeroException)",
-					ex.Message
-				);
-				Assert.Same(thrown, ex.InnerException);
-			}
-
-			[Fact]
-			public static async ValueTask DerivedExceptionThrown()
-			{
-				var thrown = new ArgumentNullException();
-				ValueTask testCode() => throw thrown;
-
-				var ex = await Record.ExceptionAsync(() => Assert.ThrowsAsync<ArgumentException>(testCode));
-
-				Assert.IsType<ThrowsException>(ex);
-				Assert.Equal(
-					"Assert.Throws() Failure: Exception type was not an exact match" + Environment.NewLine +
-					"Expected: typeof(System.ArgumentException)" + Environment.NewLine +
-					"Actual:   typeof(System.ArgumentNullException)",
-					ex.Message
-				);
-				Assert.Same(thrown, ex.InnerException);
-			}
+			Assert.IsType<ThrowsException>(ex);
+			Assert.Equal(
+				"Assert.Throws() Failure: No exception was thrown" + Environment.NewLine +
+				"Expected: typeof(System.ArgumentException)",
+				ex.Message
+			);
+			Assert.Null(ex.InnerException);
 		}
-#endif
+
+		[Fact]
+		public static async Task CorrectExceptionThrown()
+		{
+			Task testCode() => throw new ArgumentException();
+
+			await Assert.ThrowsAsync<ArgumentException>(testCode);
+		}
+
+		[Fact]
+		public static async Task IncorrectExceptionThrown()
+		{
+			var thrown = new DivideByZeroException();
+			Task testCode() => throw thrown;
+
+			var ex = await Record.ExceptionAsync(() => Assert.ThrowsAsync<ArgumentException>(testCode));
+
+			Assert.IsType<ThrowsException>(ex);
+			Assert.Equal(
+				"Assert.Throws() Failure: Exception type was not an exact match" + Environment.NewLine +
+				"Expected: typeof(System.ArgumentException)" + Environment.NewLine +
+				"Actual:   typeof(System.DivideByZeroException)",
+				ex.Message
+			);
+			Assert.Same(thrown, ex.InnerException);
+		}
+
+		[Fact]
+		public static async Task DerivedExceptionThrown()
+		{
+			var thrown = new ArgumentNullException();
+			Task testCode() => throw thrown;
+
+			var ex = await Record.ExceptionAsync(() => Assert.ThrowsAsync<ArgumentException>(testCode));
+
+			Assert.IsType<ThrowsException>(ex);
+			Assert.Equal(
+				"Assert.Throws() Failure: Exception type was not an exact match" + Environment.NewLine +
+				"Expected: typeof(System.ArgumentException)" + Environment.NewLine +
+				"Actual:   typeof(System.ArgumentNullException)",
+				ex.Message
+			);
+			Assert.Same(thrown, ex.InnerException);
+		}
 	}
 
 	public class ThrowsAsync_ArgumentException
 	{
-		public class WithTask
+		[Fact]
+		public static async Task GuardClause()
 		{
-			[Fact]
-			public static async Task GuardClause()
-			{
-				await Assert.ThrowsAsync<ArgumentNullException>("testCode", () => Assert.ThrowsAsync<ArgumentException>("paramName", default(Func<Task>)!));
-			}
-
-			[Fact]
-			public static async Task NoExceptionThrown()
-			{
-				Task testCode() => Task.FromResult(42);
-
-				var ex = await Record.ExceptionAsync(() => Assert.ThrowsAsync<ArgumentException>("paramName", testCode));
-
-				Assert.IsType<ThrowsException>(ex);
-				Assert.Equal(
-					"Assert.Throws() Failure: No exception was thrown" + Environment.NewLine +
-					"Expected: typeof(System.ArgumentException)",
-					ex.Message
-				);
-				Assert.Null(ex.InnerException);
-			}
-
-			[Fact]
-			public static async Task CorrectExceptionThrown()
-			{
-				Task testCode() => throw new ArgumentException("Hello world", "paramName");
-
-				await Assert.ThrowsAsync<ArgumentException>("paramName", testCode);
-			}
-
-			[Fact]
-			public static async Task IncorrectParameterName()
-			{
-				Task testCode() => throw new ArgumentException("Hello world", "paramName1");
-
-				var ex = await Record.ExceptionAsync(() => Assert.ThrowsAsync<ArgumentException>("paramName2", testCode));
-
-				Assert.IsType<ThrowsException>(ex);
-				Assert.Equal(
-					"Assert.Throws() Failure: Incorrect parameter name" + Environment.NewLine +
-					"Exception: typeof(System.ArgumentException)" + Environment.NewLine +
-					"Expected:  \"paramName2\"" + Environment.NewLine +
-					"Actual:    \"paramName1\"",
-					ex.Message
-				);
-			}
-
-			[Fact]
-			public static async Task IncorrectExceptionThrown()
-			{
-				var thrown = new DivideByZeroException();
-				Task testCode() => throw thrown;
-
-				var ex = await Record.ExceptionAsync(() => Assert.ThrowsAsync<ArgumentException>("paramName", testCode));
-
-				Assert.IsType<ThrowsException>(ex);
-				Assert.Equal(
-					"Assert.Throws() Failure: Exception type was not an exact match" + Environment.NewLine +
-					"Expected: typeof(System.ArgumentException)" + Environment.NewLine +
-					"Actual:   typeof(System.DivideByZeroException)",
-					ex.Message
-				);
-				Assert.Same(thrown, ex.InnerException);
-			}
-
-			[Fact]
-			public static async Task DerivedExceptionThrown()
-			{
-				var thrown = new ArgumentNullException();
-				Task testCode() => throw thrown;
-
-				var ex = await Record.ExceptionAsync(() => Assert.ThrowsAsync<ArgumentException>("paramName", testCode));
-
-				Assert.IsType<ThrowsException>(ex);
-				Assert.Equal(
-					"Assert.Throws() Failure: Exception type was not an exact match" + Environment.NewLine +
-					"Expected: typeof(System.ArgumentException)" + Environment.NewLine +
-					"Actual:   typeof(System.ArgumentNullException)",
-					ex.Message
-				);
-				Assert.Same(thrown, ex.InnerException);
-			}
+			await Assert.ThrowsAsync<ArgumentNullException>("testCode", () => Assert.ThrowsAsync<ArgumentException>("paramName", default(Func<Task>)!));
 		}
 
-#if XUNIT_VALUETASK
-		public class WithValueTask
+		[Fact]
+		public static async Task NoExceptionThrown()
 		{
-			[Fact]
-			public static async ValueTask GuardClause()
-			{
-				async ValueTask testCode()
-				{
-					await Assert.ThrowsAsync<ArgumentException>("paramName", default(Func<ValueTask>)!);
-				}
+			Task testCode() => Task.FromResult(42);
 
-				await Assert.ThrowsAsync<ArgumentNullException>("testCode", testCode);
-			}
+			var ex = await Record.ExceptionAsync(() => Assert.ThrowsAsync<ArgumentException>("paramName", testCode));
 
-			[Fact]
-			public static async ValueTask NoExceptionThrown()
-			{
-				ValueTask testCode() => default(ValueTask);
-
-				var ex = await Record.ExceptionAsync(() => Assert.ThrowsAsync<ArgumentException>("paramName", testCode));
-
-				Assert.IsType<ThrowsException>(ex);
-				Assert.Equal(
-					"Assert.Throws() Failure: No exception was thrown" + Environment.NewLine +
-					"Expected: typeof(System.ArgumentException)",
-					ex.Message
-				);
-				Assert.Null(ex.InnerException);
-			}
-
-			[Fact]
-			public static async ValueTask CorrectExceptionThrown()
-			{
-				ValueTask testCode() => throw new ArgumentException("Hello world", "paramName");
-
-				await Assert.ThrowsAsync<ArgumentException>("paramName", testCode);
-			}
-
-			[Fact]
-			public static async ValueTask IncorrectParameterName()
-			{
-				ValueTask testCode() => throw new ArgumentException("Hello world", "paramName1");
-
-				var ex = await Record.ExceptionAsync(() => Assert.ThrowsAsync<ArgumentException>("paramName2", testCode));
-
-				Assert.IsType<ThrowsException>(ex);
-				Assert.Equal(
-					"Assert.Throws() Failure: Incorrect parameter name" + Environment.NewLine +
-					"Exception: typeof(System.ArgumentException)" + Environment.NewLine +
-					"Expected:  \"paramName2\"" + Environment.NewLine +
-					"Actual:    \"paramName1\"",
-					ex.Message
-				);
-			}
-
-			[Fact]
-			public static async ValueTask IncorrectExceptionThrown()
-			{
-				var thrown = new DivideByZeroException();
-				ValueTask testCode() => throw thrown;
-
-				var ex = await Record.ExceptionAsync(() => Assert.ThrowsAsync<ArgumentException>("paramName", testCode));
-
-				Assert.IsType<ThrowsException>(ex);
-				Assert.Equal(
-					"Assert.Throws() Failure: Exception type was not an exact match" + Environment.NewLine +
-					"Expected: typeof(System.ArgumentException)" + Environment.NewLine +
-					"Actual:   typeof(System.DivideByZeroException)",
-					ex.Message
-				);
-				Assert.Same(thrown, ex.InnerException);
-			}
-
-			[Fact]
-			public static async ValueTask DerivedExceptionThrown()
-			{
-				var thrown = new ArgumentNullException();
-				ValueTask testCode() => throw thrown;
-
-				var ex = await Record.ExceptionAsync(() => Assert.ThrowsAsync<ArgumentException>("paramName", testCode));
-
-				Assert.IsType<ThrowsException>(ex);
-				Assert.Equal(
-					"Assert.Throws() Failure: Exception type was not an exact match" + Environment.NewLine +
-					"Expected: typeof(System.ArgumentException)" + Environment.NewLine +
-					"Actual:   typeof(System.ArgumentNullException)",
-					ex.Message
-				);
-				Assert.Same(thrown, ex.InnerException);
-			}
+			Assert.IsType<ThrowsException>(ex);
+			Assert.Equal(
+				"Assert.Throws() Failure: No exception was thrown" + Environment.NewLine +
+				"Expected: typeof(System.ArgumentException)",
+				ex.Message
+			);
+			Assert.Null(ex.InnerException);
 		}
-#endif
+
+		[Fact]
+		public static async Task CorrectExceptionThrown()
+		{
+			Task testCode() => throw new ArgumentException("Hello world", "paramName");
+
+			await Assert.ThrowsAsync<ArgumentException>("paramName", testCode);
+		}
+
+		[Fact]
+		public static async Task IncorrectParameterName()
+		{
+			Task testCode() => throw new ArgumentException("Hello world", "paramName1");
+
+			var ex = await Record.ExceptionAsync(() => Assert.ThrowsAsync<ArgumentException>("paramName2", testCode));
+
+			Assert.IsType<ThrowsException>(ex);
+			Assert.Equal(
+				"Assert.Throws() Failure: Incorrect parameter name" + Environment.NewLine +
+				"Exception: typeof(System.ArgumentException)" + Environment.NewLine +
+				"Expected:  \"paramName2\"" + Environment.NewLine +
+				"Actual:    \"paramName1\"",
+				ex.Message
+			);
+		}
+
+		[Fact]
+		public static async Task IncorrectExceptionThrown()
+		{
+			var thrown = new DivideByZeroException();
+			Task testCode() => throw thrown;
+
+			var ex = await Record.ExceptionAsync(() => Assert.ThrowsAsync<ArgumentException>("paramName", testCode));
+
+			Assert.IsType<ThrowsException>(ex);
+			Assert.Equal(
+				"Assert.Throws() Failure: Exception type was not an exact match" + Environment.NewLine +
+				"Expected: typeof(System.ArgumentException)" + Environment.NewLine +
+				"Actual:   typeof(System.DivideByZeroException)",
+				ex.Message
+			);
+			Assert.Same(thrown, ex.InnerException);
+		}
+
+		[Fact]
+		public static async Task DerivedExceptionThrown()
+		{
+			var thrown = new ArgumentNullException();
+			Task testCode() => throw thrown;
+
+			var ex = await Record.ExceptionAsync(() => Assert.ThrowsAsync<ArgumentException>("paramName", testCode));
+
+			Assert.IsType<ThrowsException>(ex);
+			Assert.Equal(
+				"Assert.Throws() Failure: Exception type was not an exact match" + Environment.NewLine +
+				"Expected: typeof(System.ArgumentException)" + Environment.NewLine +
+				"Actual:   typeof(System.ArgumentNullException)",
+				ex.Message
+			);
+			Assert.Same(thrown, ex.InnerException);
+		}
 	}
 }

--- a/src/Microsoft.DotNet.XUnitAssert/tests/IdentityAssertsTests.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/tests/IdentityAssertsTests.cs
@@ -51,7 +51,9 @@ public class IdentityAssertsTests
 		[Fact]
 		public void EqualValueTypeValuesAreNotSameBecauseOfBoxing()
 		{
+#pragma warning disable xUnit2005 // Do not use identity check on value type
 			Assert.Throws<SameException>(() => Assert.Same(0, 0));
+#pragma warning restore xUnit2005 // Do not use identity check on value type
 		}
 	}
 }

--- a/src/Microsoft.DotNet.XUnitAssert/tests/MemoryAssertsTests.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/tests/MemoryAssertsTests.cs
@@ -624,14 +624,14 @@ public class MemoryAssertsTests
 			{
 				var message = "Assert.Equal() Failure: Strings differ";
 
-				if (expectedPointer != null)
+				if (expectedPointer is not null)
 					message += Environment.NewLine + "           " + expectedPointer;
 
 				message +=
 					Environment.NewLine + "Expected: " + ArgumentFormatter.Format(expected) +
 					Environment.NewLine + "Actual:   " + ArgumentFormatter.Format(actual);
 
-				if (actualPointer != null)
+				if (actualPointer is not null)
 					message += Environment.NewLine + "           " + actualPointer;
 
 				void assertFailure(Action action)

--- a/src/Microsoft.DotNet.XUnitAssert/tests/MemoryExtensions.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/tests/MemoryExtensions.cs
@@ -1,0 +1,18 @@
+#if XUNIT_SPAN
+
+using System;
+
+internal static class MemoryExtensions
+{
+	public static Memory<T> Memoryify<T>(this T[]? values)
+	{
+		return new Memory<T>(values);
+	}
+
+	public static Memory<char> Memoryify(this string? value)
+	{
+		return new Memory<char>((value ?? string.Empty).ToCharArray());
+	}
+}
+
+#endif

--- a/src/Microsoft.DotNet.XUnitAssert/tests/Microsoft.DotNet.XUnitAssert.Tests.csproj
+++ b/src/Microsoft.DotNet.XUnitAssert/tests/Microsoft.DotNet.XUnitAssert.Tests.csproj
@@ -6,6 +6,7 @@
     <!-- Baseline analyzer warnings. These warnings are present in the upstream xunit.assert tests. -->
     <NoWarn>$(NoWarn);xUnit2000;xUnit2003;xUnit2005;xUnit2007;xUnit2011;xUnit2015;xUnit2017</NoWarn>
     <NoWarn>$(NoWarn);IDE0073</NoWarn>
+    <DefineConstants>$(DefineConstants);XUNIT_NULLABLE;XUNIT_SPAN;XUNIT_IMMUTABLE_COLLECTIONS;XUNIT_AOT</DefineConstants>
     <UseDotNetXUnitAssert>true</UseDotNetXUnitAssert>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.XUnitAssert/tests/PropertyAssertsTests.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/tests/PropertyAssertsTests.cs
@@ -67,11 +67,6 @@ public class PropertyAssertsTests
 		{
 			await Assert.ThrowsAsync<ArgumentNullException>("object", () => Assert.PropertyChangedAsync(null!, "propertyName", () => Task.FromResult(0)));
 			await Assert.ThrowsAsync<ArgumentNullException>("testCode", () => Assert.PropertyChangedAsync(Substitute.For<INotifyPropertyChanged>(), "propertyName", default(Func<Task>)!));
-
-#if XUNIT_VALUETASK
-			await Assert.ThrowsAsync<ArgumentNullException>("object", () => Assert.PropertyChangedAsync(null!, "propertyName", () => default(ValueTask)));
-			await Assert.ThrowsAsync<ArgumentNullException>("testCode", () => Assert.PropertyChangedAsync(Substitute.For<INotifyPropertyChanged>(), "propertyName", default(Func<ValueTask>)!));
-#endif
 		}
 
 		[Fact]
@@ -84,19 +79,6 @@ public class PropertyAssertsTests
 			Assert.IsType<PropertyChangedException>(ex);
 			Assert.Equal("Assert.PropertyChanged() failure: Property 'Property1' was not set", ex.Message);
 		}
-
-#if XUNIT_VALUETASK
-		[Fact]
-		public async Task ExceptionThrownWhenPropertyNotChanged_ValueTask()
-		{
-			var obj = new NotifiedClass();
-
-			var ex = await Record.ExceptionAsync(() => Assert.PropertyChangedAsync(obj, nameof(NotifiedClass.Property1), () => default(ValueTask)));
-
-			Assert.IsType<PropertyChangedException>(ex);
-			Assert.Equal("Assert.PropertyChanged() failure: Property 'Property1' was not set", ex.Message);
-		}
-#endif
 
 #pragma warning disable CS1998
 		[Fact]
@@ -111,20 +93,6 @@ public class PropertyAssertsTests
 			Assert.Equal("Assert.PropertyChanged() failure: Property 'Property1' was not set", ex.Message);
 		}
 
-#if XUNIT_VALUETASK
-		[Fact]
-		public async Task ExceptionThrownWhenWrongPropertyChangedAsync_ValueTask()
-		{
-			var obj = new NotifiedClass();
-			async Task setter() => obj!.Property2 = 42;
-
-			var ex = await Record.ExceptionAsync(() => Assert.PropertyChangedAsync(obj, nameof(NotifiedClass.Property1), setter));
-
-			Assert.IsType<PropertyChangedException>(ex);
-			Assert.Equal("Assert.PropertyChanged() failure: Property 'Property1' was not set", ex.Message);
-		}
-#endif
-
 		[Fact]
 		public async Task NoExceptionThrownWhenPropertyChangedAsync_Task()
 		{
@@ -133,17 +101,6 @@ public class PropertyAssertsTests
 
 			await Assert.PropertyChangedAsync(obj, nameof(NotifiedClass.Property1), setter);
 		}
-
-#if XUNIT_VALUETASK
-		[Fact]
-		public async Task NoExceptionThrownWhenPropertyChangedAsync_ValueTask()
-		{
-			var obj = new NotifiedClass();
-			async ValueTask setter() => obj!.Property1 = "NewValue";
-
-			await Assert.PropertyChangedAsync(obj, nameof(NotifiedClass.Property1), setter);
-		}
-#endif
 
 		[Fact]
 		public async Task NoExceptionThrownWhenMultiplePropertyChangesIncludesCorrectProperty_Task()
@@ -159,23 +116,6 @@ public class PropertyAssertsTests
 
 			await Assert.PropertyChangedAsync(obj, nameof(NotifiedClass.Property1), setter);
 		}
-
-#if XUNIT_VALUETASK
-		[Fact]
-		public async Task NoExceptionThrownWhenMultiplePropertyChangesIncludesCorrectProperty_ValueTask()
-		{
-			var obj = new NotifiedClass();
-
-			async ValueTask setter()
-			{
-				obj.Property2 = 12;
-				obj.Property1 = "New Value";
-				obj.Property2 = 42;
-			}
-
-			await Assert.PropertyChangedAsync(obj, nameof(NotifiedClass.Property1), setter);
-		}
-#endif
 #pragma warning restore CS1998
 	}
 

--- a/src/Microsoft.DotNet.XUnitAssert/tests/RangeAssertsTests.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/tests/RangeAssertsTests.cs
@@ -7,7 +7,11 @@ public class RangeAssertsTests
 {
 	public class InRange
 	{
+#if XUNIT_AOT
 		[Fact]
+#else
+		[CulturedFact]
+#endif
 		public void DoubleNotWithinRange()
 		{
 			var ex = Record.Exception(() => Assert.InRange(1.50, .75, 1.25));
@@ -90,7 +94,11 @@ public class RangeAssertsTests
 			Assert.InRange(400.0, .75, 1.25, new DoubleComparer(-1));
 		}
 
+#if XUNIT_AOT
 		[Fact]
+#else
+		[CulturedFact]
+#endif
 		public void DoubleValueNotWithinRange()
 		{
 			var ex = Record.Exception(() => Assert.InRange(1.0, .75, 1.25, new DoubleComparer(1)));
@@ -121,8 +129,8 @@ public class RangeAssertsTests
 			Assert.IsType<NotInRangeException>(ex);
 			Assert.Equal(
 				"Assert.NotInRange() Failure: Value in range" + Environment.NewLine +
-				"Range:  (0.75 - 1.25)" + Environment.NewLine +
-				"Actual: 1",
+				$"Range:  ({0.75:G17} - {1.25:G17})" + Environment.NewLine +
+				$"Actual: {1:G17}",
 				ex.Message
 			);
 		}
@@ -178,8 +186,8 @@ public class RangeAssertsTests
 			Assert.IsType<NotInRangeException>(ex);
 			Assert.Equal(
 				"Assert.NotInRange() Failure: Value in range" + Environment.NewLine +
-				"Range:  (0.75 - 1.25)" + Environment.NewLine +
-				"Actual: 400",
+				$"Range:  ({0.75:G17} - {1.25:G17})" + Environment.NewLine +
+				$"Actual: {400:G17}",
 				ex.Message
 			);
 		}

--- a/src/Microsoft.DotNet.XUnitAssert/tests/Sdk/ArgumentFormatterTests.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/tests/Sdk/ArgumentFormatterTests.cs
@@ -10,10 +10,14 @@ public class ArgumentFormatterTests
 {
 	public class SimpleValues
 	{
+#if XUNIT_AOT
 		[Fact]
+#else
+		[CulturedFact]
+#endif
 		public static void NullValue()
 		{
-			Assert.Equal("null", ArgumentFormatter.Format((object?)null));
+			Assert.Equal("null", ArgumentFormatter.Format(null));
 		}
 
 		// NOTE: It's important that this stays as MemberData
@@ -120,7 +124,11 @@ public class ArgumentFormatterTests
 			Assert.Equal(expected, ArgumentFormatter.Format(value));
 		}
 
+#if XUNIT_AOT
 		[Fact]
+#else
+		[CulturedFact]
+#endif
 		public static void FloatValue()
 		{
 			var floatPI = (float)Math.PI;
@@ -128,19 +136,31 @@ public class ArgumentFormatterTests
 			Assert.Equal(floatPI.ToString("G9"), ArgumentFormatter.Format(floatPI));
 		}
 
+#if XUNIT_AOT
 		[Fact]
+#else
+		[CulturedFact]
+#endif
 		public static void DoubleValue()
 		{
 			Assert.Equal(Math.PI.ToString("G17"), ArgumentFormatter.Format(Math.PI));
 		}
 
+#if XUNIT_AOT
 		[Fact]
+#else
+		[CulturedFact]
+#endif
 		public static void DecimalValue()
 		{
 			Assert.Equal(123.45M.ToString(), ArgumentFormatter.Format(123.45M));
 		}
 
+#if XUNIT_AOT
 		[Fact]
+#else
+		[CulturedFact]
+#endif
 		public static void DateTimeValue()
 		{
 			var now = DateTime.UtcNow;
@@ -148,7 +168,11 @@ public class ArgumentFormatterTests
 			Assert.Equal(now.ToString("o"), ArgumentFormatter.Format(now));
 		}
 
+#if XUNIT_AOT
 		[Fact]
+#else
+		[CulturedFact]
+#endif
 		public static void DateTimeOffsetValue()
 		{
 			var now = DateTimeOffset.UtcNow;
@@ -208,10 +232,16 @@ public class ArgumentFormatterTests
 			Value1 = 1
 		}
 
+#if XUNIT_AOT
 		[Theory]
-		[InlineData((NonFlagsEnum)0, "Value0")]
-		[InlineData((NonFlagsEnum)1, "Value1")]
-		[InlineData((NonFlagsEnum)42, "42")]
+#else
+		[CulturedTheory]
+#endif
+#pragma warning disable xUnit1010 // The value is not convertible to the method parameter type
+		[InlineData(0, "Value0")]
+		[InlineData(1, "Value1")]
+		[InlineData(42, "42")]
+#pragma warning restore xUnit1010 // The value is not convertible to the method parameter type
 		public static void NonFlags(NonFlagsEnum enumValue, string expected)
 		{
 			var actual = ArgumentFormatter.Format(enumValue);
@@ -227,12 +257,18 @@ public class ArgumentFormatterTests
 			Value2 = 2,
 		}
 
+#if XUNIT_AOT
 		[Theory]
-		[InlineData((FlagsEnum)0, "Nothing")]
-		[InlineData((FlagsEnum)1, "Value1")]
-		[InlineData((FlagsEnum)3, "Value1 | Value2")]
+#else
+		[CulturedTheory]
+#endif
+#pragma warning disable xUnit1010 // The value is not convertible to the method parameter type
+		[InlineData(0, "Nothing")]
+		[InlineData(1, "Value1")]
+		[InlineData(3, "Value1 | Value2")]
 		// This is expected, not "Value1 | Value2 | 4"
-		[InlineData((FlagsEnum)7, "7")]
+		[InlineData(7, "7")]
+#pragma warning restore xUnit1010 // The value is not convertible to the method parameter type
 		public static void Flags(FlagsEnum enumValue, string expected)
 		{
 			var actual = ArgumentFormatter.Format(enumValue);
@@ -243,7 +279,11 @@ public class ArgumentFormatterTests
 
 	public class KeyValuePair
 	{
+#if XUNIT_AOT
 		[Fact]
+#else
+		[CulturedFact]
+#endif
 		public static void KeyValuePairValue()
 		{
 			var kvp = new KeyValuePair<object, List<object>>(42, new() { 21.12M, "2600" });
@@ -256,13 +296,17 @@ public class ArgumentFormatterTests
 	public class Enumerables
 	{
 		// Both tracked and untracked should be the same
-		public static TheoryData<IEnumerable?> Collections = new()
+		public static TheoryData<IEnumerable> Collections = new()
 		{
 			new object[] { 1, 2.3M, "Hello, world!" },
 			new object[] { 1, 2.3M, "Hello, world!" }.AsTracker(),
 		};
 
+#if XUNIT_AOT
 		[Theory]
+#else
+		[CulturedTheory]
+#endif
 		[MemberData(nameof(Collections), DisableDiscoveryEnumeration = true)]
 		public static void EnumerableValue(IEnumerable collection)
 		{
@@ -271,7 +315,11 @@ public class ArgumentFormatterTests
 			Assert.Equal(expected, ArgumentFormatter.Format(collection));
 		}
 
+#if XUNIT_AOT
 		[Fact]
+#else
+		[CulturedFact]
+#endif
 		public static void DictionaryValue()
 		{
 			var value = new Dictionary<object, List<object>>
@@ -284,20 +332,28 @@ public class ArgumentFormatterTests
 			Assert.Equal(expected, ArgumentFormatter.Format(value));
 		}
 
-		public static TheoryData<IEnumerable?> LongCollections = new()
+		public static TheoryData<IEnumerable> LongCollections = new()
 		{
 			new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 },
 			new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }.AsTracker(),
 		};
 
+#if XUNIT_AOT
 		[Theory]
+#else
+		[CulturedTheory]
+#endif
 		[MemberData(nameof(LongCollections), DisableDiscoveryEnumeration = true)]
 		public static void OnlyFirstFewValuesOfEnumerableAreRendered(IEnumerable collection)
 		{
 			Assert.Equal($"[0, 1, 2, 3, 4, {ArgumentFormatter.Ellipsis}]", ArgumentFormatter.Format(collection));
 		}
 
+#if XUNIT_AOT
 		[Fact]
+#else
+		[CulturedFact]
+#endif
 		public static void EnumerablesAreRenderedWithMaximumDepthToPreventInfiniteRecursion()
 		{
 			var looping = new object[2];
@@ -310,7 +366,11 @@ public class ArgumentFormatterTests
 
 	public class ComplexTypes
 	{
+#if XUNIT_AOT
 		[Fact]
+#else
+		[CulturedFact]
+#endif
 		public static void ReturnsValuesInAlphabeticalOrder()
 		{
 			var expected = $"MyComplexType {{ MyPublicField = 42, MyPublicProperty = {21.12M} }}";
@@ -336,7 +396,11 @@ public class ArgumentFormatterTests
 			}
 		}
 
+#if XUNIT_AOT
 		[Fact]
+#else
+		[CulturedFact]
+#endif
 		public static void ComplexTypeInsideComplexType()
 		{
 			var expected = $"MyComplexTypeWrapper {{ c = 'A', s = \"Hello, world!\", t = MyComplexType {{ MyPublicField = 42, MyPublicProperty = {21.12M} }} }}";
@@ -351,13 +415,21 @@ public class ArgumentFormatterTests
 			public string s = "Hello, world!";
 		}
 
+#if XUNIT_AOT
 		[Fact]
+#else
+		[CulturedFact]
+#endif
 		public static void Empty()
 		{
 			Assert.Equal("Object { }", ArgumentFormatter.Format(new object()));
 		}
 
+#if XUNIT_AOT
 		[Fact]
+#else
+		[CulturedFact]
+#endif
 		public static void WithThrowingPropertyGetter()
 		{
 			Assert.Equal("ThrowingGetter { MyThrowingProperty = (throws NotImplementedException) }", ArgumentFormatter.Format(new ThrowingGetter()));
@@ -368,7 +440,11 @@ public class ArgumentFormatterTests
 			public string MyThrowingProperty { get { throw new NotImplementedException(); } }
 		}
 
+#if XUNIT_AOT
 		[Fact]
+#else
+		[CulturedFact]
+#endif
 		public static void LimitsOutputToFirstFewValues()
 		{
 			var expected = $@"Big {{ MyField1 = 42, MyField2 = ""Hello, world!"", MyProp1 = {21.12}, MyProp2 = typeof(ArgumentFormatterTests+ComplexTypes+Big), MyProp3 = 2014-04-17T07:45:23.0000000+00:00, {ArgumentFormatter.Ellipsis} }}";
@@ -399,7 +475,11 @@ public class ArgumentFormatterTests
 			}
 		}
 
+#if XUNIT_AOT
 		[Fact]
+#else
+		[CulturedFact]
+#endif
 		public static void TypesAreRenderedWithMaximumDepthToPreventInfiniteRecursion()
 		{
 			Assert.Equal($"Looping {{ Me = Looping {{ Me = Looping {{ {ArgumentFormatter.Ellipsis} }} }} }}", ArgumentFormatter.Format(new Looping()));

--- a/src/Microsoft.DotNet.XUnitAssert/tests/Sdk/CollectionTrackerTests.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/tests/Sdk/CollectionTrackerTests.cs
@@ -154,7 +154,11 @@ public class CollectionTrackerTests
 			Assert.Equal($"[{ArgumentFormatter.Ellipsis}]", tracker.FormatStart(ArgumentFormatter.MAX_DEPTH));
 		}
 
+#if XUNIT_AOT
 		[Fact]
+#else
+		[CulturedFact]
+#endif
 		public static void Short()
 		{
 			var tracker = new object[] { 1, 2.3M, "Hello, world!" }.AsTracker();
@@ -162,7 +166,11 @@ public class CollectionTrackerTests
 			Assert.Equal($"[1, {2.3M}, \"Hello, world!\"]", tracker.FormatStart());
 		}
 
+#if XUNIT_AOT
 		[Fact]
+#else
+		[CulturedFact]
+#endif
 		public static void Long()
 		{
 			var tracker = new object[] { 1, 2.3M, "Hello, world!", 42, 2112, new object() }.AsTracker();
@@ -189,7 +197,11 @@ public class CollectionTrackerTests
 			Assert.Equal($"[{ArgumentFormatter.Ellipsis}]", CollectionTracker<object>.FormatStart(collection, ArgumentFormatter.MAX_DEPTH));
 		}
 
+#if XUNIT_AOT
 		[Fact]
+#else
+		[CulturedFact]
+#endif
 		public static void Short()
 		{
 			IEnumerable<object> collection = new object[] { 1, 2.3M, "Hello, world!" };
@@ -197,7 +209,11 @@ public class CollectionTrackerTests
 			Assert.Equal($"[1, {2.3M}, \"Hello, world!\"]", CollectionTracker<object>.FormatStart(collection));
 		}
 
+#if XUNIT_AOT
 		[Fact]
+#else
+		[CulturedFact]
+#endif
 		public static void Long()
 		{
 			IEnumerable<object> collection = new object[] { 1, 2.3M, "Hello, world!", 42, 2112, new object() };
@@ -225,7 +241,11 @@ public class CollectionTrackerTests
 			Assert.Equal($"[{ArgumentFormatter.Ellipsis}]", CollectionTracker<object>.FormatStart(span, ArgumentFormatter.MAX_DEPTH));
 		}
 
+#if XUNIT_AOT
 		[Fact]
+#else
+		[CulturedFact]
+#endif
 		public static void Short()
 		{
 			var span = new object[] { 1, 2.3M, "Hello, world!" }.AsSpan();
@@ -233,7 +253,11 @@ public class CollectionTrackerTests
 			Assert.Equal($"[1, {2.3M}, \"Hello, world!\"]", CollectionTracker<object>.FormatStart(span));
 		}
 
+#if XUNIT_AOT
 		[Fact]
+#else
+		[CulturedFact]
+#endif
 		public static void Long()
 		{
 			var span = new object[] { 1, 2.3M, "Hello, world!", 42, 2112, new object() }.AsSpan();

--- a/src/Microsoft.DotNet.XUnitAssert/tests/SetAssertsTests.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/tests/SetAssertsTests.cs
@@ -18,11 +18,13 @@ public class SetAssertsTests
 
 			Assert.Contains("FORTY-two", set);
 			Assert.Contains("FORTY-two", (ISet<string>)set);
+			Assert.Contains("FORTY-two", set.ToSortedSet(StringComparer.OrdinalIgnoreCase));
 #if NET5_0_OR_GREATER
 			Assert.Contains("FORTY-two", (IReadOnlySet<string>)set);
 #endif
 #if XUNIT_IMMUTABLE_COLLECTIONS
 			Assert.Contains("FORTY-two", set.ToImmutableHashSet(StringComparer.OrdinalIgnoreCase));
+			Assert.Contains("FORTY-two", set.ToImmutableSortedSet(StringComparer.OrdinalIgnoreCase));
 #endif
 		}
 
@@ -46,11 +48,13 @@ public class SetAssertsTests
 
 			assertFailure(() => Assert.Contains("FORTY-two", set));
 			assertFailure(() => Assert.Contains("FORTY-two", (ISet<string>)set));
+			assertFailure(() => Assert.Contains("FORTY-two", set.ToSortedSet()));
 #if NET5_0_OR_GREATER
 			assertFailure(() => Assert.Contains("FORTY-two", (IReadOnlySet<string>)set));
 #endif
 #if XUNIT_IMMUTABLE_COLLECTIONS
 			assertFailure(() => Assert.Contains("FORTY-two", set.ToImmutableHashSet()));
+			assertFailure(() => Assert.Contains("FORTY-two", set.ToImmutableSortedSet()));
 #endif
 		}
 	}
@@ -64,11 +68,13 @@ public class SetAssertsTests
 
 			Assert.DoesNotContain("FORTY-two", set);
 			Assert.DoesNotContain("FORTY-two", (ISet<string>)set);
+			Assert.DoesNotContain("FORTY-two", set.ToSortedSet());
 #if NET5_0_OR_GREATER
 			Assert.DoesNotContain("FORTY-two", (IReadOnlySet<string>)set);
 #endif
 #if XUNIT_IMMUTABLE_COLLECTIONS
-			Assert.DoesNotContain("FORTY-two", set.ToImmutableHashSet(StringComparer.OrdinalIgnoreCase));
+			Assert.DoesNotContain("FORTY-two", set.ToImmutableHashSet());
+			Assert.DoesNotContain("FORTY-two", set.ToImmutableSortedSet());
 #endif
 		}
 
@@ -92,11 +98,13 @@ public class SetAssertsTests
 
 			assertFailure(() => Assert.DoesNotContain("FORTY-two", set));
 			assertFailure(() => Assert.DoesNotContain("FORTY-two", (ISet<string>)set));
+			assertFailure(() => Assert.DoesNotContain("FORTY-two", set.ToSortedSet(StringComparer.OrdinalIgnoreCase)));
 #if NET5_0_OR_GREATER
 			assertFailure(() => Assert.DoesNotContain("FORTY-two", (IReadOnlySet<string>)set));
 #endif
 #if XUNIT_IMMUTABLE_COLLECTIONS
 			assertFailure(() => Assert.DoesNotContain("FORTY-two", set.ToImmutableHashSet(StringComparer.OrdinalIgnoreCase)));
+			assertFailure(() => Assert.DoesNotContain("FORTY-two", set.ToImmutableSortedSet(StringComparer.OrdinalIgnoreCase)));
 #endif
 		}
 	}

--- a/src/Microsoft.DotNet.XUnitAssert/tests/SetExtensions.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/tests/SetExtensions.cs
@@ -1,0 +1,7 @@
+using System.Collections.Generic;
+
+internal static class SetExtensions
+{
+	public static SortedSet<T> ToSortedSet<T>(this ISet<T> set, IComparer<T>? comparer = null) =>
+		new SortedSet<T>(set, comparer);
+}

--- a/src/Microsoft.DotNet.XUnitAssert/tests/SpanAssertsTests.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/tests/SpanAssertsTests.cs
@@ -624,14 +624,14 @@ public class SpanAssertsTests
 			{
 				var message = "Assert.Equal() Failure: Strings differ";
 
-				if (expectedPointer != null)
+				if (expectedPointer is not null)
 					message += Environment.NewLine + "           " + expectedPointer;
 
 				message +=
 					Environment.NewLine + "Expected: " + ArgumentFormatter.Format(expected) +
 					Environment.NewLine + "Actual:   " + ArgumentFormatter.Format(actual);
 
-				if (actualPointer != null)
+				if (actualPointer is not null)
 					message += Environment.NewLine + "           " + actualPointer;
 
 				void assertFailure(Action action)

--- a/src/Microsoft.DotNet.XUnitAssert/tests/SpanExtensions.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/tests/SpanExtensions.cs
@@ -1,0 +1,18 @@
+#if XUNIT_SPAN
+
+using System;
+
+internal static class SpanExtensions
+{
+	public static Span<T> Spanify<T>(this T[]? values)
+	{
+		return new Span<T>(values);
+	}
+
+	public static Span<char> Spanify(this string? value)
+	{
+		return new Span<char>((value ?? string.Empty).ToCharArray());
+	}
+}
+
+#endif

--- a/src/Microsoft.DotNet.XUnitAssert/tests/StringAssertsTests.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/tests/StringAssertsTests.cs
@@ -387,8 +387,8 @@ public class StringAssertsTests
 		[InlineData("", "\t", false, false, true, true)]
 		[InlineData("foobar", "foo bar", false, false, true, true)]
 		public void Success(
-			string value1,
-			string value2,
+			string? value1,
+			string? value2,
 			bool ignoreCase,
 			bool ignoreLineEndingDifferences,
 			bool ignoreWhiteSpaceDifferences,
@@ -429,14 +429,14 @@ public class StringAssertsTests
 		{
 			var message = "Assert.Equal() Failure: Strings differ";
 
-			if (expectedPointer != null)
+			if (expectedPointer is not null)
 				message += Environment.NewLine + "           " + expectedPointer;
 
 			message +=
 				Environment.NewLine + "Expected: " + ArgumentFormatter.Format(expected) +
 				Environment.NewLine + "Actual:   " + ArgumentFormatter.Format(actual);
 
-			if (actualPointer != null)
+			if (actualPointer is not null)
 				message += Environment.NewLine + "           " + actualPointer;
 
 			var ex = Record.Exception(

--- a/src/Microsoft.DotNet.XUnitAssert/tests/TypeAssertsTests.cs
+++ b/src/Microsoft.DotNet.XUnitAssert/tests/TypeAssertsTests.cs
@@ -2,7 +2,7 @@ using System;
 using Xunit;
 using Xunit.Sdk;
 
-#if NETFRAMEWORK && XUNIT_VALUETASK
+#if NETFRAMEWORK
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -80,6 +80,7 @@ public class TypeAssertsTests
 		}
 	}
 
+#pragma warning disable xUnit2007 // Do not use typeof expression to check the type
 	public class IsAssignableFrom_NonGeneric
 	{
 		[Fact]
@@ -147,6 +148,7 @@ public class TypeAssertsTests
 			);
 		}
 	}
+#pragma warning restore xUnit2007 // Do not use typeof expression to check the type
 
 	public class IsNotAssignableFrom_Generic
 	{
@@ -305,6 +307,7 @@ public class TypeAssertsTests
 		}
 	}
 
+#pragma warning disable xUnit2007 // Do not use typeof expression to check the type
 	public class IsNotType_NonGeneric
 	{
 		[Fact]
@@ -335,6 +338,7 @@ public class TypeAssertsTests
 			Assert.IsNotType(typeof(object), null);
 		}
 	}
+#pragma warning restore xUnit2007 // Do not use typeof expression to check the type
 
 	public class IsType_Generic : TypeAssertsTests
 	{
@@ -370,9 +374,9 @@ public class TypeAssertsTests
 			);
 		}
 
-#if NETFRAMEWORK && XUNIT_VALUETASK
+#if NETFRAMEWORK
 		[Fact]
-		public async ValueTask UnmatchedTypesWithIdenticalNamesShowAssemblies()
+		public async Task UnmatchedTypesWithIdenticalNamesShowAssemblies()
 		{
 			var dynamicAssembly = await CSharpDynamicAssembly.Create("namespace System.Xml { public class XmlException: Exception { } }");
 			var assembly = Assembly.LoadFile(dynamicAssembly.FileName);
@@ -407,6 +411,7 @@ public class TypeAssertsTests
 		}
 	}
 
+#pragma warning disable xUnit2007 // Do not use typeof expression to check the type
 	public class IsType_NonGeneric : TypeAssertsTests
 	{
 		[Fact]
@@ -431,9 +436,9 @@ public class TypeAssertsTests
 			);
 		}
 
-#if NETFRAMEWORK && XUNIT_VALUETASK
+#if NETFRAMEWORK
 		[Fact]
-		public async ValueTask UnmatchedTypesWithIdenticalNamesShowAssemblies()
+		public async Task UnmatchedTypesWithIdenticalNamesShowAssemblies()
 		{
 			var dynamicAssembly = await CSharpDynamicAssembly.Create("namespace System.Xml { public class XmlException: Exception { } }");
 			var assembly = Assembly.LoadFile(dynamicAssembly.FileName);
@@ -467,6 +472,7 @@ public class TypeAssertsTests
 			);
 		}
 	}
+#pragma warning restore xUnit2007 // Do not use typeof expression to check the type
 
 	class DisposableClass : IDisposable
 	{
@@ -474,7 +480,7 @@ public class TypeAssertsTests
 		{ }
 	}
 
-#if NETFRAMEWORK && XUNIT_VALUETASK
+#if NETFRAMEWORK
 	class CSharpDynamicAssembly : CSharpAcceptanceTestAssembly
 	{
 		public CSharpDynamicAssembly() :
@@ -484,10 +490,10 @@ public class TypeAssertsTests
 		protected override IEnumerable<string> GetStandardReferences() =>
 			new[] { "mscorlib.dll" };
 
-		public static async ValueTask<CSharpDynamicAssembly> Create(string code)
+		public static async Task<CSharpDynamicAssembly> Create(string code)
 		{
 			var assembly = new CSharpDynamicAssembly();
-			await assembly.Compile(new[] { code }, Array.Empty<string>());
+			await assembly.Compile(new[] { code });
 			return assembly;
 		}
 	}

--- a/src/Microsoft.DotNet.XUnitConsoleRunner/src/ConsoleRunner.cs
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/src/ConsoleRunner.cs
@@ -388,7 +388,7 @@ namespace Xunit.ConsoleClient
 
                         reporterMessageHandler.OnMessage(new TestAssemblyExecutionStarting(assembly, executionOptions));
 
-#pragma warning disable CS0618 // Delegating*Sink types are marked obsolete, but we can't move to ExecutionSink yet
+#pragma warning disable CS0618 // Delegating*Sink types are marked obsolete, but we can't move to ExecutionSink yet: https://github.com/dotnet/arcade/issues/14375
                         IExecutionSink resultsSink = new DelegatingExecutionSummarySink(reporterMessageHandler, () => cancel, (path, summary) => completionMessages.TryAdd(path, summary));
                         if (assemblyElement != null)
                             resultsSink = new DelegatingXmlCreationSink(resultsSink, assemblyElement);

--- a/src/Microsoft.DotNet.XUnitConsoleRunner/src/ConsoleRunner.cs
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/src/ConsoleRunner.cs
@@ -178,7 +178,7 @@ namespace Xunit.ConsoleClient
         {
             var platform = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
 
-            Console.WriteLine($"Microsoft.DotNet.XUnitConsoleRunner v2.5.0 ({IntPtr.Size * 8}-bit {platform})");
+            Console.WriteLine($"Microsoft.DotNet.XUnitConsoleRunner v{typeof(ConsoleRunner).Assembly.GetName().Version} ({IntPtr.Size * 8}-bit {platform})");
         }
 
         void PrintUsage(IReadOnlyList<IRunnerReporter> reporters)
@@ -388,6 +388,7 @@ namespace Xunit.ConsoleClient
 
                         reporterMessageHandler.OnMessage(new TestAssemblyExecutionStarting(assembly, executionOptions));
 
+#pragma warning disable CS0618 // Delegating*Sink types are marked obsolete, but we can't move to ExecutionSink yet
                         IExecutionSink resultsSink = new DelegatingExecutionSummarySink(reporterMessageHandler, () => cancel, (path, summary) => completionMessages.TryAdd(path, summary));
                         if (assemblyElement != null)
                             resultsSink = new DelegatingXmlCreationSink(resultsSink, assemblyElement);
@@ -395,6 +396,7 @@ namespace Xunit.ConsoleClient
                             resultsSink = new DelegatingLongRunningTestDetectionSink(resultsSink, TimeSpan.FromSeconds(longRunningSeconds), MessageSinkWithTypesAdapter.Wrap(diagnosticMessageSink));
                         if (failSkips)
                             resultsSink = new DelegatingFailSkipSink(resultsSink);
+#pragma warning restore
 
                         controller.RunTests(filteredTestCases, resultsSink, executionOptions);
                         resultsSink.Finished.WaitOne();

--- a/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
@@ -34,13 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Reference xunit.runner.reporters directly via PackageDownload+Reference to avoid its netstandard1.x dependencies. -->
-    <PackageDownload Include="xunit.runner.reporters" Version="[$(XUnitVersion)]" />
-    <Reference Include="$(NuGetPackageRoot)xunit.runner.reporters\$(XUnitVersion)\lib\netcoreapp1.0\xunit.runner.reporters.netcoreapp10.dll" />
-
-    <!-- Reference xunit.runner.utility directly via PackageDownload+Reference to avoid its netstandard1.x dependencies. -->
-    <PackageDownload Include="xunit.runner.utility" Version="[$(XUnitVersion)]" />
-    <Reference Include="$(NuGetPackageRoot)xunit.runner.utility\$(XUnitVersion)\lib\netcoreapp1.0\xunit.runner.utility.netcoreapp10.dll" />
+    <PackageReference Include="xunit.runner.reporters" />
   </ItemGroup>
 
   <!-- Publish publish build assets and include them in the package under the tools directory. -->


### PR DESCRIPTION
Needed to essentially revert https://github.com/xunit/assert.xunit/commit/455865ac846c0812e80ffb1c4a46b9d5d35ff828 to make it AOT compatible.