### PR TITLE
Fix import conditional

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -49,7 +49,7 @@
   <PropertyGroup>
     <_ImportOrUseTooling>false</_ImportOrUseTooling>
     <_ImportOrUseTooling Condition="('$(ArcadeBuildVertical)' == 'true' or ($(ArcadeInnerBuildFromSource)' != 'true' and '$(DotNetBuildFromSourceFlavor)' != 'Product')) and 
-                                    ('$(DotNetBuildSourceOnly)' != 'true' or ('$(DotNetBuildPhase)' == 'Inner' and '$(DotNetBuildOrchestrator)' != 'true'))">true</ImportOrUseTooling>
+                                    ('$(DotNetBuildSourceOnly)' != 'true' or ('$(DotNetBuildPhase)' == 'Inner' and '$(DotNetBuildOrchestrator)' != 'true'))">true</_ImportOrUseTooling>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(_ImportOrUseTooling)' == 'true'">

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -48,7 +48,7 @@
 
   <PropertyGroup>
     <_ImportOrUseTooling>false</_ImportOrUseTooling>
-    <_ImportOrUseTooling Condition="('$(ArcadeBuildVertical)' == 'true' or ($(ArcadeInnerBuildFromSource)' != 'true' and '$(DotNetBuildFromSourceFlavor)' != 'Product')) and 
+    <_ImportOrUseTooling Condition="('$(ArcadeBuildVertical)' == 'true' or ('$(ArcadeInnerBuildFromSource)' != 'true' and '$(DotNetBuildFromSourceFlavor)' != 'Product')) and 
                                     ('$(DotNetBuildSourceOnly)' != 'true' or ('$(DotNetBuildPhase)' == 'Inner' and '$(DotNetBuildOrchestrator)' != 'true'))">true</_ImportOrUseTooling>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -32,7 +32,14 @@
     <PackageReference Include="Microsoft.DotNet.NuGetRepack.Tasks" Version="$(MicrosoftDotnetNuGetRepackTasksVersion)" Condition="'$(UsingToolNuGetRepack)' == 'true'" IsImplicitlyDefined="true" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
+  <!-- These package references should only be excluded when doing inner builds, and outer-builds from the orchestrator in source only build
+       configurations. non-source only build configurations should always restore these packages.
+
+       Switches are separated by legacy vs. new.
+  -->
+
+  <ItemGroup Condition="('$(ArcadeBuildVertical)' == 'true' or ($(ArcadeInnerBuildFromSource)' != 'true' and '$(DotNetBuildFromSourceFlavor)' != 'Product')) and 
+                        ('$(DotNetBuildSourceOnly)' != 'true' or ('$(DotNetBuildPhase)' == 'Inner' and '$(DotNetBuildOrchestrator)' != 'true'))">
     <!-- Copy of 'sn.exe' in form of NuGet package. -->
     <PackageReference Include="sn" Version="$(SNVersion)" IsImplicitlyDefined="true" />
     <PackageReference Include="MicroBuild.Core" Version="$(MicroBuildCoreVersion)"  IsImplicitlyDefined="true" />


### PR DESCRIPTION
I horked up the import conditional (and a few others) in SB repo mode with the last controls check-in. The new `DotNetBuildSourceOnly` is passed at all levels in source-only mode. This is in contrast to DotNetBuildFromSource today, which is passed in the inner-repo and when run from the orchestrator, but not the outer repo when run in isolation. Since the new control set corrects this inconsistency, I need to be careful when adding it in areas that may affect outer build.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
