### PR TITLE
Pack analyzer symbols in ref pack symbol packages

### DIFF
--- a/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -155,8 +155,10 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(PlatformPackageType)' == 'TargetingPack'">
-      <!-- Targeting packs don't have symbol files. -->
-      <FilesToPackage Remove="@(FilesToPackage)" Condition="'%(FilesToPackage.IsSymbolFile)' == 'true'" />
+      <!-- Targeting packs don't have symbol files except for analyzer ones. -->
+      <FilesToPackage Remove="@(FilesToPackage)"
+                      Condition="'%(FilesToPackage.IsSymbolFile)' == 'true' and 
+                                  !$([System.String]::new('%(FilesToPackage.TargetPath)').StartsWith('analyzers/')" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Analyzers only get used in build time - ship their symbols with the symbol package for the targeting pack. Fixes dotnet/runtime#107421
