### PR TITLE
Add no-emulation support in build-rootfs

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -5,7 +5,7 @@ set -e
 usage()
 {
     echo "Usage: $0 [BuildArch] [CodeName] [lldbx.y] [llvmx[.y]] [--skipunmount] --rootfsdir <directory>]"
-    echo "BuildArch can be: arm(default), arm64, armel, armv6, ppc64le, riscv64, s390x, x64, x86"
+    echo "BuildArch can be: arm(default), arm64, armel, armv6, loongarch64, ppc64le, riscv64, s390x, x64, x86"
     echo "CodeName - optional, Code name for Linux, can be: xenial(default), zesty, bionic, alpine"
     echo "                               for alpine can be specified with version: alpineX.YY or alpineedge"
     echo "                               for FreeBSD can be: freebsd13, freebsd14"
@@ -15,6 +15,7 @@ usage()
     echo "llvmx[.y] - optional, LLVM version for LLVM related packages."
     echo "--skipunmount - optional, will skip the unmount of rootfs folder."
     echo "--skipsigcheck - optional, will skip package signature checks (allowing untrusted packages)."
+    echo "--skipemulation - optional, will skip qemu and debootstrap requirement when building environment for debian based systems."
     echo "--use-mirror - optional, use mirror URL to fetch resources, when available."
     echo "--jobs N - optional, restrict to N jobs."
     exit 1
@@ -32,6 +33,7 @@ __QEMUArch=arm
 __UbuntuArch=armhf
 __UbuntuRepo=
 __UbuntuSuites="updates security backports"
+__DebianSuites=
 __LLDB_Package="liblldb-3.9-dev"
 __SkipUnmount=0
 
@@ -127,10 +129,12 @@ __AlpineKeys='
 616adfeb:MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAq0BFD1D4lIxQcsqEpQzU\npNCYM3aP1V/fxxVdT4DWvSI53JHTwHQamKdMWtEXetWVbP5zSROniYKFXd/xrD9X\n0jiGHey3lEtylXRIPxe5s+wXoCmNLcJVnvTcDtwx/ne2NLHxp76lyc25At+6RgE6\nADjLVuoD7M4IFDkAsd8UQ8zM0Dww9SylIk/wgV3ZkifecvgUQRagrNUdUjR56EBZ\nraQrev4hhzOgwelT0kXCu3snbUuNY/lU53CoTzfBJ5UfEJ5pMw1ij6X0r5S9IVsy\nKLWH1hiO0NzU2c8ViUYCly4Fe9xMTFc6u2dy/dxf6FwERfGzETQxqZvSfrRX+GLj\n/QZAXiPg5178hT/m0Y3z5IGenIC/80Z9NCi+byF1WuJlzKjDcF/TU72zk0+PNM/H\nKuppf3JT4DyjiVzNC5YoWJT2QRMS9KLP5iKCSThwVceEEg5HfhQBRT9M6KIcFLSs\nmFjx9kNEEmc1E8hl5IR3+3Ry8G5/bTIIruz14jgeY9u5jhL8Vyyvo41jgt9sLHR1\n/J1TxKfkgksYev7PoX6/ZzJ1ksWKZY5NFoDXTNYUgzFUTOoEaOg3BAQKadb3Qbbq\nXIrxmPBdgrn9QI7NCgfnAY3Tb4EEjs3ON/BNyEhUENcXOH6I1NbcuBQ7g9P73kE4\nVORdoc8MdJ5eoKBpO8Ww8HECAwEAAQ==
 616ae350:MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAyduVzi1mWm+lYo2Tqt/0\nXkCIWrDNP1QBMVPrE0/ZlU2bCGSoo2Z9FHQKz/mTyMRlhNqTfhJ5qU3U9XlyGOPJ\npiM+b91g26pnpXJ2Q2kOypSgOMOPA4cQ42PkHBEqhuzssfj9t7x47ppS94bboh46\nxLSDRff/NAbtwTpvhStV3URYkxFG++cKGGa5MPXBrxIp+iZf9GnuxVdST5PGiVGP\nODL/b69sPJQNbJHVquqUTOh5Ry8uuD2WZuXfKf7/C0jC/ie9m2+0CttNu9tMciGM\nEyKG1/Xhk5iIWO43m4SrrT2WkFlcZ1z2JSf9Pjm4C2+HovYpihwwdM/OdP8Xmsnr\nDzVB4YvQiW+IHBjStHVuyiZWc+JsgEPJzisNY0Wyc/kNyNtqVKpX6dRhMLanLmy+\nf53cCSI05KPQAcGj6tdL+D60uKDkt+FsDa0BTAobZ31OsFVid0vCXtsbplNhW1IF\nHwsGXBTVcfXg44RLyL8Lk/2dQxDHNHzAUslJXzPxaHBLmt++2COa2EI1iWlvtznk\nOk9WP8SOAIj+xdqoiHcC4j72BOVVgiITIJNHrbppZCq6qPR+fgXmXa+sDcGh30m6\n9Wpbr28kLMSHiENCWTdsFij+NQTd5S47H7XTROHnalYDuF1RpS+DpQidT5tUimaT\nJZDr++FjKrnnijbyNF8b98UCAwEAAQ==
 616db30d:MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAnpUpyWDWjlUk3smlWeA0\nlIMW+oJ38t92CRLHH3IqRhyECBRW0d0aRGtq7TY8PmxjjvBZrxTNDpJT6KUk4LRm\na6A6IuAI7QnNK8SJqM0DLzlpygd7GJf8ZL9SoHSH+gFsYF67Cpooz/YDqWrlN7Vw\ntO00s0B+eXy+PCXYU7VSfuWFGK8TGEv6HfGMALLjhqMManyvfp8hz3ubN1rK3c8C\nUS/ilRh1qckdbtPvoDPhSbTDmfU1g/EfRSIEXBrIMLg9ka/XB9PvWRrekrppnQzP\nhP9YE3x/wbFc5QqQWiRCYyQl/rgIMOXvIxhkfe8H5n1Et4VAorkpEAXdsfN8KSVv\nLSMazVlLp9GYq5SUpqYX3KnxdWBgN7BJoZ4sltsTpHQ/34SXWfu3UmyUveWj7wp0\nx9hwsPirVI00EEea9AbP7NM2rAyu6ukcm4m6ATd2DZJIViq2es6m60AE6SMCmrQF\nwmk4H/kdQgeAELVfGOm2VyJ3z69fQuywz7xu27S6zTKi05Qlnohxol4wVb6OB7qG\nLPRtK9ObgzRo/OPumyXqlzAi/Yvyd1ZQk8labZps3e16bQp8+pVPiumWioMFJDWV\nGZjCmyMSU8V6MB6njbgLHoyg2LCukCAeSjbPGGGYhnKLm1AKSoJh3IpZuqcKCk5C\n8CM1S15HxV78s9dFntEqIokCAwEAAQ==
+66ba20fe:MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAtfB12w4ZgqsXWZDfUAV/\n6Y4aHUKIu3q4SXrNZ7CXF9nXoAVYrS7NAxJdAodsY3vPCN0g5O8DFXR+390LdOuQ\n+HsGKCc1k5tX5ZXld37EZNTNSbR0k+NKhd9h6X3u6wqPOx7SIKxwAQR8qeeFq4pP\nrt9GAGlxtuYgzIIcKJPwE0dZlcBCg+GnptCUZXp/38BP1eYC+xTXSL6Muq1etYfg\nodXdb7Yl+2h1IHuOwo5rjgY5kpY7GcAs8AjGk3lDD/av60OTYccknH0NCVSmPoXK\nvrxDBOn0LQRNBLcAfnTKgHrzy0Q5h4TNkkyTgxkoQw5ObDk9nnabTxql732yy9BY\ns+hM9+dSFO1HKeVXreYSA2n1ndF18YAvAumzgyqzB7I4pMHXq1kC/8bONMJxwSkS\nYm6CoXKyavp7RqGMyeVpRC7tV+blkrrUml0BwNkxE+XnwDRB3xDV6hqgWe0XrifD\nYTfvd9ScZQP83ip0r4IKlq4GMv/R5shcCRJSkSZ6QSGshH40JYSoiwJf5FHbj9ND\n7do0UAqebWo4yNx63j/wb2ULorW3AClv0BCFSdPsIrCStiGdpgJDBR2P2NZOCob3\nG9uMj+wJD6JJg2nWqNJxkANXX37Qf8plgzssrhrgOvB0fjjS7GYhfkfmZTJ0wPOw\nA8+KzFseBh4UFGgue78KwgkCAwEAAQ==
 '
 __Keyring=
 __KeyringFile="/usr/share/keyrings/ubuntu-archive-keyring.gpg"
 __SkipSigCheck=0
+__SkipEmulation=0
 __UseMirror=0
 
 __UnprocessedBuildArgs=
@@ -177,6 +181,19 @@ while :; do
 
             if [[ -e "$__KeyringFile" ]]; then
                 __Keyring="--keyring $__KeyringFile"
+            fi
+            ;;
+        loongarch64)
+            __BuildArch=loongarch64
+            __AlpineArch=loongarch64
+            __QEMUArch=loongarch64
+            __UbuntuArch=loong64
+            __UbuntuSuites=
+            __DebianSuites=unreleased
+            __LLDB_Package="liblldb-19-dev"
+
+            if [[ "$__CodeName" == "sid" ]]; then
+                __UbuntuRepo="http://ftp.ports.debian.org/debian-ports/"
             fi
             ;;
         riscv64)
