### PR TITLE
Added the ability to provide presteps for the publish template

### DIFF
--- a/eng/common/core-templates/job/publish-build-assets.yml
+++ b/eng/common/core-templates/job/publish-build-assets.yml
@@ -32,6 +32,8 @@ parameters:
 
   is1ESPipeline: ''
 
+  preSteps: []
+
 jobs:
 - job: Asset_Registry_Publish
 
@@ -67,6 +69,7 @@ jobs:
       name: NetCore1ESPool-Publishing-Internal
       image: windows.vs2019.amd64
       os: windows
+
   steps:
   - ${{ if eq(parameters.is1ESPipeline, '') }}:
     - 'Illegal entry point, is1ESPipeline is not defined. Repository yaml should not directly reference templates in core-templates folder.': error
@@ -75,7 +78,11 @@ jobs:
     - checkout: self
       fetchDepth: 3
       clean: true
-      
+
+    - ${{ if ne(parameters.preSteps, '') }}:
+      - ${{ each preStep in parameters.preSteps }}:
+        - ${{ preStep }}
+
     - task: DownloadBuildArtifacts@0
       displayName: Download artifact
       inputs:
@@ -84,7 +91,7 @@ jobs:
         checkDownloadedFiles: true
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}
-    
+
     - task: NuGetAuthenticate@1
 
     - task: AzureCLI@2
@@ -101,7 +108,7 @@ jobs:
           /p:OfficialBuildId=$(Build.BuildNumber)
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}
-    
+
     - task: powershell@2
       displayName: Create ReleaseConfigs Artifact
       inputs:
@@ -155,4 +162,4 @@ jobs:
       - template: /eng/common/core-templates/steps/publish-logs.yml
         parameters:
           is1ESPipeline: ${{ parameters.is1ESPipeline }}
-          JobLabel: 'Publish_Artifacts_Logs'     
+          JobLabel: 'Publish_Artifacts_Logs'


### PR DESCRIPTION
## Summary

We're having an issue with the BinSkim tool in the dotnet SDK that it our filter requires the folders exist ahead of time, or BinSkim fails. The publish template has no way to inject steps into that job, which would allow us to create the folder prior to BinSkim running. This PR adds that ability for presteps, which the same logic in the job.yml template for normal jobs.