### PR TITLE
Enable NDK selection in Android rootfs build script

### DIFF
--- a/eng/common/cross/build-android-rootfs.sh
+++ b/eng/common/cross/build-android-rootfs.sh
@@ -142,10 +142,5 @@ cp -R "$__TmpDir/data/data/com.termux/files/usr/"* "$__ToolchainDir/$__SysRoot/u
 echo "Generating platform file..."
 echo "RID=android.${__ApiLevel}-${__BuildArch}" > $__ToolchainDir/$__SysRoot/android_platform
 
-echo "Now to build coreclr, libraries and installers; run:"
-echo ROOTFS_DIR=$(realpath $__ToolchainDir/$__SysRoot) ./build.sh --cross --arch $__BuildArch \
-    --subsetCategory coreclr
-echo ROOTFS_DIR=$(realpath $__ToolchainDir/$__SysRoot) ./build.sh --cross --arch $__BuildArch \
-    --subsetCategory libraries
-echo ROOTFS_DIR=$(realpath $__ToolchainDir/$__SysRoot) ./build.sh --cross --arch $__BuildArch \
-    --subsetCategory installer
+echo "Now to build coreclr, libraries and host; run:"
+echo ROOTFS_DIR=$(realpath $__ToolchainDir/$__SysRoot) ./build.sh clr+libs+host --cross --arch $__BuildArch

--- a/eng/common/cross/build-android-rootfs.sh
+++ b/eng/common/cross/build-android-rootfs.sh
@@ -6,10 +6,11 @@ usage()
 {
     echo "Creates a toolchain and sysroot used for cross-compiling for Android."
     echo
-    echo "Usage: $0 [BuildArch] [ApiLevel]"
+    echo "Usage: $0 [BuildArch] [ApiLevel] [--ndk NDKVersion]"
     echo
     echo "BuildArch is the target architecture of Android. Currently only arm64 is supported."
     echo "ApiLevel is the target Android API level. API levels usually match to Android releases. See https://source.android.com/source/build-numbers.html"
+    echo "NDKVersion is the version of Android NDK. The default is r21. See https://developer.android.com/ndk/downloads/revision_history"
     echo
     echo "By default, the toolchain and sysroot will be generated in cross/android-rootfs/toolchain/[BuildArch]. You can change this behavior"
     echo "by setting the TOOLCHAIN_DIR environment variable"
@@ -25,10 +26,15 @@ __BuildArch=arm64
 __AndroidArch=aarch64
 __AndroidToolchain=aarch64-linux-android
 
-for i in "$@"
-    do
-        lowerI="$(echo $i | tr "[:upper:]" "[:lower:]")"
-        case $lowerI in
+while :; do
+    if [[ "$#" -le 0 ]]; then
+        break
+    fi
+
+    i=$1
+
+    lowerI="$(echo $i | tr "[:upper:]" "[:lower:]")"
+    case $lowerI in
         -?|-h|--help)
             usage
             exit 1
@@ -43,6 +49,10 @@ for i in "$@"
             __AndroidArch=arm
             __AndroidToolchain=arm-linux-androideabi
             ;;
+        --ndk)
+            shift
+            __NDK_Version=$1
+            ;;
         *[0-9])
             __ApiLevel=$i
             ;;
@@ -50,7 +60,16 @@ for i in "$@"
             __UnprocessedBuildArgs="$__UnprocessedBuildArgs $i"
             ;;
     esac
+    shift
 done
+
+if [[ "$__NDK_Version" == "r21" ]] || [[ "$__NDK_Version" == "r22" ]]; then
+    __NDK_File_Arch_Spec=-x86_64
+    __SysRoot=sysroot
+else
+    __NDK_File_Arch_Spec=
+    __SysRoot=toolchains/llvm/prebuilt/linux-x86_64/sysroot
+fi
 
 # Obtain the location of the bash script to figure out where the root of the repo is.
 __ScriptBaseDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -78,6 +97,7 @@ fi
 
 echo "Target API level: $__ApiLevel"
 echo "Target architecture: $__BuildArch"
+echo "NDK version: $__NDK_Version"
 echo "NDK location: $__NDK_Dir"
 echo "Target Toolchain location: $__ToolchainDir"
 
@@ -85,8 +105,8 @@ echo "Target Toolchain location: $__ToolchainDir"
 if [ ! -d $__NDK_Dir ]; then
     echo Downloading the NDK into $__NDK_Dir
     mkdir -p $__NDK_Dir
-    wget -q --progress=bar:force:noscroll --show-progress https://dl.google.com/android/repository/android-ndk-$__NDK_Version-linux-x86_64.zip -O $__CrossDir/android-ndk-$__NDK_Version-linux-x86_64.zip
-    unzip -q $__CrossDir/android-ndk-$__NDK_Version-linux-x86_64.zip -d $__CrossDir
+    wget -q --progress=bar:force:noscroll --show-progress https://dl.google.com/android/repository/android-ndk-$__NDK_Version-linux$__NDK_File_Arch_Spec.zip -O $__CrossDir/android-ndk-$__NDK_Version-linux.zip
+    unzip -q $__CrossDir/android-ndk-$__NDK_Version-linux.zip -d $__CrossDir
 fi
 
 if [ ! -d $__lldb_Dir ]; then
@@ -116,16 +136,16 @@ for path in $(wget -qO- https://packages.termux.dev/termux-main-21/dists/stable/
     fi
 done
 
-cp -R "$__TmpDir/data/data/com.termux/files/usr/"* "$__ToolchainDir/sysroot/usr/"
+cp -R "$__TmpDir/data/data/com.termux/files/usr/"* "$__ToolchainDir/$__SysRoot/usr/"
 
 # Generate platform file for build.sh script to assign to __DistroRid
 echo "Generating platform file..."
-echo "RID=android.${__ApiLevel}-${__BuildArch}" > $__ToolchainDir/sysroot/android_platform
+echo "RID=android.${__ApiLevel}-${__BuildArch}" > $__ToolchainDir/$__SysRoot/android_platform
 
 echo "Now to build coreclr, libraries and installers; run:"
-echo ROOTFS_DIR=\$\(realpath $__ToolchainDir/sysroot\) ./build.sh --cross --arch $__BuildArch \
+echo ROOTFS_DIR=$(realpath $__ToolchainDir/$__SysRoot) ./build.sh --cross --arch $__BuildArch \
     --subsetCategory coreclr
-echo ROOTFS_DIR=\$\(realpath $__ToolchainDir/sysroot\) ./build.sh --cross --arch $__BuildArch \
+echo ROOTFS_DIR=$(realpath $__ToolchainDir/$__SysRoot) ./build.sh --cross --arch $__BuildArch \
     --subsetCategory libraries
-echo ROOTFS_DIR=\$\(realpath $__ToolchainDir/sysroot\) ./build.sh --cross --arch $__BuildArch \
+echo ROOTFS_DIR=$(realpath $__ToolchainDir/$__SysRoot) ./build.sh --cross --arch $__BuildArch \
     --subsetCategory installer


### PR DESCRIPTION
Currently, the script can only build rootfs with NDK r21. This change enables specifying the NDK version so that rootfs for more recent NDK versions can be built.

