### PR TITLE
Append attempt number to log artifact name

### DIFF
--- a/eng/common/templates-official/job/job.yml
+++ b/eng/common/templates-official/job/job.yml
@@ -210,7 +210,7 @@ jobs:
       - task: 1ES.PublishPipelineArtifact@1
         inputs:
           targetPath: 'artifacts/log'
-          artifactName: ${{ coalesce(parameters.artifacts.publish.logs.name, 'Logs_Build_$(Agent.Os)_$(_BuildConfig)') }}
+          artifactName: ${{ coalesce(parameters.artifacts.publish.logs.name, 'Logs_Build_$(Agent.Os)_$(_BuildConfig)_Attempt$(System.JobAttempt)') }}
         displayName: 'Publish logs'
         continueOnError: true
         condition: always()


### PR DESCRIPTION
Contributes to https://github.com/dotnet/arcade-services/issues/3482

Adds job attempt number to the name of the artifact containing logs. This is done as a solution to 1ES task currently failing the build in cases where a build is re-ran and the logs from the previous attempt have been published. Since the task tried to publish an artifact with an existing name, it fails.

The team is currently in discussion with 1ES to have this resolved on task level, but until then we could deal this conflict by just appending the job attempt number to the artifact
