### PR TITLE
Add UseArPowBuildInfra=false opt-out flag

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -53,7 +53,7 @@
   <Import Project="RepoDefaults.props"/>
   <Import Project="RepoLayout.props"/>
 
-  <Import Project="SourceBuild/SourceBuildArcadeBuild.targets" Condition="'$(DotNetBuildRepo)' == 'true'" />
+  <Import Project="SourceBuild/SourceBuildArcadeBuild.targets" Condition="'$(DotNetBuildRepo)' == 'true' and '$(UseArPowBuildInfra)' != 'false'" />
 
   <!-- Allow for repo specific Build properties such as the list of Projects to build -->
   <Import Project="$(RepositoryEngineeringDir)Build.props" Condition="Exists('$(RepositoryEngineeringDir)Build.props')" />
@@ -79,7 +79,7 @@
     Don't do this filtering in non-unified builds to allow repos to define how different build passes are handled
     in their own repo-specific builds.
   -->
-  <ItemGroup Condition="'$(DotNetBuildInnerRepo)' == 'true'">
+  <ItemGroup Condition="'$(DotNetBuildInnerRepo)' == 'true' or '$(UseArPowBuildInfra)' == 'false'">
     <_ProjectToBuildCurrentBuildPass Include="@(ProjectToBuild->WithMetadataValue('DotNetBuildPass', '$(_DotNetBuildPassNormalized)'))" />
     <ProjectToBuild Remove="@(ProjectToBuild)" />
     <ProjectToBuild Include="@(_ProjectToBuildCurrentBuildPass)" />
@@ -264,7 +264,7 @@
     <MSBuild Projects="AfterSolutionBuild.proj"
              Properties="@(_CommonProps);_NETCORE_ENGINEERING_TELEMETRY=Build"
              Targets="@(_SolutionBuildTargets)"
-             Condition="'@(_SolutionBuildTargets)' != '' and ('$(DotNetBuild)' != 'true' or '$(DotNetBuildPhase)' == 'InnerRepo')" />
+             Condition="'@(_SolutionBuildTargets)' != '' and ('$(DotNetBuild)' != 'true' or '$(DotNetBuildPhase)' == 'InnerRepo' or '$(UseArPowBuildInfra)' == 'false')" />
 
     <!--
       Sign artifacts.
@@ -272,12 +272,12 @@
     <MSBuild Projects="Sign.proj"
              Properties="@(_CommonProps)"
              Targets="Sign"
-             Condition="'$(Sign)' == 'true' and ('$(DotNetBuild)' != 'true' or '$(DotNetBuildPhase)' == 'InnerRepo')"/>
+             Condition="'$(Sign)' == 'true' and ('$(DotNetBuild)' != 'true' or '$(DotNetBuildPhase)' == 'InnerRepo' or '$(UseArPowBuildInfra)' == 'false')"/>
 
     <MSBuild Projects="AfterSigning.proj"
              Properties="@(_CommonProps);_NETCORE_ENGINEERING_TELEMETRY=Sign"
              Targets="@(_SolutionBuildTargets)"
-             Condition="'@(_SolutionBuildTargets)' != '' and ('$(DotNetBuild)' != 'true' or '$(DotNetBuildPhase)' == 'InnerRepo')"/>
+             Condition="'@(_SolutionBuildTargets)' != '' and ('$(DotNetBuild)' != 'true' or '$(DotNetBuildPhase)' == 'InnerRepo' or '$(UseArPowBuildInfra)' == 'false')" />
 
     <!--
       Perform post-source-build tasks. Validate source-build requirements, such as the prebuilt
@@ -287,7 +287,7 @@
     -->
     <MSBuild Projects="SourceBuild\AfterSourceBuild.proj"
              Properties="@(_CommonProps);_NETCORE_ENGINEERING_TELEMETRY=AfterSourceBuild"
-             Condition="'@(_SolutionBuildTargets)' != '' and '$(DotNetBuildRepo)' == 'true'"/>
+             Condition="'@(_SolutionBuildTargets)' != '' and '$(DotNetBuildRepo)' == 'true' and '$(UseArPowBuildInfra)' != 'false'" />
 
     <!--
       Publish artifacts. This should run in the following situations:
