### PR TITLE
Add Artifact repo extension point to Sign and Publish

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -17,7 +17,7 @@
       DotNetSymbolServerTokenSymWeb     Personal access token for SymWeb symbol server. Available from variable group DotNet-Symbol-Server-Pats.
       DotNetSymbolExpirationInDays      Symbol expiration time in days (defaults to 10 years).
       SkipPackageChecks                 Skips package safety checks.
-      EnableDefaultItems                Includes all packages under "/artifacts/packages" to publish. Defaults to true.
+      EnableDefaultArtifacts            Includes all packages under "/artifacts/packages" to publish. Defaults to true.
   -->
 
   <Import Project="BuildStep.props" />
@@ -75,7 +75,7 @@
           DependsOnTargets="$(PublishDependsOnTargets)" />
 
   <Target Name="BeforePublish">
-    <ItemGroup Condition="'$(EnableDefaultItems)' == 'true'">
+    <ItemGroup Condition="'$(EnableDefaultArtifacts)' == 'true'">
       <ExistingSymbolPackages Include="$(ArtifactsShippingPackagesDir)**/*.symbols.nupkg" IsShipping="true" />
       <ExistingSymbolPackages Include="$(ArtifactsNonShippingPackagesDir)**/*.symbols.nupkg" IsShipping="false" />
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -17,7 +17,7 @@
       DotNetSymbolServerTokenSymWeb     Personal access token for SymWeb symbol server. Available from variable group DotNet-Symbol-Server-Pats.
       DotNetSymbolExpirationInDays      Symbol expiration time in days (defaults to 10 years).
       SkipPackageChecks                 Skips package safety checks.
-      EnableDefaultPublishItems         Includes all packages under "/artifacts/packages". Defaults to true.
+      EnableDefaultItems                Includes all packages under "/artifacts/packages" to publish. Defaults to true.
   -->
 
   <Import Project="BuildStep.props" />
@@ -30,6 +30,8 @@
   <PropertyGroup Condition="'$(DotNetBuildPhase)' == 'InnerRepo' and '$(DotNetBuildOrchestrator)' == 'true'">
     <PushToLocalStorage>true</PushToLocalStorage>
   </PropertyGroup>
+
+  <Import Project="Sign.props" />
 
   <!-- Allow for repo specific Publish properties such as add additional files to be published -->
   <Import Project="$(RepositoryEngineeringDir)Publishing.props" Condition="Exists('$(RepositoryEngineeringDir)Publishing.props')" />
@@ -64,8 +66,6 @@
     <PublishDependsOnTargets Condition="$(DotNetPublishUsingPipelines)">$(PublishDependsOnTargets);PublishToAzureDevOpsArtifacts</PublishDependsOnTargets>
 
     <PublishDependsOnTargets>BeforePublish;$(PublishDependsOnTargets)</PublishDependsOnTargets>
-
-    <EnableDefaultPublishItems Condition="'$(EnableDefaultPublishItems)' == ''">true</EnableDefaultPublishItems>
   </PropertyGroup>
 
   <Import Project="$(NuGetPackageRoot)microsoft.dotnet.build.tasks.feed\$(MicrosoftDotNetBuildTasksFeedVersion)\build\Microsoft.DotNet.Build.Tasks.Feed.targets"/>
@@ -75,12 +75,18 @@
           DependsOnTargets="$(PublishDependsOnTargets)" />
 
   <Target Name="BeforePublish">
-    <ItemGroup Condition="'$(EnableDefaultPublishItems)' == 'true'">
+    <ItemGroup Condition="'$(EnableDefaultItems)' == 'true'">
       <ExistingSymbolPackages Include="$(ArtifactsShippingPackagesDir)**/*.symbols.nupkg" IsShipping="true" />
       <ExistingSymbolPackages Include="$(ArtifactsNonShippingPackagesDir)**/*.symbols.nupkg" IsShipping="false" />
 
       <PackagesToPublish Include="$(ArtifactsShippingPackagesDir)**/*.nupkg" IsShipping="true" />
       <PackagesToPublish Include="$(ArtifactsNonShippingPackagesDir)**/*.nupkg" IsShipping="false" />
+    </ItemGroup>
+
+    <!-- Respect Artifact item repo extension point for packages -->
+    <ItemGroup Condition="'@(Artifact)' != ''">
+      <ExistingSymbolPackages Include="@(Artifact)" Condition="$([System.String]::Copy('%(Filename)%(Extension)').EndsWith('.symbols.nupkg'))" />
+      <PackagesToPublish Include="@(Artifact)" Condition="$([System.String]::Copy('%(Filename)%(Extension)').EndsWith('.nupkg'))" />
     </ItemGroup>
 
     <ItemGroup>
@@ -171,6 +177,11 @@
       <ManifestBuildData Include="AzureDevOpsBuildNumber=$(BUILD_BUILDNUMBER)" />
       <ManifestBuildData Include="AzureDevOpsRepository=$(BUILD_REPOSITORY_URI)" />
       <ManifestBuildData Include="AzureDevOpsBranch=$(BUILD_SOURCEBRANCH)" />
