### PR TITLE
Use 1es provided Microsoft.DotNet.Arcade.MSBuild.Xcopy package

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -379,7 +379,7 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
 
   # If the version of msbuild is going to be xcopied,
   # use this version. Version matches a package here:
-  # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/RoslynTools.MSBuild/versions/17.8.5
+  # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/Microsoft.DotNet.Arcade.MSBuild.Xcopy/versions/17.8.5
   $defaultXCopyMSBuildVersion = '17.8.5'
 
   if (!$vsRequirements) {
@@ -445,7 +445,7 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
     if ($xcopyMSBuildVersion.Trim() -ine "none") {
         $vsInstallDir = InitializeXCopyMSBuild $xcopyMSBuildVersion $install
         if ($vsInstallDir -eq $null) {
-            throw "Could not xcopy msbuild. Please check that package 'RoslynTools.MSBuild @ $xcopyMSBuildVersion' exists on feed 'dotnet-eng'."
+            throw "Could not xcopy msbuild. Please check that package 'Microsoft.DotNet.Arcade.MSBuild.Xcopy @ $xcopyMSBuildVersion' exists on feed 'dotnet-eng'."
         }
     }
     if ($vsInstallDir -eq $null) {
@@ -482,7 +482,7 @@ function InstallXCopyMSBuild([string]$packageVersion) {
 }
 
 function InitializeXCopyMSBuild([string]$packageVersion, [bool]$install) {
-  $packageName = 'RoslynTools.MSBuild'
+  $packageName = 'Microsoft.DotNet.Arcade.MSBuild.Xcopy'
   $packageDir = Join-Path $ToolsDir "msbuild\$packageVersion"
   $packagePath = Join-Path $packageDir "$packageName.$packageVersion.nupkg"
 


### PR DESCRIPTION
1ES is now providing an xcopy MSBuild package for us.  The [17.8.5](https://dev.azure.com/corext/CoreXT%20Commandline/_artifacts/feed/CoreXT/NuGet/Microsoft.DotNet.Arcade.MSBuild.Xcopy/overview/17.8.5) version of that package has been published to `dotnet-eng`.

Validation was done by repro-ing a failure [here](https://dev.azure.com/dnceng/internal/_build/results?buildId=2366836&view=logs&j=b11b921d-8982-5bb3-754b-b114d42fd804&t=fb192a8b-e433-5fc8-e2b0-276ab015e7d5) and then validating the fix [here](https://dev.azure.com/dnceng/internal/_build/results?buildId=2367203&view=results)

After this is confirmed to not cause any regressions, I will update our instructions for xcopy-msbuild updates [here](https://dev.azure.com/dnceng/internal/_wiki/wikis/DNCEng%20Services%20Wiki/1074/RoslynTools.MSBuild-(xcopy-msbuild)-generation).  The new steps are to download the package from 1ES feed, publish to `dotnet-eng`, and update the versions in tools.ps1 and sdk-tasks.ps1.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
