### PR TITLE
Update Sign and Publish doc and default

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -208,10 +208,9 @@
       <ManifestBuildData Include="AzureDevOpsBranch=$(BUILD_SOURCEBRANCH)" />
     </ItemGroup>
 
-    <!-- Respect Artifact item repo extension point for blob items (non packages). -->
+    <!-- Add non-package Artifact items (repo extension point) as package already got added in the BeforePublish target. -->
     <ItemGroup>
-      <ItemsToPushToBlobFeed Include="@(Artifact)"
-                             Condition="'%(Artifact.SkipPublish)' != 'true' and '%(Extension)' != '.nupkg'" />
+      <ItemsToPushToBlobFeed Include="@(Artifact)" Condition="'%(Artifact.SkipPublish)' != 'true' and '%(Extension)' != '.nupkg'" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -1,11 +1,6 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project DefaultTargets="Publish">
 
-  <PropertyGroup>
-    <!-- Disable target framework filtering for top level projects -->
-    <NoTargetFrameworkFiltering>true</NoTargetFrameworkFiltering>
-  </PropertyGroup>
-
   <!--
     Documentation for publishing is available here:
       - https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Publishing.md
@@ -21,11 +16,23 @@
     
     Optional items:
       Artifact (with Metadata)          Path to the artifact to publish. Declare the item in Signing.props to sign and publish the artifact.
-        - RelativeBlobPath                The relative blob path when PublishFlatContainer is true.
-        - ChecksumPath                    The destination path to generate a checksum file for the artifact. Make sure to set the `RelativeBlobPathParent`
-                                          property so that the RelativeBlobPath for the generate checksum can be calculated.
-        - PublishFlatContainer            If true, publishes to blob artifacts, otherwise package artifacts.
+        - ChecksumPath                    The destination path to generate a checksum file for the artifact. Set the `RelativeBlobPathParent`
+                                          property if the RelativeBlobPath for the generate checksum should be automatically set.
+        - PublishFlatContainer            By default artifacts are published to blob artifacts. Set to false to publish to package artifacts.
+        - RelativeBlobPath                The relative blob path when publishing to blob artifacts.
+        - IsShipping                      Set to true to mark a package as shipping when publishing to package artifacts. Defaults to false.
   -->
+
+  <PropertyGroup>
+    <!-- Disable target framework filtering for top level projects -->
+    <NoTargetFrameworkFiltering>true</NoTargetFrameworkFiltering>
+  </PropertyGroup>
+
+  <ItemDefinitionGroup>
+    <Artifact>
+      <PublishFlatContainer>true</PublishFlatContainer>
+    </Artifact>
+  </ItemDefintionGroup>
 
   <Import Project="BuildStep.props" />
 
@@ -95,7 +102,7 @@
     <!-- Respect Artifact item repo extension point for packages -->
     <ItemGroup Condition="'@(Artifact)' != ''">
       <ExistingSymbolPackages Include="@(Artifact)" Condition="'%(Artifact.SkipPublish)' != 'true' and $([System.String]::Copy('%(Filename)%(Extension)').EndsWith('.symbols.nupkg'))" />
-      <PackagesToPublish Include="@(Artifact)" Condition="'%(Artifact.SkipPublish)' != 'true' and $([System.String]::Copy('%(Filename)%(Extension)').EndsWith('.nupkg'))" />
+      <PackagesToPublish Include="@(Artifact)" Condition="'%(Artifact.SkipPublish)' != 'true' and '%(Extension)' == '.nupkg'" />
     </ItemGroup>
 
     <ItemGroup>
@@ -119,11 +126,9 @@
 
     <!-- Include Symbols.<repo>.tar.gz, if running in inner source-only build -->
     <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetBuildInnerRepo)' == 'true'">
-      <UnifiedSymbolsPackage Include="$(ArtifactsNonShippingPackagesDir)Symbols.*.tar.gz" IsShipping="false" />
-      <PackagesToPublish Include="@(UnifiedSymbolsPackage)">
-        <PublishFlatContainer>true</PublishFlatContainer>
-        <RelativeBlobPath>Symbols/%(Filename)%(Extension)</RelativeBlobPath>
-      </PackagesToPublish>
+      <UnifiedSymbolsPackage Include="$(ArtifactsNonShippingPackagesDir)Symbols.*.tar.gz" />
+      <Artifact Include="@(UnifiedSymbolsPackage)"
+                RelativeBlobPath="Symbols/%(Filename)%(Extension)" />
     </ItemGroup>
 
     <!--
@@ -212,7 +217,7 @@
     <!-- Respect Artifact item repo extension point for blob items (non packages). -->
     <ItemGroup>
       <ItemsToPushToBlobFeed Include="@(Artifact)"
