### PR TITLE
Fix PortableBuild comparisons

### DIFF
--- a/eng/common/core-templates/steps/source-build.yml
+++ b/eng/common/core-templates/steps/source-build.yml
@@ -1,5 +1,4 @@
 parameters:
-parameters:
   # This template adds arcade-powered source-build to CI.
 
   # This is a 'steps' template, and is intended for advanced scenarios where the existing build

--- a/eng/common/core-templates/steps/source-build.yml
+++ b/eng/common/core-templates/steps/source-build.yml
@@ -1,4 +1,5 @@
 parameters:
+parameters:
   # This template adds arcade-powered source-build to CI.
 
   # This is a 'steps' template, and is intended for advanced scenarios where the existing build
@@ -78,7 +79,7 @@ steps:
 
     portableBuildArgs=
     if [ '${{ parameters.platform.portableBuild }}' != '' ]; then
-      portableBuildArgs='/p:PortabelBuild=${{ parameters.platform.portableBuild }}'
+      portableBuildArgs='/p:PortableBuild=${{ parameters.platform.portableBuild }}'
     fi
 
     ${{ coalesce(parameters.platform.buildScript, './build.sh') }} --ci \

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.targets
@@ -122,7 +122,7 @@
     <InstallerRuntimeIdentifiers Condition="'$(InstallerRuntimeIdentifiers)' == ''">$(RuntimeIdentifiers)</InstallerRuntimeIdentifiers>
     <InstallerRuntimeIdentifier Condition="'$(InstallerRuntimeIdentifier)' == ''">$(RuntimeIdentifier)</InstallerRuntimeIdentifier>
     <!-- When building a non-portable build, BaseOS specifies a known (portable) RID that is a parent of the curent runtime identifier. -->
-    <InstallerRuntimeIdentifier Condition="'$(PortableBuild)' != 'true' and '$(BaseOS)' != '$(RuntimeIdentifier)'">$(BaseOS)</InstallerRuntimeIdentifier>
+    <InstallerRuntimeIdentifier Condition="'$(PortableBuild)' == 'false' and '$(BaseOS)' != '$(RuntimeIdentifier)'">$(BaseOS)</InstallerRuntimeIdentifier>
   </PropertyGroup>
   
   <Import Project="$(MSBuildThisFileDirectory)installer.singlerid.targets"


### PR DESCRIPTION
Compare `PortableBuild` against `false` instead of `!= true` as a build is by default portable (and we don't pass PortableBuild=true in a number of scenarios).

Also fix a typo in the source-build step script.

Contributes to unblocking https://github.com/dotnet/sdk/pull/45042

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
