### PR TITLE
Add missing quotation from workaround condition

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -17,7 +17,7 @@
     due to strong-name signing.
     https://github.com/dotnet/arcade/issues/15117
   -->
-  <PropertyGroup Condition="'$(DotNetSignType)' == 'real' and '$(OS)' != 'Windows_NT'>
+  <PropertyGroup Condition="'$(DotNetSignType)' == 'real' and '$(OS)' != 'Windows_NT'">
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 


### PR DESCRIPTION
This is to fix a regression brought in by https://github.com/dotnet/arcade/pull/15118. The error was caught by arcade-validation in https://github.com/dotnet/arcade-validation/pull/4586.