### PR TITLE
Edit gather-drop documentation

### DIFF
--- a/Documentation/Darc.md
+++ b/Documentation/Darc.md
@@ -1577,7 +1577,6 @@ The output directory structure is as follows:
   folders will be two additional folders: 'assets' and 'packages'. Assets
   contains all non-package outputs, while 'packages' contains all NuGet
   packages.
-  - A publish_files directory will contain the layout required for the .NET Core release publishing pipeline to publish nuget packages.
   - A manifest file will be generated under the root folder containing information about all gathered builds
 
 **Parameters**


### PR DESCRIPTION
Removing the mention of `publish_files` folder which was removed from gather-drop with https://github.com/dotnet/arcade-services/issues/3334

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
