### PR TITLE
Infer the projects runtime identifier as the vertical's RID when doing a vertical build and filter down RID lists to the target RID in such a scenario

### DIFF
--- a/Documentation/UnifiedBuild/Unified-Build-Controls.md
+++ b/Documentation/UnifiedBuild/Unified-Build-Controls.md
@@ -135,6 +135,7 @@ These controls may be used for **infrastructure or product purposes**.
 | -------- | -------- | -------- | -------- |
 | DotNetBuildWithOnlineSources | "true", "false", "" | "false" by default when `SourceOnly` switch is active. | When "true", do not remove non-local input sources. Infrastructure switch only. This switch is only exposed at the orchestrator level.</br>This replaces the existing `DotNetBuildOffline` switch. |
 | DotNetBuildSourceOnly | "true", "false", "" | "" | When "true", build only from source. Online sources may remain unless `DotNetBuildOffline` is set to true. This is both an infrastructure and a product switch.<br/>This is roughly equivalent to `DotNetBuildFromSource` in the current infrastructure, though other controls may be better suited. |
+| DotNetBuildTargetRidOnly | "true", "false", "" | "" | When not set, defaults to "true" if the repository build transitively depends on dotnet/runtime and `DotNetBuildOrchestrator` == "true"; otherwise "false". When "true", builds projects for the current `TargetRid` instead of using the current runtime identifier. |
 
 ### Output Controls
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/BeforeNETSdkTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/BeforeNETSdkTargets.targets
@@ -1,0 +1,4 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Project>
+  <Import Project="RuntimeIdentifierInference.BeforeNETSdkTargets.targets" />
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RuntimeIdentifierInference.BeforeNETSdkTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RuntimeIdentifierInference.BeforeNETSdkTargets.targets
@@ -1,0 +1,49 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Project>
+  <PropertyGroup>
+    <_EnableArcadeRuntimeIdentifierInference>$(EnableArcadeRuntimeIdentifierInference)</_EnableArcadeRuntimeIdentifierInference>
+
+    <!-- If the user has specified a RID for their project, don't overwrite it. -->
+    <_EnableArcadeRuntimeIdentifierInference Condition="'$(_EnableArcadeRuntimeIdentifierInference)' == '' and '$(RuntimeIdentifier)' != ''">false</_EnableArcadeRuntimeIdentifierInference>
+
+    <!-- If the SDK will infer this project as "RID agnostic", don't infer RIDs. -->
+    <_RidAgnosticProject Condition="('$(OutputType)' == 'Library' or '$(IsTestProject)' == 'true') and '$(RuntimeIdentifiers)' == ''">true</_RidAgnosticProject>
+
+    <!-- If this project is RID-agnostic, don't infer RIDs. -->
+    <_EnableArcadeRuntimeIdentifierInference Condition="'$(_EnableArcadeRuntimeIdentifierInference)' == '' and ('$(IsRidAgnostic)' == 'true' or '$(_RidAgnosticProject)' == 'true')">false</_EnableArcadeRuntimeIdentifierInference>
+
+    <!--
+      When we're doing a build of a single vertical, we may not have a runtime or host available for any RID outside of our current target.
+      For many of our projects, we don't actually need to build any RID-specific assets, but the SDK may still try to pull down assets for other RIDs,
+      in particular for the RID matching the SDK's RID.
+      To avoid this, we'll default to setting the RID to the vertical's target RID.
+      To preserve expected behavior for projects that don't specify a RID in a non-vertical build, we won't append the RID to the output path if the user hasn't explicitly requested it.
+    -->
+    <_EnableArcadeRuntimeIdentifierInference Condition="'$(_EnableArcadeRuntimeIdentifierInference)' == '' and '$(DotNetBuild)' == 'true'">true</_EnableArcadeRuntimeIdentifierInference>
+
+    <_EnableArcadeRuntimeIdentifierFilters Condition="'$(EnableArcadeRuntimeIdentifierFilters)' != ''">$(EnableArcadeRuntimeIdentifierFilters)</_EnableArcadeRuntimeIdentifierFilters>
+    
+    <!--
+      If we infer a RID for the project, default to filtering down the list of RIDs the project specifies and automatically excluding projects that don't build for this RID.
+    -->
+    <_EnableArcadeRuntimeIdentifierFilters Condition="'$(_EnableArcadeRuntimeIdentifierFilters)' == '' and '$(_EnableArcadeRuntimeIdentifierInference)' == 'true'">$(_EnableArcadeRuntimeIdentifierFilters)</_EnableArcadeRuntimeIdentifierFilters>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(_EnableArcadeRuntimeIdentifierInference)' == 'true'">
+    <!-- If we're inferring a RID, regular builds wouldn't have appended the RID to the output path. Default to not appending to the output path to preserve expected output locations. -->
+    <AppendRuntimeIdentifierToOutputPath Condition="'$(AppendRuntimeIdentifierToOutputPath)' == ''">false</AppendRuntimeIdentifierToOutputPath>
+    <RuntimeIdentifier>$(TargetRid)</RuntimeIdentifier>
+
+    <!-- If this project would have been inferred as "RID agnostic", preserve that as well. -->
+    <IsRidAgnostic Condition="('$(OutputType)' == 'Library' or '$(IsTestProject)' == 'true') and '$(RuntimeIdentifiers)' == ''">true</IsRidAgnostic>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(_EnableArcadeRuntimeIdentifierFilters)' == 'true' and '$(RuntimeIdentifiers)' != ''">
+    <_ExplicitlySpecifiedRuntimeIdentifiers>;$(RuntimeIdentifiers);</_ExplicitlySpecifiedRuntimeIdentifiers>
+    <!-- If a project builds for a set of RIDs specified in the project file and this vertical isn't in the list, suppress building this project. -->
+    <_SuppressAllTargets Condition="'$(DisableArcadeExcludeFromBuildSupport)' != 'true' and $(_ExplicitlySpecifiedRuntimeIdentifiers).Contains(';$(TargetRid);')) == 'false'">true</_SuppressAllTargets>
+
+    <!-- The .NET SDK will try to restore for all specified RIDs. Change the list of RIDs to only our inferred RID to ensure that restore only restores assets that could be available. -->
+    <RuntimeIdentifiers>$(RuntimeIdentifier)</RuntimeIdentifiers>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RuntimeIdentifierInference.BeforeNETSdkTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RuntimeIdentifierInference.BeforeNETSdkTargets.targets
@@ -16,6 +16,21 @@
     <_EnableArcadeRuntimeIdentifierInference Condition="'$(_EnableArcadeRuntimeIdentifierInference)' == '' and ('$(IsRidAgnostic)' == 'true' or '$(_RidAgnosticProject)' == 'true')">false</_EnableArcadeRuntimeIdentifierInference>
 
     <!--
