### PR TITLE
Update the CreateAzureDevOpsFeed MSBuild task to acquire a PAT token if one was not specified.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
@@ -121,11 +121,10 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                 string azureDevOpsFeedsBaseUrl = $"https://feeds.dev.azure.com/{AzureDevOpsOrg}/";
 
-                Lazy<AzureCliCredential> credential = new();
                 if (string.IsNullOrEmpty(AzureDevOpsPersonalAccessToken))
                 {
                     const string AzureDevOpsScope = "499b84ac-1321-427f-aa17-267ca6975798/.default";
-                    AzureDevOpsPersonalAccessToken = credential.Value.GetToken(new TokenRequestContext(new[] { AzureDevOpsScope })).Token;
+                    AzureDevOpsPersonalAccessToken = new AzureCliCredential().GetToken(new TokenRequestContext(new[] { AzureDevOpsScope })).Token;
                 }
 
                 do

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/CreateAzureDevOpsFeed.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Azure.Core;
+using Azure.Identity;
 using Microsoft.Build.Framework;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -39,7 +41,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         /// <summary>
         /// Personal access token used to authorize to the API and create the feed
         /// </summary>
-        [Required]
         public string AzureDevOpsPersonalAccessToken { get; set; }
 
         public string RepositoryName { get; set; }
@@ -119,6 +120,14 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 }
 
                 string azureDevOpsFeedsBaseUrl = $"https://feeds.dev.azure.com/{AzureDevOpsOrg}/";
+
+                Lazy<AzureCliCredential> credential = new();
+                if (string.IsNullOrEmpty(AzureDevOpsPersonalAccessToken))
+                {
+                    const string AzureDevOpsScope = "499b84ac-1321-427f-aa17-267ca6975798/.default";
+                    AzureDevOpsPersonalAccessToken = credential.Value.GetToken(new TokenRequestContext(new[] { AzureDevOpsScope })).Token;
+                }
+
                 do
                 {
                     using (HttpClient client = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true })


### PR DESCRIPTION
The `AzureDevOpsPersonalAccessToken` parameter is no longer required. You can still manually specify an AzDo PAT token or run the task within the scope of an AzureCLI task.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
