### PR TITLE
Container exclusions should apply at all levels

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/Verification/ArchiveVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/ArchiveVerifier.cs
@@ -92,7 +92,7 @@ namespace Microsoft.SignCheck.Verification
                         {
                             var result = SignatureVerificationResult.UnsupportedFileTypeResult(
                                 archiveEntry.RelativePath,
-                                svr.Filename,
+                                svr.VirtualPath,
                                 Path.Combine(svr.VirtualPath, archiveEntry.RelativePath));
 
                             result.AddDetail(DetailKeys.Misc, "Empty or invalid archive entry");
@@ -117,7 +117,7 @@ namespace Microsoft.SignCheck.Verification
                     // and we need to ensure they are extracted before we verify the MSIs.
                     foreach (string fullName in archiveMap.Keys)
                     {
-                        SignatureVerificationResult result = VerifyFile(archiveMap[fullName], svr.Filename,
+                        SignatureVerificationResult result = VerifyFile(archiveMap[fullName], svr.VirtualPath,
                             Path.Combine(svr.VirtualPath, fullName), fullName);
 
                         // Tag the full path into the result detail

--- a/src/SignCheck/Microsoft.SignCheck/Verification/Exclusions.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Exclusions.cs
@@ -146,7 +146,7 @@ namespace Microsoft.SignCheck.Verification
         /// <returns></returns>
         public bool IsParentExcluded(string parent)
         {
-            return _exclusions.Any(e => IsMatch(e.ParentFiles.Select(pattern => $"*{pattern}*").ToArray(), parent));
+            return _exclusions.Any(e => IsMatch(e.ParentFiles.Select(pattern => !string.IsNullOrEmpty(pattern) ? $"*{pattern}*" : pattern).ToArray(), parent));
         }
 
         private bool IsMatch(string[] patterns, string value)

--- a/src/SignCheck/Microsoft.SignCheck/Verification/Exclusions.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Exclusions.cs
@@ -77,9 +77,14 @@ namespace Microsoft.SignCheck.Verification
                 //    Example: bar.dll;*.zip --> Exclude any occurence of bar.dll that is in a zip file
                 //             bar.dll;foo.zip --> Exclude bar.dll only if it is contained inside foo.zip
                 //             foo.exe;; --> Exclude any occurance of foo.exe and ignore the parent
-                if (IsMatch(e.FilePatterns, Path.GetFileName(containerPath)) || IsMatch(e.FilePatterns, containerPath) || IsMatch(e.FilePatterns, path) || IsMatch(e.FilePatterns, Path.GetFileName(path)) || IsMatch(e.FilePatterns, virtualPath))
+                if (IsMatch(e.FilePatterns, Path.GetFileName(containerPath)) ||
+                    IsMatch(e.FilePatterns, containerPath) ||
+                    IsMatch(e.FilePatterns, Path.GetFileName(path)) ||
+                    IsMatch(e.FilePatterns, path) ||
+                    IsMatch(e.FilePatterns, Path.GetFileName(virtualPath)) ||
+                    IsMatch(e.FilePatterns, virtualPath))
                 {
-                    if ((e.ParentFiles.Length == 0) || (e.ParentFiles.All(pf => String.IsNullOrEmpty(pf))) || IsMatch(e.ParentFiles, parent))
+                    if ((e.ParentFiles.Length == 0) || (e.ParentFiles.All(pf => String.IsNullOrEmpty(pf))) || IsParentExcluded(parent))
                     {
                         return true;
                     }
@@ -95,7 +100,7 @@ namespace Microsoft.SignCheck.Verification
 
             // 3. There is no file exclusion, but a parent exclusion matches.
             //    Example: ;foo.zip; --> Exclude any file in foo.zip. This is similar to using *;foo.zip;
-            return exclusions.Any(e => (e.FilePatterns.All(fp => String.IsNullOrEmpty(fp)) && IsMatch(e.ParentFiles, parent)));
+            return exclusions.Any(e => (e.FilePatterns.All(fp => String.IsNullOrEmpty(fp)) && IsParentExcluded(parent)));
         }
 
         /// <summary>
@@ -141,7 +146,7 @@ namespace Microsoft.SignCheck.Verification
         /// <returns></returns>
         public bool IsParentExcluded(string parent)
         {
-            return _exclusions.Any(e => IsMatch(e.ParentFiles, parent));
+            return _exclusions.Any(e => IsMatch(e.ParentFiles.Select(pattern => $"*{pattern}*").ToArray(), parent));
         }
 
         private bool IsMatch(string[] patterns, string value)


### PR DESCRIPTION
Fixes an issue where entries in nested containers were not being excluded despite the root-level container being excluded.

Take the following exclusion for example: `;dotnet-sdk-pgo-*.tar.gz|dotnet-sdk-pgo-*.zip;PGO, PGO builds are unsigned`. This exclusion means that files in `dotnet-sdk-pgo-*.tar.gz` and `dotnet-sdk-pgo-*.zip` should be excluded from SignCheck. The behavior of SignCheck was incorrect before the changes in this PR:

#### Original behavior (1 excluded, 1 skipped, 1 unsigned):

```xml
<File Name="dotnet-sdk-pgo-10.0.100-preview.3.25154.111-win-arm64.zip/sdk/10.0.100-preview.3.25154.111/FSharp/library-packs/FSharp.Core.9.0.300-beta.25154.111.nupkg" Outcome="Excluded">
  <File Name="dotnet-sdk-pgo-10.0.100-preview.3.25154.111-win-arm64.zip/sdk/10.0.100-preview.3.25154.111/FSharp/library-packs/FSharp.Core.9.0.300-beta.25154.111.nupkg/Icon.png" Outcome="Skipped" />
  <File Name="dotnet-sdk-pgo-10.0.100-preview.3.25154.111-win-arm64.zip/sdk/10.0.100-preview.3.25154.111/FSharp/library-packs/FSharp.Core.9.0.300-beta.25154.111.nupkg/lib/netstandard2.0/FSharp.Core.dll" Outcome="Unsigned" AuthentiCode="AuthentiCode signed: False" StrongName="StrongName signed: False" />
...
```

#### Fixed behavior (2 excluded, 1 skipped excluded)
```xml
<File Name="dotnet-sdk-pgo-10.0.100-preview.3.25154.111-win-arm64.zip/sdk/10.0.100-preview.3.25154.111/FSharp/library-packs/FSharp.Core.9.0.300-beta.25154.111.nupkg" Outcome="Excluded">
  <File Name="dotnet-sdk-pgo-10.0.100-preview.3.25154.111-win-arm64.zip/sdk/10.0.100-preview.3.25154.111/FSharp/library-packs/FSharp.Core.9.0.300-beta.25154.111.nupkg/Icon.png" Outcome="SkippedExcluded" />
  <File Name="dotnet-sdk-pgo-10.0.100-preview.3.25154.111-win-arm64.zip/sdk/10.0.100-preview.3.25154.111/FSharp/library-packs/FSharp.Core.9.0.300-beta.25154.111.nupkg/lib/netstandard2.0/FSharp.Core.dll" Outcome="Excluded" AuthentiCode="AuthentiCode signed: False" StrongName="StrongName signed: False" />
...
```
