### PR TITLE
Change the project filtering mechanism for build passes to fix failures

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -47,6 +47,7 @@
     <ProjectToBuild>
       <RestoreInParallel>true</RestoreInParallel>
       <BuildInParallel>true</BuildInParallel>
+      <DotNetBuildPass>1</DotNetBuildPass>
     </ProjectToBuild>
   </ItemDefinitionGroup>
 
@@ -78,11 +79,10 @@
     Don't do this filtering in non-unified builds to allow repos to define how different build passes are handled
     in their own repo-specific builds.
   -->
-  <ItemGroup Condition="'$(_DotNetBuildPassNormalized)' != '1' and '$(DotNetBuildInnerRepo)' == 'true'">
-    <ProjectToBuild Remove="@(ProjectToBuild)" Condition="'%(ProjectToBuild.DotNetBuildPass)' != '$(_DotNetBuildPassNormalized)'"/>
-  </ItemGroup>
-  <ItemGroup Condition="'$(_DotNetBuildPassNormalized)' == '1' and '$(DotNetBuildInnerRepo)' == 'true'">
-    <ProjectToBuild Remove="@(ProjectToBuild)" Condition="'%(ProjectToBuild.DotNetBuildPass)' != '' and '%(ProjectToBuild.BuildPass)' != '1'"/>
+  <ItemGroup Condition="'$(DotNetBuildInnerRepo)' == 'true'">
+    <_ProjectToBuildCurrentBuildPass Include="@(ProjectToBuild->WithMetadataValue('DotNetBuildPass', '$(_DotNetBuildPassNormalized)'))" />
+    <ProjectToBuild Remove="@(ProjectToBuild)" />
+    <ProjectToBuild Include="@(_ProjectToBuildCurrentBuildPass)" />
   </ItemGroup>
 
   <!--
@@ -90,7 +90,7 @@
     If Projects is unspecified and ProjectToBuild was not set via Build.props, fallback to building .sln files in the repo root.
     For build passes after the first, build nothing by default.
   -->
-  <ItemGroup Condition="'@(ProjectToBuild)' == '' and '$(_DotNetBuildPassNormalized)' != ''">
+  <ItemGroup Condition="'@(ProjectToBuild)' == '' and '$(_DotNetBuildPassNormalized)' == '1'">
     <ProjectToBuild Include="$(RepoRoot)*.sln" />
   </ItemGroup>
 


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
