### PR TITLE
[8.0] sdk-task.ps1: Update the xcopy-msbuild version to 17.12.0

### DIFF
--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -64,7 +64,7 @@ try {
       $GlobalJson.tools | Add-Member -Name "vs" -Value (ConvertFrom-Json "{ `"version`": `"16.5`" }") -MemberType NoteProperty
     }
     if( -not ($GlobalJson.tools.PSObject.Properties.Name -match "xcopy-msbuild" )) {
-      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "17.8.1-2" -MemberType NoteProperty
+      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "17.12.0" -MemberType NoteProperty
     }
     if ($GlobalJson.tools."xcopy-msbuild".Trim() -ine "none") {
         $xcopyMSBuildToolsFolder = InitializeXCopyMSBuild $GlobalJson.tools."xcopy-msbuild" -install $true


### PR DESCRIPTION
Signing validation started failing in the [maintenance-packages repo](https://dev.azure.com/dnceng/internal/_build?definitionId=1199) since we took [this arcade codeflow](https://github.com/dotnet/maintenance-packages/pull/182).

The error is:

```
Could not resolve SDK "Microsoft.NET.Sdk". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
Version 8.0.403 of the .NET SDK requires at least version 17.9.5 of MSBuild. The current available version of MSBuild is 17.8.1.47607. Change the .NET SDK specified in global.json to an older version that requires the MSBuild version currently available.
The NuGetSdkResolver did not resolve this SDK because there was no version specified in the project or global.json.
MSB4276: The default SDK resolver failed to resolve SDK "Microsoft.NET.Sdk" because directory "d:\a\_work\1\s\.tools\msbuild\17.8.1-2\tools\MSBuild\Sdks\Microsoft.NET.Sdk\Sdk" did not exist.
error MSB4236: The SDK 'Microsoft.NET.Sdk' specified could not be found.
``` 
We are consuming the [sdk version 8.0.403 in global.json](https://github.com/dotnet/maintenance-packages/blob/6f3ff023ffdc009c33d41ad5dc2ccd7b0c058a9e/global.json#L3). 

The root cause is that eng/common/sdk-task.ps1 hardcodes the `xcopy-msbuild` version to `17.8.1-2` when not found in global.json.

The [workaround](https://github.com/dotnet/maintenance-packages/pull/195) would be to set the tools->xcopy-msbuild version to 17.12.0 in global.json. Edit: It didn't work, a test in the official azdo repo shows the signing failure [is still happening](https://dev.azure.com/dnceng/internal/_build/results?buildId=2620598&view=results).

The fix is to update the hardcoded version to the supported one.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
