### PR TITLE
Add System.Security.Cryptography.Pkcs version prop

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -59,6 +59,7 @@
     <PackageVersion Include="System.Composition" Version="$(SystemCompositionVersion)" />
     <PackageVersion Include="System.IO.Packaging" Version="$(SystemIOPackagingVersion)" />
     <PackageVersion Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="$(SystemSecurityCryptographyPkcsVersion)" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
     <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -68,6 +68,7 @@
     <SystemCompositionVersion>9.0.0-preview.6.24327.7</SystemCompositionVersion>
     <SystemIOPackagingVersion>9.0.0-preview.6.24327.7</SystemIOPackagingVersion>
     <SystemReflectionMetadataVersion>9.0.0-preview.6.24327.7</SystemReflectionMetadataVersion>
+    <SystemSecurityCryptographyPkcsVersion>9.0.0-preview.6.24327.7</SystemSecurityCryptographyPkcsVersion>
     <SystemSecurityCryptographyXmlVersion>9.0.0-preview.6.24327.7</SystemSecurityCryptographyXmlVersion>
     <SystemTextEncodingsWebVersion>9.0.0-preview.6.24327.7</SystemTextEncodingsWebVersion>
     <SystemTextJsonVersion>9.0.0-preview.6.24327.7</SystemTextJsonVersion>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4601

[Pipeline test run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2536490&view=results) (internal Microsoft link) (the pipeline run fails in stage 2 due to an [unrelated issue](https://github.com/dotnet/source-build/issues/4603)).