### PR TITLE
Remove --no-lock from install-dependencies.sh

### DIFF
--- a/eng/common/native/install-dependencies.sh
+++ b/eng/common/native/install-dependencies.sh
@@ -45,7 +45,7 @@ case "$os" in
         export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
         # Skip brew update for now, see https://github.com/actions/setup-python/issues/577
         # brew update --preinstall
-        brew bundle --no-upgrade --no-lock --file=- <<EOF
+        brew bundle --no-upgrade --file=- <<EOF
 brew "cmake"
 brew "icu4c"
 brew "openssl@3"


### PR DESCRIPTION
Brew removed `--no-lock` from `brew bundle`. It was deprecated at https://github.com/Homebrew/homebrew-bundle/pull/1509, and fully removed in https://github.com/Homebrew/homebrew-bundle/commit/98d8ad7ddcca7e7b700cd496207d51fa042c0b00.

See https://github.com/dotnet/runtime/pull/113277 and https://github.com/dotnet/runtime/issues/113276 for details.