### PR TITLE
Update Workarounds.targets because of 10.0 SDK change

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -197,7 +197,7 @@
 <![CDATA[
 try
 {
-    System.Reflection.Assembly.LoadFrom(@"$(MicrosoftNETBuildTasksDirectoryRoot)\..\..\..\DotnetTools\dotnet-format\BuildHost-net472\System.Text.Json.dll");
+    System.Reflection.Assembly.LoadFrom(@"$(MicrosoftNETBuildTasksDirectoryRoot)\..\..\..\Sdks\Microsoft.NET.Sdk.StaticWebAssets\tasks\net472\System.Text.Json.dll");
 }
 catch
 {


### PR DESCRIPTION
With a 10.0.100 SDK, dotnet-watch doesn't have net472 8.0.0.4 STJ assembly anymore. Unfortunately we are still on old VS images :(

I double checked that this assembly already exists in a 9.0 RC2 SDK:

![image](https://github.com/user-attachments/assets/df16dd37-588d-49ab-91c8-8e3a69010ac8)

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
