### PR TITLE
Update Microsoft.DotNet.GenFacades.targets

### DIFF
--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.NotSupported.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.NotSupported.targets
@@ -47,7 +47,7 @@
   </Target>
 
   <Target Name="AddGenFacadeNotSupportedCompileItem"
-          DependsOnTargets="_GetGenFacadeNotSupportedCompileInputs;_GetRoslynAssembliesPath"
+          DependsOnTargets="_GetGenFacadeNotSupportedCompileInputs;_GetGenFacadesRoslynAssembliesPath"
           AfterTargets="ResolveProjectReferences"
           Condition="'$(GeneratePlatformNotSupportedAssemblyMessage)' != ''"
           Inputs="@(GenFacadeNotSupportedCompileInput)"
@@ -58,7 +58,7 @@
       LangVersion="$(LangVersion)"
       Message="$(GeneratePlatformNotSupportedAssemblyMessage)"
       ApiExclusionListPath="$(ApiExclusionListPath)"
-      RoslynAssembliesPath="$(RoslynAssembliesPath)" />
+      RoslynAssembliesPath="$(GenFacadesRoslynAssembliesPath)" />
 
     <ItemGroup>
       <Compile Include="@(GenFacadeNotSupportedCompileInput->'%(OutputPath)')" />

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.NotSupported.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.NotSupported.targets
@@ -47,7 +47,7 @@
   </Target>
 
   <Target Name="AddGenFacadeNotSupportedCompileItem"
-          DependsOnTargets="_GetGenFacadeNotSupportedCompileInputs;_GetGenFacadesRoslynAssembliesPath"
+          DependsOnTargets="_GetGenFacadeNotSupportedCompileInputs;GetGenFacadesRoslynAssembliesPath"
           AfterTargets="ResolveProjectReferences"
           Condition="'$(GeneratePlatformNotSupportedAssemblyMessage)' != ''"
           Inputs="@(GenFacadeNotSupportedCompileInput)"

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.PartialFacadeSource.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.PartialFacadeSource.targets
@@ -8,7 +8,7 @@
     <GenFacadesReferenceAssemblyItemName Condition="'$(GenFacadesReferenceAssemblyItemName)' == ''">ResolvedMatchingContract</GenFacadesReferenceAssemblyItemName>
     <!-- Tell ResolveMatchingContract to run and resolve contract to project reference -->
     <ResolveMatchingContract>true</ResolveMatchingContract>
-    <GeneratePartialFacadeSourceDependsOn>$(GeneratePartialFacadeSourceDependsOn);ResolveMatchingContract;_GetRoslynAssembliesPath</GeneratePartialFacadeSourceDependsOn>
+    <GeneratePartialFacadeSourceDependsOn>$(GeneratePartialFacadeSourceDependsOn);ResolveMatchingContract;GetGenFacadesRoslynAssembliesPath</GeneratePartialFacadeSourceDependsOn>
     <CoreCompileDependsOn Condition="'$(DesignTimeBuild)' != 'true'">$(CoreCompileDependsOn);GeneratePartialFacadeSource</CoreCompileDependsOn>
     <GenFacadesOutputSourcePath Condition="'$(GenFacadesOutputSourcePath)' == ''">$(IntermediateOutputPath)$(AssemblyTitle).Forwards.cs</GenFacadesOutputSourcePath>
   </PropertyGroup>
@@ -28,7 +28,7 @@
       OmitTypes="@(GenFacadesOmitType)"
       OutputSourcePath="$(GenFacadesOutputSourcePath)"
       SeedTypePreferences="@(SeedTypePreference)"
-      RoslynAssembliesPath="$(RoslynAssembliesPath)" />
+      RoslynAssembliesPath="$(GenFacadesRoslynAssembliesPath)" />
 
     <ItemGroup Condition="'$(GenFacadesAutoIncludeCompileItem)' != 'false' and
                           Exists('$(GenFacadesOutputSourcePath)')">

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.targets
@@ -7,13 +7,20 @@
   </PropertyGroup>
 
   <Target Name="_GetRoslynAssembliesPath">
