### PR TITLE
Add default certificate name for .rpm

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -61,6 +61,8 @@
     <FileExtensionSignInfo Include=".zip" CertificateName="None" />
     <FileExtensionSignInfo Include=".tgz" CertificateName="None" />
     <FileExtensionSignInfo Include=".tar.gz" CertificateName="None" />
+    <!-- Note, RPMs can only be unpack/repacked on Linux. They can be signed on non-Linux -->
+    <FileExtensionSignInfo Include=".rpm" CertificateName="LinuxSign" />
     <!-- Note, these can only be unpack/repacked on Mac. They can be signed on a non-Mac -->
     <FileExtensionSignInfo Include=".pkg" CertificateName="MacDeveloper" />
     <!-- .app bundles are technically directories, but the Microsoft.DotNet.MacOsPkg


### PR DESCRIPTION
Add default certificate name for RPM packages.

A follow-up on https://github.com/dotnet/arcade/pull/15405