### PR TITLE
Disable transitive pinning for Microsoft.DotNet.CodeAnalysis

### DIFF
--- a/src/Microsoft.DotNet.CodeAnalysis/Microsoft.DotNet.CodeAnalysis.csproj
+++ b/src/Microsoft.DotNet.CodeAnalysis/Microsoft.DotNet.CodeAnalysis.csproj
@@ -8,6 +8,8 @@
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddAnalyzerToOutput</TargetsForTfmSpecificContentInPackage>
+    <!-- Disable transitive pinning - we must reference the version of dependencies that CodeAnalysis references. -->
+    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/99141

See issue for detailed analysis.  Analyzers need to ensure they only reference the versions of packages that will be provided by (and unify with) the compiler host.