### PR TITLE
Fix up strong name signing for Unified Build

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -55,6 +55,9 @@
 
       <_DotNetCoreRequired>false</_DotNetCoreRequired>
       <_DotNetCoreRequired Condition="'$(_DryRun)' != 'true' and '$(OS)' != 'Windows_NT'">true</_DotNetCoreRequired>
+
+      <!-- SN is only available on Windows -->
+      <SNBinaryPath Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(NuGetPackageRoot)sn\$(SNVersion)\sn.exe</SNBinaryPath>
     </PropertyGroup>
 
     <Error Condition="'$(AllowEmptySignList)' != 'true' AND '@(ItemsToSign)' == ''" 
@@ -91,7 +94,7 @@
         LogDir="$(ArtifactsLogDir)"
         MSBuildPath="$(_DesktopMSBuildPath)"
         DotNetPath="$(_DotNetCorePath)"
-        SNBinaryPath="$(NuGetPackageRoot)sn\$(SNVersion)\sn.exe"
+        SNBinaryPath="$(SNBinaryPath)"
         MicroBuildCorePath="$(NuGetPackageRoot)microbuild.core\$(MicroBuildCoreVersion)"
         WixToolsPath="$(WixInstallPath)"
         TarToolPath="$(NuGetPackageRoot)microsoft.dotnet.tar\$(MicrosoftDotNetSignToolVersion)\tools\net9.0\any\Microsoft.Dotnet.Tar.dll"

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -41,7 +41,8 @@
     <StrongNameSignInfo Include="SilverlightCert121" PublicKeyToken="7cec85d7bea7798e" CertificateName="Microsoft400" />
     <StrongNameSignInfo Include="StrongName" PublicKeyToken="b77a5c561934e089" CertificateName="Microsoft400" />
     <StrongNameSignInfo Include="StrongName" PublicKeyToken="b03f5f7f11d50a3a" CertificateName="Microsoft400" />
-    <StrongNameSignInfo Include="$(MSBuildThisFileDirectory)snk\Open.snk" PublicKeyToken="cc7b13ffcd2ddd51" CertificateName="Microsoft400" />
+    <!-- Do not include specific key files if full assembly signing is not supported, as they will not be usable when we sign. -->
+    <StrongNameSignInfo Include="$(MSBuildThisFileDirectory)snk\Open.snk" PublicKeyToken="cc7b13ffcd2ddd51" CertificateName="Microsoft400" Condition="'$(FullAssemblySigningSupported)' != 'false'" />
 
     <!--
       Map of file extensions to default certificate name. Files with these extensions are

--- a/src/Microsoft.DotNet.SignTool.Tests/FakeSignTool.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/FakeSignTool.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.IO.Packaging;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using System.Collections.Generic;
 
 namespace Microsoft.DotNet.SignTool
 {
@@ -22,6 +23,8 @@ namespace Microsoft.DotNet.SignTool
         public override void RemovePublicSign(string assemblyPath)
         {
         }
+
+        public override bool LocalStrongNameSign(IBuildEngine buildEngine, int round, IEnumerable<FileSignInfo> files) => true;
 
         public override bool VerifySignedPEFile(Stream stream)
         {

--- a/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
+using System.Collections.Generic;
 
 namespace Microsoft.DotNet.SignTool
 {
@@ -141,6 +142,19 @@ namespace Microsoft.DotNet.SignTool
         public override bool VerifySignedVSIXFileMarker(string filePath)
         {
             return VerifySignatures.VerifySignedVSIXByFileMarker(filePath);
+        }
+        
+        public override bool LocalStrongNameSign(IBuildEngine buildEngine, int round, IEnumerable<FileSignInfo> files)
+        {
+            foreach (var file in files)
+            {
+                if (file.SignInfo.ShouldLocallyStrongNameSign)
+                {
+                    return LocalStrongNameSign(file);
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -226,17 +226,6 @@ namespace Microsoft.DotNet.SignTool
                     Log.LogError($"An incorrect full path to 'sn.exe' was specified: {SNBinaryPath}");
                     return;
                 }
-
-                var strongNameLocally = StrongNameSignInfo != null
-                    && StrongNameSignInfo
-                        .Where(ti => !string.IsNullOrEmpty(ti.ItemSpec) && ti.ItemSpec.EndsWith(".snk", StringComparison.OrdinalIgnoreCase))
-                        .Any();
-
-                if (!isValidSNPath && strongNameLocally)
-                {
-                    Log.LogError($"An incorrect full path to 'sn.exe' was specified: {SNBinaryPath}");
-                    return;
-                }
             }
             if(WixToolsPath != null && !Directory.Exists(WixToolsPath))
             {


### PR DESCRIPTION
A few tweaks to the signing infrastructure to enable unified build's signing. The desired state is that we can enable real and dry-run signing across all platforms. The primary challenge is dry run signing. When downstream repos ingest upstream binaries, they will be unsigned, so we will try and 'sign' them again. This is expected and essentially what happens with our CI builds in non-signed cases these days. In some cases, these signing operations may include using the checked in Open.snk to sign the binary. On Windows, this works fine, on Mac, not so much, since sn.exe is a native Windows binary.

The reason this is not a 'real' issue is that in real signing cases, upstream repos would have used the compiler to the sign the binary, not sn.exe. And the binary would have been authenticode signed. So we should really never have to use sn.exe at all on Windows or non-Windows.

Therefore, the following tweaks are added to the signing infra for the purpose of real and dry run signing:
- Do not pass the path to sn.exe to SignTool on non-Windows. If it's ever actually needed, it will throw an error.
- StrongNameSignInfo should not include Open.snk if full assembly signing isn't supported. Tnis is needed to match the behavior in StrongName.targets today. If FullAssemblySigningSupported is false, public sign is used and a new key should not be added. This probably doesn't affect much. Our distro partners, who use this switch, do not typically pass -sign.
- Move LocalStrongNameSign so that it is implemented as a no-op in dry-run modes on non-Windows.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
