### PR TITLE
Fix parameter is SetupNugetSources.ps1

### DIFF
--- a/eng/common/SetupNugetSources.ps1
+++ b/eng/common/SetupNugetSources.ps1
@@ -49,7 +49,7 @@ function AddPackageSource($sources, $SourceName, $SourceEndPoint, $creds, $Usern
         Write-Host "Package source $SourceName already present."
     }
     
-    AddCredential -Creds $creds -Source $SourceName -Username $Username -Password $pwd
+    AddCredential -Creds $creds -Source $SourceName -Username $Username -pwd $pwd
 }
 
 # Add a credential node for the specified source


### PR DESCRIPTION
In https://github.com/dotnet/arcade/pull/14575, the parameter names for passing the password throughout the script was updated, however the update was missing in one spot. This causes the script to write out a NuGet.config file with an empty ClearTextPassword element for each internal package source, which causes the build to fail to restore packages.

Solution: Fix the parameter name as was probably intended.

Example build before fix: https://dev.azure.com/dnceng/internal/_build/results?buildId=2403320&view=logs&j=94b1a9ad-e96b-5df4-5900-c39f457667ac&t=db3a3ac7-6687-5db1-489e-990ffa8993fd
Example build after fix: https://dev.azure.com/dnceng/internal/_build/results?buildId=2403499&view=logs&j=72d43973-3b3f-5307-5f5e-867d00ab57b3&t=29a15da8-fa15-5b51-327c-19a5c7a83931
Fix diff for built branches: https://dev.azure.com/dnceng/internal/_git/dotnet-dotnet-monitor/branchCompare?baseVersion=GBbackport-6232-to-6.x&targetVersion=GBbackport-6232-to-6.x-fix&_a=files

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
