### PR TITLE
Add --empty=keep to backport command

### DIFF
--- a/.github/workflows/backport-base.yml
+++ b/.github/workflows/backport-base.yml
@@ -129,7 +129,7 @@ jobs:
             // download and apply patch
             await exec.exec(`curl -sSL "${context.payload.issue.pull_request.patch_url}" --output changes.patch`);
 
-            const git_am_command = "git am --3way --ignore-whitespace --keep-non-patch changes.patch";
+            const git_am_command = "git am --3way --empty=keep --ignore-whitespace --keep-non-patch changes.patch";
             let git_am_output = `$ ${git_am_command}\n\n`;
             let git_am_failed = false;
             try {


### PR DESCRIPTION
If the pull request being back ported contains an empty commit, the backport command will fail during `git am` since it has not been instructed what to do with an empty commit.

This changes the backport command to preserve the empty commit.

See this pull request from `dotnet/runtime` for an example of the backport command failing in the presence of an empty commit: https://github.com/dotnet/runtime/pull/106779