### PR TITLE
Remove the duplicated args

### DIFF
--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -224,21 +224,22 @@ function Build {
     bl="/bl:\"$log_dir/Build.binlog\""
   fi
 
+  [[ $properties != *"/p:Configuration"* ]] && properties="$properties /p:Configuration=$configuration"
+  [[ $properties != *"/p:RepoRoot"* ]] && properties="$properties /p:RepoRoot=\"$repo_root\""
+  [[ $properties != *"/p:Restore"* ]] && properties="$properties /p:Restore=$restore"
+  [[ $properties != *"/p:Build"* ]] && properties="$properties /p:Build=$build"
+  [[ $properties != *"/p:DotNetBuildRepo"* ]] && properties="$properties /p:DotNetBuildRepo=$product_build"
+  [[ $properties != *"/p:DotNetBuildSourceOnly"* ]] && properties="$properties /p:DotNetBuildSourceOnly=$source_build"
+  [[ $properties != *"/p:Rebuild"* ]] && properties="$properties /p:Rebuild=$rebuild"
+  [[ $properties != *"/p:Test"* ]] && properties="$properties /p:Test=$test"
+  [[ $properties != *"/p:Pack"* ]] && properties="$properties /p:Pack=$pack"
+  [[ $properties != *"/p:IntegrationTest"* ]] && properties="$properties /p:IntegrationTest=$integration_test"
+  [[ $properties != *"/p:PerformanceTest"* ]] && properties="$properties /p:PerformanceTest=$performance_test"
+  [[ $properties != *"/p:Sign"* ]] && properties="$properties /p:Sign=$sign"
+  [[ $properties != *"/p:Publish"* ]] && properties="$properties /p:Publish=$publish"
+
   MSBuild $_InitializeToolset \
     $bl \
-    /p:Configuration=$configuration \
-    /p:RepoRoot="$repo_root" \
-    /p:Restore=$restore \
-    /p:Build=$build \
-    /p:DotNetBuildRepo=$product_build \
-    /p:DotNetBuildSourceOnly=$source_build \
-    /p:Rebuild=$rebuild \
-    /p:Test=$test \
-    /p:Pack=$pack \
-    /p:IntegrationTest=$integration_test \
-    /p:PerformanceTest=$performance_test \
-    /p:Sign=$sign \
-    /p:Publish=$publish \
     $properties
 
   ExitWithExitCode 0

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -211,6 +211,19 @@ function InitializeCustomToolset {
   fi
 }
 
+function AddPropertyIfMissing {
+  while [[ $# > 0 ]]; do  
+    local property_name=$1
+    local property_value=$2
+    
+    if [[ ${properties,,} != *"/p:${property_name,,}"* ]]; then
+      properties="$properties /p:$property_name=$property_value"
+    fi
+    shift
+    shift
+  done
+}
+
 function Build {
   InitializeToolset
   InitializeCustomToolset
@@ -224,19 +237,19 @@ function Build {
     bl="/bl:\"$log_dir/Build.binlog\""
   fi
 
-  [[ $properties != *"/p:Configuration"* ]] && properties="$properties /p:Configuration=$configuration"
-  [[ $properties != *"/p:RepoRoot"* ]] && properties="$properties /p:RepoRoot=\"$repo_root\""
-  [[ $properties != *"/p:Restore"* ]] && properties="$properties /p:Restore=$restore"
-  [[ $properties != *"/p:Build"* ]] && properties="$properties /p:Build=$build"
-  [[ $properties != *"/p:DotNetBuildRepo"* ]] && properties="$properties /p:DotNetBuildRepo=$product_build"
-  [[ $properties != *"/p:DotNetBuildSourceOnly"* ]] && properties="$properties /p:DotNetBuildSourceOnly=$source_build"
-  [[ $properties != *"/p:Rebuild"* ]] && properties="$properties /p:Rebuild=$rebuild"
-  [[ $properties != *"/p:Test"* ]] && properties="$properties /p:Test=$test"
-  [[ $properties != *"/p:Pack"* ]] && properties="$properties /p:Pack=$pack"
-  [[ $properties != *"/p:IntegrationTest"* ]] && properties="$properties /p:IntegrationTest=$integration_test"
-  [[ $properties != *"/p:PerformanceTest"* ]] && properties="$properties /p:PerformanceTest=$performance_test"
-  [[ $properties != *"/p:Sign"* ]] && properties="$properties /p:Sign=$sign"
-  [[ $properties != *"/p:Publish"* ]] && properties="$properties /p:Publish=$publish"
+  AddPropertyIfMissing Configuration $configuration \
+                       RepoRoot \"$repo_root\" \
+                       Restore $restore \
+                       Build $build \
+                       DotNetBuildRepo $product_build \
+                       DotNetBuildSourceOnly $source_build \
+                       Rebuild $rebuild \
+                       Test $test \
+                       Pack $pack \
+                       IntegrationTest $integration_test \
+                       PerformanceTest $performance_test \
+                       Sign $sign \
+                       Publish $publish
 
   MSBuild $_InitializeToolset \
     $bl \

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
@@ -101,6 +101,12 @@
 
   <Target Name="RunInnerSourceBuildCommand"
           DependsOnTargets="PrepareInnerSourceBuildRepoRoot">
+    <ItemGroup Condition="'$(BaseInnerSourceBuildCommand)' == ''">
+      <InnerCommands Include="$(ARCADE_BUILD_TOOL_COMMAND.Split(' '))" />
+      <InnerSourceBuildCommand Include="@(InnerCommands)" Condition="!$(InnerBuildArgs.Contains('$([System.String]::Copy('%(Identity)').Split('=')[0])'))" />
+      <InnerSourceBuildCommand Remove="@(InnerCommands)" Condition="$([System.String]::Copy('%(Identity)').Contains('/bl:'))" />
+    </ItemGroup>
+
     <PropertyGroup>
       <!-- Prevent any projects from building in the outside build: they would use prebuilts. -->
       <PreventPrebuiltBuild>true</PreventPrebuiltBuild>
@@ -110,7 +116,7 @@
         appended. Allow the repo to override this default behavior if the repo is e.g. not onboarded
         enough on Arcade for this to work nicely.
       -->
-      <BaseInnerSourceBuildCommand Condition="'$(BaseInnerSourceBuildCommand)' == ''">$(ARCADE_BUILD_TOOL_COMMAND)</BaseInnerSourceBuildCommand>
+      <BaseInnerSourceBuildCommand Condition="'$(BaseInnerSourceBuildCommand)' == ''">@(InnerSourceBuildCommand->'%(Identity)', ' ')</BaseInnerSourceBuildCommand>
     </PropertyGroup>
 
     <Exec


### PR DESCRIPTION
Fix https://github.com/dotnet/source-build/issues/3789

Remove the duplicated args from the outer repo build command if the args have been added to the inner repo build command.