### PR TITLE
[release/6.0] Disable source indexing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ extends:
               manifests: true
           enableMicrobuild: true
           enablePublishUsingPipelines: true
-          enableSourceIndex: true
+          enableSourceIndex: false
           enableSourceBuild: true
           workspace:
             clean: all


### PR DESCRIPTION
Probably a bad backport enabled this and it's breaking the CI.