### PR TITLE
Fix obsolete X509Certificate2 Errors

### DIFF
--- a/src/Microsoft.DotNet.SignTool/src/VerifySignatures.cs
+++ b/src/Microsoft.DotNet.SignTool/src/VerifySignatures.cs
@@ -99,20 +99,18 @@ namespace Microsoft.DotNet.SignTool
 
         internal static bool IsDigitallySigned(string fullPath)
         {
-            // We later suppress SYSLIB0057 because X509CertificateLoader does not handle authenticode inputs
-            // so we should verify that the certificate is authenticode before using X509Certificate2.CreateFromSignedFile
-            var certContentType = X509Certificate2.GetCertContentType(fullPath);
-            if (certContentType != X509ContentType.Authenticode)
-            {
-                throw new CryptographicException($"Unexpected certificate content type, got '{certContentType}' instead of Authenticode.");
-            }
-
             X509Certificate2 certificate;
             try
             {
-                // X509CertificateLoader does not handle authenticode inputs
-                // so we have to suppress the X509Certificate2 ctor obsoletion
-                #pragma warning disable SYSLIB0057
+                // We later suppress SYSLIB0057 because X509CertificateLoader does not handle authenticode inputs
+                // so we should verify that the certificate is authenticode before using X509Certificate2.CreateFromSignedFile
+                var certContentType = X509Certificate2.GetCertContentType(fullPath);
+                if (certContentType != X509ContentType.Authenticode)
+                {
+                    throw new CryptographicException($"Unexpected certificate content type, got '{certContentType}' instead of Authenticode.");
+                }
+
+                #pragma warning disable SYSLIB0057 // Suppress obsoletion warning for CreateFromSignedFile
                 X509Certificate signer = X509Certificate2.CreateFromSignedFile(fullPath);
                 certificate = new X509Certificate2(signer);
                 #pragma warning restore SYSLIB0057

--- a/src/Microsoft.DotNet.SignTool/src/VerifySignatures.cs
+++ b/src/Microsoft.DotNet.SignTool/src/VerifySignatures.cs
@@ -101,7 +101,7 @@ namespace Microsoft.DotNet.SignTool
             X509Certificate2 certificate;
             try
             {
-                X509Certificate signer = X509Certificate2.CreateFromSignedFile(fullPath);
+                X509Certificate signer = X509CertificateLoader.LoadCertificateFromFile(fullPath);
                 certificate = new X509Certificate2(signer);
             }
             catch (Exception)

--- a/src/Microsoft.DotNet.SignTool/src/VerifySignatures.cs
+++ b/src/Microsoft.DotNet.SignTool/src/VerifySignatures.cs
@@ -107,7 +107,7 @@ namespace Microsoft.DotNet.SignTool
                 var certContentType = X509Certificate2.GetCertContentType(fullPath);
                 if (certContentType != X509ContentType.Authenticode)
                 {
-                    throw new CryptographicException($"Unexpected certificate content type, got '{certContentType}' instead of Authenticode.");
+                    return false;
                 }
 
                 #pragma warning disable SYSLIB0057 // Suppress obsoletion warning for CreateFromSignedFile


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4494

[Test build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2491390&view=results)

My local build worked with thes changes, but I'm verifying with the source-build-lite pipeline as well.
