### PR TITLE
Explicitly define default for enablePublishBuildArtifacts (public)

### DIFF
--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -1,3 +1,6 @@
+parameters: 
+  enablePublishBuildArtifacts: false
+
 jobs:
 - template: /eng/common/core-templates/job/job.yml
   parameters:


### PR DESCRIPTION
The template refactor changed the default for `enablePublishBuildArtifacts` in the public templates.

The default for "official" builds is to publish only if `enablePublishBuildArtifacts` == `true`, but the default for public was `enablePublishBuildArtifacts` != `false`.  This change reverts to that previous behavior.

Validated with https://dev.azure.com/dnceng-public/public/_build/results?buildId=657477&view=results


### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
