### PR TITLE
Allow files to ignore StrongName result

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/Verification/Exclusions.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Exclusions.cs
@@ -69,7 +69,7 @@ namespace Microsoft.SignCheck.Verification
             return _exclusions.Contains(exclusion);
         }
 
-        public bool IsExcluded(string path, string parent, string virtualPath, string containerPath, IEnumerable<Exclusion> exclusions)
+        private bool IsExcluded(string path, string parent, string virtualPath, string containerPath, IEnumerable<Exclusion> exclusions)
         {
             foreach (Exclusion e in exclusions)
             {
@@ -108,7 +108,8 @@ namespace Microsoft.SignCheck.Verification
         /// <returns></returns>
         public bool IsExcluded(string path, string parent, string virtualPath, string containerPath)
         {
-            return IsExcluded(path, parent, virtualPath, containerPath, _exclusions);
+            IEnumerable<Exclusion> exclusions = _exclusions.Where(e => !e.Comment.Contains("IGNORE-STRONG-NAME"));
+            return IsExcluded(path, parent, virtualPath, containerPath, exclusions);
         }
 
         /// <summary>
@@ -122,6 +123,14 @@ namespace Microsoft.SignCheck.Verification
             IEnumerable<Exclusion> doNotSignExclusions = _exclusions.Where(e => e.Comment.Contains("DO-NOT-SIGN")).ToArray();
 
             return (doNotSignExclusions.Count() > 0) && (IsExcluded(path, parent, virtualPath, containerPath, doNotSignExclusions));
+        }
+
+        public bool IsIgnoreStrongName(string path, string parent, string virtualPath, string containerPath)
+        {
+            // Get all the exclusions with NO-STRONG-NAME markers and check only against those
+            IEnumerable<Exclusion> noStrongNameExclusions = _exclusions.Where(e => e.Comment.Contains("IGNORE-STRONG-NAME"));
+
+            return (noStrongNameExclusions.Count() > 0) && (IsExcluded(path, parent, virtualPath, containerPath, noStrongNameExclusions));
         }
 
         /// <summary>

--- a/src/SignCheck/Microsoft.SignCheck/Verification/PortableExecutableVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/PortableExecutableVerifier.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.IO;
 using Microsoft.SignCheck.Interop.PortableExecutable;
 using Microsoft.SignCheck.Logging;
 using Microsoft.DotNet.StrongName;
@@ -40,9 +42,15 @@ namespace Microsoft.SignCheck.Verification
             if (VerifyStrongNameSignature)
             {
                 VerifyStrongName(svr);
+
+                svr.IsIgnoreStrongName = Exclusions.IsIgnoreStrongName(Path.GetFileName(svr.VirtualPath), parent, svr.VirtualPath, null);
+                if (svr.IsIgnoreStrongName)
+                {
+                    svr.AddDetail(DetailKeys.StrongName, $"Ignoring strong-name result because file is IGNORE-STRONG-NAME.");
+                }
             }
 
-            svr.IsSigned = svr.IsAuthentiCodeSigned & ((svr.IsStrongNameSigned) || (!VerifyStrongNameSignature) || svr.IsNativeImage);
+            svr.IsSigned = svr.IsAuthentiCodeSigned & (svr.IsStrongNameSigned || !VerifyStrongNameSignature || svr.IsNativeImage || svr.IsIgnoreStrongName);
             svr.AddDetail(DetailKeys.File, SignCheckResources.DetailSigned, svr.IsSigned);
 
             return svr;

--- a/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationResult.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationResult.cs
@@ -80,6 +80,15 @@ namespace Microsoft.SignCheck.Verification
         }
 
         /// <summary>
+        /// True if this file was marked as IGNORE-STRONG-NAME. This result can be used with IsStrongNameSigned
+        /// </summary>
+        public bool IsIgnoreStrongName
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// True if the file was excluded from verification, false otherwise.
         /// </summary>
         public bool IsExcluded


### PR DESCRIPTION
Adds functionality to allow files to skip strong name verification.

#### Example:
`ProjectOne.dll;;random, IGNORE-STRONG-NAME` => `<File Name="test.vsix/lib/net461/ProjectOne.dll" Outcome="Unsigned" AuthentiCode="AuthentiCode signed: False" StrongName="StrongName signed: False, Ignoring strong-name result because file is IGNORE-STRONG-NAME." />`