### PR TITLE
Don't produce CBL-Mariner 1/2-specific packages

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -67,6 +67,7 @@
     <FileExtensionSignInfo Include=".tgz" CertificateName="None" />
     <FileExtensionSignInfo Include=".tar.gz" CertificateName="None" />
     <!-- Note, RPMs can only be unpack/repacked on Linux. They can be signed on non-Linux -->
+    <FileExtensionSignInfo Include=".azl.rpm" CertificateName="LinuxSignMariner" />
     <FileExtensionSignInfo Include=".rpm" CertificateName="LinuxSign" />
     <!-- Note, these can only be unpack/repacked on Mac. They can be signed on a non-Mac -->
     <FileExtensionSignInfo Include=".pkg" CertificateName="MacDeveloper" />

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.build.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.build.targets
@@ -85,6 +85,23 @@
       <ExeBundleInstallerFile>$(PackageOutputPath)$(InstallerFileNameWithoutExtension).exe</ExeBundleInstallerFile>
       <ExeBundleInstallerEngineFile>$(PackageOutputPath)$(InstallerFileNameWithoutExtension)-engine.exe</ExeBundleInstallerEngineFile>
     </PropertyGroup>
+
+    <!--
+      Packages produced for Azure Linux must be signed with a special certificate.
+      RPM v4 doesn't support multiple signatures, so we must have two separate copies of the RPM for us to sign.
+      To solve this, we make a copy of the RPM for Azure Linux, with the .azl.rpm extension (which the Arcade SDK will sign with the correct certificate).
+      If Azure Linux ever switches to RPM v6, we should be able to remove this workaround if our signing tooling adds support for multiple signatures
+      (something RPM v6 supports but RPM v4 does not).
+    -->
+    <PropertyGroup Condition="'$(GenerateRpm)' == 'true'">
+      <CreateRPMForAzureLinux>true</CreateRPMForAzureLinux>
+      <!-- PackageTargetOS is a distro-specific version suffix, used for deps packages, including the one for Azure Linux. -->
+      <CreateRPMForAzureLinux Condition="'$(PackageTargetOS)' != ''">false</CreateRPMForAzureLinux>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(CreateRPMForAzureLinux)' == 'true'">
+      <_InstallerFileAzureLinux>$(PackageOutputPath)$(InstallerFileNameWithoutExtension).azl$(InstallerExtension)</_InstallerFileAzureLinux>
+    </PropertyGroup>
   </Target>
 
   <!--
@@ -393,6 +410,19 @@
           UseHardlinksIfPossible="False" />
 
     <Message Text="$(MSBuildProjectName) -> $(_InstallerFile)" Importance="high" />
+  </Target>
+
+  <Target Name="_BuildAzureLinuxRpm"
+          AfterTargets="GenerateRpm"
+          Condition="'$(CreateRPMForAzureLinux)' == 'true'">
+    <!-- AzureLinux -->
+    <Copy SourceFiles="$(_InstallerFile)"
+          DestinationFiles="$(_InstallerFileAzureLinux)"
+          OverwriteReadOnlyFiles="True"
+          SkipUnchangedFiles="False"
+          UseHardlinksIfPossible="False" />
+
+    <Message Text="$(MSBuildProjectName) -> $(_InstallerFileAzureLinux)" Importance="high" />
   </Target>
 
   <Target Name="GetRpmInstallerJsonProperties"

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.build.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.build.targets
@@ -85,26 +85,6 @@
       <ExeBundleInstallerFile>$(PackageOutputPath)$(InstallerFileNameWithoutExtension).exe</ExeBundleInstallerFile>
       <ExeBundleInstallerEngineFile>$(PackageOutputPath)$(InstallerFileNameWithoutExtension)-engine.exe</ExeBundleInstallerEngineFile>
     </PropertyGroup>
