### PR TITLE
Change default codename for arm32 when building rootfs

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -6,7 +6,7 @@ usage()
 {
     echo "Usage: $0 [BuildArch] [CodeName] [lldbx.y] [llvmx[.y]] [--skipunmount] --rootfsdir <directory>]"
     echo "BuildArch can be: arm(default), arm64, armel, armv6, ppc64le, riscv64, s390x, x64, x86"
-    echo "CodeName - optional, Code name for Linux, can be: xenial(default), zesty, bionic, alpine"
+    echo "CodeName - optional, Code name for Linux, can be: jammy(default for arm), xenial(default), zesty, bionic, alpine"
     echo "                               for alpine can be specified with version: alpineX.YY or alpineedge"
     echo "                               for FreeBSD can be: freebsd13, freebsd14"
     echo "                               for illumos can be: illumos"
@@ -20,7 +20,8 @@ usage()
     exit 1
 }
 
-__CodeName=xenial
+__DefaultCodeName=xenial
+__CodeName=
 __CrossDir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 __BuildArch=arm
 __AlpineArch=armv7
@@ -150,6 +151,7 @@ while :; do
             __UbuntuArch=armhf
             __AlpineArch=armv7
             __QEMUArch=arm
+            __DefaultCodeName=jammy
             ;;
         arm64)
             __BuildArch=arm64
@@ -443,6 +445,10 @@ if [[ "$__BuildArch" == "armel" ]]; then
     __LLDB_Package="lldb-3.5-dev"
 fi
 
+if [[ "$__CodeName" == "" ]]; then
+    __CodeName="${__DefaultCodeName}"
+fi
+
 if [[ "$__CodeName" == "xenial" && "$__UbuntuArch" == "armhf" ]]; then
     # libnuma-dev is not available on armhf for xenial
     __UbuntuPackages="${__UbuntuPackages//libnuma-dev/}"
@@ -496,7 +502,7 @@ if [[ "$__CodeName" == "alpine" ]]; then
     arch="$(uname -m)"
 
     ensureDownloadTool
-    
+
     if [[ "$__hasWget" == 1 ]]; then
         wget -P "$__ApkToolsDir" "https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v$__ApkToolsVersion/$arch/apk.static"
     else


### PR DESCRIPTION
May fix https://github.com/dotnet/runtime/issues/107647. Not really sure what I'm doing, I don't know much about arcade.

To summarize, the default codename for arm32 is way too old for dotnet/runtime, so I think we should bump it forward far enough to get 64-bit time_t.

I haven't verified yet whether this is the correct way to fix this.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
