### PR TITLE
Revert "Reject multiple versions of same package (#15367)"

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -130,15 +130,6 @@
     </RemoveDuplicates>
 
     <ItemGroup>
-      <IntermediateFileWithoutVersion Include="$([System.Text.RegularExpressions.Regex]::Replace('%(IntermediatePackageFile.Identity)','\.(\d+\.){2}\d+(-\w+)?(\.(\d+\.){1}\d+)?',''))" />
-      <NotSupportIntermediateFile Include="@(IntermediateFileWithoutVersion)"
-                                  Condition="'%(IntermediateFileWithoutVersion.FileName) @(IntermediateFileWithoutVersion->Count())' != '%(IntermediateFileWithoutVersion.FileName) 1'" />
-    </ItemGroup>
-
-    <Error Condition="'@(NotSupportIntermediateFile)' != ''"
-           Text="There are multiple versions of these packages, please identify which version will go into the intermediate:%0a@(NotSupportIntermediateFile, '%0a')" />
-
-    <ItemGroup>
       <IntermediateNonShippingNupkgFile Include="@(IntermediatePackageFile)" Condition="$([System.Text.RegularExpressions.Regex]::Match(%(Identity),'[\\\\/]NonShipping[\\\\/]').Success)"/>
       <SupplementalIntermediateNupkgCategory Include="%(IntermediatePackageFile.Category)" />
     </ItemGroup>


### PR DESCRIPTION
This reverts commit 2ac4034732f0dbb9781beae751cf15b65aff1bcd made with https://github.com/dotnet/arcade/pull/15367.

This is causing failures in the following PRs:

- https://github.com/dotnet/source-build-reference-packages/pull/1131
- https://github.com/dotnet/symreader/pull/335
- https://github.com/dotnet/roslyn-analyzers/pull/7516

I was originally going to add an opt out mechanism as it would be needed for SBRP.  However the more I thought about this, I don't think we should be investing anything related to SB intermediates as there will be no need for them shortly.  They aren't used in full SB and only used in repo level SB legs which will be removed as part of https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/VMR-Repo-and-VMR-Validation.md.  Because of this, I am proposing we revert the addition of this check.
