### PR TITLE
[8.0] Fix mistake in generate-sbom-prep.ps1

### DIFF
--- a/eng/common/generate-sbom-prep.ps1
+++ b/eng/common/generate-sbom-prep.ps1
@@ -2,7 +2,7 @@ Param(
     [Parameter(Mandatory=$true)][string] $ManifestDirPath    # Manifest directory where sbom will be placed
 )
 
-. $PSScriptRoot\pip
+. $PSScriptRoot\pipeline-logging-functions.ps1
 
 # Normally - we'd listen to the manifest path given, but 1ES templates will overwrite if this level gets uploaded directly
 # with their own overwriting ours. So we create it as a sub directory of the requested manifest path.


### PR DESCRIPTION
https://github.com/dotnet/arcade/pull/15603 accidentally removed parts of the line, causing errors when running the script.
