### PR TITLE
Add DisableArcadeExcludeFromBuildSupport property

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/BeforeCommonTargets.CrossTargeting.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/BeforeCommonTargets.CrossTargeting.targets
@@ -12,7 +12,8 @@
 
   <!-- Import the logic to determine whether a project should not build.
        This is done at this point because we need to exclude the import of some standard Microsoft restore targets (NuGet)
-       that are loaded before the import of Arcade's Sdk.targets. See info in ExcludeFromBuild -->
-  <Import Project="ExcludeFromBuild.BeforeCommonTargets.targets"/>
+       that are loaded before the import of Arcade's Sdk.targets. See info in ExcludeFromBuild.
+       Repositories that don't require this infrastructure can set DisableArcadeExcludeFromBuildSupport to true to disable it. -->
+  <Import Project="ExcludeFromBuild.BeforeCommonTargets.targets" Condition="'$(DisableArcadeExcludeFromBuildSupport)' != 'true'" />
 
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/BeforeCommonTargets.targets
@@ -12,7 +12,8 @@
 
   <!-- Import the logic to determine whether a project should not build.
        This is done at this point because we need to exclude the import of some standard Microsoft restore targets (NuGet)
-       that are loaded before the import of Arcade's Sdk.targets. See info in ExcludeFromBuild -->
-  <Import Project="ExcludeFromBuild.BeforeCommonTargets.targets"/>
+       that are loaded before the import of Arcade's Sdk.targets. See info in ExcludeFromBuild.
+       Repositories that don't require this infrastructure can set DisableArcadeExcludeFromBuildSupport to true to disable it. -->
+  <Import Project="ExcludeFromBuild.BeforeCommonTargets.targets" Condition="'$(DisableArcadeExcludeFromBuildSupport)' != 'true'" />
 
 </Project>


### PR DESCRIPTION
Related: https://github.com/dotnet/arcade/pull/14413

In runtime we control our projects and which ones to exclude for source-build / unified-build via ProjectReference Conditions and the Microsoft.Build.Traversal SDK. That's a better mechanism to filter out projects as they aren't even visited by MSBuild (meaning no msbuild evaluation and no target invocation -> much better perf).

While https://github.com/dotnet/arcade/commit/c0c425d9b85b125bbaf59581639355f1d2b99149 fixed the issue that the `IsTestProject` and `IsTestUtilityProject` properties were read too early, it made that infrastructure now run in dotnet/runtime.

Add an opt-out switch to disable the ExcludeFromBuild infrastructure entirely.