### PR TITLE
Move IncludePreReleaseLabelInPackageVersion property evaluation out of the target

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.build.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.build.targets
@@ -37,6 +37,12 @@
     <CombinedInstallerExtension Condition="'$(TargetRuntimeOS)' != 'win'">$(InstallerExtension)</CombinedInstallerExtension>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <IncludePreReleaseLabelInPackageVersion Condition="'$(DotNetFinalVersionKind)' != 'release'">true</IncludePreReleaseLabelInPackageVersion>
+    <IncludePreReleaseLabelInPackageVersion Condition="'$(SuppressFinalPackageVersion)' == 'true'">true</IncludePreReleaseLabelInPackageVersion>
+    <IncludePreReleaseLabelInPackageVersion Condition="'$(IsShipping)' != 'true'">true</IncludePreReleaseLabelInPackageVersion>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(GenerateDeb)' == 'true'">
     <InstallerPackageVersion Condition="'$(IncludePreReleaseLabelInPackageVersion)' == 'true'">$(VersionPrefix)~$(VersionSuffix)</InstallerPackageVersion>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.targets
@@ -84,15 +84,7 @@
     <_GlobalPropertiesToRemoveForPublish Include="$(_GlobalPropertiesToRemoveForPublish)" />
   </ItemGroup>
 
-  <Target Name="_GetVersionInfo">
-    <PropertyGroup>
-      <IncludePreReleaseLabelInPackageVersion Condition="'$(DotNetFinalVersionKind)' != 'release'">true</IncludePreReleaseLabelInPackageVersion>
-      <IncludePreReleaseLabelInPackageVersion Condition="'$(SuppressFinalPackageVersion)' == 'true'">true</IncludePreReleaseLabelInPackageVersion>
-      <IncludePreReleaseLabelInPackageVersion Condition="'$(IsShipping)' != 'true'">true</IncludePreReleaseLabelInPackageVersion>
-    </PropertyGroup>
-  </Target>
-
-  <Target Name="_GetProductBrandName" DependsOnTargets="_GetVersionInfo">
+  <Target Name="_GetProductBrandName">
     <PropertyGroup
       Condition="
         '$(ReleaseBrandSuffix)' == '' and


### PR DESCRIPTION
Fixes regression introduced with https://github.com/dotnet/arcade/pull/15239

This change is not yet consumed by `runtime` repo, but I have reproed the issue in local build.

Package version is missing the prerelease part of the version. This is a result of property evaluation order. `IncludePreReleaseLabelInPackageVersion` property needs to be evaluated before it is used.

I've tested the fix locally in `runtime` build and also in my pending work to enable new installer infra in `sdk` build.
