### PR TITLE
[9.0] Generate proper Visual Studio component IDs

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/CreateVisualStudioWorkloadTests.cs
@@ -67,7 +67,8 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
                 ShortNames = shortNames,
                 WixToolsetPath = TestBase.WixToolsetPath,
                 WorkloadManifestPackageFiles = manifestsPackages,
-                IsOutOfSupportInVisualStudio = true
+                IsOutOfSupportInVisualStudio = true,
+                UseVisualStudioComponentPrefix = true,
             };
 
             bool result = createWorkloadTask.Execute();
@@ -94,13 +95,13 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             string componentSwr = File.ReadAllText(
                 Path.Combine(Path.GetDirectoryName(
                     createWorkloadTask.SwixProjects.FirstOrDefault(
-                        i => i.ItemSpec.Contains("microsoft.net.sdk.emscripten.5.6.swixproj")).ItemSpec), "component.swr"));
-            Assert.Contains("package name=microsoft.net.sdk.emscripten", componentSwr);
+                        i => i.ItemSpec.Contains("Microsoft.NET.Component.sdk.emscripten.5.6.swixproj")).ItemSpec), "component.swr"));
+            Assert.Contains("package name=Microsoft.NET.Component.sdk.emscripten", componentSwr);
             string previewComponentSwr = File.ReadAllText(
                 Path.Combine(Path.GetDirectoryName(
                     createWorkloadTask.SwixProjects.FirstOrDefault(
-                        i => i.ItemSpec.Contains("microsoft.net.sdk.emscripten.pre.5.6.swixproj")).ItemSpec), "component.swr"));
-            Assert.Contains("package name=microsoft.net.sdk.emscripten.pre", previewComponentSwr);
+                        i => i.ItemSpec.Contains("Microsoft.NET.Component.sdk.emscripten.pre.5.6.swixproj")).ItemSpec), "component.swr"));
+            Assert.Contains("package name=Microsoft.NET.Component.sdk.emscripten.pre", previewComponentSwr);
 
             // Emscripten is an abstract workload so it should be a component group.
             Assert.Contains("vs.package.type=component", componentSwr);
@@ -204,6 +205,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
                 ShortNames = shortNames,
                 WixToolsetPath = TestBase.WixToolsetPath,
                 WorkloadManifestPackageFiles = manifestsPackages,
+                UseVisualStudioComponentPrefix = true,
             };
 
             bool result = createWorkloadTask.Execute();
@@ -229,8 +231,8 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             string componentSwr = File.ReadAllText(
                 Path.Combine(Path.GetDirectoryName(
                     createWorkloadTask.SwixProjects.FirstOrDefault(
-                        i => i.ItemSpec.Contains("microsoft.net.sdk.emscripten.5.6.swixproj")).ItemSpec), "component.swr"));
-            Assert.Contains("package name=microsoft.net.sdk.emscripten", componentSwr);
+                        i => i.ItemSpec.Contains("Microsoft.NET.Component.sdk.emscripten.5.6.swixproj")).ItemSpec), "component.swr"));
+            Assert.Contains("package name=Microsoft.NET.Component.sdk.emscripten", componentSwr);
 
             // Emscripten is an abstract workload so it should be a component group.
             Assert.Contains("vs.package.type=component", componentSwr);

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/SwixComponentTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/SwixComponentTests.cs
@@ -23,13 +23,14 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
         {
             WorkloadManifest manifest = Create("WorkloadManifest.json");
             WorkloadDefinition workload = (WorkloadDefinition)manifest.Workloads.FirstOrDefault().Value;
-            SwixComponent component = SwixComponent.Create(new ReleaseVersion("6.0.300"), workload, manifest, packGroupId: null);
+            SwixComponent component = SwixComponent.Create(new ReleaseVersion("6.0.300"), workload, manifest, packGroupId: null,
+                componentPrefix: DefaultValues.VisualStudioComponentPrefix);
 
             ComponentSwixProject project = new(component, BaseIntermediateOutputPath, BaseOutputPath);
             string swixProj = project.Create();
 
             string componentSwr = File.ReadAllText(Path.Combine(Path.GetDirectoryName(swixProj), "component.swr"));
-            Assert.Contains("package name=microsoft.net.sdk.blazorwebassembly.aot", componentSwr);
+            Assert.Contains("package name=Microsoft.NET.Component.sdk.blazorwebassembly.aot", componentSwr);
             Assert.Contains("version=1.0.0", componentSwr);
 
             string componentResSwr = File.ReadAllText(Path.Combine(Path.GetDirectoryName(swixProj), "component.res.swr"));
@@ -52,13 +53,13 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             WorkloadManifest manifest = Create("WorkloadManifest.json");
             WorkloadDefinition workload = (WorkloadDefinition)manifest.Workloads.FirstOrDefault().Value;
             SwixComponent component = SwixComponent.Create(new ReleaseVersion("6.0.300"), workload, manifest, packGroupId: null,
-                componentResources);
+                componentResources, componentPrefix: DefaultValues.VisualStudioComponentPrefix);
 
             ComponentSwixProject project = new(component, BaseIntermediateOutputPath, BaseOutputPath);
             string swixProj = project.Create();
 
             string componentSwr = File.ReadAllText(Path.Combine(Path.GetDirectoryName(swixProj), "component.swr"));
