### PR TITLE
Enable signing validation of .pkg files using SignCheck

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
+++ b/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
@@ -13,6 +13,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.DotNet.MacOsPkg\Core\Microsoft.DotNet.MacOsPkg.Core.csproj" Condition="'$(TargetFramework)' == '$(NetToolCurrent)'" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="LZMA-SDK" />
     <PackageReference Include="Microsoft.VisualStudio.OLE.Interop" Condition="$(TargetFramework) != $(NetToolCurrent)"/>
     <PackageReference Include="NuGet.Frameworks" />
@@ -55,6 +59,10 @@
     <Compile Remove="Verification\VsixVerifier.cs" />
     <Compile Remove="Verification\Jar\JarFile.cs" />
     <Compile Remove="Verification\Jar\JarSignatureFile.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != '$(NetToolCurrent)'">
+    <Compile Remove="Verification\PkgVerifier.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SignCheck/Microsoft.SignCheck/Utils.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Utils.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.IO;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -67,6 +68,41 @@ namespace Microsoft.SignCheck
             {
                 return String.Concat(escapedPattern, "$");
             }            
+        }
+
+        /// <summary>
+        /// Gets the value of a named group from a regex match.
+        /// </summary>
+        /// <param name="match">The regex match.</param>
+        /// <param name="groupName">The name of the group.</param>
+        public static string GetRegexValue(Match match, string groupName) =>
+            match.Success ? match.Groups[groupName].Value : null;
+
+        /// <summary>
+        /// Captures the console output of an action.
+        /// </summary>
+        /// <param name="action">The action to execute.</param>
+        /// <returns>A tuple containing the result of the action, the standard output, and the error output.</returns>
+        public static (bool, string, string) CaptureConsoleOutput(Func<bool> action)
+        {
+            var consoleOutput = Console.Out;
+            StringWriter outputWriter = new StringWriter();
+            Console.SetOut(outputWriter);
+
+            var errorOutput = Console.Error;
+            StringWriter errorOutputWriter = new StringWriter();
+            Console.SetError(errorOutputWriter);
+
+            try
+            {
+                bool result = action();
+                return (result, outputWriter.ToString(), errorOutputWriter.ToString());
+            }
+            finally
+            {
+                Console.SetOut(consoleOutput);
+                Console.SetError(errorOutput);
+            }
         }
     }
 }

