### PR TITLE
Fix emsdk flow to sdk in create-preview-flow.ps1 and docs

### DIFF
--- a/Documentation/UnifiedBuild/Flat-Flow-Migration-Guide.md
+++ b/Documentation/UnifiedBuild/Flat-Flow-Migration-Guide.md
@@ -60,7 +60,7 @@ graph TD
     deployment-tools --> sdk
     diagnostics --> vstest
     efcore --> aspnetcore
-    emsdk --> runtime
+    emsdk --> sdk
     fsharp --> sdk
     msbuild --> sdk
     nuget-client --> sdk

--- a/Documentation/UnifiedBuild/VMR-Code-And-Build-Workflow.md
+++ b/Documentation/UnifiedBuild/VMR-Code-And-Build-Workflow.md
@@ -22,7 +22,7 @@ flowchart TD
         tradNuGet[nuget]
         tradFSharp[fsharp]
 
-        tradEmsdk-->|Build Outputs|tradRuntime
+        tradEmsdk-->|Build Outputs|tradSDK
         tradRuntime-->|Build Outputs|tradWinforms
         tradRuntime-->|Build Outputs|tradTemplating
         tradRuntime-->|Build Outputs|tradSDK

--- a/scripts/create-preview-flow.ps1
+++ b/scripts/create-preview-flow.ps1
@@ -143,7 +143,6 @@ AddArcadeFlow https://github.com/dotnet/templating $SdkBranch
 Write-Host "Adding runtime -> runtime flow"
 AddFlow https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int $RuntimeChannel https://github.com/dotnet/wpf $RuntimeBranch EveryBuild
 AddBatchedFlow https://github.com/dotnet/efcore $RuntimeChannel https://github.com/dotnet/aspnetcore $RuntimeBranch EveryBuild
-AddFlow https://github.com/dotnet/emsdk $RuntimeChannel https://github.com/dotnet/runtime $RuntimeBranch EveryBuild
 AddFlow https://github.com/dotnet/icu $RuntimeChannel https://github.com/dotnet/runtime $RuntimeBranch EveryBuild
 AddBatchedFlow https://github.com/dotnet/runtime $RuntimeChannel https://github.com/dotnet/aspnetcore $RuntimeBranch EveryBuild
 AddFlow https://github.com/dotnet/runtime $RuntimeChannel https://github.com/dotnet/efcore $RuntimeBranch EveryBuild
@@ -168,6 +167,7 @@ Write-Host "Add runtime->sdk flow"
 AddFlow https://github.com/dotnet/aspnetcore $RuntimeChannel https://github.com/dotnet/sdk $SdkBranch EveryBuild
 AddFlow https://github.com/dotnet/windowsdesktop $RuntimeChannel https://github.com/dotnet/sdk $SdkBranch EveryBuild
 AddFlow https://github.com/dotnet/runtime $RuntimeChannel https://github.com/dotnet/sdk $SdkBranch EveryBuild
+AddFlow https://github.com/dotnet/emsdk $RuntimeChannel https://github.com/dotnet/sdk $SdkBranch EveryBuild
 
 if ($AddInternalFlow) {
     Write-Host "Adding internal runtime->internal sdk flow"


### PR DESCRIPTION
emsdk now flows to the sdk repo instead of runtime.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
