### PR TITLE
Use RestoreNoHttpCache instead of RestoreNoCache for nuget

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -653,7 +653,7 @@ function GetNuGetPackageCachePath() {
       $env:NUGET_PACKAGES = Join-Path $env:UserProfile '.nuget\packages\'
     } else {
       $env:NUGET_PACKAGES = Join-Path $RepoRoot '.packages\'
-      $env:RESTORENOCACHE = $true
+      $env:RESTORENOHTTPCACHE = $true
     }
   }
 

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -347,14 +347,14 @@ function InitializeBuildTool {
   fi
 }
 
-# Set RestoreNoCache as a workaround for https://github.com/NuGet/Home/issues/3116
+# Set RestoreNoHttpCache as a workaround for https://github.com/NuGet/Home/issues/3116
 function GetNuGetPackageCachePath {
   if [[ -z ${NUGET_PACKAGES:-} ]]; then
     if [[ "$use_global_nuget_cache" == true ]]; then
       export NUGET_PACKAGES="$HOME/.nuget/packages"
     else
       export NUGET_PACKAGES="$repo_root/.packages"
-      export RESTORENOCACHE=true
+      export RESTORENOHTTPCACHE=true
     fi
   fi
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -24,7 +24,7 @@
     Workaround for https://github.com/NuGet/Home/issues/3116
   -->
   <PropertyGroup>
-    <RestoreNoCache Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</RestoreNoCache>
+    <RestoreNoHttpCache Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</RestoreNoHttpCache>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
nuget renamed this option in https://github.com/NuGet/Home/blob/dev/accepted/2023/Add-NoHttpCacheOption.md and prints a message that says the old option is deprecated in the binlog which can be confusing.
