### PR TITLE
[SignCheck] Output results to an xml file

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SigningValidation.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/SigningValidation.proj
@@ -32,6 +32,7 @@
       <SignCheckInputDir>$(PackageBasePath)</SignCheckInputDir>
       <SignCheckLog Condition="'$(SignCheckLog)' == ''">$(ArtifactsLogDir)\signcheck.log</SignCheckLog>
       <SignCheckErrorLog Condition="'$(SignCheckErrorLog)' == ''">$(ArtifactsLogDir)\signcheck.errors.log</SignCheckErrorLog>
+      <SignCheckResultsXmlFile Condition="'$(SignCheckResultsXmlFile)' == ''">$(ArtifactsLogDir)\signcheck.xml</SignCheckResultsXmlFile>
       <InputFiles Condition="'$(BuildManifestFile)' == ''">$(SignCheckInputDir)</InputFiles>
       <InputFiles Condition="'$(BuildManifestFile)' != ''">@(ItemsToSign)</InputFiles>
     </PropertyGroup>
@@ -50,6 +51,7 @@
       VerifyStrongName="$(EnableStrongNameCheck)"
       LogFile="$(SignCheckLog)"
       ErrorLogFile="$(SignCheckErrorLog)"
+      ResultsXmlFile="$(SignCheckResultsXmlFile)"
       ArtifactFolder="$(SignCheckInputDir)"/>
 
     <Error 

--- a/src/SignCheck/Microsoft.SignCheck/Logging/ConsoleLogger.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Logging/ConsoleLogger.cs
@@ -58,6 +58,16 @@ namespace Microsoft.SignCheck.Logging
             }
         }
 
+        public void WriteStartResult(string fileName, string resultType, string error = null)
+        {
+            throw new NotImplementedException("ConsoleLogger does not support WriteStartResult.");
+        }
+
+        public void WriteEndResult()
+        {
+            throw new NotImplementedException("ConsoleLogger does not support WriteEndResult.");
+        }
+
         public void WriteLine()
         {
             Console.WriteLine();

--- a/src/SignCheck/Microsoft.SignCheck/Logging/FileLogger.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Logging/FileLogger.cs
@@ -90,7 +90,6 @@ namespace Microsoft.SignCheck.Logging
             if (ResultsWriter != null)
             {
                 ResultsWriter.WriteEndElement();
-                ResultsWriter.Flush();
                 ResultsWriter.Close();
             }
         }

--- a/src/SignCheck/Microsoft.SignCheck/Logging/ILogger.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Logging/ILogger.cs
@@ -25,5 +25,9 @@ namespace Microsoft.SignCheck.Logging
         void WriteError(LogVerbosity verbosity, string message);
 
         void WriteError(LogVerbosity verbosity, string message, params object[] values);
+
+        void WriteStartResult(string fileName, string resultType, string error = null);
+
+        void WriteEndResult();
     }
 }

--- a/src/SignCheck/Microsoft.SignCheck/Logging/Log.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Logging/Log.cs
@@ -24,10 +24,10 @@ namespace Microsoft.SignCheck.Logging
             private set;
         }
 
-        public Log(string logFile, string errorFile, LogVerbosity verbosity)
+        public Log(string logFile, string errorFile, string resultsFile, LogVerbosity verbosity)
         {
             _loggers = new List<ILogger>();
-            Add(new FileLogger(verbosity, logFile, errorFile));
+            Add(new FileLogger(verbosity, logFile, errorFile, resultsFile));
             Add(new ConsoleLogger(verbosity));
             Verbosity = verbosity;
         }
@@ -70,6 +70,16 @@ namespace Microsoft.SignCheck.Logging
         public void WriteLine()
         {
             _loggers.ForEach(p => p.WriteLine());
+        }
+
+        public void WriteStartResult(string fileName, string resultType, string error = null)
+        {
+            _loggers.OfType<FileLogger>().FirstOrDefault().WriteStartResult(fileName, resultType, error);
+        }
+
+        public void WriteEndResult()
+        {
+            _loggers.OfType<FileLogger>().FirstOrDefault().WriteEndResult();
         }
 
         public void Close()

--- a/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationResult.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationResult.cs
@@ -261,6 +261,19 @@ namespace Microsoft.SignCheck.Verification
         }
 
         /// <summary>
+        /// </summary>
+        /// <param name="detailKey"></param>
+        /// <returns></returns>
+        public string ToString(string detailKey)
+        {
+            if (Detail.TryGetValue(detailKey, out string value))
+            {
+                return value;
+            }
+            return String.Empty;
+        }
+
+        /// <summary>
         /// Creates a SignatureVerificationResult for an unsupported file type or file extension.
         /// </summary>
         /// <param name="path">The path to the file that is unsupported</param>

