### PR TITLE
Don't override DeployExtension if it's already set

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.VsixBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.VsixBuild.targets
@@ -34,7 +34,7 @@
     <TargetVsixContainerName Condition="'$(TargetVsixContainerName)' == ''">$(TargetName).vsix</TargetVsixContainerName>
     <TargetVsixContainer Condition="'$(TargetVsixContainer)' == ''">$(_TargetVsixContainerDir)$(TargetVsixContainerName)</TargetVsixContainer>
 
-    <DeployExtension Condition="'$(DeployProjectOutput)' == 'true'">true</DeployExtension>
+    <DeployExtension Condition="'$(DeployProjectOutput)' == 'true' and '$(DeployExtension)' != 'false'">true</DeployExtension>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(VisualStudioInsertionComponent)' != ''">


### PR DESCRIPTION
DeployExtension is the standard VSIX project property for disabling the deployment of the created VSIX. Some projects might set this to false for various reasons (because the VSIX is useful to build but isn't something you need for local development). We shouldn't be overriding that decision.