### PR TITLE
Ignore standard error warning format in SB inner command

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
@@ -214,6 +214,7 @@
     <Exec
       Command="$(BaseInnerSourceBuildCommand) $(InnerBuildArgs)"
       WorkingDirectory="$(InnerSourceBuildRepoRoot)"
+      IgnoreStandardErrorWarningFormat="true"
       EnvironmentVariables="@(InnerBuildEnv)" />
   </Target>
 


### PR DESCRIPTION
When the infra launches the inner build command, it currently picks up on standard warning formats (rather than just exit codes). This may not be desirable. For instance, runtime invokes cmake with `IgnoreStandardErrorWarningFormat`, and that command will pass but print a warning. This then gets picked up by an outer build.

Ideally, we don't have warnings, but at the very least we should be conservative and let inner commands choose what they want to detect in the output.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
