### PR TITLE
Use pigz when available for faster tar.gz

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Archives/build/archives.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Archives/build/archives.targets
@@ -105,10 +105,12 @@
                   Overwrite="true"
                   DestinationFile="$(_DestinationFileName)"
                   Condition="'$(ArchiveFormat)' == 'zip'"/>
+    <!-- use parallel gzip implementation when available -->
     <Exec Command="tar -C '$(_OutputPathRoot)' -cf - . | pigz &gt; '$(_DestinationFileName)'"
           IgnoreExitCode="true"
           IgnoreStandardErrorWarningFormat="true"
           Condition="'$(ArchiveFormat)' == 'tar.gz' and '$(_PigzFoundExitCode)' == '0'"/>
+    <!-- otherwise, use built-in gzip feature (-z) -->
     <Exec Command="tar -C '$(_OutputPathRoot)' -czf '$(_DestinationFileName)' ."
           IgnoreExitCode="true"
           IgnoreStandardErrorWarningFormat="true"
@@ -135,10 +137,12 @@
                   Overwrite="true"
                   DestinationFile="$(_DestinationFileName)"
                   Condition="'$(ArchiveFormat)' == 'zip'"/>
+    <!-- use parallel gzip implementation when available -->
     <Exec Command="tar -C '$(_OutputPathRoot)' -cf - . | pigz &gt; '$(_DestinationFileName)'"
           IgnoreExitCode="true"
           IgnoreStandardErrorWarningFormat="true"
           Condition="'$(ArchiveFormat)' == 'tar.gz' and '$(_PigzFoundExitCode)' == '0'"/>
+    <!-- otherwise, use built-in gzip feature (-z) -->
     <Exec Command="tar -C '$(_OutputPathRoot)' -czf '$(_DestinationFileName)' ."
           IgnoreExitCode="true"
           IgnoreStandardErrorWarningFormat="true"

--- a/src/Microsoft.DotNet.Build.Tasks.Archives/build/archives.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Archives/build/archives.targets
@@ -114,7 +114,7 @@
           IgnoreStandardErrorWarningFormat="true"
           Condition="'$(ArchiveFormat)' == 'tar.gz' and '$(_PigzFoundExitCode)' != '0'"/>
 
-    <Message Text="Successfully created archive -> '$(_DestinationFileName)' from '$(_OutputPathRoot)" Importance="high" />
+    <Message Text="Successfully created archive -> '$(_DestinationFileName)' from '$(_OutputPathRoot)'" Importance="high" />
   </Target>
 
   <Target Name="_CreateSymbolsArchive"
@@ -144,7 +144,7 @@
           IgnoreStandardErrorWarningFormat="true"
           Condition="'$(ArchiveFormat)' == 'tar.gz' and '$(_PigzFoundExitCode)' != '0'"/>
 
-    <Message Text="Successfully created archive -> '$(_DestinationFileName)' from '$(_SymbolsOutputPathRoot)" Importance="high" />
+    <Message Text="Successfully created archive -> '$(_DestinationFileName)' from '$(_SymbolsOutputPathRoot)'" Importance="high" />
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Archives/build/archives.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Archives/build/archives.targets
@@ -77,7 +77,18 @@
     <SymbolsArchiveName Condition="'$(SymbolsArchiveName)' == ''">$(ArchiveName)-symbols</SymbolsArchiveName>
   </PropertyGroup>
 
+  <Target Name="_CheckPigzAvailability" Condition="'$(_PigzFoundExitCode)' == ''">
+    <PropertyGroup>
+      <_CommandProbe>command -v</_CommandProbe>
+      <_CommandProbe Condition="'$(OS)' == 'Windows_NT'">where</_CommandProbe>
+    </PropertyGroup>
+    <Exec Command="$(_CommandProbe) pigz" IgnoreExitCode="true" StandardOutputImportance="Low">
+      <Output TaskParameter="ExitCode" PropertyName="_PigzFoundExitCode" />
+    </Exec>
+  </Target>
+
   <Target Name="_CreateArchive"
