### PR TITLE
Update Aka.ms link functionality to support client certificates

### DIFF
--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -122,6 +122,15 @@ stages:
         filePath: $(Build.SourcesDirectory)/eng/common/enable-cross-org-publishing.ps1
         arguments: -token $(dn-bot-all-orgs-artifact-feeds-rw)
 
+    - task: AzureCLI@2
+      displayName: Get aka.ms client certificate
+      inputs:
+        azureSubscription: 'DotNet-Engineering-Services_KeyVault'
+        scriptType: 'pscore'
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          az keyvault secret show --vault-name EngKeyVault --name Redirection-UST-Client-NetCoreDeployment | ConvertFrom-Json | Select-Object -Expand  value > $(Agent.TempDirectory)/akamsclientcert.pfx
+
     - task: PowerShell@2
       displayName: Publish packages, blobs and symbols
       inputs:
@@ -141,6 +150,7 @@ stages:
           /p:AzureDevOpsFeedsKey='$(dn-bot-all-orgs-artifact-feeds-rw)' 
           /p:AkaMSClientId=$(akams-app-id) 
           /p:AkaMSClientSecret=$(akams-app-secret) ${{ parameters.artifactsPublishingAdditionalParameters }} 
+          /p:AkaMSClientCertificate=$(Agent.TempDirectory)/akamsclientcert.pfx
           /p:PDBArtifactsBasePath='$(Build.ArtifactStagingDirectory)/PDBArtifacts/' 
           /p:SymbolPublishingExclusionsFile='$(Build.ArtifactStagingDirectory)/ReleaseConfigs/SymbolPublishingExclusionsFile.txt' ${{ parameters.symbolPublishingAdditionalParameters}} 
           /p:MsdlToken=$(microsoft-symbol-server-pat) 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
@@ -30,8 +30,9 @@
                                                   else all the artifacts and symbols are downloaded before publishing.
 
       Optional aka.ms link generation parameters:
-        - AkaMSClientId                         : Client ID for the aka.ms AD application
-        - AkaMSClientSecret                     : Client secret for the aka.ms AD application
+        - AkaMSClientId                         : Client ID for the aka.ms Entra application
+        - AkaMSClientSecret                     : Client secret for the aka.ms Entra application (deprecated)
+        - AkaMSClientCertificate                : Client certificate for the aka.ms Entra application
         - AkaMSTenant                           : Tenant ID for aka.ms link generation. Defaults to ncd
         - AkaMSOwners                           : Semi-colon delimited list of aliases of the owners of generated links. Defaults to dn-bot
         - AkaMSCreatedBy                        : Semi-colon delimited list of aliases of the creator/updator links. Defaults to dn-bot
@@ -147,6 +148,7 @@
       NugetPath="$(NugetPath)"
       AkaMSClientId="$(AkaMSClientId)"
       AkaMSClientSecret="$(AkaMSClientSecret)"
+      AkaMSClientCertificate="$(AkaMSClientCertificate)"
       AkaMSTenant="$(AkaMSTenant)"
       AkaMSOwners="$(AkaMSOwners)"
       AkaMSGroupOwner="$(AkaMSGroupOwner)"

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -151,6 +151,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public string AkaMSClientSecret { get; set; }
 
+        /// <summary>
+        /// Path to client certificate
+        /// </summary>
+        public string AkaMSClientCertificate { get; set; }
+
         public string AkaMSTenant { get; set; }
 
         public string AkaMsOwners { get; set; }
@@ -320,6 +325,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 SkipSafetyChecks = this.SkipSafetyChecks,
                 AkaMSClientId = this.AkaMSClientId,
                 AkaMSClientSecret = this.AkaMSClientSecret,
+                AkaMSClientCertificate = !string.IsNullOrEmpty(AkaMSClientCertificate) ? new System.Security.Cryptography.X509Certificates.X509Certificate2(AkaMSClientCertificate) : null,
                 AkaMSCreatedBy = this.AkaMSCreatedBy,
                 AkaMSGroupOwner = this.AkaMSGroupOwner,
                 AkaMsOwners = this.AkaMsOwners,

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -11,7 +11,9 @@ using Microsoft.DotNet.VersionTools.BuildManifest.Model;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using System;
+using System.IO;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
 using Task = System.Threading.Tasks.Task;
@@ -325,7 +327,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 SkipSafetyChecks = this.SkipSafetyChecks,
                 AkaMSClientId = this.AkaMSClientId,
                 AkaMSClientSecret = this.AkaMSClientSecret,
