### PR TITLE
Define a concept of Artifact Visibility

### DIFF
--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -290,6 +290,7 @@ These tools are only used for build operations performed outside of the reposito
 Customization of Authenticode signing process.
 
 Configurable item groups:
+
 - `ItemsToSign`
   List of files to sign in-place, during the build. May list individual files to sign (e.g. .dll, .exe, .ps1, etc.) as well as container files (.nupkg, .vsix, .zip, etc.). All files embedded in a container file are signed (recursively) unless specified otherwise.
 - `ItemsToSignPostBuild`
@@ -302,8 +303,12 @@ Configurable item groups:
   Specifies Authenticode certificate properties, such as whether a certificate allows dual signing.
 - `StrongNameSignInfo`
   Strong Name key to use to sign a specific managed assembly.
+- `Artifact`
+  List of files to sign and publish, either in-place or post-build depending on `PostBuildSign`. May list packages and blobs to publish.
+  More documentation available in the section on Publishing.props.
 
 Properties:
+
 - `AllowEmptySignList`
   True to allow ItemsToSign to be empty (the repository doesn't have any file to sign in-build).
 - `AllowEmptyPostBuildSignList`
@@ -320,6 +325,16 @@ To change the key used for strong-naming assemblies see `StrongNameKeyId` proper
 ### /eng/Publishing.props (optional)
 
 Customization of publishing process.
+
+Configurable item groups:
+
+- `Artifact`: List of files to publish. May list packages and blobs to publish.
+  Supported Metadata:
+  - `Visibility`
+    - Visibility of the artifact. Default is `External`. Visibility options are listed below:
+      - `External`: The artifact is visible outside of the build. It will be uploaded to AzDO artifacts and published to [the Build Asset Registry (BAR)](./Maestro/BuildAssetRegistry.md) as an artifact of the build.
+      - `Internal`: The artifact is visible only within the build. It will be uploaded to AzDO artifacts but not published to BAR.
+      - `Vertical`: The artifact is only visible within a given vertical in a Vertical Build. It will be copied into the local artifacts folder for the repository on disk during a vertical build. It will not be uploaded to AzDO artifacts, nor published to BAR. Any artifacts marked with `Vertical` visibility are also not available in any other Join Points in a Unified Build. See [here](./UnifiedBuild/Unified-Build-Join-Point.md) for more information. `Vertical` visibility is only available in a Vertical Build.
 
 ### /eng/AfterSolutionBuild.targets (optional)
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -225,9 +225,6 @@
       </ItemsToPushToBlobFeed>
     </ItemGroup>
 
-    <Error Condition="'@(ItemsToPublishToBlobFeed->AnyHaveMetadataValue('Visibility','Vertical'))' == 'true' and '$(DotNetBuildOrchestrator)' != 'true'"
-           Text="Visibility 'Vertical' is only supported in vertical builds." />
-
     <ItemGroup>
       <ItemsToPushToBlobFeed>
         <ManifestArtifactData Condition="'%(ItemsToPushToBlobFeed.IsShipping)' == 'false'">%(ItemsToPushToBlobFeed.ManifestArtifactData);NonShipping=true</ManifestArtifactData>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -43,6 +43,17 @@
     <PushToLocalStorage>true</PushToLocalStorage>
   </PropertyGroup>
 
+  <!--
+    Inside the VMR, we want to include "Vertical" artifacts as they should be available to other builds within the same
+    vertical on the same build machine.
+    Inside the VMR, we also want to include "Internal" artifacts in the build manifest, as they are used by other jobs
+    so we want to inclue them here so they can be in the vertical's final manifest.
+    The VMR tooling to produce the final merged manifest for the VMR build as a whole will filter them out.
+  -->
+  <ItemGroup Condition="'$(DotNetBuildPhase)' == 'InnerRepo' and '$(DotNetBuildOrchestrator)' == 'true'">
+    <ArtifactVisibilityToPublish Include="Vertical;Internal;External" />
+  </ItemGroup>
+
   <!-- Required to determine whether full assembly strong name signing is supported, which may affect selection of some certificates. -->
   <Import Project="StrongName.targets" />
   <Import Project="Sign.props" />
@@ -272,7 +283,8 @@
       AssetsLocalStorageDir="$(SourceBuiltAssetsDir)"
       ShippingPackagesLocalStorageDir="$(SourceBuiltShippingPackagesDir)"
       NonShippingPackagesLocalStorageDir="$(SourceBuiltNonShippingPackagesDir)"
-      AssetManifestsLocalStorageDir="$(SourceBuiltAssetManifestsDir)" />
+      AssetManifestsLocalStorageDir="$(SourceBuiltAssetManifestsDir)"
+      ArtifactVisibilitiesToPublish="@(ArtifactVisibilityToPublish)" />
 
     <!-- 
         Publish Windows PDBs produced by SymStore.targets (by default, only shipping PDBs are placed there).

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -104,6 +104,13 @@
     </ItemGroup>
 
     <!-- Respect Artifact item repo extension point for packages -->
+    <ItemGroup>
+      <Artifact>
+        <!-- Build visibility means don't publish outside of this build in any way. -->
+        <SkipPublish Condition="'%(Artifact.SkipPublish)' == '' and '%(Artifact.ArtifactVisibility)' == 'Build'">true</SkipPublish>
+      </Artifact>
+    </ItemGroup>
+
     <ItemGroup Condition="'@(Artifact)' != ''">
       <ExistingSymbolPackages Include="@(Artifact)" Condition="'%(Artifact.SkipPublish)' != 'true' and $([System.String]::Copy('%(Filename)%(Extension)').EndsWith('.symbols.nupkg'))" />
       <PackagesToPublish Include="@(Artifact)" Condition="'%(Artifact.SkipPublish)' != 'true' and '%(Extension)' == '.nupkg'" />
@@ -213,13 +220,19 @@
 
     <!-- Add non-package Artifact items (repo extension point) as package already got added in the BeforePublish target. -->
     <ItemGroup>
-      <ItemsToPushToBlobFeed Include="@(Artifact)" Condition="'%(Artifact.SkipPublish)' != 'true' and '%(Extension)' != '.nupkg'" />
+      <ItemsToPushToBlobFeed Include="@(Artifact)" Condition="'%(Artifact.SkipPublish)' != 'true' and '%(Artifact.ArtifactVisibility)' != 'Build' and '%(Extension)' != '.nupkg'" />
     </ItemGroup>
 
     <ItemGroup>
       <ItemsToPushToBlobFeed>
         <ManifestArtifactData Condition="'%(ItemsToPushToBlobFeed.IsShipping)' == 'false'">%(ItemsToPushToBlobFeed.ManifestArtifactData);NonShipping=true</ManifestArtifactData>
         <ManifestArtifactData Condition="'%(ItemsToPushToBlobFeed.IsShipping)' != 'false' and '$(ProducesDotNetReleaseShippingAssets)' == 'true'">%(ItemsToPushToBlobFeed.ManifestArtifactData);DotNetReleaseShipping=true</ManifestArtifactData>
+      </ItemsToPushToBlobFeed>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ItemsToPushToBlobFeed>
+        <ManifestArtifactData Condition="'%(ItemsToPushToBlobFeed.ArtifactVisibility)' != ''">%(ItemsToPushToBlobFeed.ManifestArtifactData);ArtifactVisibility=%(ItemsToPushToBlobFeed.ArtifactVisibility)</ManifestArtifactData>
       </ItemsToPushToBlobFeed>
     </ItemGroup>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -228,7 +228,7 @@
     <ItemGroup>
       <ItemsToPushToBlobFeed>
         <ManifestArtifactData Condition="'%(ItemsToPushToBlobFeed.IsShipping)' == 'false'">%(ItemsToPushToBlobFeed.ManifestArtifactData);NonShipping=true</ManifestArtifactData>
-        <ManifestArtifactData Condition="'%(ItemsToPushToBlobFeed.IsShipping)' != 'false' and '$(ProducesDotNetReleaseShippingAssets)' == 'true'">%(ItemsToPushToBlobFeed.ManifestArtifactData);DotNetReleaseShipping=true</ManifestArtifactData>
+        <ManifestArtifactData Condition="'%(ItemsToPushToBlobFeed.IsShipping)' == 'true' and '$(ProducesDotNetReleaseShippingAssets)' == 'true'">%(ItemsToPushToBlobFeed.ManifestArtifactData);DotNetReleaseShipping=true</ManifestArtifactData>
       </ItemsToPushToBlobFeed>
     </ItemGroup>
 
@@ -236,7 +236,7 @@
            Text="Visibility 'Vertical' is not supported for shipping artifacts." />
     <Error Condition="'@(ItemsToPublishToBlobFeed->WithMetadataValue('IsShipping','true')->AnyHaveMetadataValue('Visibility','Internal'))' == 'true'"
            Text="Visibility 'Internal' is not supported for shipping artifacts." />
-    <Error Condition="'@(ItemsToPublishToBlobFeed->AnyHaveMetadataValue('Visibility','Vertical'))' == 'true' and '$(DotNetBuildOrchestrator)' != 'true'"
+    <Error Condition="'@(ItemsToPublishToBlobFeed->AnyHaveMetadataValue('Visibility','Vertical'))' == 'true' and '$(DotNetBuild)' != 'true'"
            Text="Visibility 'Vertical' is only supported in vertical builds." />
 
     <ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -225,7 +225,7 @@
       </ItemsToPushToBlobFeed>
     </ItemGroup>
 
-    <Error Condition="@(ItemsToPublishToBlobFeed->AnyWithMetadataValue('Visibility','Vertical')) and '$(DotNetBuildOrchestrator)' != 'true'"
+    <Error Condition="'@(ItemsToPublishToBlobFeed->AnyHaveMetadataValue('Visibility','Vertical'))' == 'true' and '$(DotNetBuildOrchestrator)' != 'true'"
            Text="Visibility 'Vertical' is only supported in vertical builds." />
 
     <ItemGroup>
@@ -235,11 +235,11 @@
       </ItemsToPushToBlobFeed>
     </ItemGroup>
 
-    <Error Condition="@(ItemsToPublishToBlobFeed->WithMetadataValue('IsShipping','true')->AnyHaveMetadataValue('Visibility','Vertical'))"
+    <Error Condition="'@(ItemsToPublishToBlobFeed->WithMetadataValue('IsShipping','true')->AnyHaveMetadataValue('Visibility','Vertical'))' == 'true'"
            Text="Visibility 'Vertical' is not supported for shipping artifacts." />
-    <Error Condition="@(ItemsToPublishToBlobFeed->WithMetadataValue('IsShipping','true')->AnyHaveMetadataValue('Visibility','Internal'))"
+    <Error Condition="'@(ItemsToPublishToBlobFeed->WithMetadataValue('IsShipping','true')->AnyHaveMetadataValue('Visibility','Internal'))' == 'true'"
            Text="Visibility 'Internal' is not supported for shipping artifacts." />
-    <Error Condition="@(ItemsToPublishToBlobFeed->AnyHaveMetadataValue('Visibility','Vertical')) and '$(DotNetBuildOrchestrator)' != 'true'"
+    <Error Condition="'@(ItemsToPublishToBlobFeed->AnyHaveMetadataValue('Visibility','Vertical'))' == 'true' and '$(DotNetBuildOrchestrator)' != 'true'"
            Text="Visibility 'Vertical' is only supported in vertical builds." />
 
     <ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -104,13 +104,6 @@
     </ItemGroup>
 
     <!-- Respect Artifact item repo extension point for packages -->
-    <ItemGroup>
-      <Artifact>
-        <!-- Build visibility means don't publish outside of this build in any way. -->
-        <SkipPublish Condition="'%(Artifact.SkipPublish)' == '' and '%(Artifact.ArtifactVisibility)' == 'Build'">true</SkipPublish>
-      </Artifact>
-    </ItemGroup>
-
     <ItemGroup Condition="'@(Artifact)' != ''">
       <ExistingSymbolPackages Include="@(Artifact)" Condition="'%(Artifact.SkipPublish)' != 'true' and $([System.String]::Copy('%(Filename)%(Extension)').EndsWith('.symbols.nupkg'))" />
       <PackagesToPublish Include="@(Artifact)" Condition="'%(Artifact.SkipPublish)' != 'true' and '%(Extension)' == '.nupkg'" />
@@ -220,8 +213,20 @@
 
     <!-- Add non-package Artifact items (repo extension point) as package already got added in the BeforePublish target. -->
     <ItemGroup>
-      <ItemsToPushToBlobFeed Include="@(Artifact)" Condition="'%(Artifact.SkipPublish)' != 'true' and '%(Artifact.ArtifactVisibility)' != 'Build' and '%(Extension)' != '.nupkg'" />
+      <ItemsToPushToBlobFeed Include="@(Artifact)" Condition="'%(Artifact.SkipPublish)' != 'true' and '%(Extension)' != '.nupkg'" />
     </ItemGroup>
+
+    <ItemGroup>
+      <ItemsToPushToBlobFeed>
+        <!-- Default artifact visibility is External -->
+        <Visibility Condition="'%(ItemsToPushToBlobFeed.Visibility)' == ''">External</Visibility>
+        <!-- Default to IsShipping=true -->
+        <IsShipping Condition="'%(ItemsToPushToBlobFeed.IsShipping)' == ''">true</IsShipping>
+      </ItemsToPushToBlobFeed>
+    </ItemGroup>
+
+    <Error Condition="@(ItemsToPublishToBlobFeed->AnyWithMetadataValue('Visibility','Vertical')) and '$(DotNetBuildOrchestrator)' != 'true'"
+           Text="Visibility 'Vertical' is only supported in vertical builds." />
 
     <ItemGroup>
       <ItemsToPushToBlobFeed>
@@ -230,9 +235,16 @@
       </ItemsToPushToBlobFeed>
     </ItemGroup>
 
+    <Error Condition="@(ItemsToPublishToBlobFeed->WithMetadataValue('IsShipping','true')->AnyHaveMetadataValue('Visibility','Vertical'))"
+           Text="Visibility 'Vertical' is not supported for shipping artifacts." />
+    <Error Condition="@(ItemsToPublishToBlobFeed->WithMetadataValue('IsShipping','true')->AnyHaveMetadataValue('Visibility','Internal'))"
+           Text="Visibility 'Internal' is not supported for shipping artifacts." />
+    <Error Condition="@(ItemsToPublishToBlobFeed->AnyHaveMetadataValue('Visibility','Vertical')) and '$(DotNetBuildOrchestrator)' != 'true'"
+           Text="Visibility 'Vertical' is only supported in vertical builds." />
+
     <ItemGroup>
       <ItemsToPushToBlobFeed>
-        <ManifestArtifactData Condition="'%(ItemsToPushToBlobFeed.ArtifactVisibility)' != ''">%(ItemsToPushToBlobFeed.ManifestArtifactData);ArtifactVisibility=%(ItemsToPushToBlobFeed.ArtifactVisibility)</ManifestArtifactData>
+        <ManifestArtifactData Condition="'%(ItemsToPushToBlobFeed.Visibility)' != ''">%(ItemsToPushToBlobFeed.ManifestArtifactData);Visibility=%(ItemsToPushToBlobFeed.Visibility)</ManifestArtifactData>
       </ItemsToPushToBlobFeed>
     </ItemGroup>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -11,6 +11,7 @@
     <Artifact>
       <PublishFlatContainer>true</PublishFlatContainer>
       <IsShipping>true</IsShipping>
+      <Visibility>External</Visibility>
     </Artifact>
   </ItemDefinitionGroup>
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -831,15 +831,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         private HashSet<PackageArtifactModel> FilterPackages(HashSet<PackageArtifactModel> packages, TargetFeedConfig feedConfig)
         {
-            HashSet<PackageArtifactModel> filteredPackages = new HashSet<PackageArtifactModel>(packages);
-            // We only publish externally visible packages to any feeds.
-            filteredPackages.RemoveWhere(p => p.Visibility != ArtifactVisibility.External);
-
             return feedConfig.AssetSelection switch
             {
-                AssetSelection.All => filteredPackages,
-                AssetSelection.NonShippingOnly => filteredPackages.Where(p => p.NonShipping).ToHashSet(),
-                AssetSelection.ShippingOnly => filteredPackages.Where(p => !p.NonShipping).ToHashSet(),
+                AssetSelection.All => packages,
+                AssetSelection.NonShippingOnly => packages.Where(p => p.NonShipping).ToHashSet(),
+                AssetSelection.ShippingOnly => packages.Where(p => !p.NonShipping).ToHashSet(),
 
                 // Throw NIE here instead of logging an error because error would have already been logged in the
                 // parser for the user.
@@ -1059,15 +1055,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         /// <returns></returns>
         private HashSet<BlobArtifactModel> FilterBlobs(HashSet<BlobArtifactModel> blobs, TargetFeedConfig feedConfig)
         {
-            HashSet<BlobArtifactModel> filteredBlobs = new HashSet<BlobArtifactModel>(blobs);
-            // We only publish externally visible packages to any feeds.
-            filteredBlobs.RemoveWhere(p => p.Visibility != ArtifactVisibility.External);
-
             return feedConfig.AssetSelection switch
             {
-                AssetSelection.All => filteredBlobs,
-                AssetSelection.NonShippingOnly => filteredBlobs.Where(p => p.NonShipping).ToHashSet(),
-                AssetSelection.ShippingOnly => filteredBlobs.Where(p => !p.NonShipping).ToHashSet(),
+                AssetSelection.All => blobs,
+                AssetSelection.NonShippingOnly => blobs.Where(p => p.NonShipping).ToHashSet(),
+                AssetSelection.ShippingOnly => blobs.Where(p => !p.NonShipping).ToHashSet(),
 
                 // Throw NYI here instead of logging an error because error would have already been logged in the
                 // parser for the user.

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -831,11 +831,15 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         private HashSet<PackageArtifactModel> FilterPackages(HashSet<PackageArtifactModel> packages, TargetFeedConfig feedConfig)
         {
+            IEnumerable<PackageArtifactModel> filteredPackages = new HashSet<PackageArtifactModel>(packages);
+            // We only publish externally visible packages to any feeds.
+            filteredPackages = filteredPackages.Where(p => p.Visibility == ArtifactVisibility.External);
+
             return feedConfig.AssetSelection switch
             {
-                AssetSelection.All => packages,
-                AssetSelection.NonShippingOnly => packages.Where(p => p.NonShipping).ToHashSet(),
-                AssetSelection.ShippingOnly => packages.Where(p => !p.NonShipping).ToHashSet(),
+                AssetSelection.All => filteredPackages.ToHashSet(),
+                AssetSelection.NonShippingOnly => filteredPackages.Where(p => p.NonShipping).ToHashSet(),
+                AssetSelection.ShippingOnly => filteredPackages.Where(p => !p.NonShipping).ToHashSet(),
 
                 // Throw NIE here instead of logging an error because error would have already been logged in the
                 // parser for the user.
@@ -1055,11 +1059,15 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         /// <returns></returns>
         private HashSet<BlobArtifactModel> FilterBlobs(HashSet<BlobArtifactModel> blobs, TargetFeedConfig feedConfig)
         {
+            IEnumerable<BlobArtifactModel> filteredBlobs = new HashSet<BlobArtifactModel>(blobs);
+            // We only publish externally visible blobs to any feeds.
+            filteredBlobs = filteredBlobs.Where(p => p.Visibility == ArtifactVisibility.External);
+
             return feedConfig.AssetSelection switch
             {
-                AssetSelection.All => blobs,
-                AssetSelection.NonShippingOnly => blobs.Where(p => p.NonShipping).ToHashSet(),
-                AssetSelection.ShippingOnly => blobs.Where(p => !p.NonShipping).ToHashSet(),
+                AssetSelection.All => filteredBlobs.ToHashSet(),
+                AssetSelection.NonShippingOnly => filteredBlobs.Where(p => p.NonShipping).ToHashSet(),
+                AssetSelection.ShippingOnly => filteredBlobs.Where(p => !p.NonShipping).ToHashSet(),
 
                 // Throw NYI here instead of logging an error because error would have already been logged in the
                 // parser for the user.

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -831,13 +831,13 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         private HashSet<PackageArtifactModel> FilterPackages(HashSet<PackageArtifactModel> packages, TargetFeedConfig feedConfig)
         {
-            IEnumerable<PackageArtifactModel> filteredPackages = new HashSet<PackageArtifactModel>(packages);
+            HashSet<PackageArtifactModel> filteredPackages = new HashSet<PackageArtifactModel>(packages);
             // We only publish externally visible packages to any feeds.
-            filteredPackages = filteredPackages.Where(p => p.Visibility == ArtifactVisibility.External);
+            filteredPackages.RemoveWhere(p => p.Visibility != ArtifactVisibility.External);
 
             return feedConfig.AssetSelection switch
             {
-                AssetSelection.All => filteredPackages.ToHashSet(),
+                AssetSelection.All => filteredPackages,
                 AssetSelection.NonShippingOnly => filteredPackages.Where(p => p.NonShipping).ToHashSet(),
                 AssetSelection.ShippingOnly => filteredPackages.Where(p => !p.NonShipping).ToHashSet(),
 
@@ -1059,13 +1059,13 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         /// <returns></returns>
         private HashSet<BlobArtifactModel> FilterBlobs(HashSet<BlobArtifactModel> blobs, TargetFeedConfig feedConfig)
         {
-            IEnumerable<BlobArtifactModel> filteredBlobs = new HashSet<BlobArtifactModel>(blobs);
-            // We only publish externally visible blobs to any feeds.
-            filteredBlobs = filteredBlobs.Where(p => p.Visibility == ArtifactVisibility.External);
+            HashSet<BlobArtifactModel> filteredBlobs = new HashSet<BlobArtifactModel>(blobs);
+            // We only publish externally visible packages to any feeds.
+            filteredBlobs.RemoveWhere(p => p.Visibility != ArtifactVisibility.External);
 
             return feedConfig.AssetSelection switch
             {
-                AssetSelection.All => filteredBlobs.ToHashSet(),
+                AssetSelection.All => filteredBlobs,
                 AssetSelection.NonShippingOnly => filteredBlobs.Where(p => p.NonShipping).ToHashSet(),
                 AssetSelection.ShippingOnly => filteredBlobs.Where(p => !p.NonShipping).ToHashSet(),
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBuildStorage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBuildStorage.cs
@@ -333,7 +333,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         private static ArtifactVisibility[] GetVisibilitiesToPublish(ITaskItem[] allowedVisibilities)
         {
-            if (allowedVisibilities is null or [])
+            if (allowedVisibilities is null || allowedVisibilities.Length == 0)
             {
                 return [ArtifactVisibility.External];
             }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBuildStorage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBuildStorage.cs
@@ -221,8 +221,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     // Filter out any "Internal" artifacts from the asset manifest.
                     // We don't want to publish these outside of the build, so we exclude them from the manifest but still publish them.
                     // We obviously want to include "External" artifacts as they are the ones we want to publish externally.
-                    packageArtifacts = packageArtifacts.Where(p => p.Visibility != Visibility.Internal);
-                    blobArtifacts = blobArtifacts.Where(p => p.Visibility != Visibility.Internal);
+                    packageArtifacts = packageArtifacts.Where(p => p.Visibility != ArtifactVisibility.Internal);
+                    blobArtifacts = blobArtifacts.Where(p => p.Visibility != ArtifactVisibility.Internal);
 
                     if (!PushToLocalStorage)
                     {
@@ -230,8 +230,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         // Outside the VMR, we publish to Azure DevOps artifacts storage.
                         // "Vertical" artifacts should only ever be available within a build on a single machine, and should never be uploaded
                         // to Azure DevOps artifacts storage.
-                        packageArtifacts = packageArtifacts.Where(p => p.Visibility != Visibility.Vertical);
-                        blobArtifacts = blobArtifacts.Where(p => p.Visibility != Visibility.Vertical);
+                        packageArtifacts = packageArtifacts.Where(p => p.Visibility != ArtifactVisibility.Vertical);
+                        blobArtifacts = blobArtifacts.Where(p => p.Visibility != ArtifactVisibility.Vertical);
                     }
 
                     PublishingInfraVersion targetPublishingVersion = PublishingInfraVersion.Latest;

--- a/src/VersionTools/Microsoft.DotNet.VersionTools.Tests/BuildManifest/ManifestModelTests.cs
+++ b/src/VersionTools/Microsoft.DotNet.VersionTools.Tests/BuildManifest/ManifestModelTests.cs
@@ -569,6 +569,25 @@ namespace Microsoft.DotNet.VersionTools.Tests.BuildManifest
             Assert.False(packageArtifact.Equals("thisIsNotAPackageArtifact!"));
         }
 
+        [InlineData("Vertical")]
+        [InlineData("External")]
+        [InlineData("Internal")]
+        [InlineData("")]
+        [Theory]
+        public void PackageArtifactModel_Visibility(string visibility)
+        {
+            PackageArtifactModel packageArtifact = new PackageArtifactModel
+            {
+                Id = "AssetName",
+                Attributes = new Dictionary<string, string>
+                {
+                    { "Visibility", visibility }
+                }
+            };
+
+            Assert.Equal((ArtifactVisibility)Enum.Parse(typeof(ArtifactVisibility), visibility), packageArtifact.Visibility);
+        }
+
         [Fact]
         public void BlobArtifactModelEquals_ReturnsTrueWhenTwoObjectsHaveMatchingAttributes()
         {
@@ -654,6 +673,25 @@ namespace Microsoft.DotNet.VersionTools.Tests.BuildManifest
             };
 
             Assert.False(blobArtifact.Equals("thisIsNotABlobArtifact!"));
+        }
+
+        [InlineData("Vertical")]
+        [InlineData("External")]
+        [InlineData("Internal")]
+        [InlineData("")]
+        [Theory]
+        public void BlobArtifactModel_Visibility(string visibility)
+        {
+            BlobArtifactModel blobArtifact = new BlobArtifactModel
+            {
+                Id = "AssetName",
+                Attributes = new Dictionary<string, string>
+                {
+                    { "Visibility", visibility }
+                }
+            };
+
+            Assert.Equal((ArtifactVisibility)Enum.Parse(typeof(ArtifactVisibility), visibility), blobArtifact.Visibility);
         }
 
         private BuildModel CreatePackageOnlyBuildManifestModel()

--- a/src/VersionTools/Microsoft.DotNet.VersionTools.Tests/BuildManifest/ManifestModelTests.cs
+++ b/src/VersionTools/Microsoft.DotNet.VersionTools.Tests/BuildManifest/ManifestModelTests.cs
@@ -585,7 +585,7 @@ namespace Microsoft.DotNet.VersionTools.Tests.BuildManifest
                 }
             };
 
-            Assert.Equal((ArtifactVisibility)Enum.Parse(typeof(ArtifactVisibility), visibility), packageArtifact.Visibility);
+            Assert.Equal(visibility is "" ? ArtifactVisibility.External : (ArtifactVisibility)Enum.Parse(typeof(ArtifactVisibility), visibility), packageArtifact.Visibility);
         }
 
         [Fact]
@@ -691,7 +691,7 @@ namespace Microsoft.DotNet.VersionTools.Tests.BuildManifest
                 }
             };
 
-            Assert.Equal((ArtifactVisibility)Enum.Parse(typeof(ArtifactVisibility), visibility), blobArtifact.Visibility);
+            Assert.Equal(visibility is "" ? ArtifactVisibility.External : (ArtifactVisibility)Enum.Parse(typeof(ArtifactVisibility), visibility), blobArtifact.Visibility);
         }
 
         private BuildModel CreatePackageOnlyBuildManifestModel()

--- a/src/VersionTools/Microsoft.DotNet.VersionTools/BuildManifest/Model/ArtifactVisibility.cs
+++ b/src/VersionTools/Microsoft.DotNet.VersionTools/BuildManifest/Model/ArtifactVisibility.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
+{
+    /// <summary>
+    /// Description of how an artifact should be published between different builds in various different scenarios.
+    /// </summary>
+    public enum ArtifactVisibility
+    {
+        /// <summary>
+        /// The artifact should be published for external usage, whether as a shipping or non-shipping package.
+        /// </summary>
+        External,
+        /// <summary>
+        /// The artifact is used by different jobs within the same overall build, vertical or not.
+        /// The artifact should be uploaded to build artifacts, but should not be published to any NuGet/blob feeds.
+        /// </summary>
+        /// <remarks>
+        /// This visibility should be used for artifacts that must be flowed to jobs in a later build pass but not published.
+        /// </remarks>
+        Internal,
+        /// <summary>
+        /// The artifact is used by other repositories targeting the same target RID/platform.
+        /// In vertical builds, it should be published to the "on-disk" locations, but not to any NuGet/blob feeds.
+        /// In non-vertical builds, it should be treated as a non-shipping package with <see cref="External"/> visibility.
+        /// </summary>
+        Vertical,
+    }
+}

--- a/src/VersionTools/Microsoft.DotNet.VersionTools/BuildManifest/Model/BlobArtifactModel.cs
+++ b/src/VersionTools/Microsoft.DotNet.VersionTools/BuildManifest/Model/BlobArtifactModel.cs
@@ -43,6 +43,30 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
             set => Attributes[nameof(RepoOrigin)] = value;
         }
 
+        public ArtifactVisibility Visibility
+        {
+            get
+            {
+                string val = Attributes.GetOrDefault(nameof(Visibility));
+                if (string.IsNullOrEmpty(val))
+                {
+                    return ArtifactVisibility.External;
+                }
+                else if (Enum.TryParse(val, out ArtifactVisibility visibility))
+                {
+                    return visibility;
+                }
+                else
+                {
+                    throw new ArgumentException($"Invalid value for {nameof(Visibility)}: {val}");
+                }
+            }
+            set
+            {
+                Attributes[nameof(Visibility)] = value.ToString();
+            }
+        }
+
         public override string ToString() => $"Blob {Id}";
 
         public override bool Equals(object obj)

--- a/src/VersionTools/Microsoft.DotNet.VersionTools/BuildManifest/Model/PackageArtifactModel.cs
+++ b/src/VersionTools/Microsoft.DotNet.VersionTools/BuildManifest/Model/PackageArtifactModel.cs
@@ -55,6 +55,30 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
             }
         }
 
+        public ArtifactVisibility Visibility
+        {
+            get
+            {
+                string val = Attributes.GetOrDefault(nameof(Visibility));
+                if (string.IsNullOrEmpty(val))
+                {
+                    return ArtifactVisibility.External;
+                }
+                else if (Enum.TryParse(val, out ArtifactVisibility visibility))
+                {
+                    return visibility;
+                }
+                else
+                {
+                    throw new ArgumentException($"Invalid value for {nameof(Visibility)}: {val}");
+                }
+            }
+            set
+            {
+                Attributes[nameof(Visibility)] = value.ToString();
+            }
+        }
+
         public string RepoOrigin
         {
             get => Attributes.GetOrDefault(nameof(RepoOrigin));


### PR DESCRIPTION
# Asset Visibility

As part of building the VMR, we've found that we need to produce assets in multiple jobs that we used to produce in only one job. We have talked about doing asset selection through a list of jobs or asset name patterns. This works when we're only producing the assets that we want to publish.

However, we've discovered that in the VMR, we also need to build some additional packages that we never want to ship that we are effectively forced to name like a shipping package (in particular, we need to build a crossgen2 and ilc for the build host machine). These host-machine packages aren't assets we want to ship as they are built using LKG assets and assets that aren't targeting our "portable" build setup.

To handle these cases, we'd have to be very careful with a priority list of verticals as it would need to consider the machines we build on (so macOS x64 and macOS arm64 ordering would have to be ordered such that the primary vertical matches our build machine).

We looked at different artifact types and determined we have 3 visibilities, separate from Shipping/NonShipping:

- Vertical: Used within a VMR vertical, not published in the merged manifest. Not allowed in non-VMR builds.
- Internal: Used within a single AzDo pipeline run. Published from a job up to AzDO, but excluded from BAR and darc publishing. Good for cross-job and cross-BuildPass -only assets.
- External (default): Regular publishing.

### To double check:

* [X] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md

Validation that the jobs are dropped before going to BAR and the dropped artifacts are not uploaded to feeds by darc:

WindowsDesktop job that published to BAR with all rid-agnostic assets and exe installers marked as "Internal": https://dev.azure.com/dnceng/internal/_build/results?buildId=2604238&view=results
BAR record for that job showing that no rid-agnostic packages nor exe installers are present: https://maestro.dot.net/channel/529/azdo:dnceng:internal:dotnet-windowsdesktop/build/250107
Build Promotion job that shows that the internal assets were excluded from upload (the job failure later is due to an unrelated ongoing FR issue): https://dev.azure.com/dnceng/internal/_build/results?buildId=2604256&view=logs&j=ba23343f-f710-5af9-782d-5bd26b102304&t=74531eb2-9b39-5603-839e-94e3ba212b65&l=278