### PR TITLE
Revert tar.gz unpack/repack but support parsing of .tar.gz FileExtensionSignInfo

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -41,7 +41,6 @@
     <FileExtensionSignInfo Include=".vsix" CertificateName="VsixSHA2" />
     <FileExtensionSignInfo Include=".zip" CertificateName="None" />
     <FileExtensionSignInfo Include=".tgz" CertificateName="None" />
-    <FileExtensionSignInfo Include=".tar.gz" CertificateName="None" />
   </ItemGroup>
 
   <!-- The name of the .NET specific certificate, which is a general replacement for Microsoft400

--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -1822,6 +1822,19 @@ $@"
             runTask(fileExtensionSignInfo: fileExtensionSignInfo.ToArray()).Should().BeTrue();
         }
 
+        [Fact]
+        public void ValidateParseFileExtensionEntriesForTarGzExtensionPasses()
+        {
+            var fileExtensionSignInfo = new List<ITaskItem>();
+
+            fileExtensionSignInfo.Add(new TaskItem(".tar.gz", new Dictionary<string, string>
+            {
+                { "CertificateName", "None" }
+            }));
+
+            runTask(fileExtensionSignInfo: fileExtensionSignInfo.ToArray()).Should().BeTrue();
+        }
+
         // Given:
         // - "SameFiles1.zip" contains "Simple1.exe" and "Simple2.exe"
         // - "SameFiles2.zip" contains "Simple1.exe"

--- a/src/Microsoft.DotNet.SignTool/src/FileSignInfo.cs
+++ b/src/Microsoft.DotNet.SignTool/src/FileSignInfo.cs
@@ -40,9 +40,7 @@ namespace Microsoft.DotNet.SignTool
             => Path.GetExtension(path).Equals(".zip", StringComparison.OrdinalIgnoreCase);
 
         internal static bool IsTarGZip(string path)
-            => Path.GetExtension(path).Equals(".tgz", StringComparison.OrdinalIgnoreCase)
-                || (Path.GetExtension(path).Equals(".gz", StringComparison.OrdinalIgnoreCase)
-                    && Path.GetExtension(Path.GetFileNameWithoutExtension(path)).Equals(".tar", StringComparison.OrdinalIgnoreCase));
+            => Path.GetExtension(path).EndsWith(".tgz", StringComparison.OrdinalIgnoreCase);
 
         internal static bool IsWix(string path)
             => (Path.GetExtension(path).Equals(".msi", StringComparison.OrdinalIgnoreCase)

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -372,9 +372,7 @@ namespace Microsoft.DotNet.SignTool
                     var certificate = item.GetMetadata("CertificateName");
                     var collisionPriorityId = item.GetMetadata(SignToolConstants.CollisionPriorityId);
 
-                    // Path.GetExtension will return .gz for .tar.gz files, so we need to handle that case separately
-                    var actualExtension = extension.Equals(".tar.gz", StringComparison.OrdinalIgnoreCase) ? ".tar.gz" : Path.GetExtension(extension);
-                    if (!extension.Equals(actualExtension))
+                    if (!extension.Equals(Path.GetExtension(extension)))
                     {
                         Log.LogError($"Value of {nameof(FileExtensionSignInfo)} is invalid: '{extension}'");
                         continue;

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -360,6 +360,11 @@ namespace Microsoft.DotNet.SignTool
             }
         }
 
+        private readonly HashSet<string> specialExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ".tar.gz"
+        };
+
         private Dictionary<string, List<SignInfo>> ParseFileExtensionSignInfo()
         {
             var map = new Dictionary<string, List<SignInfo>>(StringComparer.OrdinalIgnoreCase);
@@ -372,7 +377,8 @@ namespace Microsoft.DotNet.SignTool
                     var certificate = item.GetMetadata("CertificateName");
                     var collisionPriorityId = item.GetMetadata(SignToolConstants.CollisionPriorityId);
 
-                    if (!extension.Equals(Path.GetExtension(extension)))
+                    // Some supported extensions have multiple dots. Special case these so that we don't throw an error below.
+                    if (!extension.Equals(Path.GetExtension(extension)) && !specialExtensions.Contains(extension))
                     {
                         Log.LogError($"Value of {nameof(FileExtensionSignInfo)} is invalid: '{extension}'");
                         continue;

--- a/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/SigningInformationParsingExtensions.cs
+++ b/src/Microsoft.DotNet.VersionTools/lib/src/BuildManifest/Model/SigningInformationParsingExtensions.cs
@@ -38,8 +38,7 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
                     throw new ArgumentException($"Value of FileExtensionSignInfo 'Include' is invalid, must be non-empty.");
                 }
 
-                string extension = signInfo.Include.Equals(".tar.gz", StringComparison.OrdinalIgnoreCase) ? ".tar.gz" : Path.GetExtension(signInfo.Include);
-                if (!signInfo.Include.Equals(extension))
+                if (!signInfo.Include.Equals(Path.GetExtension(signInfo.Include)))
                 {
                     throw new ArgumentException($"Value of FileExtensionSignInfo Include is invalid: '{signInfo.Include}' is not returned by Path.GetExtension('{signInfo.Include}')");
                 }


### PR DESCRIPTION
This avoids introduce unexpected new changes into servicing arcade, but allows newer manifests to be read by staging.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