-    <PropertyGroup Condition="'$(RoslynAssembliesPath)' == ''">
-      <RoslynAssembliesPath>$(RoslynTargetsPath)</RoslynAssembliesPath>
-      <_packageReferenceList>@(PackageReference)</_packageReferenceList>
+    <PropertyGroup Condition="'$(GenFacadesRoslynAssembliesPath)' == ''">
+      <!-- If a custom roslyn assemblies path isn't provided, the opt-in switch 'GenFacadesUseRoslynToolsetPackagePath' is set to true and
+           the roslyn toolset package is referenced, use the assemblies from that package. -->
+      <_UseRoslynToolsetPackageForGenFacades Condition="'$(GenFacadesUseRoslynToolsetPackagePath)' == 'true' and '@(PackageReference->AnyHaveMetadataValue('Identity', 'Microsoft.Net.Compilers.Toolset'))' == 'true'">true</_UseRoslynToolsetPackageForGenFacades>
+
       <!-- CSharpCoreTargetsPath and VisualBasicCoreTargetsPath point to the same location, Microsoft.CodeAnalysis.CSharp and Microsoft.CodeAnalysis.VisualBasic
-      are on the same directory as Microsoft.CodeAnalysis. So there is no need to distinguish between csproj or vbproj. -->
-      <RoslynAssembliesPath Condition="$(_packageReferenceList.Contains('Microsoft.Net.Compilers.Toolset'))">$([System.IO.Path]::GetDirectoryName($(CSharpCoreTargetsPath)))</RoslynAssembliesPath>
-      <RoslynAssembliesPath Condition="'$(MSBuildRuntimeType)' == 'Core'">$([System.IO.Path]::Combine('$(RoslynAssembliesPath)', bincore))</RoslynAssembliesPath>
+           are on the same directory as Microsoft.CodeAnalysis. So there is no need to distinguish between csproj or vbproj. -->
+      <GenFacadesRoslynAssembliesPath Condition="'$(_UseRoslynToolsetPackageForGenFacades)' == 'true'">$([System.IO.Path]::GetDirectoryName('$(CSharpCoreTargetsPath)'))</GenFacadesRoslynAssembliesPath>
+      
+      <!-- Otherwise, default to the roslyn compiler provided by the SDK / Visual Studio. -->
+      <GenFacadesRoslynAssembliesPath Condition="'$(_UseRoslynToolsetPackageForGenFacades)' != 'true'">$(RoslynTargetsPath)</GenFacadesRoslynAssembliesPath>
+
+      <!-- The SDK stores the roslyn assemblies in the 'bincore' subdirectory. -->
+      <GenFacadesRoslynAssembliesPath Condition="'$(MSBuildRuntimeType)' == 'Core'">$([System.IO.Path]::Combine('$(RoslynAssembliesPath)', 'bincore'))</GenFacadesRoslynAssembliesPath>
     </PropertyGroup>
   </Target>
 

--- a/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.targets
+++ b/src/Microsoft.DotNet.GenFacades/build/Microsoft.DotNet.GenFacades.targets
@@ -6,7 +6,7 @@
     <GenFacadesTargetAssemblyPath Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\Microsoft.DotNet.GenFacades.dll</GenFacadesTargetAssemblyPath>
   </PropertyGroup>
 
-  <Target Name="_GetRoslynAssembliesPath">
+  <Target Name="GetGenFacadesRoslynAssembliesPath">
     <PropertyGroup Condition="'$(GenFacadesRoslynAssembliesPath)' == ''">
       <!-- If a custom roslyn assemblies path isn't provided, the opt-in switch 'GenFacadesUseRoslynToolsetPackagePath' is set to true and
            the roslyn toolset package is referenced, use the assemblies from that package. -->


### PR DESCRIPTION
Related to https://github.com/dotnet/sdk/pull/38543

Make the use of the Microsoft.Net.Compilers.Toolset package an opt-in. Use a different property name to not clash with the APICompat one.