### PR TITLE
Copy symbol files with hardlinks when possible

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -216,7 +216,8 @@
     <MakeDir Directories="$(SourceBuiltSymbolsDir)" />
     <Copy
       SourceFiles="@(AbsoluteSymbolPath)"
-      DestinationFolder="$(SourceBuiltSymbolsDir)%(RecursiveDir)" />
+      DestinationFolder="$(SourceBuiltSymbolsDir)%(RecursiveDir)"
+      UseHardlinksIfPossible="true" />
   </Target>
   <!--
     This target can be removed once we enable standard repo assets manifests and SB orchestrator


### PR DESCRIPTION
This will further reduce disk space requirements when building in the VMR.

Contributes to https://github.com/dotnet/sdk/pull/45932