### PR TITLE
Revert to previous arcade to unblock official builds

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -19,25 +19,25 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>2604b7363dc5d8c92f8b30b6518ebcf2e048fbbd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="9.0.0-beta.24203.1">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="9.0.0-beta.24178.6">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>532f956a119bce77ca279994054d08dbc24418f7</Sha>
+      <Sha>4345e14684eab24fa2f8217706756dd7c0787d84</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="9.0.0-beta.24203.1">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="9.0.0-beta.24178.6">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>532f956a119bce77ca279994054d08dbc24418f7</Sha>
+      <Sha>4345e14684eab24fa2f8217706756dd7c0787d84</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SignTool" Version="9.0.0-beta.24203.1">
+    <Dependency Name="Microsoft.DotNet.SignTool" Version="9.0.0-beta.24178.6">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>532f956a119bce77ca279994054d08dbc24418f7</Sha>
+      <Sha>4345e14684eab24fa2f8217706756dd7c0787d84</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="9.0.0-beta.24203.1">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="9.0.0-beta.24178.6">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>532f956a119bce77ca279994054d08dbc24418f7</Sha>
+      <Sha>4345e14684eab24fa2f8217706756dd7c0787d84</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SwaggerGenerator.MSBuild" Version="9.0.0-beta.24203.1">
+    <Dependency Name="Microsoft.DotNet.SwaggerGenerator.MSBuild" Version="9.0.0-beta.24178.6">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>532f956a119bce77ca279994054d08dbc24418f7</Sha>
+      <Sha>4345e14684eab24fa2f8217706756dd7c0787d84</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Maestro.Client" Version="1.1.0-beta.24202.3">
       <Uri>https://github.com/dotnet/arcade-services</Uri>
@@ -122,9 +122,9 @@
       <Sha>39aef81ec6cffa06da9964b46d4b9e3bf2fc9979</Sha>
     </Dependency>
     <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.arcade" Version="9.0.0-beta.24203.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.arcade" Version="9.0.0-beta.24178.6">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>532f956a119bce77ca279994054d08dbc24418f7</Sha>
+      <Sha>4345e14684eab24fa2f8217706756dd7c0787d84</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
     <!-- Intermediate is necessary for source build. -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- arcade -->
-    <MicrosoftDotNetBuildTasksFeedVersion>9.0.0-beta.24203.1</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetSignToolVersion>9.0.0-beta.24203.1</MicrosoftDotNetSignToolVersion>
-    <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>9.0.0-beta.24203.1</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>9.0.0-beta.24178.6</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetSignToolVersion>9.0.0-beta.24178.6</MicrosoftDotNetSignToolVersion>
+    <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>9.0.0-beta.24178.6</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
     <!-- arcade-services -->
     <MicrosoftDotNetMaestroClientVersion>1.1.0-beta.24202.3</MicrosoftDotNetMaestroClientVersion>
     <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.24202.3</MicrosoftDotNetMaestroTasksVersion>

--- a/eng/common/templates-official/job/onelocbuild.yml
+++ b/eng/common/templates-official/job/onelocbuild.yml
@@ -56,7 +56,7 @@ jobs:
       # If it's not devdiv, it's dnceng
       ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
         name: $(DncEngInternalBuildPool)
-        image: 1es-windows-2022
+        image: 1es-windows-2022-pt
         os: windows
 
   steps:

--- a/eng/common/templates-official/job/source-build.yml
+++ b/eng/common/templates-official/job/source-build.yml
@@ -52,7 +52,7 @@ jobs:
 
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: $[replace(replace(eq(contains(coalesce(variables['System.PullRequest.TargetBranch'], variables['Build.SourceBranch'], 'refs/heads/main'), 'release'), 'true'), True, 'NetCore1ESPool-Svc-Internal'), False, 'NetCore1ESPool-Internal')]
-        image: 1es-mariner-2
+        image: 1es-mariner-2-pt
         os: linux
 
   ${{ if ne(parameters.platform.pool, '') }}:

--- a/eng/common/templates-official/post-build/post-build.yml
+++ b/eng/common/templates-official/post-build/post-build.yml
@@ -110,7 +110,7 @@ stages:
         # If it's not devdiv, it's dnceng
         ${{ else }}:
           name: $(DncEngInternalBuildPool)
-          image: 1es-windows-2022
+          image: 1es-windows-2022-pt
           os: windows
 
       steps:
@@ -150,7 +150,7 @@ stages:
         # If it's not devdiv, it's dnceng
         ${{ else }}:
           name: $(DncEngInternalBuildPool)
-          image: 1es-windows-2022
+          image: 1es-windows-2022-pt
           os: windows
       steps:
         - template: setup-maestro-vars.yml
@@ -208,7 +208,7 @@ stages:
         # If it's not devdiv, it's dnceng
         ${{ else }}:
           name: $(DncEngInternalBuildPool)
-          image: 1es-windows-2022
+          image: 1es-windows-2022-pt
           os: windows
       steps:
         - template: setup-maestro-vars.yml

--- a/eng/common/templates-official/steps/component-governance.yml
+++ b/eng/common/templates-official/steps/component-governance.yml
@@ -4,7 +4,7 @@ parameters:
 
 steps:
 - ${{ if eq(parameters.disableComponentGovernance, 'true') }}:
-  - script: echo "##vso[task.setvariable variable=skipComponentGovernanceDetection]true"
+  - script: "echo ##vso[task.setvariable variable=skipComponentGovernanceDetection]true"
     displayName: Set skipComponentGovernanceDetection variable
 - ${{ if ne(parameters.disableComponentGovernance, 'true') }}:
   - task: ComponentGovernanceComponentDetection@0

--- a/eng/common/templates-official/variables/pool-providers.yml
+++ b/eng/common/templates-official/variables/pool-providers.yml
@@ -23,7 +23,7 @@
 #
 #        pool:
 #           name: $(DncEngInternalBuildPool)
-#           image: 1es-windows-2022
+#           image: 1es-windows-2022-pt
 
 variables:
   # Coalesce the target and source branches so we know when a PR targets a release branch

--- a/eng/common/templates/steps/component-governance.yml
+++ b/eng/common/templates/steps/component-governance.yml
@@ -4,7 +4,7 @@ parameters:
 
 steps:
 - ${{ if eq(parameters.disableComponentGovernance, 'true') }}:
-  - script: echo "##vso[task.setvariable variable=skipComponentGovernanceDetection]true"
+  - script: "echo ##vso[task.setvariable variable=skipComponentGovernanceDetection]true"
     displayName: Set skipComponentGovernanceDetection variable
 - ${{ if ne(parameters.disableComponentGovernance, 'true') }}:
   - task: ComponentGovernanceComponentDetection@0

--- a/global.json
+++ b/global.json
@@ -7,8 +7,8 @@
     "dotnet": "9.0.100-preview.1.24101.2"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.24203.1",
-    "Microsoft.DotNet.Helix.Sdk": "9.0.0-beta.24203.1",
+    "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.24178.6",
+    "Microsoft.DotNet.Helix.Sdk": "9.0.0-beta.24178.6",
     "Microsoft.Build.NoTargets": "3.7.0"
   }
 }


### PR DESCRIPTION
The previous bad arcade build (my fault) passed through validation and got checked into arcade. This then blocks the fix from flowing because we can't currently create an official build. Roll arcade back to the previous version to unblock.

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation
