### PR TITLE
Update subscription id for netsourceindexstage1

### DIFF
--- a/.vault-config/product-builds-netsourceindexvault.yaml
+++ b/.vault-config/product-builds-netsourceindexvault.yaml
@@ -8,7 +8,7 @@ secrets:
   source-dot-net-stage1-connection-string:
     type: azure-storage-connection-string
     parameters:
-      subscription: a4fc5514-21a9-4296-bfaf-5c7ee7fa35d1
+      subscription: 813dbf66-c320-41e6-a8a8-cb0dfd8b3187
       account: netsourceindexstage1
 
   #source-dot-net stage1 variables


### PR DESCRIPTION
Part of [dotnet/dnceng#408](https://github.com/dotnet/dnceng/issues/408).

Most Azure resources that support source.dot.net have been moved to a new subscription, including this storage account. 

Update the subscription where netsourceindexstage1 for purposes of SAS generation.