### PR TITLE
Add cpio in native dependencies script

### DIFF
--- a/eng/common/native/install-dependencies.sh
+++ b/eng/common/native/install-dependencies.sh
@@ -51,7 +51,6 @@ brew "openssl@3"
 brew "pkg-config"
 brew "python3"
 brew "pigz"
-brew "cpio"
 EOF
         ;;
 

--- a/eng/common/native/install-dependencies.sh
+++ b/eng/common/native/install-dependencies.sh
@@ -24,13 +24,13 @@ case "$os" in
             apt update
 
             apt install -y build-essential gettext locales cmake llvm clang lld lldb liblldb-dev libunwind8-dev libicu-dev liblttng-ust-dev \
-                libssl-dev libkrb5-dev zlib1g-dev pigz
+                libssl-dev libkrb5-dev zlib1g-dev pigz cpio
 
             localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
         elif [ "$ID" = "fedora" ]; then
-            dnf install -y cmake llvm lld lldb clang python curl libicu-devel openssl-devel krb5-devel zlib-devel lttng-ust-devel pigz
+            dnf install -y cmake llvm lld lldb clang python curl libicu-devel openssl-devel krb5-devel zlib-devel lttng-ust-devel pigz cpio
         elif [ "$ID" = "alpine" ]; then
-            apk add build-base cmake bash curl clang llvm-dev lld lldb krb5-dev lttng-ust-dev icu-dev zlib-dev openssl-dev pigz
+            apk add build-base cmake bash curl clang llvm-dev lld lldb krb5-dev lttng-ust-dev icu-dev zlib-dev openssl-dev pigz cpio
         else
             echo "Unsupported distro. distro: $ID"
             exit 1
@@ -51,6 +51,7 @@ brew "openssl@3"
 brew "pkg-config"
 brew "python3"
 brew "pigz"
+brew "cpio"
 EOF
         ;;
 


### PR DESCRIPTION
This installs cpio which is required for runtime's packs subset since https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1246.

cc @akoeplinger @ViktorHofer