### PR TITLE
Change the package description property to InstallerPackageDescription

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.build.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.build.targets
@@ -570,7 +570,7 @@
       <!-- Linux packaging requires 'amd64' for x64 packages -->
       <LinuxPackageArchitecture Condition="'$(LinuxPackageArchitecture)' == 'x64'">amd64</LinuxPackageArchitecture>
       <_PackageCopyright>2017 Microsoft</_PackageCopyright>
-      <_PackageLongDescription Condition="'$(PackageDescription)' != ''">$(PackageDescription)</_PackageLongDescription>
+      <_PackageLongDescription Condition="'$(InstallerPackageDescription)' != ''">$(InstallerPackageDescription)</_PackageLongDescription>
       <_PackageLongDescription Condition="'$(_PackageLongDescription)' == ''">.NET is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform and is supported by Microsoft. We hope you enjoy using it! If you do, please consider joining the active community of developers that are contributing to the project on GitHub (https://github.com/dotnet/core). We happily accept issues and PRs.</_PackageLongDescription>
     </PropertyGroup>
 


### PR DESCRIPTION
PackageDescription has bad interactions with the NuGet targets. Use a different name that's just for installers.