### PR TITLE
Don't set "build" directory as generated in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -63,3 +63,9 @@ compat text eol=lf
 *.bats text eol=lf
 *.1 text eol=lf
 *.plist text eol=lf
+
+###############################################################################
+# Set directory behavior to:
+#   not treat as generated
+###############################################################################
+**/build/** linguist-generated=false


### PR DESCRIPTION
This makes it show up in the GitHub UI: https://docs.github.com/en/search-github/searching-on-github/finding-files-on-github#customizing-excluded-files
