### PR TITLE
Add aarch64 host support in alpine rootfs

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -448,7 +448,7 @@ if [[ "$__CodeName" == "alpine" ]]; then
     __ApkKeysDir="$(mktemp -d)"
 
     arch="$(uname -m)"
-    wget "https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic//v$__ApkToolsVersion/$arch/apk.static" -P "$__ApkToolsDir"
+    wget "https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v$__ApkToolsVersion/$arch/apk.static" -P "$__ApkToolsDir"
     if [[ "$arch" == "x86_64" ]]; then
       __ApkToolsSHA512SUM="53e57b49230da07ef44ee0765b9592580308c407a8d4da7125550957bb72cb59638e04f8892a18b584451c8d841d1c7cb0f0ab680cc323a3015776affaa3be33"
     elif [[ "$arch" == "aarch64" ]]; then

--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -444,11 +444,18 @@ __RootfsDir="$( cd "$__RootfsDir" && pwd )"
 
 if [[ "$__CodeName" == "alpine" ]]; then
     __ApkToolsVersion=2.12.11
-    __ApkToolsSHA512SUM=53e57b49230da07ef44ee0765b9592580308c407a8d4da7125550957bb72cb59638e04f8892a18b584451c8d841d1c7cb0f0ab680cc323a3015776affaa3be33
     __ApkToolsDir="$(mktemp -d)"
     __ApkKeysDir="$(mktemp -d)"
 
-    wget "https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic//v$__ApkToolsVersion/x86_64/apk.static" -P "$__ApkToolsDir"
+    arch="$(uname -m)"
+    wget "https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic//v$__ApkToolsVersion/$arch/apk.static" -P "$__ApkToolsDir"
+    if [[ "$arch" == "x86_64" ]]; then
+      __ApkToolsSHA512SUM="53e57b49230da07ef44ee0765b9592580308c407a8d4da7125550957bb72cb59638e04f8892a18b584451c8d841d1c7cb0f0ab680cc323a3015776affaa3be33"
+    elif [[ "$arch" == "aarch64" ]]; then
+      __ApkToolsSHA512SUM="9e2b37ecb2b56c05dad23d379be84fd494c14bd730b620d0d576bda760588e1f2f59a7fcb2f2080577e0085f23a0ca8eadd993b4e61c2ab29549fdb71969afd0"
+    else
+      echo "WARNING: add missing hash for your host architecture. To find the value, use: `find /tmp -name apk.static -exec sha512sum {} \;`"
+    fi
     echo "$__ApkToolsSHA512SUM $__ApkToolsDir/apk.static" | sha512sum -c
     chmod +x "$__ApkToolsDir/apk.static"
 


### PR DESCRIPTION
With this patch, I was able to build alpine-arm64 rootfs on ubuntu-arm64 running in docker on osx-arm64 host. It is many times faster than using x64 cross arm64 prereq docker image (which often gets stuck on osx-arm64 machine during emulation).

```sh
$ docker run --rm -v$(pwd):/runtime -w /runtime --platform linux/arm64/v8 ubuntu sh -c '
	  eng/install-native-dependencies.sh;
	  apt install -y wget;
	  eng/common/cross/build-rootfs.sh alpine arm64;
	  ROOTFS_DIR=$(pwd)/.tools/rootfs/arm64 ./build.sh clr+libs+packs -cross'
```
cc @janvorli, @akoeplinger