### PR TITLE
Update Microsoft.DotNet.XliffTasks.csproj

### DIFF
--- a/src/Microsoft.DotNet.XliffTasks/Microsoft.DotNet.XliffTasks.csproj
+++ b/src/Microsoft.DotNet.XliffTasks/Microsoft.DotNet.XliffTasks.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- TODO: Remove this line when a new Arcade SDK is consumed. -->
-    <NetToolMinimum Condition="'$(DotNetBuildFromSource)' == 'true' or '$(DotNetBuildSourceOnly)' == 'true'">$(NetToolCurrent)</NetToolMinimum>
     <!--
        We need to target net8.0 while Arcade SDK 8 is being used.
        Xliff tasks were moved from dotnet/xliff-tasks to Arcade in V9, so they are not available in release/8.0 branch.


### PR DESCRIPTION
We had to bring this line back. With https://github.com/dotnet/installer/commit/530bfbd9d4b1d2232df9c1c6e45031256602f613, product SB now uses a newer SDK which includes the required change for this to work.