### PR TITLE
Allow managed identity in the publishing task

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -103,7 +103,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public string MaestroApiFederatedToken { get; set; }
 
         /// <summary>
-        /// Managed identity to be used to authenticate with Maestro API in case the regular Azure CLI or token is not available.
+        /// Managed identity to be used to authenticate with Maestro app in case the regular Azure CLI or token is not available.
         /// </summary>
         public string MaestroManagedIdentityId { get; set; }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -103,6 +103,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public string MaestroApiFederatedToken { get; set; }
 
         /// <summary>
+        /// Managed identity to be used to authenticate with Maestro API in case the regular Azure CLI or token is not available.
+        /// </summary>
+        public string MaestroManagedIdentityId { get; set; }
+
+        /// <summary>
         /// When running this task locally, allow the interactive browser-based authentication against Maestro.
         /// </summary>
         public bool AllowInteractiveAuthentication { get; set; }
@@ -271,7 +276,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                             MaestroApiEndpoint,
                             BuildAssetRegistryToken,
                             MaestroApiFederatedToken,
-                            managedIdentityId: null,
+                            MaestroManagedIdentityId,
                             !AllowInteractiveAuthentication);
                         Maestro.Client.Models.Build buildInformation = await client.Builds.GetBuildAsync(BARBuildId);
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -79,6 +79,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public string MaestroApiFederatedToken { get; set; }
 
         /// <summary>
+        /// Managed identity to be used to authenticate with Maestro API in case the regular Azure CLI or token is not available.
+        /// </summary>
+        public string MaestroManagedIdentityId { get; set; }
+
+        /// <summary>
         /// When running this task locally, allow the interactive browser-based authentication against Maestro.
         /// </summary>
         public bool AllowInteractiveAuthentication { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
@@ -95,7 +95,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     MaestroApiEndpoint,
                     BuildAssetRegistryToken,
                     MaestroApiFederatedToken,
-                    managedIdentityId: null,
+                    MaestroManagedIdentityId,
                     disableInteractiveAuth: !AllowInteractiveAuthentication);
 
                 Maestro.Client.Models.Build buildInformation = await client.Builds.GetBuildAsync(BARBuildId);


### PR DESCRIPTION
Extending MSBuild properties so that we can create MI-based credentials for Maestro API