### PR TITLE
Update pipelines to run on Azure Linux 3

### DIFF
--- a/azure-pipelines-codeql.yml
+++ b/azure-pipelines-codeql.yml
@@ -34,7 +34,6 @@ schedules:
       include:
       - main
       - release/6.0
-      - release/7.0
       - release/8.0
     always: true
 

--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -4,7 +4,6 @@ trigger:
     include:
     - main
     - release/6.0
-    - release/7.0
     - release/8.0
     exclude:
     - .github/*
@@ -21,7 +20,6 @@ pr:
     include:
     - main
     - release/6.0
-    - release/7.0
     - release/8.0
     - templates
   paths:
@@ -47,7 +45,7 @@ variables:
 resources:
   containers:
   - container: LinuxContainer
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-fpm-amd64
 
 stages:
 - stage: build

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -4,7 +4,6 @@ trigger:
     include:
     - main
     - release/6.0
-    - release/7.0
     - release/8.0
 
 pr: none

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,6 @@ trigger:
     include:
     - main
     - release/6.0
-    - release/7.0
     - release/8.0
   paths:
     include:
@@ -28,7 +27,7 @@ variables:
 resources:
   containers:
   - container: LinuxContainer
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-fpm-amd64
   repositories:
   - repository: 1ESPipelineTemplates
     type: git


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md

Updated pipelines to remove release/7.0. 
Replaced Mariner 2.0 with Azure Linux 3.0