### PR TITLE
Add flags to support easy disablement of SB prebuilt checking

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
@@ -12,16 +12,13 @@
   </ItemGroup>
 
   <!-- Because the condition here is rather complex, it should read as the following:
-      - Don't collect intermediates if running the product build
-      - Otherwise, collect if we're forcing it using SetUpSourceBuildIntermediateNupkgCache
-      - Otherwise, collect if:
-        - Building from source and we're in the inner build OR
-        - Building in DotNetBuild mode and we're in the inner repo and this is a source-only build -->
+      - Don't collect intermediates if running the product build or the inedermediat nupkg cache feature is explicitly disabled
+      - Otherwise, collect if Building from source and we're in the inner build -->
   <Target Name="CollectSourceBuildIntermediateNupkgDependencies"
           Condition="
             '$(DotNetBuildOrchestrator)' != 'true' and
-            ('$(SetUpSourceBuildIntermediateNupkgCache)' == 'true' or
-            ('$(DotNetBuildPhase)' == 'InnerRepo' and '$(DotNetBuildSourceOnly)' == 'true'))"
+            '$(SetUpSourceBuildIntermediateNupkgCache)' != 'false' and
+            ('$(DotNetBuildPhase)' == 'InnerRepo' and '$(DotNetBuildSourceOnly)' == 'true')"
           DependsOnTargets="GetSourceBuildIntermediateNupkgNameConvention"
           BeforeTargets="CollectPackageReferences">
     <ReadSourceBuildIntermediateNupkgDependencies
@@ -37,16 +34,13 @@
   </Target>
 
   <!-- Because the condition here i rather complex, it should read as the following:
-       - Don't set up the intermediate cache if running the product build
-       - Otherwise, set it up if we're forcing it to be set up using SetUpSourceBuildIntermediateNupkgCache
-       - Otherwise, set it up if there are intermediate nupkg referencs AND
-         - If building from source and we're in the inner build OR
-         - If building in DotNetBuild mode and we're in the inner repo and this is a source-only build -->
+      - Don't collect intermediates if running the product build or the inedermediat nupkg cache feature is explicitly disabled
+      - Otherwise, collect if Building from source and we're in the inner build -->
   <Target Name="SetUpSourceBuildIntermediateNupkgCache"
           Condition="
             '$(DotNetBuildOrchestrator)' != 'true' and
-            ('$(SetUpSourceBuildIntermediateNupkgCache)' == 'true' or
-              ('@(SourceBuildIntermediateNupkgReference)' != '' and '$(DotNetBuildPhase)' == 'InnerRepo' and '$(DotNetBuildSourceOnly)' == 'true'))"
+            '$(SetUpSourceBuildIntermediateNupkgCache)' != 'false' and
+            ('@(SourceBuildIntermediateNupkgReference)' != '' and '$(DotNetBuildPhase)' == 'InnerRepo' and '$(DotNetBuildSourceOnly)' == 'true')"
           AfterTargets="Restore">
     <ItemGroup>
       <IntermediateNupkgSourceDir Include="$([MSBuild]::NormalizeDirectory(

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <!-- Because the condition here is rather complex, it should read as the following:
-      - Don't collect intermediates if running the product build or the inedermediat nupkg cache feature is explicitly disabled
+      - Don't collect intermediates if running the product build or the intermediate nupkg cache feature is explicitly disabled
       - Otherwise, collect if Building from source and we're in the inner build -->
   <Target Name="CollectSourceBuildIntermediateNupkgDependencies"
           Condition="
@@ -34,7 +34,7 @@
   </Target>
 
   <!-- Because the condition here i rather complex, it should read as the following:
-      - Don't collect intermediates if running the product build or the inedermediat nupkg cache feature is explicitly disabled
+      - Don't collect intermediates if running the product build or the intermediate nupkg cache feature is explicitly disabled
       - Otherwise, collect if Building from source and we're in the inner build -->
   <Target Name="SetUpSourceBuildIntermediateNupkgCache"
           Condition="

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -97,8 +97,7 @@
         Condition="'$(Restore)' == 'true'"/>
   </Target>
 
-  <Import Project="SourceBuild/SourceBuildArcadeTools.targets" Condition="'$(DotNetBuildRepo)' == 'true' or
-                                                                          '$(SetUpSourceBuildIntermediateNupkgCache)' == 'true'" />
+  <Import Project="SourceBuild/SourceBuildArcadeTools.targets" Condition="'$(DotNetBuildRepo)' == 'true'" />
 
   <!-- Repository extensibility point -->
   <Import Project="$(RepositoryEngineeringDir)Tools.props" Condition="Exists('$(RepositoryEngineeringDir)Tools.props')" />


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/5034

Setting `SetUpSourceBuildIntermediateNupkgCache=false` will disable the intermediate restoration and setting 
`ReportPrebuiltUsage=false` will disable the prebuilt validation.  Both will be necessary to set during the flat flow enablement.

`SetUpSourceBuildIntermediateNupkgCache` was previously unused so I repurposed it.