### PR TITLE
pass the template context through as a parameter to job.yml

### DIFF
--- a/eng/common/templates-official/job/job.yml
+++ b/eng/common/templates-official/job/job.yml
@@ -36,7 +36,7 @@ parameters:
   runAsPublic: false
 # Sbom related params
   enableSbom: true
-  PackageVersion: 9.0.0
+  PackageVersion: 7.0.0
   BuildDropPath: '$(Build.SourcesDirectory)/artifacts'
 
 jobs:

--- a/eng/common/templates-official/job/job.yml
+++ b/eng/common/templates-official/job/job.yml
@@ -15,6 +15,7 @@ parameters:
   timeoutInMinutes: ''
   variables: []
   workspace: ''
+  templateContext: ''
 
 # Job base template specific parameters
   # See schema documentation - https://github.com/dotnet/arcade/blob/master/Documentation/AzureDevOps/TemplateSchema.md
@@ -35,7 +36,7 @@ parameters:
   runAsPublic: false
 # Sbom related params
   enableSbom: true
-  PackageVersion: 7.0.0
+  PackageVersion: 9.0.0
   BuildDropPath: '$(Build.SourcesDirectory)/artifacts'
 
 jobs:
@@ -67,6 +68,9 @@ jobs:
 
   ${{ if ne(parameters.timeoutInMinutes, '') }}:
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+
+  ${{ if ne(parameters.templateContext, '') }}:
+    templateContext: ${{ parameters.templateContext }}
 
   variables:
   - ${{ if ne(parameters.enableTelemetry, 'false') }}:

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -15,6 +15,7 @@ parameters:
   timeoutInMinutes: ''
   variables: []
   workspace: ''
+  templateContext: ''
 
 # Job base template specific parameters
   # See schema documentation - https://github.com/dotnet/arcade/blob/master/Documentation/AzureDevOps/TemplateSchema.md
@@ -67,6 +68,9 @@ jobs:
 
   ${{ if ne(parameters.timeoutInMinutes, '') }}:
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+
+  ${{ if ne(parameters.templateContext, '') }}:
+    timeoutInMinutes: ${{ parameters.templateContext }}
 
   variables:
   - ${{ if ne(parameters.enableTelemetry, 'false') }}:

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -70,7 +70,7 @@ jobs:
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
 
   ${{ if ne(parameters.templateContext, '') }}:
-    timeoutInMinutes: ${{ parameters.templateContext }}
+    templateContext: ${{ parameters.templateContext }}
 
   variables:
   - ${{ if ne(parameters.enableTelemetry, 'false') }}:


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/14561

We need to pass the template context around to the job template so that it gets preserved, just like we pass the pool and other job schema properties.

I'm using this vstest build to validate, as they were the repo that had the initial reports: https://dev.azure.com/dnceng/internal/_build/results?buildId=2398161&view=results

This build uploaded the missing artifacts from https://dev.azure.com/dnceng/internal/_build/results?buildId=2396988&view=results

I added it to the non-official templates as well, for the most part because why not.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
