### PR TITLE
Packaging: support explicit runtime.json opt-out by setting IncludeRuntimeJson=false.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
@@ -538,7 +538,7 @@
     <!-- determine if there is a file to be updated, and setup the output file -->
     <PropertyGroup>
       <RuntimeFileSource Condition="'%(File.FileName)%(File.Extension)' == 'runtime.json'">%(File.Identity)</RuntimeFileSource>
-      <_runtimeJsonIncluded Condition="'$(IsLineupPackage)' == 'true' OR '$(IncludeRuntimeJson)' == 'true'">true</_runtimeJsonIncluded>
+      <_runtimeJsonIncluded Condition="'$(IncludeRuntimeJson)' != 'false' and ('$(IsLineupPackage)' == 'true' OR '$(IncludeRuntimeJson)' == 'true')">true</_runtimeJsonIncluded>
     </PropertyGroup>
 
     <!-- only include runtime.json in lineup packages -->


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/1215

@dsplaisted @baronfel @ViktorHofer @jkotas ptal

cc @omajid