### PR TITLE
Skip publishing wixpacks added to the Artifact item group by default

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -59,6 +59,14 @@
   <Import Project="StrongName.targets" />
   <Import Project="Sign.props" />
 
+  
+  <ItemDefinitionGroup>
+    <Artifact>
+      <!-- By default, don't publish wixpacks. They're only needed for signing and can be dropped from the publish phase. -->
+      <SkipPublish Condition="$([System.String]::new('%(Filename)%(Extension)').EndsWith('.wixpack.zip'))">true</SkipPublish>
+    </Artifact>
+  </ItemDefinitionGroup>
+
   <PropertyGroup>
     <!-- Default publishing target is 3. -->
     <PublishingVersion>3</PublishingVersion>


### PR DESCRIPTION
This explicitly doesn't touch ItemsToPushToBlobFeed as that item group is undocumented and Artifact items with SkipPublish=true don't even make it into ItemsToPushToBlobFeed, so we'd have to remove items instead, which doesn't give a good user gesture to force publishing wixpacks anyway for some reason.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