@@ -305,6 +305,7 @@
       <!-- Run publish in inner VMR builds, or outer non-VMR builds. -->
       <_ShouldRunPublish Condition="'$(DotNetBuildPhase)' == 'InnerRepo' and '$(DotNetBuildOrchestrator)' == 'true'">true</_ShouldRunPublish>
       <_ShouldRunPublish Condition="'$(DotNetBuildPhase)' != 'InnerRepo' and '$(DotNetBuildOrchestrator)' != 'true'">true</_ShouldRunPublish>
+      <_ShouldRunPublish Condition="'$(UseArPowBuildInfra)' == 'false'">true</_ShouldRunPublish>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -41,7 +41,7 @@
     Inner-repo builds outside of VMR do not use arcade publishing.
     Define this property before importing repo Publishing.props, to have it control any repo-specific publishing.
   -->
-  <PropertyGroup Condition="'$(DotNetBuildPhase)' == 'InnerRepo' and '$(DotNetBuildOrchestrator)' == 'true'">
+  <PropertyGroup Condition="('$(DotNetBuildPhase)' == 'InnerRepo' or '$(UseArPowBuildInfra)' == 'false') and '$(DotNetBuildOrchestrator)' == 'true'">
     <PushToLocalStorage>true</PushToLocalStorage>
   </PropertyGroup>
 
@@ -52,7 +52,7 @@
     so we want to inclue them here so they can be in the vertical's final manifest.
     The VMR tooling to produce the final merged manifest for the VMR build as a whole will filter them out.
   -->
-  <ItemGroup Condition="'$(DotNetBuildPhase)' == 'InnerRepo' and '$(DotNetBuildOrchestrator)' == 'true'">
+  <ItemGroup Condition="('$(DotNetBuildPhase)' == 'InnerRepo' or '$(UseArPowBuildInfra)' == 'false') and '$(DotNetBuildOrchestrator)' == 'true'">
     <ArtifactVisibilityToPublish Include="Vertical;Internal;External" />
   </ItemGroup>
 
@@ -76,7 +76,7 @@
          Do not generate symbol packages if in outer source build mode, to avoid creating copies of the intermediates.
          Also do not generate symbol packages if in inner source build, in product build. -->
     <AutoGenerateSymbolPackages Condition="'$(AutoGenerateSymbolPackages)' == '' and 
-      ('$(DotNetBuildSourceOnly)' != 'true' or ('$(DotNetBuildInnerRepo)' == 'true' and '$(DotNetBuildOrchestrator)' != 'true'))">true</AutoGenerateSymbolPackages>
+      ('$(DotNetBuildSourceOnly)' != 'true' or (('$(DotNetBuildInnerRepo)' == 'true' or '$(UseArPowBuildInfra)' == 'false') and '$(DotNetBuildOrchestrator)' != 'true'))">true</AutoGenerateSymbolPackages>
 
     <PreserveRepoOrigin Condition="'$(PreserveRepoOrigin)' == ''">false</PreserveRepoOrigin>
     <PublishManifestOnly Condition="'$(PublishManifestOnly)' == ''">false</PublishManifestOnly>
@@ -376,6 +376,6 @@
   </Target>
 
   <!-- Import the publish targets when in the inner or outer repo builds. -->
-  <Import Project="SourceBuild/SourceBuildArcadePublish.targets" Condition="'$(DotNetBuildRepo)' == 'true'" />
+  <Import Project="SourceBuild/SourceBuildArcadePublish.targets" Condition="'$(DotNetBuildRepo)' == 'true' and '$(UseArPowBuildInfra)' != 'false'" />
 
 </Project>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -60,15 +60,6 @@
 
     <EnableDefaultSourceBuildIntermediateItems Condition="'$(EnableDefaultSourceBuildIntermediateItems)' == ''">true</EnableDefaultSourceBuildIntermediateItems>
 
