### PR TITLE
Workaround to allow rc1 uptake

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -184,4 +184,29 @@
     </ItemGroup>
   </Target>
 
+  <!-- BEGIN workaround for https://github.com/dotnet/sdk/issues/43339; remove after updated to VS 17.12 or a future 17.11 patch -->
+  <Target Name="WorkaroundDotnetSdk43339" BeforeTargets="ResolvePackageAssets" Condition=" '$(MSBuildRuntimeType)' == 'Full' and $([MSBuild]::VersionLessThan($(MSBuildVersion), 17.12.0))">
+    <PrimeSystemTextJson804 />
+  </Target>
+  <UsingTask
+    TaskName="PrimeSystemTextJson804"
+    TaskFactory="RoslynCodeTaskFactory"
+    AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >
+    <Task>
+      <Code Type="Fragment" Language="cs">
+<![CDATA[
+try
+{
+    System.Reflection.Assembly.LoadFrom(@"$(MicrosoftNETBuildTasksDirectoryRoot)\..\..\..\DotnetTools\dotnet-format\BuildHost-net472\System.Text.Json.dll");
+}
+catch
+{
+    // Best effort: if something moves in the SDK don't break the build.
+}
+]]>
+      </Code>
+    </Task>
+  </UsingTask>
+  <!-- END workaround for https://github.com/dotnet/sdk/issues/43339 -->
+
 </Project>


### PR DESCRIPTION
This works around dotnet/sdk#43339 for Arcade projects, unblocking
updating to .NET SDK 9.0.100-rc.1, even when official or PR builds use
Visual Studio 17.11.

Vetted in https://github.com/dotnet/msbuild/pull/10643.