### PR TITLE
Update SDK to 10.0.100-alpha.1.25063.11

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "10.0.100-alpha.1.24573.1",
+    "version": "10.0.100-alpha.1.25063.11",
     "rollForward": "latestFeature"
   },
   "tools": {
-    "dotnet": "10.0.100-alpha.1.24573.1"
+    "dotnet": "10.0.100-alpha.1.25063.11"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25061.1",

--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "10.0.100-alpha.1.25063.11",
+    "version": "10.0.100-alpha.1.25064.3",
     "rollForward": "latestFeature"
   },
   "tools": {
-    "dotnet": "10.0.100-alpha.1.25063.11"
+    "dotnet": "10.0.100-alpha.1.25064.3"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25061.1",

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/LatestLinksManagerTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/LatestLinksManagerTests.cs
@@ -104,7 +104,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                 flatten: true
             );
 
-            var manager = new LatestLinksManager("clientId", new System.Security.Cryptography.X509Certificates.X509Certificate2(), "tenant", "groupOwner", "createdBy", "owners", taskLoggingHelper);
+            var manager = new LatestLinksManager("clientId", null, "tenant", "groupOwner", "createdBy", "owners", taskLoggingHelper);
 
             var links = manager.GetLatestLinksToCreate(assetsToPublish, feedConfig, "https://example.com/feed/");
 
@@ -140,7 +140,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                 flatten: true
             );
 
-            var manager = new LatestLinksManager("clientId", new System.Security.Cryptography.X509Certificates.X509Certificate2(), "tenant", "groupOwner", "createdBy", "owners", taskLoggingHelper);
+            var manager = new LatestLinksManager("clientId", null, "tenant", "groupOwner", "createdBy", "owners", taskLoggingHelper);
 
             var links = manager.GetLatestLinksToCreate(assetsToPublish, feedConfig, "https://example.com/feed/");
 
@@ -170,7 +170,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                 flatten: true
             );
 
-            var manager = new LatestLinksManager("clientId", new System.Security.Cryptography.X509Certificates.X509Certificate2(), "tenant", "groupOwner", "createdBy", "owners", taskLoggingHelper);
+            var manager = new LatestLinksManager("clientId", null, "tenant", "groupOwner", "createdBy", "owners", taskLoggingHelper);
 
             var links = manager.GetLatestLinksToCreate(assetsToPublish, feedConfig, "https://example.com/feed/");
 
@@ -207,7 +207,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                 flatten: false
             );
 
-            var manager = new LatestLinksManager("clientId", new System.Security.Cryptography.X509Certificates.X509Certificate2(), "tenant", "groupOwner", "createdBy", "owners", taskLoggingHelper);
+            var manager = new LatestLinksManager("clientId", null, "tenant", "groupOwner", "createdBy", "owners", taskLoggingHelper);
 
             var links = manager.GetLatestLinksToCreate(assetsToPublish, feedConfig, "https://example.com/feed/");
 

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <IncludeDotNetCli Condition=" '$(IncludeDotNetCli)' != 'true' ">false</IncludeDotNetCli>
-    <AspNetCoreRuntimeVersion>10.0.0-alpha.2.25061.1</AspNetCoreRuntimeVersion>
+    <AspNetCoreRuntimeVersion>10.0.0-alpha.2.25064.1</AspNetCoreRuntimeVersion>
     <DotNetCliPackageType Condition=" '$(DotNetCliPackageType)' == '' ">runtime</DotNetCliPackageType>
     <DotNetCliVersion Condition=" '$(DotNetCliVersion)' == '' AND '$(DotNetCliPackageType)' == 'runtime' ">$(BundledNETCoreAppPackageVersion)</DotNetCliVersion>
     <!-- TODO (https://github.com/dotnet/arcade/issues/7022): We are hardcoding this version to use the one tied to the SDK version from global.json -->

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <IncludeDotNetCli Condition=" '$(IncludeDotNetCli)' != 'true' ">false</IncludeDotNetCli>
-    <AspNetCoreRuntimeVersion>10.0.0-alpha.2.24572.1</AspNetCoreRuntimeVersion>
+    <AspNetCoreRuntimeVersion>10.0.0-alpha.2.25061.1</AspNetCoreRuntimeVersion>
     <DotNetCliPackageType Condition=" '$(DotNetCliPackageType)' == '' ">runtime</DotNetCliPackageType>
     <DotNetCliVersion Condition=" '$(DotNetCliVersion)' == '' AND '$(DotNetCliPackageType)' == 'runtime' ">$(BundledNETCoreAppPackageVersion)</DotNetCliVersion>
     <!-- TODO (https://github.com/dotnet/arcade/issues/7022): We are hardcoding this version to use the one tied to the SDK version from global.json -->


### PR DESCRIPTION
There were to independent asks to update the toolset SDK. One comes from https://github.com/dotnet/sdk/pull/45917/#issuecomment-2587192022

cc @am11 @MichalStrehovsky 