### PR TITLE
Adding dotnet property setting for the 8.0 release branch to ensure the target .net core sdk matches the sdk setting for arcade.

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,4 +1,8 @@
 {
+  "sdk": {
+    "version": "8.0.101",
+    "rollForward": "latestFeature"
+  },
   "tools": {
     "dotnet": "8.0.101"
   },


### PR DESCRIPTION
Adding dotnet property setting for the 8.0 release branch to ensure the target .net core sdk matches the sdk setting for arcade.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
