### PR TITLE
Move most of source-index job template to a step template

### DIFF
--- a/eng/common/core-templates/job/source-index-stage1.yml
+++ b/eng/common/core-templates/job/source-index-stage1.yml
@@ -1,8 +1,5 @@
 parameters:
   runAsPublic: false
-  sourceIndexUploadPackageVersion: 2.0.0-20240522.1
-  sourceIndexProcessBinlogPackageVersion: 1.0.1-20240522.1
-  sourceIndexPackageSource: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
   sourceIndexBuildCommand: powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "eng/common/build.ps1 -restore -build -binarylog -ci"
   preSteps: []
   binlogPath: artifacts/log/Debug/Build.binlog
@@ -16,12 +13,6 @@ jobs:
   dependsOn: ${{ parameters.dependsOn }}
   condition: ${{ parameters.condition }}
   variables:
-  - name: SourceIndexUploadPackageVersion
-    value: ${{ parameters.sourceIndexUploadPackageVersion }}
-  - name: SourceIndexProcessBinlogPackageVersion
-    value: ${{ parameters.sourceIndexProcessBinlogPackageVersion }}
-  - name: SourceIndexPackageSource
-    value: ${{ parameters.sourceIndexPackageSource }}
   - name: BinlogPath
     value: ${{ parameters.binlogPath }}
   - template: /eng/common/core-templates/variables/pool-providers.yml
@@ -34,12 +25,10 @@ jobs:
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         name: $(DncEngPublicBuildPool)
-        image: 1es-windows-2022-open
-        os: windows
+        image: windows.vs2022.amd64.open
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: $(DncEngInternalBuildPool)
-        image: 1es-windows-2022
-        os: windows
+        image: windows.vs2022.amd64
 
   steps:
   - ${{ if eq(parameters.is1ESPipeline, '') }}:
@@ -47,35 +36,9 @@ jobs:
 
   - ${{ each preStep in parameters.preSteps }}:
     - ${{ preStep }}
-
-  - task: UseDotNet@2
-    displayName: Use .NET 8 SDK
-    inputs:
-      packageType: sdk
-      version: 8.0.x
-      installationPath: $(Agent.TempDirectory)/dotnet
-      workingDirectory: $(Agent.TempDirectory)
-
-  - script: |
-      $(Agent.TempDirectory)/dotnet/dotnet tool install BinLogToSln --version $(sourceIndexProcessBinlogPackageVersion) --add-source $(SourceIndexPackageSource) --tool-path $(Agent.TempDirectory)/.source-index/tools
-      $(Agent.TempDirectory)/dotnet/dotnet tool install UploadIndexStage1 --version $(sourceIndexUploadPackageVersion) --add-source $(SourceIndexPackageSource) --tool-path $(Agent.TempDirectory)/.source-index/tools
-    displayName: Download Tools
-    # Set working directory to temp directory so 'dotnet' doesn't try to use global.json and use the repo's sdk.
-    workingDirectory: $(Agent.TempDirectory)
-
   - script: ${{ parameters.sourceIndexBuildCommand }}
     displayName: Build Repository
 
-  - script: $(Agent.TempDirectory)/.source-index/tools/BinLogToSln -i $(BinlogPath) -r $(Build.SourcesDirectory) -n $(Build.Repository.Name) -o .source-index/stage1output
-    displayName: Process Binlog into indexable sln
-
-  - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - task: AzureCLI@2
-      displayName: Log in to Azure and upload stage1 artifacts to source index
-      inputs:
-        azureSubscription: 'SourceDotNet Stage1 Publish'
-        addSpnToEnvironment: true
-        scriptType: 'ps'
-        scriptLocation: 'inlineScript'
-        inlineScript: |
-          $(Agent.TempDirectory)/.source-index/tools/UploadIndexStage1 -i .source-index/stage1output -n $(Build.Repository.Name) -s netsourceindexstage1 -b stage1
+  - template: /eng/common/core-templates/steps/source-index-stage1-publish.yml
+    parameters:
+      binLogPath: ${{ parameters.binLogPath }}

