### PR TITLE
Copy Maestro tasks back into Arcade and update to new APIs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
   <ItemGroup>
     <!-- arcade-services -->
     <PackageVersion Include="Microsoft.DotNet.ProductConstructionService.Client" Version="$(MicrosoftDotNetProductConstructionServiceClientVersion)" />
-    <PackageVersion Include="Microsoft.DotNet.DarcLib" Version="$(MicrosoftDotNetProductConstructionServiceClientVersion)" />
+    <PackageVersion Include="Microsoft.DotNet.DarcLib" Version="$(MicrosoftDotNetDarcLibVersion)" />
     <!-- command-line-api -->
     <PackageVersion Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
     <!-- corefx -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,6 +22,7 @@
   <ItemGroup>
     <!-- arcade-services -->
     <PackageVersion Include="Microsoft.DotNet.ProductConstructionService.Client" Version="$(MicrosoftDotNetProductConstructionServiceClientVersion)" />
+    <PackageVersion Include="Microsoft.DotNet.DarcLib" Version="$(MicrosoftDotNetProductConstructionServiceClientVersion)" />
     <!-- command-line-api -->
     <PackageVersion Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
     <!-- corefx -->
@@ -95,7 +96,7 @@
     <PackageVersion Include="Mono.Options" Version="5.3.0.1" />
     <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageVersion Include="Octokit" Version="12.0.0" />
+    <PackageVersion Include="Octokit" Version="13.0.1" />
     <PackageVersion Include="Polly.Core" Version="8.4.1" />
     <PackageVersion Include="sn" Version="1.0.0" />
     <PackageVersion Include="xunit" Version="$(XUnitVersion)" />

--- a/Documentation/Darc.md
+++ b/Documentation/Darc.md
@@ -418,10 +418,6 @@ PS C:\enlistments\arcade> cat .\eng\Version.Details.xml
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>14d1133b6074b463784a7adbbf385df0462f4010</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Maestro.Tasks" Version="1.0.0-beta.19060.8">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>67384d20d310611afc1c2b4dd3b953fda182def4</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.DotNet.SignTool" Version="1.0.0-beta.19080.6">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>14d1133b6074b463784a7adbbf385df0462f4010</Sha>
@@ -1086,10 +1082,6 @@ PS D:\enlistments\arcade> cat .\eng\Version.Details.xml
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>14d1133b6074b463784a7adbbf385df0462f4010</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Maestro.Tasks" Version="1.0.0-beta.19060.8">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>67384d20d310611afc1c2b4dd3b953fda182def4</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.DotNet.SignTool" Version="1.0.0-beta.19080.6">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>14d1133b6074b463784a7adbbf385df0462f4010</Sha>
@@ -1129,10 +1121,6 @@ PS D:\enlistments\arcade> cat .\eng\Version.Details.xml
     <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="2.2.0-beta.19080.6">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>14d1133b6074b463784a7adbbf385df0462f4010</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.DotNet.Maestro.Tasks" Version="1.0.0-beta.19060.8">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>67384d20d310611afc1c2b4dd3b953fda182def4</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.SignTool" Version="1.0.0-beta.19080.6">
       <Uri>https://github.com/dotnet/arcade</Uri>
@@ -2041,12 +2029,6 @@ Name:    Microsoft.DotNet.Build.Tasks.Feed
 Version: 2.2.0-beta.19081.3
 Repo:    https://github.com/dotnet/arcade
 Commit:  1e859f1c17fffbe9c4fb6bbfc0fc71cd0c56563b
