### PR TITLE
Update `NetPrevious` and `NetMinimum` TFM properties for .NET 8

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/TargetFrameworkDefaults.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/TargetFrameworkDefaults.props
@@ -15,10 +15,16 @@
        <TargetFrameworks>$(NetCurrent);$(NetPrevious);$(NetFrameworkMinimum);net472</TargetFrameworks>
   -->
   <PropertyGroup>
-    <!-- .NET -->
+    <!-- The TFM of the major release of .NET that the Arcade SDK aligns with. -->
     <NetCurrent>net8.0</NetCurrent>
-    <NetPrevious>net7.0</NetPrevious>
-    <NetMinimum>net6.0</NetMinimum>
+
+    <!-- The previously released version of .NET.
+         Undefined when NetMinimum and NetPrevious are identical. -->
+    <NetPrevious />
+
+    <!-- Lowest supported version of .NET at the time of the release of NetCurrent.
+         Undefined when NetCurrent and NetMinimum are identical. -->
+    <NetMinimum />
 
     <!-- .NET Framework -->
     <NetFrameworkMinimum>net462</NetFrameworkMinimum>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/TargetFrameworkDefaults.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/TargetFrameworkDefaults.props
@@ -22,9 +22,8 @@
          Undefined when NetMinimum and NetPrevious are identical. -->
     <NetPrevious />
 
-    <!-- Lowest supported version of .NET at the time of the release of NetCurrent.
-         Undefined when NetCurrent and NetMinimum are identical. -->
-    <NetMinimum />
+    <!-- Lowest supported version of .NET at the time of the release of NetCurrent. -->
+    <NetMinimum>net8.0</NetMinimum>
 
     <!-- .NET Framework -->
     <NetFrameworkMinimum>net462</NetFrameworkMinimum>


### PR DESCRIPTION
## Description

On `release/8.0 branch` the `NetPrevious` and `NetMinimum` are pointing to EOL versions of .NET which can cause dependent projects using these properties fail to build.

This PR sets: 
- `NetPrevious` as undefined and
- `NetMinimum` as `net8.0`

### Note

This affects xharness builds.