### PR TITLE
[Mono] move consolerunner instantiation to separate function

### DIFF
--- a/src/Microsoft.DotNet.XUnitConsoleRunner/src/Program.cs
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/src/Program.cs
@@ -17,13 +17,13 @@ namespace Xunit.ConsoleClient
             var internalDiagnosticsMessageSink = DiagnosticMessageSink.ForInternalDiagnostics(consoleLock, args.Contains("-internaldiagnostics"), args.Contains("-nocolor"));
 
             using (AssemblyHelper.SubscribeResolveForAssembly(typeof(Program), internalDiagnosticsMessageSink))
-                 return callEntryPoint(consoleLock, args);
+                return CallEntryPoint(consoleLock, args);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static int callEntryPoint(object consoleLock , string[] args)
+        [MethodImpl(MethodImplOptions.NoInlining)] // separate method to workaround Mono JIT eagerly resolving types of ConsoleRunner fields
+        private static int CallEntryPoint(object consoleLock, string[] args)
         {
-                 return new ConsoleRunner(consoleLock).EntryPoint(args);
+            return new ConsoleRunner(consoleLock).EntryPoint(args);
         }
     }
 }

--- a/src/Microsoft.DotNet.XUnitConsoleRunner/src/Program.cs
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/src/Program.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace Xunit.ConsoleClient
 {
@@ -16,7 +17,13 @@ namespace Xunit.ConsoleClient
             var internalDiagnosticsMessageSink = DiagnosticMessageSink.ForInternalDiagnostics(consoleLock, args.Contains("-internaldiagnostics"), args.Contains("-nocolor"));
 
             using (AssemblyHelper.SubscribeResolveForAssembly(typeof(Program), internalDiagnosticsMessageSink))
-                return new ConsoleRunner(consoleLock).EntryPoint(args);
+                 return callEntryPoint(consoleLock, args);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static int callEntryPoint(object consoleLock , string[] args)
+        {
+                 return new ConsoleRunner(consoleLock).EntryPoint(args);
         }
     }
 }


### PR DESCRIPTION
This is on platforms where the Mono SDK is supported.

When Mono JIT compiles `Main()`, it encounters a call to `new ConsoleRunner()`. Unlike CoreCLR, Mono JIT **attempts to resolve all field types of ConsoleRunner at JIT compilation time**, rather than deferring resolution until runtime.
The problem arises because some fields inside `ConsoleRunner` depend on **assemblies that are only resolvable via the assembly resolve event handler**. However, this resolve handler is **only installed after Main() has been compiled and execution starts**. As a result, Mono JIT fails when it attempts to load these types too early, leading to runtime errors.

This is a workaround for a limitation in Mono JIT by moving the instantiation to an another function.

Allow `Main()` to execute first**, ensuring that the assembly resolve handler is installed **before** `ConsoleRunner` is instantiated 

 see: dotnet/runtime#60550
