### PR TITLE
Add option in Arcade to preserve RepoOrigin and insert it into the publish-to-disk path

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -86,7 +86,7 @@
     <AutoGenerateSymbolPackages Condition="'$(AutoGenerateSymbolPackages)' == '' and 
       ('$(DotNetBuildSourceOnly)' != 'true' or ('$(DotNetBuildInnerRepo)' == 'true' and '$(DotNetBuildOrchestrator)' != 'true'))">true</AutoGenerateSymbolPackages>
 
-    <PackagesLocalStorageIncludesRepoOrigin Condition="'$(PackagesLocalStorageIncludesRepoOrigin)' == ''">false</PackagesLocalStorageIncludesRepoOrigin>
+    <PreserveRepoOrigin Condition="'$(PreserveRepoOrigin)' == ''">false</PreserveRepoOrigin>
 
     <!-- This tracks the dependent targets of PublishToAzureDevOpsArtifacts and PublishSymbols. We can't rename this
          property as it is used by other repositories already. -->
@@ -338,7 +338,7 @@
       IsReleaseOnlyPackageVersion="$(IsReleaseOnlyPackageVersion)"
       PushToLocalStorage="$(PushToLocalStorage)"
       AssetsLocalStorageDir="$(SourceBuiltAssetsDir)"
-      PackagesLocalStorageIncludesRepoOrigin="$(PackagesLocalStorageIncludesRepoOrigin)"
+      PreserveRepoOrigin="$(PreserveRepoOrigin)"
       ShippingPackagesLocalStorageDir="$(SourceBuiltShippingPackagesDir)"
       NonShippingPackagesLocalStorageDir="$(SourceBuiltNonShippingPackagesDir)"
       AssetManifestsLocalStorageDir="$(SourceBuiltAssetManifestsDir)"

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -86,6 +86,8 @@
     <AutoGenerateSymbolPackages Condition="'$(AutoGenerateSymbolPackages)' == '' and 
       ('$(DotNetBuildSourceOnly)' != 'true' or ('$(DotNetBuildInnerRepo)' == 'true' and '$(DotNetBuildOrchestrator)' != 'true'))">true</AutoGenerateSymbolPackages>
 
+    <PackagesLocalStorageIncludesRepoOrigin Condition="'$(PackagesLocalStorageIncludesRepoOrigin)' == ''">false</PackagesLocalStorageIncludesRepoOrigin>
+
     <!-- This tracks the dependent targets of PublishToAzureDevOpsArtifacts and PublishSymbols. We can't rename this
          property as it is used by other repositories already. -->
     <PublishDependsOnTargets>BeforePublish;AutoGenerateSymbolPackages</PublishDependsOnTargets>
@@ -336,6 +338,7 @@
       IsReleaseOnlyPackageVersion="$(IsReleaseOnlyPackageVersion)"
       PushToLocalStorage="$(PushToLocalStorage)"
       AssetsLocalStorageDir="$(SourceBuiltAssetsDir)"
+      PackagesLocalStorageIncludesRepoOrigin="$(PackagesLocalStorageIncludesRepoOrigin)"
       ShippingPackagesLocalStorageDir="$(SourceBuiltShippingPackagesDir)"
       NonShippingPackagesLocalStorageDir="$(SourceBuiltNonShippingPackagesDir)"
       AssetManifestsLocalStorageDir="$(SourceBuiltAssetManifestsDir)"

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/BuildModelFactoryTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/BuildModelFactoryTests.cs
@@ -80,7 +80,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                                                repoBranch: _testBuildBranch,
                                                repoCommit: _testBuildCommit,
                                                repoOrigin: _testRepoOrigin,
-                                               preserveRepoOrigin: false,
                                                isStableBuild: false,
                                                publishingVersion: PublishingInfraVersion.Latest,
                                                isReleaseOnlyPackageVersion: true);
@@ -158,7 +157,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                                                        repoBranch: _testBuildBranch,
                                                        repoCommit: _testBuildCommit,
                                                        repoOrigin: _testRepoOrigin,
