### PR TITLE
Remove WPF work around

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -13,16 +13,6 @@
   </Target>
 
   <!--
-    Workaround to fix IntelliSense file generation for XAML projects
-    https://github.com/dotnet/project-system/issues/2488
-  -->
-  <Target Name="WorkaroundForXamlIntelliSenseBuildIssue" AfterTargets="_CheckCompileDesignTimePrerequisite">
-    <PropertyGroup>
-      <BuildingProject>false</BuildingProject>
-    </PropertyGroup>
-  </Target>
-
-  <!--
     WPF temp project sets OutDir, which makes the SDK create an empty directory for it,
     polluting the output dir. Avoid creating these directories.
     https://github.com/dotnet/sdk/issues/1367


### PR DESCRIPTION
This WPF work around is breaking incremental builds in Visual Studio. The `<BuildingProject>false</BuildingProject>` explicit setting triggers the target `_ComputeNonExistentFileProperty` which breaks up to date checks by design. This is showing up as a reason for Roslyn builds to not be incremental in VS.

The associated issue in the project system's been closed for four years now. This should be safe to remove or if it's not we should be reactivating the issue in project-system.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
