### PR TITLE
Add the ConflictVersion table to the RPM headers

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/RpmBuilder.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/RpmBuilder.cs
@@ -171,6 +171,7 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
             {
                 entries.Add(new(RpmHeaderTag.ConflictName, RpmHeaderEntryType.StringArray, _conflicts.ToArray()));
                 entries.Add(new(RpmHeaderTag.ConflictFlags, RpmHeaderEntryType.Int32, _conflicts.Select(_ => 0).ToArray()));
+                entries.Add(new(RpmHeaderTag.ConflictVersion, RpmHeaderEntryType.StringArray, _conflicts.Select(_ => "").ToArray()));
             }
             if (_requires.Count != 0)
             {


### PR DESCRIPTION
This table was missing and was causing errors.