### PR TITLE
Update Maestro App ID reference in CI

### DIFF
--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -79,7 +79,9 @@ stages:
         scriptType: ps
         scriptLocation: inlineScript
         inlineScript: |
-          $token = (az account get-access-token --resource "$env:servicePrincipalId" | ConvertFrom-Json).accessToken
+          # MaestroAppClientId provided by Publish-Build-Assets
+          $token = (az account get-access-token --resource "$(MaestroAppClientId)" | ConvertFrom-Json).accessToken
+          
           echo "##vso[task.setvariable variable=MaestroToken;isOutput=true;isSecret=true]$token"
 
     - task: AzureCLI@2


### PR DESCRIPTION
Contributes to https://dev.azure.com/dnceng/internal/_workitems/edit/6604/

When fetching the Maestro token, the promotion pipeline currently gets the Maestro application client ID from the service connection itself, relying on the fact that we use the same application to authenticate and to fetch the token. We would like to use a different application for the service connection, so we are updating the reference for the Maestro application to be retrieved from a variable group instead.

Currently the value in the variable group and in the service connection are identical. Once this change is merged and has flowed in, we will update the service connection.