### PR TITLE
[release/6.0] Use new `NetCore1ESPool-Publishing-Internal` pool

### DIFF
--- a/eng/common/post-build/publish-using-darc.ps1
+++ b/eng/common/post-build/publish-using-darc.ps1
@@ -12,7 +12,7 @@ param(
 try {
   . $PSScriptRoot\post-build-utils.ps1
 
-  $darc = Get-Darc 
+  $darc = Get-Darc
 
   $optionalParams = [System.Collections.ArrayList]::new()
 
@@ -46,7 +46,7 @@ try {
   }
 
   Write-Host 'done.'
-} 
+}
 catch {
   Write-Host $_
   Write-PipelineTelemetryError -Category 'PromoteBuild' -Message "There was an error while trying to publish build '$BuildId' to default channels."

--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -51,7 +51,7 @@ jobs:
         checkDownloadedFiles: true
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}
-    
+
     - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - task: NuGetAuthenticate@1
 
@@ -74,7 +74,7 @@ jobs:
           /p:OfficialBuildId=$(Build.BuildNumber)
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}
-    
+
     - task: powershell@2
       displayName: Create ReleaseConfigs Artifact
       inputs:
@@ -83,7 +83,7 @@ jobs:
           Add-Content -Path "$(Build.StagingDirectory)/ReleaseConfigs.txt" -Value $(BARBuildId)
           Add-Content -Path "$(Build.StagingDirectory)/ReleaseConfigs.txt" -Value "$(DefaultChannels)"
           Add-Content -Path "$(Build.StagingDirectory)/ReleaseConfigs.txt" -Value $(IsStableBuild)
-    
+
     - task: PublishBuildArtifacts@1
       displayName: Publish ReleaseConfigs Artifact
       inputs:
@@ -109,7 +109,7 @@ jobs:
 
     - task: PublishBuildArtifacts@1
       displayName: Publish SymbolPublishingExclusionsFile Artifact
-      condition: eq(variables['SymbolExclusionFile'], 'true') 
+      condition: eq(variables['SymbolExclusionFile'], 'true')
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)/eng/SymbolPublishingExclusionsFile.txt'
         PublishLocation: Container
@@ -118,4 +118,4 @@ jobs:
     - ${{ if eq(parameters.enablePublishBuildArtifacts, 'true') }}:
       - template: /eng/common/templates/steps/publish-logs.yml
         parameters:
-          JobLabel: 'Publish_Artifacts_Logs'     
+          JobLabel: 'Publish_Artifacts_Logs'

--- a/eng/common/templates/jobs/jobs.yml
+++ b/eng/common/templates/jobs/jobs.yml
@@ -20,7 +20,7 @@ parameters:
     enabled: false
     # Optional: Include toolset dependencies in the generated graph files
     includeToolset: false
-    
+
   # Required: A collection of jobs to run - https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=vsts&tabs=schema#job
   jobs: []
 
@@ -40,7 +40,7 @@ parameters:
 jobs:
 - ${{ each job in parameters.jobs }}:
   - template: ../job/job.yml
-    parameters: 
+    parameters:
       # pass along parameters
       ${{ each parameter in parameters }}:
         ${{ if ne(parameter.key, 'jobs') }}:
@@ -68,7 +68,7 @@ jobs:
         ${{ parameter.key }}: ${{ parameter.value }}
 
 - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  
+
   - ${{ if or(eq(parameters.enablePublishBuildAssets, true), eq(parameters.artifacts.publish.manifests, 'true'), ne(parameters.artifacts.publish.manifests, '')) }}:
     - template: ../job/publish-build-assets.yml
       parameters:
@@ -88,8 +88,8 @@ jobs:
             name: VSEngSS-MicroBuild2022-1ES
             demands: Cmd
           # If it's not devdiv, it's dnceng
