### PR TITLE
Add registry search for upgrade policy keys

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/bundle/bundle.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/bundle/bundle.wxs
@@ -24,6 +24,11 @@
       </bal:Condition>
     <?endif?>
 
+    <!-- Search references for upgrade policy keys -->
+    <util:RegistrySearchRef Id="RemovePreviousVersionRegistryKeySearch"/>
+    <util:RegistrySearchRef Id="RemoveSpecificPreviousVersionRegistryKeyExistsSearch"/>
+    <util:RegistrySearchRef Id="RemoveSpecificPreviousVersionRegistryKeySearch"/>
+
     <!--
       List of bundles that this bundle is an upgrade for. Used to support upgrade from bundles
       that were produced before UpdateCode was standardized per major-minor channel.

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/bundle/upgradePolicies.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/bundle/upgradePolicies.wxs
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
-  <?include "..\variables.wxi" ?>
-
   <Fragment>
     <!-- Bundle variables become unset if a search fails. The global key is retrieved first. If this fails,
          RemoveUpgradeRelatedBundle becomes unset, allowing the version specific search to potentially set 
@@ -36,5 +34,4 @@
                          Variable="RemoveUpgradeRelatedBundle"
                          Win64="yes" />
   </Fragment>
-
 </Wix>

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/bundle/upgradePolicies.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/bundle/upgradePolicies.wxs
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+  <?include "..\variables.wxi" ?>
+
+  <Fragment>
+    <!-- Bundle variables become unset if a search fails. The global key is retrieved first. If this fails,
+         RemoveUpgradeRelatedBundle becomes unset, allowing the version specific search to potentially set 
+         or override the bundle variable. -->
+    <util:RegistrySearch Id="RemovePreviousVersionRegistryKeySearch"
+                         Root="HKLM"
+                         Key="SOFTWARE\Microsoft\.NET"
+                         Value="RemovePreviousVersion"
+                         Result="value"
+                         Variable="RemoveUpgradeRelatedBundle"
+                         Win64="yes" />
+
+    <!-- The version specific key matching the major/minor of the .NET bundle takes precedence. The first search
+         checks whether the registry value exists and creates a variable that can be used as a condition
+         to executes the second part of the search to retrieve it. If the value doesn't exist, RemoveUpgradeRelatedBundle
+         retains its original value, or if it wasn't set, will be assigned a proper default through the BA (wixstdba). -->
+    <util:RegistrySearch Id="RemoveSpecificPreviousVersionRegistryKeyExistsSearch"
+                         After="RemovePreviousVersionRegistryKeySearch"
+                         Root="HKLM"
+                         Key="SOFTWARE\Microsoft\.NET\$(var.MajorVersion).$(var.MinorVersion)"
+                         Value="RemovePreviousVersion"
+                         Result="exists"
+                         Variable="RemoveSpecificPreviousVersionRegistryKeyExists"
+                         Win64="yes" />
+    <util:RegistrySearch Id="RemoveSpecificPreviousVersionRegistryKeySearch"
+                         After="RemoveSpecificPreviousVersionRegistryKeyExistsSearch"
+                         Condition="RemoveSpecificPreviousVersionRegistryKeyExists=1"
+                         Root="HKLM"
+                         Key="SOFTWARE\Microsoft\.NET\$(var.MajorVersion).$(var.MinorVersion)"
+                         Value="RemovePreviousVersion"
+                         Result="value"
+                         Variable="RemoveUpgradeRelatedBundle"
+                         Win64="yes" />
+  </Fragment>
+
+</Wix>

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets
@@ -125,6 +125,7 @@
       <WixExtensions Include="WixUtilExtension.dll" />
 
       <WixSrcFile Include="$(MSBuildThisFileDirectory)bundle/bundle.wxs" />
+      <WixSrcFile Include="$(MSBuildThisFileDirectory)bundle/upgradePolicies.wxs" />
     </ItemGroup>
   </Target>
 
@@ -181,6 +182,8 @@
       <LocFile Include="$(BundleThemeDirectory)\theme\**\bundle.wxl" />
       <LocDirName Include="$([System.String]::new('%(LocFile.RecursiveDir)').TrimEnd('\'))" />
 
+      <CandleVariables Include="MajorVersion" Value="$(MajorVersion)" />
+      <CandleVariables Include="MinorVersion" Value="$(MinorVersion)" />
       <CandleVariables Include="DisplayVersion" Value="$(MajorVersion).$(MinorVersion).$(PatchVersion).$(BuildNumberMajor)" />
       <CandleVariables Include="LcidList" Value="@(LocDirName)" />
       <CandleVariables Include="BundleThmDir" Value="$(BundleThemeDirectory)" />


### PR DESCRIPTION
# Description

Add registry search operations to Windows installer bundles. The search operation will check for a global and version specific registry key. The version specific key takes precedence when present. 

This is related to a customer request and part of a larger change. This PR only includes infrastructure changes to support changes in the Windows installer bundles.

# Risk

Low, this change only adds detection for the key, nothing will currently act on its value.

# Testing

Verified against a private build of Windows Desktop. Log excerpt below. The test machine contained both a global and version specific key.

```
HKEY_LOCAL_MACHINE\software\microsoft\.NET
    RemovePreviousVersion    REG_SZ    nextSession

HKEY_LOCAL_MACHINE\software\microsoft\.NET\6.0
    RemovePreviousVersion    REG_SZ    never
```

```
[0E70:11A0][2024-07-24T10:28:11]i000: Setting string variable 'WixBundleName' to value 'Microsoft Windows Desktop Runtime - 6.0.33 (x64)'
[0E70:0EBC][2024-07-24T10:28:11]i000: Setting version variable 'WixBundleFileVersion' to value '6.0.33.33924'
[0E70:11A0][2024-07-24T10:28:11]i000: Setting string variable 'RemoveUpgradeRelatedBundle' to value 'nextSession'
[0E70:11A0][2024-07-24T10:28:11]i000: Setting numeric variable 'RemoveSpecificPreviousVersionRegistryKeyExists' to value 1
[0E70:11A0][2024-07-24T10:28:11]i052: Condition 'RemoveSpecificPreviousVersionRegistryKeyExists=1' evaluates to true.
[0E70:11A0][2024-07-24T10:28:11]i000: Setting string variable 'RemoveUpgradeRelatedBundle' to value 'never'
```