### PR TITLE
Permit fail-open to avoid CRL check failures on Mac

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs
+++ b/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs
@@ -123,7 +123,31 @@ namespace Microsoft.DotNet.Arcade.Sdk
 
             Log.LogMessage($"Downloading '{uri}' to '{DestinationPath}'");
 
-            using (var httpClient = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true }))
+            // Configure the cert revocation check in a fail-open state to avoid intermittent failures
+            // on Mac if the endpoint is not available.
+
+            using SocketsHttpHandler handler = new SocketsHttpHandler();
+            handler.SslOptions.CertificateChainPolicy = new X509ChainPolicy
+            {
+                // Yes, check revocation.
+                // Yes, allow it to be downloaded if needed.
+                // Online is the default, but it doesn't hurt to be explicit.
+                RevocationMode = X509RevocationMode.Online,
+                // Roots never bother with revocation.
+                // ExcludeRoot is the default, but it doesn't hurt to be explicit.
+                RevocationFlag = X509RevocationFlag.ExcludeRoot,
+                // RevocationStatusUnknown at the EndEntity/Leaf certificate will not fail the chain build.
+                // RevocationStatusUnknown for any intermediate CA will not fail the chain build.
+                // IgnoreRootRevocationUnknown could also be specified, but it won't apply given ExcludeRoot above.
+                // The default is that all status codes are bad, this is not the default.
+                VerificationFlags =
+                    X509VerificationFlags.IgnoreCertificateAuthorityRevocationUnknown |
+                    X509VerificationFlags.IgnoreEndRevocationUnknown,
+                // Always use the "now" when building the chain, rather than the "now" of when this policy object was constructed.
+                VerificationTimeIgnored = true,
+            };
+
+            using (var httpClient = new HttpClient(handler))
             {
                 httpClient.Timeout = TimeSpan.FromSeconds(TimeoutInSeconds);
                 try


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
