### PR TITLE
Avoid calling string.Trim(ReadOnlySpan<char>)

### DIFF
--- a/src/Common/Microsoft.Arcade.Common/Helpers.cs
+++ b/src/Common/Microsoft.Arcade.Common/Helpers.cs
@@ -12,9 +12,11 @@ namespace Microsoft.Arcade.Common
 {
     public class Helpers : IHelpers
     {
+        private static readonly char[] s_slashes = [ '/', '\\' ];
+
         public string RemoveTrailingSlash(string directoryPath)
         {
-            return directoryPath.TrimEnd('/', '\\');
+            return directoryPath.TrimEnd(s_slashes);
         }
 
         public string ComputeSha256Hash(string normalizedPath)

--- a/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/InstallDotNetCore.cs
@@ -25,6 +25,8 @@ namespace Microsoft.DotNet.Arcade.Sdk
     public class InstallDotNetCore : Microsoft.Build.Utilities.Task
     {
 #endif
+        private static readonly char[] s_keyTrimChars = [ '$', '(', ')' ];
+
         public string VersionsPropsPath { get; set; }
 
         [Required]
@@ -107,7 +109,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
                                     // Try to parse version
                                     if (!SemanticVersion.TryParse(item.Key, out version))
                                     {
-                                        var propertyName = item.Key.Trim('$', '(', ')');
+                                        var propertyName = item.Key.Trim(s_keyTrimChars);
 
                                         // Unable to parse version, try to find the corresponding identifier from the MSBuild loaded MSBuild properties
                                         ProjectProperty property = properties[propertyName].FirstOrDefault();

--- a/src/Microsoft.DotNet.XUnitConsoleRunner/src/common/AssemblyResolution/Microsoft.DotNet.PlatformAbstractions/Native/PlatformApis.cs
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/src/common/AssemblyResolution/Microsoft.DotNet.PlatformAbstractions/Native/PlatformApis.cs
@@ -17,6 +17,7 @@ namespace Internal.Microsoft.DotNet.PlatformAbstractions.Native
 
         private static readonly Lazy<Platform> _platform = new Lazy<Platform>(DetermineOSPlatform);
         private static readonly Lazy<DistroInfo> _distroInfo = new Lazy<DistroInfo>(LoadDistroInfo);
+        private static readonly char[] _idTrimChars = [ '"', '\'' ];
 
         public static string GetOSName()
         {
@@ -105,11 +106,11 @@ namespace Internal.Microsoft.DotNet.PlatformAbstractions.Native
                 {
                     if (line.StartsWith("ID=", StringComparison.Ordinal))
                     {
-                        result.Id = line.Substring(3).Trim('"', '\'');
+                        result.Id = line.Substring(3).Trim(_idTrimChars);
                     }
                     else if (line.StartsWith("VERSION_ID=", StringComparison.Ordinal))
                     {
-                        result.VersionId = line.Substring(11).Trim('"', '\'');
+                        result.VersionId = line.Substring(11).Trim(_idTrimChars);
                     }
                 }
 

--- a/src/Microsoft.DotNet.XliffTasks/Model/XamlRuleDocument.cs
+++ b/src/Microsoft.DotNet.XliffTasks/Model/XamlRuleDocument.cs
@@ -19,6 +19,8 @@ namespace XliffTasks.Model
     {
         private const string XliffTasksNs = "https://github.com/dotnet/xliff-tasks";
         private const string LocalizedPropertiesAttributeName = "LocalizedProperties";
+
+        private static readonly char[] s_attrValueTrimChars = [ ':', ' ', '\t' ];
         
         protected override IEnumerable<TranslatableNode> GetTranslatableNodes()
         {
@@ -197,7 +199,7 @@ namespace XliffTasks.Model
                 {
                     if (line.StartsWith(attributeName))
                     {
-                        return line.Substring(attributeName.Length).Trim(':', ' ', '\t');
+                        return line.Substring(attributeName.Length).Trim(s_attrValueTrimChars);
                     }
                 }
             }


### PR DESCRIPTION
The methods are being removed, but the test suite depends on arcade, which is already calling the removed members.

Contributes to https://github.com/dotnet/runtime/pull/108537