--- a/src/SignCheck/Microsoft.SignCheck/Utils.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Utils.cs
@@ -9,7 +9,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.SignCheck
 {
-    public class Utils
+    public static class Utils
     {
         /// <summary>
         /// Generate a hash for a string value using a given hash algorithm.
@@ -72,10 +72,12 @@ namespace Microsoft.SignCheck
 
         /// <summary>
         /// Gets the value of a named group from a regex match.
+        /// Returns null if the match is unsuccessful.
         /// </summary>
         /// <param name="match">The regex match.</param>
         /// <param name="groupName">The name of the group.</param>
-        public static string GetRegexValue(Match match, string groupName) =>
+        /// <returns>The value of the named group or null if the match is unsuccessful.</returns>
+        public static string GroupValueOrDefault(this Match match, string groupName) =>
             match.Success ? match.Groups[groupName].Value : null;
 
         /// <summary>

--- a/src/SignCheck/Microsoft.SignCheck/Verification/ArchiveVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/ArchiveVerifier.cs
@@ -35,33 +35,47 @@ namespace Microsoft.SignCheck.Verification
                 Log.WriteMessage(LogVerbosity.Diagnostic, SignCheckResources.DiagExtractingFileContents, tempPath);
                 Dictionary<string, string> archiveMap = new Dictionary<string, string>();
 
-                foreach (ArchiveEntry archiveEntry in ReadArchiveEntries(svr.FullPath))
+                try
                 {
-                    string aliasFullName = GenerateArchiveEntryAlias(archiveEntry, tempPath);
-                    if (File.Exists(aliasFullName))
+                    foreach (ArchiveEntry archiveEntry in ReadArchiveEntries(svr.FullPath))
                     {
-                        Log.WriteMessage(LogVerbosity.Normal, SignCheckResources.FileAlreadyExists, aliasFullName);
+                        string aliasFullName = GenerateArchiveEntryAlias(archiveEntry, tempPath);
+                        if (File.Exists(aliasFullName))
+                        {
+                            Log.WriteMessage(LogVerbosity.Normal, SignCheckResources.FileAlreadyExists, aliasFullName);
+                        }
+                        else
+                        {
+                            CreateDirectory(Path.GetDirectoryName(aliasFullName));
+                            WriteArchiveEntry(archiveEntry, aliasFullName);
+                            archiveMap[archiveEntry.RelativePath] = aliasFullName;
+                        }
                     }
-                    else
+
+                    // We can only verify once everything is extracted. This is mainly because MSIs can have mutliple external CAB files
+                    // and we need to ensure they are extracted before we verify the MSIs.
+                    foreach (string fullName in archiveMap.Keys)
                     {
-                        CreateDirectory(Path.GetDirectoryName(aliasFullName));
-                        WriteArchiveEntry(archiveEntry, aliasFullName);
-                        archiveMap[archiveEntry.RelativePath] = aliasFullName;
+                        SignatureVerificationResult result = VerifyFile(archiveMap[fullName], svr.Filename,
+                            Path.Combine(svr.VirtualPath, fullName), fullName);
+
+                        // Tag the full path into the result detail
+                        result.AddDetail(DetailKeys.File, SignCheckResources.DetailFullName, fullName);
+                        svr.NestedResults.Add(result);
                     }
                 }
-
-                // We can only verify once everything is extracted. This is mainly because MSIs can have mutliple external CAB files
-                // and we need to ensure they are extracted before we verify the MSIs.
-                foreach (string fullName in archiveMap.Keys)
+                catch (PlatformNotSupportedException)
                 {
-                    SignatureVerificationResult result = VerifyFile(archiveMap[fullName], svr.Filename,
-                        Path.Combine(svr.VirtualPath, fullName), fullName);
-
-                    // Tag the full path into the result detail
-                    result.AddDetail(DetailKeys.File, SignCheckResources.DetailFullName, fullName);
-                    svr.NestedResults.Add(result);
+                    // Log the error and return an unsupported file type result
+                    // because some archive types are not supported on all platforms
+                    string parent = Path.GetDirectoryName(svr.FullPath) ?? SignCheckResources.NA;
+                    svr = SignatureVerificationResult.UnsupportedFileTypeResult(svr.FullPath, parent, svr.VirtualPath);
+                    svr.AddDetail(DetailKeys.File, SignCheckResources.DetailSigned, SignCheckResources.NA);
                 }
-                DeleteDirectory(tempPath);
+                finally
+                {
+                    DeleteDirectory(tempPath);
+                }
             }
         }
 

--- a/src/SignCheck/Microsoft.SignCheck/Verification/PkgVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/PkgVerifier.cs
@@ -141,7 +141,7 @@ namespace Microsoft.SignCheck.Verification
             string timestampRegex = @"(?<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \+\d{4})";
 
             Regex signedOnRegex = new Regex(@"Signed with a trusted timestamp on: " + timestampRegex);
-            string signedOnString = Utils.GetRegexValue(signedOnRegex.Match(signingVerificationOutput), "timestamp");
+            string signedOnString = signedOnRegex.Match(signingVerificationOutput).GroupValueOrDefault("timestamp");
             if(!DateTime.TryParse(signedOnString, out DateTime signedOnTimestamp))
             {
                 signedOnTimestamp = DateTime.MaxValue;
@@ -152,7 +152,7 @@ namespace Microsoft.SignCheck.Verification
 
             return matches.Select(match =>
                 {
-                    string certificateString = Utils.GetRegexValue(match, "timestamp");
+                    string certificateString = match.GroupValueOrDefault("timestamp");
                     if (!DateTime.TryParse(certificateString, out DateTime certificateTimestamp))
                     {
                         certificateTimestamp = DateTime.MinValue;
@@ -162,7 +162,7 @@ namespace Microsoft.SignCheck.Verification
                         EffectiveDate = signedOnTimestamp,
                         ExpiryDate = certificateTimestamp,
                         SignedOn = signedOnTimestamp,
-                        SignatureAlgorithm = Utils.GetRegexValue(match, "algorithm")
+                        SignatureAlgorithm = match.GroupValueOrDefault("algorithm")
                     };
                 });
         }

