### PR TITLE
Remove prebuilt report from intermediate packages

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -34,7 +34,6 @@
     <CurrentRepoSourceBuildSourceDir>$([MSBuild]::NormalizeDirectory('$(SourceBuildOutputDir)', 'src'))</CurrentRepoSourceBuildSourceDir>
     <CurrentRepoSourceBuildSourceDir Condition="'$(UseInnerClone)' != 'true'">$(RepoRoot)</CurrentRepoSourceBuildSourceDir>
     <CurrentRepoSourceBuildPackageCache>$([MSBuild]::NormalizeDirectory('$(SourceBuildOutputDir)', 'package-cache'))</CurrentRepoSourceBuildPackageCache>
-    <SourceBuildSelfPrebuiltReportDir>$([MSBuild]::NormalizeDirectory('$(SourceBuildOutputDir)', 'prebuilt-report'))</SourceBuildSelfPrebuiltReportDir>
 
     <!--
       Keep artifacts/ inside source dir so that ancestor-based file lookups find the inner repo, not
@@ -123,9 +122,6 @@
     
     <ItemGroup>
       <IntermediateNupkgFile Include="@(IntermediateNupkgArtifactFile)" PackagePath="artifacts" />
-
-      <!-- Report goes into the 'main' intermediate nupkg, if we're creating it. -->
-      <IntermediateNupkgFile Condition="'$(CreateIntermediatePackage)' == 'true'" Include="$(SourceBuildSelfPrebuiltReportDir)**\*" PackagePath="prebuilt-report" />
     </ItemGroup>
 
     <RemoveDuplicates Inputs="@(IntermediateNupkgFile)">


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/3931

The prebuilt report will be stored as pipeline artifacts with https://github.com/dotnet/dotnet/blob/main/repo-projects/Directory.Build.targets#L592-L594 in VMR.

It's no need to include prebuilt report in repo's intermediate package.