--- a/eng/common/core-templates/steps/source-index-stage1-publish.yml
+++ b/eng/common/core-templates/steps/source-index-stage1-publish.yml
@@ -1,0 +1,35 @@
+parameters:
+  sourceIndexUploadPackageVersion: 2.0.0-20240522.1
+  sourceIndexProcessBinlogPackageVersion: 1.0.1-20240522.1
+  sourceIndexPackageSource: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
+  binlogPath: artifacts/log/Debug/Build.binlog
+
+steps:
+- task: UseDotNet@2
+  displayName: "Source Index: Use .NET 8 SDK"
+  inputs:
+    packageType: sdk
+    version: 8.0.x
+    installationPath: $(Agent.TempDirectory)/dotnet
+    workingDirectory: $(Agent.TempDirectory)
+
+- script: |
+    $(Agent.TempDirectory)/dotnet/dotnet tool install BinLogToSln --version ${{parameters.sourceIndexProcessBinlogPackageVersion}} --add-source ${{parameters.SourceIndexPackageSource}} --tool-path $(Agent.TempDirectory)/.source-index/tools
+    $(Agent.TempDirectory)/dotnet/dotnet tool install UploadIndexStage1 --version ${{parameters.sourceIndexUploadPackageVersion}} --add-source ${{parameters.SourceIndexPackageSource}} --tool-path $(Agent.TempDirectory)/.source-index/tools
+  displayName: "Source Index: Download netsourceindex Tools"
+  # Set working directory to temp directory so 'dotnet' doesn't try to use global.json and use the repo's sdk.
+  workingDirectory: $(Agent.TempDirectory)
+
+- script: $(Agent.TempDirectory)/.source-index/tools/BinLogToSln -i ${{parameters.BinlogPath}} -r $(Build.SourcesDirectory) -n $(Build.Repository.Name) -o .source-index/stage1output
+  displayName: "Source Index: Process Binlog into indexable sln"
+
+- ${{ if and(ne(parameters.runAsPublic, 'true'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - task: AzureCLI@2
+    displayName: "Source Index: Upload Source Index stage1 artifacts to Azure"
+    inputs:
+      azureSubscription: 'SourceDotNet Stage1 Publish'
+      addSpnToEnvironment: true
+      scriptType: 'ps'
+      scriptLocation: 'inlineScript'
+      inlineScript: |
+        $(Agent.TempDirectory)/.source-index/tools/UploadIndexStage1 -i .source-index/stage1output -n $(Build.Repository.Name) -s netsourceindexstage1 -b stage1

--- a/eng/common/templates-official/steps/source-index-stage1-publish.yml
+++ b/eng/common/templates-official/steps/source-index-stage1-publish.yml
@@ -1,0 +1,7 @@
+steps:
+- template: /eng/common/core-templates/steps/source-index-stage1-publish.yml
+  parameters:
+    is1ESPipeline: true
+
+    ${{ each parameter in parameters }}:
+      ${{ parameter.key }}: ${{ parameter.value }}

--- a/eng/common/templates/steps/source-index-stage1-publish.yml
+++ b/eng/common/templates/steps/source-index-stage1-publish.yml
@@ -1,0 +1,7 @@
+steps:
+- template: /eng/common/core-templates/steps/source-index-stage1-publish.yml
+  parameters:
+    is1ESPipeline: true
+
+    ${{ each parameter in parameters }}:
+      ${{ parameter.key }}: ${{ parameter.value }}

--- a/eng/common/templates/steps/source-index-stage1-publish.yml
+++ b/eng/common/templates/steps/source-index-stage1-publish.yml
@@ -1,7 +1,7 @@
 steps:
 - template: /eng/common/core-templates/steps/source-index-stage1-publish.yml
   parameters:
-    is1ESPipeline: true
+    is1ESPipeline: false
 
     ${{ each parameter in parameters }}:
       ${{ parameter.key }}: ${{ parameter.value }}


### PR DESCRIPTION
This has been requested by repos which don't want to include an entire extra job with the commensurate duplicated build command line, such as SDK.

The old job template is maintained for backward compatibility.

I've validated the new idiom, and baseline-case old idiom, within a branch on the SDK repo. Edge cases may exist.