### PR TITLE
Update SDK to Preview 2 and reaction

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "10.0.100-alpha.1.25077.2",
+    "version": "10.0.100-preview.2.25104.28",
     "rollForward": "latestFeature"
   },
   "tools": {
-    "dotnet": "10.0.100-alpha.1.25077.2"
+    "dotnet": "10.0.100-preview.2.25104.28"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25105.3",

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/Microsoft.DotNet.Helix.Client.csproj
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/Microsoft.DotNet.Helix.Client.csproj
@@ -14,8 +14,11 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="Newtonsoft.Json" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Text.Encodings.Web" />
   </ItemGroup>


### PR DESCRIPTION
- Update SDK to a Preview 2 nightly SDK to be able to use NuGet's new package pruning feature.
- React to one package pruning warning

No DotNetCli.props change as arcade is still on the same version.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
