### PR TITLE
Fix a devdiv image usage in the official arcade templates

### DIFF
--- a/eng/common/templates-official/job/publish-build-assets.yml
+++ b/eng/common/templates-official/job/publish-build-assets.yml
@@ -55,7 +55,7 @@ jobs:
     # We don't use the collection uri here because it might vary (.visualstudio.com vs. dev.azure.com)
     ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
       name: AzurePipelines-EO
-      image: 1ESPT-WINDOWS2022
+      image: 1ESPT-Windows2022
       demands: Cmd
       os: windows
     # If it's not devdiv, it's dnceng


### PR DESCRIPTION
Related to https://github.com/dotnet/arcade/pull/14534. I missed this one in my previous PR

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
