### PR TITLE
Propagate data about whether specific assets could be stable

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -284,6 +284,19 @@
       <ItemsToPushToBlobFeed>
         <ManifestArtifactData Condition="'%(ItemsToPushToBlobFeed.IsShipping)' == 'false'">%(ItemsToPushToBlobFeed.ManifestArtifactData);NonShipping=true</ManifestArtifactData>
         <ManifestArtifactData Condition="'%(ItemsToPushToBlobFeed.IsShipping)' == 'true' and '$(ProducesDotNetReleaseShippingAssets)' == 'true'">%(ItemsToPushToBlobFeed.ManifestArtifactData);DotNetReleaseShipping=true</ManifestArtifactData>
+		    <!-- Propagate stability data to the asset level for packages. We do this so that VMR builds which have some repo builds that are not stable, and others that are, do not end up having to use the default logic
+			       where ALL assets that are shipping in a stable build go to isolated feeds. Instead, we can just choose CouldBeStable==true, CouldBeStable==false.
+				     This only applies currently to Packages. Blobs are required to provide paths that are always non-stable. Pdbs don't have a stability concept.
+
+             NOTE: This flag doesn't strictly mean that the package is stable versioned. A repo might suppress a stable version for a given package. -->
+			  <ManifestArtifactData Condition="'%(ItemsToPushToBlobFeed.Kind)' == 'Package' and
+																			   '$(IsStableBuild)' == 'true' and
+																			   '$(IsReleaseOnlyPackageVersion)' != 'true' and
+																			   '%(ItemsToPushToBlobFeed.IsShipping)' == 'true'">%(ItemsToPushToBlobFeed.ManifestArtifactData);CouldBeStable=true</ManifestArtifactData>
+				<ManifestArtifactData Condition="'%(ItemsToPushToBlobFeed.Kind)' == 'Package' and
+																				 ('$(IsStableBuild)' == 'false' or
+																				  '$(IsReleaseOnlyPackageVersion)' == 'true' or
+																				  '%(ItemsToPushToBlobFeed.IsShipping)' == 'false')">%(ItemsToPushToBlobFeed.ManifestArtifactData);CouldBeStable=false</ManifestArtifactData>
       </ItemsToPushToBlobFeed>
     </ItemGroup>
 

--- a/src/VersionTools/Microsoft.DotNet.VersionTools/BuildManifest/Model/PackageArtifactModel.cs
+++ b/src/VersionTools/Microsoft.DotNet.VersionTools/BuildManifest/Model/PackageArtifactModel.cs
@@ -34,6 +34,12 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
             set { Attributes[nameof(OriginBuildName)] = value; }
         }
 
+        public string CouldBeStable
+        {
+            get { return Attributes.GetOrDefault(nameof(CouldBeStable)); }
+            set { Attributes[nameof(CouldBeStable)] = value; }
+        }
+
         public override string ToString() => $"Package {Id} {Version}";
 
         public override XElement ToXml() => new XElement(


### PR DESCRIPTION
This allows VMR builds with mixed repo stability to avoid default logic, using `CouldBeStable==true` or `CouldBeStable==false` instead. Applies only to Packages; Blobs must always have relative paths that are non-stable, and Pdbs lack a stability concept. Note: This flag doesn't guarantee stable versioning; a repo might suppress a stable version for a package.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
