### PR TITLE
Only set RestoreConfigFile if it's not already set

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -20,7 +20,7 @@
     NuGet.Config, NuGet.config, and nuget.config are all allowed casings according to NuGet:
     https://github.com/NuGet/NuGet.Client/blob/b83566ec2369c4e9fd07e6f95d734dfe370a1e66/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs#L34-L36
   -->
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(RestoreConfigFile)' == ''">
     <RestoreConfigFile Condition="Exists('$(RepoRoot)NuGet.config')">$(RepoRoot)NuGet.config</RestoreConfigFile>
     <RestoreConfigFile Condition="Exists('$(RepoRoot)NuGet.Config')">$(RepoRoot)NuGet.Config</RestoreConfigFile>
     <RestoreConfigFile Condition="Exists('$(RepoRoot)nuget.config')">$(RepoRoot)nuget.config</RestoreConfigFile>


### PR DESCRIPTION
The changes from https://github.com/dotnet/arcade/pull/14691 caused a regression in source build when building the aspnetcore repo. This is due to `RestoreConfigFile` no longer being set as an environment variable in the [repotasks build](https://github.com/dotnet/aspnetcore/blob/79ef5e329b1e31c3775a1977798253cc8f7da6cc/eng/DotNetBuild.props#L48-L53). Because it's not set as an environment variable, the `RestoreConfigFile` value that was [passed from command line](https://github.com/dotnet/aspnetcore/blob/79ef5e329b1e31c3775a1977798253cc8f7da6cc/eng/DotNetBuild.props#L35) is being [overwritten](https://github.com/dotnet/arcade/blob/a4f367bfa9602e4c24f509902285176fa3153a64/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj#L23-L27).

This is fixed by conditionally setting `RestoreConfigFile` only if it's not already set. This allows the passed `RestoreConfigFile` value to be preserved.

Fixes https://github.com/dotnet/source-build/issues/4304