-    <!--
-      This is fed into the inner source build as an environment variable (DotNetTargetFrameworkFilter) to enable filtering.
-      The default target framework filter includes all recent netcoreapps in SBRP, as well as 8.0 (latest) and 7.0 (working to get rid of it.
-
-      TFM filtering is enabled by default and can be disabled, at repo level, by setting NoTargetFrameworkFiltering property to true,
-      in repo's root Directory.Build.props file.
-    -->
-    <_DefaultNetFrameworkFilter>netstandard2.0%3bnetstandard2.1%3bnetcoreapp2.1%3bnetcoreapp3.1%3bnet5.0%3bnet6.0%3bnet7.0%3bnet8.0%3bnet9.0%3bnet10.0</_DefaultNetFrameworkFilter>
-    <SourceBuildTargetFrameworkFilter Condition="'$(SourceBuildTargetFrameworkFilter)' == ''">$(_DefaultNetFrameworkFilter)</SourceBuildTargetFrameworkFilter>
     <RepoManifestFile>$(ArtifactsDir)RepoManifest.xml</RepoManifestFile>
     <CreateRepoSymbolsArchiveDependsOn Condition="'$(CreateIntermediatePackage)' == 'true'">GetCategorizedIntermediateNupkgContents</CreateRepoSymbolsArchiveDependsOn>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
@@ -76,7 +76,6 @@
     <ItemGroup>
       <!-- Override package cache to separate source-built packages from upstream. -->
       <InnerBuildEnv Include="NUGET_PACKAGES=$(CurrentRepoSourceBuildPackageCache)" />
-      <InnerBuildEnv Include="DotNetTargetFrameworkFilter=$(SourceBuildTargetFrameworkFilter)" Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
     </ItemGroup>
   </Target>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/TargetFrameworkFilters.BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/TargetFrameworkFilters.BeforeCommonTargets.targets
@@ -2,6 +2,10 @@
 <Project>
 
   <PropertyGroup>
+    <!-- TFM filtering is enabled by default and can be disabled, at repo level, by setting NoTargetFrameworkFiltering propert
+         to true, in repo's root Directory.Build.props file. -->
+    <DotNetTargetFrameworkFilter Condition="'$(DotNetTargetFrameworkFilter)' == '' and '$(DotNetBuildSourceOnly)' == 'true'">netstandard2.0%3bnetstandard2.1%3bnetcoreapp2.1%3bnetcoreapp3.1%3bnet5.0%3bnet6.0%3bnet7.0%3bnet8.0%3bnet9.0%3bnet10.0</DotNetTargetFrameworkFilter>
+
     <_EnableTargetFrameworkFiltering>false</_EnableTargetFrameworkFiltering>
     <_EnableTargetFrameworkFiltering Condition="'$(NoTargetFrameworkFiltering)' != 'true' and '$(DotNetTargetFrameworkFilter)' != ''">true</_EnableTargetFrameworkFiltering>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -97,7 +97,7 @@
         Condition="'$(Restore)' == 'true'"/>
   </Target>
 
-  <Import Project="SourceBuild/SourceBuildArcadeTools.targets" Condition="'$(DotNetBuildRepo)' == 'true'" />
+  <Import Project="SourceBuild/SourceBuildArcadeTools.targets" Condition="'$(DotNetBuildRepo)' == 'true' and '$(UseArPowBuildInfra)' != 'false'" />
 
   <!-- Repository extensibility point -->
   <Import Project="$(RepositoryEngineeringDir)Tools.props" Condition="Exists('$(RepositoryEngineeringDir)Tools.props')" />


### PR DESCRIPTION
Needed for https://github.com/dotnet/dotnet/pull/176

This is a temporary flag that allows to build without the ArPow build infra in a DotNetBuild. This flag also makes the following conditions true: `'$(DotNetBuildPhase)' == 'InnerRepo'` and `'$(DotNetBuildInnerRepo)' == 'true'`

This can be removed when the outer/inner build infra is removed.

---

Also move the `DotNetTargetFrameworkFilter` logic into TargetFrameworkFilters.BeforeCommonTargets.targets so that it applies to non ArPow infra builds as well.