### PR TITLE
Update MicroBuildSigningPlugin to v4

### DIFF
--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -128,7 +128,7 @@ jobs:
 
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
-      - task: MicroBuildSigningPlugin@3
+      - task: MicroBuildSigningPlugin@4
         displayName: Install MicroBuild plugin
         inputs:
           signType: $(_SignType)


### PR DESCRIPTION
This was already done in `release/9.0` and `main` and since `dotnet-release` depends on 8.0 Arcade, it needs to be done here as well.