### PR TITLE
Publishing authentication changed to use AzurePipelineCredentials

### DIFF
--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -86,9 +86,10 @@ stages:
 
     - task: AzureCLI@2
       displayName: Publish packages, blobs and symbols
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       inputs:
         azureSubscription: maestro-build-promotion
-        addSpnToEnvironment: true
         scriptType: ps
         scriptLocation: scriptPath
         scriptPath: $(Build.SourcesDirectory)/eng/common/sdk-task.ps1
@@ -108,7 +109,6 @@ stages:
           /p:AzureDevOpsFeedsKey='$(dn-bot-all-orgs-artifact-feeds-rw)'
           /p:AkaMSClientId=$(akams-app-id)
           /p:AkaMSClientCertificate=$(Agent.TempDirectory)/akamsclientcert.pfx
-          /p:ManagedIdentityClientId=$env:servicePrincipalId
           ${{ parameters.artifactsPublishingAdditionalParameters }} 
           /p:PDBArtifactsBasePath='$(Build.ArtifactStagingDirectory)/PDBArtifacts/'
           /p:SymbolPublishingExclusionsFile='$(Build.ArtifactStagingDirectory)/ReleaseConfigs/SymbolPublishingExclusionsFile.txt'


### PR DESCRIPTION
Remove of ManagedIdentityClientId will disable using of ManagedIdentityCredential in the auth chain
Providing System.AccessToken to the publishing will enable usage of AzurePipelineCredentials instead
More can be found in DefaultIdentityTokenCredential implementation