### PR TITLE
Change devdiv code mirror sdl pool

### DIFF
--- a/azure-pipelines-code-mirror.yml
+++ b/azure-pipelines-code-mirror.yml
@@ -13,10 +13,20 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+
     pool:
       name: $(DncEngInternalBuildPool)
       image: windows.vs2019.amd64
       os: windows
+
+    # devdiv has different agent pools
+    ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+      sdl:
+        sourceAnalysisPool:
+          name: AzurePipelines-EO  
+          image: 1ESPT-Windows2022
+          os: windows
+
 # Moves code from GitHub into internal repos
     stages:
     - stage: Merge_GitHub_to_Azure_DevOps


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation

If you look at Arcade commit history, all of the merged changes show red x's...

![image](https://github.com/dotnet/arcade/assets/10092143/55aa5c6c-8101-4ecb-9879-04ecbe04b72f)

this is because there's a [devdiv code mirror](https://devdiv.visualstudio.com/DevDiv/_build?definitionId=16952&_a=summary) which has been reporting failure since we switched to 1ES pipeline templates.  The issue is that the 1ES PT injects an sdl analysis task which uses an agent pool and the one defined for dnceng is not applicable to devdiv.

This change fixes the agent pool so the code mirror reports success.