-                                                       preserveRepoOrigin: false,
                                                        isStableBuild: false,
                                                        publishingVersion: PublishingInfraVersion.Latest,
                                                        isReleaseOnlyPackageVersion: true);
@@ -249,7 +247,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                                                        repoBranch: _testBuildBranch,
                                                        repoCommit: _testBuildCommit,
                                                        repoOrigin: _testRepoOrigin,
-                                                       preserveRepoOrigin: false,
                                                        isStableBuild: false,
                                                        publishingVersion: PublishingInfraVersion.Latest,
                                                        isReleaseOnlyPackageVersion: true);
@@ -303,7 +300,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                                            repoBranch: _testBuildBranch,
                                            repoCommit: _testBuildCommit,
                                            repoOrigin: _testRepoOrigin,
-                                           preserveRepoOrigin: false,
                                            isStableBuild: false,
                                            publishingVersion: PublishingInfraVersion.Latest,
                                            isReleaseOnlyPackageVersion: true);
@@ -340,7 +336,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                                            repoBranch: _testBuildBranch,
                                            repoCommit: _testBuildCommit,
                                            repoOrigin: _testRepoOrigin,
-                                           preserveRepoOrigin: false,
                                            isStableBuild: false,
                                            publishingVersion: PublishingInfraVersion.Latest,
                                            isReleaseOnlyPackageVersion: true);
@@ -374,7 +369,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                                            repoBranch: _testBuildBranch,
                                            repoCommit: _testBuildCommit,
                                            repoOrigin: _testRepoOrigin,
-                                           preserveRepoOrigin: false,
                                            isStableBuild: false,
                                            publishingVersion: PublishingInfraVersion.Latest,
                                            isReleaseOnlyPackageVersion: true);
@@ -417,7 +411,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                                                        repoBranch: _testBuildBranch,
                                                        repoCommit: _testBuildCommit,
                                                        repoOrigin: _testRepoOrigin,
-                                                       preserveRepoOrigin: false,
                                                        isStableBuild: false,
                                                        publishingVersion: PublishingInfraVersion.Latest,
                                                        isReleaseOnlyPackageVersion: true);
@@ -501,7 +494,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                                                                     repoBranch: _testBuildBranch,
                                                                     repoCommit: _testBuildCommit,
                                                                     repoOrigin: _testRepoOrigin,
-                                                                    preserveRepoOrigin: false,
                                                                     isStableBuild: true,
                                                                     publishingVersion: PublishingInfraVersion.Latest,
                                                                     isReleaseOnlyPackageVersion: false);
@@ -643,7 +635,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                                                                 repoBranch: _testBuildBranch,
                                                                 repoCommit: _testBuildCommit,
                                                                 repoOrigin: _testRepoOrigin,
-                                                                preserveRepoOrigin: true,
                                                                 isStableBuild: true,
                                                                 publishingVersion: PublishingInfraVersion.Latest,
                                                                 isReleaseOnlyPackageVersion: false);
@@ -720,7 +711,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                 repoBranch: _testBuildBranch,
                 repoCommit: _testBuildCommit,
                 repoOrigin: _testRepoOrigin,
-                preserveRepoOrigin: false,
                 isStableBuild: false,
                 publishingVersion: PublishingInfraVersion.Latest,
                 isReleaseOnlyPackageVersion: true);

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/BuildModelFactoryTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/BuildModelFactoryTests.cs
@@ -80,6 +80,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                                                repoBranch: _testBuildBranch,
                                                repoCommit: _testBuildCommit,
                                                repoOrigin: _testRepoOrigin,
+                                               preserveRepoOrigin: false,
                                                isStableBuild: false,
                                                publishingVersion: PublishingInfraVersion.Latest,
                                                isReleaseOnlyPackageVersion: true);
@@ -157,6 +158,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                                                        repoBranch: _testBuildBranch,
                                                        repoCommit: _testBuildCommit,
                                                        repoOrigin: _testRepoOrigin,
