### PR TITLE
Make default artifact visibility customizable

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -13,6 +13,7 @@
       DotNetSymbolExpirationInDays      Symbol expiration time in days (defaults to 10 years).
       SkipPackageChecks                 Skips package safety checks.
       EnableDefaultArtifacts            Includes packages under "/artifacts/packages/**" for publishing. Defaults to true.
+      DefaultArtifactVisibility         The default visibility for Artifact items. Defaults to External.
       DotNetBuildPass                   While building the repo as part of the entire .NET stack, this parameter specifies which build pass the current build is part of.
                                           The build pass number gets added to the asset manifest file name to avoid collisions.
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -8,6 +8,7 @@
     Optional variables:
       EnableDefaultArtifacts            Includes *.nupkg, *.vsix and *.wixpack.zip under "/artifacts/packages/**" for sigining.
                                         Defaults to true.
+      DefaultArtifactVisibility         The default visibility for Artifact items. Defaults to External.
 
     Optional items:
       Artifact (with Metadata)          Path to the artifact to publish. Declare the item in Signing.props to sign and publish the artifact.

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -4,6 +4,8 @@
   <PropertyGroup>
     <!-- By default, search for sign aritfacts under the list of known directories. -->
     <EnableDefaultArtifacts>true</EnableDefaultArtifacts>
+    <!-- By default, artifacts are externally visible -->
+    <DefaultArtifactVisibility>External</DefaultArtifactVisibility>
   </PropertyGroup>
 
   <!-- Repo extension point to sign and/or publish. Artifacts are shipping and blobs by default. -->
@@ -11,7 +13,7 @@
     <Artifact>
       <PublishFlatContainer>true</PublishFlatContainer>
       <IsShipping>true</IsShipping>
-      <Visibility>External</Visibility>
+      <Visibility>$(DefaultArtifactVisibility)</Visibility>
     </Artifact>
   </ItemDefinitionGroup>
 


### PR DESCRIPTION
We can use this to filter PgoInstrument artifacts down primarily in the VMR orchestrator and only need to make changes in dotnet/sdk to still publish the `dotnet-sdk-pgo-*` archives.
