### PR TITLE
Use __UbuntuSuites on debian as well

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -33,7 +33,6 @@ __QEMUArch=arm
 __UbuntuArch=armhf
 __UbuntuRepo=
 __UbuntuSuites="updates security backports"
-__DebianSuites=
 __LLDB_Package="liblldb-3.9-dev"
 __SkipUnmount=0
 
@@ -188,8 +187,7 @@ while :; do
             __AlpineArch=loongarch64
             __QEMUArch=loongarch64
             __UbuntuArch=loong64
-            __UbuntuSuites=
-            __DebianSuites=unreleased
+            __UbuntuSuites=unreleased
             __LLDB_Package="liblldb-19-dev"
 
             if [[ "$__CodeName" == "sid" ]]; then
@@ -795,7 +793,7 @@ elif [[ -n "$__CodeName" ]]; then
         fi
 
         # shellcheck disable=SC2086
-        suites="$__CodeName $__DebianSuites $(echo $__UbuntuSuites | xargs -n 1 | xargs -I {} echo -n "$__CodeName-{} ")"
+        suites="$__CodeName $(echo $__UbuntuSuites | xargs -n 1 | xargs -I {} echo -n "$__CodeName-{} ")"
 
         PYTHON=${PYTHON_EXECUTABLE:-python3}
 
@@ -837,7 +835,7 @@ elif [[ -n "$__CodeName" ]]; then
     cat > "$__RootfsDir/etc/apt/sources.list.d/$__CodeName.sources" <<EOF
 Types: deb
 URIs: $__UbuntuRepo
-Suites: $__CodeName $__DebianSuites $(echo $__UbuntuSuites | xargs -n 1 | xargs -I {} echo -n "$__CodeName-{} ")
+Suites: $__CodeName $(echo $__UbuntuSuites | xargs -n 1 | xargs -I {} echo -n "$__CodeName-{} ")
 Components: main universe
 Signed-By: $__KeyringFile
 EOF

--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -780,7 +780,7 @@ elif [[ "$__CodeName" == "haiku" ]]; then
     popd
     rm -rf "$__RootfsDir/tmp"
 elif [[ -n "$__CodeName" ]]; then
-    __Suites="$__CodeName $(echo "$__UbuntuSuites" | xargs -n 1 | xargs -I {} echo -n "$__CodeName-{} ")"
+    __Suites="$__CodeName $(for suite in $__UbuntuSuites; do echo -n "$__CodeName-$suite "; done)"
 
     if [[ "$__SkipEmulation" == "1" ]]; then
         if [[ -z "$AR" ]]; then
@@ -798,12 +798,12 @@ elif [[ -n "$__CodeName" ]]; then
 
         # shellcheck disable=SC2086,SC2046
         echo running "$PYTHON" "$__CrossDir/install-debs.py" --arch "$__UbuntuArch" --mirror "$__UbuntuRepo" --rootfsdir "$__RootfsDir" --artool "$AR" \
-            $(echo "$__Suites" | xargs -n 1 | xargs -I {} echo -n "--suite {} ") \
+            $(for suite in $__Suites; do echo -n "--suite $suite "; done) \
             $__UbuntuPackages
 
         # shellcheck disable=SC2086,SC2046
         "$PYTHON" "$__CrossDir/install-debs.py" --arch "$__UbuntuArch" --mirror "$__UbuntuRepo" --rootfsdir "$__RootfsDir" --artool "$AR" \
-            $(echo "$__Suites" | xargs -n 1 | xargs -I {} echo -n "--suite {} ") \
+            $(for suite in $__Suites; do echo -n "--suite $suite "; done) \
             $__UbuntuPackages
 
         exit 0

--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -780,6 +780,8 @@ elif [[ "$__CodeName" == "haiku" ]]; then
     popd
     rm -rf "$__RootfsDir/tmp"
 elif [[ -n "$__CodeName" ]]; then
+    __Suites="$__CodeName $(echo "$__UbuntuSuites" | xargs -n 1 | xargs -I {} echo -n "$__CodeName-{} ")"
+
     if [[ "$__SkipEmulation" == "1" ]]; then
         if [[ -z "$AR" ]]; then
             if command -v ar &>/dev/null; then
@@ -792,19 +794,16 @@ elif [[ -n "$__CodeName" ]]; then
             fi
         fi
 
-        # shellcheck disable=SC2086
-        suites="$__CodeName $(echo $__UbuntuSuites | xargs -n 1 | xargs -I {} echo -n "$__CodeName-{} ")"
-
         PYTHON=${PYTHON_EXECUTABLE:-python3}
 
         # shellcheck disable=SC2086,SC2046
         echo running "$PYTHON" "$__CrossDir/install-debs.py" --arch "$__UbuntuArch" --mirror "$__UbuntuRepo" --rootfsdir "$__RootfsDir" --artool "$AR" \
-            $(echo $suites | xargs -n 1 | xargs -I {} echo -n "--suite {} ") \
+            $(echo "$__Suites" | xargs -n 1 | xargs -I {} echo -n "--suite {} ") \
             $__UbuntuPackages
 
         # shellcheck disable=SC2086,SC2046
         "$PYTHON" "$__CrossDir/install-debs.py" --arch "$__UbuntuArch" --mirror "$__UbuntuRepo" --rootfsdir "$__RootfsDir" --artool "$AR" \
-            $(echo $suites | xargs -n 1 | xargs -I {} echo -n "--suite {} ") \
+            $(echo "$__Suites" | xargs -n 1 | xargs -I {} echo -n "--suite {} ") \
             $__UbuntuPackages
 
         exit 0
@@ -835,7 +834,7 @@ elif [[ -n "$__CodeName" ]]; then
     cat > "$__RootfsDir/etc/apt/sources.list.d/$__CodeName.sources" <<EOF
 Types: deb
 URIs: $__UbuntuRepo
-Suites: $__CodeName $(echo $__UbuntuSuites | xargs -n 1 | xargs -I {} echo -n "$__CodeName-{} ")
+Suites: $__Suites
 Components: main universe
 Signed-By: $__KeyringFile
 EOF


### PR DESCRIPTION
Fixes https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1315

Instead of declaring a new var, we can reuse it for Debian as well. This was causing issues with old Ubuntu versions.

@mthalman