### PR TITLE
Fix .net sdk version issue

### DIFF
--- a/Restore.cmd
+++ b/Restore.cmd
@@ -1,2 +1,2 @@
 @echo off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\common\Build.ps1""" -restore -ci %*"
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\common\Build.ps1""" -restore %*"

--- a/Restore.cmd
+++ b/Restore.cmd
@@ -1,2 +1,2 @@
 @echo off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\common\Build.ps1""" -restore %*"
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\common\Build.ps1""" -restore -ci %*"

--- a/azure-pipelines-daily.yaml
+++ b/azure-pipelines-daily.yaml
@@ -40,4 +40,4 @@ stages:
           scriptType: pscore
           scriptLocation: inlineScript
           inlineScript: |
-            Get-ChildItem .vault-config/*.yaml |% { dotnet secret-manager synchronize $_}
+            Get-ChildItem .vault-config/*.yaml |% { $(Build.SourcesDirectory)/.dotnet/dotnet.exe secret-manager synchronize $_}

--- a/azure-pipelines-daily.yaml
+++ b/azure-pipelines-daily.yaml
@@ -19,18 +19,12 @@ stages:
         demands: ImageOverride -equals 1es-windows-2022
 
       steps:
-      - task: UseDotNet@2
-        displayName: Install global.json SDK
+      - task: CmdLine@2
+        displayName: Run restore.cmd
         inputs:
-          useGlobalJson: true
+          script: "restore.cmd"
 
-      - task: UseDotNet@2
-        displayName: Install .NET 6 runtime
-        inputs:
-          packageType: runtime
-          version: 6.x
-
-      - script: dotnet tool restore
+      - script: $(Build.SourcesDirectory)/.dotnet/dotnet.exe tool restore
         displayName: Restore dotnet tools
 
       - task: AzureCLI@2

--- a/azure-pipelines-daily.yaml
+++ b/azure-pipelines-daily.yaml
@@ -24,6 +24,12 @@ stages:
         inputs:
           script: "restore.cmd"
 
+      - task: UseDotNet@2
+        displayName: Install .NET 6 runtime
+        inputs:
+          packageType: runtime
+          version: 6.x
+
       - script: $(Build.SourcesDirectory)/.dotnet/dotnet.exe tool restore
         displayName: Restore dotnet tools
 

--- a/azure-pipelines-daily.yaml
+++ b/azure-pipelines-daily.yaml
@@ -19,10 +19,8 @@ stages:
         demands: ImageOverride -equals 1es-windows-2022
 
       steps:
-      - task: CmdLine@2
+      - script: restore.cmd -ci
         displayName: Run restore.cmd
-        inputs:
-          script: "restore.cmd"
 
       - task: UseDotNet@2
         displayName: Install .NET 6 runtime

--- a/azure-pipelines-daily.yaml
+++ b/azure-pipelines-daily.yaml
@@ -29,6 +29,7 @@ stages:
         inputs:
           packageType: runtime
           version: 6.x
+          installationPath: $(Build.SourcesDirectory)/.dotnet
 
       - script: $(Build.SourcesDirectory)/.dotnet/dotnet.exe tool restore
         displayName: Restore dotnet tools

--- a/azure-pipelines-daily.yaml
+++ b/azure-pipelines-daily.yaml
@@ -24,14 +24,14 @@ stages:
         inputs:
           script: "restore.cmd"
 
-      - script: $(Build.SourcesDirectory)/.dotnet/dotnet.exe tool restore
-        displayName: Restore dotnet tools
-
       - task: UseDotNet@2
         displayName: Install .NET 6 runtime
         inputs:
           packageType: runtime
           version: 6.x
+
+      - script: $(Build.SourcesDirectory)/.dotnet/dotnet.exe tool restore
+        displayName: Restore dotnet tools
 
       - task: AzureCLI@2
         displayName: Run secret-manager synchronize
@@ -40,4 +40,4 @@ stages:
           scriptType: pscore
           scriptLocation: inlineScript
           inlineScript: |
-            Get-ChildItem .vault-config/*.yaml |% { $(Build.SourcesDirectory)/.dotnet/dotnet.exe secret-manager synchronize $_}
+            Get-ChildItem .vault-config/*.yaml |% { dotnet secret-manager synchronize $_}

--- a/azure-pipelines-daily.yaml
+++ b/azure-pipelines-daily.yaml
@@ -24,14 +24,14 @@ stages:
         inputs:
           script: "restore.cmd"
 
+      - script: $(Build.SourcesDirectory)/.dotnet/dotnet.exe tool restore
+        displayName: Restore dotnet tools
+
       - task: UseDotNet@2
         displayName: Install .NET 6 runtime
         inputs:
           packageType: runtime
           version: 6.x
-
-      - script: $(Build.SourcesDirectory)/.dotnet/dotnet.exe tool restore
-        displayName: Restore dotnet tools
 
       - task: AzureCLI@2
         displayName: Run secret-manager synchronize


### PR DESCRIPTION
## Related Issue
https://github.com/dotnet/dnceng/issues/4635

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md


#### PR Summary
This pull request runs the `restore.cmd` script with the `-ci` flag to fix the .NET SDK version issue.
