### PR TITLE
Ensure we rewrite all entries, even if not signed

### DIFF
--- a/src/Microsoft.DotNet.SignTool/src/ZipData.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ZipData.cs
@@ -338,21 +338,20 @@ namespace Microsoft.DotNet.SignTool
                     {
                         var relativeName = entry.Name;
                         var signedPart = FindNestedPart(relativeName);
-                        if (!signedPart.HasValue)
+
+                        if (signedPart.HasValue)
+                        {
+                            using var signedStream = File.OpenRead(signedPart.Value.FileSignInfo.FullPath);
+                            log.LogMessage(MessageImportance.Low, $"Copying signed stream from {signedPart.Value.FileSignInfo.FullPath} to {FileSignInfo.FullPath} -> {relativeName}.");
+                            entry.DataStream = signedStream;
+                        }
+                        else
                         {
                             log.LogMessage(MessageImportance.Low, $"Didn't find signed part for nested file: {FileSignInfo.FullPath} -> {relativeName}");
-                            continue;
                         }
+                    }
 
-                        using var signedStream = File.OpenRead(signedPart.Value.FileSignInfo.FullPath);
-                        log.LogMessage(MessageImportance.Low, $"Copying signed stream from {signedPart.Value.FileSignInfo.FullPath} to {FileSignInfo.FullPath} -> {relativeName}.");
-                        entry.DataStream = signedStream;
-                        writer.WriteEntry(entry);
-                    }
-                    else
-                    {
-                        writer.WriteEntry(entry);
-                    }
+                    writer.WriteEntry(entry);
                 }
             }
 

--- a/src/Microsoft.DotNet.SignTool/src/ZipData.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ZipData.cs
@@ -344,6 +344,8 @@ namespace Microsoft.DotNet.SignTool
                             using var signedStream = File.OpenRead(signedPart.Value.FileSignInfo.FullPath);
                             log.LogMessage(MessageImportance.Low, $"Copying signed stream from {signedPart.Value.FileSignInfo.FullPath} to {FileSignInfo.FullPath} -> {relativeName}.");
                             entry.DataStream = signedStream;
+                            writer.WriteEntry(entry);
+                            continue;
                         }
                         else
                         {


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
