### PR TITLE
Attempting to fix a local build break for the 6.0 branch when using Visual Studio 2022 int preview by picking up a change to GetNextWord from the 7.0 branch.

### DIFF
--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Helpers.cs
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Helpers.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.SwaggerGenerator
         ///   A 'word' is the next logical piece of a variable/property/parameter name
         /// </remarks>
         /// <returns>The 'word'</returns>
-        private static ReadOnlySpan<char> GetNextWord(ReadOnlySpan<char> value, ref int pos)
+        private static ReadOnlySpan<char> GetNextWord(ReadOnlySpan<char> value, scoped ref int pos)
         {
             int? wordStart = null;
             for (int idx = pos; idx < value.Length; idx++)


### PR DESCRIPTION
Attempting to fix a local build break for the 6.0 branch when using Visual Studio 2022 int preview by picking up a change to GetNextWord from the 7.0 branch.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
