### PR TITLE
Fix FailOnceThenPass test on Unix in Microsoft.DotNet.Helix.Sdk.Tests

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelpersTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelpersTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         [Fact]
         public void FailOnceThenPass()
         {
-            string target = Path.Combine(Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") ?? Environment.GetEnvironmentVariable("TEMP"), "my-test-file-123456.snt");
+            string target = Path.Combine(Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") ?? Environment.GetEnvironmentVariable("TEMP") ?? Environment.GetEnvironmentVariable("TMPDIR"), "my-test-file-123456.snt");
 
             // If we're inside a Helix Docker work item, GetTempPath() is cleaned every execution, 
             // but the work item's own directory is not (and is writeable from inside Docker), so use it.


### PR DESCRIPTION
When running outside of Helix the test tries to use the `TEMP` environment variable, but that is Windows specific, Unix uses `TMPDIR`.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
