### PR TITLE
Remove TFM workaround

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,11 +16,6 @@
     <RepositoryUrl>https://github.com/dotnet/arcade</RepositoryUrl>
     <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->
     <WarningsNotAsErrors Condition="'$(OfficialBuild)' != 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
-    <!-- TODO: Remove when the VMR uses a new bootstrap Arcade.Sdk in source-only builds that has the TFM changes in TargetFrameworkDefaults.props. -->
-    <NetCurrent>net10.0</NetCurrent>
-    <NetPrevious>net9.0</NetPrevious>
-    <NetToolCurrent>$(NetCurrent)</NetToolCurrent>
-    <NetToolMinimum Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(NetToolCurrent)</NetToolMinimum>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
We are now using a new re-bootstrapped SDK in the VMR.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
