### PR TITLE
Include .tar.gz extension in VersionTools infra

### DIFF
--- a/src/VersionTools/Microsoft.DotNet.VersionTools/BuildManifest/Model/SigningInformationParsingExtensions.cs
+++ b/src/VersionTools/Microsoft.DotNet.VersionTools/BuildManifest/Model/SigningInformationParsingExtensions.cs
@@ -38,7 +38,8 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
                     throw new ArgumentException($"Value of FileExtensionSignInfo 'Include' is invalid, must be non-empty.");
                 }
 
-                if (!signInfo.Include.Equals(Path.GetExtension(signInfo.Include)))
+                string extension = signInfo.Include.Equals(".tar.gz", StringComparison.OrdinalIgnoreCase) ? ".tar.gz" : Path.GetExtension(signInfo.Include);
+                if (!signInfo.Include.Equals(extension))
                 {
                     throw new ArgumentException($"Value of FileExtensionSignInfo Include is invalid: '{signInfo.Include}' is not returned by Path.GetExtension('{signInfo.Include}')");
                 }


### PR DESCRIPTION
Related to https://github.com/dotnet/arcade/pull/15137 and https://github.com/dotnet/arcade-validation/pull/4596

`src/VersionTools/Microsoft.DotNet.VersionTools/BuildManifest/Model/SigningInformationParsingExtensions.cs` also needs to be adjusted to accommodate the `tar.gz` extension.

This did not come up in my local testing because `/p:DotNetPublishUsingPipelines=true` in order to encounter the error, and I was testing with `./build.sh --sign`.