### PR TITLE
[release/8.0] Stop testing on windows.10.amd64.android.open

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -48,9 +48,9 @@
       <Uri>https://github.com/dotnet/arcade-services</Uri>
       <Sha>25745248c19ebbca84d70591a0adb5fba8957085</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="8.0.0-prerelease.23477.1">
+    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="8.0.0-prerelease.24452.3">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>2b1d423ce08e1ed78c0a821d0850e0f5ab3b193a</Sha>
+      <Sha>c2c79961da93101b0ab76c95e3b817165d36e9fe</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.5.2-3.23266.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -77,7 +77,7 @@
     <!-- vstest -->
     <MicrosoftNetTestSdkVersion>17.5.0</MicrosoftNetTestSdkVersion>
     <!-- xharness -->
-    <MicrosoftDotNetXHarnessCLIVersion>8.0.0-prerelease.23477.1</MicrosoftDotNetXHarnessCLIVersion>
+    <MicrosoftDotNetXHarnessCLIVersion>8.0.0-prerelease.24452.3</MicrosoftDotNetXHarnessCLIVersion>
     <!-- xliff-tasks -->
     <MicrosoftDotNetXliffTasksVersion>1.0.0-beta.23475.1</MicrosoftDotNetXliffTasksVersion>
     <!-- external -->

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.android.ps1
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/xharness-runner.android.ps1
@@ -29,6 +29,9 @@ function xharness() {
     dotnet exec $Env:XHARNESS_CLI_PATH @args
 }
 
+dotnet exec $Env:XHARNESS_CLI_PATH android adb -- shell settings put global verifier_verify_adb_installs 0
+dotnet exec $Env:XHARNESS_CLI_PATH android adb -- shell settings put global package_verifier_enable 0
+
 # User can call this when they detect a problem they think is caused by the infrastructure
 function report_infrastructure_failure($message) {
     Write-Output "Infrastructural problem reported by the user, requesting retry+reboot: $message"

--- a/tests/XHarness.Android.DeviceTests.proj
+++ b/tests/XHarness.Android.DeviceTests.proj
@@ -5,7 +5,7 @@
     <XHarnessAndroidProject Include="$(MSBuildThisFileDirectory)XHarness/XHarness.TestApks.proj">
       <AdditionalProperties>XHarnessTestARM64_V8A=true</AdditionalProperties>
     </XHarnessAndroidProject>
-    <HelixTargetQueue Include="windows.10.amd64.android.open" />
+    <HelixTargetQueue Include="windows.11.amd64.android.open" />
   </ItemGroup>
 
   <Target Name="Pack"/>


### PR DESCRIPTION
- see https://github.com/dotnet/dnceng/issues/1994
- use windows.11.amd64.android.open instead
- was previously done as part of https://github.com/dotnet/arcade/pull/14453 for release/9.0

### To double check:

* [x] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
