### PR TITLE
Use AzureCLI for Publishing with Darc

### DIFF
--- a/eng/common/core-templates/job/publish-build-assets.yml
+++ b/eng/common/core-templates/job/publish-build-assets.yml
@@ -155,10 +155,13 @@ jobs:
           PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
           is1ESPipeline: ${{ parameters.is1ESPipeline }}
 
-      - task: PowerShell@2
+      - task: AzureCLI@2
         displayName: Publish Using Darc
         inputs:
-          filePath: $(Build.SourcesDirectory)/eng/common/post-build/publish-using-darc.ps1
+          azureSubscription: "Darc: Maestro Production"
+          scriptType: ps
+          scriptLocation: scriptPath
+          scriptPath: $(Build.SourcesDirectory)/eng/common/post-build/publish-using-darc.ps1
           arguments: -BuildId $(BARBuildId) 
             -PublishingInfraVersion 3
             -AzdoToken '$(publishing-dnceng-devdiv-code-r-build-re)'


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/4483

This PR fixes a bug introduced by https://github.com/dotnet/arcade/pull/14880:

The [Publish Using Darc task](https://github.com/dotnet/arcade/pull/14880/files#diff-02566fa472aae261a77ce16e1282063deda281ada97bc5e26b7e8386c204584dR158-R167) in `eng/common/core-templates/job/publish-build-assets.yml` was still using powershell instead of the AzureCLI. This caused a break in the SBRP CI pipeline. Changing the task to use the AzureCLI task fixed the issue.

[Example build with fix](https://dev.azure.com/dnceng/internal/_build/results?buildId=2483150&view=results) (internal Microsoft link)