### PR TITLE
Remove unnecessary UseDotNetCertificate block in Publish.proj

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -372,16 +372,6 @@
                     Condition="$(PublishToSymbolServer)"/>
   </Target>
 
-  <!-- Update sign infos that were using Microsoft400 to use the .NET-specific cert if UseDotNetCertificate is present.
-       This will update any use, even if explicitly specified.
-       NOTE: This is outside the target on purpose, as Update will not correctly evaluate in the target. See
-       https://github.com/dotnet/msbuild/issues/1618. -->
-  <ItemGroup Condition="$(UseDotNetCertificate)">
-    <FileExtensionSignInfo Update="@(FileExtensionSignInfo->WithMetadataValue('CertificateName','Microsoft400'))" CertificateName="$(DotNetCertificateName)" />
-    <StrongNameSignInfo Update="@(StrongNameSignInfo->WithMetadataValue('CertificateName','Microsoft400'))" CertificateName="$(DotNetCertificateName)" />
-    <FileSignInfo Update="@(FileSignInfo->WithMetadataValue('CertificateName','Microsoft400'))" CertificateName="$(DotNetCertificateName)" />
-  </ItemGroup>
-
   <!-- Import the publish targets when in the inner or outer repo builds. -->
   <Import Project="SourceBuild/SourceBuildArcadePublish.targets" Condition="'$(DotNetBuildRepo)' == 'true'" />
 


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
