### PR TITLE
Update backport-base.yml to quote branch names

### DIFF
--- a/.github/workflows/backport-base.yml
+++ b/.github/workflows/backport-base.yml
@@ -64,7 +64,7 @@ jobs:
       with:
         script: |
           const target_branch = '${{ steps.target-branch-extractor.outputs.result }}';
-          const backport_start_body = `Started backporting to _${target_branch}_": https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+          const backport_start_body = `Started backporting to _${target_branch}_: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
           await github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,

--- a/.github/workflows/backport-base.yml
+++ b/.github/workflows/backport-base.yml
@@ -102,7 +102,7 @@ jobs:
               throw new Error(`Error: @${comment_user} is not a repo collaborator, backporting is not allowed. If you're a collaborator please make sure your ${repo_owner} team membership visibility is set to Public on https://github.com/orgs/${repo_owner}/people?query=${comment_user}`);
             }
 
-            try { await exec.exec(`git ls-remote --exit-code --heads origin ${target_branch}`) } catch { throw new Error(`Error: The specified backport target branch ${target_branch} wasn't found in the repo.`); }
+            try { await exec.exec(`git ls-remote --exit-code --heads origin ${target_branch}`) } catch { throw new Error(`Error: The specified backport target branch "${target_branch}" wasn't found in the repo.`); }
             console.log(`Backport target branch: ${target_branch}`);
 
             console.log("Applying backport patch");
@@ -145,7 +145,7 @@ jobs:
             }
 
             if (git_am_failed) {
-              const git_am_failed_body = `@${context.payload.comment.user.login} backporting to ${target_branch} failed, the patch most likely resulted in conflicts:\n\n\`\`\`shell\n${git_am_output}\n\`\`\`\n\nPlease backport manually!`;
+              const git_am_failed_body = `@${context.payload.comment.user.login} backporting to "${target_branch}" failed, the patch most likely resulted in conflicts:\n\n\`\`\`shell\n${git_am_output}\n\`\`\`\n\nPlease backport manually!`;
               await github.rest.issues.createComment({
                 owner: repo_owner,
                 repo: repo_name,
@@ -201,7 +201,7 @@ jobs:
             core.setFailed(error);
 
             // post failure to GitHub comment
-            const unknown_error_body = `@${comment_user} an error occurred while backporting to ${target_branch}, please check the run log for details!\n\n${error.message}`;
+            const unknown_error_body = `@${comment_user} an error occurred while backporting to "${target_branch}", please check the run log for details!\n\n${error.message}`;
             await github.rest.issues.createComment({
               owner: repo_owner,
               repo: repo_name,

--- a/.github/workflows/backport-base.yml
+++ b/.github/workflows/backport-base.yml
@@ -64,7 +64,7 @@ jobs:
       with:
         script: |
           const target_branch = '${{ steps.target-branch-extractor.outputs.result }}';
-          const backport_start_body = `Started backporting to ${target_branch}: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+          const backport_start_body = `Started backporting to _${target_branch}_": https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
           await github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,


### PR DESCRIPTION
It's kind of hard to see the branch name in question in the error when you typo a branch name: 

![image](https://github.com/user-attachments/assets/bab9f896-3434-4c39-abc7-2fbd2ef23508)

So if we quote the branch names being used instead in the error messages, that might be a more clear signal?

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
