### PR TITLE
Hardcode previous darc version

### DIFF
--- a/eng/publishing/v3/validate-and-locate-build.ps1
+++ b/eng/publishing/v3/validate-and-locate-build.ps1
@@ -5,7 +5,7 @@ param(
 
 try {
   . $PSScriptRoot\..\..\common\tools.ps1
-  $darc = Get-Darc
+  $darc = Get-Darc -version "1.1.0-beta.24373.1"
 
   $buildInfo = & $darc get-build `
     --id $BuildId `


### PR DESCRIPTION
### To double check:
We accidentally broke a darc function that's used in publishing during https://github.com/dotnet/arcade-services/issues/3745. Hardcoding it till we rollout again to unblock publishing
* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
