### PR TITLE
Explicitly set `PublicSign` and `DelaySign` in workaround

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -19,6 +19,7 @@
   -->
   <PropertyGroup Condition="'$(DotNetSignType)' == 'real' and '$(OS)' != 'Windows_NT'">
     <SignAssembly>false</SignAssembly>
+    <PublicSign>false</PublicSign>
   </PropertyGroup>
 
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -20,6 +20,7 @@
   <PropertyGroup Condition="'$(DotNetSignType)' == 'real' and '$(OS)' != 'Windows_NT'">
     <SignAssembly>false</SignAssembly>
     <PublicSign>false</PublicSign>
+    <DelaySign></DelaySign>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
Related to https://github.com/dotnet/arcade/issues/15117

Reassigning the `SignAssembly` property to `false` in the workaround does not automatically trigger the `PublicSign` property to also be false. This resulted in the following error in my [test run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2551238&view=logs&j=1295a90a-32ad-54ea-34e1-74b5e62ea3f1&t=a09fa6bb-38e4-5b5c-886e-6d9bde72d5ff&l=62) for the changes in https://github.com/dotnet/arcade-validation/pull/4575:

`##[error]CSC(0,0): error CS8102: (NETCORE_ENGINEERING_TELEMETRY=Build) Public signing was specified and requires a public key, but no public key was specified.`

Interestingly, if `SignAssembly` is explicitly set to false within the project's csproj file, `PublicSign` is automatically set to false. It's just when the property is reassigned via `Workarounds.targets` that the `PublicSign` property does not also change.

I validated the change in this PR by writing the change into my local copy of `arcade-validation/.packages/microsoft.dotnet.arcade.sdk/10.0.0-beta.24501.6/tools/Workarounds.targets` and running `eng/common/cibuild.sh --configuration Release --prepareMachine --sign /p:DotNetSignType=real /p:TeamName=DotNetCore /p:DotNetPublishUsingPipelines=true /p:OfficialBuildId=20240921.1`