### PR TITLE
Only hook up VSIX up-to-date check when VSToolsPath is defined

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.VsixBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.VsixBuild.targets
@@ -284,7 +284,7 @@
   <!--
     Make sure to include information about inputs and outputs to CreateVsixContainer for fast up-to-date check.
   -->
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(VSToolsPath)' != '' and ('$(IsVsixProject)' == 'true' or '$(GeneratePkgDefFile)' == 'true')">
     <CollectUpToDateCheckInputDesignTimeDependsOn>$(CollectUpToDateCheckInputDesignTimeDependsOn);CollectVsixUpToDateCheckInput</CollectUpToDateCheckInputDesignTimeDependsOn>
     <CollectUpToDateCheckBuiltDesignTimeDependsOn>$(CollectUpToDateCheckBuiltDesignTimeDependsOn);CollectVsixUpToDateCheckBuilt</CollectUpToDateCheckBuiltDesignTimeDependsOn>
   </PropertyGroup>


### PR DESCRIPTION
In other cases, the VSIX container properties are not defined, leading to failures in early design time build scenarios.
