### PR TITLE
Float Application Insights Version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,8 @@
 
   <!-- Version properties used outside of PackageReference items -->
   <PropertyGroup>
+      <!-- Version gets overridden by VMR to keep SBE component at n-1 version. -->
+    <MicrosoftApplicationInsightsVersion>2.22.0</MicrosoftApplicationInsightsVersion>
     <MicrosoftCciVersion>4.0.0-rc3-24214-00</MicrosoftCciVersion>
     <!-- Keep Microsoft.Data.Services.Client package version in sync with Microsoft.Data.OData -->
     <MicrosoftDataServicesClientVersion>5.8.4</MicrosoftDataServicesClientVersion>
@@ -65,8 +67,6 @@
     <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
     <!-- sdk -->
     <PackageVersion Include="Microsoft.NET.Sdk.WorkloadManifestReader" Version="$(MicrosoftNetSdkWorkloadManifestReaderVersion)" />
-    <!-- source-build-externals -->
-    <PackageVersion Include="Microsoft.ApplicationInsights" Version="$(MicrosoftApplicationInsightsVersion)" />
   </ItemGroup>
 
   <!-- external -->
@@ -80,6 +80,7 @@
     <PackageVersion Include="JetBrains.Annotations" Version="2018.2.1" />
     <PackageVersion Include="LZMA-SDK" Version="19.0.0" />
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights" Version="$(MicrosoftApplicationInsightsVersion)" />
     <PackageVersion Include="Microsoft.Data.OData" Version="5.8.4" />
     <PackageVersion Include="Microsoft.DataServices.Client" Version="$(MicrosoftDataServicesClientVersion)" />
     <PackageVersion Include="Microsoft.Diagnostics.Runtime" Version="1.0.5" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -78,7 +78,7 @@
     <PackageVersion Include="JetBrains.Annotations" Version="2018.2.1" />
     <PackageVersion Include="LZMA-SDK" Version="19.0.0" />
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="2.3.0" />
-    <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.22.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights" Version="$(MicrosoftApplicationInsightsVersion)" />
     <PackageVersion Include="Microsoft.Data.OData" Version="5.8.4" />
     <PackageVersion Include="Microsoft.DataServices.Client" Version="$(MicrosoftDataServicesClientVersion)" />
     <PackageVersion Include="Microsoft.Diagnostics.Runtime" Version="1.0.5" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -65,6 +65,8 @@
     <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
     <!-- sdk -->
     <PackageVersion Include="Microsoft.NET.Sdk.WorkloadManifestReader" Version="$(MicrosoftNetSdkWorkloadManifestReaderVersion)" />
+    <!-- source-build-externals -->
+    <PackageVersion Include="Microsoft.ApplicationInsights" Version="$(MicrosoftApplicationInsightsVersion)" />
   </ItemGroup>
 
   <!-- external -->
@@ -78,7 +80,6 @@
     <PackageVersion Include="JetBrains.Annotations" Version="2018.2.1" />
     <PackageVersion Include="LZMA-SDK" Version="19.0.0" />
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="2.3.0" />
-    <PackageVersion Include="Microsoft.ApplicationInsights" Version="$(MicrosoftApplicationInsightsVersion)" />
     <PackageVersion Include="Microsoft.Data.OData" Version="5.8.4" />
     <PackageVersion Include="Microsoft.DataServices.Client" Version="$(MicrosoftDataServicesClientVersion)" />
     <PackageVersion Include="Microsoft.Diagnostics.Runtime" Version="1.0.5" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,8 +9,6 @@
 
   <!-- Version properties used outside of PackageReference items -->
   <PropertyGroup>
