### PR TITLE
Fix Publish.proj and Sign.props syntax errors

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -104,42 +104,33 @@
     <AssetManifestPass Condition="'$(DotNetBuildPass)' != '' and '$(DotNetBuildPass)' != '1'">-Pass$(DotNetBuildPass)</AssetManifestPass>
   </PropertyGroup>
 
-  <Choose Condition="'$(EnableDefaultArtifacts)' == 'true'">
-    <When Condition="'$(EnableDefaultRidSpecificArtifacts)' == 'true'">
-      <!--
-        Only publish packages that contain this build's Target RID in the name.
-      -->
-      <ItemGroup>
-        <Artifact Include="$(ArtifactsShippingPackagesDir)**/*.$(TargetRid).*.nupkg" Kind="Package" />
-        <Artifact Include="$(ArtifactsNonShippingPackagesDir)**/*.$(TargetRid).*.nupkg" IsShipping="false" Kind="Package" />
-        <!--
-          Integration with Microsoft.DotNet.Build.Tasks.Installers: Publish packages of the following formats as well.
-          These are arch-specific Visual Studio insertion packages. As they're Windows-only, they only include architecture in the name:
-          - VS.Redist.Common.*.$(TargetArchitecture).*.nupkg
-          - VS.Redist.Common.*.$(TargetArchitecture)-*.*.nupkg
-          
-          These packages are always non-shipping, so only look there.
-        -->
-        <Artifact Include="$(ArtifactsNonShippingPackagesDir)**/VS.Redist.Common.*.$(TargetArchitecture).*.nupkg" IsShipping="false" Kind="Package" />
-        <Artifact Include="$(ArtifactsNonShippingPackagesDir)**/VS.Redist.Common.*.$(TargetArchitecture)-*.*.nupkg" IsShipping="false" Kind="Package" />
-      </ItemGroup>
+  <!-- Only publish packages that contain this build's Target RID in the name. -->
+  <ItemGroup Condition="'$(EnableDefaultArtifacts)' == 'true' and '$(EnableDefaultRidSpecificArtifacts)' == 'true'">
+    <Artifact Include="$(ArtifactsShippingPackagesDir)**/*.$(TargetRid).*.nupkg" Kind="Package" />
+    <Artifact Include="$(ArtifactsNonShippingPackagesDir)**/*.$(TargetRid).*.nupkg" IsShipping="false" Kind="Package" />
+    <!--
+      Integration with Microsoft.DotNet.Build.Tasks.Installers: Publish packages of the following formats as well.
+      These are arch-specific Visual Studio insertion packages. As they're Windows-only, they only include architecture in the name:
+      - VS.Redist.Common.*.$(TargetArchitecture).*.nupkg
+      - VS.Redist.Common.*.$(TargetArchitecture)-*.*.nupkg
+      
+      These packages are always non-shipping, so only look there.
+    -->
+    <Artifact Include="$(ArtifactsNonShippingPackagesDir)**/VS.Redist.Common.*.$(TargetArchitecture).*.nupkg" IsShipping="false" Kind="Package" />
+    <Artifact Include="$(ArtifactsNonShippingPackagesDir)**/VS.Redist.Common.*.$(TargetArchitecture)-*.*.nupkg" IsShipping="false" Kind="Package" />
 
-      <!--
-        In the VMR, don't publish packages that didn't match the above conditions externally.
-        Instead, add them with Vertical visibility as they still may be needed to build RID-specific packages in other repos.
-      -->
-      <ItemGroup Condition="'$(DotNetBuildOrchestrator)' == 'true'">
-        <Artifact Include="$(ArtifactsShippingPackagesDir)**/*.nupkg" Exclude="@(Artifact)" Kind="Package" Visibility="Vertical" />
-        <Artifact Include="$(ArtifactsNonShippingPackagesDir)**/*.nupkg" Exclude="@(Artifact)" IsShipping="false" Kind="Package" Visibility="Vertical" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <Artifact Include="$(ArtifactsShippingPackagesDir)**/*.nupkg" Kind="Package" />
-        <Artifact Include="$(ArtifactsNonShippingPackagesDir)**/*.nupkg" IsShipping="false" Kind="Package" />
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
+    <!--
+      In the VMR, don't publish packages that didn't match the above conditions externally.
+      Instead, add them with Vertical visibility as they still may be needed to build RID-specific packages in other repos.
+    -->
+    <Artifact Include="$(ArtifactsShippingPackagesDir)**/*.nupkg" Exclude="@(Artifact)" Kind="Package" Visibility="Vertical" Condition="'$(DotNetBuildOrchestrator)' == 'true'" />
+    <Artifact Include="$(ArtifactsNonShippingPackagesDir)**/*.nupkg" Exclude="@(Artifact)" IsShipping="false" Kind="Package" Visibility="Vertical" Condition="'$(DotNetBuildOrchestrator)' == 'true'" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(EnableDefaultArtifacts)' == 'true' and '$(EnableDefaultRidSpecificArtifacts)' != 'true'">
+    <Artifact Include="$(ArtifactsShippingPackagesDir)**/*.nupkg" Kind="Package" />
+    <Artifact Include="$(ArtifactsNonShippingPackagesDir)**/*.nupkg" IsShipping="false" Kind="Package" />
+  </ItemGroup>
 
   <!-- Allow for repo specific Publish properties such as add additional files to be published -->
   <Import Project="$(RepositoryEngineeringDir)Publishing.props" Condition="Exists('$(RepositoryEngineeringDir)Publishing.props')" />

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -32,42 +32,34 @@
     <CertificatesSignInfo Include="MacDeveloperVNextHardenWithNotarization" MacCertificate="MacDeveloperVNextHarden" MacNotarizationAppName="dotnet" />
   </ItemGroup>
 
