### PR TITLE
Fix calling Maestro from the publishing task

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
@@ -93,6 +93,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 // of the assets being published so we can add a new location for them.
                 IMaestroApi client = MaestroApiFactory.GetAuthenticated(
                     MaestroApiEndpoint,
+                    BuildAssetRegistryToken,
                     MaestroApiFederatedToken,
                     disableInteractiveAuth: !AllowInteractiveAuthentication);
 


### PR DESCRIPTION
Fixes this: https://dev.azure.com/dnceng/internal/_build/results?buildId=2470585&view=logs&j=ba23343f-f710-5af9-782d-5bd26b102304&t=c7a8693b-2f9c-5ea8-c909-cde9405ac2e1&l=45
