### PR TITLE
Azure credentials update

### DIFF
--- a/src/Microsoft.DotNet.ArcadeAzureIntegration/DefaultIdentityTokenCredential.cs
+++ b/src/Microsoft.DotNet.ArcadeAzureIntegration/DefaultIdentityTokenCredential.cs
@@ -40,18 +40,18 @@ public class DefaultIdentityTokenCredential : ChainedTokenCredential
             );
         }
 
-        // Add work load identity credential if the environment variables are set
-        var workloadIdentityCredential = GetWorkloadIdentityCredentialForAzurePipelineTask();
-        if (workloadIdentityCredential != null)
-        {
-            tokenCredentials.Add(workloadIdentityCredential);
-        }
-
         // Add Azure Pipelines credential if the environment variables are set
         var azurePipelinesCredential = GetAzurePipelinesCredentialForAzurePipelineTask();
         if (azurePipelinesCredential != null)
         {
             tokenCredentials.Add(azurePipelinesCredential);
+        }
+
+        // Add work load identity credential if the environment variables are set
+        var workloadIdentityCredential = GetWorkloadIdentityCredentialForAzurePipelineTask();
+        if (workloadIdentityCredential != null)
+        {
+            tokenCredentials.Add(workloadIdentityCredential);
         }
 
         if (!options.ExcludeAzureCliCredential)

--- a/src/Microsoft.DotNet.ArcadeAzureIntegration/DefaultIdentityTokenCredential.cs
+++ b/src/Microsoft.DotNet.ArcadeAzureIntegration/DefaultIdentityTokenCredential.cs
@@ -10,32 +10,53 @@ using System.Collections.Generic;
 using System.IO;
 using Azure.Core;
 using Azure.Identity;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace Microsoft.DotNet.ArcadeAzureIntegration;
 
 
 // This implementation of TokenCredential will try to cover all common ways of
 // authentication to Azure services used in Arcade tooling
-public class DefaultIdentityTokenCredential : ChainedTokenCredential
+public class DefaultIdentityTokenCredential : TokenCredential
 {
+    private readonly TokenCredential _tokenCredential;
+
     public DefaultIdentityTokenCredential()
         : this(new DefaultIdentityTokenCredentialOptions())
     {
     }
 
     public DefaultIdentityTokenCredential(DefaultIdentityTokenCredentialOptions options)
-        : base(CreateAvailableTokenCredentials(options))
     {
+        _tokenCredential = CreateAvailableTokenCredential(options);
     }
 
-    private static TokenCredential[] CreateAvailableTokenCredentials(DefaultIdentityTokenCredentialOptions options)
+    public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
     {
-        List<TokenCredential> tokenCredentials = [
-            new ManagedIdentityCredential(options.ManagedIdentityClientId)
-        ];
+        return _tokenCredential.GetTokenAsync(requestContext, cancellationToken);
+    }
+
+    public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+    {
+        return _tokenCredential.GetToken(requestContext, cancellationToken);
+    }
+
+    private static TokenCredential CreateAvailableTokenCredential(DefaultIdentityTokenCredentialOptions options)
+    {
+        TokenCredential? azurePipelinesCredential = GetAzurePipelinesCredentialForAzurePipelineTask();
+
+        if (options.UseAzurePipelineCredentialAloneIfConfigured)
+        {
+            if (azurePipelinesCredential != null)
+            {
+                return azurePipelinesCredential;
+            }
+        }
+
+        List<TokenCredential> tokenCredentials = [];
 
         // Add Azure Pipelines credential if the environment variables are set
-        TokenCredential? azurePipelinesCredential = GetAzurePipelinesCredentialForAzurePipelineTask();
         if (azurePipelinesCredential != null)
         {
             if (!options.DisableShortCache)
@@ -44,6 +65,9 @@ public class DefaultIdentityTokenCredential : ChainedTokenCredential
             }
             tokenCredentials.Add(azurePipelinesCredential);
         }
+
+        // Add Managed Identity credential
+        tokenCredentials.Add(new ManagedIdentityCredential(options.ManagedIdentityClientId));
 
         // Add work load identity credential if the environment variables are set
         TokenCredential? workloadIdentityCredential = GetWorkloadIdentityCredentialForAzurePipelineTask();
@@ -79,7 +103,8 @@ public class DefaultIdentityTokenCredential : ChainedTokenCredential
             throw new InvalidOperationException("No valid credential class detected and configured for authentication to Azure services.");
         }
 