-          ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
-            name: NetCore1ESPool-Svc-Internal
+          ${{ else }}:
+            name: NetCore1ESPool-Publishing-Internal
             demands: ImageOverride -equals windows.vs2019.amd64
 
         runAsPublic: ${{ parameters.runAsPublic }}

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -39,7 +39,7 @@ parameters:
     displayName: Enable NuGet validation
     type: boolean
     default: true
-    
+
   - name: publishInstallersAndChecksums
     displayName: Publish installers and checksums
     type: boolean
@@ -124,8 +124,8 @@ stages:
           displayName: Validate
           inputs:
             filePath: $(Build.SourcesDirectory)/eng/common/post-build/nuget-validation.ps1
-            arguments: -PackagesPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/ 
-              -ToolDestinationPath $(Agent.BuildDirectory)/Extract/ 
+            arguments: -PackagesPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/
+              -ToolDestinationPath $(Agent.BuildDirectory)/Extract/
 
     - job:
       displayName: Signing Validation
@@ -220,9 +220,9 @@ stages:
           displayName: Validate
           inputs:
             filePath: $(Build.SourcesDirectory)/eng/common/post-build/sourcelink-validation.ps1
-            arguments: -InputPath $(Build.ArtifactStagingDirectory)/BlobArtifacts/ 
-              -ExtractPath $(Agent.BuildDirectory)/Extract/ 
-              -GHRepoName $(Build.Repository.Name) 
+            arguments: -InputPath $(Build.ArtifactStagingDirectory)/BlobArtifacts/
+              -ExtractPath $(Agent.BuildDirectory)/Extract/
+              -GHRepoName $(Build.Repository.Name)
               -GHCommit $(Build.SourceVersion)
               -SourcelinkCliVersion $(SourceLinkCLIVersion)
           continueOnError: true
@@ -253,8 +253,8 @@ stages:
           name: VSEngSS-MicroBuild2022-1ES
           demands: Cmd
         # If it's not devdiv, it's dnceng
-        ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
-          name: NetCore1ESPool-Svc-Internal
+        ${{ else }}:
+          name: NetCore1ESPool-Publishing-Internal
           demands: ImageOverride -equals windows.vs2019.amd64
     steps:
       - template: setup-maestro-vars.yml
@@ -266,7 +266,7 @@ stages:
         displayName: Publish Using Darc
         inputs:
           filePath: $(Build.SourcesDirectory)/eng/common/post-build/publish-using-darc.ps1
-          arguments: -BuildId $(BARBuildId) 
+          arguments: -BuildId $(BARBuildId)
             -PublishingInfraVersion ${{ parameters.publishingInfraVersion }}
             -AzdoToken '$(publishing-dnceng-devdiv-code-r-build-re)'
             -MaestroToken '$(MaestroApiAccessToken)'

--- a/eng/promote-build.yml
+++ b/eng/promote-build.yml
@@ -14,22 +14,17 @@ parameters:
 
   - name: PromoteToChannelIds
     displayName: Which Maestro channels' IDs should the build be promoted to? (comma separated)
-    type: string 
+    type: string
     default: ' '
-
-  - name: UseServicingBuildPool
-    displayName: If true, use the assigned 'Servicing' pool for publishing jobs
-    type: boolean
-    default: false
 
   - name: SymbolPublishingAdditionalParameters
     displayName: Additional (MSBuild) properties for symbol publishing
-    type: string 
+    type: string
     default: ' '
 
   - name: ArtifactsPublishingAdditionalParameters
     displayName: Additional (MSBuild) properties for general asset publishing
-    type: string 
+    type: string
     default: ' '
 
   # The parameters below here are legacy. They are passed by add-build-to-channel
@@ -38,27 +33,27 @@ parameters:
 
   - name: EnableSourceLinkValidation
     displayName: Should Sourcelink validation be performed?
-    type: boolean 
+    type: boolean
     default: false
 
   - name: EnableNugetValidation
     displayName: Should NuGet metadata validation be performed?
