### PR TITLE
Apply the DefaultArtifactVisibility on ItemsToPushToBlobFeed

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -225,7 +225,7 @@
     <ItemGroup>
       <ItemsToPushToBlobFeed>
         <!-- Default artifact visibility is External -->
-        <Visibility Condition="'%(ItemsToPushToBlobFeed.Visibility)' == ''">External</Visibility>
+        <Visibility Condition="'%(ItemsToPushToBlobFeed.Visibility)' == ''">$([MSBuild]::ValueOrDefault('$(DefaultArtifactVisibility)', 'External'))</Visibility>
         <!-- Default to IsShipping=true -->
         <IsShipping Condition="'%(ItemsToPushToBlobFeed.IsShipping)' == ''">true</IsShipping>
       </ItemsToPushToBlobFeed>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -4,8 +4,6 @@
   <PropertyGroup>
     <!-- By default, search for sign aritfacts under the list of known directories. -->
     <EnableDefaultArtifacts>true</EnableDefaultArtifacts>
-    <!-- By default, artifacts are externally visible -->
-    <DefaultArtifactVisibility>External</DefaultArtifactVisibility>
   </PropertyGroup>
 
   <!-- Repo extension point to sign and/or publish. Artifacts are shipping and blobs by default. -->
@@ -13,7 +11,6 @@
     <Artifact>
       <PublishFlatContainer>true</PublishFlatContainer>
       <IsShipping>true</IsShipping>
-      <Visibility>$(DefaultArtifactVisibility)</Visibility>
     </Artifact>
   </ItemDefinitionGroup>
 


### PR DESCRIPTION
I noticed that DefaultArtifactVisibility is currently only applied on Artifact but not on ItemsToPushToBlobFeed which some repositories use as an extension point and is the item definition that the Artifact items feed into.

---

Overall, when we get to the "Fit and Finish" stage of VMR, I will remove the `Artifact` extension point and make the existing sign and publish items easier to use. This makes sense as we will stop importing Sign.props from Publish.proj now that we don't have post build signing infra support anymore. In the (5?) repos where we use the Artifact extension point, I plan to add a file that gets imported by Signing.props and Publishing.props (i.e. SignAndPublishArtifacts.props) that allows to keep the single definition of artifacts.