### PR TITLE
Don't assume that BaseOS has a value

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.targets
@@ -121,8 +121,8 @@
   <PropertyGroup>
     <InstallerRuntimeIdentifiers Condition="'$(InstallerRuntimeIdentifiers)' == ''">$(RuntimeIdentifiers)</InstallerRuntimeIdentifiers>
     <InstallerRuntimeIdentifier Condition="'$(InstallerRuntimeIdentifier)' == ''">$(RuntimeIdentifier)</InstallerRuntimeIdentifier>
-    <!-- When building a non-portable build, BaseOS specifies a known (portable) RID that is a parent of the curent runtime identifier. -->
-    <InstallerRuntimeIdentifier Condition="'$(PortableBuild)' == 'false' and '$(BaseOS)' != '$(RuntimeIdentifier)'">$(BaseOS)</InstallerRuntimeIdentifier>
+    <!-- When building a non-portable build, BaseOS can specify a known (portable) RID that is a parent of the curent runtime identifier. -->
+    <InstallerRuntimeIdentifier Condition="'$(PortableBuild)' == 'false' and '$(BaseOS)' != '' and '$(BaseOS)' != '$(RuntimeIdentifier)'">$(BaseOS)</InstallerRuntimeIdentifier>
   </PropertyGroup>
   
   <Import Project="$(MSBuildThisFileDirectory)installer.singlerid.targets"


### PR DESCRIPTION
Sometimes we can end up building a non-portable build with a portable rid and without specifying a BaseOS value. Handle that in the installer targets logic.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
