### PR TITLE
Add short lived memory cache for DefaultAzureCredential

### DIFF
--- a/Arcade.sln
+++ b/Arcade.sln
@@ -149,6 +149,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.XliffTasks
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Internal.SymbolHelper", "src\Microsoft.DotNet.Internal.SymbolHelper\Microsoft.DotNet.Internal.SymbolHelper.csproj", "{D2B5D28E-CC80-4468-A037-05C2385FA4C4}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.ArcadeAzureIntegration", "src\Microsoft.DotNet.ArcadeAzureIntegration\Microsoft.DotNet.ArcadeAzureIntegration.csproj", "{CA159C84-CD7D-4364-9121-3842F97D4B60}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -935,6 +937,18 @@ Global
 		{D2B5D28E-CC80-4468-A037-05C2385FA4C4}.Release|x64.Build.0 = Release|Any CPU
 		{D2B5D28E-CC80-4468-A037-05C2385FA4C4}.Release|x86.ActiveCfg = Release|Any CPU
 		{D2B5D28E-CC80-4468-A037-05C2385FA4C4}.Release|x86.Build.0 = Release|Any CPU
+		{CA159C84-CD7D-4364-9121-3842F97D4B60}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CA159C84-CD7D-4364-9121-3842F97D4B60}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CA159C84-CD7D-4364-9121-3842F97D4B60}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CA159C84-CD7D-4364-9121-3842F97D4B60}.Debug|x64.Build.0 = Debug|Any CPU
+		{CA159C84-CD7D-4364-9121-3842F97D4B60}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CA159C84-CD7D-4364-9121-3842F97D4B60}.Debug|x86.Build.0 = Debug|Any CPU
+		{CA159C84-CD7D-4364-9121-3842F97D4B60}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CA159C84-CD7D-4364-9121-3842F97D4B60}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CA159C84-CD7D-4364-9121-3842F97D4B60}.Release|x64.ActiveCfg = Release|Any CPU
+		{CA159C84-CD7D-4364-9121-3842F97D4B60}.Release|x64.Build.0 = Release|Any CPU
+		{CA159C84-CD7D-4364-9121-3842F97D4B60}.Release|x86.ActiveCfg = Release|Any CPU
+		{CA159C84-CD7D-4364-9121-3842F97D4B60}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Microsoft.DotNet.ArcadeAzureIntegration/AzureCliCredentialWithAzNoUpdateWrapper.cs
+++ b/src/Microsoft.DotNet.ArcadeAzureIntegration/AzureCliCredentialWithAzNoUpdateWrapper.cs
@@ -1,0 +1,139 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if !NET472_OR_GREATER
+
+#nullable enable
+
+using System;
+using System.IO;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Identity;
+
+namespace Microsoft.DotNet.ArcadeAzureIntegration;
+
+
+// This class is an workaround for disable az cli auto update mechanism which cause timeout when waiting for
+// console input in case of new version of az available
+// - this wrppper will run "az config set auto-upgrade.enable=no" only once before first call to az for acquiring the token
+public class AzureCliCredentialWithAzNoUpdateWrapper : TokenCredential
+{
+    private readonly AzureCliCredential _azureCliCredential;
+
+    public AzureCliCredentialWithAzNoUpdateWrapper(AzureCliCredential azureCliCredential)
+    {
+        _azureCliCredential = azureCliCredential;
+    }
+
+    public static string? EnvProgramFilesX86 => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable("ProgramFiles(x86)"));
+    public static string? EnvProgramFiles => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable("ProgramFiles"));
+    public static string? EnvPath => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable("PATH"));
+
+    private static readonly string DefaultPathWindows = $"{EnvProgramFilesX86}\\Microsoft SDKs\\Azure\\CLI2\\wbin;{EnvProgramFiles}\\Microsoft SDKs\\Azure\\CLI2\\wbin";
+    private static readonly string DefaultWorkingDirWindows = Environment.GetFolderPath(Environment.SpecialFolder.System);
+    private const string DefaultPathNonWindows = "/usr/bin:/usr/local/bin";
+    private const string DefaultWorkingDirNonWindows = "/bin/";
+    private static readonly string DefaultPath = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? DefaultPathWindows : DefaultPathNonWindows;
+    private static readonly string DefaultWorkingDir = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? DefaultWorkingDirWindows : DefaultWorkingDirNonWindows;
+
+    private static string? GetNonEmptyStringOrNull(string? str)
+    {
+        return !string.IsNullOrEmpty(str) ? str : null;
+    }
+
+    private static SemaphoreSlim _azCliInitSemaphore = new SemaphoreSlim(1, 1);
+    private static bool _azCliInitialized = false;
+
+    private async Task SetUpAzAsync()
+    {
+        await _azCliInitSemaphore.WaitAsync();
+        try
+        {
+            if (_azCliInitialized) return;
+
+            string fileName;
+            string argument;
+            string command = $"az config set auto-upgrade.enable=no";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                fileName = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "cmd.exe");
+                argument = $"/d /c \"{command}\"";
+            }
+            else
+            {
+                fileName = "/bin/sh";
+                argument = $"-c \"{command}\"";
+            }
+
+            string path = !string.IsNullOrEmpty(EnvPath) ? EnvPath : DefaultPath;
+            var processInfo = new ProcessStartInfo
+            {
+                FileName = fileName,
+                Arguments = argument,
+                UseShellExecute = false,
+                ErrorDialog = false,
+                CreateNoWindow = true,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                WorkingDirectory = DefaultWorkingDir,
+                Environment = { { "PATH", path } }
+            };
+
+            using Process? process = Process.Start(processInfo);
+            if (process == null)
+            {
+                throw new InvalidOperationException("Failed to start process to disable auto update of Azure CLI");
+            }
+
+            using var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken.None);
+            tokenSource.CancelAfter(TimeSpan.FromSeconds(30));
+            await process.WaitForExitAsync(tokenSource.Token);
+
+            if (!process.HasExited)
+            {
+                // try clean up the process if it is still running after timeout
+                try { process.Kill(); } catch { /* ignore this excpetion */}
+                throw new InvalidOperationException("Could not finish az config command to disable auto update on time");
+            }
+
+            process.StandardInput.Close();
+            process.Close();
+        }
+        catch (Exception e)
+        {
+            // silent catch with direct console output as this is not a critical error
+            Console.WriteLine($"Warning - Disable auto update of Azure CLI failed: {e.Message}");
+        }
+        finally
+        {
+            _azCliInitialized = true;
+            _azCliInitSemaphore.Release();
+        }
+    }
+
+    public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken = default)
+    {
+        if (!_azCliInitialized)
+        {
+            SetUpAzAsync().Wait();
+        }
+        return _azureCliCredential.GetToken(requestContext, cancellationToken);
+    }
+
+    public override async ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken = default)
+    {
+        if (!_azCliInitialized)
+        {
+            await SetUpAzAsync();
+        }
+        return await _azureCliCredential.GetTokenAsync(requestContext, cancellationToken);
+    }
+}
+
+#endif

