### PR TITLE
Use NetCore1ESPool-Publishing-Internal pool for publishing

### DIFF
--- a/eng/common/templates-official/job/publish-build-assets.yml
+++ b/eng/common/templates-official/job/publish-build-assets.yml
@@ -60,8 +60,8 @@ jobs:
       os: windows
     # If it's not devdiv, it's dnceng
     ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
-      name: $(DncEngInternalBuildPool)
-      image: 1es-windows-2022-pt
+      name: NetCore1ESPool-Publishing-Internal
+      image: windows.vs2019.amd64
       os: windows
   steps:
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/common/templates-official/post-build/post-build.yml
+++ b/eng/common/templates-official/post-build/post-build.yml
@@ -261,8 +261,8 @@ stages:
           os: windows
         # If it's not devdiv, it's dnceng
         ${{ else }}:
-          name: $(DncEngInternalBuildPool)
-          image: 1es-windows-2022-pt
+          name: NetCore1ESPool-Publishing-Internal
+          image: windows.vs2019.amd64
           os: windows
       steps:
         - template: setup-maestro-vars.yml


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/14603

Now that this pool and image support the templates, we can move this back to using them.

Test build at: https://dev.azure.com/dnceng/internal/_build/results?buildId=2417256&view=results

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
