### PR TITLE
Import azure linux public key

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/Verification/LinuxPackageVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/LinuxPackageVerifier.cs
@@ -39,7 +39,7 @@ namespace Microsoft.SignCheck.Verification
             // https://microsoft.sharepoint.com/teams/prss/esrp/info/SitePages/Linux%20GPG%20Signing.aspx
             try
             {
-                Utils.DownloadAndConfigureMicrosoftPublicKey(tempDir);
+                Utils.DownloadAndConfigurePublicKeys(tempDir);
 
                 (string signatureDocument, string signableContent) = GetSignatureDocumentAndSignableContent(path, tempDir);
 


### PR DESCRIPTION
Azure linux RPMs are signed with the `LinuxSignMariner` cert, so they have a different public key than the RPMs that are signed with the `LinuxSign` cert. As a result, signing verification was failing for these files despite the fact that they were correctly signed. This PR fixes the signing verification failures by importing the azure linux public key into the keyring.

[Test pipeline run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2667564&view=results)