### PR TITLE
Update the PublishSignedAssets MSBuild task to acquire a PAT token if one was not specified.

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishSignedAssets.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishSignedAssets.proj
@@ -34,7 +34,6 @@
       <AzureDevOpsOrg Condition="'$(AzureDevOpsOrg)' == ''">dnceng</AzureDevOpsOrg>
       <AzureDevOpsProject Condition="'(AzureDevOpsProject)' == '' and '(AzureDevOpsOrg)' == 'dnceng' and '$(IsInternalBuild)' == 'true'">internal</AzureDevOpsProject>
       <AzureDevOpsProject Condition="'(AzureDevOpsProject)' == '' and '(AzureDevOpsOrg)' == 'dnceng' and '$(IsInternalBuild)' == 'false'">public</AzureDevOpsProject>
-      <AzureDevOpsPersonalAccessToken Condition="'$(AzdoTargetFeedPAT)' != ''">$(AzdoTargetFeedPAT)</AzureDevOpsPersonalAccessToken>
     </PropertyGroup>
 
     <Error
@@ -43,7 +42,7 @@
 
     <!--Create the shipping feed-->
     <CreateAzureDevOpsFeed
-        AzureDevOpsPersonalAccessToken="$(AzureDevOpsPersonalAccessToken)"
+        AzureDevOpsPersonalAccessToken="$(AzdoTargetFeedPAT)"
         FeedName="$(FeedName)-shipping"
         AzureDevOpsOrg="$(AzureDevOpsOrg)"
         AzureDevOpsProject="$(AzureDevOpsProject)">
@@ -52,7 +51,7 @@
 
     <!--Create the nonshipping feed-->
     <CreateAzureDevOpsFeed
-        AzureDevOpsPersonalAccessToken="$(AzureDevOpsPersonalAccessToken)"
+        AzureDevOpsPersonalAccessToken="$(AzdoTargetFeedPAT)"
         FeedName="$(FeedName)-nonshipping"
         AzureDevOpsOrg="$(AzureDevOpsOrg)"
         AzureDevOpsProject="$(AzureDevOpsProject)">
@@ -60,7 +59,7 @@
     </CreateAzureDevOpsFeed>
 
     <PublishSignedAssets
-      AzureDevOpsPersonalAccessToken="$(AzureDevOpsPersonalAccessToken)"
+      AzureDevOpsPersonalAccessToken="$(AzdoTargetFeedPAT)"
       ShippingFeedName="$(ShippingAzdoPackageFeedURL)"
       NonShippingFeedName="$(NonShippingAzdoPackageFeedURL)"
       ShippingAssetsFolder="$(ShippingFolder)"

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishSignedAssets.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishSignedAssets.proj
@@ -13,8 +13,8 @@
       - NonShippingFolder                       : Location of the nonshipping assets about to be published.
       - FeedName                                : Name of the feed that will be created. This will
                                                   be appended by '-shipping' and '-nonshipping' depending the case
-      - NugetPath                               : Path to nuget.exe                                            
-      - AzdoTargetFeedPAT                       : Required token to publish assets to feeds
+      - NugetPath                               : Path to nuget.exe
+      - AzdoTargetFeedPAT                       : Token to publish assets to feeds
   -->
 
   <Target Name="Execute">
@@ -30,14 +30,11 @@
       Condition="'$(NonShippingFolder)' == ''"
       Text="Parameters 'NonShippingFolder' is empty." />
 
-    <Error
-      Condition="'$(AzdoTargetFeedPAT)' == ''"
-      Text="Parameters 'AzdoTargetFeedPAT' is empty." />
-
     <PropertyGroup>
       <AzureDevOpsOrg Condition="'$(AzureDevOpsOrg)' == ''">dnceng</AzureDevOpsOrg>
       <AzureDevOpsProject Condition="'(AzureDevOpsProject)' == '' and '(AzureDevOpsOrg)' == 'dnceng' and '$(IsInternalBuild)' == 'true'">internal</AzureDevOpsProject>
       <AzureDevOpsProject Condition="'(AzureDevOpsProject)' == '' and '(AzureDevOpsOrg)' == 'dnceng' and '$(IsInternalBuild)' == 'false'">public</AzureDevOpsProject>
