### PR TITLE
Skip pkg signature verification on non-OSX

### DIFF
--- a/src/Microsoft.DotNet.SignTool/src/VerifySignatures.cs
+++ b/src/Microsoft.DotNet.SignTool/src/VerifySignatures.cs
@@ -142,9 +142,9 @@ namespace Microsoft.DotNet.SignTool
 
         internal static SigningStatus IsSignedPkgOrAppBundle(TaskLoggingHelper log, string filePath, string pkgToolPath)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                log.LogMessage(MessageImportance.Low, $"Skipping signature verification of {filePath} for Windows.");
+                log.LogMessage(MessageImportance.Low, $"Skipping signature verification of {filePath} for non-OSX.");
                 return SigningStatus.Unknown;
             }
 


### PR DESCRIPTION
When testing pkg signature verification on Linux, I encountered the following error:

```bash
/root/.nuget/packages/microsoft.dotnet.arcade.sdk/10.0.0-beta.25071.2/tools/Sign.proj(75,5): error MSB4018: 
   The "Microsoft.DotNet.SignTool.SignToolTask" task failed unexpectedly.
   System.Exception: Pkg tooling is only supported on MacOS.
     at Microsoft.DotNet.SignTool.ZipData.RunPkgProcess(String srcPath, String dstPath, String action, String pkgToolPath) in 
  /_/src/Microsoft.DotNet.SignTool/src/ZipData.cs:line 308
     at Microsoft.DotNet.SignTool.VerifySignatures.IsSignedPkgOrAppBundle(TaskLoggingHelper log, String filePath, String pkgToolPath) in /_/src/Microsoft.DotNet.SignTool/src/VerifySignatures.cs:line 151
     at Microsoft.DotNet.SignTool.Configuration.ExtractSignInfo(PathWithHash file, PathWithHash parentContainer, String collisionPriorityId, String wixContentFilePath) in /_/src/Microsoft.DotNet.SignTool
  /src/Configuration.cs:line 422
     at Microsoft.DotNet.SignTool.Configuration.TrackFile(PathWithHash file, PathWithHash parentContainer, String collisionPriorityId) in /_/src/Microsoft.DotNet.SignTool/src/Configuration.cs:line 211
     at Microsoft.DotNet.SignTool.Configuration.GenerateListOfFiles() in /_/src/Microsoft.DotNet.SignTool/src/Configuration.cs:line 165
     at Microsoft.DotNet.SignTool.SignToolTask.ExecuteImpl() in /_/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs:line 257
     at Microsoft.DotNet.SignTool.SignToolTask.Execute() in /_/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs:line 167
     at Microsoft.Build.BackEnd.TaskExecutionHost.Execute()
     at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(TaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode how
ToExecuteTask)
```

This issue occurred because the pkg tooling attempted to run on Linux, which is unexpected as the tooling is designed to run only on macOS. To fix this, we should skip signature verification on any non-macOS platform.