### PR TITLE
Restore internal tools correctly in VisualStudio.InsertionManifests.targets

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -11,6 +11,9 @@
     <TargetFrameworkIdentifier  Condition="'$(TargetFrameworkIdentifier)' == ''">.NETFramework</TargetFrameworkIdentifier>
     <TargetFrameworkMoniker Condition="'$(TargetFrameworkMoniker)' == ''">.NETFramework,Version=v4.7.2</TargetFrameworkMoniker>   
     <MSBuildProjectExtensionsPath>$(BaseIntermediateOutputPath)</MSBuildProjectExtensionsPath>
+    <!-- Invoke restore internal tooling target when necessary.
+         - VisualStudio.BuildIbcTrainingInputs.targets: Keep condition in sync with import in AfterSigning.proj. -->
+    <RestoreInternalToolingAfterTargets Condition="'$(UsingToolVSSDK)' == 'true' and '$(UsingToolVisualStudioIbcTraining)' == 'true' and '$(MSBuildRuntimeType)' != 'Core'">Restore</RestoreInternalToolingAfterTargets>
   </PropertyGroup>
 
   <!-- 
@@ -79,7 +82,8 @@
   </Target>
 
   <!-- Set as DependsOnTargets when internal tools (e.g. IBC data, optprof) is required -->
-  <Target Name="RestoreInternalTooling">
+  <Target Name="RestoreInternalTooling"
+          AfterTargets="$(RestoreInternalToolingAfterTargets)">
     <MSBuild Projects="$(RepoRoot)eng/common/internal/Tools.csproj"
         Targets="Restore"
         Properties="@(_RestoreToolsProps);_NETCORE_ENGINEERING_TELEMETRY=Restore"

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -11,9 +11,11 @@
     <TargetFrameworkIdentifier  Condition="'$(TargetFrameworkIdentifier)' == ''">.NETFramework</TargetFrameworkIdentifier>
     <TargetFrameworkMoniker Condition="'$(TargetFrameworkMoniker)' == ''">.NETFramework,Version=v4.7.2</TargetFrameworkMoniker>   
     <MSBuildProjectExtensionsPath>$(BaseIntermediateOutputPath)</MSBuildProjectExtensionsPath>
-    <!-- Invoke restore internal tooling target when necessary.
-         - VisualStudio.BuildIbcTrainingInputs.targets: Keep condition in sync with import in AfterSigning.proj. -->
-    <RestoreInternalToolingAfterTargets Condition="'$(UsingToolVSSDK)' == 'true' and '$(MSBuildRuntimeType)' != 'Core'">Restore</RestoreInternalToolingAfterTargets>
+
+    <!-- Internal tool restore settings -->
+    <!-- VisualStudio.InsertionManifests.targets: Keep condition in sync with import in AfterSigning.proj. -->
+    <RestoreInternalTooling Condition="'$(UsingToolVSSDK)' == 'true' and '$(MSBuildRuntimeType)' != 'Core'">true</RestoreInternalTooling>
+    <RestoreInternalToolingAfterTargets Condition="'$(RestoreInternalTooling)' == 'true'">Restore</RestoreInternalToolingAfterTargets>
   </PropertyGroup>
 
   <!-- 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -13,7 +13,7 @@
     <MSBuildProjectExtensionsPath>$(BaseIntermediateOutputPath)</MSBuildProjectExtensionsPath>
     <!-- Invoke restore internal tooling target when necessary.
          - VisualStudio.BuildIbcTrainingInputs.targets: Keep condition in sync with import in AfterSigning.proj. -->
-    <RestoreInternalToolingAfterTargets Condition="'$(UsingToolVSSDK)' == 'true' and '$(UsingToolVisualStudioIbcTraining)' == 'true' and '$(MSBuildRuntimeType)' != 'Core'">Restore</RestoreInternalToolingAfterTargets>
+    <RestoreInternalToolingAfterTargets Condition="'$(UsingToolVSSDK)' == 'true' and '$(MSBuildRuntimeType)' != 'Core'">Restore</RestoreInternalToolingAfterTargets>
   </PropertyGroup>
 
   <!-- 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.InsertionManifests.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.InsertionManifests.targets
