### PR TITLE
Default auth use AzurePipelinesCredential only, if configured

### DIFF
--- a/src/Microsoft.DotNet.ArcadeAzureIntegration/DefaultIdentityTokenCredentialOptions.cs
+++ b/src/Microsoft.DotNet.ArcadeAzureIntegration/DefaultIdentityTokenCredentialOptions.cs
@@ -10,6 +10,7 @@ namespace Microsoft.DotNet.ArcadeAzureIntegration;
 
 public class DefaultIdentityTokenCredentialOptions
 {
+    public bool UseAzurePipelineCredentialOnlyIfConfigured { get; set; } = true;
     public string? ManagedIdentityClientId { get; set; } = null;
     public bool ExcludeAzureCliCredential { get; set; }
 }


### PR DESCRIPTION
Change the implementation of DefaultIdentityTokenCredential not to be chained Credential but dependent on configuration
- Default behavior would be to use AzureDevOpsPipelineCredential if all the required environment variables are provided