### PR TITLE
[release/6.0] Only run XHarness tests sometimes

### DIFF
--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -51,8 +51,9 @@ stages:
         preSteps:
         - checkout: self
           clean: true
-        steps:
+          fetchDepth: 0
 
+        steps:
         - script: eng\common\cibuild.cmd
             -configuration $(_BuildConfig)
             -prepareMachine

--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -125,6 +125,9 @@ stages:
         timeoutInMinutes: 90
         pool:
           vmimage: windows-latest
+        variables:
+          - name: runXHarnessTests
+            value: $[ dependencies.build.Windows_NT.Build_Release.outputs['XHarnessChangeDetection.RunXHarnessTests'] ]
         strategy:
           matrix:
             Build_Release:
@@ -177,13 +180,16 @@ stages:
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
             HelixAccessToken: ''
-          condition: and(succeeded(), eq(stageDependencies.build.Windows_NT.Build_Release.outputs['XHarnessChangeDetection.RunXHarnessTests'], 'True'))
+          condition: and(succeeded(), eq(variables.runXHarnessTests, 'true'))
 
       - job: Linux
         timeoutInMinutes: 180
         container: LinuxContainer
         pool:
           vmimage: ubuntu-latest
+        variables:
+          - name: runXHarnessTests
+            value: $[ dependencies.build.Windows_NT.Build_Release.outputs['XHarnessChangeDetection.RunXHarnessTests'] ]
         strategy:
           matrix:
             Build_Debug:
@@ -223,7 +229,7 @@ stages:
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
             HelixAccessToken: ''
-          condition: and(succeeded(), eq(stageDependencies.build.Windows_NT.Build_Release.outputs['XHarnessChangeDetection.RunXHarnessTests'], 'True'))
+          condition: and(succeeded(), eq(variables.runXHarnessTests, 'true'))
 
         - script: eng/common/build.sh
             -configuration $(_BuildConfig)
@@ -239,4 +245,4 @@ stages:
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
             HelixAccessToken: ''
-          condition: and(succeeded(), eq(stageDependencies.build.Windows_NT.Build_Release.outputs['XHarnessChangeDetection.RunXHarnessTests'], 'True'))
+          condition: and(succeeded(), eq(variables.runXHarnessTests, 'true'))

--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -52,6 +52,14 @@ stages:
         - checkout: self
           clean: true
         steps:
+
+        - script: eng\common\cibuild.cmd
+            -configuration $(_BuildConfig)
+            -prepareMachine
+            $(_InternalBuildArgs)
+            /p:Test=false
+          displayName: Windows Build / Publish
+
         - powershell: |
             # Detects if current change contains change for which we need to run XHarness E2E tests
             git fetch --all
@@ -76,13 +84,6 @@ stages:
             Write-Host "No changes detected that will require running XHarness E2E tests"
           name: XHarnessChangeDetection
           displayName: Detect XHarness changes
-
-        - script: eng\common\cibuild.cmd
-            -configuration $(_BuildConfig)
-            -prepareMachine
-            $(_InternalBuildArgs)
-            /p:Test=false
-          displayName: Windows Build / Publish
 
       - job: Linux
         container: LinuxContainer

--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -52,6 +52,31 @@ stages:
         - checkout: self
           clean: true
         steps:
+        - powershell: |
+            # Detects if current change contains change for which we need to run XHarness E2E tests
+            git fetch --all
+            $diff=$(git diff HEAD HEAD~ --name-only -- src/Microsoft.DotNet.Helix/Sdk 'tests/XHarness*')
+
+            if ($diff) {
+              Write-Host "Detected changes that will require running XHarness E2E tests. Changed files:"
+              Write-Host $diff
+              Write-Host "##vso[task.setvariable variable=RunXHarnessTests;isOutput=true]True"
+              exit 0
+            }
+
+            # Detects if Version.Details.xml or Versions.props changed (a version bump)
+            $fullDiff=$(git diff --unified=0 HEAD HEAD~ -- eng/Version.Details.xml eng/Versions.props)
+            if ($fullDiff -match 'Microsoft.DotNet.XHarness.CLI')
+            {
+              Write-Host "Detected a version bump of Microsoft.DotNet.XHarness.CLI, will run XHarness E2E tests"
+              Write-Host "##vso[task.setvariable variable=RunXHarnessTests;isOutput=true]True"
+              exit 0
+            }
+
+            Write-Host "No changes detected that will require running XHarness E2E tests"
+          name: XHarnessChangeDetection
+          displayName: Detect XHarness changes
+
         - script: eng\common\cibuild.cmd
             -configuration $(_BuildConfig)
             -prepareMachine