--- a/src/SignCheck/Microsoft.SignCheck/Verification/PkgVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/PkgVerifier.cs
@@ -1,0 +1,170 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using Microsoft.SignCheck.Logging;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using System.Linq;
+using Microsoft.DotNet.MacOsPkg.Core;
+using Microsoft.Tools.WindowsInstallerXml;
+using System.IO.Pipelines;
+
+namespace Microsoft.SignCheck.Verification
+{
+    public class PkgVerifier : ArchiveVerifier
+    {
+        public PkgVerifier(Log log, Exclusions exclusions, SignatureVerificationOptions options, string fileExtension) : base(log, exclusions, options, fileExtension)
+        {
+            if (fileExtension != ".pkg" && fileExtension != ".app")
+            {
+                throw new ArgumentException("PkgVerifier can only be used with .pkg and .app files.");
+            }
+        }
+
+        public override SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath) 
+        {
+            SignatureVerificationResult svr = new SignatureVerificationResult(path, parent, virtualPath);
+            string fullPath = svr.FullPath;
+
+            try
+            {
+                svr.IsSigned = IsSigned(fullPath, svr);
+                svr.AddDetail(DetailKeys.File, SignCheckResources.DetailSigned, svr.IsSigned);
+            }
+            catch (PlatformNotSupportedException)
+            {
+                // Log the error and return an unsupported file type result
+                // because processing pkgs and apps is not supported on non-OSX platforms
+                svr = SignatureVerificationResult.UnsupportedFileTypeResult(path, parent, virtualPath);
+                svr.AddDetail(DetailKeys.File, SignCheckResources.DetailSigned, SignCheckResources.NA);
+            }
+
+            VerifyContent(svr);
+
+            return svr;
+        }
+        
+        protected override IEnumerable<ArchiveEntry> ReadArchiveEntries(string archivePath)
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                throw new PlatformNotSupportedException("The MacOsPkg tooling is only supported on macOS.");
+            }
+
+            string extractionPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            try
+            {
+                if (MacOsPkgCore.Unpack(archivePath, extractionPath) != 0)
+                {
+                    throw new Exception($"Failed to unpack pkg '{archivePath}'");
+                }
+
+                foreach (var path in Directory.EnumerateFiles(extractionPath, "*.*", SearchOption.AllDirectories))
+                {
+                    var relativePath = path.Substring(extractionPath.Length + 1).Replace(Path.DirectorySeparatorChar, '/');
+                    using var stream = (Stream)File.Open(path, FileMode.Open);
+                    yield return new ArchiveEntry()
+                    {
+                        RelativePath = relativePath,
+                        ContentStream = stream,
+                        ContentSize = stream?.Length ?? 0
+                    };
+                }
+            }
+            finally
+            {
+                // Cleanup the extraction path if it was created by the Unpack method
+                if (Directory.Exists(extractionPath))
+                {
+                    Directory.Delete(extractionPath, true);
+                }
+            }
+        }
+
+        private bool IsSigned(string path, SignatureVerificationResult svr)
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                throw new PlatformNotSupportedException("The MacOsPkg tooling is only supported on macOS.");
+            }
+
+            (bool result, string output, string error) = Utils.CaptureConsoleOutput(() =>
+            {
+                return MacOsPkgCore.VerifySignature(path) == 0;
+            });
+
+            if (!result)
+            {
+                if (!error.Contains("--check-signature"))
+                {
+                    // Something other than a missing signature went wrong
+                    svr.AddDetail(DetailKeys.Error, error);
+                }
+                return false;
+            }
+
+            return ValidateAndAddTimestamps(output, svr);
+        }
+
+        /// <summary>
+        /// Validates the timestamps in the output of the pkgutil command
+        /// and adds them to the SignatureVerificationResult.
+        /// </summary>
+        private bool ValidateAndAddTimestamps(string output, SignatureVerificationResult svr)
+        {
+            IEnumerable<Timestamp> timestamps = GetTimestamps(output);
+            if (!timestamps.Any())
+            {
+                svr.AddDetail(DetailKeys.Error, SignCheckResources.ErrorInvalidOrMissingTimestamp);
+                return false;
+            }
+
+            foreach (Timestamp ts in timestamps)
+            {
+                ts.AddToSignatureVerificationResult(svr);
+                if (!ts.IsValid)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Get the timestamps from the output of the pkgutil command.
+        /// </summary>
+        private IEnumerable<Timestamp> GetTimestamps(string signingVerificationOutput)
+        {
+            string timestampRegex = @"(?<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \+\d{4})";
+
+            Regex signedOnRegex = new Regex(@"Signed with a trusted timestamp on: " + timestampRegex);
+            string signedOnString = Utils.GetRegexValue(signedOnRegex.Match(signingVerificationOutput), "timestamp");
+            if(!DateTime.TryParse(signedOnString, out DateTime signedOnTimestamp))
+            {
+                signedOnTimestamp = DateTime.MaxValue;
+            }
+
+            Regex certificateChainRegex = new Regex(@"Expires: " + timestampRegex + "\n (?<algorithm>.+) Fingerprint:");
+            IEnumerable<Match> matches = certificateChainRegex.Matches(signingVerificationOutput).ToList();
+
+            return matches.Select(match =>
+                {
+                    string certificateString = Utils.GetRegexValue(match, "timestamp");
+                    if (!DateTime.TryParse(certificateString, out DateTime certificateTimestamp))
+                    {
+                        certificateTimestamp = DateTime.MinValue;
+                    }
+                    return new Timestamp()
+                    {
+                        EffectiveDate = signedOnTimestamp,
+                        ExpiryDate = certificateTimestamp,
+                        SignedOn = signedOnTimestamp,
+                        SignatureAlgorithm = Utils.GetRegexValue(match, "algorithm")
+                    };
+                });
+        }
+    }
+}

