### PR TITLE
Delete the DotNet-MSRC-Storage var group

### DIFF
--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -15,7 +15,6 @@ stages:
     - group: DotNet-Symbol-Server-Pats
     - group: DotNetBuilds storage account tokens
     - group: AzureDevOps-Artifact-Feeds-Pats
-    - group: DotNet-MSRC-Storage
     - group: Publish-Build-Assets
   
     # Default Maestro++ API Endpoint and API Version


### PR DESCRIPTION
BuildPromotion pipeline was failing in DevDiv because it was trying to download secrets that don't exist anymore. The connection between the KV and the Variable Group was removed in dnceng, and I did the same in DevDiv, this is just a bit of cleanup