### PR TITLE
Add support for a custom package summary and description

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
@@ -523,7 +523,8 @@
       <!-- Linux packaging requires 'amd64' for x64 packages -->
       <LinuxPackageArchitecture Condition="'$(LinuxPackageArchitecture)' == 'x64'">amd64</LinuxPackageArchitecture>
       <_PackageCopyright>2017 Microsoft</_PackageCopyright>
-      <_PackageLongDescription>.NET is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform and is supported by Microsoft. We hope you enjoy using it! If you do, please consider joining the active community of developers that are contributing to the project on GitHub (https://github.com/dotnet/core). We happily accept issues and PRs.</_PackageLongDescription>
+      <_PackageLongDescription Condition="'$(PackageDescription)' != ''">$(PackageDescription)</_PackageLongDescription>
+      <_PackageLongDescription Condition="'$(_PackageLongDescription)' != ''">.NET is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform and is supported by Microsoft. We hope you enjoy using it! If you do, please consider joining the active community of developers that are contributing to the project on GitHub (https://github.com/dotnet/core). We happily accept issues and PRs.</_PackageLongDescription>
     </PropertyGroup>
 
     <ItemGroup>
@@ -551,8 +552,9 @@
     </GenerateJsonObjectString>
 
     <PropertyGroup>
-      <_ShortDescription>$(MSBuildProjectName) $(InstallerPackageVersion)</_ShortDescription>
-      <_ShortDescription Condition="'$(UseBrandingNameInLinuxPackageDescription)' == 'true'">$(ProductBrandName)</_ShortDescription>
+      <_ShortDescription Condition="'$(PackageSummary)' != ''">$(PackageSummary)</_ShortDescription>
+      <_ShortDescription Condition="'$(PackageSummary)' == ''">$(MSBuildProjectName) $(InstallerPackageVersion)</_ShortDescription>
+      <_ShortDescription Condition="'$(PackageSummary)' == '' and '$(UseBrandingNameInLinuxPackageDescription)' == 'true'">$(ProductBrandName)</_ShortDescription>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
@@ -524,7 +524,7 @@
       <LinuxPackageArchitecture Condition="'$(LinuxPackageArchitecture)' == 'x64'">amd64</LinuxPackageArchitecture>
       <_PackageCopyright>2017 Microsoft</_PackageCopyright>
       <_PackageLongDescription Condition="'$(PackageDescription)' != ''">$(PackageDescription)</_PackageLongDescription>
-      <_PackageLongDescription Condition="'$(_PackageLongDescription)' != ''">.NET is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform and is supported by Microsoft. We hope you enjoy using it! If you do, please consider joining the active community of developers that are contributing to the project on GitHub (https://github.com/dotnet/core). We happily accept issues and PRs.</_PackageLongDescription>
+      <_PackageLongDescription Condition="'$(_PackageLongDescription)' == ''">.NET is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform and is supported by Microsoft. We hope you enjoy using it! If you do, please consider joining the active community of developers that are contributing to the project on GitHub (https://github.com/dotnet/core). We happily accept issues and PRs.</_PackageLongDescription>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This is required to maintain the existing package metadata for ASP.NET Core installers.