### PR TITLE
[release/8.0] Bump deprecated version of `AzureKeyVault@1`

### DIFF
--- a/eng/common/templates/steps/telemetry-start.yml
+++ b/eng/common/templates/steps/telemetry-start.yml
@@ -8,7 +8,7 @@ parameters:
 
 steps:
 - ${{ if and(eq(parameters.runAsPublic, 'false'), not(eq(variables['System.TeamProject'], 'public'))) }}:
-  - task: AzureKeyVault@1
+  - task: AzureKeyVault@2
     inputs:
       azureSubscription: 'HelixProd_KeyVault'
       KeyVaultName: HelixProdKV


### PR DESCRIPTION
We started seeing these:

![image](https://github.com/user-attachments/assets/d580198a-eb11-404e-9c4d-92c9ef29c0f9)
