### PR TITLE
Remove usage of -pt images in arcade official templates

### DIFF
--- a/eng/common/templates-official/job/onelocbuild.yml
+++ b/eng/common/templates-official/job/onelocbuild.yml
@@ -56,7 +56,7 @@ jobs:
       # If it's not devdiv, it's dnceng
       ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
         name: $(DncEngInternalBuildPool)
-        image: 1es-windows-2022-pt
+        image: 1es-windows-2022
         os: windows
 
   steps:

--- a/eng/common/templates-official/job/source-build.yml
+++ b/eng/common/templates-official/job/source-build.yml
@@ -52,7 +52,7 @@ jobs:
 
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: $[replace(replace(eq(contains(coalesce(variables['System.PullRequest.TargetBranch'], variables['Build.SourceBranch'], 'refs/heads/main'), 'release'), 'true'), True, 'NetCore1ESPool-Svc-Internal'), False, 'NetCore1ESPool-Internal')]
-        image: 1es-mariner-2-pt
+        image: 1es-mariner-2
         os: linux
 
   ${{ if ne(parameters.platform.pool, '') }}:

--- a/eng/common/templates-official/post-build/post-build.yml
+++ b/eng/common/templates-official/post-build/post-build.yml
@@ -110,7 +110,7 @@ stages:
         # If it's not devdiv, it's dnceng
         ${{ else }}:
           name: $(DncEngInternalBuildPool)
-          image: 1es-windows-2022-pt
+          image: 1es-windows-2022
           os: windows
 
       steps:
@@ -150,7 +150,7 @@ stages:
         # If it's not devdiv, it's dnceng
         ${{ else }}:
           name: $(DncEngInternalBuildPool)
-          image: 1es-windows-2022-pt
+          image: 1es-windows-2022
           os: windows
       steps:
         - template: setup-maestro-vars.yml
@@ -208,7 +208,7 @@ stages:
         # If it's not devdiv, it's dnceng
         ${{ else }}:
           name: $(DncEngInternalBuildPool)
-          image: 1es-windows-2022-pt
+          image: 1es-windows-2022
           os: windows
       steps:
         - template: setup-maestro-vars.yml

--- a/eng/common/templates-official/variables/pool-providers.yml
+++ b/eng/common/templates-official/variables/pool-providers.yml
@@ -23,7 +23,7 @@
 #
 #        pool:
 #           name: $(DncEngInternalBuildPool)
-#           image: 1es-windows-2022-pt
+#           image: 1es-windows-2022
 
 variables:
   # Coalesce the target and source branches so we know when a PR targets a release branch


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/14652

As the non-pt images also have the 1ES PT requirements, we don't need to keep using them.

Validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2418151&view=results

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
