### PR TITLE
Fix handling publishing cross-arch pack packages

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -114,12 +114,12 @@
       Integration with Microsoft.DotNet.Build.Tasks.Installers: Publish packages of the following formats as well.
       These are arch-specific Visual Studio insertion packages. As they're Windows-only, they only include architecture in the name:
       - VS.Redist.Common.*.$(TargetArchitecture).*.nupkg
-      - VS.Redist.Common.*.$(TargetArchitecture)-*.*.nupkg
+      - VS.Redist.Common.*.*_$(TargetArchitecture).*.nupkg
       
       These packages are always non-shipping, so only look there.
     -->
     <Artifact Include="$(ArtifactsNonShippingPackagesDir)**/VS.Redist.Common.*.$(TargetArchitecture).*.nupkg" IsShipping="false" Kind="Package" />
-    <Artifact Include="$(ArtifactsNonShippingPackagesDir)**/VS.Redist.Common.*.$(TargetArchitecture)-*.*.nupkg" IsShipping="false" Kind="Package" />
+    <Artifact Include="$(ArtifactsNonShippingPackagesDir)**/VS.Redist.Common.*.*_$(TargetArchitecture).*.nupkg" IsShipping="false" Kind="Package" />
 
     <!--
       In the VMR, don't publish packages that didn't match the above conditions externally.


### PR DESCRIPTION
The handling for these paths had the wrong separator and was on the wrong side. Contributes to 
https://github.com/dotnet/source-build/issues/4984

Validated against the package listings from specific verticals

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
