### PR TITLE
Don't sign F# projects during DotNetBuildSourceOnly.

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.props
@@ -11,6 +11,14 @@
   </PropertyGroup>
 
   <!--
+    Public signing (as performed under DotNetBuildSourceOnly) fails with the F# compiler.
+    https://github.com/dotnet/fsharp/issues/17451
+  -->
+  <PropertyGroup Condition=" '$(DotNetBuildSourceOnly)' == 'true' and '$(MSBuildProjectExtension)' == '.fsproj' ">
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+
+  <!--
     WPF temp-projects do not import .props and .targets files from NuGet packages.
     (see https://github.com/dotnet/sourcelink/issues/91).
     

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -22,14 +22,6 @@
   </PropertyGroup>
 
   <!--
-    Public signing (as performed under DotNetBuildSourceOnly) fails with the F# compiler.
-    https://github.com/dotnet/fsharp/issues/17451
-  -->
-  <PropertyGroup Condition=" '$(DotNetBuildSourceOnly)' == 'true' and '$(MSBuildProjectExtension)' == '.fsproj' ">
-    <SignAssembly>false</SignAssembly>
-  </PropertyGroup>
-
-  <!--
     Workaround to fix that Visual Studio sometimes uses a special MSBuild evaluation
     mode where all common conditions (e.g., inside ItemGroup) are ignored.
   -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets
@@ -22,6 +22,14 @@
   </PropertyGroup>
 
   <!--
+    Public signing (as performed under DotNetBuildSourceOnly) fails with the F# compiler.
+    https://github.com/dotnet/fsharp/issues/17451
+  -->
+  <PropertyGroup Condition=" '$(DotNetBuildSourceOnly)' == 'true' and '$(MSBuildProjectExtension)' == '.fsproj' ">
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+
+  <!--
     Workaround to fix that Visual Studio sometimes uses a special MSBuild evaluation
     mode where all common conditions (e.g., inside ItemGroup) are ignored.
   -->


### PR DESCRIPTION
Workaround for https://github.com/dotnet/fsharp/issues/17451.

@ViktorHofer ptal.
