### PR TITLE
Introduce Kind for artifact data

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -22,6 +22,7 @@
         - ChecksumPath                    The destination path to generate a checksum file for the artifact. Set the `RelativeBlobPathParent`
                                           property if the RelativeBlobPath for the generate checksum should be automatically set.
         - PublishFlatContainer            By default artifacts are published to blob artifacts. Set to false to publish to package artifacts.
+        - Kind                            [Package, Blob]. If set, overrides PublishFlatContainer usage. If not, then PublishFlatContainer=false == Package, true == Blob.
         - RelativeBlobPath                The relative blob path when publishing to blob artifacts.
         - IsShipping                      Set to false to mark the artifact as non-shipping. Defaults to true.
   -->
@@ -101,8 +102,8 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(EnableDefaultArtifacts)' == 'true'">
-    <Artifact Include="$(ArtifactsShippingPackagesDir)**/*.nupkg" PublishFlatContainer="false" />
-    <Artifact Include="$(ArtifactsNonShippingPackagesDir)**/*.nupkg" IsShipping="false" PublishFlatContainer="false" />
+    <Artifact Include="$(ArtifactsShippingPackagesDir)**/*.nupkg" Kind="Package" />
+    <Artifact Include="$(ArtifactsNonShippingPackagesDir)**/*.nupkg" IsShipping="false" Kind="Package" />
   </ItemGroup>
 
   <!-- Allow for repo specific Publish properties such as add additional files to be published -->
@@ -116,7 +117,10 @@
   <Target Name="BeforePublish" Condition="'@(Artifact)' != ''">
     <ItemGroup>
       <!-- Exclude all existing *.symbols.nupkg in source-only build - we create a unified symbols archive instead. -->
-      <_ExistingSymbolPackage Include="@(Artifact)" Condition="'$(DotNetBuildSourceOnly)' != 'true' and '%(Artifact.SkipPublish)' != 'true' and $([System.String]::Copy('%(Filename)%(Extension)').EndsWith('.symbols.nupkg'))" />
+      <_ExistingSymbolPackage Include="@(Artifact)" Condition="'$(DotNetBuildSourceOnly)' != 'true' and '%(Artifact.SkipPublish)' != 'true' and $([System.String]::Copy('%(Filename)%(Extension)').EndsWith('.symbols.nupkg'))">
+        <!-- Update the kind of the symbol packages to blob -->
+        <Kind>Blob</Blob>
+      <_ExistingSymbolPackage>
       <_PackageToPublish Include="@(Artifact)" Exclude="@(_ExistingSymbolPackage)" Condition="'%(Artifact.SkipPublish)' != 'true' and '%(Extension)' == '.nupkg'" />
     </ItemGroup>
 
@@ -140,6 +144,7 @@
                                 Condition="'%(_PackageToPublish.SymbolPackageToGenerate)' != ''">
         <OriginalPackage>%(_PackageToPublish.Identity)</OriginalPackage>
         <IsShipping>%(_PackageToPublish.IsShipping)</IsShipping>
+        <Kind>Blob</Kind>
       </_SymbolPackageToGenerate>
     </ItemGroup>
 
@@ -183,6 +188,7 @@
       <GenerateChecksumItemsWithDestinationPath Include="@(GenerateChecksumItems -> '%(DestinationPath)')" />
       <Artifact Include="@(GenerateChecksumItemsWithDestinationPath)">
         <RelativeBlobPath Condition="'$(RelativeBlobPathParent)' != ''">$(RelativeBlobPathParent.TrimEnd('/'))/%(Filename)%(Extension)</RelativeBlobPath>
+        <Kind>Blob</Kind>
       </Artifact>
     </ItemGroup>
   </Target>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -10,6 +10,11 @@
   <ItemDefinitionGroup>
     <Artifact>
       <PublishFlatContainer>true</PublishFlatContainer>
+      <!-- Possible values: Blob, Package -->
+      <!-- Currently unset, indicating that a repo hasn't started using this property. If it's set, then it
+           wins over PublishFlatContaner. If it is not set, then PublishFlatContainer wins.
+           After existing usage of PublishFlatContainer is no longer around, set to "Blob" -->
+      <Kind></Kind>
       <IsShipping>true</IsShipping>
     </Artifact>
   </ItemDefinitionGroup>


### PR DESCRIPTION
This is a replacement for PublishFlatContainer, with the intention of extending this to include PDBArtifacts, so that we can remove the separate handling of these prior to build promotion. Kind has 2 current types, and is valid on artifact data: Package and Blob. If Kind is set, it overrides the PublishFlatContainer setting for the given artifact. Otherwise the existing defaults/behavior are used.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
