### PR TITLE
Temporarily uninstall pkg-config@0.29.2 in install-dependencies.sh

### DIFF
--- a/eng/common/native/install-dependencies.sh
+++ b/eng/common/native/install-dependencies.sh
@@ -44,6 +44,10 @@ case "$os" in
         export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
         # Skip brew update for now, see https://github.com/actions/setup-python/issues/577
         # brew update --preinstall
+
+        # Temporarily uninstall pkg-config@0.29.2 to work around https://github.com/actions/runner-images/issues/10984
+        brew uninstall --ignore-dependencies --force pkg-config@0.29.2
+
         brew bundle --no-upgrade --no-lock --file=- <<EOF
 brew "cmake"
 brew "icu4c"


### PR DESCRIPTION
This was added by AzDO in https://github.com/actions/runner-images/pull/10971 as a workaround for https://github.com/actions/runner-images/issues/10984, but that means the old package now conflicts with the new pkg-config which is an alias to pkgconf.

Fixes the build issues we've seen with OSX image version 20241119.505

Port of https://github.com/dotnet/runtime/pull/109968 to arcade