### PR TITLE
Use Core MSBuild to run MicroBuild in SignTool

### DIFF
--- a/Documentation/CorePackages/Signing.md
+++ b/Documentation/CorePackages/Signing.md
@@ -26,8 +26,7 @@ This is a MSBuild custom task that provides batch signing and simple verificatio
 | FileExtensionSignInfo  | Array    | This is a mapping between extension (in the format ".ext") to default sign information for those kind of files. Overriding of the default sign info is done using the other parameters. |
 | CertificatesSignInfo   | Array    | List of certificate names that can be flagged using the `DualSigningAllowed` attribute as dual certificates. |
 | **MicroBuildCorePath** | Dir Path | Path to MicroBuild.Core package directory.                   |
-| MSBuildPath            | Exe path | Path to the MSBuild.exe binary used to run the signing process on MicroBuild for Windows. |
-| DotNetPath             | Exe path | Path to the dotnet executable used to run the signing process on MicroBuild for Linux and Mac. |
+| DotNetPath             | Exe path | Path to the dotnet executable used to run the signing process on MicroBuild. |
 | SNBinaryPath           | Exe path | Path to the sn.exe binary used to strong-name sign / validate signature of managed files. |
 | **TempDir**            | Dir path | Used to store temporary files during the process of calling MicroBuild signing. |
 | LogDir                 | Dir path | MSBuild binary log information from the signing rounds will be stored in this directory. |
@@ -36,7 +35,7 @@ This is a MSBuild custom task that provides batch signing and simple verificatio
 
 ​	Items in bold are required: `ItemsToSign`, `MicroBuildCorePath` and `TempDir`.
 
-​	`MSBuildPath`, `SNBinaryPath` and `LogDir` are only required if `DryRun == false`.
+​	`DotNetPath`, `SNBinaryPath` and `LogDir` are only required if `DryRun == false`.
 
 
 # Arguments Metadata

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -52,11 +52,8 @@
       <_TestSign>false</_TestSign>
       <_TestSign Condition="'$(DotNetSignType)' == 'test'">true</_TestSign>
 
-      <_DesktopMSBuildRequired>false</_DesktopMSBuildRequired>
-      <_DesktopMSBuildRequired Condition="'$(_DryRun)' != 'true' and '$(MSBuildRuntimeType)' == 'Core'  and '$(OS)' == 'Windows_NT'">true</_DesktopMSBuildRequired>
-
       <_DotNetCoreRequired>false</_DotNetCoreRequired>
-      <_DotNetCoreRequired Condition="'$(_DryRun)' != 'true' and '$(OS)' != 'Windows_NT'">true</_DotNetCoreRequired>
+      <_DotNetCoreRequired Condition="'$(_DryRun)' != 'true'">true</_DotNetCoreRequired>
 
       <!-- SN is only available on Windows -->
       <SNBinaryPath Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(NuGetPackageRoot)sn\$(SNVersion)\sn.exe</SNBinaryPath>
@@ -64,19 +61,6 @@
 
     <Error Condition="'$(AllowEmptySignList)' != 'true' AND '@(ItemsToSign)' == ''" 
            Text="List of files to sign is empty. Make sure that ItemsToSign is configured correctly." />
-
-    <!-- We only need this if we are going to use the executable version. -->
-    <Exec Command='"$(NuGetPackageRoot)vswhere\$(VSWhereVersion)\tools\vswhere.exe" -latest -prerelease -property installationPath -requires Microsoft.Component.MSBuild'
-          ConsoleToMsBuild="true"
-          StandardErrorImportance="high"
-          Condition="$(_DesktopMSBuildRequired)">
-      <Output TaskParameter="ConsoleOutput" PropertyName="_VSInstallDir" />
-    </Exec>
-
-    <PropertyGroup Condition="$(_DesktopMSBuildRequired)">
-      <_DesktopMSBuildPath>$(_VSInstallDir)\MSBuild\Current\Bin\msbuild.exe</_DesktopMSBuildPath>
-      <_DesktopMSBuildPath Condition="!Exists('$(_DesktopMSBuildPath)')">$(_VSInstallDir)\MSBuild\15.0\Bin\msbuild.exe</_DesktopMSBuildPath>
-    </PropertyGroup>
 
     <PropertyGroup Condition="$(_DotNetCoreRequired)">
       <_DotNetCorePath>$(DotNetTool)</_DotNetCorePath>
@@ -95,7 +79,6 @@
         FileExtensionSignInfo="@(FileExtensionSignInfo)"
         TempDir="$(ArtifactsTmpDir)"
         LogDir="$(ArtifactsLogDir)"