+      We only need to infer if the project would use the RID
+    -->
+    <_BuildFlavorRequiredRid
+      Condition="
+        '$(SelfContained)' == 'true' or
+        ('$(_IsPublishing)' == 'true' and
+          (
+            '$(PublishReadyToRun)' == 'true' or
+            '$(PublishSingleFile)' == 'true' or
+            '$(PublishAot)' == 'true'
+          )
+        )">true</_BuildFlavorRequiredRid>
+    <_EnableArcadeRuntimeIdentifierInference Condition="'$(_EnableArcadeRuntimeIdentifierInference)' == '' and '$(_BuildFlavorRequiredRid)' != 'true'">false</_EnableArcadeRuntimeIdentifierInference>
+
+    <!--
       When we're doing a build of a single vertical, we may not have a runtime or host available for any RID outside of our current target.
       For many of our projects, we don't actually need to build any RID-specific assets, but the SDK may still try to pull down assets for other RIDs,
       in particular for the RID matching the SDK's RID.

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RuntimeIdentifierInference.BeforeNETSdkTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RuntimeIdentifierInference.BeforeNETSdkTargets.targets
@@ -22,7 +22,7 @@
     <_EnableArcadeRuntimeIdentifierInference Condition="'$(_EnableArcadeRuntimeIdentifierInference)' == '' and '$(DotNetBuild)' == 'true'">true</_EnableArcadeRuntimeIdentifierInference>
 
     <_EnableArcadeRuntimeIdentifierFilters Condition="'$(EnableArcadeRuntimeIdentifierFilters)' != ''">$(EnableArcadeRuntimeIdentifierFilters)</_EnableArcadeRuntimeIdentifierFilters>
