### PR TITLE
Allow CreateIntermediatePackage to be overridable

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -27,7 +27,7 @@
     <UseInnerClone Condition="'$(UseInnerClone)' == '' and '$(DotNetBuildOrchestrator)' != 'true'">true</UseInnerClone>
 
     <!-- Do not create intermediate package in full product source-build. -->
-    <CreateIntermediatePackage Condition="'$(DotNetBuildOrchestrator)' != 'true'">true</CreateIntermediatePackage>
+    <CreateIntermediatePackage Condition="'$(CreateIntermediatePackage)' == '' and '$(DotNetBuildOrchestrator)' != 'true'">true</CreateIntermediatePackage>
 
     <!-- Prefer abbreviations to avoid long paths (breaks on Windows) -->
     <SourceBuildOutputDir Condition="'$(SourceBuildOutputDir)' == ''">$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'sb'))</SourceBuildOutputDir>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/4754

The `CreateIntermediatePackage` property is currently only set to `true` when doing a repo build. We need to enable it for full product source build as well, but not by default. So the property needs to allow for being overridden.