### PR TITLE
Opt-in TargetRid publish mode

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -14,7 +14,7 @@
       SkipPackageChecks                 Skips package safety checks.
       EnableDefaultArtifacts            Includes packages under "/artifacts/packages/**" for publishing. Defaults to true.
       DefaultArtifactVisibility         The default visibility for Artifact items. Defaults to External.
-      PublishOnlyRidSpecificArtifacts   Only externally publish packages for this build's TargetRid.
+      EnableDefaultRidSpecificArtifacts   Only externally publish packages for this build's TargetRid.
       DotNetBuildPass                   While building the repo as part of the entire .NET stack, this parameter specifies which build pass the current build is part of.
                                           The build pass number gets added to the asset manifest file name to avoid collisions.
 
@@ -103,7 +103,7 @@
   </PropertyGroup>
 
   <Choose Condition="'$(EnableDefaultArtifacts)' == 'true'">
-    <When Condition="'$(PublishOnlyRidSpecificArtifacts)' == 'true'">
+    <When Condition="'$(EnableDefaultRidSpecificArtifacts)' == 'true'">
       <!--
         Only publish packages that contain this build's Target RID in the name.
       -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -14,6 +14,7 @@
       SkipPackageChecks                 Skips package safety checks.
       EnableDefaultArtifacts            Includes packages under "/artifacts/packages/**" for publishing. Defaults to true.
       DefaultArtifactVisibility         The default visibility for Artifact items. Defaults to External.
+      PublishOnlyRidSpecificArtifacts   Only externally publish packages for this build's TargetRid.
       DotNetBuildPass                   While building the repo as part of the entire .NET stack, this parameter specifies which build pass the current build is part of.
                                           The build pass number gets added to the asset manifest file name to avoid collisions.
 
@@ -101,10 +102,42 @@
     <AssetManifestPass Condition="'$(DotNetBuildPass)' != '' and '$(DotNetBuildPass)' != '1'">-Pass$(DotNetBuildPass)</AssetManifestPass>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(EnableDefaultArtifacts)' == 'true'">
-    <Artifact Include="$(ArtifactsShippingPackagesDir)**/*.nupkg" Kind="Package" />
-    <Artifact Include="$(ArtifactsNonShippingPackagesDir)**/*.nupkg" IsShipping="false" Kind="Package" />
-  </ItemGroup>
+  <Choose Condition="'$(EnableDefaultArtifacts)' == 'true'">
+    <When Condition="'$(PublishOnlyRidSpecificArtifacts)' == 'true'">
+      <!--
+        Only publish packages that contain this build's Target RID in the name.
+      -->
+      <ItemGroup>
+        <Artifact Include="$(ArtifactsShippingPackagesDir)**/*.$(TargetRid).*.nupkg" Kind="Package" />
+        <Artifact Include="$(ArtifactsNonShippingPackagesDir)**/*.$(TargetRid).*.nupkg" IsShipping="false" Kind="Package" />
+        <!--
+          Integration with Microsoft.DotNet.Build.Tasks.Installers: Publish packages of the following formats as well.
+          These are arch-specific Visual Studio insertion packages. As they're Windows-only, they only include architecture in the name:
+          - VS.Redist.Common.*.$(TargetArchitecture).*.nupkg
+          - VS.Redist.Common.*.$(TargetArchitecture)-*.*.nupkg
+          
+          These packages are always non-shipping, so only look there.
+        -->
+        <Artifact Include="$(ArtifactsNonShippingPackagesDir)**/VS.Redist.Common.*.$(TargetArchitecture).*.nupkg" IsShipping="false" Kind="Package" />
+        <Artifact Include="$(ArtifactsNonShippingPackagesDir)**/VS.Redist.Common.*.$(TargetArchitecture)-*.*.nupkg" IsShipping="false" Kind="Package" />
+      </ItemGroup>
+
+      <!--
+        In the VMR, don't publish packages that didn't match the above conditions externally.
+        Instead, add them with Vertical visibility as they still may be needed to build RID-specific packages in other repos.
+      -->
+      <ItemGroup Condition="'$(DotNetBuildOrchestrator)' == 'true'">
+        <Artifact Include="$(ArtifactsShippingPackagesDir)**/*.nupkg" Exclude="@(Artifact)" Kind="Package" Visibility="Vertical" />
+        <Artifact Include="$(ArtifactsNonShippingPackagesDir)**/*.nupkg" Exclude="@(Artifact)" IsShipping="false" Kind="Package" Visibility="Vertical" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Artifact Include="$(ArtifactsShippingPackagesDir)**/*.nupkg" Kind="Package" />
+        <Artifact Include="$(ArtifactsNonShippingPackagesDir)**/*.nupkg" IsShipping="false" Kind="Package" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
 
   <!-- Allow for repo specific Publish properties such as add additional files to be published -->
   <Import Project="$(RepositoryEngineeringDir)Publishing.props" Condition="Exists('$(RepositoryEngineeringDir)Publishing.props')" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -8,6 +8,7 @@
     Optional variables:
       EnableDefaultArtifacts            Includes *.nupkg, *.vsix and *.wixpack.zip under "/artifacts/packages/**" for sigining.
                                         Defaults to true.
