### PR TITLE
Revert "V4 Publishing should only place assets marked CouldBeStable on isolated feeds"

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -321,22 +321,22 @@
     </ItemGroup>
 
     <!-- Propagate stability data to the asset level for packages. We do this so that VMR builds which have some repo builds that are not stable, and others that are, do not end up having to use the default logic
-         where ALL assets that are shipping in a stable build go to isolated feeds. Instead, we can just choose CouldBeStable==true, CouldBeStable==false.
-         This only applies currently to Packages. Blobs are required to provide paths that are always non-stable. Pdbs don't have a stability concept.
+          where ALL assets that are shipping in a stable build go to isolated feeds. Instead, we can just choose CouldBeStable==true, CouldBeStable==false.
+          This only applies currently to Packages. Blobs are required to provide paths that are always non-stable. Pdbs don't have a stability concept.
 
-         NOTE: This flag doesn't strictly mean that the package is stable versioned. A repo might suppress a stable version for a given package. -->
+          NOTE: This flag doesn't strictly mean that the package is stable versioned. A repo might suppress a stable version for a given package. -->
     <ItemGroup>
       <ItemsToPushToBlobFeed>
-			  <ManifestArtifactData Condition="'$(PublishingVersion)' == '4' and
-                                         '%(ItemsToPushToBlobFeed.Kind)' == 'Package' and
+			  <ManifestArtifactData Condition="'%(ItemsToPushToBlobFeed.Kind)' == 'Package' and
 																			   '$(IsStableBuild)' == 'true' and
 																			   '$(IsReleaseOnlyPackageVersion)' != 'true' and
 																			   '%(ItemsToPushToBlobFeed.IsShipping)' == 'true'">%(ItemsToPushToBlobFeed.ManifestArtifactData);CouldBeStable=true</ManifestArtifactData>
