### PR TITLE
Set runAsPublic explicitly

### DIFF
--- a/eng/common/templates-official/job/job.yml
+++ b/eng/common/templates-official/job/job.yml
@@ -1,6 +1,7 @@
 parameters:
 # Sbom related params
   enableSbom: true
+  runAsPublic: false
   PackageVersion: 9.0.0
   BuildDropPath: '$(Build.SourcesDirectory)/artifacts'
 

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -4,6 +4,7 @@ parameters:
   componentGovernanceIgnoreDirectories: ''
 # Sbom related params
   enableSbom: true
+  runAsPublic: false
   PackageVersion: 9.0.0
   BuildDropPath: '$(Build.SourcesDirectory)/artifacts'
 


### PR DESCRIPTION
This is a parameter in jobs.yml as well as core-templates, but is not in the outer templates, despite being used here. Repos that are not using jobs.yml would have arcade generated SBOMs dropped