--- a/src/Microsoft.DotNet.ArcadeAzureIntegration/AzureCliCredentialWithAzNoUpdateWrapper.cs
+++ b/src/Microsoft.DotNet.ArcadeAzureIntegration/AzureCliCredentialWithAzNoUpdateWrapper.cs
@@ -91,7 +91,7 @@ public class AzureCliCredentialWithAzNoUpdateWrapper : TokenCredential
                 throw new InvalidOperationException("Failed to start process to disable auto update of Azure CLI");
             }
 
-            using var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken.None);
+            using var tokenSource = new CancellationTokenSource();
             tokenSource.CancelAfter(TimeSpan.FromSeconds(30));
             await process.WaitForExitAsync(tokenSource.Token);
 

--- a/src/Microsoft.DotNet.ArcadeAzureIntegration/DefaultIdentityTokenCredential.cs
+++ b/src/Microsoft.DotNet.ArcadeAzureIntegration/DefaultIdentityTokenCredential.cs
@@ -1,0 +1,137 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if !NET472_OR_GREATER
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Azure.Core;
+using Azure.Identity;
+
+namespace Microsoft.DotNet.ArcadeAzureIntegration;
+
+
+// This implementation of TokenCredential will try cover all common ways to
+// authenticate to Azure services used in Arcade tooling
+public class DefaultIdentityTokenCredential : ChainedTokenCredential
+{
+    public DefaultIdentityTokenCredential()
+        : this(new DefaultIdentityTokenCredentialOptions())
+    {
+    }
+
+    public DefaultIdentityTokenCredential(DefaultIdentityTokenCredentialOptions options)
+        : base(CreateAvailableTokenCredentials(options))
+    {
+    }
+
+    private static TokenCredential[] CreateAvailableTokenCredentials(DefaultIdentityTokenCredentialOptions options)
+    {
+        var tokenCredentials = new List<TokenCredential>();
+
+        // Add Managed Identity credential if the client id is provided
+        if (!string.IsNullOrEmpty(options.ManagedIdentityClientId))
+        {
+            tokenCredentials.Add(
+                new ManagedIdentityCredential(options.ManagedIdentityClientId)
+            );
+        }
+
+        // Add work load identity credential if the environment variables are set
+        var workloadIdentityCredential = GetWorkloadIdentityCredentialForAzurePipelineTask();
+        if (workloadIdentityCredential != null)
+        {
+            tokenCredentials.Add(workloadIdentityCredential);
+        }
+
+        // Add Azure Pipelines credential if the environment variables are set
+        var azurePipelinesCredential = GetAzurePipelinesCredentialForAzurePipelineTask();
+        if (azurePipelinesCredential != null)
+        {
+            tokenCredentials.Add(azurePipelinesCredential);
+        }
+
+        if (!options.ExcludeAzureCliCredential)
+        {
+            // Add Azure CLI credential as the last resort
+            // az command to disable auto update of the Azure CLI to avoid timeout waiting for
+            // console input will be called before first use of AzureCliCredential
+            tokenCredentials.Add(
+                new AzureCliCredentialWithAzNoUpdateWrapper(
+                    new AzureCliCredential(
+                        new AzureCliCredentialOptions
+                        {
+                            ProcessTimeout = TimeSpan.FromSeconds(30)
+                        }
+                    )
+                )
+             );
+        }
+
+        if (tokenCredentials.Count == 0)
+        {
+            throw new InvalidOperationException("No valid credential class detected and configured for authentication to Azure services.");
+        }
+
+        return tokenCredentials.ToArray();
+    }
+
+    private static object _workloadToeknFileLock = new object();
+    private static string? _workloadTokenFile = null;
+    private static string? _workloadToken = null;
+
+    // Create WorkloadIdentityCredential if the environment variables are set by AzurePipeline are provided
+    private static WorkloadIdentityCredential? GetWorkloadIdentityCredentialForAzurePipelineTask()
+    {
+        string? servicePrincipalId = Environment.GetEnvironmentVariable("servicePrincipalId");
+        string? idToken = Environment.GetEnvironmentVariable("idToken");
+        string? tenantId = Environment.GetEnvironmentVariable("tenantId");
+
+        if (!string.IsNullOrEmpty(idToken) &&
+            !string.IsNullOrEmpty(tenantId) &&
+            !string.IsNullOrEmpty(servicePrincipalId))
+        {
+            lock (_workloadToeknFileLock)
+            {
+                if (idToken != _workloadToken)
+                {
+                    // create token file
+                    var tokenFileName = Path.GetTempFileName();
+                    File.WriteAllText(tokenFileName, idToken);
+                    _workloadTokenFile = tokenFileName;
+                    _workloadToken = idToken;
+                }
+                return new WorkloadIdentityCredential(new WorkloadIdentityCredentialOptions
+                {
+                    ClientId = servicePrincipalId,
+                    TokenFilePath = _workloadTokenFile,
+                    TenantId = tenantId,
+                });
+            }
+        }
+        return null;
+    }
+
+    // Create AzurePipelinesCredential if the environment variables are set by AzureCli task and SYSTEM_ACCESSTOKEN is provided
+    private static AzurePipelinesCredential? GetAzurePipelinesCredentialForAzurePipelineTask()
+    {
+        string? systemAccessToken = Environment.GetEnvironmentVariable("SYSTEM_ACCESSTOKEN");
+        string? clientId = Environment.GetEnvironmentVariable("AZURESUBSCRIPTION_CLIENT_ID");
+        string? tenantId = Environment.GetEnvironmentVariable("AZURESUBSCRIPTION_TENANT_ID");
+        string? serviceConnectionId = Environment.GetEnvironmentVariable("AZURESUBSCRIPTION_SERVICE_CONNECTION_ID");
+
+        if (!string.IsNullOrEmpty(systemAccessToken) &&
+            !string.IsNullOrEmpty(clientId) &&
+            !string.IsNullOrEmpty(tenantId) &&
+            !string.IsNullOrEmpty(serviceConnectionId))
+        {
+            return new AzurePipelinesCredential(tenantId, clientId, serviceConnectionId, systemAccessToken);
+        }
+        return null;
+    }
+}
+
+#endif