-        <!-- We narrowly set CouldBeStable=false only for packages we know won't generate a stable version because of IsReleaseOnlyPackageVersion == true.
-             This allows for the default 'stable asset to non-isolated feed' detection behavior to still pick up accidental cases of stabilization. -->
-				<ManifestArtifactData Condition="'$(PublishingVersion)' == '4' and
-                                         '%(ItemsToPushToBlobFeed.Kind)' == 'Package' and
-																				 '$(IsReleaseOnlyPackageVersion)' == 'true'">%(ItemsToPushToBlobFeed.ManifestArtifactData);CouldBeStable=false</ManifestArtifactData>
+				<ManifestArtifactData Condition="'%(ItemsToPushToBlobFeed.Kind)' == 'Package' and
+																				 (
+                                          '$(IsStableBuild)' != 'true' or
+																				  '$(IsReleaseOnlyPackageVersion)' == 'true' or
+																				  '%(ItemsToPushToBlobFeed.IsShipping)' != 'true'
+                                         )">%(ItemsToPushToBlobFeed.ManifestArtifactData);CouldBeStable=false</ManifestArtifactData>
       </ItemsToPushToBlobFeed>
     </ItemGroup>
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/BuildModelFactoryTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/BuildModelFactoryTests.cs
@@ -923,7 +923,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
             {
                 Id = "packageA",
                 Version = "1.0.0",
-                CouldBeStable = true,
+                CouldBeStable = "true",
                 NonShipping = false,
                 OriginalFile = "OriginalPathA",
                 Visibility = ArtifactVisibility.External,
@@ -937,7 +937,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
             {
                 Id = "packageB",
                 Version = "2.0.0",
-                CouldBeStable = false,
+                CouldBeStable = "false",
                 NonShipping = true,
                 OriginalFile = "OriginalPathB",
                 Visibility = ArtifactVisibility.Internal,
@@ -1020,7 +1020,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                 {
                     package.Id.Should().Be("packageA");
                     package.Version.Should().Be("1.0.0");
-                    package.CouldBeStable.Should().Be(true);
+                    package.CouldBeStable.Should().Be("true");
                     package.NonShipping.Should().BeFalse();
                     package.Visibility.Should().Be(ArtifactVisibility.External);
                     package.OriginalFile.Should().Be("OriginalPathA");
@@ -1033,7 +1033,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                 {
                     package.Id.Should().Be("packageB");
                     package.Version.Should().Be("2.0.0");
-                    package.CouldBeStable.Should().Be(false);
+                    package.CouldBeStable.Should().Be("false");
                     package.NonShipping.Should().BeTrue();
                     package.Visibility.Should().Be(ArtifactVisibility.Internal);
                     package.OriginalFile.Should().Be("OriginalPathB");

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -39,7 +40,7 @@ using MsBuildUtils = Microsoft.Build.Utilities;
 namespace Microsoft.DotNet.Build.Tasks.Feed
 {
 
-#if NET
+#if !NET472_OR_GREATER
     /// <summary>
     /// The intended use of this task is to push artifacts described in
     /// a build manifest to a static package feed.
@@ -375,6 +376,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         /// </summary>
         public void CheckForStableAssetsInNonIsolatedFeeds()
         {
+            if (BuildModel.Identity.IsReleaseOnlyPackageVersion || SkipSafetyChecks)
+            {
+                return;
+            }
+
             foreach (var packagesPerCategory in PackagesByCategory)
             {
                 var category = packagesPerCategory.Key;
@@ -385,13 +391,13 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     foreach (var feedConfig in feedConfigsForCategory)
                     {
                         // Look at the version numbers. If any of the packages here are stable and about to be published to a
-                        // non-isolated feed, then issue an error. Isolated feeds may receive all packages.
+                        // non-isolated feed, then issue an error. Isolated feeds may recieve all packages.
                         if (feedConfig.Isolated)
                         {
                             continue;
                         }
 
-                        HashSet<PackageArtifactModel> filteredPackages = SplitPackageByAssetSelection(packages, feedConfig);
+                        HashSet<PackageArtifactModel> filteredPackages = FilterPackages(packages, feedConfig);
 
                         foreach (var package in filteredPackages)
                         {
@@ -408,7 +414,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                             // use by the public. This is for technical (can't overwrite the original packages) reasons as well as 
                             // to avoid confusion. Because .NET core generally brands its "final" bits without prerelease version
                             // suffixes (e.g. 3.0.0-preview1), test to see whether a prerelease suffix exists.
-                            else if (!version.IsPrerelease && package.CouldBeStable != false)
+                            else if (!version.IsPrerelease)
                             {
                                 Log.LogError($"Package '{package.Id}' has stable version '{package.Version}' but is targeted at a non-isolated feed '{feedConfig.TargetURL}'");
                             }
@@ -772,7 +778,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 {
                     foreach (var feedConfig in feedConfigsForCategory)
                     {
-                        HashSet<PackageArtifactModel> filteredPackages = SplitPackageByAssetSelection(packages, feedConfig);
+                        HashSet<PackageArtifactModel> filteredPackages = FilterPackages(packages, feedConfig);
 
                         foreach (var package in filteredPackages)
                         {
@@ -811,7 +817,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             Log.LogMessage(MessageImportance.High, "\nCompleted publishing of packages: ");
         }
 
-        protected virtual HashSet<PackageArtifactModel> SplitPackageByAssetSelection(HashSet<PackageArtifactModel> packages, TargetFeedConfig feedConfig)
+        private HashSet<PackageArtifactModel> FilterPackages(HashSet<PackageArtifactModel> packages, TargetFeedConfig feedConfig)
         {
             return feedConfig.AssetSelection switch
             {

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
@@ -181,10 +181,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     }
                 }
 
-                if (!BuildModel.Identity.IsReleaseOnlyPackageVersion && !SkipSafetyChecks)
-                {
-                    CheckForStableAssetsInNonIsolatedFeeds();
-                }
+                CheckForStableAssetsInNonIsolatedFeeds();
 
                 if (Log.HasLoggedErrors)
                 {

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishSignedAssets.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishSignedAssets.cs
@@ -5,7 +5,6 @@ using Azure.Core;
 using Azure.Identity;
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.Tasks.Feed.Model;
-using Microsoft.DotNet.VersionTools.BuildManifest.Model;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using System;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigBase.cs
@@ -10,6 +10,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
     public abstract class SetupTargetFeedConfigBase
     {
         protected bool IsInternalBuild { get; set; }
+        protected bool IsStableBuild { get; set; }
         protected string RepositoryName { get; set; }
         protected string CommitSha { get; set; }
         protected bool PublishInstallersAndChecksums { get; set; }
@@ -23,8 +24,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         protected ImmutableList<string> LatestLinkShortUrlPrefixes { get; set; }
         protected string AzureDevOpsFeedsKey { get; set; }
 
-        protected SetupTargetFeedConfigBase(
-            bool isInternalBuild,
+        protected SetupTargetFeedConfigBase(bool isInternalBuild,
+            bool isStableBuild,
             string repositoryName,
             string commitSha,
             bool publishInstallersAndChecksums,
@@ -39,6 +40,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             string azureDevOpsFeedsKey)
         {
             IsInternalBuild = isInternalBuild;
+            IsStableBuild = isStableBuild;
             RepositoryName = repositoryName;
             CommitSha = commitSha;
             PublishInstallersAndChecksums = publishInstallersAndChecksums;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/SetupTargetFeedConfigV3.cs
@@ -30,9 +30,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public string AzureDevOpsOrg => "dnceng";
 
-        protected bool IsStableBuild { get; set; }
-
-
         public SetupTargetFeedConfigV3(
             TargetChannelConfig targetChannelConfig,
             bool isInternalBuild,
@@ -51,21 +48,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             ImmutableList<string> filesToExclude = null,
             bool flatten = true,
             TaskLoggingHelper log = null) 
-            : base(isInternalBuild: isInternalBuild,
-                   repositoryName: repositoryName,
-                   commitSha: commitSha,
-                   publishInstallersAndChecksums: publishInstallersAndChecksums,
-                   installersTargetStaticFeed: null,
-                   installersAzureAccountKey: null,
-                   checksumsTargetStaticFeed: null,
-                   checksumsAzureAccountKey: null,
-                   azureDevOpsStaticShippingFeed: null,
-                   azureDevOpsStaticTransportFeed: null,
-                   azureDevOpsStaticSymbolsFeed: null,
-                   latestLinkShortUrlPrefixes: latestLinkShortUrlPrefixes,
-                   azureDevOpsFeedsKey: null)
+            : base(isInternalBuild, isStableBuild, repositoryName, commitSha, publishInstallersAndChecksums, null, null, null, null, null, null, null, latestLinkShortUrlPrefixes, null)
         {
-            IsStableBuild = isStableBuild;
             _targetChannelConfig = targetChannelConfig;
             BuildEngine = buildEngine;
             StableSymbolsFeed = stableSymbolsFeed;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetFeedConfig.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetFeedConfig.cs
@@ -189,7 +189,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
     {
         All,
         ShippingOnly,
-        NonShippingOnly,
-        CouldBeStable, // V4 only. Assets that could be stable (whether shipping or non-shipping)
+        NonShippingOnly
     }
 }

--- a/src/VersionTools/Microsoft.DotNet.VersionTools/BuildManifest/Model/PackageArtifactModel.cs
+++ b/src/VersionTools/Microsoft.DotNet.VersionTools/BuildManifest/Model/PackageArtifactModel.cs
@@ -34,28 +34,10 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
             set { Attributes[nameof(OriginBuildName)] = value; }
         }
 
-        public bool? CouldBeStable
+        public string CouldBeStable
         {
-            get
-            {
-                string val = Attributes.GetOrDefault(nameof(CouldBeStable));
-                if (!string.IsNullOrEmpty(val))
-                {
-                    return bool.Parse(val);
-                }
-                return null;
-            }
-            set
-            {
-                if (!value.HasValue)
-                {
-                    Attributes.Remove(nameof(CouldBeStable));
-                }
-                else
-                {
-                    Attributes[nameof(CouldBeStable)] = value.Value.ToString();
-                }
-            }
+            get { return Attributes.GetOrDefault(nameof(CouldBeStable)); }
+            set { Attributes[nameof(CouldBeStable)] = value; }
         }
 
         public override string ToString() => $"Package {Id} {Version}";


### PR DESCRIPTION
Reverts dotnet/arcade#15561 