### PR TITLE
Remove unused azdo PAT from sdl validation

### DIFF
--- a/eng/common/sdl/execute-all-sdl-tools.ps1
+++ b/eng/common/sdl/execute-all-sdl-tools.ps1
@@ -6,7 +6,6 @@ Param(
   [string] $BranchName=$env:BUILD_SOURCEBRANCH,                                                  # Optional: name of branch or version of gdn settings; defaults to master
   [string] $SourceDirectory=$env:BUILD_SOURCESDIRECTORY,                                         # Required: the directory where source files are located
   [string] $ArtifactsDirectory = (Join-Path $env:BUILD_ARTIFACTSTAGINGDIRECTORY ('artifacts')),  # Required: the directory where build artifacts are located
-  [string] $AzureDevOpsAccessToken,                                                              # Required: access token for dnceng; should be provided via KeyVault
 
   # Optional: list of SDL tools to run on source code. See 'configure-sdl-tool.ps1' for tools list
   # format.
@@ -75,7 +74,7 @@ try {
   }
 
   Exec-BlockVerbosely {
-    & $(Join-Path $PSScriptRoot 'init-sdl.ps1') -GuardianCliLocation $guardianCliLocation -Repository $RepoName -BranchName $BranchName -WorkingDirectory $workingDirectory -AzureDevOpsAccessToken $AzureDevOpsAccessToken -GuardianLoggerLevel $GuardianLoggerLevel
+    & $(Join-Path $PSScriptRoot 'init-sdl.ps1') -GuardianCliLocation $guardianCliLocation -Repository $RepoName -BranchName $BranchName -WorkingDirectory $workingDirectory -GuardianLoggerLevel $GuardianLoggerLevel
   }
   $gdnFolder = Join-Path $workingDirectory '.gdn'
 
@@ -104,7 +103,6 @@ try {
           -TargetDirectory $targetDirectory `
           -GdnFolder $gdnFolder `
           -ToolsList $tools `
-          -AzureDevOpsAccessToken $AzureDevOpsAccessToken `
           -GuardianLoggerLevel $GuardianLoggerLevel `
           -CrScanAdditionalRunConfigParams $CrScanAdditionalRunConfigParams `
           -PoliCheckAdditionalRunConfigParams $PoliCheckAdditionalRunConfigParams `

--- a/eng/common/sdl/init-sdl.ps1
+++ b/eng/common/sdl/init-sdl.ps1
@@ -3,7 +3,6 @@ Param(
   [string] $Repository,
   [string] $BranchName='master',
   [string] $WorkingDirectory,
-  [string] $AzureDevOpsAccessToken,
   [string] $GuardianLoggerLevel='Standard'
 )
 
@@ -21,14 +20,7 @@ $ci = $true
 # Don't display the console progress UI - it's a huge perf hit
 $ProgressPreference = 'SilentlyContinue'
 
-# Construct basic auth from AzDO access token; construct URI to the repository's gdn folder stored in that repository; construct location of zip file
-$encodedPat = [Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$AzureDevOpsAccessToken"))
-$escapedRepository = [Uri]::EscapeDataString("/$Repository/$BranchName/.gdn")
-$uri = "https://dev.azure.com/dnceng/internal/_apis/git/repositories/sdl-tool-cfg/Items?path=$escapedRepository&versionDescriptor[versionOptions]=0&`$format=zip&api-version=5.0"
-$zipFile = "$WorkingDirectory/gdn.zip"
-
 Add-Type -AssemblyName System.IO.Compression.FileSystem
-$gdnFolder = (Join-Path $WorkingDirectory '.gdn')
 
 try {
   # if the folder does not exist, we'll do a guardian init and push it to the remote repository

--- a/eng/common/templates/steps/execute-sdl.yml
+++ b/eng/common/templates/steps/execute-sdl.yml
@@ -34,6 +34,8 @@ steps:
     displayName: Execute SDL (Overridden)
     continueOnError: ${{ parameters.sdlContinueOnError }}
     condition: ${{ parameters.condition }}
+    env:
+      GUARDIAN_DEFAULT_PACKAGE_SOURCE_SECRET: $(System.AccessToken)
 
 - ${{ if eq(parameters.overrideParameters, '') }}:
   - powershell: ${{ parameters.executeAllSdlToolsScript }}
@@ -44,6 +46,8 @@ steps:
     displayName: Execute SDL
     continueOnError: ${{ parameters.sdlContinueOnError }}
     condition: ${{ parameters.condition }}
+    env:
+      GUARDIAN_DEFAULT_PACKAGE_SOURCE_SECRET: $(System.AccessToken)
 
 - ${{ if ne(parameters.publishGuardianDirectoryToPipeline, 'false') }}:
   # We want to publish the Guardian results and configuration for easy diagnosis. However, the

--- a/eng/common/templates/steps/execute-sdl.yml
+++ b/eng/common/templates/steps/execute-sdl.yml
@@ -41,7 +41,6 @@ steps:
   - powershell: ${{ parameters.executeAllSdlToolsScript }}
       -GuardianCliLocation $(GuardianCliLocation)
       -NugetPackageDirectory $(Build.SourcesDirectory)\.packages
-      -AzureDevOpsAccessToken $(dn-bot-dotnet-build-rw-code-rw)
       ${{ parameters.additionalParameters }}
     displayName: Execute SDL
     continueOnError: ${{ parameters.sdlContinueOnError }}


### PR DESCRIPTION
Follow-up of https://github.com/dotnet/arcade/pull/14944
I missed adding the `GUARDIAN_DEFAULT_PACKAGE_SOURCE_SECRET` environment variable which is needed in the script
also removing a token that is not used anywhere

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
