### PR TITLE
Revert Disabling Strong-Name Sign

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -13,17 +13,6 @@
   </Target>
 
   <!--
-    Workaround for failed signing of Non-Windows artifacts
-    due to strong-name signing.
-    https://github.com/dotnet/arcade/issues/15117
-  -->
-  <PropertyGroup Condition="'$(DotNetSignType)' == 'real' and '$(OS)' != 'Windows_NT'">
-    <SignAssembly>false</SignAssembly>
-    <PublicSign>false</PublicSign>
-    <DelaySign></DelaySign>
-  </PropertyGroup>
-
-  <!--
     WPF temp project sets OutDir, which makes the SDK create an empty directory for it,
     polluting the output dir. Avoid creating these directories.
     https://github.com/dotnet/sdk/issues/1367


### PR DESCRIPTION
Closes https://github.com/dotnet/arcade/issues/15117

[Test run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2556727&view=results) with an arcade SDK that does not contain the workaround. Verified via the binlogs that strong-name signing was enabled in the test run.