+                                                       preserveRepoOrigin: false,
                                                        isStableBuild: false,
                                                        publishingVersion: PublishingInfraVersion.Latest,
                                                        isReleaseOnlyPackageVersion: true);
@@ -247,6 +249,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                                                        repoBranch: _testBuildBranch,
                                                        repoCommit: _testBuildCommit,
                                                        repoOrigin: _testRepoOrigin,
+                                                       preserveRepoOrigin: false,
                                                        isStableBuild: false,
                                                        publishingVersion: PublishingInfraVersion.Latest,
                                                        isReleaseOnlyPackageVersion: true);
@@ -300,6 +303,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                                            repoBranch: _testBuildBranch,
                                            repoCommit: _testBuildCommit,
                                            repoOrigin: _testRepoOrigin,
+                                           preserveRepoOrigin: false,
                                            isStableBuild: false,
                                            publishingVersion: PublishingInfraVersion.Latest,
                                            isReleaseOnlyPackageVersion: true);
@@ -336,6 +340,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                                            repoBranch: _testBuildBranch,
                                            repoCommit: _testBuildCommit,
                                            repoOrigin: _testRepoOrigin,
+                                           preserveRepoOrigin: false,
                                            isStableBuild: false,
                                            publishingVersion: PublishingInfraVersion.Latest,
                                            isReleaseOnlyPackageVersion: true);
@@ -369,6 +374,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                                            repoBranch: _testBuildBranch,
                                            repoCommit: _testBuildCommit,
                                            repoOrigin: _testRepoOrigin,
+                                           preserveRepoOrigin: false,
                                            isStableBuild: false,
                                            publishingVersion: PublishingInfraVersion.Latest,
                                            isReleaseOnlyPackageVersion: true);
@@ -411,6 +417,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                                                        repoBranch: _testBuildBranch,
                                                        repoCommit: _testBuildCommit,
                                                        repoOrigin: _testRepoOrigin,
+                                                       preserveRepoOrigin: false,
                                                        isStableBuild: false,
                                                        publishingVersion: PublishingInfraVersion.Latest,
                                                        isReleaseOnlyPackageVersion: true);
@@ -494,6 +501,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                                                                     repoBranch: _testBuildBranch,
                                                                     repoCommit: _testBuildCommit,
                                                                     repoOrigin: _testRepoOrigin,
+                                                                    preserveRepoOrigin: false,
                                                                     isStableBuild: true,
                                                                     publishingVersion: PublishingInfraVersion.Latest,
                                                                     isReleaseOnlyPackageVersion: false);
@@ -579,6 +587,113 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
             }
         }
 
