### PR TITLE
Fix item patterns and don't download unmerged manifests

### DIFF
--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -32,20 +32,6 @@ stages:
           -DarcVersion $(DarcVersion)
 
     - task: DownloadPipelineArtifact@2
-      displayName: Download Asset Manifests
-      continueOnError: true
-      enabled: true
-      inputs:
-        buildType: specific
-        buildVersionToDownload: specific
-        project: $(AzDOProject)
-        pipeline: $(AzDOPipelineId)
-        buildId: $(AzDOBuildId)
-        downloadType: 'specific'
-        artifact: AssetManifests
-        downloadPath: '$(Build.ArtifactStagingDirectory)/AssetManifests'
-
-    - task: DownloadPipelineArtifact@2
       displayName: Download Merged Manifest
       continueOnError: true
       enabled: true
@@ -58,7 +44,7 @@ stages:
         downloadType: 'specific'
         artifact: BlobArtifacts
         itemPattern: |
-          MergedManifest.xml
+          BlobArtifacts/MergedManifest.xml
         downloadPath: '$(Build.ArtifactStagingDirectory)/BlobArtifacts'
 
     - task: DownloadPipelineArtifact@2
@@ -88,7 +74,7 @@ stages:
         downloadType: 'specific'
         artifact: ReleaseConfigs
         itemPattern: |
-          SymbolPublishingExclusionsFile.txt
+          ReleaseConfigs/SymbolPublishingExclusionsFile.txt
         downloadPath: '$(Build.ArtifactStagingDirectory)/ReleaseConfigs'
 
     - task: NuGetToolInstaller@1


### PR DESCRIPTION
The item patterns when using DownloadPipelineArtifact include the artifact name. In addition, don't download unmerged manifests. This code was from days before we always had a merged manifests. This ended up meaning that promotions happened for the same assets like 10 times.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
