### PR TITLE
Enable signing validation of tar files using SignCheck

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
+++ b/src/SignCheck/Microsoft.SignCheck/Microsoft.DotNet.SignCheckLibrary.csproj
@@ -62,7 +62,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != '$(NetToolCurrent)'">
+    <!-- Unsupported file types -->
     <Compile Remove="Verification\PkgVerifier.cs" />
+    <Compile Remove="Verification\TarVerifier.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SignCheck/Microsoft.SignCheck/Verification/ArchiveVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/ArchiveVerifier.cs
@@ -23,6 +23,19 @@ namespace Microsoft.SignCheck.Verification
         protected abstract IEnumerable<ArchiveEntry> ReadArchiveEntries(string archivePath);
 
         /// <summary>
+        /// Verifies the signature of an unsupported file type.
+        /// </summary>
+        protected SignatureVerificationResult VerifyUnsupportedFileType(string path, string parent, string virtualPath)
+        {
+            var svr = SignatureVerificationResult.UnsupportedFileTypeResult(path, parent, virtualPath);
+            string fullPath = svr.FullPath;
+            svr.AddDetail(DetailKeys.File, SignCheckResources.DetailSigned, SignCheckResources.NA);
+
+            VerifyContent(svr);
+            return svr;
+        }
+
+        /// <summary>
         /// Verify the contents of a package archive and add the results to the container result.
         /// </summary>
         /// <param name="svr">The container result</param>

--- a/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationManager.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationManager.cs
@@ -105,6 +105,8 @@ namespace Microsoft.SignCheck.Verification
 #else
             AddFileVerifier(new PkgVerifier(log, exclusions, options, ".pkg"));
             AddFileVerifier(new PkgVerifier(log, exclusions, options, ".app"));
+            AddFileVerifier(new TarVerifier(log, exclusions, options, ".tar"));
+            AddFileVerifier(new TarVerifier(log, exclusions, options, ".gz"));
 #endif
             AddFileVerifier(new LzmaVerifier(log, exclusions, options));
             AddFileVerifier(new NupkgVerifier(log, exclusions, options));

--- a/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationManager.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationManager.cs
@@ -106,6 +106,7 @@ namespace Microsoft.SignCheck.Verification
             AddFileVerifier(new PkgVerifier(log, exclusions, options, ".pkg"));
             AddFileVerifier(new PkgVerifier(log, exclusions, options, ".app"));
             AddFileVerifier(new TarVerifier(log, exclusions, options, ".tar"));
+            AddFileVerifier(new TarVerifier(log, exclusions, options, ".tgz"));
             AddFileVerifier(new TarVerifier(log, exclusions, options, ".gz"));
 #endif
             AddFileVerifier(new LzmaVerifier(log, exclusions, options));

--- a/src/SignCheck/Microsoft.SignCheck/Verification/TarVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/TarVerifier.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Collections.Generic;
+using System.Formats.Tar;
+using Microsoft.SignCheck.Logging;
+
+namespace Microsoft.SignCheck.Verification
+{
+    public class TarVerifier : ArchiveVerifier
+    {
+        public TarVerifier(Log log, Exclusions exclusions, SignatureVerificationOptions options, string fileExtension) : base(log, exclusions, options, fileExtension)
+        {
+            if (fileExtension != ".tar" && fileExtension != ".gz")
+            {
+                throw new ArgumentException("fileExtension must be .tar or .gz");
+            }
+        }
+
+        public override SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath)
+            => VerifyUnsupportedFileType(path, parent, virtualPath);
+
+        protected override IEnumerable<ArchiveEntry> ReadArchiveEntries(string archivePath)
+        {
+            using (var fileStream = File.Open(archivePath, FileMode.Open))
+            using (var gzipStream = new GZipStream(fileStream, CompressionMode.Decompress))
+            using (var reader = new TarReader(gzipStream))
+            {
+                TarEntry entry;
+                while ((entry = reader.GetNextEntry()) != null)
+                {
+                    // Skip directories
+                    if (!entry.Name.EndsWith("/"))
+                    {
+                        yield return new ArchiveEntry()
+                        {
+                            RelativePath = entry.Name,
+                            ContentStream = entry.DataStream,
+                            ContentSize = entry.Length
+                        };
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/SignCheck/Microsoft.SignCheck/Verification/TarVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/TarVerifier.cs
@@ -14,7 +14,7 @@ namespace Microsoft.SignCheck.Verification
     {
         public TarVerifier(Log log, Exclusions exclusions, SignatureVerificationOptions options, string fileExtension) : base(log, exclusions, options, fileExtension)
         {
-            if (fileExtension != ".tar" && fileExtension != ".gz")
+            if (fileExtension != ".tar" && fileExtension != ".gz" && fileExtension != ".tgz")
             {
                 throw new ArgumentException("fileExtension must be .tar or .gz");
             }

--- a/src/SignCheck/Microsoft.SignCheck/Verification/ZipVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/ZipVerifier.cs
@@ -16,14 +16,7 @@ namespace Microsoft.SignCheck.Verification
         }
 
         public override SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath)
-        {
-            var svr = SignatureVerificationResult.UnsupportedFileTypeResult(path, parent, virtualPath);
-            string fullPath = svr.FullPath;
-            svr.AddDetail(DetailKeys.File, SignCheckResources.DetailSigned, SignCheckResources.NA);
-
-            VerifyContent(svr);
-            return svr;
-        }
+            => VerifyUnsupportedFileType(path, parent, virtualPath);
 
         protected override IEnumerable<ArchiveEntry> ReadArchiveEntries(string archivePath)
         {


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/4897

#### Example output

```bash
arcade-validation# ./eng/common/sdk-task.sh --task SigningValidation --restore /p:PackageBasePath=/root/repos/arcade-validation/src/Validation/Resources/*.tar.gz

Results

[File] sample.tar.gz, Skipped (unsupported file type), Signed: N/A
  [File] 5d4ced5771ae2c7fc401c0acf235f9232629c77d5025436bb311353d05759cab.nupkg, Signed: False, Virtual path: sample.tar.gz/ContainerOne.1.0.0.nupkg, Full Name: ContainerOne.1.0.0.nupkg
[File] test.tar.gz, Skipped (unsupported file type), Signed: N/A
  [File] 39329cbda43448107a41aad6930abc7f3928be3e1e377d4dfd030c0bab290b28.vsix, Skipped (unsupported file type), Signed: N/A, Virtual path: test.tar.gz/test.vsix, Full Name: test.vsix
    [File] 4593421a045154fdbe92fd48774f936c80f0c2fc1c5a978d9982d8c96a6c66c9.vsix, Skipped (unsupported file type), Signed: N/A, Virtual path: test.tar.gz/test.vsix/PackageWithRelationships.vsix, Full Name: PackageWithRelationships.vsix

Signing issues found
Total Time: 00:00:00.0850455
Total Files: 27, Signed: 0, Unsigned: 1, Skipped: 26, Excluded: 0, Skipped & Excluded: 0                         (0.2s)
```