### PR TITLE
Actually write the .version file when publishing a runtime pack to disk

### DIFF
--- a/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -582,7 +582,7 @@
     </ItemGroup>
     <ItemGroup Condition="'$(PlatformPackageType)' == 'RuntimePack'">
       <FilesToPublish Include="@(_PackagedFilesToPublish)"
-                       Condition="$([System.String]::new('%(_PackagedFilesToPublish.TargetPath)').StartsWith('runtimes/'))"
+                       Condition="$([System.String]::new('%(_PackagedFilesToPublish.TargetPath)').StartsWith('runtimes/')) or '%(_PackagedFilesToPublish.PublishOnly)' == 'true'"
                        TargetPath="shared/$(SharedFrameworkName)/$(Version)/" />
     </ItemGroup>
     <ItemGroup Condition="'$(PlatformPackageType)' == 'TargetingPack' or '$(PlatformPackageType)' == 'AppHostPack'">


### PR DESCRIPTION
We weren't actually publishing the `.version` file to disk. Existing users have their own implementation here that kicks in, so that's how we haven't noticed.

Discovered in https://github.com/dotnet/aspnetcore/pull/58612