### PR TITLE
Declare SB XliffTasks Intermediate in Version.Details

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -85,6 +85,11 @@
       <Sha>547c506abe05e510bd43330fc8f6d4c5961e9223</Sha>
       <SourceBuild RepoName="runtime" ManagedOnly="false" />
     </Dependency>
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.xliff-tasks" Version="1.0.0-beta.23475.1">
+      <Uri>https://github.com/dotnet/xliff-tasks</Uri>
+      <Sha>73f0850939d96131c28cf6ea6ee5aacb4da0083a</Sha>
+      <SourceBuild RepoName="xliff-tasks" ManagedOnly="true" />
+    </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="9.0.0-alpha.1.23475.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
       <Sha>0650b50b2a5263c735d12b5c36c5deb34e7e6b60</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -85,6 +85,7 @@
       <Sha>547c506abe05e510bd43330fc8f6d4c5961e9223</Sha>
       <SourceBuild RepoName="runtime" ManagedOnly="false" />
     </Dependency>
+    <!-- Explicit dependency because msbuild has a coherency tie to this dependency. -->
     <Dependency Name="Microsoft.SourceBuild.Intermediate.xliff-tasks" Version="1.0.0-beta.23475.1">
       <Uri>https://github.com/dotnet/xliff-tasks</Uri>
       <Sha>73f0850939d96131c28cf6ea6ee5aacb4da0083a</Sha>


### PR DESCRIPTION
Adds the xliff-tasks intermediate - related to https://github.com/dotnet/msbuild/pull/10153.

In detail, msbuild declares the xliff-tasks source-build intermediate as a dependency and coherency ties it to Arcade. The issue arose because Arcade does not explicitly declare this dependency, thus resulting in the inability to do a coherency update in msbuild. The issue is resolved by explicitly adding the xliff intermediate to Arcade for 8.0.
