### PR TITLE
Fix building on ARMhf userland on top of AARCH64 kernel

### DIFF
--- a/eng/common/native/init-os-and-arch.sh
+++ b/eng/common/native/init-os-and-arch.sh
@@ -35,6 +35,10 @@ fi
 case "$CPUName" in
     arm64|aarch64)
         arch=arm64
+        if [ "$(getconf LONG_BIT)" -lt 64 ]; then
+            # This is 32-bit OS running on 64-bit CPU (for example Raspberry Pi OS)
+            arch=arm
+        fi
         ;;
 
     loongarch64)


### PR DESCRIPTION
Raspberry Pi 4/5 supports running 32-bit user land with a 64-bit Linux kernel. Detect that, and report "arm" architecture.

Ref: https://github.com/dotnet/runtime/pull/97929
Ref: https://github.com/dotnet/arcade/commit/e2334b2be36919347923d0ec872a46acddb1e385

