### PR TITLE
Fix ConditionalFact not working with new xunit.runner.visualstudio version

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions/src/SkippedTestCase.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/src/SkippedTestCase.cs
@@ -38,8 +38,11 @@ namespace Microsoft.DotNet.XUnitExtensions
 
         public override void Deserialize(IXunitSerializationInfo data)
         {
-            base.Deserialize(data);
             _skipReason = data.GetValue<string>(nameof(_skipReason));
+
+            // we need to call base after reading our value, because Deserialize will call
+            // into GetSkipReason.
+            base.Deserialize(data);
         }
 
         public override void Serialize(IXunitSerializationInfo data)

--- a/src/Microsoft.DotNet.XUnitExtensions/tests/ConditionalAttributeTests.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions/tests/ConditionalAttributeTests.cs
@@ -14,15 +14,24 @@ namespace Microsoft.DotNet.XUnitExtensions.Tests
         // This test class is test order dependent so do not rename the tests.
         // If new tests need to be added, follow the same naming pattern ConditionalAttribute{LetterToOrderTest} and then add a Validate{TestName}.
 
-        private static bool s_conditionalFactExecuted;
-        private static int s_conditionalTheoryCount;
+        private static bool s_conditionalFactTrueExecuted;
+        private static bool s_conditionalFactFalseExecuted;
+        private static int s_conditionalTheoryTrueCount;
+        private static int s_conditionalTheoryFalseCount;
 
         public static bool AlwaysTrue => true;
+        public static bool AlwaysFalse => false;
 
         [ConditionalFact(nameof(AlwaysTrue))]
-        public void ConditionalAttributeA()
+        public void ConditionalAttributeTrue()
         {
-            s_conditionalFactExecuted = true;
+            s_conditionalFactTrueExecuted = true;
+        }
+
+        [ConditionalFact(nameof(AlwaysFalse))]
+        public void ConditionalAttributeFalse()
+        {
+            s_conditionalFactFalseExecuted = true;
         }
 
         [Fact]
@@ -62,22 +71,45 @@ namespace Microsoft.DotNet.XUnitExtensions.Tests
         [InlineData(2)]
         [InlineData(3)]
 #pragma warning disable xUnit1026 // Theory methods should use all of their parameters
-        public void ConditionalAttributeB(int _)
+        public void ConditionalTheoryTrue(int _)
 #pragma warning restore xUnit1026 // Theory methods should use all of their parameters
         {
-            s_conditionalTheoryCount++;
+            s_conditionalTheoryTrueCount++;
+        }
+
+        [ConditionalTheory(nameof(AlwaysFalse))]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+#pragma warning disable xUnit1026 // Theory methods should use all of their parameters
+        public void ConditionalTheoryFalse(int _)
+#pragma warning restore xUnit1026 // Theory methods should use all of their parameters
+        {
+            s_conditionalTheoryFalseCount++;
         }
 
         [Fact]
-        public void ValidateConditionalFact()
+        public void ValidateConditionalFactTrue()
         {
-            Assert.True(s_conditionalFactExecuted);
+            Assert.True(s_conditionalFactTrueExecuted);
         }
 
         [Fact]
-        public void ValidateConditionalTheory()
+        public void ValidateConditionalFactFalse()
         {
-            Assert.Equal(3, s_conditionalTheoryCount);
+            Assert.False(s_conditionalFactFalseExecuted);
+        }
+
+        [Fact]
+        public void ValidateConditionalTheoryTrue()
+        {
+            Assert.Equal(3, s_conditionalTheoryTrueCount);
+        }
+
+        [Fact]
+        public void ValidateConditionalTheoryFalse()
+        {
+            Assert.Equal(0, s_conditionalTheoryFalseCount);
         }
     }
 }


### PR DESCRIPTION
After https://github.com/dotnet/arcade/pull/15651 I noticed that tests would fail that shouldn't even be executed because of a ConditionalFact that was false.

It turned out that with the new xunit.runner.visualstudio version these tests were always running regardless of the condition.

The reason is that we were setting the `_skipReason` _after_ calling the base [Deserialize()](https://github.com/xunit/xunit/blob/9712244020d385955d33136b3fe3e87de43539cd/src/xunit.execution/Sdk/Frameworks/XunitTestCase.cs#L181-L186), but that one sets the [Timeout](https://github.com/xunit/xunit/blob/9712244020d385955d33136b3fe3e87de43539cd/src/xunit.execution/Sdk/Frameworks/XunitTestCase.cs#L74-L86) property which in turn calls Initialize which [calls GetSkipReason()](https://github.com/xunit/xunit/blob/9712244020d385955d33136b3fe3e87de43539cd/src/xunit.execution/Sdk/Frameworks/XunitTestCase.cs#L128) which then calls into our overridden GetSkipReason method in SkippedTestCase and at that point we don't have _skipReason yet so we return null which means the test case is _not_ skipped.

The fix is to set _skipReason before calling the base Deserialize. This is actually exactly what aspnetcore discovered ages ago in https://github.com/dotnet/aspnetcore/commit/b1987c75cbceb42c2da539d4df956a5204af07fd / https://github.com/xunit/visualstudio.xunit/issues/266#issuecomment-530557920.

So why did we not notice this until now? It turns out the old version of xunit.runner.visualstudio does not go through the Serialize/Deserialize codepath when running on the command line. If I run with the old version in VS Test Explorer however I see exactly the same issue:

<img width="1098" alt="image" src="https://github.com/user-attachments/assets/cbfaede6-1adc-4fab-988c-cfdc72451423" />

The new version seems to use the Serialize/Deserialize protocol also on the command line so that's why we hit it there.

Additionally, the tests in arcade didn't catch this because they were never testing that a ConditionalFact=false method is _not_ executed, only the inverse. Added tests for that scenario too.

It works correctly now both inside and outside of VS with both the old and new version of xunit.runner.visualstudio:
<img width="836" alt="image" src="https://github.com/user-attachments/assets/b78a186d-ae4b-4646-ab99-379e8f30fdda" />
