### PR TITLE
Fixes an error caused by file paths containing special characters.

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -78,7 +78,7 @@
     <!-- Respect a restore config file passed in via /p:RestoreConfigFile, common in VMR builds -->
     <PropertyGroup>
       <RestoreConfigFileOption></RestoreConfigFileOption>
-      <RestoreConfigFileOption Condition="'$(RestoreConfigFile)' != ''">--configfile $(RestoreConfigFile)</RestoreConfigFileOption>
+      <RestoreConfigFileOption Condition="'$(RestoreConfigFile)' != ''">--configfile "$(RestoreConfigFile)"</RestoreConfigFileOption>
     </PropertyGroup>
 
     <Exec Command='"$(DotNetTool)" tool restore $(RestoreConfigFileOption)' WorkingDirectory="$(RepoRoot)" />


### PR DESCRIPTION
This fixes errors presented when restoring if the config file path contains spaces.

```
➜ ./restore.cmd

Building of C# project is enabled and has dependencies on NodeJS projects. Building of NodeJS projects is enabled since node is detected in C:\Program Files.
Note that if you are running Source Build, building NodeJS projects will be disabled later on.
Detected JDK in C:\Program Files\Eclipse Adoptium\jdk-11.0.14.101-hotspot\ (via JAVA_HOME)

  --interactive             Allows the command to stop and wait for user input or action (for example to complete authentication).
    C:\Users\Kieran Devlin\.nuget\packages\microsoft.dotnet.arcade.sdk\10.0.0-beta.24578.2\tools\Tools.proj(84,5): error MSB3073: The command ""C:\Users\Kieran Devlin\Documents\git\sources\aspnetcore\.dotnet\dotnet.exe" tool restore --configfile C:\Users\Kieran Devlin\Documents\git\sources\aspnetcore\nuget.config" exited with code 1.

Restore failed with 1 error(s) in 1.2s
Build failed with exit code 1. Check errors above.
```

### To double check:

* [x] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
