### PR TITLE
[release/6.0] Add DotNetReleaseShipping metadata to assets in manifest

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -94,6 +94,7 @@
       
       <ItemsToPushToBlobFeed Include="@(PackagesToPublish);@(ExistingSymbolPackages);@(SymbolPackagesToGenerate)">
         <ManifestArtifactData Condition="'%(IsShipping)' != 'true'">NonShipping=true</ManifestArtifactData>
+        <ManifestArtifactData Condition="'%(IsShipping)' == 'true' and '$(ProducesDotNetReleaseShippingAssets)' == 'true'">DotNetReleaseShipping=true</ManifestArtifactData>
       </ItemsToPushToBlobFeed>
 
       <PackagesToPublish Remove="@(PackagesToPublish)" />


### PR DESCRIPTION
Backport of https://github.com/dotnet/arcade/pull/14495