-                AkaMSClientCertificate = !string.IsNullOrEmpty(AkaMSClientCertificate) ? new System.Security.Cryptography.X509Certificates.X509Certificate2(AkaMSClientCertificate) : null,
+                AkaMSClientCertificate = !string.IsNullOrEmpty(AkaMSClientCertificate) ?
+                    new X509Certificate2(Convert.FromBase64String(File.ReadAllText(AkaMSClientCertificate))) : null,
                 AkaMSCreatedBy = this.AkaMSCreatedBy,
                 AkaMSGroupOwner = this.AkaMSGroupOwner,
                 AkaMsOwners = this.AkaMsOwners,

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLink.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLink.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.DotNet.Deployment.Tasks.Links.src
+namespace Microsoft.DotNet.Deployment.Tasks.Links
 {
     /// <summary>
     ///     A single aka.ms link.

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksBase.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksBase.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Net.Http;
-using System.Threading.Tasks;
+using System.Security.Cryptography.X509Certificates;
 using Microsoft.Build.Framework;
 
 namespace Microsoft.DotNet.Deployment.Tasks.Links
@@ -13,10 +12,29 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links
         [Required]
         // Authentication data
         public string ClientId { get; set; }
-        [Required]
         // Authentication data
         public string ClientSecret { get; set; }
+        public string ClientCertificate { get; set; }
         [Required]
         public string Tenant { get; set; }
+
+        protected AkaMSLinkManager CreateAkaMSLinksManager()
+        {
+            AkaMSLinkManager manager;
+            if (!string.IsNullOrEmpty(ClientCertificate))
+            {
+                manager = new AkaMSLinkManager(ClientId, new X509Certificate2(ClientSecret), Tenant, Log);
+            }
+            else if (!string.IsNullOrEmpty(ClientSecret))
+            {
+                manager = new AkaMSLinkManager(ClientId, ClientSecret, Tenant, Log);
+            }
+            else
+            {
+                throw new Exception("aka.ms Authentication information not provided.");
+            }
+
+            return manager;
+        }
     }
 }

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksBase.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksBase.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links
             AkaMSLinkManager manager;
             if (!string.IsNullOrEmpty(ClientCertificate))
             {
-                manager = new AkaMSLinkManager(ClientId, new X509Certificate2(ClientSecret), Tenant, Log);
+                manager = new AkaMSLinkManager(ClientId, new X509Certificate2(ClientCertificate), Tenant, Log);
             }
             else if (!string.IsNullOrEmpty(ClientSecret))
             {

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksBase.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/AkaMSLinksBase.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Build.Framework;
 
@@ -23,7 +24,7 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links
             AkaMSLinkManager manager;
             if (!string.IsNullOrEmpty(ClientCertificate))
             {
-                manager = new AkaMSLinkManager(ClientId, new X509Certificate2(ClientCertificate), Tenant, Log);
+                manager = new AkaMSLinkManager(ClientId, new X509Certificate2(Convert.FromBase64String(File.ReadAllText(ClientCertificate))), Tenant, Log);
             }
             else if (!string.IsNullOrEmpty(ClientSecret))
             {

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/CreateAkaMSLinks.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/CreateAkaMSLinks.cs
@@ -1,12 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Build.Framework;
-using Microsoft.DotNet.Deployment.Tasks.Links.src;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.Deployment.Tasks.Links
 {
@@ -91,7 +90,8 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links
                     string descriptionString = !string.IsNullOrEmpty(link.Description) ? $" ({link.Description})" : "";
                     Log.LogMessage(MessageImportance.High, $"Creating link aka.ms/{link.ShortUrl} -> {link.TargetUrl}{descriptionString}");
                 }
-                AkaMSLinkManager manager = new AkaMSLinkManager(ClientId, ClientSecret, Tenant, Log);
+                AkaMSLinkManager manager = CreateAkaMSLinksManager();
+
                 await manager.CreateOrUpdateLinksAsync(linksToCreate, Owners, CreatedBy, GroupOwner, Overwrite);
             }
             catch (Exception e)

--- a/src/Microsoft.DotNet.Deployment.Tasks.Links/src/DeleteAkaMSLinks.cs
+++ b/src/Microsoft.DotNet.Deployment.Tasks.Links/src/DeleteAkaMSLinks.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Build.Framework;
-using Microsoft.DotNet.Deployment.Tasks.Links.src;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -27,7 +26,7 @@ namespace Microsoft.DotNet.Deployment.Tasks.Links
         {
             try
             {
-                AkaMSLinkManager manager = new AkaMSLinkManager(ClientId, ClientSecret, Tenant, Log);
+                AkaMSLinkManager manager = CreateAkaMSLinksManager();
                 await manager.DeleteLinksAsync(new List<string>(ShortUrls));
             }
             catch (Exception e)


### PR DESCRIPTION
Enable client certificate usage. If the client cert is provided, it is biased over secret support. I left secret support in for now to enable onboarding to certs and offboarding of client secrets.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
