### PR TITLE
Update Publish.proj

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -175,8 +175,8 @@
 
     <ItemGroup>
       <ItemsToPushToBlobFeed>
-        <ManifestArtifactData Condition="'%(IsShipping)' != 'true'">NonShipping=true</ManifestArtifactData>
-        <ManifestArtifactData Condition="'%(IsShipping)' == 'true' and '$(ProducesDotNetReleaseShippingAssets)' == 'true'">DotNetReleaseShipping=true</ManifestArtifactData>
+        <ManifestArtifactData Condition="'%(ItemsToPushToBlobFeed.IsShipping)' != 'true'">NonShipping=true</ManifestArtifactData>
+        <ManifestArtifactData Condition="'%(ItemsToPushToBlobFeed.IsShipping)' == 'true' and '$(ProducesDotNetReleaseShippingAssets)' == 'true'">DotNetReleaseShipping=true</ManifestArtifactData>
       </ItemsToPushToBlobFeed>
     </ItemGroup>
 


### PR DESCRIPTION
Fixes

> .packages\microsoft.dotnet.arcade.sdk\9.0.0-beta.24168.1\tools\Publish.proj(176,5): error MSB4096: (NETCORE_ENGINEERING_TELEMETRY=Publish) The item "D:\a\_work\1\s\.packages\Microsoft.FSharp.Compiler\12.8.300-beta.24168.9\contentFiles\Shipping\FSharp.Core.8.0.300-beta.24168.9.nupkg" in item list "ItemsToPushToBlobFeed" does not define a value for metadata "IsShipping".  In order to use this metadata, either qualify it by specifying %(ItemsToPushToBlobFeed.IsShipping), or ensure that all items in this list define a value for this metadata.