### PR TITLE
Fix restore internal tools condition

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -14,7 +14,7 @@
 
     <!-- Internal tool restore settings -->
     <!-- VisualStudio.InsertionManifests.targets: Keep condition in sync with import in AfterSigning.proj. -->
-    <RestoreInternalTooling Condition="'$(UsingToolVSSDK)' == 'true' and '$(MSBuildRuntimeType)' != 'Core' and '$(OfficialBuild)' == 'true'">true</RestoreInternalTooling>
+    <RestoreInternalTooling Condition="'$(UsingToolVSSDK)' == 'true' and '$(GenerateSbom)' == 'true' and '$(MSBuildRuntimeType)' != 'Core'">true</RestoreInternalTooling>
     <RestoreInternalToolingAfterTargets Condition="'$(RestoreInternalTooling)' == 'true'">Restore</RestoreInternalToolingAfterTargets>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.InsertionManifests.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.InsertionManifests.targets
@@ -35,7 +35,7 @@
       <_Args Include="SwixBuildPath=$(NuGetPackageRoot)microsoft.visualstudioeng.microbuild.plugins.swixbuild\$(MicrosoftVisualStudioEngMicroBuildPluginsSwixBuildVersion)\" />
       <_Args Include="VisualStudioDropName=$(VisualStudioDropName)" />
       <_Args Include="DotNetTool=$(DotNetTool)" />
-      <_Args Include="ManifestTool=$(NuGetPackageRoot)microsoft.manifesttool.crossplatform\$(MicrosoftManifestToolCrossPlatformVersion)\Content\Microsoft.ManifestTool.dll "/>
+      <_Args Include="ManifestTool=$(NuGetPackageRoot)microsoft.manifesttool.crossplatform\$(MicrosoftManifestToolCrossPlatformVersion)\Content\Microsoft.ManifestTool.dll" />
       <_Args Include="GenerateSbom=$(GenerateSbom)" />
     </ItemGroup>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.InsertionManifests.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.InsertionManifests.targets
@@ -27,26 +27,15 @@
     <Error Condition="'$(VisualStudioDropName)' == '' and '$(OfficialBuild)' == 'true'"
            Text="Property VisualStudioDropName must be specified in official build that produces Visual Studio insertion components." />
 
-    <PropertyGroup>
-      <_SwixRestoredPackagePath>$(NuGetPackageRoot)microsoft.visualstudioeng.microbuild.plugins.swixbuild\$(MicrosoftVisualStudioEngMicroBuildPluginsSwixBuildVersion)\</_SwixRestoredPackagePath>
-      <_ManifestToolRestoredPackagePath>$(NuGetPackageRoot)microsoft.manifesttool.crossplatform\$(MicrosoftManifestToolCrossPlatformVersion)\Content\Microsoft.ManifestTool.dll</_ManifestToolRestoredPackagePath>
-    </PropertyGroup>
-
-   <Error Text="Internal tool not found: 'microsoft.visualstudioeng.microbuild.plugins.swixbuild'. Run restore on '$(RepositoryEngineeringDir)common\internal\Tools.csproj'."
-           Condition="!Exists('$(_SwixRestoredPackagePath)')" />
-
-    <Error Text="Internal tool not found: 'microsoft.manifesttool.crossplatform'. Run restore on '$(RepositoryEngineeringDir)common\internal\Tools.csproj'."
-           Condition="!Exists('$(_ManifestToolRestoredPackagePath)')" />
-
     <ItemGroup>
       <_Args Include="OfficialBuild=$(OfficialBuild)" />
       <_Args Include="ComponentName=$(_ComponentName)"/>
       <_Args Include="SetupOutputPath=$(VisualStudioSetupInsertionPath)"/>
       <_Args Include="ComponentIntermediateOutputPath=$(VisualStudioSetupIntermediateOutputPath)$(_ComponentName)\"/>
-      <_Args Include="SwixBuildPath=$(_SwixRestoredPackagePath)" />
+      <_Args Include="SwixBuildPath=$(NuGetPackageRoot)microsoft.visualstudioeng.microbuild.plugins.swixbuild\$(MicrosoftVisualStudioEngMicroBuildPluginsSwixBuildVersion)\" />
       <_Args Include="VisualStudioDropName=$(VisualStudioDropName)" />
       <_Args Include="DotNetTool=$(DotNetTool)" />
-      <_Args Include="ManifestTool=$(_ManifestToolRestoredPackagePath) "/>
+      <_Args Include="ManifestTool=$(NuGetPackageRoot)microsoft.manifesttool.crossplatform\$(MicrosoftManifestToolCrossPlatformVersion)\Content\Microsoft.ManifestTool.dll "/>
       <_Args Include="GenerateSbom=$(GenerateSbom)" />
     </ItemGroup>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.SetupPackage.vsmanproj
@@ -24,7 +24,7 @@
     <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
   </PropertyGroup>
 
-  <Import Project="$(SwixBuildPath)build\MicroBuild.Plugins.*.props" />
+  <Import Project="$(SwixBuildPath)build\MicroBuild.Plugins.*.props" Condition="'$(SwixBuildPath)' != ''" />
 
   <PropertyGroup>
     <FinalizeManifest>true</FinalizeManifest>
@@ -44,7 +44,7 @@
     <_PackageStubFiles Include="$(ComponentIntermediateOutputPath)*.stub"/>
   </ItemGroup>
 
-  <Import Project="$(SwixBuildPath)build\Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild.targets" />
+  <Import Project="$(SwixBuildPath)build\Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild.targets" Condition="'$(SwixBuildPath)' != ''" />
 
   <Target Name="_BuildManifest" DependsOnTargets="_GetVsixFileInfo;_GenerateSbomForVsixAndAddManifestItem;_GenerateVSManifest;GenerateSetupManifest" />
 
@@ -99,6 +99,9 @@
           DependsOnTargets="_GetVsixFileInfo"
           Condition="'$(GenerateSbom)' != 'false'">
     <Message Text="Generating SBOM manifest for '%(_VsixFileInfo.Identity)'" Importance="high"/>
+
+    <Error Text="Internal tool not found: 'microsoft.manifesttool.crossplatform'. Run restore on '$(RepositoryEngineeringDir)common\internal\Tools.csproj'."
+           Condition="!Exists('$(ManifestTool)')" />
 
     <MakeDir Directories="%(_VsixFileInfo.SbomDir);%(_VsixFileInfo.UnpackDir)"/>
     <Copy SourceFiles="%(_VsixFileInfo.VsixPath)" DestinationFolder="%(_VsixFileInfo.UnpackDir)" Condition = "'%(_VsixFileInfo.Extension)' == '.exe'" />


### PR DESCRIPTION
The ManifestTool is only needed when GenerateSbom
is true. This fixes the condition to only restore
internal tools when needed.

Fixes issues in https://github.com/dotnet/fsharp/pull/17429

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
