### PR TITLE
Fix arm64 deb suffix

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.build.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.build.targets
@@ -73,7 +73,7 @@
     
     <PropertyGroup Condition="'$(GenerateDeb)' == 'true' or '$(GenerateRpm)' == 'true'">
       <_InstallerArchSuffix>$(InstallerTargetArchitecture)</_InstallerArchSuffix>
-      <_InstallerArchSuffix Condition="'$(BuildRpmPackage)' == 'true' and '$(InstallerTargetArchitecture)' == 'arm64'">aarch64</_InstallerArchSuffix>
+      <_InstallerArchSuffix Condition="'$(GenerateRpm)' == 'true' and '$(InstallerTargetArchitecture)' == 'arm64'">aarch64</_InstallerArchSuffix>
       <InstallerBuildPart>$(Version)-$(_InstallerArchSuffix)</InstallerBuildPart>
       <InstallerBuildPart Condition="'$(PackageTargetOS)' != ''">$(Version)-$(PackageTargetOS)-$(_InstallerArchSuffix)</InstallerBuildPart>
     </PropertyGroup>


### PR DESCRIPTION
This is a prerequisite for arm64 debian packages. It fixes the issue with repos that build both RPMs and DEPs in a single build instance.

Two more changes are needed in aspnetcore and sdk repo to get the packages produced in CI.
