### PR TITLE
Condition source-build specific targets

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
@@ -7,6 +7,7 @@
 
   <PropertyGroup>
     <MicrosoftDotNetSourceBuildTasksBuildDir>$(NuGetPackageRoot)microsoft.dotnet.sourcebuild.tasks\$(MicrosoftDotNetSourceBuildTasksVersion)\build\</MicrosoftDotNetSourceBuildTasksBuildDir>
+    <ReportPrebuiltUsage Condition="'$(ReportPrebuiltUsage)' == '' and '$(DotNetBuildSourceOnly)' == 'true'">true</ReportPrebuiltUsage>
   </PropertyGroup>
 
   <Import Project="$(MicrosoftDotNetSourceBuildTasksBuildDir)Microsoft.DotNet.SourceBuild.Tasks.props" />
@@ -62,6 +63,7 @@
   </Target>
 
   <Target Name="ReportPrebuiltUsage"
+          Condition="'$(ReportPrebuiltUsage)' == 'true'"
           DependsOnTargets="WritePrebuiltUsageData">
     <PropertyGroup>
       <FailOnPrebuiltBaselineError Condition="'$(FailOnPrebuiltBaselineError)' == ''">true</FailOnPrebuiltBaselineError>
@@ -85,7 +87,7 @@
       OutputBaselineFile="$(SourceBuildSelfPrebuiltReportDir)generated-new-baseline.xml"
       OutputReportFile="$(SourceBuildSelfPrebuiltReportDir)baseline-comparison.xml"
       ContinueOnError="$(ContinueOnPrebuiltBaselineError)"
-      Condition="'$(DotNetBuildOrchestrator)' != 'true' and '$(DotNetBuildSourceOnly)' == 'true'" />
+      Condition="'$(DotNetBuildOrchestrator)' != 'true'" />
   </Target>
 
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -221,13 +221,15 @@
   </Target>
 
   <Target Name="CopyRepoSymbolsToIntermediates"
-          DependsOnTargets="DiscoverRepoSymbols">
+          DependsOnTargets="DiscoverRepoSymbols"
+          Condition="'$(SourceBuiltSymbolsDir)' != ''">
     <MakeDir Directories="$(SourceBuiltSymbolsDir)" />
     <Copy
       SourceFiles="@(AbsoluteSymbolPath)"
       DestinationFolder="$(SourceBuiltSymbolsDir)%(RecursiveDir)"
       UseHardlinksIfPossible="true" />
   </Target>
+
   <!--
     This target can be removed once we enable standard repo assets manifests and SB orchestrator
     starts using it - https://github.com/dotnet/source-build/issues/3970
@@ -255,4 +257,5 @@
       <Content Include="$(RepoManifestFile)" PackagePath="." />
     </ItemGroup>
   </Target>
+
 </Project>


### PR DESCRIPTION
- ReportPrebuiltUsage (and WritePrebuiltUsageData) shouldn't run when not building source-only
- CopyRepoSymbolsToIntermediates should only run when a `SourceBuiltSymbolsDir` dir path is passed in.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
