### PR TITLE
Avoid regex lookups

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/Verification/Exclusion.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Exclusion.cs
@@ -119,54 +119,22 @@ namespace Microsoft.SignCheck.Verification
             return defaultValue;
         }
 
-        public bool TryGetIsFileExcluded(
-            string exclusionsClassification,
-            IEnumerable<string> values,
-            out bool isExcluded)
-        {
-            if (TryGetIsExcluded(_fileExcludedCache, _fileNotExcludedCache, exclusionsClassification, values, out isExcluded))
-            {
-                return true;
-            }
+        public bool TryGetIsFileExcluded(string exclusionsClassification, IEnumerable<string> values, out bool isExcluded)
+            => TryGetIsExcluded(_fileExcludedCache, _fileNotExcludedCache, exclusionsClassification, values, out isExcluded); 
 
-            return false;
-        }
-
-        public bool TryGetIsParentExcluded(
-            string exclusionsClassification,
-            string parent,
-            out bool isExcluded)
-        {
-            if (TryGetIsExcluded(_parentExcludedCache, _parentNotExcludedCache, exclusionsClassification, new[] { parent }, out isExcluded))
-            {
-                return true;
-            }
-
-            return false;
-        }
+        public bool TryGetIsParentExcluded(string exclusionsClassification, string parent, out bool isExcluded)
+            => TryGetIsExcluded(_parentExcludedCache, _parentNotExcludedCache, exclusionsClassification, new[] { parent }, out isExcluded);
 
         public void AddToFileCache(string exclusionsClassification, IEnumerable<string> values, bool isExcluded)
         {
-            if (isExcluded)
-            {
-                AddToCache(_fileExcludedCache, exclusionsClassification, values);
-            }
-            else
-            {
-                AddToCache(_fileNotExcludedCache, exclusionsClassification, values);
-            }
+            Dictionary<string, HashSet<string>> cache = isExcluded ? _fileExcludedCache : _fileNotExcludedCache;
+            AddToCache(cache, exclusionsClassification, values);
         }
 
         public void AddToParentCache(string exclusionsClassification, string parent, bool isExcluded)
         {
-            if (isExcluded)
-            {
-                AddToCache(_parentExcludedCache, exclusionsClassification, new[] { parent });
-            }
-            else
-            {
-                AddToCache(_parentNotExcludedCache, exclusionsClassification, new[] { parent });
-            }
+            Dictionary<string, HashSet<string>> cache = isExcluded ? _parentExcludedCache : _parentNotExcludedCache;
+            AddToCache(cache, exclusionsClassification, new[] { parent });
         }
 
         private bool TryGetIsExcluded(

--- a/src/SignCheck/Microsoft.SignCheck/Verification/Exclusions.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Exclusions.cs
@@ -12,8 +12,8 @@ namespace Microsoft.SignCheck.Verification
     public class Exclusions
     {
         /// <summary>
-        /// Cache for file and parent exclusions. This is used to speed up the
-        /// exclusion check because regex lookups are expensive.
+        /// Cache for regex exclusions.
+        /// Helps avoid recompiling the regex for the same pattern multiple times.
         /// </summary>
         private Dictionary<string, Regex> _regexCache = new Dictionary<string, Regex>();
         private static readonly char[] _wildCards = new char[] { '*', '?' };

--- a/src/SignCheck/Microsoft.SignCheck/Verification/Exclusions.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Exclusions.cs
@@ -19,6 +19,10 @@ namespace Microsoft.SignCheck.Verification
         private static readonly char[] _wildCards = new char[] { '*', '?' };
         private List<Exclusion> _exclusions = new List<Exclusion>();
 
+        private const string DoNotSign = "DO-NOT-SIGN";
+        private const string General = "GENERAL";
+        private const string IgnoreStrongName = "IGNORE-STRONG-NAME";
+
         public int Count
         {
             get
@@ -109,8 +113,8 @@ namespace Microsoft.SignCheck.Verification
         /// <returns></returns>
         public bool IsExcluded(string path, string parent, string virtualPath, string containerPath)
         {
-            IEnumerable<Exclusion> exclusions = _exclusions.Where(e => !e.Comment.Contains("IGNORE-STRONG-NAME"));
-            return IsExcluded(path, parent, virtualPath, containerPath, "GENERAL", exclusions);
+            IEnumerable<Exclusion> exclusions = _exclusions.Where(e => !e.Comment.Contains(IgnoreStrongName));
+            return IsExcluded(path, parent, virtualPath, containerPath, General, exclusions);
         }
 
         /// <summary>
@@ -121,17 +125,17 @@ namespace Microsoft.SignCheck.Verification
         public bool IsDoNotSign(string path, string parent, string virtualPath, string containerPath)
         {
             // Get all the exclusions with DO-NOT-SIGN markers and check only against those
-            IEnumerable<Exclusion> doNotSignExclusions = _exclusions.Where(e => e.Comment.Contains("DO-NOT-SIGN")).ToArray();
+            IEnumerable<Exclusion> doNotSignExclusions = _exclusions.Where(e => e.Comment.Contains(DoNotSign)).ToArray();
 
-            return (doNotSignExclusions.Count() > 0) && (IsExcluded(path, parent, virtualPath, containerPath, "DO-NOT-SIGN", doNotSignExclusions));
+            return (doNotSignExclusions.Count() > 0) && (IsExcluded(path, parent, virtualPath, containerPath, DoNotSign, doNotSignExclusions));
         }
 
         public bool IsIgnoreStrongName(string path, string parent, string virtualPath, string containerPath)
         {
             // Get all the exclusions with NO-STRONG-NAME markers and check only against those
-            IEnumerable<Exclusion> noStrongNameExclusions = _exclusions.Where(e => e.Comment.Contains("IGNORE-STRONG-NAME"));
+            IEnumerable<Exclusion> noStrongNameExclusions = _exclusions.Where(e => e.Comment.Contains(IgnoreStrongName));
 
-            return (noStrongNameExclusions.Count() > 0) && (IsExcluded(path, parent, virtualPath, containerPath, "IGNORE-STRONG-NAME", noStrongNameExclusions));
+            return (noStrongNameExclusions.Count() > 0) && (IsExcluded(path, parent, virtualPath, containerPath, IgnoreStrongName, noStrongNameExclusions));
         }
 
         /// <summary>

--- a/src/SignCheck/Microsoft.SignCheck/Verification/Exclusions.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Exclusions.cs
@@ -11,6 +11,11 @@ namespace Microsoft.SignCheck.Verification
 {
     public class Exclusions
     {
+        /// <summary>
+        /// Cache for file and parent exclusions. This is used to speed up the
+        /// exclusion check because regex lookups are expensive.
+        /// </summary>
+        private Dictionary<string, Regex> _regexCache = new Dictionary<string, Regex>();
         private static readonly char[] _wildCards = new char[] { '*', '?' };
         private List<Exclusion> _exclusions = new List<Exclusion>();
 
@@ -69,38 +74,29 @@ namespace Microsoft.SignCheck.Verification
             return _exclusions.Contains(exclusion);
         }
 
-        private bool IsExcluded(string path, string parent, string virtualPath, string containerPath, IEnumerable<Exclusion> exclusions)
+        private bool IsExcluded(string path, string parent, string virtualPath, string containerPath, string exclusionClassification, IEnumerable<Exclusion> exclusions)
         {
-            foreach (Exclusion e in exclusions)
+            foreach (var exclusion in exclusions)
             {
                 // 1. The file/container path matches a file part of the exclusion and the parent matches the parent part of the exclusion.
                 //    Example: bar.dll;*.zip --> Exclude any occurence of bar.dll that is in a zip file
                 //             bar.dll;foo.zip --> Exclude bar.dll only if it is contained inside foo.zip
                 //             foo.exe;; --> Exclude any occurance of foo.exe and ignore the parent
-                if (IsMatch(e.FilePatterns, Path.GetFileName(containerPath)) ||
-                    IsMatch(e.FilePatterns, containerPath) ||
-                    IsMatch(e.FilePatterns, Path.GetFileName(path)) ||
-                    IsMatch(e.FilePatterns, path) ||
-                    IsMatch(e.FilePatterns, Path.GetFileName(virtualPath)) ||
-                    IsMatch(e.FilePatterns, virtualPath))
+                if (IsFileExcluded(exclusion, path, containerPath, virtualPath, exclusionClassification) &&
+                    (!exclusion.HasParentFiles || IsParentExcluded(exclusion, parent, exclusionClassification)))
                 {
-                    if ((e.ParentFiles.Length == 0) || (e.ParentFiles.All(pf => String.IsNullOrEmpty(pf))) || IsParentExcluded(parent))
-                    {
-                        return true;
-                    }
+                    return true;
                 }
 
-                // 2. The file/container path matches the file part of the exclusion and there is no parent exclusion. 
-                //    Example: *.dll;; --> Exclude any file with a .dll extension
-                if ((IsMatch(e.FilePatterns, path) || IsMatch(e.FilePatterns, containerPath)) && (e.ParentFiles.All(pf => String.IsNullOrEmpty(pf))))
+                // 2. There is no file exclusion, but a parent exclusion matches.
+                //    Example: ;foo.zip; --> Exclude any file in foo.zip. This is similar to using *;foo.zip;
+                if (!exclusion.HasFilePatterns && IsParentExcluded(exclusion, parent, exclusionClassification))
                 {
                     return true;
                 }
             }
 
-            // 3. There is no file exclusion, but a parent exclusion matches.
-            //    Example: ;foo.zip; --> Exclude any file in foo.zip. This is similar to using *;foo.zip;
-            return exclusions.Any(e => (e.FilePatterns.All(fp => String.IsNullOrEmpty(fp)) && IsParentExcluded(parent)));
+            return false;
         }
 
         /// <summary>
@@ -114,7 +110,7 @@ namespace Microsoft.SignCheck.Verification
         public bool IsExcluded(string path, string parent, string virtualPath, string containerPath)
         {
             IEnumerable<Exclusion> exclusions = _exclusions.Where(e => !e.Comment.Contains("IGNORE-STRONG-NAME"));
-            return IsExcluded(path, parent, virtualPath, containerPath, exclusions);
+            return IsExcluded(path, parent, virtualPath, containerPath, "GENERAL", exclusions);
         }
 
         /// <summary>
@@ -127,7 +123,7 @@ namespace Microsoft.SignCheck.Verification
             // Get all the exclusions with DO-NOT-SIGN markers and check only against those
             IEnumerable<Exclusion> doNotSignExclusions = _exclusions.Where(e => e.Comment.Contains("DO-NOT-SIGN")).ToArray();
 
-            return (doNotSignExclusions.Count() > 0) && (IsExcluded(path, parent, virtualPath, containerPath, doNotSignExclusions));
+            return (doNotSignExclusions.Count() > 0) && (IsExcluded(path, parent, virtualPath, containerPath, "DO-NOT-SIGN", doNotSignExclusions));
         }
 
         public bool IsIgnoreStrongName(string path, string parent, string virtualPath, string containerPath)
@@ -135,27 +131,44 @@ namespace Microsoft.SignCheck.Verification
             // Get all the exclusions with NO-STRONG-NAME markers and check only against those
             IEnumerable<Exclusion> noStrongNameExclusions = _exclusions.Where(e => e.Comment.Contains("IGNORE-STRONG-NAME"));
 
-            return (noStrongNameExclusions.Count() > 0) && (IsExcluded(path, parent, virtualPath, containerPath, noStrongNameExclusions));
+            return (noStrongNameExclusions.Count() > 0) && (IsExcluded(path, parent, virtualPath, containerPath, "IGNORE-STRONG-NAME", noStrongNameExclusions));
         }
 
         /// <summary>
-        /// Returns true if any <see cref="Exclusion.FilePatterns"/> matches the value of <paramref name="path"/>.
+        /// Returns true if any <see cref="Exclusion.FilePatterns"/> matches the value of
+        /// <paramref name="path"/>, <paramref name="containerPath"/> or <paramref name="virtualPath"/>.
         /// </summary>
-        /// <param name="path">The value to match against any <see cref="Exclusion.FilePatterns"/>.</param>
+        /// <param name="path">The value to match against <see cref="Exclusion.FilePatterns"/>.</param>
+        /// <param name="containerPath">The value to match against <see cref="Exclusion.FilePatterns"/>.</param>
+        /// <param name="virtualPath">The value to match against <see cref="Exclusion.FilePatterns"/>.</param>
         /// <returns></returns>
-        public bool IsFileExcluded(string path)
+        public bool IsFileExcluded(Exclusion exclusion, string path, string containerPath, string virtualPath, string exclusionsClassification)
         {
-            return _exclusions.Any(e => IsMatch(e.FilePatterns, path));
+            var values = new[] { path, containerPath, virtualPath, Path.GetFileName(path), Path.GetFileName(containerPath), Path.GetFileName(virtualPath) };
+
+            if(!exclusion.TryGetIsFileExcluded(exclusionsClassification, values, out bool isExcluded))
+            {
+                isExcluded = values.Any(v => IsMatch(exclusion.FilePatterns, v));
+                exclusion.AddToFileCache(exclusionsClassification, values, isExcluded);
+            }
+
+            return isExcluded;
         }
 
         /// <summary>
         /// Returns true if any <see cref="Exclusion.ParentFiles"/> matches the value of <paramref name="parent"/>.
         /// </summary>
-        /// <param name="parent">The value to match against any <see cref="Exclusion.ParentFiles"/>.</param>
+        /// <param name="parent">The value to match against <see cref="Exclusion.ParentFiles"/>.</param>
         /// <returns></returns>
-        public bool IsParentExcluded(string parent)
+        public bool IsParentExcluded(Exclusion exclusion, string parent, string exclusionsClassification)
         {
-            return _exclusions.Any(e => IsMatch(e.ParentFiles.Select(pattern => !string.IsNullOrEmpty(pattern) ? $"*{pattern}*" : pattern).ToArray(), parent));
+            if(!exclusion.TryGetIsParentExcluded(exclusionsClassification, parent, out bool isExcluded))
+            {
+                isExcluded = IsMatch(exclusion.ParentFiles, parent);
+                exclusion.AddToParentCache(exclusionsClassification, parent, isExcluded);
+            }
+    
+            return isExcluded;
         }
 
         private bool IsMatch(string[] patterns, string value)
@@ -172,8 +185,8 @@ namespace Microsoft.SignCheck.Verification
 
             if (pattern.IndexOfAny(_wildCards) > -1)
             {
-                string regexPattern = Utils.ConvertToRegexPattern(pattern);
-                return Regex.IsMatch(value, regexPattern, RegexOptions.IgnoreCase);
+                var regex = GetRegex(pattern);
+                return regex.IsMatch(value);
             }
             else
             {
@@ -184,6 +197,16 @@ namespace Microsoft.SignCheck.Verification
         public bool Remove(Exclusion exclusion)
         {
             return false;
+        }
+
+        private Regex GetRegex(string pattern)
+        {
+            if (!_regexCache.ContainsKey(pattern))
+            {
+                string regexPattern = Utils.ConvertToRegexPattern(pattern);
+                _regexCache[pattern] = new Regex(regexPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            }
+            return _regexCache[pattern];
         }
     }
 }


### PR DESCRIPTION
Regex lookups are VERY slow on .NET Framework, so when the regex matching was fixed in https://github.com/dotnet/arcade/pull/15680, the VMR signing validation time went from 1.5hrs to 14.5hrs. This PR fixes that increase in time by reducing the number of calls made to Regex.Match via new caching logic.

[Pipeline run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2681284&view=logs&j=2e220694-fd2b-5e09-0c04-ea9444ccf11c&t=84e2c8aa-fb9e-5a27-eabf-df881616f3c4&l=345)

This change decreased the windows validation time by almost 71% (from ~1 hr 39 minutes to ~29 minutes)!