+    </ItemGroup>
+
+    <!-- Respect Artifact item repo extension point for blob items (non packages). -->
+    <ItemGroup>
+      <ItemsToPushToBlobFeed Include="@(Artifact->WithMetadataValue('PublishFlatContainer', 'true'))" />
     </ItemGroup>
 
     <ItemGroup>
@@ -301,8 +312,6 @@
                     PdbConversionTreatAsWarning=""
                     Condition="$(PublishToSymbolServer)"/>
   </Target>
-
-  <Import Project="Sign.props" />
 
   <!-- Update sign infos that were using Microsoft400 to use the .NET-specific cert if UseDotNetCertificate is present.
        This will update any use, even if explicitly specified.

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -1,6 +1,11 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
+  <PropertyGroup>
+    <!-- By default, search for sign aritfacts under the list of known directories. -->
+    <EnableDefaultItems>true</EnableDefaultItems>
+  </PropertyGroup>
+
   <ItemGroup>
     <!--
       This is intended to hold information about the certificates used for signing.
@@ -9,7 +14,9 @@
     -->
     <CertificatesSignInfo Include="3PartyDual" DualSigningAllowed="true" />
     <CertificatesSignInfo Include="3PartySHA2" DualSigningAllowed="true" />
+  </ItemGroup>
 
+  <ItemGroup Condition="'$(EnableDefaultItems)' == 'true'">
     <!-- List of container files that will be opened and checked for files that need to be signed. -->
     <_DefaultItemsToSign Include="$(ArtifactsPackagesDir)**\*.nupkg" />
     <_DefaultItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.vsix" />
@@ -21,7 +28,9 @@
     <ItemsToSign Include="@(_DefaultItemsToSign)" Condition="'$(PostBuildSign)' != 'true'" />
     <ItemsToSignPostBuild Include="@(_DefaultItemsToSign->'%(Filename)%(Extension)')" Condition="'$(PostBuildSign)' == 'true'" />
     <ItemsToSignPostBuild Include="@(_ItemsToOnlySignPostBuild->'%(Filename)%(Extension)')" Condition="'$(PostBuildSign)' == 'true'" />
+  </ItemGroup>
 
+  <ItemGroup>
     <!-- Default certificate/strong-name to be used for all files with PKT=="31bf3856ad364e35". -->
     <StrongNameSignInfo Include="MsSharedLib72" PublicKeyToken="31bf3856ad364e35" CertificateName="Microsoft400" />
     <StrongNameSignInfo Include="SilverlightCert121" PublicKeyToken="7cec85d7bea7798e" CertificateName="Microsoft400" />
@@ -76,5 +85,19 @@
 
   <!-- Allow repository to customize signing configuration -->
   <Import Project="$(RepositoryEngineeringDir)Signing.props" Condition="Exists('$(RepositoryEngineeringDir)Signing.props')" />
+
+  <!-- Respect Artifact item repo extension point -->
+  <ItemGroup Condition="'@(Artifact)' != ''">
+    <!-- Sign wixpacks to correspond to msi/exe signing -->
+    <_ItemsToOnlySignPostBuild Include="@(Artifact)"
+                               Condition="$([System.String]::Copy('%(Filename)%(Extension)').EndsWith('.wixpack.zip'))" />
+
+    <!-- If PostBuildSign == true, these are added to ItemsToSignPostBuild, otherwise these are added to ItemsToSign -->
+    <ItemsToSign Include="@(Artifact)"
+                 Exclude="@(_ItemsToOnlySignPostBuild)"
+                 Condition="'$(PostBuildSign)' != 'true'" />
+    <ItemsToSignPostBuild Include="@(Artifact->'%(Filename)%(Extension)')"
+                          Condition="'$(PostBuildSign)' == 'true'" />
+  </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <!-- By default, search for sign aritfacts under the list of known directories. -->
-    <EnableDefaultItems>true</EnableDefaultItems>
+    <EnableDefaultArtifacts>true</EnableDefaultArtifacts>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,7 +16,7 @@
     <CertificatesSignInfo Include="3PartySHA2" DualSigningAllowed="true" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(EnableDefaultItems)' == 'true'">
+  <ItemGroup Condition="'$(EnableDefaultArtifacts)' == 'true'">
     <!-- List of container files that will be opened and checked for files that need to be signed. -->
     <_DefaultItemsToSign Include="$(ArtifactsPackagesDir)**\*.nupkg" />
     <_DefaultItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.vsix" />


### PR DESCRIPTION
When repositories don't want to publish the default set of artifacts that are globbed, they need to align the items that are (post build) signed and published. To make easily possible, add an `Artifact` item extension point that is respected in both Sign.proj and Publish.proj.

Also rename the previous EnableDefaultPublishItems to EnableDefaultItems as it now applies to both signing and publishing.

Import Sign.props earlier so that Publishing.props (repo file) can use its properties and items outside of targets.

---

I'm not yet documenting the `Artifact` extension point as I first want to add checksum generation support directly in Publish.proj (follow-up PR) which adds metadata to that item.

Required for https://github.com/dotnet/windowsdesktop/pull/4268