### PR TITLE
Update WiX version used by build tasks

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets
@@ -25,7 +25,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <WixVersion>1.0.0-v3.14.0.5722</WixVersion>
+      <WixVersion>3.14.0.8606</WixVersion>
       <WixToolsDir>$(BaseIntermediateOutputPath)WixTools.$(WixVersion)/</WixToolsDir>
       <!-- Used in WiX targets to locate files. -->
       <WixInstallPath>$(WixToolsDir)</WixInstallPath>


### PR DESCRIPTION
This was missed in the previous PR. It's the version of the zip archive used by runtime/desktop.
