### PR TITLE
Reject multiple versions of same package

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -130,6 +130,16 @@
     </RemoveDuplicates>
 
     <ItemGroup>
+      <IntermediateFileWithoutVersion Include="$([System.Text.RegularExpressions.Regex]::Replace('%(IntermediatePackageFile.Identity)','\.(\d+\.){2}\d+(-\w+)?(\.(\d+\.){1}\d+)?',''))" />
+      <NotSupportIntermediateFile Include="@(IntermediateFileWithoutVersion)"
+                                  Condition="'%(IntermediateFileWithoutVersion.FileName) @(IntermediateFileWithoutVersion->Count())' != '%(IntermediateFileWithoutVersion.FileName) 1'
+                                  and '$(GitHubRepositoryName)' != 'source-build-reference-packages'" />
+    </ItemGroup>
+
+    <Error Condition="'@(NotSupportIntermediateFile)' != ''"
+           Text="There are multiple versions of these packages, please identify which version will go into the intermediate:%0a@(NotSupportIntermediateFile, '%0a')" />
+
+    <ItemGroup>
       <IntermediateNonShippingNupkgFile Include="@(IntermediatePackageFile)" Condition="$([System.Text.RegularExpressions.Regex]::Match(%(Identity),'[\\\\/]NonShipping[\\\\/]').Success)"/>
       <SupplementalIntermediateNupkgCategory Include="%(IntermediatePackageFile.Category)" />
     </ItemGroup>


### PR DESCRIPTION
Fix the regression caused by https://github.com/dotnet/arcade/pull/15367

SBRP is expected to include numerous packages with different versions. Add an opt out mechanism -`$(GitHubRepositoryName)` in arcade to skip check the version within SBRP repo.