### PR TITLE
add source_pr_author template to backport action

### DIFF
--- a/.github/workflows/backport-base.yml
+++ b/.github/workflows/backport-base.yml
@@ -169,7 +169,6 @@ jobs:
 
             // get users to cc (append PR author if different from user who issued the backport command)
             let cc_users = `@${comment_user}`;
-
             if (comment_user != context.payload.issue.user.login) cc_users += ` @${context.payload.issue.user.login}`;
 
             // replace the special placeholder tokens with values

--- a/.github/workflows/backport-base.yml
+++ b/.github/workflows/backport-base.yml
@@ -2,12 +2,12 @@ on:
   workflow_call:
     inputs:
       pr_title_template:
-        description: 'The template used for the PR title. Special placeholder tokens that will be replaced with a value: %target_branch%, %source_pr_title%, %source_pr_number%, %cc_users%.'
+        description: 'The template used for the PR title. Special placeholder tokens that will be replaced with a value: %target_branch%, %source_pr_title%, %source_pr_number%, %source_pr_author%, %cc_users%.'
         required: false
         type: string
         default: '[%target_branch%] %source_pr_title%'
       pr_description_template:
-        description: 'The template used for the PR description. Special placeholder tokens that will be replaced with a value: %target_branch%, %source_pr_title%, %source_pr_number%, %cc_users%.'
+        description: 'The template used for the PR description. Special placeholder tokens that will be replaced with a value: %target_branch%, %source_pr_title%, %source_pr_number%, %source_pr_author%, %cc_users%.'
         required: false
         type: string
         default: |
@@ -169,6 +169,7 @@ jobs:
 
             // get users to cc (append PR author if different from user who issued the backport command)
             let cc_users = `@${comment_user}`;
+
             if (comment_user != context.payload.issue.user.login) cc_users += ` @${context.payload.issue.user.login}`;
 
             // replace the special placeholder tokens with values
@@ -178,12 +179,14 @@ jobs:
               .replace(/%target_branch%/g, target_branch)
               .replace(/%source_pr_title%/g, context.payload.issue.title)
               .replace(/%source_pr_number%/g, context.payload.issue.number)
+              .replace(/%source_pr_author%/g, context.payload.issue.user.login)
               .replace(/%cc_users%/g, cc_users);
 
             const backport_pr_description = BACKPORT_PR_DESCRIPTION_TEMPLATE
               .replace(/%target_branch%/g, target_branch)
               .replace(/%source_pr_title%/g, context.payload.issue.title)
               .replace(/%source_pr_number%/g, context.payload.issue.number)
+              .replace(/%source_pr_author%/g, context.payload.issue.user.login)
               .replace(/%cc_users%/g, cc_users);
 
             // open the GitHub PR


### PR DESCRIPTION
Allow substituting PR author in the title and description templates. This allows the PR title to mimic the message that GH would autogenerate in release notes, so backported PRs don't look out of place and don't have to be manually fixed.

`pr_title_template: '%source_pr_title% by @%source_pr_author% in #%source_pr_number% (backport to %target_branch%)'`

would backport with title:

`Update CONTRIBUTING.md by @nohwnd in #2605 (backport to rel/5.x.x)`

Which will then autogenerate into release notes as:

`Update CONTRIBUTING.md by @nohwnd in #2605 (backport to rel/5.x.x) by @dotnet-bot in #2606`

And I can go and simply delete the by dotnet bot and backport PR title, or keep it if needed.

Proof that the change works: 
![image](https://github.com/user-attachments/assets/f966ebc6-3894-4848-a111-32533a820f73)

I did not prefix the name with `@` in the replacement to keep it consistent with the PR name that also does not prefix `#`.