-      <!-- Version gets overridden by VMR to keep SBE component at n-1 version. -->
-    <MicrosoftApplicationInsightsVersion>2.22.0</MicrosoftApplicationInsightsVersion>
     <MicrosoftCciVersion>4.0.0-rc3-24214-00</MicrosoftCciVersion>
     <!-- Keep Microsoft.Data.Services.Client package version in sync with Microsoft.Data.OData -->
     <MicrosoftDataServicesClientVersion>5.8.4</MicrosoftDataServicesClientVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -113,10 +113,6 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>2874d26cb343fc55be295a628b3ee474e19ff95e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.ApplicationInsights" Version="2.22.0">
-      <Uri>https://github.com/microsoft/ApplicationInsights-dotnet</Uri>
-      <Sha>43825e06a22cdfb702fc199a7ba99a7d541d48c6</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.Deployment.DotNet.Releases" Version="1.0.0-preview6.1.23159.4" CoherentParentDependency="Microsoft.NET.Sdk.WorkloadManifestReader">
       <Uri>https://github.com/dotnet/deployment-tools</Uri>
       <Sha>b60c95e1ce736630d17e16626c59e3dd85ebae2b</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -113,6 +113,10 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>2874d26cb343fc55be295a628b3ee474e19ff95e</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.ApplicationInsights" Version="2.22.0">
+      <Uri>https://github.com/microsoft/ApplicationInsights-dotnet</Uri>
+      <Sha>43825e06a22cdfb702fc199a7ba99a7d541d48c6</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.Deployment.DotNet.Releases" Version="1.0.0-preview6.1.23159.4" CoherentParentDependency="Microsoft.NET.Sdk.WorkloadManifestReader">
       <Uri>https://github.com/dotnet/deployment-tools</Uri>
       <Sha>b60c95e1ce736630d17e16626c59e3dd85ebae2b</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -75,8 +75,6 @@
     <SystemTextJsonVersion>9.0.0-alpha.1.24059.2</SystemTextJsonVersion>
     <!-- sdk -->
     <MicrosoftNetSdkWorkloadManifestReaderVersion>8.0.100-preview.3.23178.3</MicrosoftNetSdkWorkloadManifestReaderVersion>
-    <!-- source-build-externals -->
-    <MicrosoftApplicationInsightsVersion>2.22.0</MicrosoftApplicationInsightsVersion>
     <!-- symreader-converter -->
     <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta2-19575-01</MicrosoftDiaSymReaderPdb2PdbVersion>
     <!-- templating -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -75,6 +75,9 @@
     <SystemTextJsonVersion>9.0.0-alpha.1.24059.2</SystemTextJsonVersion>
     <!-- sdk -->
     <MicrosoftNetSdkWorkloadManifestReaderVersion>8.0.100-preview.3.23178.3</MicrosoftNetSdkWorkloadManifestReaderVersion>
+    <!-- source-build-externals -->
+    <!-- The version is overridden by the VMR to use the version from the previous (n-1) build of Arcade. -->
+    <MicrosoftApplicationInsightsVersion>2.22.0</MicrosoftApplicationInsightsVersion>
     <!-- symreader-converter -->
     <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta2-19575-01</MicrosoftDiaSymReaderPdb2PdbVersion>
     <!-- templating -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -75,6 +75,8 @@
     <SystemTextJsonVersion>9.0.0-alpha.1.24059.2</SystemTextJsonVersion>
     <!-- sdk -->
     <MicrosoftNetSdkWorkloadManifestReaderVersion>8.0.100-preview.3.23178.3</MicrosoftNetSdkWorkloadManifestReaderVersion>
+    <!-- source-build-externals -->
+    <MicrosoftApplicationInsightsVersion>2.22.0</MicrosoftApplicationInsightsVersion>
     <!-- symreader-converter -->
     <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta2-19575-01</MicrosoftDiaSymReaderPdb2PdbVersion>
     <!-- templating -->


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build-externals/pull/302#issuecomment-2030345736

This PR floats the version of the Microsoft.ApplicationInsights dependency. This adjustment is necessary to prevent the creation of multiple Application Insights components within source-build externals whenever there's an upgrade to a different version of Application Insights.