### PR TITLE
Do not add an empty Conflicts property

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.build.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.build.targets
@@ -234,7 +234,7 @@
       <_ConflictsProperty Condition="'@(LinuxPackageConflicts)' != ''">@(LinuxPackageConflicts->'%(Identity)',', ')</_ConflictsProperty>
     </PropertyGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(_ConflictsProperty)' != ''">
       <_ConflictsControlProperty Include="Conflicts" Value="$(_ConflictsProperty)" />
     </ItemGroup>
 


### PR DESCRIPTION
This is a follow-up on https://github.com/dotnet/arcade/pull/15504 which fixed the incorrectly-formatted `Conflicts` property and unblocked the installation of `dotnet-host` Debian package. That PR added an empty `Conflicts` property to all other packages. While that does not impact installation in any way, it should be fixed, and this PR is doing just that.
