### PR TITLE
Only invoke signing on inner repo

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -298,7 +298,7 @@
     <MSBuild Projects="Sign.proj"
              Properties="@(_CommonProps)"
              Targets="Sign"
-             Condition="'$(Sign)' == 'true'"/>
+             Condition="'$(Sign)' == 'true' and ('$(DotNetBuild)' != 'true' or '$(DotNetBuildPhase)' == 'InnerRepo')"/>
 
     <MSBuild Projects="AfterSigning.proj"
              Properties="@(_CommonProps);_NETCORE_ENGINEERING_TELEMETRY=Sign"


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
