### PR TITLE
Shorten output path for wix install layout

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets
@@ -132,7 +132,7 @@
 
   <Target Name="PublishFilesForWixInstaller">
     <PropertyGroup>
-      <FilesOutputPathRoot>$(IntermediateOutputPath)output/</FilesOutputPathRoot>
+      <FilesOutputPathRoot>$(IntermediateOutputPath)o/</FilesOutputPathRoot>
       </PropertyGroup>
 
     <MSBuild Projects="$(MSBuildProjectFullPath)"


### PR DESCRIPTION
The Wix tooling we use doesn't have long-path support. Shorten the paths in our control to avoid hitting long-path issues in VMR.

Contributes to unblocking https://github.com/dotnet/sdk/pull/42742