### PR TITLE
Add SBE dependencies to Version.Details & Versions.prop

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -89,7 +89,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.OLE.Interop" Version="7.10.6071" />
     <PackageVersion Include="Mono.Options" Version="5.3.0.1" />
     <PackageVersion Include="Moq" Version="4.18.4" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageVersion Include="Octokit" Version="10.0.0" />
     <PackageVersion Include="xunit" Version="$(XUnitVersion)" />
     <PackageVersion Include="xunit.abstractions" Version="2.0.3" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -3,8 +3,9 @@
   <ProductDependencies>
   </ProductDependencies>
   <ToolsetDependencies>
-    <!-- Needed for when this dependency gets updated in Source-Build externals.
-         Otherwise, a prebuilt will be introduced until the VMR is rebootstrapped. -->
+    <!-- Needed for when this dependency gets updated in 
+         https://github.com/dotnet/source-build-externals, otherwise
+         a prebuilt will be introduced until the VMR is rebootstrapped. -->
     <Dependency Name="Microsoft.ApplicationInsights" Version="2.22.0">
       <Uri>https://github.com/microsoft/ApplicationInsights-dotnet</Uri>
       <Sha>43825e06a22cdfb702fc199a7ba99a7d541d48c6</Sha>
@@ -111,8 +112,9 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>2874d26cb343fc55be295a628b3ee474e19ff95e</Sha>
     </Dependency>
-    <!-- Needed for when this dependency gets updated in Source-Build externals. 
-         Otherwise, a prebuilt will be introduced until the VMR is rebootstrapped. -->
+    <!-- Needed for when this dependency gets updated in 
+         https://github.com/dotnet/source-build-externals, otherwise
+         a prebuilt will be introduced until the VMR is rebootstrapped. -->
     <Dependency Name="Newtonsoft.Json" Version="13.0.3">
       <Uri>https://github.com/JamesNK/Newtonsoft.Json</Uri>
       <Sha>0a2e291c0d9c0c7675d445703e51750363a549ef</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -3,6 +3,12 @@
   <ProductDependencies>
   </ProductDependencies>
   <ToolsetDependencies>
+    <!-- Needed for when this dependency gets updated in Source-Build externals. -->
+    <!-- Otherwise, a prebuilt will be introduced until the VMR is rebootstrapped. -->
+    <Dependency Name="Microsoft.ApplicationInsights" Version="2.22.0">
+      <Uri>https://github.com/microsoft/ApplicationInsights-dotnet</Uri>
+      <Sha>43825e06a22cdfb702fc199a7ba99a7d541d48c6</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.8.0">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>e091728607ca0fc9efca55ccfb3e59259c6b5a0a</Sha>
@@ -104,6 +110,12 @@
     <Dependency Name="Microsoft.Extensions.Logging.Console" Version="9.0.0-alpha.1.24059.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>2874d26cb343fc55be295a628b3ee474e19ff95e</Sha>
+    </Dependency>
+      <!-- Needed for when this dependency gets updated in Source-Build externals. -->
+    <!-- Otherwise, a prebuilt will be introduced until the VMR is rebootstrapped. -->
+    <Dependency Name="Newtonsoft.Json" Version="13.0.3">
+      <Uri>https://github.com/JamesNK/Newtonsoft.Json</Uri>
+      <Sha>0a2e291c0d9c0c7675d445703e51750363a549ef</Sha>
     </Dependency>
     <Dependency Name="System.Text.Encodings.Web" Version="9.0.0-alpha.1.24059.2">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -3,8 +3,8 @@
   <ProductDependencies>
   </ProductDependencies>
   <ToolsetDependencies>
-    <!-- Needed for when this dependency gets updated in Source-Build externals. -->
-    <!-- Otherwise, a prebuilt will be introduced until the VMR is rebootstrapped. -->
+    <!-- Needed for when this dependency gets updated in Source-Build externals.
+         Otherwise, a prebuilt will be introduced until the VMR is rebootstrapped. -->
     <Dependency Name="Microsoft.ApplicationInsights" Version="2.22.0">
       <Uri>https://github.com/microsoft/ApplicationInsights-dotnet</Uri>
       <Sha>43825e06a22cdfb702fc199a7ba99a7d541d48c6</Sha>
@@ -111,8 +111,8 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>2874d26cb343fc55be295a628b3ee474e19ff95e</Sha>
     </Dependency>
-      <!-- Needed for when this dependency gets updated in Source-Build externals. -->
-    <!-- Otherwise, a prebuilt will be introduced until the VMR is rebootstrapped. -->
+    <!-- Needed for when this dependency gets updated in Source-Build externals. 
+         Otherwise, a prebuilt will be introduced until the VMR is rebootstrapped. -->
     <Dependency Name="Newtonsoft.Json" Version="13.0.3">
       <Uri>https://github.com/JamesNK/Newtonsoft.Json</Uri>
       <Sha>0a2e291c0d9c0c7675d445703e51750363a549ef</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -78,6 +78,7 @@
     <!-- source-build-externals -->
     <!-- The version is overridden by the VMR to use the version from the previous (n-1) build of Arcade. -->
     <MicrosoftApplicationInsightsVersion>2.22.0</MicrosoftApplicationInsightsVersion>
+    <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <!-- symreader-converter -->
     <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta2-19575-01</MicrosoftDiaSymReaderPdb2PdbVersion>
     <!-- templating -->


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/4286

This PR adds a verison property for Newtonsoft.Json and adds entries for Newtonsoft.Json and Microsoft.ApplicationInsights to the Version.Details file. This is done so that if the dependencies were to be updated in SBE, the n-1 versions of these dependencies would be used instead of the current version. This mitigates having to deal with prebuilts possibly being introduced.

[Build with changes](https://dev.azure.com/dnceng/internal/_build/results?buildId=2425326&view=results) (internal Microsoft link)
