### PR TITLE
Pack the console runner output in the subpath that the props file expects it to be in.

### DIFF
--- a/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
@@ -42,7 +42,7 @@
   <Target Name="_AddBuildOutputToPackage" DependsOnTargets="Publish">
     <ItemGroup>
       <TfmSpecificPackageFile Include="$(PublishDir)**" 
-                              PackagePath="tools/$(TargetFramework)/%(RecursiveDir)%(FileName)%(Extension)"/>
+                              PackagePath="tools/net/%(RecursiveDir)%(FileName)%(Extension)"/>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Unblocks injestion in dotnet/runtime.