### PR TITLE
add retries

### DIFF
--- a/eng/common/templates-official/job/job.yml
+++ b/eng/common/templates-official/job/job.yml
@@ -31,6 +31,7 @@ jobs:
             PathtoPublish: '$(Build.ArtifactStagingDirectory)/artifacts'
             ArtifactName: ${{ coalesce(parameters.artifacts.publish.artifacts.name , 'Artifacts_$(Agent.Os)_$(_BuildConfig)') }}
             condition: always()
+            retryCountOnTaskFailure: 10 # for any logs being locked
             continueOnError: true
         - ${{ if and(ne(parameters.artifacts.publish.logs, 'false'), ne(parameters.artifacts.publish.logs, '')) }}:
           - output: pipelineArtifact
@@ -39,6 +40,7 @@ jobs:
             displayName: 'Publish logs'
             continueOnError: true
             condition: always()
+            retryCountOnTaskFailure: 10 # for any logs being locked
             sbomEnabled: false  # we don't need SBOM for logs
 
       - ${{ if eq(parameters.enablePublishBuildArtifacts, true) }}:

--- a/eng/common/templates-official/steps/publish-build-artifacts.yml
+++ b/eng/common/templates-official/steps/publish-build-artifacts.yml
@@ -24,6 +24,9 @@ parameters:
 - name: is1ESPipeline
   type: boolean
   default: true
+
+- name: retryCountOnTaskFailure
+  type: string
   
 steps:
 - ${{ if ne(parameters.is1ESPipeline, true) }}:
@@ -38,4 +41,5 @@ steps:
     PathtoPublish: ${{ parameters.pathToPublish }}
     ${{ if parameters.artifactName }}:
       ArtifactName: ${{ parameters.artifactName }}
-      
+    ${{ if parameters.retryCountOnTaskFailure }}:
+      retryCountOnTaskFailure: ${{ parameters.retryCountOnTaskFailure }}

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -46,6 +46,7 @@ jobs:
               artifactName: ${{ coalesce(parameters.artifacts.publish.artifacts.name , 'Artifacts_$(Agent.Os)_$(_BuildConfig)') }}
               continueOnError: true
               condition: always()
+              retryCountOnTaskFailure: 10 # for any logs being locked
       - ${{ if and(ne(parameters.artifacts.publish.logs, 'false'), ne(parameters.artifacts.publish.logs, '')) }}:
         - template: /eng/common/core-templates/steps/publish-pipeline-artifacts.yml
           parameters:
@@ -56,6 +57,7 @@ jobs:
               displayName: 'Publish logs'
               continueOnError: true
               condition: always()
+              retryCountOnTaskFailure: 10 # for any logs being locked
               sbomEnabled: false  # we don't need SBOM for logs
 
     - ${{ if ne(parameters.enablePublishBuildArtifacts, 'false') }}:

--- a/eng/common/templates/steps/publish-build-artifacts.yml
+++ b/eng/common/templates/steps/publish-build-artifacts.yml
@@ -25,6 +25,9 @@ parameters:
   type: string
   default: 'Container'
 
+- name: retryCountOnTaskFailure
+  type: string
+
 steps:
 - ${{ if eq(parameters.is1ESPipeline, true) }}:
   - 'eng/common/templates cannot be referenced from a 1ES managed template': error
@@ -38,3 +41,5 @@ steps:
     PathtoPublish: ${{ parameters.pathToPublish }}
     ${{ if parameters.artifactName }}:
       ArtifactName: ${{ parameters.artifactName }}
+    ${{ if parameters.retryCountOnTaskFailure }}:
+      retryCountOnTaskFailure: ${{ parameters.retryCountOnTaskFailure }}


### PR DESCRIPTION
In dotnet/aspire, we have a log that is written during test runs and closed only at the end. It can take 10 sec-2 mins to unlock. Occasionally this causes

> System.IO.IOException: The process cannot access the file 'D:\a_work\1\a\artifacts\log\dcp\dcpctrl-1741041174-9644.log' because it is being used by another process.

during artefact publishing. I added retries which should cause no effect in the normal case, but give it a chance of succeeding in this failure case.

I chose 10 because the time between retries would then have summed to over 2 minutes. https://learn.microsoft.com/en-us/azure/devops/pipelines/process/tasks?view=azure-devops&tabs=yaml#number-of-retries-if-task-failed

This assumes publish is idempotent, which @mmitche believes is true.
