### PR TITLE
Fix skipping Component Governance on public pipelines

### DIFF
--- a/eng/common/templates-official/steps/component-governance.yml
+++ b/eng/common/templates-official/steps/component-governance.yml
@@ -4,7 +4,7 @@ parameters:
 
 steps:
 - ${{ if eq(parameters.disableComponentGovernance, 'true') }}:
-  - script: "echo ##vso[task.setvariable variable=skipComponentGovernanceDetection]true"
+  - script: echo "##vso[task.setvariable variable=skipComponentGovernanceDetection]true"
     displayName: Set skipComponentGovernanceDetection variable
 - ${{ if ne(parameters.disableComponentGovernance, 'true') }}:
   - task: ComponentGovernanceComponentDetection@0

--- a/eng/common/templates/steps/component-governance.yml
+++ b/eng/common/templates/steps/component-governance.yml
@@ -4,7 +4,7 @@ parameters:
 
 steps:
 - ${{ if eq(parameters.disableComponentGovernance, 'true') }}:
-  - script: "echo ##vso[task.setvariable variable=skipComponentGovernanceDetection]true"
+  - script: echo "##vso[task.setvariable variable=skipComponentGovernanceDetection]true"
     displayName: Set skipComponentGovernanceDetection variable
 - ${{ if ne(parameters.disableComponentGovernance, 'true') }}:
   - task: ComponentGovernanceComponentDetection@0


### PR DESCRIPTION
I noticed that we weren't skipping CG on public pipelines on Linux/Mac, only on Windows.

We need to make sure to enclose the AzDO logging commands in quotes, otherwise the `#` will be interpreted as a comment by bash.