### PR TITLE
Enable installing MicroBuild plugin on Mac + Linux

### DIFF
--- a/eng/common/core-templates/job/job.yml
+++ b/eng/common/core-templates/job/job.yml
@@ -24,6 +24,7 @@ parameters:
   enablePublishTestResults: false
   enablePublishUsingPipelines: false
   enableBuildRetry: false
+  installMicrobuildForMac: false
   mergeTestResults: false
   testRunTitle: ''
   testResultsFormat: ''
@@ -128,17 +129,21 @@ jobs:
 
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
-      - task: MicroBuildSigningPlugin@4
-        displayName: Install MicroBuild plugin
-        inputs:
-          signType: $(_SignType)
-          zipSources: false
-          feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-        env:
-          TeamName: $(_TeamName)
-          MicroBuildOutputFolderOverride: '$(Agent.TempDirectory)'
-        continueOnError: ${{ parameters.continueOnError }}
-        condition: and(succeeded(), in(variables['_SignType'], 'real', 'test'), eq(variables['Agent.Os'], 'Windows_NT'))
+      - ${{ if or(eq(variables['Agent.Os'], 'Windows_NT'), eq(parameters.installMicrobuildForMac, 'true')) }}:
+        - task: MicroBuildSigningPlugin@4
+          displayName: Install MicroBuild plugin
+          inputs:
+            signType: $(_SignType)
+            zipSources: false
+            feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+            ${{ if and(ne(variables['Agent.Os'], 'Windows_NT'), eq(parameters.installMicrobuildForMac, 'true')) }}:
+              # Needed to install the MicroBuild plugin for Mac
+              azureSubscription: 'MicroBuild Signing Task (DevDiv)'
+          env:
+            TeamName: $(_TeamName)
+            MicroBuildOutputFolderOverride: '$(Agent.TempDirectory)'
+          continueOnError: ${{ parameters.continueOnError }}
+          condition: and(succeeded(), in(variables['_SignType'], 'real', 'test'))
 
   - ${{ if and(eq(parameters.runAsPublic, 'false'), eq(variables['System.TeamProject'], 'internal')) }}:
     - task: NuGetAuthenticate@1

--- a/eng/common/core-templates/job/job.yml
+++ b/eng/common/core-templates/job/job.yml
@@ -129,21 +129,35 @@ jobs:
 
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
-      - ${{ if or(eq(variables['Agent.Os'], 'Windows_NT'), eq(parameters.installMicrobuildForMac, 'true')) }}:
+
+      - ${{ if eq(parameters.installMicrobuildForMac, 'true') }}:
+        # Install MicroBuild plugin for Mac and Linux
         - task: MicroBuildSigningPlugin@4
           displayName: Install MicroBuild plugin
           inputs:
             signType: $(_SignType)
             zipSources: false
             feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-            ${{ if and(ne(variables['Agent.Os'], 'Windows_NT'), eq(parameters.installMicrobuildForMac, 'true')) }}:
-              # Needed to install the MicroBuild plugin for Mac
-              azureSubscription: 'MicroBuild Signing Task (DevDiv)'
+            azureSubscription: 'MicroBuild Signing Task (DevDiv)'
           env:
             TeamName: $(_TeamName)
             MicroBuildOutputFolderOverride: '$(Agent.TempDirectory)'
           continueOnError: ${{ parameters.continueOnError }}
-          condition: and(succeeded(), in(variables['_SignType'], 'real', 'test'))
+          condition: and(succeeded(), in(variables['_SignType'], 'real', 'test'), ne(variables['Agent.Os'], 'Windows_NT'))
+
+      - ${{ else }}:
+        # Install MicroBuild plugin for Windows
+        - task: MicroBuildSigningPlugin@4
+          displayName: Install MicroBuild plugin
+          inputs:
+            signType: $(_SignType)
+            zipSources: false
+            feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+          env:
+            TeamName: $(_TeamName)
+            MicroBuildOutputFolderOverride: '$(Agent.TempDirectory)'
+          continueOnError: ${{ parameters.continueOnError }}
+          condition: and(succeeded(), in(variables['_SignType'], 'real', 'test'), eq(variables['Agent.Os'], 'Windows_NT'))
 
   - ${{ if and(eq(parameters.runAsPublic, 'false'), eq(variables['System.TeamProject'], 'internal')) }}:
     - task: NuGetAuthenticate@1

--- a/eng/common/core-templates/job/job.yml
+++ b/eng/common/core-templates/job/job.yml
@@ -129,35 +129,19 @@ jobs:
 
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
-
-      - ${{ if eq(parameters.installMicrobuildForMac, 'true') }}:
-        # Install MicroBuild plugin for Mac and Linux
-        - task: MicroBuildSigningPlugin@4
-          displayName: Install MicroBuild plugin
-          inputs:
-            signType: $(_SignType)
-            zipSources: false
-            feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+      - task: MicroBuildSigningPlugin@4
+        displayName: Install MicroBuild plugin
+        inputs:
+          signType: $(_SignType)
+          zipSources: false
+          feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+          ${{ if and(eq(parameters.installMicrobuildForMac, 'true'), ne(variables['Agent.Os'], 'Windows_NT')) }}:
             azureSubscription: 'MicroBuild Signing Task (DevDiv)'
