### PR TITLE
Skip CG in public source-build jobs

### DIFF
--- a/eng/common/core-templates/steps/component-governance.yml
+++ b/eng/common/core-templates/steps/component-governance.yml
@@ -2,7 +2,8 @@ parameters:
   disableComponentGovernance: false
   componentGovernanceIgnoreDirectories: ''
   is1ESPipeline: false
-  
+  displayName: 'Component Detection'
+
 steps:
 - ${{ if eq(parameters.disableComponentGovernance, 'true') }}:
   - script: echo "##vso[task.setvariable variable=skipComponentGovernanceDetection]true"
@@ -10,5 +11,6 @@ steps:
 - ${{ if ne(parameters.disableComponentGovernance, 'true') }}:
   - task: ComponentGovernanceComponentDetection@0
     continueOnError: true
+    displayName: ${{ parameters.displayName }}
     inputs:
       ignoreDirectories: ${{ parameters.componentGovernanceIgnoreDirectories }}

--- a/eng/common/core-templates/steps/source-build.yml
+++ b/eng/common/core-templates/steps/source-build.yml
@@ -117,15 +117,13 @@ steps:
       condition: succeededOrFailed()
       sbomEnabled: false  # we don't need SBOM for logs
 
-- ${{ if eq(variables['System.TeamProject'], 'public') }}:
-  - script: echo "##vso[task.setvariable variable=skipComponentGovernanceDetection]true"
-    displayName: Set skipComponentGovernanceDetection variable
-- ${{ else }}:
-  # Manually inject component detection so that we can ignore the source build upstream cache, which contains
-  # a nupkg cache of input packages (a local feed).
-  # This path must match the upstream cache path in property 'CurrentRepoSourceBuiltNupkgCacheDir'
-  # in src\Microsoft.DotNet.Arcade.Sdk\tools\SourceBuild\SourceBuildArcade.targets
-  - task: ComponentGovernanceComponentDetection@0
+# Manually inject component detection so that we can ignore the source build upstream cache, which contains
+# a nupkg cache of input packages (a local feed).
+# This path must match the upstream cache path in property 'CurrentRepoSourceBuiltNupkgCacheDir'
+# in src\Microsoft.DotNet.Arcade.Sdk\tools\SourceBuild\SourceBuildArcade.targets
+- template: /eng/common/core-templates/steps/component-governance.yml
+  parameters:
     displayName: Component Detection (Exclude upstream cache)
-    inputs:
-      ignoreDirectories: '$(Build.SourcesDirectory)/artifacts/sb/src/artifacts/obj/source-built-upstream-cache'
+    is1ESPipeline: ${{ parameters.is1ESPipeline }}
+    componentGovernanceIgnoreDirectories: '$(Build.SourcesDirectory)/artifacts/sb/src/artifacts/obj/source-built-upstream-cache'
+    disableComponentGovernance: ${{ eq(variables['System.TeamProject'], 'public') }}

--- a/eng/common/core-templates/steps/source-build.yml
+++ b/eng/common/core-templates/steps/source-build.yml
@@ -117,11 +117,15 @@ steps:
       condition: succeededOrFailed()
       sbomEnabled: false  # we don't need SBOM for logs
 
-# Manually inject component detection so that we can ignore the source build upstream cache, which contains
-# a nupkg cache of input packages (a local feed).
-# This path must match the upstream cache path in property 'CurrentRepoSourceBuiltNupkgCacheDir'
-# in src\Microsoft.DotNet.Arcade.Sdk\tools\SourceBuild\SourceBuildArcade.targets
-- task: ComponentGovernanceComponentDetection@0
-  displayName: Component Detection (Exclude upstream cache)
-  inputs:
-    ignoreDirectories: '$(Build.SourcesDirectory)/artifacts/sb/src/artifacts/obj/source-built-upstream-cache'
+- ${{ if eq(variables['System.TeamProject'], 'public') }}:
+  - script: echo "##vso[task.setvariable variable=skipComponentGovernanceDetection]true"
+    displayName: Set skipComponentGovernanceDetection variable
+- ${{ else }}:
+  # Manually inject component detection so that we can ignore the source build upstream cache, which contains
+  # a nupkg cache of input packages (a local feed).
+  # This path must match the upstream cache path in property 'CurrentRepoSourceBuiltNupkgCacheDir'
+  # in src\Microsoft.DotNet.Arcade.Sdk\tools\SourceBuild\SourceBuildArcade.targets
+  - task: ComponentGovernanceComponentDetection@0
+    displayName: Component Detection (Exclude upstream cache)
+    inputs:
+      ignoreDirectories: '$(Build.SourcesDirectory)/artifacts/sb/src/artifacts/obj/source-built-upstream-cache'


### PR DESCRIPTION
I noticed we still ran Component Governance in public builds in the source-build job. We skip CG for normal jobs in eng/common/core-templates/job/job.yml.

Refactored so we reuse the existing component-governance.yml.