### PR TITLE
Revert "Temporarily uninstall pkg-config@0.29.2 in install-dependencies.sh"

### DIFF
--- a/eng/common/native/install-dependencies.sh
+++ b/eng/common/native/install-dependencies.sh
@@ -48,7 +48,7 @@ case "$os" in
 brew "cmake"
 brew "icu4c"
 brew "openssl@3"
-brew "pkg-config"
+brew "pkgconf"
 brew "python3"
 brew "pigz"
 EOF

--- a/eng/common/native/install-dependencies.sh
+++ b/eng/common/native/install-dependencies.sh
@@ -44,10 +44,6 @@ case "$os" in
         export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
         # Skip brew update for now, see https://github.com/actions/setup-python/issues/577
         # brew update --preinstall
-
-        # Temporarily uninstall pkg-config@0.29.2 to work around https://github.com/actions/runner-images/issues/10984
-        brew uninstall --ignore-dependencies --force pkg-config@0.29.2
-
         brew bundle --no-upgrade --no-lock --file=- <<EOF
 brew "cmake"
 brew "icu4c"


### PR DESCRIPTION
Reverts dotnet/arcade#15259, Azure Pipelines fixed the issue on the macOS image.