### PR TITLE
Do not copy `NativeVersion.rc` if unchanged.

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
@@ -107,6 +107,7 @@
     -->
     <Copy SourceFiles="$(MSBuildThisFileDirectory)NativeVersion.rc"
           DestinationFolder="$([System.IO.Path]::GetDirectoryName($(NativeVersionFile)))"
+          SkipUnchangedFiles="true"
           Condition="'$(OS)' == 'Windows_NT'" />
 
     <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">


### PR DESCRIPTION
I noticed that when I build the runtime with nothing changed since the last time I did it, `NativeVersion.rc` always gets compiled, and the potentially expensive linking step always runs.

```
  [1/7] Building RC object mono\mini\CMakeFiles\monosgen-objects.dir\C_\Users\teo\code\dotnet-runtime\artifacts\obj\NativeVersion.rc.res
  [2/7] Building RC object mono\mini\CMakeFiles\monosgen-objects_shared.dir\C_\Users\teo\code\dotnet-runtime\artifacts\obj\NativeVersion.rc.res
  [3/7] Building RC object mono\mini\CMakeFiles\mono-sgen.dir\C_\Users\teo\code\dotnet-runtime\artifacts\obj\NativeVersion.rc.res
  [4/7] Linking C static library mono\mini\monosgen-2.0.lib
  [5/7] Linking C shared library mono\mini\coreclr.dll
  [6/7] Linking C executable mono\mini\mono-sgen.exe
  [6/7] Install the project...
```

This PR might fix this.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
