### PR TITLE
Don't run AfterSolutionBuild.proj and AfterSigning.proj in outer-build

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -279,7 +279,7 @@
     <MSBuild Projects="AfterSolutionBuild.proj"
              Properties="@(_CommonProps);_NETCORE_ENGINEERING_TELEMETRY=Build"
              Targets="@(_SolutionBuildTargets)"
-             Condition="'@(_SolutionBuildTargets)' != ''" />
+             Condition="'@(_SolutionBuildTargets)' != '' and ('$(DotNetBuild)' != 'true' or '$(DotNetBuildPhase)' == 'InnerRepo')" />
 
     <!--
       Sign artifacts.
@@ -292,7 +292,7 @@
     <MSBuild Projects="AfterSigning.proj"
              Properties="@(_CommonProps);_NETCORE_ENGINEERING_TELEMETRY=Sign"
              Targets="@(_SolutionBuildTargets)"
-             Condition="'@(_SolutionBuildTargets)' != ''"/>
+             Condition="'@(_SolutionBuildTargets)' != '' and ('$(DotNetBuild)' != 'true' or '$(DotNetBuildPhase)' == 'InnerRepo')"/>
 
     <!--
       Perform post-source-build tasks. Validate source-build requirements, such as the prebuilt


### PR DESCRIPTION
In the VMR, these two extension points shouldn't run in an outer build. The inner-build handles building and signing inside the VMR. Local "dev" VMR builds are currently broken because of this.

>  C:\git\dotnet\artifacts\source-built-sdks\Microsoft.DotNet.Arcade.Sdk\tools\BuildReleasePackages.targets(21,5): error MSB4062: The "Microsoft.DotNet.Tools.UpdatePackageVersionTask" task could not be loaded from the assembly