### PR TITLE
Fix generated symbol package relative blob paths

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -157,6 +157,7 @@
     <ItemGroup>
       <_PackageToPublish Update="@(_PackageToPublish)">
         <SymbolPackageToGenerate Condition="!Exists('%(RootDir)%(Directory)%(Filename).symbols.nupkg')">$(SymbolPackagesDir)%(Filename).symbols.nupkg</SymbolPackageToGenerate>
+        <SymbolPackageRelativeBlobPath>assets/symbols/%(Filename).symbols.nupkg</SymbolPackageRelativeBlobPath>
       </_PackageToPublish>
 
       <_SymbolPackageToGenerate Include="@(_PackageToPublish->'%(SymbolPackageToGenerate)')"
@@ -165,7 +166,7 @@
         <OriginalPackage>%(_PackageToPublish.Identity)</OriginalPackage>
         <IsShipping>%(_PackageToPublish.IsShipping)</IsShipping>
         <Kind>Blob</Kind>
-        <RelativeBlobPath>assets/symbols/%(Filename)%(Extension)</RelativeBlobPath>
+        <RelativeBlobPath>%(_PackageToPublish.SymbolPackageRelativeBlobPath)</RelativeBlobPath>
       </_SymbolPackageToGenerate>
     </ItemGroup>
 


### PR DESCRIPTION
Add SymbolPackageRelativeBlobPath to Publish.proj to correctly set the symbol package file name.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
