### PR TITLE
Fix daily build SDK references

### DIFF
--- a/azure-pipelines-daily.yaml
+++ b/azure-pipelines-daily.yaml
@@ -25,8 +25,8 @@ stages:
           packageType: runtime
           version: 6.x
 
-      - powershell: |
-          . .\eng\scripts\dotnet-install.ps1
+      - pwsh: |
+          . ./eng/common/dotnet-install.ps1
           dotnet-install
         displayName: Install Arcade dotnet
 

--- a/azure-pipelines-daily.yaml
+++ b/azure-pipelines-daily.yaml
@@ -20,19 +20,21 @@ stages:
 
       steps:
       - task: UseDotNet@2
+        displayName: Install global.json SDK
+        inputs:
+          useGlobalJson: true
+
+      - task: UseDotNet@2
         displayName: Install .NET 6 runtime
         inputs:
           packageType: runtime
           version: 6.x
 
-      - task: UseDotNet@2
-        displayName: Install global.json SDK
-        inputs:
-          useGlobalJson: true
-
       - script: dotnet tool restore
+        displayName: Restore dotnet tools
 
       - task: AzureCLI@2
+        displayName: Run secret-manager synchronize
         inputs:
           azureSubscription: DotNet Eng Services Secret Manager
           scriptType: pscore

--- a/azure-pipelines-daily.yaml
+++ b/azure-pipelines-daily.yaml
@@ -25,10 +25,10 @@ stages:
           packageType: runtime
           version: 6.x
 
-      - pwsh: |
-          . ./eng/common/dotnet-install.ps1
-          dotnet-install
-        displayName: Install Arcade dotnet
+      - task: UseDotNet@2
+        displayName: Install global.json SDK
+        inputs:
+          useGlobalJson: true
 
       - script: dotnet tool restore
 

--- a/azure-pipelines-daily.yaml
+++ b/azure-pipelines-daily.yaml
@@ -25,6 +25,11 @@ stages:
           packageType: runtime
           version: 6.x
 
+      - powershell: |
+          . .\eng\scripts\dotnet-install.ps1
+          dotnet-install
+        displayName: Install Arcade dotnet
+
       - script: dotnet tool restore
 
       - task: AzureCLI@2


### PR DESCRIPTION
Follow-up to dotnet/arcade#14804 to fix an error in getting the required dotnet SDK, plus a few minor display tweaks.

Successful test runs may be found in the pipeline: [dotnet-arcade-daily 2024060503](https://dev.azure.com/dnceng/internal/_build/results?buildId=2467483&view=results).