### PR TITLE
Don't take package metadata into account when computing nupkg filename.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -1167,7 +1167,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 async (feed, httpClient, package, feedAccount, feedVisibility, feedName) =>
                 {
                     string localPackagePath =
-                        Path.Combine(PackageAssetsBasePath, $"{package.Id}.{package.Version}.nupkg");
+                        Path.Combine(PackageAssetsBasePath, package.NuPkgFilename);
                     if (!File.Exists(localPackagePath))
                     {
                         Log.LogError($"Could not locate '{package.Id}.{package.Version}' at '{localPackagePath}'");
@@ -1210,7 +1210,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 try
                 {
                     await clientThrottle.WaitAsync();
-                    var packageFilename = $"{package.Id}.{package.Version}.nupkg";
+                    var packageFilename = package.NuPkgFilename;
                     string temporaryPackageDirectory =
                         Path.GetFullPath(Path.Combine(ArtifactsBasePath, Guid.NewGuid().ToString()));
                     EnsureTemporaryDirectoryExists(temporaryPackageDirectory);

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishSignedAssets.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishSignedAssets.cs
@@ -5,6 +5,7 @@ using Azure.Core;
 using Azure.Identity;
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.Tasks.Feed.Model;
+using Microsoft.DotNet.VersionTools.BuildManifest.Model;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using System;
@@ -94,7 +95,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.src
             await PushNugetPackagesAsync<PackageIdentity>(packagesToPublish, targetFeedConfig, 5,
                 async (feed, httpClient, package, feedAccount, feedVisibility, feedName) =>
                 {
-                    string localPackagePath = Path.Combine(packagesFolder, $"{package.Id}.{package.Version}.nupkg");
+                    string localPackagePath = Path.Combine(packagesFolder, PackageArtifactModel.GetNuPkgFileName(package.Id, package.Version.ToString ()));
 
                     if (!File.Exists(localPackagePath))
                     {

--- a/src/VersionTools/Microsoft.DotNet.VersionTools/BuildManifest/Model/PackageArtifactModel.cs
+++ b/src/VersionTools/Microsoft.DotNet.VersionTools/BuildManifest/Model/PackageArtifactModel.cs
@@ -42,6 +42,19 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
             set { Attributes[nameof(OriginBuildName)] = value; }
         }
 
+        public string NuPkgFilename
+        {
+            get => GetNuPkgFileName(Id, Version);
+        }
+
+        public static string GetNuPkgFileName (string id, string version)
+        {
+            var metadataStart = version.IndexOf('+');
+            if (metadataStart >= 0)
+                version = version.Substring(0, metadataStart);
+            return $"{id}.{version}.nupkg";
+        }
+
         public bool NonShipping
         {
             get


### PR DESCRIPTION
nupkg filenames don't contain the metadata from the package version, so compute filenames without the metadata.

This naming behavior can be tested like this:

```shell
$ mkdir nupkgtest && cd nupkgtest
$ dotnet new classlib
[...]

$ dotnet pack -p:PackageVersion=3.14
[...]
$ ls **/*.nupkg
bin/Release/nupkgtest.3.14.0.nupkg

$ rm -rf bin obj
$ dotnet pack -p:PackageVersion=2.718+metadata
[...]
$ ls **/*.nupkg
bin/Release/nupkgtest.2.718.0.nupkg
```

This hopefully fixes a problem where arcade fails to find packages:
https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=10082514&view=logs&j=ba23343f-f710-5af9-782d-5bd26b102304&t=74531eb2-9b39-5603-839e-94e3ba212b65


### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md