### PR TITLE
Fix bot name in manifest

### DIFF
--- a/.vault-config/dnceng-partners-kv.yaml
+++ b/.vault-config/dnceng-partners-kv.yaml
@@ -58,7 +58,7 @@ secrets:
       gitHubBotAccountSecret:
         name: BotAccount-dotnet-bot
         location: EngKeyVault
-      gitHubBotAccountName: BotAccount-dotnet-build-bot
+      gitHubBotAccountName: BotAccount-dotnet-bot
       requiredScopes: content
       description: "This pat is under the beta fine-grained tokens using dotnet as owner and repository specific for vscode-csharp and roslyn. The permissions are: Content - Read and write."
 


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md


`gitHubBotAccountName` doesn't match `gitHubBotAccountSecret` which caused secret-manager to provide wrong login credentials when force rotating a secret