### PR TITLE
Use alternate syntax for post-build usage which is not under 1ES PT

### DIFF
--- a/eng/common/core-templates/post-build/post-build.yml
+++ b/eng/common/core-templates/post-build/post-build.yml
@@ -166,7 +166,7 @@ stages:
             os: windows
           ${{ else }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2019.amd64          
+            demands: ImageOverride -equals windows.vs2022.amd64          
       steps:
         - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
           parameters:
@@ -230,7 +230,7 @@ stages:
             os: windows
           ${{ else }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2019.amd64          
+            demands: ImageOverride -equals windows.vs2022.amd64          
       steps:
         - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
           parameters:

--- a/eng/common/core-templates/post-build/post-build.yml
+++ b/eng/common/core-templates/post-build/post-build.yml
@@ -116,12 +116,12 @@ stages:
         # If it's not devdiv, it's dnceng
         ${{ else }}:
           ${{ if eq(parameters.is1ESPipeline, true) }}:
-            name: NetCore1ESPool-Validation-Internal
-            image: windows.vs2019.amd64
+            name: $(DncEngInternalBuildPool)
+            image: windows.vs2022.amd64
             os: windows
           ${{ else }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2019.amd64
+            demands: ImageOverride -equals windows.vs2022.amd64
 
       steps:
         - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml

--- a/eng/common/core-templates/post-build/post-build.yml
+++ b/eng/common/core-templates/post-build/post-build.yml
@@ -115,9 +115,13 @@ stages:
           os: windows
         # If it's not devdiv, it's dnceng
         ${{ else }}:
-          name: $(DncEngInternalBuildPool)
-          image: 1es-windows-2022
-          os: windows
+          ${{ if eq(parameters.is1ESPipeline, true) }}:
+            name: NetCore1ESPool-Validation-Internal
+            image: windows.vs2019.amd64
+            os: windows
+          ${{ else }}:
+            name: $(DncEngInternalBuildPool)
+            demands: ImageOverride -equals windows.vs2019.amd64
 
       steps:
         - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
@@ -156,9 +160,13 @@ stages:
           os: windows
         # If it's not devdiv, it's dnceng
         ${{ else }}:
-          name: $(DncEngInternalBuildPool)
-          image: 1es-windows-2022
-          os: windows
+          ${{ if eq(parameters.is1ESPipeline, true) }}:        
+            name: $(DncEngInternalBuildPool)
+            image: 1es-windows-2022
+            os: windows
+          ${{ else }}:
+            name: $(DncEngInternalBuildPool)
+            demands: ImageOverride -equals windows.vs2019.amd64          
       steps:
         - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
           parameters:
@@ -216,9 +224,13 @@ stages:
           os: windows
         # If it's not devdiv, it's dnceng
         ${{ else }}:
-          name: $(DncEngInternalBuildPool)
-          image: 1es-windows-2022
-          os: windows
+          ${{ if eq(parameters.is1ESPipeline, true) }}:          
+            name: $(DncEngInternalBuildPool)
+            image: 1es-windows-2022
+            os: windows
+          ${{ else }}:
+            name: $(DncEngInternalBuildPool)
+            demands: ImageOverride -equals windows.vs2019.amd64          
       steps:
         - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
           parameters:
@@ -273,9 +285,13 @@ stages:
           os: windows
         # If it's not devdiv, it's dnceng
         ${{ else }}:
-          name: NetCore1ESPool-Publishing-Internal
-          image: windows.vs2019.amd64
-          os: windows
+          ${{ if eq(parameters.is1ESPipeline, true) }}:          
+            name: NetCore1ESPool-Publishing-Internal
+            image: windows.vs2019.amd64
+            os: windows
+          ${{ else }}:
+            name: NetCore1ESPool-Publishing-Internal
+            demands: ImageOverride -equals windows.vs2019.amd64          
       steps:
         - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
           parameters:


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md

@akoeplinger reported this failure - https://dev.azure.com/dnceng/internal/_build/results?buildId=2445847&view=results

Problem:
The issue is that their repo is running internal builds, and doing "post-build" things, but it's not production so it runs outside of 1ES PT.  1ES PT has different syntax for defining agent pools which ends up ignored if you're not running as 1ES PT and we end up with the wrong agent pool.  That leads to running by default on Ubuntu 18.04 which does not have the required pre-reqs for Node and leads to the build failure.

Impact:
This would affect any "official" build which has decided it is non-production and doesn't utilize 1ES PT but does do post-build things.

Validation:
Validated this fix with https://dev.azure.com/dnceng/internal/_build/results?buildId=2445969&view=logs&j=a13e9384-d6d3-5a14-7a96-79282fc11262&t=5254e7fd-b1f1-4d04-8b9d-e51752bafa8b

*Note: the validation build job is running very long.  I'm not super familiar with the SourceLink step, but I think that it's running long because i am using my dev branch. 