-
-    <PropertyGroup Condition="'$(GenerateRpm)' == 'true'">
-      <CreateRPMForCblMariner>true</CreateRPMForCblMariner>
-      <!-- PackageTargetOS is a distro-specific version suffix, used for deps packages, including the one for CBL Mariner.
-          We do not want to create additional CBL Mariner named RPMs of those packages. -->
-      <CreateRPMForCblMariner Condition="'$(PackageTargetOS)' != ''">false</CreateRPMForCblMariner>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(CreateRPMForCblMariner)' == 'true'">
-      <!-- CBL-Mariner 1.0 -->
-      <_CblMarinerVersionSuffix>cm.1</_CblMarinerVersionSuffix>
-      <_InstallerBuildPartCblMariner>$(Version)-$(_CblMarinerVersionSuffix)-$(_InstallerArchSuffix)</_InstallerBuildPartCblMariner>
-      <_InstallerFileNameWithoutExtensionCblMariner>$(InstallerName)-$(_InstallerBuildPartCblMariner)$(CrossArchContentsBuildPart)</_InstallerFileNameWithoutExtensionCblMariner>
-      <_InstallerFileCblMariner>$(PackageOutputPath)$(_InstallerFileNameWithoutExtensionCblMariner)$(InstallerExtension)</_InstallerFileCblMariner>
-      <!-- CBL-Mariner 2.0 -->
-      <_CblMariner2VersionSuffix>cm.2</_CblMariner2VersionSuffix>
-      <_InstallerBuildPartCblMariner2>$(Version)-$(_CblMariner2VersionSuffix)-$(_InstallerArchSuffix)</_InstallerBuildPartCblMariner2>
-      <_InstallerFileNameWithoutExtensionCblMariner2>$(InstallerName)-$(_InstallerBuildPartCblMariner2)$(CrossArchContentsBuildPart)</_InstallerFileNameWithoutExtensionCblMariner2>
-      <_InstallerFileCblMariner2>$(PackageOutputPath)$(_InstallerFileNameWithoutExtensionCblMariner2)$(InstallerExtension)</_InstallerFileCblMariner2>
-    </PropertyGroup>
   </Target>
 
   <!--
@@ -413,28 +393,6 @@
           UseHardlinksIfPossible="False" />
 
     <Message Text="$(MSBuildProjectName) -> $(_InstallerFile)" Importance="high" />
-  </Target>
-
-  <Target Name="_BuildMarinerRpms"
-          AfterTargets="GenerateRpm"
-          Condition="'$(CreateRPMForCblMariner)' == 'true'">
-    <!-- CBL-Mariner 1.0 -->
-    <Copy SourceFiles="$(_InstallerFile)"
-          DestinationFiles="$(_InstallerFileCblMariner)"
-          OverwriteReadOnlyFiles="True"
-          SkipUnchangedFiles="False"
-          UseHardlinksIfPossible="False" />
-
-    <Message Text="$(MSBuildProjectName) -> $(_InstallerFileCblMariner)" Importance="high" />
-
-    <!-- CBL-Mariner 2.0 -->
-    <Copy SourceFiles="$(_InstallerFile)"
-          DestinationFiles="$(_InstallerFileCblMariner2)"
-          OverwriteReadOnlyFiles="True"
-          SkipUnchangedFiles="False"
-          UseHardlinksIfPossible="False" />
-
-    <Message Text="$(MSBuildProjectName) -> $(_InstallerFileCblMariner2)" Importance="high" />
   </Target>
 
   <Target Name="GetRpmInstallerJsonProperties"

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -396,6 +396,7 @@ namespace Microsoft.DotNet.SignTool
 
         private readonly HashSet<string> specialExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
+            ".azl.rpm",
             ".tar.gz"
         };
 


### PR DESCRIPTION
~~We don't ship these any more, so we can stop producing them.~~

Instead, produce a special .azl.rpm copy that's not versioned with Azure Linux (to avoid having to update this regularly) that has a configuration in Arcade to be signed with the correct certificate.

Contributes to https://github.com/dotnet/arcade/issues/15486

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
