### PR TITLE
Wait for process to exit if killed

### DIFF
--- a/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
@@ -77,8 +77,9 @@ namespace Microsoft.DotNet.SignTool
                 bool success = true;
                 if (!process.WaitForExit(_dotnetTimeout))
                 {
-                    process.Kill();
                     _log.LogError($"MSBuild process did not exit within '{_dotnetTimeout}' ms.");
+                    process.Kill();
+                    process.WaitForExit();
                     success = false;
                 }
 
@@ -89,13 +90,13 @@ namespace Microsoft.DotNet.SignTool
                     success = false;
                 }
 
-                string outputStr = output.ToString();
+                string outputStr = output.ToString().Trim();
                 if (!string.IsNullOrWhiteSpace(outputStr))
                 {
                     File.WriteAllText(logPath, outputStr);
                 }
                 
-                string errorStr = error.ToString();
+                string errorStr = error.ToString().Trim();
                 if (!string.IsNullOrWhiteSpace(errorStr))
                 {
                     File.WriteAllText(errorLogPath, errorStr);


### PR DESCRIPTION
Related to https://github.com/dotnet/arcade/pull/15510

After killing the process, the exit status cannot be checked until the process exits. This needs to be fixed because it is causing an exception to be thrown, resulting in the logs not being written to.