### PR TITLE
Make the legacy properties respect DotNetBuildSkipTests

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ExcludeFromBuild.BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ExcludeFromBuild.BeforeCommonTargets.targets
@@ -28,16 +28,14 @@
           where the BeforeCommonTargets hook is not used (see https://github.com/dotnet/arcade/issues/2676).
           In that case, Sdk.targets imports it explicitly. -->
 
+  <!-- Exclude test projects from source-only builds by default. Exclude from non-source only .NET product
+       builds if explicitly set. -->
   <PropertyGroup Condition="'$(IsTestProject)' == 'true' or '$(IsTestUtilityProject)' == 'true'">
-    <!-- Exclude test projects from source-build by default -->
-    <ExcludeFromSourceBuild Condition="'$(ExcludeFromSourceBuild)' == ''">true</ExcludeFromSourceBuild>
-    <!-- Vertical Build PoC. Exclude test projects. -->
-    <ExcludeFromVerticalBuild Condition="'$(ExcludeFromVerticalBuild)' == ''">true</ExcludeFromVerticalBuild>
-
-    <!-- Exclude test projects from source-only builds by default. Exclude from non-source only .NET product
-         builds if explicitly set. -->
     <ExcludeFromSourceOnlyBuild Condition="'$(ExcludeFromSourceOnlyBuild)' == '' and '$(DotNetBuildSkipTests)' != 'false'">true</ExcludeFromSourceOnlyBuild>
+    <ExcludeFromSourceBuild Condition="'$(ExcludeFromSourceBuild)' == '' and '$(DotNetBuildSkipTests)' != 'false'">true</ExcludeFromSourceBuild>
+
     <ExcludeFromDotNetBuild Condition="'$(ExcludeFromDotNetBuild)' == '' and '$(DotNetBuildSkipTests)' == 'true'">true</ExcludeFromDotNetBuild>
+    <ExcludeFromVerticalBuild Condition="'$(ExcludeFromVerticalBuild)' == '' and '$(DotNetBuildSkipTests)' == 'true'">true</ExcludeFromVerticalBuild>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
This will fix https://github.com/dotnet/runtime/issues/97470

While looking at Tom's binlog I noticed that the ExcludeFrom* infrastructure kicks in when building test projects in runtime.

This wasn't the case before https://github.com/dotnet/arcade/commit/c0c425d9b85b125bbaf59581639355f1d2b99149 as the `IsTestProject` property was read before it got defined in runtime. My commit fixed that... but unintentionally broke Tom's scenario (building tests although DotNetBuildFromSource is true).

I asked Tom to add `DotNetBuildSkipTests=false` to their pipeline so that they can continue to build and run tests under source-build.

To make this work, the legacy switches need to respect `DotNetBuildSkipTests` otherwise they would have to wait weeks or months. Also, I don't see any reason why the legacy switches can't respect that setting.

cc @tmds 