### PR TITLE
[Release/6.0] Fix broken devdiv image use in templates-official

### DIFF
--- a/eng/common/templates-official/post-build/post-build.yml
+++ b/eng/common/templates-official/post-build/post-build.yml
@@ -137,6 +137,7 @@ stages:
         # We don't use the collection uri here because it might vary (.visualstudio.com vs. dev.azure.com)
         ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
           name: AzurePipelines-EO
+          image: 1ESPT-Windows2022
           demands: Cmd
           os: windows
         # If it's not devdiv, it's dnceng
@@ -251,6 +252,7 @@ stages:
       # We don't use the collection uri here because it might vary (.visualstudio.com vs. dev.azure.com)
         ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
           name: AzurePipelines-EO
+          image: 1ESPT-Windows2022
           demands: Cmd
           os: windows
         # If it's not devdiv, it's dnceng


### PR DESCRIPTION
### To double check:
https://github.com/dotnet/arcade/issues/14651

Fixes the devdiv pool usage for this branch. These were the only instances I could find where we were not passing the image through.

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
