### PR TITLE
Update SDK to 10.0.100-preview.3.25125.5

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "10.0.100-preview.3.25122.1",
+    "version": "10.0.100-preview.3.25125.5",
     "rollForward": "latestFeature"
   },
   "tools": {
-    "dotnet": "10.0.100-preview.3.25122.1"
+    "dotnet": "10.0.100-preview.3.25125.5"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25120.6",


### PR DESCRIPTION
Contains a newer runtime to avoid https://github.com/dotnet/sdk/issues/47070

No DotNetCli.props change as aspnetcore didn't get updated

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
