### PR TITLE
Do not comment twice if backporting fails due to merge conflicts.

### DIFF
--- a/.github/workflows/backport-base.yml
+++ b/.github/workflows/backport-base.yml
@@ -152,7 +152,7 @@ jobs:
                 issue_number: pr_number,
                 body: git_am_failed_body
               });
-              core.setFailed(new Error("Error: git am failed, most likely due to a merge conflict.", false));
+              core.setFailed("Error: git am failed, most likely due to a merge conflict.");
               return;
             }
             else {

--- a/.github/workflows/backport-base.yml
+++ b/.github/workflows/backport-base.yml
@@ -152,7 +152,8 @@ jobs:
                 issue_number: pr_number,
                 body: git_am_failed_body
               });
-              throw new Error("Error: git am failed, most likely due to a merge conflict.", false);
+              core.setFailed(new Error("Error: git am failed, most likely due to a merge conflict.", false));
+              return;
             }
             else {
               // push the temp branch to the repository


### PR DESCRIPTION
Since we already posted a comment with the output of `git am`, we don't have to do it again in the exception's handler. Instead of throwing, we manually fail the step and exit.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
