### PR TITLE
Copy repo symbols to intermediates

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -118,14 +118,6 @@
       <ItemsToSignPostBuild Include="@(SymbolPackagesToGenerate->'%(Filename)%(Extension)')" Condition="'$(PostBuildSign)' == 'true'" />
     </ItemGroup>
 
-    <!-- Include Symbols.<repo>.tar.gz, if running in inner source-only build -->
-    <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetBuildInnerRepo)' == 'true'">
-      <UnifiedSymbolsPackage Include="$(ArtifactsNonShippingPackagesDir)Symbols.*.tar.gz" />
-      <Artifact Include="@(UnifiedSymbolsPackage)"
-                RelativeBlobPath="Symbols/%(Filename)%(Extension)"
-                IsShipping="false" />
-    </ItemGroup>
-
     <!--
       If a symbol package doesn't exist yet we assume that the regular package contains Portable PDBs.
       Such packages can act as symbol packages since they have the same structure.

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
@@ -14,7 +14,7 @@
   <Target Name="AfterSourceBuildInnerBuild"
           Condition="('$(ArcadeInnerBuildFromSource)' == 'true' or '$(DotNetBuildInnerRepo)' == 'true') and
                      '$(DotNetBuildOrchestrator)' == 'true'"
-          DependsOnTargets="CreateRepoSymbolsArchive;ClearPreviousSBRP" />
+          DependsOnTargets="CopyRepoSymbolsToIntermediates;ClearPreviousSBRP" />
 
   <Target Name="ClearPreviousSBRP"
           Condition="'$(GitHubRepositoryName)' == 'source-build-reference-packages'">

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -161,7 +161,7 @@
   -->
 
   <Target Name="CreateRepoSymbolsArchive"
-          Condition="'$(OS)' != 'Windows_NT' and ('$(DotNetBuildFromSourceFlavor)' == 'Product' or '$(DotNetBuildOrchestrator)' == 'true' or '$(SupplementalIntermediateNupkgCategory)' == '$(SymbolsIntermediateNupkgCategory)')"
+          Condition="'$(OS)' != 'Windows_NT' and '$(SupplementalIntermediateNupkgCategory)' == '$(SymbolsIntermediateNupkgCategory)'"
           DependsOnTargets="$(CreateRepoSymbolsArchiveDependsOn);
                             DiscoverRepoSymbols;
                             PackageRepoSymbols"/>
@@ -184,7 +184,7 @@
   </Target>
 
   <Target Name="PackageRepoSymbols"
-          Condition="'$(OS)' != 'Windows_NT' and ('$(DotNetBuildFromSourceFlavor)' == 'Product' or '$(DotNetBuildOrchestrator)' == 'true' or '$(SupplementalIntermediateNupkgCategory)' == '$(SymbolsIntermediateNupkgCategory)')"
+          Condition="'$(OS)' != 'Windows_NT' and '$(SupplementalIntermediateNupkgCategory)' == '$(SymbolsIntermediateNupkgCategory)'"
           DependsOnTargets="$(CreateRepoSymbolsArchiveDependsOn);DiscoverRepoSymbols">
     <PropertyGroup>
       <SymbolsArchiveLocation>$(CurrentRepoSourceBuildArtifactsNonShippingPackagesDir)</SymbolsArchiveLocation>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -166,8 +166,7 @@
                             DiscoverRepoSymbols;
                             PackageRepoSymbols"/>
 
-  <Target Name="DiscoverRepoSymbols"
-          DependsOnTargets="$(CreateRepoSymbolsArchiveDependsOn)">
+  <Target Name="DiscoverRepoSymbols">
     <PropertyGroup>
       <SymbolsRoot>$(CurrentRepoSourceBuildArtifactsDir)</SymbolsRoot>
       <!-- Fall back to repo root for source-build-externals or repos that don't have the regular SymbolsRoot as defined above -->
