### PR TITLE
Change azl file naming

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -86,7 +86,6 @@
     <FileExtensionSignInfo Include=".tgz" CertificateName="None" />
     <FileExtensionSignInfo Include=".tar.gz" CertificateName="None" />
     <!-- Note, RPMs can only be unpack/repacked on Linux. They can be signed on non-Linux -->
-    <FileExtensionSignInfo Include=".azl.rpm" CertificateName="LinuxSignMariner" />
     <FileExtensionSignInfo Include=".rpm" CertificateName="LinuxSign" />
     <!-- Note, these can only be unpack/repacked on Mac. They can be signed on a non-Mac -->
     <FileExtensionSignInfo Include=".pkg" CertificateName="MacDeveloper" />

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.build.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.build.targets
@@ -100,7 +100,10 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(CreateRPMForAzureLinux)' == 'true'">
-      <_InstallerFileAzureLinux>$(PackageOutputPath)$(InstallerFileNameWithoutExtension).azl$(InstallerExtension)</_InstallerFileAzureLinux>
+      <_AzureLinuxVersionSuffix>azl</_AzureLinuxVersionSuffix>
+      <_InstallerBuildPartAzureLinux>$(Version)-$(_AzureLinuxVersionSuffix)-$(_InstallerArchSuffix)</_InstallerBuildPartAzureLinux>
+      <_InstallerFileNameWithoutExtensionAzureLinux>$(InstallerName)-$(_InstallerBuildPartAzureLinux)$(CrossArchContentsBuildPart)</_InstallerFileNameWithoutExtensionAzureLinux>
+      <_InstallerFileAzureLinux>$(PackageOutputPath)$(_InstallerFileNameWithoutExtensionAzureLinux)$(InstallerExtension)</_InstallerFileAzureLinux>
     </PropertyGroup>
   </Target>
 

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -407,7 +407,6 @@ namespace Microsoft.DotNet.SignTool
 
         private readonly HashSet<string> specialExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
-            ".azl.rpm",
             ".tar.gz"
         };
 


### PR DESCRIPTION
This PR changes the name of Azure Linux packages (copies) to use the old naming convention. It is a requirement by the release process.

Naming of these packages was updated with https://github.com/dotnet/arcade/pull/15488

This new PR changes the naming from:
```
aspnetcore-runtime-${ASP_VERSION}-x64.azl.rpm
```
to
```
aspnetcore-runtime-${ASP_VERSION}-azl-x64.rpm
```

This now follows the old model we've had for several years, with various `*-cm.1-*rpm` and `*-cm.2-*rpm` packages.

Changes are also needed in signing and release processes.

@mmitche @leecow 