@@ -339,10 +356,28 @@ while :; do
             ;;
         sid) # Debian sid
             __CodeName=sid
-            __KeyringFile="/usr/share/keyrings/debian-archive-keyring.gpg"
+            __UbuntuSuites=
 
-            if [[ -z "$__UbuntuRepo" ]]; then
-                __UbuntuRepo="http://ftp.debian.org/debian/"
+            # Debian-Ports architectures need different values
+            case "$__UbuntuArch" in
+            amd64|arm64|armel|armhf|i386|mips64el|ppc64el|riscv64|s390x)
+                __KeyringFile="/usr/share/keyrings/debian-archive-keyring.gpg"
+
+                if [[ -z "$__UbuntuRepo" ]]; then
+                    __UbuntuRepo="http://ftp.debian.org/debian/"
+                fi
+                ;;
+            *)
+                __KeyringFile="/usr/share/keyrings/debian-ports-archive-keyring.gpg"
+
+                if [[ -z "$__UbuntuRepo" ]]; then
+                    __UbuntuRepo="http://ftp.ports.debian.org/debian-ports/"
+                fi
+                ;;
+            esac
+
+            if [[ -e "$__KeyringFile" ]]; then
+                __Keyring="--keyring $__KeyringFile"
             fi
             ;;
         tizen)
