### PR TITLE
Fix nuget warnings on linux

### DIFF
--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -351,9 +351,9 @@ function InitializeBuildTool {
 function GetNuGetPackageCachePath {
   if [[ -z ${NUGET_PACKAGES:-} ]]; then
     if [[ "$use_global_nuget_cache" == true ]]; then
-      export NUGET_PACKAGES="$HOME/.nuget/packages"
+      export NUGET_PACKAGES="$HOME/.nuget/packages/"
     else
-      export NUGET_PACKAGES="$repo_root/.packages"
+      export NUGET_PACKAGES="$repo_root/.packages/"
       export RESTORENOHTTPCACHE=true
     fi
   fi


### PR DESCRIPTION
Fixes errors like `/home/andrha/razor/Directory.Build.targets(43,5): error : NUGET_PACKAGES should end with a slash or it will lead to editorconfig issues: /home/andrha/.nuget/packages [/home/andrha/razor/src/Razor/src/Microsoft.VisualStudio.DevKit.Razor/Microsoft.VisualStudio.DevKit.Razor.csproj::TargetFramework=net8.0]`