### PR TITLE
Revert freebsd pkg version back to 1.17.0

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -72,7 +72,7 @@ __AlpinePackages+=" openssl-dev"
 __AlpinePackages+=" zlib-dev"
 
 __FreeBSDBase="13.2-RELEASE"
-__FreeBSDPkg="1.20.0"
+__FreeBSDPkg="1.17.0"
 __FreeBSDABI="13"
 __FreeBSDPackages="libunwind"
 __FreeBSDPackages+=" icu"


### PR DESCRIPTION
See https://github.com/freebsd/pkg/issues/2232

Fixes https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/965