### PR TITLE
Fix publishing of checksums when RelativeBlobPathParent is provided

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -182,8 +182,9 @@
 
     <ItemGroup>
       <!-- Set RelativeBlobPath if RelativeBlobPathParent is provided. -->
-      <Artifact Include="@(GenerateChecksumItems -> '%(DestinationPath)')">
-        <RelativeBlobPath Condition="'$(RelativeBlobPathParent)' != ''">$(RelativeBlobPathParent)%(Filename)%(Extension)</RelativeBlobPath>
+      <GenerateChecksumItemsWithDestinationPath Include="@(GenerateChecksumItems -> '%(DestinationPath)')" />
+      <Artifact Include="@(GenerateChecksumItemsWithDestinationPath)">
+        <RelativeBlobPath Condition="'$(RelativeBlobPathParent)' != ''">$(RelativeBlobPathParent.TrimEnd('/'))/%(Filename)%(Extension)</RelativeBlobPath>
       </Artifact>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/46388

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