-    type: boolean 
+    type: boolean
     default: false
 
   - name: EnableSigningValidation
     displayName: Should signing validation be performed?
-    type: boolean 
+    type: boolean
     default: false
 
   - name: PublishInstallersAndChecksums
     displayName: Should installers and checksums be published?
-    type: boolean 
+    type: boolean
     default: true
 
   - name: SigningValidationAdditionalParameters
     displayName: Additional (MSBuild) properties for signing validation
-    type: string 
+    type: string
     default: ' '
 
 trigger: none
@@ -70,4 +65,3 @@ stages:
     BARBuildId: ${{ parameters.BARBuildId }}
     symbolPublishingAdditionalParameters: ${{ parameters.SymbolPublishingAdditionalParameters }}
     artifactsPublishingAdditionalParameters: ${{ parameters.ArtifactsPublishingAdditionalParameters }}
-    useServicingBuildPools : ${{ parameters.UseServicingBuildPool }}

--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -4,7 +4,6 @@ parameters:
   BARBuildId: ''
   symbolPublishingAdditionalParameters: ''
   buildQuality: 'daily'
-  useServicingBuildPools: false
 
 stages:
   - stage: publish
@@ -21,7 +20,7 @@ stages:
         - group: DotNet-DotNetCli-Storage
         - group: DotNet-MSRC-Storage
         - group: Publish-Build-Assets
-          
+
         # Default Maestro++ API Endpoint and API Version
         - name: MaestroApiEndPoint
           value: "https://maestro.dot.net"
@@ -35,14 +34,9 @@ stages:
         ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
           name: VSEngSS-MicroBuild2022-1ES
           demands: Cmd
-        # If it's not devdiv, it's dnceng: 
-        # If useServicingBuildPools = false, it's a main branch:
-        ${{ if and(ne(variables['System.TeamProject'], 'DevDiv'), eq(parameters['useServicingBuildPools'], false)) }}:
-          name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals windows.vs2019.amd64
-        # If useServicingBuildPools = true, it's a release branch:
-        ${{ if and(ne(variables['System.TeamProject'], 'DevDiv'), eq(parameters['useServicingBuildPools'], true)) }}:
-          name: NetCore1ESPool-Svc-Internal
+        # If it's not devdiv, it's dnceng:
+        ${{ else }}:
+          name: NetCore1ESPool-Publishing-Internal
           demands: ImageOverride -equals windows.vs2019.amd64
 
       steps:
@@ -80,7 +74,7 @@ stages:
 
                     $channelNames += "'$($channelInfo.name)'"
                   }
-                  
+
                   $azureDevOpsBuildNumber = $buildInfo.azureDevOpsBuildNumber
                   $azureDevOpsRepository = "Unknown"
                   $lastIndexOfSlash = $buildInfo.azureDevOpsRepository.LastIndexOf('/')
@@ -100,7 +94,7 @@ stages:
                     $buildNumberName = $buildNumberName.Substring(0, 255)
                   }
 
-                  # Set tags on publishing for visibility 
+                  # Set tags on publishing for visibility
 
                   Write-Host "##vso[build.updatebuildnumber]$buildNumberName"
                   Write-Host "##vso[build.addbuildtag]Channel(s) - $channelNames"


### PR DESCRIPTION
- see #14445
- `cherry-pick` from 'main' of e9a8e07465ad
- update the dnceng pool used for the `Publish to Build Asset Registry` job of eng/common/templates/job/publish-build-assets.yml to the new one
  - change in jobs.yml
- update the dnceng pool used in `Publish using Darc` job of eng/common/templates/post-build/post-build.yml to use the new one
- update the dnceng pool used in eng/publishing/v3/publish.yml to new one
- eliminate all mention of the `useServicingBuildPool[s]` parameters from eng/promote-build.yml and eng/publishing/v3/publish.yml

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation