### PR TITLE
Revert "Update to Preview 6"

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "9.0.100-preview.6.24328.19",
+    "version": "9.0.100-preview.5.24307.3",
     "rollForward": "latestFeature"
   },
   "tools": {
-    "dotnet": "9.0.100-preview.6.24328.19"
+    "dotnet": "9.0.100-preview.5.24307.3"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.24352.2",

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <IncludeDotNetCli Condition=" '$(IncludeDotNetCli)' != 'true' ">false</IncludeDotNetCli>
-    <AspNetCoreRuntimeVersion>9.0.0-preview.6.24328.4</AspNetCoreRuntimeVersion>
+    <AspNetCoreRuntimeVersion>9.0.0-preview.5.24306.11</AspNetCoreRuntimeVersion>
     <DotNetCliPackageType Condition=" '$(DotNetCliPackageType)' == '' ">runtime</DotNetCliPackageType>
     <DotNetCliVersion Condition=" '$(DotNetCliVersion)' == '' AND '$(DotNetCliPackageType)' == 'runtime' ">$(BundledNETCoreAppPackageVersion)</DotNetCliVersion>
     <!-- TODO (https://github.com/dotnet/arcade/issues/7022): We are hardcoding this version to use the one tied to the SDK version from global.json -->


### PR DESCRIPTION
Reverts dotnet/arcade#14925

Potentially unblocks some symbol publishing timeouts in build promotion