### PR TITLE
Allow pkgprojs without specifying a package index

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ApplyMetaPackages.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ApplyMetaPackages.cs
@@ -97,6 +97,11 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             foreach (var originalDependency in OriginalDependencies)
             {
                 var metaPackage = index?.MetaPackages?.GetMetaPackageId(originalDependency.ItemSpec);
+
+                // convert to meta-package dependency
+                var tfm = originalDependency.GetMetadata("TargetFramework");
+                var fx = NuGetFramework.Parse(tfm);
+
                 if (metaPackage != null && !ShouldSuppressMetapackage(suppressMetaPackages, metaPackage, fx))
                 {
                     HashSet<NuGetFramework> metaPackageFrameworks;
@@ -105,10 +110,6 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                     {
                         metaPackagesToAdd[metaPackage] = metaPackageFrameworks = new HashSet<NuGetFramework>();
                     }
-
-                    // convert to meta-package dependency
-                    var tfm = originalDependency.GetMetadata("TargetFramework");
-                    var fx = NuGetFramework.Parse(tfm);
 
                     metaPackageFrameworks.Add(fx);
                 }

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/CreateTrimDependencyGroups.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/CreateTrimDependencyGroups.cs
@@ -35,7 +35,6 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         /// <summary>
         /// Package index files used to define stable package list.
         /// </summary>
-        [Required]
         public ITaskItem[] PackageIndexes
         {
             get;
@@ -54,12 +53,12 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         reduce the set of frameworks to the minimum set of frameworks which is compatible (preferring inbox frameworks. */
         public override bool Execute()
         {
-            if (null == Dependencies)
+            if (Dependencies == null)
             {
                 Log.LogError("Dependencies argument must be specified");
                 return false;
             }
-            if (PackageIndexes == null && PackageIndexes.Length == 0)
+            if (PackageIndexes == null || PackageIndexes.Length == 0)
             {
                 Log.LogError("PackageIndexes argument must be specified");
                 return false;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/CreateTrimDependencyGroups.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/CreateTrimDependencyGroups.cs
@@ -35,6 +35,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         /// <summary>
         /// Package index files used to define stable package list.
         /// </summary>
+        [Required]
         public ITaskItem[] PackageIndexes
         {
             get;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GeneratePackageReport.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GeneratePackageReport.cs
@@ -233,14 +233,17 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             }
 
             // inspect any TFMs inbox
-            var index = PackageIndex.Load(PackageIndexes.Select(pi => pi.GetMetadata("FullPath")));
-            var inboxFrameworks = index.GetInboxFrameworks(PackageId).NullAsEmpty();
-            
-            foreach (var inboxFramework in inboxFrameworks)
+            if (PackageIndexes != null && PackageIndexes.Length > 0)
             {
-                if (!_frameworks.ContainsKey(inboxFramework))
+                var index = PackageIndex.Load(PackageIndexes.Select(pi => pi.GetMetadata("FullPath")));
+                var inboxFrameworks = index.GetInboxFrameworks(PackageId).NullAsEmpty();
+                
+                foreach (var inboxFramework in inboxFrameworks)
                 {
-                    _frameworks.Add(inboxFramework, s_noRids);
+                    if (!_frameworks.ContainsKey(inboxFramework))
+                    {
+                        _frameworks.Add(inboxFramework, s_noRids);
+                    }
                 }
             }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PromoteDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PromoteDependencies.cs
@@ -33,13 +33,9 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         
         public override bool Execute()
         {
-            if (PackageIndexes == null && PackageIndexes.Length == 0)
-            {
-                Log.LogError("PackageIndexes argument must be specified");
-                return false;
-            }
-
-            index = PackageIndex.Load(PackageIndexes.Select(pi => pi.GetMetadata("FullPath")));
+            index = PackageIndexes != null && PackageIndexes.Length > 0 ?
+                PackageIndex.Load(PackageIndexes.Select(pi => pi.GetMetadata("FullPath"))) :
+                null;
 
             List<ITaskItem> promotedDependencies = new List<ITaskItem>();
 
@@ -92,7 +88,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         {
             foreach (var dependency in dependencies)
             {
-                if (!index.IsInbox(dependency.Id, targetFramework, dependency.Version))
+                if (index == null || !index.IsInbox(dependency.Id, targetFramework, dependency.Version))
                 {
                     var copiedDepenedency = new TaskItem(dependency.OriginalItem);
                     copiedDepenedency.SetMetadata(TargetFrameworkMetadataName, targetFramework.GetShortFolderName());

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/SplitReferences.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/SplitReferences.cs
@@ -25,7 +25,6 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             set;
         }
 
-        [Required]
         public ITaskItem[] PackageIndexes
         {
             get;
@@ -51,13 +50,9 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             if (References == null || References.Length == 0)
                 return true;
 
-            if (PackageIndexes == null && PackageIndexes.Length == 0)
-            {
-                Log.LogError("PackageIndexes argument must be specified");
-                return false;
-            }
-
-            var index = PackageIndex.Load(PackageIndexes.Select(pi => pi.GetMetadata("FullPath")));
+            PackageIndex index = PackageIndexes != null && PackageIndexes.Length > 0 ?
+                PackageIndex.Load(PackageIndexes.Select(pi => pi.GetMetadata("FullPath"))) :
+                null;
 
             Dictionary<string, ITaskItem> packageReferences = new Dictionary<string, ITaskItem>();
             Dictionary<string, ITaskItem> assemblyReferences = new Dictionary<string, ITaskItem>();
@@ -72,7 +67,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 referencesMscorlib |= referenceName.Equals("mscorlib");
                 string referenceVersion = reference.GetMetadata("Version");
                 reference.SetMetadata("TargetFramework", TargetFramework);
-                if (!string.IsNullOrEmpty(TargetFramework) && index.IsInbox(referenceName, targetFx, referenceVersion))
+                if (!string.IsNullOrEmpty(TargetFramework) && index != null && index.IsInbox(referenceName, targetFx, referenceVersion))
                 {
                     AddReference(assemblyReferences, reference);
                 }

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidatePackage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidatePackage.cs
@@ -585,7 +585,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             // determine which Frameworks should support inbox
 
             PackageInfo packageInfo;
-            if (_index.Packages.TryGetValue(ContractName, out packageInfo))
+            if (_index != null && _index.Packages.TryGetValue(ContractName, out packageInfo))
             {
                 foreach (var inboxPair in packageInfo.InboxOn.GetInboxVersions())
                 {

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidationTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidationTask.cs
@@ -38,7 +38,6 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         /// <summary>
         /// Package index files used to define package version mapping.
         /// </summary>
-        [Required]
         public ITaskItem[] PackageIndexes { get; set; }
 
         /// <summary>
@@ -147,7 +146,9 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         }
         private void LoadIndex()
         {
-            _index = PackageIndex.Load(PackageIndexes.Select(pi => pi.GetMetadata("FullPath")));
+            _index = PackageIndexes != null && PackageIndexes.Length > 0 ?
+                PackageIndex.Load(PackageIndexes.Select(pi => pi.GetMetadata("FullPath"))) :
+                null;
         }
     }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
@@ -678,7 +678,7 @@
     <CreateTrimDependencyGroups Dependencies="@(FilePackageDependency);@(Dependency)"
                       PackageIndexes="@(PackageIndex)"
                       Files="@(File)"
-                      Condition="'@(FilePackageDependency)' != '' AND '$(PackageTargetRuntime)' == '' AND '@(PackageIndex)' != ''">
+                      Condition="'@(FilePackageDependency)' != '' AND '$(PackageTargetRuntime)' == ''">
       <Output TaskParameter="TrimmedDependencies" ItemName="FilePackageDependency" />
     </CreateTrimDependencyGroups>
 

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
@@ -678,7 +678,7 @@
     <CreateTrimDependencyGroups Dependencies="@(FilePackageDependency);@(Dependency)"
                       PackageIndexes="@(PackageIndex)"
                       Files="@(File)"
-                      Condition="'@(FilePackageDependency)' != '' AND '$(PackageTargetRuntime)' == ''">
+                      Condition="'@(FilePackageDependency)' != '' AND '$(PackageTargetRuntime)' == '' AND '@(PackageIndex)' != ''">
       <Output TaskParameter="TrimmedDependencies" ItemName="FilePackageDependency" />
     </CreateTrimDependencyGroups>
 


### PR DESCRIPTION
The current infra in dotnet/runtime always passes an empty packageindex.json in. Allow not passing a package index in to remove the empty files and the infra for it in dotnet/runtime. Unblocks https://github.com/dotnet/runtime/pull/111002

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
