### PR TITLE
Refactor ArchiveVerifier

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/Verification/ArchiveVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/ArchiveVerifier.cs
@@ -4,74 +4,110 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Security.Cryptography;
 using Microsoft.SignCheck.Logging;
 
 namespace Microsoft.SignCheck.Verification
 {
-    public class ArchiveVerifier : FileVerifier
+    public abstract class ArchiveVerifier : FileVerifier
     {
-        public ArchiveVerifier(Log log, Exclusions exclusions, SignatureVerificationOptions options, string fileExtension) : base(log, exclusions, options, fileExtension)
+        protected ArchiveVerifier(Log log, Exclusions exclusions, SignatureVerificationOptions options, string fileExtension) : base(log, exclusions, options, fileExtension)
         {
 
         }
 
         /// <summary>
-        /// Verify the contents of a zip-based archive and add the results to the container result.
+        /// Read the entries from the archive.
+        /// </summary>
+        /// <param name="archivePath">Path to the archive</param>
+        protected abstract IEnumerable<ArchiveEntry> ReadArchiveEntries(string archivePath);
+
+        /// <summary>
+        /// Verify the contents of a package archive and add the results to the container result.
         /// </summary>
         /// <param name="svr">The container result</param>
         protected void VerifyContent(SignatureVerificationResult svr)
         {
             if (VerifyRecursive)
             {
-                using (ZipArchive zipArchive = ZipFile.OpenRead(svr.FullPath))
+                string tempPath = svr.TempPath;
+                CreateDirectory(tempPath);
+                Log.WriteMessage(LogVerbosity.Diagnostic, SignCheckResources.DiagExtractingFileContents, tempPath);
+                Dictionary<string, string> archiveMap = new Dictionary<string, string>();
+
+                foreach (ArchiveEntry archiveEntry in ReadArchiveEntries(svr.FullPath))
                 {
-                    string tempPath = svr.TempPath;
-                    CreateDirectory(tempPath);
-                    Log.WriteMessage(LogVerbosity.Diagnostic, SignCheckResources.DiagExtractingFileContents, tempPath);
-                    Dictionary<string, string> archiveMap = new Dictionary<string, string>();
-
-                    foreach (ZipArchiveEntry archiveEntry in zipArchive.Entries)
+                    string aliasFullName = GenerateArchiveEntryAlias(archiveEntry, tempPath);
+                    if (File.Exists(aliasFullName))
                     {
-                        // Generate an alias for the actual file that has the same extension. We do this to avoid path too long errors so that
-                        // containers can be flattened.
-                        string directoryName = Path.GetDirectoryName(archiveEntry.FullName);
-                        string hashedPath = String.IsNullOrEmpty(directoryName) ? Utils.GetHash(@".\", HashAlgorithmName.SHA256.Name) :
-                            Utils.GetHash(directoryName, HashAlgorithmName.SHA256.Name);
-                        string extension = Path.GetExtension(archiveEntry.FullName);
-
-                        // CAB files cannot be aliased since they're referred to from the Media table inside the MSI
-                        string aliasFileName = String.Equals(extension.ToLowerInvariant(), ".cab") ? Path.GetFileName(archiveEntry.FullName) :
-                            Utils.GetHash(archiveEntry.FullName, HashAlgorithmName.SHA256.Name) + Path.GetExtension(archiveEntry.FullName); // lgtm [cs/zipslip] Archive from trusted source
-                        string aliasFullName = Path.Combine(tempPath, hashedPath, aliasFileName);
-
-                        if (File.Exists(aliasFullName))
-                        {
-                            Log.WriteMessage(LogVerbosity.Normal, SignCheckResources.FileAlreadyExists, aliasFullName);
-                        }
-                        else
-                        {
-                            CreateDirectory(Path.GetDirectoryName(aliasFullName));
-                            archiveEntry.ExtractToFile(aliasFullName); // lgtm [cs/microsoft/zipslip] Archive from trusted source
-                            archiveMap[archiveEntry.FullName] = aliasFullName;
-                        }
+                        Log.WriteMessage(LogVerbosity.Normal, SignCheckResources.FileAlreadyExists, aliasFullName);
                     }
-
-                    // We can only verify once everything is extracted. This is mainly because MSIs can have mutliple external CAB files
-                    // and we need to ensure they are extracted before we verify the MSIs.
-                    foreach (string fullName in archiveMap.Keys)
+                    else
                     {
-                        SignatureVerificationResult result = VerifyFile(archiveMap[fullName], svr.Filename,
-                            Path.Combine(svr.VirtualPath, fullName), fullName);
-
-                        // Tag the full path into the result detail
-                        result.AddDetail(DetailKeys.File, SignCheckResources.DetailFullName, fullName);
-                        svr.NestedResults.Add(result);
+                        CreateDirectory(Path.GetDirectoryName(aliasFullName));
+                        WriteArchiveEntry(archiveEntry, aliasFullName);
+                        archiveMap[archiveEntry.RelativePath] = aliasFullName;
                     }
-                    DeleteDirectory(tempPath);
                 }
+
+                // We can only verify once everything is extracted. This is mainly because MSIs can have mutliple external CAB files
+                // and we need to ensure they are extracted before we verify the MSIs.
+                foreach (string fullName in archiveMap.Keys)
+                {
+                    SignatureVerificationResult result = VerifyFile(archiveMap[fullName], svr.Filename,
+                        Path.Combine(svr.VirtualPath, fullName), fullName);
+
+                    // Tag the full path into the result detail
+                    result.AddDetail(DetailKeys.File, SignCheckResources.DetailFullName, fullName);
+                    svr.NestedResults.Add(result);
+                }
+                DeleteDirectory(tempPath);
             }
+        }
+
+        /// <summary>
+        /// Writes the archive entry to the specified path.
+        /// </summary>
+        /// <param name="archiveEntry"></param>
+        /// <param name="targetPath"></param>
+        protected void WriteArchiveEntry(ArchiveEntry archiveEntry, string targetPath)
+        {
+            using (var fileStream = new FileStream(targetPath, FileMode.Create, FileAccess.Write))
+            {
+                archiveEntry.ContentStream.CopyTo(fileStream);
+            }
+        }
+
+        /// <summary>
+        /// Generates an alias for the actual file that has the same extension.
+        /// We do this to avoid path too long errors so that containers can be flattened.
+        /// </summary>
+        /// <param name="archiveEntry">The archive entry to generate the alias for.</param>
+        /// <param name="tempPath">The temporary path for the archive entry.</param>
+        private string GenerateArchiveEntryAlias(ArchiveEntry archiveEntry, string tempPath)
+        {
+            // Generate an alias for the actual file that has the same extension. We do this to avoid path too long errors so that
+            // containers can be flattened.
+            string directoryName = Path.GetDirectoryName(archiveEntry.RelativePath);
+            string hashedPath = String.IsNullOrEmpty(directoryName) ? Utils.GetHash(@".\", HashAlgorithmName.SHA256.Name) :
+                Utils.GetHash(directoryName, HashAlgorithmName.SHA256.Name);
+            string extension = Path.GetExtension(archiveEntry.RelativePath);
+
+            // CAB files cannot be aliased since they're referred to from the Media table inside the MSI
+            string aliasFileName = String.Equals(extension.ToLowerInvariant(), ".cab") ? Path.GetFileName(archiveEntry.RelativePath) :
+                Utils.GetHash(archiveEntry.RelativePath, HashAlgorithmName.SHA256.Name) + Path.GetExtension(archiveEntry.RelativePath); // lgtm [cs/zipslip] Archive from trusted source
+
+            return Path.Combine(tempPath, hashedPath, aliasFileName);
+        }
+
+        /// <summary>
+        /// Represents an entry in an archive.
+        /// </summary>
+        protected class ArchiveEntry
+        {
+            public string RelativePath { get; set; }
+            public Stream ContentStream { get; set; }
+            public long ContentSize { get; set; }
         }
     }
 }

--- a/src/SignCheck/Microsoft.SignCheck/Verification/NupkgVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/NupkgVerifier.cs
@@ -12,7 +12,7 @@ using NuGet.Packaging.Signing;
 
 namespace Microsoft.SignCheck.Verification
 {
-    public class NupkgVerifier : ArchiveVerifier
+    public class NupkgVerifier : ZipVerifier
     {
         public NupkgVerifier(Log log, Exclusions exclusions, SignatureVerificationOptions options) : base(log, exclusions, options, fileExtension: ".nupkg")
         {

--- a/src/SignCheck/Microsoft.SignCheck/Verification/VsixVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/VsixVerifier.cs
@@ -14,7 +14,7 @@ using Microsoft.SignCheck.Logging;
 
 namespace Microsoft.SignCheck.Verification
 {
-    public class VsixVerifier : ArchiveVerifier
+    public class VsixVerifier : ZipVerifier
     {
         public VsixVerifier(Log log, Exclusions exclusions, SignatureVerificationOptions options) : base(log, exclusions, options, fileExtension: ".vsix")
         {

--- a/src/SignCheck/Microsoft.SignCheck/Verification/ZipVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/ZipVerifier.cs
@@ -1,13 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO;
+using System.IO.Compression;
+using System.Collections.Generic;
 using Microsoft.SignCheck.Logging;
 
 namespace Microsoft.SignCheck.Verification
 {
     public class ZipVerifier : ArchiveVerifier
     {
-        public ZipVerifier(Log log, Exclusions exclusions, SignatureVerificationOptions options) : base(log, exclusions, options, fileExtension: ".zip")
+        public ZipVerifier(Log log, Exclusions exclusions, SignatureVerificationOptions options, string fileExtension = ".zip") : base(log, exclusions, options, fileExtension)
         {
 
         }
@@ -20,6 +23,30 @@ namespace Microsoft.SignCheck.Verification
 
             VerifyContent(svr);
             return svr;
+        }
+
+        protected override IEnumerable<ArchiveEntry> ReadArchiveEntries(string archivePath)
+        {
+            using (var archive = new ZipArchive(File.OpenRead(archivePath), ZipArchiveMode.Read, leaveOpen: false))
+            {
+                foreach (var entry in archive.Entries)
+                {
+                    string relativePath = entry.FullName;
+
+                    // Skip directories and empty entries
+                    if (!relativePath.EndsWith("/") || entry.Name != "")
+                    {
+                        var contentStream = entry.Open();
+                        yield return new ArchiveEntry()
+                        {
+                            RelativePath = relativePath,
+                            ContentStream = contentStream,
+                            ContentSize = entry.Length
+                        };
+                        contentStream.Close();
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/4068

[Test pipeline run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2641569&view=results)

This PR includes the following changes:

- Made `ArchiveVerifier` an abstract class and added an abstract method `ReadArchiveEntries` to read archive entries.
- Introduced a new `ArchiveEntry` class to represent an entry in an archive
- Added `WriteArchiveEntry` method to write archive entries to a specified path.
- Moved the reading of .zip archive entries from `ArchiveVerifier.VerifyContent` to `ZipVerifier.ReadArchiveEntries`
- Changed the base class of `NupkgVerifier` and `VsixVerifier` from `ArchiveVerifier` to `ZipVerifier` since they are Zip-based archives.

These changes will make the implementation of other package archive verifiers (such as .pkg, .deb, rpm, .tar.gz) simpler.