### PR TITLE
Remove extra RestoreSources when restoring internal tools

### DIFF
--- a/eng/common/internal/Tools.csproj
+++ b/eng/common/internal/Tools.csproj
@@ -15,16 +15,6 @@
     <PackageReference Include="Microsoft.DotNet.IBCMerge" Version="$(MicrosoftDotNetIBCMergeVersion)" Condition="'$(UsingToolIbcOptimization)' == 'true'" />
     <PackageReference Include="Drop.App" Version="$(DropAppVersion)" ExcludeAssets="all" Condition="'$(UsingToolVisualStudioIbcTraining)' == 'true'"/>
   </ItemGroup>
-  <PropertyGroup>
-    <RestoreSources></RestoreSources>
-    <RestoreSources Condition="'$(UsingToolIbcOptimization)' == 'true'">
-      https://devdiv.pkgs.visualstudio.com/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json;
-    </RestoreSources>
-    <RestoreSources Condition="'$(UsingToolVisualStudioIbcTraining)' == 'true'">
-      $(RestoreSources);
-      https://devdiv.pkgs.visualstudio.com/_packaging/VS/nuget/v3/index.json;
-    </RestoreSources>
-  </PropertyGroup>
 
   <!-- Repository extensibility point -->
   <Import Project="$(RepositoryEngineeringDir)InternalTools.props" Condition="Exists('$(RepositoryEngineeringDir)InternalTools.props')" />


### PR DESCRIPTION
The NuGet.config corresponding to the csproj already has the internal tooling feed in it, which has the packages for IBC opt and training.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
