### PR TITLE
Limited the UpToDateCheckInput/Output to a set

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.VsixBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.VsixBuild.targets
@@ -287,25 +287,14 @@
 
   <Target Name="CollectVsixUpToDateCheckInput" DependsOnTargets="GetVsixSourceItems;FindSourceVsixManifest">
     <ItemGroup Condition="$(CreateVsixContainer)">
-      <_InputVSIXSourceItem Include="@(VSIXSourceItem)" />
-      <_InputVSIXSourceItem Remove="@(IntermediateAssembly)" />
-      <_InputVSIXSourceItem Remove="@(AddModules)" />
-      <_InputVSIXSourceItem Remove="$(IntermediateOutputPath)$(_SGenDllName)" />
-      <_InputVSIXSourceItem Remove="@(_DebugSymbolsIntermediatePath)" />
-      <_InputVSIXSourceItem Remove="@(DocFileItem)" />
-      <_InputVSIXSourceItem Remove="@(SatelliteDllsProjectOutputGroupOutput->'%(FinalOutputPath)')" />
-      <_InputVSIXSourceItem Remove="@(SatelliteDllsProjectOutputGroupOutput)" />
-      <_InputVSIXSourceItem Remove="$(IntermediateOutputPath)$(TargetName).pkgdef" />
-      <_InputVSIXSourceItem Remove="@(_GeneratedExtensionJson)" />
-
-      <UpToDateCheckInput Include="@(_InputVSIXSourceItem)" />
-      <UpToDateCheckInput Include="@(SourceVsixManifest)" />
+      <UpToDateCheckInput Include="@(VSIXSourceItem)" Set="VSIXSet"/>
+      <UpToDateCheckInput Include="@(SourceVsixManifest)" Set="VSIXSet" />
     </ItemGroup>
   </Target>
 
   <Target Name="CollectVsixUpToDateCheckBuilt">
     <ItemGroup Condition="$(CreateVsixContainer)">
-      <UpToDateCheckBuilt Include="$(TargetVsixContainer)" />
+      <UpToDateCheckOutput Include="$(TargetVsixContainer)" Set="VSIXSet"/>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
In a VSIX project, it will generate 
1. VSIX
2. VSIX.dll

For UpToDateCheck, it should only check the input with the VSIX output, rather than the `VSIX.dll`.

So according to the doc: https://github.com/dotnet/project-system/blob/main/docs/up-to-date-check.md#grouping-inputs-and-outputs-into-sets
It is achievable via a Set.

Thanks for @drewnoakes for providing help!