### PR TITLE
Enable signing validation of .deb files using SignCheck

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/Microsoft.DotNet.Build.Tasks.Installers.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/Microsoft.DotNet.Build.Tasks.Installers.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="Microsoft.DotNet.SignCheck" />
+    <InternalsVisibleTo Include="Microsoft.DotNet.SignCheckLibrary" />
     <InternalsVisibleTo Include="Microsoft.DotNet.SignTool" />
     <InternalsVisibleTo Include="Microsoft.DotNet.SignTool.Tests" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/Microsoft.DotNet.Build.Tasks.Installers.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/Microsoft.DotNet.Build.Tasks.Installers.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.DotNet.SignCheck" />
     <InternalsVisibleTo Include="Microsoft.DotNet.SignTool" />
     <InternalsVisibleTo Include="Microsoft.DotNet.SignTool.Tests" />
   </ItemGroup>

--- a/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
+++ b/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.DotNet.Build.Tasks.Installers\Microsoft.DotNet.Build.Tasks.Installers.csproj" Condition="'$(TargetFramework)' == '$(NetToolCurrent)'" />
     <ProjectReference Include="..\..\Microsoft.DotNet.MacOsPkg\Core\Microsoft.DotNet.MacOsPkg.Core.csproj" Condition="'$(TargetFramework)' == '$(NetToolCurrent)'" />
   </ItemGroup>
 
@@ -63,6 +64,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' != '$(NetToolCurrent)'">
     <!-- Unsupported file types -->
+    <Compile Remove="Verification\DebVerifier.cs" />
     <Compile Remove="Verification\PkgVerifier.cs" />
     <Compile Remove="Verification\TarVerifier.cs" />
   </ItemGroup>

--- a/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
+++ b/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
@@ -12,9 +12,9 @@
     <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Microsoft.DotNet.Build.Tasks.Installers\Microsoft.DotNet.Build.Tasks.Installers.csproj" Condition="'$(TargetFramework)' == '$(NetToolCurrent)'" />
-    <ProjectReference Include="..\..\Microsoft.DotNet.MacOsPkg\Core\Microsoft.DotNet.MacOsPkg.Core.csproj" Condition="'$(TargetFramework)' == '$(NetToolCurrent)'" />
+  <ItemGroup Condition="'$(TargetFramework)' == '$(NetToolCurrent)'">
+    <ProjectReference Include="..\..\Microsoft.DotNet.Build.Tasks.Installers\Microsoft.DotNet.Build.Tasks.Installers.csproj" />
+    <ProjectReference Include="..\..\Microsoft.DotNet.MacOsPkg\Core\Microsoft.DotNet.MacOsPkg.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SignCheck/Microsoft.SignCheck/Utils.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Utils.cs
@@ -13,7 +13,7 @@ namespace Microsoft.SignCheck
 {
     public static class Utils
     {
-#if NETCOREAPP
+#if NET
         private static readonly HttpClient s_client = new(new SocketsHttpHandler { PooledConnectionLifetime = TimeSpan.FromMinutes(10) });
 #endif
         /// <summary>
@@ -164,7 +164,7 @@ namespace Microsoft.SignCheck
             }
         }
 
-#if NETCOREAPP
+#if NET
         /// <summary>
         /// Download the Microsoft public key and import it into the keyring.
         /// </summary>

