### PR TITLE
Explicitly set the restore config file when restoring the internal tools project

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -87,9 +87,13 @@
   <!-- Set as DependsOnTargets when internal tools (e.g. IBC data, optprof) is required -->
   <Target Name="RestoreInternalTooling"
           AfterTargets="$(RestoreInternalToolingAfterTargets)">
-    <MSBuild Projects="$(RepoRoot)eng/common/internal/Tools.csproj"
+    <PropertyGroup>
+      <InternalToolsRestoreProject>$(RepoRoot)eng/common/internal/Tools.csproj</InternalToolsRestoreProject>
+      <InternalToolsRestoreConfig>$(RepoRoot)eng/common/internal/NuGet.config</InternalToolsRestoreConfig>
+    </PropertyGroup>
+    <MSBuild Projects="$(InternalToolsRestoreProject)"
         Targets="Restore"
-        Properties="@(_RestoreToolsProps);_NETCORE_ENGINEERING_TELEMETRY=Restore"
+        Properties="@(_RestoreToolsProps);RestoreConfigFile=$(InternalToolsRestoreConfig);_NETCORE_ENGINEERING_TELEMETRY=Restore"
         Condition="'$(Restore)' == 'true'"/>
   </Target>
 


### PR DESCRIPTION
This ensures that global VMR restore config variables don't get used when restoring this project, which has its own nuget.config.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
