### PR TITLE
Fix sbom generation in publish-build-assets.yml

### DIFF
--- a/eng/common/templates-official/job/publish-build-assets.yml
+++ b/eng/common/templates-official/job/publish-build-assets.yml
@@ -107,7 +107,7 @@ jobs:
     - task: 1ES.PublishBuildArtifacts@1
       displayName: Publish ReleaseConfigs Artifact
       inputs:
-        PathtoPublish: '$(Build.StagingDirectory)/ReleaseConfigs.txt'
+        PathtoPublish: '$(Build.StagingDirectory)/ReleaseConfigs'
         PublishLocation: Container
         ArtifactName: ReleaseConfigs
 

--- a/eng/common/templates-official/job/publish-build-assets.yml
+++ b/eng/common/templates-official/job/publish-build-assets.yml
@@ -98,9 +98,11 @@ jobs:
       inputs:
         targetType: inline
         script: |
-          Add-Content -Path "$(Build.StagingDirectory)/ReleaseConfigs.txt" -Value $(BARBuildId)
-          Add-Content -Path "$(Build.StagingDirectory)/ReleaseConfigs.txt" -Value "$(DefaultChannels)"
-          Add-Content -Path "$(Build.StagingDirectory)/ReleaseConfigs.txt" -Value $(IsStableBuild)
+          New-Item -Path "$(Build.StagingDirectory)/ReleaseConfigs" -ItemType Directory -Force
+          $filePath = "$(Build.StagingDirectory)/ReleaseConfigs/ReleaseConfigs.txt"
+          Add-Content -Path $filePath -Value $(BARBuildId)
+          Add-Content -Path $filePath -Value "$(DefaultChannels)"
+          Add-Content -Path $filePath -Value $(IsStableBuild)
     
     - task: 1ES.PublishBuildArtifacts@1
       displayName: Publish ReleaseConfigs Artifact


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/14560

The pipeline templates expect a directory for their upload tasks instead of a file for the automatic scans to all succeed, so stick this file in its own directory and upload that.

Used my trusty symreader branch to test this fixes the error: https://dev.azure.com/dnceng/internal/_build/results?buildId=2403481&view=results

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
