### PR TITLE
Update BuildTask.Packages.props

### DIFF
--- a/eng/BuildTask.Packages.props
+++ b/eng/BuildTask.Packages.props
@@ -1,6 +1,6 @@
 <Project>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <PackageVersion Update="System.Text.Json" Version="7.0.1" />
     <PackageVersion Update="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     <PackageVersion Update="Microsoft.Extensions.DependencyModel" Version="7.0.0" />


### PR DESCRIPTION
This condition should apply to all possible .NET Framework versions in a task project, not only `net472`.