### PR TITLE
SignTool: Use .NET Core MSBuild for Non-Windows

### DIFF
--- a/Documentation/CorePackages/Signing.md
+++ b/Documentation/CorePackages/Signing.md
@@ -26,7 +26,8 @@ This is a MSBuild custom task that provides batch signing and simple verificatio
 | FileExtensionSignInfo  | Array    | This is a mapping between extension (in the format ".ext") to default sign information for those kind of files. Overriding of the default sign info is done using the other parameters. |
 | CertificatesSignInfo   | Array    | List of certificate names that can be flagged using the `DualSigningAllowed` attribute as dual certificates. |
 | **MicroBuildCorePath** | Dir Path | Path to MicroBuild.Core package directory.                   |
-| MSBuildPath            | Exe path | Path to the MSBuild.exe binary used to run the signing process on MicroBuild. |
+| MSBuildPath            | Exe path | Path to the MSBuild.exe binary used to run the signing process on MicroBuild for Windows. |
+| DotNetPath             | Exe path | Path to the dotnet executable used to run the signing process on MicroBuild for Linux and Mac. |
 | SNBinaryPath           | Exe path | Path to the sn.exe binary used to strong-name sign / validate signature of managed files. |
 | **TempDir**            | Dir path | Used to store temporary files during the process of calling MicroBuild signing. |
 | LogDir                 | Dir path | MSBuild binary log information from the signing rounds will be stored in this directory. |

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -50,7 +50,10 @@
       <_TestSign Condition="'$(DotNetSignType)' == 'test'">true</_TestSign>
 
       <_DesktopMSBuildRequired>false</_DesktopMSBuildRequired>
-      <_DesktopMSBuildRequired Condition="'$(_DryRun)' != 'true' and '$(MSBuildRuntimeType)' == 'Core'">true</_DesktopMSBuildRequired>
+      <_DesktopMSBuildRequired Condition="'$(_DryRun)' != 'true' and '$(MSBuildRuntimeType)' == 'Core'  and '$(OS)' == 'Windows_NT'">true</_DesktopMSBuildRequired>
+
+      <_DotNetCoreRequired>false</_DotNetCoreRequired>
+      <_DotNetCoreRequired Condition="'$(_DryRun)' != 'true' and '$(OS)' != 'Windows_NT'">true</_DotNetCoreRequired>
     </PropertyGroup>
 
     <Error Condition="'$(AllowEmptySignList)' != 'true' AND '@(ItemsToSign)' == ''" 
@@ -69,6 +72,10 @@
       <_DesktopMSBuildPath Condition="!Exists('$(_DesktopMSBuildPath)')">$(_VSInstallDir)\MSBuild\15.0\Bin\msbuild.exe</_DesktopMSBuildPath>
     </PropertyGroup>
 
+    <PropertyGroup Condition="$(_DotNetCoreRequired)">
+      <_DotNetCorePath>$(DotNetTool)</_DotNetCorePath>
+    </PropertyGroup>
+
     <Microsoft.DotNet.SignTool.SignToolTask
         DryRun="$(_DryRun)"
         TestSign="$(_TestSign)"
@@ -82,6 +89,7 @@
         TempDir="$(ArtifactsTmpDir)"
         LogDir="$(ArtifactsLogDir)"
         MSBuildPath="$(_DesktopMSBuildPath)"
+        DotNetPath="$(_DotNetCorePath)"
         SNBinaryPath="$(NuGetPackageRoot)sn\$(SNVersion)\sn.exe"
         MicroBuildCorePath="$(NuGetPackageRoot)microbuild.core\$(MicroBuildCoreVersion)"
         WixToolsPath="$(WixInstallPath)"

--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -311,10 +311,10 @@ namespace Microsoft.DotNet.SignTool.Tests
 
             var task = new SignToolTask { BuildEngine = buildEngine };
 
-            // The path to MSBuild will always be null in these tests, this will force
+            // The path to MSBuild and DotNet will always be null in these tests, this will force
             // the signing logic to call our FakeBuildEngine.BuildProjectFile with a path
             // to the XML that store the content of the would be Microbuild sign request.