+      <AzureDevOpsPersonalAccessToken Condition="'$(AzdoTargetFeedPAT)' != ''">$(AzdoTargetFeedPAT)</AzureDevOpsPersonalAccessToken>
     </PropertyGroup>
 
     <Error
@@ -46,7 +43,7 @@
 
     <!--Create the shipping feed-->
     <CreateAzureDevOpsFeed
-        AzureDevOpsPersonalAccessToken="$(AzdoTargetFeedPAT)"
+        AzureDevOpsPersonalAccessToken="$(AzureDevOpsPersonalAccessToken)"
         FeedName="$(FeedName)-shipping"
         AzureDevOpsOrg="$(AzureDevOpsOrg)"
         AzureDevOpsProject="$(AzureDevOpsProject)">
@@ -55,7 +52,7 @@
 
     <!--Create the nonshipping feed-->
     <CreateAzureDevOpsFeed
-        AzureDevOpsPersonalAccessToken="$(AzdoTargetFeedPAT)"
+        AzureDevOpsPersonalAccessToken="$(AzureDevOpsPersonalAccessToken)"
         FeedName="$(FeedName)-nonshipping"
         AzureDevOpsOrg="$(AzureDevOpsOrg)"
         AzureDevOpsProject="$(AzureDevOpsProject)">
@@ -63,7 +60,7 @@
     </CreateAzureDevOpsFeed>
 
     <PublishSignedAssets
-      AzureDevOpsPersonalAccessToken="$(AzdoTargetFeedPAT)"
+      AzureDevOpsPersonalAccessToken="$(AzureDevOpsPersonalAccessToken)"
       ShippingFeedName="$(ShippingAzdoPackageFeedURL)"
       NonShippingFeedName="$(NonShippingAzdoPackageFeedURL)"
       ShippingAssetsFolder="$(ShippingFolder)"

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishSignedAssets.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishSignedAssets.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Azure.Core;
+using Azure.Identity;
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.Tasks.Feed.Model;
 using NuGet.Packaging;
@@ -15,10 +17,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.src
 {
     public class PublishSignedAssets : PublishArtifactsInManifestBase
     {
+        private static readonly string AzureDevOpsScope = "499b84ac-1321-427f-aa17-267ca6975798/.default";
+
         /// <summary>
         /// Required token to publishe packages to the feeds
         /// </summary>
-        [Required]
         public string AzureDevOpsPersonalAccessToken { get; set; }
 
         /// <summary>
@@ -54,6 +57,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.src
         {
             try
             {
+                if (string.IsNullOrEmpty(AzureDevOpsPersonalAccessToken))
+                {
+                    AzureDevOpsPersonalAccessToken = new AzureCliCredential().GetToken(new TokenRequestContext(new[] { AzureDevOpsScope })).Token;
+                }
+
                 // Push shipping packages
                 await PushPackagesToFeed(ShippingAssetsFolder, ShippingFeedName);
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishSignedAssets.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishSignedAssets.cs
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.src
             {
                 if (string.IsNullOrEmpty(AzureDevOpsPersonalAccessToken))
                 {
-                    AzureDevOpsPersonalAccessToken = new AzureCliCredential().GetToken(new TokenRequestContext(new[] { AzureDevOpsScope })).Token;
+                    AzureDevOpsPersonalAccessToken = (await new AzureCliCredential().GetTokenAsync(new TokenRequestContext(new[] { AzureDevOpsScope }))).Token;
                 }
 
                 // Push shipping packages


### PR DESCRIPTION
The AzureDevOpsPersonalAccessToken parameter is no longer required. You can still manually specify an AzDo PAT token or run the task within the scope of an AzureCLI task.

To double check:
### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