@@ -387,6 +422,9 @@ while :; do
         --skipsigcheck)
             __SkipSigCheck=1
             ;;
+        --skipemulation)
+            __SkipEmulation=1
+            ;;
         --rootfsdir|-rootfsdir)
             shift
             __RootfsDir="$1"
@@ -419,9 +457,9 @@ case "$__AlpineVersion" in
         elif [[ "$__AlpineArch" == "x86" ]]; then
             __AlpineVersion=3.17 # minimum version that supports lldb-dev
             __AlpinePackages+=" llvm15-libs"
-        elif [[ "$__AlpineArch" == "riscv64" ]]; then
-            __AlpineLlvmLibsLookup=1
-            __AlpineVersion=edge # minimum version with APKINDEX.tar.gz (packages archive)
+        elif [[ "$__AlpineArch" == "riscv64" || "$__AlpineArch" == "loongarch64" ]]; then
+            __AlpineVersion=3.21 # minimum version that supports lldb-dev
+            __AlpinePackages+=" llvm19-libs"
         elif [[ -n "$__AlpineMajorVersion" ]]; then
             # use whichever alpine version is provided and select the latest toolchain libs
             __AlpineLlvmLibsLookup=1
@@ -505,11 +543,6 @@ if [[ "$__CodeName" == "alpine" ]]; then
     echo "$__ApkToolsSHA512SUM $__ApkToolsDir/apk.static" | sha512sum -c
     chmod +x "$__ApkToolsDir/apk.static"
 
