### PR TITLE
Respect restore config file in dotnet tool restore in Tools.proj

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -80,7 +80,13 @@
           Condition="'$(_ImportOrUseTooling)' == 'true' and Exists('$(_RepoToolManifest)')"
           BeforeTargets="Restore">
 
-    <Exec Command='"$(DotNetTool)" tool restore' WorkingDirectory="$(RepoRoot)" />
+    <!-- Respect a restore config file passed in via /p:RestoreConfigFile, common in VMR builds -->
+    <PropertyGroup>
+      <RestoreConfigFileOption></RestoreConfigFileOption>
+      <RestoreConfigFileOption Condition="'$(RestoreConfigFile)' != ''">--configfile $(RestoreConfigFile)</RestoreConfigFileOption>
+    </PropertyGroup>
+
+    <Exec Command='"$(DotNetTool)" tool restore $(RestoreConfigFileOption)' WorkingDirectory="$(RepoRoot)" />
   </Target>
 
   <!-- Set as DependsOnTargets when internal tools (e.g. IBC data, optprof) is required -->


### PR DESCRIPTION
dotnet tool restore needs the generated config file. Some tool packages come from upstream repos

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