--- a/src/SignCheck/SignCheckTask/src/Options.cs
+++ b/src/SignCheck/SignCheckTask/src/Options.cs
@@ -58,6 +58,14 @@ namespace SignCheckTask
             set;
         }
 
+        [Option("results-xml-file",
+            HelpText = "Output signing results to the specified XML log file. If the file already exists it will be overwritten.")]
+        public string ResultsXmlFile
+        {
+            get;
+            set;
+        }
+
         [Option('m', "verify-xml",
             HelpText = "Enable XML signature verification. By default, .xml files are not verified.")]
         public bool EnableXmlSignatureVerification

--- a/src/SignCheck/SignCheckTask/src/SignCheck.cs
+++ b/src/SignCheck/SignCheckTask/src/SignCheck.cs
@@ -135,7 +135,7 @@ namespace SignCheckTask
         {
             Options = options;
 
-            Log = new Log(options.LogFile, options.ErrorLogFile, options.Verbosity);
+            Log = new Log(options.LogFile, options.ErrorLogFile, options.ResultsXmlFile, options.Verbosity);
 
             if (Options.FileStatus.Count() > 0)
             {
@@ -308,29 +308,35 @@ namespace SignCheckTask
             foreach (SignatureVerificationResult result in results)
             {
                 TotalFiles++;
+                string resultType = "Unknown";
 
                 if (result.IsSigned && !result.IsExcluded)
                 {
                     TotalSignedFiles++;
+                    resultType = "Signed";
                 }
                 else if (!(result.IsExcluded || result.IsSkipped) && (!result.IsSigned && !result.IsDoNotSign))
                 {
                     TotalUnsignedFiles++;
+                    resultType = "Unsigned";
                 }
 
                 if (result.IsExcluded || (!result.IsSigned && result.IsDoNotSign))
                 {
                     TotalExcludedFiles++;
+                    resultType = "Excluded";
                 }
 
                 if (result.IsSkipped)
                 {
                     TotalSkippedFiles++;
+                    resultType = "Skipped";
                 }
 
                 if (result.IsSkipped && result.IsExcluded)
                 {
                     TotalSkippedExcludedFiles++;
+                    resultType = "SkippedExcluded";
                 }
 
                 // Regardless of the file status reporting settings, a container file like an MSI or NuGet package
@@ -352,10 +358,12 @@ namespace SignCheckTask
                     NoSignIssues = false;
                 }
 
+                Log.WriteStartResult(result.VirtualPath, resultType, result.ToString(DetailKeys.Error));
                 if (result.NestedResults.Count > 0)
                 {
                     ProcessResults(result.NestedResults, indent + 2);
                 }
+                Log.WriteEndResult();
             }
         }
 

--- a/src/SignCheck/SignCheckTask/src/SignCheckTask.cs
+++ b/src/SignCheck/SignCheckTask/src/SignCheckTask.cs
@@ -86,6 +86,11 @@ namespace SignCheckTask
             get;
             set;
         }
+        public string ResultsXmlFile
+        {
+            get;
+            set;
+        }
         public string Verbosity
         {
             get;
@@ -130,6 +135,7 @@ namespace SignCheckTask
             options.VerifyStrongName = VerifyStrongName;
             options.LogFile = LogFile;
             options.ErrorLogFile = ErrorLogFile;
+            options.ResultsXmlFile = ResultsXmlFile;
 
             List<string> inputFiles = new List<string>();
             if (InputFiles != null)


### PR DESCRIPTION
The logged signing results are difficult to parse because they only show files that are containers or are unexpectedly unsigned. This new logic adds functionality to output all results to an xml file for easier viewing.

#### Example output:

```xml
<SignCheckResults>
  <File Name="FakeSignedContents.nupkg" ResultType="Unsigned">
    <File Name="FakeSignedContents.nupkg/.signature.p7s" ResultType="Skipped" />
    <File Name="FakeSignedContents.nupkg/tools/SignedScript.ps1" ResultType="Skipped" />
  </File>
  <File Name="MsiSetup.msi.wixpack.zip" ResultType="Skipped">
    <File Name="MsiSetup.msi.wixpack.zip/ABCDEFG/MsiApplication.exe" ResultType="Skipped" />
    <File Name="MsiSetup.msi.wixpack.zip/create.cmd" ResultType="Skipped" />
    <File Name="MsiSetup.msi.wixpack.zip/Product.wixobj" ResultType="Skipped" />
  </File>
  <File Name="WithApp.pkg" ResultType="Skipped" />
  <File Name="SameFiles1.zip" ResultType="Skipped">
    <File Name="SameFiles1.zip/Simple1.exe" ResultType="Skipped" />
    <File Name="SameFiles1.zip/Simple2.exe" ResultType="Skipped" />
  </File>
</SignCheckResults>
```