### PR TITLE
Allow for forcing of dry-run signing

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -44,7 +44,8 @@
 
     <PropertyGroup>
       <_DryRun>true</_DryRun>
-      <_DryRun Condition="'$(OfficialBuild)' == 'true'">false</_DryRun>
+      <!-- Allow an official build to force dry run signing. This allows the VMR's build to test signing in CI without changing versions. -->
+      <_DryRun Condition="'$(OfficialBuild)' == 'true' and '$(ForceDryRunSigning)' != 'true'">false</_DryRun>
 
       <_TestSign>false</_TestSign>
       <_TestSign Condition="'$(DotNetSignType)' == 'test'">true</_TestSign>


### PR DESCRIPTION
This enables us to turn on the VMR signing switches in PR/CI builds without losing our ability to match the current MSFT versions.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
