### PR TITLE
[release/8.0] Add $(NetMinimum) to RemoteExecutor TFMs to help maintenance-packages and machinelearning

### DIFF
--- a/src/Microsoft.DotNet.RemoteExecutor/src/Microsoft.DotNet.RemoteExecutor.csproj
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/Microsoft.DotNet.RemoteExecutor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
+    <TargetFrameworks>$(NetMinimum);$(NetCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
     <!-- The assembly is used as both a library and an executable. -->
     <OutputType>Exe</OutputType>
     <Description>This package provides support for running tests out-of-process.</Description>

--- a/src/Microsoft.DotNet.RemoteExecutor/src/Microsoft.DotNet.RemoteExecutor.csproj
+++ b/src/Microsoft.DotNet.RemoteExecutor/src/Microsoft.DotNet.RemoteExecutor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetMinimum);$(NetCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);$(NetMinimum);$(NetFrameworkMinimum)</TargetFrameworks>
     <!-- The assembly is used as both a library and an executable. -->
     <OutputType>Exe</OutputType>
     <Description>This package provides support for running tests out-of-process.</Description>


### PR DESCRIPTION
In the maintenance-packages repo, we are unable to run test projects against $(NetMinimum) when they depend on RemoteExecutor because it that package version is not available for net6.0 (maintenance-packages uses the 8.0 version of arcade).

Legend says that machinelearning might have a similar need.