### PR TITLE
Increase revision number limit to 199

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/CalculateAssemblyAndFileVersions.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/CalculateAssemblyAndFileVersions.cs
@@ -9,7 +9,7 @@ using NuGet.Versioning;
 namespace Microsoft.DotNet.Arcade.Sdk
 {
     /// <summary>
-    /// File version has 4 parts and need to increase every official build.This is especially important when building MSIs.
+    /// File version has 4 parts and need to increase every official build. This is especially important when building MSIs.
     /// See https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md#assembly-version.
     /// </summary>
     public class CalculateAssemblyAndFileVersions : Microsoft.Build.Utilities.Task
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.Arcade.Sdk
                     yy = mm = dd = r = -1;
                 }
 
-                if (yy < 0 || yy > 99 || mm < 1 || mm > 12 || dd < 1 || dd > 31 || r < 0 || r > 99)
+                if (yy < 0 || yy > 99 || mm < 1 || mm > 12 || dd < 1 || dd > 31 || r < 0 || r > 199)
                 {
                     Log.LogError($"Invalid format of {nameof(BuildNumber)}: {BuildNumber}");
                     return;


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/15294

There doesn't seem to be reason why the revision number can't be 100 or higher. The maximum file revision number with this change is now 12 * 5000 + 31 * 100 + 199 = 63299 instead of 63199. Both number are smaller than a ushort which I believe was the reason for restriction, originally.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
