### PR TITLE
Enable Restore binary log by default when enabling binary logging

### DIFF
--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -132,6 +132,7 @@ function Build {
     /p:PerformanceTest=$performanceTest `
     /p:Sign=$sign `
     /p:Publish=$publish `
+    /p:RestoreStaticGraphEnableBinaryLogger=$binaryLog `
     @properties
 }
 

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -250,6 +250,7 @@ function Build {
     /p:PerformanceTest=$performance_test \
     /p:Sign=$sign \
     /p:Publish=$publish \
+    /p:RestoreStaticGraphEnableBinaryLogger=$binary_log \
     $properties
 
   ExitWithExitCode 0

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -201,6 +201,8 @@
       <_SolutionRestoreProps Include="_NETCORE_ENGINEERING_TELEMETRY=Restore" />
       <_SolutionRestoreProps Include="MSBuildRestoreSessionId=$([System.Guid]::NewGuid())" />
       <_SolutionRestoreProps Include="RestoreUseStaticGraphEvaluation=$(RestoreUseStaticGraphEvaluation)" />
+      <_SolutionRestoreProps Include="RestoreEmbedFilesInBinlog=true" />
+      <_SolutionRestoreProps Include="RestoreStaticGraphEnableBinaryLogger=$(GenerateRestoreUseStaticGraphEvaluationBinlog)" />
     </ItemGroup>
 
     <PropertyGroup>
@@ -245,7 +247,7 @@
     <!-- Enable binlog generation during static graph restore evaluation -->
     <ItemGroup Condition="'$(GenerateRestoreUseStaticGraphEvaluationBinlog)' == 'true'">
       <_ProjectToRestore>
-        <AdditionalProperties>RESTORE_TASK_BINLOG_PARAMETERS=$(ArtifactsLogDir)Restore-%(Filename)%(Extension).binlog</AdditionalProperties>
+        <AdditionalProperties>RestoreStaticGraphBinaryLoggerParameters=$(ArtifactsLogDir)Restore-%(Filename)%(Extension).binlog</AdditionalProperties>
       </_ProjectToRestore>
     </ItemGroup>
 


### PR DESCRIPTION
Also fix the support in Build.proj. The current one passes a property that must be an environment variable and as such doesn't do anything.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
