### PR TITLE
Extend RunTests target condition to also check that there are no tests to run

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VSTest.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VSTest.targets
@@ -3,7 +3,7 @@
 
   <Target Name="RunTests"
           Outputs="%(TestToRun.ResultsStdOutPath)"
-          Condition="'$(SkipTests)' != 'true'">
+          Condition="'$(SkipTests)' != 'true' and '@(TestToRun)' != ''">
     <PropertyGroup>
       <_TestEnvironment>%(TestToRun.EnvironmentDisplay)</_TestEnvironment>
       <_TestAssembly>%(TestToRun.Identity)</_TestAssembly>


### PR DESCRIPTION
In the dotnet/maintenance-packages repo, [the CI is failing](https://dev.azure.com/dnceng-public/public/_build/results?buildId=618358&view=logs&j=ec685536-f43b-5a9a-92ff-89175ccc3932&t=1f5934e1-94d3-500b-1b02-b1064dab718f&l=135) unexpectedly attempting to execute .NET Framework unit tests in Unix, even though we properly set the `SkipTests` property to `true`. This is happening when using `dotnet build -t:test`. The error output looks like this:

```
/home/carlos/.nuget/packages/microsoft.dotnet.arcade.sdk/8.0.0-beta.24165.4/tools/VSTest.targets(46,5): error MSB3073: The command "echo === COMMAND LINE === >  [/home/carlos/maintenance-packages/src/System.Runtime.CompilerServices.Unsafe/tests/System.Runtime.CompilerServices.Unsafe.Tests.csproj]
/home/carlos/.nuget/packages/microsoft.dotnet.arcade.sdk/8.0.0-beta.24165.4/tools/VSTest.targets(46,5): error MSB3073:                    echo "/home/carlos/maintenance-packages/.dotnet/dotnet" test  --logger:"console;verbosity=normal" --logger:"trx;LogFileName=" --logger:"html;LogFileName=" "--ResultsDirectory:" "--Framework:,Version=" >> "" 2>&1 >> " exited with code 2. [/home/carlos/maintenance-packages/src/System.Runtime.CompilerServices.Unsafe/tests/System.Runtime.CompilerServices.Unsafe.Tests.csproj]
```

The unexpected error output comes from inside the `RunTests` targets, which depends on the `TestToRun` items that are being used in the `Outputs` attribute. They come all the way from the `_InnerGetTestsToRun` target which does not get evaluated because it also depends on `SkipTests` not being `true`.

By adding the extra condition to the `RunTests` target to execute when `SkipTests` is not `true` and the `TestToRun` item group is not empty, we prevent that error.

While this gets fixed, we will be using a workaround in Directory.Build.targets in maintenance-packages to achieve a similar result:

```xml
  <Target Name="_SetSkipTests" AfterTargets="_OuterGetTestsToRun">

    <PropertyGroup>
      <SkipTests Condition="'@(TestToRun)' == ''">true</SkipTests>
    </PropertyGroup>

  </Target>
```