-          env:
-            TeamName: $(_TeamName)
-            MicroBuildOutputFolderOverride: '$(Agent.TempDirectory)'
-          continueOnError: ${{ parameters.continueOnError }}
-          condition: and(succeeded(), in(variables['_SignType'], 'real', 'test'), ne(variables['Agent.Os'], 'Windows_NT'))
-
-      - ${{ else }}:
-        # Install MicroBuild plugin for Windows
-        - task: MicroBuildSigningPlugin@4
-          displayName: Install MicroBuild plugin
-          inputs:
-            signType: $(_SignType)
-            zipSources: false
-            feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-          env:
-            TeamName: $(_TeamName)
-            MicroBuildOutputFolderOverride: '$(Agent.TempDirectory)'
-          continueOnError: ${{ parameters.continueOnError }}
-          condition: and(succeeded(), in(variables['_SignType'], 'real', 'test'), eq(variables['Agent.Os'], 'Windows_NT'))
+        env:
+          TeamName: $(_TeamName)
+          MicroBuildOutputFolderOverride: '$(Agent.TempDirectory)'
+        continueOnError: ${{ parameters.continueOnError }}
+        condition: and(succeeded(), in(variables['_SignType'], 'real', 'test'))
 
   - ${{ if and(eq(parameters.runAsPublic, 'false'), eq(variables['System.TeamProject'], 'internal')) }}:
     - task: NuGetAuthenticate@1

--- a/eng/common/core-templates/job/job.yml
+++ b/eng/common/core-templates/job/job.yml
@@ -19,12 +19,12 @@ parameters:
   # publishing defaults
   artifacts: ''
   enableMicrobuild: false
+  enableMicrobuildForMacAndLinux: false
   enablePublishBuildArtifacts: false
   enablePublishBuildAssets: false
   enablePublishTestResults: false
   enablePublishUsingPipelines: false
   enableBuildRetry: false
-  installMicrobuildForMac: false
   mergeTestResults: false
   testRunTitle: ''
   testResultsFormat: ''
@@ -135,13 +135,26 @@ jobs:
           signType: $(_SignType)
           zipSources: false
           feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-          ${{ if and(eq(parameters.installMicrobuildForMac, 'true'), ne(variables['Agent.Os'], 'Windows_NT')) }}:
+          ${{ if and(eq(parameters.enableMicrobuildForMacAndLinux, 'true'), ne(variables['Agent.Os'], 'Windows_NT')) }}:
             azureSubscription: 'MicroBuild Signing Task (DevDiv)'
         env:
           TeamName: $(_TeamName)
           MicroBuildOutputFolderOverride: '$(Agent.TempDirectory)'
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         continueOnError: ${{ parameters.continueOnError }}
-        condition: and(succeeded(), in(variables['_SignType'], 'real', 'test'))
+        condition: and(
+          succeeded(),
+          or(
+            and(
+              eq(variables['Agent.Os'], 'Windows_NT'),
+              in(variables['_SignType'], 'real', 'test')
+            ),
+            and(
+              ${{ eq(parameters.enableMicrobuildForMacAndLinux, true) }},
+              ne(variables['Agent.Os'], 'Windows_NT'),
+              eq(variables['_SignType'], 'real')
+            )
+          ))
 
   - ${{ if and(eq(parameters.runAsPublic, 'false'), eq(variables['System.TeamProject'], 'internal')) }}:
     - task: NuGetAuthenticate@1
@@ -174,7 +187,19 @@ jobs:
     - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - task: MicroBuildCleanup@1
         displayName: Execute Microbuild cleanup tasks
-        condition: and(always(), in(variables['_SignType'], 'real', 'test'), eq(variables['Agent.Os'], 'Windows_NT'))
+        condition: and(
+          always(),
+          or(
+            and(
+              eq(variables['Agent.Os'], 'Windows_NT'),
+              in(variables['_SignType'], 'real', 'test')
+            ),
+            and(
+              ${{ eq(parameters.enableMicrobuildForMacAndLinux, true) }},
+              ne(variables['Agent.Os'], 'Windows_NT'),
+              eq(variables['_SignType'], 'real')
+            )
+          ))
         continueOnError: ${{ parameters.continueOnError }}
         env:
           TeamName: $(_TeamName)


### PR DESCRIPTION
Related to https://github.com/dotnet/arcade/issues/14431

This PR configures the installation of the MicroBuild plugin on Mac via a new parameter called `installMicrobuildForMac`.

Note that the conditions were changed to match the requirement that test signing is not available on Linux and Mac builds.

[Example pipeline run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2546920&view=results)