### PR TITLE
Add azurelinux in install-dependencies

### DIFF
--- a/eng/common/native/install-dependencies.sh
+++ b/eng/common/native/install-dependencies.sh
@@ -27,8 +27,9 @@ case "$os" in
                 libssl-dev libkrb5-dev pigz cpio
 
             localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
-        elif [ "$ID" = "fedora" ] || [ "$ID" = "rhel" ]; then
-            dnf install -y cmake llvm lld lldb clang python curl libicu-devel openssl-devel krb5-devel lttng-ust-devel pigz cpio
+        elif [ "$ID" = "fedora" ] || [ "$ID" = "rhel" ] || [ "$ID" = "azurelinux" ]; then
+            pkg_mgr="$(command -v tdnf 2>/dev/null || command -v dnf)"
+            $pkg_mgr install -y cmake llvm lld lldb clang python curl libicu-devel openssl-devel krb5-devel lttng-ust-devel pigz cpio
         elif [ "$ID" = "alpine" ]; then
             apk add build-base cmake bash curl clang llvm-dev lld lldb krb5-dev lttng-ust-dev icu-dev openssl-dev pigz cpio
         else


### PR DESCRIPTION
Sometimes in cross-build scenario, we need to build cross toolchain for host (e.g. nativeaot), where this script comes handy (e.g. https://github.com/am11/CrossRepoCITesting/actions/runs/13657189328/workflow#L23).