--- a/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationManager.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationManager.cs
@@ -102,8 +102,10 @@ namespace Microsoft.SignCheck.Verification
             AddFileVerifier(new AuthentiCodeVerifier(log, exclusions, options, ".ps1"));
             AddFileVerifier(new AuthentiCodeVerifier(log, exclusions, options, ".ps1xml"));
             AddFileVerifier(new VsixVerifier(log, exclusions, options));
+#else
+            AddFileVerifier(new PkgVerifier(log, exclusions, options, ".pkg"));
+            AddFileVerifier(new PkgVerifier(log, exclusions, options, ".app"));
 #endif
-
             AddFileVerifier(new LzmaVerifier(log, exclusions, options));
             AddFileVerifier(new NupkgVerifier(log, exclusions, options));
             AddFileVerifier(new XmlVerifier(log, exclusions, options));

--- a/src/SignCheck/Microsoft.SignCheck/Verification/Timestamp.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Timestamp.cs
@@ -46,6 +46,28 @@ namespace Microsoft.SignCheck.Verification
         {
             get;
             set;
-        }       
+        }
+
+        /// <summary>
+        /// Adds a timestamp detail to the <see cref="SignatureVerificationResult"/>.
+        /// </summary>
+        public void AddToSignatureVerificationResult(SignatureVerificationResult svr)
+        {
+            if (IsValid)
+            {
+                svr.AddDetail(DetailKeys.Misc, SignCheckResources.DetailTimestamp, SignedOn, SignatureAlgorithm);
+            }
+            else
+            {
+                if (SignedOn == DateTime.MaxValue || ExpiryDate == DateTime.MinValue)
+                {
+                    svr.AddDetail(DetailKeys.Error, SignCheckResources.ErrorInvalidOrMissingTimestamp);
+                }
+                else
+                {
+                    svr.AddDetail(DetailKeys.Error, SignCheckResources.DetailTimestampOutisdeCertValidity, SignedOn, EffectiveDate, ExpiryDate);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/4857

#### Example output:

```bash
arcade-validation % ./eng/common/sdk-task.sh --task SigningValidation --restore /p:PackageBasePath=test-signed.pkg
  SigningValidation                            CheckForDuplicateItems (0.0s)
  SigningValidation                                           Execute (0.4s)

Results

[File] test-signed.pkg, Signed: True
  [File] 6741a098e863e0ff41f9bddf2c67747dbd9adde100e3deca6e308852287baddd.pkg, Signed: False, Virtual path: test-signed.pkg/NestedPkg.pkg, Full Name: NestedPkg.pkg

Signing issues found
Total Time: 00:00:00.4007260
Total Files: 11, Signed: 1, Unsigned: 1, Skipped: 9, Excluded: 0, Skipped & Excluded: 0
```