-            Assert.Contains("package name=microsoft.net.sdk.blazorwebassembly.aot", componentSwr);
+            Assert.Contains("package name=Microsoft.NET.Component.sdk.blazorwebassembly.aot", componentSwr);
             Assert.Contains("version=4.5.6", componentSwr);
             Assert.Contains("isAdvertisedPackage=yes", componentSwr);
 
@@ -81,13 +82,13 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             WorkloadManifest manifest = Create("WorkloadManifest.json");
             WorkloadDefinition workload = (WorkloadDefinition)manifest.Workloads.FirstOrDefault().Value;
             SwixComponent component = SwixComponent.Create(new ReleaseVersion("6.0.300"), workload, manifest, packGroupId: null,
-                componentResources);
+                componentResources, componentPrefix: DefaultValues.VisualStudioComponentPrefix);
 
             ComponentSwixProject project = new(component, BaseIntermediateOutputPath, BaseOutputPath);
             string swixProj = project.Create();
 
             string componentSwr = File.ReadAllText(Path.Combine(Path.GetDirectoryName(swixProj), "component.swr"));
-            Assert.Contains("package name=microsoft.net.sdk.blazorwebassembly.aot", componentSwr);
+            Assert.Contains("package name=Microsoft.NET.Component.sdk.blazorwebassembly.aot", componentSwr);
             Assert.Contains("version=4.5.6", componentSwr);
             Assert.Contains("isAdvertisedPackage=no", componentSwr);
 
@@ -100,6 +101,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
         [WindowsOnlyFact]
         public void ItShortensComponentIds()
         {
+            // Shortnames can trim out potential prefix values.
             ITaskItem[] shortNames = new TaskItem[]
             {
                 new TaskItem("Microsoft.NET.Runtime", new Dictionary<string, string> { { Metadata.Replacement, "MSFT" } })
@@ -107,7 +109,8 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
 
             WorkloadManifest manifest = Create("WorkloadManifest.json");
             WorkloadDefinition workload = (WorkloadDefinition)manifest.Workloads.FirstOrDefault().Value;
-            SwixComponent component = SwixComponent.Create(new ReleaseVersion("6.0.300"), workload, manifest, packGroupId: null, shortNames: shortNames);
+            SwixComponent component = SwixComponent.Create(new ReleaseVersion("6.0.300"), workload, manifest, packGroupId: null, shortNames: shortNames,
+                componentPrefix: DefaultValues.VisualStudioComponentPrefix);
 
             ComponentSwixProject project = new(component, BaseIntermediateOutputPath, BaseOutputPath);
             string swixProj = project.Create();
@@ -121,19 +124,20 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
         {
             WorkloadManifest manifest = Create("AbstractWorkloadsNonWindowsPacks.json");
             WorkloadDefinition workload = (WorkloadDefinition)manifest.Workloads.FirstOrDefault().Value;
-            SwixComponent component = SwixComponent.Create(new ReleaseVersion("6.0.300"), workload, manifest, packGroupId: null, null, null);
+            SwixComponent component = SwixComponent.Create(new ReleaseVersion("6.0.300"), workload, manifest, packGroupId: null, 
+                componentPrefix: DefaultValues.VisualStudioComponentPrefix);
 
             ComponentSwixProject project = new(component, BaseIntermediateOutputPath, BaseOutputPath);
             string swixProj = project.Create();
 
             string componentSwr = File.ReadAllText(Path.Combine(Path.GetDirectoryName(swixProj), "component.swr"));
-            Assert.Contains(@"package name=microsoft.net.runtime.ios", componentSwr);
+            Assert.Contains(@"package name=Microsoft.NET.Component.runtime.ios", componentSwr);
             Assert.DoesNotContain(@"vs.dependency id=Microsoft.NETCore.App.Runtime.AOT.Cross.ios-arm", componentSwr);
             Assert.DoesNotContain(@"vs dependency id=Microsoft.NETCore.App.Runtime.AOT.Cross.ios-arm64", componentSwr);
             Assert.DoesNotContain(@"vs dependency id=Microsoft.NETCore.App.Runtime.AOT.Cross.iossimulator-arm64", componentSwr);
             Assert.DoesNotContain(@"vs dependency id=Microsoft.NETCore.App.Runtime.AOT.Cross.iossimulator-x64", componentSwr);
             Assert.DoesNotContain(@"vs dependency id=Microsoft.NETCore.App.Runtime.AOT.Cross.iossimulator-x86", componentSwr);
-            Assert.Contains(@"vs.dependency id=runtimes.ios", componentSwr);
+            Assert.Contains(@"vs.dependency id=Microsoft.NET.Component.runtimes.ios", componentSwr);
         }
 
         [WindowsOnlyFact]
@@ -151,7 +155,8 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
                 })
             };
 