+        [Fact]
+        public void PreserveRepoOrigin()
+        {
+            var localPackagePath = TestInputs.GetFullPath(Path.Combine("Nupkgs", "test-package-a.1.0.0.nupkg"));
+
+            const string bopSymbolsNupkg = "foo/bar/baz/bop.symbols.nupkg";
+            string bobSymbolsExpectedId = $"assets/symbols/{Path.GetFileName(bopSymbolsNupkg)}";
+            const string zipArtifact = "foo/bar/baz/bing.zip";
+            // New PDB artifact
+            const string pdbArtifact = "foo/bar/baz/bing.pdb";
+
+            var artifacts = new ITaskItem[]
+            {
+                new TaskItem(bopSymbolsNupkg, new Dictionary<string, string>
+                {
+                    { "ManifestArtifactData", "NonShipping=true;Category=SMORKELER" },
+                    { "RelativeBlobPath", bobSymbolsExpectedId},
+                    { "RepoOrigin", "runtime" },
+                    { "ThisIsntArtifactMetadata", "YouGoofed!" },
+                    { "Kind", "Blob" }
+                }),
+                // Include a package and a fake zip too
+                // Note that the relative blob path is a "first class" attribute,
+                // not parsed from ManifestArtifactData
+                new TaskItem(zipArtifact, new Dictionary<string, string>
+                {
+                    { "RelativeBlobPath", zipArtifact },
+                    { "ManifestArtifactData", "ARandomBitOfMAD=" },
+                    { "Kind", "Blob" }
+                }),
+                new TaskItem(localPackagePath, new Dictionary<string, string>()
+                {
+                    // This isn't recognized or used for a nupkg
+                    { "RelativeBlobPath", zipArtifact },
+                    { "RepoOrigin", "runtime" },
+                    { "ManifestArtifactData", "ShouldWePushDaNorpKeg=YES" },
+                    { "Kind", "Package" }
+                }),
+                // New PDB artifact with RelativePdbPath
+                new TaskItem(pdbArtifact, new Dictionary<string, string>
+                {
+                    { "RelativePdbPath", pdbArtifact },
+                    { "RepoOrigin", "runtime" },
+                    { "ManifestArtifactData", "NonShipping=false;Category=PDB" },
+                    { "Kind", "PDB" }
+                })
+            };
+
+            var modelFromItems = _buildModelFactory.CreateModel(artifacts: artifacts,
+                                                                artifactVisibilitiesToInclude: ArtifactVisibility.All,
+                                                                buildId: _testAzdoBuildId,
+                                                                manifestBuildData: _defaultManifestBuildData,
+                                                                repoUri: _testAzdoRepoUri,
+                                                                repoBranch: _testBuildBranch,
+                                                                repoCommit: _testBuildCommit,
+                                                                repoOrigin: _testRepoOrigin,
+                                                                preserveRepoOrigin: true,
+                                                                isStableBuild: true,
+                                                                publishingVersion: PublishingInfraVersion.Latest,
+                                                                isReleaseOnlyPackageVersion: false);
+
+            modelFromItems.Should().NotBeNull();
+            _taskLoggingHelper.HasLoggedErrors.Should().BeFalse();
+
+            modelFromItems.Artifacts.Blobs.Should().SatisfyRespectively(
+                blob =>
+                {
+                    blob.Id.Should().Be(bobSymbolsExpectedId);
+                    blob.NonShipping.Should().BeTrue();
+                    blob.Attributes.Should().Contain("Id", bobSymbolsExpectedId);
+                    blob.Attributes.Should().Contain("Category", "SMORKELER");
+                    blob.Attributes.Should().Contain("NonShipping", "true");
+                    blob.Attributes.Should().Contain("RepoOrigin", "runtime");
+                },
+                blob =>
+                {
+                    blob.Id.Should().Be(zipArtifact);
+                    blob.NonShipping.Should().BeFalse();
+                    blob.Attributes.Should().Contain("Id", zipArtifact);
+                    blob.Attributes.Should().Contain("ARandomBitOfMAD", string.Empty);
+                    blob.Attributes.Should().Contain("RepoOrigin", _testRepoOrigin);
+                });
+
+            modelFromItems.Artifacts.Packages.Should().SatisfyRespectively(
+                package =>
+                {
+                    package.Id.Should().Be("test-package-a");
+                    package.Version.Should().Be("1.0.0");
+                    package.NonShipping.Should().BeFalse();
+                    package.Attributes.Should().Contain("Id", "test-package-a");
+                    package.Attributes.Should().Contain("Version", "1.0.0");
+                    package.Attributes.Should().Contain("ShouldWePushDaNorpKeg", "YES");
+                    package.Attributes.Should().Contain("RepoOrigin", "runtime");
+                });
+
+            modelFromItems.Artifacts.Pdbs.Should().SatisfyRespectively(
+                pdb =>
+                {
+                    pdb.Id.Should().Be(pdbArtifact);
+                    pdb.NonShipping.Should().BeFalse();
+                    pdb.Attributes.Should().Contain("NonShipping", "false");
+                    pdb.Attributes.Should().Contain("Category", "PDB");
+                    pdb.Attributes.Should().Contain("Id", pdbArtifact);
+                    pdb.Attributes.Should().Contain("RepoOrigin", "runtime");
+                });
+        }
+
         /// <summary>
         /// Validates that errors are logged and null is returned when Kind metadata is missing from an artifact.
         /// </summary>
@@ -605,6 +720,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                 repoBranch: _testBuildBranch,
                 repoCommit: _testBuildCommit,
                 repoOrigin: _testRepoOrigin,
