### PR TITLE
Go back to older SetupNuGetSources.ps1

### DIFF
--- a/eng/common/SetupNugetSources.sh
+++ b/eng/common/SetupNugetSources.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# This script adds internal feeds required to build commits that depend on intenral package sources. For instance,
+# This script adds internal feeds required to build commits that depend on internal package sources. For instance,
 # dotnet6-internal would be added automatically if dotnet6 was found in the nuget.config file. In addition also enables
 # disabled internal Maestro (darc-int*) feeds.
 # 

--- a/eng/common/core-templates/steps/enable-internal-sources.yml
+++ b/eng/common/core-templates/steps/enable-internal-sources.yml
@@ -6,30 +6,40 @@ parameters:
 - name: is1ESPipeline
   type: boolean
   default: false
+# Legacy parameters to allow for PAT usage
+- name: legacyCredential
+  type: string
+  default: ''
 
 steps:
 - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-  # If running on dnceng (internal project), just use the default behavior for NuGetAuthenticate.
-  # If running on DevDiv, NuGetAuthenticate is not really an option. It's scoped to a single feed, and we have many feeds that
-  # may be added. Instead, we'll use the traditional approach (add cred to nuget.config), but use an account token.
-  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - ${{ if ne(parameters.legacyCredential, '') }}:
     - task: PowerShell@2
       displayName: Setup Internal Feeds
       inputs:
         filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
         arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config
-    - task: NuGetAuthenticate@1
+  # If running on dnceng (internal project), just use the default behavior for NuGetAuthenticate.
+  # If running on DevDiv, NuGetAuthenticate is not really an option. It's scoped to a single feed, and we have many feeds that
+  # may be added. Instead, we'll use the traditional approach (add cred to nuget.config), but use an account token.
   - ${{ else }}:
-    - template: /eng/common/templates/steps/get-federated-access-token.yml
-      parameters:
-        federatedServiceConnection: ${{ parameters.nugetFederatedServiceConnection }}
-        outputVariableName: 'dnceng-artifacts-feeds-read-access-token'
-    - task: PowerShell@2
-      displayName: Setup Internal Feeds
-      inputs:
-        filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-        arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $(dnceng-artifacts-feeds-read-access-token)
-    # This is required in certain scenarios to install the ADO credential provider.
-    # It installed by default in some msbuild invocations (e.g. VS msbuild), but needs to be installed for others
-    # (e.g. dotnet msbuild).
-    - task: NuGetAuthenticate@1
+    - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      - task: PowerShell@2
+        displayName: Setup Internal Feeds
+        inputs:
+          filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+          arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config
+    - ${{ else }}:
+      - template: /eng/common/templates/steps/get-federated-access-token.yml
+        parameters:
+          federatedServiceConnection: ${{ parameters.nugetFederatedServiceConnection }}
+          outputVariableName: 'dnceng-artifacts-feeds-read-access-token'
+      - task: PowerShell@2
+        displayName: Setup Internal Feeds
+        inputs:
+          filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+          arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $(dnceng-artifacts-feeds-read-access-token)
+  # This is required in certain scenarios to install the ADO credential provider.
+  # It installed by default in some msbuild invocations (e.g. VS msbuild), but needs to be installed for others
+  # (e.g. dotnet msbuild).
+  - task: NuGetAuthenticate@1


### PR DESCRIPTION
The new version of SetupNuGetSources.ps1 and associated templates should work equivalently to the old script, but appears to have odd behavior in some repos. It doens't seem to work at all in aspnetcore, and SDK has a few scenarios where using env vars for the creds instead of the cleartext cred does not work. Furthermore, some repos may rely on the nguet.config containing creds for some test scenarios.

This PR simplifies the cred transition for now.
- Revert to the old script, but allow for no cred to be passed
- Add legacy cred support to the new templates.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