--- a/src/SignCheck/Microsoft.SignCheck/Verification/DebVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/DebVerifier.cs
@@ -1,0 +1,175 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using Microsoft.DotNet.Build.Tasks.Installers;
+using Microsoft.SignCheck.Logging;
+
+namespace Microsoft.SignCheck.Verification
+{
+    public class DebVerifier : ArchiveVerifier
+    {
+        private static readonly HttpClient s_client = new(new SocketsHttpHandler { PooledConnectionLifetime = TimeSpan.FromMinutes(10) });
+
+        public DebVerifier(Log log, Exclusions exclusions, SignatureVerificationOptions options) : base(log, exclusions, options, ".deb") { }
+
+        public override SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath)
+            => VerifySupportedFileType(path, parent, virtualPath);
+
+        protected override IEnumerable<ArchiveEntry> ReadArchiveEntries(string archivePath)
+            => ReadDebContainerEntries(archivePath, "data.tar");
+
+        protected override bool IsSigned(string path, SignatureVerificationResult svr)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                throw new PlatformNotSupportedException("Deb verification is not supported on Windows.");
+            }
+
+            string tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(tempDir);
+
+            // https://microsoft.sharepoint.com/teams/prss/esrp/info/SitePages/Linux%20GPG%20Signing.aspx
+            try
+            {
+                DownloadAndConfigureMicrosoftPublicKey(tempDir);
+
+                string debianBinary = ExtractDebContainerEntry(path, "debian-binary", tempDir);
+                string controlTar = ExtractDebContainerEntry(path, "control.tar", tempDir);
+                string dataTar = ExtractDebContainerEntry(path, "data.tar", tempDir);
+                string gpgOrigin = ExtractDebContainerEntry(path, "_gpgorigin", tempDir);
+
+                Utils.RunBashCommand($"cat {debianBinary} {controlTar} {dataTar} > {tempDir}/combined-contents");
+
+                (int exitCode, string output, string error) = Utils.RunBashCommand($"gpg --verify --status-fd 1 {gpgOrigin} {tempDir}/combined-contents");
+                string verificationOutput = output + error;
+
+                if (!verificationOutput.Contains("Good signature"))
+                {
+                    if (exitCode != 0 && !verificationOutput.Contains("no signature found"))
+                    {
+                        // Log an error if something other than a missing
+                        // signature caused the verification to fail
+                        svr.AddDetail(DetailKeys.Error, error);
+                    }
+                    return false;
+                }
+
+                Timestamp ts = GetTimestamp(path, verificationOutput);
+                ts.AddToSignatureVerificationResult(svr);
+                return ts.IsValid;
+            }
+            catch (FileNotFoundException e)
+            {
+                if (!e.Message.Contains("_gpgorigin"))
+                {
+                    // The _gpgorigin file will not be found if the deb is not signed
+                    // Log an error if something other than "_gpgorigin" was not found
+                    svr.AddDetail(DetailKeys.Error, e.Message);
+                }
+                return false;
+            }
+            finally
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+
+        protected override void WriteArchiveEntry(ArchiveEntry archiveEntry, string targetPath)
+            => File.WriteAllBytes(targetPath, ((MemoryStream)archiveEntry.ContentStream).ToArray());
+
+        /// <summary>
+        /// Read the entries in the deb container.
+        /// </summary>
+        private IEnumerable<ArchiveEntry> ReadDebContainerEntries(string archivePath, string match = null)
+        {
+            using var archive = new ArReader(File.OpenRead(archivePath), leaveOpen: false);
+
+            while (archive.GetNextEntry() is ArEntry entry)
+            {
+                string relativePath = entry.Name; // lgtm [cs/zipslip] Archive from trusted source
+
+                // The relative path ocassionally ends with a '/', which is not a valid path given that the path is a file.
+                // Remove the following workaround once https://github.com/dotnet/arcade/issues/15384 is resolved.
+                if (relativePath.EndsWith("/"))
+                {
+                    relativePath = relativePath.TrimEnd('/');
+                }
+
+                if (match == null || relativePath.StartsWith(match))
+                {
+                    yield return new ArchiveEntry()
+                    {
+                        RelativePath = relativePath,
+                        ContentStream = entry.DataStream,
+                        ContentSize = entry.DataStream.Length
+                    };
+                }
+            }
+        }
+
+        /// <summary>
+        /// Download the Microsoft public key and import it into the keyring.
+        /// </summary>
+        public static void DownloadAndConfigureMicrosoftPublicKey(string tempDir)
+        {
+            using (Stream stream = s_client.GetStreamAsync("https://packages.microsoft.com/keys/microsoft.asc").Result)
+            {
+                using (FileStream fileStream = File.Create($"{tempDir}/microsoft.asc"))
+                {
+                    stream.CopyTo(fileStream);
+                }
+            }
+            Utils.RunBashCommand($"gpg --import {tempDir}/microsoft.asc");
+        }
+
+        /// <summary>
+        /// Extract a single entry from the deb container.
+        /// </summary>
+        private string ExtractDebContainerEntry(string archivePath, string entryName, string workingDir)
+        {
+            IEnumerable<ArchiveEntry> entries = ReadDebContainerEntries(archivePath, entryName);
+            if (!entries.Any())
+            {
+                throw new FileNotFoundException($"The entry '{entryName}' was not found in the archive '{archivePath}'");
+            }
+            ArchiveEntry archiveEntry = entries.First();
+            string entryPath = Path.Combine(workingDir, archiveEntry.RelativePath);
+            WriteArchiveEntry(archiveEntry, entryPath);
+
+            return entryPath;
+        }
+
+        /// <summary>
+        /// Get the timestamp of the signature in the deb package.
+        /// </summary>
+        private Timestamp GetTimestamp(string archivePath, string verificationOutput)
+        {
+            Regex signatureTimestampsRegex = new Regex(@"VALIDSIG .+ \d+-\d+-\d+ (?<signedOn>\d+) (?<expiresOn>\d+) ");
+            Match signatureTimestampsMatch = signatureTimestampsRegex.Match(verificationOutput);
+
+            Regex signatureKeyInfoRegex = new Regex(@"using (?<algorithm>.+) key (?<keyId>.+)");
+            Match signatureKeyInfoMatch = signatureKeyInfoRegex.Match(verificationOutput);
+
+            string keyId = signatureKeyInfoMatch.GroupValueOrDefault("keyId");
+            (_, string keyInfo, _) = Utils.RunBashCommand($"gpg --list-keys --with-colons {keyId} | grep '^pub:'");
+            Regex keyInfoRegex = new Regex(@$"pub.+{keyId}:(?<createdOn>\d+):");
+            Match keyInfoMatch = keyInfoRegex.Match(keyInfo);
+
+            return new Timestamp()
+            {
+                SignedOn = signatureTimestampsMatch.GroupValueOrDefault("signedOn").DateTimeOrDefault(DateTime.MaxValue),
+                ExpiryDate = signatureTimestampsMatch.GroupValueOrDefault("expiresOn").DateTimeOrDefault(DateTime.MaxValue),
+                SignatureAlgorithm = signatureKeyInfoMatch.GroupValueOrDefault("algorithm"),
+                EffectiveDate = keyInfoMatch.GroupValueOrDefault("createdOn").DateTimeOrDefault(DateTime.MaxValue)
+            };
+        }
+    }
+}

