### PR TITLE
Check authority in MachOVerifier

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/Utils.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Utils.cs
@@ -88,6 +88,11 @@ namespace Microsoft.SignCheck
         /// <returns>The parsed DateTime value or the default value.</returns>
         public static DateTime DateTimeOrDefault(this string timestamp, DateTime defaultValue)
         {
+            if (string.IsNullOrEmpty(timestamp))
+            {
+                return defaultValue;
+            }
+
             timestamp = Regex.Replace(timestamp, @"\s{2,}", " ").Trim();
 
             // Try to parse the timestamp as a Unix timestamp (seconds since epoch)


### PR DESCRIPTION
Some macho files have been ad-hoc signed, so they're passing signing when they shouldn't be. To avoid these files passing signing verification, we should also verify that one of the signature authorities is Microsoft.