### PR TITLE
Append attempt number to logs

### DIFF
--- a/eng/common/templates-official/job/job.yml
+++ b/eng/common/templates-official/job/job.yml
@@ -46,7 +46,7 @@ jobs:
           displayName: Publish Logs
           PathtoPublish: '$(Build.ArtifactStagingDirectory)/artifacts/log/$(_BuildConfig)'
           publishLocation: Container
-          ArtifactName: ${{ coalesce(parameters.enablePublishBuildArtifacts.artifactName, '$(Agent.Os)_$(Agent.JobName)' ) }}
+          ArtifactName: ${{ coalesce(parameters.enablePublishBuildArtifacts.artifactName, '$(Agent.Os)_$(Agent.JobName)_Attempt$(System.JobAttempt)' ) }}
           continueOnError: true
           condition: always()
           sbomEnabled: false  # we don't need SBOM for logs

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -66,7 +66,7 @@ jobs:
             displayName: Publish Logs
             pathToPublish: '$(Build.ArtifactStagingDirectory)/artifacts/log/$(_BuildConfig)'
             publishLocation: Container
-            artifactName: ${{ coalesce(parameters.enablePublishBuildArtifacts.artifactName, '$(Agent.Os)_$(Agent.JobName)' ) }}
+            artifactName: ${{ coalesce(parameters.enablePublishBuildArtifacts.artifactName, '$(Agent.Os)_$(Agent.JobName)_Attempt$(System.JobAttempt)' ) }}
             continueOnError: true
             condition: always()
 


### PR DESCRIPTION
Builds logs are getting overwritten on retry. See https://dev.azure.com/dnceng/internal/_build/results?buildId=2656951&view=results as an example. To prevent this, append the job attempt to the artifact name.