### PR TITLE
Add flatten parameter to TargetChannelConfig as a temporary workaround for issue SB #5004

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
@@ -830,7 +830,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
                 akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet10Feeds,
-                symbolTargetType: SymbolPublishVisibility.Public),
+                symbolTargetType: SymbolPublishVisibility.Public,
+                // Temporarily work around https://github.com/dotnet/source-build/issues/5004
+                flatten: false),
 
             // .NET 10 Preview 1,
             new TargetChannelConfig(


### PR DESCRIPTION
We flatten the paths in links normally. IIRC this is a requirement of the dotnet-install script. This breaks for UB builds because multiple repos produce a productVersion.txt.

Temporarily work around this by avoiding flattening.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
