### PR TITLE
[release/6.0] Fix SBoM generation

### DIFF
--- a/eng/common/generate-sbom-prep.ps1
+++ b/eng/common/generate-sbom-prep.ps1
@@ -4,18 +4,25 @@ Param(
 
 . $PSScriptRoot\pipeline-logging-functions.ps1
 
+# Normally - we'd listen to the manifest path given, but 1ES templates will overwrite if this level gets uploaded directly
+# with their own overwriting ours. So we create it as a sub directory of the requested manifest path.
+$ArtifactName = "${env:SYSTEM_STAGENAME}_${env:AGENT_JOBNAME}_SBOM"
+$SafeArtifactName = $ArtifactName -replace '["/:<>\\|?@*"() ]', '_'
+$SbomGenerationDir = Join-Path $ManifestDirPath $SafeArtifactName
+
+Write-Host "Artifact name before : $ArtifactName"
+Write-Host "Artifact name after : $SafeArtifactName"
+
 Write-Host "Creating dir $ManifestDirPath"
 # create directory for sbom manifest to be placed
-if (!(Test-Path -path $ManifestDirPath))
+if (!(Test-Path -path $SbomGenerationDir))
 {
-  New-Item -ItemType Directory -path $ManifestDirPath
-  Write-Host "Successfully created directory $ManifestDirPath"
+  New-Item -ItemType Directory -path $SbomGenerationDir
+  Write-Host "Successfully created directory $SbomGenerationDir"
 }
 else{
   Write-PipelineTelemetryError -category 'Build'  "Unable to create sbom folder."
 }
 
 Write-Host "Updating artifact name"
-$artifact_name = "${env:SYSTEM_STAGENAME}_${env:AGENT_JOBNAME}_SBOM" -replace '["/:<>\\|?@*"() ]', '_'
-Write-Host "Artifact name $artifact_name"
-Write-Host "##vso[task.setvariable variable=ARTIFACT_NAME]$artifact_name"
+Write-Host "##vso[task.setvariable variable=ARTIFACT_NAME]$SafeArtifactName"

--- a/eng/common/generate-sbom-prep.sh
+++ b/eng/common/generate-sbom-prep.sh
@@ -14,19 +14,23 @@ done
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 . $scriptroot/pipeline-logging-functions.sh
 
+# replace all special characters with _, some builds use special characters like : in Agent.Jobname, that is not a permissible name while uploading artifacts.
+artifact_name=$SYSTEM_STAGENAME"_"$AGENT_JOBNAME"_SBOM"
+safe_artifact_name="${artifact_name//["/:<>\\|?@*$" ]/_}"
 manifest_dir=$1
 
-if [ ! -d "$manifest_dir" ] ; then
-  mkdir -p "$manifest_dir"
-  echo "Sbom directory created." $manifest_dir
+# Normally - we'd listen to the manifest path given, but 1ES templates will overwrite if this level gets uploaded directly
+# with their own overwriting ours. So we create it as a sub directory of the requested manifest path.
+sbom_generation_dir="$manifest_dir/$safe_artifact_name"
+
+if [ ! -d "$sbom_generation_dir" ] ; then
+  mkdir -p "$sbom_generation_dir"
+  echo "Sbom directory created." $sbom_generation_dir
 else
   Write-PipelineTelemetryError -category 'Build'  "Unable to create sbom folder."
 fi
 
-artifact_name=$SYSTEM_STAGENAME"_"$AGENT_JOBNAME"_SBOM"
 echo "Artifact name before : "$artifact_name
-# replace all special characters with _, some builds use special characters like : in Agent.Jobname, that is not a permissible name while uploading artifacts.
-safe_artifact_name="${artifact_name//["/:<>\\|?@*$" ]/_}"
 echo "Artifact name after : "$safe_artifact_name
 export ARTIFACT_NAME=$safe_artifact_name
 echo "##vso[task.setvariable variable=ARTIFACT_NAME]$safe_artifact_name"

--- a/eng/common/templates-official/job/job.yml
+++ b/eng/common/templates-official/job/job.yml
@@ -36,6 +36,7 @@ parameters:
   enableSbom: true
   PackageVersion: 6.0.0
   BuildDropPath: '$(Build.SourcesDirectory)/artifacts'
+  ManifestDirPath: $(Build.ArtifactStagingDirectory)/sbom
 
 jobs:
 - job: ${{ parameters.name }}

--- a/eng/common/templates-official/steps/generate-sbom.yml
+++ b/eng/common/templates-official/steps/generate-sbom.yml
@@ -33,7 +33,7 @@ steps:
       PackageName: ${{ parameters.packageName }}
       BuildDropPath: ${{ parameters.buildDropPath }}
       PackageVersion: ${{ parameters.packageVersion }}
-      ManifestDirPath: ${{ parameters.manifestDirPath }}
+      ManifestDirPath: ${{ parameters.manifestDirPath }}/$(ARTIFACT_NAME)
 
 - task: 1ES.PublishPipelineArtifact@1
   displayName: Publish SBOM manifest


### PR DESCRIPTION
Same as dotnet/arcade#15578 but for the release/8.0 branch.

1ES templates generates SBoM's for all artifacts uploaded - only issue is it does it in the root of the artifact that's uploaded inside the _manifest folder. If there's a manifest in the uploaded artifact, it will clobber the SBOM with an SBOM for the SBOM. The quick and dirty solution for now: generate the SBoM in a subdirectory of the upload root.