### PR TITLE
Fix sharedfx.targets packaging condition

### DIFF
--- a/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -158,7 +158,7 @@
       <!-- Targeting packs don't have symbol files except for analyzer ones. -->
       <FilesToPackage Remove="@(FilesToPackage)"
                       Condition="'%(FilesToPackage.IsSymbolFile)' == 'true' and 
-                                  !$([System.String]::new('%(FilesToPackage.TargetPath)').StartsWith('analyzers/')" />
+                                  !$([System.String]::new('%(DownloadedArtifactFile.TargetPath)').StartsWith('analyzers/'))" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
My change on Friday had a typo missing a matching parenthesis. Had fixed locally but didn't commit.