### PR TITLE
Adding the 9.0.2xx channels

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
@@ -795,6 +795,26 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 symbolTargetType: SymbolPublishVisibility.Internal,
                 filenamesToExclude: FilenamesToExclude),
 
+            // .NET 9.0.2xx SDK,
+            new TargetChannelConfig(
+                id: 5286,
+                isInternal: false,
+                publishingInfraVersion: PublishingInfraVersion.Latest,
+                akaMSChannelNames: new List<string>() { "9.0.2xx" },
+                targetFeeds: DotNet9Feeds,
+                symbolTargetType: SymbolPublishVisibility.Public,
+                filenamesToExclude: FilenamesToExclude),
+
+            // .NET 9.0.2xx SDK Internal,
+            new TargetChannelConfig(
+                id: 5287,
+                isInternal: true,
+                publishingInfraVersion: PublishingInfraVersion.Latest,
+                akaMSChannelNames: new List<string>() { "internal/9.0.2xx" },
+                targetFeeds: DotNet9InternalFeeds,
+                symbolTargetType: SymbolPublishVisibility.Internal,
+                filenamesToExclude: FilenamesToExclude),
+
             // .NET 9 RC 1
             new TargetChannelConfig(
                 id: 5119,


### PR DESCRIPTION
@mmitche since 9.0.1xx is now in QB mode, I wanted to open up 9.0.2xx branches in the sdk and templating in case folks had work they wanted to start on for the next feature band release. Let me know if I missed anything in this change.