### PR TITLE
Enable publishing to build storage

### DIFF
--- a/Documentation/DependencyFlowOnboardingWithoutArcade.md
+++ b/Documentation/DependencyFlowOnboardingWithoutArcade.md
@@ -4,14 +4,14 @@
 
 Dependency flow is the method by which .NET repos consume other product repo's assets.  In order to participate in dependency flow, a repo must produce a [manifest](#generate-a-manifest) of what assets / packages that repo produces and then publish that manifest to the Build Asset Registry (B.A.R.).  This document is intended to provide guidance for repos which are not using the Arcade Sdk but still need to participate in dependency flow. The end goal is that the repo is able to produce a manifest and publish that to B.A.R.
 
-To do so, a repo follows almost the same process as [normal arcade publishing](DependencyFlowOnboarding.md). The repo directly uses the [`PushToAzureDevOpsArtifacts`](https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs) task in the [Microsoft.DotNet.Build.Tasks.Feed](https://github.com/dotnet/arcade/tree/master/src/Microsoft.DotNet.Build.Tasks.Feed) package (available from the dotnet-eng feed - `https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json`). This task uploads the artifacts to build storage and generates a manifest describing the build. The manifest is the used to publish the new build to the build asset registry (BAR).
+To do so, a repo follows almost the same process as [normal arcade publishing](DependencyFlowOnboarding.md). The repo directly uses the [`PushToBuildStorage`](https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBuildStorage.cs) task in the [Microsoft.DotNet.Build.Tasks.Feed](https://github.com/dotnet/arcade/tree/master/src/Microsoft.DotNet.Build.Tasks.Feed) package (available from the dotnet-eng feed - `https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json`). This task uploads the artifacts to build storage and generates a manifest describing the build. The manifest is the used to publish the new build to the build asset registry (BAR).
 
 ## Creating a manifest
 
-To create a manifest, use the PushToAzureDevOpsArtifacts, providing the feed that packages pushed to. The below target performs this task.
+To create a manifest, use the PushToBuildStorage, providing the feed that packages pushed to. The below target performs this task.
 
 ```
-<UsingTask TaskName="Microsoft.DotNet.Build.Tasks.Feed.PushToAzureDevOpsArtifacts" AssemblyFile="$(MicrosoftDotNetBuildTasksFeedFilePath)" />
+<UsingTask TaskName="Microsoft.DotNet.Build.Tasks.Feed.PushToBuildStorage" AssemblyFile="$(MicrosoftDotNetBuildTasksFeedFilePath)" />
 
 <Target Name="PublishToBuildAssetRegistry">
   <PropertyGroup>
@@ -52,7 +52,7 @@ To create a manifest, use the PushToAzureDevOpsArtifacts, providing the feed tha
     <ManifestBuildData Include="AzureDevOpsBranch=$(BUILD_SOURCEBRANCH)" />
   </ItemGroup>
 
-  <PushToAzureDevOpsArtifacts
+  <PushToBuildStorage
     ItemsToPush="@(ItemsToPush)"
     ManifestBuildData="@(ManifestBuildData)"
     ManifestRepoUri="$(BUILD_REPOSITORY_NAME)"

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -308,18 +308,27 @@
     <!--
       Publish artifacts. This should run in the following situations:
       - Regular single repo builds
-      - When running a the outer build phase of a source-only repo build, to properly publish the source-build intermediate nupkg.
+        - When running in the outer build phase of a source-only repo build, to properly publish the source-build intermediate nupkg.
+      - VMR builds
+        - When running in the inner build phase
 
       It shouldn't run:
-      - In any inner build
+      - In an inner build if running from single repo build.
       - In an outer build if running from the full product build.
     -->
+
+    <PropertyGroup>
+      <_VmrBuild Condition="'$(DotNetBuildFromSourceFlavor)' == 'Product' or '$(DotNetBuildOrchestrator)' == 'true'">true</_VmrBuild>
+      <_InnerRepoBuild Condition="'$(ArcadeInnerBuildFromSource)' == 'true' or '$(DotNetBuildPhase)' == 'InnerRepo'">true</_InnerRepoBuild>
+      <_ShouldRunPublish Condition="'$(_InnerRepoBuild)' == 'true' and '$(_VmrBuild)' == 'true'">true</_ShouldRunPublish>
+      <_ShouldRunPublish Condition="'$(_InnerRepoBuild)' != 'true' and '$(_VmrBuild)' != 'true'">true</_ShouldRunPublish>
+    </PropertyGroup>
+
+      <!-- Make sure we always publish in VMR build - working around runtime repo which sets Publish to false. -->
     <MSBuild Projects="Publish.proj"
              Properties="@(_PublishProps);_NETCORE_ENGINEERING_TELEMETRY=Publish"
              Targets="Publish"
-             Condition="'$(Publish)' == 'true' and
-                        ('$(ArcadeInnerBuildFromSource)' != 'true' and  '$(DotNetBuildFromSourceFlavor)' != 'Product') and 
-                        ('$(DotNetBuildPhase)' != 'Inner' and '$(DotNetBuildOrchestrator)' != 'true')"/>
+             Condition="'$(Publish)' == 'true' and '$(_ShouldRunPublish)' == 'true'"/>
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -41,9 +41,10 @@
     
     <!-- If `AutoGenerateSymbolPackages` is not set we default it to true. -->
     <!-- Do not generate symbol packages if in outer source build mode, to avoid creating copies of the intermediates. -->
+    <!-- Also do not generate symbol packages if in inner source build, in product build. -->
     <AutoGenerateSymbolPackages Condition="'$(AutoGenerateSymbolPackages)' == '' and
-      (('$(ArcadeBuildFromSource)' != 'true' or '$(ArcadeInnerBuildFromSource)' == 'true') or 
-       ('$(DotNetBuild)' != 'true' or '$(DotNetBuildPhase)' == 'InnerRepo'))">true</AutoGenerateSymbolPackages>
+       ('$(DotNetBuildSourceOnly)' != 'true' or
+       ('$(ArcadeInnerBuildFromSource)' == 'true' and '$(DotNetBuildFromSourceFlavor)' != 'Product'))">true</AutoGenerateSymbolPackages>
 
     <AssetManifestOS Condition="'$(AssetManifestOS)' == ''">$(OS)</AssetManifestOS>
 
@@ -85,6 +86,13 @@
         <IsShipping>%(PackagesToPublish.IsShipping)</IsShipping>
       </SymbolPackagesToGenerate>
 
+      <!-- Include Symbols.<repo>.tar.gz, if running in inner source-only build -->
+      <UnifiedSymbolsPackage Include="$(ArtifactsPackagesDir)**/Symbols*.tar.gz" IsShipping="false" />
+      <PackagesToPublish Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetBuildInnerRepo)' == 'true'" Include="@(UnifiedSymbolsPackage)">
+        <PublishFlatContainer>true</PublishFlatContainer>
+        <RelativeBlobPath>%(Filename)%(Extension)</RelativeBlobPath>
+      </PackagesToPublish>
+
       <!-- If PostBuildSign is true, then we need to include newly generated packages in ItemsToSignPostBuild. -->
       <ItemsToSignPostBuild Include="@(SymbolPackagesToGenerate->'%(Filename)%(Extension)')" Condition="'$(PostBuildSign)' == 'true'" />
     </ItemGroup>
@@ -105,8 +113,11 @@
       -->
       <SymbolPackagesToGenerate Remove="$(SymbolPackagesDir)**/Microsoft.DotNet.Darc.*" />
       <SymbolPackagesToGenerate Remove="$(SymbolPackagesDir)**/Microsoft.DotNet.Maestro.Tasks.*" />
-      
-      <ItemsToPushToBlobFeed Include="@(PackagesToPublish);@(ExistingSymbolPackages);@(SymbolPackagesToGenerate)">
+
+      <!-- Exclude all existing *.symbols.nupkg in source-only build - we create a unified symbols archive instead. -->
+      <ExistingSymbolPackages Remove="@(ExistingSymbolPackages)" Condition="'$(DotNetBuildSourceOnly)' == 'true'"/>
+
+      <ItemsToPushToBlobFeed Include="@(PackagesToPublish);@(ExistingSymbolPackages);@(SymbolPackagesToGenerate)" Exclude="@(ItemsToPushToBlobFeed)">
         <ManifestArtifactData Condition="'%(IsShipping)' != 'true'">NonShipping=true</ManifestArtifactData>
         <ManifestArtifactData Condition="'%(IsShipping)' == 'true' and '$(ProducesDotNetReleaseShippingAssets)' == 'true'">DotNetReleaseShipping=true</ManifestArtifactData>
       </ItemsToPushToBlobFeed>
@@ -145,6 +156,11 @@
       <PDBsToPublishTempLocation>$(ArtifactsTmpDir)PDBsToPublish/</PDBsToPublishTempLocation>
     </PropertyGroup>
     
+    <!-- In VMR inner-build copy to local storage, do not push to AzDO -->
+    <PropertyGroup Condition="'$(ArcadeInnerBuildFromSource)' == 'true' or '$(DotNetBuildPhase)' == 'InnerRepo'">
+      <PushToLocalStorage>true</PushToLocalStorage>
+    </PropertyGroup>
+
     <!--
       The new Maestro/BAR build model keeps separate Azure DevOps and GitHub build information.
       The GitHub information will be extracted based on the Azure DevOps repository.
@@ -163,7 +179,7 @@
     <!--
       The user can set `PublishingVersion` via eng\Publishing.props
     -->
-    <PushToAzureDevOpsArtifacts
+    <PushToBuildStorage
       AzureDevOpsCollectionUri="$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)"
       AzureDevOpsProject="$(SYSTEM_TEAMPROJECT)"
       AzureDevOpsBuildId="$(BUILD_BUILDID)"
@@ -181,7 +197,12 @@
       IsStableBuild="$(IsStableBuild)"
       PublishingVersion="$(PublishingVersion)"
       AssetManifestPath="$(AssetManifestFilePath)" 
-      IsReleaseOnlyPackageVersion="$(IsReleaseOnlyPackageVersion)" />
+      IsReleaseOnlyPackageVersion="$(IsReleaseOnlyPackageVersion)"
+      PushToLocalStorage="$(PushToLocalStorage)"
+      AssetsLocalStorageDir="$(SourceBuiltAssetsDir)"
+      ShippingPackagesLocalStorageDir="$(SourceBuiltShippingPackagesDir)"
+      NonShippingPackagesLocalStorageDir="$(SourceBuiltNonShippingPackagesDir)"
+      AssetManifestsLocalStorageDir="$(SourceBuiltAssetManifestsDir)" />
 
     <!-- 
         Publish Windows PDBs produced by SymStore.targets (by default, only shipping PDBs are placed there).

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
@@ -1,5 +1,5 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
-<Project DefaultTargets="AfterSourceBuild">
+<Project DefaultTargets="AfterSourceBuildInnerBuild;AfterSourceBuild">
 
   <Import Project="..\BuildStep.props" />
 
@@ -11,22 +11,16 @@
 
   <Import Project="$(MicrosoftDotNetSourceBuildTasksBuildDir)Microsoft.DotNet.SourceBuild.Tasks.props" />
 
+  <Target Name="AfterSourceBuildInnerBuild"
+          Condition="('$(ArcadeInnerBuildFromSource)' == 'true' or '$(DotNetBuildInnerRepo)' == 'true') and
+                     '$(DotNetBuildOrchestrator)' == 'true'"
+          DependsOnTargets="CreateRepoSymbolsArchive" />
+
   <Target Name="AfterSourceBuild"
           Condition="'$(ArcadeInnerBuildFromSource)' != 'true' and '$(DotNetBuildInnerRepo)' != 'true'"
           DependsOnTargets="
             ReportPrebuiltUsage;
-            PackSourceBuildIntermediateNupkgs;
-            GetProductSourceBuildManifest" />
-
-  <!--
-    Repo build creates the manifest in SourceBuildIntermediate.proj,
-    however AfterSourceBuild runs in both repo and product builds.
-
-    AfterSourceBuild should only create the manifest in product build.
-  -->
-  <Target Name="GetProductSourceBuildManifest"
-          Condition="'$(DotNetBuildFromSourceFlavor)' == 'Product' or '$(DotNetBuildOrchestrator)' == 'true'"
-          DependsOnTargets="CreateRepoManifest" />
+            PackSourceBuildIntermediateNupkgs" />
 
   <Target Name="WritePrebuiltUsageData">
     <ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -69,6 +69,7 @@
     <_DefaultNetFrameworkFilter>netstandard2.0%3bnetstandard2.1%3bnetcoreapp2.1%3bnetcoreapp3.1%3bnet5.0%3bnet6.0%3bnet7.0%3bnet8.0%3bnet9.0</_DefaultNetFrameworkFilter>
     <SourceBuildTargetFrameworkFilter Condition="'$(SourceBuildTargetFrameworkFilter)' == ''">$(_DefaultNetFrameworkFilter)</SourceBuildTargetFrameworkFilter>
     <RepoManifestFile>$(ArtifactsDir)RepoManifest.xml</RepoManifestFile>
+    <CreateRepoSymbolsArchiveDependsOn Condition="'$(CreateIntermediatePackage)' == 'true'">GetCategorizedIntermediateNupkgContents</CreateRepoSymbolsArchiveDependsOn>
   </PropertyGroup>
 
   <Target Name="GetSourceBuildIntermediateNupkgNameConvention">
@@ -159,12 +160,12 @@
   -->
   <Target Name="CreateRepoSymbolsArchive"
           Condition="'$(OS)' != 'Windows_NT' and ('$(DotNetBuildFromSourceFlavor)' == 'Product' or '$(DotNetBuildOrchestrator)' == 'true' or '$(SupplementalIntermediateNupkgCategory)' == '$(SymbolsIntermediateNupkgCategory)')"
-          DependsOnTargets="GetCategorizedIntermediateNupkgContents">
+          DependsOnTargets="$(CreateRepoSymbolsArchiveDependsOn)">
     <PropertyGroup>
       <SymbolsRoot>$(CurrentRepoSourceBuildArtifactsDir)</SymbolsRoot>
       <!-- Fall back to repo root for source-build-externals or repos that don't have the regular SymbolsRoot as defined above -->
       <SymbolsRoot Condition="!Exists('$(SymbolsRoot)') or '$(GitHubRepositoryName)' == 'source-build-externals'">$(RepoRoot)</SymbolsRoot>
-      <SymbolsArchiveLocation>$(CurrentRepoSourceBuildArtifactsPackagesDir)</SymbolsArchiveLocation>
+      <SymbolsArchiveLocation>$(CurrentRepoSourceBuildArtifactsPackagesDir)NonShipping/</SymbolsArchiveLocation>
       <SymbolsArchiveLocation Condition="'$(GitHubRepositoryName)' == 'nuget-client' and '$(PackageOutputPath)' != ''">$([MSBuild]::EnsureTrailingSlash('$(PackageOutputPath)'))</SymbolsArchiveLocation>
       <SymbolsList>$([MSBuild]::NormalizePath('$(SymbolsArchiveLocation)', 'symbols.lst'))</SymbolsList>
       <SymbolsArchivePrefix>Symbols.</SymbolsArchivePrefix>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
@@ -84,6 +84,9 @@
       <InnerBuildArgs Condition="'$(DotNetPackageVersionPropsPath)' != ''">$(InnerBuildArgs) /p:DotNetPackageVersionPropsPath="$(DotNetPackageVersionPropsPath)"</InnerBuildArgs>
 
       <InnerBuildArgs>$(InnerBuildArgs) /p:FullAssemblySigningSupported=$(FullAssemblySigningSupported)</InnerBuildArgs>
+
+      <!-- We need to utilize publishing to copy packages, assets and manifest to shared source-build location. -->
+      <InnerBuildArgs>$(InnerBuildArgs) /p:DotNetPublishUsingPipelines=true</InnerBuildArgs>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadePublish.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadePublish.targets
@@ -3,23 +3,4 @@
 
   <Import Project="SourceBuildArcade.targets" />
 
-  <!--
-    If an inner source-build attempts to publish its packages, they could find their way onto a dev
-    feed and be used unintentionally by downstream repos and devs, or the duplicate packages could
-    break the build in a confusing way. This target should detect this and break the build in a
-    clear way, instead.
-
-    If this happens, it's likely caused by incompatible build scripts vs. the source-build job
-    template. Publish may need to be disabled in eng/DotNetBuild.props.
-  -->
-  <Target Name="EnsureSourceBuildInnerBuildDoesNotPublish"
-          Condition="'$(ArcadeInnerBuildFromSource)' == 'true' or '$(DotNetBuildInnerRepo)' == 'true'"
-          BeforeTargets="
-            Publish;
-            PublishSymbols;
-            PublishToSourceBuildStorage;
-            PublishToAzureDevOpsArtifacts">
-    <Error Text="Detected unexpected attempt by inner source-build to publish artifacts." />
-  </Target>
-
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.SourceBuild.Tasks" Version="$(MicrosoftDotNetSourceBuildTasksVersion)" IsImplicitlyDefined="true" />
+    <PackageReference Condition="'$(DotNetBuildInnerRepo)' == 'true' and '$(DotNetBuildFromSourceFlavor)' == 'Product' and '$(_ImportOrUseTooling)' != 'true'" Include="Microsoft.DotNet.Build.Tasks.Feed" Version="$(MicrosoftDotNetBuildTasksFeedVersion)" IsImplicitlyDefined="true" />
   </ItemGroup>
 
   <!-- Because the condition here is rather complex, it should read as the following:

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/GeneralTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/GeneralTests.cs
@@ -13,6 +13,7 @@ using Microsoft.DotNet.Build.Tasks.Feed.Model;
 using Microsoft.DotNet.Build.Tasks.Feed.Tests.TestDoubles;
 using Xunit;
 using static Microsoft.DotNet.Build.Tasks.Feed.GeneralUtils;
+using static Microsoft.DotNet.Build.CloudTestTasks.AzureStorageUtils;
 
 namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
 {
@@ -123,7 +124,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
 
             var httpClient = FakeHttpClient.WithResponses(response);
 
-            var result = await GeneralUtils.CompareLocalPackageToFeedPackage(
+            var result = await CompareLocalPackageToFeedPackage(
                 localPackagePath,
                 packageContentUrl,
                 httpClient,
@@ -164,7 +165,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
 
             var httpClient = FakeHttpClient.WithResponses(responses);
 
-            await GeneralUtils.CompareLocalPackageToFeedPackage(
+            await CompareLocalPackageToFeedPackage(
                 localPackagePath,
                 packageContentUrl,
                 httpClient,

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
@@ -18,6 +18,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using static Microsoft.DotNet.Build.Tasks.Feed.GeneralUtils;
+using static Microsoft.DotNet.Build.CloudTestTasks.AzureStorageUtils;
 using MsBuildUtils = Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.Build.Tasks.Feed.Tests

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PushToBuildStorageTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PushToBuildStorageTests.cs
@@ -12,7 +12,6 @@ using Microsoft.DotNet.VersionTools.BuildManifest.Model;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Moq;
-using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using System.Collections.Generic;
 using System.IO;
@@ -21,7 +20,7 @@ using Xunit;
 
 namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
 {
-    public class PushToAzureDevOpsArtifactsTests
+    public class PushToBuildStorageTests
     {
         private static string TARGET_MANIFEST_PATH = Path.Combine("C:", "manifests", "TestManifest.xml");
         private static string PACKAGE_A = Path.Combine("C:", "packages", "test-package-a.6.0.492.nupkg");
@@ -52,9 +51,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
             }),
         };
 
-        private PushToAzureDevOpsArtifacts ConstructPushToAzureDevOpsArtifactsTask(bool setAdditionalData = true)
+        private PushToBuildStorage ConstructPushToBuildStorageTask(bool setAdditionalData = true)
         {
-            var task = new PushToAzureDevOpsArtifacts
+            var task = new PushToBuildStorage
             {
                 BuildEngine = new MockBuildEngine(),
                 AssetManifestPath = TARGET_MANIFEST_PATH,                
@@ -200,7 +199,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
         public void HasRecordedPublishingVersion()
         {
             var expectedManifestContent = BuildExpectedManifestContent();
-            var task = ConstructPushToAzureDevOpsArtifactsTask(setAdditionalData: false);
+            var task = ConstructPushToBuildStorageTask(setAdditionalData: false);
             task.ItemsToPush = new TaskItem[0];
             task.IsStableBuild = false;
 
@@ -230,7 +229,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
             var publishingInfraVersion = "456";
             var expectedManifestContent = BuildExpectedManifestContent(
                 publishingInfraVersion: publishingInfraVersion);
-            var task = ConstructPushToAzureDevOpsArtifactsTask(setAdditionalData: false);
+            var task = ConstructPushToBuildStorageTask(setAdditionalData: false);
             task.ItemsToPush = new TaskItem[0];
             task.IsStableBuild = false;
             task.PublishingVersion = publishingInfraVersion;
@@ -265,7 +264,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                 isStable: true,
                 includePackages: true);
 
-            PushToAzureDevOpsArtifacts task = ConstructPushToAzureDevOpsArtifactsTask();
+            PushToBuildStorage task = ConstructPushToBuildStorageTask();
 
             // Mocks
             Mock<IFileSystem> fileSystemMock = new Mock<IFileSystem>();
@@ -279,11 +278,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
             IList<string> actualNupkgInfoPath = new List<string>();
             nupkgInfoFactoryMock.Setup(m => m.CreateNupkgInfo(PACKAGE_A)).Returns(new NupkgInfo(new PackageIdentity(
                 id: Path.GetFileNameWithoutExtension(PACKAGE_A),
-                version: new NuGetVersion(NUPKG_VERSION)
+                version: NUPKG_VERSION
             )));
             nupkgInfoFactoryMock.Setup(m => m.CreateNupkgInfo(PACKAGE_B)).Returns(new NupkgInfo(new PackageIdentity(
                 id: Path.GetFileNameWithoutExtension(PACKAGE_B),
-                version: new NuGetVersion(NUPKG_VERSION)
+                version: NUPKG_VERSION
             )));
 
             // Dependency Injection setup
@@ -306,7 +305,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
         [Fact]
         public void PublishFlatContainerManifest()
         {
-            PushToAzureDevOpsArtifacts task = ConstructPushToAzureDevOpsArtifactsTask();
+            PushToBuildStorage task = ConstructPushToBuildStorageTask();
             task.PublishFlatContainer = true;
 
             string expectedManifestContent = BuildExpectedManifestContent(
@@ -328,11 +327,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
             IList<string> actualNupkgInfoPath = new List<string>();
             nupkgInfoFactoryMock.Setup(m => m.CreateNupkgInfo(PACKAGE_A)).Returns(new NupkgInfo(new PackageIdentity(
                 id: Path.GetFileNameWithoutExtension(PACKAGE_A),
-                version: new NuGetVersion(NUPKG_VERSION)
+                version: NUPKG_VERSION
             )));
             nupkgInfoFactoryMock.Setup(m => m.CreateNupkgInfo(PACKAGE_B)).Returns(new NupkgInfo(new PackageIdentity(
                 id: Path.GetFileNameWithoutExtension(PACKAGE_B),
-                version: new NuGetVersion(NUPKG_VERSION)
+                version: NUPKG_VERSION
             )));
 
             // Dependency Injection setup
@@ -355,7 +354,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
         [Fact]
         public void IsNotStableBuildPath()
         {
-            PushToAzureDevOpsArtifacts task = ConstructPushToAzureDevOpsArtifactsTask();
+            PushToBuildStorage task = ConstructPushToBuildStorageTask();
             task.IsStableBuild = false;
 
             string expectedManifestContent = BuildExpectedManifestContent(
@@ -375,11 +374,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
             Mock<INupkgInfoFactory> nupkgInfoFactoryMock = new Mock<INupkgInfoFactory>();
             nupkgInfoFactoryMock.Setup(m => m.CreateNupkgInfo(PACKAGE_A)).Returns(new NupkgInfo(new PackageIdentity(
                 id: Path.GetFileNameWithoutExtension(PACKAGE_A),
-                version: new NuGetVersion(NUPKG_VERSION)
+                version: NUPKG_VERSION
             )));
             nupkgInfoFactoryMock.Setup(m => m.CreateNupkgInfo(PACKAGE_B)).Returns(new NupkgInfo(new PackageIdentity(
                 id: Path.GetFileNameWithoutExtension(PACKAGE_B),
-                version: new NuGetVersion(NUPKG_VERSION)
+                version: NUPKG_VERSION
             )));
 
             // Dependency Injection setup
@@ -402,7 +401,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
         [Fact]
         public void IsReleaseOnlyPackageVersionPath()
         {
-            PushToAzureDevOpsArtifacts task = ConstructPushToAzureDevOpsArtifactsTask();
+            PushToBuildStorage task = ConstructPushToBuildStorageTask();
             task.IsReleaseOnlyPackageVersion = true;
 
             string expectedManifestContent = BuildExpectedManifestContent(
@@ -425,11 +424,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
             IList<string> actualNupkgInfoPath = new List<string>();
             nupkgInfoFactoryMock.Setup(m => m.CreateNupkgInfo(PACKAGE_A)).Returns(new NupkgInfo(new PackageIdentity(
                 id: Path.GetFileNameWithoutExtension(PACKAGE_A),
-                version: new NuGetVersion(NUPKG_VERSION)
+                version: NUPKG_VERSION
             )));
             nupkgInfoFactoryMock.Setup(m => m.CreateNupkgInfo(PACKAGE_B)).Returns(new NupkgInfo(new PackageIdentity(
                 id: Path.GetFileNameWithoutExtension(PACKAGE_B),
-                version: new NuGetVersion(NUPKG_VERSION)
+                version: NUPKG_VERSION
             )));
 
             // Dependency Injection setup
@@ -453,7 +452,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
         [Fact]
         public void SigningInfoInManifest()
         {
-            PushToAzureDevOpsArtifacts task = ConstructPushToAzureDevOpsArtifactsTask();
+            PushToBuildStorage task = ConstructPushToBuildStorageTask();
             task.FileExtensionSignInfo = new ITaskItem[]
             {
                 new TaskItem(".dll", new Dictionary<string, string>
@@ -529,11 +528,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
             IList<string> actualNupkgInfoPath = new List<string>();
             nupkgInfoFactoryMock.Setup(m => m.CreateNupkgInfo(PACKAGE_A)).Returns(new NupkgInfo(new PackageIdentity(
                 id: "test-package-a",
-                version: new NuGetVersion(NUPKG_VERSION)
+                version: NUPKG_VERSION
             )));
             nupkgInfoFactoryMock.Setup(m => m.CreateNupkgInfo(PACKAGE_B)).Returns(new NupkgInfo(new PackageIdentity(
                 id: "test-package-b",
-                version: new NuGetVersion(NUPKG_VERSION)
+                version: NUPKG_VERSION
             )));
 
             // Dependency Injection setup
@@ -557,7 +556,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
         [Fact]
         public void AreDependenciesRegistered()
         {
-            PushToAzureDevOpsArtifacts task = new PushToAzureDevOpsArtifacts();
+            PushToBuildStorage task = new PushToBuildStorage();
 
             var collection = new ServiceCollection();
             task.ConfigureServices(collection);

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -7,17 +7,19 @@
     <DevelopmentDependency>true</DevelopmentDependency>
     <IsBuildTaskProject>true</IsBuildTaskProject>
     <PackageType>MSBuildSdk</PackageType>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
-    <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
+    <DefineConstants>$(DefineConstants);DOTNET_BUILD_SOURCE_ONLY</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" />
-    <PackageReference Include="Azure.Storage.Blobs" />
+    <PackageReference Include="Azure.Core" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
+    <PackageReference Include="Azure.Storage.Blobs" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" />
 
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
-    <PackageReference Include="Microsoft.SymbolUploader" />
+    <PackageReference Include="Microsoft.SymbolUploader" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
   </ItemGroup>
 
   <!-- Upgrade SymbolUploader's transitive NETStandard.Library dependency to avoid .NET Standard 1.x dependencies. -->
@@ -29,7 +31,7 @@
                       VersionOverride="2.0.3" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(DotNetBuildSourceOnly)' != 'true'">
     <!-- Maestro.Client stopped supporting .NET 4.7.2 long ago.
          This functionality should eventually be moved into an arcade-services package,
          but for users consuming other functionality we'll still support 4.7.2 by ifdefing it out. -->
@@ -42,12 +44,43 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Common\Microsoft.Arcade.Common\Microsoft.Arcade.Common.csproj" />
-    <ProjectReference Include="..\Microsoft.DotNet.Deployment.Tasks.Links\Microsoft.DotNet.Deployment.Tasks.Links.csproj" />
+    <ProjectReference Include="..\Microsoft.DotNet.Deployment.Tasks.Links\Microsoft.DotNet.Deployment.Tasks.Links.csproj" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
     <ProjectReference Include="..\Microsoft.DotNet.VersionTools\lib\Microsoft.DotNet.VersionTools.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\Common\Internal\EnumExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
+    <Compile Remove="src\AssetPublisherFactory.cs" />
+    <Compile Remove="src\AzureDevOpsArtifactFeed.cs" />
+    <Compile Remove="src\AzureDevOpsFeedPermission.cs" />
+    <Compile Remove="src\AzureDevOpsNugetFeedAssetPublisher.cs" />
+    <Compile Remove="src\AzureStorageAssetPublisher.cs" />
+    <Compile Remove="src\AzureStorageContainerAssetPublisher.cs" />
+    <Compile Remove="src\AzureStorageExtensions.cs" />
+    <Compile Remove="src\BlobFeedAction.cs" />
+    <Compile Remove="src\common\AssetComparer.cs" />
+    <Compile Remove="src\common\AzureConnectionStringBuildTask.cs" />
+    <Compile Remove="src\common\AzureStorageUtils.cs" />
+    <Compile Remove="src\common\CreateAzureContainer.cs" />
+    <Compile Remove="src\common\CreateAzureContainerIfNotExists.cs" />
+    <Compile Remove="src\common\CreateNewAzureContainer.cs" />
+    <Compile Remove="src\common\LatestLinksManager.cs" />
+    <Compile Remove="src\common\UploadToAzure.cs" />
+    <Compile Remove="src\model\PublishingConstants.cs" />
+    <Compile Remove="src\model\SetupTargetFeedConfigBase.cs" />
+    <Compile Remove="src\model\SetupTargetFeedConfigV3.cs" />
+    <Compile Remove="src\model\TargetChannelConfig.cs" />
+    <Compile Remove="src\model\TargetFeedConfig.cs" />
+    <Compile Remove="src\PublishArtifactsInManifest.cs" />
+    <Compile Remove="src\PublishArtifactsInManifestBase.cs" />
+    <Compile Remove="src\PublishArtifactsInManifestV3.cs" />
+    <Compile Remove="src\PublishSignedAssets.cs" />
+    <Compile Remove="src\PublishSymbolsHelper.cs" />
+    <Compile Remove="src\IAssetPublisher.cs" />
+    <Compile Remove="src\CreateAzureDevOpsFeed.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/build/Microsoft.DotNet.Build.Tasks.Feed.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/build/Microsoft.DotNet.Build.Tasks.Feed.targets
@@ -47,7 +47,7 @@
     <_MicrosoftDotNetBuildTasksFeedTaskDir Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)../tools/net9.0/</_MicrosoftDotNetBuildTasksFeedTaskDir>
   </PropertyGroup>
 
-  <UsingTask TaskName="PushToAzureDevOpsArtifacts" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
+  <UsingTask TaskName="PushToBuildStorage" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
   <UsingTask TaskName="PublishArtifactsInManifest" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
   <UsingTask TaskName="CreateAzureDevOpsFeed" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
   <UsingTask TaskName="PublishSignedAssets" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AzureStorageUtils.cs
@@ -8,6 +8,8 @@ using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using Azure.Storage.Sas;
 using Microsoft.Arcade.Common;
+using Microsoft.Build.Framework;
+using MsBuildUtils = Microsoft.Build.Utilities;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -32,6 +34,17 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
         {
             {".svg", "no-cache"}
         };
+
+        /// <summary>
+        ///  Enum describing the states of a given package on a feed
+        /// </summary>
+        public enum PackageFeedStatus
+        {
+            DoesNotExist,
+            ExistsAndIdenticalToLocal,
+            ExistsAndDifferent,
+            Unknown
+        }
 
         // Save the credential so we can sign SAS tokens
         private readonly StorageSharedKeyCredential _credential;
@@ -167,6 +180,125 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             }
 
             return headers;
+        }
+
+        /// <summary>
+        ///     Determine whether a local package is the same as a package on an AzDO feed.
+        /// </summary>
+        /// <param name="localPackageFullPath"></param>
+        /// <param name="packageContentUrl"></param>
+        /// <param name="client"></param>
+        /// <param name="log"></param>
+        /// <returns></returns>
+        /// <remarks>
+        ///     Open a stream to the local file and an http request to the package. There are a couple possibilities:
+        ///     - The returned headers include a content MD5 header, in which case we can
+        ///       hash the local file and just compare those.
+        ///     - No content MD5 hash, and the streams must be compared in blocks. This is a bit trickier to do efficiently,
+        ///       since we do not necessarily want to read all bytes if we can help it. Thus, we should compare in blocks.  However,
+        ///       the streams make no guarantee that they will return a full block each time when read operations are performed, so we
+        ///       must be sure to only compare the minimum number of bytes returned.
+        /// </remarks>
+        public static async Task<PackageFeedStatus> CompareLocalPackageToFeedPackage(
+            string localPackageFullPath,
+            string packageContentUrl,
+            HttpClient client,
+            MsBuildUtils.TaskLoggingHelper log)
+        {
+            return await CompareLocalPackageToFeedPackage(
+                localPackageFullPath,
+                packageContentUrl,
+                client,
+                log,
+                GeneralUtils.CreateDefaultRetryHandler());
+        }
+
+        /// <summary>
+        ///     Determine whether a local package is the same as a package on an AzDO feed.
+        /// </summary>
+        /// <param name="localPackageFullPath"></param>
+        /// <param name="packageContentUrl"></param>
+        /// <param name="client"></param>
+        /// <param name="log"></param>
+        /// <param name="retryHandler"></param>
+        /// <returns></returns>
+        /// <remarks>
+        ///     Open a stream to the local file and an http request to the package. There are a couple possibilities:
+        ///     - The returned headers include a content MD5 header, in which case we can
+        ///       hash the local file and just compare those.
+        ///     - No content MD5 hash, and the streams must be compared in blocks. This is a bit trickier to do efficiently,
+        ///       since we do not necessarily want to read all bytes if we can help it. Thus, we should compare in blocks.  However,
+        ///       the streams make no guarantee that they will return a full block each time when read operations are performed, so we
+        ///       must be sure to only compare the minimum number of bytes returned.
+        /// </remarks>
+        public static async Task<PackageFeedStatus> CompareLocalPackageToFeedPackage(
+            string localPackageFullPath,
+            string packageContentUrl,
+            HttpClient client,
+            MsBuildUtils.TaskLoggingHelper log,
+            IRetryHandler retryHandler)
+        {
+            log.LogMessage($"Getting package content from {packageContentUrl} and comparing to {localPackageFullPath}");
+
+            PackageFeedStatus result = PackageFeedStatus.Unknown;
+
+            bool success = await retryHandler.RunAsync(async attempt =>
+            {
+                try
+                {
+                    using (Stream localFileStream = File.OpenRead(localPackageFullPath))
+                    using (HttpResponseMessage response = await client.GetAsync(packageContentUrl))
+                    {
+                        response.EnsureSuccessStatusCode();
+
+                        // Check the headers for content length and md5 
+                        bool md5HeaderAvailable = response.Headers.TryGetValues("Content-MD5", out var md5);
+                        bool lengthHeaderAvailable = response.Headers.TryGetValues("Content-Length", out var contentLength);
+
+                        if (lengthHeaderAvailable && long.Parse(contentLength.Single()) != localFileStream.Length)
+                        {
+                            log.LogMessage(MessageImportance.Low, $"Package '{localPackageFullPath}' has different length than remote package '{packageContentUrl}'.");
+                            result = PackageFeedStatus.ExistsAndDifferent;
+                            return true;
+                        }
+
+                        if (md5HeaderAvailable)
+                        {
+                            var localMD5 = AzureStorageUtils.CalculateMD5(localPackageFullPath);
+                            if (!localMD5.Equals(md5.Single(), StringComparison.OrdinalIgnoreCase))
+                            {
+                                log.LogMessage(MessageImportance.Low, $"Package '{localPackageFullPath}' has different MD5 hash than remote package '{packageContentUrl}'.");
+                            }
+
+                            result = PackageFeedStatus.ExistsAndDifferent;
+                            return true;
+                        }
+
+                        const int BufferSize = 64 * 1024;
+
+                        // Otherwise, compare the streams
+                        var remoteStream = await response.Content.ReadAsStreamAsync();
+                        var streamsMatch = await GeneralUtils.CompareStreamsAsync(localFileStream, remoteStream, BufferSize);
+                        result = streamsMatch ? PackageFeedStatus.ExistsAndIdenticalToLocal : PackageFeedStatus.ExistsAndDifferent;
+                        return true;
+                    }
+                }
+                // String based comparison because the status code isn't exposed in HttpRequestException
+                // see here: https://github.com/dotnet/runtime/issues/23648
+                catch (Exception e) when (e is HttpRequestException || e is TaskCanceledException)
+                {
+                    if (e.Message.Contains("404 (Not Found)"))
+                    {
+                        result = PackageFeedStatus.DoesNotExist;
+                        return true;
+                    }
+
+                    // Retry this. Could be an http client timeout, 500, etc.
+                    return false;
+                }
+            });
+
+            return result;
         }
     }
 }

--- a/src/Microsoft.DotNet.VersionTools/Directory.Build.props
+++ b/src/Microsoft.DotNet.VersionTools/Directory.Build.props
@@ -2,10 +2,4 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)\.., Directory.Build.props))\Directory.Build.props" />
 
-  <!-- Don't include VersionTools in source-build until we find a reason to use it. -->
-  <PropertyGroup>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
-    <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
-  </PropertyGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/NupkgInfo.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/NupkgInfo.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using NuGet.Packaging.Core;
+using System;
 
 namespace Microsoft.DotNet.VersionTools.Automation
 {
@@ -10,14 +10,40 @@ namespace Microsoft.DotNet.VersionTools.Automation
         public NupkgInfo(PackageIdentity identity)
         {
             Id = identity.Id;
-            Version = identity.Version.ToString();
-            Prerelease = identity.Version.Release;
+            Version = identity.Version;
         }
 
         public string Id { get; }
         public string Version { get; }
-        public string Prerelease { get; }
+        public string Prerelease { get { throw new NotImplementedException();} }
 
         public static bool IsSymbolPackagePath(string path) => path.EndsWith(".symbols.nupkg");
+    }
+
+    public class PackageIdentity
+    {
+        private readonly string _id;
+        private readonly string _version;
+
+        public PackageIdentity(string id, string version)
+        {
+            if (id == null)
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+
+            _id = id;
+            _version = version;
+        }
+
+        public string Id
+        {
+            get { return _id; }
+        }
+
+        public string Version
+        {
+            get { return _version; }
+        }
     }
 }

--- a/src/Microsoft.DotNet.VersionTools/lib/src/Automation/NupkgInfoFactory.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/Automation/NupkgInfoFactory.cs
@@ -1,8 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using NuGet.Packaging;
-using NuGet.Packaging.Core;
+using System;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Xml.Linq;
 
 namespace Microsoft.DotNet.VersionTools.Automation
 {
@@ -22,10 +26,61 @@ namespace Microsoft.DotNet.VersionTools.Automation
 
         public NupkgInfo CreateNupkgInfo(string path)
         {
-            using PackageArchiveReader archiveReader = _packageArchiveReaderFactory.CreatePackageArchiveReader(path);
-            PackageIdentity identity = archiveReader.GetIdentity();
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
 
-            return new NupkgInfo(identity);
+            Stream stream = null;
+            Stream ZipReadStream = null;
+            ZipArchive _zipArchive;
+            try
+            {
+                stream = File.OpenRead(path);
+                ZipReadStream = stream;
+                _zipArchive = new ZipArchive(stream, ZipArchiveMode.Read);
+                string nuspecFile = Path.GetTempFileName();
+                foreach (ZipArchiveEntry entry in _zipArchive.Entries)
+                {
+                    if (entry.Name.EndsWith(".nuspec"))
+                    {
+                        Directory.CreateDirectory(Path.GetDirectoryName(nuspecFile));
+                        entry.ExtractToFile(nuspecFile, true);
+                    }
+                }
+
+                if (!File.Exists(nuspecFile))
+                {
+                    throw new InvalidDataException(string.Format(CultureInfo.CurrentCulture, "Did not extract nuspec file from package: {0}", path));
+                }
+
+                PackageIdentity identity = GetIdentity(nuspecFile);
+                return new NupkgInfo(identity);
+            }
+            catch (Exception ex)
+            {
+                stream?.Dispose();
+                throw new InvalidDataException(string.Format(CultureInfo.CurrentCulture, "Invalid package", path), ex);
+            }
+        }
+
+        private static PackageIdentity GetIdentity(string nuspecFile)
+        {
+            if (nuspecFile == null)
+            {
+                throw new ArgumentNullException(nameof(nuspecFile));
+            }
+
+            XDocument doc = XDocument.Load(nuspecFile, LoadOptions.PreserveWhitespace);
+            XElement metadataElement = GetSingleElement(doc.Root, "metadata");
+            return new PackageIdentity(GetSingleElement(metadataElement, "id").Value, GetSingleElement(metadataElement, "version").Value);
+        }   
+
+        private static XElement GetSingleElement(XElement el, string name)
+        {
+            return el.Descendants()
+                .Where(c => c.Name.LocalName.ToString() == name)
+                .ToArray().First();
         }
     }
 }

--- a/src/Microsoft.DotNet.VersionTools/tasks/Microsoft.DotNet.VersionTools.Tasks.csproj
+++ b/src/Microsoft.DotNet.VersionTools/tasks/Microsoft.DotNet.VersionTools.Tasks.csproj
@@ -7,6 +7,12 @@
     <PackageType>MSBuildSdk</PackageType>
   </PropertyGroup>
 
+  <!-- Don't include VersionTools.Tasks in source-build until we find a reason to use it. -->
+  <PropertyGroup>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Tasks.Core" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.VersionTools/tests/Microsoft.DotNet.VersionTools.Tests.csproj
+++ b/src/Microsoft.DotNet.VersionTools/tests/Microsoft.DotNet.VersionTools.Tests.csproj
@@ -4,6 +4,12 @@
     <TargetFramework>$(NetToolCurrent)</TargetFramework>
   </PropertyGroup>
 
+  <!-- Don't include VersionTools.Tests in source-build until we find a reason to use it. -->
+  <PropertyGroup>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Moq" />
     <PackageReference Include="FluentAssertions" />

--- a/src/Microsoft.DotNet.VersionTools/tools/Microsoft.DotNet.VersionTools.Cli.Tests/Microsoft.DotNet.VersionTools.Cli.Tests.csproj
+++ b/src/Microsoft.DotNet.VersionTools/tools/Microsoft.DotNet.VersionTools.Cli.Tests/Microsoft.DotNet.VersionTools.Cli.Tests.csproj
@@ -4,6 +4,12 @@
     <TargetFramework>$(NetToolCurrent)</TargetFramework>
   </PropertyGroup>
 
+  <!-- Don't include VersionTools.Cli.Tests in source-build until we find a reason to use it. -->
+  <PropertyGroup>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Moq" />
     <PackageReference Include="FluentAssertions" />

--- a/src/Microsoft.DotNet.VersionTools/tools/Microsoft.DotNet.VersionTools.Cli.Tests/VersionTrimmingOperationTests.cs
+++ b/src/Microsoft.DotNet.VersionTools/tools/Microsoft.DotNet.VersionTools.Cli.Tests/VersionTrimmingOperationTests.cs
@@ -4,7 +4,6 @@
 using FluentAssertions;
 using Microsoft.DotNet.VersionTools.Automation;
 using Moq;
-using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using System.IO;
 using System;
@@ -22,7 +21,7 @@ public class VersionTrimmingOperationTests
     {
         var nupkgInfoFactory = new Mock<INupkgInfoFactory>();
         nupkgInfoFactory.Setup(m => m.CreateNupkgInfo(It.IsAny<string>()))
-            .Returns(new NupkgInfo(new PackageIdentity("id", new NuGetVersion("8.0.0-dev"))));
+            .Returns(new NupkgInfo(new PackageIdentity("id", "8.0.0-dev")));
 
         var fileProxy = new Mock<IFileProxy>();
         fileProxy.Setup(m => m.Move(It.IsAny<string>(), It.IsAny<string>())).Verifiable();

--- a/src/Microsoft.DotNet.VersionTools/tools/Microsoft.DotNet.VersionTools.Cli/Microsoft.DotNet.VersionTools.Cli.csproj
+++ b/src/Microsoft.DotNet.VersionTools/tools/Microsoft.DotNet.VersionTools.Cli/Microsoft.DotNet.VersionTools.Cli.csproj
@@ -9,6 +9,12 @@
     <Description>This package provides a CLI interface to the Microsoft.DotNet.VersionTools library.</Description>
   </PropertyGroup>
 
+  <!-- Don't include VersionTools.Cli in source-build until we find a reason to use it. -->
+  <PropertyGroup>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\lib\Microsoft.DotNet.VersionTools.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/4101

Enables publishing to local build storage. It will be used in VMR and requires a new optional task parameter.

Some highlights:
- A bit of refactoring of some of `arcade` projects to enable building in source-only build
- Removal of NuGet.Packaging dependency and implementation of required APIs
- Exclusion of a set of sources in `Microsoft.DotNet.Build.Tasks.Feed` project
- Renaming of `PushToAzureDevOpsArtifacts` task to `PushToBuildStorage`

I've verified that regular repo build and source-build are working fine with these changes. I have also fully verified Windows and Linux VMR build Additional PRs for `installer` and other repos will follow soon.

Full set of VMR changes for my testing can be seen here: https://github.com/dotnet/dotnet/compare/d3e9fdb1..9ac3fddf