-    if [[ -f "/usr/bin/qemu-$__QEMUArch-static" ]]; then
-        mkdir -p "$__RootfsDir"/usr/bin
-        cp -v "/usr/bin/qemu-$__QEMUArch-static" "$__RootfsDir/usr/bin"
-    fi
-
     if [[ "$__AlpineVersion" == "edge" ]]; then
         version=edge
     else
@@ -527,6 +560,10 @@ if [[ "$__CodeName" == "alpine" ]]; then
         __ApkSignatureArg="--allow-untrusted"
     else
         __ApkSignatureArg="--keys-dir $__ApkKeysDir"
+    fi
+
+    if [[ "$__SkipEmulation" == "1" ]]; then
+        __NoEmulationArg="--no-scripts"
     fi
 
     # initialize DB
@@ -550,7 +587,7 @@ if [[ "$__CodeName" == "alpine" ]]; then
     "$__ApkToolsDir/apk.static" \
         -X "http://dl-cdn.alpinelinux.org/alpine/$version/main" \
         -X "http://dl-cdn.alpinelinux.org/alpine/$version/community" \
-        -U $__ApkSignatureArg --root "$__RootfsDir" --arch "$__AlpineArch" \
+        -U $__ApkSignatureArg --root "$__RootfsDir" --arch "$__AlpineArch" $__NoEmulationArg \
         add $__AlpinePackages
 
     rm -r "$__ApkToolsDir"
@@ -745,25 +782,68 @@ elif [[ "$__CodeName" == "haiku" ]]; then
     popd
     rm -rf "$__RootfsDir/tmp"
 elif [[ -n "$__CodeName" ]]; then
+    if [[ "$__SkipEmulation" == "1" ]]; then
+        if [[ -z "$AR" ]]; then
+            if command -v ar &>/dev/null; then
+                AR="$(command -v ar)"
+            elif command -v llvm-ar &>/dev/null; then
+                AR="$(command -v llvm-ar)"
+            else
+                echo "Unable to find ar or llvm-ar on PATH, add them to PATH or set AR environment variable pointing to the available AR tool"
+                exit 1
+            fi
+        fi
 
+        # shellcheck disable=SC2086
+        suites="$__CodeName $__DebianSuites $(echo $__UbuntuSuites | xargs -n 1 | xargs -I {} echo -n "$__CodeName-{} ")"
+
+        PYTHON=${PYTHON_EXECUTABLE:-python3}
+
+        # shellcheck disable=SC2086,SC2046
+        echo running "$PYTHON" "$__CrossDir/install-debs.py" --arch "$__UbuntuArch" --rootfsdir "$__RootfsDir" --artool "$AR" \
+            $(echo $suites | xargs -n 1 | xargs -I {} echo -n "--suite {} ") \
+            $__UbuntuPackages
+
+        # shellcheck disable=SC2086,SC2046
+        "$PYTHON" "$__CrossDir/install-debs.py" --arch "$__UbuntuArch" --mirror "$__UbuntuRepo" --rootfsdir "$__RootfsDir" --artool "$AR" \
+            $(echo $suites | xargs -n 1 | xargs -I {} echo -n "--suite {} ") \
+            $__UbuntuPackages
+
+        exit 0
+    fi
+
+    __UpdateOptions=
     if [[ "$__SkipSigCheck" == "0" ]]; then
         __Keyring="$__Keyring --force-check-gpg"
+    else
+        __Keyring=
+        __UpdateOptions="--allow-unauthenticated --allow-insecure-repositories"
     fi
 
     # shellcheck disable=SC2086
     echo running debootstrap "--variant=minbase" $__Keyring --arch "$__UbuntuArch" "$__CodeName" "$__RootfsDir" "$__UbuntuRepo"