-            SwixComponent component = SwixComponent.Create(new ReleaseVersion("6.0.300"), workload, manifest, packGroupId: null, componentResources);
+            SwixComponent component = SwixComponent.Create(new ReleaseVersion("6.0.300"), workload, manifest, packGroupId: null, componentResources,
+                componentPrefix: DefaultValues.VisualStudioComponentPrefix);
             ComponentSwixProject project = new(component, BaseIntermediateOutputPath, BaseOutputPath);
             string swixProj = project.Create();
 
@@ -170,8 +175,10 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             SwixComponent component = SwixComponent.Create(new ReleaseVersion("7.0.100"), workload, manifest, packGroupId: null);
             ComponentSwixProject project = new(component, BaseIntermediateOutputPath, BaseOutputPath);
             string swixProj = project.Create();
-
             string componentSwr = File.ReadAllText(Path.Combine(Path.GetDirectoryName(swixProj), "component.swr"));
+
+            // Component prefix is defaults to null when creating a SWIX component, so these values remain
+            // unchanged.
             Assert.Contains(@"vs.dependency id=maui.mobile", componentSwr);
             Assert.Contains(@"vs.dependency id=maui.desktop", componentSwr);
         }
@@ -191,6 +198,16 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Tests
             //  Should have only one dependency, use string.Split to check how many times vs.dependency occurs in swr
             Assert.Equal(2, componentSwr.Split(new[] { "vs.dependency" }, StringSplitOptions.None).Length);
             Assert.Contains($"vs.dependency id={packGroupId}", componentSwr);
+        }
+
+        [Theory]
+        [InlineData("wasm-tools", "Microsoft.NET.Component.wasm.tools", DefaultValues.VisualStudioComponentPrefix)]
+        [InlineData("wasm-tools", "wasm.tools")]
+        [InlineData("microsoft-net-runtime-android", "Microsoft.NET.Component.runtime.android", DefaultValues.VisualStudioComponentPrefix)]
+        [InlineData("microsoft-net-runtime-android", "Foo.runtime.android", "Foo")]
+        public void ItGeneratesValidComponentIds(string workloadId, string expectedComponentId, string prefix = null)
+        {
+            Assert.Equal(expectedComponentId, Utils.ToSafeComponentId(workloadId, null, prefix));
         }
 
         private static WorkloadManifest Create(string filename)

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
@@ -84,6 +84,15 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             set;
         }
 
+        /// <summary>
+        /// Overrides the default component prefix when generating component IDs.
+        /// </summary>
+        public string VisualStudioComponentPrefix
+        {
+            get;
+            set;
+        } = DefaultValues.VisualStudioComponentPrefix;
+
         public bool CreateWorkloadPackGroups
         {
             get;
@@ -125,6 +134,15 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
         /// Allow VS workload generation to proceed if any nupkgs declared in the manifest are not found on disk.
         /// </summary>
         public bool AllowMissingPacks
+        {
+            get;
+            set;
+        } = false;
+
+        /// <summary>
+        /// Generate components using a fixed prefix that follow the Visual Studio component naming convention.
+        /// </summary>
+        public bool UseVisualStudioComponentPrefix
         {
             get;
             set;
@@ -307,12 +325,14 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                             }
                         }
 
