### PR TITLE
Fix quoting in MSBuild function in tools.sh

### DIFF
--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -438,7 +438,7 @@ function StopProcesses {
 }
 
 function MSBuild {
-  local args=$@
+  local args=( "$@" )
   if [[ "$pipelines_log" == true ]]; then
     InitializeBuildTool
     InitializeToolset
@@ -473,7 +473,7 @@ function MSBuild {
     args+=( "-logger:$selectedPath" )
   fi
 
-  MSBuild-Core ${args[@]}
+  MSBuild-Core "${args[@]}"
 }
 
 function MSBuild-Core {


### PR DESCRIPTION
Without this, any arguments that need proper quoting (eg, an argument contains spaces) get mangled.

I can reproduce the issue via the VMR by using something like:

    $ ./build.sh "/p:OfficialBuilder=foo bar"

This builds on top of https://github.com/dotnet/installer/pull/19686, which fixed quoting in build.sh.
