### PR TITLE
Reapply "Update NuGet global packages cache detection" (#14874)

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -650,7 +650,20 @@ function GetNuGetPackageCachePath() {
     # use global cache in dev builds to avoid cost of downloading packages.
     # For directory normalization, see also: https://github.com/NuGet/Home/issues/7968
     if ($useGlobalNuGetCache) {
-      $env:NUGET_PACKAGES = Join-Path $env:UserProfile '.nuget\packages\'
+      # Check NuGet.Config to see if the packages folder has been redirected https://github.com/dotnet/arcade/issues/14761
+      $nugetConfig = Join-Path $env:APPDATA "NuGet\NuGet.Config"
+      if (Test-Path -Path $nugetConfig) {
+        [xml]$nugetConfigXml = Get-Content $nugetConfig
+
+        # Set the NUGET_PACKAGES environment variable to match the configured globalPackagesFolder. If there is no
+        # global packages folder, this expression will evaluate to the empty string which will effectively leave the
+        # environment variable set to null.
+        $env:NUGET_PACKAGES = $nugetConfigXml.SelectSingleNode("//configuration/config/add[@key='globalPackagesFolder']").value
+      }
+
+      if ($env:NUGET_PACKAGES -eq $null) {
+        $env:NUGET_PACKAGES = Join-Path $env:UserProfile '.nuget\packages\'
+      }
     } else {
       $env:NUGET_PACKAGES = Join-Path $RepoRoot '.packages\'
       $env:RESTORENOHTTPCACHE = $true

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepoLayout.props
@@ -6,14 +6,6 @@
   -->
 
   <PropertyGroup>
-    <!-- Respect environment variable for the NuGet Packages Root if set; otherwise, use the current default location -->
-    <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' != ''">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)'))</NuGetPackageRoot>
-    <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == '' and '$(NUGET_PACKAGES)' != ''">$([MSBuild]::NormalizeDirectory('$(NUGET_PACKAGES)'))</NuGetPackageRoot>
-    <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == '' and '$(OS)' == 'Windows_NT'">$([MSBuild]::NormalizeDirectory('$(UserProfile)', '.nuget', 'packages'))</NuGetPackageRoot>
-    <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == '' and '$(OS)' != 'Windows_NT'">$([MSBuild]::NormalizeDirectory('$(HOME)', '.nuget', 'packages'))</NuGetPackageRoot>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <RepoRoot Condition="'$(RepoRoot)' == ''">$([MSBuild]::NormalizeDirectory('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'global.json'))'))</RepoRoot>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.VsixBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.VsixBuild.targets
@@ -19,6 +19,10 @@
          Writes a stub file to component intermediate directory.
   -->
 
+  <PropertyGroup>
+    <ArcadeVisualStudioBuildTasksAssembly>$(NuGetPackageRoot)microsoft.dotnet.build.tasks.visualstudio\$(MicrosoftDotNetBuildTasksVisualStudioVersion)\tools\net472\Microsoft.DotNet.Build.Tasks.VisualStudio.dll</ArcadeVisualStudioBuildTasksAssembly>
+  </PropertyGroup>
+
   <UsingTask TaskName="Microsoft.DotNet.Build.Tasks.VisualStudio.FinalizeInsertionVsixFile" AssemblyFile="$(ArcadeVisualStudioBuildTasksAssembly)" />
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.props
@@ -1,10 +1,6 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
-  <PropertyGroup>
-    <ArcadeVisualStudioBuildTasksAssembly>$(NuGetPackageRoot)microsoft.dotnet.build.tasks.visualstudio\$(MicrosoftDotNetBuildTasksVisualStudioVersion)\tools\net472\Microsoft.DotNet.Build.Tasks.VisualStudio.dll</ArcadeVisualStudioBuildTasksAssembly>
-  </PropertyGroup>
-
   <!-- Default settings for VSIX projects -->
 
   <PropertyGroup>


### PR DESCRIPTION
This reverts commit a1cd79a2b483a09f58fa9f6286b589bb759d391d.

Due to the merge policy mentioned in https://github.com/dotnet/arcade/pull/14868#issuecomment-2182140553, which limits a single pull request to a single change, this pull request is unable to contain the fixes from #14868 that will instead be submitted as follow-up changes after this merges.