### PR TITLE
Fix DEB Conflicts property

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.build.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.build.targets
@@ -231,11 +231,11 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <_ConflictsProperty Condition="'@(LinuxPackageConflicts)' != ''">Conflicts: @(LinuxPackageConflicts->'%(Identity)',', ')</_ConflictsProperty>
+      <_ConflictsProperty Condition="'@(LinuxPackageConflicts)' != ''">@(LinuxPackageConflicts->'%(Identity)',', ')</_ConflictsProperty>
     </PropertyGroup>
 
     <ItemGroup>
-      <_ConflictsControlProperty Include="$(_ConflictsProperty)" />
+      <_ConflictsControlProperty Include="Conflicts" Value="$(_ConflictsProperty)" />
     </ItemGroup>
 
     <CreateControlFile


### PR DESCRIPTION
`dotnet-host` Debian installer is failing to install with the following error:
```
dpkg: error processing archive dotnet-host-10.0.0-preview.2.25106.109-x64.deb (--install):
parsing file '/var/lib/dpkg/tmp.ci/control' near line 10 package 'dotnet-host':
'Conflicts' field, missing architecture name, or garbage where architecture name expected
Errors were encountered while processing:
```

This was introduced with new Debian packaging infra. `Conflicts` property is not evaluated correctly at https://github.com/dotnet/arcade/blob/c80f5199af3eb3ebf00ca30ec4fa3af93faf0439/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.build.targets#L233-L239 which then causes an extra `:` to be appended to the `Conflicts` value in control file. In case of `dotnet-host`, the value is: `dotnet, dotnet-nightly:`

`Controls` property gets added to Debian control file at https://github.com/dotnet/arcade/blob/c80f5199af3eb3ebf00ca30ec4fa3af93faf0439/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateControlFile.cs#L74

The fix is simple - I've tested the new package and it was installed without issues.