### PR TITLE
Update .NET SDK to 10.0.100-preview.2.25118.3

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "10.0.100-preview.2.25104.28",
+    "version": "10.0.100-preview.2.25118.3",
     "rollForward": "latestFeature"
   },
   "tools": {
-    "dotnet": "10.0.100-preview.2.25104.28"
+    "dotnet": "10.0.100-preview.2.25118.3"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25113.2",

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/dotnet-cli/DotNetCli.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <IncludeDotNetCli Condition=" '$(IncludeDotNetCli)' != 'true' ">false</IncludeDotNetCli>
-    <AspNetCoreRuntimeVersion>10.0.0-alpha.2.25073.4</AspNetCoreRuntimeVersion>
+    <AspNetCoreRuntimeVersion>10.0.0-preview.2.25114.1</AspNetCoreRuntimeVersion>
     <DotNetCliPackageType Condition=" '$(DotNetCliPackageType)' == '' ">runtime</DotNetCliPackageType>
     <DotNetCliVersion Condition=" '$(DotNetCliVersion)' == '' AND '$(DotNetCliPackageType)' == 'runtime' ">$(BundledNETCoreAppPackageVersion)</DotNetCliVersion>
     <!-- TODO (https://github.com/dotnet/arcade/issues/7022): We are hardcoding this version to use the one tied to the SDK version from global.json -->


### PR DESCRIPTION
The previous version didn't have the NuGet Package Pruning feature enabled.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
