### PR TITLE
Don't allow empty repo builds when DotNetBuildPass > 1

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -95,7 +95,7 @@
   </ItemGroup>
 
   <Target Name="Execute">
-    <Error Text="No projects were found to build. Either the 'Projects' property or 'ProjectToBuild' item group must be specified." Condition="'@(ProjectToBuild)' == '' and '$(_DotNetBuildPassNormalized)' != '1'"/>
+    <Error Text="No projects were found to build. Either the 'Projects' property or 'ProjectToBuild' item group must be specified." Condition="'@(ProjectToBuild)' == ''"/>
     <Error Text="Property 'RepoRoot' must be specified" Condition="'$(RepoRoot)' == ''"/>
     <Error Text="File 'global.json' must exist in directory specified by RepoRoot: '$(RepoRoot)'" Condition="'$(RepoRoot)' != '' and !Exists('$(RepoRoot)global.json')"/>
 


### PR DESCRIPTION
We explicitly don't want empty repo builds and are changing the VMR orchestrator infra in https://github.com/dotnet/sdk/pull/44153 to not trigger such repo builds.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
