### PR TITLE
Correct condition for running the publish step in source-only builds

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -305,12 +305,20 @@
              Condition="'$(ArcadeBuildFromSource)' == 'true' or '$(ArcadeBuildVertical)' == 'true' or '$(DotNetBuildRepo)' == 'true'"/>
 
     <!--
-      Publish artifacts.
+      Publish artifacts. This should run in the following situations:
+      - Regular single repo builds
+      - When running a the outer build phase of a source-only repo build, to properly publish the source-build intermediate nupkg.
+
+      It shouldn't run:
+      - In any inner build
+      - In an outer build if running from the full product build.
     -->
     <MSBuild Projects="Publish.proj"
              Properties="@(_PublishProps);_NETCORE_ENGINEERING_TELEMETRY=Publish"
              Targets="Publish"
-             Condition="'$(Publish)' == 'true' and '$(DotNetBuildFromSource)' != 'true' and '$(DotNetBuildVertical)' != 'true'"/>
+             Condition="'$(Publish)' == 'true' and
+                        ('$(ArcadeInnerBuildFromSource)' != 'true' and  '$(DotNetBuildFromSourceFlavor)' != 'Product') and 
+                        ('$(DotNetBuildPhase)' != 'Inner' and '$(DotNetBuildOrchestrator)' != 'true')"/>
   </Target>
 
 </Project>


### PR DESCRIPTION
I long wondered why DotNetBuildFromSource is passed at the top level of the orchestrator, but not in the repo legs. It appears that this is a way to avoid running the publish step in source-only builds, but continue running it in repo legs, where we want to use it to gather up the intermediate nupkgs.

This condition should have the same effect, but allow us to remove setting the top level DotNetBuildFromSource environment variables, or at least get closer.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
