### PR TITLE
Rework SetupNuGetSources to support WIF Service Connections

### DIFF
--- a/eng/common/SetupNugetSources.ps1
+++ b/eng/common/SetupNugetSources.ps1
@@ -8,14 +8,19 @@
 #
 # See example call for this script below.
 #
-#  - task: NuGetAuthenticate@1
 #  - task: PowerShell@2
 #    displayName: Setup Internal Feeds
 #    condition: eq(variables['Agent.OS'], 'Windows_NT')
 #    inputs:
 #      filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
 #      arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config
+#  - task: NuGetAuthenticate@1
 # 
+# Note that the NuGetAuthenticate task should be called after SetupNugetSources.
+# This ensures that:
+# - Appropriate creds are set for the added internal feeds (if not supplied to the scrupt)
+# - The credential provider is installed
+#
 # This logic is also abstracted into enable-internal-sources.yml.
 
 [CmdletBinding()]

--- a/eng/common/SetupNugetSources.ps1
+++ b/eng/common/SetupNugetSources.ps1
@@ -34,7 +34,7 @@ $feedEndpoints = $null
 
 # If a credential is provided, ensure that we don't overwrite the current set of
 # credentials that may have been provided by a previous call to the credential provider.
-if ($Password -and $env:VSS_NUGET_EXTERNAL_FEED_ENDPOINTS -ne $null) {
+if ($Password -and $null -ne $env:VSS_NUGET_EXTERNAL_FEED_ENDPOINTS) {
     $feedEndpoints = $env:VSS_NUGET_EXTERNAL_FEED_ENDPOINTS | ConvertFrom-Json
 } elseif ($Password) {
     $feedEndpoints = @{ endpointCredentials = @() }
@@ -44,7 +44,7 @@ if ($Password -and $env:VSS_NUGET_EXTERNAL_FEED_ENDPOINTS -ne $null) {
 function AddPackageSource($sources, $SourceName, $SourceEndPoint, $pwd) {
     $packageSource = $sources.SelectSingleNode("add[@key='$SourceName']")
     
-    if ($packageSource -eq $null)
+    if ($null -eq $packageSource)
     {
         Write-Host "`tAdding package source" $SourceName
         $packageSource = $doc.CreateElement("add")
@@ -100,14 +100,14 @@ $doc.Load($filename)
 
 # Get reference to <PackageSources> or create one if none exist already
 $sources = $doc.DocumentElement.SelectSingleNode("packageSources")
-if ($sources -eq $null) {
+if ($null -eq $sources) {
     $sources = $doc.CreateElement("packageSources")
     $doc.DocumentElement.AppendChild($sources) | Out-Null
 }
 
 # Check for disabledPackageSources; we'll enable any darc-int ones we find there
 $disabledSources = $doc.DocumentElement.SelectSingleNode("disabledPackageSources")
-if ($disabledSources -ne $null) {
+if ($null -ne $disabledSources) {
     Write-Host "Checking for any darc-int disabled package sources in the disabledPackageSources node"
     EnableInternalPackageSources -DisabledPackageSources $disabledSources
 }
@@ -118,7 +118,7 @@ if ($Password) {
 
 # 3.1 uses a different feed url format so it's handled differently here
 $dotnet31Source = $sources.SelectSingleNode("add[@key='dotnet3.1']")
-if ($dotnet31Source -ne $null) {
+if ($null -ne $dotnet31Source) {
     AddPackageSource -Sources $sources -SourceName "dotnet3.1-internal" -SourceEndPoint "https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3.1-internal/nuget/v3/index.json" -pwd $Password
     AddPackageSource -Sources $sources -SourceName "dotnet3.1-internal-transport" -SourceEndPoint "https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3.1-internal-transport/nuget/v3/index.json" -pwd $Password
 }
@@ -128,7 +128,7 @@ $dotnetVersions = @('5','6','7','8')
 foreach ($dotnetVersion in $dotnetVersions) {
     $feedPrefix = "dotnet" + $dotnetVersion;
     $dotnetSource = $sources.SelectSingleNode("add[@key='$feedPrefix']")
-    if ($dotnetSource -ne $null) {
+    if ($dotnetSource) {
         AddPackageSource -Sources $sources -SourceName "$feedPrefix-internal" -SourceEndPoint "https://pkgs.dev.azure.com/dnceng/internal/_packaging/$feedprefix-internal/nuget/v3/index.json" -pwd $Password
         AddPackageSource -Sources $sources -SourceName "$feedPrefix-internal-transport" -SourceEndPoint "https://pkgs.dev.azure.com/dnceng/internal/_packaging/$feedPrefix-internal-transport/nuget/v3/index.json" -pwd $Password
     }
@@ -137,7 +137,7 @@ foreach ($dotnetVersion in $dotnetVersions) {
 $doc.Save($filename)
 
 # If any credentials were added or altered, update the VSS_NUGET_EXTERNAL_FEED_ENDPOINTS environment variable
-if ($feedEndpoints -ne $null) {
+if ($null -ne $feedEndpoints) {
     # ci is set to true so vso logging commands will be used.
     $ci = $true
     Write-PipelineSetVariable -Name 'VSS_NUGET_EXTERNAL_FEED_ENDPOINTS' -Value $($feedEndpoints | ConvertTo-Json) -IsMultiJobVariable $false

--- a/eng/common/SetupNugetSources.ps1
+++ b/eng/common/SetupNugetSources.ps1
@@ -1,4 +1,4 @@
-# This script adds internal feeds required to build commits that depend on intenral package sources. For instance,
+# This script adds internal feeds required to build commits that depend on internal package sources. For instance,
 # dotnet6-internal would be added automatically if dotnet6 was found in the nuget.config file. In addition also enables
 # disabled internal Maestro (darc-int*) feeds.
 # 
@@ -46,7 +46,7 @@ function AddPackageSource($sources, $SourceName, $SourceEndPoint, $pwd) {
     
     if ($packageSource -eq $null)
     {
-        Write-Host "`tAdding package source" $PackageSource.Key
+        Write-Host "`tAdding package source" $SourceName
         $packageSource = $doc.CreateElement("add")
         $packageSource.SetAttribute("key", $SourceName)
         $packageSource.SetAttribute("value", $SourceEndPoint)

--- a/eng/common/SetupNugetSources.ps1
+++ b/eng/common/SetupNugetSources.ps1
@@ -1,31 +1,26 @@
-# This file is a temporary workaround for internal builds to be able to restore from private AzDO feeds.
-# This file should be removed as part of this issue: https://github.com/dotnet/arcade/issues/4080
+# This script adds internal feeds required to build commits that depend on intenral package sources. For instance,
+# dotnet6-internal would be added automatically if dotnet6 was found in the nuget.config file. In addition also enables
+# disabled internal Maestro (darc-int*) feeds.
+# 
+# Optionally, this script also adds a credential entry for each of the internal feeds if supplied.
+# This option will be removed ASAP, when no longer in use. This is a workaround for feed auth issues that dates to the 3.1 release.
 #
-# What the script does is iterate over all package sources in the pointed NuGet.config and add a credential entry
-# under <packageSourceCredentials> for each Maestro managed private feed. Two additional credential 
-# entries are also added for the two private static internal feeds: dotnet3-internal and dotnet3-internal-transport.
+# See example call for this script below.
 #
-# This script needs to be called in every job that will restore packages and which the base repo has
-# private AzDO feeds in the NuGet.config.
-#
-# See example YAML call for this script below. Note the use of the variable `$(dn-bot-dnceng-artifact-feeds-rw)`
-# from the AzureDevOps-Artifact-Feeds-Pats variable group.
-#
-# Any disabledPackageSources entries which start with "darc-int" will be re-enabled as part of this script executing
-#
+#  - task: NuGetAuthenticate@1
 #  - task: PowerShell@2
 #    displayName: Setup Private Feeds Credentials
 #    condition: eq(variables['Agent.OS'], 'Windows_NT')
 #    inputs:
 #      filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-#      arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-#    env:
-#      Token: $(dn-bot-dnceng-artifact-feeds-rw)
+#      arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config
+# 
+# This logic is also abstracted into enable-internal-sources.yml.
 
 [CmdletBinding()]
 param (
     [Parameter(Mandatory = $true)][string]$ConfigFile,
-    [Parameter(Mandatory = $true)][string]$Password
+    [string]$Password
 )
 
 $ErrorActionPreference = "Stop"
@@ -71,18 +66,20 @@ function AddCredential($creds, $source, $username, $pwd) {
     }
     $usernameElement.SetAttribute("value", $Username)
 
-    # Add the <ClearTextPassword> to the credential if none is found.
-    # Add it as a clear text because there is no support for encrypted ones in non-windows .Net SDKs.
-    #   -> https://github.com/NuGet/Home/issues/5526
-    $passwordElement = $sourceElement.SelectSingleNode("add[@key='ClearTextPassword']")
-    if ($passwordElement -eq $null)
-    {
-        $passwordElement = $doc.CreateElement("add")
-        $passwordElement.SetAttribute("key", "ClearTextPassword")
-        $sourceElement.AppendChild($passwordElement) | Out-Null
+    if ($Password){
+        # Add the <ClearTextPassword> to the credential if none is found.
+        # Add it as a clear text because there is no support for encrypted ones in non-windows .Net SDKs.
+        #   -> https://github.com/NuGet/Home/issues/5526
+        $passwordElement = $sourceElement.SelectSingleNode("add[@key='ClearTextPassword']")
+        if ($passwordElement -eq $null)
+        {
+            $passwordElement = $doc.CreateElement("add")
+            $passwordElement.SetAttribute("key", "ClearTextPassword")
+            $sourceElement.AppendChild($passwordElement) | Out-Null
+        }
+        
+        $passwordElement.SetAttribute("value", $pwd)
     }
-    
-    $passwordElement.SetAttribute("value", $pwd)
 }
 
 function InsertMaestroPrivateFeedCredentials($Sources, $Creds, $Username, $pwd) {
@@ -108,11 +105,6 @@ function EnablePrivatePackageSources($DisabledPackageSources) {
 if (!(Test-Path $ConfigFile -PathType Leaf)) {
   Write-PipelineTelemetryError -Category 'Build' -Message "Eng/common/SetupNugetSources.ps1 returned a non-zero exit code. Couldn't find the NuGet config file: $ConfigFile"
   ExitWithExitCode 1
-}
-
-if (!$Password) {
-    Write-PipelineTelemetryError -Category 'Build' -Message 'Eng/common/SetupNugetSources.ps1 returned a non-zero exit code. Please supply a valid PAT'
-    ExitWithExitCode 1
 }
 
 # Load NuGet.config

--- a/eng/common/SetupNugetSources.sh
+++ b/eng/common/SetupNugetSources.sh
@@ -5,7 +5,6 @@
 # disabled internal Maestro (darc-int*) feeds.
 # 
 # Optionally, this script also adds a credential entry for each of the internal feeds if supplied.
-# This option will be removed ASAP, when no longer in use. This is a workaround for feed auth issues that dates to the 3.1 release.
 #
 # See example call for this script below.
 #
@@ -15,6 +14,12 @@
 #      filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
 #      arguments: $(Build.SourcesDirectory)/NuGet.config
 #    condition: ne(variables['Agent.OS'], 'Windows_NT')
+#  - task: NuGetAuthenticate@1
+#
+# Note that the NuGetAuthenticate task should be called after SetupNugetSources.
+# This ensures that:
+# - Appropriate creds are set for the added internal feeds (if not supplied to the scrupt)
+# - The credential provider is installed.
 #
 # This logic is also abstracted into enable-internal-sources.yml.
 

--- a/eng/common/SetupNugetSources.sh
+++ b/eng/common/SetupNugetSources.sh
@@ -1,28 +1,22 @@
 #!/usr/bin/env bash
 
-# This file is a temporary workaround for internal builds to be able to restore from private AzDO feeds.
-# This file should be removed as part of this issue: https://github.com/dotnet/arcade/issues/4080
+# This script adds internal feeds required to build commits that depend on intenral package sources. For instance,
+# dotnet6-internal would be added automatically if dotnet6 was found in the nuget.config file. In addition also enables
+# disabled internal Maestro (darc-int*) feeds.
+# 
+# Optionally, this script also adds a credential entry for each of the internal feeds if supplied.
+# This option will be removed ASAP, when no longer in use. This is a workaround for feed auth issues that dates to the 3.1 release.
 #
-# What the script does is iterate over all package sources in the pointed NuGet.config and add a credential entry
-# under <packageSourceCredentials> for each Maestro's managed private feed. Two additional credential 
-# entries are also added for the two private static internal feeds: dotnet3-internal and dotnet3-internal-transport.
-#
-# This script needs to be called in every job that will restore packages and which the base repo has
-# private AzDO feeds in the NuGet.config.
-#
-# See example YAML call for this script below. Note the use of the variable `$(dn-bot-dnceng-artifact-feeds-rw)`
-# from the AzureDevOps-Artifact-Feeds-Pats variable group.
-#
-# Any disabledPackageSources entries which start with "darc-int" will be re-enabled as part of this script executing.
+# See example call for this script below.
 #
 #  - task: Bash@3
 #    displayName: Setup Private Feeds Credentials
 #    inputs:
 #      filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
-#      arguments: $(Build.SourcesDirectory)/NuGet.config $Token
+#      arguments: $(Build.SourcesDirectory)/NuGet.config
 #    condition: ne(variables['Agent.OS'], 'Windows_NT')
-#    env:
-#      Token: $(dn-bot-dnceng-artifact-feeds-rw)
+#
+# This logic is also abstracted into enable-internal-sources.yml.
 
 ConfigFile=$1
 CredToken=$2
@@ -45,11 +39,6 @@ scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 
 if [ ! -f "$ConfigFile" ]; then
     Write-PipelineTelemetryError -Category 'Build' "Error: Eng/common/SetupNugetSources.sh returned a non-zero exit code. Couldn't find the NuGet config file: $ConfigFile"
-    ExitWithExitCode 1
-fi
-
-if [ -z "$CredToken" ]; then
-    Write-PipelineTelemetryError -category 'Build' "Error: Eng/common/SetupNugetSources.sh returned a non-zero exit code. Please supply a valid PAT"
     ExitWithExitCode 1
 fi
 
@@ -140,18 +129,20 @@ PackageSources+="$IFS"
 PackageSources+=$(grep -oh '"darc-int-[^"]*"' $ConfigFile | tr -d '"')
 IFS=$PrevIFS
 
-for FeedName in ${PackageSources[@]} ; do
-    # Check if there is no existing credential for this FeedName
-    grep -i "<$FeedName>" $ConfigFile 
-    if [ "$?" != "0" ]; then
-        echo "Adding credentials for $FeedName."
+if [ "$CredToken" ]; then
+    for FeedName in ${PackageSources[@]} ; do
+        # Check if there is no existing credential for this FeedName
+        grep -i "<$FeedName>" $ConfigFile 
+        if [ "$?" != "0" ]; then
+            echo "Adding credentials for $FeedName."
 
-        PackageSourceCredentialsNodeFooter="</packageSourceCredentials>"
-        NewCredential="${TB}${TB}<$FeedName>${NL}<add key=\"Username\" value=\"dn-bot\" />${NL}<add key=\"ClearTextPassword\" value=\"$CredToken\" />${NL}</$FeedName>"
+            PackageSourceCredentialsNodeFooter="</packageSourceCredentials>"
+            NewCredential="${TB}${TB}<$FeedName>${NL}<add key=\"Username\" value=\"dn-bot\" />${NL}<add key=\"ClearTextPassword\" value=\"$CredToken\" />${NL}</$FeedName>"
 
-        sed -i.bak "s|$PackageSourceCredentialsNodeFooter|$NewCredential${NL}$PackageSourceCredentialsNodeFooter|" $ConfigFile
-    fi
-done
+            sed -i.bak "s|$PackageSourceCredentialsNodeFooter|$NewCredential${NL}$PackageSourceCredentialsNodeFooter|" $ConfigFile
+        fi
+    done
+fi
 
 # Re-enable any entries in disabledPackageSources where the feed name contains darc-int
 grep -i "<disabledPackageSources>" $ConfigFile

--- a/eng/common/SetupNugetSources.sh
+++ b/eng/common/SetupNugetSources.sh
@@ -10,7 +10,7 @@
 # See example call for this script below.
 #
 #  - task: Bash@3
-#    displayName: Setup Private Feeds Credentials
+#    displayName: Setup Internal Feeds
 #    inputs:
 #      filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
 #      arguments: $(Build.SourcesDirectory)/NuGet.config

--- a/eng/common/core-templates/steps/enable-internal-sources.yml
+++ b/eng/common/core-templates/steps/enable-internal-sources.yml
@@ -5,20 +5,24 @@ parameters:
   default: 'dnceng-artifacts-feeds-read'
 
 steps:
-- ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'))) }}:
+- ${{ if ne(variables['System.TeamProject'], 'public') }}:
   # If running on dnceng (internal project), just use the default behavior for NuGetAuthenticate.
   # If running on DevDiv, NuGetAuthenticate is not really an option. It's scoped to a single feed, and we have many feeds that
   # may be added. Instead, we'll use the traditional approach (add cred to nuget.config), but use an account token.
-  - ${{ if eq(variables['System.TeamProject'], 'internal')) }}:
+  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    - task: PowerShell@2
+      displayName: Setup Private Feeds
+      inputs:
+        filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+        arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config
     - task: NuGetAuthenticate@1
-      displayName: 'Authenticate to dnceng internal feeds'
   - ${{ else }}:
     - template: /eng/common/core-templates/steps/get-federated-access-token.yml
       parameters:
         federatedServiceConnection: ${{ parameters.nugetFederatedServiceConnection }}
         outputVariableName: 'dnceng-artifacts-feeds-read-access-token'
     - task: PowerShell@2
-      displayName: Setup Private Feeds Credentials (Windows)
+      displayName: Setup Private Feeds
       inputs:
         filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
         arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $(dnceng-artifacts-feeds-read-access-token)

--- a/eng/common/core-templates/steps/enable-internal-sources.yml
+++ b/eng/common/core-templates/steps/enable-internal-sources.yml
@@ -1,0 +1,24 @@
+parameters:
+# This is the Azure federated service connection that we log into to get an access token.
+- name: nugetFederatedServiceConnection
+  type: string
+  default: 'dnceng-artifacts-feeds-read'
+
+steps:
+- ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'))) }}:
+  # If running on dnceng (internal project), just use the default behavior for NuGetAuthenticate.
+  # If running on DevDiv, NuGetAuthenticate is not really an option. It's scoped to a single feed, and we have many feeds that
+  # may be added. Instead, we'll use the traditional approach (add cred to nuget.config), but use an account token.
+  - ${{ if eq(variables['System.TeamProject'], 'internal')) }}:
+    - task: NuGetAuthenticate@1
+      displayName: 'Authenticate to dnceng internal feeds'
+  - ${{ else }}:
+    - template: /eng/common/core-templates/steps/get-federated-access-token.yml
+      parameters:
+        federatedServiceConnection: ${{ parameters.nugetFederatedServiceConnection }}
+        outputVariableName: 'dnceng-artifacts-feeds-read-access-token'
+    - task: PowerShell@2
+      displayName: Setup Private Feeds Credentials (Windows)
+      inputs:
+        filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+        arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $(dnceng-artifacts-feeds-read-access-token)

--- a/eng/common/core-templates/steps/enable-internal-sources.yml
+++ b/eng/common/core-templates/steps/enable-internal-sources.yml
@@ -7,7 +7,7 @@ parameters:
 steps:
 - ${{ if ne(variables['System.TeamProject'], 'public') }}:
   # If running on dnceng (internal project), just use the default behavior for NuGetAuthenticate.
-  # If running on DevDiv, NuGetAuthenticate is not really an option. It's scoped to a single feed, and we have many feeds that
+  # If running on DevDiv or a non-dnceng org, NuGetAuthenticate is not really an option. It's scoped to a single feed, and we have many feeds that
   # may be added. Instead, we'll use the traditional approach (add cred to nuget.config), but use an account token.
   - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
     - task: PowerShell@2

--- a/eng/common/core-templates/steps/enable-internal-sources.yml
+++ b/eng/common/core-templates/steps/enable-internal-sources.yml
@@ -11,7 +11,7 @@ steps:
   # may be added. Instead, we'll use the traditional approach (add cred to nuget.config), but use an account token.
   - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
     - task: PowerShell@2
-      displayName: Setup Private Feeds
+      displayName: Setup Internal Feeds
       inputs:
         filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
         arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config
@@ -22,7 +22,7 @@ steps:
         federatedServiceConnection: ${{ parameters.nugetFederatedServiceConnection }}
         outputVariableName: 'dnceng-artifacts-feeds-read-access-token'
     - task: PowerShell@2
-      displayName: Setup Private Feeds
+      displayName: Setup Internal Feeds
       inputs:
         filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
         arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $(dnceng-artifacts-feeds-read-access-token)

--- a/eng/common/core-templates/steps/enable-internal-sources.yml
+++ b/eng/common/core-templates/steps/enable-internal-sources.yml
@@ -7,7 +7,7 @@ parameters:
 steps:
 - ${{ if ne(variables['System.TeamProject'], 'public') }}:
   # If running on dnceng (internal project), just use the default behavior for NuGetAuthenticate.
-  # If running on DevDiv or a non-dnceng org, NuGetAuthenticate is not really an option. It's scoped to a single feed, and we have many feeds that
+  # If running on DevDiv, NuGetAuthenticate is not really an option. It's scoped to a single feed, and we have many feeds that
   # may be added. Instead, we'll use the traditional approach (add cred to nuget.config), but use an account token.
   - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
     - task: PowerShell@2
@@ -17,7 +17,7 @@ steps:
         arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config
     - task: NuGetAuthenticate@1
   - ${{ else }}:
-    - template: /eng/common/core-templates/steps/get-federated-access-token.yml
+    - template: /eng/common/templates/steps/get-federated-access-token.yml
       parameters:
         federatedServiceConnection: ${{ parameters.nugetFederatedServiceConnection }}
         outputVariableName: 'dnceng-artifacts-feeds-read-access-token'
@@ -26,3 +26,7 @@ steps:
       inputs:
         filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
         arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $(dnceng-artifacts-feeds-read-access-token)
+    # This is required in certain scenarios to install the ADO credential provider.
+    # It installed by default in some msbuild invocations (e.g. VS msbuild), but needs to be installed for others
+    # (e.g. dotnet msbuild).
+    - task: NuGetAuthenticate@1

--- a/eng/common/core-templates/steps/enable-internal-sources.yml
+++ b/eng/common/core-templates/steps/enable-internal-sources.yml
@@ -11,7 +11,7 @@ steps:
   # may be added. Instead, we'll use the traditional approach (add cred to nuget.config), but use an account token.
   - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
     - task: PowerShell@2
-      displayName: Setup Internal Feeds
+      displayName: Setup Private Feeds
       inputs:
         filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
         arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config
@@ -22,7 +22,7 @@ steps:
         federatedServiceConnection: ${{ parameters.nugetFederatedServiceConnection }}
         outputVariableName: 'dnceng-artifacts-feeds-read-access-token'
     - task: PowerShell@2
-      displayName: Setup Internal Feeds
+      displayName: Setup Private Feeds
       inputs:
         filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
         arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $(dnceng-artifacts-feeds-read-access-token)

--- a/eng/common/core-templates/steps/get-federated-access-token.yml
+++ b/eng/common/core-templates/steps/get-federated-access-token.yml
@@ -1,19 +1,25 @@
 parameters:
 - name: federatedServiceConnection
   type: string
-  default: ''
 - name: outputVariableName
   type: string
+# Resource to get a token for. Common values include:
+# - '499b84ac-1321-427f-aa17-267ca6975798' for Azure DevOps
+# - 'https://storage.azure.com/' for storage
+# Defaults to Azure DevOps
+- name: resource
+  type: string
+  default: '499b84ac-1321-427f-aa17-267ca6975798'
 
 steps:
 - task: AzureCLI@2
+  displayName: 'Getting federated access token for feeds'
   inputs:
-    azureSubscription: ${{ coalesce(parameters.federatedServiceConnection, 'dnceng-artifacts-feeds-read') }}
+    azureSubscription: ${{ parameters.federatedServiceConnection }}
     scriptType: 'pscore'
     scriptLocation: 'inlineScript'
     inlineScript: |
-      $accessToken = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 --output tsv
+      $accessToken = az account get-access-token --query accessToken --resource ${{ parameters.resource }} --output tsv
 
-      # Set the access token as a secret, so it doesn't get leaked in the logs
-      Write-Host "##vso[task.setsecret]$accessToken"
-      Write-Host "##vso[task.setvariable variable=${{ parameters.outputVariableName }}]$accessToken"
+      Write-Host "Setting '${{ parameters.outputVariableName }}' with the access token value"
+      Write-Host "##vso[task.setvariable variable=${{ parameters.outputVariableName }};issecret=true]$accessToken"

--- a/eng/common/core-templates/steps/get-federated-access-token.yml
+++ b/eng/common/core-templates/steps/get-federated-access-token.yml
@@ -1,0 +1,19 @@
+parameters:
+- name: federatedServiceConnection
+  type: string
+  default: ''
+- name: outputVariableName
+  type: string
+
+steps:
+- task: AzureCLI@2
+  inputs:
+    azureSubscription: ${{ coalesce(parameters.federatedServiceConnection, 'dnceng-artifacts-feeds-read') }}
+    scriptType: 'pscore'
+    scriptLocation: 'inlineScript'
+    inlineScript: |
+      $accessToken = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
+
+      # Set the access token as a secret, so it doesn't get leaked in the logs
+      Write-Host "##vso[task.setsecret]$accessToken"
+      Write-Host "##vso[task.setvariable variable=${{ parameters.outputVariableName }}]$accessToken"

--- a/eng/common/core-templates/steps/get-federated-access-token.yml
+++ b/eng/common/core-templates/steps/get-federated-access-token.yml
@@ -7,8 +7,9 @@ parameters:
 
 steps:
 - task: AzureCLI@2
+  displayName: 'Get federated access token'
   inputs:
-    azureSubscription: ${{ coalesce(parameters.federatedServiceConnection, 'dnceng-artifacts-feeds-read') }}
+    azureSubscription: ${{ parameters.federatedServiceConnection }}
     scriptType: 'pscore'
     scriptLocation: 'inlineScript'
     inlineScript: |

--- a/eng/common/core-templates/steps/get-federated-access-token.yml
+++ b/eng/common/core-templates/steps/get-federated-access-token.yml
@@ -7,9 +7,8 @@ parameters:
 
 steps:
 - task: AzureCLI@2
-  displayName: 'Get federated access token'
   inputs:
-    azureSubscription: ${{ parameters.federatedServiceConnection }}
+    azureSubscription: ${{ coalesce(parameters.federatedServiceConnection, 'dnceng-artifacts-feeds-read') }}
     scriptType: 'pscore'
     scriptLocation: 'inlineScript'
     inlineScript: |

--- a/eng/common/core-templates/steps/get-federated-access-token.yml
+++ b/eng/common/core-templates/steps/get-federated-access-token.yml
@@ -20,6 +20,9 @@ steps:
     scriptLocation: 'inlineScript'
     inlineScript: |
       $accessToken = az account get-access-token --query accessToken --resource ${{ parameters.resource }} --output tsv
-
+      if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to get access token for resource '${{ parameters.resource }}'"
+        exit 1
+      }
       Write-Host "Setting '${{ parameters.outputVariableName }}' with the access token value"
       Write-Host "##vso[task.setvariable variable=${{ parameters.outputVariableName }};issecret=true]$accessToken"

--- a/eng/common/core-templates/steps/source-build.yml
+++ b/eng/common/core-templates/steps/source-build.yml
@@ -14,23 +14,16 @@ parameters:
   is1ESPipeline: false
 
 steps:
+- template: /eng/common/core-templates/steps/enable-internal-sources.yml
 # Build. Keep it self-contained for simple reusability. (No source-build-specific job variables.)
 - script: |
     set -x
     df -h
 
-    # If building on the internal project, the artifact feeds variable may be available (usually only if needed)
-    # In that case, call the feed setup script to add internal feeds corresponding to public ones.
-    # In addition, add an msbuild argument to copy the WIP from the repo to the target build location.
-    # This is because SetupNuGetSources.sh will alter the current NuGet.config file, and we need to preserve those
-    # changes.
+    # If file changes are detected, set CopyWipIntoInnerSourceBuildRepo to copy the WIP changes into the inner source build repo.
     internalRestoreArgs=
-    if [ '$(dn-bot-dnceng-artifact-feeds-rw)' != '$''(dn-bot-dnceng-artifact-feeds-rw)' ]; then
-      # Temporarily work around https://github.com/dotnet/arcade/issues/7709
-      chmod +x $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
-      $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh $(Build.SourcesDirectory)/NuGet.config $(dn-bot-dnceng-artifact-feeds-rw)
+    if ! git diff --quiet; then
       internalRestoreArgs='/p:CopyWipIntoInnerSourceBuildRepo=true'
-
       # The 'Copy WIP' feature of source build uses git stash to apply changes from the original repo.
       # This only works if there is a username/email configured, which won't be the case in most CI runs.
       git config --get user.email

--- a/eng/common/core-templates/steps/source-build.yml
+++ b/eng/common/core-templates/steps/source-build.yml
@@ -14,6 +14,7 @@ parameters:
   is1ESPipeline: false
 
 steps:
+- template: /eng/common/core-templates/steps/enable-internal-sources.yml
 # Build. Keep it self-contained for simple reusability. (No source-build-specific job variables.)
 - script: |
     set -x

--- a/eng/common/core-templates/steps/source-build.yml
+++ b/eng/common/core-templates/steps/source-build.yml
@@ -14,16 +14,23 @@ parameters:
   is1ESPipeline: false
 
 steps:
-- template: /eng/common/core-templates/steps/enable-internal-sources.yml
 # Build. Keep it self-contained for simple reusability. (No source-build-specific job variables.)
 - script: |
     set -x
     df -h
 
-    # If file changes are detected, set CopyWipIntoInnerSourceBuildRepo to copy the WIP changes into the inner source build repo.
+    # If building on the internal project, the artifact feeds variable may be available (usually only if needed)
+    # In that case, call the feed setup script to add internal feeds corresponding to public ones.
+    # In addition, add an msbuild argument to copy the WIP from the repo to the target build location.
+    # This is because SetupNuGetSources.sh will alter the current NuGet.config file, and we need to preserve those
+    # changes.
     internalRestoreArgs=
-    if [ $(git diff --exit-code) ]; then
+    if [ '$(dn-bot-dnceng-artifact-feeds-rw)' != '$''(dn-bot-dnceng-artifact-feeds-rw)' ]; then
+      # Temporarily work around https://github.com/dotnet/arcade/issues/7709
+      chmod +x $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
+      $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh $(Build.SourcesDirectory)/NuGet.config $(dn-bot-dnceng-artifact-feeds-rw)
       internalRestoreArgs='/p:CopyWipIntoInnerSourceBuildRepo=true'
+
       # The 'Copy WIP' feature of source build uses git stash to apply changes from the original repo.
       # This only works if there is a username/email configured, which won't be the case in most CI runs.
       git config --get user.email
@@ -116,6 +123,7 @@ steps:
       artifactName: BuildLogs_SourceBuild_${{ parameters.platform.name }}_Attempt$(System.JobAttempt)
       continueOnError: true
       condition: succeededOrFailed()
+      sbomEnabled: false  # we don't need SBOM for logs
 
 # Manually inject component detection so that we can ignore the source build upstream cache, which contains
 # a nupkg cache of input packages (a local feed).

--- a/eng/common/core-templates/steps/source-build.yml
+++ b/eng/common/core-templates/steps/source-build.yml
@@ -20,18 +20,10 @@ steps:
     set -x
     df -h
 
-    # If building on the internal project, the artifact feeds variable may be available (usually only if needed)
-    # In that case, call the feed setup script to add internal feeds corresponding to public ones.
-    # In addition, add an msbuild argument to copy the WIP from the repo to the target build location.
-    # This is because SetupNuGetSources.sh will alter the current NuGet.config file, and we need to preserve those
-    # changes.
+    # If file changes are detected, set CopyWipIntoInnerSourceBuildRepo to copy the WIP changes into the inner source build repo.
     internalRestoreArgs=
-    if [ '$(dn-bot-dnceng-artifact-feeds-rw)' != '$''(dn-bot-dnceng-artifact-feeds-rw)' ]; then
-      # Temporarily work around https://github.com/dotnet/arcade/issues/7709
-      chmod +x $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
-      $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh $(Build.SourcesDirectory)/NuGet.config $(dn-bot-dnceng-artifact-feeds-rw)
+    if [ $(git diff --exit-code) ]; then
       internalRestoreArgs='/p:CopyWipIntoInnerSourceBuildRepo=true'
-
       # The 'Copy WIP' feature of source build uses git stash to apply changes from the original repo.
       # This only works if there is a username/email configured, which won't be the case in most CI runs.
       git config --get user.email

--- a/eng/common/templates-official/steps/enable-internal-sources.yml
+++ b/eng/common/templates-official/steps/enable-internal-sources.yml
@@ -1,7 +1,7 @@
 steps:
-- template: /eng/common/core-templates/steps/get-federated-access-token.yml
+- template: /eng/common/core-templates/steps/enable-internal-sources.yml
   parameters:
-    is1ESPipeline: false
+    is1ESPipeline: true
 
     ${{ each parameter in parameters }}:
       ${{ parameter.key }}: ${{ parameter.value }}

--- a/eng/common/templates-official/steps/get-federated-access-token.yml
+++ b/eng/common/templates-official/steps/get-federated-access-token.yml
@@ -1,7 +1,7 @@
 steps:
 - template: /eng/common/core-templates/steps/get-federated-access-token.yml
   parameters:
-    is1ESPipeline: false
+    is1ESPipeline: true
 
     ${{ each parameter in parameters }}:
       ${{ parameter.key }}: ${{ parameter.value }}

--- a/eng/common/templates/steps/enable-internal-sources.yml
+++ b/eng/common/templates/steps/enable-internal-sources.yml
@@ -1,32 +1,7 @@
-parameters:
-# This is the Azure federated service connection that we log into to get an access token.
-- name: nugetFederatedServiceConnection
-  type: string
-  default: 'dnceng-artifacts-feeds-read'
-
 steps:
-- ${{ if ne(variables['System.TeamProject'], 'public') }}:
-  # If running on dnceng (internal project), just use the default behavior for NuGetAuthenticate.
-  # If running on DevDiv, NuGetAuthenticate is not really an option. It's scoped to a single feed, and we have many feeds that
-  # may be added. Instead, we'll use the traditional approach (add cred to nuget.config), but use an account token.
-  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-    - task: PowerShell@2
-      displayName: Setup Private Feeds
-      inputs:
-        filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-        arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config
-    - task: NuGetAuthenticate@1
-  - ${{ else }}:
-    - template: /eng/common/templates/steps/get-federated-access-token.yml
-      parameters:
-        federatedServiceConnection: ${{ parameters.nugetFederatedServiceConnection }}
-        outputVariableName: 'dnceng-artifacts-feeds-read-access-token'
-    - task: PowerShell@2
-      displayName: Setup Private Feeds
-      inputs:
-        filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-        arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $(dnceng-artifacts-feeds-read-access-token)
-    # This is required in certain scenarios to install the ADO credential provider.
-    # It installed by default in some msbuild invocations (e.g. VS msbuild), but needs to be installed for others
-    # (e.g. dotnet msbuild).
-    - task: NuGetAuthenticate@1
+- template: /eng/common/core-templates/steps/enable-internal-sources.yml
+  parameters:
+    is1ESPipeline: false
+
+    ${{ each parameter in parameters }}:
+      ${{ parameter.key }}: ${{ parameter.value }}

--- a/eng/common/templates/steps/enable-internal-sources.yml
+++ b/eng/common/templates/steps/enable-internal-sources.yml
@@ -1,0 +1,32 @@
+parameters:
+# This is the Azure federated service connection that we log into to get an access token.
+- name: nugetFederatedServiceConnection
+  type: string
+  default: 'dnceng-artifacts-feeds-read'
+
+steps:
+- ${{ if ne(variables['System.TeamProject'], 'public') }}:
+  # If running on dnceng (internal project), just use the default behavior for NuGetAuthenticate.
+  # If running on DevDiv, NuGetAuthenticate is not really an option. It's scoped to a single feed, and we have many feeds that
+  # may be added. Instead, we'll use the traditional approach (add cred to nuget.config), but use an account token.
+  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    - task: PowerShell@2
+      displayName: Setup Private Feeds
+      inputs:
+        filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+        arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config
+    - task: NuGetAuthenticate@1
+  - ${{ else }}:
+    - template: /eng/common/templates/steps/get-federated-access-token.yml
+      parameters:
+        federatedServiceConnection: ${{ parameters.nugetFederatedServiceConnection }}
+        outputVariableName: 'dnceng-artifacts-feeds-read-access-token'
+    - task: PowerShell@2
+      displayName: Setup Private Feeds
+      inputs:
+        filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+        arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $(dnceng-artifacts-feeds-read-access-token)
+    # This is required in certain scenarios to install the ADO credential provider.
+    # It installed by default in some msbuild invocations (e.g. VS msbuild), but needs to be installed for others
+    # (e.g. dotnet msbuild).
+    - task: NuGetAuthenticate@1

--- a/eng/common/templates/steps/get-federated-access-token.yml
+++ b/eng/common/templates/steps/get-federated-access-token.yml
@@ -1,0 +1,26 @@
+parameters:
+- name: federatedServiceConnection
+  type: string
+- name: outputVariableName
+  type: string
+# Resource to get a token for. Common values include:
+# - '499b84ac-1321-427f-aa17-267ca6975798' for Azure DevOps
+# - 'https://storage.azure.com/' for storage
+# Defaults to Azure DevOps
+- name: resource
+  type: string
+  default: '499b84ac-1321-427f-aa17-267ca6975798'
+
+steps:
+- task: AzureCLI@2
+  displayName: 'Getting federated access token for feeds'
+  inputs:
+    azureSubscription: ${{ parameters.federatedServiceConnection }}
+    scriptType: 'pscore'
+    scriptLocation: 'inlineScript'
+    inlineScript: |
+      $accessToken = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 --output tsv
+
+      # Set the access token as a secret, so it doesn't get leaked in the logs
+      Write-Host "Setting '${{ parameters.outputVariableName }}' with the access token value"
+      Write-Host "##vso[task.setvariable variable=${{ parameters.outputVariableName }};issecret=true]$accessToken"

--- a/eng/common/templates/steps/publish-pipeline-artifacts.yml
+++ b/eng/common/templates/steps/publish-pipeline-artifacts.yml
@@ -19,16 +19,16 @@ steps:
   ${{ if parameters.args.continueOnError }}:
     continueOnError: ${{ parameters.args.continueOnError }}
   inputs:
-    TargetPath: ${{ parameters.args.TargetPath }}
-    ${{ if parameters.args.ArtifactName }}:
-      ArtifactName: ${{ parameters.args.ArtifactName }}
-    ${{ if parameters.args.PublishLocation }}:
-      PublishLocation: ${{ parameters.args.PublishLocation }}
-    ${{ if parameters.args.FileSharePath }}:
-      FileSharePath: ${{ parameters.args.FileSharePath }}
+    targetPath: ${{ parameters.args.targetPath }}
+    ${{ if parameters.args.artifactName }}:
+      artifactName: ${{ parameters.args.artifactName }}
+    ${{ if parameters.args.publishLocation }}:
+      publishLocation: ${{ parameters.args.publishLocation }}
+    ${{ if parameters.args.fileSharePath }}:
+      fileSharePath: ${{ parameters.args.fileSharePath }}
     ${{ if parameters.args.Parallel }}:
-      Parallel: ${{ parameters.args.Parallel }}
-    ${{ if parameters.args.ParallelCount }}:
-      ParallelCount: ${{ parameters.args.ParallelCount }}
-    ${{ if parameters.args.Properties }}:
-      Properties: ${{ properties.args.Properties }}
+      parallel: ${{ parameters.args.Parallel }}
+    ${{ if parameters.args.parallelCount }}:
+      parallelCount: ${{ parameters.args.parallelCount }}
+    ${{ if parameters.args.properties }}:
+      properties: ${{ properties.args.properties }}


### PR DESCRIPTION
Adds a set of templates which generate aad tokens in pipelines, and uses these templates in a new template which enables internal sources.

There are a few interesting aspects to this:
- Remove the use of PATs when authenticating to feeds that are in the same project. Instead, just add the feeds and call NuGetAuthenticate.
- Alter SetupNuGetSources.ps1 so that it doesn't bake a PAT into the NuGet.config. Instead, use the environment variable strategy.
- I did not change SetupNuGetSources.sh except to enable its use without a PAT (so that devs can use it on a local machine). The reason is that I wanted to avoid having to parse and generate json in bash. in addition, the powershell ecosystem is pretty robust at this point. We can use powershell in all build cases.
- Existing uses of SetupNuGetSources.ps1 should still work even without switching over from PAT usage, if they have a subsequent call to NuGetAuthenticate

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