-        return tokenCredentials.ToArray();
+        var ret = new ChainedTokenCredential(tokenCredentials.ToArray());
+        return ret;
     }
 
     private static object _workloadTokenFileLock = new object();
@@ -129,7 +154,8 @@ public class DefaultIdentityTokenCredential : ChainedTokenCredential
         if (!string.IsNullOrEmpty(systemAccessToken) &&
             !string.IsNullOrEmpty(clientId) &&
             !string.IsNullOrEmpty(tenantId) &&
-            !string.IsNullOrEmpty(serviceConnectionId))
+            !string.IsNullOrEmpty(serviceConnectionId) &&
+            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SYSTEM_OIDCREQUESTURI")))
         {
             return new AzurePipelinesCredential(tenantId, clientId, serviceConnectionId, systemAccessToken);
         }

--- a/src/Microsoft.DotNet.ArcadeAzureIntegration/DefaultIdentityTokenCredentialOptions.cs
+++ b/src/Microsoft.DotNet.ArcadeAzureIntegration/DefaultIdentityTokenCredentialOptions.cs
@@ -12,6 +12,7 @@ public class DefaultIdentityTokenCredentialOptions
 {
     public string? ManagedIdentityClientId { get; set; } = null;
     public bool ExcludeAzureCliCredential { get; set; }
+    public bool DisableShortCache { get; set; }
 }
 
 #endif

