### PR TITLE
Bump Arcade to `9.0.0-beta.24320.2`

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -26,13 +26,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>5cbcd39027f739dd3ce1e5d50cfb99446a605491</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="9.0.0-beta.24317.3">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="9.0.0-beta.24320.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>579b9d3c2a51de22be7685f0bd624bf83265c901</Sha>
+      <Sha>a1cd79a2b483a09f58fa9f6286b589bb759d391d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="9.0.0-beta.24317.3">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="9.0.0-beta.24320.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>579b9d3c2a51de22be7685f0bd624bf83265c901</Sha>
+      <Sha>a1cd79a2b483a09f58fa9f6286b589bb759d391d</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Maestro.Client" Version="1.1.0-beta.24317.3">
       <Uri>https://github.com/dotnet/arcade-services</Uri>
@@ -124,9 +124,9 @@
       <Sha>39aef81ec6cffa06da9964b46d4b9e3bf2fc9979</Sha>
     </Dependency>
     <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.arcade" Version="9.0.0-beta.24317.3">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.arcade" Version="9.0.0-beta.24320.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>579b9d3c2a51de22be7685f0bd624bf83265c901</Sha>
+      <Sha>a1cd79a2b483a09f58fa9f6286b589bb759d391d</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
     <!-- Intermediate is necessary for source build. -->

--- a/global.json
+++ b/global.json
@@ -7,8 +7,8 @@
     "dotnet": "9.0.100-preview.5.24307.3"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.24317.3",
-    "Microsoft.DotNet.Helix.Sdk": "9.0.0-beta.24317.3",
+    "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.24320.2",
+    "Microsoft.DotNet.Helix.Sdk": "9.0.0-beta.24320.2",
     "Microsoft.Build.NoTargets": "3.7.0"
   }
 }


### PR DESCRIPTION
Doing this separate from the usual Maestro PR because that one will clump it together with `arcade-services` which is now blocked