-        MSBuildPath="$(_DesktopMSBuildPath)"
         DotNetPath="$(_DotNetCorePath)"
         SNBinaryPath="$(SNBinaryPath)"
         MicroBuildCorePath="$(NuGetPackageRoot)microbuild.core\$(MicroBuildCoreVersion)"

--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -324,10 +324,10 @@ namespace Microsoft.DotNet.SignTool.Tests
 
             var task = new SignToolTask { BuildEngine = buildEngine };
 
-            // The path to MSBuild and DotNet will always be null in these tests, this will force
+            // The path to DotNet will always be null in these tests, this will force
             // the signing logic to call our FakeBuildEngine.BuildProjectFile with a path
             // to the XML that store the content of the would be Microbuild sign request.
-            var signToolArgs = new SignToolArgs(_tmpDir, microBuildCorePath: "MicroBuildCorePath", testSign: true, msBuildPath: null, dotnetPath: null, _tmpDir, enclosingDir: "", "", wixToolsPath: wixToolsPath, tarToolPath: s_tarToolPath);
+            var signToolArgs = new SignToolArgs(_tmpDir, microBuildCorePath: "MicroBuildCorePath", testSign: true, dotnetPath: null, _tmpDir, enclosingDir: "", "", wixToolsPath: wixToolsPath, tarToolPath: s_tarToolPath);
 
             var signTool = new FakeSignTool(signToolArgs, task.Log);
             var configuration = new Configuration(signToolArgs.TempDir, itemsToSign, strongNameSignInfo, fileSignInfo, extensionsSignInfo, dualCertificates, tarToolPath: s_tarToolPath, snPath: s_snPath, task.Log);
@@ -477,7 +477,6 @@ namespace Microsoft.DotNet.SignTool.Tests
                 TempDir = "TempDir",
                 DryRun = false,
                 TestSign = true,
-                MSBuildPath = CreateTestResource("msbuild.fake"),
                 DotNetPath = CreateTestResource("dotnet.fake"),
                 SNBinaryPath = CreateTestResource("fake.sn.exe")
             };
@@ -497,7 +496,6 @@ namespace Microsoft.DotNet.SignTool.Tests
                 TempDir = "TempDir",
                 DryRun = false,
                 TestSign = true,
-                MSBuildPath = CreateTestResource("msbuild.fake"),
                 DotNetPath = CreateTestResource("dotnet.fake"),
                 DoStrongNameCheck = false,
                 SNBinaryPath = null,
@@ -1629,8 +1627,7 @@ $@"<FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "Container
                 LogDir = "LogDir",
                 TempDir = "TempDir",
                 DryRun = true,
-                MSBuildPath = CreateTestResource("msbuild.fake"),
-                DotNetPath = null,
+                DotNetPath = CreateTestResource("dotnet.fake"),
                 DoStrongNameCheck = false,
                 SNBinaryPath = null,
                 WixToolsPath = badPath
@@ -2213,7 +2210,6 @@ $@"
                 LogDir = "LogDir",
                 TempDir = "TempDir",
                 DryRun = true,
-                MSBuildPath = CreateTestResource("msbuild.fake"),
                 DotNetPath = CreateTestResource("dotnet.fake"),
                 MicroBuildCorePath = "MicroBuildCorePath",
                 DoStrongNameCheck = false,
@@ -2248,7 +2244,6 @@ $@"
                 LogDir = "LogDir",
                 TempDir = "TempDir",
                 DryRun = true,
-                MSBuildPath = CreateTestResource("msbuild.fake"),
                 DotNetPath = CreateTestResource("dotnet.fake"),
                 DoStrongNameCheck = false,
                 SNBinaryPath = null,

--- a/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection.PortableExecutable;
-using System.Runtime.InteropServices;
 using System.Collections.Generic;
 
 namespace Microsoft.DotNet.SignTool