+                preserveRepoOrigin: false,
                 isStableBuild: false,
                 publishingVersion: PublishingInfraVersion.Latest,
                 isReleaseOnlyPackageVersion: true);

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildModelFactory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildModelFactory.cs
@@ -25,6 +25,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             string repoBranch,
             string repoCommit,
             string repoOrigin,
+            bool preserveRepoOrigin,
             bool isStableBuild,
             PublishingInfraVersion publishingVersion,
             bool isReleaseOnlyPackageVersion);
@@ -72,6 +73,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             string repoBranch,
             string repoCommit,
             string repoOrigin,
+            bool preserveRepoOrigin,
             bool isStableBuild,
             PublishingInfraVersion publishingVersion,
             bool isReleaseOnlyPackageVersion)
@@ -107,17 +109,17 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
             var blobArtifacts = itemsToPushNoExcludes
                 .Where(i => i.GetMetadata(ArtifactKindMetadata).Equals(nameof(ArtifactKind.Blob), StringComparison.OrdinalIgnoreCase))
-                .Select(i => _blobArtifactModelFactory.CreateBlobArtifactModel(i, repoOrigin))
+                .Select(i => _blobArtifactModelFactory.CreateBlobArtifactModel(i, preserveRepoOrigin && i.GetMetadata("RepoOrigin") is string origin and not "" ? origin : repoOrigin))
                 .Where(b => artifactVisibilitiesToInclude.HasFlag(b.Visibility));
 
             var packageArtifacts = itemsToPushNoExcludes
                 .Where(i => i.GetMetadata(ArtifactKindMetadata).Equals(nameof(ArtifactKind.Package), StringComparison.OrdinalIgnoreCase))
-                .Select(i => _packageArtifactModelFactory.CreatePackageArtifactModel(i, repoOrigin))
+                .Select(i => _packageArtifactModelFactory.CreatePackageArtifactModel(i, preserveRepoOrigin && i.GetMetadata("RepoOrigin") is string origin and not "" ? origin : repoOrigin))
                 .Where(b => artifactVisibilitiesToInclude.HasFlag(b.Visibility));
 
             var pdbArtifacts = itemsToPushNoExcludes
                 .Where(i => i.GetMetadata(ArtifactKindMetadata).Equals(nameof(ArtifactKind.Pdb), StringComparison.OrdinalIgnoreCase))
-                .Select(i => _pdbArtifactModelFactory.CreatePdbArtifactModel(i, repoOrigin))
+                .Select(i => _pdbArtifactModelFactory.CreatePdbArtifactModel(i, preserveRepoOrigin && i.GetMetadata("RepoOrigin") is string origin and not "" ? origin : repoOrigin))
                 .Where(b => artifactVisibilitiesToInclude.HasFlag(b.Visibility));
 
             return CreateModel(

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildModelFactory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildModelFactory.cs
@@ -25,7 +25,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             string repoBranch,
             string repoCommit,
             string repoOrigin,
-            bool preserveRepoOrigin,
             bool isStableBuild,
             PublishingInfraVersion publishingVersion,
             bool isReleaseOnlyPackageVersion);
@@ -73,7 +72,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             string repoBranch,
             string repoCommit,
             string repoOrigin,
-            bool preserveRepoOrigin,
             bool isStableBuild,
             PublishingInfraVersion publishingVersion,
             bool isReleaseOnlyPackageVersion)
@@ -109,17 +107,17 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
             var blobArtifacts = itemsToPushNoExcludes
                 .Where(i => i.GetMetadata(ArtifactKindMetadata).Equals(nameof(ArtifactKind.Blob), StringComparison.OrdinalIgnoreCase))
