### PR TITLE
Fix incompatibility between shared .projitems and UpdateXlfOnBuild

### DIFF
--- a/src/Microsoft.DotNet.XliffTasks/build/Microsoft.DotNet.XliffTasks.targets
+++ b/src/Microsoft.DotNet.XliffTasks/build/Microsoft.DotNet.XliffTasks.targets
@@ -93,7 +93,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="GetXlfSources" Returns="@(XlfSource)" DependsOnTargets="$(GetXlfSourcesDependsOnTargets)">
+  <Target Name="GetXlfSources" Returns="@(XlfSource)" DependsOnTargets="AssignLinkMetadata;$(GetXlfSourcesDependsOnTargets)">
     <ItemGroup>
       <EmbeddedResource Update="@(EmbeddedResource)">
         <XlfInput Condition="'%(EmbeddedResource.XlfInput)' == '' and '%(EmbeddedResource.Extension)' == '.resx'">true</XlfInput>


### PR DESCRIPTION
* Shared items from .projitems projects with HasSharedItems=true property get their Link metadata assigned by AssignLinkMetadata target
* XliffTasks needs this Link metadata to work correctly
* XliffTasks had no manifested dependency on AssignLinkMetadata
* Without UpdateXlfOnBuild set, XliffTasks got lucky and ran after AssignLinkMetadata
* With UpdateXlfOnBuild, XliffTasks registers itself to do some work before BeforeBuild which causes it to run before AssignLinkMetadata, which breaks it. 

The fix here is to manifest a dependency on AssignLinkMetadata.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md

No, I have done only manual testing. Please take over this PR from me and test as appropriate. 😆

Here is the minimal repro that I used to debug this: https://github.com/nguerrera/repros/commit/392d4bb910602563cf7ddfe419ab8b1003e81049

Please make this into a test that can run automatically to prevent regression. When you run repro.cmd, it will build with and without UpdateXlfOnBuild and put binlogs and ildasmed fr resource dlls in tmp/with_update. Diff the ildasm output and you will see that without this fix, there is a bad resource name used:

``` diff
$ diff tmp\without_update\XliffResourceNames.il tmp\with_update\XliffResourceNames.il | grep .resources
< .mresource public XliffResourceNames.Test.fr.resources
> .mresource public XliffResourceNames.D_.Src.repros.OutsideXliffResourceNames.Test.fr.resources
<   // WARNING: managed resource file XliffResourceNames.Test.fr.resources created
>   // WARNING: managed resource file XliffResourceNames.D_.Src.repros.OutsideXliffResourceNames.Test.fr.resources created``
```

Fix #15296 