### PR TITLE
Update Workload Set Package Version Generation

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadSetTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadSetTests.cs
@@ -59,6 +59,11 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             // Workload sets are SxS. Verify that we don't have an Upgrade table.
             Assert.False(MsiUtils.HasTable(msi.ItemSpec, "Upgrade"));
 
+            // Verify the workloadset version directory and only look at the long name version.
+            DirectoryRow versionDir = MsiUtils.GetAllDirectories(msi.ItemSpec).FirstOrDefault(d => string.Equals(d.Directory, "WorkloadSetVersionDir"));
+            Assert.NotNull(versionDir);
+            Assert.Contains("|9.0.0.100-baseline.1.23464.1", versionDir.DefaultDir);
+
             // Verify the SWIX authoring for one of the workload set MSIs. 
             ITaskItem workloadSetSwixItem = createWorkloadSetTask.SwixProjects.Where(s => s.ItemSpec.Contains(@"Microsoft.NET.Workloads.9.0.100.9.0.100-baseline.1.23464.1\x64")).FirstOrDefault();
             Assert.Equal(DefaultValues.PackageTypeMsiWorkloadSet, workloadSetSwixItem.GetMetadata(Metadata.PackageType));

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/PackageTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/PackageTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.Deployment.DotNet.Releases;
+using NuGet.Versioning;
 using Xunit;
 
 namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
@@ -47,6 +48,21 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             ITaskItem workloadSetPackageItem = new TaskItem(Path.Combine(TestAssetsPath, "microsoft.net.workloads.9.0.100.9.0.100-baseline.1.23464.1.nupkg"));
 
             Assert.Throws<ArgumentOutOfRangeException>(() => { WorkloadSetPackage p = new(workloadSetPackageItem, PackageRootDirectory, new Version("256.12.3")); });
+        }
+
+        [WindowsOnlyTheory]
+        [InlineData("8.0.200", "8.200.0", "8.0.200")]
+        [InlineData("8.0.200", "8.201.0", "8.0.201")]
+        [InlineData("8.0.200", "8.203.1", "8.0.203.1")]
+        [InlineData("9.0.100-preview.2", "9.100.0-preview.2.3.4.5.6.7.8", "9.0.100-preview.2.3.4.5.6.7.8")]
+        [InlineData("8.0.200", "8.201.1-preview", "8.0.201.1-preview")]
+        [InlineData("8.0.200", "8.201.1-preview.2", "8.0.201.1-preview.2")]
+        [InlineData("8.0.200", "8.201.0-servicing.23015", "8.0.201-servicing.23015")]
+        public void ItCanComputeWorkloadSetVersion(string sdkFeatureBand, string packageVersion, string expectedWorkloadSetVerion)
+        {
+            string workloadSetVersion = WorkloadSetPackage.GetWorkloadSetVersion(new ReleaseVersion(sdkFeatureBand), new NuGetVersion(packageVersion));
+
+            Assert.Equal(expectedWorkloadSetVerion, workloadSetVersion);
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Msi/WorkloadSetMsi.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Msi/WorkloadSetMsi.wix.cs
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Msi
             candle.AddPreprocessorDefinition(PreprocessorDefinitionNames.DependencyProviderKeyName, $"{providerKeyName}");
             candle.AddPreprocessorDefinition(PreprocessorDefinitionNames.SourceDir, $"{packageDataDirectory}");
             candle.AddPreprocessorDefinition(PreprocessorDefinitionNames.SdkFeatureBandVersion, $"{_package.SdkFeatureBand}");
-            candle.AddPreprocessorDefinition(PreprocessorDefinitionNames.WorkloadSetVersion, $"{_package.PackageVersion}");
+            candle.AddPreprocessorDefinition(PreprocessorDefinitionNames.WorkloadSetVersion, $"{_package.WorkloadSetVersion}");
             candle.AddPreprocessorDefinition(PreprocessorDefinitionNames.InstallationRecordKey, $"InstalledWorkloadSets");
 
             if (!candle.Execute())


### PR DESCRIPTION
# Description

Ensure workload sets are installed into the correct directory. Previously, the version was simply based off the workload set package version, but it needs to account for possible hotfixes.

The current implementation is based off the new [examples](https://github.com/dotnet/designs/pull/294/commits/16c553b7905e60a83c0c87acaeb3fd192221dca9?short_path=ab104db#diff-ab104db694a9386180073fed5271729b627ada894f9f78cffbd0020ff15425a1).

# Testing

Existing tests were updated and new tests have been added.