### PR TITLE
Copy full directory structure when indexing loose files

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishToSymbolServerTest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishToSymbolServerTest.cs
@@ -167,7 +167,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
             Assert.Contains("Loose symbol file count: 1", message.Message);
 
             Assert.Contains(buildEngine.BuildMessageEvents, x => x.Message.Contains("Creating symbol request"));
-            Assert.Contains(buildEngine.BuildMessageEvents, x => x.Message.Contains("Adding files to request"));
+            Assert.Equal(2, buildEngine.BuildMessageEvents.Where(x => x.Message.Contains("Adding directory")).Count());
 
             // Message per package per server
             Assert.Equal(symbolPackages.Keys.Count, buildEngine.BuildMessageEvents.Where(x => x.Message.Contains($"Extracting symbol package")).Count());
@@ -212,6 +212,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
             var task = new PublishArtifactsInManifestV3()
             {
                 BuildEngine = buildEngine,
+                ArtifactsBasePath = "testPath",
                 BlobAssetsBasePath = symbolFilesDir,
                 TempSymbolsAzureDevOpsOrg = "dncengtest",
                 TempSymbolsAzureDevOpsOrgToken = "token",

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -536,7 +536,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             ArgumentNullException.ThrowIfNull(buildInfo);
 
             (string[] symbolPackageNames, string looseSymbolFilesDirectory) = GetSymbolAssetsToPublish(buildAssets, pdbArtifactsBasePath);
-            int looseFileCount = Directory.EnumerateFiles(looseSymbolFilesDirectory).Count();
+            int looseFileCount = Directory.EnumerateFiles(looseSymbolFilesDirectory, "*", SearchOption.AllDirectories).Count();
 
             if (symbolPackageNames.Length == 0 && looseFileCount == 0)
             {
@@ -731,7 +731,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
             if (Directory.Exists(pdbArtifactsBasePath))
             {
-                foreach (string looseFile in Directory.EnumerateFiles(pdbArtifactsBasePath))
+                foreach (string looseFile in Directory.EnumerateFiles(pdbArtifactsBasePath, "*", SearchOption.AllDirectories))
                 {
                     string extension = Path.GetExtension(looseFile);
                     if (extension == "pdb" || extension == ".dll")

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -734,7 +734,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 foreach (string looseFile in Directory.EnumerateFiles(pdbArtifactsBasePath))
                 {
                     string extension = Path.GetExtension(looseFile);
-                    if (extension.AsSpan().SequenceEqual(".pdb") || extension.AsSpan().SequenceEqual(".dll"))
+                    if (extension == "pdb" || extension == ".dll")
                     {
                         string relativePath = Path.GetRelativePath(pdbArtifactsBasePath, looseFile);
                         FileInfo looseFileStagePath = new(Path.Combine(pdbStagePath, relativePath));

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -734,7 +734,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 foreach (string looseFile in Directory.EnumerateFiles(pdbArtifactsBasePath, "*", SearchOption.AllDirectories))
                 {
                     string extension = Path.GetExtension(looseFile);
-                    if (extension == "pdb" || extension == ".dll")
+                    if (extension == ".pdb" || extension == ".dll")
                     {
                         string relativePath = Path.GetRelativePath(pdbArtifactsBasePath, looseFile);
                         FileInfo looseFileStagePath = new(Path.Combine(pdbStagePath, relativePath));


### PR DESCRIPTION
WinForms designer uploads several dlls with the same name under PDBArtifacts. The tool was not preserving full structure when copying prior to calling symbol.exe so only the last one got published. Copy all files to a temp location. 