+                        string prefix = UseVisualStudioComponentPrefix ? VisualStudioComponentPrefix : null;
+
                         // Finally, add a component for the workload in Visual Studio.
                         SwixComponent component = SwixComponent.Create(manifestPackage.SdkFeatureBand, workload, manifest, packGroupId,
-                            ComponentResources, ShortNames);
+                            ComponentResources, ShortNames, null, prefix);
                         // Create an additional component for shipping previews
                         SwixComponent previewComponent = SwixComponent.Create(manifestPackage.SdkFeatureBand, workload, manifest, packGroupId,
-                            ComponentResources, ShortNames, "pre");
+                            ComponentResources, ShortNames, "pre", prefix);
 
                         // Check for duplicates, e.g. manifests that were copied without changing workload definition IDs and
                         // provide a more usable error message so users can track down the duplication.

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/DefaultValues.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/DefaultValues.cs
@@ -9,6 +9,11 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
     internal static class DefaultValues
     {
         /// <summary>
+        /// Default prefix to use for Visual Studio component and component group IDs.
+        /// </summary>
+        public const string VisualStudioComponentPrefix = "Microsoft.NET.Component";
+
+        /// <summary>
         /// Prefix used in Visual Studio for SWIX based package group.
         /// </summary>
         public const string PackageGroupPrefix = "PackageGroup";

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/DefaultValues.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/DefaultValues.cs
@@ -9,6 +9,12 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
     internal static class DefaultValues
     {
         /// <summary>
+        /// Well-known prefixes used by some workloads that can be replaced when generating component IDs
+        /// using <see cref="VisualStudioComponentPrefix"/>.
+        /// </summary>
+        public static readonly string[] WellKnownWorkloadPrefixes = { "Microsoft.NET.", "Microsoft." };
+
+        /// <summary>
         /// Default prefix to use for Visual Studio component and component group IDs.
         /// </summary>
         public const string VisualStudioComponentPrefix = "Microsoft.NET.Component";

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/SwixComponent.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Swix/SwixComponent.cs
@@ -150,10 +150,13 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
         /// <param name="componentResources">Additional resources that can be used to override component attributes such
         /// as the title, description, and category.</param>
         /// <param name="shortNames">A set of items used to shorten the names of setup packages.</param>
+        /// <param name="componentSuffix">Optional suffix to use for component IDs.</param>
+        /// <param name="componentPrefix">Optional prefix to use for component IDs.</param>
         /// <returns>A SWIX component.</returns>
         public static SwixComponent Create(ReleaseVersion sdkFeatureBand, WorkloadDefinition workload, WorkloadManifest manifest,
             string? packGroupId,
-            ITaskItem[]? componentResources = null, ITaskItem[]? shortNames = null, string? componentSuffix = null)
+            ITaskItem[]? componentResources = null, ITaskItem[]? shortNames = null, string? componentSuffix = null,
+            string? componentPrefix = null)
         {
             ITaskItem? resourceItem = componentResources?.Where(r => string.Equals(r.ItemSpec, workload.Id)).FirstOrDefault();
 
@@ -167,7 +170,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
 
             // Since workloads only define a description, if no custom resources were provided, both the title and description of
             // the SWIX component will default to the workload description. 
-            SwixComponent component = new(sdkFeatureBand, Utils.ToSafeId(workload.Id, componentSuffix),
+            SwixComponent component = new(sdkFeatureBand, Utils.ToSafeComponentId(workload.Id, componentSuffix, componentPrefix),
                 resourceItem != null && !string.IsNullOrEmpty(resourceItem.GetMetadata(Metadata.Title)) ? resourceItem.GetMetadata(Metadata.Title) : workload.Description ?? throw new Exception(Strings.ComponentTitleCannotBeNull),
                 resourceItem != null && !string.IsNullOrEmpty(resourceItem.GetMetadata(Metadata.Description)) ? resourceItem.GetMetadata(Metadata.Description) : workload.Description ?? throw new Exception(Strings.ComponentDescriptionCannotBeNull),
                 componentVersion, workload.IsAbstract,
@@ -179,7 +182,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Swix
             // processing direct pack dependencies.
             foreach (WorkloadId dependency in workload.Extends ?? Enumerable.Empty<WorkloadId>())
             {
-                component.AddDependency(Utils.ToSafeId(dependency, componentSuffix), s_v1);
+                component.AddDependency(Utils.ToSafeComponentId(dependency, componentSuffix, componentPrefix), s_v1);
             }
 
             // TODO: Check for missing packs

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Utils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Utils.cs
@@ -51,10 +51,36 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
         /// Generates a safe SWIX ID by replacing "-", " ", and "_" with ".".
         /// </summary>
         /// <param name="id">The identifier to convert to a safe identifier</param>
+        /// <param name="suffix">Optional suffix to add to the identifier.</param>
         /// <returns>The safe identifier.</returns>
         internal static string ToSafeId(string id, string suffix = null) =>
             id.Replace("-", ".").Replace(" ", ".").Replace("_", ".") +
             (string.IsNullOrWhiteSpace(suffix) ? null : $".{suffix}");
+
+        /// <summary>
+        /// Generates a safe SWIX ID that conforms with the Visual Studio naming convention.
+        /// Well-known prefixes (Microsoft. and Microsoft.NET.) are automatically removed.
+        /// </summary>
+        /// <param name="id">The identifier to convert to a safe identifier</param>
+        /// <param name="suffix">Optional suffix to add to the identifier.</param>
+        /// <param name="prefix">The component prefix to add.</param>
+        /// <returns>The safe component identifier.</returns>
+        internal static string ToSafeComponentId(string id, string suffix = null, string prefix = null)
+        {
+            // The suffix is always included in the safe ID.
+            string safeId = ToSafeId(id, suffix);
+
+            if (string.IsNullOrWhiteSpace(prefix))
+            {
+                return safeId;
+            }
+
+            // Trim well-known prefixes manually since net472 doesn't support all the string.Replace overloads
+            return prefix + '.' + (
+                safeId = safeId.StartsWith("Microsoft.NET.", StringComparison.OrdinalIgnoreCase) ? safeId.Substring(14) :
+                safeId.StartsWith("Microsoft.", StringComparison.OrdinalIgnoreCase) ? safeId.Substring(10) :
+                safeId);
+        }
 
         /// <summary>
         /// Replaces all the tokens in a file using the provided dictionary. The dictionary keys define the tokens and

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Utils.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Utils.cs
@@ -75,11 +75,17 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                 return safeId;
             }
 
+            foreach (string wellKnownPrefix in DefaultValues.WellKnownWorkloadPrefixes)
+            {
+                if (safeId.StartsWith(wellKnownPrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    safeId = safeId.Substring(wellKnownPrefix.Length);
+                    break;
+                }
+            }
+
             // Trim well-known prefixes manually since net472 doesn't support all the string.Replace overloads
-            return prefix + '.' + (
-                safeId = safeId.StartsWith("Microsoft.NET.", StringComparison.OrdinalIgnoreCase) ? safeId.Substring(14) :
-                safeId.StartsWith("Microsoft.", StringComparison.OrdinalIgnoreCase) ? safeId.Substring(10) :
-                safeId);
+            return prefix + '.' + safeId;
         }
 
         /// <summary>


### PR DESCRIPTION
# Description

Visual Studio [publishes](https://learn.microsoft.com/en-us/visualstudio/install/workload-and-component-ids?view=vs-2022) all the component and component group IDs from their catalog to support extension developers. The norm is to follow their naming convention and include a prefix like `Microsoft.VisualStudio.Component` in the ID. .NET optional workloads (including abstract workloads) generate components and component groups that matches the .NET workload ID. This enables features like IPA to easily locate components when SDK resolvers report missing optional workloads.

Visual Studio asked that we follow their guidelines so starting in .NET 9, we will prefix our components with 'Microsoft.NET.Component'. Repos will be able to opt-in and generate new IDs.

# Risk

Medium - Runtime, EMSDK, SDK, Maui all need to use the new feature simultaneously and we won't discover all the issues until we can insert new workloads and do full E2E testing. Risk is mitigated by having this as an opt-in feature.

# Testing

We have sufficient unit tests to feel confident about the change. We'll be able to further assess problems once the first repos onboard to it and again when we have full E2E testing.