### PR TITLE
Remove signing opt-out in rid-specific caes.

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -32,29 +32,8 @@
     <CertificatesSignInfo Include="MacDeveloperVNextHardenWithNotarization" MacCertificate="MacDeveloperVNextHarden" MacNotarizationAppName="dotnet" />
   </ItemGroup>
 
-  <!-- Only publish packages that contain this build's Target RID in the name.
-       PostBuildSign switch is kept for avoiding breaks in repos that use it to avoid signing. -->
-  <ItemGroup Condition="'$(EnableDefaultArtifacts)' == 'true' and '$(PostBuildSign)' != 'true' and '$(EnableDefaultRidSpecificArtifacts)' == 'true'">
-    <ItemsToSign Include="$(ArtifactsShippingPackagesDir)**/*.$(TargetRid).*.nupkg"/>
-    <ItemsToSign Include="$(ArtifactsNonShippingPackagesDir)**/*.$(TargetRid).*.nupkg" />
-    <!--
-      Integration with Microsoft.DotNet.Build.Tasks.Installers: Publish packages of the following formats as well.
-      These are arch-specific Visual Studio insertion packages. As they're Windows-only, they only include architecture in the name:
-      - VS.Redist.Common.*.$(TargetArchitecture).*.nupkg
-      - VS.Redist.Common.*.$(TargetArchitecture)-*.*.nupkg
-      
-      These packages are always non-shipping, so only look there.
-    -->
-    <ItemsToSign Include="$(ArtifactsNonShippingPackagesDir)**/VS.Redist.Common.*.$(TargetArchitecture).*.nupkg" />
-    <ItemsToSign Include="$(ArtifactsNonShippingPackagesDir)**/VS.Redist.Common.*.$(TargetArchitecture)-*.*.nupkg" />
-
-    <!-- Always sign all vsix packages and VS Build Packages. These may be arch specific or agnostic, but they likely won't have the RID included. -->
-    <ItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.vsix" />
-    <ItemsToSign Include="$(VisualStudioBuildPackagesDir)**\*.nupkg" />
-  </ItemGroup>
-
   <!-- PostBuildSign switch is kept for avoiding breaks in repos that use it to avoid signing. -->
-  <ItemGroup Condition="'$(EnableDefaultArtifacts)' == 'true' and '$(PostBuildSign)' != 'true' and '$(EnableDefaultRidSpecificArtifacts)' != 'true'">
+  <ItemGroup Condition="'$(EnableDefaultArtifacts)' == 'true' and '$(PostBuildSign)' != 'true'">
     <!-- List of container files that will be opened and checked for files that need to be signed. -->
     <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.nupkg" />
     <ItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.vsix" />


### PR DESCRIPTION
We really need to always sign all of our artifacts, because we don't know how they will get repackaged in downstream legs.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