-                             Condition="'%(Artifact.SkipPublish)' != 'true' and '%(Artifact.PublishFlatContainer)' == 'true'" />
+                             Condition="'%(Artifact.SkipPublish)' != 'true' and '%(Extension)' != '.nupkg'" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -28,12 +28,6 @@
     <NoTargetFrameworkFiltering>true</NoTargetFrameworkFiltering>
   </PropertyGroup>
 
-  <ItemDefinitionGroup>
-    <Artifact>
-      <PublishFlatContainer>true</PublishFlatContainer>
-    </Artifact>
-  </ItemDefintionGroup>
-
   <Import Project="BuildStep.props" />
 
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GenerateChecksums" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -1,11 +1,6 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project DefaultTargets="Sign">
 
-  <PropertyGroup>
-    <!-- Disable target framework filtering for top level projects -->
-    <NoTargetFrameworkFiltering>true</NoTargetFrameworkFiltering>
-  </PropertyGroup>
-
   <!--
     Documentation for publishing is available here:
       - https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Signing.md
@@ -23,6 +18,11 @@
         - IsShipping                      Set to true to mark a package as shipping when publishing to package artifacts. Defaults to false.
         - SkipPublish                     If true, skips publishing the artifact.
   -->
+
+  <PropertyGroup>
+    <!-- Disable target framework filtering for top level projects -->
+    <NoTargetFrameworkFiltering>true</NoTargetFrameworkFiltering>
+  </PropertyGroup>
 
   <Import Project="BuildStep.props" />
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -13,14 +13,15 @@
     Optional variables:
       EnableDefaultArtifacts            Includes *.nupkg, *.vsix and *.wixpack.zip under "/artifacts/packages/**" for sigining.
                                         Defaults to true.
-    
+
     Optional items:
-      Artifact (with Metadata)          Path to the artifact to publish. Can be set in Signing.props to sign and publish the artifact.
-        - RelativeBlobPath              The relative blob path when PublishFlatContainer is true.
-        - ChecksumPath                  The destination path to generate a checksum file for the artifact. Make sure to also set the
-                                        `RelativeBlobPathParent` property so that the RelativeBlobPath can be calculated.
-        - PublishFlatContainer          If true, publishes to blob artifacts, otherwise package artifacts.
-        - SkipPublish                   If true, skips publishing the artifact.
+      Artifact (with Metadata)          Path to the artifact to publish. Declare the item in Signing.props to sign and publish the artifact.
+        - ChecksumPath                    The destination path to generate a checksum file for the artifact. Set the `RelativeBlobPathParent`
+                                          property if the RelativeBlobPath for the generate checksum should be automatically set.
+        - PublishFlatContainer            By default artifacts are published to blob artifacts. Set to false to publish to package artifacts.
+        - RelativeBlobPath                The relative blob path when publishing to blob artifacts.
+        - IsShipping                      Set to true to mark a package as shipping when publishing to package artifacts. Defaults to false.
+        - SkipPublish                     If true, skips publishing the artifact.
   -->
 
   <Import Project="BuildStep.props" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -6,7 +6,7 @@
     <EnableDefaultArtifacts>true</EnableDefaultArtifacts>
   </PropertyGroup>
 
-  <!-- Repo extension point to sign and publish. PublishFlatcontainer defaults to true for Artifacts. -->
+  <!-- Repo extension point to sign and/or publish. PublishFlatcontainer defaults to true for Artifact items. -->
   <ItemDefinitionGroup>
     <Artifact>
       <PublishFlatContainer>true</PublishFlatContainer>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -11,7 +11,7 @@
     <Artifact>
       <PublishFlatContainer>true</PublishFlatContainer>
     </Artifact>
-  </ItemDefintionGroup>
+  </ItemDefinitionGroup>
 
   <ItemGroup>
     <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -6,6 +6,13 @@
     <EnableDefaultArtifacts>true</EnableDefaultArtifacts>
   </PropertyGroup>
 
+  <!-- Repo extension point to sign and publish. PublishFlatcontainer defaults to true for Artifacts. -->
+  <ItemDefinitionGroup>
+    <Artifact>
+      <PublishFlatContainer>true</PublishFlatContainer>
+    </Artifact>
+  </ItemDefintionGroup>
+
   <ItemGroup>
     <!--
       This is intended to hold information about the certificates used for signing.


### PR DESCRIPTION
PublishFlatContainer should be the default when using the `Artifact` extension point.

Just tested locally, no syntax errors :D

This needs reaction in windowsdesktop and deployment-tools.