### PR TITLE
Ensure `setuptools` Python module is available

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/AzurePipelines.MonoQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/AzurePipelines.MonoQueue.targets
@@ -6,13 +6,16 @@
     <HelixProperties Include="AzurePipelinesTestRunId" Value="$(TestRunId)" />
   </ItemGroup>
 
+  <!-- Install setuptools if not already installed. Unnecessary if running in a Linux Docker container. -->
   <PropertyGroup>
     <HelixPostCommands Condition="$(IsPosixShell)">
       $(HelixPostCommands);
+      [ -n ${HELIX_DOCKER_ENTRYPOINT:-} ] || %HELIX_PYTHONPATH% -m pip --disable-pip-version-check install setuptools;
       $HELIX_PYTHONPATH $HELIX_CORRELATION_PAYLOAD/reporter/run.py $(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI) $(SYSTEM_TEAMPROJECT) $(TestRunId) $(SYSTEM_ACCESSTOKEN) || exit $?
     </HelixPostCommands>
     <HelixPostCommands Condition="!$(IsPosixShell)">
       $(HelixPostCommands);
+      %HELIX_PYTHONPATH% -m pip --disable-pip-version-check install setuptools;
       %HELIX_PYTHONPATH% %HELIX_CORRELATION_PAYLOAD%\reporter\run.py $(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI) $(SYSTEM_TEAMPROJECT) $(TestRunId) $(SYSTEM_ACCESSTOKEN) || exit /b
     </HelixPostCommands>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/xharness-runner/XHarnessRunner.targets
@@ -61,6 +61,7 @@
     <!-- When using a dotnet 'tool' that is not installed globally, we must set DOTNET_ROOT.
          This is because a framework dependent dotnet tool only searches in program files folders for runtimes.
          When .NET is not already installed there, we set DOTNET_ROOT to help it find the right one. -->
+    <!-- Install setuptools if not already installed. Unnecessary if running in a Linux Docker container. -->
     <PropertyGroup Condition="$(IsPosixShell)">
       <HelixPreCommands>$(HelixPreCommands);export PATH=$HELIX_CORRELATION_PAYLOAD/xharness-cli:$PATH</HelixPreCommands>
       <HelixPreCommands>$(HelixPreCommands);export XHARNESS_DISABLE_COLORED_OUTPUT=true</HelixPreCommands>
@@ -68,7 +69,12 @@
       <HelixPreCommands>$(HelixPreCommands);export XHARNESS_CLI_PATH=$HELIX_CORRELATION_PAYLOAD/microsoft.dotnet.xharness.cli/$(_XHarnessPackageVersion)/tools/$(XHarnessTargetFramework)/any/Microsoft.DotNet.XHarness.CLI.dll</HelixPreCommands>
 
       <HelixPreCommands Condition=" '$(EnableXHarnessTelemetry)' == 'true' ">$(HelixPreCommands);export XHARNESS_DIAGNOSTICS_PATH=$HELIX_WORKITEM_ROOT/diagnostics.json</HelixPreCommands>
-      <HelixPostCommands Condition=" '$(EnableXHarnessTelemetry)' == 'true' ">"$HELIX_PYTHONPATH" -u "$HELIX_WORKITEM_PAYLOAD/xharness-event-processor.py";$(HelixPostCommands)</HelixPostCommands>
+
+      <HelixPostCommands Condition=" '$(EnableXHarnessTelemetry)' == 'true' ">
+        [ -n ${HELIX_DOCKER_ENTRYPOINT:-} ] || %HELIX_PYTHONPATH% -m pip --disable-pip-version-check install setuptools;
+        $HELIX_PYTHONPATH -u "$HELIX_WORKITEM_PAYLOAD/xharness-event-processor.py";
+        $(HelixPostCommands)
+      </HelixPostCommands>
     </PropertyGroup>
 
     <PropertyGroup Condition="!$(IsPosixShell)">
@@ -79,7 +85,12 @@
       <HelixPreCommands>$(HelixPreCommands);doskey xharness="dotnet exec %XHARNESS_CLI_PATH%"</HelixPreCommands>
 
       <HelixPreCommands Condition=" '$(EnableXHarnessTelemetry)' == 'true' ">$(HelixPreCommands);set XHARNESS_DIAGNOSTICS_PATH=%HELIX_WORKITEM_ROOT%\diagnostics.json</HelixPreCommands>
-      <HelixPostCommands Condition=" '$(EnableXHarnessTelemetry)' == 'true' ">"%HELIX_PYTHONPATH%" -u "%HELIX_WORKITEM_PAYLOAD%\xharness-event-processor.py";$(HelixPostCommands)</HelixPostCommands>
+
+      <HelixPostCommands Condition=" '$(EnableXHarnessTelemetry)' == 'true' ">
+        %HELIX_PYTHONPATH% -m pip --disable-pip-version-check install setuptools;
+        %HELIX_PYTHONPATH% -u "%HELIX_WORKITEM_PAYLOAD%\xharness-event-processor.py";
+        $(HelixPostCommands)
+      </HelixPostCommands>
     </PropertyGroup>
   </Target>
 


### PR DESCRIPTION
- see https://github.com/dotnet/dnceng/issues/4756
- with this, executing `python3` should not result in `pkg_resources not found` error
  - note direct Python dependencies in dotnet/arcade include only default modules
  - change in Microsoft.DotNet.Build.Tasks.Installers likely less important

### To double check:

* [x] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md

### Note

this PR will need to be back-ported to every active production branch in the repo