-                .Select(i => _blobArtifactModelFactory.CreateBlobArtifactModel(i, preserveRepoOrigin && i.GetMetadata("RepoOrigin") is string origin and not "" ? origin : repoOrigin))
+                .Select(i => _blobArtifactModelFactory.CreateBlobArtifactModel(i, i.GetMetadata("RepoOrigin") is string origin and not "" ? origin : repoOrigin))
                 .Where(b => artifactVisibilitiesToInclude.HasFlag(b.Visibility));
 
             var packageArtifacts = itemsToPushNoExcludes
                 .Where(i => i.GetMetadata(ArtifactKindMetadata).Equals(nameof(ArtifactKind.Package), StringComparison.OrdinalIgnoreCase))
-                .Select(i => _packageArtifactModelFactory.CreatePackageArtifactModel(i, preserveRepoOrigin && i.GetMetadata("RepoOrigin") is string origin and not "" ? origin : repoOrigin))
+                .Select(i => _packageArtifactModelFactory.CreatePackageArtifactModel(i, i.GetMetadata("RepoOrigin") is string origin and not "" ? origin : repoOrigin))
                 .Where(b => artifactVisibilitiesToInclude.HasFlag(b.Visibility));
 
             var pdbArtifacts = itemsToPushNoExcludes
                 .Where(i => i.GetMetadata(ArtifactKindMetadata).Equals(nameof(ArtifactKind.Pdb), StringComparison.OrdinalIgnoreCase))
-                .Select(i => _pdbArtifactModelFactory.CreatePdbArtifactModel(i, preserveRepoOrigin && i.GetMetadata("RepoOrigin") is string origin and not "" ? origin : repoOrigin))
+                .Select(i => _pdbArtifactModelFactory.CreatePdbArtifactModel(i, i.GetMetadata("RepoOrigin") is string origin and not "" ? origin : repoOrigin))
                 .Where(b => artifactVisibilitiesToInclude.HasFlag(b.Visibility));
 
             return CreateModel(

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/GenerateBuildManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/GenerateBuildManifest.cs
@@ -88,11 +88,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public string RepoOrigin { get; set; }
 
         /// <summary>
-        /// Indicates whether the RepoOrigin for provided assets should be preserved in the manifest.
-        /// </summary>
-        public bool PreserveRepoOrigin { get; set; }
-
-        /// <summary>
         /// Is this manifest for a stable build?
         /// </summary>
         public bool IsStableBuild { get; set; }
@@ -144,7 +139,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     RepoBranch,
                     RepoCommit,
                     RepoOrigin,
-                    PreserveRepoOrigin,
                     IsStableBuild,
                     targetPublishingVersion,
                     IsReleaseOnlyPackageVersion);

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/GenerateBuildManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/GenerateBuildManifest.cs
@@ -88,6 +88,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public string RepoOrigin { get; set; }
 
         /// <summary>
+        /// Indicates whether the RepoOrigin for provided assets should be preserved in the manifest.
+        /// </summary>
+        public bool PreserveRepoOrigin { get; set; }
+
+        /// <summary>
         /// Is this manifest for a stable build?
         /// </summary>
         public bool IsStableBuild { get; set; }
@@ -139,6 +144,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     RepoBranch,
                     RepoCommit,
                     RepoOrigin,
+                    PreserveRepoOrigin,
                     IsStableBuild,
                     targetPublishingVersion,
                     IsReleaseOnlyPackageVersion);

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBuildStorage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBuildStorage.cs
@@ -95,6 +95,14 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public bool PushToLocalStorage { get; set; }
 
+        /// <summary>
+        /// When <see cref="PushToLocalStorage" /> is <c>true</c>, this property indicates whether the
+        /// final path for any packages published to <see cref="ShippingPackagesLocalStorageDir"/>
+        /// or <see cref="NonShippingPackagesLocalStorageDir"/> should have the artifact's RepoOrigin
+        /// appended as a subfolder to the published path.
+        /// </summary>
+        public bool PackagesLocalStorageIncludesRepoOrigin { get; set; }
+
         public ITaskItem[] ArtifactVisibilitiesToPublish { get; set; }
 
         /// <summary>
@@ -263,17 +271,20 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         break;
 
                     case PackageArtifactModel _:
