### PR TITLE
Unpack and Repack .tar.gz

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -56,6 +56,7 @@
     <FileExtensionSignInfo Include=".vsix" CertificateName="VsixSHA2" />
     <FileExtensionSignInfo Include=".zip" CertificateName="None" />
     <FileExtensionSignInfo Include=".tgz" CertificateName="None" />
+    <FileExtensionSignInfo Include=".tar.gz" CertificateName="None" />
   </ItemGroup>
 
   <!-- The name of the .NET specific certificate, which is a general replacement for Microsoft400

--- a/src/Microsoft.DotNet.SignTool/src/FileSignInfo.cs
+++ b/src/Microsoft.DotNet.SignTool/src/FileSignInfo.cs
@@ -40,7 +40,9 @@ namespace Microsoft.DotNet.SignTool
             => Path.GetExtension(path).Equals(".zip", StringComparison.OrdinalIgnoreCase);
 
         internal static bool IsTarGZip(string path)
-            => Path.GetExtension(path).EndsWith(".tgz", StringComparison.OrdinalIgnoreCase);
+            => Path.GetExtension(path).EndsWith(".tgz", StringComparison.OrdinalIgnoreCase)
+                || (Path.GetExtension(path).EndsWith(".gz", StringComparison.OrdinalIgnoreCase)
+                    && Path.GetFileNameWithoutExtension(path).EndsWith(".tar", StringComparison.OrdinalIgnoreCase));
 
         internal static bool IsWix(string path)
             => (Path.GetExtension(path).Equals(".msi", StringComparison.OrdinalIgnoreCase)

--- a/src/Microsoft.DotNet.SignTool/src/FileSignInfo.cs
+++ b/src/Microsoft.DotNet.SignTool/src/FileSignInfo.cs
@@ -40,9 +40,9 @@ namespace Microsoft.DotNet.SignTool
             => Path.GetExtension(path).Equals(".zip", StringComparison.OrdinalIgnoreCase);
 
         internal static bool IsTarGZip(string path)
-            => Path.GetExtension(path).EndsWith(".tgz", StringComparison.OrdinalIgnoreCase)
-                || (Path.GetExtension(path).EndsWith(".gz", StringComparison.OrdinalIgnoreCase)
-                    && Path.GetFileNameWithoutExtension(path).EndsWith(".tar", StringComparison.OrdinalIgnoreCase));
+            => Path.GetExtension(path).Equals(".tgz", StringComparison.OrdinalIgnoreCase)
+                || (Path.GetExtension(path).Equals(".gz", StringComparison.OrdinalIgnoreCase)
+                    && Path.GetExtension(Path.GetFileNameWithoutExtension(path)).Equals(".tar", StringComparison.OrdinalIgnoreCase));
 
         internal static bool IsWix(string path)
             => (Path.GetExtension(path).Equals(".msi", StringComparison.OrdinalIgnoreCase)

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -386,7 +386,9 @@ namespace Microsoft.DotNet.SignTool
                     var certificate = item.GetMetadata("CertificateName");
                     var collisionPriorityId = item.GetMetadata(SignToolConstants.CollisionPriorityId);
 
-                    if (!extension.Equals(Path.GetExtension(extension)))
+                    // Path.GetExtension will return .gz for .tar.gz files, so we need to handle that case separately
+                    var actualExtension = extension.Equals(".tar.gz", StringComparison.OrdinalIgnoreCase) ? ".tar.gz" : Path.GetExtension(extension);
+                    if (!extension.Equals(actualExtension))
                     {
                         Log.LogError($"Value of {nameof(FileExtensionSignInfo)} is invalid: '{extension}'");
                         continue;


### PR DESCRIPTION
Related to https://github.com/dotnet/arcade/issues/15132

Most of the unpack and repack work was done in https://github.com/dotnet/arcade/pull/13999, we just had to allow the .tar.gz file extension.

[Binlog](https://github.com/user-attachments/files/17264236/UnpackRepackTarGz.zip) of local arcade-validation run using a version of arcade built with the changes in this PR:

![image](https://github.com/user-attachments/assets/6481b55b-c7ca-48e9-a722-41ec6e8bda19)

