### PR TITLE
Adding instructions to target the c# 10 language in the Microsoft.DotNet.SwaggerGenerator.CodeGenerator project in order to address compile failures when using default setting in a Visual Studio 2022 preview IDE.

### DIFF
--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Helpers.cs
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Helpers.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.SwaggerGenerator
         ///   A 'word' is the next logical piece of a variable/property/parameter name
         /// </remarks>
         /// <returns>The 'word'</returns>
-        private static ReadOnlySpan<char> GetNextWord(ReadOnlySpan<char> value, ref int pos)
+        private static ReadOnlySpan<char> GetNextWord(ReadOnlySpan<char> value, scoped ref int pos)
         {
             int? wordStart = null;
             for (int idx = pos; idx < value.Length; idx++)

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Helpers.cs
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Helpers.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.SwaggerGenerator
         ///   A 'word' is the next logical piece of a variable/property/parameter name
         /// </remarks>
         /// <returns>The 'word'</returns>
-        private static ReadOnlySpan<char> GetNextWord(ReadOnlySpan<char> value, scoped ref int pos)
+        private static ReadOnlySpan<char> GetNextWord(ReadOnlySpan<char> value, ref int pos)
         {
             int? wordStart = null;
             for (int idx = pos; idx < value.Length; idx++)

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator.csproj
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <LangVersion>10.0</LangVersion>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Microsoft.DotNet.SwaggerGenerator</RootNamespace>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>


### PR DESCRIPTION
Adding instructions to target the c# 10 language in the Microsoft.DotNet.SwaggerGenerator.CodeGenerator project in order to address compile failures when using default setting in a Visual Studio 2022 preview IDE.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
