### PR TITLE
Add more runtime test modes to match the options used in the runtime test tree

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/CoreClrConfigurationDetection.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/CoreClrConfigurationDetection.cs
@@ -19,8 +19,14 @@ namespace Xunit
         public static bool IsZapDisable => string.Equals(GetEnvironmentVariableValue("ZapDisable"), "1", StringComparison.InvariantCulture);
         public static bool IsGCStress3 => CompareGCStressModeAsLower(GetEnvironmentVariableValue("GCStress"), "0x3", "3");
         public static bool IsGCStressC => CompareGCStressModeAsLower(GetEnvironmentVariableValue("GCStress"), "0xC", "C");
+        public static bool IsTieredCompilation => string.Equals(GetEnvironmentVariableValue("TieredCompilation", "1"), "1", StringComparison.InvariantCulture);
+        public static bool IsHeapVerify => string.Equals(GetEnvironmentVariableValue("HeapVerify"), "1", StringComparison.InvariantCulture);
 
         public static bool IsGCStress => !string.Equals(GetEnvironmentVariableValue("GCStress"), "0", StringComparison.InvariantCulture);
+        
+        public static bool IsAnyJitStress => IsJitStress || IsJitStressRegs || IsJitMinOpts || IsTailCallStress;
+
+        public static bool IsAnyJitOptimizationStress => IsAnyJitStress || IsTieredCompilation;
 
         public static bool IsCheckedRuntime => AssemblyConfigurationEquals("Checked");
         public static bool IsReleaseRuntime => AssemblyConfigurationEquals("Release");
@@ -29,13 +35,11 @@ namespace Xunit
         public static bool IsStressTest =>
             IsGCStress ||
             IsZapDisable ||
-            IsTailCallStress ||
-            IsJitStressRegs ||
-            IsJitStress ||
-            IsJitMinOpts;
+            IsAnyJitStress ||
+            IsHeapVerify;
 
-        private static string GetEnvironmentVariableValue(string name) =>
-            Environment.GetEnvironmentVariable("DOTNET_" + name) ?? Environment.GetEnvironmentVariable("COMPlus_" + name) ?? "0";
+        private static string GetEnvironmentVariableValue(string name, string defaultValue = "0") =>
+            Environment.GetEnvironmentVariable("DOTNET_" + name) ?? Environment.GetEnvironmentVariable("COMPlus_" + name) ?? defaultValue;
 
         private static bool AssemblyConfigurationEquals(string configuration)
         {

--- a/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeTestModes.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeTestModes.cs
@@ -34,5 +34,15 @@ namespace Xunit
         // including in NGEN/ReadyToRun code.
         GCStressC = 1 << 7, // DOTNET_GCStress (or COMPlus_GCStress) includes mode 0xC.
         AnyGCStress = GCStress3 | GCStressC // Disable when any GCStress is exercised.
+
+        // TieredCompilation is on by default, but can cause some tests to fail
+        // As TieredCompilation is on by default, it does not count as a stress mode for RegularRun.
+        TieredCompilation = 1 << 8, // DOTNET_TieredCompilation (or COMPlus_TieredCompilation) is not set to 0.
+
+        AnyJitStress = JitStress | JitStressRegs | JitMinOpts | TailcallStress, // Disable when any JIT stress mode is exercised.
+
+        AnyJitOptimizationStress = AnyJitStress | TieredCompilation, // Disable when any JIT non-full optimization stress mode is exercised.
+
+        HeapVerify = 1 << 9, // DOTNET_HeapVerify (or COMPlus_HeapVerify) is set.
     }
 }

--- a/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeTestModes.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/RuntimeTestModes.cs
@@ -33,7 +33,7 @@ namespace Xunit
         // GCStressC forces a GC at every JIT-generated code instruction,
         // including in NGEN/ReadyToRun code.
         GCStressC = 1 << 7, // DOTNET_GCStress (or COMPlus_GCStress) includes mode 0xC.
-        AnyGCStress = GCStress3 | GCStressC // Disable when any GCStress is exercised.
+        AnyGCStress = GCStress3 | GCStressC, // Disable when any GCStress is exercised.
 
         // TieredCompilation is on by default, but can cause some tests to fail
         // As TieredCompilation is on by default, it does not count as a stress mode for RegularRun.


### PR DESCRIPTION
To move to the next phase of the runtime test consolidation, we need to move our project-level test disable checks to be test-level. It's easier if we can do these checks with SkipOnCoreClrAttribute instead of a manual check, so lets add the options to enable us to do that.

I'll follow this up with a PR into dotnet/runtime to update the XUnitWrapperGenerator.