### PR TITLE
Default FullAssemblySigningSupported == false only in source-only cases

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -43,6 +43,8 @@
     <PushToLocalStorage>true</PushToLocalStorage>
   </PropertyGroup>
 
+  <!-- Required to determine whether full assembly strong name signing is supported, which may affect selection of some certificates. -->
+  <Import Project="StrongName.targets" />
   <Import Project="Sign.props" />
 
   <!-- Allow for repo specific Publish properties such as add additional files to be published -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -23,6 +23,8 @@
 
   <Import Project="$(NuGetPackageRoot)microsoft.dotnet.signtool\$(MicrosoftDotNetSignToolVersion)\build\Microsoft.DotNet.SignTool.props" />
 
+  <!-- Required to determine whether full assembly strong name signing is supported, which may affect selection of some certificates. -->
+  <Import Project="StrongName.props" />
   <Import Project="Sign.props" />
 
   <!-- Import the wix props to get the install path -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
@@ -15,8 +15,6 @@
 
     <CleanInnerSourceBuildRepoRoot Condition="'$(CleanInnerSourceBuildRepoRoot)' == ''">true</CleanInnerSourceBuildRepoRoot>
 
-    <FullAssemblySigningSupported Condition="'$(FullAssemblySigningSupported)' == ''">false</FullAssemblySigningSupported>
-
     <_DirSeparatorEscapedCharForExecArg Condition="'$(OS)' == 'Windows_NT'">\</_DirSeparatorEscapedCharForExecArg>
     <_DirSeparatorEscapedCharForExecArg Condition="'$(OS)' != 'Windows_NT'" />
   </PropertyGroup>
@@ -70,8 +68,6 @@
       <InnerBuildArgs>$(InnerBuildArgs) /p:SourceBuildOutputDir="$(SourceBuildOutputDir)$(_DirSeparatorEscapedCharForExecArg)"</InnerBuildArgs>
 
       <InnerBuildArgs Condition="'$(DotNetPackageVersionPropsPath)' != ''">$(InnerBuildArgs) /p:DotNetPackageVersionPropsPath="$(DotNetPackageVersionPropsPath)"</InnerBuildArgs>
-
-      <InnerBuildArgs>$(InnerBuildArgs) /p:FullAssemblySigningSupported=$(FullAssemblySigningSupported)</InnerBuildArgs>
 
       <!-- We need to utilize publishing to copy packages, assets and manifest to shared source-build location. -->
       <InnerBuildArgs>$(InnerBuildArgs) /p:DotNetPublishUsingPipelines=true</InnerBuildArgs>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/StrongName.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/StrongName.props
@@ -1,6 +1,7 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
+  <!-- Known public keys -->
   <PropertyGroup>
     <MicrosoftSharedPublicKey>0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9</MicrosoftSharedPublicKey>
     <MicrosoftPublicKey>002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293</MicrosoftPublicKey>
@@ -10,4 +11,17 @@
     <SilverlightPlatformPublicKey>00240000048000009400000006020000002400005253413100040000010001008d56c76f9e8649383049f383c44be0ec204181822a6c31cf5eb7ef486944d032188ea1d3920763712ccb12d75fb77e9811149e6148e5d32fbaab37611c1878ddc19e20ef135d0cb2cff2bfec3d115810c3d9069638fe4be215dbf795861920e5ab6f7db2e2ceef136ac23d5dd2bf031700aec232f6c6b1c785b4305c123b37ab</SilverlightPlatformPublicKey>
   </PropertyGroup>
 
+  <!--
+      FullAssemblySigningSupported    "false" to use public signing even when full signing is possible. This is useful
+                                      in environments where full signing is non-functional or not desired. For example,
+                                      in some Linux distributions RSA+SHA1 (required for full signing) is not
+                                      functional/available, and trying to use full signing results in the runtime
+                                      throwing an exception. For more details and an example, see
+                                      https://github.com/dotnet/runtime/issues/65874. We default to full assembly
+                                      signing not being supported in source-only modes.
+  -->
+  
+  <PropertyGroup>
+    <FullAssemblySigningSupported Condition="'$(FullAssemblySigningSupported)' == '' and '$(DotNetBuildSourceOnly)' == 'true'">false</FullAssemblySigningSupported>
+  </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/StrongName.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/StrongName.targets
@@ -9,7 +9,8 @@
                                       in some Linux distributions RSA+SHA1 (required for full signing) is not
                                       functional/available, and trying to use full signing results in the runtime
                                       throwing an exception. For more details and an example, see
-                                      https://github.com/dotnet/runtime/issues/65874.
+                                      https://github.com/dotnet/runtime/issues/65874. We default to full assembly
+                                      signing not being supported in source-only modes.
       StrongNameKeyId The id of the key used for strong name generation
 
     Writes variables:


### PR DESCRIPTION
In addition, move around how this property is set:
- Do not set the default in the build infra. Use strongname.props instead
- No need to pass this value through globally. Global properties passed through the outer build make it into the inner build
- Import strongname.props before Sign.props in Sign.proj and Publish.proj. This ensures that signing strongname settings that depend on FullAssemblySigningSupported are correct.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
