### PR TITLE
Don't round-trip download through service principal login during stage 1 upload

### DIFF
--- a/eng/common/core-templates/job/source-index-stage1.yml
+++ b/eng/common/core-templates/job/source-index-stage1.yml
@@ -69,23 +69,11 @@ jobs:
 
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - task: AzureCLI@2
-      displayName: Get stage 1 auth token
+      displayName: Log in to Azure and upload stage1 artifacts to source index
       inputs:
         azureSubscription: 'SourceDotNet Stage1 Publish'
         addSpnToEnvironment: true
         scriptType: 'ps'
         scriptLocation: 'inlineScript'
         inlineScript: |
-          echo "##vso[task.setvariable variable=ARM_CLIENT_ID]$env:servicePrincipalId"
-          echo "##vso[task.setvariable variable=ARM_ID_TOKEN]$env:idToken"
-          echo "##vso[task.setvariable variable=ARM_TENANT_ID]$env:tenantId"
-
-    - script: |
-        echo "Client ID: $(ARM_CLIENT_ID)"
-        echo "ID Token: $(ARM_ID_TOKEN)"
-        echo "Tenant ID: $(ARM_TENANT_ID)"
-        az login --service-principal -u $(ARM_CLIENT_ID) --tenant $(ARM_TENANT_ID) --allow-no-subscriptions --federated-token $(ARM_ID_TOKEN)
-      displayName: "Login to Azure"
-
-    - script: $(Agent.TempDirectory)/.source-index/tools/UploadIndexStage1 -i .source-index/stage1output -n $(Build.Repository.Name) -s netsourceindexstage1 -b stage1
-      displayName: Upload stage1 artifacts to source index
+          $(Agent.TempDirectory)/.source-index/tools/UploadIndexStage1 -i .source-index/stage1output -n $(Build.Repository.Name) -s netsourceindexstage1 -b stage1

--- a/eng/common/core-templates/job/source-index-stage1.yml
+++ b/eng/common/core-templates/job/source-index-stage1.yml
@@ -67,12 +67,13 @@ jobs:
   - script: $(Agent.TempDirectory)/.source-index/tools/BinLogToSln -i $(BinlogPath) -r $(Build.SourcesDirectory) -n $(Build.Repository.Name) -o .source-index/stage1output
     displayName: Process Binlog into indexable sln
 
-  - task: AzureCLI@2
-    displayName: Log in to Azure and upload stage1 artifacts to source index
-    inputs:
-      azureSubscription: 'SourceDotNet Stage1 Publish'
-      addSpnToEnvironment: true
-      scriptType: 'ps'
-      scriptLocation: 'inlineScript'
-      inlineScript: |
-        $(Agent.TempDirectory)/.source-index/tools/UploadIndexStage1 -i .source-index/stage1output -n $(Build.Repository.Name) -s netsourceindexstage1 -b stage1
+  - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - task: AzureCLI@2
+      displayName: Log in to Azure and upload stage1 artifacts to source index
+      inputs:
+        azureSubscription: 'SourceDotNet Stage1 Publish'
+        addSpnToEnvironment: true
+        scriptType: 'ps'
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          $(Agent.TempDirectory)/.source-index/tools/UploadIndexStage1 -i .source-index/stage1output -n $(Build.Repository.Name) -s netsourceindexstage1 -b stage1

--- a/eng/common/core-templates/job/source-index-stage1.yml
+++ b/eng/common/core-templates/job/source-index-stage1.yml
@@ -67,13 +67,12 @@ jobs:
   - script: $(Agent.TempDirectory)/.source-index/tools/BinLogToSln -i $(BinlogPath) -r $(Build.SourcesDirectory) -n $(Build.Repository.Name) -o .source-index/stage1output
     displayName: Process Binlog into indexable sln
 
-  - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - task: AzureCLI@2
-      displayName: Log in to Azure and upload stage1 artifacts to source index
-      inputs:
-        azureSubscription: 'SourceDotNet Stage1 Publish'
-        addSpnToEnvironment: true
-        scriptType: 'ps'
-        scriptLocation: 'inlineScript'
-        inlineScript: |
-          $(Agent.TempDirectory)/.source-index/tools/UploadIndexStage1 -i .source-index/stage1output -n $(Build.Repository.Name) -s netsourceindexstage1 -b stage1
+  - task: AzureCLI@2
+    displayName: Log in to Azure and upload stage1 artifacts to source index
+    inputs:
+      azureSubscription: 'SourceDotNet Stage1 Publish'
+      addSpnToEnvironment: true
+      scriptType: 'ps'
+      scriptLocation: 'inlineScript'
+      inlineScript: |
+        $(Agent.TempDirectory)/.source-index/tools/UploadIndexStage1 -i .source-index/stage1output -n $(Build.Repository.Name) -s netsourceindexstage1 -b stage1


### PR DESCRIPTION
Security changes on the Azure subscription side have blocked us from using the previous idiom for getting a temporary service principal credential. Instead, use the managed identity service connection directly during upload of stage 1 artifacts.

Repo builds (e.g. runtime) are expected to fail until this is merged & repos take an Arcade update

CI build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2486258&view=logs&j=316d5c15-0c50-544e-8051-e6b14a1ab674&t=316d5c15-0c50-544e-8051-e6b14a1ab674 (ignore the Windows failure, that's not my fault)