### PR TITLE
Stop upgrading .NETStandard to 2.0.3 globally

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,15 +3,4 @@
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
   <Import Project="$(RepositoryEngineeringDir)Microsoft.DotNet.XliffTasks.InTree.targets" Condition="'$(UsingInTreeToolXliff)' == 'true'" />
 
-  <ItemGroup>
-    <!-- Upgrade xunit's transitive NETStandard.Library dependency to avoid .NET Standard 1.x dependencies. -->
-    <PackageReference Include="NETStandard.Library"
-                      IsImplicitlyDefined="false"
-                      PrivateAssets="all"
-                      ExcludeAssets="runtime"
-                      VersionOverride="2.0.3"
-                      Condition="'$(TargetFrameworkIdentifier)' != '.NETStandard' and
-                                 '$(SkipNETStandardLibraryPackageAutoInclude)' != 'true'" />
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj
@@ -19,6 +19,15 @@
     <ProjectReference Include="..\Microsoft.DotNet.VersionTools\lib\Microsoft.DotNet.VersionTools.csproj" />
   </ItemGroup>
 
+  <!-- Upgrade SymbolUploader's transitive NETStandard.Library dependency to avoid .NET Standard 1.x dependencies. -->
+  <ItemGroup>
+    <PackageReference Include="NETStandard.Library"
+                      IsImplicitlyDefined="false"
+                      PrivateAssets="all"
+                      ExcludeAssets="runtime"
+                      VersionOverride="2.0.3" />
+  </ItemGroup>
+
   <ItemGroup>
     <Content Include="TestInputs\**"
              CopyToOutputDirectory="Always" />

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -18,6 +18,15 @@
     <PackageReference Include="Microsoft.SymbolUploader" />
   </ItemGroup>
 
+  <!-- Upgrade SymbolUploader's transitive NETStandard.Library dependency to avoid .NET Standard 1.x dependencies. -->
+  <ItemGroup>
+    <PackageReference Include="NETStandard.Library"
+                      IsImplicitlyDefined="false"
+                      PrivateAssets="all"
+                      ExcludeAssets="runtime"
+                      VersionOverride="2.0.3" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <!-- Maestro.Client stopped supporting .NET 4.7.2 long ago.
          This functionality should eventually be moved into an arcade-services package,

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="..\Directory.Build.props" />
-
-  <PropertyGroup>
-    <SkipNETStandardLibraryPackageAutoInclude>true</SkipNETStandardLibraryPackageAutoInclude>
-  </PropertyGroup>
-
-</Project>


### PR DESCRIPTION
Now that xunit 2.6.6 doesn't bring .NET Standard 1.x in anymore, don't globally update NETStandard.Library to 2.0.3. Instead just define it in the two projects that need it: Microsoft.DotNet.Build.Tasks.Feed.

That project references SymbolUploader which still brings old dependencies including .NET Standard 1.x.