+      EnableDefaultRidSpecificArtifacts Do not sign *.nupkg packages under "/artifacts/packages/**" that do not contain the current TargetRid.
       DefaultArtifactVisibility         The default visibility for Artifact items. Defaults to External.
 
     Optional items:

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -32,15 +32,42 @@
     <CertificatesSignInfo Include="MacDeveloperVNextHardenWithNotarization" MacCertificate="MacDeveloperVNextHarden" MacNotarizationAppName="dotnet" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(EnableDefaultArtifacts)' == 'true'">
-    <!-- List of container files that will be opened and checked for files that need to be signed. -->
-    <_DefaultItemsToSign Include="$(ArtifactsPackagesDir)**\*.nupkg" />
-    <_DefaultItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.vsix" />
-    <_DefaultItemsToSign Include="$(VisualStudioBuildPackagesDir)**\*.nupkg" />
-
-    <!-- PostBuildSign switch is kept for avoiding breaks in repos that use it to avoid signing. -->
-    <ItemsToSign Include="@(_DefaultItemsToSign)" Condition="'$(PostBuildSign)' != 'true'" />
-  </ItemGroup>
+  <!-- PostBuildSign switch is kept for avoiding breaks in repos that use it to avoid signing. -->
+  <Choose Condition="'$(EnableDefaultArtifacts)' == 'true' and '$(PostBuildSign)' != 'true'">
+    <When Condition="'$(EnableDefaultRidSpecificArtifacts)' == 'true'">
+      <!--
+        Only publish packages that contain this build's Target RID in the name.
+      -->
+      <ItemGroup>
+        <ItemsToSign Include="$(ArtifactsShippingPackagesDir)**/*.$(TargetRid).*.nupkg"/>
+        <ItemsToSign Include="$(ArtifactsNonShippingPackagesDir)**/*.$(TargetRid).*.nupkg" />
+        <!--
+          Integration with Microsoft.DotNet.Build.Tasks.Installers: Publish packages of the following formats as well.
+          These are arch-specific Visual Studio insertion packages. As they're Windows-only, they only include architecture in the name:
+          - VS.Redist.Common.*.$(TargetArchitecture).*.nupkg
+          - VS.Redist.Common.*.$(TargetArchitecture)-*.*.nupkg
+          
+          These packages are always non-shipping, so only look there.
+        -->
+        <ItemsToSign Include="$(ArtifactsNonShippingPackagesDir)**/VS.Redist.Common.*.$(TargetArchitecture).*.nupkg" />
+        <ItemsToSign Include="$(ArtifactsNonShippingPackagesDir)**/VS.Redist.Common.*.$(TargetArchitecture)-*.*.nupkg" />
+      </ItemGroup>
+      
+      <ItemGroup>
+        <!-- Always sign all vsix packages and VS Build Packages. These may be arch specific or agnostic, but they likely won't have the RID included. -->
+        <ItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.vsix" />
+        <ItemsToSign Include="$(VisualStudioBuildPackagesDir)**\*.nupkg" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <!-- List of container files that will be opened and checked for files that need to be signed. -->
+        <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.nupkg" />
+        <ItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.vsix" />
+        <ItemsToSign Include="$(VisualStudioBuildPackagesDir)**\*.nupkg" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
 
   <ItemGroup>
     <!-- Default certificate/strong-name to be used for all files with PKT=="31bf3856ad364e35". -->


### PR DESCRIPTION
To enable us to fully dedup our vertical asset manifests in the VMR, we need some mechanism to specify that RID-agnostic packages shouldn't be published in particular verticals.

One options would be to have the VMR automatically use "Vertical" visibility as the default for all non-"Win-x64 BuildPass1" legs and require repos that have RID-specific assets to mark them with the correct visibility. In this model, every repo that has RID specific assets would have to have almost the same logic in Publishing.props.

Another option (this PR) is to add support into Arcade for a switch to automatically only add RID-specific packages as non-Vertical packages by default. This model ensures that we don't need to change every repo that produces RID-specific artifacts. It also provides a mechanism to opt-in for repositories that need to publish in this manner normally (useful for dotnet/runtime for the short period between the MicroBuild fixes and the official build being shut off).

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md


Contributes to https://github.com/dotnet/source-build/issues/4905
