### PR TITLE
Update dependencies consistently and downgrade NuGet from 6.9.1 to 6.8.1

### DIFF
--- a/eng/BuildTask.Packages.props
+++ b/eng/BuildTask.Packages.props
@@ -10,6 +10,12 @@
     <PackageVersion Update="System.Text.Encodings.Web" Version="8.0.0" />
     <PackageVersion Update="System.Text.Json" Version="8.0.0" />
     <PackageVersion Update="System.Threading.Tasks.Dataflow" Version="8.0.0" />
+
+    <!-- Packages that transitively bring above dependencies in. -->
+    <PackageVersion Update="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageVersion Update="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
+    <PackageVersion Update="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/eng/BuildTask.Packages.props
+++ b/eng/BuildTask.Packages.props
@@ -1,11 +1,14 @@
 <Project>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <PackageVersion Update="System.Text.Json" Version="8.0.0" />
-    <PackageVersion Update="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-    <PackageVersion Update="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
+    <PackageVersion Update="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageVersion Update="System.Collections.Immutable" Version="8.0.0" />
     <PackageVersion Update="System.Reflection.Metadata" Version="8.0.0" />
+    <PackageVersion Update="System.Reflection.MetadataLoadContext" Version="8.0.0" />
+    <PackageVersion Update="System.Resources.Extensions" Version="8.0.0" />
+    <PackageVersion Update="System.Text.Encodings.Web" Version="8.0.0" />
+    <PackageVersion Update="System.Text.Json" Version="8.0.0" />
+    <PackageVersion Update="System.Threading.Tasks.Dataflow" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/eng/BuildTask.Packages.props
+++ b/eng/BuildTask.Packages.props
@@ -1,5 +1,6 @@
 <Project>
 
+  <!-- Don't go higher than binding redirects entries in the toolset MSBuild.exe.config file. --> 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <PackageVersion Update="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageVersion Update="System.Collections.Immutable" Version="8.0.0" />

--- a/eng/BuildTask.Packages.props
+++ b/eng/BuildTask.Packages.props
@@ -1,11 +1,11 @@
 <Project>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <PackageVersion Update="System.Text.Json" Version="7.0.1" />
-    <PackageVersion Update="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-    <PackageVersion Update="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
-    <PackageVersion Update="System.Collections.Immutable" Version="7.0.0" />
-    <PackageVersion Update="System.Reflection.Metadata" Version="7.0.0" />
+    <PackageVersion Update="System.Text.Json" Version="8.0.0" />
+    <PackageVersion Update="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageVersion Update="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
+    <PackageVersion Update="System.Collections.Immutable" Version="8.0.0" />
+    <PackageVersion Update="System.Reflection.Metadata" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/eng/BuildTask.Packages.props
+++ b/eng/BuildTask.Packages.props
@@ -12,10 +12,10 @@
     <PackageVersion Update="System.Threading.Tasks.Dataflow" Version="8.0.0" />
 
     <!-- Packages that transitively bring above dependencies in. -->
-    <PackageVersion Update="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-    <PackageVersion Update="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
-    <PackageVersion Update="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageVersion Update="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageVersion Update="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
+    <PackageVersion Update="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/eng/BuildTask.targets
+++ b/eng/BuildTask.targets
@@ -37,7 +37,7 @@
     <PackageReference Update="Microsoft.Build.Tasks.Core" Publish="false" />
     <PackageReference Update="Microsoft.Build.Utilities.Core" Publish="false" />
     <PackageReference Update="Microsoft.NET.StringTools" Publish="false" />
-    <PackageReference Update="System.Collections.Immutable" Publish="false" />
+    <PackageReference Update="System.Resources.Extensions" Publish="false" />
   </ItemGroup>
 
   <!-- Don't include assemblies that are provided by the SDK, next to MSBuild. -->
@@ -50,19 +50,24 @@
     <PackageReference Update="NuGet.Packaging" Publish="false" />
     <PackageReference Update="NuGet.ProjectModel" Publish="false" />
     <PackageReference Update="NuGet.Versioning" Publish="false" />
+    <PackageReference Update="System.CodeDom" Publish="false" />
+    <PackageReference Update="System.Security.Cryptography.ProtectedData" Publish="false" />
+    <PackageReference Update="System.Text.Encoding.CodePages" Publish="false" />
   </ItemGroup>
 
   <!-- Don't include assemblies that are inbox in Desktop MSBuild -->
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <PackageReference Update="Microsoft.Bcl.AsyncInterfaces" Publish="false" />
     <PackageReference Update="System.Buffers" Publish="false" />
