### PR TITLE
Introduce v4 publishing.

### DIFF
--- a/Arcade.sln
+++ b/Arcade.sln
@@ -149,7 +149,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.MacOsPkg.C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.MacOsPkg.Core", "src\Microsoft.DotNet.MacOsPkg\Core\Microsoft.DotNet.MacOsPkg.Core.csproj", "{57C888D8-80EC-48E1-A52E-00B14AE56A77}"
 EndProject
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.MacOsPkg.Tests", "src\Microsoft.DotNet.MacOsPkg.Tests\Microsoft.DotNet.MacOsPkg.Tests.csproj", "{1F5118A8-A5C5-4D18-AF34-FFB60FECCD45}"
 EndProject
 Global
@@ -966,18 +965,6 @@ Global
 		{CA159C84-CD7D-4364-9121-3842F97D4B60}.Release|x64.Build.0 = Release|Any CPU
 		{CA159C84-CD7D-4364-9121-3842F97D4B60}.Release|x86.ActiveCfg = Release|Any CPU
 		{CA159C84-CD7D-4364-9121-3842F97D4B60}.Release|x86.Build.0 = Release|Any CPU
-		{1F5118A8-A5C5-4D18-AF34-FFB60FECCD45}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{1F5118A8-A5C5-4D18-AF34-FFB60FECCD45}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1F5118A8-A5C5-4D18-AF34-FFB60FECCD45}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{1F5118A8-A5C5-4D18-AF34-FFB60FECCD45}.Debug|x64.Build.0 = Debug|Any CPU
-		{1F5118A8-A5C5-4D18-AF34-FFB60FECCD45}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{1F5118A8-A5C5-4D18-AF34-FFB60FECCD45}.Debug|x86.Build.0 = Debug|Any CPU
-		{1F5118A8-A5C5-4D18-AF34-FFB60FECCD45}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1F5118A8-A5C5-4D18-AF34-FFB60FECCD45}.Release|Any CPU.Build.0 = Release|Any CPU
-		{1F5118A8-A5C5-4D18-AF34-FFB60FECCD45}.Release|x64.ActiveCfg = Release|Any CPU
-		{1F5118A8-A5C5-4D18-AF34-FFB60FECCD45}.Release|x64.Build.0 = Release|Any CPU
-		{1F5118A8-A5C5-4D18-AF34-FFB60FECCD45}.Release|x86.ActiveCfg = Release|Any CPU
-		{1F5118A8-A5C5-4D18-AF34-FFB60FECCD45}.Release|x86.Build.0 = Release|Any CPU
 		{495E4649-F0E9-4D62-97A0-644E84419C6F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{495E4649-F0E9-4D62-97A0-644E84419C6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{495E4649-F0E9-4D62-97A0-644E84419C6F}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -1002,6 +989,18 @@ Global
 		{57C888D8-80EC-48E1-A52E-00B14AE56A77}.Release|x64.Build.0 = Release|Any CPU
 		{57C888D8-80EC-48E1-A52E-00B14AE56A77}.Release|x86.ActiveCfg = Release|Any CPU
 		{57C888D8-80EC-48E1-A52E-00B14AE56A77}.Release|x86.Build.0 = Release|Any CPU
+		{1F5118A8-A5C5-4D18-AF34-FFB60FECCD45}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1F5118A8-A5C5-4D18-AF34-FFB60FECCD45}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1F5118A8-A5C5-4D18-AF34-FFB60FECCD45}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1F5118A8-A5C5-4D18-AF34-FFB60FECCD45}.Debug|x64.Build.0 = Debug|Any CPU
+		{1F5118A8-A5C5-4D18-AF34-FFB60FECCD45}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1F5118A8-A5C5-4D18-AF34-FFB60FECCD45}.Debug|x86.Build.0 = Debug|Any CPU
+		{1F5118A8-A5C5-4D18-AF34-FFB60FECCD45}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1F5118A8-A5C5-4D18-AF34-FFB60FECCD45}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1F5118A8-A5C5-4D18-AF34-FFB60FECCD45}.Release|x64.ActiveCfg = Release|Any CPU
+		{1F5118A8-A5C5-4D18-AF34-FFB60FECCD45}.Release|x64.Build.0 = Release|Any CPU
+		{1F5118A8-A5C5-4D18-AF34-FFB60FECCD45}.Release|x86.ActiveCfg = Release|Any CPU
+		{1F5118A8-A5C5-4D18-AF34-FFB60FECCD45}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishArtifactsInManifestTests.cs
@@ -57,6 +57,32 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
             which.Should().BeOfType<PublishArtifactsInManifestV3>();
         }
 