--- a/src/SignCheck/Microsoft.SignCheck/Verification/NupkgVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/NupkgVerifier.cs
@@ -20,18 +20,9 @@ namespace Microsoft.SignCheck.Verification
         }
 
         public override SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath) 
-        {
-            SignatureVerificationResult svr = new SignatureVerificationResult(path, parent, virtualPath);
-            string fullPath = svr.FullPath;
+            => VerifySupportedFileType(path, parent, virtualPath);
 
-            svr.IsSigned = IsSigned(fullPath);
-            svr.AddDetail(DetailKeys.File, SignCheckResources.DetailSigned, svr.IsSigned);
-            VerifyContent(svr);
-
-            return svr;
-        }
-
-        private bool IsSigned(string path)
+        protected override bool IsSigned(string path, SignatureVerificationResult svr)
         {
             List<ISignatureVerificationProvider> providers = new()
             {

--- a/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationManager.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationManager.cs
@@ -103,6 +103,7 @@ namespace Microsoft.SignCheck.Verification
             AddFileVerifier(new AuthentiCodeVerifier(log, exclusions, options, ".ps1xml"));
             AddFileVerifier(new VsixVerifier(log, exclusions, options));
 #else
+            AddFileVerifier(new DebVerifier(log, exclusions, options));
             AddFileVerifier(new PkgVerifier(log, exclusions, options, ".pkg"));
             AddFileVerifier(new PkgVerifier(log, exclusions, options, ".app"));
             AddFileVerifier(new TarVerifier(log, exclusions, options, ".tar"));

--- a/src/SignCheck/Microsoft.SignCheck/Verification/Timestamp.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Timestamp.cs
@@ -59,7 +59,7 @@ namespace Microsoft.SignCheck.Verification
             }
             else
             {
-                if (SignedOn == DateTime.MaxValue || ExpiryDate == DateTime.MinValue)
+                if (SignedOn == DateTime.MaxValue || ExpiryDate == DateTime.MinValue || EffectiveDate == DateTime.MaxValue)
                 {
                     svr.AddDetail(DetailKeys.Error, SignCheckResources.ErrorInvalidOrMissingTimestamp);
                 }

--- a/src/SignCheck/Microsoft.SignCheck/Verification/VsixVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/VsixVerifier.cs
@@ -22,15 +22,7 @@ namespace Microsoft.SignCheck.Verification
         }
 
         public override SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath)