-  <!-- PostBuildSign switch is kept for avoiding breaks in repos that use it to avoid signing. -->
-  <Choose Condition="'$(EnableDefaultArtifacts)' == 'true' and '$(PostBuildSign)' != 'true'">
-    <When Condition="'$(EnableDefaultRidSpecificArtifacts)' == 'true'">
-      <!--
-        Only publish packages that contain this build's Target RID in the name.
-      -->
-      <ItemGroup>
-        <ItemsToSign Include="$(ArtifactsShippingPackagesDir)**/*.$(TargetRid).*.nupkg"/>
-        <ItemsToSign Include="$(ArtifactsNonShippingPackagesDir)**/*.$(TargetRid).*.nupkg" />
-        <!--
-          Integration with Microsoft.DotNet.Build.Tasks.Installers: Publish packages of the following formats as well.
-          These are arch-specific Visual Studio insertion packages. As they're Windows-only, they only include architecture in the name:
-          - VS.Redist.Common.*.$(TargetArchitecture).*.nupkg
-          - VS.Redist.Common.*.$(TargetArchitecture)-*.*.nupkg
-          
-          These packages are always non-shipping, so only look there.
-        -->
-        <ItemsToSign Include="$(ArtifactsNonShippingPackagesDir)**/VS.Redist.Common.*.$(TargetArchitecture).*.nupkg" />
-        <ItemsToSign Include="$(ArtifactsNonShippingPackagesDir)**/VS.Redist.Common.*.$(TargetArchitecture)-*.*.nupkg" />
-      </ItemGroup>
+  <!-- Only publish packages that contain this build's Target RID in the name.
+       PostBuildSign switch is kept for avoiding breaks in repos that use it to avoid signing. -->
+  <ItemGroup Condition="'$(EnableDefaultArtifacts)' == 'true' and '$(PostBuildSign)' != 'true' and '$(EnableDefaultRidSpecificArtifacts)' == 'true'">
+    <ItemsToSign Include="$(ArtifactsShippingPackagesDir)**/*.$(TargetRid).*.nupkg"/>
+    <ItemsToSign Include="$(ArtifactsNonShippingPackagesDir)**/*.$(TargetRid).*.nupkg" />
+    <!--
+      Integration with Microsoft.DotNet.Build.Tasks.Installers: Publish packages of the following formats as well.
+      These are arch-specific Visual Studio insertion packages. As they're Windows-only, they only include architecture in the name:
+      - VS.Redist.Common.*.$(TargetArchitecture).*.nupkg
+      - VS.Redist.Common.*.$(TargetArchitecture)-*.*.nupkg
       
-      <ItemGroup>
-        <!-- Always sign all vsix packages and VS Build Packages. These may be arch specific or agnostic, but they likely won't have the RID included. -->
-        <ItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.vsix" />
-        <ItemsToSign Include="$(VisualStudioBuildPackagesDir)**\*.nupkg" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <!-- List of container files that will be opened and checked for files that need to be signed. -->
-        <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.nupkg" />
-        <ItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.vsix" />
-        <ItemsToSign Include="$(VisualStudioBuildPackagesDir)**\*.nupkg" />
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
+      These packages are always non-shipping, so only look there.
+    -->
+    <ItemsToSign Include="$(ArtifactsNonShippingPackagesDir)**/VS.Redist.Common.*.$(TargetArchitecture).*.nupkg" />
+    <ItemsToSign Include="$(ArtifactsNonShippingPackagesDir)**/VS.Redist.Common.*.$(TargetArchitecture)-*.*.nupkg" />
+
+    <!-- Always sign all vsix packages and VS Build Packages. These may be arch specific or agnostic, but they likely won't have the RID included. -->
+    <ItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.vsix" />
+    <ItemsToSign Include="$(VisualStudioBuildPackagesDir)**\*.nupkg" />
+  </ItemGroup>
+
+  <!-- PostBuildSign switch is kept for avoiding breaks in repos that use it to avoid signing. -->
+  <ItemGroup Condition="'$(EnableDefaultArtifacts)' == 'true' and '$(PostBuildSign)' != 'true' and '$(EnableDefaultRidSpecificArtifacts)' != 'true'">
+    <!-- List of container files that will be opened and checked for files that need to be signed. -->
+    <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.nupkg" />
+    <ItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.vsix" />
+    <ItemsToSign Include="$(VisualStudioBuildPackagesDir)**\*.nupkg" />
+  </ItemGroup>
 
   <ItemGroup>
     <!-- Default certificate/strong-name to be used for all files with PKT=="31bf3856ad364e35". -->


### PR DESCRIPTION
Regressed with https://github.com/dotnet/arcade/pull/15549

MSBuild doesn't allow `Condition` attributes on `Choose` elements. Avoid the `Choose` element and just use `Condition` directly on the item groups.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
