### PR TITLE
Check for aarch64 instead of arm64 in CreateRpmPackage

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateRpmPackage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateRpmPackage.cs
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.Build.Tasks.Installers.src
                 "x86" => Architecture.X86,
                 "x64" => Architecture.X64,
                 "arm" => Architecture.Arm,
-                "arm64" => Architecture.Arm64,
+                "aarch64" => Architecture.Arm64,
 #if NET
                 "armv6" => Architecture.Armv6,
                 "s390x" => Architecture.S390x,


### PR DESCRIPTION
Fixes building RPM packages for ARM64

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