+    <PackageReference Update="System.Collections.Immutable" Publish="false" />
     <PackageReference Update="System.Memory" Publish="false" />
     <PackageReference Update="System.Numerics.Vectors" Publish="false" />
     <PackageReference Update="System.Reflection.Metadata" Publish="false" />
     <PackageReference Update="System.Reflection.MetadataLoadContext" Publish="false" />
     <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Publish="false" />
-    <PackageReference Update="System.Security.Cryptography.Xml" Publish="false" />
     <PackageReference Update="System.Text.Encodings.Web" Publish="false" />
     <PackageReference Update="System.Text.Json" Publish="false" />
+    <PackageReference Update="System.Threading.Channels" Publish="false" />
     <PackageReference Update="System.Threading.Tasks.Dataflow" Publish="false" />
     <PackageReference Update="System.Threading.Tasks.Extensions" Publish="false" />
     <PackageReference Update="System.ValueTuple" Publish="false" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -158,18 +158,18 @@
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
     <!-- Transitive dependency needed for source build. -->
-    <Dependency Name="System.Collections.Immutable" Version="7.0.0">
+    <Dependency Name="System.Collections.Immutable" Version="9.0.0-alpha.1.24059.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
+      <Sha>2874d26cb343fc55be295a628b3ee474e19ff95e</Sha>
     </Dependency>
     <Dependency Name="System.CommandLine" Version="2.0.0-beta4.23307.1">
       <Uri>https://github.com/dotnet/command-line-api</Uri>
       <Sha>02fe27cd6a9b001c8feb7938e6ef4b3799745759</Sha>
     </Dependency>
     <!-- Transitive dependency needed for source build. -->
-    <Dependency Name="System.Reflection.Metadata" Version="7.0.0">
+    <Dependency Name="System.Reflection.Metadata" Version="9.0.0-alpha.1.24059.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
+      <Sha>2874d26cb343fc55be295a628b3ee474e19ff95e</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,12 +62,10 @@
     <MicrosoftNETWorkloadMonoToolChainManifest_60300Version_6022>6.0.22</MicrosoftNETWorkloadMonoToolChainManifest_60300Version_6022>
     <MicrosoftiOSTemplatesVersion>15.2.302-preview.14.122</MicrosoftiOSTemplatesVersion>
     <MicrosoftiOSTemplatesVersion160527>16.0.527</MicrosoftiOSTemplatesVersion160527>
-    <!-- Keep this version in sync with what msbuild / VS ships with. -->
-    <SystemCollectionsImmutableVersion>7.0.0</SystemCollectionsImmutableVersion>
+    <SystemCollectionsImmutableVersion>9.0.0-alpha.1.24059.2</SystemCollectionsImmutableVersion>
     <SystemCompositionVersion>9.0.0-alpha.1.24059.2</SystemCompositionVersion>
     <SystemIOPackagingVersion>9.0.0-alpha.1.24059.2</SystemIOPackagingVersion>
-    <!-- Keep this version in sync with what msbuild / VS ships with. -->
-    <SystemReflectionMetadataVersion>7.0.0</SystemReflectionMetadataVersion>
+    <SystemReflectionMetadataVersion>9.0.0-alpha.1.24059.2</SystemReflectionMetadataVersion>
     <!-- Do not move too far ahead of what Microsoft.Build.Tasks.Core depends on (currently >=6.0.0). -->
     <SystemSecurityCryptographyXmlVersion>6.0.1</SystemSecurityCryptographyXmlVersion>
     <SystemTextEncodingsWebVersion>9.0.0-alpha.1.24059.2</SystemTextEncodingsWebVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -26,10 +26,10 @@
     <MicrosoftSymbolUploaderBuildTaskVersion>2.0.0-preview.1.23470.14</MicrosoftSymbolUploaderBuildTaskVersion>
     <MicrosoftSymbolUploaderVersion>2.0.0-preview.1.23470.14</MicrosoftSymbolUploaderVersion>
     <!-- msbuild -->
