### PR TITLE
Use .snk file in StrongNameSignInfo example

### DIFF
--- a/Documentation/CorePackages/Signing.md
+++ b/Documentation/CorePackages/Signing.md
@@ -100,11 +100,11 @@ The [default configuration](../../src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.pro
 
 #### 2. Use a different certificate for an specific Public Key Token
 
-If you repo have signable files that have a different Public Key Token than the one preconfigured in the SDK (i.e., `31bf3856ad364e35`) you might add an entry to `StrongNameSignInfo` to specify the certificate name that should be used for those files. To do that, place an entry like the one show below in your `eng\Signing.props` file.
+If your repo has signable files that have a different Public Key Token than the one preconfigured in the SDK (i.e., `31bf3856ad364e35`) you might add an entry to `StrongNameSignInfo` to specify the certificate name that should be used for those files. To do that, place an entry like the one show below in your `eng\Signing.props` file.
 
 ```xml
 <ItemGroup>
-	<StrongNameSignInfo Include="StrongName1" PublicKeyToken="4321abcda1b2c3d4" CertificateName="DifferentCertName" />
+	<StrongNameSignInfo Include="(MSBuildThisFileDirectory)..\StrongName1.snk" PublicKeyToken="4321abcda1b2c3d4" CertificateName="DifferentCertName" />
 </ItemGroup>
 ```
 


### PR DESCRIPTION
When trying to figure out custom strong name signing (https://github.com/dotnet/cecil/pull/227), we thought the StrongNameSignInfo ItemSpec just needed to be a unique name, but it failed signing until we changed it to point to a `.snk` file. I wanted to double check that this is the correct usage and update the documentation to be more clear if so.
