### PR TITLE
Update PackageVersion to 10.0 in generate-sbom.yml

### DIFF
--- a/eng/common/core-templates/steps/generate-sbom.yml
+++ b/eng/common/core-templates/steps/generate-sbom.yml
@@ -5,7 +5,7 @@
 # IgnoreDirectories - Directories to ignore for SBOM generation. This will be passed through to the CG component detector.
 
 parameters:
-  PackageVersion: 9.0.0
+  PackageVersion: 10.0.0
   BuildDropPath: '$(Build.SourcesDirectory)/artifacts'
   PackageName: '.NET'
   ManifestDirPath: $(Build.ArtifactStagingDirectory)/sbom


### PR DESCRIPTION
Noticed that we didn't bump this yet.

@riarenas @chcosta this was discussed in https://github.com/dotnet/arcade/issues/14531 but looks like it got overlooked. Or is the plan still to replace our SBOM with the 1ES version?