### PR TITLE
Adding information to arcadesdk.md to explain why we specify dotnet.exe properties to target a matching .Net Core SDK version in servicing branches. 

### DIFF
--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -425,16 +425,7 @@ Example
 
 Note: defining `runtimes` in your global.json will signal to Arcade to install a local version of the SDK for the runtimes to use rather than depending on a matching global SDK.
 
-**Servicing Support Notes:**
-
-Arcade uses dotnet.exe to specify the target .Net Core SDK. However dotnet.exe has it's own property settings in global.json and does not 
-obey the arcade tools.dotnet JSON specification. Dotnet.exe's default behavior is to use the latest version of the .Net Core SDK. As products 
-move to servicing life cycles, CI build machine may have multiple versions of the SDK installed and arcade will point to an old version. When 
-that occurs dotnet.exe by default will still use the latest version of the SDK which will lead to Validation failures in our CI builds do to 
-version mismatches between Asp.Net and .Net Core SDKs. To resolve this issue we must add explicit property setting to the global.json file
-that will force dotnet.exe to target the same version that arcade targets
-
-Settings to ensure arcade and dotnet.exe target the same .Net Core SDK version:
+We include tools/dotnet to install the SDK version requested (that's all that section does in this case) and sdk to ensure that SDK (or a slightly newer one) is what's used in builds. we want that alignment to avoid unexpected issues, especially in servicing.
 
 ```json
 {

--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -425,7 +425,7 @@ Example
 
 Note: defining `runtimes` in your global.json will signal to Arcade to install a local version of the SDK for the runtimes to use rather than depending on a matching global SDK.
 
-We include tools/dotnet to install the SDK version requested (that's all that section does in this case) and sdk to ensure that SDK (or a slightly newer one) is what's used in builds. we want that alignment to avoid unexpected issues, especially in servicing.
+We include `tools/dotnet` to install the SDK version requested and `sdk` to ensure that SDK (or a slightly newer one) is what's used in builds. we want that alignment to avoid unexpected issues, especially in servicing.
 
 ```json
 {

--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -425,6 +425,29 @@ Example
 
 Note: defining `runtimes` in your global.json will signal to Arcade to install a local version of the SDK for the runtimes to use rather than depending on a matching global SDK.
 
+**Servicing Support Notes:**
+
+Arcade uses dotnet.exe to specify the target .Net Core SDK. However dotnet.exe has it's own property settings in global.json and does not 
+obey the arcade tools.dotnet JSON specification. Dotnet.exe's default behavior is to use the latest version of the .Net Core SDK. As products 
+move to servicing life cycles, CI build machine may have multiple versions of the SDK installed and arcade will point to an old version. When 
+that occurs dotnet.exe by default will still use the latest version of the SDK which will lead to Validation failures in our CI builds do to 
+version mismatches between Asp.Net and .Net Core SDKs. To resolve this issue we must add explicit property setting to the global.json file
+that will force dotnet.exe to target the same version that arcade targets
+
+Settings to ensure arcade and dotnet.exe target the same .Net Core SDK version:
+
+```json
+{
+  "sdk": {
+    "version": "7.0.116",
+    "rollForward": "latestFeature"
+  },
+  "tools": {
+    "dotnet": "7.0.116"
+  }
+}
+```
+
 ### /NuGet.config
 
 `/NuGet.config` file is present and specifies the MyGet feed to retrieve Arcade SDK from and other feeds required by the repository like so:


### PR DESCRIPTION
Adding information to arcadesdk.md to explain why we specify dotnet.exe properties to target a matching .Net Core SDK version in servicing branches. 

### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
