### PR TITLE
Do not sign zero length files

### DIFF
--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -38,6 +38,7 @@ namespace Microsoft.DotNet.SignTool.Tests
             {".vsix",  new List<SignInfo>{ new SignInfo("VsixSHA2") } },
             {".zip",  new List<SignInfo>{ SignInfo.Ignore } },
             {".tgz",  new List<SignInfo>{ SignInfo.Ignore } },
+            {".py",  new List<SignInfo>{ new SignInfo("Microsof400") } },
             {".nupkg",  new List<SignInfo>{ new SignInfo("NuGet") } },
             {".symbols.nupkg",  new List<SignInfo>{ SignInfo.Ignore } },
         };
@@ -1765,6 +1766,24 @@ $@"
   <Authenticode>VsixSHA2</Authenticode>
 </FilesToSign>"
             });
+        }
+
+        [Fact]
+        public void ZeroLengthFilesShouldNotBeSigned()
+        {
+            // List of files to be considered for signing
+            var itemsToSign = new ITaskItem[]
+            {
+                new TaskItem(GetResourcePath("ZeroLengthPythonFile.py"))
+            };
+            // Default signing information
+            var strongNameSignInfo = new Dictionary<string, List<SignInfo>>();
+            // Overriding information
+            var fileSignInfo = new Dictionary<ExplicitCertificateKey, string>()
+            {
+                { new ExplicitCertificateKey("ZeroLengthPythonFile.py"), "3PartySHA2" }
+            };
+            ValidateFileSignInfos(itemsToSign, strongNameSignInfo, fileSignInfo, s_fileExtensionSignInfo, Array.Empty<string>());
         }
 
         [Fact]

--- a/src/Microsoft.DotNet.SignTool/src/Configuration.cs
+++ b/src/Microsoft.DotNet.SignTool/src/Configuration.cs
@@ -288,6 +288,14 @@ namespace Microsoft.DotNet.SignTool
             PEInfo peInfo = null;
             SignedFileContentKey signedFileContentKey = new SignedFileContentKey(file.ContentHash, file.FileName);
 
+            // First check for zero length files. These occasionally occur in python and
+            // cannot be signed.
+            if (file.ContentHash == ContentUtil.EmptyFileContentHash)
+            {
+                _log.LogMessage(MessageImportance.Low, $"Ignoring zero length file: {file.FullPath}");
+                return new FileSignInfo(file, SignInfo.Ignore, wixContentFilePath: wixContentFilePath);
+            }
+
             // handle multi-part extensions like ".symbols.nupkg" specified in FileExtensionSignInfo
             if (_fileExtensionSignInfo != null)
             {

--- a/src/Microsoft.DotNet.SignTool/src/ContentUtil.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ContentUtil.cs
@@ -16,13 +16,25 @@ namespace Microsoft.DotNet.SignTool
 {
     internal static class ContentUtil
     {
+        /// <summary>
+        /// Returns the hash of the content of the file at the given path.
+        /// If the file is empty, returns the hash of an empty stream.
+        /// </summary>
+        /// <param name="fullPath">Path of file to hash</param>
+        /// <returns>Hash of content.</returns>
         public static ImmutableArray<byte> GetContentHash(string fullPath)
         {
             using (var stream = File.OpenRead(fullPath))
             {
+                if (stream.Length == 0)
+                {
+                    return EmptyFileContentHash;
+                }
                 return GetContentHash(stream);
             }
         }
+
+        public static readonly ImmutableArray<byte> EmptyFileContentHash = GetContentHash(new MemoryStream()).ToImmutableArray();
 
         public static ImmutableArray<byte> GetContentHash(Stream stream)
         {


### PR DESCRIPTION
The signing service does not like zero length files, and they don't have content that could be hashed for signing anyway. Avoid signing them.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
