### PR TITLE
Use regex to match version in MicroBuild workaround

### DIFF
--- a/eng/common/core-templates/steps/install-microbuild.yml
+++ b/eng/common/core-templates/steps/install-microbuild.yml
@@ -91,8 +91,18 @@ steps:
           script: |
             Write-Host "Copying Linux Path"
             $MBSIGN_APPFOLDER = '$(MBSIGN_APPFOLDER)'
-            $MBSIGN_APPFOLDER = $MBSIGN_APPFOLDER -replace '/build', ''
-            $MBSIGN_APPFOLDER = $MBSIGN_APPFOLDER + '/1.1.1032' + '/build'
+            $MBSIGN_APPFOLDER = ($MBSIGN_APPFOLDER -replace '/build', '')
+
+            $versionRegex = '\d+\.\d+\.\d+'
+            $package = Get-ChildItem -Path $MBSIGN_APPFOLDER -Directory |
+              Where-Object { $_.Name -match $versionRegex }
+
+            if ($package.Count -ne 1) {
+                Write-Host "There should be exactly one matching subfolder, but found $($package.Count)."
+                exit 1
+            }
+
+            $MBSIGN_APPFOLDER = $package[0].FullName + '/build'
             $MBSIGN_APPFOLDER | Write-Host
             $SignConfigPath = $MBSIGN_APPFOLDER + '/signconfig.xml'
             Copy-Item -Path "$(MBSIGN_APPFOLDER)/signconfig.xml" -Destination $SignConfigPath -Force


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/5042

The workaround cannot be removed yet, so instead avoid hardcoding the version in the workaround.

[Test pipeline run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2685083&view=results)