--- a/src/Microsoft.DotNet.ArcadeAzureIntegration/DefaultIdentityTokenCredentialOptions.cs
+++ b/src/Microsoft.DotNet.ArcadeAzureIntegration/DefaultIdentityTokenCredentialOptions.cs
@@ -10,6 +10,7 @@ namespace Microsoft.DotNet.ArcadeAzureIntegration;
 
 public class DefaultIdentityTokenCredentialOptions
 {
+    public bool UseAzurePipelineCredentialAloneIfConfigured { get; set; } = true;
     public string? ManagedIdentityClientId { get; set; } = null;
     public bool ExcludeAzureCliCredential { get; set; }
     public bool DisableShortCache { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/AssetPublisherFactory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/AssetPublisherFactory.cs
@@ -53,13 +53,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         private TokenCredential GetAzureTokenCredential(string managedIdentityClientId)
         {
             TokenCredential tokenCredential = _tokenCredentialsPerManagedIdentity.GetOrAdd(managedIdentityClientId ?? string.Empty, static (mi) =>
-                new TokenCredentialShortCache(
-                    new DefaultIdentityTokenCredential(
-                        new DefaultIdentityTokenCredentialOptions
-                        {
-                            ManagedIdentityClientId = string.IsNullOrEmpty(mi) ? null : mi
-                        }
-                    )
+                new DefaultIdentityTokenCredential(
+                    new DefaultIdentityTokenCredentialOptions
+                    {
+                        ManagedIdentityClientId = string.IsNullOrEmpty(mi) ? null : mi
+                    }
                 )
             );
             return tokenCredential;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -574,13 +574,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     $"\tSymbol package count: {symbolPackageNames.Length}" + Environment.NewLine +
                     $"\tLoose symbol file count: {looseFileCount}");
 
-            var creds = new TokenCredentialShortCache(
-                new DefaultIdentityTokenCredential(
-                    new DefaultIdentityTokenCredentialOptions
-                    {
-                        ManagedIdentityClientId = ManagedIdentityClientId
-                    }
-                )
+            var creds = new DefaultIdentityTokenCredential(
+                new DefaultIdentityTokenCredentialOptions
+                {
+                    ManagedIdentityClientId = ManagedIdentityClientId
+                }
             );
             TaskTracer tracer = new(Log, verbose: true);
 
@@ -681,7 +679,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     isDryRun: dryRun);
 
                 // In dry run mode, we never hit the symbol server. Don't download symbol.exe in such scenario.
-                return dryRun ? Task.FromResult(SymbolUploadHelperFactory.GetSymbolHelperFromLocalTool(tracer, options, ".")) 
+                return dryRun ? Task.FromResult(SymbolUploadHelperFactory.GetSymbolHelperFromLocalTool(tracer, options, "."))
                     : SymbolUploadHelperFactory.GetSymbolHelperWithDownloadAsync(tracer, options);
 
                 FrozenSet<string> LoadExclusions(string symbolPublishingExclusionsFile)
@@ -1470,7 +1468,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 await PublishAssetsWithoutStreamingPublishingAsync(assetPublisher, assetsToPublish, buildAssets, feedConfig);
             }
 
-            if (feedConfig.Type == FeedType.AzureStorageContainer && 
+            if (feedConfig.Type == FeedType.AzureStorageContainer &&
                 feedConfig.LatestLinkShortUrlPrefixes.Any())
             {
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -28,6 +28,7 @@ using Azure.Identity;
 using Microsoft.DotNet.ProductConstructionService.Client;
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
 using Microsoft.DotNet.Internal.SymbolHelper;
+using Microsoft.DotNet.ArcadeAzureIntegration;
 #endif
 using Microsoft.DotNet.VersionTools.BuildManifest.Model;
 using Newtonsoft.Json;
@@ -573,18 +574,14 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     $"\tSymbol package count: {symbolPackageNames.Length}" + Environment.NewLine +
                     $"\tLoose symbol file count: {looseFileCount}");
 
-            // The OIDC token that the AzureCLI task generates is short lived (10 mins). The operations below can take longer than that.
-            // So we send at least one request to symbolrequest to ensure the CLI caches a valid token. We will need to revisit this if we
-            // run this for over the token's validity period (1hr). At that point, we might need to inject OIDC refreshes to the task call site.
-            DefaultAzureCredential creds = new(new DefaultAzureCredentialOptions
-            {
-                ExcludeVisualStudioCodeCredential = true,
-                ExcludeVisualStudioCredential = true,
-                ExcludeAzureDeveloperCliCredential = true,
-                ExcludeInteractiveBrowserCredential = true,
-                ManagedIdentityClientId = ManagedIdentityClientId,
-                CredentialProcessTimeout = TimeSpan.FromSeconds(60.0)
-            });
+            var creds = new TokenCredentialShortCache(
+                new DefaultIdentityTokenCredential(
+                    new DefaultIdentityTokenCredentialOptions
+                    {
+                        ManagedIdentityClientId = ManagedIdentityClientId
+                    }
+                )
+            );
             TaskTracer tracer = new(Log, verbose: true);
 
             _ = await SymbolPromotionHelper.CheckRequestRegistration(tracer, creds, env, SymbolRequestProject, requestName);

--- a/src/Microsoft.DotNet.Internal.SymbolHelper/SymbolPromotionHelper.cs
+++ b/src/Microsoft.DotNet.Internal.SymbolHelper/SymbolPromotionHelper.cs
@@ -289,8 +289,8 @@ public static class SymbolPromotionHelper
 
         string? tokenResource = env switch
         {
-            Environment.PPE => "api://2748228d-54c2-4c34-a8ed-c4ae31661b39",
-            Environment.Prod => "api://30471ccf-0966-45b9-a979-065dbedb24c1",
+            Environment.PPE => "api://2748228d-54c2-4c34-a8ed-c4ae31661b39/.default",
+            Environment.Prod => "api://30471ccf-0966-45b9-a979-065dbedb24c1/.default",
             _ => default
         };
 


### PR DESCRIPTION
Update Azure Identity Credentials
- prefer AzurePipelineCredential if all environment variables are set
- cache initialization moved to DefaultIdentityTokenCredential so you can use only DefaultIdentityTokenCredential class with options and optionally disable short cache by DisableShortCache option
- Publish packages, blobs and symbols task set to use AzurePipelineCredential by adding SYSTEM_ACCESSTOKEN env value
- PublishArtifactsInManifestBase - use DefaultIdentityTokenCredential in symbols publishing