@@ -183,7 +182,7 @@
   </Target>
 
   <Target Name="PackageRepoSymbols"
-          DependsOnTargets="$(CreateRepoSymbolsArchiveDependsOn);DiscoverRepoSymbols">
+          DependsOnTargets="DiscoverRepoSymbols">
     <PropertyGroup>
       <SymbolsArchiveLocation>$(CurrentRepoSourceBuildArtifactsNonShippingPackagesDir)</SymbolsArchiveLocation>
       <SymbolsArchiveLocation Condition="'$(GitHubRepositoryName)' == 'nuget-client' and '$(PackageOutputPath)' != ''">$([MSBuild]::EnsureTrailingSlash('$(PackageOutputPath)'))</SymbolsArchiveLocation>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -167,7 +167,6 @@
                             PackageRepoSymbols"/>
 
   <Target Name="DiscoverRepoSymbols"
-          Condition="'$(OS)' != 'Windows_NT' and ('$(DotNetBuildFromSourceFlavor)' == 'Product' or '$(DotNetBuildOrchestrator)' == 'true' or '$(SupplementalIntermediateNupkgCategory)' == '$(SymbolsIntermediateNupkgCategory)')"
           DependsOnTargets="$(CreateRepoSymbolsArchiveDependsOn)">
     <PropertyGroup>
       <SymbolsRoot>$(CurrentRepoSourceBuildArtifactsDir)</SymbolsRoot>
@@ -184,7 +183,6 @@
   </Target>
 
   <Target Name="PackageRepoSymbols"
-          Condition="'$(OS)' != 'Windows_NT' and '$(SupplementalIntermediateNupkgCategory)' == '$(SymbolsIntermediateNupkgCategory)'"
           DependsOnTargets="$(CreateRepoSymbolsArchiveDependsOn);DiscoverRepoSymbols">
     <PropertyGroup>
       <SymbolsArchiveLocation>$(CurrentRepoSourceBuildArtifactsNonShippingPackagesDir)</SymbolsArchiveLocation>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -159,20 +159,20 @@
 
     Conditioning out for Windows as the tar execution below doesn't work cross-plat.
   -->
+
   <Target Name="CreateRepoSymbolsArchive"
+          Condition="'$(OS)' != 'Windows_NT' and ('$(DotNetBuildFromSourceFlavor)' == 'Product' or '$(DotNetBuildOrchestrator)' == 'true' or '$(SupplementalIntermediateNupkgCategory)' == '$(SymbolsIntermediateNupkgCategory)')"
+          DependsOnTargets="$(CreateRepoSymbolsArchiveDependsOn);
+                            DiscoverRepoSymbols;
+                            PackageRepoSymbols"/>
+
+  <Target Name="DiscoverRepoSymbols"
           Condition="'$(OS)' != 'Windows_NT' and ('$(DotNetBuildFromSourceFlavor)' == 'Product' or '$(DotNetBuildOrchestrator)' == 'true' or '$(SupplementalIntermediateNupkgCategory)' == '$(SymbolsIntermediateNupkgCategory)')"
           DependsOnTargets="$(CreateRepoSymbolsArchiveDependsOn)">
     <PropertyGroup>
       <SymbolsRoot>$(CurrentRepoSourceBuildArtifactsDir)</SymbolsRoot>
       <!-- Fall back to repo root for source-build-externals or repos that don't have the regular SymbolsRoot as defined above -->
       <SymbolsRoot Condition="!Exists('$(SymbolsRoot)') or '$(GitHubRepositoryName)' == 'source-build-externals'">$(RepoRoot)</SymbolsRoot>
