### PR TITLE
Update source index package version

### DIFF
--- a/eng/common/templates/job/source-index-stage1.yml
+++ b/eng/common/templates/job/source-index-stage1.yml
@@ -1,6 +1,6 @@
 parameters:
   runAsPublic: false
-  sourceIndexPackageVersion: 1.0.1-20231213.4
+  sourceIndexPackageVersion: 1.0.1-20240129.2
   sourceIndexPackageSource: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
   sourceIndexBuildCommand: powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "eng/common/build.ps1 -restore -build -binarylog -ci"
   preSteps: []


### PR DESCRIPTION
The ASP.NET official builds are failing with

"Unsupported log file format. Latest supported version is 17, the log file has version 18."

Updating BinLogToSln to the latest version which supports the new log format version.

See also:

* https://github.com/dotnet/aspnetcore/pull/53698
* https://github.com/dotnet/source-indexer/pull/133