-    <MicrosoftBuildFrameworkVersion>17.3.2</MicrosoftBuildFrameworkVersion>
-    <MicrosoftBuildTasksCoreVersion>17.3.2</MicrosoftBuildTasksCoreVersion>
-    <MicrosoftBuildUtilitiesCoreVersion>17.3.2</MicrosoftBuildUtilitiesCoreVersion>
-    <MicrosoftBuildVersion>17.3.2</MicrosoftBuildVersion>
+    <MicrosoftBuildFrameworkVersion>17.8.3</MicrosoftBuildFrameworkVersion>
+    <MicrosoftBuildTasksCoreVersion>17.8.3</MicrosoftBuildTasksCoreVersion>
+    <MicrosoftBuildUtilitiesCoreVersion>17.8.3</MicrosoftBuildUtilitiesCoreVersion>
+    <MicrosoftBuildVersion>17.8.3</MicrosoftBuildVersion>
     <!-- netstandard -->
     <NETStandardLibraryVersion>2.0.3</NETStandardLibraryVersion>
     <!-- nuget -->
@@ -66,8 +66,7 @@
     <SystemCompositionVersion>9.0.0-alpha.1.24059.2</SystemCompositionVersion>
     <SystemIOPackagingVersion>9.0.0-alpha.1.24059.2</SystemIOPackagingVersion>
     <SystemReflectionMetadataVersion>9.0.0-alpha.1.24059.2</SystemReflectionMetadataVersion>
-    <!-- Do not move too far ahead of what Microsoft.Build.Tasks.Core depends on (currently >=6.0.0). -->
-    <SystemSecurityCryptographyXmlVersion>6.0.1</SystemSecurityCryptographyXmlVersion>
+    <SystemSecurityCryptographyXmlVersion>9.0.0-alpha.1.24059.</SystemSecurityCryptographyXmlVersion>
     <SystemTextEncodingsWebVersion>9.0.0-alpha.1.24059.2</SystemTextEncodingsWebVersion>
     <SystemTextJsonVersion>9.0.0-alpha.1.24059.2</SystemTextJsonVersion>
     <!-- sdk -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -33,10 +33,10 @@
     <!-- netstandard -->
     <NETStandardLibraryVersion>2.0.3</NETStandardLibraryVersion>
     <!-- nuget -->
-    <NuGetCommandsVersion>6.7.0</NuGetCommandsVersion>
+    <NuGetCommandsVersion>6.9.1</NuGetCommandsVersion>
     <NuGetFrameworksVersion>6.9.1</NuGetFrameworksVersion>
     <NuGetPackagingVersion>6.9.1</NuGetPackagingVersion>
-    <NuGetProjectModelVersion>6.7.0</NuGetProjectModelVersion>
+    <NuGetProjectModelVersion>6.9.1</NuGetProjectModelVersion>
     <NuGetVersioningVersion>6.9.1</NuGetVersioningVersion>
     <!-- roslyn -->
     <MicrosoftCodeAnalysisCSharpVersion>4.8.0</MicrosoftCodeAnalysisCSharpVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -33,6 +33,8 @@
     <!-- netstandard -->
     <NETStandardLibraryVersion>2.0.3</NETStandardLibraryVersion>
     <!-- nuget -->
+    <!-- Important: Don't version higher than what's available in the toolset SDK as
+         NuGet assemblies aren't redistributed with .NETCoreApp msbuild tasks. -->
     <NuGetCommandsVersion>6.8.1</NuGetCommandsVersion>
     <NuGetFrameworksVersion>6.8.1</NuGetFrameworksVersion>
     <NuGetPackagingVersion>6.8.1</NuGetPackagingVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -66,7 +66,7 @@
     <SystemCompositionVersion>9.0.0-alpha.1.24059.2</SystemCompositionVersion>
     <SystemIOPackagingVersion>9.0.0-alpha.1.24059.2</SystemIOPackagingVersion>
     <SystemReflectionMetadataVersion>9.0.0-alpha.1.24059.2</SystemReflectionMetadataVersion>
-    <SystemSecurityCryptographyXmlVersion>9.0.0-alpha.1.24059.</SystemSecurityCryptographyXmlVersion>
+    <SystemSecurityCryptographyXmlVersion>9.0.0-alpha.1.24059.2</SystemSecurityCryptographyXmlVersion>
     <SystemTextEncodingsWebVersion>9.0.0-alpha.1.24059.2</SystemTextEncodingsWebVersion>
     <SystemTextJsonVersion>9.0.0-alpha.1.24059.2</SystemTextJsonVersion>
     <!-- sdk -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -33,11 +33,11 @@
     <!-- netstandard -->
     <NETStandardLibraryVersion>2.0.3</NETStandardLibraryVersion>
     <!-- nuget -->
