### PR TITLE
Adopt latest secret-manager

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "microsoft.dnceng.secretmanager": {
-      "version": "1.1.0-beta.23451.13",
+      "version": "1.1.0-beta.24209.2",
       "commands": [
         "secret-manager"
       ]


### PR DESCRIPTION
Part of [dotnet/dnceng#2433](https://github.com/dotnet/dnceng/issues/2433)

Adopt latest secret-manager. Specifically, this is to get changes from [
Shorten Azure DevOps PAT duration (2464)](https://github.com/dotnet/dnceng/commit/07a2c58acba2c789f3e3786edb8fa8e270102d69). This is required to ensure secret-manager records proper information during the next PAT rotations.