### PR TITLE
SignCheck files without extensions

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/Verification/FileVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/FileVerifier.cs
@@ -121,7 +121,7 @@ namespace Microsoft.SignCheck.Verification
         /// <returns>A FileVerifier that can be used to verify the signature of the specified file.</returns>
         protected FileVerifier GetFileVerifier(string path)
         {
-            string extension = Path.GetExtension(path);
+            string extension = Path.GetExtension(path) ?? string.Empty;
             FileVerifier fileVerifier = SignatureVerificationManager.GetFileVerifierByExtension(extension);
 
             if (fileVerifier == null)

--- a/src/SignCheck/Microsoft.SignCheck/Verification/NoExtensionVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/NoExtensionVerifier.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Microsoft.SignCheck.Logging;
+
+namespace Microsoft.SignCheck.Verification
+{
+    public class NoExtensionVerifier : AuthentiCodeVerifier
+    {
+        public NoExtensionVerifier(Log log, Exclusions exclusions, SignatureVerificationOptions options) : base(log, exclusions, options, string.Empty) { }
+
+        public override SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath)
+        {
+#if NET
+            bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            if (!isWindows && IsExecutable(path))
+            {
+                return base.VerifySignature(path, parent, virtualPath);
+            }
+
+            string detailMessage = isWindows ?
+                "Cannot verify files without extensions on Windows." :
+                "Not an executable.";
+#else
+            string detailMessage = "Cannot verify files without extensions on NET Framework.";
+#endif
+
+            SignatureVerificationResult svr = new SignatureVerificationResult(path, parent, virtualPath);
+            svr.IsSkipped = true;
+            svr.AddDetail(DetailKeys.Misc, detailMessage);
+
+            return svr;
+        }
+
+        /// <summary>
+        /// Determines if the file is executable.
+        /// </summary>
+        /// <param name="path">The path to the file.</param>
+#if NET
+        [UnsupportedOSPlatform("windows")]
+        private bool IsExecutable(string path)
+        {
+            UnixFileMode mode = File.GetUnixFileMode(path);
+            return mode.HasFlag(UnixFileMode.UserExecute) ||
+                    mode.HasFlag(UnixFileMode.GroupExecute) ||
+                    mode.HasFlag(UnixFileMode.OtherExecute);
+        }
+#endif
+    }
+}

--- a/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationManager.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationManager.cs
@@ -109,6 +109,7 @@ namespace Microsoft.SignCheck.Verification
 #endif
             AddFileVerifier(new ExeVerifier(log, exclusions, options, ".exe"));
             AddFileVerifier(new LzmaVerifier(log, exclusions, options));
+            AddFileVerifier(new NoExtensionVerifier(log, exclusions, options));
             AddFileVerifier(new NupkgVerifier(log, exclusions, options));
             AddFileVerifier(new PortableExecutableVerifier(log, exclusions, options, ".dll"));
             AddFileVerifier(new XmlVerifier(log, exclusions, options));
@@ -181,7 +182,7 @@ namespace Microsoft.SignCheck.Verification
         /// <returns>A FileVerifier that can verify the file or null if verifier could be found.</returns>
         public static FileVerifier GetFileVerifier(string path)
         {
-            string extension = Path.GetExtension(path);
+            string extension = Path.GetExtension(path) ?? string.Empty;
             FileVerifier fileVerifier = GetFileVerifierByExtension(extension);
 
             if (fileVerifier == null)
@@ -204,9 +205,9 @@ namespace Microsoft.SignCheck.Verification
         /// <returns>A FileVerifier that can verify the file or null if the verifier could not be found.</returns>
         public static FileVerifier GetFileVerifierByExtension(string extension)
         {
-            if (!String.IsNullOrEmpty(extension))
+            if (extension != null)
             {
-                // If the file has an extension, try to find a matching verifier
+                // Try to find a matching verifier
                 if (_fileVerifiers.ContainsKey(extension))
                 {
                     return _fileVerifiers[extension];


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/4937

Allows SignCheck to run on files without extensions, as long as the file is an executable.