### PR TITLE
Fixup conditional for _ImportOrUseTooling

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -37,20 +37,14 @@
     <PackageReference Include="Microsoft.DotNet.NuGetRepack.Tasks" Version="$(MicrosoftDotnetNuGetRepackTasksVersion)" Condition="'$(UsingToolNuGetRepack)' == 'true'" IsImplicitlyDefined="true" />
   </ItemGroup>
 
-  <!-- These package references should only be excluded when doing inner builds, and outer-builds from the orchestrator in source only build
-       configurations. non-source only build configurations should always restore these packages.
-
-       Switches are separated by legacy vs. new.
-
-       This looks complicated right now, but will get simpler as legacy switches disappear:
-       - ArcadeInnerBuildFromSource/DotNetBuildFromSource disappear:
-         ('$(DotNetBuildSourceOnly)' != 'true' or ('$(DotNetBuildPhase)' == 'Repo' and '$(DotNetBuildOrchestrator)' != 'true')
+  <!-- These package references should only be included when:
+       - Not in source-only mode OR
+       - When in source-only mode in the outer repo build but not launched from the orchestrator.
   -->
 
   <PropertyGroup>
     <_ImportOrUseTooling>false</_ImportOrUseTooling>
-    <_ImportOrUseTooling Condition="('$(ArcadeInnerBuildFromSource)' != 'true' and '$(DotNetBuildFromSourceFlavor)' != 'Product') and 
-                                    ('$(DotNetBuildSourceOnly)' != 'true' or ('$(DotNetBuildPhase)' == 'Repo' and '$(DotNetBuildOrchestrator)' != 'true'))">true</_ImportOrUseTooling>
+    <_ImportOrUseTooling Condition="('$(DotNetBuildSourceOnly)' != 'true' or ('$(DotNetBuildPhase)' == 'Repo' and '$(DotNetBuildOrchestrator)' != 'true')">true</_ImportOrUseTooling>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(_ImportOrUseTooling)' == 'true'">


### PR DESCRIPTION
I found we were skipping the restore of internal tooling when I started working on the signing support. This conditional is the culprit. I am removing the legacy switches from it. I believe its original intent was that it should read that we import tooling if not doing source only builds, or if doing a source only build and we're in the outer repo build of a non-orchestrated build.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
