### PR TITLE
Fix source-only conditionals

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -59,7 +59,7 @@
   <!--
     Disable features when building from source.
   -->
-  <PropertyGroup Condition="'$(ArcadeBuildFromSource)' == 'true' or '$(DotNetBuildRepo)' == 'true'">
+  <PropertyGroup Condition="'$(ArcadeBuildFromSource)' == 'true' or '$(DotNetBuildSourceOnly)' == 'true'">
     <UsingToolPdbConverter>false</UsingToolPdbConverter>
     <UsingToolVSSDK>false</UsingToolVSSDK>
     <UsingToolIbcOptimization>false</UsingToolIbcOptimization>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
@@ -75,7 +75,7 @@
       OutputReportFile="$(SourceBuildSelfPrebuiltReportDir)baseline-comparison.xml"
       ContinueOnError="$(ContinueOnPrebuiltBaselineError)"
       Condition="'$(DotNetBuildFromSourceFlavor)' != 'Product' and 
-        ('$(ArcadeBuildFromSource)' == 'true' or '$(DotNetBuildFromSourceOnly)' == 'true')" />
+        ('$(ArcadeBuildFromSource)' == 'true' or '$(DotNetBuildSourceOnly)' == 'true')" />
   </Target>
 
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
@@ -22,7 +22,7 @@
             '$(DotNetBuildFromSourceFlavor)' != 'Product' and
             ('$(SetUpSourceBuildIntermediateNupkgCache)' == 'true' or
             ('$(ArcadeBuildFromSource)' == 'true' and '$(ArcadeInnerBuildFromSource)' == 'true') or
-            ('$(DotNetBuildPhase)' == 'InnerRepo' and '$(DotNetBuildFromSourceOnly)' == 'true'))"
+            ('$(DotNetBuildPhase)' == 'InnerRepo' and '$(DotNetBuildSourceOnly)' == 'true'))"
           DependsOnTargets="GetSourceBuildIntermediateNupkgNameConvention"
           BeforeTargets="CollectPackageReferences">
     <ReadSourceBuildIntermediateNupkgDependencies
@@ -49,7 +49,7 @@
             ('$(SetUpSourceBuildIntermediateNupkgCache)' == 'true' or
               ('@(SourceBuildIntermediateNupkgReference)' != '' and
                 (('$(ArcadeBuildFromSource)' == 'true' and '$(ArcadeInnerBuildFromSource)' == 'true') or
-                 ('$(DotNetBuildPhase)' == 'InnerRepo' and '$(DotNetBuildFromSourceOnly)' == 'true'))))"
+                 ('$(DotNetBuildPhase)' == 'InnerRepo' and '$(DotNetBuildSourceOnly)' == 'true'))))"
           AfterTargets="Restore">
     <ItemGroup>
       <IntermediateNupkgSourceDir Include="$([MSBuild]::NormalizeDirectory(


### PR DESCRIPTION
- When introducing the repo control, in DefaultVersions.props we should have been using the SourceOnly conditional.
- Fix the name of the property elsewhere to match the spec.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
