### PR TITLE
Update the SDK to "10.0.100-alpha.1.25077.2"

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "10.0.100-alpha.1.25074.2",
+    "version": "10.0.100-alpha.1.25077.2",
     "rollForward": "latestFeature"
   },
   "tools": {
-    "dotnet": "10.0.100-alpha.1.25074.2"
+    "dotnet": "10.0.100-alpha.1.25077.2"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25074.4",


### PR DESCRIPTION
The newer SDK contains https://github.com/dotnet/sdk/commit/23e2ba847d79562b972dbf54eca3f87c3044d925 which will unblock repos that use packages with runtime assets. I.e. https://github.com/dotnet/wpf/pull/10291

aspnetcore is still on the same version
