### PR TITLE
Do not chop extension when zipping mac files

### DIFF
--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -1288,7 +1288,7 @@ $@"
             ValidateGeneratedProject(itemsToSign, strongNameSignInfo, fileSignInfo, s_fileExtensionSignInfo, new[]
             {
                 $@"
-                <FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "test.zip"))}"">
+                <FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "test.pkg.zip"))}"">
                 <Authenticode>MacDeveloperHarden</Authenticode>
                 </FilesToSign>",
             });
@@ -1341,11 +1341,11 @@ $@"
                 </FilesToSign>
                 ",
                 $@"
-                <FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "ContainerSigning", "1", "NestedPkg.zip"))}"">
+                <FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "ContainerSigning", "1", "NestedPkg.pkg.zip"))}"">
                 <Authenticode>MacDeveloperHarden</Authenticode>
                 </FilesToSign>",
                 $@"
-                <FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "test.zip"))}"">
+                <FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "test.pkg.zip"))}"">
                 <Authenticode>MacDeveloperHarden</Authenticode>
                 </FilesToSign>",
             });
@@ -1411,16 +1411,16 @@ $@"
                 </FilesToSign>
                 ",
                 $@"
-                <FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "ContainerSigning", "1", "NestedPkg.zip"))}"">
+                <FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "ContainerSigning", "1", "NestedPkg.pkg.zip"))}"">
                 <Authenticode>MacDeveloperHarden</Authenticode>
                 </FilesToSign>",
                 $@"
-                <FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "test.zip"))}"">
+                <FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "test.pkg.zip"))}"">
                 <Authenticode>MacDeveloperHarden</Authenticode>
                 </FilesToSign>
                 ",
                 $@"
-                <FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "test.zip"))}"">
+                <FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "test.pkg.zip"))}"">
                 <Authenticode>8020</Authenticode>
                 <MacAppName>com.microsoft.dotnet</MacAppName>
                 </FilesToSign>",
@@ -1473,7 +1473,7 @@ $@"
                 </FilesToSign>
                 ",
                 $@"
-                <FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "NestedPkg.zip"))}"">
+                <FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "NestedPkg.pkg.zip"))}"">
                 <Authenticode>MacDeveloperHarden</Authenticode>
                 </FilesToSign>"
             });
@@ -1514,12 +1514,12 @@ $@"
                 </FilesToSign>
                 ",
                 $@"
-                <FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "ContainerSigning", "2", "Payload", "test.zip"))}"">
+                <FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "ContainerSigning", "2", "Payload", "test.app.zip"))}"">
                 <Authenticode>MacDeveloperHarden</Authenticode>
                 </FilesToSign>
                 ",
                 $@"
-                <FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "WithApp.zip"))}"">
+                <FilesToSign Include=""{Uri.EscapeDataString(Path.Combine(_tmpDir, "WithApp.pkg.zip"))}"">
                 <Authenticode>MacDeveloperHarden</Authenticode>
                 </FilesToSign>"
             });

--- a/src/Microsoft.DotNet.SignTool/src/SignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignTool.cs
@@ -11,6 +11,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using NuGet.Packaging;
 
 namespace Microsoft.DotNet.SignTool
 {
@@ -131,6 +132,8 @@ namespace Microsoft.DotNet.SignTool
                     ZipFile.ExtractToDirectory(item.Value, Path.GetDirectoryName(item.Key), true);
 #endif
                 }
+
+                File.Delete(item.Value);
             }
         }
 
@@ -219,7 +222,14 @@ namespace Microsoft.DotNet.SignTool
 
         protected virtual string GetZipFilePath(string fullPath)
         {
-            return Path.Combine(Path.GetDirectoryName(fullPath), Path.GetFileNameWithoutExtension(fullPath) + ".zip");
+            var zipFilePath = Path.Combine(Path.GetDirectoryName(fullPath), Path.GetFileName(fullPath) + ".zip");
+            // If the file already exists, it means that the user asked for another file to be signed with a colliding name.
+            // This is very unlikely. Throw in this case.
+            if (File.Exists(zipFilePath))
+            {
+                throw new NotImplementedException($"The zip file path '{zipFilePath}' already exists.");
+            }
+            return zipFilePath;
         }
 
         private static void AppendLine(StringBuilder builder, int depth, string text)


### PR DESCRIPTION
Avoid chopping off the extension. If we do, we will cause signing failures if a repo ever has two files with the same name, one with extension .pkg and one with .zip. Instead, just append .zip. Collisions are very unlikely. Handle any that might occur with a NotImplementedException.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
