### PR TITLE
Add daily secret-manager run

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "microsoft.dnceng.secretmanager": {
-      "version": "1.1.0-beta.24209.2",
+      "version": "1.1.0-beta.24279.3",
       "commands": [
         "secret-manager"
       ]

--- a/azure-pipelines-daily.yaml
+++ b/azure-pipelines-daily.yaml
@@ -1,8 +1,8 @@
 trigger: none
 
 schedules:
-- cron: 0 12 * * 1
-  displayName: Weekly Monday build
+- cron: 0 12 * * *
+  displayName: Daily build
   branches:
     include:
     - main
@@ -18,11 +18,6 @@ stages:
         demands: ImageOverride -equals 1es-windows-2022
 
       steps:
-      - task: UseDotNet@2
-        displayName: Install Correct .NET Version
-        inputs:
-          useGlobalJson: true
-
       - task: UseDotNet@2
         displayName: Install .NET 6 runtime
         inputs:

--- a/azure-pipelines-daily.yaml
+++ b/azure-pipelines-daily.yaml
@@ -29,7 +29,7 @@ stages:
       - task: AzureCLI@2
         inputs:
           azureSubscription: DotNet Eng Services Secret Manager
-          scriptType: ps
+          scriptType: pscore
           scriptLocation: inlineScript
           inlineScript: |
             Get-ChildItem .vault-config/*.yaml |% { dotnet secret-manager synchronize $_}

--- a/azure-pipelines-daily.yaml
+++ b/azure-pipelines-daily.yaml
@@ -13,6 +13,7 @@ stages:
   - stage: SynchronizeSecrets
     jobs:
     - job: Synchronize
+      displayName: Synchronize secrets
       pool:
         name: NetCore1ESPool-Internal-NoMSI
         demands: ImageOverride -equals 1es-windows-2022


### PR DESCRIPTION
Related to [dotnet/dnceng#2963](https://github.com/dotnet/dnceng/issues/2963)

The reduction in maximum PAT duration requires more frequent secret-manager checkups. This PR converts the existing weekly build, which only ran secret-manager, into a daily build.

I've also repurposed the weekly pipeline to be the daily pipeline: [dotnet-arcade-daily](https://dev.azure.com/dnceng/internal/_build?definitionId=1020&_a=summary)