-      <SymbolsArchiveLocation>$(CurrentRepoSourceBuildArtifactsNonShippingPackagesDir)</SymbolsArchiveLocation>
-      <SymbolsArchiveLocation Condition="'$(GitHubRepositoryName)' == 'nuget-client' and '$(PackageOutputPath)' != ''">$([MSBuild]::EnsureTrailingSlash('$(PackageOutputPath)'))</SymbolsArchiveLocation>
-      <SymbolsList>$([MSBuild]::NormalizePath('$(SymbolsArchiveLocation)', 'symbols.lst'))</SymbolsList>
-      <SymbolsArchivePrefix>Symbols.</SymbolsArchivePrefix>
-      <!-- $(Version) and $(TargetRid) are only available when target is executed as part of intermediate package creation. -->
-      <SymbolsArchiveSuffix Condition="'$(CreateIntermediatePackage)' == 'true'">.$(Version).$(TargetRid)</SymbolsArchiveSuffix>
-      <SymbolsArchiveFile>$(SymbolsArchiveLocation)$(SymbolsArchivePrefix)$(GitHubRepositoryName)$(SymbolsArchiveSuffix)$(ArchiveExtension)</SymbolsArchiveFile>
     </PropertyGroup>
 
     <ItemGroup>
@@ -181,6 +181,20 @@
         <RelativePath>$([MSBuild]::MakeRelative($(SymbolsRoot), %(FullPath)))</RelativePath>
       </AbsoluteSymbolPath>
     </ItemGroup>
+  </Target>
+
+  <Target Name="PackageRepoSymbols"
+          Condition="'$(OS)' != 'Windows_NT' and ('$(DotNetBuildFromSourceFlavor)' == 'Product' or '$(DotNetBuildOrchestrator)' == 'true' or '$(SupplementalIntermediateNupkgCategory)' == '$(SymbolsIntermediateNupkgCategory)')"
+          DependsOnTargets="$(CreateRepoSymbolsArchiveDependsOn);DiscoverRepoSymbols">
+    <PropertyGroup>
+      <SymbolsArchiveLocation>$(CurrentRepoSourceBuildArtifactsNonShippingPackagesDir)</SymbolsArchiveLocation>
+      <SymbolsArchiveLocation Condition="'$(GitHubRepositoryName)' == 'nuget-client' and '$(PackageOutputPath)' != ''">$([MSBuild]::EnsureTrailingSlash('$(PackageOutputPath)'))</SymbolsArchiveLocation>
+      <SymbolsList>$([MSBuild]::NormalizePath('$(SymbolsArchiveLocation)', 'symbols.lst'))</SymbolsList>
+      <SymbolsArchivePrefix>Symbols.</SymbolsArchivePrefix>
+      <!-- $(Version) and $(TargetRid) are only available when target is executed as part of intermediate package creation. -->
+      <SymbolsArchiveSuffix Condition="'$(CreateIntermediatePackage)' == 'true'">.$(Version).$(TargetRid)</SymbolsArchiveSuffix>
+      <SymbolsArchiveFile>$(SymbolsArchiveLocation)$(SymbolsArchivePrefix)$(GitHubRepositoryName)$(SymbolsArchiveSuffix)$(ArchiveExtension)</SymbolsArchiveFile>
+    </PropertyGroup>
 
     <WriteLinesToFile
       File="$(SymbolsList)"
@@ -203,6 +217,13 @@
     <Delete Files="$(SymbolsList)" Condition="Exists($(SymbolsList))" />
   </Target>
 
+  <Target Name="CopyRepoSymbolsToIntermediates"
+          DependsOnTargets="DiscoverRepoSymbols">
+    <MakeDir Directories="$(SourceBuiltSymbolsDir)" />
+    <Copy
+      SourceFiles="@(AbsoluteSymbolPath)"
+      DestinationFolder="$(SourceBuiltSymbolsDir)%(RecursiveDir)" />
+  </Target>
   <!--
     This target can be removed once we enable standard repo assets manifests and SB orchestrator
     starts using it - https://github.com/dotnet/source-build/issues/3970


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/4225

Changes:
- Remove infra related to symbols tarball from Publish.proj
- Modify AfterSourceBuild.proj to copy symbols to intermediates