-        {
-            var svr = new SignatureVerificationResult(path, parent, virtualPath);
-            string fullPath = svr.FullPath;
-            svr.IsSigned = IsSigned(fullPath, svr);
-            svr.AddDetail(DetailKeys.File, SignCheckResources.DetailSigned, svr.IsSigned);
-            VerifyContent(svr);
-
-            return svr;
-        }
+            => VerifySupportedFileType(path, parent, virtualPath);
 
         private bool TryGetTimestamp(PackageDigitalSignature packageSignature, out Timestamp timestamp)
         {
@@ -119,7 +111,7 @@ namespace Microsoft.SignCheck.Verification
             return isValidTimestampSignature;
         }
 
-        private bool IsSigned(string path, SignatureVerificationResult result)
+        protected override bool IsSigned(string path, SignatureVerificationResult result)
         {
             PackageDigitalSignature packageSignature = null;
 


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/4859

#### Example output

```bash
arcade-validation# ./eng/common/sdk-task.sh --task SigningValidation --restore /p:PackageBasePath=/root/repos/arcade/src/Microsoft.DotNet.SignTool.Tests/Resources/*.deb

  SigningValidation                          CollectPackageReferences (0.1s)
  SigningValidation                                           Execute (0.6s)

Results

[File] test.deb, Signed: False
  [File] 2f351a859fd863f6a351705345e707f97b59cf57eb29ddcbe1e52333dfc89975.gz, Skipped (unsupported file type), Signed: N/A, Virtual path: test.deb/data.tar.gz, Full Name: data.tar.gz
[File] IncorrectlySignedDeb.deb, Signed: False
  [File] 2f351a859fd863f6a351705345e707f97b59cf57eb29ddcbe1e52333dfc89975.gz, Skipped (unsupported file type), Signed: N/A, Virtual path: IncorrectlySignedDeb.deb/data.tar.gz, Full Name: data.tar.gz
[File] SignedDeb.deb, Signed: True
  [File] 2f351a859fd863f6a351705345e707f97b59cf57eb29ddcbe1e52333dfc89975.gz, Skipped (unsupported file type), Signed: N/A, Virtual path: SignedDeb.deb/data.tar.gz, Full Name: data.tar.gz

Signing issues found
Total Time: 00:00:00.4937602
Total Files: 10, Signed: 1, Unsigned: 2, Skipped: 7, Excluded: 0, Skipped & Excluded: 0
```