### PR TITLE
VMR Permissible Sources documentation

### DIFF
--- a/Documentation/UnifiedBuild/VMR-Permissible-Sources.md
+++ b/Documentation/UnifiedBuild/VMR-Permissible-Sources.md
@@ -1,0 +1,39 @@
+# The Unified Build Almanac (TUBA) - Permissible Source Policy
+
+## Purpose
+
+This document provides guidelines on the types of source code that are permissible in the VMR. It explains how the VMR detects binaries and licenses, and it outlines the steps to be taken when a new binary or license is encountered.
+
+## Binaries
+
+### Policy
+
+OSS licensed binaries are allowed in the VMR, but they require explicit inclusion in the VMR.
+
+This action involves adding the binary or its exclusion pattern to either [`allowed-binaries.txt`](https://github.com/dotnet/dotnet/blob/main/src/installer/src/VirtualMonoRepo/allowed-binaries.txt) or [`disallowed-sb-binaries.txt`](https://github.com/dotnet/dotnet/blob/main/src/installer/src/VirtualMonoRepo/disallowed-sb-binaries.txt). Which file to add the binary or exclusion pattern to depends on whether or not the binary is allowed for source build. For help determining if the newly detected binary is allowed in the source-build context, please contact a member of the source-build team at @dotnet/source-build-internal.
+
+If the binary is allowed for source build, add it to `allowed-binaries.txt`. This binary will not be removed during a source build of the product and it will no longer be considered a new binary in the VMR.
+
+If the binary is not allowed for source build, add it to `disallowed-binaries.txt`. This binary will be removed during a source build of the product, but it will not longer be considered a new binary in the VMR.
+
+When adding a binary or pattern to either file, remember to include a link to the relevant issue and tag @dotnet/source-build-internal as a reviewer.
+
+### Detection and Removal
+
+The [BinaryTool](https://github.com/dotnet/dotnet/tree/main/eng/tools/BinaryToolKit) is used to detect and remove binaries in the VMR. You can run the tool locally by running `eng/prep-source-build.sh`.
+
+For detection, the tool identifies binaries not listed in `allowed-binaries.txt` and `disallowed-sb-binaries.txt`. Any binary not listed in these files is considered "new" and requires explicit action as discussed above.
+
+For removal, the tool identifies binaries not listed in `allowed-binaries.txt`. Any binary not listed in this file is not allowed for source-building and will be removed from the VMR.
+
+## Licenses
+
+### Policy
+
+The VMR does not permit code and binaries licensed under non-OSS licenses.
+
+When a non-OSS license is detected, the offending code and binaries must be cloaked from the VMR. See [the VMR](./VMR-Design-And-Operation.md#repository-source-mappings) and [source-build documentation](https://github.com/dotnet/source-build/blob/main/Documentation/sourcebuild-in-repos/new-repo.md#cloaking-filtering-the-repository-sources) on cloaking.
+
+### Detection
+
+Licenses are detected by the [license scan smoke test](https://github.com/dotnet/dotnet/blob/main/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs). This smoke test is run as part of the [source-build license scan pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=1301&_a=summary). The test detects any license in the VMR that is not listed in [`LicenseExclusions.txt`](https://github.com/dotnet/dotnet/blob/main/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt).

--- a/Documentation/UnifiedBuild/VMR-Permissible-Sources.md
+++ b/Documentation/UnifiedBuild/VMR-Permissible-Sources.md
@@ -89,3 +89,6 @@ When a non-OSS license is detected, the offending code and binaries must be cloa
 
 Licenses are detected by the [license scan test](https://github.com/dotnet/dotnet/blob/main/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs). This test is run as part of the [source-build license scan pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=1301&_a=summary) (internal Microsoft link). The test detects any license in the VMR that is not part of an exclusion listed in [`LicenseExclusions.txt`](https://github.com/dotnet/dotnet/blob/main/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt).
 
+Common cases for adding a license to [`LicenseExclusions.txt`](https://github.com/dotnet/dotnet/blob/main/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt) include false positives, licenses related to test data, or needing to get a clean scan result with a relevant backport issue to remove the offending license later.
+
+To have a license be added to the list of exclusions in [`LicenseExclusions.txt`](https://github.com/dotnet/dotnet/blob/main/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt), open a PR, include a link to the relevant issue above the exclusion, and tag [@dotnet/source-build-internal](https://github.com/orgs/dotnet/teams/source-build-internal) as a reviewer.

--- a/Documentation/UnifiedBuild/VMR-Permissible-Sources.md
+++ b/Documentation/UnifiedBuild/VMR-Permissible-Sources.md
@@ -23,13 +23,13 @@ When adding a binary or pattern to either `allowed-sb-binaries.txt` or `allowed-
 
 ### Validation and Cleaning
 
-The [BinaryTool](https://github.com/dotnet/dotnet/tree/main/eng/tools/BinaryToolKit) is used to validate binaries in the VMR and clean binaries from the VMR. You can run the tool locally by running `./eng/run-binary-tooling.sh --validate` or `./eng/run-binary-tooling.sh --clean`.
+The [BinaryTool](https://github.com/dotnet/dotnet/tree/main/eng/tools/BinaryToolKit) is used to validate binaries in the VMR and clean binaries from the VMR. You can run the tool locally by running `./eng/detect-binaries.sh`, `./eng/detect-binaries.sh --clean`, or `./prep-source-build/sh`.
 
 #### Validation
 
 The tool detects "new" binaries by checking if they are listed in either `allowed-vmr-binaries.txt` or `allowed-sb-binaries.txt`. Note that the tool only uses `allowed-vmr-binaries.txt` as a baseline, but `allowed-sb-binaries.txt` is imported at the top of `allowed-vmr-binaries.txt`. This means that all binaries in `allowed-sb-binaries.txt` are also relevent.
 
-To run default validation, execute `eng/run-binary-tooling.sh --validate`.
+To run default validation, execute `eng/detect-binaries.sh`.
 
 An example output is as follows:
 
@@ -54,28 +54,26 @@ If these binaries are permitted for source-build, add the binaries and/or releve
 
 The tool cleans binaries from the VMR that are not listed in `allowed-sb-binaries.txt`. Binary cleaning runs automatically as part of `./prep-source-build.sh`.
 
-To run default cleaning, execute `./eng/run-binary-tooling.sh --clean` or `./prep-source-build.sh`. Executing `./prep-source-build.sh` will build the tool using previously source-built artifacts whereas executing `./eng/run-binary-tooling.sh --clean` will build the tool using online resources.
+To run cleaning, execute `./eng/detect-binaries.sh --clean` or `./prep-source-build.sh`. Executing `./prep-source-build.sh` will build the tool using previously source-built artifacts and remove non-source-build allowed binaries from the VMR whereas executing `./eng/detect-binaries.sh --clean` will build the tool using online resources and remove new binaries from the VMR.
 
 An example output is as follows:
 
 ```
 16:42:19 info: BinaryTool[0] Starting binary tool at 3/19/2024 4:42:19 PM in Clean mode
-16:42:19 info: BinaryTool[0] Detecting binaries in '/vmr' not listed in '/vmr/eng/allowed-sb-binaries.txt'...
+16:42:19 info: BinaryTool[0] Detecting binaries in '/vmr' not listed in '/vmr/eng/allowed-vmr-binaries.txt'...
 16:42:23 info: BinaryTool[0] Finished binary detection.
 16:42:24 info: BinaryTool[0] Removing binaries from '/vmr'...
-16:42:24 dbug: BinaryTool[0]     src/winforms/src/System.Windows.Forms.Design/src/Resources/colordlg.data
 16:42:24 dbug: BinaryTool[0]     src/wpf/src/Microsoft.DotNet.Wpf/src/Shared/Tracing/resources/MSG00001.bin
 16:42:24 dbug: BinaryTool[0]     src/wpf/src/Microsoft.DotNet.Wpf/src/Shared/Tracing/resources/wpf-etwTEMP.BIN
-16:42:24 info: BinaryTool[0] Finished binary removal. Removed 3 binaries.
+16:42:24 info: BinaryTool[0] Finished binary removal. Removed 2 binaries.
 16:42:24 info: BinaryTool[0] Finished all binary tasks. Took 4.9003778 seconds.
 ```
 
-In this example, the tool removed 3 binaries: 
- - `src/winforms/src/System.Windows.Forms.Design/src/Resources/colordlg.data`
+In this example, the tool removed 2 binaries: 
  - `src/wpf/src/Microsoft.DotNet.Wpf/src/Shared/Tracing/resources/MSG00001.bin`
  - `src/wpf/src/Microsoft.DotNet.Wpf/src/Shared/Tracing/resources/wpf-etwTEMP.BIN`.
  
-If you no longer wish for these binaries to be removed, add the binaries and/or relevent file glob pattern(s) to `allowed-sb-binaries.txt`.
+If these binaries are permitted for source-build, add the binaries and/or relevent file glob pattern(s), such as `src/wpf/src/Microsoft.DotNet.Wpf/src/Shared/Tracing/resources/*.bin`, to `allowed-sb-binaries.txt`. Otherwise, add the binaries or relevent file glob pattern(s) to `allowed-vmr-binaries.txt`.
 
 ## Licenses
 


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/4086

This PR introduces documentation that describes what sources are permissible in the VMR and what action to take when a new source is encountered. The documentation breaks the sources down into binaries and licenses, and it describes the tooling used for each source.

The `disallowed-sb-binaries.txt` file will be added in https://github.com/dotnet/source-build/issues/4087 since this PR will introduce binaries into the VMR that are disallowed for source-build. https://github.com/dotnet/source-build/issues/4087 cannot be updated until https://github.com/dotnet/installer/pull/18726 is merged.