### PR TITLE
Add PR filtration by source branch

### DIFF
--- a/.github/workflows/scripts/inter-branch-merge.ps1
+++ b/.github/workflows/scripts/inter-branch-merge.ps1
@@ -155,9 +155,9 @@ try {
     $prOwnerName = $RepoOwner
     $prRepoName = $RepoName
 
-    $query = 'query ($repoOwner: String!, $repoName: String!, $baseRefName: String!) {
+    $query = 'query ($repoOwner: String!, $repoName: String!, $baseRefName: String!, $headRefName: String!) {
         repository(owner: $repoOwner, name: $repoName) {
-          pullRequests(baseRefName: $baseRefName, states: OPEN, first: 100) {
+          pullRequests(baseRefName: $baseRefName, headRefName: $headRefName, states: OPEN, first: 100) {
             totalCount
             nodes {
               number
@@ -181,6 +181,7 @@ try {
             repoOwner   = $RepoOwner
             repoName    = $RepoName
             baseRefName = $MergeToBranch
+            headRefName = $mergeBranchName
         }
     }
 


### PR DESCRIPTION
Fixes #15352
Add additional filter for fetching already existing PRs. 

### Context
Current filtration: 
https://github.com/dotnet/arcade/blob/110ba755f2b00749b230e7f61c791f90047e170b/.github/workflows/scripts/inter-branch-merge.ps1#L158C5-L177C1

Includes every PR which is open to the destination branch and limits the results by 100. (The limit is the maximum allowed by api)
So in https://github.com/dotnet/sdk/pull/45547 the logic didn't find the existing PR and force-pushed to the branch. (Force push happens if there are no open PRs and we can safely override the code, but it should not be the case with open PR )

### What is changed
Adding filtration to the query (headRefName, the source branch name from where the PR is created) leaving the PR results only the list with specified branch . 

The rest of the logic does not change. 
Ownership of the branch will be still verified: 
https://github.com/dotnet/arcade/blob/110ba755f2b00749b230e7f61c791f90047e170b/.github/workflows/scripts/inter-branch-merge.ps1#L193C4-L195C26
