### PR TITLE
Adding comment properties to explain why we are adding dotnet.exe targeted settings to the arcade global.json file.

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,24 +1,14 @@
 {
+  // Please refer to the following wiki for more information about the .NET SDK configuration file and it's use cases.
+  // https://github.com/dotnet/arcade/blob/main/Documentation/ArcadeSdk.md
   "sdk": {
-    "_comment": [
-      "THESE ARE DOTNET.EXE PROPERTIES. These settings are used by dotnet.exe and are not used by arcade.",
-      "We need to explicitly specify the SDK used by dotnet.exe so it matches the setting used by arcade",
-      "because the default behavior of dotnet.exe will pick the latest version of the SDK installed regardless",
-      "of the setting used by arcade. This can happen if the build box has multiple versions of the SDK installed."
-    ],
     "version": "7.0.116",
     "rollForward": "latestFeature"
   },
   "tools": {
-    "_comment": [
-      "THESE ARE ARCADE.EXE PROPERTIES. These settings are used by arcade."
-    ],
     "dotnet": "7.0.116"
   },
   "msbuild-sdks": {
-    "_comment": [
-      "THESE ARE ARCADE.EXE PROPERTIES. These settings are used by arcade."
-    ],
     "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22426.8",
     "Microsoft.DotNet.Helix.Sdk": "7.0.0-beta.22426.8"
   }

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
-  // Please refer to the following wiki for more information about the .NET SDK configuration file and it's use cases.
+  // Please refer to the following wiki for more information about the global.json configuration file and it's use cases.
   // https://github.com/dotnet/arcade/blob/main/Documentation/ArcadeSdk.md
   "sdk": {
     "version": "7.0.116",

--- a/global.json
+++ b/global.json
@@ -1,12 +1,24 @@
 {
   "sdk": {
+    "_comment": [
+      "THESE ARE DOTNET.EXE PROPERTIES. These settings are used by dotnet.exe and are not used by arcade.",
+      "We need to explicitly specify the SDK used by dotnet.exe so it matches the setting used by arcade",
+      "because the default behavior of dotnet.exe will pick the latest version of the SDK installed regardless",
+      "of the setting used by arcade. This can happen if the build box has multiple versions of the SDK installed."
+    ],
     "version": "7.0.116",
     "rollForward": "latestFeature"
   },
   "tools": {
+    "_comment": [
+      "THESE ARE ARCADE.EXE PROPERTIES. These settings are used by arcade."
+    ],
     "dotnet": "7.0.116"
   },
   "msbuild-sdks": {
+    "_comment": [
+      "THESE ARE ARCADE.EXE PROPERTIES. These settings are used by arcade."
+    ],
     "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22426.8",
     "Microsoft.DotNet.Helix.Sdk": "7.0.0-beta.22426.8"
   }


### PR DESCRIPTION
Adding comment properties to explain why we are adding dotnet.exe targeted settings to the arcade global.json file.

For issue : 2119
https://github.com/dotnet/dnceng/issues/2119

### To double check:

* [x] The right tests are in and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
