### PR TITLE
BuildCheck adjustments

### DIFF
--- a/eng/common/CIBuild.cmd
+++ b/eng/common/CIBuild.cmd
@@ -1,2 +1,2 @@
 @echo off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0Build.ps1""" -restore -build -test -sign -pack -publish -ci %*"
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0Build.ps1""" -restore -build -test -sign -pack -publish -ci -buildCheck %*"

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -7,6 +7,7 @@ Param(
   [string] $msbuildEngine = $null,
   [bool] $warnAsError = $true,
   [bool] $nodeReuse = $true,
+  [switch] $buildCheck = $false,
   [switch][Alias('r')]$restore,
   [switch] $deployDeps,
   [switch][Alias('b')]$build,
@@ -71,6 +72,8 @@ function Print-Usage() {
   Write-Host "  -msbuildEngine <value>  Msbuild engine to use to run build ('dotnet', 'vs', or unspecified)."
   Write-Host "  -excludePrereleaseVS    Set to exclude build engines in prerelease versions of Visual Studio"
   Write-Host "  -nativeToolsOnMachine   Sets the native tools on machine environment variable (indicating that the script should use native tools on machine)"
+  Write-Host "  -nodeReuse <value>      Sets nodereuse msbuild parameter ('true' or 'false')"
+  Write-Host "  -buildCheck             Sets /check msbuild parameter"
   Write-Host ""
 
   Write-Host "Command line arguments not listed above are passed thru to msbuild."
@@ -97,6 +100,7 @@ function Build {
 
   $bl = if ($binaryLog) { '/bl:' + (Join-Path $LogDir 'Build.binlog') } else { '' }
   $platformArg = if ($platform) { "/p:Platform=$platform" } else { '' }
+  $check = if ($buildCheck) { '/check' } else { '' }
 
   if ($projects) {
     # Re-assign properties to a new variable because PowerShell doesn't let us append properties directly for unclear reasons.
@@ -113,7 +117,7 @@ function Build {
   MSBuild $toolsetBuildProj `
     $bl `
     $platformArg `
-    /check `
+    $check `
     /p:Configuration=$configuration `
     /p:RepoRoot=$RepoRoot `
     /p:Restore=$restore `

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -42,6 +42,7 @@ usage()
   echo "  --prepareMachine         Prepare machine for CI run, clean up processes after build"
   echo "  --nodeReuse <value>      Sets nodereuse msbuild parameter ('true' or 'false')"
   echo "  --warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
+  echo "  --buildCheck <value>     Sets /check msbuild parameter"
   echo ""
   echo "Command line arguments not listed above are passed thru to msbuild."
   echo "Arguments can also be passed in with a single hyphen."
@@ -76,6 +77,7 @@ clean=false
 
 warn_as_error=true
 node_reuse=true
+build_check=false
 binary_log=false
 exclude_ci_binary_log=false
 pipelines_log=false
@@ -173,6 +175,9 @@ while [[ $# > 0 ]]; do
       node_reuse=$2
       shift
       ;;
+    -buildcheck)
+      build_check=true
+      ;;
     -runtimesourcefeed)
       runtime_source_feed=$2
       shift
@@ -224,9 +229,14 @@ function Build {
     bl="/bl:\"$log_dir/Build.binlog\""
   fi
 
+  local check=""
+  if [[ "$build_check" == true ]]; then
+    check="/check"
+  fi
+
   MSBuild $_InitializeToolset \
     $bl \
-    /check \
+    $check \
     /p:Configuration=$configuration \
     /p:RepoRoot="$repo_root" \
     /p:Restore=$restore \

--- a/eng/common/cibuild.sh
+++ b/eng/common/cibuild.sh
@@ -13,4 +13,4 @@ while [[ -h $source ]]; do
 done
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 
-. "$scriptroot/build.sh" --restore --build --test --pack --publish --ci $@
+. "$scriptroot/build.sh" --restore --build --test --pack --publish --ci --buildcheck $@

--- a/src/Microsoft.DotNet.XUnitAssert/src/.editorconfig
+++ b/src/Microsoft.DotNet.XUnitAssert/src/.editorconfig
@@ -219,3 +219,17 @@ dotnet_naming_style.begins_with_i.required_prefix = I
 dotnet_naming_style.begins_with_i.required_suffix =
 dotnet_naming_style.begins_with_i.word_separator =
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+# Build Checks
+[*.{csproj,proj,metaproj}]
+build_check.BC0101.Severity=suggestion
+build_check.BC0102.Severity=suggestion
+build_check.BC0103.Severity=suggestion
+build_check.BC0104.Severity=suggestion
+build_check.BC0105.Severity=suggestion
+build_check.BC0106.Severity=suggestion
+build_check.BC0107.Severity=suggestion
+
+build_check.BC0201.Severity=suggestion
+build_check.BC0202.Severity=suggestion
+build_check.BC0203.Severity=suggestion


### PR DESCRIPTION
### To double check:

* [x] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md


This PR fixes several problems caused by BuildCheck:

1) For internal build the changes were needed in 
/src/Microsoft.DotNet.XUnitAssert/src/.editorconfig (validation PR https://dev.azure.com/dnceng/internal/_build/results?buildId=2667954&view=results)

2) When `/check` is enabled by default, the way we restore/build projects **locally** don't allow to pick `.editorconfig` immediately and it reports violations for Tools.proj/Build.proj
<img width="1583" alt="{11EBA068-4FE3-45C8-9332-8F12F2C1E726}" src="https://github.com/user-attachments/assets/3200f4fb-169c-4a5e-8862-8b6e6b7360b2" />

It's not the case for CI builds, so I updated the scripts to skip `check` for local runs,
We will contemplate on a better workaround for this limitation.