### PR TITLE
Update tools.ps1 GUID creation

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -900,7 +900,7 @@ function IsWindowsPlatform() {
 }
 
 function Get-Darc($version) {
-  $darcPath  = "$TempDir\darc\$(New-Guid)"
+  $darcPath  = "$TempDir\darc\$([guid]::NewGuid())"
   if ($version -ne $null) {
     & $PSScriptRoot\darc-init.ps1 -toolpath $darcPath -darcVersion $version | Out-Host
   } else {


### PR DESCRIPTION
## Summary

The cmdlet `New-Guid` only exists in PowerShell Core version 5 and greater. If you want to run the `tools.ps1` script in Windows PowerShell, it will error with something similar to this:

```
  C:\Code\workload-versions\eng\download-workloads.ps1 : The term 'New-Guid' is not recognized as
  the name of a cmdlet, function, script file, or operable program. Check the spelling of the name,
  or if a path was included, verify that the path is correct and try again.
  At line:1 char:1
  + . C:\Code\workload-versions\eng\download-workloads.ps1 -workloadOutpu ...
  + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      + CategoryInfo          : ObjectNotFound: (New-Guid:String) [download-workloads.ps1], CommandN
     otFoundException
      + FullyQualifiedErrorId : CommandNotFoundException,download-workloads.ps1
```

To fix this problem, we instead just call the `NewGuid()` method directly, which works on both PowerShell Core and Windows PowerShell.

## Other Actions

I'll need this functionality backported to the .NET 8 branch as well.