--- a/src/Microsoft.DotNet.ArcadeAzureIntegration/DefaultIdentityTokenCredential.cs
+++ b/src/Microsoft.DotNet.ArcadeAzureIntegration/DefaultIdentityTokenCredential.cs
@@ -14,8 +14,8 @@ using Azure.Identity;
 namespace Microsoft.DotNet.ArcadeAzureIntegration;
 
 
-// This implementation of TokenCredential will try cover all common ways to
-// authenticate to Azure services used in Arcade tooling
+// This implementation of TokenCredential will try to cover all common ways of
+// authentication to Azure services used in Arcade tooling
 public class DefaultIdentityTokenCredential : ChainedTokenCredential
 {
     public DefaultIdentityTokenCredential()
@@ -30,7 +30,7 @@ public class DefaultIdentityTokenCredential : ChainedTokenCredential
 
     private static TokenCredential[] CreateAvailableTokenCredentials(DefaultIdentityTokenCredentialOptions options)
     {
-        var tokenCredentials = new List<TokenCredential>();
+        List<TokenCredential> tokenCredentials = [];
 
         // Add Managed Identity credential if the client id is provided
         if (!string.IsNullOrEmpty(options.ManagedIdentityClientId))
@@ -79,11 +79,11 @@ public class DefaultIdentityTokenCredential : ChainedTokenCredential
         return tokenCredentials.ToArray();
     }
 
-    private static object _workloadToeknFileLock = new object();
+    private static object _workloadTokenFileLock = new object();
     private static string? _workloadTokenFile = null;
     private static string? _workloadToken = null;
 
-    // Create WorkloadIdentityCredential if the environment variables are set by AzurePipeline are provided
+    // Create WorkloadIdentityCredential if the environment variables set by AzurePipeline are provided
     private static WorkloadIdentityCredential? GetWorkloadIdentityCredentialForAzurePipelineTask()
     {
         string? servicePrincipalId = Environment.GetEnvironmentVariable("servicePrincipalId");
@@ -94,7 +94,7 @@ public class DefaultIdentityTokenCredential : ChainedTokenCredential
             !string.IsNullOrEmpty(tenantId) &&
             !string.IsNullOrEmpty(servicePrincipalId))
         {
-            lock (_workloadToeknFileLock)
+            lock (_workloadTokenFileLock)
             {
                 if (idToken != _workloadToken)
                 {
@@ -115,7 +115,7 @@ public class DefaultIdentityTokenCredential : ChainedTokenCredential
         return null;
     }
 
-    // Create AzurePipelinesCredential if the environment variables are set by AzureCli task and SYSTEM_ACCESSTOKEN is provided
+    // Create AzurePipelinesCredential if the environment variables set by AzureCli task and SYSTEM_ACCESSTOKEN are provided
     private static AzurePipelinesCredential? GetAzurePipelinesCredentialForAzurePipelineTask()
     {
         string? systemAccessToken = Environment.GetEnvironmentVariable("SYSTEM_ACCESSTOKEN");

--- a/src/Microsoft.DotNet.ArcadeAzureIntegration/DefaultIdentityTokenCredentialOptions.cs
+++ b/src/Microsoft.DotNet.ArcadeAzureIntegration/DefaultIdentityTokenCredentialOptions.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if !NET472_OR_GREATER
+
+#nullable enable
+
+namespace Microsoft.DotNet.ArcadeAzureIntegration;
+
+
+public class DefaultIdentityTokenCredentialOptions
+{
+    public string? ManagedIdentityClientId { get; set; } = null;
+    public bool ExcludeAzureCliCredential { get; set; }
+}
+
+#endif

--- a/src/Microsoft.DotNet.ArcadeAzureIntegration/Microsoft.DotNet.ArcadeAzureIntegration.csproj
+++ b/src/Microsoft.DotNet.ArcadeAzureIntegration/Microsoft.DotNet.ArcadeAzureIntegration.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(NetToolCurrent);$(NetFrameworkToolCurrent)</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
+    <Compile Remove="AzureCliCredentialWithAzNoUpdateWrapper.cs" />
+    <Compile Remove="DefaultIdentityTokenCredential.cs" />
+    <Compile Remove="DefaultIdentityTokenCredentialOptions.cs" />
+    <Compile Remove="TokenCredentialShortCache.cs" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.DotNet.ArcadeAzureIntegration/TokenCredentialShortCache.cs
+++ b/src/Microsoft.DotNet.ArcadeAzureIntegration/TokenCredentialShortCache.cs
@@ -15,8 +15,8 @@ namespace Microsoft.DotNet.ArcadeAzureIntegration;
 
 
 /// <summary>
-/// TokenCredentialShortCache is a wrapper around TokenCredential that caches the token for the same scope and requrest parameters.
-/// Cache time is short, 3 minutes only because we don't want to affect expiration window handled still by underlying TokenCredential implementation. 
+/// TokenCredentialShortCache is a wrapper around TokenCredential that caches the token for the same scope and request parameters.
+/// Cache time is short, 3 minutes only because we don't want to affect the expiration window that's still handled by the underlying TokenCredential implementation. 
 /// It helps with reducing the number of requests to Entra or AzureCLI external process during heavy paralellized operations.
 /// </summary>
 public class TokenCredentialShortCache : TokenCredential

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -69,6 +69,7 @@
     <Compile Remove="src\common\CreateNewAzureContainer.cs" />
     <Compile Remove="src\common\LatestLinksManager.cs" />
     <Compile Remove="src\common\UploadToAzure.cs" />
+    <Compile Remove="src\common\TokenCredentialShortCache.cs" />
     <Compile Remove="src\CreateAzureDevOpsFeed.cs" />
     <Compile Remove="src\model\PublishingConstants.cs" />
     <Compile Remove="src\model\SetupTargetFeedConfigBase.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -44,6 +44,7 @@
     <ProjectReference Include="..\Common\Microsoft.Arcade.Common\Microsoft.Arcade.Common.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Deployment.Tasks.Links\Microsoft.DotNet.Deployment.Tasks.Links.csproj" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
     <ProjectReference Include="..\VersionTools\Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.csproj" />
+    <ProjectReference Include="..\Microsoft.DotNet.ArcadeAzureIntegration\Microsoft.DotNet.ArcadeAzureIntegration.csproj" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
   </ItemGroup>
 
   <ItemGroup>
@@ -69,7 +70,6 @@
     <Compile Remove="src\common\CreateNewAzureContainer.cs" />
     <Compile Remove="src\common\LatestLinksManager.cs" />
     <Compile Remove="src\common\UploadToAzure.cs" />
-    <Compile Remove="src\common\TokenCredentialShortCache.cs" />
     <Compile Remove="src\CreateAzureDevOpsFeed.cs" />
     <Compile Remove="src\model\PublishingConstants.cs" />
     <Compile Remove="src\model\SetupTargetFeedConfigBase.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/AssetPublisherFactory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/AssetPublisherFactory.cs
@@ -52,12 +52,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         private TokenCredential GetAzureTokenCredential(string managedIdentityClientId)
         {
-            TokenCredential tokenCredential = _tokenCredentialsPerManagedIdentity.GetOrAdd(managedIdentityClientId, static (mi) =>
+            TokenCredential tokenCredential = _tokenCredentialsPerManagedIdentity.GetOrAdd(managedIdentityClientId ?? string.Empty, static (mi) =>
                 new TokenCredentialShortCache(
                     new DefaultIdentityTokenCredential(
                         new DefaultIdentityTokenCredentialOptions
                         {
-                            ManagedIdentityClientId = mi
+                            ManagedIdentityClientId = string.IsNullOrEmpty(mi) ? null : mi
                         }
                     )
                 )

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/AssetPublisherFactory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/AssetPublisherFactory.cs
@@ -3,12 +3,12 @@
 
 #if !NET472_OR_GREATER
 using Azure;
-using Azure.Identity;
 using System;
 using Microsoft.Build.Utilities;
 using Microsoft.DotNet.Build.Tasks.Feed.Model;
 using Azure.Core;
 using System.Collections.Concurrent;
+using Microsoft.DotNet.ArcadeAzureIntegration;
 
 namespace Microsoft.DotNet.Build.Tasks.Feed
 {
@@ -54,15 +54,10 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         {
             TokenCredential tokenCredential = _tokenCredentialsPerManagedIdentity.GetOrAdd(managedIdentityClientId, static (mi) =>
                 new TokenCredentialShortCache(
-                    new DefaultAzureCredential(
-                        new DefaultAzureCredentialOptions
+                    new DefaultIdentityTokenCredential(
+                        new DefaultIdentityTokenCredentialOptions
                         {
-                            ExcludeVisualStudioCodeCredential = true,
-                            ExcludeVisualStudioCredential = true,
-                            ExcludeAzureDeveloperCliCredential = true,
-                            ExcludeInteractiveBrowserCredential = true,
-                            ManagedIdentityClientId = mi,
-                            CredentialProcessTimeout = TimeSpan.FromSeconds(60.0)
+                            ManagedIdentityClientId = mi
                         }
                     )
                 )

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/AssetPublisherFactory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/AssetPublisherFactory.cs
@@ -7,6 +7,8 @@ using Azure.Identity;
 using System;
 using Microsoft.Build.Utilities;
 using Microsoft.DotNet.Build.Tasks.Feed.Model;
+using Azure.Core;
+using System.Collections.Concurrent;
 
 namespace Microsoft.DotNet.Build.Tasks.Feed
 {
@@ -38,21 +40,34 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     {
                         return new AzureStorageContainerAssetTokenCredentialPublisher(
                             new Uri(feedConfig.TargetURL),
-                            new DefaultAzureCredential(
-                                new DefaultAzureCredentialOptions
-                                {
-                                    ExcludeVisualStudioCodeCredential = true,
-                                    ExcludeVisualStudioCredential = true,
-                                    ExcludeAzureDeveloperCliCredential = true,
-                                    ExcludeInteractiveBrowserCredential = true,
-                                    ManagedIdentityClientId = task.ManagedIdentityClientId,
-                                    CredentialProcessTimeout = TimeSpan.FromSeconds(60.0)
-                                }),
+                            GetAzureTokenCredential(task.ManagedIdentityClientId),
                             _log);
                     }
                 default:
                     throw new NotImplementedException();
             }
+        }
+
+        private ConcurrentDictionary<string, TokenCredential> _tokenCredentialsPerManagedIdentity = new ConcurrentDictionary<string, TokenCredential>(-1, 10);
+
+        private TokenCredential GetAzureTokenCredential(string managedIdentityClientId)
+        {
+            TokenCredential tokenCredential = _tokenCredentialsPerManagedIdentity.GetOrAdd(managedIdentityClientId, static (mi) =>
+                new TokenCredentialShortCache(
+                    new DefaultAzureCredential(
+                        new DefaultAzureCredentialOptions
+                        {
+                            ExcludeVisualStudioCodeCredential = true,
+                            ExcludeVisualStudioCredential = true,
+                            ExcludeAzureDeveloperCliCredential = true,
+                            ExcludeInteractiveBrowserCredential = true,
+                            ManagedIdentityClientId = mi,
+                            CredentialProcessTimeout = TimeSpan.FromSeconds(60.0)
+                        }
+                    )
+                )
+            );
+            return tokenCredential;
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/TokenCredentialShortCache.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/TokenCredentialShortCache.cs
@@ -1,0 +1,106 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+
+#if !NET472_OR_GREATER
+
+namespace Microsoft.DotNet.Build.Tasks.Feed;
+
+
+public class TokenCredentialShortCache : TokenCredential
+{
+    private const int CacheExpirationMinutes = 3;
+
+    public TokenCredentialShortCache(TokenCredential tokenCredential)
+    {
+        _tokenCredential = tokenCredential;
+    }
+
+    private TokenCredential _tokenCredential;
+    private ConcurrentDictionary<CacheKey, CachedToken> _tokenCache = new ConcurrentDictionary<CacheKey, CachedToken>();
+
+    public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+    {
+        return GetTokenAsync(requestContext, cancellationToken).Result;
+    }
+
+    public override async ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+    {
+        CacheKey cacheKey = new CacheKey
+        {
+            Scopes = string.Join(":", requestContext.Scopes),
+            Claims = requestContext.Claims,
+            TenantId = requestContext.TenantId,
+            IsCaeEnabled = requestContext.IsCaeEnabled
+        };
+
+        bool doCleanUpCache = false;
+
+        CachedToken cachedToken = _tokenCache.GetOrAdd(cacheKey, _ => new CachedToken());
+        var token = await cachedToken.GetToken(requestContext, () => {
+            // initiate cleanup of cache only when we are going to get any fresh token
+            doCleanUpCache = true;
+            return _tokenCredential.GetTokenAsync(requestContext, cancellationToken);
+        });
+
+        if (doCleanUpCache)
+        {
+            // go over all the cache items and remove the ones that are eligible to remove
+            // cached token items not used for CacheExpirationMinutes will be removed
+            _tokenCache.Keys.ToList().ForEach(key =>
+            {
+                if (_tokenCache.TryGetValue(key, out CachedToken ct) && ct.EligibleToRemove)
+                {
+                    _tokenCache.TryRemove(key, out _);
+                }
+            });
+        }
+
+        return token;
+    }
+
+    private record struct CacheKey
+    {
+        public required string Scopes { get; init; }
+        public required string Claims { get; init; }
+        public required string TenantId { get; init; }
+        public required bool IsCaeEnabled { get; init; }
+    }
+
+    private class CachedToken
+    {
+        private AccessToken? token { get; set; }
+        private DateTime shortTimeCacheExpiresOn = DateTime.UtcNow.AddMinutes(CacheExpirationMinutes);
+        private SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
+
+        public bool EligibleToRemove => shortTimeCacheExpiresOn.AddMinutes(CacheExpirationMinutes) < DateTime.UtcNow;
+
+        public async ValueTask<AccessToken> GetToken(TokenRequestContext requestContext, Func<ValueTask<AccessToken>> getFreshToken)
+        {
+            await _semaphore.WaitAsync();
+            try
+            {
+                if (token != null && shortTimeCacheExpiresOn > DateTime.UtcNow)
+                {
+                    return token.Value;
+                }
+
+                token = await getFreshToken();
+                shortTimeCacheExpiresOn = DateTime.UtcNow.AddMinutes(CacheExpirationMinutes);
+                return token.Value;
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
This implements complex handling for Azure identity Token credentials by creating new pre-configured ChainedTokenCredential which know about common AzDO Task called AzureCLI@2
There are few cases how you can preconfigure this and provide identity to the DefaultIdentityTokenCredential class.

1. Enable addSpnToEnvironment property on AzureCLI@2 params. This will use idToken and other provided environment vars to configure WorkloadIdentityCredential
2. Provide SYSTEM_ACCESSTOKEN environment variable by assigning it to System.AccessToken Azure pipeline variable. Access token together with all provided environment variables will enable AzurePipelineCredential
3. If none of these are available AzureCliCredential fallback is still there wrapped to AzureCliCredentialWithAzNoUpdateWrapper which will run command for disabling az update mechanism before first token acquire call.

In Feed publishing task where this authentication is used all of these are wrapped to in-memory short lived cache of tokens.
You can see that one in TokenCredentialShortCache class. It works again as wrapper of TokenCredential and caches only for really small amount of time not to affect timeouts defined by specific implementations.
