### PR TITLE
Allow using SharedFramework.Sdk tasks without importing all the infra

### DIFF
--- a/src/Microsoft.DotNet.SharedFramework.Sdk/sdk/BuildTask.props
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/sdk/BuildTask.props
@@ -1,0 +1,16 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Project>
+
+  <!-- This file exists so that consumers can import only this part of the Shared Framework SDK infrastructure
+       without importing all the props and targets definitions. This is useful when a task should be invoked.
+       Example: <Import Project="BuildTask.props" Sdk="Microsoft.DotNet.SharedFramework.Sdk" />  -->
+  <PropertyGroup Condition="'$(DotNetSharedFrameworkTaskDir)' == ''">
+    <DotNetSharedFrameworkTaskDir Condition="'$(MSBuildRuntimeType)' == 'core'">$(MSBuildThisFileDirectory)../tools/net/</DotNetSharedFrameworkTaskDir>
+    <DotNetSharedFrameworkTaskDir Condition="'$(MSBuildRuntimeType)' != 'core'">$(MSBuildThisFileDirectory)../tools/netframework/</DotNetSharedFrameworkTaskDir>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DotNetSharedFrameworkTaskFile>$(DotNetSharedFrameworkTaskDir)Microsoft.DotNet.SharedFramework.Sdk.dll</DotNetSharedFrameworkTaskFile>
+  </PropertyGroup>
+
+</Project>

--- a/src/Microsoft.DotNet.SharedFramework.Sdk/sdk/Sdk.props
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/sdk/Sdk.props
@@ -8,14 +8,10 @@
     See https://github.com/dotnet/arcade/blob/238f1bbb23ba67616818d0b242c5b55a18edec55/Documentation/ArcadeSdk.md#directorybuildprops
   -->
 
-  <PropertyGroup Condition="'$(DotNetSharedFrameworkTaskDir)' == ''">
-    <DotNetSharedFrameworkTaskDir Condition="'$(MSBuildRuntimeType)' == 'core'">$(MSBuildThisFileDirectory)../tools/net/</DotNetSharedFrameworkTaskDir>
-    <DotNetSharedFrameworkTaskDir Condition="'$(MSBuildRuntimeType)' != 'core'">$(MSBuildThisFileDirectory)../tools/netframework/</DotNetSharedFrameworkTaskDir>
-  </PropertyGroup>
+  <Import Project="$(MSBuildThisFileDirectory)BuildTask.props" />
 
   <PropertyGroup>
     <UsingMicrosoftDotNetSharedFrameworkSdk>true</UsingMicrosoftDotNetSharedFrameworkSdk>
-    <DotNetSharedFrameworkTaskFile>$(DotNetSharedFrameworkTaskDir)Microsoft.DotNet.SharedFramework.Sdk.dll</DotNetSharedFrameworkTaskFile>
   </PropertyGroup>
 
   <!-- Allow setting a property to use targets from a development dir for faster iteration. -->


### PR DESCRIPTION
Unblocks https://github.com/dotnet/runtime/pull/110778

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
