### PR TITLE
Don't enable SBOM for logs in 1ES PT outputs

### DIFF
--- a/eng/common/core-templates/steps/source-build.yml
+++ b/eng/common/core-templates/steps/source-build.yml
@@ -123,6 +123,7 @@ steps:
       artifactName: BuildLogs_SourceBuild_${{ parameters.platform.name }}_Attempt$(System.JobAttempt)
       continueOnError: true
       condition: succeededOrFailed()
+      sbomEnabled: false  # we don't need SBOM for logs
 
 # Manually inject component detection so that we can ignore the source build upstream cache, which contains
 # a nupkg cache of input packages (a local feed).

--- a/eng/common/templates-official/job/job.yml
+++ b/eng/common/templates-official/job/job.yml
@@ -23,6 +23,7 @@ jobs:
             displayName: 'Publish logs'
             continueOnError: true
             condition: always()
+            sbomEnabled: false  # we don't need SBOM for logs
 
       - ${{ if eq(parameters.enablePublishBuildArtifacts, true) }}:
         - output: buildArtifacts
@@ -32,13 +33,15 @@ jobs:
           ArtifactName: ${{ coalesce(parameters.enablePublishBuildArtifacts.artifactName, '$(Agent.Os)_$(Agent.JobName)' ) }}
           continueOnError: true
           condition: always()
+          sbomEnabled: false  # we don't need SBOM for logs
 
       - ${{ if eq(parameters.enableBuildRetry, 'true') }}:
         - output: pipelineArtifact
           targetPath: '$(Build.ArtifactStagingDirectory)/artifacts/eng/common/BuildConfiguration'
           artifactName: 'BuildConfiguration'
           displayName: 'Publish build retry configuration'
-          continueOnError: true  
+          continueOnError: true
+          sbomEnabled: false  # we don't need SBOM for BuildConfiguration
 
       - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(parameters.enableSbom, 'true')) }}:
         - output: pipelineArtifact

--- a/eng/common/templates-official/steps/publish-pipeline-artifacts.yml
+++ b/eng/common/templates-official/steps/publish-pipeline-artifacts.yml
@@ -24,3 +24,5 @@ steps:
       artifactName: ${{ parameters.args.artifactName }}
     ${{ if parameters.args.properties }}:
       properties: ${{ parameters.args.properties }}
+    ${{ if parameters.args.sbomEnabled }}:
+      sbomEnabled: ${{ parameters.args.sbomEnabled }}

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -37,6 +37,7 @@ jobs:
                 displayName: 'Publish logs'
                 continueOnError: true
                 condition: always()
+                sbomEnabled: false  # we don't need SBOM for logs
 
       - ${{ if ne(parameters.enablePublishBuildArtifacts, 'false') }}:
         - template: /eng/common/core-templates/steps/publish-build-artifacts.yml
@@ -59,3 +60,4 @@ jobs:
               artifactName: 'BuildConfiguration'
               displayName: 'Publish build retry configuration'
               continueOnError: true
+              sbomEnabled: false  # we don't need SBOM for BuildConfiguration


### PR DESCRIPTION
1ES PT allows disabling generating an SBOM manifest per output: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sbom#per-output-sbom-customization

We can use this for logs/BuildConfiguration artifacts since those don't need an SBOM as they're not shipping artifacts.
This reduces the amount of SBOM processing we're doing.