### PR TITLE
Invert CopySrcInsteadOfClone default behavior

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
@@ -95,7 +95,7 @@
 
   <!--
     PrepareInnerSourceBuildRepoRoot either clones the source to the inner repo
-    or copies the source to the inner repo depending on CopySrcInsteadOfClone.
+    or copies the source to the inner repo depending on CloneSrcInsteadOfCopy.
     Repos take a dependency on PrepareInnerSourceBuildRepoRoot, so this target
     exists to wait until either the source is cloned or copied.
   -->
@@ -103,7 +103,7 @@
           DependsOnTargets="CopyInnerSourceBuildRepoRoot;CloneInnerSourceBuildRepoRoot">
   </Target>
 
-  <Target Name="CopyInnerSourceBuildRepoRoot" Condition=" '$(CopySrcInsteadOfClone)' == 'true' and '$(UseInnerClone)' == 'true' ">
+  <Target Name="CopyInnerSourceBuildRepoRoot" Condition=" '$(CloneSrcInsteadOfCopy)' != 'true' and '$(UseInnerClone)' == 'true' ">
     <ItemGroup>
       <SourceBuildFilesToCopy Include="$(RepoRoot)/**/*" />
       <SourceBuildFilesToCopy Include="$(RepoRoot)/**/.*" />
@@ -123,7 +123,7 @@
     access to the git data, this also makes it easy to see what changes the source-build infra has
     made, for diagnosis or exploratory purposes.
   -->
-  <Target Name="CloneInnerSourceBuildRepoRoot" Condition=" '$(CopySrcInsteadOfClone)' != 'true' and '$(UseInnerClone)' == 'true' ">
+  <Target Name="CloneInnerSourceBuildRepoRoot" Condition=" '$(CloneSrcInsteadOfCopy)' == 'true' and '$(UseInnerClone)' == 'true' ">
     <PropertyGroup>
       <!--
         By default, copy WIP. WIP copy helps with local machine dev work. Don't copy WIP if this is


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/4117

This is a quick fix to unblock the arcade dependency flows to repos.  There is an ongoing discussion if the clone behavior should be retained.  Either way follow-up work is needed to make it work or to remove it.