### PR TITLE
Use the 1ES publishing tasks in some missed places in templates-official job.yml

### DIFF
--- a/eng/common/templates-official/job/job.yml
+++ b/eng/common/templates-official/job/job.yml
@@ -202,9 +202,11 @@ jobs:
         continueOnError: true
         condition: always()
     - ${{ if and(ne(parameters.artifacts.publish.logs, 'false'), ne(parameters.artifacts.publish.logs, '')) }}:
-      - publish: artifacts/log
-        artifact: ${{ coalesce(parameters.artifacts.publish.logs.name, 'Logs_Build_$(Agent.Os)_$(_BuildConfig)') }}
-        displayName: Publish logs
+      - task: 1ES.PublishPipelineArtifact@1
+        inputs:
+          targetPath: 'artifacts/log'
+          artifactName: ${{ coalesce(parameters.artifacts.publish.logs.name, 'Logs_Build_$(Agent.Os)_$(_BuildConfig)') }}
+        displayName: 'Publish logs'
         continueOnError: true
         condition: always()
 
@@ -249,7 +251,9 @@ jobs:
         IgnoreDirectories: ${{ parameters.componentGovernanceIgnoreDirectories }}
 
   - ${{ if eq(parameters.enableBuildRetry, 'true') }}:
-    - publish: $(Build.SourcesDirectory)\eng\common\BuildConfiguration
-      artifact: BuildConfiguration
-      displayName: Publish build retry configuration
+    - task: 1ES.PublishPipelineArtifact@1
+      inputs:
+        targetPath: '$(Build.SourcesDirectory)\eng\common\BuildConfiguration'
+        artifactName: 'BuildConfiguration'
+      displayName: 'Publish build retry configuration'
       continueOnError: true


### PR DESCRIPTION
https://github.com/dotnet/dnceng/issues/2133

The `- publish:` steps that are shortcuts to the publish pipeline artifact task were not converted.

I'm working on getting a test build of these changes (I need a better process for this... at this rate maybe it makes sense to convert arcade just to speed up testing) and I will share one as soon as I have it.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
