### PR TITLE
Add ProcessFrameworkReferences target to Empty.targets

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Empty.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Empty.targets
@@ -22,5 +22,6 @@
   <Target Name="Test"/>
   <Target Name="Pack"/>
   <Target Name="Publish"/>
+  <Target Name="ProcessFrameworkReferences" />
 
 </Project>


### PR DESCRIPTION
First of all, I hate this whole filtering model. It's super hacky and constantly causes issues. https://github.com/dotnet/source-build/issues/4047 tracks this.

Here we need to also empty the `ProcessFrameworkReferences` target as it still runs as it has a Before/AfterTargets hook. Keep it running is causing issues when RuntimeIdentifier is set to a custom value even though the project should be excluded.

Unblocks https://github.com/dotnet/sdk/pull/45362

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
