### PR TITLE
[release/6.0] Fix NuGet validation

### DIFF
--- a/eng/common/templates-official/post-build/post-build.yml
+++ b/eng/common/templates-official/post-build/post-build.yml
@@ -128,7 +128,6 @@ stages:
           inputs:
             filePath: $(Build.SourcesDirectory)/eng/common/post-build/nuget-validation.ps1
             arguments: -PackagesPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/
-              -ToolDestinationPath $(Agent.BuildDirectory)/Extract/
 
     - job:
       displayName: Signing Validation

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -125,7 +125,6 @@ stages:
           inputs:
             filePath: $(Build.SourcesDirectory)/eng/common/post-build/nuget-validation.ps1
             arguments: -PackagesPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/
-              -ToolDestinationPath $(Agent.BuildDirectory)/Extract/
 
     - job:
       displayName: Signing Validation


### PR DESCRIPTION
Break introduced in https://github.com/dotnet/arcade/commit/6319213ffa01054de0f767521d8292c64ed146db

Example: https://dev.azure.com/dnceng/internal/_build/results?buildId=2497602&view=logs&j=a13e9384-d6d3-5a14-7a96-79282fc11262&t=62b78796-390e-5a19-0957-0b46593907e3