-    <NuGetCommandsVersion>6.9.1</NuGetCommandsVersion>
-    <NuGetFrameworksVersion>6.9.1</NuGetFrameworksVersion>
-    <NuGetPackagingVersion>6.9.1</NuGetPackagingVersion>
-    <NuGetProjectModelVersion>6.9.1</NuGetProjectModelVersion>
-    <NuGetVersioningVersion>6.9.1</NuGetVersioningVersion>
+    <NuGetCommandsVersion>6.8.1</NuGetCommandsVersion>
+    <NuGetFrameworksVersion>6.8.1</NuGetFrameworksVersion>
+    <NuGetPackagingVersion>6.8.1</NuGetPackagingVersion>
+    <NuGetProjectModelVersion>6.8.1</NuGetProjectModelVersion>
+    <NuGetVersioningVersion>6.8.1</NuGetVersioningVersion>
     <!-- roslyn -->
     <MicrosoftCodeAnalysisCSharpVersion>4.8.0</MicrosoftCodeAnalysisCSharpVersion>
     <MicrosoftNetCompilersToolsetVersion>4.8.0</MicrosoftNetCompilersToolsetVersion>

--- a/src/Common/Microsoft.Arcade.Common/Microsoft.Arcade.Common.csproj
+++ b/src/Common/Microsoft.Arcade.Common/Microsoft.Arcade.Common.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$(RepositoryEngineeringDir)BuildTask.Packages.props"/>
-
   <PropertyGroup>
     <!-- Treat this as a tooling library as it references msbuild. -->
     <TargetFrameworks>$(NetToolCurrent);netstandard2.0;$(NetFrameworkToolCurrent)</TargetFrameworks>
@@ -20,5 +18,8 @@
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>
+
+  <!-- This project is a build task dependency and needs to follow desktop version requirements. -->
+  <Import Project="$(RepositoryEngineeringDir)BuildTask.Packages.props" />
 
 </Project>

--- a/src/Microsoft.Cci.Extensions/Microsoft.Cci.Extensions.csproj
+++ b/src/Microsoft.Cci.Extensions/Microsoft.Cci.Extensions.csproj
@@ -29,4 +29,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
+  <!-- This project is a build task dependency and needs to follow desktop version requirements. -->
+  <Import Project="$(RepositoryEngineeringDir)BuildTask.Packages.props" />
+
 </Project>

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/Microsoft.DotNet.Helix.Client.csproj
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/Microsoft.DotNet.Helix.Client.csproj
@@ -22,4 +22,7 @@
     <None Include="$(RepoRoot)LICENSE.TXT;$(RepoRoot)THIRD-PARTY-NOTICES.TXT" Pack="true" PackagePath="%(Filename)%(Extension)" />
   </ItemGroup>
 
+  <!-- This project is a build task dependency and needs to follow desktop version requirements. -->
+  <Import Project="$(RepositoryEngineeringDir)BuildTask.Packages.props" />
+
 </Project>

--- a/src/Microsoft.DotNet.Helix/JobSender/Microsoft.DotNet.Helix.JobSender.csproj
+++ b/src/Microsoft.DotNet.Helix/JobSender/Microsoft.DotNet.Helix.JobSender.csproj
@@ -26,4 +26,7 @@
     <None Include="$(RepoRoot)LICENSE.TXT;$(RepoRoot)THIRD-PARTY-NOTICES.TXT" Pack="true" PackagePath="%(Filename)%(Extension)" />
   </ItemGroup>
 
+  <!-- This project is a build task dependency and needs to follow desktop version requirements. -->
+  <Import Project="$(RepositoryEngineeringDir)BuildTask.Packages.props" />
+
 </Project>

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator.csproj
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator.csproj
@@ -28,4 +28,7 @@
           Pack="true" />
   </ItemGroup>
 
+  <!-- This project is a build task dependency and needs to follow desktop version requirements. -->
+  <Import Project="$(RepositoryEngineeringDir)BuildTask.Packages.props" />
+
 </Project>


### PR DESCRIPTION
Update versions consistently:
- MSBuild -> 17.8.3
- NuGet -> 6.8.1
- Runtime -> 9.0 alpha1

Also update the .NET Framework versions in BuildTask.Packages.props to the 8.0.0 versions to mimic what roslyn, msbuild, sdk and runtime recently did. This was necessary to avoid package downgrade errors but is general goodness.

Downgrade NuGet to 6.8.1. which is recent enough
6.9.1. is too new and could cause msbuild task loading issues on non nightly SDKs. That's because we don't redistribute NuGet assemblies in .NETCoreApp msbuild task packages: https://github.com/dotnet/arcade/blob/14f744af4dab67c88f2f217f54c0f0a8fadf76aa/eng/BuildTask.targets#L46-L52
6.8.1 is also the latest version available on SBRP.