### PR TITLE
[release/6.0] Prepend ? when dealing with runtime query string prefixes

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs
@@ -84,6 +84,12 @@ namespace Microsoft.DotNet.Arcade.Sdk
                     {
                         var encodedTokenBytes = System.Convert.FromBase64String(encodedToken);
                         var decodedToken = System.Text.Encoding.UTF8.GetString(encodedTokenBytes);
+                        // It's possible that the decoded SAS does not begin with the query string parameter.
+                        // Handle cleanly before constructing the final URL
+                        if (!decodedToken.StartsWith("?"))
+                        {
+                            decodedToken = $"?{decodedToken}";
+                        }
                         uri = $"{uri}{decodedToken}";
                     }
 


### PR DESCRIPTION
Prepend ? when dealing with runtime query string prefixes

cherry pick of 9c9fe32557e537905d8f61f5f30f58c4fdfb9998 - [release/8.0] Prepend ? when dealing with runtime query string prefixes (#14945)
