### PR TITLE
Add link filtering to 8.0

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/LatestLinksManagerTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/LatestLinksManagerTests.cs
@@ -1,0 +1,123 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using FluentAssertions;
+using Microsoft.DotNet.Build.Tasks.Feed.Model;
+using Xunit;
+
+namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
+{
+    public class LatestLinksManagerTests
+    {
+        [Fact]
+        public void FilterAssetsToLink_ExcludesSpecifiedFilenames()
+        {
+            // Arrange
+            var assetsToPublish = new HashSet<string>
+            {
+                "path/to/file1.zip",
+                "path/to/file2.rpm",
+                "path/to/file7.rpm",
+                "path/to/file3.wixpack.zip",
+                "path/to/file4.exe",
+                "path/to/file5.symbols.nupkg",
+                "path/to/file5.nupkg"
+            };
+            var filenamesToExclude = new List<string> { "file2.rpm" }.ToImmutableList();
+
+            // Act
+            var result = LatestLinksManager.FilterAssetsToLink(assetsToPublish, filenamesToExclude);
+
+            result.Should().BeEquivalentTo(new[] { "path/to/file1.zip", "path/to/file7.rpm", "path/to/file4.exe" });
+        }
+
+        [Fact]
+        public void FilterAssetsToLink_IncludesCreateLinkPatterns()
+        {
+            // Arrange
+            var assetsToPublish = new HashSet<string>
+            {
+                "file1.zip",
+                "file2.rpm",
+                "file3.wixpack",
+                "file4.exe"
+            };
+            var filenamesToExclude = ImmutableList<string>.Empty;
+
+            // Act
+            var result = LatestLinksManager.FilterAssetsToLink(assetsToPublish, filenamesToExclude);
+
+            // Assert
+            result.Should().BeEquivalentTo(new[] { "file1.zip", "file2.rpm", "file4.exe" });
+        }
+
+        [Fact]
+        public void FilterAssetsToLink_ExcludesNonMatchingPatterns()
+        {
+            // Arrange
+            var assetsToPublish = new HashSet<string>
+            {
+                "file1.unknown",
+                "file2.unknown"
+            };
+            var filenamesToExclude = ImmutableList<string>.Empty;
+
+            // Act
+            var result = LatestLinksManager.FilterAssetsToLink(assetsToPublish, filenamesToExclude);
+
+            result.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData("https://dotnetcli.blob.core.windows.net/test", "https://builds.dotnet.microsoft.com/test/")]
+        [InlineData("https://dotnetbuilds.blob.core.windows.net/test/", "https://ci.dot.net/test/")]
+        public void ComputeLatestLinkBase_WithValidFeedConfig_ReturnsExpectedBaseUrl(string safeTargetUrl, string expectedTargetUrl)
+        {
+            // Arrange
+            var feedConfig = new TargetFeedConfig(
+                contentType: TargetFeedContentType.Installer,
+                targetURL: safeTargetUrl,
+                type: FeedType.AzureStorageContainer,
+                token: "dummyToken",
+                latestLinkShortUrlPrefixes: ["prefix"]
+            );
+
+            // Act
+            LatestLinksManager.ComputeLatestLinkBase(feedConfig).Should().Be(expectedTargetUrl);
+        }
+
+        [Fact]
+        public void ComputeLatestLinkBase_WithTrailingSlash_ReturnsExpectedBaseUrl()
+        {
+            // Arrange
+            var feedConfig = new TargetFeedConfig(
+                contentType: TargetFeedContentType.Installer,
+                targetURL: "https://dotnetcli.blob.core.windows.net/test/",
+                type: FeedType.AzureStorageContainer,
+                token: "dummyToken",
+                latestLinkShortUrlPrefixes: ["prefix"]
+            );
+
+            // Act
+            LatestLinksManager.ComputeLatestLinkBase(feedConfig).Should().Be("https://builds.dotnet.microsoft.com/test/");
+        }
+
+        [Fact]
+        public void ComputeLatestLinkBase_WithUnknownAuthority_ReturnsOriginalBaseUrl()
+        {
+            // Arrange
+            var feedConfig = new TargetFeedConfig(
+                contentType: TargetFeedContentType.Installer,
+                targetURL: "https://unknown.blob.core.windows.net/test",
+                type: FeedType.AzureStorageContainer,
+                token: "dummyToken",
+                latestLinkShortUrlPrefixes: ["prefix"]
+            );
+
+            // Act
+            LatestLinksManager.ComputeLatestLinkBase(feedConfig).Should().Be("https://unknown.blob.core.windows.net/test/");
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/LatestLinksManager.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/LatestLinksManager.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
+using System.Text.RegularExpressions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.DotNet.Build.Tasks.Feed.Model;
@@ -22,10 +24,32 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         private string _akaMSCreatedBy { get; }
         private string _akaMSGroupOwner { get; }
 
-        private static HashSet<string> AccountsWithCdns { get; } = new()
+        private static Dictionary<string, string> AccountsWithCdns { get; } = new()
         {
-            "dotnetcli.blob.core.windows.net", "dotnetbuilds.blob.core.windows.net",
+            {"dotnetcli.blob.core.windows.net", "builds.dotnet.microsoft.com" },
+            {"dotnetbuilds.blob.core.windows.net", "ci.dot.net" }
         };
+
+        public static readonly ImmutableList<Regex> AkaMSCreateLinkPatterns = new List<Regex>() {
+            new Regex(@"\.rpm(\.sha512)?$", RegexOptions.IgnoreCase),
+            new Regex(@"\.zip(\.sha512)?$", RegexOptions.IgnoreCase),
+            new Regex(@"\.version(\.sha512)?$", RegexOptions.IgnoreCase),
+            new Regex(@"\.deb(\.sha512)?$", RegexOptions.IgnoreCase),
+            new Regex(@"\.gz(\.sha512)?$", RegexOptions.IgnoreCase),
+            new Regex(@"\.pkg(\.sha512)?$", RegexOptions.IgnoreCase),
+            new Regex(@"\.msi(\.sha512)?$", RegexOptions.IgnoreCase),
+            new Regex(@"\.exe(\.sha512)?$", RegexOptions.IgnoreCase),
+            new Regex(@"\.svg(\.sha512)?$", RegexOptions.IgnoreCase),
+            new Regex(@"\.tgz(\.sha512)?$", RegexOptions.IgnoreCase),
+            new Regex(@"\.jar(\.sha512)?$", RegexOptions.IgnoreCase),
+            new Regex(@"\.pom(\.sha512)?$", RegexOptions.IgnoreCase),
+            new Regex(@"productcommit", RegexOptions.IgnoreCase),
+            new Regex(@"productversion", RegexOptions.IgnoreCase)
+        }.ToImmutableList();
+
+        public static readonly ImmutableList<Regex> AkaMSDoNotCreateLinkPatterns = new List<Regex>() {
+            new Regex(@"wixpack", RegexOptions.IgnoreCase),
+        }.ToImmutableList();
 
         public LatestLinksManager(
             string akaMSClientId,
@@ -59,6 +83,25 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             _linkManager = new AkaMSLinkManager(akaMSClientId, certificate, akaMSTenant, _logger);
         }
 
+        public static string ComputeLatestLinkBase(TargetFeedConfig feedConfig)
+        {
+            string feedBaseUrl = feedConfig.SafeTargetURL;
+            if (!feedBaseUrl.EndsWith("/", StringComparison.OrdinalIgnoreCase))
+            {
+                feedBaseUrl += "/";
+            }
+            var authority = new Uri(feedBaseUrl).Authority;
+            if (AccountsWithCdns.TryGetValue(authority, out var replacementAuthority))
+            {
+                // The storage accounts are in a single datacenter in the US and thus download 
+                // times can be painful elsewhere. The CDN helps with this therefore we point the target 
+                // of the aka.ms links to the CDN.
+                feedBaseUrl = feedBaseUrl.Replace(authority, replacementAuthority);
+            }
+
+            return feedBaseUrl;
+        }
+
         public async System.Threading.Tasks.Task CreateOrUpdateLatestLinksAsync(
             HashSet<string> assetsToPublish,
             TargetFeedConfig feedConfig,
@@ -71,48 +114,35 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 throw new ArgumentException("No link prefixes specified.");
             }
 
-            string feedBaseUrl = feedConfig.SafeTargetURL;
-            if (expectedSuffixLength != 0)
-            {
-                // Strip away the feed expected suffix (index.json)
-                feedBaseUrl = feedBaseUrl.Substring(0, feedBaseUrl.Length - expectedSuffixLength);
-            }
-            if (!feedBaseUrl.EndsWith("/", StringComparison.OrdinalIgnoreCase))
-            {
-                feedBaseUrl += "/";
-            }
-            if (AccountsWithCdns.Any(account => feedBaseUrl.Contains(account)))
-            {
-                // The storage accounts are in a single datacenter in the US and thus download 
-                // times can be painful elsewhere. The CDN helps with this therefore we point the target 
-                // of the aka.ms links to the CDN.
-                feedBaseUrl = feedBaseUrl.Replace(".blob.core.windows.net", ".azureedge.net");
-            }
+            string feedBaseUrl = ComputeLatestLinkBase(feedConfig);
 
             _logger.LogMessage(MessageImportance.High, "\nThe following aka.ms links for blobs will be created:");
-            IEnumerable<AkaMSLink> linksToCreate = assetsToPublish
-                .Where(asset => !feedConfig.FilenamesToExclude.Contains(Path.GetFileName(asset)))
-                .Select(asset =>
-                    {
+            IEnumerable<AkaMSLink> linksToCreate = FilterAssetsToLink(assetsToPublish, feedConfig.FilenamesToExclude).Select(asset =>
+            {
 
-                        // blob path.
-                        string actualTargetUrl = feedBaseUrl + asset;
+                // blob path.
+                string actualTargetUrl = feedBaseUrl + asset;
 
-                        List<AkaMSLink> newLinks = new List<AkaMSLink>();
-                        foreach (string shortUrlPrefix in feedConfig.LatestLinkShortUrlPrefixes)
-                        {
-                            newLinks.Add(GetAkaMSLinkForAsset(shortUrlPrefix, feedBaseUrl, asset, feedConfig.Flatten));
-                        }
+                List<AkaMSLink> newLinks = new List<AkaMSLink>();
+                foreach (string shortUrlPrefix in feedConfig.LatestLinkShortUrlPrefixes)
+                {
+                    newLinks.Add(GetAkaMSLinkForAsset(shortUrlPrefix, feedBaseUrl, asset, feedConfig.Flatten));
+                }
 
-                        return newLinks;
-                    })
+                return newLinks;
+            })
                 .SelectMany(links => links)
                 .ToList();
 
             await _linkManager.CreateOrUpdateLinksAsync(linksToCreate, _akaMSOwners, _akaMSCreatedBy, _akaMSGroupOwner, true);
         }
 
-        /// <sunnary>
+        public static IEnumerable<string> FilterAssetsToLink(HashSet<string> assetsToPublish, IEnumerable<string> filenamesToExclude) => assetsToPublish
+                        .Where(asset => !filenamesToExclude.Contains(Path.GetFileName(asset)))
+                        .Where(asset => !AkaMSDoNotCreateLinkPatterns.Any(p => p.IsMatch(asset)) &&
+                                         AkaMSCreateLinkPatterns.Any(p => p.IsMatch(asset)));
+
+        /// <summary>
         ///     Create the aka.ms link info
         /// </summary>
         /// <param name="shortUrlPrefix">aka.ms short url prefix</param>


### PR DESCRIPTION
Do this cheaply compared to main, since the sources have diverged and it's a hard direct port. We use the same patterns as main, but just don't alter the data structures to pass the patterns through.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
