### PR TITLE
Set DotNetBuildPass when using Projects property in build.proj

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -71,6 +71,7 @@
     <!-- Setting 'Projects' overrides the ProjectToBuild list. -->
     <ProjectToBuild Remove="@(ProjectToBuild)" />
     <ProjectToBuild Include="$(Projects)" />
+    <ProjectToBuild Update="@(PackageReference)" Condition="'$(_DotNetBuildPassNormalized)' != '' DotNetBuildPass="$(_DotNetBuildPassNormalized)" />
   </ItemGroup>
 
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -71,7 +71,7 @@
     <!-- Setting 'Projects' overrides the ProjectToBuild list. -->
     <ProjectToBuild Remove="@(ProjectToBuild)" />
     <ProjectToBuild Include="$(Projects)" />
-    <ProjectToBuild Update="@(ProjectToBuild)" Condition="'$(_DotNetBuildPassNormalized)' != '' DotNetBuildPass="$(_DotNetBuildPassNormalized)" />
+    <ProjectToBuild Update="@(ProjectToBuild)" Condition="'$(_DotNetBuildPassNormalized)' != ''" DotNetBuildPass="$(_DotNetBuildPassNormalized)" />
   </ItemGroup>
 
   <!--

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -71,7 +71,7 @@
     <!-- Setting 'Projects' overrides the ProjectToBuild list. -->
     <ProjectToBuild Remove="@(ProjectToBuild)" />
     <ProjectToBuild Include="$(Projects)" />
-    <ProjectToBuild Update="@(PackageReference)" Condition="'$(_DotNetBuildPassNormalized)' != '' DotNetBuildPass="$(_DotNetBuildPassNormalized)" />
+    <ProjectToBuild Update="@(ProjectToBuild)" Condition="'$(_DotNetBuildPassNormalized)' != '' DotNetBuildPass="$(_DotNetBuildPassNormalized)" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
Currently if a repo uses the `-Projects` switch to `build.ps1` (or explicitly sets the `Projects` property), the Pass 2 build will fail in the VMR, because the `DotNetBuildPass` metadata won't be set on the `ProjectToBuild` Item.