### PR TITLE
Error on missing SB intermediate prefix

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/SourceBuild/ReadSourceBuildIntermediateNupkgDependencies.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/SourceBuild/ReadSourceBuildIntermediateNupkgDependencies.cs
@@ -72,10 +72,10 @@ namespace Microsoft.DotNet.Arcade.Sdk.SourceBuild
 
                     string dependencyName = d.Attribute("Name")?.Value ?? string.Empty;
 
-                    if (string.IsNullOrEmpty(dependencyName))
+                    if (!dependencyName.Contains(SourceBuildIntermediateNupkgPrefix))
                     {
-                        // Log name missing as FYI, but this is not an error case for source-build.
-                        Log.LogMessage($"Dependency Name null or empty in '{VersionDetailsXmlFile}' element {d}");
+                        Log.LogError($"Dependency Name does not contain '{SourceBuildIntermediateNupkgPrefix}' in '{VersionDetailsXmlFile}' element {d}. Only place <SourceBuild> elements on source-build intermediate nupkgs.");
+                        return null;
                     }
 
                     string dependencyVersion = d.Attribute("Version")?.Value;


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/3373

This PR updates the Source-Build metadata attribute checks. If a SourceBuild element is placed on a non-intermediate, it triggers a failure and alerts the user. This ensures SourceBuild elements are exclusive to intermediates, avoiding duplicate package references from non-intermediate packages with the metadata elements, and mandates proper SourceBuild element usage.