### PR TITLE
explicitly define is1ESpipeline in public template

### DIFF
--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -16,7 +16,7 @@ jobs:
         - ${{ if and(ne(parameters.artifacts.publish.artifacts, 'false'), ne(parameters.artifacts.publish.artifacts, '')) }}:
           - template: /eng/common/core-templates/steps/publish-build-artifacts.yml
             parameters:
-              is1ESPipeline: ${{ parameters.is1ESPipeline }}
+              is1ESPipeline: false
               args:
                 displayName: Publish pipeline artifacts
                 pathToPublish: '$(Build.ArtifactStagingDirectory)/artifacts'
@@ -27,7 +27,7 @@ jobs:
         - ${{ if and(ne(parameters.artifacts.publish.logs, 'false'), ne(parameters.artifacts.publish.logs, '')) }}:
           - template: /eng/common/core-templates/steps/publish-pipeline-artifacts.yml
             parameters:
-              is1ESPipeline: ${{ parameters.is1ESPipeline }}
+              is1ESPipeline: false
               args:
                 targetPath: '$(Build.ArtifactStagingDirectory)/artifacts/log'
                 artifactName: ${{ coalesce(parameters.artifacts.publish.logs.name, 'Logs_Build_$(Agent.Os)_$(_BuildConfig)') }}
@@ -38,7 +38,7 @@ jobs:
       - ${{ if ne(parameters.enablePublishBuildArtifacts, 'false') }}:
         - template: /eng/common/core-templates/steps/publish-build-artifacts.yml
           parameters:
-            is1ESPipeline: ${{ parameters.is1ESPipeline }}
+            is1ESPipeline: false
             args:
               displayName: Publish Logs
               pathToPublish: '$(Build.ArtifactStagingDirectory)/artifacts/log/$(_BuildConfig)'
@@ -50,7 +50,7 @@ jobs:
       - ${{ if eq(parameters.enableBuildRetry, 'true') }}:
         - template: /eng/common/core-templates/steps/publish-pipeline-artifacts.yml
           parameters:
-            is1ESPipeline: ${{ parameters.is1ESPipeline }}
+            is1ESPipeline: false
             args:
               targetPath: '$(Build.SourcesDirectory)\eng\common\BuildConfiguration'
               artifactName: 'BuildConfiguration'


### PR DESCRIPTION
installer is different than some of the other repos i validated because it explicitly references job.yml for its public ci rather than the more typical jobs.yml.  That makes this a good validation candidate .

### To double check:

* [ ] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation

Addresses https://github.com/dotnet/arcade/pull/14736#issuecomment-2074825950

Validated with https://dev.azure.com/dnceng-public/public/_build/results?buildId=654906&view=results

