### PR TITLE
Fix .deb signature verification

### DIFF
--- a/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
+++ b/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
@@ -564,9 +564,9 @@ namespace Microsoft.DotNet.SignTool
             }
             else if (file.IsDeb())
             {
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
-                    _log.LogMessage(MessageImportance.Low, $"Skipping signature verification of {file.FullPath} on Windows.");
+                    _log.LogMessage(MessageImportance.Low, $"Skipping signature verification of {file.FullPath} on non-Linux platform.");
                 }
                 else if (!_signTool.VerifySignedDeb(log, file.FullPath))
                 {


### PR DESCRIPTION
Related to https://github.com/dotnet/arcade/issues/14432

While checking the changes in https://github.com/dotnet/arcade/pull/15216 via real signing in arcade-validation CI, I discovered that the signed `test.deb` file was being reported as "not signed" even after it had been properly signed. The changes in this PR fix this failure.

To validate these changes, I locally ran `arcade-validation# ./build.sh --sign /p:OfficialBuildId=20241111.1` with the signed `test.deb` file that I pulled from https://dev.azure.com/dnceng/internal/_build/results?buildId=2579780&view=artifacts&pathAsName=false&type=publishedArtifacts. The signing passed, with the binlog indicating that the `.deb` file was already signed:

![image](https://github.com/user-attachments/assets/d6537f57-ad32-45fc-93ab-ed75080cd0d0)