+          DependsOnTargets="_CheckPigzAvailability"
           Condition="'$(SkipArchivesBuild)' != 'true'">
     <PropertyGroup>
       <_OutputPathRoot>$(IntermediateOutputPath)output/</_OutputPathRoot>
@@ -94,15 +105,20 @@
                   Overwrite="true"
                   DestinationFile="$(_DestinationFileName)"
                   Condition="'$(ArchiveFormat)' == 'zip'"/>
-    <Exec Command="tar -C '$(_OutputPathRoot)' -czf $(_DestinationFileName) ."
+    <Exec Command="tar -C '$(_OutputPathRoot)' -cf - . | pigz &gt; '$(_DestinationFileName)'"
           IgnoreExitCode="true"
           IgnoreStandardErrorWarningFormat="true"
-          Condition="'$(ArchiveFormat)' == 'tar.gz'"/>
+          Condition="'$(ArchiveFormat)' == 'tar.gz' and '$(_PigzFoundExitCode)' == '0'"/>
+    <Exec Command="tar -C '$(_OutputPathRoot)' -czf '$(_DestinationFileName)' ."
+          IgnoreExitCode="true"
+          IgnoreStandardErrorWarningFormat="true"
+          Condition="'$(ArchiveFormat)' == 'tar.gz' and '$(_PigzFoundExitCode)' != '0'"/>
 
-    <Message Text="$(_OutputPathRoot) -> $(_DestinationFileName)" Importance="high" />
+    <Message Text="Successfully created archive -> '$(_DestinationFileName)' from '$(_OutputPathRoot)" Importance="high" />
   </Target>
 
   <Target Name="_CreateSymbolsArchive"
+          DependsOnTargets="_CheckPigzAvailability"
           Condition="'$(CreateSymbolsArchive)' == 'true' and '$(SkipArchivesBuild)' != 'true'">
     <PropertyGroup>
       <_SymbolsOutputPathRoot>$(IntermediateOutputPath)symbols/</_SymbolsOutputPathRoot>
@@ -119,12 +135,16 @@
                   Overwrite="true"
                   DestinationFile="$(_DestinationFileName)"
                   Condition="'$(ArchiveFormat)' == 'zip'"/>
-    <Exec Command="tar -C '$(_SymbolsOutputPathRoot)' -czf $(_DestinationFileName) ."
+    <Exec Command="tar -C '$(_OutputPathRoot)' -cf - . | pigz &gt; '$(_DestinationFileName)'"
           IgnoreExitCode="true"
           IgnoreStandardErrorWarningFormat="true"
-          Condition="'$(ArchiveFormat)' == 'tar.gz'"/>
+          Condition="'$(ArchiveFormat)' == 'tar.gz' and '$(_PigzFoundExitCode)' == '0'"/>
+    <Exec Command="tar -C '$(_OutputPathRoot)' -czf '$(_DestinationFileName)' ."
+          IgnoreExitCode="true"
+          IgnoreStandardErrorWarningFormat="true"
+          Condition="'$(ArchiveFormat)' == 'tar.gz' and '$(_PigzFoundExitCode)' != '0'"/>
 
-    <Message Text="$(_SymbolsOutputPathRoot) -> $(_DestinationFileName)" Importance="high" />
+    <Message Text="Successfully created archive -> '$(_DestinationFileName)' from '$(_SymbolsOutputPathRoot)" Importance="high" />
   </Target>
 
 </Project>


### PR DESCRIPTION
`pigz` (Parallel Implementation of GZip) is much faster than the tradition `gzip` utility on Unix. Ideally, we should move to System.Formats.Tar based task for this, but for now this uses pigz over gzip tool to parallaleize the compression task. Consequently, `dotnet-runtime-10.0.0-dev-osx-arm64.tar.gz` creation goes from `3.7s` to `0.57s` after `brew install pigz`. 

cc @akoeplinger, @ViktorHofer