+        [Fact]
+        public void ConstructV4PublishingTask()
+        {
+            var manifestFullPath = TestInputs.GetFullPath(Path.Combine("Manifests", "SampleV4.xml"));
+
+            var buildEngine = new MockBuildEngine();
+            var task = new PublishArtifactsInManifest()
+            {
+                BuildEngine = buildEngine,
+                TargetChannels = GeneralTestingChannelId
+            };
+
+            // Dependency Injection setup
+            var collection = new ServiceCollection()
+                .AddSingleton<IFileSystem, FileSystem>()
+                .AddSingleton<IBuildModelFactory, BuildModelFactory>();
+            task.ConfigureServices(collection);
+            using var provider = collection.BuildServiceProvider();
+
+            // Act and Assert
+            task.InvokeExecute(provider);
+
+            var which = task.WhichPublishingTask(manifestFullPath);
+            which.Should().BeOfType<PublishArtifactsInManifestV4>();
+        }
+
         [Theory]
         [InlineData("https://pkgs.dev.azure.com/dnceng/public/_packaging/mmitche-test-transport/nuget/v3/index.json", "dnceng", "public/", "mmitche-test-transport")]
         [InlineData("https://pkgs.dev.azure.com/DevDiv/public/_packaging/1234.5/nuget/v3/index.json", "DevDiv", "public/", "1234.5")]

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/SetupTargetFeedConfigV4Tests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/SetupTargetFeedConfigV4Tests.cs
@@ -1,0 +1,467 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using FluentAssertions;
+using Microsoft.Arcade.Test.Common;
+using Microsoft.DotNet.Build.Tasks.Feed.Model;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+using Microsoft.DotNet.VersionTools.BuildManifest.Model;
+
+namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
+{
+    public class SetupTargetFeedConfigV4Tests
+    {
+        private const string LatestLinkShortUrlPrefix = "LatestLinkShortUrlPrefix";
+        private const string BuildQuality = "quality";
+        private const string AzureDevOpsFeedsKey = "AzureDevOpsFeedsKey";
+
+        private const string StablePackageFeed = "StablePackageFeed";
+        private const string StableSymbolsFeed = "StableSymbolsFeed";
+
+        private const string ChecksumsTargetStaticFeed = "ChecksumsTargetStaticFeed";
+        private const string ChecksumsTargetStaticFeedKey = "ChecksumsTargetStaticFeedKey";
+
+        private const string InstallersTargetStaticFeed = "InstallersTargetStaticFeed";
+        private const string InstallersTargetStaticFeedKey = "InstallersTargetStaticFeedKey";
+
+        private const string AzureDevOpsStaticShippingFeed = "AzureDevOpsStaticShippingFeed";
+        private const string AzureDevOpsStaticTransportFeed = "AzureDevOpsStaticTransportFeed";
+        private const string AzureDevOpsStaticSymbolsFeed = "AzureDevOpsStaticSymbolsFeed";
+
+        private static ImmutableList<string> FilesToExclude = ImmutableList.Create(
+            "filename",
+            "secondfilename"
+        );
+
+        private readonly List<TargetFeedContentType> InstallersAndSymbols = new List<TargetFeedContentType>() {
+            TargetFeedContentType.OSX,
+            TargetFeedContentType.Deb,
+            TargetFeedContentType.Rpm,
+            TargetFeedContentType.Node,
+            TargetFeedContentType.BinaryLayout,
+            TargetFeedContentType.Installer,
+            TargetFeedContentType.Maven,
+            TargetFeedContentType.VSIX,
+            TargetFeedContentType.Badge,
+            TargetFeedContentType.Symbols,
+            TargetFeedContentType.Other
+        };
+
+        private readonly ITaskItem[] FeedKeys = GetFeedKeys();
+
+        private static ITaskItem[] GetFeedKeys()
+        {
+            var installersKey = new TaskItem(PublishingConstants.FeedStagingForInstallers);
+            installersKey.SetMetadata("Key", InstallersTargetStaticFeedKey);
+            var checksumsKey = new TaskItem(PublishingConstants.FeedStagingForChecksums);
+            checksumsKey.SetMetadata("Key", ChecksumsTargetStaticFeedKey);
+            var azureDevops = new TaskItem("https://pkgs.dev.azure.com/dnceng");
+            azureDevops.SetMetadata("Key", AzureDevOpsFeedsKey);
+            return new ITaskItem[]
+            {
+                installersKey,
+                checksumsKey,
+                azureDevops,
+            };
+        }
+
+        private const SymbolPublishVisibility symbolVisibility = SymbolPublishVisibility.Internal;
+
+        private readonly ITestOutputHelper Output;
+
+        public SetupTargetFeedConfigV4Tests(ITestOutputHelper output)
+        {
+            this.Output = output;
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void StableFeeds(bool publishInstallersAndChecksums, bool isInternalBuild)
+        {
+            var expectedFeeds = new List<TargetFeedConfig>();
+
+            expectedFeeds.Add(
+                new TargetFeedConfig(
+                    TargetFeedContentType.Package,
+                    StablePackageFeed,
+                    FeedType.AzDoNugetFeed,
+                    AzureDevOpsFeedsKey,
+                    latestLinkShortUrlPrefixes: [$"{LatestLinkShortUrlPrefix}/{BuildQuality}"],
+                    akaMSCreateLinkPatterns: PublishingConstants.DefaultAkaMSCreateLinkPatterns,
+                    akaMSDoNotCreateLinkPatterns: PublishingConstants.DefaultAkaMSDoNotCreateLinkPatterns,
+                    assetSelection: AssetSelection.ShippingOnly,
+                    isolated: true,
+                    @internal: isInternalBuild,
+                    allowOverwrite: false,
+                    symbolPublishVisibility: symbolVisibility));
+
+            expectedFeeds.Add(
+                new TargetFeedConfig(
+                    TargetFeedContentType.Symbols,
+                    StableSymbolsFeed,
+                    FeedType.AzDoNugetFeed,
+                    AzureDevOpsFeedsKey,
+                    latestLinkShortUrlPrefixes: [$"{LatestLinkShortUrlPrefix}/{BuildQuality}"],
+                    akaMSCreateLinkPatterns: PublishingConstants.DefaultAkaMSCreateLinkPatterns,
+                    akaMSDoNotCreateLinkPatterns: PublishingConstants.DefaultAkaMSDoNotCreateLinkPatterns,
+                    assetSelection: AssetSelection.All,
+                    isolated: true,
+                    @internal: isInternalBuild,
+                    allowOverwrite: false,
+                    symbolPublishVisibility: symbolVisibility));
+
+            expectedFeeds.Add(
+                new TargetFeedConfig(
+                    TargetFeedContentType.Package,
+                    PublishingConstants.FeedDotNetEng,
+                    FeedType.AzDoNugetFeed,
+                    AzureDevOpsFeedsKey,
+                    latestLinkShortUrlPrefixes: [$"{LatestLinkShortUrlPrefix}/{BuildQuality}"],
+                    akaMSCreateLinkPatterns: PublishingConstants.DefaultAkaMSCreateLinkPatterns,
+                    akaMSDoNotCreateLinkPatterns: PublishingConstants.DefaultAkaMSDoNotCreateLinkPatterns,
+                    assetSelection: AssetSelection.NonShippingOnly,
+                    isolated: false,
+                    @internal: isInternalBuild,
+                    allowOverwrite: false,
+                    symbolPublishVisibility: symbolVisibility));
+
+            if (publishInstallersAndChecksums)
+            {
+                foreach (var contentType in InstallersAndSymbols)
+                {
+                    if (contentType == TargetFeedContentType.Symbols)
+                    {
+                        continue;
+                    }
+                    expectedFeeds.Add(
+                        new TargetFeedConfig(
+                            contentType,
+                            PublishingConstants.FeedStagingForInstallers,
+                            FeedType.AzureStorageContainer,
+                            InstallersTargetStaticFeedKey,
+                            latestLinkShortUrlPrefixes: [$"{LatestLinkShortUrlPrefix}/{BuildQuality}"],
+                            akaMSCreateLinkPatterns: PublishingConstants.DefaultAkaMSCreateLinkPatterns,
+                            akaMSDoNotCreateLinkPatterns: PublishingConstants.DefaultAkaMSDoNotCreateLinkPatterns,
+                            assetSelection: AssetSelection.All,
+                            isolated: false,
+                            @internal: isInternalBuild,
+                            allowOverwrite: false,
+                            symbolPublishVisibility: symbolVisibility));
+                }
+                expectedFeeds.Add(
+                    new TargetFeedConfig(
+                        TargetFeedContentType.Checksum,
+                        PublishingConstants.FeedStagingForChecksums,
+                        FeedType.AzureStorageContainer,
+                        ChecksumsTargetStaticFeedKey,
+                        latestLinkShortUrlPrefixes: [$"{LatestLinkShortUrlPrefix}/{BuildQuality}"],
+                        akaMSCreateLinkPatterns: PublishingConstants.DefaultAkaMSCreateLinkPatterns,
+                        akaMSDoNotCreateLinkPatterns: PublishingConstants.DefaultAkaMSDoNotCreateLinkPatterns,
+                        assetSelection: AssetSelection.All,
+                        isolated: false,
+                        @internal: isInternalBuild,
+                        allowOverwrite: false,
+                        symbolPublishVisibility: symbolVisibility));
+            }
+
+
+            var buildEngine = new MockBuildEngine();
+            var channelConfig = PublishingConstants.ChannelInfos.First(c => c.Id == 2);
+            var config = new SetupTargetFeedConfigV4(
+                    channelConfig,
+                    isInternalBuild,
+                    true,
+                    repositoryName: "test-repo",
+                    commitSha: "c0c0c0c0",
+                    publishInstallersAndChecksums,
+                    FeedKeys,
+                    Array.Empty<ITaskItem>(),
+                    Array.Empty<ITaskItem>(),
+                    [$"{LatestLinkShortUrlPrefix}/{BuildQuality}"],
+                    buildEngine,
+                    symbolVisibility,
+                    StablePackageFeed,
+                    StableSymbolsFeed,
+                    filesToExclude: FilesToExclude
+                );
+
+            var actualFeeds = config.Setup();
+
+            actualFeeds.Should().BeEquivalentTo(expectedFeeds);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void NonStableAndInternal(bool publishInstallersAndChecksums)
+        {
+            var expectedFeeds = new List<TargetFeedConfig>();
+
+            expectedFeeds.Add(new TargetFeedConfig(
+                TargetFeedContentType.Package,
+                PublishingConstants.FeedDotNetEng,
+                FeedType.AzDoNugetFeed,
+                AzureDevOpsFeedsKey,
+                latestLinkShortUrlPrefixes: [$"{LatestLinkShortUrlPrefix}/{BuildQuality}"],
+                akaMSCreateLinkPatterns: PublishingConstants.DefaultAkaMSCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: PublishingConstants.DefaultAkaMSDoNotCreateLinkPatterns,
+                assetSelection: AssetSelection.ShippingOnly,
+                isolated: false,
+                @internal: true,
+                allowOverwrite: false,
+                symbolPublishVisibility: symbolVisibility));
+
+            expectedFeeds.Add(new TargetFeedConfig(
+                TargetFeedContentType.Package,
+                PublishingConstants.FeedDotNetEng,
+                FeedType.AzDoNugetFeed,
+                AzureDevOpsFeedsKey,
+                latestLinkShortUrlPrefixes: [$"{LatestLinkShortUrlPrefix}/{BuildQuality}"],
+                akaMSCreateLinkPatterns: PublishingConstants.DefaultAkaMSCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: PublishingConstants.DefaultAkaMSDoNotCreateLinkPatterns,
+                assetSelection: AssetSelection.NonShippingOnly,
+                isolated: false,
+                @internal: true,
+                allowOverwrite: false,
+                symbolPublishVisibility: symbolVisibility));
+
+            if (publishInstallersAndChecksums)
+            {
+                foreach (var contentType in InstallersAndSymbols)
+                {
+                    expectedFeeds.Add(
+                        new TargetFeedConfig(
+                            contentType,
+                            PublishingConstants.FeedStagingForInstallers,
+                            FeedType.AzureStorageContainer,
+                            InstallersTargetStaticFeedKey,
+                            latestLinkShortUrlPrefixes: [$"{LatestLinkShortUrlPrefix}/{BuildQuality}"],
+                            akaMSCreateLinkPatterns: PublishingConstants.DefaultAkaMSCreateLinkPatterns,
+                            akaMSDoNotCreateLinkPatterns: PublishingConstants.DefaultAkaMSDoNotCreateLinkPatterns,
+                            assetSelection: AssetSelection.All,
+                            isolated: false,
+                            @internal: true,
+                            allowOverwrite: false,
+                            symbolPublishVisibility: symbolVisibility));
+                }
+
+                expectedFeeds.Add(
+                    new TargetFeedConfig(
+                        TargetFeedContentType.Checksum,
+                        PublishingConstants.FeedStagingForChecksums,
+                        FeedType.AzureStorageContainer,
+                        ChecksumsTargetStaticFeedKey,
+                        latestLinkShortUrlPrefixes: [$"{LatestLinkShortUrlPrefix}/{BuildQuality}"],
+                        akaMSCreateLinkPatterns: PublishingConstants.DefaultAkaMSCreateLinkPatterns,
+                        akaMSDoNotCreateLinkPatterns: PublishingConstants.DefaultAkaMSDoNotCreateLinkPatterns,
+                        assetSelection: AssetSelection.All,
+                        isolated: false,
+                        @internal: true,
+                        allowOverwrite: false,
+                        symbolPublishVisibility: symbolVisibility));
+
+            }
+            else
+            {
+                expectedFeeds.Add(
+                    new TargetFeedConfig(
+                        TargetFeedContentType.Symbols,
+                        PublishingConstants.FeedStagingForInstallers,
+                        FeedType.AzureStorageContainer,
+                        InstallersTargetStaticFeedKey,
+                        latestLinkShortUrlPrefixes: [$"{LatestLinkShortUrlPrefix}/{BuildQuality}"],
+                        akaMSCreateLinkPatterns: PublishingConstants.DefaultAkaMSCreateLinkPatterns,
+                        akaMSDoNotCreateLinkPatterns: PublishingConstants.DefaultAkaMSDoNotCreateLinkPatterns,
+                        assetSelection: AssetSelection.All,
+                        isolated: false,
+                        @internal: true,
+                        allowOverwrite: false,
+                        symbolPublishVisibility: symbolVisibility));
+            }
+
+            var buildEngine = new MockBuildEngine();
+            var channelConfig = PublishingConstants.ChannelInfos.First(c => c.Id == 2);
+            var config = new SetupTargetFeedConfigV4(
+                    channelConfig,
+                    isInternalBuild: true,
+                    isStableBuild: false,
+                    repositoryName: "test-repo",
+                    commitSha: "c0c0c0c0",
+                    publishInstallersAndChecksums,
+                    FeedKeys,
+                    Array.Empty<ITaskItem>(),
+                    Array.Empty<ITaskItem>(),
+                    latestLinkShortUrlPrefixes: [$"{LatestLinkShortUrlPrefix}/{BuildQuality}"],
+                    buildEngine: buildEngine,
+                    symbolVisibility
+                );
+
+            var actualFeeds = config.Setup();
+
+            actualFeeds.Should().BeEquivalentTo(expectedFeeds);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void NonStableAndPublic(bool publishInstallersAndChecksums)
+        {
+            var expectedFeeds = new List<TargetFeedConfig>();
+
+            expectedFeeds.Add(
+                new TargetFeedConfig(
+                    TargetFeedContentType.Package,
+                    PublishingConstants.FeedDotNetEng,
+                    FeedType.AzDoNugetFeed,
+                    AzureDevOpsFeedsKey,
+                    latestLinkShortUrlPrefixes: [$"{LatestLinkShortUrlPrefix}/{BuildQuality}"],
+                    akaMSCreateLinkPatterns: PublishingConstants.DefaultAkaMSCreateLinkPatterns,
+                        akaMSDoNotCreateLinkPatterns: PublishingConstants.DefaultAkaMSDoNotCreateLinkPatterns,
+                    assetSelection: AssetSelection.ShippingOnly,
+                    isolated: false,
+                    @internal: false,
+                    allowOverwrite: false,
+                    symbolPublishVisibility: symbolVisibility));
+
+            expectedFeeds.Add(
+                new TargetFeedConfig(
+                    TargetFeedContentType.Package,
+                    PublishingConstants.FeedDotNetEng,
+                    FeedType.AzDoNugetFeed,
+                    AzureDevOpsFeedsKey,
+                    latestLinkShortUrlPrefixes: [$"{LatestLinkShortUrlPrefix}/{BuildQuality}"],
+                    akaMSCreateLinkPatterns: PublishingConstants.DefaultAkaMSCreateLinkPatterns,
+                    akaMSDoNotCreateLinkPatterns: PublishingConstants.DefaultAkaMSDoNotCreateLinkPatterns,
+                    assetSelection: AssetSelection.NonShippingOnly,
+                    isolated: false,
+                    @internal: false,
+                    allowOverwrite: false,
+                    symbolPublishVisibility: symbolVisibility));
+
+            if (publishInstallersAndChecksums)
+            {
+                foreach (var contentType in InstallersAndSymbols)
+                {
+                    expectedFeeds.Add(
+                        new TargetFeedConfig(
+                            contentType,
+                            PublishingConstants.FeedStagingForInstallers,
+                            FeedType.AzureStorageContainer,
+                            InstallersTargetStaticFeedKey,
+                            latestLinkShortUrlPrefixes: [$"{LatestLinkShortUrlPrefix}/{BuildQuality}"],
+                            akaMSCreateLinkPatterns: PublishingConstants.DefaultAkaMSCreateLinkPatterns,
+                            akaMSDoNotCreateLinkPatterns: PublishingConstants.DefaultAkaMSDoNotCreateLinkPatterns,
+                            assetSelection: AssetSelection.All,
+                            isolated: false,
+                            @internal: false,
+                            allowOverwrite: false,
+                            symbolPublishVisibility: symbolVisibility));
+                }
+
+                expectedFeeds.Add(
+                    new TargetFeedConfig(
+                        TargetFeedContentType.Checksum,
+                        PublishingConstants.FeedStagingForChecksums,
+                        FeedType.AzureStorageContainer,
+                        ChecksumsTargetStaticFeedKey,
+                        latestLinkShortUrlPrefixes: [$"{LatestLinkShortUrlPrefix}/{BuildQuality}"],
+                        akaMSCreateLinkPatterns: PublishingConstants.DefaultAkaMSCreateLinkPatterns,
+                        akaMSDoNotCreateLinkPatterns: PublishingConstants.DefaultAkaMSDoNotCreateLinkPatterns,
+                        assetSelection: AssetSelection.All,
+                        isolated: false,
+                        @internal: false,
+                        allowOverwrite: false,
+                        symbolPublishVisibility: symbolVisibility));
+            }
+            else
+            {
+                expectedFeeds.Add(
+                    new TargetFeedConfig(
+                        TargetFeedContentType.Symbols,
+                        PublishingConstants.FeedStagingForInstallers,
+                        FeedType.AzureStorageContainer,
+                        InstallersTargetStaticFeedKey,
+                        latestLinkShortUrlPrefixes: [$"{LatestLinkShortUrlPrefix}/{BuildQuality}"],
+                        akaMSCreateLinkPatterns: PublishingConstants.DefaultAkaMSCreateLinkPatterns,
+                        akaMSDoNotCreateLinkPatterns: PublishingConstants.DefaultAkaMSDoNotCreateLinkPatterns,
+                        assetSelection: AssetSelection.All,
+                        isolated: false,
+                        @internal: false,
+                        allowOverwrite: false,
+                        symbolPublishVisibility: symbolVisibility));
+            }
+
+            var buildEngine = new MockBuildEngine();
+            var channelConfig = PublishingConstants.ChannelInfos.First(c => c.Id == 2);
+            var config = new SetupTargetFeedConfigV4(
+                    channelConfig,
+                    isInternalBuild: false,
+                    isStableBuild: false,
+                    repositoryName: "test-repo",
+                    commitSha: "c0c0c0c0",
+                    publishInstallersAndChecksums,
+                    FeedKeys,
+                    Array.Empty<ITaskItem>(),
+                    Array.Empty<ITaskItem>(),
+                    latestLinkShortUrlPrefixes: [$"{LatestLinkShortUrlPrefix}/{BuildQuality}"],
+                    buildEngine: buildEngine,
+                    symbolVisibility
+                );
+
+            var actualFeeds = config.Setup();
+
+            actualFeeds.Should().BeEquivalentTo(expectedFeeds);
+        }
+
+        private bool AreEquivalent(List<TargetFeedConfig> expectedItems, List<TargetFeedConfig> actualItems)
+        {
+            if (expectedItems.Count() != actualItems.Count())
+            {
+                Output.WriteLine($"The expected items list has {expectedItems.Count()} item(s) but the list of actual items has {actualItems.Count()}.");
+
+                return false;
+            }
+
+            foreach (var expected in expectedItems)
+            {
+                if (actualItems.Contains(expected) == false)
+                {
+                    Output.WriteLine($"Expected item was not found in the actual collection of items: {expected}");
+
+                    Output.WriteLine("Actual items are: ");
+                    foreach (var actual in actualItems)
+                    {
+                        Output.WriteLine($"\t {actual}");
+                    }
+
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        [Fact]
+        public void MustHaveSeparateTargetFeedSpecificationsForShippingAndNonShipping()
+        {
+            Action shouldFail = () => new TargetFeedSpecification(new TargetFeedContentType[] { TargetFeedContentType.Package }, "FooFeed", AssetSelection.All);
+            shouldFail.Should().Throw<ArgumentException>();
+
+            Action shouldPassShippingOnly = () => new TargetFeedSpecification(new TargetFeedContentType[] { TargetFeedContentType.Package }, "FooFeed", AssetSelection.ShippingOnly);
+            shouldPassShippingOnly.Should().NotThrow();
+
+            Action shouldPassNonShippingOnly = () => new TargetFeedSpecification(new TargetFeedContentType[] { TargetFeedContentType.Package }, "FooFeed", AssetSelection.NonShippingOnly);
+            shouldPassNonShippingOnly.Should().NotThrow();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/TestInputs/Manifests/SampleV4.xml
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/TestInputs/Manifests/SampleV4.xml
@@ -1,0 +1,2 @@
+<Build PublishingVersion="4" Name="IsRequired">
+</Build>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -75,12 +75,14 @@
     <Compile Remove="src\model\PublishingConstants.cs" />
     <Compile Remove="src\model\SetupTargetFeedConfigBase.cs" />
     <Compile Remove="src\model\SetupTargetFeedConfigV3.cs" />
+    <Compile Remove="src\model\SetupTargetFeedConfigV4.cs" />
     <Compile Remove="src\model\TargetChannelConfig.cs" />
     <Compile Remove="src\model\TargetFeedConfig.cs" />
     <Compile Remove="src\PATCredential.cs" />
     <Compile Remove="src\PublishArtifactsInManifest.cs" />
     <Compile Remove="src\PublishArtifactsInManifestBase.cs" />
     <Compile Remove="src\PublishArtifactsInManifestV3.cs" />
+    <Compile Remove="src\PublishArtifactsInManifestV4.cs" />
     <Compile Remove="src\PublishSignedAssets.cs" />
     <Compile Remove="src\TaskTracer.cs" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -221,11 +221,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public int NonStreamingPublishingMaxClients {get; set;}
 
-        /// <summary>
-        /// Just an internal flag to keep track whether we published assets via a V3 manifest or not.
-        /// </summary>
-        private static bool PublishedV3Manifest { get; set; }
-
         private IBuildModelFactory _buildModelFactory;
         private IFileSystem _fileSystem;
 
@@ -274,31 +269,22 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 // Check that all tasks returned true
                 if (results.All(t => t))
                 {
-                    // Currently a build can produce several build manifests and publish them independently.
-                    // It's also possible that somehow we have manifests using different versions of the publishing infra.
-                    //
-                    // The V3 infra, once all assets have been published, promotes the build to the target channels informed. 
+                    // Once all assets have been published, promotes the build to the target channels informed. 
                     // Since we can have multiple manifests (perhaps using different versions), things
-                    // get a bit more complicated. For now, we are going to just promote the build to the target 
-                    // channels if it creates at least one V3 manifest.
-                    //
-                    // There is an issue to merge all build manifests into a single one before publishing:
-                    //         https://github.com/dotnet/arcade/issues/5489
-                    if (PublishedV3Manifest)
+                    // get a bit more complicated.
+
+                    IProductConstructionServiceApi client = PcsApiFactory.GetAuthenticated(
+                        MaestroApiEndpoint,
+                        BuildAssetRegistryToken,
+                        MaestroManagedIdentityId,
+                        !AllowInteractiveAuthentication);
+                    ProductConstructionService.Client.Models.Build buildInformation = await client.Builds.GetBuildAsync(BARBuildId);
+
+                    var targetChannelsIds = TargetChannels.Split('-').Select(ci => int.Parse(ci));
+
+                    foreach (var targetChannelId in targetChannelsIds)
                     {
-                        IProductConstructionServiceApi client = PcsApiFactory.GetAuthenticated(
-                            MaestroApiEndpoint,
-                            BuildAssetRegistryToken,
-                            MaestroManagedIdentityId,
-                            !AllowInteractiveAuthentication);
-                        ProductConstructionService.Client.Models.Build buildInformation = await client.Builds.GetBuildAsync(BARBuildId);
-
-                        var targetChannelsIds = TargetChannels.Split('-').Select(ci => int.Parse(ci));
-
-                        foreach (var targetChannelId in targetChannelsIds)
-                        {
-                            await client.Channels.AddBuildToChannelAsync(BARBuildId, targetChannelId);
-                        }
+                        await client.Channels.AddBuildToChannelAsync(BARBuildId, targetChannelId);
                     }
 
                     return true;
@@ -335,6 +321,10 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             {
                 return ConstructPublishingV3Task(buildModel);
             }
+            else if (buildModel.Identity.PublishingVersion == PublishingInfraVersion.Dev)
+            {
+                return ConstructPublishingV4Task(buildModel);
+            }
             else
             {
                 Log.LogError($"The manifest version '{buildModel.Identity.PublishingVersion}' is not recognized by the publishing task.");
@@ -344,8 +334,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         internal PublishArtifactsInManifestBase ConstructPublishingV3Task(BuildModel buildModel)
         {
-            PublishedV3Manifest = true;
-
             return new PublishArtifactsInManifestV3(new AssetPublisherFactory(Log))
             {
                 BuildEngine = this.BuildEngine,
@@ -381,6 +369,56 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 PublishSpecialClrFiles = this.PublishSpecialClrFiles,
                 BuildQuality = this.BuildQuality,
                 ArtifactsBasePath =  this.ArtifactsBasePath,
+                AzdoApiToken = this.AzdoApiToken,
+                BuildId = this.BuildId,
+                AzureProject = this.AzureProject,
+                AzureDevOpsOrg = this.AzureDevOpsOrg,
+                TempSymbolsAzureDevOpsOrg = this.TempSymbolsAzureDevOpsOrg,
+                TempSymbolsAzureDevOpsOrgToken = this.TempSymbolsAzureDevOpsOrgToken,
+                SymbolRequestProject = this.SymbolRequestProject,
+                UseStreamingPublishing = this.UseStreamingPublishing,
+                StreamingPublishingMaxClients = this.StreamingPublishingMaxClients,
+                NonStreamingPublishingMaxClients = this.NonStreamingPublishingMaxClients
+            };
+        }
+
+        internal PublishArtifactsInManifestBase ConstructPublishingV4Task(BuildModel buildModel)
+        {
+            return new PublishArtifactsInManifestV4(new AssetPublisherFactory(Log))
+            {
+                BuildEngine = this.BuildEngine,
+                TargetChannels = this.TargetChannels,
+                BuildModel = buildModel,
+                BlobAssetsBasePath = this.BlobAssetsBasePath,
+                PackageAssetsBasePath = this.PackageAssetsBasePath,
+                BARBuildId = this.BARBuildId,
+                MaestroApiEndpoint = this.MaestroApiEndpoint,
+                BuildAssetRegistryToken = this.BuildAssetRegistryToken,
+                NugetPath = this.NugetPath,
+                InternalBuild = this.InternalBuild,
+                SkipSafetyChecks = this.SkipSafetyChecks,
+                AkaMSClientId = this.AkaMSClientId,
+                AkaMSClientCertificate = !string.IsNullOrEmpty(AkaMSClientCertificate) ?
+#if NET9_0_OR_GREATER
+                    X509CertificateLoader.LoadPkcs12(Convert.FromBase64String(File.ReadAllText(AkaMSClientCertificate)), password: null) : null,
+#else
+                    new X509Certificate2(Convert.FromBase64String(File.ReadAllText(AkaMSClientCertificate))) : null,
+#endif
+                AkaMSCreatedBy = this.AkaMSCreatedBy,
+                AkaMSGroupOwner = this.AkaMSGroupOwner,
+                AkaMsOwners = this.AkaMsOwners,
+                AkaMSTenant = this.AkaMSTenant,
+                ManagedIdentityClientId = this.ManagedIdentityClientId,
+                PublishInstallersAndChecksums = this.PublishInstallersAndChecksums,
+                FeedKeys = this.FeedKeys,
+                FeedSasUris = this.FeedSasUris,
+                FeedOverrides = this.FeedOverrides,
+                AllowFeedOverrides = this.AllowFeedOverrides,
+                PdbArtifactsBasePath = this.PdbArtifactsBasePath,
+                SymbolPublishingExclusionsFile = this.SymbolPublishingExclusionsFile,
+                PublishSpecialClrFiles = this.PublishSpecialClrFiles,
+                BuildQuality = this.BuildQuality,
+                ArtifactsBasePath = this.ArtifactsBasePath,
                 AzdoApiToken = this.AzdoApiToken,
                 BuildId = this.BuildId,
                 AzureProject = this.AzureProject,

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV4.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV4.cs
@@ -1,0 +1,232 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.DotNet.Build.Tasks.Feed.Model;
+#if !NET472_OR_GREATER
+using Microsoft.DotNet.ProductConstructionService.Client;
+using Microsoft.DotNet.ProductConstructionService.Client.Models;
+using Microsoft.DotNet.VersionTools.BuildManifest.Model;
+
+namespace Microsoft.DotNet.Build.Tasks.Feed
+{
+    public class PublishArtifactsInManifestV4 : PublishArtifactsInManifestBase
+    {
+        /// <summary>
+        /// Comma separated list of Maestro++ Channel IDs to which the build should
+        /// be assigned to once the assets are published.
+        /// </summary>
+        [Required]
+        public string TargetChannels { get; set; }
+
+        public bool PublishInstallersAndChecksums { get; set; }
+
+        public string PdbArtifactsBasePath { get; set; }
+
+        public string SymbolPublishingExclusionsFile { get; set; }
+
+        public bool PublishSpecialClrFiles { get; set; }
+
+        public bool AllowFeedOverrides { get; set; }
+
+        public ITaskItem[] FeedKeys { get; set; }
+        public ITaskItem[] FeedSasUris { get; set; }
+
+        public ITaskItem[] FeedOverrides { get; set; }
+
+        public override bool Execute()
+        {
+            ExecuteAsync().GetAwaiter().GetResult();
+            return !Log.HasLoggedErrors;
+        }
+
+        public override async Task<bool> ExecuteAsync()
+        {
+            if (AnyMissingRequiredProperty())
+            {
+                Log.LogError("Missing required properties. Aborting execution.");
+                return false;
+            }
+
+            try
+            {
+                List<int> targetChannelsIds = new List<int>();
+
+                foreach (var channelIdStr in TargetChannels.Split('-'))
+                {
+                    if (!int.TryParse(channelIdStr, out var channelId))
+                    {
+                        Log.LogError(
+                            $"Value '{channelIdStr}' isn't recognized as a valid Maestro++ channel ID. To add a channel refer to https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Publishing.md#how-to-add-a-new-channel-to-use-v3-publishing.");
+                        continue;
+                    }
+
+                    targetChannelsIds.Add(channelId);
+                }
+
+                if (Log.HasLoggedErrors)
+                {
+                    Log.LogError(
+                        $"Could not parse the target channels list '{TargetChannels}'. It should be a comma separated list of integers.");
+                    return false;
+                }
+
+                SplitArtifactsInCategories(BuildModel);
+
+                if (Log.HasLoggedErrors)
+                {
+                    return false;
+                }
+
+                // Fetch Maestro record of the build. We're going to use it to get the BAR ID
+                // of the assets being published so we can add a new location for them.
+                IProductConstructionServiceApi client = PcsApiFactory.GetAuthenticated(
+                    MaestroApiEndpoint,
+                    BuildAssetRegistryToken,
+                    MaestroManagedIdentityId,
+                    disableInteractiveAuth: !AllowInteractiveAuthentication);
+
+                ProductConstructionService.Client.Models.Build buildInformation = await client.Builds.GetBuildAsync(BARBuildId);
+                ReadOnlyDictionary<string, Asset> buildAssets = CreateBuildAssetDictionary(buildInformation);
+
+                if (Log.HasLoggedErrors)
+                {
+                    return false;
+                }
+
+                foreach (var targetChannelId in targetChannelsIds.Distinct())
+                {
+                    TargetChannelConfig targetChannelConfig = PublishingConstants.ChannelInfos
+                        .Where(ci =>
+                            ci.Id == targetChannelId &&
+                            ci.PublishingInfraVersion == PublishingInfraVersion.Latest)
+                        .FirstOrDefault();
+
+                    // Invalid channel ID was supplied
+                    if (targetChannelConfig.Equals(default(TargetChannelConfig)))
+                    {
+                        Log.LogError($"Channel with ID '{targetChannelId}' is not configured to be published to.");
+                        return false;
+                    }
+
+                    if (await client.Channels.GetChannelAsync(targetChannelId) == null)
+                    {
+                        Log.LogError($"Channel with ID '{targetChannelId}' does not exist in BAR.");
+                        return false;
+                    }
+
+                    Log.LogMessage(MessageImportance.High, $"Publishing to this target channel: {targetChannelConfig}");
+
+                    List<string> shortLinkUrls = new List<string>();
+
+                    foreach (string akaMSChannelName in targetChannelConfig.AkaMSChannelNames)
+                    {
+                        shortLinkUrls.Add($"dotnet/{akaMSChannelName}/{BuildQuality}");
+                    }
+
+                    // If there are no channel names, default to dotnet/
+                    if (!targetChannelConfig.AkaMSChannelNames.Any())
+                    {
+                        shortLinkUrls.Add("dotnet/");
+                    }
+
+                    var targetFeedsSetup = new SetupTargetFeedConfigV4(
+                        targetChannelConfig: targetChannelConfig,
+                        isInternalBuild: targetChannelConfig.IsInternal,
+                        isStableBuild: BuildModel.Identity.IsStable,
+                        repositoryName: BuildModel.Identity.Name,
+                        commitSha: BuildModel.Identity.Commit,
+                        publishInstallersAndChecksums: PublishInstallersAndChecksums,
+                        feedKeys: FeedKeys,
+                        feedSasUris: FeedSasUris,
+                        feedOverrides: AllowFeedOverrides ? FeedOverrides : Array.Empty<ITaskItem>(),
+                        latestLinkShortUrlPrefixes: shortLinkUrls.ToImmutableList(),
+                        buildEngine: BuildEngine,
+                        targetChannelConfig.SymbolTargetType,
+                        flatten: targetChannelConfig.Flatten,
+                        log: Log);
+
+                    var targetFeedConfigs = targetFeedsSetup.Setup();
+
+                    // No target feeds to publish to, very likely this is an error
+                    if (!targetFeedConfigs.Any())
+                    {
+                        Log.LogError($"No target feeds were found to publish the assets to.");
+                        return false;
+                    }
+
+                    foreach (var feedConfig in targetFeedConfigs)
+                    {
+                        Log.LogMessage(MessageImportance.High, $"Target feed config: {feedConfig}");
+
+                        TargetFeedContentType categoryKey = feedConfig.ContentType;
+                        if (!FeedConfigs.TryGetValue(categoryKey, out _))
+                        {
+                            FeedConfigs[categoryKey] = new HashSet<TargetFeedConfig>();
+                        }
+
+                        FeedConfigs[categoryKey].Add(feedConfig);
+                    }
+                }
+
+                CheckForStableAssetsInNonIsolatedFeeds();
+
+                if (Log.HasLoggedErrors)
+                {
+                    return false;
+                }
+
+                using var clientThrottle = new SemaphoreSlim(MaxClients, MaxClients);
+
+                await Task.WhenAll(new Task[]
+                {
+                    HandlePackagePublishingAsync(buildAssets, clientThrottle),
+                    HandleBlobPublishingAsync(buildAssets, clientThrottle),
+                    HandleSymbolPublishingAsync(
+                        buildInformation,
+                        buildAssets,
+                        PdbArtifactsBasePath,
+                        SymbolPublishingExclusionsFile,
+                        PublishSpecialClrFiles,
+                        clientThrottle)
+                });
+
+                await PersistPendingAssetLocationAsync(client);
+            }
+            catch (Exception e)
+            {
+                Log.LogErrorFromException(e, true);
+            }
+
+            if (!Log.HasLoggedErrors)
+            {
+                Log.LogMessage(MessageImportance.High, "Publishing finished with success.");
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+
+        public string GetFeed(string feed, string feedOverride)
+        {
+            return (AllowFeedOverrides && !string.IsNullOrEmpty(feedOverride)) ? feedOverride : feed;
+        }
+
+        public PublishArtifactsInManifestV4(AssetPublisherFactory assetPublisherFactory = null) : base(assetPublisherFactory)
+        {
+        }
+    }
+}
+#else
+public class PublishArtifactsInManifestV4 : Microsoft.Build.Utilities.Task
+{
+    public override bool Execute() => throw new NotSupportedException("PublishArtifactsInManifestV4 depends on ProductConstructionService.Client, which has discontinued support for desktop frameworks.");
+}
+#endif

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigV4.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigV4.cs
@@ -1,0 +1,285 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.DotNet.Build.Tasks.Feed.Model;
+
+namespace Microsoft.DotNet.Build.Tasks.Feed
+{
+    public class SetupTargetFeedConfigV4 : SetupTargetFeedConfigBase
+    {
+        private readonly TargetChannelConfig _targetChannelConfig;
+
+        private IBuildEngine BuildEngine { get; }
+
+        private string StablePackagesFeed { get; set; }
+
+        private string StableSymbolsFeed { get; set; }
+
+        private SymbolPublishVisibility SymbolServerVisibility { get; }
+
+        private bool Flatten { get; }
+
+        public TaskLoggingHelper Log { get; }
+
+        public string AzureDevOpsOrg => "dnceng";
+
+        public SetupTargetFeedConfigV4(
+            TargetChannelConfig targetChannelConfig,
+            bool isInternalBuild,
+            bool isStableBuild,
+            string repositoryName,
+            string commitSha,
+            bool publishInstallersAndChecksums,
+            ITaskItem[] feedKeys,
+            ITaskItem[] feedSasUris,
+            ITaskItem[] feedOverrides,
+            ImmutableList<string> latestLinkShortUrlPrefixes,
+            IBuildEngine buildEngine,
+            SymbolPublishVisibility symbolPublishVisibility,
+            string stablePackagesFeed = null,
+            string stableSymbolsFeed = null,
+            ImmutableList<string> filesToExclude = null,
+            bool flatten = true,
+            TaskLoggingHelper log = null)
+            : base(isInternalBuild, isStableBuild, repositoryName, commitSha, publishInstallersAndChecksums, null, null, null, null, null, null, null, latestLinkShortUrlPrefixes, null)
+        {
+            _targetChannelConfig = targetChannelConfig;
+            BuildEngine = buildEngine;
+            StableSymbolsFeed = stableSymbolsFeed;
+            StablePackagesFeed = stablePackagesFeed;
+            SymbolServerVisibility = symbolPublishVisibility;
+            Flatten = flatten;
+            FeedKeys = feedKeys.ToImmutableDictionary(i => i.ItemSpec, i => i.GetMetadata("Key"));
+            FeedSasUris = feedSasUris.ToImmutableDictionary(i => i.ItemSpec, i => ConvertFromBase64(i.GetMetadata("Base64Uri")));
+            FeedOverrides = feedOverrides.ToImmutableDictionary(i => i.ItemSpec, i => i.GetMetadata("Replacement"));
+            AzureDevOpsFeedsKey = FeedKeys.TryGetValue("https://pkgs.dev.azure.com/dnceng", out string key) ? key : null;
+            Log = log;
+        }
+
+        private static string ConvertFromBase64(string value)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+            return Encoding.UTF8.GetString(Convert.FromBase64String(value));
+        }
+
+        public ImmutableDictionary<string, string> FeedOverrides { get; set; }
+
+        public ImmutableDictionary<string, string> FeedSasUris { get; set; }
+
+        public ImmutableDictionary<string, string> FeedKeys { get; set; }
+
+        public override List<TargetFeedConfig> Setup()
+        {
+            return Feeds().Distinct().ToList();
+        }
+
+        private IEnumerable<TargetFeedConfig> Feeds()
+        {
+            // If the build is stable, we need to create two new feeds (if not provided)
+            // that can contain stable packages. These packages cannot be pushed to the normal
+            // feeds specified in the feed config because it would mean pushing the same package more than once
+            // to the same feed on successive builds, which is not allowed.
+
+            if (IsStableBuild)
+            {
+                CreateStablePackagesFeedIfNeeded();
+                CreateStableSymbolsFeedIfNeeded();
+
+                yield return new TargetFeedConfig(
+                    TargetFeedContentType.Package,
+                    StablePackagesFeed,
+                    FeedType.AzDoNugetFeed,
+                    AzureDevOpsFeedsKey,
+                    LatestLinkShortUrlPrefixes,
+                    _targetChannelConfig.AkaMSCreateLinkPatterns,
+                    _targetChannelConfig.AkaMSDoNotCreateLinkPatterns,
+                    assetSelection: AssetSelection.ShippingOnly,
+                    symbolPublishVisibility: SymbolServerVisibility,
+                    isolated: true,
+                    @internal: IsInternalBuild,
+                    flatten: Flatten);
+
+                yield return new TargetFeedConfig(
+                    TargetFeedContentType.Symbols,
+                    StableSymbolsFeed,
+                    FeedType.AzDoNugetFeed,
+                    AzureDevOpsFeedsKey,
+                    LatestLinkShortUrlPrefixes,
+                    _targetChannelConfig.AkaMSCreateLinkPatterns,
+                    _targetChannelConfig.AkaMSDoNotCreateLinkPatterns,
+                    symbolPublishVisibility: SymbolServerVisibility,
+                    isolated: true,
+                    @internal: IsInternalBuild,
+                    flatten: Flatten);
+            }
+
+            foreach (var spec in _targetChannelConfig.TargetFeeds)
+            {
+                foreach (var type in spec.ContentTypes)
+                {
+                    if (!PublishInstallersAndChecksums)
+                    {
+                        if (PublishingConstants.InstallersAndChecksums.Contains(type))
+                        {
+                            continue;
+                        }
+                    }
+
+                    // If dealing with a stable build, the package feed targeted for shipping packages and symbols
+                    // should be skipped, as it is added above.
+                    if (IsStableBuild && ((type is TargetFeedContentType.Package && spec.Assets == AssetSelection.ShippingOnly) || type is TargetFeedContentType.Symbols))
+                    {
+                        continue;
+                    }
+
+                    var oldFeed = spec.FeedUrl;
+                    var feed = GetFeedOverride(oldFeed);
+                    if (type is TargetFeedContentType.Package &&
+                        spec.Assets == AssetSelection.NonShippingOnly &&
+                        FeedOverrides.TryGetValue("transport-packages", out string newFeed))
+                    {
+                        feed = newFeed;
+                    }
+                    else if (type is TargetFeedContentType.Package &&
+                        spec.Assets == AssetSelection.ShippingOnly &&
+                        FeedOverrides.TryGetValue("shipping-packages", out newFeed))
+                    {
+                        feed = newFeed;
+                    }
+                    var key = GetFeedKey(feed);
+                    var sasUri = GetFeedSasUri(feed);
+
+                    var feedType = feed.StartsWith("https://pkgs.dev.azure.com")
+                        ? FeedType.AzDoNugetFeed : FeedType.AzureStorageContainer;
+
+                    // If no SAS is specified, then the default azure credential will be used.
+                    if (feedType == FeedType.AzDoNugetFeed && string.IsNullOrEmpty(key))
+                    {
+                        Log?.LogError($"No key found for {feed}, unable to publish to it.");
+                        continue;
+                    }
+
+                    yield return new TargetFeedConfig(
+                        type,
+                        feed,
+                        feedType,
+                        sasUri ?? key,
+                        LatestLinkShortUrlPrefixes,
+                        _targetChannelConfig.AkaMSCreateLinkPatterns,
+                        _targetChannelConfig.AkaMSDoNotCreateLinkPatterns,
+                        spec.Assets,
+                        false,
+                        IsInternalBuild,
+                        false,
+                        SymbolServerVisibility,
+                        flatten: Flatten
+                    );
+                }
+            }
+        }
+
+        /// <summary>
+        /// Create the stable symbol packages feed if one is not already explicitly provided
+        /// </summary>
+        /// <exception cref="Exception">Throws if the feed cannot be created</exception>
+        private void CreateStableSymbolsFeedIfNeeded()
+        {
+            if (string.IsNullOrEmpty(StableSymbolsFeed))
+            {
+                var symbolsFeedTask = new CreateAzureDevOpsFeed()
+                {
+                    BuildEngine = BuildEngine,
+                    AzureDevOpsOrg = AzureDevOpsOrg,
+                    AzureDevOpsProject = IsInternalBuild ? "internal" : "public",
+                    AzureDevOpsPersonalAccessToken = AzureDevOpsFeedsKey,
+                    RepositoryName = RepositoryName,
+                    CommitSha = CommitSha,
+                    ContentIdentifier = "sym"
+                };
+
+                if (!symbolsFeedTask.Execute())
+                {
+                    throw new Exception($"Problems creating an AzureDevOps (symbols) feed for repository '{RepositoryName}' and commit '{CommitSha}'.");
+                }
+
+                StableSymbolsFeed = symbolsFeedTask.TargetFeedURL;
+            }
+        }
+
+        /// <summary>
+        /// Create the stable packages feed if one is not already explicitly provided
+        /// </summary>
+        /// <exception cref="Exception">Throws if the feed cannot be created</exception>
+        private void CreateStablePackagesFeedIfNeeded()
+        {
+            if (string.IsNullOrEmpty(StablePackagesFeed))
+            {
+                var packagesFeedTask = new CreateAzureDevOpsFeed()
+                {
+                    BuildEngine = BuildEngine,
+                    AzureDevOpsOrg = AzureDevOpsOrg,
+                    AzureDevOpsProject = IsInternalBuild ? "internal" : "public",
+                    AzureDevOpsPersonalAccessToken = AzureDevOpsFeedsKey,
+                    RepositoryName = RepositoryName,
+                    CommitSha = CommitSha
+                };
+
+                if (!packagesFeedTask.Execute())
+                {
+                    throw new Exception($"Problems creating an AzureDevOps feed for repository '{RepositoryName}' and commit '{CommitSha}'.");
+                }
+
+                StablePackagesFeed = packagesFeedTask.TargetFeedURL;
+            }
+        }
+
+        private string GetFeedOverride(string feed)
+        {
+            foreach (var prefix in FeedOverrides.Keys.OrderByDescending(f => f.Length))
+            {
+                if (feed.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    return FeedOverrides[prefix];
+                }
+            }
+
+            return feed;
+        }
+
+        private string GetFeedSasUri(string feed)
+        {
+            foreach (var prefix in FeedSasUris.Keys.OrderByDescending(f => f.Length))
+            {
+                if (feed.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    return FeedSasUris[prefix];
+                }
+            }
+
+            return null;
+        }
+
+        private string GetFeedKey(string feed)
+        {
+            foreach (var prefix in FeedKeys.Keys.OrderByDescending(f => f.Length))
+            {
+                if (feed.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    return FeedKeys[prefix];
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/VersionTools/Microsoft.DotNet.VersionTools/BuildManifest/Model/BuildIdentity.cs
+++ b/src/VersionTools/Microsoft.DotNet.VersionTools/BuildManifest/Model/BuildIdentity.cs
@@ -12,7 +12,8 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
     {
         UnsupportedV1 = 1,
         UnsupportedV2 = 2,
-        Latest = 3
+        Latest = 3,
+        Dev = 4
     }
 
     public class BuildIdentity


### PR DESCRIPTION
This sets the stage for publishing tweaks that will not be backwards compatible with v3. I decided this is a good course of action after attempting to figure out the logic of how we would decide which assets go to stable feeds and which not. Right now, we will place all shipping assets on the isolated feed if the build is stable. In future builds, especially VMR, this should be restricted to just assets that are actually stable. Implementing this logic in v3 would have required detecting whether the current manifest is v3+new properties for isolated asset info, or just stock v3. Instead, it would be better to introduce a new publishing version where a bunch of cruft can be cleaned up.

Some parts of v3 and v4 may eventually be refactored into common code, including maybe some of SetupTargetFeedConfigV3/4. For now, I just made copies of the code rather than trying a refactor out of the gate.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
