### PR TITLE
Reference Roslyn ref assemblies when available when building a targeting pack

### DIFF
--- a/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -100,6 +100,7 @@
                             ResolveFrameworkReferences;
                             ResolveLockFileCopyLocalFiles;
                             ResolveReferences;
+                            FindReferenceAssembliesForReferences;
                             _ReadyToRunSharedFramework;
                             _FindSymbolFilesForSharedFrameworkFiles"
           Returns="@(FilesToPackage)">
@@ -122,7 +123,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(PlatformPackageType)' == 'TargetingPack'">
-      <FilesToPackage Include="@(ReferencePath)" Condition="'%(ReferencePath.FrameworkReferenceName)' == ''">
+      <FilesToPackage Include="@(ReferencePath->Metadata('ReferenceAssembly'))" Condition="'%(ReferencePath.FrameworkReferenceName)' == ''">
         <TargetPath>ref/$(TargetFramework)</TargetPath>
       </FilesToPackage>
 

--- a/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -123,12 +123,18 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(PlatformPackageType)' == 'TargetingPack'">
+      <!-- include all doc files from explicitly added files to package -->
+      <DocFilesToPackage Include="%(FilesToPackage.RootDir)%(FilesToPackage.Directory)**\%(FilesToPackage.FileName).xml" />
+
       <FilesToPackage Include="@(ReferencePath->Metadata('ReferenceAssembly'))" Condition="'%(ReferencePath.FrameworkReferenceName)' == ''">
         <TargetPath>ref/$(TargetFramework)</TargetPath>
       </FilesToPackage>
 
-      <!-- include all doc files -->
-      <DocFilesToPackage Include="%(FilesToPackage.RootDir)%(FilesToPackage.Directory)**\%(FilesToPackage.FileName).xml" />
+      <!--
+        Include all doc files from referenced assemblies.
+        We need to do this separately as the Roslyn-generated ref assembly is in the wrong folder, so we wouldn't find doc files in that case.
+      -->
+      <DocFilesToPackage Include="%(ReferencePath.RootDir)%(ReferencePath.Directory)**\%(ReferencePath.FileName).xml" />
 
       <FilesToPackage Include="@(DocFilesToPackage)">
         <TargetPath>ref/$(TargetFramework)/%(RecursiveDir)</TargetPath>


### PR DESCRIPTION
This enables projects like ASP.NET Core to use Roslyn-based ref assemblies in their ref pack instead of explicitly defined ref assemblies (as done in dotnet/runtime).

Contributes to https://github.com/dotnet/aspnetcore/pull/58612