-    debootstrap "--variant=minbase" $__Keyring --arch "$__UbuntuArch" "$__CodeName" "$__RootfsDir" "$__UbuntuRepo"
 
+    # shellcheck disable=SC2086
+    if ! debootstrap "--variant=minbase" $__Keyring --arch "$__UbuntuArch" "$__CodeName" "$__RootfsDir" "$__UbuntuRepo"; then
+        echo "debootstrap failed! dumping debootstrap.log"
+        cat "$__RootfsDir/debootstrap/debootstrap.log"
+        exit 1
+    fi
+
+    rm -rf "$__RootfsDir"/etc/apt/*.{sources,list} "$__RootfsDir"/etc/apt/sources.list.d
     mkdir -p "$__RootfsDir/etc/apt/sources.list.d/"
+
+    # shellcheck disable=SC2086
     cat > "$__RootfsDir/etc/apt/sources.list.d/$__CodeName.sources" <<EOF
 Types: deb
 URIs: $__UbuntuRepo
-Suites: $__CodeName $(echo $__UbuntuSuites | xargs -n 1 | xargs -I {} echo -n "$__CodeName-{} ")
+Suites: $__CodeName $__DebianSuites $(echo $__UbuntuSuites | xargs -n 1 | xargs -I {} echo -n "$__CodeName-{} ")
 Components: main universe
 Signed-By: $__KeyringFile
 EOF
 
-    chroot "$__RootfsDir" apt-get update
+    # shellcheck disable=SC2086
+    chroot "$__RootfsDir" apt-get update $__UpdateOptions
     chroot "$__RootfsDir" apt-get -f -y install
     # shellcheck disable=SC2086
     chroot "$__RootfsDir" apt-get -y install $__UbuntuPackages

--- a/eng/common/cross/install-debs.py
+++ b/eng/common/cross/install-debs.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+
+import argparse
+import asyncio
+import aiohttp
+import gzip
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import zstandard
+
+from collections import deque
+from functools import cmp_to_key
+
+async def download_file(session, url, dest_path, max_retries=3, retry_delay=2, timeout=60):
+    """Asynchronous file download with retries."""
+    attempt = 0
+    while attempt < max_retries:
+        try:
+            async with session.get(url, timeout=aiohttp.ClientTimeout(total=timeout)) as response:
+                if response.status == 200:
+                    with open(dest_path, "wb") as f:
+                        content = await response.read()
+                        f.write(content)
+                    print(f"Downloaded {url} at {dest_path}")
+                    return
+                else:
+                    print(f"Failed to download {url}, Status Code: {response.status}")
+                    break
+        except (asyncio.CancelledError, asyncio.TimeoutError, aiohttp.ClientError) as e:
+            print(f"Error downloading {url}: {type(e).__name__} - {e}. Retrying...")
+
+        attempt += 1
+        await asyncio.sleep(retry_delay)
+
+    print(f"Failed to download {url} after {max_retries} attempts.")
+
+async def download_deb_files_parallel(mirror, packages, tmp_dir):
+    """Download .deb files in parallel."""
+    os.makedirs(tmp_dir, exist_ok=True)
+
+    tasks = []
+    timeout = aiohttp.ClientTimeout(total=60)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        for pkg, info in packages.items():
+            filename = info.get("Filename")
+            if filename:
+                url = f"{mirror}/{filename}"
+                dest_path = os.path.join(tmp_dir, os.path.basename(filename))
+                tasks.append(asyncio.create_task(download_file(session, url, dest_path)))
+
+        await asyncio.gather(*tasks)
+
+async def download_package_index_parallel(mirror, arch, suites):
+    """Download package index files for specified suites and components entirely in memory."""
+    tasks = []
+    timeout = aiohttp.ClientTimeout(total=60)
+
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        for suite in suites:
+            for component in ["main", "universe"]:
+                url = f"{mirror}/dists/{suite}/{component}/binary-{arch}/Packages.gz"
+                tasks.append(fetch_and_decompress(session, url))
+
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    merged_content = ""
+    for result in results:
+        if isinstance(result, str):
+            if merged_content:
+                merged_content += "\n\n"
+            merged_content += result
+
+    return merged_content
+
+async def fetch_and_decompress(session, url):
+    """Fetch and decompress the Packages.gz file."""
+    try:
+        async with session.get(url) as response:
+            if response.status == 200:
+                compressed_data = await response.read()
+                decompressed_data = gzip.decompress(compressed_data).decode('utf-8')
+                print(f"Downloaded index: {url}")
+                return decompressed_data
+            else:
+                print(f"Skipped index: {url} (doesn't exist)")
+                return None
+    except Exception as e:
+        print(f"Error fetching {url}: {e}")
+
+def parse_debian_version(version):
+    """Parse a Debian package version into epoch, upstream version, and revision."""
+    match = re.match(r'^(?:(\d+):)?([^-]+)(?:-(.+))?$', version)
+    if not match:
+        raise ValueError(f"Invalid Debian version format: {version}")
+    epoch, upstream, revision = match.groups()
+    return int(epoch) if epoch else 0, upstream, revision or ""
+
+def compare_upstream_version(v1, v2):
+    """Compare upstream or revision parts using Debian rules."""
+    def tokenize(version):
+        tokens = re.split(r'([0-9]+|[A-Za-z]+)', version)
+        return [int(x) if x.isdigit() else x for x in tokens if x]
+
+    tokens1 = tokenize(v1)
+    tokens2 = tokenize(v2)
+
+    for token1, token2 in zip(tokens1, tokens2):
+        if type(token1) == type(token2):
+            if token1 != token2:
+                return (token1 > token2) - (token1 < token2)
+        else:
+            return -1 if isinstance(token1, str) else 1
+
+    return len(tokens1) - len(tokens2)
+
+def compare_debian_versions(version1, version2):
+    """Compare two Debian package versions."""
+    epoch1, upstream1, revision1 = parse_debian_version(version1)
+    epoch2, upstream2, revision2 = parse_debian_version(version2)
+
+    if epoch1 != epoch2:
+        return epoch1 - epoch2
+
+    result = compare_upstream_version(upstream1, upstream2)
+    if result != 0:
+        return result
+
+    return compare_upstream_version(revision1, revision2)
+
+def resolve_dependencies(packages, aliases, desired_packages):
+    """Recursively resolves dependencies for the desired packages."""
+    resolved = []
+    to_process = deque(desired_packages)
+
+    while to_process:
+        current = to_process.popleft()
+        resolved_package = current if current in packages else aliases.get(current, [None])[0]
+
+        if not resolved_package:
+            print(f"Error: Package '{current}' was not found in the available packages.")
+            sys.exit(1)
+
+        if resolved_package not in resolved:
+            resolved.append(resolved_package)
+
+            deps = packages.get(resolved_package, {}).get("Depends", "")
+            if deps:
+                deps = [dep.split(' ')[0] for dep in deps.split(', ') if dep]
+                for dep in deps:
+                    if dep not in resolved and dep not in to_process and dep in packages:
+                        to_process.append(dep)
+
+    return resolved
+
+def parse_package_index(content):
+    """Parses the Packages.gz file and returns package information."""
+    packages = {}
+    aliases = {}
+    entries = re.split(r'\n\n+', content)
+    for entry in entries:
+        fields = dict(re.findall(r'^(\S+): (.+)$', entry, re.MULTILINE))
+        if "Package" in fields:
+            package_name = fields["Package"]
+            packages[package_name] = {
+                "Version": fields.get("Version"),
+                "Filename": fields.get("Filename"),
+                "Depends": fields.get("Depends")
+            }
+            if "Provides" in fields:
+                provides_list = [x.strip() for x in fields["Provides"].split(",")]
+                for alias in provides_list:
+                    # strip version specifiers
+                    alias_name = re.sub(r'\s*\(=.*\)', '', alias)
+                    if alias_name not in aliases:
+                        aliases[alias_name] = []
+                    aliases[alias_name].append(package_name)
+    return packages, aliases
+
+def install_packages(mirror, packages_info, aliases, tmp_dir, extract_dir, ar_tool, desired_packages):
+    """Downloads .deb files and extracts them."""
+    resolved_packages = resolve_dependencies(packages_info, aliases, desired_packages)
+    print(f"Resolved packages (including dependencies): {resolved_packages}")
+
+    packages_to_download = {}
+
+    for pkg in resolved_packages:
+        available_versions = [pkg]
+
+        if pkg in aliases:
+            available_versions.extend(aliases[pkg])
+
+        # Choose the package with the latest version
+        if available_versions:
+            best_package = max(
+                (p for p in available_versions if p in packages_info),
+                key=lambda p: (
+                    1 if p == pkg else 0,
+                    cmp_to_key(lambda p1, p2: compare_debian_versions(
+                        packages_info[p1]["Version"],
+                        packages_info[p2]["Version"]
+                    ))(p)
+                ),
+                default=None
+            )
+
+            if best_package:
+                packages_to_download[best_package] = packages_info[best_package]
+
+    asyncio.run(download_deb_files_parallel(mirror, packages_to_download, tmp_dir))
+
+    package_to_deb_file_map = {}
+    for pkg in resolved_packages:
+        pkg_info = packages_info.get(pkg)
+        if pkg_info:
+            deb_filename = pkg_info.get("Filename")
+            if deb_filename:
+                deb_file_path = os.path.join(tmp_dir, os.path.basename(deb_filename))
+                package_to_deb_file_map[pkg] = deb_file_path
+
+    for pkg in reversed(resolved_packages):
+        deb_file = package_to_deb_file_map.get(pkg)
+        if deb_file and os.path.exists(deb_file):
+            extract_deb_file_using_dpkg(deb_file, tmp_dir, extract_dir, ar_tool)
+
+    print("All done!")
+
+def extract_deb_file_using_dpkg(deb_file, tmp_dir, extract_dir, ar_tool):
+    """Extract .deb file contents"""
+
+    os.makedirs(extract_dir, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(dir=tmp_dir) as tmp_subdir:
+        result = subprocess.run(f"{ar_tool} t {os.path.abspath(deb_file)}", cwd=tmp_subdir, check=True, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        tar_filename = None
+        for line in result.stdout.decode().splitlines():
+            if line.startswith("data.tar"):
+                tar_filename = line.strip()
+                break
+
+        if not tar_filename:
+            raise FileNotFoundError(f"Could not find 'data.tar.*' in {deb_file}.")
+
+        tar_file_path = os.path.join(tmp_subdir, tar_filename)
+        print(f"Extracting {tar_filename} from {deb_file}..")
+
+        subprocess.run(f"{ar_tool} p {os.path.abspath(deb_file)} {tar_filename} > {tar_file_path}", check=True, shell=True)
+
+        file_extension = os.path.splitext(tar_file_path)[1].lower()
+
+        if file_extension == ".xz":
+            mode = "r:xz"
+        elif file_extension == ".gz":
+            mode = "r:gz"
+        elif file_extension == ".zst":
+            # zstd is not supported by standard library yet
+            decompressed_tar_path = tar_file_path.replace(".zst", "")
+            with open(tar_file_path, "rb") as zst_file, open(decompressed_tar_path, "wb") as decompressed_file:
+                dctx = zstandard.ZstdDecompressor()
+                dctx.copy_stream(zst_file, decompressed_file)
+
+            tar_file_path = decompressed_tar_path
+            mode = "r"
+        else:
+            raise ValueError(f"Unsupported compression format: {file_extension}")
+
+        with tarfile.open(tar_file_path, mode) as tar:
+            tar.extractall(path=extract_dir, filter=None)
+
+def finalize_setup(rootfsdir):
+    lib_dir = os.path.join(rootfsdir, 'lib')
+    usr_lib_dir = os.path.join(rootfsdir, 'usr', 'lib')
+
+    if os.path.exists(lib_dir):
+        if os.path.islink(lib_dir):
+            os.remove(lib_dir)
+        else:
+            os.makedirs(usr_lib_dir, exist_ok=True)
+
+            for item in os.listdir(lib_dir):
+                src = os.path.join(lib_dir, item)
+                dest = os.path.join(usr_lib_dir, item)
+
+                if os.path.isdir(src):
+                    shutil.copytree(src, dest, dirs_exist_ok=True)
+                else:
+                    shutil.copy2(src, dest)
+
+            shutil.rmtree(lib_dir)
+
+    os.symlink(usr_lib_dir, lib_dir)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate rootfs for .NET runtime on Debian-like OS")
+    parser.add_argument("--distro", required=False, help="Distro name (e.g., debian, ubuntu, etc.)")
+    parser.add_argument("--arch", required=True, help="Architecture (e.g., amd64, loong64, etc.)")
+    parser.add_argument("--rootfsdir", required=True, help="Destination directory.")
+    parser.add_argument('--suite', required=True, action='append', help='Specify one or more repository suites to collect index data.')
+    parser.add_argument("--mirror", required=False, help="Mirror (e.g., http://ftp.debian.org/debian-ports etc.)")
+    parser.add_argument("--artool", required=False, default="ar", help="ar tool to extract debs (e.g., ar, llvm-ar etc.)")
+    parser.add_argument("packages", nargs="+", help="List of package names to be installed.")
+
+    args = parser.parse_args()
+
+    if args.mirror is None:
+        if args.distro == "ubuntu":
+            args.mirror = "http://archive.ubuntu.com/ubuntu" if args.arch in ["amd64", "i386"] else "http://ports.ubuntu.com/ubuntu-ports"
+        elif args.distro == "debian":
+            args.mirror = "http://ftp.debian.org/debian-ports"
+        else:
+            raise Exception("Unsupported distro")
+
+    DESIRED_PACKAGES = args.packages + [ # base packages
+        "dpkg",
+        "busybox",
+        "libc-bin",
+        "base-files",
+        "base-passwd",
+        "debianutils"
+    ]
+
+    print(f"Creating rootfs. rootfsdir: {args.rootfsdir}, distro: {args.distro}, arch: {args.arch}, suites: {args.suite}, mirror: {args.mirror}")
+
+    package_index_content = asyncio.run(download_package_index_parallel(args.mirror, args.arch, args.suite))
+
+    packages_info, aliases = parse_package_index(package_index_content)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        install_packages(args.mirror, packages_info, aliases, tmp_dir, args.rootfsdir, args.artool, DESIRED_PACKAGES)
+
+    finalize_setup(args.rootfsdir)


### PR DESCRIPTION
Building rootfs currently requires emulation to run post-install, maintainers scripts. That mean qemu, debootstrap, binfmt all need to support the $newPlatform. Locally things work because docker/podman are typically supporting the new platform like loongarch64, but on Azure DevOps side, qemu is pretty old.

Once the rootfs environment is built, no part of the infra in runtime/diagnostics repos ever `chroot` into the rootfsdir. Instead, all we rely on is headers, libs and toolchains in place and --sysroot with host clang. The maintainers scripts can compile stuff post-install and create symlinks etc. Our use-cases are simple enough to avoid running maintainer scripts.

On Alpine Linux, it's just a matter of `--no-scripts` passed to `apk add`. debootstrap doesn't provide such option.

This PR:
* adds `--skipemulation` arg to build rootfs to skip the post-install scripts. For debian-based distros, a python script is added which resolves, downloads and extracts the deb files and skips the maintainers scripts.
  * I've used python because we are using it in crossdeps and we haven't used dotnet so availability is unknown. We can revisit the decision later
* adds LA64 support to supersede https://github.com/dotnet/arcade/pull/8333 and https://github.com/dotnet/arcade/pull/15291.

Tested at https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1306 with `--skipemulation`.