### PR TITLE
Delete the targets for fast-up-to-date-check items for VSIX building

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.VsixBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.VsixBuild.targets
@@ -276,26 +276,4 @@
   <PropertyGroup>
     <GetVsixSourceItemsDependsOn>$(GetVsixSourceItemsDependsOn);_GetVsixTemplateItems</GetVsixSourceItemsDependsOn>
   </PropertyGroup>
-
-  <!--
-    Make sure to include information about inputs and outputs to CreateVsixContainer for fast up-to-date check.
-  -->
-  <PropertyGroup Condition="'$(VSToolsPath)' != '' and ('$(IsVsixProject)' == 'true' or '$(GeneratePkgDefFile)' == 'true')">
-    <CollectUpToDateCheckInputDesignTimeDependsOn>$(CollectUpToDateCheckInputDesignTimeDependsOn);CollectVsixUpToDateCheckInput</CollectUpToDateCheckInputDesignTimeDependsOn>
-    <CollectUpToDateCheckBuiltDesignTimeDependsOn>$(CollectUpToDateCheckBuiltDesignTimeDependsOn);CollectVsixUpToDateCheckBuilt</CollectUpToDateCheckBuiltDesignTimeDependsOn>
-  </PropertyGroup>
-
-  <Target Name="CollectVsixUpToDateCheckInput" DependsOnTargets="GetVsixSourceItems;FindSourceVsixManifest">
-    <ItemGroup Condition="$(CreateVsixContainer)">
-      <UpToDateCheckInput Include="@(VSIXSourceItem)" Set="VSIXSet"/>
-      <UpToDateCheckInput Include="@(SourceVsixManifest)" Set="VSIXSet" />
-    </ItemGroup>
-  </Target>
-
-  <Target Name="CollectVsixUpToDateCheckBuilt">
-    <ItemGroup Condition="$(CreateVsixContainer)">
-      <UpToDateCheckOutput Include="$(TargetVsixContainer)" Set="VSIXSet"/>
-    </ItemGroup>
-  </Target>
-
 </Project>


### PR DESCRIPTION
This is being moved to the VS SDK itself, and having multiple copies can cause overbuilding if we're not careful.