### PR TITLE
Remove trailing open parenthesis in tools.proj

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -44,7 +44,7 @@
 
   <PropertyGroup>
     <_ImportOrUseTooling>false</_ImportOrUseTooling>
-    <_ImportOrUseTooling Condition="('$(DotNetBuildSourceOnly)' != 'true' or ('$(DotNetBuildPhase)' == 'Repo' and '$(DotNetBuildOrchestrator)' != 'true'))">true</_ImportOrUseTooling>
+    <_ImportOrUseTooling Condition="'$(DotNetBuildSourceOnly)' != 'true' or ('$(DotNetBuildPhase)' == 'Repo' and '$(DotNetBuildOrchestrator)' != 'true')">true</_ImportOrUseTooling>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(_ImportOrUseTooling)' == 'true'">

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -44,7 +44,7 @@
 
   <PropertyGroup>
     <_ImportOrUseTooling>false</_ImportOrUseTooling>
-    <_ImportOrUseTooling Condition="('$(DotNetBuildSourceOnly)' != 'true' or ('$(DotNetBuildPhase)' == 'Repo' and '$(DotNetBuildOrchestrator)' != 'true')">true</_ImportOrUseTooling>
+    <_ImportOrUseTooling Condition="('$(DotNetBuildSourceOnly)' != 'true' or ('$(DotNetBuildPhase)' == 'Repo' and '$(DotNetBuildOrchestrator)' != 'true'))">true</_ImportOrUseTooling>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(_ImportOrUseTooling)' == 'true'">


### PR DESCRIPTION
This was lost in https://github.com/dotnet/arcade/commit/aceee7d96c6554b410f50ec1a8ed2f1464c171c6#diff-929b1158791b608c6a417f92fa7b92ea993c30c4089b7d8a67a71368fda16594R47

This was caught by arcade-validation: https://github.com/dotnet/arcade-validation/pull/4572

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
