### PR TITLE
Prepend wix tooling to the path.

### DIFF
--- a/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
+++ b/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
@@ -431,7 +431,7 @@ namespace Microsoft.DotNet.SignTool
             };
 
             string path = processStartInfo.EnvironmentVariables["PATH"];
-            path = $"{path};{wixToolsPath}";
+            path = $"{wixToolsPath};{path}";
             processStartInfo.EnvironmentVariables.Remove("PATH");
             processStartInfo.EnvironmentVariables.Add("PATH", path);
 


### PR DESCRIPTION
In some newer images, WiX tooling is on the path, so we should prepend rather than append to use the desired version. Note that we put the tools on the path because the "wix tool" we run may actually be a script that invokes tools.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