-    
+
     <!--
       If we infer a RID for the project, default to filtering down the list of RIDs the project specifies and automatically excluding projects that don't build for this RID.
     -->
@@ -39,9 +39,21 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(_EnableArcadeRuntimeIdentifierFilters)' == 'true' and '$(RuntimeIdentifiers)' != ''">
+    <!-- Prepend and append with semicolons to make the Contains call below simpler. -->
     <_ExplicitlySpecifiedRuntimeIdentifiers>;$(RuntimeIdentifiers);</_ExplicitlySpecifiedRuntimeIdentifiers>
+
+    <!--
+      Sometimes we may need to filter the RuntimeIdentifiers list by a RID that is not TargetRid.
+      Determine which RID to filter on here.
+
+      We can't actually use the RID graph here as RID graph filtering is only possible in a task, and we need to do this during property evaluation.
+    -->
+    <_FilterRuntimeIdentifier>$(TargetRid)</_FilterRuntimeIdentifier>
+    <!-- If we're introducing a new runtime identifier with TargetRid, filter instead on BaseOS. -->
+    <_FilterRuntimeIdentifier Condition="'$(BaseOS)' != ''">$(BaseOS)</_FilterRuntimeIdentifier>
+
     <!-- If a project builds for a set of RIDs specified in the project file and this vertical isn't in the list, suppress building this project. -->
-    <_SuppressAllTargets Condition="'$(DisableArcadeExcludeFromBuildSupport)' != 'true' and $(_ExplicitlySpecifiedRuntimeIdentifiers).Contains(';$(TargetRid);')) == 'false'">true</_SuppressAllTargets>
+    <_SuppressAllTargets Condition="'$(DisableArcadeExcludeFromBuildSupport)' != 'true' and $(_ExplicitlySpecifiedRuntimeIdentifiers).Contains(';$(_FilterRuntimeIdentifier);')) == 'false'">true</_SuppressAllTargets>
 
     <!-- The .NET SDK will try to restore for all specified RIDs. Change the list of RIDs to only our inferred RID to ensure that restore only restores assets that could be available. -->
     <RuntimeIdentifiers>$(RuntimeIdentifier)</RuntimeIdentifiers>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RuntimeIdentifierInference.BeforeNETSdkTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RuntimeIdentifierInference.BeforeNETSdkTargets.targets
@@ -1,12 +1,15 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <PropertyGroup>
-    <_EnableArcadeRuntimeIdentifierInference>$(EnableArcadeRuntimeIdentifierInference)</_EnableArcadeRuntimeIdentifierInference>
+    <_EnableArcadeRuntimeIdentifierInference Condition="'$(_EnableArcadeRuntimeIdentifierInference)' == ''">$(EnableArcadeRuntimeIdentifierInference)</_EnableArcadeRuntimeIdentifierInference>
 
     <!-- If the user has specified a RID for their project, don't overwrite it. -->
     <_EnableArcadeRuntimeIdentifierInference Condition="'$(_EnableArcadeRuntimeIdentifierInference)' == '' and '$(RuntimeIdentifier)' != ''">false</_EnableArcadeRuntimeIdentifierInference>
 
-    <!-- If the SDK will infer this project as "RID agnostic", don't infer RIDs. -->
+    <!--
+      If the SDK will infer this project as "RID agnostic", don't infer RIDs.
+      This should generally match the logic for setting IsRidAgnostic in the SDK.
+    -->
     <_RidAgnosticProject Condition="('$(OutputType)' == 'Library' or '$(IsTestProject)' == 'true') and '$(RuntimeIdentifiers)' == ''">true</_RidAgnosticProject>
 
     <!-- If this project is RID-agnostic, don't infer RIDs. -->
@@ -19,7 +22,7 @@
       To avoid this, we'll default to setting the RID to the vertical's target RID.
       To preserve expected behavior for projects that don't specify a RID in a non-vertical build, we won't append the RID to the output path if the user hasn't explicitly requested it.
     -->
