### PR TITLE
Remove hardcoded list of compiler versions in init-compiler.sh

### DIFF
--- a/eng/common/native/init-compiler.sh
+++ b/eng/common/native/init-compiler.sh
@@ -2,7 +2,9 @@
 #
 # This file detects the C/C++ compiler and exports it to the CC/CXX environment variables
 #
-# NOTE: some scripts source this file and rely on stdout being empty, make sure to not output anything here!
+# NOTE: some scripts source this file and rely on stdout being empty, make sure
+# to not output *anything* here, unless it is an error message that fails the
+# build.
 
 if [ -z "$build_arch" ] || [ -z "$compiler" ]; then
   echo "Usage..."
@@ -58,6 +60,25 @@ check_version_exists() {
     echo "$desired_version"
 }
 
+set_compiler_version_from_CC() {
+    if [ "$(uname)" == "Darwin" ]; then
+        # On Darwin, the versions from -version/-dumpversion refer to Xcode
+        # versions, not llvm versions, so we can't rely on them.
+        return
+    fi
+
+    version="$("$CC" -dumpversion)"
+    if [ "$version" = "" ]; then
+        echo "Error: $CC -dumpversion didn't provide a version"
+        exit 1
+    fi
+
+    # gcc and clang often display 3 part versions. However, gcc can show only 1 part in some environments.
+    IFS=. read -r majorVersion minorVersion _ <<EOF
+$version
+EOF
+}
+
 if [ -z "$CLR_CC" ]; then
 
     # Set default versions
@@ -74,28 +95,30 @@ if [ -z "$CLR_CC" ]; then
         done
 
         if [ -z "$majorVersion" ]; then
-            if command -v "$compiler" > /dev/null; then
-                if [ "$(uname)" != "Darwin" ]; then
-                    echo "Warning: Specific version of $compiler not found, falling back to use the one in PATH."
-                fi
-                CC="$(command -v "$compiler")"
-                CXX="$(command -v "$cxxCompiler")"
-            else
-                echo "No usable version of $compiler found."
+            if [ "$(uname)" == "Darwin" ]; then
+                echo "Error: Specific version of $compiler not found"
                 exit 1
             fi
+
+            if ! command -v "$compiler" > /dev/null; then
+                echo "Error: No usable version of $compiler found."
+                exit 1
+            fi
+
+            CC="$(command -v "$compiler")"
+            CXX="$(command -v "$cxxCompiler")"
+            set_compiler_version_from_CC
         else
-            if [ "$compiler" = "clang" ] && [ "$majorVersion" -lt 5 ]; then
-                if [ "$build_arch" = "arm" ] || [ "$build_arch" = "armel" ]; then
-                    if command -v "$compiler" > /dev/null; then
-                        echo "Warning: Found clang version $majorVersion which is not supported on arm/armel architectures, falling back to use clang from PATH."
-                        CC="$(command -v "$compiler")"
-                        CXX="$(command -v "$cxxCompiler")"
-                    else
-                        echo "Found clang version $majorVersion which is not supported on arm/armel architectures, and there is no clang in PATH."
-                        exit 1
-                    fi
+            if ( [ "$compiler" = "clang" ] && [ "$majorVersion" -lt 5 ] ) && ( [ "$build_arch" = "arm" ] || [ "$build_arch" = "armel" ] ); then
+                # If a major version was provided explicitly, and it was too old, find a newer compiler instead
+                if ! command -v "$compiler" > /dev/null; then
+                    echo "Found clang version $majorVersion which is not supported on arm/armel architectures, and there is no clang in PATH."
+                    exit 1
                 fi
+
+                CC="$(command -v "$compiler")"
+                CXX="$(command -v "$cxxCompiler")"
+                set_compiler_version_from_CC
             fi
         fi
     else
@@ -110,6 +133,7 @@ if [ -z "$CLR_CC" ]; then
         CC="$(command -v "$compiler$desired_version")"
         CXX="$(command -v "$cxxCompiler$desired_version")"
         if [ -z "$CXX" ]; then CXX="$(command -v "$cxxCompiler")"; fi
+        set_compiler_version_from_CC
     fi
 else
     if [ ! -f "$CLR_CC" ]; then
@@ -118,6 +142,7 @@ else
     fi
     CC="$CLR_CC"
     CXX="$CLR_CXX"
+    set_compiler_version_from_CC
 fi
 
 if [ -z "$CC" ]; then
@@ -125,10 +150,14 @@ if [ -z "$CC" ]; then
     exit 1
 fi
 
-# Only lld version >= 9 can be considered stable. lld supports s390x starting from 18.0.
-if [ "$compiler" = "clang" ] && [ -n "$majorVersion" ] && [ "$majorVersion" -ge 9 ] && ([ "$build_arch" != "s390x" ] || [ "$majorVersion" -ge 18 ]); then
-    if "$CC" -fuse-ld=lld -Wl,--version >/dev/null 2>&1; then
-        LDFLAGS="-fuse-ld=lld"
+if [ "$(uname)" != "Darwin" ]; then
+    # On Darwin, we always want to use the Apple linker.
+
+    # Only lld version >= 9 can be considered stable. lld supports s390x starting from 18.0.
+    if [ "$compiler" = "clang" ] && [ -n "$majorVersion" ] && [ "$majorVersion" -ge 9 ] && ( [ "$build_arch" != "s390x" ] || [ "$majorVersion" -ge 18 ] ); then
+        if "$CC" -fuse-ld=lld -Wl,--version >/dev/null 2>&1; then
+            LDFLAGS="-fuse-ld=lld"
+        fi
     fi
 fi
 


### PR DESCRIPTION
If a version-specific compiler (eg, `clang-17`) is passed to the script, it works as before. However, if a generic compiler (eg, `clang`) is passed to the script, it uses the version in $PATH. This is a change from earlier, where it was iterating through a known list of versions to find the latest version of the compiler and using that.

This change can break or modify existing build scenarios where the following are all true:

- The script is called with a generic compiler name, without a version
- Multiple versions of compilers are installed on the system
- The default compiler (`$compiler`) is not the latest version

In this scenario, an older version of the compiler will be used, which may not be desired.

 With a generic compiler, this script now also invokes it via `$compiler -dumpversion` (which works on both clang and gcc) to find the version for various (existing) version checks. The compiler was already being invoked to check if `-fuse-ld=lld` is supported.

Fixes: #14632