### PR TITLE
Force interpretation as decimal

### DIFF
--- a/eng/common/native/init-compiler.sh
+++ b/eng/common/native/init-compiler.sh
@@ -21,7 +21,7 @@ case "$compiler" in
         majorVersion="${version%%.*}"
 
         # LLVM based on v18 released in early 2024, with two releases per year
-        maxVersion="$((18 + ((($(date +%Y) - 2024) * 12 + $(date +%-m) - 3) / 6)))"
+        maxVersion="$((18 + ((($(date +%Y) - 2024) * 12 + 10#$(date +%-m)) - 3) / 6)))"
         compiler=clang
         ;;
 
@@ -31,7 +31,7 @@ case "$compiler" in
         majorVersion="${version%%.*}"
 
         # GCC based on v14 released in early 2024, with one release per year
-        maxVersion="$((14 + ((($(date +%Y) - 2024) * 12 + $(date +%-m) - 3) / 12)))"
+        maxVersion="$((14 + ((($(date +%Y) - 2024) * 12 + 10#$(date +%-m) - 3) / 12)))"
         compiler=gcc
         ;;
 esac


### PR DESCRIPTION
Numbers starting with '0' in bash are interpreted as octal. That works fine in months 1-7, but in month 8, that value is too great for an octal number, so it errors.

This (hopefully) forces the number to be interpreted as decimal.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
