### PR TITLE
Exclude some methods from DefaultAzureCredentialOptions

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/AssetPublisherFactory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/AssetPublisherFactory.cs
@@ -39,8 +39,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         return new AzureStorageContainerAssetTokenCredentialPublisher(
                             new Uri(feedConfig.TargetURL),
                             new DefaultAzureCredential(
-                                new DefaultAzureCredentialOptions 
-                                {  
+                                new DefaultAzureCredentialOptions
+                                {
+                                    ExcludeVisualStudioCodeCredential = true,
+                                    ExcludeVisualStudioCredential = true,
+                                    ExcludeAzureDeveloperCliCredential = true,
+                                    ExcludeInteractiveBrowserCredential = true,
                                     ManagedIdentityClientId = task.ManagedIdentityClientId,
                                     CredentialProcessTimeout = TimeSpan.FromSeconds(60.0)
                                 }),


### PR DESCRIPTION
Remove few methods from Azure credentials
Main suspected one causing problem in CD pipeline is ExcludeInteractiveBrowserCredential

