### PR TITLE
Enable git long path for inter-branch workflow

### DIFF
--- a/.github/workflows/inter-branch-merge-base.yml
+++ b/.github/workflows/inter-branch-merge-base.yml
@@ -37,7 +37,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    steps:
+    steps:  
+      - name: Enable git longpath
+        run: git config --global core.longpaths true
       - name: Checkout caller repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### Context
The workflow failed on dotnet/templating repository due to the long path of the file name.
![image](https://github.com/dotnet/arcade/assets/104755925/06726ce2-5c74-4f0b-a723-e9c823b7cf09)
https://github.com/dotnet/templating/actions/runs/9670964853/job/26680671521#step:2:354

### Changes
Beefore actual checkout of the repository set the core.longpaths enabled for git. 

Change tested on forked repository: 
https://github.com/f-alizada/dotnet-templating/actions/runs/9676019214/job/26697652132

FYI: @marcpopMSFT 