@@ -18,7 +17,6 @@ namespace Microsoft.DotNet.SignTool
     /// </summary>
     internal sealed class RealSignTool : SignTool
     {
-        private readonly string _msbuildPath;
         private readonly string _dotnetPath;
         private readonly string _logDir;
         private readonly string _snPath;
@@ -37,7 +35,6 @@ namespace Microsoft.DotNet.SignTool
         internal RealSignTool(SignToolArgs args, TaskLoggingHelper log) : base(args, log)
         {
             TestSign = args.TestSign;
-            _msbuildPath = args.MSBuildPath;
             _dotnetPath = args.DotNetPath;
             _snPath = args.SNBinaryPath;
             _logDir = args.LogDir;
@@ -45,25 +42,17 @@ namespace Microsoft.DotNet.SignTool
 
         public override bool RunMSBuild(IBuildEngine buildEngine, string projectFilePath, string binLogPath)
         {
-            if (_msbuildPath == null && _dotnetPath == null)
+            if (_dotnetPath == null)
             {
                 return buildEngine.BuildProjectFile(projectFilePath, null, null, null);
             }
 
             Directory.CreateDirectory(_logDir);
 
-            string processFileName = _dotnetPath;
-            string processArguments = $@"build ""{projectFilePath}"" -bl:""{binLogPath}""";
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                processFileName = _msbuildPath;
-                processArguments = $@"""{projectFilePath}"" /bl:""{binLogPath}""";
-            }
-
             var process = Process.Start(new ProcessStartInfo()
             {
-                FileName = processFileName,
-                Arguments = processArguments,
+                FileName = _dotnetPath,
+                Arguments = $@"build ""{projectFilePath}"" -bl:""{binLogPath}""",
                 UseShellExecute = false,
                 WorkingDirectory = TempDir,
             });

--- a/src/Microsoft.DotNet.SignTool/src/SignToolArgs.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolArgs.cs
@@ -8,7 +8,6 @@ namespace Microsoft.DotNet.SignTool
         internal string TempDir { get; }
         internal string MicroBuildCorePath { get; }
         internal bool TestSign { get; }
-        internal string MSBuildPath { get; }
         internal string DotNetPath { get; }
         internal string SNBinaryPath { get; }
         internal string LogDir { get; }
@@ -16,12 +15,11 @@ namespace Microsoft.DotNet.SignTool
         internal string WixToolsPath { get; }
         internal string TarToolPath { get; }
 
-        internal SignToolArgs(string tempPath, string microBuildCorePath, bool testSign, string msBuildPath, string dotnetPath, string logDir, string enclosingDir, string snBinaryPath, string wixToolsPath, string tarToolPath)
+        internal SignToolArgs(string tempPath, string microBuildCorePath, bool testSign, string dotnetPath, string logDir, string enclosingDir, string snBinaryPath, string wixToolsPath, string tarToolPath)
         {
             TempDir = tempPath;
             MicroBuildCorePath = microBuildCorePath;
             TestSign = testSign;
-            MSBuildPath = msBuildPath;
             DotNetPath = dotnetPath;
             LogDir = logDir;
             EnclosingDir = enclosingDir;

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -13,7 +13,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Resources;
-using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 
 namespace Microsoft.DotNet.SignTool
@@ -127,12 +126,7 @@ namespace Microsoft.DotNet.SignTool
         public ITaskItem[] CertificatesSignInfo { get; set; }
 
         /// <summary>
-        /// Path to msbuild.exe. Required if <see cref="DryRun"/> is <c>false</c>, OS is <c>Windows_NT</c>, and project is using .NET Core.
-        /// </summary>
-        public string MSBuildPath { get; set; }
-
-        /// <summary>
-        /// Path to dotnet executable. Required if <see cref="DryRun"/> is <c>false</c> and OS is not <c>Windows_NT</c>.
+        /// Path to dotnet executable. Required if <see cref="DryRun"/> is <c>false</c>.
         /// </summary>
         public string DotNetPath { get; set; }
 
@@ -201,16 +195,8 @@ namespace Microsoft.DotNet.SignTool
 
             if (!DryRun)
             {
-                bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-                if (isWindows && typeof(object).Assembly.GetName().Name != "mscorlib" && !File.Exists(MSBuildPath))
+                if (!File.Exists(DotNetPath))
                 {
-                    // For Windows, desktop msbuild is required if running on .NET Core.
-                    Log.LogError($"MSBuild was not found at this path: '{MSBuildPath}'.");
-                    return;
-                }
-                else if (!isWindows && !File.Exists(DotNetPath))
-                {
-                    // For Mac and Linux, dotnet is required.
                     Log.LogError($"DotNet was not found at this path: '{DotNetPath}'.");
                     return;
                 }
@@ -237,7 +223,7 @@ namespace Microsoft.DotNet.SignTool
 
             if (Log.HasLoggedErrors) return;
 
-            var signToolArgs = new SignToolArgs(TempDir, MicroBuildCorePath, TestSign, MSBuildPath, DotNetPath, LogDir, enclosingDir, SNBinaryPath, WixToolsPath, TarToolPath);
+            var signToolArgs = new SignToolArgs(TempDir, MicroBuildCorePath, TestSign, DotNetPath, LogDir, enclosingDir, SNBinaryPath, WixToolsPath, TarToolPath);
             var signTool = DryRun ? new ValidationOnlySignTool(signToolArgs, Log) : (SignTool)new RealSignTool(signToolArgs, Log);
 
             Telemetry telemetry = new Telemetry();


### PR DESCRIPTION
Closes https://github.com/dotnet/arcade/issues/15046

Ran arcade's unit tests and did local e2e testing on Windows with arcade-validation & a local arcade package's feed.

[VMR test run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2617697&view=results) (manually cancelled after a few successful repo builds completed)