### PR TITLE
Port 'Add Microsoft.DotNet.XliffTasks into arcade #14158' to release/8.0

### DIFF
--- a/Arcade.sln
+++ b/Arcade.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29019.234
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34212.112
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Build.Tasks.Feed", "src\Microsoft.DotNet.Build.Tasks.Feed\Microsoft.DotNet.Build.Tasks.Feed.csproj", "{941D335B-AA65-4089-9502-F306B108D182}"
 EndProject
@@ -154,6 +154,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.VersionTools.Cli.Tests", "src\Microsoft.DotNet.VersionTools\tools\Microsoft.DotNet.VersionTools.Cli.Tests\Microsoft.DotNet.VersionTools.Cli.Tests.csproj", "{650B7526-7B8A-45B5-B14E-C16D828891B2}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Tar", "src\Microsoft.DotNet.Tar\Microsoft.DotNet.Tar.csproj", "{B7489F31-1C2D-4FD9-BB42-6F8EF1340BAC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.XliffTasks", "src\Microsoft.DotNet.XliffTasks\Microsoft.DotNet.XliffTasks.csproj", "{19A9472B-3984-4FF1-B0BF-28A50E69A240}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.XliffTasks.Tests", "src\Microsoft.DotNet.XliffTasks.Tests\Microsoft.DotNet.XliffTasks.Tests.csproj", "{6BA81447-C61D-4F91-BF0F-5B17AF4CFFAC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -965,6 +969,30 @@ Global
 		{B7489F31-1C2D-4FD9-BB42-6F8EF1340BAC}.Release|x64.Build.0 = Release|Any CPU
 		{B7489F31-1C2D-4FD9-BB42-6F8EF1340BAC}.Release|x86.ActiveCfg = Release|Any CPU
 		{B7489F31-1C2D-4FD9-BB42-6F8EF1340BAC}.Release|x86.Build.0 = Release|Any CPU
+		{19A9472B-3984-4FF1-B0BF-28A50E69A240}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{19A9472B-3984-4FF1-B0BF-28A50E69A240}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{19A9472B-3984-4FF1-B0BF-28A50E69A240}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{19A9472B-3984-4FF1-B0BF-28A50E69A240}.Debug|x64.Build.0 = Debug|Any CPU
+		{19A9472B-3984-4FF1-B0BF-28A50E69A240}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{19A9472B-3984-4FF1-B0BF-28A50E69A240}.Debug|x86.Build.0 = Debug|Any CPU
+		{19A9472B-3984-4FF1-B0BF-28A50E69A240}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{19A9472B-3984-4FF1-B0BF-28A50E69A240}.Release|Any CPU.Build.0 = Release|Any CPU
+		{19A9472B-3984-4FF1-B0BF-28A50E69A240}.Release|x64.ActiveCfg = Release|Any CPU
+		{19A9472B-3984-4FF1-B0BF-28A50E69A240}.Release|x64.Build.0 = Release|Any CPU
+		{19A9472B-3984-4FF1-B0BF-28A50E69A240}.Release|x86.ActiveCfg = Release|Any CPU
+		{19A9472B-3984-4FF1-B0BF-28A50E69A240}.Release|x86.Build.0 = Release|Any CPU
+		{6BA81447-C61D-4F91-BF0F-5B17AF4CFFAC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6BA81447-C61D-4F91-BF0F-5B17AF4CFFAC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6BA81447-C61D-4F91-BF0F-5B17AF4CFFAC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6BA81447-C61D-4F91-BF0F-5B17AF4CFFAC}.Debug|x64.Build.0 = Debug|Any CPU
+		{6BA81447-C61D-4F91-BF0F-5B17AF4CFFAC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6BA81447-C61D-4F91-BF0F-5B17AF4CFFAC}.Debug|x86.Build.0 = Debug|Any CPU
+		{6BA81447-C61D-4F91-BF0F-5B17AF4CFFAC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6BA81447-C61D-4F91-BF0F-5B17AF4CFFAC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6BA81447-C61D-4F91-BF0F-5B17AF4CFFAC}.Release|x64.ActiveCfg = Release|Any CPU
+		{6BA81447-C61D-4F91-BF0F-5B17AF4CFFAC}.Release|x64.Build.0 = Release|Any CPU
+		{6BA81447-C61D-4F91-BF0F-5B17AF4CFFAC}.Release|x86.ActiveCfg = Release|Any CPU
+		{6BA81447-C61D-4F91-BF0F-5B17AF4CFFAC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1007,6 +1035,7 @@ Global
 		{AB8D5F86-60FA-416A-B047-83B1E9118425} = {3C542789-2576-48C8-9772-C9D7575F7E42}
 		{14462553-E4E1-4F67-B954-4BF24B1DAAFE} = {3C542789-2576-48C8-9772-C9D7575F7E42}
 		{650B7526-7B8A-45B5-B14E-C16D828891B2} = {C53DD924-C212-49EA-9BC4-1827421361EF}
+		{6BA81447-C61D-4F91-BF0F-5B17AF4CFFAC} = {C53DD924-C212-49EA-9BC4-1827421361EF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {32B9C883-432E-4FC8-A1BF-090EB033DD5B}

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,7 @@
 <Project>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+  <Import Project="$(RepositoryEngineeringDir)Microsoft.DotNet.XliffTasks.InTree.targets" Condition="'$(UsingInTreeToolXliff)' == 'true'" />
 
   <ItemGroup>
     <!-- Upgrade the NETStandard.Library transitive dependency to avoid transitive 1.x NS dependencies. -->

--- a/Documentation/V3StatusUpdate.md
+++ b/Documentation/V3StatusUpdate.md
@@ -31,7 +31,6 @@ This table represents the status of the .NET 5 V3 publishing status on a Per-Rep
 | sourcelink          | tmat         | ❌     |                                      |
 | clrmd               | leculver     | ❌     |                                      |
 | msbuild             | marcpopMSFT  | ❌     |                                      |
-| xliff-tasks         | epananth     | ❌     |                                      |
 | roslyn-analyzer     | epananth     | ✔️     |                                      |
 | Nuget.Client        | epananth     | ❌     |                                      |
 | mono/linker         | masafa       | ❌     |                                      |

--- a/eng/Microsoft.DotNet.XliffTasks.InTree.targets
+++ b/eng/Microsoft.DotNet.XliffTasks.InTree.targets
@@ -1,0 +1,29 @@
+<Project>
+
+  <PropertyGroup>
+    <XliffTasksProjectDirectory>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'src', 'Microsoft.DotNet.XliffTasks'))</XliffTasksProjectDirectory>
+    <XliffTasksBaseOutputDirectory>$(ArtifactsBinDir)Microsoft.DotNet.XliffTasks\$(Configuration)\</XliffTasksBaseOutputDirectory>
+    <!-- Keep TFMs in sync with Microsoft.DotNet.XliffTasks.csproj -->
+    <XliffTasksDirectory Condition="'$(MSBuildRuntimeType)' == 'Core'">$(XliffTasksBaseOutputDirectory)$(NetCurrent)\</XliffTasksDirectory>
+    <XliffTasksDirectory Condition="'$(MSBuildRuntimeType)' != 'Core'">$(XliffTasksBaseOutputDirectory)$(NetFrameworkToolCurrent)\</XliffTasksDirectory>
+  </PropertyGroup>
+
+  <!-- Props and targets files get automatically imported when referencing XliffTasks via a PackageReference,
+       but that's not the case when using ProjectReference: https://github.com/NuGet/Home/issues/6624.
+       Props files should ideally be imported from the project file or other props files but it doesn't matter in this case. -->
+  <Import Project="$(XliffTasksProjectDirectory)build\Microsoft.DotNet.XliffTasks.props" />
+  <Import Project="$(XliffTasksProjectDirectory)build\Microsoft.DotNet.XliffTasks.targets" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
+  <Import Project="$(XliffTasksProjectDirectory)buildCrossTargeting\Microsoft.DotNet.XliffTasks.targets" Condition="'$(IsCrossTargetingBuild)' == 'true'" />
+
+  <ItemGroup>
+    <ProjectReference Include="$(XliffTasksProjectDirectory)Microsoft.DotNet.XliffTasks.csproj"
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="all"
+                      Private="false">
+      <!-- Keep TFMs in sync with Microsoft.DotNet.XliffTasks.csproj -->
+      <SetTargetFramework Condition="'$(MSBuildRuntimeType)' == 'Core'">TargetFramework=$(NetCurrent)</SetTargetFramework>
+      <SetTargetFramework Condition="'$(MSBuildRuntimeType)' != 'Core'">TargetFramework=$(NetFrameworkToolCurrent)</SetTargetFramework>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/global.json
+++ b/global.json
@@ -1,4 +1,9 @@
 {
+  "sdk": {
+    "version": "8.0.100",
+    "allowPrerelease": false,
+    "rollForward": "disable"
+  },
   "tools": {
     "dotnet": "8.0.101"
   },

--- a/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
@@ -70,7 +70,7 @@
     <MicrosoftNetCompilersToolsetVersion>$(MicrosoftNetCompilersToolsetVersion)</MicrosoftNetCompilersToolsetVersion>
     <MicrosoftNetILLinkTasksVersion>$(MicrosoftNetILLinkTasksVersion)</MicrosoftNetILLinkTasksVersion>
     <MicrosoftDiaSymReaderPdb2PdbVersion>$(MicrosoftDiaSymReaderPdb2PdbVersion)</MicrosoftDiaSymReaderPdb2PdbVersion>
-    <MicrosoftDotNetXliffTasksVersion>$(MicrosoftDotNetXliffTasksVersion)</MicrosoftDotNetXliffTasksVersion>
+    <MicrosoftDotNetXliffTasksVersion>$(PackageVersion)</MicrosoftDotNetXliffTasksVersion>
     <MicrosoftDotNetMaestroTasksVersion>$(MicrosoftDotNetMaestroTasksVersion)</MicrosoftDotNetMaestroTasksVersion>
     <MicrosoftSymbolUploaderBuildTaskVersion>$(MicrosoftSymbolUploaderBuildTaskVersion)</MicrosoftSymbolUploaderBuildTaskVersion>
     <MicrosoftTemplateEngineAuthoringTasksVersion>$(MicrosoftTemplateEngineAuthoringTasksVersion)</MicrosoftTemplateEngineAuthoringTasksVersion>

--- a/src/Microsoft.DotNet.AsmDiff/Microsoft.DotNet.AsmDiff.csproj
+++ b/src/Microsoft.DotNet.AsmDiff/Microsoft.DotNet.AsmDiff.csproj
@@ -10,6 +10,8 @@
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <UsingToolXliff>true</UsingToolXliff>
+    <!-- Use xliff localization. -->
+    <UsingInTreeToolXliff>true</UsingInTreeToolXliff>
   </PropertyGroup>
   
   <ItemGroup>
@@ -26,9 +28,6 @@
   
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="$(McMasterExtensionsCommandLineUtils)" />
-    <!-- Arcade only makes shipping assemblies localizable by default, we'd like to localize this tool without treating it as "shipping". -->
-    <PackageReference Include="Microsoft.DotNet.XliffTasks" Version="$(MicrosoftDotNetXliffTasksVersion)" PrivateAssets="all" />
-
     <!-- Manually reference Microsoft.Cci.dll via a PackageDownload+Reference item instead of
          using a PackageReference to avoid bringing in the old dependency graph. -->
     <PackageDownload Include="Microsoft.Cci" Version="[$(MicrosoftCciVersion)]" />

--- a/src/Microsoft.DotNet.XliffTasks.Tests/AssertHelper.cs
+++ b/src/Microsoft.DotNet.XliffTasks.Tests/AssertHelper.cs
@@ -1,0 +1,14 @@
+﻿using Xunit;
+
+namespace XliffTasks.Tests
+{
+    static class AssertEx
+    {
+        public static void EqualIgnoringLineEndings(string expected, string actual)
+        {
+            Assert.Equal(
+                expected.Replace("\r", string.Empty),
+                actual.Replace("\r", string.Empty));
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks.Tests/Microsoft.DotNet.XliffTasks.Tests.csproj
+++ b/src/Microsoft.DotNet.XliffTasks.Tests/Microsoft.DotNet.XliffTasks.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
+    <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.DotNet.XliffTasks\Microsoft.DotNet.XliffTasks.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.DotNet.XliffTasks.Tests/ResxDocumentTests.cs
+++ b/src/Microsoft.DotNet.XliffTasks.Tests/ResxDocumentTests.cs
@@ -1,0 +1,84 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+using XliffTasks.Model;
+using Xunit;
+
+namespace XliffTasks.Tests
+{
+    public class ResxTranslationTests
+    {
+        [Fact]
+        public void BasicLoadAndTranslate()
+        {
+            string source =
+@"<root>
+  <data name=""Hello"" xml:space=""preserve"">
+    <value>Hello!</value>
+  </data>
+  <data name=""Goodbye"" xml:space=""preserve"">
+    <value>Goodbye!</value>
+  </data>
+</root>";
+
+            Dictionary<string, string> translations = new()
+            {
+                ["Hello"] = "Bonjour!",
+                ["Goodbye"] = "Au revoir!",
+            };
+
+            string expectedTranslation =
+@"<root>
+  <data name=""Hello"" xml:space=""preserve"">
+    <value>Bonjour!</value>
+  </data>
+  <data name=""Goodbye"" xml:space=""preserve"">
+    <value>Au revoir!</value>
+  </data>
+</root>";
+
+            ResxDocument document = new();
+            StringWriter writer = new();
+            document.Load(new StringReader(source));
+            document.Translate(translations);
+            document.Save(writer);
+
+            AssertEx.EqualIgnoringLineEndings(expectedTranslation, writer.ToString());
+        }
+
+        [Fact]
+        public void RewriteFileReferenceToAbsoluteInDestinyFolder()
+        {
+            string sourceFolder = Directory.GetCurrentDirectory();
+            string expectedAbsoluteLocation = Path.Combine(
+              Directory.GetCurrentDirectory(),
+              @"Resources\Package.ico".Replace('\\', Path.DirectorySeparatorChar));
+            string source =
+@"<root>
+  <data name=""400"" type=""System.Resources.ResXFileRef, System.Windows.Forms"">
+    <value>Resources\Package.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+</root>";
+
+            string expectedTranslation =
+@"<root>
+  <data name=""400"" type=""System.Resources.ResXFileRef, System.Windows.Forms"">
+    <value>ABSOLUTEPATH;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+</root>".Replace("ABSOLUTEPATH", expectedAbsoluteLocation);
+
+            ResxDocument document = new();
+            StringWriter writer = new();
+            document.Load(new StringReader(source));
+            document.RewriteRelativePathsToAbsolute(
+                Path.Combine(sourceFolder, "Resources.resx"));
+            document.Save(writer);
+
+            AssertEx.EqualIgnoringLineEndings(expectedTranslation, writer.ToString());
+        }
+
+        
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks.Tests/StringExtensionsTests.cs
+++ b/src/Microsoft.DotNet.XliffTasks.Tests/StringExtensionsTests.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+
+namespace XliffTasks.Tests
+{
+    public class StringExtensionsTests
+    {
+        [Fact]
+        public void GetReplacementCount_NoPlaceholders()
+        {
+            string text = "Alpha";
+            int replacementCount = text.GetReplacementCount();
+
+            Assert.Equal(expected: 0, actual: replacementCount);
+        }
+
+        [Fact]
+        public void GetReplacementCount_OneSimplePlaceholder()
+        {
+            string text = "{0}";
+            int replacementCount = text.GetReplacementCount();
+
+            Assert.Equal(expected: 1, actual: replacementCount);
+        }
+
+        [Fact]
+        public void GetReplacementCount_PlaceholderWithAlignment()
+        {
+            string text = "{0,-3}";
+            int replacementCount = text.GetReplacementCount();
+
+            Assert.Equal(expected: 1, actual: replacementCount);
+        }
+
+        [Fact]
+        public void GetReplacementCount_PlaceholderWithFormatString()
+        {
+            string text = "{0:N}";
+            int replacementCount = text.GetReplacementCount();
+
+            Assert.Equal(expected: 1, actual: replacementCount);
+        }
+
+        [Fact]
+        public void GetReplacementCount_WithAlignmentAndFormatString()
+        {
+            string text = "{0,-10:G1}";
+            int replacementCount = text.GetReplacementCount();
+
+            Assert.Equal(expected: 1, actual: replacementCount);
+        }
+
+        [Fact]
+        public void GetReplacementCount_MultiplePlaceholders()
+        {
+            string text = "{0} {1}";
+            int replacementCount = text.GetReplacementCount();
+
+            Assert.Equal(expected: 2, actual: replacementCount);
+        }
+
+        [Fact]
+        public void GetReplacementCount_MultipleIdenticalPlaceholders()
+        {
+            string text = "{2} {2}";
+            int replacementCount = text.GetReplacementCount();
+
+            Assert.Equal(expected: 3, actual: replacementCount);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks.Tests/UnstructuredDocumentTests.cs
+++ b/src/Microsoft.DotNet.XliffTasks.Tests/UnstructuredDocumentTests.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+using XliffTasks.Model;
+using Xunit;
+
+namespace XliffTasks.Tests
+{
+    public class UnstructuredDocumentTests
+    {
+        [Fact]
+        public void BasicLoadAndTranslate()
+        {
+            string source =
+@"
+Say hello: @@@idhello|Hello@@@<end>
+Say goodbye: @@@idgoodbye|Goodbye@@@<end>
+";
+
+            Dictionary<string, string> translations = new()
+            {
+                ["idhello"] = "Bonjour!",
+                ["idgoodbye"] = "Au revoir!",
+            };
+
+            string expectedTranslation =
+@"
+Say hello: Bonjour!<end>
+Say goodbye: Au revoir!<end>
+";
+
+            UnstructuredDocument document = new();
+            StringWriter writer = new();
+            document.Load(new StringReader(source));
+            document.Translate(translations);
+            document.Save(writer);
+
+            AssertEx.EqualIgnoringLineEndings(expectedTranslation, writer.ToString());
+        }
+
+        [Fact]
+        public void SourceEndsWithTranslatableSpan()
+        {
+            string source = "@@@idhello|Hello@@@";
+
+            Dictionary<string, string> translations = new()
+            {
+                ["idhello"] = "Bonjour!",
+            };
+
+            string expectedTranslation = "Bonjour!";
+
+            UnstructuredDocument document = new();
+            StringWriter writer = new();
+            document.Load(new StringReader(source));
+            document.Translate(translations);
+            document.Save(writer);
+
+            AssertEx.EqualIgnoringLineEndings(expectedTranslation, writer.ToString());
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks.Tests/VsctDocumentTests.cs
+++ b/src/Microsoft.DotNet.XliffTasks.Tests/VsctDocumentTests.cs
@@ -1,0 +1,199 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+using XliffTasks.Model;
+using Xunit;
+
+namespace XliffTasks.Tests
+{
+    public class VsctTranslationTests
+    {
+        [Fact]
+        public void BasicLoadAndTranslate()
+        {
+            string source =
+@"<CommandTable xmlns=""http://schemas.microsoft.com/VisualStudio/2005-10-18/CommandTable"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"">
+  <Commands package=""guidTestPackage"">
+    <Menus>
+      <Menu id=""menuidOne"">
+        <Strings>
+          <MenuText>Some menu text</MenuText>
+          <ButtonText>Some button text</ButtonText>
+        </Strings>
+      </Menu>
+      <Menu id=""menuidTwo"">
+        <Strings>
+          <MenuText>More menu text</MenuText>
+          <ButtonText>More button text</ButtonText>
+        </Strings>
+      </Menu>
+    </Menus>
+  </Commands>
+</CommandTable>";
+
+            Dictionary<string, string> translations = new()
+            {
+                ["menuidOne|MenuText"] = "Texte de menu",
+                ["menuidOne|ButtonText"] = "Texte de button",
+                ["menuidTwo|MenuText"] = "Plus de texte de menu",
+                ["menuidTwo|ButtonText"] = "Plus de texte de button",
+            };
+
+            string expectedTranslation =
+@"<CommandTable xmlns=""http://schemas.microsoft.com/VisualStudio/2005-10-18/CommandTable"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"">
+  <Commands package=""guidTestPackage"">
+    <Menus>
+      <Menu id=""menuidOne"">
+        <Strings>
+          <MenuText>Texte de menu</MenuText>
+          <ButtonText>Texte de button</ButtonText>
+        </Strings>
+      </Menu>
+      <Menu id=""menuidTwo"">
+        <Strings>
+          <MenuText>Plus de texte de menu</MenuText>
+          <ButtonText>Plus de texte de button</ButtonText>
+        </Strings>
+      </Menu>
+    </Menus>
+  </Commands>
+</CommandTable>";
+
+            VsctDocument document = new();
+            StringWriter writer = new();
+            document.Load(new StringReader(source));
+            document.Translate(translations);
+            document.Save(writer);
+
+            AssertEx.EqualIgnoringLineEndings(expectedTranslation, writer.ToString());
+        }
+
+        [Fact]
+        public void RewriteHrefOfImageToAbsoluteInDestinyFolder()
+        {
+            string sourceFolder = Directory.GetCurrentDirectory();
+            string expectedAbsoluteLocation = Path.Combine(
+              Directory.GetCurrentDirectory(), 
+              @"Resources\Images.png".Replace('\\', Path.DirectorySeparatorChar));
+
+            string source =
+@"<CommandTable xmlns=""http://schemas.microsoft.com/VisualStudio/2005-10-18/CommandTable"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"">
+  <Bitmaps>
+    <Bitmap guid=""guidImages"" href=""Resources\Images.png"" usedList=""bmpPic1, bmpPic2, bmpPicSearch, bmpPicX, bmpPicArrows"" />
+  </Bitmaps>
+</CommandTable>";
+
+            string expectedTranslation =
+@"<CommandTable xmlns=""http://schemas.microsoft.com/VisualStudio/2005-10-18/CommandTable"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"">
+  <Bitmaps>
+    <Bitmap guid=""guidImages"" href=""ABSOLUTEPATH"" usedList=""bmpPic1, bmpPic2, bmpPicSearch, bmpPicX, bmpPicArrows"" />
+  </Bitmaps>
+</CommandTable>".Replace("ABSOLUTEPATH", expectedAbsoluteLocation);
+
+            VsctDocument document = new();
+            StringWriter writer = new();
+            document.Load(new StringReader(source));
+            document.RewriteRelativePathsToAbsolute(
+                        Path.Combine(sourceFolder, "Resources.resx"));
+            document.Save(writer);
+
+            AssertEx.EqualIgnoringLineEndings(expectedTranslation, writer.ToString());
+        }
+
+        [Fact]
+        public void DoesNotNullReferenceWhenNoHRef()
+        {
+            string source =
+@"<CommandTable xmlns=""http://schemas.microsoft.com/VisualStudio/2005-10-18/CommandTable"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"">
+  <Bitmaps>
+    <Bitmap guid=""guidImages"" usedList=""bmpPic1, bmpPic2, bmpPicSearch, bmpPicX, bmpPicArrows"" />
+  </Bitmaps>
+</CommandTable>";
+
+            VsctDocument document = new();
+            StringWriter writer = new();
+            document.Load(new StringReader(source));
+            document.RewriteRelativePathsToAbsolute(
+                        Path.Combine(Directory.GetCurrentDirectory(), "Resources.resx"));
+            document.Save(writer);
+
+            AssertEx.EqualIgnoringLineEndings(source, writer.ToString());
+        }
+
+        [Fact]
+        public void NonUniqueIds()
+        {
+            string source =
+@"<CommandTable xmlns=""http://schemas.microsoft.com/VisualStudio/2005-10-18/CommandTable"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"">
+  <Commands package=""guidTestPackage"">
+    <Menus>
+      <Menu guid=""firstGuid"" id=""menuid"">
+        <Strings>
+          <MenuText>Some menu text</MenuText>
+          <ButtonText>Some button text</ButtonText>
+        </Strings>
+      </Menu>
+      <Menu guid=""secondGuid"" id=""menuid"">
+        <Strings>
+          <MenuText>More menu text</MenuText>
+          <ButtonText>More button text</ButtonText>
+        </Strings>
+      </Menu>
+      <Menu guid=""thirdGuid"" id=""otherMenuId"">
+        <Strings>
+          <MenuText>Even more menu text</MenuText>
+          <ButtonText>Even more button text</ButtonText>
+        </Strings>
+      </Menu>
+    </Menus>
+  </Commands>
+</CommandTable>";
+
+            Dictionary<string, string> translations = new()
+            {
+                ["firstGuid|menuid|MenuText"] = "Texte du menu",
+                ["firstGuid|menuid|ButtonText"] = "Texte du bouton",
+                ["secondGuid|menuid|MenuText"] = "Plus de texte de menu",
+                ["secondGuid|menuid|ButtonText"] = "Plus de texte de bouton",
+                ["otherMenuId|MenuText"] = "Encore plus de texte de menu",
+                ["otherMenuId|ButtonText"] = "Encore plus de texte de bouton",
+            };
+
+            string expectedTranslation =
+@"<CommandTable xmlns=""http://schemas.microsoft.com/VisualStudio/2005-10-18/CommandTable"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"">
+  <Commands package=""guidTestPackage"">
+    <Menus>
+      <Menu guid=""firstGuid"" id=""menuid"">
+        <Strings>
+          <MenuText>Texte du menu</MenuText>
+          <ButtonText>Texte du bouton</ButtonText>
+        </Strings>
+      </Menu>
+      <Menu guid=""secondGuid"" id=""menuid"">
+        <Strings>
+          <MenuText>Plus de texte de menu</MenuText>
+          <ButtonText>Plus de texte de bouton</ButtonText>
+        </Strings>
+      </Menu>
+      <Menu guid=""thirdGuid"" id=""otherMenuId"">
+        <Strings>
+          <MenuText>Encore plus de texte de menu</MenuText>
+          <ButtonText>Encore plus de texte de bouton</ButtonText>
+        </Strings>
+      </Menu>
+    </Menus>
+  </Commands>
+</CommandTable>";
+
+            VsctDocument document = new();
+            StringWriter writer = new();
+            document.Load(new StringReader(source));
+            document.Translate(translations);
+            document.Save(writer);
+
+            AssertEx.EqualIgnoringLineEndings(expectedTranslation, writer.ToString());
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks.Tests/XElementExtensionsTests.cs
+++ b/src/Microsoft.DotNet.XliffTasks.Tests/XElementExtensionsTests.cs
@@ -1,0 +1,154 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Xml.Linq;
+using XliffTasks.Model;
+using Xunit;
+using static XliffTasks.Model.XlfNames;
+
+namespace XliffTasks.Tests
+{
+    public class XElementExtensionsTests
+    {
+        [Fact]
+        public void GetTargetValueOrDefault_ReturnsTargetWhenTargetIsPresent()
+        {
+            XElement transUnitElement =
+                new(TransUnit,
+                    new XElement(Source, "source text"),
+                    new XElement(Target, "target text"));
+
+            string targetValue = transUnitElement.GetTargetValue();
+
+            Assert.Equal(expected: "target text", actual: targetValue);
+        }
+
+        [Fact]
+        public void GetTargetValueOrDefault_ReturnsEmptyStringWhenTargetIsEmpty()
+        {
+            XElement transUnitElement =
+                new(TransUnit,
+                    new XElement(Source, "source text"),
+                    new XElement(Target, string.Empty));
+
+            string targetValue = transUnitElement.GetTargetValue();
+
+            Assert.Equal(expected: string.Empty, actual: targetValue);
+        }
+
+        [Fact]
+        public void GetTargetValueOrDefault_ReturnsSourceWhenTargetIsMissing()
+        {
+            XElement transUnitElement =
+                new(TransUnit,
+                    new XElement(Source, "source text"));
+
+            string targetValue = transUnitElement.GetTargetValue();
+
+            Assert.Equal(expected: "source text", actual: targetValue);
+        }
+
+        [Fact]
+        public void SetTargetValue_SetsValueIfTargetIsPresent()
+        {
+            XElement transUnitElement =
+                new(TransUnit,
+                    new XElement(Source, "source text"),
+                    new XElement(Target, "original target text"),
+                    new XElement(Note));
+
+            transUnitElement.SetTargetValue("new target text");
+
+            Assert.Equal(expected: "new target text", actual: transUnitElement.Element(Target).Value);
+        }
+
+        [Fact]
+        public void SetTargetValue_TargetIsCreatedIfNotPresent()
+        {
+            XElement transUnitElement =
+                new(TransUnit,
+                    new XElement(Source, "source text"),
+                    new XElement(Note));
+
+            transUnitElement.SetTargetValue("new target text");
+
+            Assert.Equal(expected: "new target text", actual: transUnitElement.Element(Target).Value);
+            Assert.Equal(expected: transUnitElement.Element(Source), actual: transUnitElement.Element(Target).PreviousNode);
+        }
+
+        [Fact]
+        public void GetTargetState_ReturnsStateWhenStateIsPresent()
+        {
+            XElement transUnitElement =
+                new(TransUnit,
+                    new XElement(Target,
+                        new XAttribute("state", "original state value")));
+
+            string stateValue = transUnitElement.GetTargetState();
+
+            Assert.Equal(expected: "original state value", actual: stateValue);
+        }
+
+        [Fact]
+        public void GetTargetState_ReturnsDefaultWhenTargetIsPresentButStateIsNot()
+        {
+            XElement transUnitElement =
+                new(TransUnit,
+                    new XElement(Target));
+
+            string stateValue = transUnitElement.GetTargetState();
+
+            Assert.Equal(expected: "new", actual: stateValue);
+        }
+
+        [Fact]
+        public void GetTargetState_ReturnsDefaultWhenTargetIsNotPresent()
+        {
+            XElement transUnitElement = new(TransUnit);
+
+            string stateValue = transUnitElement.GetTargetState();
+
+            Assert.Equal(expected: "new", actual: stateValue);
+        }
+
+        [Fact]
+        public void SetTargetState_SetsStateWhenAlreadyPresent()
+        {
+            XElement transUnitElement =
+                new(TransUnit,
+                    new XElement(Source, "soruce text"),
+                    new XElement(Target,
+                        new XAttribute("state", "new"),
+                        "target text"));
+
+            transUnitElement.SetTargetState("translated");
+
+            Assert.Equal(expected: "translated", actual: transUnitElement.Element(Target).Attribute("state").Value);
+        }
+
+        [Fact]
+        public void SetTargetState_AddsStateAttributeIfNotPresent()
+        {
+            XElement transUnitElement =
+                new(TransUnit,
+                    new XElement(Source, "soruce text"),
+                    new XElement(Target, "target text"));
+
+            transUnitElement.SetTargetState("translated");
+
+            Assert.Equal(expected: "translated", actual: transUnitElement.Element(Target).Attribute("state").Value);
+        }
+
+        [Fact]
+        public void SetTargetState_AddsTargetElementIfNotPresent()
+        {
+            XElement transUnitElement =
+                new(TransUnit,
+                    new XElement(Source, "soruce text"));
+
+            transUnitElement.SetTargetState("translated");
+
+            Assert.Equal(expected: "translated", actual: transUnitElement.Element(Target).Attribute("state").Value);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks.Tests/XamlRuleDocumentTests.cs
+++ b/src/Microsoft.DotNet.XliffTasks.Tests/XamlRuleDocumentTests.cs
@@ -1,0 +1,364 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+using XliffTasks.Model;
+using Xunit;
+
+namespace XliffTasks.Tests
+{
+    public class XamlRuleTranslationTests
+    {
+      [Fact]
+        public void BasicLoadAndTranslate()
+        {
+            string source =
+@"<Rule Name=""MyRule""
+        DisplayName=""My rule display name""
+        PageTemplate=""generic""
+        Description=""My rule description""
+        xmlns=""http://schemas.microsoft.com/build/2009/properties"" xmlns:xliff=""https://github.com/dotnet/xliff-tasks"" xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+        mc:Ignorable=""xliff"">
+  <!-- DisplayName: My rule display name comment -->
+  <!-- Description: My rule description comment -->
+  <Rule.Categories>
+    <Category Name=""MyCategory"" DisplayName=""My category display name"">
+      <!-- DisplayName: My category display name comment -->
+    </Category>
+  </Rule.Categories>
+  <EnumProperty Name=""MyEnumProperty"" DisplayName=""My enum property display name"" Category=""MyCategory"" Description=""Specifies the source file will be copied to the output directory."">
+    <!-- DisplayName: My enum property display name comment -->
+    <!-- Description: My enum property description comment -->
+    <EnumValue Name=""First"" DisplayName=""Do the first thing"">
+      <!-- DisplayName: My first item comment -->
+    </EnumValue>
+    <EnumValue Name=""Second"" DisplayName=""Do the second thing"" />
+    <EnumValue Name=""Third"" DisplayName=""Do the third thing"" />
+  </EnumProperty>
+  <BoolProperty Name=""MyBoolProperty"" Description=""My bool property description."" />
+  <StringProperty Name=""MyStringProperty"">
+    <StringProperty.Metadata>
+      <NameValuePair Name=""SearchTerms"" Value=""My;Search;Terms"" TranslatableProp1=""tr1"" TranslatableProp2=""tr2"" NonTranslatableProp3=""same"" xliff:LocalizedProperties=""TranslatableProp1;TranslatableProp2"">
+        <!-- Value: My search terms comment -->
+      </NameValuePair>
+      <NameValuePair Name=""TypeDescriptorText"" Value=""Custom symbols"" xliff:LocalizedProperties=""Value"">
+        <!-- Value: My type descriptor text comment -->
+      </NameValuePair>
+    </StringProperty.Metadata>
+  </StringProperty>
+</Rule>";
+
+            string expectedXlf =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.xaml"">
+    <body>
+      <trans-unit id=""BoolProperty|MyBoolProperty|Description"">
+        <source>My bool property description.</source>
+        <target state=""new"">My bool property description.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Category|MyCategory|DisplayName"">
+        <source>My category display name</source>
+        <target state=""new"">My category display name</target>
+        <note>My category display name comment</note>
+      </trans-unit>
+      <trans-unit id=""EnumProperty|MyEnumProperty|Description"">
+        <source>Specifies the source file will be copied to the output directory.</source>
+        <target state=""new"">Specifies the source file will be copied to the output directory.</target>
+        <note>My enum property description comment</note>
+      </trans-unit>
+      <trans-unit id=""EnumProperty|MyEnumProperty|DisplayName"">
+        <source>My enum property display name</source>
+        <target state=""new"">My enum property display name</target>
+        <note>My enum property display name comment</note>
+      </trans-unit>
+      <trans-unit id=""EnumValue|MyEnumProperty.First|DisplayName"">
+        <source>Do the first thing</source>
+        <target state=""new"">Do the first thing</target>
+        <note>My first item comment</note>
+      </trans-unit>
+      <trans-unit id=""EnumValue|MyEnumProperty.Second|DisplayName"">
+        <source>Do the second thing</source>
+        <target state=""new"">Do the second thing</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""EnumValue|MyEnumProperty.Third|DisplayName"">
+        <source>Do the third thing</source>
+        <target state=""new"">Do the third thing</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Rule|MyRule|Description"">
+        <source>My rule description</source>
+        <target state=""new"">My rule description</target>
+        <note>My rule description comment</note>
+      </trans-unit>
+      <trans-unit id=""Rule|MyRule|DisplayName"">
+        <source>My rule display name</source>
+        <target state=""new"">My rule display name</target>
+        <note>My rule display name comment</note>
+      </trans-unit>
+      <trans-unit id=""StringProperty|MyStringProperty|Metadata|SearchTerms"">
+        <source>My;Search;Terms</source>
+        <target state=""new"">My;Search;Terms</target>
+        <note>My search terms comment</note>
+      </trans-unit>
+      <trans-unit id=""StringProperty|MyStringProperty|Metadata|SearchTerms|TranslatableProp1"">
+        <source>tr1</source>
+        <target state=""new"">tr1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""StringProperty|MyStringProperty|Metadata|SearchTerms|TranslatableProp2"">
+        <source>tr2</source>
+        <target state=""new"">tr2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""StringProperty|MyStringProperty|Metadata|TypeDescriptorText|Value"">
+        <source>Custom symbols</source>
+        <target state=""new"">Custom symbols</target>
+        <note>My type descriptor text comment</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            Dictionary<string, string> translations = new()
+            {
+                ["Rule|MyRule|DisplayName"] = "AAA",
+                ["Rule|MyRule|Description"] = "BBB",
+                ["Category|MyCategory|DisplayName"] = "CCC",
+                ["EnumProperty|MyEnumProperty|DisplayName"] = "DDD",
+                ["EnumProperty|MyEnumProperty|Description"] = "EEE",
+                ["EnumValue|MyEnumProperty.First|DisplayName"] = "FFF",
+                ["EnumValue|MyEnumProperty.Second|DisplayName"] = "GGG",
+                ["EnumValue|MyEnumProperty.Third|DisplayName"] = "HHH",
+                ["BoolProperty|MyBoolProperty|Description"] = "III",
+                ["StringProperty|MyStringProperty|Metadata|SearchTerms"] = "JJJ",
+                ["StringProperty|MyStringProperty|Metadata|TypeDescriptorText|Value"] = "NNN",
+                ["StringProperty|MyStringProperty|Metadata|SearchTerms|TranslatableProp1"] = "LLL",
+                ["StringProperty|MyStringProperty|Metadata|SearchTerms|TranslatableProp2"] = "MMM",
+            };
+
+            string expectedTranslation =
+@"<Rule Name=""MyRule"" DisplayName=""AAA"" PageTemplate=""generic"" Description=""BBB"" xmlns=""http://schemas.microsoft.com/build/2009/properties"" xmlns:xliff=""https://github.com/dotnet/xliff-tasks"" xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006"" mc:Ignorable=""xliff"">
+  <!-- DisplayName: My rule display name comment -->
+  <!-- Description: My rule description comment -->
+  <Rule.Categories>
+    <Category Name=""MyCategory"" DisplayName=""CCC"">
+      <!-- DisplayName: My category display name comment -->
+    </Category>
+  </Rule.Categories>
+  <EnumProperty Name=""MyEnumProperty"" DisplayName=""DDD"" Category=""MyCategory"" Description=""EEE"">
+    <!-- DisplayName: My enum property display name comment -->
+    <!-- Description: My enum property description comment -->
+    <EnumValue Name=""First"" DisplayName=""FFF"">
+      <!-- DisplayName: My first item comment -->
+    </EnumValue>
+    <EnumValue Name=""Second"" DisplayName=""GGG"" />
+    <EnumValue Name=""Third"" DisplayName=""HHH"" />
+  </EnumProperty>
+  <BoolProperty Name=""MyBoolProperty"" Description=""III"" />
+  <StringProperty Name=""MyStringProperty"">
+    <StringProperty.Metadata>
+      <NameValuePair Name=""SearchTerms"" Value=""JJJ"" TranslatableProp1=""LLL"" TranslatableProp2=""MMM"" NonTranslatableProp3=""same"" xliff:LocalizedProperties=""TranslatableProp1;TranslatableProp2"">
+        <!-- Value: My search terms comment -->
+      </NameValuePair>
+      <NameValuePair Name=""TypeDescriptorText"" Value=""NNN"" xliff:LocalizedProperties=""Value"">
+        <!-- Value: My type descriptor text comment -->
+      </NameValuePair>
+    </StringProperty.Metadata>
+  </StringProperty>
+</Rule>";
+
+            RunXamlTranslationTest(source, translations, expectedTranslation, expectedXlf);
+        }
+
+        
+        /* the purpose of this test is to ensure that deeply nested translations translate as expected, as well as attributes declared as a nested element:
+          such as:
+          <A Name="MyName">
+            <A.Description>MyName Description</A.Description>
+            <B>
+              <C>
+                <D>
+                  <NameValuePair Name="SearchTerms" TranslatableProp1="this-is-translated" xliff:LocalizedProperties="TranslatableProp1">
+                    <NameValuePair.Value>My Search Terms</NameValuePair.Value> 
+                </D>
+                ....
+    
+        */
+        [Fact]
+        public void LoadAndTranslateWithDeeplyNestedTranslationAndElementAttributeSyntax()
+        {
+            string source =
+@"<Rule Name=""MyRule""
+        DisplayName=""My rule display name""
+        PageTemplate=""generic""
+        Description=""My rule description""
+        xmlns=""http://schemas.microsoft.com/build/2009/properties"" xmlns:xliff=""https://github.com/dotnet/xliff-tasks"" xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+        mc:Ignorable=""xliff"">
+  <!-- DisplayName: My rule display name comment -->
+  <!-- Description: My rule description comment -->
+  <Rule.Categories>
+    <Category Name=""MyCategory"" Description=""My category description"">
+      <Category.DisplayName>My category display name</Category.DisplayName>
+      <!-- DisplayName: My category display name comment -->
+    </Category>
+  </Rule.Categories>
+  <StringProperty Name=""MyStringProperty"" DisplayName=""MyStringProperty display name"">
+    <StringProperty.Description>MyStringProperty description</StringProperty.Description>
+    <StringProperty.ValueEditors>
+      <ValueEditor EditorType=""MultiStringSelector"">
+        <ValueEditor.Metadata>
+          <NameValuePair Name=""TypeDescriptorText"" Value=""Custom symbols"" xliff:LocalizedProperties=""Value"" />
+          <NameValuePair Name=""SearchTerms"">
+            <NameValuePair.Value>My search terms</NameValuePair.Value>
+          </NameValuePair>
+
+          <TestElement Name=""TranslatableElement"" LocalizablePropC=""LocalizableC attribute"" xliff:LocalizedProperties=""LocalizablePropA;LocalizablePropB;LocalizablePropC"">
+            <TestElement.LocalizablePropA>LocalizableA descendent prop</TestElement.LocalizablePropA>
+            <TestElement.LocalizablePropB>LocalizableB descendent prop</TestElement.LocalizablePropB>
+          </TestElement>
+
+          <NameValuePair Name=""ShouldDisplayEvaluatedPreview"" Value=""True"" />
+        </ValueEditor.Metadata>
+      </ValueEditor>
+    </StringProperty.ValueEditors>
+  </StringProperty>
+</Rule>";
+
+            string expectedXlf =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.xaml"">
+    <body>
+      <trans-unit id=""Category|MyCategory|Description"">
+        <source>My category description</source>
+        <target state=""new"">My category description</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Category|MyCategory|DisplayName"">
+        <source>My category display name</source>
+        <target state=""new"">My category display name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Rule|MyRule|Description"">
+        <source>My rule description</source>
+        <target state=""new"">My rule description</target>
+        <note>My rule description comment</note>
+      </trans-unit>
+      <trans-unit id=""Rule|MyRule|DisplayName"">
+        <source>My rule display name</source>
+        <target state=""new"">My rule display name</target>
+        <note>My rule display name comment</note>
+      </trans-unit>
+      <trans-unit id=""StringProperty|MyStringProperty|Description"">
+        <source>MyStringProperty description</source>
+        <target state=""new"">MyStringProperty description</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""StringProperty|MyStringProperty|DisplayName"">
+        <source>MyStringProperty display name</source>
+        <target state=""new"">MyStringProperty display name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""StringProperty|MyStringProperty|ValueEditors|ValueEditor|Metadata|Metadata|LocalizablePropA"">
+        <source>LocalizableA descendent prop</source>
+        <target state=""new"">LocalizableA descendent prop</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""StringProperty|MyStringProperty|ValueEditors|ValueEditor|Metadata|Metadata|LocalizablePropB"">
+        <source>LocalizableB descendent prop</source>
+        <target state=""new"">LocalizableB descendent prop</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""StringProperty|MyStringProperty|ValueEditors|ValueEditor|Metadata|SearchTerms"">
+        <source>My search terms</source>
+        <target state=""new"">My search terms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""StringProperty|MyStringProperty|ValueEditors|ValueEditor|Metadata|TranslatableElement|LocalizablePropC"">
+        <source>LocalizableC attribute</source>
+        <target state=""new"">LocalizableC attribute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""StringProperty|MyStringProperty|ValueEditors|ValueEditor|Metadata|TypeDescriptorText|Value"">
+        <source>Custom symbols</source>
+        <target state=""new"">Custom symbols</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            Dictionary<string, string> translations = new()
+            {
+                ["Rule|MyRule|DisplayName"] = "AAA",
+                ["Rule|MyRule|Description"] = "BBB",
+                ["Category|MyCategory|DisplayName"] = "CCC",
+                ["EnumProperty|MyEnumProperty|DisplayName"] = "DDD",
+                ["EnumProperty|MyEnumProperty|Description"] = "EEE",
+                ["EnumValue|MyEnumProperty.First|DisplayName"] = "FFF",
+                ["EnumValue|MyEnumProperty.Second|DisplayName"] = "GGG",
+                ["EnumValue|MyEnumProperty.Third|DisplayName"] = "HHH",
+                ["BoolProperty|MyBoolProperty|Description"] = "III",
+                ["StringProperty|MyStringProperty|Metadata|SearchTerms"] = "JJJ",
+                ["StringProperty|MyStringProperty|Metadata|TypeDescriptorText|Value"] = "NNN",
+                ["StringProperty|MyStringProperty|Metadata|SearchTerms|TranslatableProp1"] = "LLL",
+                ["StringProperty|MyStringProperty|Metadata|SearchTerms|TranslatableProp2"] = "MMM",
+            };
+
+            string expectedTranslation =
+@"<Rule Name=""MyRule"" DisplayName=""AAA"" PageTemplate=""generic"" Description=""BBB"" xmlns=""http://schemas.microsoft.com/build/2009/properties"" xmlns:xliff=""https://github.com/dotnet/xliff-tasks"" xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006"" mc:Ignorable=""xliff"">
+  <!-- DisplayName: My rule display name comment -->
+  <!-- Description: My rule description comment -->
+  <Rule.Categories>
+    <Category Name=""MyCategory"" Description=""My category description"">
+      <Category.DisplayName>CCC</Category.DisplayName>
+      <!-- DisplayName: My category display name comment -->
+    </Category>
+  </Rule.Categories>
+  <StringProperty Name=""MyStringProperty"" DisplayName=""MyStringProperty display name"">
+    <StringProperty.Description>MyStringProperty description</StringProperty.Description>
+    <StringProperty.ValueEditors>
+      <ValueEditor EditorType=""MultiStringSelector"">
+        <ValueEditor.Metadata>
+          <NameValuePair Name=""TypeDescriptorText"" Value=""Custom symbols"" xliff:LocalizedProperties=""Value"" />
+          <NameValuePair Name=""SearchTerms"">
+            <NameValuePair.Value>My search terms</NameValuePair.Value>
+          </NameValuePair>
+          <TestElement Name=""TranslatableElement"" LocalizablePropC=""LocalizableC attribute"" xliff:LocalizedProperties=""LocalizablePropA;LocalizablePropB;LocalizablePropC"">
+            <TestElement.LocalizablePropA>LocalizableA descendent prop</TestElement.LocalizablePropA>
+            <TestElement.LocalizablePropB>LocalizableB descendent prop</TestElement.LocalizablePropB>
+          </TestElement>
+          <NameValuePair Name=""ShouldDisplayEvaluatedPreview"" Value=""True"" />
+        </ValueEditor.Metadata>
+      </ValueEditor>
+    </StringProperty.ValueEditors>
+  </StringProperty>
+</Rule>";
+
+            RunXamlTranslationTest(source, translations, expectedTranslation, expectedXlf);
+        }
+        
+        private static void RunXamlTranslationTest(string source, Dictionary<string, string> translations, string expectedTranslation, string expectedXlf)
+        {
+          XamlRuleDocument document = new();
+          StringWriter writer = new();
+          document.Load(new StringReader(source));
+
+          XlfDocument xliffDocument = new();
+          xliffDocument.LoadNew("fr");
+          xliffDocument.Update(document, "test.xaml");
+
+          document.Translate(translations);
+          document.Save(writer);
+
+          AssertEx.EqualIgnoringLineEndings(expectedTranslation, writer.ToString());
+
+          StringWriter xliffWriter = new();
+          xliffDocument.Save(xliffWriter);
+
+          AssertEx.EqualIgnoringLineEndings(expectedXlf, xliffWriter.ToString());
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks.Tests/XlfDocumentTests.cs
+++ b/src/Microsoft.DotNet.XliffTasks.Tests/XlfDocumentTests.cs
@@ -1,0 +1,659 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml.Schema;
+using XliffTasks.Model;
+using Xunit;
+
+namespace XliffTasks.Tests
+{
+    public class XlfDocumentTests
+    {
+        [Fact]
+        public void LoadNewInitializesNewDocumentWithCorrectContent()
+        {
+            XlfDocument xliffDocument = new();
+            xliffDocument.LoadNew("es");
+
+            StringWriter writer = new();
+            xliffDocument.Save(writer);
+
+            string expected =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""es"" original=""_"">
+    <body />
+  </file>
+</xliff>";
+
+            AssertEx.EqualIgnoringLineEndings(expected, writer.ToString());
+        }
+
+        [Fact]
+        public void UpdateBehavesCorrectlyAsSourceDocumentEvolves()
+        {
+            // dev authors new resx with no corresponding xliff
+            string resx =
+@"<root>
+  <data name=""Hello"">
+    <value>Hello!</value>
+    <comment>Greeting</comment>
+  </data>
+  <data name=""Goodbye"">
+    <value>Goodbye!</value>
+  </data>
+  <data name=""Apple"">
+   <value>Apple</value>
+   <comment>Tasty</comment>
+  </data>
+</root>";
+
+            string xliff =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Apple"">
+        <source>Apple</source>
+        <target state=""new"">Apple</target>
+        <note>Tasty</note>
+      </trans-unit>
+      <trans-unit id=""Goodbye"">
+        <source>Goodbye!</source>
+        <target state=""new"">Goodbye!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Hello"">
+        <source>Hello!</source>
+        <target state=""new"">Hello!</target>
+        <note>Greeting</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+            AssertEx.EqualIgnoringLineEndings(xliff, Update(xliff: "", resx: resx));
+
+            // loc team translates
+            string xliffAfterFirstTranslation =
+ @"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Apple"">
+        <source>Apple</source>
+        <target state=""translated"">Apple</target>
+        <note>Tasty</note>
+      </trans-unit>
+      <trans-unit id=""Goodbye"">
+        <source>Goodbye!</source>
+        <target state=""translated"">Au revoir!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Hello"">
+        <source>Hello!</source>
+        <target state=""translated"">Bonjour!</target>
+        <note>Greeting</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            // dev makes some changes
+            string resxAfterFirstModification =
+@"<root>
+  <data name=""HelloWorld"">
+    <value>Hello World!</value>
+  </data>
+  <data name=""Goodbye"" xml:space=""preserve"">
+    <value>Goodbye World!</value>
+  </data>
+  <data name=""Apple"">
+    <value>Apple</value>
+    <comment>This is referring to fruit.</comment>
+  </data>
+  <data name=""Banana"">
+    <value>Banana</value>
+  </data>
+</root>";
+
+            string xliffAfterApplyingResxModification =
+ @"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Apple"">
+        <source>Apple</source>
+        <target state=""needs-review-translation"">Apple</target>
+        <note>This is referring to fruit.</note>
+      </trans-unit>
+      <trans-unit id=""Banana"">
+        <source>Banana</source>
+        <target state=""new"">Banana</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Goodbye"">
+        <source>Goodbye World!</source>
+        <target state=""needs-review-translation"">Au revoir!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""HelloWorld"">
+        <source>Hello World!</source>
+        <target state=""new"">Hello World!</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            AssertEx.EqualIgnoringLineEndings(
+               xliffAfterApplyingResxModification,
+               Update(xliff: xliffAfterFirstTranslation, resx: resxAfterFirstModification));
+        }
+
+        [Fact]
+        public void UpdateBehavesCorrectlyWhenTargetIsMissing()
+        {
+            string initialXliff =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Apple"">
+        <source>Apple</source>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Banana"">
+        <source>Banana</source>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            string resxWithModifications =
+@"<root>
+  <data name=""Apple"">
+   <value>Better apples</value>
+  </data>
+  <data name=""Banana"">
+    <value>Banana</value>
+  </data>
+</root>";
+
+            string xliffAfterUpdate =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Apple"">
+        <source>Better apples</source>
+        <target state=""new"">Better apples</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Banana"">
+        <source>Banana</source>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            AssertEx.EqualIgnoringLineEndings(
+                expected: xliffAfterUpdate,
+                actual: Update(initialXliff, resxWithModifications));
+        }
+
+        [Fact]
+        public void UpdateBehavesCorrectlyWhenNoteIsMissing()
+        {
+            string initialXliff =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Apple"">
+        <source>Apple</source>
+        <target state=""new"">Apple</target>
+      </trans-unit>
+      <trans-unit id=""Banana"">
+        <source>Banana</source>
+        <target state=""new"">Banana</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            string resxWithModifications =
+@"<root>
+  <data name=""Apple"">
+   <value>Apple</value>
+   <comment>Make sure they're green apples.</comment>
+  </data>
+  <data name=""Banana"">
+    <value>Banana</value>
+  </data>
+</root>";
+
+            string xliffAfterUpdate =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Apple"">
+        <source>Apple</source>
+        <target state=""new"">Apple</target>
+        <note>Make sure they're green apples.</note>
+      </trans-unit>
+      <trans-unit id=""Banana"">
+        <source>Banana</source>
+        <target state=""new"">Banana</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            AssertEx.EqualIgnoringLineEndings(
+                expected: xliffAfterUpdate,
+                actual: Update(initialXliff, resxWithModifications));
+        }
+
+        [Fact]
+        public void UpdateBehavesCorrectlyWhenTargetStateIsMissing()
+        {
+            string initialXliff =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Apple"">
+        <source>Apple</source>
+        <target>Apple</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            string resxWithModifications =
+@"<root>
+  <data name=""Apple"">
+   <value>Better apples</value>
+  </data>
+</root>";
+
+            string xliffAfterUpdate =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Apple"">
+        <source>Better apples</source>
+        <target state=""new"">Better apples</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            AssertEx.EqualIgnoringLineEndings(
+                expected: xliffAfterUpdate,
+                actual: Update(initialXliff, resxWithModifications));
+        }
+
+        [Fact]
+        public void NewItemThatShouldBeLastEndsUpLast()
+        {
+            // Dev has just added "Zucchini" item to RESX
+            string resx =
+@"<root>
+  <data name=""Hello"">
+    <value>Hello!</value>
+    <comment>Greeting</comment>
+  </data>
+  <data name=""Goodbye"">
+    <value>Goodbye!</value>
+  </data>
+  <data name=""Apple"">
+   <value>Apple</value>
+   <comment>Tasty</comment>
+  </data>
+  <data name=""Zucchini"">
+    <value>Zucchini</value>
+    <comment>My children won't eat it.</comment>
+  </data>
+</root>";
+
+            string xliffBeforeUpdate =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Apple"">
+        <source>Apple</source>
+        <target state=""new"">Apple</target>
+        <note>Tasty</note>
+      </trans-unit>
+      <trans-unit id=""Goodbye"">
+        <source>Goodbye!</source>
+        <target state=""new"">Goodbye!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Hello"">
+        <source>Hello!</source>
+        <target state=""new"">Hello!</target>
+        <note>Greeting</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            string xliffAfterUpdate =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Apple"">
+        <source>Apple</source>
+        <target state=""new"">Apple</target>
+        <note>Tasty</note>
+      </trans-unit>
+      <trans-unit id=""Goodbye"">
+        <source>Goodbye!</source>
+        <target state=""new"">Goodbye!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Hello"">
+        <source>Hello!</source>
+        <target state=""new"">Hello!</target>
+        <note>Greeting</note>
+      </trans-unit>
+      <trans-unit id=""Zucchini"">
+        <source>Zucchini</source>
+        <target state=""new"">Zucchini</target>
+        <note>My children won't eat it.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            AssertEx.EqualIgnoringLineEndings(
+                xliffAfterUpdate,
+                Update(xliff: xliffBeforeUpdate, resx: resx));
+
+        }
+
+        [Fact]
+        public void CheckSorting()
+        {
+            string xliff =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Gamma"">
+        <source>Hello!</source>
+        <target state=""new"">Hello!</target>
+        <note>Greeting</note>
+      </trans-unit>
+      <trans-unit id=""Beta"">
+        <source>Goodbye!</source>
+        <target state=""new"">Goodbye!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Alpha"">
+        <source>Apple</source>
+        <target state=""new"">Apple</target>
+        <note>Tasty</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            string xliffAfterSorting =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Alpha"">
+        <source>Apple</source>
+        <target state=""new"">Apple</target>
+        <note>Tasty</note>
+      </trans-unit>
+      <trans-unit id=""Beta"">
+        <source>Goodbye!</source>
+        <target state=""new"">Goodbye!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Gamma"">
+        <source>Hello!</source>
+        <target state=""new"">Hello!</target>
+        <note>Greeting</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            AssertEx.EqualIgnoringLineEndings(
+                xliffAfterSorting,
+                Sort(xliff));
+        }
+
+        [Fact]
+        public void UntranslatedResourceCount_Zero()
+        {
+            string xliff =
+ @"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Apple"">
+        <source>Apple</source>
+        <target state=""translated"">Apple</target>
+        <note>Tasty</note>
+      </trans-unit>
+      <trans-unit id=""Goodbye"">
+        <source>Goodbye!</source>
+        <target state=""translated"">Au revoir!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Hello"">
+        <source>Hello!</source>
+        <target state=""translated"">Bonjour!</target>
+        <note>Greeting</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            ISet<string> untranslatedResources = UntranslatedResources(xliff);
+            Assert.Empty(untranslatedResources);
+        }
+
+        [Fact]
+        public void UntranslatedResourceCount_Two()
+        {
+            string xliff =
+ @"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Apple"">
+        <source>Apple</source>
+        <target state=""translated"">Apple</target>
+        <note>Tasty</note>
+      </trans-unit>
+      <trans-unit id=""Goodbye"">
+        <source>Goodbye!</source>
+        <target state=""new"">Goodbye!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Hello"">
+        <source>Hello!</source>
+        <target state=""needs-review-translation"">Hallo!</target>
+        <note>Greeting</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            ISet<string> untranslatedResources = UntranslatedResources(xliff);
+            Assert.Contains("Goodbye", untranslatedResources, StringComparer.Ordinal);
+            Assert.Contains("Hello", untranslatedResources, StringComparer.Ordinal);
+            Assert.DoesNotContain("Apple", untranslatedResources, StringComparer.Ordinal);
+        }
+
+        [Fact]
+        public void ResetTranslationOnMismatchedPlaceholders()
+        {
+            // Dev has just added additional placeholders to items Alpha and Beta.
+            // Gamma already had a placeholder and is not being changed.
+
+            string resx =
+@"<root>
+  <data name=""Alpha"">
+    <value>Alpha {0}</value>
+  </data>
+  <data name=""Beta"">
+    <value>Beta {0} {1}</value>
+  </data>
+  <data name=""Gamma"">
+    <value>Gamma {0}</value>
+  </data>
+</root>";
+
+            string xliffBeforeUpdate =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Alpha"">
+        <source>Alpha</source>
+        <target state=""translated"">Translated Alpha</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Beta"">
+        <source>Beta {0}</source>
+        <target state=""translated"">Translated Beta {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Gamma"">
+        <source>Gamma {0}</source>
+        <target state=""translated"">Translated Gamma {0}</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            string xliffAfterUpdate =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Alpha"">
+        <source>Alpha {0}</source>
+        <target state=""new"">Alpha {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Beta"">
+        <source>Beta {0} {1}</source>
+        <target state=""new"">Beta {0} {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Gamma"">
+        <source>Gamma {0}</source>
+        <target state=""translated"">Translated Gamma {0}</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            AssertEx.EqualIgnoringLineEndings(
+                xliffAfterUpdate,
+                Update(xliff: xliffBeforeUpdate, resx: resx));
+
+        }
+
+        [Fact]
+        public void ValidationReportsNoErrorsOnDocumentWithNoContent()
+        {
+            XlfDocument document = new();
+            List<XmlSchemaException> validationErrors = GetValidationErrors(document);
+
+            Assert.Empty(validationErrors);
+        }
+
+        [Fact]
+        public void ValidationReportsNoErrorsOnNewDocument()
+        {
+            XlfDocument document = new();
+            document.LoadNew("cs");
+            List<XmlSchemaException> validationErrors = GetValidationErrors(document);
+
+            Assert.Empty(validationErrors);
+        }
+
+        [Fact]
+        public void ValidationReportsErrorsOnMissingSourceElement()
+        {
+            string xliffText =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Alpha"">
+        <target state=""new"">Alpha {0}</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+            XlfDocument document = new();
+            document.Load(new StringReader(xliffText));
+
+            List<XmlSchemaException> validationErrors = GetValidationErrors(document);
+
+            Assert.Collection(validationErrors,
+                new Action<XmlSchemaException>[]
+                {
+                    e => Assert.Equal(expected: "The element 'trans-unit' in namespace 'urn:oasis:names:tc:xliff:document:1.2' has invalid child element 'target' in namespace 'urn:oasis:names:tc:xliff:document:1.2'. List of possible elements expected: 'source' in namespace 'urn:oasis:names:tc:xliff:document:1.2'.", actual: e.Message)
+                });
+        }
+
+        private static List<XmlSchemaException> GetValidationErrors(XlfDocument document)
+        {
+            List<XmlSchemaException> validationErrors = new();
+            void exceptionHandler(XmlSchemaException e) => validationErrors.Add(e);
+            document.Validate(exceptionHandler);
+            return validationErrors;
+        }
+
+        private static string Sort(string xliff)
+        {
+            XlfDocument xliffDocument = new();
+            xliffDocument.Load(new StringReader(xliff));
+
+            xliffDocument.Sort();
+
+            StringWriter writer = new();
+            xliffDocument.Save(writer);
+            return writer.ToString();
+        }
+
+        private static string Update(string xliff, string resx)
+        {
+            XlfDocument xliffDocument = new();
+
+            if (string.IsNullOrEmpty(xliff))
+            {
+                xliffDocument.LoadNew("fr");
+            }
+            else
+            {
+                xliffDocument.Load(new StringReader(xliff));
+            }
+
+            ResxDocument resxDocument = new();
+            resxDocument.Load(new StringReader(resx));
+            xliffDocument.Update(resxDocument, "test.resx");
+
+            StringWriter writer = new();
+            xliffDocument.Save(writer);
+            return writer.ToString();
+        }
+
+        private static ISet<string> UntranslatedResources(string xliff)
+        {
+            XlfDocument xliffDocument = new();
+            xliffDocument.Load(new StringReader(xliff));
+
+            return xliffDocument.GetUntranslatedResourceIDs();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/EnumerableExtensions.cs
+++ b/src/Microsoft.DotNet.XliffTasks/EnumerableExtensions.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace XliffTasks
+{
+    internal static class EnumerableExtensions
+    {
+        public static bool IsSorted<T, U>(this IEnumerable<T> source, Func<T, U> keySelector, IComparer<U> comparer)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (keySelector == null)
+            {
+                throw new ArgumentNullException(nameof(keySelector));
+            }
+
+            if (comparer == null)
+            {
+                throw new ArgumentNullException(nameof(comparer));
+            }
+
+            U priorKey = default(U);
+            bool first = true;
+
+            foreach (T item in source)
+            {
+                U key = keySelector(item);
+
+                if (!first
+                    && comparer.Compare(priorKey, key) > 0)
+                {
+                    return false;
+                }
+
+                first = false;
+                priorKey = key;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/ExponentialRetry.cs
+++ b/src/Microsoft.DotNet.XliffTasks/ExponentialRetry.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+
+namespace XliffTasks
+{
+    public class ExponentialRetry
+    {
+        public static void ExecuteWithRetryOnIOException(
+           Action action,
+           int maxRetryCount)
+        {
+            int count = 1;
+            foreach (TimeSpan t in Intervals)
+            {
+                try
+                {
+                    action();
+                    return;
+                }
+                catch (IOException e)
+                {
+                    if (count == maxRetryCount)
+                        throw new IOException($"Retry failed after {count} times", e);
+                    count++;
+                }
+                Thread.Sleep(t);
+            }
+            throw new Exception("Timer should not be exhausted");
+        }
+
+        private static IEnumerable<TimeSpan> Intervals
+        {
+            get
+            {
+                int milliseconds = 5;
+                while (true)
+                {
+                    yield return TimeSpan.FromMilliseconds(milliseconds);
+                    milliseconds *= 2;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/Microsoft.DotNet.XliffTasks.csproj
+++ b/src/Microsoft.DotNet.XliffTasks/Microsoft.DotNet.XliffTasks.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Utilities.Core" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.XliffTasks/Microsoft.DotNet.XliffTasks.csproj
+++ b/src/Microsoft.DotNet.XliffTasks/Microsoft.DotNet.XliffTasks.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(NetCurrent);$(NetFrameworkToolCurrent)</TargetFrameworks>
+    <IsPackable>true</IsPackable>
+    <RootNamespace>XliffTasks</RootNamespace>
+    <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.DotNet.XliffTasks.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Utilities.Core" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Model\xliff-core-1.2-transitional.xsd" />
+    <EmbeddedResource Include="Model\xml.xsd" />
+  </ItemGroup>
+
+  <Import Project="$(RepositoryEngineeringDir)BuildTask.targets" />
+
+</Project>

--- a/src/Microsoft.DotNet.XliffTasks/Model/Document.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Model/Document.cs
@@ -1,0 +1,122 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Text;
+
+namespace XliffTasks.Model
+{
+    internal abstract class Document
+    {
+        /// <summary>
+        /// Indicates if content has been loaded in to the document.
+        /// </summary>
+        public abstract bool HasContent { get; }
+
+        private static readonly Encoding s_utf8WithBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+        private static readonly Encoding s_utf8WithoutBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+        /// <summary>
+        /// The encoding to use when saving the document to a stream.
+        /// This is the encoding that was detected on Load, or default value of UTF8-with-BOM for new documents.
+        /// </summary>
+        public Encoding Encoding { get; set; } = s_utf8WithBom;
+
+        /// <summary>
+        /// Loads (or reloads) the document content from the given file path.
+        /// </summary>
+        public void Load(string path)
+        {
+            using FileStream stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            Load(stream);
+        }
+
+        /// <summary>
+        /// Loads (or reloads) the document content from the given stream.
+        /// </summary>
+        public void Load(Stream stream)
+        {
+            // NOTE: It is important to pass UTF8-without-BOM here and not UTF8-with-BOM (aka Encoding.UTF8 and also same
+            // as default when not passing encoding). The reason is that CurrentEncoding is only different from the encoding 
+            // provided when the StreamReader encounters a BOM. As such, if we start off with UTF8-with-BOM, we'll end up with 
+            // UTF8-with-BOM even if the document has no BOM, which would defeat our purpose of preserving the encoding and BOM
+            // of the original document in a Load/Modify/Save cycle.
+
+            using StreamReader reader = new(stream, s_utf8WithoutBom, detectEncodingFromByteOrderMarks: true);
+            Load(reader);
+            Encoding = reader.CurrentEncoding;
+        }
+
+        /// <summary>
+        /// Loads (or reloads) the document content from the given reader.
+        /// </summary>
+        public abstract void Load(TextReader reader);
+
+        /// <summary>
+        /// Saves the document's content to the given file path.
+        /// </summary>
+        public void Save(string path)
+        {
+            //On Windows:
+            // Readers will prevent the file from being overwritten due to FileShare.Read.
+            // Readers can read in parallel, but when there's contention with a writer, the retrying will kick in to resolve it.
+            //On Unix:
+            // FileShare.Read does nothing, but...
+            // File.Replace is implemented with rename system call that will mean that even though writers can overwrite while 
+            // reading is happening, each reader will see file before or after overwrite, not in between
+
+            EnsureContent();
+            string tempPath = Path.Combine(Path.GetDirectoryName(path), Path.GetRandomFileName());
+
+            using (FileStream stream = File.Open(tempPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
+            {
+                Save(stream);
+            }
+
+            ExponentialRetry.ExecuteWithRetryOnIOException(() =>
+            {
+                if (File.Exists(path))
+                {
+                    File.Replace(
+                        sourceFileName: tempPath,
+                        destinationFileName: path,
+                        destinationBackupFileName: null,
+                        ignoreMetadataErrors: true);
+                }
+                else
+                {
+                    File.Move(sourceFileName: tempPath, destFileName: path);
+                }
+            }, maxRetryCount: 3);
+        }
+
+        /// <summary>
+        /// Saves the document's content to the given stream.
+        /// </summary>
+        public void Save(Stream stream)
+        {
+            EnsureContent();
+
+            using StreamWriter writer = new(stream, Encoding);
+            Save(writer);
+        }
+
+        /// <summary>
+        /// Saves the document's content to the given writer.
+        /// </summary>
+        public abstract void Save(TextWriter writer);
+
+        /// <summary>
+        /// Throws if this document has no content.
+        /// </summary>
+        /// <exception cref="InvalidOperationException"><see cref="HasContent"/> is false.</exception>
+        protected void EnsureContent()
+        {
+            if (!HasContent)
+            {
+                throw new InvalidOperationException("Document has no content loaded.");
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/Model/ResxDocument.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Model/ResxDocument.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Xml.Linq;
+
+namespace XliffTasks.Model
+{
+    /// <summary>
+    /// A <see cref="TranslatableDocument"/> for files in .resx format.
+    /// See https://msdn.microsoft.com/en-us/library/ekyft91f(v=vs.100).aspx
+    /// </summary>
+    internal sealed class ResxDocument : TranslatableXmlDocument
+    {
+        protected override IEnumerable<TranslatableNode> GetTranslatableNodes()
+        {
+            foreach (XElement node in Document.Descendants("data"))
+            {
+                // skip non-string data
+                if (node.Attribute("type") != null || node.Attribute("mimetype") != null)
+                {
+                    continue;
+                }
+
+                string name = node.Attribute("name").Value;
+                XElement valueElement = node.Element("value");
+                string value = valueElement?.Value;
+                string comment = node.Element("comment")?.Value ?? "";
+
+                // skip designer goo that should not be translated
+                if (name.StartsWith(">>") || name.EndsWith(".LayoutSettings"))
+                {
+                    continue;
+                }
+
+                // skip fully "locked" strings
+                if (comment == "{Locked}")
+                {
+                    continue;
+                }
+
+                // skip empty strings
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    continue;
+                }
+
+                yield return new TranslatableXmlElement(
+                    id: name,
+                    source: value, 
+                    note: comment, 
+                    element: valueElement);
+            }
+        }
+
+        public override void RewriteRelativePathsToAbsolute(string sourceFullPath)
+        {
+            foreach (XElement node in Document.Descendants("data"))
+            {
+                if (node.Attribute("type")?.Value == "System.Resources.ResXFileRef, System.Windows.Forms")
+                {
+                    XElement valueNodeOfFileRef = node.Element("value");
+                    string[] splitRelativePathAndSerializedType = valueNodeOfFileRef.Value.Split(';');
+                    string resourceRelativePath = splitRelativePathAndSerializedType[0].Replace('\\', Path.DirectorySeparatorChar);
+
+                    string absolutePath = Path.Combine(Path.GetDirectoryName(sourceFullPath), resourceRelativePath);
+                    splitRelativePathAndSerializedType[0] = absolutePath;
+
+                    valueNodeOfFileRef.Value = string.Join(";", splitRelativePathAndSerializedType);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/Model/TranslatableDocument.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Model/TranslatableDocument.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace XliffTasks.Model
+{
+    /// <summary>
+    /// Represents a document that can be translated by applying substitutions to nodes.
+    /// </summary>
+    internal abstract class TranslatableDocument : Document
+    {
+        /// <summary>
+        /// The nodes of the document that can have substitutions.
+        /// </summary>
+        public IReadOnlyList<TranslatableNode> Nodes { get; private set; } = Array.Empty<TranslatableNode>();
+
+        /// <summary>
+        /// Indicates if content has been loaded in to the document.
+        /// </summary>
+        public override bool HasContent => _hasContent;
+        private bool _hasContent;
+
+        /// <summary>
+        /// Loads (or reloads) the document content from the given reader.
+        /// </summary>
+        public sealed override void Load(TextReader reader)
+        {
+            LoadCore(reader);
+            Nodes = GetTranslatableNodes().ToList().AsReadOnly();
+            _hasContent = true;
+        }
+
+        /// <summary>
+        /// Saves the document's content to the given file path.
+        /// </summary>
+        public sealed override void Save(TextWriter writer)
+        {
+            EnsureContent();
+            SaveCore(writer);
+        }
+
+        /// <summary>
+        /// Applies the given translations to the document. 
+        /// Keys align with <see cref="TranslatableNode.Id"/>.
+        /// Values indicate the text with which to replace <see cref="TranslatableNode.Source"/>.
+        /// </summary>
+        public void Translate(IReadOnlyDictionary<string, string> translations)
+        {
+            EnsureContent();
+
+            foreach (TranslatableNode node in Nodes)
+            {
+                if (translations.TryGetValue(node.Id, out string translation))
+                {
+                    node.Translate(translation);
+                }
+            }
+       }
+
+        // rewrite nodes that point to external files (used often for icons, etc.)
+        // these will have relative paths adjusted to absolute path.
+        public virtual void RewriteRelativePathsToAbsolute(string sourceFullPath)
+        {
+        }
+
+        protected abstract void LoadCore(TextReader reader);
+
+        protected abstract void SaveCore(TextWriter writer);
+
+        protected abstract IEnumerable<TranslatableNode> GetTranslatableNodes();
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/Model/TranslatableNode.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Model/TranslatableNode.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace XliffTasks.Model
+{
+    internal abstract class TranslatableNode
+    {
+        protected TranslatableNode(string id, string source, string note)
+        {
+            Validation.ThrowIfNullOrEmpty(id, nameof(id));
+            Validation.ThrowIfNullOrEmpty(source, nameof(source));
+
+            Id = id;
+            Source = source;
+            Note = note;
+        }
+
+        /// <summary>
+        /// The unique ID of the node within a translatable document.
+        /// </summary>
+        public string Id { get; }
+
+        /// <summary>
+        /// The original text of the node before any translation.
+        /// </summary>
+        public string Source { get; }
+
+        /// <summary>
+        /// A comment associated with the node.
+        /// Null if this node cannot have comments, empty if it has none.
+        /// </summary>
+        public string Note { get; }
+
+        /// <summary>
+        /// Mutates the parent document such that subsequent calls to <see cref="TranslatableDocument.Save(string)" />
+        /// will replace <see cref="Source"/> with <paramref name="translation"/> in this node.
+        /// <summary>
+        public abstract void Translate(string translation);
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/Model/TranslatableXmlDocument.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Model/TranslatableXmlDocument.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace XliffTasks.Model
+{
+    /// <summary>
+    /// A <see cref="TranslatableDocument"/> backed by an XML-based format
+    /// </summary>
+    internal abstract class TranslatableXmlDocument : TranslatableDocument
+    {
+        protected XDocument Document { get; private set; }
+
+        protected override void LoadCore(TextReader reader)
+        {
+            Document = XDocument.Load(reader);
+        }
+
+        protected override void SaveCore(TextWriter writer)
+        {
+            Document.SaveCustom(writer);
+        }
+
+        protected sealed class TranslatableXmlElement : TranslatableNode
+        {
+            private readonly XElement _element;
+
+            public TranslatableXmlElement(string id, string source, string note, XElement element)
+               : base(id, source, note)
+            {
+                _element = element;
+            }
+
+            public override void Translate(string translation)
+            {
+                _element.Value = translation;
+            }
+        }
+
+        protected sealed class TranslatableXmlAttribute : TranslatableNode
+        {
+            private readonly XAttribute _attribute;
+
+            public TranslatableXmlAttribute(string id, string source, string note, XAttribute attribute)
+               : base(id, source, note)
+            {
+                _attribute = attribute;
+            }
+
+            public override void Translate(string translation)
+            {
+                _attribute.Value = translation;
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/Model/UnstructuredDocument.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Model/UnstructuredDocument.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace XliffTasks.Model
+{
+    internal sealed class UnstructuredDocument : TranslatableDocument
+    {
+        const string TranslatableSpanMarker = "@@@";
+        const string TranslatableSpanSeparator = "|";
+
+        private List<string> _fragments = new();
+        private List<UnstructuredTranslatableNode> _nodes = new();
+
+        protected override IEnumerable<TranslatableNode> GetTranslatableNodes()
+        {
+            return _nodes;
+        }
+
+        protected override void LoadCore(TextReader reader)
+        {
+            string text = reader.ReadToEnd();
+            int lastSpanEnd = 0;
+            int spanStart = text.IndexOf(TranslatableSpanMarker);
+            while (spanStart >= 0)
+            {
+                // the previous span of text is untranslatable and is simply copied
+                string plainSpan = text.Substring(lastSpanEnd, spanStart - lastSpanEnd);
+                _fragments.Add(plainSpan);
+
+                // next, find the translatable span
+                lastSpanEnd = text.IndexOf(TranslatableSpanMarker, spanStart + 1);
+                if (lastSpanEnd < 0)
+                {
+                    throw new InvalidOperationException($"No end of span marker '{TranslatableSpanMarker}' found.");
+                }
+
+                lastSpanEnd += TranslatableSpanMarker.Length; // account for the length of the end marker
+                int spanLength = lastSpanEnd - spanStart - TranslatableSpanMarker.Length * 2; // trim off the marker start/end length
+                string translatableSpan = text.Substring(spanStart + TranslatableSpanMarker.Length, spanLength);
+                int separatorIndex = translatableSpan.IndexOf(TranslatableSpanSeparator);
+                if (separatorIndex < 0)
+                {
+                    throw new InvalidOperationException($"No span separator '{TranslatableSpanSeparator}' found.");
+                }
+
+                string id = translatableSpan.Substring(0, separatorIndex);
+                string source = translatableSpan.Substring(separatorIndex + TranslatableSpanSeparator.Length);
+
+                // keep the original span's text
+                _nodes.Add(new UnstructuredTranslatableNode(_fragments, _fragments.Count, id, source));
+                _fragments.Add(source);
+
+                spanStart = lastSpanEnd >= text.Length
+                    ? -1 // don't search beyond the end of the text
+                    : text.IndexOf(TranslatableSpanMarker, lastSpanEnd + 1);
+            }
+
+            if (lastSpanEnd < text.Length)
+            {
+                // add final span
+                _fragments.Add(text.Substring(lastSpanEnd));
+            }
+        }
+
+        protected override void SaveCore(TextWriter writer)
+        {
+            foreach (string fragment in _fragments)
+            {
+                writer.Write(fragment);
+            }
+        }
+
+        private sealed class UnstructuredTranslatableNode : TranslatableNode
+        {
+            private IList<string> _fragments;
+            private int _fragmentIndex;
+
+            public UnstructuredTranslatableNode(IList<string> fragments, int fragmentIndex, string id, string source)
+                : base(id, source, null)
+            {
+                _fragments = fragments;
+                _fragmentIndex = fragmentIndex;
+            }
+
+            public override void Translate(string translation)
+            {
+                _fragments[_fragmentIndex] = translation;
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/Model/VsctDocument.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Model/VsctDocument.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Xml.Linq;
+
+namespace XliffTasks.Model
+{
+    /// <summary>
+    /// A <see cref="TranslatableDocument"/> for files in .vsct format.
+    /// See https://msdn.microsoft.com/en-us/library/bb164699.aspx
+    /// </summary>
+    internal sealed class VsctDocument : TranslatableXmlDocument
+    {
+        protected override IEnumerable<TranslatableNode> GetTranslatableNodes()
+        {
+            HashSet<string> nonUniqueIds = FindNonUniqueIds();
+
+            foreach (XElement strings in Document.Descendants(Document.Root.Name.Namespace + "Strings"))
+            {
+                string id = strings.Parent.Attribute("id").Value;
+                if (nonUniqueIds.Contains(id))
+                {
+                    // The ID by itself is not unique in this document; we must include
+                    // the GUID as well.
+                    string guid = strings.Parent.Attribute("guid").Value;
+                    id = guid + "|" + id;
+                }
+
+                foreach (XElement child in strings.Elements())
+                {
+                    XName name = child.Name;
+
+                    if (name.LocalName == "CanonicalName")
+                    {
+                        // CanonicalName is never localized.
+                        // LocCanonicalName can be used to specify a localized alternative.
+                        // See https://msdn.microsoft.com/en-us/library/bb491712.aspx
+                        continue;
+                    }
+
+                    yield return new TranslatableXmlElement(
+                        id: $"{id}|{name.LocalName}",
+                        source: child.Value,
+                        note: null,
+                        element: child);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Finds the set of IDs that do not uniquely identify a single set of strings.
+        /// Within a .vsct file only the combination of GUID and ID needs to be unique,
+        /// but for brevity we'd prefer to use just the ID when we can. By finding the
+        /// set of non-unique IDs we can identify when this will not be sufficient.
+        /// </summary>
+        /// <returns></returns>
+        private HashSet<string> FindNonUniqueIds()
+        {
+            HashSet<string> idsAlreadySeen = new();
+            HashSet<string> conflictingIds = new();
+
+            foreach (XElement strings in Document.Descendants(Document.Root.Name.Namespace + "Strings"))
+            {
+                string id = strings.Parent.Attribute("id").Value;
+
+                if (!idsAlreadySeen.Add(id))
+                {
+                    conflictingIds.Add(id);
+                }
+            }
+
+            return conflictingIds;
+        }
+
+        public override void RewriteRelativePathsToAbsolute(string sourceFullPath)
+        {
+            foreach (XElement imageTag in Document.Descendants(Document.Root.Name.Namespace + "Bitmap"))
+            {
+                XAttribute hrefAttribute = imageTag.Attribute("href");
+
+                if (hrefAttribute != null)
+                {
+                    string resourceRelativePath = hrefAttribute.Value.Replace('\\', Path.DirectorySeparatorChar);
+
+                    string absolutePath = Path.Combine(Path.GetDirectoryName(sourceFullPath), resourceRelativePath);
+
+                    imageTag.Attribute("href").Value = absolutePath;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/Model/XDocumentExtensions.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Model/XDocumentExtensions.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace XliffTasks.Model
+{
+    internal static class XDocumentExtensions
+    {
+        /// <summary>
+        /// Save the given document to the given writer, with shared defaults
+        /// for all XML writing by this library.
+        /// </summary>
+        public static void SaveCustom(this XDocument document, TextWriter writer)
+        {
+            XmlWriterSettings settings = new()
+            {
+                Indent = true,
+                OmitXmlDeclaration = writer is StringWriter,
+            };
+
+            using XmlWriter xmlWriter = XmlWriter.Create(writer, settings);
+            document.Save(xmlWriter);
+        }
+
+        public static void SelfCloseIfPossible(this XElement element)
+        {
+            if (element.Value.Length == 0)
+            {
+                element.RemoveNodes();
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/Model/XElementExtensions.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Model/XElementExtensions.cs
@@ -1,0 +1,138 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Xml.Linq;
+using static XliffTasks.Model.XlfNames;
+
+namespace XliffTasks.Model
+{
+    internal static class XElementExtensions
+    {
+        /// <summary>
+        /// Returns the effective target value of a <code>trans-unit</code> element in an XLIFF file.
+        /// If the <code>trans-unit</code> has no <code>target</code> child, returns the value of the <code>source</code>
+        /// child.
+        /// </summary>
+        /// <param name="transUnitElement">An <see cref="XElement"/> representing the <code>trans-unit</code>.</param>
+        /// <returns>The value of the <code>target</code> element if it exists; otherwise the value of the
+        /// <code>source</code> element.</returns>
+        public static string GetTargetValue(this XElement transUnitElement) => 
+            transUnitElement.Element(Target)?.Value
+            ?? transUnitElement.Element(Source).Value;
+
+        /// <summary>
+        /// Sets the target value of a <code>trans-unit</code> element in an XLIFF file.
+        /// Creates the <code>target</code> element and <code>state</code> attribute as necessary.
+        /// </summary>
+        /// <param name="transUnitElement">An <see cref="XElement"/> representing the <code>trans-unit</code>.</param>
+        /// <param name="value">The new target value.</param>
+        public static void SetTargetValue(this XElement transUnitElement, string value)
+        {
+            XElement targetElement = transUnitElement.Element(Target);
+            if (targetElement == null)
+            {
+                XElement sourceElement = transUnitElement.Element(Source);
+                targetElement = new XElement(Target, new XAttribute("state", "new"));
+                sourceElement.AddAfterSelf(targetElement);
+            }
+
+            targetElement.Value = value;
+            if (targetElement.Attribute("state") == null)
+            {
+                targetElement.Add(new XAttribute("state", "new"));
+            }
+        }
+
+        /// <summary>
+        /// Returns the effective target translation of a <code>trans-unit</code> element in an XLIFF file.
+        /// If the <code>trans-unit</code> has no <code>target</code> element or <code>state</code> attribute,
+        /// returns a default value ("new").
+        /// </summary>
+        /// <param name="transUnitElement">An <see cref="XElement"/> representing the <code>trans-unit</code>.</param>
+        /// <returns>The value of the <code>state</code> attribute if it exists, otherwise "new".</returns>
+        public static string GetTargetState(this XElement transUnitElement) =>
+            transUnitElement.Element(Target)?.Attribute("state")?.Value
+            ?? "new";
+
+        /// <summary>
+        /// Sets the target translation state of a <code>trans-unit</code> element in an XLIFF file.
+        /// Creates the <code>target</code> element and <code>state</code> attribute as necessary.
+        /// </summary>
+        /// <param name="transUnitElement">An <see cref="XElement"/> representing the <code>trans-unit</code>.</param>
+        /// <param name="value">The new state value.</param>
+        public static void SetTargetState(this XElement transUnitElement, string value)
+        {
+            XElement targetElement = transUnitElement.Element(Target);
+            if (targetElement == null)
+            {
+                XElement sourceElement = transUnitElement.Element(Source);
+                targetElement = new XElement(Target);
+                sourceElement.AddAfterSelf(targetElement);
+            }
+
+            XAttribute stateAttribute = targetElement.Attribute("state");
+            if (stateAttribute == null)
+            {
+                stateAttribute = new XAttribute("state", value);
+                targetElement.Add(stateAttribute);
+            }
+            else
+            {
+                stateAttribute.Value = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the <code>source</code> value of a <code>trans-unit</code> element in an XLIFF file.
+        /// </summary>
+        /// <param name="transUnitElement">An <see cref="XElement"/> representing the <code>trans-unit</code>.</param>
+        /// <returns>The value of the <code>source</code> element.</returns>
+        public static string GetSourceValue(this XElement transUnitElement) =>
+            transUnitElement.Element(Source).Value;
+
+        /// <summary>
+        /// Sets the <code>source</code> value of a <code>trans-unit</code> element in an XLIFF file.
+        /// </summary>
+        /// <param name="transUnitElement">An <see cref="XElement"/> representing the <code>trans-unit</code>.</param>
+        /// <param name="value">The new <code>source</code> value.</param>
+        public static void SetSourceValue(this XElement transUnitElement, string value) =>
+            transUnitElement.Element(Source).Value = value;
+
+        /// <summary>
+        /// Gets the <code>note</code> value of a <code>trans-unit</code> element in an XLIFF file.
+        /// </summary>
+        /// <param name="transUnitElement">An <see cref="XElement"/> representing the <code>trans-unit</code>.</param>
+        /// <returns>The value of the <code>note</code> element, or <code>null</code> if it does not exist.</returns>
+        public static string GetNoteValue(this XElement transUnitElement) =>
+            transUnitElement.Element(Note)?.Value;
+
+        /// <summary>
+        /// Sets the <code>note</code> value of a <code>trans-unit</code> element in an XLIFF file.
+        /// Creates the <code>note</code> element as needed, and places it in the correct location
+        /// relative to the <code>source</code> and <code>target</code> elements.
+        /// </summary>
+        /// <param name="transUnitElement">An <see cref="XElement"/> representing the <code>trans-unit</code>.</param>
+        /// <param name="value">The new <code>note</code> value.</param>
+        public static void SetNoteValue(this XElement transUnitElement, string value)
+        {
+            XElement noteElement = transUnitElement.Element(Note);
+            if (noteElement == null)
+            {
+                XElement priorElement = transUnitElement.Element(Target) ?? transUnitElement.Element(Source);
+                noteElement = new XElement(Note);
+                priorElement.AddAfterSelf(noteElement);
+            }
+
+            noteElement.Value = value;
+            noteElement.SelfCloseIfPossible();
+        }
+
+        /// <summary>
+        /// Gets the <code>id</code> value of a <code>trans-unit</code> element in an XLIFF file.
+        /// </summary>
+        /// <param name="transUnitElement">An <see cref="XElement"/> representing the <code>trans-unit</code>.</param>
+        /// <returns>The value of the <code>id</code> attribute.</returns>
+        public static string GetId(this XElement transUnitElement) =>
+            transUnitElement.Attribute("id").Value;
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/Model/XamlRuleDocument.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Model/XamlRuleDocument.cs
@@ -1,0 +1,220 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace XliffTasks.Model
+{
+    /// <summary>
+    /// A <see cref="TranslatableDocument"/> for files in CPS rule .xaml format
+    /// See https://msdn.microsoft.com/en-us/library/ekyft91f(v=vs.100).aspx
+    /// </summary>
+    internal sealed class XamlRuleDocument : TranslatableXmlDocument
+    {
+        private const string XliffTasksNs = "https://github.com/dotnet/xliff-tasks";
+        private const string LocalizedPropertiesAttributeName = "LocalizedProperties";
+        
+        protected override IEnumerable<TranslatableNode> GetTranslatableNodes()
+        {
+            foreach (XElement? element in Document.Descendants())
+            {
+                // first, let's check if the element has a descendent by the name of {elementLocalName.Description/DisplayName}
+                var descendentDisplayName = element.Elements(XName.Get($"{element.Name.LocalName}.DisplayName", element.Name.NamespaceName)).FirstOrDefault();
+                var descendentDescription = element.Elements(XName.Get($"{element.Name.LocalName}.Description", element.Name.NamespaceName)).FirstOrDefault();
+
+                if (descendentDisplayName is not null)
+                {
+                    yield return new TranslatableXmlElement(
+                        id: GenerateIdForDisplayNameOrDescription(descendentDisplayName),
+                        source: descendentDisplayName.Value,
+                        note: GetComment(descendentDisplayName, XmlName(descendentDisplayName)),
+                        element: descendentDisplayName
+                    );
+                }
+                
+                if (descendentDescription is not null)
+                {
+                    yield return new TranslatableXmlElement(
+                        id: GenerateIdForDisplayNameOrDescription(descendentDescription),
+                        source: descendentDescription.Value,
+                        note: GetComment(descendentDescription, XmlName(descendentDescription)),
+                        element: descendentDescription
+                    );
+                }
+                
+                var localizableProperties = element.Attribute(XName.Get(LocalizedPropertiesAttributeName, XliffTasksNs))?.Value?.Split(';');
+
+                if (localizableProperties is not null)
+                {
+                    // we could have any number of descendent localizable properties
+                    foreach (var localizableProperty in localizableProperties)
+                    {
+                        if (element.Elements(XName.Get($"{element.Name.LocalName}.{localizableProperty}", element.Name.NamespaceName)).FirstOrDefault() is { } descendentValue)
+                        {
+                            yield return new TranslatableXmlElement(
+                                id: GenerateIdForPropertyMetadata(descendentValue),
+                                source: descendentValue.Value,
+                                note: GetComment(descendentValue, localizableProperty),
+                                element: descendentValue);
+                        }
+                    }
+                }
+
+                foreach (XAttribute? attribute in element.Attributes())
+                {
+                    if ((descendentDisplayName is null && XmlName(attribute) == "DisplayName")
+                        || (descendentDescription is null && XmlName(attribute) == "Description"))
+                    {
+                        yield return new TranslatableXmlAttribute(
+                            id: GenerateIdForDisplayNameOrDescription(attribute),
+                            source: attribute.Value,
+                            note: GetComment(element, XmlName(attribute)),
+                            attribute: attribute);
+                    }
+                    else if (AttributedName(element) == "SearchTerms" && (XmlName(attribute) == "Value" || element.Elements(XName.Get($"{element.Name.LocalName}.Value", element.Name.NamespaceName)).FirstOrDefault() is { }))
+                    {
+                        if (XmlName(attribute) == "Value")
+                        {
+                            yield return new TranslatableXmlAttribute(
+                                id: GenerateIdForPropertyMetadata(element),
+                                source: attribute.Value,
+                                note: GetComment(element, XmlName(attribute)),
+                                attribute: attribute);
+                        }
+                        // else if we have a descendent in the form of {elementLocalName}.Value, we should translate that descendent
+                        else if (element.Elements(XName.Get($"{element.Name.LocalName}.Value", element.Name.NamespaceName)).FirstOrDefault() is { } descendentValue)
+                        {
+                            yield return new TranslatableXmlElement(
+                                id: GenerateIdForPropertyMetadata(element),
+                                source: descendentValue.Value,
+                                note: GetComment(descendentValue, XmlName(attribute)),
+                                element: descendentValue);
+                        }
+                    }
+                    else
+                    {
+                        if (localizableProperties is null)
+                        {
+                            continue;
+                        }
+                        
+                        // if the property value is directly specified as an attribute
+                        if (localizableProperties.Contains(attribute.Name.LocalName))
+                        {
+                            yield return new TranslatableXmlAttribute(
+                                id: GenerateIdForPropertyMetadata(element, attribute),
+                                source: attribute.Value,
+                                note: GetComment(element, XmlName(attribute)),
+                                attribute: attribute);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static string GenerateIdForDisplayNameOrDescription(XObject xObject)
+        {
+            var parent = xObject.Parent;
+            if (parent is null)
+            {
+                throw new ArgumentException("Attribute must have a parent element", nameof(xObject));
+            }
+
+            if (XmlName(parent) == "EnumValue")
+            {
+                var grandparent = parent.Parent;
+                if (grandparent is null)
+                {
+                    throw new ArgumentException("Attribute must have a grandparent element", nameof(xObject));
+                }
+                
+                return $"{XmlName(parent)}|{AttributedName(grandparent)}.{AttributedName(parent)}|{XmlName(xObject)}";
+            }
+
+            return $"{XmlName(parent)}|{AttributedName(parent)}|{XmlName(xObject)}";
+        }
+
+        private static string GenerateIdForPropertyMetadata(XElement element, XAttribute? attribute = null)
+        {
+            var ancestorWithNameAttributeCandidate = element.Parent?.Parent; // start at grandparent
+            var idBuilder = new StringBuilder();
+
+            // if has no grandparent, we'll try parent
+            if (ancestorWithNameAttributeCandidate is null)
+            {
+                if (element.Parent is not null)
+                {
+                    idBuilder.Append(element.Parent.Attribute("Name") is null ? XmlName(element.Parent) : $"{XmlName(element.Parent)}|{AttributedName(element.Parent)}");
+                    idBuilder.Append("|Metadata|");
+                }
+
+                idBuilder.Append(XmlName(element));
+                if (element.Attribute("Name") is null)
+                {
+                    idBuilder.Append($"|{AttributedName(element)}");
+                }
+                
+                if (attribute is not null)
+                {
+                    idBuilder.Append($"|{XmlName(attribute)}");
+                }
+
+                return idBuilder.ToString();
+            }
+
+            // while the current ancestor has a parent and does not have a name, append its XmlName to the id and go up a level  
+            while (ancestorWithNameAttributeCandidate?.Attribute("Name") is null && ancestorWithNameAttributeCandidate?.Parent is not null) {
+            {
+                idBuilder.Insert(0, $"{XmlName(ancestorWithNameAttributeCandidate)}|");
+                ancestorWithNameAttributeCandidate = ancestorWithNameAttributeCandidate.Parent;
+            }}
+
+            idBuilder.Insert(0, $"{XmlName(ancestorWithNameAttributeCandidate!)}|{AttributedName(ancestorWithNameAttributeCandidate!)}|");
+
+            idBuilder.Append($"Metadata|");
+            idBuilder.Append(element.Attribute("Name") is not null ? AttributedName(element) : XmlName(element));
+
+            if (attribute is not null)
+            {
+                idBuilder.Append($"|{attribute.Name.LocalName}");
+            }
+
+
+            return idBuilder.ToString();
+        }
+
+        private static string? GetComment(XElement element, string attributeName)
+        {
+            foreach (XComment comment in element.Nodes().OfType<XComment>())
+            {
+                foreach (string? line in comment.Value.Split(new[] { '\n' }, System.StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()))
+                {
+                    if (line.StartsWith(attributeName))
+                    {
+                        return line.Substring(attributeName.Length).Trim(':', ' ', '\t');
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static string XmlName(XObject container) => container is XElement element ? XmlName(element) : XmlName((XAttribute)container);
+        private static string XmlName(XElement element)
+        {
+            var localName = element.Name.LocalName;
+            // if we have a descendent element, we should only take the last part of the name after the dot
+            return localName.Contains('.') ? localName.Split('.').Last() : localName;
+        }
+
+        private static string XmlName(XAttribute attribute) => attribute.Name.LocalName;
+
+        private static string? AttributedName(XElement element) => element.Attribute("Name")?.Value;
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/Model/XlfDocument.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Model/XlfDocument.cs
@@ -1,0 +1,325 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.Schema;
+using XliffTasks.Tasks;
+using static XliffTasks.Model.XlfNames;
+
+namespace XliffTasks.Model
+{
+    /// <summary>
+    /// Represents a document in XLIFF format which can be updated from source from
+    /// <see cref="TranslatableDocument"/> instances and produce translation data
+    /// for <see cref="TranslatableDocument.Translate"/>.
+    /// 
+    /// See https://en.wikipedia.org/wiki/XLIFF
+    /// </summary>
+    internal sealed class XlfDocument : Document
+    {
+        private static XmlSchemaSet s_schemaSet;
+        
+        private static readonly XNamespace XsiNS = "http://www.w3.org/2001/XMLSchema-instance";
+
+        private XDocument _document;
+
+        /// <summary>
+        /// Indicates if content has been loaded in to the document.
+        /// </summary>
+        public override bool HasContent => _document != null;
+
+        /// <summary>
+        /// Loads (or reloads) the document content from the given reader.
+        /// </summary>
+        public override void Load(System.IO.TextReader reader)
+        {
+            _document = XDocument.Load(reader);
+        }
+
+        /// <summary>
+        /// Loads initial document content for a new XLIFF document.
+        /// </summary>
+        public void LoadNew(string targetLanguage)
+        {
+            _document = new XDocument(
+                new XElement(Xliff,
+                    new XAttribute("xmlns", XliffNS.NamespaceName),
+                    new XAttribute(XNamespace.Xmlns + "xsi", XsiNS.NamespaceName),
+                    new XAttribute("version", "1.2"),
+                    new XAttribute(XsiNS + "schemaLocation", $"{XliffNS.NamespaceName} xliff-core-1.2-transitional.xsd"),
+                    new XElement(File,
+                        new XAttribute("datatype", "xml"),
+                        new XAttribute("source-language", "en"),
+                        new XAttribute("target-language", targetLanguage),
+                        new XAttribute("original", "_"), // placeholder will be replaced on first update
+                        new XElement(Body))));
+        }
+
+        /// <summary>
+        /// Saves the document's content (with translations applied if <see cref="Translate" /> was called) to the given file path.
+        /// </summary>
+        public override void Save(System.IO.TextWriter writer)
+        {
+            EnsureContent();
+            _document.SaveCustom(writer);
+        }
+
+        /// <summary>
+        /// Updates this XLIFF document with the source data from the given translatable document.
+        /// </summary>
+        /// <returns>True if any changes were made to this document.</returns>
+        public bool Update(TranslatableDocument sourceDocument, string sourceDocumentId)
+        {
+            bool changed = false;
+            Dictionary<string, TranslatableNode> nodesById = new();
+            foreach (TranslatableNode node in sourceDocument.Nodes)
+            {
+                if (nodesById.ContainsKey(node.Id))
+                {
+                    throw new BuildErrorException($"The document '{sourceDocumentId}' has a duplicate node '{node.Id}'.");
+                }
+
+                nodesById.Add(node.Id, node);
+            }
+
+            XElement fileElement = _document.Root.Element(File);
+            XAttribute originalAttribute = fileElement.Attribute("original");
+            if (originalAttribute.Value != sourceDocumentId)
+            {
+                // update original path in case where user has renaned source file and corresponding xlf
+                originalAttribute.Value = sourceDocumentId;
+                changed = true;
+            }
+
+            XElement bodyElement = fileElement.Element(Body);
+            XElement groupElement = bodyElement.Element(Group);
+
+            if (groupElement != null && !groupElement.Elements().Any())
+            {
+                // remove unnecessary empty group added by older tool. We don't want to bother keeping that unnecessary id up-to-date.
+                groupElement.Remove();
+                changed = true;
+            }
+
+            foreach (XElement unitElement in bodyElement.Descendants(TransUnit).ToList())
+            {
+                string id = unitElement.GetId();
+                string state = unitElement.GetTargetState();
+                string source = unitElement.GetSourceValue();
+                string note = unitElement.GetNoteValue();
+
+                // delete node in document that has been removed from source.
+                if (!nodesById.TryGetValue(id, out TranslatableNode sourceNode))
+                {
+                    unitElement.Remove();
+                    changed = true;
+                    continue;
+                }
+
+                // update trans-unit state if either the source text or associated note has change.
+                if (source != sourceNode.Source || (sourceNode.Note != null && note != sourceNode.Note))
+                {
+                    unitElement.SetSourceValue(sourceNode.Source);
+
+                    // if sourceNode.Note is null, it indicates that the source format can't have notes, in which case
+                    // they may be applied directly to the xlf by the user and we should not revert that on update
+                    if (sourceNode.Note != null)
+                    {
+                        unitElement.SetNoteValue(sourceNode.Note);
+                    }
+
+                    switch (state)
+                    {
+                        case "new":
+                            // when a new string gets modified before it has been translated,
+                            // update untranslated target to match the new source
+                            unitElement.SetTargetValue(sourceNode.Source);
+                            break;
+
+                        case "translated":
+                            // flag strings that have been modified after translation for review/re-translation
+                            unitElement.SetTargetState("needs-review-translation");
+                            break;
+                    }
+
+                    changed = true;
+                }
+
+                // If the source and target require different numbers of formatting items then reset
+                // the target string completely. This avoids problems when the source has been updated
+                // to remove formatting items--when formatting the target string we won't have as many
+                // replacement items as it calls for, leading to an exception.
+                // And if the source string is updated to use _more_ items then formatting with the
+                // target string is likely to produce misleading (or outright meaningless) text. In
+                // either case we lose nothing by just reverting the string until it can be localized
+                // again.
+                // Note we don't limit this check to when the source has changed in the original
+                // document because we also want to catch errors introduced during translation.
+                int sourceReplacementCount = unitElement.GetSourceValue().GetReplacementCount();
+                int targetReplacementCount = unitElement.GetTargetValue().GetReplacementCount();
+
+                if (targetReplacementCount != sourceReplacementCount)
+                {
+                    unitElement.SetTargetValue(sourceNode.Source);
+                    unitElement.SetTargetState("new");
+
+                    changed = true;
+                }
+
+                // signal to loop below that this node is not new
+                nodesById.Remove(id);
+            }
+
+            // Add new trans-units
+            foreach (TranslatableNode sourceNode in sourceDocument.Nodes)
+            {
+                // Nodes that have been removed from nodesById table are not new and have already been handled.
+                // Do not refactor this check away by iterating over dictionary values as the document order must be maintained deterministically.
+                if (!nodesById.ContainsKey(sourceNode.Id))
+                {
+                    continue;
+                }
+
+                XElement newTransUnit = 
+                    new(TransUnit,
+                        new XAttribute("id", sourceNode.Id),
+                        new XElement(Source, sourceNode.Source),
+                        new XElement(Target, new XAttribute("state", "new"), sourceNode.Source),
+                        new XElement(Note, sourceNode.Note == "" ? null : sourceNode.Note));
+
+                bool inserted = false;
+                foreach (XElement transUnit in bodyElement.Elements(TransUnit))
+                {
+                    if (StringComparer.Ordinal.Compare(newTransUnit.GetId(), transUnit.GetId()) < 0)
+                    {
+                        transUnit.AddBeforeSelf(newTransUnit);
+                        inserted = true;
+                        break;
+                    }
+                }
+
+                if (!inserted)
+                {
+                    bodyElement.Add(newTransUnit);
+                }
+
+                changed = true;
+            }
+
+            return changed;
+        }
+
+        /// <summary>
+        /// Sorts the <code>trans-unit</code> elements in the document by their <code>id</code> attribute.
+        /// </summary>
+        /// <returns>Returns <code>true</code> if the document was modified; <code>false</code> otherwise.</returns>
+        public bool Sort()
+        {
+            bool changed = false;
+
+            XNamespace ns = _document.Root.Name.Namespace;
+
+            XElement fileElement = _document.Root.Element(File);
+            XElement bodyElement = fileElement.Element(Body);
+
+            IEnumerable<XElement> transUnits = bodyElement.Elements(TransUnit);
+
+            IComparer<string> comparer = StringComparer.Ordinal;
+            if (!transUnits.IsSorted(tu => tu.GetId(), comparer))
+            {
+                changed = true;
+                SortedList<string, XElement> sortedTransUnits = new(comparer);
+
+                // Sort the translation units
+                foreach (XElement transUnit in transUnits)
+                {
+                    sortedTransUnits.Add(transUnit.GetId(), transUnit);
+                }
+
+                // Remove them from the body element
+                foreach (XElement transUnit in sortedTransUnits.Values)
+                {
+                    transUnit.Remove();
+                }
+
+                // Add them back in sorted order
+                bodyElement.Add(sortedTransUnits.Values);
+            }
+
+            return changed;
+        }
+
+        /// <summary>
+        /// Gets the translations (key=id, value=target), which can
+        /// be passed on to <see cref="TranslatableDocument.Translate"/>.
+        /// </summary>
+        public IReadOnlyDictionary<string, string> GetTranslations()
+        {
+            Dictionary<string, string> dictionary = new();
+
+            foreach (XElement element in _document.Descendants(TransUnit))
+            {
+                string id = element.GetId();
+                string target = element.GetTargetValue();
+
+                dictionary.Add(id, target);
+            }
+
+            return dictionary;
+        }
+
+        public ISet<string> GetUntranslatedResourceIDs()
+        {
+            XNamespace ns = _document.Root.Name.Namespace;
+
+            IEnumerable<string> untranslatedResourceIDs =
+                (_document.Descendants(TransUnit)
+                 .Where(tu =>
+                 {
+                     return tu.GetTargetState() != "translated";
+                 })
+                 .Select(tu => tu.GetId()));
+
+            return new HashSet<string>(untranslatedResourceIDs, StringComparer.Ordinal);
+        }
+
+        /// <summary>
+        /// Runs the document through XSD schema validation and reports any errors.
+        /// </summary>
+        /// <param name="validationErrorHandler">Handler invoked for each validation error.</param>
+        public void Validate(Action<XmlSchemaException> validationErrorHandler)
+        {
+            if (!HasContent)
+            {
+                return;
+            }
+
+            XmlSchemaSet schemas = GetSchemaSet();
+
+            _document.Validate(schemas, (o, e) => validationErrorHandler(e.Exception));
+        }
+
+        private static XmlSchemaSet GetSchemaSet()
+        {
+            if (s_schemaSet == null)
+            {
+                System.IO.Stream xmlSchemaResourceStream = typeof(XlfDocument).Assembly.GetManifestResourceStream("XliffTasks.Model.xml.xsd");
+                XmlReader xmlSchemaReader = XmlReader.Create(xmlSchemaResourceStream);
+                System.IO.Stream xliffSchemaResourceStream = typeof(XlfDocument).Assembly.GetManifestResourceStream("XliffTasks.Model.xliff-core-1.2-transitional.xsd");
+                XmlReader xliffSchemaReader = XmlReader.Create(xliffSchemaResourceStream);
+
+                XmlSchemaSet schemas = new();
+                schemas.Add(targetNamespace: null, xmlSchemaReader);
+                schemas.Add(targetNamespace: null, xliffSchemaReader);
+
+                s_schemaSet = schemas;
+            }
+
+            return s_schemaSet;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/Model/XlfNames.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Model/XlfNames.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Xml.Linq;
+
+namespace XliffTasks.Model
+{
+    internal static class XlfNames
+    {
+        public static readonly XNamespace XliffNS = "urn:oasis:names:tc:xliff:document:1.2";
+        public static readonly XName Xliff = XliffNS + "xliff";
+        public static readonly XName File = XliffNS + "file";
+        public static readonly XName Body = XliffNS + "body";
+        public static readonly XName Group = XliffNS + "group";
+        public static readonly XName TransUnit = XliffNS + "trans-unit";
+        public static readonly XName Source = XliffNS + "source";
+        public static readonly XName Target = XliffNS + "target";
+        public static readonly XName Note = XliffNS + "note";
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/Model/xliff-core-1.2-transitional.xsd
+++ b/src/Microsoft.DotNet.XliffTasks/Model/xliff-core-1.2-transitional.xsd
@@ -1,0 +1,2261 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+May-19-2004:
+- Changed the <choice> for ElemType_header, moving minOccurs="0" maxOccurs="unbounded" from its elements 
+to <choice> itself.
+- Added <choice> for ElemType_trans-unit to allow "any order" for <context-group>, <count-group>, <prop-group>, <note>, and
+<alt-trans>.
+
+Oct-2005
+- updated version info to 1.2
+- equiv-trans attribute to <trans-unit> element 
+- merged-trans attribute for <group> element
+- Add the <seg-source> element as optional in the <trans-unit> and <alt-trans> content models, at the same level as <source> 
+- Create a new value "seg" for the mtype attribute of the <mrk> element
+- Add mid as an optional attribute for the <alt-trans> element
+
+Nov-14-2005
+- Changed name attribute for <context-group> from required to optional
+- Added extension point at <xliff>
+
+Jan-9-2006
+- Added alttranstype type attribute to <alt-trans>, and values
+
+Jan-10-2006
+- Corrected error with overwritten purposeValueList
+- Corrected name="AttrType_Version",  attribute should have been "name"
+
+-->
+<xsd:schema xmlns:xlf="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="urn:oasis:names:tc:xliff:document:1.2" xml:lang="en">
+	<!-- Import for xml:lang and xml:space -->
+	<xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+	<!-- Attributes Lists -->
+	<xsd:simpleType name="XTend">
+		<xsd:restriction base="xsd:string">
+			<xsd:pattern value="x-[^\s]+"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="context-typeValueList">
+		<xsd:annotation>
+			<xsd:documentation>Values for the attribute 'context-type'.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="database">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a database content.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="element">
+				<xsd:annotation>
+					<xsd:documentation>Indicates the content of an element within an XML document.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="elementtitle">
+				<xsd:annotation>
+					<xsd:documentation>Indicates the name of an element within an XML document.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="linenumber">
+				<xsd:annotation>
+					<xsd:documentation>Indicates the line number from the sourcefile (see context-type="sourcefile") where the &lt;source&gt; is found.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="numparams">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a the number of parameters contained within the &lt;source&gt;.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="paramnotes">
+				<xsd:annotation>
+					<xsd:documentation>Indicates notes pertaining to the parameters in the &lt;source&gt;.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="record">
+				<xsd:annotation>
+					<xsd:documentation>Indicates the content of a record within a database.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="recordtitle">
+				<xsd:annotation>
+					<xsd:documentation>Indicates the name of a record within a database.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="sourcefile">
+				<xsd:annotation>
+					<xsd:documentation>Indicates the original source file in the case that multiple files are merged to form the original file from which the XLIFF file is created. This differs from the original &lt;file&gt; attribute in that this sourcefile is one of many that make up that file.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="count-typeValueList">
+		<xsd:annotation>
+			<xsd:documentation>Values for the attribute 'count-type'.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:NMTOKEN">
+			<xsd:enumeration value="num-usages">
+				<xsd:annotation>
+					<xsd:documentation>Indicates the count units are items that are used X times in a certain context; example: this is a reusable text unit which is used 42 times in other texts.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="repetition">
+				<xsd:annotation>
+					<xsd:documentation>Indicates the count units are translation units existing already in the same document.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="total">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a total count.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="InlineDelimitersValueList">
+		<xsd:annotation>
+			<xsd:documentation>Values for the attribute 'ctype' when used other elements than &lt;ph&gt; or &lt;x&gt;.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:NMTOKEN">
+			<xsd:enumeration value="bold">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a run of bolded text.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="italic">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a run of text in italics.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="underlined">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a run of underlined text.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="link">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a run of hyper-text.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="InlinePlaceholdersValueList">
+		<xsd:annotation>
+			<xsd:documentation>Values for the attribute 'ctype' when used with &lt;ph&gt; or &lt;x&gt;.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:NMTOKEN">
+			<xsd:enumeration value="image">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a inline image.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="pb">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a page break.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="lb">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a line break.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="mime-typeValueList">
+		<xsd:restriction base="xsd:string">
+			<xsd:pattern value="(text|multipart|message|application|image|audio|video|model)(/.+)*"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="datatypeValueList">
+		<xsd:annotation>
+			<xsd:documentation>Values for the attribute 'datatype'.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:NMTOKEN">
+			<xsd:enumeration value="asp">
+				<xsd:annotation>
+					<xsd:documentation>Indicates Active Server Page data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="c">
+				<xsd:annotation>
+					<xsd:documentation>Indicates C source file data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="cdf">
+				<xsd:annotation>
+					<xsd:documentation>Indicates Channel Definition Format (CDF) data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="cfm">
+				<xsd:annotation>
+					<xsd:documentation>Indicates ColdFusion data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="cpp">
+				<xsd:annotation>
+					<xsd:documentation>Indicates C++ source file data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="csharp">
+				<xsd:annotation>
+					<xsd:documentation>Indicates C-Sharp data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="cstring">
+				<xsd:annotation>
+					<xsd:documentation>Indicates strings from C, ASM, and driver files data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="csv">
+				<xsd:annotation>
+					<xsd:documentation>Indicates comma-separated values data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="database">
+				<xsd:annotation>
+					<xsd:documentation>Indicates database data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="documentfooter">
+				<xsd:annotation>
+					<xsd:documentation>Indicates portions of document that follows data and contains metadata.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="documentheader">
+				<xsd:annotation>
+					<xsd:documentation>Indicates portions of document that precedes data and contains metadata.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="filedialog">
+				<xsd:annotation>
+					<xsd:documentation>Indicates data from standard UI file operations dialogs (e.g., Open, Save, Save As, Export, Import).</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="form">
+				<xsd:annotation>
+					<xsd:documentation>Indicates standard user input screen data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="html">
+				<xsd:annotation>
+					<xsd:documentation>Indicates HyperText Markup Language (HTML) data - document instance.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="htmlbody">
+				<xsd:annotation>
+					<xsd:documentation>Indicates content within an HTML document’s &lt;body&gt; element.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="ini">
+				<xsd:annotation>
+					<xsd:documentation>Indicates Windows INI file data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="interleaf">
+				<xsd:annotation>
+					<xsd:documentation>Indicates Interleaf data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="javaclass">
+				<xsd:annotation>
+					<xsd:documentation>Indicates Java source file data (extension '.java').</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="javapropertyresourcebundle">
+				<xsd:annotation>
+					<xsd:documentation>Indicates Java property resource bundle data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="javalistresourcebundle">
+				<xsd:annotation>
+					<xsd:documentation>Indicates Java list resource bundle data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="javascript">
+				<xsd:annotation>
+					<xsd:documentation>Indicates JavaScript source file data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="jscript">
+				<xsd:annotation>
+					<xsd:documentation>Indicates JScript source file data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="layout">
+				<xsd:annotation>
+					<xsd:documentation>Indicates information relating to formatting.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="lisp">
+				<xsd:annotation>
+					<xsd:documentation>Indicates LISP source file data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="margin">
+				<xsd:annotation>
+					<xsd:documentation>Indicates information relating to margin formats.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="menufile">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a file containing menu.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="messagefile">
+				<xsd:annotation>
+					<xsd:documentation>Indicates numerically identified string table.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="mif">
+				<xsd:annotation>
+					<xsd:documentation>Indicates Maker Interchange Format (MIF) data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="mimetype">
+				<xsd:annotation>
+					<xsd:documentation>Indicates that the datatype attribute value is a MIME Type value and is defined in the mime-type attribute.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="mo">
+				<xsd:annotation>
+					<xsd:documentation>Indicates GNU Machine Object data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="msglib">
+				<xsd:annotation>
+					<xsd:documentation>Indicates Message Librarian strings created by Novell's Message Librarian Tool.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="pagefooter">
+				<xsd:annotation>
+					<xsd:documentation>Indicates information to be displayed at the bottom of each page of a document.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="pageheader">
+				<xsd:annotation>
+					<xsd:documentation>Indicates information to be displayed at the top of each page of a document.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="parameters">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a list of property values (e.g., settings within INI files or preferences dialog).</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="pascal">
+				<xsd:annotation>
+					<xsd:documentation>Indicates Pascal source file data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="php">
+				<xsd:annotation>
+					<xsd:documentation>Indicates Hypertext Preprocessor data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="plaintext">
+				<xsd:annotation>
+					<xsd:documentation>Indicates plain text file (no formatting other than, possibly, wrapping).</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="po">
+				<xsd:annotation>
+					<xsd:documentation>Indicates GNU Portable Object file.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="report">
+				<xsd:annotation>
+					<xsd:documentation>Indicates dynamically generated user defined document. e.g. Oracle Report, Crystal Report, etc.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="resources">
+				<xsd:annotation>
+					<xsd:documentation>Indicates Windows .NET binary resources.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="resx">
+				<xsd:annotation>
+					<xsd:documentation>Indicates Windows .NET Resources.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="rtf">
+				<xsd:annotation>
+					<xsd:documentation>Indicates Rich Text Format (RTF) data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="sgml">
+				<xsd:annotation>
+					<xsd:documentation>Indicates Standard Generalized Markup Language (SGML) data - document instance.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="sgmldtd">
+				<xsd:annotation>
+					<xsd:documentation>Indicates Standard Generalized Markup Language (SGML) data - Document Type Definition (DTD).</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="svg">
+				<xsd:annotation>
+					<xsd:documentation>Indicates Scalable Vector Graphic (SVG) data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="vbscript">
+				<xsd:annotation>
+					<xsd:documentation>Indicates VisualBasic Script source file.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="warning">
+				<xsd:annotation>
+					<xsd:documentation>Indicates warning message.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="winres">
+				<xsd:annotation>
+					<xsd:documentation>Indicates Windows (Win32) resources (i.e. resources extracted from an RC script, a message file, or a compiled file).</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="xhtml">
+				<xsd:annotation>
+					<xsd:documentation>Indicates Extensible HyperText Markup Language (XHTML) data - document instance.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="xml">
+				<xsd:annotation>
+					<xsd:documentation>Indicates Extensible Markup Language (XML) data - document instance.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="xmldtd">
+				<xsd:annotation>
+					<xsd:documentation>Indicates Extensible Markup Language (XML) data - Document Type Definition (DTD).</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="xsl">
+				<xsd:annotation>
+					<xsd:documentation>Indicates Extensible Stylesheet Language (XSL) data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="xul">
+				<xsd:annotation>
+					<xsd:documentation>Indicates XUL elements.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="mtypeValueList">
+		<xsd:annotation>
+			<xsd:documentation>Values for the attribute 'mtype'.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:NMTOKEN">
+			<xsd:enumeration value="abbrev">
+				<xsd:annotation>
+					<xsd:documentation>Indicates the marked text is an abbreviation.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="abbreviated-form">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.8: A term resulting from the omission of any part of the full term while designating the same concept.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="abbreviation">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.8.1: An abbreviated form of a simple term resulting from the omission of some of its letters (e.g. 'adj.' for 'adjective').</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="acronym">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.8.4: An abbreviated form of a term made up of letters from the full form of a multiword term strung together into a sequence pronounced only syllabically (e.g. 'radar' for 'radio detecting and ranging').</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="appellation">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620: A proper-name term, such as the name of an agency or other proper entity.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="collocation">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.18.1: A recurrent word combination characterized by cohesion in that the components of the collocation must co-occur within an utterance or series of utterances, even though they do not necessarily have to maintain immediate proximity to one another.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="common-name">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.5: A synonym for an international scientific term that is used in general discourse in a given language.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="datetime">
+				<xsd:annotation>
+					<xsd:documentation>Indicates the marked text is a date and/or time.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="equation">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.15: An expression used to represent a concept based on a statement that two mathematical expressions are, for instance, equal as identified by the equal sign (=), or assigned to one another by a similar sign.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="expanded-form">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.7: The complete representation of a term for which there is an abbreviated form.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="formula">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.14: Figures, symbols or the like used to express a concept briefly, such as a mathematical or chemical formula.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="head-term">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.1: The concept designation that has been chosen to head a terminological record.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="initialism">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.8.3: An abbreviated form of a term consisting of some of the initial letters of the words making up a multiword term or the term elements making up a compound term when these letters are pronounced individually (e.g. 'BSE' for 'bovine spongiform encephalopathy').</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="international-scientific-term">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.4: A term that is part of an international scientific nomenclature as adopted by an appropriate scientific body.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="internationalism">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.6: A term that has the same or nearly identical orthographic or phonemic form in many languages.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="logical-expression">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.16: An expression used to represent a concept based on mathematical or logical relations, such as statements of inequality, set relationships, Boolean operations, and the like.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="materials-management-unit">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.17: A unit to track object.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="name">
+				<xsd:annotation>
+					<xsd:documentation>Indicates the marked text is a name.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="near-synonym">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.3: A term that represents the same or a very similar concept as another term in the same language, but for which interchangeability is limited to some contexts and inapplicable in others.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="part-number">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.17.2: A unique alphanumeric designation assigned to an object in a manufacturing system.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="phrase">
+				<xsd:annotation>
+					<xsd:documentation>Indicates the marked text is a phrase.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="phraseological-unit">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.18: Any group of two or more words that form a unit, the meaning of which frequently cannot be deduced based on the combined sense of the words making up the phrase.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="protected">
+				<xsd:annotation>
+					<xsd:documentation>Indicates the marked text should not be translated.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="romanized-form">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.12: A form of a term resulting from an operation whereby non-Latin writing systems are converted to the Latin alphabet.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="seg">
+				<xsd:annotation>
+					<xsd:documentation>Indicates that the marked text represents a segment.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="set-phrase">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.18.2: A fixed, lexicalized phrase.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="short-form">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.8.2: A variant of a multiword term that includes fewer words than the full form of the term (e.g. 'Group of Twenty-four' for 'Intergovernmental Group of Twenty-four on International Monetary Affairs').</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="sku">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.17.1: Stock keeping unit, an inventory item identified by a unique alphanumeric designation assigned to an object in an inventory control system.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="standard-text">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.19: A fixed chunk of recurring text.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="symbol">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.13: A designation of a concept by letters, numerals, pictograms or any combination thereof.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="synonym">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.2: Any term that represents the same or a very similar concept as the main entry term in a term entry.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="synonymous-phrase">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.18.3: Phraseological unit in a language that expresses the same semantic content as another phrase in that same language.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="term">
+				<xsd:annotation>
+					<xsd:documentation>Indicates the marked text is a term.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="transcribed-form">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.11: A form of a term resulting from an operation whereby the characters of one writing system are represented by characters from another writing system, taking into account the pronunciation of the characters converted.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="transliterated-form">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.10: A form of a term resulting from an operation whereby the characters of an alphabetic writing system are represented by characters from another alphabetic writing system.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="truncated-term">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.8.5: An abbreviated form of a term resulting from the omission of one or more term elements or syllables (e.g. 'flu' for 'influenza').</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="variant">
+				<xsd:annotation>
+					<xsd:documentation>ISO-12620 2.1.9: One of the alternate forms of a term.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="restypeValueList">
+		<xsd:annotation>
+			<xsd:documentation>Values for the attribute 'restype'.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:NMTOKEN">
+			<xsd:enumeration value="auto3state">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a Windows RC AUTO3STATE control.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="autocheckbox">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a Windows RC AUTOCHECKBOX control.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="autoradiobutton">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a Windows RC AUTORADIOBUTTON control.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="bedit">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a Windows RC BEDIT control.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="bitmap">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a bitmap, for example a BITMAP resource in Windows.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="button">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a button object, for example a BUTTON control Windows.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="caption">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a caption, such as the caption of a dialog box.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="cell">
+				<xsd:annotation>
+					<xsd:documentation>Indicates the cell in a table, for example the content of the &lt;td&gt; element in HTML.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="checkbox">
+				<xsd:annotation>
+					<xsd:documentation>Indicates check box object, for example a CHECKBOX control in Windows.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="checkboxmenuitem">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a menu item with an associated checkbox.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="checkedlistbox">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a list box, but with a check-box for each item.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="colorchooser">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a color selection dialog.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="combobox">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a combination of edit box and listbox object, for example a COMBOBOX control in Windows.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="comboboxexitem">
+				<xsd:annotation>
+					<xsd:documentation>Indicates an initialization entry of an extended combobox DLGINIT resource block. (code 0x1234).</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="comboboxitem">
+				<xsd:annotation>
+					<xsd:documentation>Indicates an initialization entry of a combobox DLGINIT resource block (code 0x0403).</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="component">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a UI base class element that cannot be represented by any other element.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="contextmenu">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a context menu.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="ctext">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a Windows RC CTEXT control.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="cursor">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a cursor, for example a CURSOR resource in Windows.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="datetimepicker">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a date/time picker.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="defpushbutton">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a Windows RC DEFPUSHBUTTON control.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="dialog">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a dialog box.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="dlginit">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a Windows RC DLGINIT resource block.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="edit">
+				<xsd:annotation>
+					<xsd:documentation>Indicates an edit box object, for example an EDIT control in Windows.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="file">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a filename.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="filechooser">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a file dialog.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="fn">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a footnote.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="font">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a font name.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="footer">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a footer.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="frame">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a frame object.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="grid">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a XUL grid element.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="groupbox">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a groupbox object, for example a GROUPBOX control in Windows.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="header">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a header item.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="heading">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a heading, such has the content of &lt;h1&gt;, &lt;h2&gt;, etc. in HTML.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="hedit">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a Windows RC HEDIT control.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="hscrollbar">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a horizontal scrollbar.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="icon">
+				<xsd:annotation>
+					<xsd:documentation>Indicates an icon, for example an ICON resource in Windows.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="iedit">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a Windows RC IEDIT control.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="keywords">
+				<xsd:annotation>
+					<xsd:documentation>Indicates keyword list, such as the content of the Keywords meta-data in HTML, or a K footnote in WinHelp RTF.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="label">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a label object.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="linklabel">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a label that is also a HTML link (not necessarily a URL).</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="list">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a list (a group of list-items, for example an &lt;ol&gt; or &lt;ul&gt; element in HTML).</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="listbox">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a listbox object, for example an LISTBOX control in Windows.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="listitem">
+				<xsd:annotation>
+					<xsd:documentation>Indicates an list item (an entry in a list).</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="ltext">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a Windows RC LTEXT control.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="menu">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a menu (a group of menu-items).</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="menubar">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a toolbar containing one or more tope level menus.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="menuitem">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a menu item (an entry in a menu).</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="menuseparator">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a XUL menuseparator element.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="message">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a message, for example an entry in a MESSAGETABLE resource in Windows.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="monthcalendar">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a calendar control.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="numericupdown">
+				<xsd:annotation>
+					<xsd:documentation>Indicates an edit box beside a spin control.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="panel">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a catch all for rectangular areas.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="popupmenu">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a standalone menu not necessarily associated with a menubar.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="pushbox">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a pushbox object, for example a PUSHBOX control in Windows.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="pushbutton">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a Windows RC PUSHBUTTON control.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="radio">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a radio button object.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="radiobuttonmenuitem">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a menuitem with associated radio button.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="rcdata">
+				<xsd:annotation>
+					<xsd:documentation>Indicates raw data resources for an application.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="row">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a row in a table.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="rtext">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a Windows RC RTEXT control.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="scrollpane">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a user navigable container used to show a portion of a document.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="separator">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a generic divider object (e.g. menu group separator).</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="shortcut">
+				<xsd:annotation>
+					<xsd:documentation>Windows accelerators, shortcuts in resource or property files.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="spinner">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a UI control to indicate process activity but not progress.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="splitter">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a splitter bar.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="state3">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a Windows RC STATE3 control.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="statusbar">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a window for providing feedback to the users, like 'read-only', etc.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="string">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a string, for example an entry in a STRINGTABLE resource in Windows.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="tabcontrol">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a layers of controls with a tab to select layers.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="table">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a display and edits regular two-dimensional tables of cells.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="textbox">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a XUL textbox element.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="togglebutton">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a UI button that can be toggled to on or off state.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="toolbar">
+				<xsd:annotation>
+					<xsd:documentation>Indicates an array of controls, usually buttons.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="tooltip">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a pop up tool tip text.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="trackbar">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a bar with a pointer indicating a position within a certain range.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="tree">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a control that displays a set of hierarchical data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="uri">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a URI (URN or URL).</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="userbutton">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a Windows RC USERBUTTON control.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="usercontrol">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a user-defined control like CONTROL control in Windows.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="var">
+				<xsd:annotation>
+					<xsd:documentation>Indicates the text of a variable.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="versioninfo">
+				<xsd:annotation>
+					<xsd:documentation>Indicates version information about a resource like VERSIONINFO in Windows.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="vscrollbar">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a vertical scrollbar.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="window">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a graphical window.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="size-unitValueList">
+		<xsd:annotation>
+			<xsd:documentation>Values for the attribute 'size-unit'.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:NMTOKEN">
+			<xsd:enumeration value="byte">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a size in 8-bit bytes.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="char">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a size in Unicode characters.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="col">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a size in columns. Used for HTML text area.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="cm">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a size in centimeters.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="dlgunit">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a size in dialog units, as defined in Windows resources.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="em">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a size in 'font-size' units (as defined in CSS).</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="ex">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a size in 'x-height' units (as defined in CSS).</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="glyph">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a size in glyphs. A glyph is considered to be one or more combined Unicode characters that represent a single displayable text character. Sometimes referred to as a 'grapheme cluster'</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="in">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a size in inches.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="mm">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a size in millimeters.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="percent">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a size in percentage.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="pixel">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a size in pixels.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="point">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a size in point.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="row">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a size in rows. Used for HTML text area.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="stateValueList">
+		<xsd:annotation>
+			<xsd:documentation>Values for the attribute 'state'.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:NMTOKEN">
+			<xsd:enumeration value="final">
+				<xsd:annotation>
+					<xsd:documentation>Indicates the terminating state.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="needs-adaptation">
+				<xsd:annotation>
+					<xsd:documentation>Indicates only non-textual information needs adaptation.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="needs-l10n">
+				<xsd:annotation>
+					<xsd:documentation>Indicates both text and non-textual information needs adaptation.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="needs-review-adaptation">
+				<xsd:annotation>
+					<xsd:documentation>Indicates only non-textual information needs review.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="needs-review-l10n">
+				<xsd:annotation>
+					<xsd:documentation>Indicates both text and non-textual information needs review.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="needs-review-translation">
+				<xsd:annotation>
+					<xsd:documentation>Indicates that only the text of the item needs to be reviewed.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="needs-translation">
+				<xsd:annotation>
+					<xsd:documentation>Indicates that the item needs to be translated.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="new">
+				<xsd:annotation>
+					<xsd:documentation>Indicates that the item is new. For example, translation units that were not in a previous version of the document.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="signed-off">
+				<xsd:annotation>
+					<xsd:documentation>Indicates that changes are reviewed and approved.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="translated">
+				<xsd:annotation>
+					<xsd:documentation>Indicates that the item has been translated.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="state-qualifierValueList">
+		<xsd:annotation>
+			<xsd:documentation>Values for the attribute 'state-qualifier'.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:NMTOKEN">
+			<xsd:enumeration value="exact-match">
+				<xsd:annotation>
+					<xsd:documentation>Indicates an exact match. An exact match occurs when a source text of a segment is exactly the same as the source text of a segment that was translated previously.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="fuzzy-match">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a fuzzy match. A fuzzy match occurs when a source text of a segment is very similar to the source text of a segment that was translated previously (e.g. when the difference is casing, a few changed words, white-space discripancy, etc.).</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="id-match">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a match based on matching IDs (in addition to matching text).</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="leveraged-glossary">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a translation derived from a glossary.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="leveraged-inherited">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a translation derived from existing translation.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="leveraged-mt">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a translation derived from machine translation.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="leveraged-repository">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a translation derived from a translation repository.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="leveraged-tm">
+				<xsd:annotation>
+					<xsd:documentation>Indicates a translation derived from a translation memory.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="mt-suggestion">
+				<xsd:annotation>
+					<xsd:documentation>Indicates the translation is suggested by machine translation.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="rejected-grammar">
+				<xsd:annotation>
+					<xsd:documentation>Indicates that the item has been rejected because of incorrect grammar.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="rejected-inaccurate">
+				<xsd:annotation>
+					<xsd:documentation>Indicates that the item has been rejected because it is incorrect.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="rejected-length">
+				<xsd:annotation>
+					<xsd:documentation>Indicates that the item has been rejected because it is too long or too short.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="rejected-spelling">
+				<xsd:annotation>
+					<xsd:documentation>Indicates that the item has been rejected because of incorrect spelling.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="tm-suggestion">
+				<xsd:annotation>
+					<xsd:documentation>Indicates the translation is suggested by translation memory.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="unitValueList">
+		<xsd:annotation>
+			<xsd:documentation>Values for the attribute 'unit'.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:NMTOKEN">
+			<xsd:enumeration value="word">
+				<xsd:annotation>
+					<xsd:documentation>Refers to words.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="page">
+				<xsd:annotation>
+					<xsd:documentation>Refers to pages.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="trans-unit">
+				<xsd:annotation>
+					<xsd:documentation>Refers to &lt;trans-unit&gt; elements.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="bin-unit">
+				<xsd:annotation>
+					<xsd:documentation>Refers to &lt;bin-unit&gt; elements.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="glyph">
+				<xsd:annotation>
+					<xsd:documentation>Refers to glyphs.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="item">
+				<xsd:annotation>
+					<xsd:documentation>Refers to &lt;trans-unit&gt; and/or &lt;bin-unit&gt; elements.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="instance">
+				<xsd:annotation>
+					<xsd:documentation>Refers to the occurrences of instances defined by the count-type value.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="character">
+				<xsd:annotation>
+					<xsd:documentation>Refers to characters.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="line">
+				<xsd:annotation>
+					<xsd:documentation>Refers to lines.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="sentence">
+				<xsd:annotation>
+					<xsd:documentation>Refers to sentences.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="paragraph">
+				<xsd:annotation>
+					<xsd:documentation>Refers to paragraphs.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="segment">
+				<xsd:annotation>
+					<xsd:documentation>Refers to segments.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="placeable">
+				<xsd:annotation>
+					<xsd:documentation>Refers to placeables (inline elements).</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="priorityValueList">
+		<xsd:annotation>
+			<xsd:documentation>Values for the attribute 'priority'.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:positiveInteger">
+			<xsd:enumeration value="1">
+				<xsd:annotation>
+					<xsd:documentation>Highest priority.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="2">
+				<xsd:annotation>
+					<xsd:documentation>High priority.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="3">
+				<xsd:annotation>
+					<xsd:documentation>High priority, but not as important as 2.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="4">
+				<xsd:annotation>
+					<xsd:documentation>High priority, but not as important as 3.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="5">
+				<xsd:annotation>
+					<xsd:documentation>Medium priority, but more important than 6.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="6">
+				<xsd:annotation>
+					<xsd:documentation>Medium priority, but less important than 5.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="7">
+				<xsd:annotation>
+					<xsd:documentation>Low priority, but more important than 8.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="8">
+				<xsd:annotation>
+					<xsd:documentation>Low priority, but more important than 9.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="9">
+				<xsd:annotation>
+					<xsd:documentation>Low priority.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="10">
+				<xsd:annotation>
+					<xsd:documentation>Lowest priority.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="reformatValueYesNo">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="yes">
+				<xsd:annotation>
+					<xsd:documentation>This value indicates that all properties can be reformatted. This value must be used alone.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="no">
+				<xsd:annotation>
+					<xsd:documentation>This value indicates that no properties should be reformatted. This value must be used alone.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="reformatValueList">
+		<xsd:list>
+			<xsd:simpleType>
+		        <xsd:union memberTypes="xlf:XTend"> 
+			        <xsd:simpleType> 
+						<xsd:restriction base="xsd:string">
+							<xsd:enumeration value="coord">
+								<xsd:annotation>
+									<xsd:documentation>This value indicates that all information in the coord attribute can be modified.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:enumeration>
+							<xsd:enumeration value="coord-x">
+								<xsd:annotation>
+									<xsd:documentation>This value indicates that the x information in the coord attribute can be modified.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:enumeration>
+							<xsd:enumeration value="coord-y">
+								<xsd:annotation>
+									<xsd:documentation>This value indicates that the y information in the coord attribute can be modified.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:enumeration>
+							<xsd:enumeration value="coord-cx">
+								<xsd:annotation>
+									<xsd:documentation>This value indicates that the cx information in the coord attribute can be modified.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:enumeration>
+							<xsd:enumeration value="coord-cy">
+								<xsd:annotation>
+									<xsd:documentation>This value indicates that the cy information in the coord attribute can be modified.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:enumeration>
+							<xsd:enumeration value="font">
+								<xsd:annotation>
+									<xsd:documentation>This value indicates that all the information in the font attribute can be modified.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:enumeration>
+							<xsd:enumeration value="font-name">
+								<xsd:annotation>
+									<xsd:documentation>This value indicates that the name information in the font attribute can be modified.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:enumeration>
+							<xsd:enumeration value="font-size">
+								<xsd:annotation>
+									<xsd:documentation>This value indicates that the size information in the font attribute can be modified.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:enumeration>
+							<xsd:enumeration value="font-weight">
+								<xsd:annotation>
+									<xsd:documentation>This value indicates that the weight information in the font attribute can be modified.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:enumeration>
+							<xsd:enumeration value="css-style">
+								<xsd:annotation>
+									<xsd:documentation>This value indicates that the information in the css-style attribute can be modified.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:enumeration>
+							<xsd:enumeration value="style">
+								<xsd:annotation>
+									<xsd:documentation>This value indicates that the information in the style attribute can be modified.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:enumeration>
+							<xsd:enumeration value="ex-style">
+								<xsd:annotation>
+									<xsd:documentation>This value indicates that the information in the exstyle attribute can be modified.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:enumeration>
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:union>
+			</xsd:simpleType>
+		</xsd:list>
+	</xsd:simpleType>
+	<xsd:simpleType name="purposeValueList">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="information">
+				<xsd:annotation>
+					<xsd:documentation>Indicates that the context is informational in nature, specifying for example, how a term should be translated. Thus, should be displayed to anyone editing the XLIFF document.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="location">
+				<xsd:annotation>
+					<xsd:documentation>Indicates that the context-group is used to specify where the term was found in the translatable source. Thus, it is not displayed.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="match">
+				<xsd:annotation>
+					<xsd:documentation>Indicates that the context information should be used during translation memory lookups. Thus, it is not displayed.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="alttranstypeValueList">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="proposal">
+				<xsd:annotation>
+					<xsd:documentation>Represents a translation proposal from a translation memory or other resource.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="previous-version">
+				<xsd:annotation>
+					<xsd:documentation>Represents a previous version of the target element.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="rejected">
+				<xsd:annotation>
+					<xsd:documentation>Represents a rejected version of the target element.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="reference">
+				<xsd:annotation>
+					<xsd:documentation>Represents a translation to be used for reference purposes only, for example from a related product or a different language.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="accepted">
+				<xsd:annotation>
+					<xsd:documentation>Represents a proposed translation that was used for the translation of the trans-unit, possibly modified.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<!-- Other Types -->
+	<xsd:complexType name="ElemType_ExternalReference">
+		<xsd:choice>
+			<xsd:element ref="xlf:internal-file"/>
+			<xsd:element ref="xlf:external-file"/>
+		</xsd:choice>
+	</xsd:complexType>
+	<xsd:simpleType name="AttrType_purpose">
+		<xsd:list>
+			<xsd:simpleType>
+				<xsd:union memberTypes="xlf:purposeValueList xlf:XTend"/>
+			</xsd:simpleType>
+		</xsd:list>
+	</xsd:simpleType>
+	<xsd:simpleType name="AttrType_datatype">
+		<xsd:union memberTypes="xlf:datatypeValueList xlf:XTend"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="AttrType_restype">
+		<xsd:union memberTypes="xlf:restypeValueList xlf:XTend"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="AttrType_alttranstype">
+		<xsd:union memberTypes="xlf:alttranstypeValueList xlf:XTend"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="AttrType_context-type">
+		<xsd:union memberTypes="xlf:context-typeValueList xlf:XTend"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="AttrType_state">
+		<xsd:union memberTypes="xlf:stateValueList xlf:XTend"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="AttrType_state-qualifier">
+		<xsd:union memberTypes="xlf:state-qualifierValueList xlf:XTend"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="AttrType_count-type">
+		<xsd:union memberTypes="xlf:restypeValueList xlf:count-typeValueList xlf:datatypeValueList xlf:stateValueList xlf:state-qualifierValueList xlf:XTend"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="AttrType_InlineDelimiters">
+		<xsd:union memberTypes="xlf:InlineDelimitersValueList xlf:XTend"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="AttrType_InlinePlaceholders">
+		<xsd:union memberTypes="xlf:InlinePlaceholdersValueList xlf:XTend"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="AttrType_size-unit">
+		<xsd:union memberTypes="xlf:size-unitValueList xlf:XTend"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="AttrType_mtype">
+		<xsd:union memberTypes="xlf:mtypeValueList xlf:XTend"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="AttrType_unit">
+		<xsd:union memberTypes="xlf:unitValueList xlf:XTend"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="AttrType_priority">
+		<xsd:union memberTypes="xlf:priorityValueList"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="AttrType_reformat">
+		<xsd:union memberTypes="xlf:reformatValueYesNo xlf:reformatValueList"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="AttrType_YesNo">
+		<xsd:restriction base="xsd:NMTOKEN">
+			<xsd:enumeration value="yes"/>
+			<xsd:enumeration value="no"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="AttrType_Position">
+		<xsd:restriction base="xsd:NMTOKEN">
+			<xsd:enumeration value="open"/>
+			<xsd:enumeration value="close"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="AttrType_assoc">
+		<xsd:restriction base="xsd:NMTOKEN">
+			<xsd:enumeration value="preceding"/>
+			<xsd:enumeration value="following"/>
+			<xsd:enumeration value="both"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="AttrType_annotates">
+		<xsd:restriction base="xsd:NMTOKEN">
+			<xsd:enumeration value="source"/>
+			<xsd:enumeration value="target"/>
+			<xsd:enumeration value="general"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="AttrType_Coordinates">
+		<xsd:annotation>
+			<xsd:documentation>Values for the attribute 'coord'.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:pattern value="(-?\d+|#);(-?\d+|#);(-?\d+|#);(-?\d+|#)"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="AttrType_Version">
+		<xsd:annotation>
+			<xsd:documentation>Version values: 1.0 and 1.1 are allowed for backward compatibility.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="1.2"/>
+			<xsd:enumeration value="1.1"/>
+			<xsd:enumeration value="1.0"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<!-- Groups -->
+	<xsd:group name="ElemGroup_TextContent">
+		<xsd:choice>
+			<xsd:element ref="xlf:g"/>
+			<xsd:element ref="xlf:bpt"/>
+			<xsd:element ref="xlf:ept"/>
+			<xsd:element ref="xlf:ph"/>
+			<xsd:element ref="xlf:it"/>
+			<xsd:element ref="xlf:mrk"/>
+			<xsd:element ref="xlf:x"/>
+			<xsd:element ref="xlf:bx"/>
+			<xsd:element ref="xlf:ex"/>
+		</xsd:choice>
+	</xsd:group>
+	<xsd:attributeGroup name="AttrGroup_TextContent">
+		<xsd:attribute name="id" type="xsd:string" use="required"/>
+		<xsd:attribute name="ts" type="xsd:string" use="optional"/>
+		<xsd:attribute name="xid" type="xsd:string" use="optional"/>
+		<xsd:attribute name="equiv-text" type="xsd:string" use="optional"/>
+		<xsd:anyAttribute namespace="##any" processContents="skip"/>
+	</xsd:attributeGroup>
+	<!-- XLIFF Structure -->
+	<xsd:element name="xliff">
+		<xsd:complexType>
+			<xsd:sequence maxOccurs="unbounded">
+                <xsd:any maxOccurs="unbounded" minOccurs="0" namespace="##other" processContents="skip"/>
+				<xsd:element ref="xlf:file"/>
+			</xsd:sequence>
+			<xsd:attribute name="version" type="xlf:AttrType_Version" use="required"/>
+			<xsd:attribute ref="xml:lang" use="optional"/>
+			<xsd:anyAttribute namespace="##any" processContents="skip"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="file">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element minOccurs="0" ref="xlf:header"/>
+				<xsd:element ref="xlf:body"/>
+			</xsd:sequence>
+			<xsd:attribute name="original" type="xsd:string" use="required"/>
+			<xsd:attribute name="source-language" type="xsd:language" use="required"/>
+			<xsd:attribute name="datatype" type="xlf:AttrType_datatype" use="required"/>
+			<xsd:attribute name="tool-id" type="xsd:string" use="optional"/>
+			<xsd:attribute default="manual" name="tool" type="xsd:string" use="optional"/>
+			<xsd:attribute name="date" type="xsd:dateTime" use="optional"/>
+			<xsd:attribute ref="xml:space" use="optional"/>
+			<xsd:attribute name="ts" type="xsd:string" use="optional"/>
+			<xsd:attribute name="category" type="xsd:string" use="optional"/>
+			<xsd:attribute name="target-language" type="xsd:language" use="optional"/>
+			<xsd:attribute name="product-name" type="xsd:string" use="optional"/>
+			<xsd:attribute name="product-version" type="xsd:string" use="optional"/>
+			<xsd:attribute name="build-num" type="xsd:string" use="optional"/>
+			<xsd:anyAttribute namespace="##any" processContents="skip"/>
+		</xsd:complexType>
+		<xsd:unique name="U_group_id">
+			<xsd:selector xpath=".//xlf:group"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:key name="K_unit_id">
+			<xsd:selector xpath=".//xlf:trans-unit|.//xlf:bin-unit"/>
+			<xsd:field xpath="@id"/>
+		</xsd:key>
+		<xsd:keyref name="KR_unit_id" refer="xlf:K_unit_id">
+			<xsd:selector xpath=".//bpt|.//ept|.//it|.//ph|.//g|.//x|.//bx|.//ex|.//sub"/>
+			<xsd:field xpath="@xid"/>
+		</xsd:keyref>
+		<xsd:key name="K_tool-id">
+			<xsd:selector xpath="xlf:header/xlf:tool"/>
+			<xsd:field xpath="@tool-id"/>
+		</xsd:key>
+		<xsd:keyref name="KR_file_tool-id" refer="xlf:K_tool-id">
+			<xsd:selector xpath="."/>
+			<xsd:field xpath="@tool-id"/>
+		</xsd:keyref>
+		<xsd:keyref name="KR_phase_tool-id" refer="xlf:K_tool-id">
+			<xsd:selector xpath="xlf:header/xlf:phase-group/xlf:phase"/>
+			<xsd:field xpath="@tool-id"/>
+		</xsd:keyref>
+		<xsd:keyref name="KR_alt-trans_tool-id" refer="xlf:K_tool-id">
+			<xsd:selector xpath=".//xlf:trans-unit/xlf:alt-trans"/>
+			<xsd:field xpath="@tool-id"/>
+		</xsd:keyref>
+		<xsd:key name="K_count-group_name">
+			<xsd:selector xpath=".//xlf:count-group"/>
+			<xsd:field xpath="@name"/>
+		</xsd:key>
+		<xsd:unique name="U_context-group_name">
+			<xsd:selector xpath=".//xlf:context-group"/>
+			<xsd:field xpath="@name"/>
+		</xsd:unique>
+		<xsd:key name="K_phase-name">
+			<xsd:selector xpath="xlf:header/xlf:phase-group/xlf:phase"/>
+			<xsd:field xpath="@phase-name"/>
+		</xsd:key>
+		<xsd:keyref name="KR_phase-name" refer="xlf:K_phase-name">
+			<xsd:selector xpath=".//xlf:count|.//xlf:trans-unit|.//xlf:target|.//bin-unit|.//bin-target"/>
+			<xsd:field xpath="@phase-name"/>
+		</xsd:keyref>
+		<xsd:unique name="U_uid">
+			<xsd:selector xpath=".//xlf:external-file"/>
+			<xsd:field xpath="@uid"/>
+		</xsd:unique>
+	</xsd:element>
+	<xsd:element name="header">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element minOccurs="0" name="skl" type="xlf:ElemType_ExternalReference"/>
+				<xsd:element minOccurs="0" ref="xlf:phase-group"/>
+				<xsd:choice maxOccurs="unbounded" minOccurs="0">
+					<xsd:element name="glossary" type="xlf:ElemType_ExternalReference"/>
+					<xsd:element name="reference" type="xlf:ElemType_ExternalReference"/>
+					<xsd:element ref="xlf:count-group"/>
+					<xsd:element ref="xlf:prop-group"/>
+					<xsd:element ref="xlf:note"/>
+					<xsd:element ref="xlf:tool"/>
+				</xsd:choice>
+				<xsd:any maxOccurs="unbounded" minOccurs="0" namespace="##other" processContents="skip"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="internal-file">
+		<xsd:complexType>
+			<xsd:simpleContent>
+				<xsd:extension base="xsd:string">
+					<xsd:attribute name="form" type="xsd:string"/>
+					<xsd:attribute name="crc" type="xsd:NMTOKEN"/>
+				</xsd:extension>
+			</xsd:simpleContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="external-file">
+		<xsd:complexType>
+			<xsd:attribute name="href" type="xsd:string" use="required"/>
+			<xsd:attribute name="crc" type="xsd:NMTOKEN"/>
+			<xsd:attribute name="uid" type="xsd:NMTOKEN"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="note">
+		<xsd:complexType>
+			<xsd:simpleContent>
+				<xsd:extension base="xsd:string">
+					<xsd:attribute ref="xml:lang" use="optional"/>
+					<xsd:attribute default="1" name="priority" type="xlf:AttrType_priority" use="optional"/>
+					<xsd:attribute name="from" type="xsd:string" use="optional"/>
+					<xsd:attribute default="general" name="annotates" type="xlf:AttrType_annotates" use="optional"/>
+				</xsd:extension>
+			</xsd:simpleContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="phase-group">
+		<xsd:complexType>
+			<xsd:sequence maxOccurs="unbounded">
+				<xsd:element ref="xlf:phase"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="phase">
+		<xsd:complexType>
+			<xsd:sequence maxOccurs="unbounded" minOccurs="0">
+				<xsd:element ref="xlf:note"/>
+			</xsd:sequence>
+			<xsd:attribute name="phase-name" type="xsd:string" use="required"/>
+			<xsd:attribute name="process-name" type="xsd:string" use="required"/>
+			<xsd:attribute name="company-name" type="xsd:string" use="optional"/>
+			<xsd:attribute name="tool-id" type="xsd:string" use="optional"/>
+			<xsd:attribute name="tool" type="xsd:string" use="optional"/>
+			<xsd:attribute name="date" type="xsd:dateTime" use="optional"/>
+			<xsd:attribute name="job-id" type="xsd:string" use="optional"/>
+			<xsd:attribute name="contact-name" type="xsd:string" use="optional"/>
+			<xsd:attribute name="contact-email" type="xsd:string" use="optional"/>
+			<xsd:attribute name="contact-phone" type="xsd:string" use="optional"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="count-group">
+		<xsd:complexType>
+			<xsd:sequence maxOccurs="unbounded" minOccurs="0">
+				<xsd:element ref="xlf:count"/>
+			</xsd:sequence>
+			<xsd:attribute name="name" type="xsd:string" use="required"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="count">
+		<xsd:complexType>
+			<xsd:simpleContent>
+				<xsd:extension base="xsd:string">
+					<xsd:attribute name="count-type" type="xlf:AttrType_count-type" use="optional"/>
+					<xsd:attribute name="phase-name" type="xsd:string" use="optional"/>
+					<xsd:attribute default="word" name="unit" type="xlf:AttrType_unit" use="optional"/>
+				</xsd:extension>
+			</xsd:simpleContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="context-group">
+		<xsd:complexType>
+			<xsd:sequence maxOccurs="unbounded">
+				<xsd:element ref="xlf:context"/>
+			</xsd:sequence>
+			<xsd:attribute name="name" type="xsd:string" use="optional"/>
+			<xsd:attribute name="crc" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="purpose" type="xlf:AttrType_purpose" use="optional"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="context">
+		<xsd:complexType>
+			<xsd:simpleContent>
+				<xsd:extension base="xsd:string">
+					<xsd:attribute name="context-type" type="xlf:AttrType_context-type" use="required"/>
+					<xsd:attribute default="no" name="match-mandatory" type="xlf:AttrType_YesNo" use="optional"/>
+					<xsd:attribute name="crc" type="xsd:NMTOKEN" use="optional"/>
+				</xsd:extension>
+			</xsd:simpleContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="prop-group">
+		<xsd:complexType>
+			<xsd:sequence maxOccurs="unbounded">
+				<xsd:element ref="xlf:prop"/>
+			</xsd:sequence>
+			<xsd:attribute name="name" type="xsd:string" use="optional"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="prop">
+		<xsd:complexType>
+			<xsd:simpleContent>
+				<xsd:extension base="xsd:string">
+					<xsd:attribute name="prop-type" type="xsd:string" use="required"/>
+					<xsd:attribute ref="xml:lang" use="optional"/>
+				</xsd:extension>
+			</xsd:simpleContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="tool">
+		<xsd:complexType mixed="true">
+			<xsd:sequence>
+				<xsd:any namespace="##any" processContents="skip" minOccurs="0" maxOccurs="unbounded"/>
+			</xsd:sequence>
+			<xsd:attribute name="tool-id" type="xsd:string" use="required"/>
+			<xsd:attribute name="tool-name" type="xsd:string" use="required"/>
+			<xsd:attribute name="tool-version" type="xsd:string" use="optional"/>
+			<xsd:attribute name="tool-company" type="xsd:string" use="optional"/>
+			<xsd:anyAttribute namespace="##any" processContents="skip"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="body">
+		<xsd:complexType>
+			<xsd:choice maxOccurs="unbounded" minOccurs="0">
+				<xsd:element maxOccurs="unbounded" minOccurs="0" ref="xlf:group"/>
+				<xsd:element maxOccurs="unbounded" minOccurs="0" ref="xlf:trans-unit"/>
+				<xsd:element maxOccurs="unbounded" minOccurs="0" ref="xlf:bin-unit"/>
+			</xsd:choice>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="group">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:sequence>
+					<xsd:element maxOccurs="unbounded" minOccurs="0" ref="xlf:context-group"/>
+					<xsd:element maxOccurs="unbounded" minOccurs="0" ref="xlf:count-group"/>
+					<xsd:element maxOccurs="unbounded" minOccurs="0" ref="xlf:prop-group"/>
+					<xsd:element maxOccurs="unbounded" minOccurs="0" ref="xlf:note"/>
+					<xsd:any maxOccurs="unbounded" minOccurs="0" namespace="##other" processContents="skip"/>
+				</xsd:sequence>
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element maxOccurs="unbounded" minOccurs="0" ref="xlf:group"/>
+					<xsd:element maxOccurs="unbounded" minOccurs="0" ref="xlf:trans-unit"/>
+					<xsd:element maxOccurs="unbounded" minOccurs="0" ref="xlf:bin-unit"/>
+				</xsd:choice>
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:string" use="optional"/>
+			<xsd:attribute name="datatype" type="xlf:AttrType_datatype" use="optional"/>
+			<xsd:attribute default="default" ref="xml:space" use="optional"/>
+			<xsd:attribute name="ts" type="xsd:string" use="optional"/>
+			<xsd:attribute name="restype" type="xlf:AttrType_restype" use="optional"/>
+			<xsd:attribute name="resname" type="xsd:string" use="optional"/>
+			<xsd:attribute name="extradata" type="xsd:string" use="optional"/>
+			<xsd:attribute name="extype" type="xsd:string" use="optional"/>
+			<xsd:attribute name="help-id" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="menu" type="xsd:string" use="optional"/>
+			<xsd:attribute name="menu-option" type="xsd:string" use="optional"/>
+			<xsd:attribute name="menu-name" type="xsd:string" use="optional"/>
+			<xsd:attribute name="coord" type="xlf:AttrType_Coordinates" use="optional"/>
+			<xsd:attribute name="font" type="xsd:string" use="optional"/>
+			<xsd:attribute name="css-style" type="xsd:string" use="optional"/>
+			<xsd:attribute name="style" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="exstyle" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute default="yes" name="translate" type="xlf:AttrType_YesNo" use="optional"/>
+			<xsd:attribute default="yes" name="reformat" type="xlf:AttrType_reformat" use="optional"/>
+			<xsd:attribute default="pixel" name="size-unit" type="xlf:AttrType_size-unit" use="optional"/>
+			<xsd:attribute name="maxwidth" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="minwidth" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="maxheight" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="minheight" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="maxbytes" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="minbytes" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="charclass" type="xsd:string" use="optional"/>
+			<xsd:attribute default="no" name="merged-trans" type="xlf:AttrType_YesNo" use="optional"/>
+			<xsd:anyAttribute namespace="##any" processContents="skip"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="trans-unit">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="xlf:source"/>
+				<xsd:element minOccurs="0" ref="xlf:seg-source"/>
+				<xsd:element minOccurs="0" ref="xlf:target"/>
+				<xsd:choice maxOccurs="unbounded" minOccurs="0">
+					<xsd:element ref="xlf:context-group"/>
+					<xsd:element ref="xlf:count-group"/>
+					<xsd:element ref="xlf:prop-group"/>
+					<xsd:element ref="xlf:note"/>
+					<xsd:element ref="xlf:alt-trans"/>
+				</xsd:choice>
+				<xsd:any maxOccurs="unbounded" minOccurs="0" namespace="##other" processContents="skip"/>
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:string" use="required"/>
+			<xsd:attribute name="approved" type="xlf:AttrType_YesNo" use="optional"/>
+			<xsd:attribute default="yes" name="translate" type="xlf:AttrType_YesNo" use="optional"/>
+			<xsd:attribute default="yes" name="reformat" type="xlf:AttrType_reformat" use="optional"/>
+			<xsd:attribute default="default" ref="xml:space" use="optional"/>
+			<xsd:attribute name="datatype" type="xlf:AttrType_datatype" use="optional"/>
+			<xsd:attribute name="ts" type="xsd:string" use="optional"/>
+			<xsd:attribute name="phase-name" type="xsd:string" use="optional"/>
+			<xsd:attribute name="restype" type="xlf:AttrType_restype" use="optional"/>
+			<xsd:attribute name="resname" type="xsd:string" use="optional"/>
+			<xsd:attribute name="extradata" type="xsd:string" use="optional"/>
+			<xsd:attribute name="extype" type="xsd:string" use="optional"/>
+			<xsd:attribute name="help-id" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="menu" type="xsd:string" use="optional"/>
+			<xsd:attribute name="menu-option" type="xsd:string" use="optional"/>
+			<xsd:attribute name="menu-name" type="xsd:string" use="optional"/>
+			<xsd:attribute name="coord" type="xlf:AttrType_Coordinates" use="optional"/>
+			<xsd:attribute name="font" type="xsd:string" use="optional"/>
+			<xsd:attribute name="css-style" type="xsd:string" use="optional"/>
+			<xsd:attribute name="style" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="exstyle" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute default="pixel" name="size-unit" type="xlf:AttrType_size-unit" use="optional"/>
+			<xsd:attribute name="maxwidth" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="minwidth" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="maxheight" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="minheight" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="maxbytes" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="minbytes" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="charclass" type="xsd:string" use="optional"/>
+			<xsd:attribute default="yes" name="merged-trans" type="xlf:AttrType_YesNo" use="optional"/>
+			<xsd:anyAttribute namespace="##any" processContents="skip"/>
+		</xsd:complexType>
+		<xsd:unique name="U_tu_segsrc_mid">
+			<xsd:selector xpath="./xlf:seg-source/xlf:mrk"/>
+			<xsd:field xpath="@mid"/>
+		</xsd:unique>
+		<xsd:keyref name="KR_tu_segsrc_mid" refer="xlf:U_tu_segsrc_mid">
+			<xsd:selector xpath="./xlf:target/xlf:mrk|./xlf:alt-trans"/>
+			<xsd:field xpath="@mid"/>
+		</xsd:keyref>
+	</xsd:element>
+	<xsd:element name="source">
+		<xsd:complexType mixed="true">
+			<xsd:group maxOccurs="unbounded" minOccurs="0" ref="xlf:ElemGroup_TextContent"/>
+			<xsd:attribute ref="xml:lang" use="optional"/>
+			<xsd:attribute name="ts" type="xsd:string" use="optional"/>
+			<xsd:anyAttribute namespace="##any" processContents="skip"/>
+		</xsd:complexType>
+		<xsd:unique name="U_source_bpt_rid">
+			<xsd:selector xpath=".//xlf:bpt"/>
+			<xsd:field xpath="@rid"/>
+		</xsd:unique>
+		<xsd:keyref name="KR_source_ept_rid" refer="xlf:U_source_bpt_rid">
+			<xsd:selector xpath=".//xlf:ept"/>
+			<xsd:field xpath="@rid"/>
+		</xsd:keyref>
+		<xsd:unique name="U_source_bx_rid">
+			<xsd:selector xpath=".//xlf:bx"/>
+			<xsd:field xpath="@rid"/>
+		</xsd:unique>
+		<xsd:keyref name="KR_source_ex_rid" refer="xlf:U_source_bx_rid">
+			<xsd:selector xpath=".//xlf:ex"/>
+			<xsd:field xpath="@rid"/>
+		</xsd:keyref>
+	</xsd:element>
+	<xsd:element name="seg-source">
+		<xsd:complexType mixed="true">
+			<xsd:group maxOccurs="unbounded" minOccurs="0" ref="xlf:ElemGroup_TextContent"/>
+			<xsd:attribute ref="xml:lang" use="optional"/>
+			<xsd:attribute name="ts" type="xsd:string" use="optional"/>
+			<xsd:anyAttribute namespace="##any" processContents="skip"/>
+		</xsd:complexType>
+		<xsd:unique name="U_segsrc_bpt_rid">
+			<xsd:selector xpath=".//xlf:bpt"/>
+			<xsd:field xpath="@rid"/>
+		</xsd:unique>
+		<xsd:keyref name="KR_segsrc_ept_rid" refer="xlf:U_segsrc_bpt_rid">
+			<xsd:selector xpath=".//xlf:ept"/>
+			<xsd:field xpath="@rid"/>
+		</xsd:keyref>
+		<xsd:unique name="U_segsrc_bx_rid">
+			<xsd:selector xpath=".//xlf:bx"/>
+			<xsd:field xpath="@rid"/>
+		</xsd:unique>
+		<xsd:keyref name="KR_segsrc_ex_rid" refer="xlf:U_segsrc_bx_rid">
+			<xsd:selector xpath=".//xlf:ex"/>
+			<xsd:field xpath="@rid"/>
+		</xsd:keyref>
+	</xsd:element>
+	<xsd:element name="target">
+		<xsd:complexType mixed="true">
+			<xsd:group maxOccurs="unbounded" minOccurs="0" ref="xlf:ElemGroup_TextContent"/>
+			<xsd:attribute name="state" type="xlf:AttrType_state" use="optional"/>
+			<xsd:attribute name="state-qualifier" type="xlf:AttrType_state-qualifier" use="optional"/>
+			<xsd:attribute name="phase-name" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute ref="xml:lang" use="optional"/>
+			<xsd:attribute name="ts" type="xsd:string" use="optional"/>
+			<xsd:attribute name="restype" type="xlf:AttrType_restype" use="optional"/>
+			<xsd:attribute name="resname" type="xsd:string" use="optional"/>
+			<xsd:attribute name="coord" type="xlf:AttrType_Coordinates" use="optional"/>
+			<xsd:attribute name="font" type="xsd:string" use="optional"/>
+			<xsd:attribute name="css-style" type="xsd:string" use="optional"/>
+			<xsd:attribute name="style" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="exstyle" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute default="yes" name="equiv-trans" type="xlf:AttrType_YesNo" use="optional"/>
+			<xsd:anyAttribute namespace="##any" processContents="skip"/>
+		</xsd:complexType>
+		<xsd:unique name="U_target_bpt_rid">
+			<xsd:selector xpath=".//xlf:bpt"/>
+			<xsd:field xpath="@rid"/>
+		</xsd:unique>
+		<xsd:keyref name="KR_target_ept_rid" refer="xlf:U_target_bpt_rid">
+			<xsd:selector xpath=".//xlf:ept"/>
+			<xsd:field xpath="@rid"/>
+		</xsd:keyref>
+		<xsd:unique name="U_target_bx_rid">
+			<xsd:selector xpath=".//xlf:bx"/>
+			<xsd:field xpath="@rid"/>
+		</xsd:unique>
+		<xsd:keyref name="KR_target_ex_rid" refer="xlf:U_target_bx_rid">
+			<xsd:selector xpath=".//xlf:ex"/>
+			<xsd:field xpath="@rid"/>
+		</xsd:keyref>
+	</xsd:element>
+	<xsd:element name="alt-trans">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element minOccurs="0" ref="xlf:source"/>
+				<xsd:element minOccurs="0" ref="xlf:seg-source"/>
+				<xsd:element maxOccurs="unbounded" ref="xlf:target"/>
+				<xsd:element maxOccurs="unbounded" minOccurs="0" ref="xlf:context-group"/>
+				<xsd:element maxOccurs="unbounded" minOccurs="0" ref="xlf:prop-group"/>
+				<xsd:element maxOccurs="unbounded" minOccurs="0" ref="xlf:note"/>
+				<xsd:any maxOccurs="unbounded" minOccurs="0" namespace="##other" processContents="skip"/>
+			</xsd:sequence>
+			<xsd:attribute name="match-quality" type="xsd:string" use="optional"/>
+			<xsd:attribute name="tool-id" type="xsd:string" use="optional"/>
+			<xsd:attribute name="tool" type="xsd:string" use="optional"/>
+			<xsd:attribute name="crc" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute ref="xml:lang" use="optional"/>
+			<xsd:attribute name="origin" type="xsd:string" use="optional"/>
+			<xsd:attribute name="datatype" type="xlf:AttrType_datatype" use="optional"/>
+			<xsd:attribute default="default" ref="xml:space" use="optional"/>
+			<xsd:attribute name="ts" type="xsd:string" use="optional"/>
+			<xsd:attribute name="restype" type="xlf:AttrType_restype" use="optional"/>
+			<xsd:attribute name="resname" type="xsd:string" use="optional"/>
+			<xsd:attribute name="extradata" type="xsd:string" use="optional"/>
+			<xsd:attribute name="extype" type="xsd:string" use="optional"/>
+			<xsd:attribute name="help-id" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="menu" type="xsd:string" use="optional"/>
+			<xsd:attribute name="menu-option" type="xsd:string" use="optional"/>
+			<xsd:attribute name="menu-name" type="xsd:string" use="optional"/>
+			<xsd:attribute name="mid" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="coord" type="xlf:AttrType_Coordinates" use="optional"/>
+			<xsd:attribute name="font" type="xsd:string" use="optional"/>
+			<xsd:attribute name="css-style" type="xsd:string" use="optional"/>
+			<xsd:attribute name="style" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="exstyle" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="phase-name" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute default="proposal" name="alttranstype" type="xlf:AttrType_alttranstype" use="optional"/>
+			<xsd:anyAttribute namespace="##any" processContents="skip"/>
+		</xsd:complexType>
+		<xsd:unique name="U_at_segsrc_mid">
+			<xsd:selector xpath="./xlf:seg-source/xlf:mrk"/>
+			<xsd:field xpath="@mid"/>
+		</xsd:unique>
+		<xsd:keyref name="KR_at_segsrc_mid" refer="xlf:U_at_segsrc_mid">
+			<xsd:selector xpath="./xlf:target/xlf:mrk"/>
+			<xsd:field xpath="@mid"/>
+		</xsd:keyref>
+	</xsd:element>
+	<xsd:element name="bin-unit">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="xlf:bin-source"/>
+				<xsd:element minOccurs="0" ref="xlf:bin-target"/>
+				<xsd:choice maxOccurs="unbounded" minOccurs="0">
+					<xsd:element ref="xlf:context-group"/>
+					<xsd:element ref="xlf:count-group"/>
+					<xsd:element ref="xlf:prop-group"/>
+					<xsd:element ref="xlf:note"/>
+					<xsd:element ref="xlf:trans-unit"/>
+				</xsd:choice>
+				<xsd:any maxOccurs="unbounded" minOccurs="0" namespace="##other" processContents="skip"/>
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:string" use="required"/>
+			<xsd:attribute name="mime-type" type="xlf:mime-typeValueList" use="required"/>
+			<xsd:attribute name="approved" type="xlf:AttrType_YesNo" use="optional"/>
+			<xsd:attribute default="yes" name="translate" type="xlf:AttrType_YesNo" use="optional"/>
+			<xsd:attribute default="yes" name="reformat" type="xlf:AttrType_reformat" use="optional"/>
+			<xsd:attribute name="ts" type="xsd:string" use="optional"/>
+			<xsd:attribute name="restype" type="xlf:AttrType_restype" use="optional"/>
+			<xsd:attribute name="resname" type="xsd:string" use="optional"/>
+			<xsd:attribute name="phase-name" type="xsd:string" use="optional"/>
+			<xsd:anyAttribute namespace="##any" processContents="skip"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="bin-source">
+		<xsd:complexType>
+			<xsd:choice>
+				<xsd:element ref="xlf:internal-file"/>
+				<xsd:element ref="xlf:external-file"/>
+			</xsd:choice>
+			<xsd:attribute name="ts" type="xsd:string" use="optional"/>
+			<xsd:anyAttribute namespace="##any" processContents="skip"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="bin-target">
+		<xsd:complexType>
+			<xsd:choice>
+				<xsd:element ref="xlf:internal-file"/>
+				<xsd:element ref="xlf:external-file"/>
+			</xsd:choice>
+			<xsd:attribute name="mime-type" type="xlf:mime-typeValueList" use="optional"/>
+			<xsd:attribute name="ts" type="xsd:string" use="optional"/>
+			<xsd:attribute name="state" type="xlf:AttrType_state" use="optional"/>
+			<xsd:attribute name="state-qualifier" type="xlf:AttrType_state-qualifier" use="optional"/>
+			<xsd:attribute name="phase-name" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="restype" type="xlf:AttrType_restype" use="optional"/>
+			<xsd:attribute name="resname" type="xsd:string" use="optional"/>
+			<xsd:anyAttribute namespace="##any" processContents="skip"/>
+		</xsd:complexType>
+	</xsd:element>
+	<!-- Element for inline codes -->
+	<xsd:element name="g">
+		<xsd:complexType mixed="true">
+			<xsd:group maxOccurs="unbounded" minOccurs="0" ref="xlf:ElemGroup_TextContent"/>
+			<xsd:attribute name="ctype" type="xlf:AttrType_InlineDelimiters" use="optional"/>
+			<xsd:attribute default="yes" name="clone" type="xlf:AttrType_YesNo" use="optional"/>
+			<xsd:attributeGroup ref="xlf:AttrGroup_TextContent"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="x">
+		<xsd:complexType>
+			<xsd:attribute name="ctype" type="xlf:AttrType_InlinePlaceholders" use="optional"/>
+			<xsd:attribute default="yes" name="clone" type="xlf:AttrType_YesNo" use="optional"/>
+			<xsd:attributeGroup ref="xlf:AttrGroup_TextContent"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="bx">
+		<xsd:complexType>
+			<xsd:attribute name="rid" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="ctype" type="xlf:AttrType_InlineDelimiters" use="optional"/>
+			<xsd:attribute default="yes" name="clone" type="xlf:AttrType_YesNo" use="optional"/>
+			<xsd:attributeGroup ref="xlf:AttrGroup_TextContent"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="ex">
+		<xsd:complexType>
+			<xsd:attribute name="rid" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attributeGroup ref="xlf:AttrGroup_TextContent"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="ph">
+		<xsd:complexType mixed="true">
+			<xsd:sequence maxOccurs="unbounded" minOccurs="0">
+				<xsd:element ref="xlf:sub"/>
+			</xsd:sequence>
+			<xsd:attribute name="ctype" type="xlf:AttrType_InlinePlaceholders" use="optional"/>
+			<xsd:attribute name="crc" type="xsd:string" use="optional"/>
+			<xsd:attribute name="assoc" type="xlf:AttrType_assoc" use="optional"/>
+			<xsd:attributeGroup ref="xlf:AttrGroup_TextContent"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="bpt">
+		<xsd:complexType mixed="true">
+			<xsd:sequence maxOccurs="unbounded" minOccurs="0">
+				<xsd:element ref="xlf:sub"/>
+			</xsd:sequence>
+			<xsd:attribute name="rid" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="ctype" type="xlf:AttrType_InlineDelimiters" use="optional"/>
+			<xsd:attribute name="crc" type="xsd:string" use="optional"/>
+			<xsd:attributeGroup ref="xlf:AttrGroup_TextContent"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="ept">
+		<xsd:complexType mixed="true">
+			<xsd:sequence maxOccurs="unbounded" minOccurs="0">
+				<xsd:element ref="xlf:sub"/>
+			</xsd:sequence>
+			<xsd:attribute name="rid" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="crc" type="xsd:string" use="optional"/>
+			<xsd:attributeGroup ref="xlf:AttrGroup_TextContent"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="it">
+		<xsd:complexType mixed="true">
+			<xsd:sequence maxOccurs="unbounded" minOccurs="0">
+				<xsd:element ref="xlf:sub"/>
+			</xsd:sequence>
+			<xsd:attribute name="pos" type="xlf:AttrType_Position" use="required"/>
+			<xsd:attribute name="rid" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="ctype" type="xlf:AttrType_InlineDelimiters" use="optional"/>
+			<xsd:attribute name="crc" type="xsd:string" use="optional"/>
+			<xsd:attributeGroup ref="xlf:AttrGroup_TextContent"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="sub">
+		<xsd:complexType mixed="true">
+			<xsd:group maxOccurs="unbounded" minOccurs="0" ref="xlf:ElemGroup_TextContent"/>
+			<xsd:attribute name="datatype" type="xlf:AttrType_datatype" use="optional"/>
+			<xsd:attribute name="ctype" type="xlf:AttrType_InlineDelimiters" use="optional"/>
+			<xsd:attribute name="xid" type="xsd:string" use="optional"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="mrk">
+		<xsd:complexType mixed="true">
+			<xsd:group maxOccurs="unbounded" minOccurs="0" ref="xlf:ElemGroup_TextContent"/>
+			<xsd:attribute name="mtype" type="xlf:AttrType_mtype" use="required"/>
+			<xsd:attribute name="mid" type="xsd:NMTOKEN" use="optional"/>
+			<xsd:attribute name="comment" type="xsd:string" use="optional"/>
+			<xsd:attribute name="ts" type="xsd:string" use="optional"/>
+			<xsd:anyAttribute namespace="##any" processContents="skip"/>
+		</xsd:complexType>
+	</xsd:element>
+</xsd:schema>

--- a/src/Microsoft.DotNet.XliffTasks/Model/xml.xsd
+++ b/src/Microsoft.DotNet.XliffTasks/Model/xml.xsd
@@ -1,0 +1,317 @@
+﻿<?xml version='1.0'?>
+<?xml-stylesheet href="../2008/09/xsd.xsl" type="text/xsl"?>
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns   ="http://www.w3.org/1999/xhtml"
+  xml:lang="en">
+
+  <xs:annotation>
+    <xs:documentation>
+      <div>
+        <h1>About the XML namespace</h1>
+
+        <div class="bodytext">
+          <p>
+            This schema document describes the XML namespace, in a form
+            suitable for import by other schema documents.
+          </p>
+          <p>
+            See <a href="http://www.w3.org/XML/1998/namespace.html">
+              http://www.w3.org/XML/1998/namespace.html
+            </a> and
+            <a href="http://www.w3.org/TR/REC-xml">
+              http://www.w3.org/TR/REC-xml
+            </a> for information
+            about this namespace.
+          </p>
+          <p>
+            Note that local names in this namespace are intended to be
+            defined only by the World Wide Web Consortium or its subgroups.
+            The names currently defined in this namespace are listed below.
+            They should not be used with conflicting semantics by any Working
+            Group, specification, or document instance.
+          </p>
+          <p>
+            See further below in this document for more information about <a
+      href="#usage">
+              how to refer to this schema document from your own
+              XSD schema documents
+            </a> and about <a href="#nsversioning">
+              the
+              namespace-versioning policy governing this schema document
+            </a>.
+          </p>
+        </div>
+      </div>
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:attribute name="lang">
+    <xs:annotation>
+      <xs:documentation>
+        <div>
+
+          <h3>lang (as an attribute name)</h3>
+          <p>
+            denotes an attribute whose value
+            is a language code for the natural language of the content of
+            any element; its value is inherited.  This name is reserved
+            by virtue of its definition in the XML specification.
+          </p>
+
+        </div>
+        <div>
+          <h4>Notes</h4>
+          <p>
+            Attempting to install the relevant ISO 2- and 3-letter
+            codes as the enumerated possible values is probably never
+            going to be a realistic possibility.
+          </p>
+          <p>
+            See BCP 47 at <a href="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">
+              http://www.rfc-editor.org/rfc/bcp/bcp47.txt
+            </a>
+            and the IANA language subtag registry at
+            <a href="http://www.iana.org/assignments/language-subtag-registry">
+              http://www.iana.org/assignments/language-subtag-registry
+            </a>
+            for further information.
+          </p>
+          <p>
+            The union allows for the 'un-declaration' of xml:lang with
+            the empty string.
+          </p>
+        </div>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:simpleType>
+      <xs:union memberTypes="xs:language">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value=""/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:union>
+    </xs:simpleType>
+  </xs:attribute>
+
+  <xs:attribute name="space">
+    <xs:annotation>
+      <xs:documentation>
+        <div>
+
+          <h3>space (as an attribute name)</h3>
+          <p>
+            denotes an attribute whose
+            value is a keyword indicating what whitespace processing
+            discipline is intended for the content of the element; its
+            value is inherited.  This name is reserved by virtue of its
+            definition in the XML specification.
+          </p>
+
+        </div>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:simpleType>
+      <xs:restriction base="xs:NCName">
+        <xs:enumeration value="default"/>
+        <xs:enumeration value="preserve"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+
+  <xs:attribute name="base" type="xs:anyURI">
+    <xs:annotation>
+      <xs:documentation>
+        <div>
+
+          <h3>base (as an attribute name)</h3>
+          <p>
+            denotes an attribute whose value
+            provides a URI to be used as the base for interpreting any
+            relative URIs in the scope of the element on which it
+            appears; its value is inherited.  This name is reserved
+            by virtue of its definition in the XML Base specification.
+          </p>
+
+          <p>
+            See <a
+    href="http://www.w3.org/TR/xmlbase/">http://www.w3.org/TR/xmlbase/</a>
+            for information about this attribute.
+          </p>
+        </div>
+      </xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
+
+  <xs:attribute name="id" type="xs:ID">
+    <xs:annotation>
+      <xs:documentation>
+        <div>
+
+          <h3>id (as an attribute name)</h3>
+          <p>
+            denotes an attribute whose value
+            should be interpreted as if declared to be of type ID.
+            This name is reserved by virtue of its definition in the
+            xml:id specification.
+          </p>
+
+          <p>
+            See <a
+    href="http://www.w3.org/TR/xml-id/">http://www.w3.org/TR/xml-id/</a>
+            for information about this attribute.
+          </p>
+        </div>
+      </xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
+
+  <xs:attributeGroup name="specialAttrs">
+    <xs:attribute ref="xml:base"/>
+    <xs:attribute ref="xml:lang"/>
+    <xs:attribute ref="xml:space"/>
+    <xs:attribute ref="xml:id"/>
+  </xs:attributeGroup>
+
+  <xs:annotation>
+    <xs:documentation>
+      <div>
+
+        <h3>Father (in any context at all)</h3>
+
+        <div class="bodytext">
+          <p>
+            denotes Jon Bosak, the chair of
+            the original XML Working Group.  This name is reserved by
+            the following decision of the W3C XML Plenary and
+            XML Coordination groups:
+          </p>
+          <blockquote>
+            <p>
+              In appreciation for his vision, leadership and
+              dedication the W3C XML Plenary on this 10th day of
+              February, 2000, reserves for Jon Bosak in perpetuity
+              the XML name "xml:Father".
+            </p>
+          </blockquote>
+        </div>
+      </div>
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:annotation>
+    <xs:documentation>
+      <div xml:id="usage" id="usage">
+        <h2>
+          <a name="usage">About this schema document</a>
+        </h2>
+
+        <div class="bodytext">
+          <p>
+            This schema defines attributes and an attribute group suitable
+            for use by schemas wishing to allow <code>xml:base</code>,
+            <code>xml:lang</code>, <code>xml:space</code> or
+            <code>xml:id</code> attributes on elements they define.
+          </p>
+          <p>
+            To enable this, such a schema must import this schema for
+            the XML namespace, e.g. as follows:
+          </p>
+          <pre>
+            &lt;schema . . .>
+            . . .
+            &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+            schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+          </pre>
+          <p>
+            or
+          </p>
+          <pre>
+            &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+            schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+          </pre>
+          <p>
+            Subsequently, qualified reference to any of the attributes or the
+            group defined below will have the desired effect, e.g.
+          </p>
+          <pre>
+            &lt;type . . .>
+            . . .
+            &lt;attributeGroup ref="xml:specialAttrs"/>
+          </pre>
+          <p>
+            will define a type which will schema-validate an instance element
+            with any of those attributes.
+          </p>
+        </div>
+      </div>
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:annotation>
+    <xs:documentation>
+      <div id="nsversioning" xml:id="nsversioning">
+        <h2>
+          <a name="nsversioning">Versioning policy for this schema document</a>
+        </h2>
+        <div class="bodytext">
+          <p>
+            In keeping with the XML Schema WG's standard versioning
+            policy, this schema document will persist at
+            <a href="http://www.w3.org/2009/01/xml.xsd">
+              http://www.w3.org/2009/01/xml.xsd
+            </a>.
+          </p>
+          <p>
+            At the date of issue it can also be found at
+            <a href="http://www.w3.org/2001/xml.xsd">
+              http://www.w3.org/2001/xml.xsd
+            </a>.
+          </p>
+          <p>
+            The schema document at that URI may however change in the future,
+            in order to remain compatible with the latest version of XML
+            Schema itself, or with the XML namespace itself.  In other words,
+            if the XML Schema or XML namespaces change, the version of this
+            document at <a href="http://www.w3.org/2001/xml.xsd">
+              http://www.w3.org/2001/xml.xsd
+            </a>
+            will change accordingly; the version at
+            <a href="http://www.w3.org/2009/01/xml.xsd">
+              http://www.w3.org/2009/01/xml.xsd
+            </a>
+            will not change.
+          </p>
+          <p>
+            Previous dated (and unchanging) versions of this schema
+            document are at:
+          </p>
+          <ul>
+            <li>
+              <a href="http://www.w3.org/2009/01/xml.xsd">
+                http://www.w3.org/2009/01/xml.xsd
+              </a>
+            </li>
+            <li>
+              <a href="http://www.w3.org/2007/08/xml.xsd">
+                http://www.w3.org/2007/08/xml.xsd
+              </a>
+            </li>
+            <li>
+              <a href="http://www.w3.org/2004/10/xml.xsd">
+                http://www.w3.org/2004/10/xml.xsd
+              </a>
+            </li>
+            <li>
+              <a href="http://www.w3.org/2001/03/xml.xsd">
+                http://www.w3.org/2001/03/xml.xsd
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </xs:documentation>
+  </xs:annotation>
+
+</xs:schema>

--- a/src/Microsoft.DotNet.XliffTasks/README.md
+++ b/src/Microsoft.DotNet.XliffTasks/README.md
@@ -1,0 +1,71 @@
+# xliff-tasks
+
+A set of MSBuild tasks and targets to automatically update xliff (.xlf) files for localizable resources, and to build satellite assemblies from those xliff files.
+
+## Build Status
+
+|Windows x64 |
+|:------:|
+|[![Build Status][win-x64-build-badge]][win-x64-build]|
+
+## Installing
+
+If you're using the [Arcade Toolset][arcade-toolset] then the `Microsoft.DotNet.XliffTasks` package is already pulled in, and enabled by default.
+
+Otherwise, you'll need to add the Azure DevOps feed `https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json` ([browse](https://dev.azure.com/dnceng/public/_packaging?_a=feed&feed=dotnet-eng)) to your NuGet.config file, and then add a `PackageReference` for the XliffTasks package, like so:
+
+```
+<PackageReference Include="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.19253.1" PrivateAssets="all" />
+```
+
+The `PrivateAssets` metadata is needed to prevent `dotnet pack` or `msbuild /t:pack` from listing `Microsoft.DotNet.XliffTasks` as one of your package's dependencies.
+
+## Using Microsoft.DotNet.XliffTasks
+
+### Updating .xlf files
+
+Once `Microsoft.DotNet.XliffTasks` is installed building a project will automatically build satellite assemblies from .xlf files. To _update_ .xlf files to bring them in line with the source .resx/.vsct/.xaml files you need to run the `UpdateXlf` target, like so:
+
+```
+msbuild /t:UpdateXlf
+```
+
+This will only update the .xlf files. Alternatively, run a normal build with the `UpdateXlfOnBuild` property set:
+
+```
+msbuild /p:UpdateXlfOnBuild=true
+```
+
+By default, `XliffTasks` will produce an error during build if it detects that the .xlf files are out of data with the source .resx/.vsct/.xaml files.
+
+Many teams using `XliffTasks` default `UpdateXlfOnBuild` to true for local developer builds, but leave it off for CI builds. This way the .xlf files are automatically updated as the developer works, and the CI build will fail if the developer forgets to include the changes to the .xlf files as part of their PR. This way the .xlf files are always in sync with the source files, and can be handed off to a localization team at any time.
+
+Other workflows are possible by changing the `XliffTasks` properties (see below)
+
+### Sorting .xlf files
+
+`XliffTasks` attempts to keep .xlf files sorted when inserting new items. This doesn't matter for the generation of satellite assemblies, but can reduce merge conflicts when localizable resources are being added in multiple branches (as opposed to always adding new items at the end, which more or less guarantees merge conflicts).
+
+Note `XliffTasks` does not force the items into a sorted order if they are not already sorted. You can do that manually by running `msbuild /t:SortXlf`.
+
+## Project Properties
+
+`EnableXlfLocalization` - The "master switch" for turning locallization with `XliffTasks` on or off completely. When set to false, .xlf files will not be updated and satellite assemblies will not be generated from the .xlf files, regardless of the other properties. Defaults to true, but it is useful to set it to false for any project that does not need to produce localized resources (unit test projects, packaging projects, etc.).
+
+`UpdateXlfOnBuild` - When set to true, .xlf files will automatically be brought in sync with the source .resx/.vsct/.xaml files. This may involve adding or removing items from the .xlf files, or creating new .xlf files. Defaults to false.
+
+`ErrorOnOutOfDateXlf` - When set to true the build will produce an error if the .xlf files are out-of-date with respect to the source files. Defaults to true.
+
+`XlfLanguages` - The set of locales to which the project is localized. Defaults to the thirteen locales supported by Visual Studio: `cs;de;es;fr;it;ja;ko;pl;pt-BR;ru;tr;zh-Hans;zh-Hant`.
+
+## Source File Properties
+
+`XlfInput` - Set this to false to opt out of .xlf file generation for a specific source file that would otherwise be included by default.
+
+## Contact
+
+For more information, contact @dotnet/dnceng on GitHub, or file an issue.
+
+[win-x64-build-badge]: https://dev.azure.com/dnceng/internal/_apis/build/status/dotnet/xliff-tasks/dotnet-xliff-tasks-official-ci?branchName=main
+[win-x64-build]: https://dev.azure.com/dnceng/internal/_build?definitionId=485&branchName=main
+[arcade-toolset]: https://github.com/dotnet/arcade

--- a/src/Microsoft.DotNet.XliffTasks/Release.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Release.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+
+namespace XliffTasks
+{
+    internal static class Release
+    {
+        public static void Assert(bool condition)
+        {
+            Debug.Assert(condition);
+
+            if (!condition)
+            {
+                throw new InvalidOperationException("Assertion failure.");
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/StringExtensions.cs
+++ b/src/Microsoft.DotNet.XliffTasks/StringExtensions.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace XliffTasks
+{
+    internal static class StringExtensions
+    {
+        /// <summary>
+        /// Attempts to match formatting placeholders as documented at
+        /// https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting.
+        ///
+        /// Explanation:
+        ///
+        /// \{
+        ///    A placeholder starts with an open curly brace. Since curly braces are used in
+        ///    regex syntax we escape it to be clear that we mean a literal {.
+        ///
+        /// (\d+)
+        ///    The "index" component; one or more decimal digits. This is captured in a group
+        ///    to facilitate extracting the numeric value.
+        ///
+        /// (\,\-?\d+)?
+        ///    The optional "alignment" component. This is a comma, followed by an optional
+        ///    minus sign, followed by one or more decimal digits.
+        ///
+        /// (\:[^\}]+)?
+        ///    The optional "format string" component. This is a colon, followed by one or more
+        ///    characters that aren't close curly braces.
+        ///
+        /// \}
+        ///    The close curly brace indicates the end of the placeholder.
+        /// </summary>
+        private static readonly Regex s_placeholderRegex = new(@"\{(\d+)(\,\-?\d+)?(\:[^\}]+)?\}", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Returns the number of replacement strings needed to properly format the given text.
+        /// </summary>
+        public static int GetReplacementCount(this string text)
+        {
+            int replacementCount = 0;
+
+            foreach (Match placeholder in s_placeholderRegex.Matches(text))
+            {
+                int index = int.Parse(placeholder.Groups[1].Value);
+                replacementCount = Math.Max(replacementCount, index + 1);
+            }
+
+            return replacementCount;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/Tasks/BuildErrorException.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Tasks/BuildErrorException.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace XliffTasks.Tasks
+{
+    internal sealed class BuildErrorException : Exception
+    {
+        /// <summary>
+        /// The file associated with this <see cref="BuildErrorException"/>.
+        /// </summary>
+        public string RelatedFile { get; set;}
+
+        public BuildErrorException(string message) : base(message)
+        {
+        }
+
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/Tasks/EnsureAllResourcesTranslated.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Tasks/EnsureAllResourcesTranslated.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.Framework;
+using XliffTasks.Model;
+
+namespace XliffTasks.Tasks
+{
+    public sealed class EnsureAllResourcesTranslated : XlfTask
+    {
+        [Required]
+        public ITaskItem[] Sources { get; set; }
+
+        [Required]
+        public string[] Languages { get; set; }
+
+        protected override void ExecuteCore()
+        {
+            foreach (ITaskItem item in Sources)
+            {
+                string sourceDocumentPath = item.GetMetadataOrDefault(MetadataKey.SourceDocumentPath, item.ItemSpec);
+
+                SortedSet<string> untranslatedResourceSet = new(StringComparer.Ordinal);
+
+                foreach (string language in Languages)
+                {
+                    string xlfPath = XlfTask.GetXlfPath(sourceDocumentPath, language);
+                    XlfDocument xlfDocument;
+
+                    try
+                    {
+                        xlfDocument = XlfTask.LoadXlfDocument(xlfPath);
+                    }
+                    catch (FileNotFoundException)
+                    {
+                        // If the file doesn't exist, we don't need to worry about it having
+                        // untranslated resources.
+                        continue;
+                    }
+
+                    untranslatedResourceSet.UnionWith(xlfDocument.GetUntranslatedResourceIDs());
+                }
+
+                if (untranslatedResourceSet.Count > 0)
+                {
+                    string untranslatedResourceNames = string.Join(", ", untranslatedResourceSet);
+                    Log.LogErrorInFile(sourceDocumentPath, $"Found {untranslatedResourceSet.Count} untranslated resource(s): {untranslatedResourceNames}");
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/Tasks/GatherTranslatedSource.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Tasks/GatherTranslatedSource.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System.IO;
+
+namespace XliffTasks.Tasks
+{
+    public sealed class GatherTranslatedSource : XlfTask
+    {
+        [Required]
+        public ITaskItem[] XlfFiles { get; set; }
+
+        [Output]
+        public ITaskItem[] Outputs { get; private set; }
+
+        protected override void ExecuteCore()
+        {
+            int index = 0;
+            ITaskItem[] outputs = new ITaskItem[XlfFiles.Length];
+
+            foreach (ITaskItem xlf in XlfFiles)
+            {
+                string translatedFullPath = xlf.GetMetadataOrThrow(MetadataKey.XlfTranslatedFullPath);
+                string language = xlf.GetMetadataOrThrow(MetadataKey.XlfLanguage);
+
+                TaskItem output = new(xlf) { ItemSpec = translatedFullPath };
+
+                // Set up metadata required to give the correct resource names to translated source.
+                SetLink(xlf, output, translatedFullPath);
+                AdjustManifestResourceName(xlf, output, language);
+                AdjustLogicalName(xlf, output, language);
+                AdjustDependentUpon(xlf, output);
+
+                outputs[index++] = output;
+            }
+
+            Release.Assert(index == XlfFiles.Length);
+            Outputs = outputs;
+        }
+
+        private static readonly char[] s_directorySeparatorChars = new[]
+        {
+            Path.DirectorySeparatorChar,
+            Path.AltDirectorySeparatorChar
+        };
+
+        private static void SetLink(ITaskItem xlf, ITaskItem output, string translatedFullPath)
+        {
+            // Set link metadata to logically locate translated source next to untranslated source
+            // so that the correct resource names are generated.
+            string link = xlf.GetMetadata(MetadataKey.Link);
+            if (string.IsNullOrEmpty(link))
+            {
+                link = xlf.GetMetadataOrThrow(MetadataKey.XlfSource);
+            }
+
+            string linkFileName = Path.GetFileName(translatedFullPath);
+            if (link.IndexOfAny(s_directorySeparatorChars) < 0)
+            {
+                link = linkFileName;
+            }
+            else
+            {
+                string linkDirectory = Path.GetDirectoryName(link);
+                link = Path.Combine(linkDirectory, linkFileName);
+            }
+
+            output.SetMetadata(MetadataKey.Link, link);
+        }
+
+        private static void AdjustManifestResourceName(ITaskItem xlf, ITaskItem output, string language)
+        {
+            string manifestResourceName = xlf.GetMetadata(MetadataKey.ManifestResourceName);
+            if (!string.IsNullOrEmpty(manifestResourceName))
+            {
+                manifestResourceName = $"{manifestResourceName}.{language}";
+                output.SetMetadata(MetadataKey.ManifestResourceName, manifestResourceName);
+            }
+        }
+
+        private static void AdjustLogicalName(ITaskItem xlf, ITaskItem output, string language)
+        {
+            string logicalName = xlf.GetMetadata(MetadataKey.LogicalName);
+            if (!string.IsNullOrEmpty(logicalName))
+            {
+                string logicalExtension = Path.GetExtension(logicalName);
+                logicalName = Path.ChangeExtension(logicalName, $".{language}{logicalExtension}");
+                output.SetMetadata(MetadataKey.LogicalName, logicalName);
+            }
+        }
+
+        private static void AdjustDependentUpon(ITaskItem xlf, ITaskItem output)
+        {
+            string dependentUpon = xlf.GetMetadata(MetadataKey.DependentUpon);
+            if (!string.IsNullOrEmpty(dependentUpon))
+            {
+                string sourceDirectory = Path.GetDirectoryName(xlf.GetMetadataOrThrow(MetadataKey.XlfSource));
+                dependentUpon = Path.GetFullPath(Path.Combine(sourceDirectory, dependentUpon));
+                output.SetMetadata(MetadataKey.DependentUpon, dependentUpon);
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/Tasks/GatherXlf.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Tasks/GatherXlf.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System.IO;
+using System;
+using System.Collections.Generic;
+
+namespace XliffTasks.Tasks
+{
+    public sealed class GatherXlf : XlfTask
+    {
+        [Required]
+        public ITaskItem[] Sources { get; set; }
+
+        [Required]
+        public string[] Languages { get; set; }
+
+        [Required]
+        public string TranslatedOutputDirectory { get; set; }
+
+        [Output]
+        public ITaskItem[] Outputs { get; private set; }
+
+        protected override void ExecuteCore()
+        {
+            int index = 0;
+            ITaskItem[] outputs = new ITaskItem[Sources.Length * Languages.Length];
+            HashSet<string> outputPaths = new(StringComparer.OrdinalIgnoreCase);
+
+            foreach (ITaskItem source in Sources)
+            {
+                string sourceDocumentPath = source.GetMetadataOrDefault(MetadataKey.SourceDocumentPath, source.ItemSpec);
+
+                foreach (string language in Languages)
+                {
+                    string xlfPath = XlfTask.GetXlfPath(sourceDocumentPath, language);
+                    TaskItem xlf = new(source) { ItemSpec = xlfPath };
+                    xlf.SetMetadata(MetadataKey.XlfSource, source.ItemSpec);
+                    xlf.SetMetadata(MetadataKey.XlfTranslatedFullPath, GetTranslatedOutputPath(source, language, outputPaths));
+                    xlf.SetMetadata(MetadataKey.XlfLanguage, language);
+                    outputs[index++] = xlf;
+                }
+            }
+
+            Release.Assert(index == outputs.Length);
+            Outputs = outputs;
+        }
+
+        private string GetTranslatedOutputPath(ITaskItem source, string language, HashSet<string> outputPaths)
+        {
+            string translatedFilename = source.GetMetadata(MetadataKey.XlfTranslatedFilename);
+            if (string.IsNullOrEmpty(translatedFilename))
+            {
+                translatedFilename = Path.GetFileNameWithoutExtension(source.ItemSpec);
+                source.SetMetadata(MetadataKey.XlfTranslatedFilename, translatedFilename);
+            }
+
+            string sourceDocumentPath = source.GetMetadataOrDefault(MetadataKey.SourceDocumentPath, source.ItemSpec);
+            string extension = Path.GetExtension(source.ItemSpec);
+            string outputPath = Path.Combine(TranslatedOutputDirectory, $"{translatedFilename}.{language}{extension}");
+
+            if (!outputPaths.Add(outputPath))
+            {
+                throw new BuildErrorException(
+                    $"Two or more source files to be translated in the same project are named {Path.GetFileName(sourceDocumentPath)}. " +
+                    $"Give them unique names or set unique {MetadataKey.XlfTranslatedFilename} metadata.");
+            }
+
+            return outputPath;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/Tasks/MetadataKey.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Tasks/MetadataKey.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace XliffTasks
+{
+    internal static class MetadataKey
+    {
+        public const string DependentUpon = nameof(DependentUpon);
+        public const string Link = nameof(Link);
+        public const string LogicalName = nameof(LogicalName);
+        public const string ManifestResourceName = nameof(ManifestResourceName);
+        public const string SourceDocumentPath = nameof(SourceDocumentPath);
+        public const string XlfLanguage = nameof(XlfLanguage);
+        public const string XlfSource = nameof(XlfSource);
+        public const string XlfSourceFormat = nameof(XlfSourceFormat);
+        public const string XlfTranslatedFilename = nameof(XlfTranslatedFilename);
+        public const string XlfTranslatedFullPath = nameof(XlfTranslatedFullPath);
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/Tasks/SortXlf.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Tasks/SortXlf.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using System.IO;
+using XliffTasks.Model;
+
+namespace XliffTasks.Tasks
+{
+    public sealed class SortXlf : XlfTask
+    {
+        [Required]
+        public ITaskItem[] Sources { get; set; }
+
+        [Required]
+        public string[] Languages { get; set; }
+
+        protected override void ExecuteCore()
+        {
+            foreach (ITaskItem item in Sources)
+            {
+                string sourceDocumentPath = item.GetMetadataOrDefault(MetadataKey.SourceDocumentPath, item.ItemSpec);
+
+                foreach (string language in Languages)
+                {
+                    string xlfPath = XlfTask.GetXlfPath(sourceDocumentPath, language);
+                    XlfDocument xlfDocument;
+
+                    try
+                    {
+                        xlfDocument = XlfTask.LoadXlfDocument(xlfPath);
+                    }
+                    catch (FileNotFoundException)
+                    {
+                        // If the file doesn't exist, we don't need to worry about sorting it.
+                        continue;
+                    }
+
+                    bool modified = xlfDocument.Sort();
+                    if (!modified)
+                    {
+                        continue; // no changes
+                    }
+
+                    Directory.CreateDirectory(Path.GetDirectoryName(xlfPath));
+                    xlfDocument.Save(xlfPath);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/Tasks/TaskItemExtensions.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Tasks/TaskItemExtensions.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+
+namespace XliffTasks.Tasks
+{
+    internal static class TaskItemExtensions
+    {
+        public static string GetMetadataOrThrow(this ITaskItem item, string key)
+        {
+            string value = item.GetMetadata(key);
+
+            if (string.IsNullOrEmpty(value))
+            {
+                throw new BuildErrorException($"Item '{item}' is missing '{key}' metadata.");
+            }
+
+            return value;
+        }
+
+        public static string GetMetadataOrDefault(this ITaskItem item, string key, string defaultValue)
+        {
+            string value = item.GetMetadata(key);
+
+            if (string.IsNullOrEmpty(value))
+            {
+                return defaultValue;
+            }
+
+            return value;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/Tasks/TaskLoggingHelperExtensions.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Tasks/TaskLoggingHelperExtensions.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Utilities;
+
+namespace XliffTasks.Tasks
+{
+    internal static class TaskLoggingHelperExtensions
+    {
+        /// <summary>
+        /// Helper method to log MSBuild errors associated with a particular file.
+        /// </summary>
+        public static void LogErrorInFile(this TaskLoggingHelper log, string file, string message)
+        {
+            log.LogError(
+                subcategory: null,
+                errorCode: null,
+                helpKeyword: null,
+                file: file,
+                lineNumber: 0,
+                columnNumber: 0,
+                endLineNumber: 0,
+                endColumnNumber: 0,
+                message: message);
+        }
+
+        /// <summary>
+        /// Helper method to log MSBuild errors associated with a particular file and line.
+        /// </summary>
+        public static void LogErrorInFile(this TaskLoggingHelper log, string file, int line, string message)
+        {
+            log.LogError(
+                subcategory: null,
+                errorCode: null,
+                helpKeyword: null,
+                file: file,
+                lineNumber: line,
+                columnNumber: 0,
+                endLineNumber: 0,
+                endColumnNumber: 0,
+                message: message);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/Tasks/TransformTemplates.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Tasks/TransformTemplates.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using XliffTasks.Model;
+
+namespace XliffTasks.Tasks
+{
+    public sealed class TransformTemplates : XlfTask
+    {
+        [Required]
+        public ITaskItem[] Templates { get; set; }
+
+        [Required]
+        public ITaskItem[] UnstructuredResources { get; set; }
+
+        [Required]
+        public string[] Languages { get; set; }
+
+        [Required]
+        public string TranslatedOutputDirectory { get; set; }
+
+        [Output]
+        public ITaskItem[] TransformedTemplates { get; set; }
+
+        protected override void ExecuteCore()
+        {
+            List<ITaskItem> transformedTemplates = new();
+            Dictionary<string, ITaskItem> resourceMap = UnstructuredResources.ToDictionary(item => item.GetMetadata("FullPath"));
+            foreach (ITaskItem template in Templates)
+            {
+                // special-case the default template items as the 1033 culture
+                ITaskItem defaultTemplate = TransformTemplate(template, language: null, resourceMap: null);
+                transformedTemplates.Add(defaultTemplate);
+
+                // and process other languages like normal
+                foreach (string language in Languages)
+                {
+                    ITaskItem item = TransformTemplate(template, language, resourceMap);
+                    transformedTemplates.Add(item);
+                }
+            }
+
+            TransformedTemplates = transformedTemplates.ToArray();
+        }
+
+        private ITaskItem TransformTemplate(ITaskItem template, string language, IDictionary<string, ITaskItem> resourceMap)
+        {
+            if ((language == null) ^ (resourceMap == null))
+            {
+                throw new ArgumentException($"Either both '{nameof(language)}' and '{nameof(resourceMap)}' must be specified, or they both must be 'null'.");
+            }
+
+            bool transformingDefaultTemplate = language == null;
+            string templateCulture = transformingDefaultTemplate ? "1033" : language;
+
+            string templateName = Path.GetFileNameWithoutExtension(template.ItemSpec);
+            string templatePath = template.GetMetadata("FullPath");
+            string templateDirectory = Path.GetDirectoryName(templatePath);
+            XDocument templateXml = XDocument.Load(templatePath);
+
+            // create a copy of the .vstemplate and all files
+            string localizedTemplateDirectory = transformingDefaultTemplate
+                ? Path.Combine(TranslatedOutputDirectory, $"{templateName}.default.1033")
+                : Path.Combine(TranslatedOutputDirectory, $"{templateName}.{language}");
+            Directory.CreateDirectory(localizedTemplateDirectory);
+            string cultureSpecificTemplateFile = Path.Combine(localizedTemplateDirectory, Path.GetFileName(template.ItemSpec));
+            File.Copy(templatePath, cultureSpecificTemplateFile, overwrite: true);
+
+            // copy the template project files
+            foreach (XElement projectNode in templateXml.Descendants().Where(d => d.Name.LocalName == "Project"))
+            {
+                string projectFileFullPath = Path.Combine(templateDirectory, projectNode.Attribute("File").Value);
+                File.Copy(projectFileFullPath, Path.Combine(localizedTemplateDirectory, Path.GetFileName(projectNode.Attribute("File").Value)), overwrite: true);
+            }
+
+            // copy the template project items
+            foreach (XElement templateItem in templateXml.Descendants().Where(d => d.Name.LocalName == "ProjectItem"))
+            {
+                string templateItemFullPath = Path.Combine(templateDirectory, templateItem.Value);
+                string templateItemDestinationPath = Path.Combine(localizedTemplateDirectory, templateItem.Value);
+                if (transformingDefaultTemplate)
+                {
+                    // if not localizing anything, simply strip out the translation markers
+                    UnstructuredDocument document = new();
+                    document.Load(templateItemFullPath);
+                    Dictionary<string, string> defaultTranslation = document.Nodes.ToDictionary(node => node.Id, node => node.Source);
+                    document.Translate(defaultTranslation);
+                    document.Save(templateItemDestinationPath);
+                }
+                else
+                {
+                    // try to localize the template items
+                    if (resourceMap.TryGetValue(templateItemFullPath, out ITaskItem unstructuredResource))
+                    {
+                        // copy a localized file
+                        string localizedFileName = string.Concat(
+                            Path.GetFileNameWithoutExtension(unstructuredResource.ItemSpec),
+                            ".",
+                            language,
+                            Path.GetExtension(unstructuredResource.ItemSpec));
+                        File.Copy(Path.Combine(TranslatedOutputDirectory, localizedFileName), templateItemDestinationPath, overwrite: true);
+                    }
+                    else
+                    {
+                        // copy the original unaltered file
+                        File.Copy(templateItemFullPath, templateItemDestinationPath, overwrite: true);
+                    }
+                }
+            }
+
+            TaskItem item = new(cultureSpecificTemplateFile);
+            item.SetMetadata("Culture", templateCulture);
+            return item;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/Tasks/TranslateSource.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Tasks/TranslateSource.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using System.Collections.Generic;
+using System.IO;
+using XliffTasks.Model;
+
+namespace XliffTasks.Tasks
+{
+    public sealed class TranslateSource : XlfTask
+    {
+        [Required]
+        public ITaskItem XlfFile { get; set; }
+
+        protected override void ExecuteCore()
+        {
+            string sourcePath = XlfFile.GetMetadataOrThrow(MetadataKey.XlfSource);
+            string sourceFormat = XlfFile.GetMetadataOrThrow(MetadataKey.XlfSourceFormat);
+            string language = XlfFile.GetMetadataOrThrow(MetadataKey.XlfLanguage);
+            string translatedFullPath = XlfFile.GetMetadataOrThrow(MetadataKey.XlfTranslatedFullPath);
+
+            TranslatableDocument sourceDocument = XlfTask.LoadSourceDocument(sourcePath, XlfFile.GetMetadata(MetadataKey.XlfSourceFormat));
+            XlfDocument xlfDocument = XlfTask.LoadXlfDocument(XlfFile.ItemSpec);
+
+            bool validationFailed = false;
+            xlfDocument.Validate(validationError =>
+            {
+                validationFailed = true;
+                Log.LogErrorInFile(XlfFile.ItemSpec, validationError.LineNumber, validationError.Message);
+            });
+
+            IReadOnlyDictionary<string, string> translations = validationFailed
+                ? new Dictionary<string, string>()
+                : xlfDocument.GetTranslations();
+
+            sourceDocument.Translate(translations);
+
+            Directory.CreateDirectory(Path.GetDirectoryName(translatedFullPath));
+
+            sourceDocument.RewriteRelativePathsToAbsolute(Path.GetFullPath(sourcePath));
+            sourceDocument.Save(translatedFullPath);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/Tasks/UpdateXlf.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Tasks/UpdateXlf.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using System.IO;
+using XliffTasks.Model;
+
+namespace XliffTasks.Tasks
+{
+    public sealed class UpdateXlf : XlfTask
+    {
+        [Required]
+        public ITaskItem[] Sources { get; set; }
+
+        [Required]
+        public string[] Languages { get; set; }
+
+        [Required]
+        public bool AllowModification { get; set; }
+
+        private const string HowToUpdate =
+            "Run `msbuild /t:UpdateXlf` to update .xlf files or set UpdateXlfOnBuild=true"
+            + " to update them on every build, but note that it is strongly discouraged to set"
+            + " UpdateXlfOnBuild=true in official/CI build environments as they should not"
+            + " modify source code during the build.";
+
+        protected override void ExecuteCore()
+        {
+            foreach (ITaskItem item in Sources)
+            {
+                string sourcePath = item.ItemSpec;
+                string sourceDocumentPath = item.GetMetadataOrDefault(MetadataKey.SourceDocumentPath, item.ItemSpec);
+                string sourceFormat = item.GetMetadataOrThrow(MetadataKey.XlfSourceFormat);
+                TranslatableDocument sourceDocument = XlfTask.LoadSourceDocument(sourcePath, sourceFormat);
+                string sourceDocumentId = XlfTask.GetSourceDocumentId(sourcePath);
+
+                foreach (string language in Languages)
+                {
+                    string xlfPath = XlfTask.GetXlfPath(sourceDocumentPath, language);
+                    XlfDocument xlfDocument;
+
+                    try
+                    {
+                        xlfDocument = XlfTask.LoadXlfDocument(xlfPath, language, createIfNonExistent: AllowModification);
+                    }
+                    catch (FileNotFoundException fileNotFoundEx) when (fileNotFoundEx.FileName == xlfPath)
+                    {
+                        Release.Assert(!AllowModification);
+                        throw new BuildErrorException($"'{xlfPath}' for '{sourcePath}' does not exist. {HowToUpdate}");
+                    }
+                    catch (System.Xml.XmlException xmlEx)
+                    {
+                        throw new BuildErrorException($"Unable to load file: {xmlEx.Message}")
+                        {
+                            RelatedFile = xlfPath
+                        };
+                    }
+
+                    bool updated = xlfDocument.Update(sourceDocument, sourceDocumentId);
+
+                    if (!updated)
+                    {
+                        continue; // no changes
+                    }
+
+                    if (!AllowModification)
+                    {
+                        throw new BuildErrorException($"'{xlfPath}' is out-of-date with '{sourcePath}'. {HowToUpdate}");
+                    }
+
+                    Directory.CreateDirectory(Path.GetDirectoryName(xlfPath));
+                    xlfDocument.Save(xlfPath);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/Tasks/XlfTask.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Tasks/XlfTask.cs
@@ -1,0 +1,109 @@
+﻿
+using Microsoft.Build.Utilities;
+using System;
+using System.IO;
+using XliffTasks.Model;
+
+namespace XliffTasks.Tasks
+{
+    public abstract class XlfTask : Task
+    {
+        internal XlfTask()
+        {
+        }
+
+        public sealed override bool Execute()
+        {
+            try
+            {
+                ExecuteCore();
+            }
+            catch (BuildErrorException ex)
+            {
+                Log.LogErrorFromException(ex, showStackTrace: false, showDetail: false, file: ex.RelatedFile);
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+
+        protected abstract void ExecuteCore();
+
+        internal static TranslatableDocument LoadSourceDocument(string path, string format)
+        {
+            TranslatableDocument document;
+
+            if (format.Equals("Resx", StringComparison.OrdinalIgnoreCase))
+            {
+                document = new ResxDocument();
+            }
+            else if (format.Equals("Unstructured", StringComparison.OrdinalIgnoreCase))
+            {
+                document = new UnstructuredDocument();
+            }
+            else if (format.Equals("Vsct", StringComparison.OrdinalIgnoreCase))
+            {
+                document = new VsctDocument();
+            }
+            else if (format.Equals("XamlRule", StringComparison.OrdinalIgnoreCase))
+            {
+                document = new XamlRuleDocument();
+            }
+            else
+            {
+                throw new BuildErrorException($"Unknown source file format '{format}'.")
+                {
+                    RelatedFile = path
+                };
+            }
+
+            document.Load(path);
+            return document;
+        }
+
+        internal static XlfDocument LoadXlfDocument(string path, string language = null, bool createIfNonExistent = false)
+        {
+            XlfDocument document = new();
+
+            if (File.Exists(path))
+            {
+                document.Load(path);
+            }
+            else if (createIfNonExistent)
+            {
+                Release.Assert(!string.IsNullOrEmpty(language));
+                document.LoadNew(language);
+            }
+            else
+            {
+                throw new FileNotFoundException($"File not found: {path}", path);
+            }
+
+            return document;
+        }
+
+        internal static string GetXlfPath(string sourcePath, string language)
+        {
+            string directory = Path.GetDirectoryName(sourcePath);
+            string filename = Path.GetFileNameWithoutExtension(sourcePath);
+            string extension = Path.GetExtension(sourcePath);
+
+            string xlfExtension;
+            if (extension.Equals(".resx", StringComparison.OrdinalIgnoreCase))
+            {
+                xlfExtension = $".{language}.xlf";
+            }
+            else
+            {
+                xlfExtension = $"{extension}.{language}.xlf";
+            }
+
+            return Path.Combine(directory, "xlf", filename + xlfExtension);
+        }
+
+        internal static string GetSourceDocumentId(string sourcePath)
+        {
+            return $"../{Path.GetFileName(sourcePath)}";
+        }
+    }
+}
+

--- a/src/Microsoft.DotNet.XliffTasks/Validation.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Validation.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace XliffTasks
+{
+    internal static class Validation
+    {
+        public static void ThrowIfNullOrEmpty(string value, string parameterName)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(parameterName);
+            }
+
+            if (value.Length == 0)
+            {
+                throw new ArgumentException("Value cannot be empty", parameterName);
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XliffTasks/build/Microsoft.DotNet.XliffTasks.props
+++ b/src/Microsoft.DotNet.XliffTasks/build/Microsoft.DotNet.XliffTasks.props
@@ -1,0 +1,69 @@
+﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project>
+
+  <PropertyGroup>
+    <!-- 
+      Set this to to true to update .xlf files with corresponding .resx/.vcst/.xaml on every build.
+
+      If used, it should be configured so that official/CI builds keep it off as those should never
+      modify source code in the repository.
+    -->
+    <UpdateXlfOnBuild Condition="'$(UpdateXlfOnBuild)' == ''">false</UpdateXlfOnBuild>
+
+    <!--
+      Set this to false to use .xlf files as they are without verifying that they are up-to-date
+      with corresponding .resx/.vsct/.xaml files.
+    -->
+    <ErrorOnOutOfDateXlf Condition="'$(ErrorOnOutOfDateXlf)' == ''">true</ErrorOnOutOfDateXlf>
+    
+    <!--
+       The set of languages to which the project is localized. The default matches Visual Studio.
+    -->
+    <XlfLanguages Condition="'$(XlfLanguages)' == ''">cs;de;es;fr;it;ja;ko;pl;pt-BR;ru;tr;zh-Hans;zh-Hant</XlfLanguages>
+
+    <!--
+      Set this to to false to skip all xlf processing.
+    -->
+    <EnableXlfLocalization Condition="'$(EnableXlfLocalization)' == ''">true</EnableXlfLocalization>
+  </PropertyGroup>
+
+  <ItemDefinitionGroup>
+    <EmbeddedResource>
+      <!-- XlfInput set in targets to true if not already set and %(Extension) is .resx -->
+      <XlfSourceFormat>Resx</XlfSourceFormat>
+      <XlfOutputItem>EmbeddedResource</XlfOutputItem>
+    </EmbeddedResource>
+
+    <UnstructuredResource>
+      <Visible>false</Visible>
+      <XlfInput>true</XlfInput>
+      <XlfSourceFormat>Unstructured</XlfSourceFormat>
+      <XlfOutputItem>UnstructuredResourceTranslated</XlfOutputItem>
+    </UnstructuredResource>
+
+    <VSCTCompile>
+      <XlfInput>true</XlfInput>
+      <XlfSourceFormat>Vsct</XlfSourceFormat>
+      <XlfOutputItem>VSCTCompile</XlfOutputItem>
+    </VSCTCompile>
+
+    <XamlPropertyRule>
+      <XlfInput>true</XlfInput>
+      <XlfSourceFormat>XamlRule</XlfSourceFormat>
+      <XlfOutputItem>XamlPropertyRuleTranslated</XlfOutputItem>
+    </XamlPropertyRule>
+
+    <XamlPropertyRuleNoCodeBehind>
+      <XlfInput>true</XlfInput>
+      <XlfSourceFormat>XamlRule</XlfSourceFormat>
+      <XlfOutputItem>XamlPropertyRuleTranslated</XlfOutputItem>
+    </XamlPropertyRuleNoCodeBehind>
+
+    <XamlPropertyProjectItemsSchema>
+      <XlfInput>true</XlfInput>
+      <XlfSourceFormat>XamlRule</XlfSourceFormat>
+      <XlfOutputItem>XamlPropertyRuleTranslated</XlfOutputItem>
+    </XamlPropertyProjectItemsSchema>
+  </ItemDefinitionGroup>
+
+</Project>

--- a/src/Microsoft.DotNet.XliffTasks/build/Microsoft.DotNet.XliffTasks.targets
+++ b/src/Microsoft.DotNet.XliffTasks/build/Microsoft.DotNet.XliffTasks.targets
@@ -1,0 +1,174 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project>
+
+  <PropertyGroup>
+    <XliffTasksDirectory Condition="'$(XliffTasksDirectory)' == '' and '$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net8.0\</XliffTasksDirectory>
+    <XliffTasksDirectory Condition="'$(XliffTasksDirectory)' == '' and '$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net462\</XliffTasksDirectory>
+    <XliffTasksAssembly>$(XliffTasksDirectory)Microsoft.DotNet.XliffTasks.dll</XliffTasksAssembly>
+  </PropertyGroup>
+
+  <UsingTask TaskName="GatherXlf" AssemblyFile="$(XliffTasksAssembly)" Condition="'$(XliffTasksAssembly)' != ''" />
+  <UsingTask TaskName="GatherTranslatedSource" AssemblyFile="$(XliffTasksAssembly)" Condition="'$(XliffTasksAssembly)' != ''" />
+  <UsingTask TaskName="TransformTemplates" AssemblyFile="$(XliffTasksAssembly)" Condition="'$(XliffTasksAssembly)' != ''" />
+  <UsingTask TaskName="TranslateSource" AssemblyFile="$(XliffTasksAssembly)" Condition="'$(XliffTasksAssembly)' != ''" />
+  <UsingTask TaskName="UpdateXlf" AssemblyFile="$(XliffTasksAssembly)" Condition="'$(XliffTasksAssembly)' != ''" />
+  <UsingTask TaskName="SortXlf" AssemblyFile="$(XliffTasksAssembly)" Condition="'$(XliffTasksAssembly)' != ''" />
+  <UsingTask TaskName="EnsureAllResourcesTranslated" AssemblyFile="$(XliffTasksAssembly)" Condition="'$(XliffTasksAssembly)' != ''" />
+
+  <!--
+    Note that .xlf files are source files, not build outputs. We therefore cannot use their modification time
+    to drive incremental build. It is possible for .xlf files to be out-of-sync with their source
+    documents without being older than them. For example, you can be in this state after pulling from
+    a repository with out-of-sync xlf files. To deal with this, we instead use a marker file with a
+    timestamp corresponding to the last successful update to drive fast incremental builds. We also keep
+    a list of all the XlfSource files and if that list changes (e.g. new .resx is added to the project), we
+    also trigger a new update.
+  -->
+  <PropertyGroup>
+    <XlfIntermediateOutputPath Condition="'$(XlfIntermediateOutputPath)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).xlf\</XlfIntermediateOutputPath>
+    <_XlfSourceList>$(XlfIntermediateOutputPath)XlfSources.txt</_XlfSourceList>
+    <_UpdateXlfLastRun>$(XlfIntermediateOutputPath)UpdateXlf.lastrun</_UpdateXlfLastRun>
+
+    <!--
+      This is an "inner build" of a cross-targeted project if there are multiple target frameworks, but 
+      we're instantiated with a single one. We musn't trigger an update  of .xlf source files on inner build
+      because inner builds happen in parallel, which would cause a race when modifying the same files. Instead,
+      there is an outer build trigger that calls inner UpdateXlf serially.
+    -->
+    <_IsInnerXlfBuild Condition="'$(TargetFrameworks)' != '' and '$(TargetFramework)' != ''">true</_IsInnerXlfBuild>
+  </PropertyGroup>
+
+  <!-- Updates the list of XlfSource items that drives incremental update (see above) -->
+  <Target Name="UpdateXlfSourceList"
+          DependsOnTargets="GetXlfSources">
+    <MakeDir Directories="$(XlfIntermediateOutputPath)" />
+
+    <WriteLinesToFile File="$(_XlfSourceList)"
+                      Lines="@(XlfSource)"
+                      Overwrite="true"
+                      WriteOnlyWhenDifferent="true" />
+
+    <ItemGroup>
+      <FileWrites Include="$(_XlfSourceList)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="UpdateXlfOnBuild"
+          Condition="'$(EnableXlfLocalization)' == 'true' and '$(UpdateXlfOnBuild)' == 'true' and '$(_IsInnerXlfBuild)' != 'true'"
+          BeforeTargets="BeforeBuild"
+          DependsOnTargets="UpdateXlf" />
+
+  <Target Name="EnsureXlfIsUpToDate"
+          Condition="'$(ErrorOnOutOfDateXlf)' == 'true' and '$(DesignTimeBuild)' != 'true' and '$(BuildingProject)' != 'false'"
+          DependsOnTargets="_DisallowXlfModification;_UpdateXlf" />
+
+  <Target Name="UpdateXlf"
+          DependsOnTargets="_AllowXlfModification;_UpdateXlf" />
+
+  <Target Name="_AllowXlfModification">
+    <PropertyGroup>
+      <_AllowXlfModification>true</_AllowXlfModification>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="_DisallowXlfModification">
+    <PropertyGroup>
+      <_AllowXlfModification>false</_AllowXlfModification>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="_UpdateXlf"
+          DependsOnTargets="GetXlfSources;UpdateXlfSourceList"
+          Inputs="@(XlfSource);$(_XlfSourceList)"
+          Outputs="$(_UpdateXlfLastRun)">
+    <UpdateXlf Sources="@(XlfSource)"
+               Languages="$(XlfLanguages)"
+               AllowModification="$(_AllowXlfModification)" />
+
+    <Touch Files="$(_UpdateXlfLastRun)" AlwaysCreate="true" />
+
+    <ItemGroup>
+      <FileWrites Include="$(_UpdateXlfLastRun)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="GetXlfSources" Returns="@(XlfSource)">
+    <ItemGroup>
+      <EmbeddedResource Update="@(EmbeddedResource)">
+        <XlfInput Condition="'%(EmbeddedResource.XlfInput)' == '' and '%(EmbeddedResource.Extension)' == '.resx'">true</XlfInput>
+      </EmbeddedResource>
+
+      <UnstructuredResource Include="%(VSTemplate.TranslatableResources)" />
+
+      <XlfSource Include="@(EmbeddedResource->WithMetadataValue('XlfInput', 'true'))" />
+      <XlfSource Include="@(UnstructuredResource->WithMetadataValue('XlfInput', 'true'))" />
+      <XlfSource Include="@(VSCTCompile->WithMetadataValue('XlfInput', 'true'))" />
+      <XlfSource Include="@(XamlPropertyRule->WithMetadataValue('XlfInput', 'true'))" />
+      <XlfSource Include="@(XamlPropertyRuleNoCodeBehind->WithMetadataValue('XlfInput', 'true'))" />
+      <XlfSource Include="@(XamlPropertyProjectItemsSchema->WithMetadataValue('XlfInput', 'true'))" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="GatherXlf"
+          DependsOnTargets="GetXlfSources;EnsureXlfIsUpToDate">
+    <GatherXlf Sources="@(XlfSource)"
+               Languages="$(XlfLanguages)"
+               TranslatedOutputDirectory="$(XlfIntermediateOutputPath)">
+      <Output TaskParameter="Outputs" ItemName="Xlf" />
+    </GatherXlf>
+  </Target>
+
+  <Target Name="TranslateSourceFromXlf"
+          Condition="'$(EnableXlfLocalization)' == 'true'"
+          DependsOnTargets="GatherXlf;BatchTranslateSourceFromXlf"
+          BeforeTargets="VSCTCompile;PrepareResourceNames;$(PrepareResourceNamesDependsOn)">
+    <GatherTranslatedSource XlfFiles="@(Xlf)" Condition="'@(Xlf)' != ''">
+      <Output TaskParameter="Outputs" ItemName="%(Xlf.XlfOutputItem)" />
+      <Output TaskParameter="Outputs" ItemName="FileWrites" />
+    </GatherTranslatedSource>
+
+    <ItemGroup>
+      <_VSTemplatesToLocalize Include="@(VSTemplate)" Condition="'%(VSTemplate.TranslatableResources)' != ''" />
+    </ItemGroup>
+
+    <TransformTemplates Templates="@(_VSTemplatesToLocalize)"
+                        UnstructuredResources="@(UnstructuredResource)"
+                        Languages="$(XlfLanguages)"
+                        TranslatedOutputDirectory="$(XlfIntermediateOutputPath)"
+                        Condition="'@(VSTemplate)' != '' and '@(UnstructuredResource)' != ''">
+      <Output TaskParameter="TransformedTemplates" ItemName="VSTemplate" />
+    </TransformTemplates>
+    <ItemGroup>
+      <!--
+      All items of the @(_VSTemplatesToLocalize) group (which was populated from @(VSTemplate)) have been
+      re-added to the collection with the string holes removed, so @(_VSTemplatesToLocalize) can all be
+      removed from the @(VSTemplate) collection.
+      -->
+      <VSTemplate Remove="@(_VSTemplatesToLocalize)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="BatchTranslateSourceFromXlf"
+          Inputs="@(Xlf);%(Xlf.XlfSource)"
+          Outputs="%(Xlf.XlfTranslatedFullPath)">
+    <TranslateSource XlfFile="@(Xlf)" />
+  </Target>
+
+  <!--
+    Sorts the trans-unit elements in the .xlf files by the value of their id attributes.
+  -->
+  <Target Name="SortXlf"
+          DependsOnTargets="GetXlfSources">
+    <SortXlf Sources="@(XlfSource)"
+             Languages="$(XlfLanguages)" />
+  </Target>
+
+  <!--
+    Checks that all trans-unit elements in the .xlf files have an up-to-date translation.
+  -->
+  <Target Name="EnsureAllResourcesTranslated"
+          DependsOnTargets="GetXlfSources">
+    <EnsureAllResourcesTranslated Sources="@(XlfSource)"
+                                  Languages="$(XlfLanguages)" />
+  </Target>
+</Project>

--- a/src/Microsoft.DotNet.XliffTasks/buildCrossTargeting/Microsoft.DotNet.XliffTasks.props
+++ b/src/Microsoft.DotNet.XliffTasks/buildCrossTargeting/Microsoft.DotNet.XliffTasks.props
@@ -1,0 +1,6 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\build\Microsoft.DotNet.XliffTasks.props" />
+
+</Project>

--- a/src/Microsoft.DotNet.XliffTasks/buildCrossTargeting/Microsoft.DotNet.XliffTasks.targets
+++ b/src/Microsoft.DotNet.XliffTasks/buildCrossTargeting/Microsoft.DotNet.XliffTasks.targets
@@ -1,0 +1,59 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project>
+
+  <Target Name="UpdateXlfOnBuild"
+          DependsOnTargets="UpdateXlf"
+          BeforeTargets="DispatchToInnerBuilds"
+          Condition="'$(EnableXlfLocalization)' == 'true' and '$(UpdateXlfOnBuild)' == 'true'" />
+
+  <Target Name="UpdateXlf">
+    <ItemGroup>
+      <_XlfTargetFramework Include="$(TargetFrameworks)" />
+    </ItemGroup>
+
+    <!--
+      These inner builds cannot be parallelized as they would race to 
+      update the same inner xlf files.
+    -->
+    <MSBuild Projects="$(MSBuildProjectFile)"
+             Targets="UpdateXlf"
+             Properties="TargetFramework=%(_XlfTargetFramework.Identity)" />
+  </Target>
+
+  <!--
+    Sorts the trans-unit elements in the .xlf files by the value of their id attributes.
+    Runs a sort per target framework as resource files may be conditioned on the framework.
+  -->
+  <Target Name="SortXlf">
+    <ItemGroup>
+      <_XlfTargetFramework Include="$(TargetFrameworks)" />
+    </ItemGroup>
+
+    <!--
+      These inner builds cannot be parallelized as they would race to 
+      update the same inner xlf files.
+    -->
+    <MSBuild Projects="$(MSBuildProjectFile)"
+             Targets="SortXlf"
+             Properties="TargetFramework=%(_XlfTargetFramework.Identity)" />
+  </Target>
+
+  <!--
+    Checks that all trans-unit elements in the .xlf files have an up-to-date translation.
+    Runs a sort per target framework as resource files may be conditioned on the framework.
+  -->
+  <Target Name="EnsureAllResourcesTranslated">
+    <ItemGroup>
+      <_XlfTargetFramework Include="$(TargetFrameworks)" />
+    </ItemGroup>
+    
+    <!--
+      These inner builds can be run in parallel as they don't modify any files.
+    -->
+    <MSBuild Projects="$(MSBuildProjectFile)"
+             Targets="EnsureAllResourcesTranslated"
+             Properties="TargetFramework=%(_XlfTargetFramework.Identity)"
+             BuildInParallel="true" />
+  </Target>
+
+</Project>


### PR DESCRIPTION
Roslyn needs this feature: https://github.com/dotnet/arcade/issues/14275 in Arcade SDK 8.
Xliff tasks were only added to main for V9 and the original repo is archived.

Follow up: port https://github.com/dotnet/arcade/pull/14391 to release/8.0