### PR TITLE
Revert "Don't sign F# projects during DotNetBuildSourceOnly. (#15380)"

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.props
@@ -11,14 +11,6 @@
   </PropertyGroup>
 
   <!--
-    Public signing (as performed under DotNetBuildSourceOnly) fails with the F# compiler.
-    https://github.com/dotnet/fsharp/issues/17451
-  -->
-  <PropertyGroup Condition=" '$(DotNetBuildSourceOnly)' == 'true' and '$(MSBuildProjectExtension)' == '.fsproj' ">
-    <SignAssembly>false</SignAssembly>
-  </PropertyGroup>
-
-  <!--
     WPF temp-projects do not import .props and .targets files from NuGet packages.
     (see https://github.com/dotnet/sourcelink/issues/91).
     


### PR DESCRIPTION
This change aimed to work around an issue in the F# compiler which doesn't permit public signing when the provided key is a full public/private key pair.

It unintentionally resulted in the fsharp repository no longer being compiled with public signing, which causes product issues.

Fixes https://github.com/dotnet/runtime/issues/111457.

@ViktorHofer ptal.