### PR TITLE
Bring back properties until we re-bootstrap to a newer Arcade SDK

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,11 @@
     <RepositoryUrl>https://github.com/dotnet/arcade</RepositoryUrl>
     <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->
     <WarningsNotAsErrors Condition="'$(OfficialBuild)' != 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+    <!-- TODO: Remove when the VMR uses a new bootstrap Arcade.Sdk in source-only builds that has the TFM changes in TargetFrameworkDefaults.props. -->
+    <NetCurrent>net10.0</NetCurrent>
+    <NetPrevious>net9.0</NetPrevious>
+    <NetToolCurrent>$(NetCurrent)</NetToolCurrent>
+    <NetToolMinimum Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(NetToolCurrent)</NetToolMinimum>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Partially unblocks https://github.com/dotnet/sdk/pull/45353

I removed these properties in https://github.com/dotnet/arcade/commit/3f344358dea318c1fdcedaa2679de94183c12e41. I should have waited until the VMR uses a newer Arcade Sdk with the TFM change. Bring this back to unblock the arcade -> sdk PR.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