-                        if (!artifactModel.NonShipping)
+                    {
+                        string packageDestinationPath = artifactModel.NonShipping
+                            ? NonShippingPackagesLocalStorageDir
+                            : ShippingPackagesLocalStorageDir;
+
+                        if (PackagesLocalStorageIncludesRepoOrigin)
                         {
-                            Directory.CreateDirectory(ShippingPackagesLocalStorageDir);
-                            CopyFileAsHardLinkIfPossible(path, Path.Combine(ShippingPackagesLocalStorageDir, filename), true);
+                            packageDestinationPath = Path.Combine(packageDestinationPath, artifactModel.RepoOrigin);
                         }
-                        else
-                        {
-                            Directory.CreateDirectory(NonShippingPackagesLocalStorageDir);
-                            CopyFileAsHardLinkIfPossible(path, Path.Combine(NonShippingPackagesLocalStorageDir, filename), true);
-                        }
+
+                        Directory.CreateDirectory(packageDestinationPath);
+                        CopyFileAsHardLinkIfPossible(path, Path.Combine(packageDestinationPath, filename), true);
                         break;
+                    }
 
                     case BlobArtifactModel _:
                         string relativeBlobPath = artifactModel.Id;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBuildStorage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBuildStorage.cs
@@ -96,12 +96,13 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public bool PushToLocalStorage { get; set; }
 
         /// <summary>
-        /// When <see cref="PushToLocalStorage" /> is <c>true</c>, this property indicates whether the
+        /// Preserve provided artifact's RepoOrigin metadata if it already exists.
+        /// When <see cref="PushToLocalStorage" /> is <c>true</c>, this property also indicates whether the
         /// final path for any packages published to <see cref="ShippingPackagesLocalStorageDir"/>
         /// or <see cref="NonShippingPackagesLocalStorageDir"/> should have the artifact's RepoOrigin
         /// appended as a subfolder to the published path.
         /// </summary>
-        public bool PackagesLocalStorageIncludesRepoOrigin { get; set; }
+        public bool PreserveRepoOrigin { get; set; }
 
         public ITaskItem[] ArtifactVisibilitiesToPublish { get; set; }
 
@@ -181,6 +182,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         ManifestBranch,
                         ManifestCommit,
                         ManifestRepoOrigin,
+                        PreserveRepoOrigin,
                         IsStableBuild,
                         targetPublishingVersion,
                         IsReleaseOnlyPackageVersion);
@@ -276,7 +278,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                             ? NonShippingPackagesLocalStorageDir
                             : ShippingPackagesLocalStorageDir;
 
-                        if (PackagesLocalStorageIncludesRepoOrigin)
+                        if (PreserveRepoOrigin)
                         {
                             packageDestinationPath = Path.Combine(packageDestinationPath, artifactModel.RepoOrigin);
                         }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBuildStorage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBuildStorage.cs
@@ -96,9 +96,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public bool PushToLocalStorage { get; set; }
 
         /// <summary>
-        /// Preserve provided artifact's RepoOrigin metadata if it already exists.
-        /// When <see cref="PushToLocalStorage" /> is <c>true</c>, this property also indicates whether the
-        /// final path for any packages published to <see cref="ShippingPackagesLocalStorageDir"/>
+        /// The final path for any packages published to <see cref="ShippingPackagesLocalStorageDir"/>
         /// or <see cref="NonShippingPackagesLocalStorageDir"/> should have the artifact's RepoOrigin
         /// appended as a subfolder to the published path.
         /// </summary>
@@ -182,7 +180,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         ManifestBranch,
                         ManifestCommit,
                         ManifestRepoOrigin,
-                        PreserveRepoOrigin,
                         IsStableBuild,
                         targetPublishingVersion,
                         IsReleaseOnlyPackageVersion);


### PR DESCRIPTION
Allow publishing to publish packages to a repo-specific subfolder when publishing to disk.

This (in combination with changes in the VMR orchestrator) will allow us to publish a given VMR vertical with the built-in Arcade publishing logic instead of the custom task we have today.

Contributes to https://github.com/dotnet/sdk/pull/47076

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
