### PR TITLE
Contributes to https://github.com/dotnet/arcade/issues/15022

### DIFF
--- a/src/Common/Microsoft.Arcade.Common/Microsoft.Arcade.Common.csproj
+++ b/src/Common/Microsoft.Arcade.Common/Microsoft.Arcade.Common.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Utilities.Core" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.XliffTasks/Microsoft.DotNet.XliffTasks.csproj
+++ b/src/Microsoft.DotNet.XliffTasks/Microsoft.DotNet.XliffTasks.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="System.Text.Json" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
   </ItemGroup>
 

--- a/src/VersionTools/Microsoft.DotNet.VersionTools.Tasks.Tests/Microsoft.DotNet.VersionTools.Tasks.Tests.csproj
+++ b/src/VersionTools/Microsoft.DotNet.VersionTools.Tasks.Tests/Microsoft.DotNet.VersionTools.Tasks.Tests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 


### PR DESCRIPTION
Remove the Microsoft.Build.* dependency nodes
from the Microsoft.Arcade.Common package.

Remove the copy of STJ in the XliffTasks package

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
