### PR TITLE
Update FreeBSD 13 version

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -72,7 +72,7 @@ __AlpinePackages+=" krb5-dev"
 __AlpinePackages+=" openssl-dev"
 __AlpinePackages+=" zlib-dev"
 
-__FreeBSDBase="13.2-RELEASE"
+__FreeBSDBase="13.3-RELEASE"
 __FreeBSDPkg="1.17.0"
 __FreeBSDABI="13"
 __FreeBSDPackages="libunwind"


### PR DESCRIPTION
13.2 is EOL per https://www.freebsd.org/releases/.

Fixes https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1129