### PR TITLE
Add pats requested for Roslyn perf bot support.

### DIFF
--- a/.vault-config/dnceng-partners-kv.yaml
+++ b/.vault-config/dnceng-partners-kv.yaml
@@ -76,3 +76,39 @@ secrets:
       gitHubBotAccountName: BotAccount-dotnet-build-bot
       requiredScopes: content
       description: "This pat is under the beta fine-grained tokens using dotnet as owner and repository specific for vscode-csharp and roslyn. The permissions are: Content - Read and write."
+
+  dn-bot-devdiv-build-r-release-r-code-r:
+    type: azure-devops-access-token
+    parameters:
+      description: Created for roslyn-tools pr-tagger
+      organizations: devdiv
+      scopes: build relese code
+      domainAccountName: dn-bot
+      domainAccountSecret:
+        name: dn-bot-account-redmond
+        location: helixkv
+
+  dn-bot-dnceng-build-r:
+    type: azure-devops-access-token
+    parameters:
+      description: Created for roslyn-tools pr-tagger
+      organizations: dnceng
+      scopes: build 
+      domainAccountName: dn-bot
+      domainAccountSecret:
+        name: dn-bot-account-redmond
+        location: helixkv
+
+  # Fine-grained pat with "issue read and write" permission
+  # Restricted to the following repositories:
+  # - dotnet/roslyn
+  # - dotnet/razor
+  # - dotnet/fsharp
+  dotnet-bot-roslyn-issue-w-pat:
+    type: github-access-token
+    parameters:
+      description: Created for roslyn-tools pr-tagger
+      gitHubBotAccountSecret:
+        name: BotAccount-dotnet-bot
+        location: EngKeyVault
+      gitHubBotAccountName: BotAccount-dotnet-bot

--- a/.vault-config/dnceng-partners-kv.yaml
+++ b/.vault-config/dnceng-partners-kv.yaml
@@ -82,7 +82,7 @@ secrets:
     parameters:
       description: Created for roslyn-tools pr-tagger
       organizations: devdiv
-      scopes: build relese code
+      scopes: build release code
       domainAccountName: dn-bot
       domainAccountSecret:
         name: dn-bot-account-redmond

--- a/.vault-config/dnceng-partners-kv.yaml
+++ b/.vault-config/dnceng-partners-kv.yaml
@@ -77,7 +77,7 @@ secrets:
       requiredScopes: content
       description: "This pat is under the beta fine-grained tokens using dotnet as owner and repository specific for vscode-csharp and roslyn. The permissions are: Content - Read and write."
 
-  dn-bot-devdiv-build-r-release-r-code-r:
+  roslyn-dn-bot-devdiv-build-r-release-r-code-r:
     type: azure-devops-access-token
     parameters:
       description: Created for roslyn-tools pr-tagger
@@ -88,7 +88,7 @@ secrets:
         name: dn-bot-account-redmond
         location: helixkv
 
-  dn-bot-dnceng-build-r:
+  roslyn-dn-bot-dnceng-build-r:
     type: azure-devops-access-token
     parameters:
       description: Created for roslyn-tools pr-tagger
@@ -104,7 +104,7 @@ secrets:
   # - dotnet/roslyn
   # - dotnet/razor
   # - dotnet/fsharp
-  dotnet-bot-roslyn-issue-w-pat:
+  roslyn-dotnet-bot-issue-w-pat:
     type: github-access-token
     parameters:
       description: Created for roslyn-tools pr-tagger


### PR DESCRIPTION
Resolves [dotnet/dnceng#2087](https://github.com/dotnet/dnceng/issues/2087)

Add three new PATs to support Roslyn.

See internal conversations [here](https://teams.microsoft.com/l/message/19:83953de1ddd34bcaa9ebaba54cb8eba4@thread.skype/1708721490476?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=147df318-61de-4f04-8f7b-ecd328c256bb&parentMessageId=1708721490476&teamName=.NET%20Eng%20Services&channelName=General&createdTime=1708721490476) and [here](https://teams.microsoft.com/l/message/19:afba3d1545dd45d7b79f34c1821f6055@thread.skype/1699032306849?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=4d73664c-9f2f-450d-82a5-c2f02756606d&parentMessageId=1699032306849&teamName=.NET%20Core%20Eng%20Services%20Partners&channelName=First%20Responders&createdTime=1699032306849).