### PR TITLE
Set origin URI when doing inner clone

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/git-clone-to-dir.sh
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/git-clone-to-dir.sh
@@ -134,6 +134,9 @@ fi
       git clone -c protocol.file.allow=always --no-checkout "$sourceDir" "$destDir"
     fi
 
+    # For sourcelink, ensure that the origin remote URI is updated to match the outer repo's
+    git -C "$destDir" remote set-url origin $(git -C "$sourceDir" remote get-url origin)
+
     (
       cd "$destDir"
       echo "Checking out sources..."


### PR DESCRIPTION
The SourceLink integrated into the 8.0 SDK will look at the origin URI to generate sourcelink information. When we clone to the inner dir, we lose the origin URI (it ends up being empty), which then confuses sourcelink.

To fix this, copy the outer repo's origin URI to the inner.