-    <_EnableArcadeRuntimeIdentifierInference Condition="'$(_EnableArcadeRuntimeIdentifierInference)' == '' and '$(DotNetBuild)' == 'true'">true</_EnableArcadeRuntimeIdentifierInference>
+    <_EnableArcadeRuntimeIdentifierInference Condition="'$(_EnableArcadeRuntimeIdentifierInference)' == '' and '$(DotNetBuildTargetRidOnly)' == 'true'">true</_EnableArcadeRuntimeIdentifierInference>
 
     <_EnableArcadeRuntimeIdentifierFilters Condition="'$(EnableArcadeRuntimeIdentifierFilters)' != ''">$(EnableArcadeRuntimeIdentifierFilters)</_EnableArcadeRuntimeIdentifierFilters>
 
@@ -35,7 +38,7 @@
     <RuntimeIdentifier>$(TargetRid)</RuntimeIdentifier>
 
     <!-- If this project would have been inferred as "RID agnostic", preserve that as well. -->
-    <IsRidAgnostic Condition="('$(OutputType)' == 'Library' or '$(IsTestProject)' == 'true') and '$(RuntimeIdentifiers)' == ''">true</IsRidAgnostic>
+    <IsRidAgnostic Condition="'$(_RidAgnosticProject)' == 'true'">true</IsRidAgnostic>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(_EnableArcadeRuntimeIdentifierFilters)' == 'true' and '$(RuntimeIdentifiers)' != ''">

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Settings.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Settings.props
@@ -6,6 +6,7 @@
     <_ArcadeOverriddenCustomBeforeMicrosoftCommonCrossTargetingTargets>$(CustomBeforeMicrosoftCommonCrossTargetingTargets)</_ArcadeOverriddenCustomBeforeMicrosoftCommonCrossTargetingTargets>
     <CustomBeforeMicrosoftCommonTargets>$(MSBuildThisFileDirectory)BeforeCommonTargets.targets</CustomBeforeMicrosoftCommonTargets>
     <CustomBeforeMicrosoftCommonCrossTargetingTargets>$(MSBuildThisFileDirectory)BeforeCommonTargets.CrossTargeting.targets</CustomBeforeMicrosoftCommonCrossTargetingTargets>
+    <BeforeMicrosoftNETSdkTargets>$(BeforeMicrosoftNETSdkTargets);$(MSBuildThisFileDirectory)BeforeNETSdkTargets.targets</BeforeMicrosoftNETSdkTargets>
     <!-- MSBuild has "global" variables (ie command-line or MSBuild task properties) override local declarations.  That's generally not the behavior that we want in Arcade.
          We want to be able to have Arcade MSBuild a project / target with the property set as a default, but let the project override that value.  To work around MSBuild,
          we pass in `_blah` and set it to a local property (`blah`) which is not global. -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
@@ -55,6 +55,7 @@
            - DotNetBuildSourceOnly - Build from source only. Pass through outer build value if present. -->
       <InnerBuildArgs Condition="'$(DotNetBuildRepo)' == 'true'">$(InnerBuildArgs) /p:DotNetBuildInnerRepo=true</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(DotNetBuildSourceOnly)' != ''">$(InnerBuildArgs) /p:DotNetBuildSourceOnly=$(DotNetBuildSourceOnly)</InnerBuildArgs>
+      <InnerBuildArgs Condition="'$(DotNetBuildTargetRidOnly)' != ''">$(InnerBuildArgs) /p:DotNetBuildTargetRidOnly=$(DotNetBuildTargetRidOnly)</InnerBuildArgs>
       <!-- Use a fresh clone of the repo so that source-build modifications are isolated. -->
       <InnerBuildArgs>$(InnerBuildArgs) /p:RepoRoot="$(InnerSourceBuildRepoRoot)$(_DirSeparatorEscapedCharForExecArg)"</InnerBuildArgs>
       <!-- Override the artifacts dir to cleanly separate the inner build from outer build. -->


### PR DESCRIPTION
In vertical builds, repos that build targeting the live runtime only have one runtime available, the runtime for the target RID. Add a new UB control property (which will need updates in the orchestrator to pass correctly) to select a default RID (the target RID) before the SDK infers one.
 
Contributes to https://github.com/dotnet/source-build/issues/4784

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
