### PR TITLE
Upgrade STJ to 8.0.4 on .NET Framework

### DIFF
--- a/eng/BuildTask.Packages.props
+++ b/eng/BuildTask.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Update="System.Reflection.MetadataLoadContext" Version="8.0.0" />
     <PackageVersion Update="System.Resources.Extensions" Version="8.0.0" />
     <PackageVersion Update="System.Text.Encodings.Web" Version="8.0.0" />
-    <PackageVersion Update="System.Text.Json" Version="8.0.3" />
+    <PackageVersion Update="System.Text.Json" Version="8.0.4" />
     <PackageVersion Update="System.Threading.Tasks.Dataflow" Version="8.0.0" />
 
     <!-- Packages that transitively bring above dependencies in. -->
@@ -18,9 +18,8 @@
     <PackageVersion Update="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
   </ItemGroup>
 
-  <!-- Suppress System.Text.Json/8.0.0 and 8.0.4 advisories as desktop msbuild doesn't yet provide binding redirects for the non-vulnerable version (8.0.5). -->
+  <!-- Suppress System.Text.Json/8.0.4 advisory as desktop msbuild doesn't yet provide binding redirects for the non-vulnerable version (8.0.5). -->
   <ItemGroup>
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-hh2w-p6rv-4g7w" />
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-8g4q-xg66-9fp4" />
   </ItemGroup>
 


### PR DESCRIPTION
We should already be using a desktop msbuild with the updated binding redirects in CI. The binding redirect entry for 8.0.4 got added in July: https://github.com/dotnet/msbuild/commit/7500f064233494f673100e3c1d260006792cf9c6

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