-            var signToolArgs = new SignToolArgs(_tmpDir, microBuildCorePath: "MicroBuildCorePath", testSign: true, msBuildPath: null, _tmpDir, enclosingDir: "", "", wixToolsPath: wixToolsPath, tarToolPath: s_tarToolPath);
+            var signToolArgs = new SignToolArgs(_tmpDir, microBuildCorePath: "MicroBuildCorePath", testSign: true, msBuildPath: null, dotnetPath: null, _tmpDir, enclosingDir: "", "", wixToolsPath: wixToolsPath, tarToolPath: s_tarToolPath);
 
             var signTool = new FakeSignTool(signToolArgs, task.Log);
             var configuration = new Configuration(signToolArgs.TempDir, itemsToSign, strongNameSignInfo, fileSignInfo, extensionsSignInfo, dualCertificates, tarToolPath: s_tarToolPath, task.Log);
@@ -401,6 +401,7 @@ namespace Microsoft.DotNet.SignTool.Tests
                 DryRun = false,
                 TestSign = true,
                 MSBuildPath = CreateTestResource("msbuild.fake"),
+                DotNetPath = CreateTestResource("dotnet.fake"),
                 SNBinaryPath = CreateTestResource("fake.sn.exe")
             };
 
@@ -420,6 +421,7 @@ namespace Microsoft.DotNet.SignTool.Tests
                 DryRun = false,
                 TestSign = true,
                 MSBuildPath = CreateTestResource("msbuild.fake"),
+                DotNetPath = CreateTestResource("dotnet.fake"),
                 DoStrongNameCheck = false,
                 SNBinaryPath = null,
             };
@@ -1381,6 +1383,7 @@ $@"<FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "Container
                 TempDir = "TempDir",
                 DryRun = true,
                 MSBuildPath = CreateTestResource("msbuild.fake"),
+                DotNetPath = null,
                 DoStrongNameCheck = false,
                 SNBinaryPath = null,
                 WixToolsPath = badPath
@@ -1933,6 +1936,7 @@ $@"
                 TempDir = "TempDir",
                 DryRun = true,
                 MSBuildPath = CreateTestResource("msbuild.fake"),
+                DotNetPath = CreateTestResource("dotnet.fake"),
                 MicroBuildCorePath = "MicroBuildCorePath",
                 DoStrongNameCheck = false,
                 SNBinaryPath = null,
@@ -1967,6 +1971,7 @@ $@"
                 TempDir = "TempDir",
                 DryRun = true,
                 MSBuildPath = CreateTestResource("msbuild.fake"),
+                DotNetPath = CreateTestResource("dotnet.fake"),
                 DoStrongNameCheck = false,
                 SNBinaryPath = null,
             };

--- a/src/Microsoft.DotNet.SignTool/src/SignToolArgs.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolArgs.cs
@@ -9,18 +9,20 @@ namespace Microsoft.DotNet.SignTool
         internal string MicroBuildCorePath { get; }
         internal bool TestSign { get; }
         internal string MSBuildPath { get; }
+        internal string DotNetPath { get; }
         internal string SNBinaryPath { get; }
         internal string LogDir { get; }
         internal string EnclosingDir { get; }
         internal string WixToolsPath { get; }
         internal string TarToolPath { get; }
 
-        internal SignToolArgs(string tempPath, string microBuildCorePath, bool testSign, string msBuildPath, string logDir, string enclosingDir, string snBinaryPath, string wixToolsPath, string tarToolPath)
+        internal SignToolArgs(string tempPath, string microBuildCorePath, bool testSign, string msBuildPath, string dotnetPath, string logDir, string enclosingDir, string snBinaryPath, string wixToolsPath, string tarToolPath)
         {
             TempDir = tempPath;
             MicroBuildCorePath = microBuildCorePath;
             TestSign = testSign;
             MSBuildPath = msBuildPath;
+            DotNetPath = dotnetPath;
             LogDir = logDir;
             EnclosingDir = enclosingDir;
             SNBinaryPath = snBinaryPath;


### PR DESCRIPTION
Closes https://github.com/dotnet/arcade/issues/14430

I tested these changes locally by running the unit tests via `./test.sh`. For e2e testing, I initially considered configuring a local project to pull the SignTool package from a local feed. While this seems viable, the setup can be tedious. If there's a better method for e2e testing, please let me know.