-Type:    Toolset
-
-Name:    Microsoft.DotNet.Maestro.Tasks
-Version: 1.0.0-beta.19060.8
-Repo:    https://github.com/dotnet/arcade
-Commit:  67384d20d310611afc1c2b4dd3b953fda182def4
 Type:    Toolset
 ```
 

--- a/eng/BuildTask.Packages.props
+++ b/eng/BuildTask.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Update="System.Reflection.MetadataLoadContext" Version="8.0.0" />
     <PackageVersion Update="System.Resources.Extensions" Version="8.0.0" />
     <PackageVersion Update="System.Text.Encodings.Web" Version="8.0.0" />
-    <PackageVersion Update="System.Text.Json" Version="8.0.4" />
+    <PackageVersion Update="System.Text.Json" Version="8.0.5" />
     <PackageVersion Update="System.Threading.Tasks.Dataflow" Version="8.0.0" />
 
     <!-- Packages that transitively bring above dependencies in. -->

--- a/eng/SymbolPublishingExclusionsFile.txt
+++ b/eng/SymbolPublishingExclusionsFile.txt
@@ -1,0 +1,3 @@
+tools/net/runtimes/linux-musl-arm64/native/libgit2-a418d9d.so
+tools/net/runtimes/linux-musl-arm/native/libgit2-a418d9d.so
+tools/net/runtimes/linux-musl-x64/native/libgit2-a418d9d.so

--- a/eng/SymbolPublishingExclusionsFile.txt
+++ b/eng/SymbolPublishingExclusionsFile.txt
@@ -1,3 +1,1 @@
-tools/net/runtimes/linux-musl-arm64/native/libgit2-a418d9d.so
-tools/net/runtimes/linux-musl-arm/native/libgit2-a418d9d.so
-tools/net/runtimes/linux-musl-x64/native/libgit2-a418d9d.so
+libgit2-a418d9d.so

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -38,7 +38,7 @@
       <Uri>https://github.com/dotnet/arcade-services</Uri>
       <Sha>1ac3bc3aab7be12d50e4315eb5d1314bf4867530</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.25154.1">
+    <Dependency Name="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.25155.3">
       <Uri>https://github.com/dotnet/arcade-services</Uri>
       <Sha>1ac3bc3aab7be12d50e4315eb5d1314bf4867530</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -26,13 +26,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>bcb27f16702686a7eb24af2250574c2daff25ecf</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25126.4">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25154.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>6d4b01bce3a29c172faff5abc0bfe2ae3d1fef3d</Sha>
+      <Sha>70ad93a53d5364b01cb14fb194312f8d0e81c73b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25126.4">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25154.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>6d4b01bce3a29c172faff5abc0bfe2ae3d1fef3d</Sha>
+      <Sha>70ad93a53d5364b01cb14fb194312f8d0e81c73b</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.ProductConstructionService.Client" Version="1.1.0-beta.25153.2">
       <Uri>https://github.com/dotnet/arcade-services</Uri>
@@ -132,9 +132,9 @@
       <Sha>ef4c24166691977558e5312758df4313ab310dc0</Sha>
     </Dependency>
     <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.arcade" Version="10.0.0-beta.25126.4">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.arcade" Version="10.0.0-beta.25154.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>6d4b01bce3a29c172faff5abc0bfe2ae3d1fef3d</Sha>
+      <Sha>70ad93a53d5364b01cb14fb194312f8d0e81c73b</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
     <!-- Intermediate is necessary for source build. -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -38,7 +38,7 @@
       <Uri>https://github.com/dotnet/arcade-services</Uri>
       <Sha>93d595cd728ae90cdf26e86aaa9051c7f76054d6</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Maestro.Tasks" Version="1.1.0-beta.25154.1">
+    <Dependency Name="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.25154.1">
       <Uri>https://github.com/dotnet/arcade-services</Uri>
       <Sha>93d595cd728ae90cdf26e86aaa9051c7f76054d6</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,8 +12,8 @@
     <!-- arcade -->
     <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>9.0.0-beta.24223.1</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
     <!-- arcade-services -->
-    <MicrosoftDotNetProductConstructionServiceClientVersion>1.1.0-beta.25154.1</MicrosoftDotNetProductConstructionServiceClientVersion>
-    <MicrosoftDotNetDarcLibVersion>1.1.0-beta.25154.1</MicrosoftDotNetDarcLibVersion>
+    <MicrosoftDotNetProductConstructionServiceClientVersion>1.1.0-beta.25155.3</MicrosoftDotNetProductConstructionServiceClientVersion>
+    <MicrosoftDotNetDarcLibVersion>1.1.0-beta.25155.3</MicrosoftDotNetDarcLibVersion>
     <!-- command-line-api -->
     <SystemCommandLineVersion>2.0.0-beta4.24126.1</SystemCommandLineVersion>
     <!-- corefx -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,7 +13,7 @@
     <MicrosoftDotNetSwaggerGeneratorMSBuildVersion>9.0.0-beta.24223.1</MicrosoftDotNetSwaggerGeneratorMSBuildVersion>
     <!-- arcade-services -->
     <MicrosoftDotNetProductConstructionServiceClientVersion>1.1.0-beta.25154.1</MicrosoftDotNetProductConstructionServiceClientVersion>
-    <MicrosoftDotNetMaestroTasksVersion>1.1.0-beta.25154.1</MicrosoftDotNetMaestroTasksVersion>
+    <MicrosoftDotNetDarcLibVersion>1.1.0-beta.25154.1</MicrosoftDotNetDarcLibVersion>
     <!-- command-line-api -->
     <SystemCommandLineVersion>2.0.0-beta4.24126.1</SystemCommandLineVersion>
     <!-- corefx -->

--- a/global.json
+++ b/global.json
@@ -7,8 +7,8 @@
     "dotnet": "10.0.100-preview.3.25125.5"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25126.4",
-    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25126.4",
+    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25154.4",
+    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25154.4",
     "Microsoft.Build.NoTargets": "3.7.0"
   }
 }

--- a/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/Microsoft.DotNet.Arcade.Sdk.csproj
@@ -68,7 +68,6 @@
     <MicrosoftNetCompilersToolsetVersion>$(MicrosoftNetCompilersToolsetVersion)</MicrosoftNetCompilersToolsetVersion>
     <MicrosoftDiaSymReaderPdb2PdbVersion>$(MicrosoftDiaSymReaderPdb2PdbVersion)</MicrosoftDiaSymReaderPdb2PdbVersion>
     <MicrosoftDotNetXliffTasksVersion>$(PackageVersion)</MicrosoftDotNetXliffTasksVersion>
-    <MicrosoftDotNetMaestroTasksVersion>$(MicrosoftDotNetMaestroTasksVersion)</MicrosoftDotNetMaestroTasksVersion>
     <MicrosoftSymbolUploaderBuildTaskVersion>$(MicrosoftSymbolUploaderBuildTaskVersion)</MicrosoftSymbolUploaderBuildTaskVersion>
     <MicrosoftTemplateEngineAuthoringTasksVersion>$(MicrosoftTemplateEngineAuthoringTasksVersion)</MicrosoftTemplateEngineAuthoringTasksVersion>
     <MicrosoftDotNetXUnitAssertVersion>$(PackageVersion)</MicrosoftDotNetXUnitAssertVersion>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishBuildAssets.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishBuildAssets.proj
@@ -24,25 +24,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Maestro.Tasks" Version="$(MicrosoftDotNetMaestroTasksVersion)" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="$(MicrosoftDotNetBuildTasksFeedVersion)" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <!-- Microsoft.DotNet.Maestro.Tasks is produced from arcade-services, which should always target an LTS TFM -->
-    <_MicrosoftDotNetMaestroTasksBaseDir>$(NuGetPackageRoot)microsoft.dotnet.maestro.tasks\$(MicrosoftDotNetMaestroTasksVersion)\tools\</_MicrosoftDotNetMaestroTasksBaseDir>
-    <_MicrosoftDotNetMaestroTasksDir>$(_MicrosoftDotNetMaestroTasksBaseDir)net6.0</_MicrosoftDotNetMaestroTasksDir>
-  </PropertyGroup>
   
-  <UsingTask TaskName="PushMetadataToBuildAssetRegistry" AssemblyFile="$(_MicrosoftDotNetMaestroTasksDir)\Microsoft.DotNet.Maestro.Tasks.dll"/>
+  <Import Project="$(NuGetPackageRoot)microsoft.dotnet.build.tasks.feed\$(MicrosoftDotNetBuildTasksFeedVersion)\build\Microsoft.DotNet.Build.Tasks.Feed.targets"/>
 
   <Target Name="Execute">
     <Error Text="The ManifestsPath property must be set on the command line." Condition="'$(ManifestsPath)' == ''" />
     <Error Text="The MaestroApiEndpoint property must be set on the command line." Condition="'$(MaestroApiEndpoint)' == ''" />
-    
-    <PushMetadataToBuildAssetRegistry ManifestsPath="$(ManifestsPath)"
-                                      MaestroApiEndpoint="$(MaestroApiEndpoint)"
-                                      RepoRoot="$(RepoRoot)"
-                                      AssetVersion="$(Version)"/>
+
+    <PublishBuildToMaestro ManifestsPath="$(ManifestsPath)"
+                           MaestroApiEndpoint="$(MaestroApiEndpoint)"
+                           RepoRoot="$(RepoRoot)"
+                           AssetVersion="$(Version)"/>
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Versions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/Versions.props
@@ -4,7 +4,6 @@
   <Import Project="..\DefaultVersions.Generated.props"/>
 
   <PropertyGroup>
-    <MicrosoftDotNetMaestroTasksVersion>$(MicrosoftDotNetMaestroTasksVersion)</MicrosoftDotNetMaestroTasksVersion>
     <MicrosoftDotNetBuildTasksVisualStudioVersion>$(ArcadeSdkVersion)</MicrosoftDotNetBuildTasksVisualStudioVersion>
     <MicrosoftDotNetBuildTasksFeedVersion Condition="'$(MicrosoftDotNetBuildTasksFeedVersion)' == ''">$(ArcadeSdkVersion)</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetSignCheckTaskVersion Condition="'$(MicrosoftDotNetSignCheckTaskVersion)' == ''">$(ArcadeSdkVersion)</MicrosoftDotNetSignCheckTaskVersion>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/BuildModelFactoryTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/BuildModelFactoryTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Xml.Linq;
+using Azure.Storage.Blobs.Models;
 using FluentAssertions;
 using Microsoft.Arcade.Common;
 using Microsoft.Arcade.Test.Common;
@@ -14,7 +15,9 @@ using Microsoft.DotNet.Build.Tasks.Feed.Tests.TestDoubles;
 using Microsoft.DotNet.VersionTools.Automation;
 using Microsoft.DotNet.VersionTools.BuildManifest.Model;
 using Microsoft.Extensions.DependencyInjection;
+using Moq;
 using Xunit;
+using static Microsoft.Build.Utilities.SDKManifest;
 
 namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
 {
@@ -613,6 +616,348 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
             model.Should().BeNull();
             _taskLoggingHelper.HasLoggedErrors.Should().BeTrue();
             _buildEngine.BuildErrorEvents.Should().Contain(e => e.Message.Contains("Missing 'Kind' property on artifact missingKindArtifact.nupkg"));
+        }
+
+        [Fact]
+        public void CreateMergedModel_NullModels_LogsErrorAndReturnsNull()
+        {
+            // Act
+            var result = _buildModelFactory.CreateMergedModel(null);
+
+            // Assert
+            _taskLoggingHelper.HasLoggedErrors.Should().BeTrue();
+            _buildEngine.BuildErrorEvents.Should().Contain(e => e.Message.Contains("No manifests to merge."));
+            result.Should().BeNull();
+        }
+
+        [Fact]
+        public void CreateMergedModel_EmptyModels_LogsErrorAndReturnsNull()
+        {
+            // Act
+            var result = _buildModelFactory.CreateMergedModel(new List<BuildModel>());
+
+            // Assert
+            _buildEngine.BuildErrorEvents.Should().Contain(e => e.Message.Contains("No manifests to merge."));
+            result.Should().BeNull();
+        }
+
+        [Fact]
+        public void CreateMergedModel_SingleModel_ReturnsSameModel()
+        {
+            // Arrange
+            var buildModel = new BuildModel(new BuildIdentity());
+
+            // Act
+            var result = _buildModelFactory.CreateMergedModel(new List<BuildModel> { buildModel });
+
+            // Assert
+            result.Should().Be(buildModel);
+        }
+
+        /*
+         * var identity = manifest.Identity;
+                if (!string.Equals(refIdentity.AzureDevOpsAccount, identity.AzureDevOpsAccount, StringComparison.OrdinalIgnoreCase) ||
+                    !string.Equals(refIdentity.AzureDevOpsBranch, identity.AzureDevOpsBranch, StringComparison.OrdinalIgnoreCase) ||
+                    refIdentity.AzureDevOpsBuildDefinitionId != identity.AzureDevOpsBuildDefinitionId ||
+                    refIdentity.AzureDevOpsBuildId != identity.AzureDevOpsBuildId ||
+                    !string.Equals(refIdentity.AzureDevOpsBuildNumber, identity.AzureDevOpsBuildNumber, StringComparison.OrdinalIgnoreCase) ||
+                    !string.Equals(refIdentity.AzureDevOpsProject, identity.AzureDevOpsProject, StringComparison.OrdinalIgnoreCase) ||
+                    !string.Equals(refIdentity.AzureDevOpsRepository, identity.AzureDevOpsRepository, StringComparison.OrdinalIgnoreCase) ||
+                    !string.Equals(refIdentity.Branch, identity.Branch, StringComparison.OrdinalIgnoreCase) ||
+                    !string.Equals(refIdentity.BuildId, identity.BuildId, StringComparison.OrdinalIgnoreCase) ||
+                    !string.Equals(refIdentity.InitialAssetsLocation, identity.InitialAssetsLocation, StringComparison.OrdinalIgnoreCase) ||
+                    refIdentity.IsReleaseOnlyPackageVersion != identity.IsReleaseOnlyPackageVersion ||
+                    refIdentity.IsStable != identity.IsStable ||
+                    !string.Equals(refIdentity.ProductVersion, identity.ProductVersion, StringComparison.OrdinalIgnoreCase) ||
+                    refIdentity.PublishingVersion != identity.PublishingVersion ||
+                    !string.Equals(refIdentity.VersionStamp, identity.VersionStamp, StringComparison.OrdinalIgnoreCase))
+                {
+                    _log.LogError("Build identity properties are not identical across manifests.");
+                    return null;
+                }
+        */
+
+        [Theory]
+        [InlineData("AzureDevOpsAccount", "https://dev.azure.com/dnceng", "https://dnceng.visualstudio.com")]
+        [InlineData("AzureDevOpsBranch", "refs/heads/main", "main")]
+        [InlineData("AzureDevOpsBuildDefinitionId", "100", "1001")]
+        [InlineData("AzureDevOpsBuildId", "100", "1001")]
+        [InlineData("AzureDevOpsBuildNumber", "20250102.1", "20250102.2")]
+        [InlineData("AzureDevOpsProject", "internal", "DevDiv")]
+        [InlineData("AzureDevOpsRepository", "dotnet-arcade", "dotnet-roslyn")]
+        [InlineData("Branch", "main", "main2")]
+        [InlineData("BuildId", "100", "1001")]
+        [InlineData("InitialAssetsLocation", "https://dev.azure.com/dnceng/internal/_apis/build/builds/2650337/artifacts", "https://dev.azure.com/dnceng/internal/_apis/build/builds/2650332/artifacts")]
+        [InlineData("IsReleaseOnlyPackageVersion", "true", "false")]
+        [InlineData("IsStable", "true", "false")]
+        [InlineData("ProductVersion", "1", "2")]
+        [InlineData("PublishingVersion", "3", "4")]
+        [InlineData("VersionStamp", "3", "4")]
+        public void CreateMergedModel_MultipleModelsWithDifferentIdentities_LogsErrorAndReturnsNull(string propertyName, string valueA, string valueB)
+        {
+            var buildIdentityA = new BuildIdentity();
+            buildIdentityA.Attributes[propertyName] = valueA;
+            var buildIdentityB = new BuildIdentity();
+            buildIdentityB.Attributes[propertyName] = valueB;
+            // Arrange
+            var buildModel1 = new BuildModel(buildIdentityA);
+            var buildModel2 = new BuildModel(buildIdentityB);
+
+            // Act
+            var result = _buildModelFactory.CreateMergedModel(new List<BuildModel> { buildModel1, buildModel2 });
+
+            // Assert
+            _buildEngine.BuildErrorEvents.Should().Contain(e => e.Message.Contains("Build identity properties are not identical across manifests."));
+            result.Should().BeNull();
+        }
+
+        [Fact]
+        public void CreateMergedModel_MultipleModelsWithSameIdentities_MergesArtifacts()
+        {
+            // Arrange
+            var buildIdentityA = new BuildIdentity {
+                AzureDevOpsAccount = "https://dev.azure.com/dnceng",
+                AzureDevOpsBranch = "refs/heads/main",
+                AzureDevOpsBuildDefinitionId = 100,
+                AzureDevOpsBuildId = 100000,
+                AzureDevOpsBuildNumber = "20250102.1",
+                AzureDevOpsProject = "internal",
+                AzureDevOpsRepository = "dotnet-arcade",
+                Branch = "refs/heads/main", // Typically not seen but should merge properly
+                BuildId = "100000",
+                InitialAssetsLocation = "https://dev.azure.com/dnceng/internal/_apis/build/builds/100000/artifacts",
+                IsReleaseOnlyPackageVersion = false,
+                IsStable = false,
+                ProductVersion = "1.0.0",
+                PublishingVersion = VersionTools.BuildManifest.Model.PublishingInfraVersion.Latest,
+                VersionStamp = "1.0.0"
+            };
+            var buildIdentityB = new BuildIdentity();
+            // Copy all attributes from A
+            foreach (var kvp in buildIdentityA.Attributes)
+            {
+                buildIdentityB.Attributes[kvp.Key] = kvp.Value;
+            }
+
+
+            var buildModel1 = new BuildModel(buildIdentityA)
+            {
+                Artifacts = new ArtifactSet
+                {
+                    Blobs = new List<BlobArtifactModel> { new BlobArtifactModel() },
+                    Packages = new List<PackageArtifactModel> { new PackageArtifactModel() },
+                    Pdbs = new List<PdbArtifactModel> { new PdbArtifactModel() }
+                }
+            };
+            var buildModel2 = new BuildModel(buildIdentityB)
+            {
+                Artifacts = new ArtifactSet
+                {
+                    Blobs = new List<BlobArtifactModel> { new BlobArtifactModel() },
+                    Packages = new List<PackageArtifactModel> { new PackageArtifactModel() },
+                    Pdbs = new List<PdbArtifactModel> { new PdbArtifactModel() }
+                }
+            };
+
+            // Act
+            var result = _buildModelFactory.CreateMergedModel(new List<BuildModel> { buildModel1, buildModel2 });
+
+            // Assert
+            result.Artifacts.Blobs.Count.Should().Be(2);
+            result.Artifacts.Packages.Count.Should().Be(2);
+            result.Artifacts.Pdbs.Count.Should().Be(2);
+
+            // Verify that the attributes of the merged model match the first model
+            result.Identity.AzureDevOpsAccount.Should().Be(buildIdentityA.AzureDevOpsAccount);
+            result.Identity.AzureDevOpsBranch.Should().Be(buildIdentityA.AzureDevOpsBranch);
+            result.Identity.AzureDevOpsBuildDefinitionId.Should().Be(buildIdentityA.AzureDevOpsBuildDefinitionId);
+            result.Identity.AzureDevOpsBuildId.Should().Be(buildIdentityA.AzureDevOpsBuildId);
+            result.Identity.AzureDevOpsBuildNumber.Should().Be(buildIdentityA.AzureDevOpsBuildNumber);
+            result.Identity.AzureDevOpsProject.Should().Be(buildIdentityA.AzureDevOpsProject);
+            result.Identity.AzureDevOpsRepository.Should().Be(buildIdentityA.AzureDevOpsRepository);
+            result.Identity.Branch.Should().Be(buildIdentityA.Branch);
+            result.Identity.BuildId.Should().Be(buildIdentityA.BuildId);
+            result.Identity.InitialAssetsLocation.Should().Be(buildIdentityA.InitialAssetsLocation);
+            result.Identity.IsReleaseOnlyPackageVersion.Should().Be(buildIdentityA.IsReleaseOnlyPackageVersion);
+            result.Identity.IsStable.Should().Be(buildIdentityA.IsStable);
+            result.Identity.ProductVersion.Should().Be(buildIdentityA.ProductVersion);
+            result.Identity.PublishingVersion.Should().Be(buildIdentityA.PublishingVersion);
+            result.Identity.VersionStamp.Should().Be(buildIdentityA.VersionStamp);
+        }
+        [Fact]
+        public void CreateMergedModel_ArtifactsWithAttributes_PreservesAttributes()
+        {
+            // Arrange
+            var buildIdentityA = new BuildIdentity();
+            var buildIdentityB = new BuildIdentity();
+
+            var blobArtifactA = new BlobArtifactModel
+            {
+                Id = "blobA",
+                NonShipping = true,
+                RepoOrigin = "repoA",
+                OriginalFile = "OriginalPathA",
+                Visibility = ArtifactVisibility.External,
+            };
+            blobArtifactA.Attributes["AttributeA"] = "ValueA";
+            blobArtifactA.Attributes["AttributeB"] = "ValueB";
+
+            var blobArtifactB = new BlobArtifactModel
+            {
+                Id = "blobB",
+                NonShipping = false,
+                RepoOrigin = "repoB",
+                OriginalFile = "OriginalPathB",
+                Visibility = ArtifactVisibility.Internal,
+            };
+            blobArtifactB.Attributes["AttributeC"] = "ValueC";
+            blobArtifactB.Attributes["AttributeD"] = "ValueD";
+
+            var packageArtifactA = new PackageArtifactModel
+            {
+                Id = "packageA",
+                Version = "1.0.0",
+                CouldBeStable = "true",
+                NonShipping = false,
+                OriginalFile = "OriginalPathA",
+                Visibility = ArtifactVisibility.External,
+                OriginBuildName = "OriginBuildNameA",
+                RepoOrigin = "repoA"
+            };
+            packageArtifactA.Attributes["AttributeE"] = "ValueE";
+            packageArtifactA.Attributes["AttributeF"] = "ValueF";
+
+            var packageArtifactB = new PackageArtifactModel
+            {
+                Id = "packageB",
+                Version = "2.0.0",
+                CouldBeStable = "false",
+                NonShipping = true,
+                OriginalFile = "OriginalPathB",
+                Visibility = ArtifactVisibility.Internal,
+                OriginBuildName = "OriginBuildNameB",
+                RepoOrigin = "repoB"
+            };
+            packageArtifactB.Attributes["AttributeG"] = "ValueG";
+            packageArtifactB.Attributes["AttributeH"] = "ValueH";
+
+            var pdbArtifactA = new PdbArtifactModel
+            {
+                Id = "pdbA",
+                NonShipping = false,
+                OriginalFile = "OriginalPathA",
+                Visibility = ArtifactVisibility.External,
+                RepoOrigin = "repoA"
+            };
+            pdbArtifactA.Attributes["AttributeI"] = "ValueI";
+            pdbArtifactA.Attributes["AttributeJ"] = "ValueJ";
+
+            var pdbArtifactB = new PdbArtifactModel
+            {
+                Id = "pdbB",
+                NonShipping = true,
+                OriginalFile = "OriginalPathB",
+                Visibility = ArtifactVisibility.Internal,
+                RepoOrigin = "repoB"
+            };
+            pdbArtifactB.Attributes["AttributeK"] = "ValueK";
+            pdbArtifactB.Attributes["AttributeL"] = "ValueL";
+
+            var buildModel1 = new BuildModel(buildIdentityA)
+            {
+                Artifacts = new ArtifactSet
+                {
+                    Blobs = new List<BlobArtifactModel> { blobArtifactA },
+                    Packages = new List<PackageArtifactModel> { packageArtifactA },
+                    Pdbs = new List<PdbArtifactModel> { pdbArtifactA }
+                }
+            };
+
+            var buildModel2 = new BuildModel(buildIdentityB)
+            {
+                Artifacts = new ArtifactSet
+                {
+                    Blobs = new List<BlobArtifactModel> { blobArtifactB },
+                    Packages = new List<PackageArtifactModel> { packageArtifactB },
+                    Pdbs = new List<PdbArtifactModel> { pdbArtifactB }
+                }
+            };
+
+            // Act
+            var result = _buildModelFactory.CreateMergedModel(new List<BuildModel> { buildModel1, buildModel2 });
+
+            // Assert
+            result.Artifacts.Blobs.Should().SatisfyRespectively(
+                blob =>
+                {
+                    blob.Id.Should().Be("blobA");
+                    blob.NonShipping.Should().BeTrue();
+                    blob.RepoOrigin.Should().Be("repoA");
+                    blob.Visibility.Should().Be(ArtifactVisibility.External);
+                    blob.OriginalFile.Should().Be("OriginalPathA");
+                    blob.Attributes.Should().Contain("AttributeA", "ValueA");
+                    blob.Attributes.Should().Contain("AttributeB", "ValueB");
+                },
+                blob =>
+                {
+                    blob.Id.Should().Be("blobB");
+                    blob.NonShipping.Should().BeFalse();
+                    blob.RepoOrigin.Should().Be("repoB");
+                    blob.Visibility.Should().Be(ArtifactVisibility.Internal);
+                    blob.OriginalFile.Should().Be("OriginalPathB");
+                    blob.Attributes.Should().Contain("AttributeC", "ValueC");
+                    blob.Attributes.Should().Contain("AttributeD", "ValueD");
+                });
+
+            result.Artifacts.Packages.Should().SatisfyRespectively(
+                package =>
+                {
+                    package.Id.Should().Be("packageA");
+                    package.Version.Should().Be("1.0.0");
+                    package.CouldBeStable.Should().Be("true");
+                    package.NonShipping.Should().BeFalse();
+                    package.Visibility.Should().Be(ArtifactVisibility.External);
+                    package.OriginalFile.Should().Be("OriginalPathA");
+                    package.OriginBuildName.Should().Be("OriginBuildNameA");
+                    package.RepoOrigin.Should().Be("repoA");
+                    package.Attributes.Should().Contain("AttributeE", "ValueE");
+                    package.Attributes.Should().Contain("AttributeF", "ValueF");
+                },
+                package =>
+                {
+                    package.Id.Should().Be("packageB");
+                    package.Version.Should().Be("2.0.0");
+                    package.CouldBeStable.Should().Be("false");
+                    package.NonShipping.Should().BeTrue();
+                    package.Visibility.Should().Be(ArtifactVisibility.Internal);
+                    package.OriginalFile.Should().Be("OriginalPathB");
+                    package.OriginBuildName.Should().Be("OriginBuildNameB");
+                    package.RepoOrigin.Should().Be("repoB");
+                    package.Attributes.Should().Contain("AttributeG", "ValueG");
+                    package.Attributes.Should().Contain("AttributeH", "ValueH");
+                });
+
+            result.Artifacts.Pdbs.Should().SatisfyRespectively(
+                pdb =>
+                {
+                    pdb.Id.Should().Be("pdbA");
+                    pdb.NonShipping.Should().BeFalse();
+                    pdb.RepoOrigin.Should().Be("repoA");
+                    pdb.Visibility.Should().Be(ArtifactVisibility.External);
+                    pdb.OriginalFile.Should().Be("OriginalPathA");
+                    pdb.Attributes.Should().Contain("AttributeI", "ValueI");
+                    pdb.Attributes.Should().Contain("AttributeJ", "ValueJ");
+                },
+                pdb =>
+                {
+                    pdb.Id.Should().Be("pdbB");
+                    pdb.NonShipping.Should().BeTrue();
+                    pdb.RepoOrigin.Should().Be("repoB");
+                    pdb.Visibility.Should().Be(ArtifactVisibility.Internal);
+                    pdb.OriginalFile.Should().Be("OriginalPathB");
+                    pdb.Attributes.Should().Contain("AttributeK", "ValueK");
+                    pdb.Attributes.Should().Contain("AttributeL", "ValueL");
+                });
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(NetToolCurrent)</TargetFramework>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(NetToolCurrent);$(NetFrameworkToolCurrent)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>false</SignAssembly>
     <Description>This package provides support for publishing assets to appropriate channels.</Description>
     <DevelopmentDependency>true</DevelopmentDependency>
     <IsBuildTaskProject>true</IsBuildTaskProject>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -27,6 +27,7 @@
     This functionality should eventually be moved into an arcade-services package,
     but for users consuming other functionality we'll still support 4.7.2 by ifdefing it out. -->
     <PackageReference Include="Microsoft.DotNet.ProductConstructionService.Client" />
+    <PackageReference Include="Microsoft.DotNet.DarcLib" />
     <!-- SymbolUploadHelper uses Azure SDKs, S.T.Json, and several other dependencies that can't be downgraded safely.
     On .NET Core/.NET these deps come from the shared framework and we don't need try to do version fixups, and 
     the symbol publishing doesn't run on framework anyway (this project has a throwing stub for .NET framework in that path
@@ -47,9 +48,14 @@
     <ProjectReference Include="..\VersionTools\Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.ArcadeAzureIntegration\Microsoft.DotNet.ArcadeAzureIntegration.csproj" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
   </ItemGroup>
-
+ 
   <ItemGroup>
     <Compile Include="..\Common\Internal\EnumExtensions.cs" />
+  </ItemGroup>
+
+  <!-- Task is not supported on Framework -->
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <Compile Remove="src\PublishBuildToMaestro.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
@@ -84,6 +90,7 @@
     <Compile Remove="src\PublishArtifactsInManifestV3.cs" />
     <Compile Remove="src\PublishArtifactsInManifestV4.cs" />
     <Compile Remove="src\PublishSignedAssets.cs" />
+    <Compile Remove="src\PublishBuildToMaestro.cs" />
     <Compile Remove="src\TaskTracer.cs" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/build/Microsoft.DotNet.Build.Tasks.Feed.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/build/Microsoft.DotNet.Build.Tasks.Feed.targets
@@ -52,5 +52,6 @@
   <UsingTask TaskName="CreateAzureDevOpsFeed" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
   <UsingTask TaskName="PublishSignedAssets" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
   <UsingTask TaskName="CreateNewAzureContainer" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
+  <UsingTask TaskName="PublishBuildToMaestro" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" Condition="'$(MSBuildRuntimeType)' == 'Core'"/>
 
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/GetEnvProxy.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/GetEnvProxy.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.DotNet.Build.Tasks.Feed
+{
+    public interface IGetEnvProxy
+    {
+        public string GetEnv(string key);
+    }
+
+    internal class GetEnvProxy : IGetEnvProxy
+    {
+        public string GetEnv(string key)
+        {
+            var value = Environment.GetEnvironmentVariable(key);
+
+            if (string.IsNullOrEmpty(value))
+            {
+                throw new InvalidOperationException($"Required Environment variable {key} not found.");
+            }
+
+            return value;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/MSBuildLogger.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/MSBuildLogger.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Build.Utilities;
+using Microsoft.Build.Framework;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.Build.Tasks.Feed
+{
+    public class MSBuildLogger : Extensions.Logging.ILogger
+    {
+        private readonly TaskLoggingHelper _log;
+
+        public MSBuildLogger(TaskLoggingHelper log)
+        {
+            _log = log;
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            var message = formatter(state, exception);
+            switch (logLevel)
+            {
+                case LogLevel.Critical:
+                    _log.LogCriticalMessage(null, null, null, null, 0, 0, 0, 0, message);
+                    break;
+                case LogLevel.Error:
+                    _log.LogError(message);
+                    break;
+                case LogLevel.Warning:
+                    _log.LogWarning(message);
+                    break;
+                case LogLevel.Information:
+                    _log.LogMessage(MessageImportance.High, message);
+                    break;
+                case LogLevel.Debug:
+                    _log.LogMessage(MessageImportance.Normal, message);
+                    break;
+                case LogLevel.Trace:
+                    _log.LogMessage(MessageImportance.Low, message);
+                    break;
+            }
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            return NullScope.Instance;
+        }
+    }
+
+    /// <summary>
+    /// An empty scope without any logic
+    /// </summary>
+    internal class NullScope : IDisposable
+    {
+        public static NullScope Instance { get; } = new NullScope();
+
+        private NullScope()
+        {
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishBuildToMaestro.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishBuildToMaestro.cs
@@ -57,7 +57,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         internal IVersionIdentifierProxy _versionIdentifier = new VersionIdentifierProxy();
         internal IGetEnvProxy _getEnvProxy = new GetEnvProxy();
         private IBuildModelFactory _buildModelFactory;
-        private IBlobArtifactModelFactory _blobArtifactModelFactory;
         private IFileSystem _fileSystem;
 
         public const string NonShippingAttributeName = "NonShipping";
@@ -70,12 +69,10 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         }
 
         public bool ExecuteTask(IBuildModelFactory buildModelFactory,
-                                IFileSystem fileSystem,
-                                IBlobArtifactModelFactory blobArtifactModelFactory)
+                                IFileSystem fileSystem)
         {
             _buildModelFactory = buildModelFactory;
             _fileSystem = fileSystem;
-            _blobArtifactModelFactory = blobArtifactModelFactory;
 
             ExecuteAsync().GetAwaiter().GetResult();
             return !Log.HasLoggedErrors;
@@ -89,7 +86,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public override void ConfigureServices(IServiceCollection collection)
         {
             collection.TryAddSingleton<IBuildModelFactory, BuildModelFactory>();
-            collection.TryAddSingleton<IBlobArtifactModelFactory, BlobArtifactModelFactory>();
             collection.TryAddSingleton<IFileSystem, FileSystem>();
         }
 
@@ -134,7 +130,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     var mergedManifestAsset = AddManifestAsAsset(mergedManifest, mergedManifestPath);
 
                     // Write the merged manifest
-                    File.WriteAllText(mergedManifestPath, mergedManifest.ToXml().ToString());
+                    _fileSystem.WriteToFile(mergedManifestPath, mergedManifest.ToXml().ToString());
 
                     Log.LogMessage(MessageImportance.High,
                                 $"##vso[artifact.upload containerfolder=BlobArtifacts;artifactname=BlobArtifacts]{mergedManifestPath}");

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishBuildToMaestro.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishBuildToMaestro.cs
@@ -1,0 +1,581 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using System.Xml.Serialization;
+using Microsoft.Arcade.Common;
+using Microsoft.Build.Framework;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.DarcLib.Models.Darc;
+using Microsoft.DotNet.ProductConstructionService.Client;
+using Microsoft.DotNet.ProductConstructionService.Client.Models;
+using Microsoft.DotNet.VersionTools.BuildManifest.Model;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using MSBuild = Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.Build.Tasks.Feed
+{
+    public class PublishBuildToMaestro : MSBuildTaskBase, ICancelableTask
+    {
+        [Required]
+        public string ManifestsPath { get; set; }
+
+        public string BuildAssetRegistryToken { get; set; }
+
+        [Required]
+        public string MaestroApiEndpoint { get; set; }
+
+        private bool IsStableBuild { get; set; } = false;
+
+        public bool AllowInteractive { get; set; } = false;
+
+        public string RepoRoot { get; set; }
+
+        public string AssetVersion { get; set; }
+
+        [Output]
+        public int BuildId { get; set; }
+
+        private const string SearchPattern = "*.xml";
+        private const string MergedManifestFileName = "MergedManifest.xml";
+        private const string NoCategory = "NONE";
+        private readonly CancellationTokenSource _tokenSource = new CancellationTokenSource();
+        private string _gitHubRepository = "";
+        private string _gitHubBranch = "";
+
+        // Set up proxy objects to allow unit test mocking
+        internal IVersionIdentifierProxy _versionIdentifier = new VersionIdentifierProxy();
+        internal IGetEnvProxy _getEnvProxy = new GetEnvProxy();
+        private IBuildModelFactory _buildModelFactory;
+        private IBlobArtifactModelFactory _blobArtifactModelFactory;
+        private IFileSystem _fileSystem;
+
+        public const string NonShippingAttributeName = "NonShipping";
+        public const string DotNetReleaseShippingAttributeName = "DotNetReleaseShipping";
+        public const string CategoryAttributeName = "Category";
+
+        public void Cancel()
+        {
+            _tokenSource.Cancel();
+        }
+
+        public bool ExecuteTask(IBuildModelFactory buildModelFactory,
+                                IFileSystem fileSystem,
+                                IBlobArtifactModelFactory blobArtifactModelFactory)
+        {
+            _buildModelFactory = buildModelFactory;
+            _fileSystem = fileSystem;
+            _blobArtifactModelFactory = blobArtifactModelFactory;
+
+            ExecuteAsync().GetAwaiter().GetResult();
+            return !Log.HasLoggedErrors;
+        }
+
+        public async Task ExecuteAsync()
+        {
+            await PushMetadataAsync(_tokenSource.Token);
+        }
+
+        public override void ConfigureServices(IServiceCollection collection)
+        {
+            collection.TryAddSingleton<IBuildModelFactory, BuildModelFactory>();
+            collection.TryAddSingleton<IBlobArtifactModelFactory, BlobArtifactModelFactory>();
+            collection.TryAddSingleton<IFileSystem, FileSystem>();
+        }
+
+        public async Task<bool> PushMetadataAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                Log.LogMessage(MessageImportance.High, "Starting build metadata push to the Build Asset Registry...");
+
+                if (!Directory.Exists(ManifestsPath))
+                {
+                    Log.LogError($"Required folder '{ManifestsPath}' does not exist.");
+                }
+                else
+                {
+                    //get the list of manifests
+                    List<BuildModel> parsedManifests = LoadBuildModels(ManifestsPath, cancellationToken);
+
+                    if (parsedManifests.Count == 0)
+                    {
+                        Log.LogError(
+                            $"No manifests found matching the search pattern {SearchPattern} in {ManifestsPath}");
+                        return !Log.HasLoggedErrors;
+                    }
+
+                    var mergedManifest = _buildModelFactory.CreateMergedModel(parsedManifests);
+
+                    // Update the merged manifest with any missing manifest build data based on the environment.
+                    mergedManifest.Identity.AzureDevOpsAccount = mergedManifest.Identity.AzureDevOpsAccount ?? GetAzDevAccount();
+                    mergedManifest.Identity.AzureDevOpsProject = mergedManifest.Identity.AzureDevOpsProject ?? GetAzDevProject();
+                    mergedManifest.Identity.AzureDevOpsBuildNumber = mergedManifest.Identity.AzureDevOpsBuildNumber ?? GetAzDevBuildNumber();
+                    mergedManifest.Identity.AzureDevOpsBuildId = mergedManifest.Identity.AzureDevOpsBuildId ?? GetAzDevBuildId();
+                    mergedManifest.Identity.AzureDevOpsRepository = mergedManifest.Identity.AzureDevOpsRepository ?? GetAzDevRepository();
+                    mergedManifest.Identity.AzureDevOpsBranch = mergedManifest.Identity.AzureDevOpsBranch ?? GetAzDevBranch();
+                    mergedManifest.Identity.AzureDevOpsBuildDefinitionId = mergedManifest.Identity.AzureDevOpsBuildDefinitionId ?? GetAzDevBuildDefinitionId();
+
+                    string mergedManifestPath = Path.Combine(GetAzDevStagingDirectory(), MergedManifestFileName);
+
+                    //add manifest as an asset to the buildModel
+                    var mergedManifestAsset = AddManifestAsAsset(mergedManifest, mergedManifestPath);
+
+                    // Write the merged manifest
+                    File.WriteAllText(mergedManifestPath, mergedManifest.ToXml().ToString());
+
+                    Log.LogMessage(MessageImportance.High,
+                                $"##vso[artifact.upload containerfolder=BlobArtifacts;artifactname=BlobArtifacts]{mergedManifestPath}");
+
+                    // populate buildData and assetData using merged manifest data 
+                    BuildData buildData = GetMaestroBuildDataFromMergedManifest(mergedManifest, cancellationToken);
+
+                    IProductConstructionServiceApi client = PcsApiFactory.GetAuthenticated(
+                        MaestroApiEndpoint,
+                        BuildAssetRegistryToken,
+                        managedIdentityId: null,
+                        !AllowInteractive);
+
+                    var deps = await GetBuildDependenciesAsync(client, cancellationToken);
+                    Log.LogMessage(MessageImportance.High, "Calculated Dependencies:");
+                    foreach (var dep in deps)
+                    {
+                        Log.LogMessage(MessageImportance.High, $"    {dep.BuildId}, IsProduct: {dep.IsProduct}");
+                    }
+
+                    buildData.Dependencies = deps;
+                    LookupForMatchingGitHubRepository(mergedManifest.Identity);
+                    buildData.GitHubBranch = _gitHubBranch;
+                    buildData.GitHubRepository = _gitHubRepository;
+
+                    ProductConstructionService.Client.Models.Build recordedBuild = await client.Builds.CreateAsync(buildData, cancellationToken);
+                    BuildId = recordedBuild.Id;
+
+                    Log.LogMessage(MessageImportance.High,
+                        $"Metadata has been pushed. Build id in the Build Asset Registry is '{recordedBuild.Id}'");
+                    Console.WriteLine($"##vso[build.addbuildtag]BAR ID - {recordedBuild.Id}");
+
+                    // Only 'create' the AzDO (VSO) variables if running in an AzDO build
+                    if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("BUILD_BUILDID")))
+                    {
+                        IEnumerable<DefaultChannel> defaultChannels =
+                            await GetBuildDefaultChannelsAsync(client, recordedBuild);
+
+                        var targetChannelIds = new HashSet<int>(defaultChannels.Select(dc => dc.Channel.Id));
+
+                        var defaultChannelsStr = "[" + string.Join("][", targetChannelIds) + "]";
+                        Log.LogMessage(MessageImportance.High,
+                            $"Determined build will be added to the following channels: {defaultChannelsStr}");
+
+                        Console.WriteLine($"##vso[task.setvariable variable=BARBuildId]{recordedBuild.Id}");
+                        Console.WriteLine($"##vso[task.setvariable variable=DefaultChannels]{defaultChannelsStr}");
+                        Console.WriteLine($"##vso[task.setvariable variable=IsStableBuild]{IsStableBuild}");
+                    }
+                }
+            }
+            catch (Exception exc)
+            {
+                Log.LogErrorFromException(exc, true, true, null);
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private async Task<IEnumerable<DefaultChannel>> GetBuildDefaultChannelsAsync(IProductConstructionServiceApi client,
+            ProductConstructionService.Client.Models.Build recordedBuild)
+        {
+            IEnumerable<DefaultChannel> defaultChannels = await client.DefaultChannels.ListAsync(
+                branch: recordedBuild.GetBranch(),
+                channelId: null,
+                enabled: true,
+                repository: recordedBuild.GetRepository()
+            );
+
+            Log.LogMessage(MessageImportance.High, "Found the following default channels:");
+            foreach (var defaultChannel in defaultChannels)
+            {
+                Log.LogMessage(
+                    MessageImportance.High,
+                    $"    {defaultChannel.Repository}@{defaultChannel.Branch} " +
+                    $"=> ({defaultChannel.Channel.Id}) {defaultChannel.Channel.Name}");
+            }
+
+            return defaultChannels;
+        }
+
+        private async Task<List<BuildRef>> GetBuildDependenciesAsync(
+            IProductConstructionServiceApi client,
+            CancellationToken cancellationToken)
+        {
+            var logger = new MSBuildLogger(Log);
+            var local = new Local(new RemoteTokenProvider(), logger, RepoRoot);
+            IEnumerable<DependencyDetail> dependencies = await local.GetDependenciesAsync();
+            var builds = new Dictionary<int, bool>();
+            var assetCache = new Dictionary<(string name, string version, string commit), int>();
+            var buildCache = new Dictionary<int, ProductConstructionService.Client.Models.Build>();
+            foreach (var dep in dependencies)
+            {
+                var buildId = await GetBuildId(dep, client, buildCache, assetCache, cancellationToken);
+                if (buildId == null)
+                {
+                    Log.LogMessage(
+                        MessageImportance.High,
+                        $"Asset '{dep.Name}@{dep.Version}' not found in BAR, most likely this is an external dependency, ignoring...");
+                    continue;
+                }
+
+                Log.LogMessage(
+                    MessageImportance.Normal,
+                    $"Dependency '{dep.Name}@{dep.Version}' found in build {buildId.Value}");
+
+                var isProduct = dep.Type == DependencyType.Product;
+
+                if (!builds.ContainsKey(buildId.Value))
+                {
+                    builds[buildId.Value] = isProduct;
+                }
+                else
+                {
+                    builds[buildId.Value] = isProduct || builds[buildId.Value];
+                }
+            }
+
+            return builds.Select(t => new BuildRef(t.Key, t.Value, 0)).ToList();
+        }
+
+        private static async Task<int?> GetBuildId(DependencyDetail dep, IProductConstructionServiceApi client,
+            Dictionary<int, ProductConstructionService.Client.Models.Build> buildCache,
+            Dictionary<(string name, string version, string commit), int> assetCache,
+            CancellationToken cancellationToken)
+        {
+            if (assetCache.TryGetValue((dep.Name, dep.Version, dep.Commit), out int value))
+            {
+                return value;
+            }
+
+            var assets = client.Assets.ListAssetsAsync(name: dep.Name, version: dep.Version,
+                cancellationToken: cancellationToken);
+            List<Asset> matchingAssetsFromSameSha = new List<Asset>();
+
+            // Filter out those assets which do not have matching commits
+            await foreach (Asset asset in assets)
+            {
+                if (!buildCache.TryGetValue(asset.BuildId, out ProductConstructionService.Client.Models.Build producingBuild))
+                {
+                    producingBuild = await client.Builds.GetBuildAsync(asset.BuildId, cancellationToken);
+                    buildCache.Add(asset.BuildId, producingBuild);
+                }
+
+                if (producingBuild.Commit == dep.Commit)
+                {
+                    matchingAssetsFromSameSha.Add(asset);
+                }
+            }
+
+            var buildId = matchingAssetsFromSameSha.OrderByDescending(a => a.Id).FirstOrDefault()?.BuildId;
+            if (!buildId.HasValue)
+            {
+                return null;
+            }
+
+            // Commonly, if a repository has a dependency on an asset from a build, more dependencies will be to that same build
+            // lets fetch all assets from that build to save time later.
+            var build = await client.Builds.GetBuildAsync(buildId.Value, cancellationToken);
+            foreach (var asset in build.Assets)
+            {
+                if (!assetCache.ContainsKey((asset.Name, asset.Version, build.Commit)))
+                {
+                    assetCache.Add((asset.Name, asset.Version, build.Commit), build.Id);
+                }
+            }
+
+            return buildId;
+        }
+
+        private string GetVersion(string assetId)
+        {
+            return _versionIdentifier.GetVersion(assetId);
+        }
+
+        internal List<BuildModel> LoadBuildModels(
+            string manifestsFolderPath,
+            CancellationToken cancellationToken)
+        {
+            return Directory.GetFiles(manifestsFolderPath, SearchPattern, SearchOption.AllDirectories)
+                .Select(manifest => _buildModelFactory.ManifestFileToModel(manifest))
+                .ToList();
+        }
+
+
+        internal BuildData GetMaestroBuildDataFromMergedManifest(
+            BuildModel buildModel,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var assets = new List<AssetData>();
+
+            IsStableBuild = buildModel.Identity.IsStable;
+
+            // The AzureDevOps properties can be null in the Manifest, but maestro needs them. Read them from the environment if they are null in the manifest.
+            var buildInfo = new BuildData(
+                commit: buildModel.Identity.Commit,
+                azureDevOpsAccount: buildModel.Identity.AzureDevOpsAccount,
+                azureDevOpsProject: buildModel.Identity.AzureDevOpsProject,
+                azureDevOpsBuildNumber: buildModel.Identity.AzureDevOpsBuildNumber,
+                azureDevOpsRepository: buildModel.Identity.AzureDevOpsRepository,
+                azureDevOpsBranch: buildModel.Identity.AzureDevOpsBranch,
+                stable: buildModel.Identity.IsStable,
+                released: false)
+            {
+                Assets = new List<AssetData>(),
+                AzureDevOpsBuildId = buildModel.Identity.AzureDevOpsBuildId,
+                AzureDevOpsBuildDefinitionId = buildModel.Identity.AzureDevOpsBuildDefinitionId,
+                GitHubRepository = buildModel.Identity.Name,
+                GitHubBranch = buildModel.Identity.Branch,
+            };
+
+            foreach (var package in buildModel.Artifacts.Packages)
+            {
+                AddAsset(
+                    assets,
+                    package.Id,
+                    package.Version,
+                    buildModel.Identity.InitialAssetsLocation,
+                    (buildModel.Identity.InitialAssetsLocation == null) ? LocationType.NugetFeed : LocationType.Container,
+                    package.NonShipping);
+            }
+
+            foreach (var blob in buildModel.Artifacts.Blobs)
+            {
+                string version = GetVersion(blob.Id);
+
+                if (string.IsNullOrEmpty(version))
+                {
+                    Log.LogWarning($"Version could not be extracted from '{blob.Id}'");
+                    version = string.Empty;
+                }
+
+                AddAsset(
+                    assets,
+                    blob.Id,
+                    version,
+                    buildModel.Identity.InitialAssetsLocation, // What is this FOR?
+                    LocationType.Container,
+                    blob.NonShipping);
+            }
+
+            // At some point, maybe we want to include PDBs? No version information, but they do have locations which I suppose are
+            // somewhat useful for tracking. They're not blobs though.
+
+            buildInfo.Assets = buildInfo.Assets.Concat(assets).ToList();
+
+            return buildInfo;
+        }
+
+        private string GetAzDevAccount()
+        {
+            var uri = new Uri(_getEnvProxy.GetEnv("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI"));
+            if (uri.Host == "dev.azure.com")
+            {
+                return uri.AbsolutePath.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries).First();
+            }
+
+            return uri.Host.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries).First();
+        }
+
+        private string GetAzDevProject()
+        {
+            return _getEnvProxy.GetEnv("SYSTEM_TEAMPROJECT");
+        }
+
+        private string GetAzDevBuildNumber()
+        {
+            return _getEnvProxy.GetEnv("BUILD_BUILDNUMBER");
+        }
+
+        private string GetAzDevRepository()
+        {
+            return _getEnvProxy.GetEnv("BUILD_REPOSITORY_URI");
+        }
+
+        private string GetAzDevRepositoryName()
+        {
+            return _getEnvProxy.GetEnv("BUILD_REPOSITORY_NAME");
+        }
+
+        private string GetAzDevBranch()
+        {
+            return _getEnvProxy.GetEnv("BUILD_SOURCEBRANCH");
+        }
+
+        private int GetAzDevBuildId()
+        {
+            return int.Parse(_getEnvProxy.GetEnv("BUILD_BUILDID"));
+        }
+
+        private int GetAzDevBuildDefinitionId()
+        {
+            return int.Parse(_getEnvProxy.GetEnv("SYSTEM_DEFINITIONID"));
+        }
+
+        private string GetAzDevCommit()
+        {
+            return _getEnvProxy.GetEnv("BUILD_SOURCEVERSION");
+        }
+
+        private string GetAzDevStagingDirectory()
+        {
+            return _getEnvProxy.GetEnv("BUILD_STAGINGDIRECTORY");
+        }
+
+        /// <summary>
+        ///     Add a new asset to the list of assets that will be uploaded to BAR
+        /// </summary>
+        /// <param name="assets">List of assets</param>
+        /// <param name="assetName">Name of new asset</param>
+        /// <param name="version">Version of asset</param>
+        /// <param name="location">Location of asset</param>
+        /// <param name="locationType">Type of location</param>
+        /// <param name="nonShipping">If true, the asset is not intended for end customers</param>
+        internal static void AddAsset(List<AssetData> assets, string assetName, string version, string location,
+            LocationType locationType, bool nonShipping)
+        {
+            assets.Add(new AssetData(nonShipping)
+            {
+                Locations = location == null
+                    ? null
+                    : new List<AssetLocationData>() { new AssetLocationData(locationType) { Location = location } },
+                Name = assetName,
+                Version = version,
+            });
+        }
+
+        /// <summary>
+        /// When we flow dependencies we expect source and target repos to be the same i.e github.com or dev.azure.com/dnceng. 
+        /// When this task is executed the repository is an Azure DevOps repository even though the real source is GitHub 
+        /// since we just mirror the code. When we detect an Azure DevOps repository we check if the latest commit exists in 
+        /// GitHub to determine if the source is GitHub or not. If the commit exists in the repo we transform the Url from 
+        /// Azure DevOps to GitHub. If not we continue to work with the original Url.
+        /// </summary>
+        /// <returns></returns>
+        private void LookupForMatchingGitHubRepository(BuildIdentity buildIdentity)
+        {
+            if (buildIdentity == null)
+            {
+                throw new ArgumentNullException(nameof(buildIdentity));
+            }
+
+            using (var client = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true }))
+            {
+                string repoIdentity = string.Empty;
+                string gitHubHost = "github.com";
+
+                if (!Uri.TryCreate(buildIdentity.AzureDevOpsRepository, UriKind.Absolute, out Uri repoAddr))
+                {
+                    throw new Exception($"Can't parse the repository URL: {buildIdentity.AzureDevOpsRepository}");
+                }
+
+                if (repoAddr.Host.Equals(gitHubHost, StringComparison.OrdinalIgnoreCase))
+                {
+                    repoIdentity = repoAddr.AbsolutePath.Trim('/');
+                }
+                else
+                {
+                    repoIdentity = GetGithubRepoName(buildIdentity.AzureDevOpsRepository);
+                }
+
+                client.BaseAddress = new Uri($"https://api.{gitHubHost}");
+                client.DefaultRequestHeaders.Add("User-Agent", "PushToBarTask");
+
+                HttpResponseMessage response =
+                    client.GetAsync($"/repos/{repoIdentity}/commits/{buildIdentity.Commit}").Result;
+
+                if (response.IsSuccessStatusCode)
+                {
+                    _gitHubRepository = $"https://github.com/{repoIdentity}";
+                    _gitHubBranch = buildIdentity.AzureDevOpsBranch;
+                }
+                else
+                {
+                    if (response.StatusCode == System.Net.HttpStatusCode.Forbidden
+                        || response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
+                    {
+                        string responseBody = response.Content.ReadAsStringAsync().Result;
+                        throw new HttpRequestException($"API rate limit exceeded, HttpResponse: {response.StatusCode} {responseBody}. Please retry");
+                    }
+                    Log.LogMessage(MessageImportance.High,
+                        $" Unable to translate AzDO to GitHub URL. HttpResponse: {response.StatusCode} {response.ReasonPhrase} for repoIdentity: {repoIdentity} and commit: {buildIdentity.Commit}.");
+                    _gitHubRepository = null;
+                    _gitHubBranch = null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get repo name from the Azure DevOps repo url
+        /// </summary>
+        /// <param name="repoUrl"></param>
+        /// <returns></returns>
+        public static string GetGithubRepoName(string repoUrl)
+        {
+            // In case the URL comes in ending with a '/', prevent an indexing exception
+            repoUrl = repoUrl.TrimEnd('/');
+
+            string[] segments = repoUrl.Split('/');
+            string repoName = segments[segments.Length - 1].ToLower();
+
+            if (repoUrl.Contains("DevDiv", StringComparison.OrdinalIgnoreCase)
+                && repoName.EndsWith("-Trusted", StringComparison.OrdinalIgnoreCase))
+            {
+                repoName = repoName.Remove(repoName.LastIndexOf("-trusted"));
+            }
+
+            StringBuilder builder = new StringBuilder(repoName);
+            int index = repoName.IndexOf('-');
+
+            if (index > -1)
+            {
+                builder[index] = '/';
+            }
+
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// Creates a merged manifest blob
+        /// </summary>
+        /// <param name="mergedModel">Merged build manifest model</param>
+        /// <param name="manifestFileName">Merged manifest file name</param>
+        /// <returns>A blob with data about the merged manifest</returns>
+        internal BlobArtifactModel AddManifestAsAsset(BuildModel mergedModel, string manifestFileName)
+        {
+            string repoName = mergedModel.Identity.AzureDevOpsRepository.TrimEnd('/').Replace('/', '-');
+            string buildNumber = mergedModel.Identity.AzureDevOpsBuildNumber;
+            string id = $"assets/manifests/{repoName}/{buildNumber}/{Path.GetFileName(manifestFileName)}";
+
+            var mergedManifestAsset = new BlobArtifactModel()
+            {
+                Id = $"{id}",
+                NonShipping = true,
+                RepoOrigin = mergedModel.Identity.AzureDevOpsRepository,
+            };
+
+            mergedModel.Artifacts.Blobs.Add(mergedManifestAsset);
+
+            return mergedManifestAsset;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishBuildToMaestro.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishBuildToMaestro.cs
@@ -86,7 +86,13 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public override void ConfigureServices(IServiceCollection collection)
         {
             collection.TryAddSingleton<IBuildModelFactory, BuildModelFactory>();
+            collection.TryAddSingleton<IBlobArtifactModelFactory, BlobArtifactModelFactory>();
+            collection.TryAddSingleton<IPdbArtifactModelFactory, PdbArtifactModelFactory>();
+            collection.TryAddSingleton<IPackageArtifactModelFactory, PackageArtifactModelFactory>();
+            collection.TryAddSingleton<INupkgInfoFactory, NupkgInfoFactory>();
+            collection.TryAddSingleton<IPackageArchiveReaderFactory, PackageArchiveReaderFactory>();
             collection.TryAddSingleton<IFileSystem, FileSystem>();
+            collection.TryAddSingleton(Log);
         }
 
         public async Task<bool> PushMetadataAsync(CancellationToken cancellationToken)

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishBuildToMaestro.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishBuildToMaestro.cs
@@ -18,6 +18,7 @@ using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Models.Darc;
 using Microsoft.DotNet.ProductConstructionService.Client;
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
+using Microsoft.DotNet.VersionTools.Automation;
 using Microsoft.DotNet.VersionTools.BuildManifest.Model;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishBuildToMaestro.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishBuildToMaestro.cs
@@ -527,12 +527,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             }
         }
 
-        /// <summary>
-        /// Get repo name from the Azure DevOps repo url
-        /// </summary>
-        /// <param name="repoUrl"></param>
-        /// <returns></returns>
-        public static string GetGithubRepoName(string repoUrl)
+        public static string GetRepoName(string repoUrl)
         {
             // In case the URL comes in ending with a '/', prevent an indexing exception
             repoUrl = repoUrl.TrimEnd('/');
@@ -545,6 +540,18 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             {
                 repoName = repoName.Remove(repoName.LastIndexOf("-trusted"));
             }
+
+            return repoName;
+        }
+
+        /// <summary>
+        /// Get repo name from the Azure DevOps repo url
+        /// </summary>
+        /// <param name="repoUrl"></param>
+        /// <returns></returns>
+        public static string GetGithubRepoName(string repoUrl)
+        {
+            var repoName = GetRepoName(repoUrl);
 
             StringBuilder builder = new StringBuilder(repoName);
             int index = repoName.IndexOf('-');
@@ -565,7 +572,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         /// <returns>A blob with data about the merged manifest</returns>
         internal BlobArtifactModel AddManifestAsAsset(BuildModel mergedModel, string manifestFileName)
         {
-            string repoName = mergedModel.Identity.AzureDevOpsRepository.TrimEnd('/').Replace('/', '-');
+            string repoName = mergedModel.Identity.Name ?? GetRepoName(mergedModel.Identity.AzureDevOpsRepository);
             string buildNumber = mergedModel.Identity.AzureDevOpsBuildNumber;
             string id = $"assets/manifests/{repoName}/{buildNumber}/{Path.GetFileName(manifestFileName)}";
 
@@ -573,7 +580,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             {
                 Id = $"{id}",
                 NonShipping = true,
-                RepoOrigin = mergedModel.Identity.AzureDevOpsRepository,
+                RepoOrigin = repoName,
             };
 
             mergedModel.Artifacts.Blobs.Add(mergedManifestAsset);

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/VersionIdentifierProxy.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/VersionIdentifierProxy.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.VersionTools.BuildManifest;
+
+namespace Microsoft.DotNet.Build.Tasks.Feed
+{
+    internal abstract class IVersionIdentifierProxy
+    {
+        internal abstract string GetVersion(string assetName);
+        internal abstract string RemoveVersions(string assetName);
+    }
+
+    internal class VersionIdentifierProxy : IVersionIdentifierProxy
+    {
+        internal override string GetVersion(string assetName)
+        {
+            return VersionIdentifier.GetVersion(assetName);
+        }
+
+        internal override string RemoveVersions(string assetName)
+        {
+            return VersionIdentifier.RemoveVersions(assetName);
+        }
+    }
+}

--- a/src/VersionTools/Microsoft.DotNet.VersionTools/BuildManifest/Model/ArtifactModel.cs
+++ b/src/VersionTools/Microsoft.DotNet.VersionTools/BuildManifest/Model/ArtifactModel.cs
@@ -43,6 +43,10 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
                 }
                 return false;
             }
+            set
+            {
+                Attributes[nameof(NonShipping)] = value.ToString();
+            }
         }
 
         public ArtifactVisibility Visibility

--- a/src/VersionTools/Microsoft.DotNet.VersionTools/BuildManifest/Model/BuildIdentity.cs
+++ b/src/VersionTools/Microsoft.DotNet.VersionTools/BuildManifest/Model/BuildIdentity.cs
@@ -12,7 +12,8 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
     {
         UnsupportedV1 = 1,
         UnsupportedV2 = 2,
-        Latest = 3,
+        V3 = 3,
+        Latest = V3,
         Dev = 4
     }
 
@@ -63,6 +64,100 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
         {
             get { return Attributes.GetOrDefault(nameof(Commit)); }
             set { Attributes[nameof(Commit)] = value; }
+        }
+
+        public string AzureDevOpsRepository
+        {
+            get { return Attributes.GetOrDefault(nameof(AzureDevOpsRepository)); }
+            set { Attributes[nameof(AzureDevOpsRepository)] = value; }
+        }
+
+        public string AzureDevOpsBranch
+        {
+            get { return Attributes.GetOrDefault(nameof(AzureDevOpsBranch)); }
+            set { Attributes[nameof(AzureDevOpsBranch)] = value; }
+        }
+
+        public string AzureDevOpsBuildNumber
+        {
+            get { return Attributes.GetOrDefault(nameof(AzureDevOpsBuildNumber)); }
+            set { Attributes[nameof(AzureDevOpsBuildNumber)] = value; }
+        }
+
+        public string AzureDevOpsAccount
+        {
+            get { return Attributes.GetOrDefault(nameof(AzureDevOpsAccount)); }
+            set { Attributes[nameof(AzureDevOpsAccount)] = value; }
+        }
+
+        public string AzureDevOpsProject
+        {
+            get { return Attributes.GetOrDefault(nameof(AzureDevOpsProject)); }
+            set { Attributes[nameof(AzureDevOpsProject)] = value; }
+        }
+
+        public int? AzureDevOpsBuildDefinitionId
+        {
+            get
+            {
+                string value = Attributes.GetOrDefault(nameof(AzureDevOpsBuildDefinitionId));
+
+                if (string.IsNullOrEmpty(value))
+                {
+                    return null;
+                }
+                else
+                {
+                    return int.Parse(value);
+                }
+            }
+
+            set
+            {
+                if (value == null)
+                {
+                    Attributes.Remove(nameof(AzureDevOpsBuildDefinitionId));
+                }
+                else
+                {
+                    Attributes[nameof(AzureDevOpsBuildDefinitionId)] = value.ToString();
+                }
+            }
+        }
+
+        public int? AzureDevOpsBuildId
+        {
+            get
+            {
+                string value = Attributes.GetOrDefault(nameof(AzureDevOpsBuildId));
+
+                if (string.IsNullOrEmpty(value))
+                {
+                    return null;
+                }
+                else
+                {
+                    return int.Parse(value);
+                }
+            }
+
+            set
+            {
+                if (value == null)
+                {
+                    Attributes.Remove(nameof(AzureDevOpsBuildId));
+                }
+                else
+                {
+                    Attributes[nameof(AzureDevOpsBuildId)] = value.ToString();
+                }
+            }
+        }
+
+        public string InitialAssetsLocation
+        {
+            get { return Attributes.GetOrDefault(nameof(InitialAssetsLocation)); }
+            set { Attributes[nameof(InitialAssetsLocation)] = value; }
         }
 
         public bool IsStable


### PR DESCRIPTION
Copies the Maestro tasks back into arcade and updates 10.0 Arcade to keep using those tasks.

The eventual goal here is that most likely all the publishing and manifest management will move out of arcade and into a separate repo which serves all of the repos. We're a ways away from this though, as it means the manifest handling and task need to be compatible with all versions of .NET (this is no longer the case as signing data has been removed). For now, I believe the right way to go is to consider the task dead in arcade-services for .NET 10+, but keep it around for fixes if necessary (unlikely). Make tweaks as necessary for new publishing versions in .NET 10 arcade. When .NET 6 is well and truly gone, move the publishing and manifest code out of arcade and into a new repo with a design focused on preserving support for old manifest+publishing versions. The arcade services code would get deleted at this time.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
