### PR TITLE
Hardcode python version when installing MicroBuild

### DIFF
--- a/eng/common/core-templates/job/job.yml
+++ b/eng/common/core-templates/job/job.yml
@@ -129,6 +129,12 @@ jobs:
 
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
+
+      - ${{ if and(eq(parameters.enableMicrobuildForMacAndLinux, 'true'), ne(variables['Agent.Os'], 'Windows_NT')) }}:
+        - task: UsePythonVersion@0
+          inputs:
+            versionSpec: '3.11.x'
+
       - task: MicroBuildSigningPlugin@4
         displayName: Install MicroBuild plugin
         inputs:


### PR DESCRIPTION
Related to https://github.com/dotnet/arcade/issues/14431

Needed to unblock MicroBuild failures in macOS and Linux builds

Pipeline example with failures before fix ([mac](https://dev.azure.com/dnceng/internal/_build/results?buildId=2550492&view=logs&j=8e9e2812-09db-5a5d-c249-d96adf9f47fa&t=51e8c4b1-e760-5f88-6965-6fecd74b90ed&l=1547)) ([linux](https://dev.azure.com/dnceng/internal/_build/results?buildId=2550492&view=logs&j=4a1f0fe1-d87a-57fd-c29d-71ea15e38f30&t=0008bc80-8cac-53ad-8ae2-89ecbf3b18a9&l=164))
Pipeline example after fix ([mac](https://dev.azure.com/dnceng/internal/_build/results?buildId=2552085&view=logs&j=8e9e2812-09db-5a5d-c249-d96adf9f47fa&t=51e8c4b1-e760-5f88-6965-6fecd74b90ed)) ([linux](https://dev.azure.com/dnceng/internal/_build/results?buildId=2552085&view=logs&j=b72e85ab-3386-5aa9-6405-3837662d9688&t=1319cf8e-de21-5071-b4f6-a1466cfe243e))