### PR TITLE
Add targets to restore internal tooling within the arcade build

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -78,6 +78,14 @@
     <Exec Command='"$(DotNetTool)" tool restore' WorkingDirectory="$(RepoRoot)" />
   </Target>
 
+  <!-- Set as DependsOnTargets when internal tools (e.g. IBC data, optprof) is required -->
+  <Target Name="RestoreInternalTooling">
+    <MSBuild Projects="$(RepoRoot)eng/common/internal/Tools.csproj"
+        Targets="Restore"
+        Properties="@(_RestoreToolsProps);_NETCORE_ENGINEERING_TELEMETRY=Restore"
+        Condition="'$(Restore)' == 'true'"/>
+  </Target>
+
   <Import Project="SourceBuild/SourceBuildArcadeTools.targets" Condition="'$(ArcadeBuildFromSource)' == 'true' or
                                                                           '$(ArcadeBuildVertical)' == 'true' or
                                                                           '$(DotNetBuildRepo)' == 'true' or

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.AcquireOptimizationData.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.AcquireOptimizationData.targets
@@ -30,7 +30,8 @@
           Condition="'$(EnableNgenOptimization)' == 'true'">
   </Target>
   
-  <Target Name="_PrepareAcquireVisualStudioOptimizationData">
+  <Target Name="_PrepareAcquireVisualStudioOptimizationData"
+          DependsOnTargets="RestoreInternalTooling">
     <PropertyGroup>
       <_DropToolPath>$(NuGetPackageRoot)drop.app\$(DropAppVersion)\lib\net45\drop.exe</_DropToolPath>
       <_DropToolExists>false</_DropToolExists>


### PR DESCRIPTION
Usually repos have a separate YAML step to restore internal tooling when building officially and they need IBC/OptProf data. This doesn't work as well with the VMR vertical builds. Instead, integrate it into the arcade restore process.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
