### PR TITLE
Make AssetManifest* properties more extensible and use a better default in CI

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -90,6 +90,7 @@
     <PublishDependsOnTargets>BeforePublish;AutoGenerateSymbolPackages</PublishDependsOnTargets>
   </PropertyGroup>
 
+  <!-- Keep these asset manifest properties here as other repos already depend on them in Publishing.props. -->
   <PropertyGroup>
     <!-- Prefer TargetOS when set over OS -->
     <AssetManifestOS Condition="'$(AssetManifestOS)' == ''">$([MSBuild]::ValueOrDefault('$(TargetOS)', '$(OS)'))</AssetManifestOS>
@@ -97,9 +98,6 @@
     <AssetManifestArch Condition="'$(AssetManifestArch)' == ''">$([MSBuild]::ValueOrDefault('$(TargetArchitecture)', '$(PlatformName)'))</AssetManifestArch>
     <!-- Add the build pass number when DotNetBuildPass is set to a value other than 1. -->
     <AssetManifestPass Condition="'$(DotNetBuildPass)' != '' and '$(DotNetBuildPass)' != '1'">-Pass$(DotNetBuildPass)</AssetManifestPass>
-
-    <AssetManifestFileName>$(AssetManifestOS)-$(AssetManifestArch)$(AssetManifestPass).xml</AssetManifestFileName>
-    <AssetManifestFilePath>$(ArtifactsLogDir)AssetManifest\$(AssetManifestFileName)</AssetManifestFilePath>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(EnableDefaultArtifacts)' == 'true'">
@@ -208,6 +206,12 @@
       
       <!-- Directory where pdbs pointed in `FilesToPublishToSymbolServer` are copied before publishing to AzDO artifacts. -->
       <PDBsToPublishTempLocation>$(ArtifactsTmpDir)PDBsToPublish/</PDBsToPublishTempLocation>
+
+      <!-- Use the AGENT_JOBNAME variable when available as that is guaranteed to be a unique identifier.
+           For local scenarios and when the variable isn't available, use "<os>-<arch>-<buildpass>"" as the manifest name. -->
+      <AssetManifestFileName Condition="'$(AssetManifestFileName)' == '' and '$(AGENT_JOBNAME)' != ''">$(AGENT_JOBNAME).xml</AssetManifestFileName>
+      <AssetManifestFileName Condition="'$(AssetManifestFileName)' == ''">$(AssetManifestOS)-$(AssetManifestArch)$(AssetManifestPass).xml</AssetManifestFileName>
+      <AssetManifestFilePath Condition="'$(AssetManifestFilePath)' == ''">$(ArtifactsLogDir)AssetManifest\$(AssetManifestFileName)</AssetManifestFilePath>
     </PropertyGroup>
     
     <!--


### PR DESCRIPTION
Move the AssetManifestFileName and AssetManifestFilePath properties after the Publishing.props import so that repos don't have to redefine `AssetManifestFilePath` anymore when changing `AssetManifestFileName`.

When `AssetManifestFileName` isn't provided externally, use the Agent.JobName env var when available. That is guaranteed to be unique and avoids the need for repos to come up with a unique name themselves. This should remove the need for all cases that pass a name in externally.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
