### PR TITLE
Flow live versions of runtime dependencies

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -86,12 +86,6 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>2874d26cb343fc55be295a628b3ee474e19ff95e</Sha>
     </Dependency>
-    <!-- Necessary for source-build. This allows the live version of the dependency to be used by source-build
-         and eliminates related prebuilts. -->
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="9.0.0-alpha.1.24059.2">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2874d26cb343fc55be295a628b3ee474e19ff95e</Sha>
-    </Dependency>
     <!-- Latest preview version required by source-build. The dependency is loaded in during built-time
          by consumers of SharedFramework.Sdk (such as runtime), so we cannot use a ref pack for it -->
     <Dependency Name="Microsoft.Extensions.DependencyModel" Version="9.0.0-alpha.1.24059.2">
@@ -104,6 +98,12 @@
       <Sha>2874d26cb343fc55be295a628b3ee474e19ff95e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.FileSystemGlobbing" Version="9.0.0-alpha.1.24059.2">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>2874d26cb343fc55be295a628b3ee474e19ff95e</Sha>
+    </Dependency>
+    <!-- Necessary for source-build. This allows the live version of the dependency to be used by source-build
+         and eliminates related prebuilts. -->
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="9.0.0-alpha.1.24059.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>2874d26cb343fc55be295a628b3ee474e19ff95e</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -74,6 +74,24 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>2874d26cb343fc55be295a628b3ee474e19ff95e</Sha>
     </Dependency>
+    <!-- Necessary for source-build. This allows the live version of the dependency to be used by source-build
+         and eliminates related prebuilts. -->
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0-alpha.1.24059.2">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>2874d26cb343fc55be295a628b3ee474e19ff95e</Sha>
+    </Dependency>
+    <!-- Necessary for source-build. This allows the live version of the dependency to be used by source-build
+         and eliminates related prebuilts. -->
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="9.0.0-alpha.1.24059.2">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>2874d26cb343fc55be295a628b3ee474e19ff95e</Sha>
+    </Dependency>
+    <!-- Necessary for source-build. This allows the live version of the dependency to be used by source-build
+         and eliminates related prebuilts. -->
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="9.0.0-alpha.1.24059.2">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>2874d26cb343fc55be295a628b3ee474e19ff95e</Sha>
+    </Dependency>
     <!-- Latest preview version required by source-build. The dependency is loaded in during built-time
          by consumers of SharedFramework.Sdk (such as runtime), so we cannot use a ref pack for it -->
     <Dependency Name="Microsoft.Extensions.DependencyModel" Version="9.0.0-alpha.1.24059.2">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -64,7 +64,7 @@
       <Uri>https://github.com/dotnet/symreader-converter</Uri>
       <Sha>c5ba7c88f92e2dde156c324a8c8edc04d9fa4fe0</Sha>
     </Dependency>
-    <!-- Latest preview version required by source-build. The dependency is loaded in during built-time
+    <!-- Necessary for source-build. The dependency is loaded in during built-time
          by consumers of NuGetRepack.Tasks, so we cannot use a ref pack for it -->
     <Dependency Name="System.IO.Packaging" Version="9.0.0-alpha.1.24059.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
@@ -74,19 +74,19 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>2874d26cb343fc55be295a628b3ee474e19ff95e</Sha>
     </Dependency>
-    <!-- Necessary for source-build. This allows the live version of the dependency to be used by source-build
-         and eliminates related prebuilts. -->
+    <!-- Necessary for source-build. This allows the live version of the dependency
+         to flow in and eliminates related prebuilts. -->
     <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0-alpha.1.24059.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>2874d26cb343fc55be295a628b3ee474e19ff95e</Sha>
     </Dependency>
-    <!-- Necessary for source-build. This allows the live version of the dependency to be used by source-build
-         and eliminates related prebuilts. -->
+    <!-- Necessary for source-build. This allows the live version of the dependency
+         to flow in and eliminates related prebuilts. -->
     <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="9.0.0-alpha.1.24059.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>2874d26cb343fc55be295a628b3ee474e19ff95e</Sha>
     </Dependency>
-    <!-- Latest preview version required by source-build. The dependency is loaded in during built-time
+    <!-- Necessary for source-build. The dependency is loaded in during built-time
          by consumers of SharedFramework.Sdk (such as runtime), so we cannot use a ref pack for it -->
     <Dependency Name="Microsoft.Extensions.DependencyModel" Version="9.0.0-alpha.1.24059.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
@@ -101,8 +101,8 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>2874d26cb343fc55be295a628b3ee474e19ff95e</Sha>
     </Dependency>
-    <!-- Necessary for source-build. This allows the live version of the dependency to be used by source-build
-         and eliminates related prebuilts. -->
+    <!-- Necessary for source-build. This allows the live version of the dependency
+         to flow in and eliminates related prebuilts. -->
     <Dependency Name="Microsoft.Extensions.Logging.Console" Version="9.0.0-alpha.1.24059.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>2874d26cb343fc55be295a628b3ee474e19ff95e</Sha>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/3985

The VMR currently expects 9.0.0-alpha.1.24059.2 versions of Microsoft.Extensions.DependencyInjection.Abstractions, Microsoft.Extensions.DependencyInjection, and Microsoft.Extensions.Logging.Console when building offline, but the bootstrapped VMR has built 9.0.0-alpha.1.24061.26 versions of these dependencies from runtime. This means that these three dependencies are introducing prebuilts in current builds of the VMR.

These changes ensure that the VMR pulls the live versions of these dependencies instead and eliminates any related prebuilts.

[Example build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2357146&view=logs&s=f34d2453-27de-5761-b405-af338b8c11cc&j=d5cf1590-3c3d-53c9-4b7e-21ce150d85a0) (internal)