@@ -120,6 +145,7 @@ stages:
               /p:SymbolPublishingExclusionsFile='$(Build.SourcesDirectory)/eng/SymbolPublishingExclusionsFile.txt'
               /p:Configuration=Release
               /p:PublishToMSDL=false
+
         - powershell: eng\common\build.ps1
             -configuration $(_BuildConfig)
             -prepareMachine
@@ -134,6 +160,7 @@ stages:
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
             HelixAccessToken: ''
+
         - powershell: eng\common\build.ps1
             -configuration $(_BuildConfig)
             -prepareMachine
@@ -148,6 +175,8 @@ stages:
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
             HelixAccessToken: ''
+          condition: and(succeeded(), eq(dependencies.build.outputs['Windows_NT.Build_Release.XHarnessChangeDetection.RunXHarnessTests'], 'True'))
+
       - job: Linux
         timeoutInMinutes: 180
         container: LinuxContainer
@@ -177,6 +206,7 @@ stages:
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
             HelixAccessToken: ''
+
         - script: eng/common/build.sh
             -configuration $(_BuildConfig)
             -prepareMachine
@@ -191,6 +221,8 @@ stages:
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
             HelixAccessToken: ''
+          condition: and(succeeded(), eq(dependencies.build.outputs['Windows_NT.Build_Release.XHarnessChangeDetection.RunXHarnessTests'], 'True'))
+
         - script: eng/common/build.sh
             -configuration $(_BuildConfig)
             -prepareMachine
@@ -205,3 +237,4 @@ stages:
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
             HelixAccessToken: ''
+          condition: and(succeeded(), eq(dependencies.build.outputs['Windows_NT.Build_Release.XHarnessChangeDetection.RunXHarnessTests'], 'True'))

--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -177,7 +177,7 @@ stages:
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
             HelixAccessToken: ''
-          condition: and(succeeded(), eq(dependencies.build.outputs['Windows_NT.Build_Release.XHarnessChangeDetection.RunXHarnessTests'], 'True'))
+          condition: and(succeeded(), eq(stageDependencies.build.Windows_NT.Build_Release.outputs['XHarnessChangeDetection.RunXHarnessTests'], 'True'))
 
       - job: Linux
         timeoutInMinutes: 180
@@ -223,7 +223,7 @@ stages:
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
             HelixAccessToken: ''
-          condition: and(succeeded(), eq(dependencies.build.outputs['Windows_NT.Build_Release.XHarnessChangeDetection.RunXHarnessTests'], 'True'))
+          condition: and(succeeded(), eq(stageDependencies.build.Windows_NT.Build_Release.outputs['XHarnessChangeDetection.RunXHarnessTests'], 'True'))
 
         - script: eng/common/build.sh
             -configuration $(_BuildConfig)
@@ -239,4 +239,4 @@ stages:
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
             HelixAccessToken: ''
-          condition: and(succeeded(), eq(dependencies.build.outputs['Windows_NT.Build_Release.XHarnessChangeDetection.RunXHarnessTests'], 'True'))
+          condition: and(succeeded(), eq(stageDependencies.build.Windows_NT.Build_Release.outputs['XHarnessChangeDetection.RunXHarnessTests'], 'True'))


### PR DESCRIPTION
Similar to `main`, we will only run these tests when we detect changes that are relevant (as these tests are flaky)