@@ -14,6 +14,7 @@
     This is important since the manifest contain hashes of the VSIX files.
   -->
   <Target Name="GenerateVisualStudioInsertionManifests"
+          DependsOnTargets="RestoreInternalTooling"
           BeforeTargets="AfterPack"
           Outputs="%(_StubDirs.Identity)"
           Condition="'@(_StubDirs)' != ''">
@@ -27,15 +28,26 @@
     <Error Condition="'$(VisualStudioDropName)' == '' and '$(OfficialBuild)' == 'true'"
            Text="Property VisualStudioDropName must be specified in official build that produces Visual Studio insertion components." />
 
+    <PropertyGroup>
+      <_SwixRestoredPackagePath>$(NuGetPackageRoot)microsoft.visualstudioeng.microbuild.plugins.swixbuild\$(MicrosoftVisualStudioEngMicroBuildPluginsSwixBuildVersion)\</_SwixRestoredPackagePath>
+      <_ManifestToolRestoredPackagePath>$(NuGetPackageRoot)microsoft.manifesttool.crossplatform\$(MicrosoftManifestToolCrossPlatformVersion)\Content\Microsoft.ManifestTool.dll</_ManifestToolRestoredPackagePath>
+    </PropertyGroup>
+
+   <Error Text="Internal tool not found: 'microsoft.visualstudioeng.microbuild.plugins.swixbuild'. Run restore on '$(RepositoryEngineeringDir)common\internal\Tools.csproj'."
+           Condition="!Exists('$(_SwixRestoredPackagePath)')" />
+
+    <Error Text="Internal tool not found: 'microsoft.manifesttool.crossplatform'. Run restore on '$(RepositoryEngineeringDir)common\internal\Tools.csproj'."
+           Condition="!Exists('$(_ManifestToolRestoredPackagePath)')" />
+
     <ItemGroup>
       <_Args Include="OfficialBuild=$(OfficialBuild)" />
       <_Args Include="ComponentName=$(_ComponentName)"/>
       <_Args Include="SetupOutputPath=$(VisualStudioSetupInsertionPath)"/>
       <_Args Include="ComponentIntermediateOutputPath=$(VisualStudioSetupIntermediateOutputPath)$(_ComponentName)\"/>
-      <_Args Include="SwixBuildPath=$(NuGetPackageRoot)microsoft.visualstudioeng.microbuild.plugins.swixbuild\$(MicrosoftVisualStudioEngMicroBuildPluginsSwixBuildVersion)\"/>
+      <_Args Include="SwixBuildPath=$(_SwixRestoredPackagePath)" />
       <_Args Include="VisualStudioDropName=$(VisualStudioDropName)" />
       <_Args Include="DotNetTool=$(DotNetTool)" />
-      <_Args Include="ManifestTool=$(NuGetPackageRoot)microsoft.manifesttool.crossplatform\$(MicrosoftManifestToolCrossPlatformVersion)\Content\Microsoft.ManifestTool.dll"/>
+      <_Args Include="ManifestTool=$(_ManifestToolRestoredPackagePath) "/>
       <_Args Include="GenerateSbom=$(GenerateSbom)" />
     </ItemGroup>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.InsertionManifests.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.InsertionManifests.targets
@@ -14,7 +14,6 @@
     This is important since the manifest contain hashes of the VSIX files.
   -->
   <Target Name="GenerateVisualStudioInsertionManifests"
-          DependsOnTargets="RestoreInternalTooling"
           BeforeTargets="AfterPack"
           Outputs="%(_StubDirs.Identity)"
           Condition="'@(_StubDirs)' != ''">


### PR DESCRIPTION
Reported offline by @Evangelink.

This was probably overlooked in https://github.com/dotnet/arcade/commit/db8765409d91a7ac626f5ff932459876a5bea9c6. cc @mmitche 

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
