### PR TITLE
Don't produce an aka.ms link for productVersion.txt for .NET 10

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
@@ -340,7 +340,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
         ];
 
         private static readonly ImmutableList<Regex> DotNet10AkaMSDoNotCreateLinkPatterns = [
-            ...DefaultAkaMSDoNotCreateLinkPatterns,
+            ..DefaultAkaMSDoNotCreateLinkPatterns,
             new Regex(@"productversion", RegexOptions.IgnoreCase)
         ];
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
@@ -339,6 +339,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
             new Regex(@"wixpack", RegexOptions.IgnoreCase),
         ];
 
+        private static readonly ImmutableList<Regex> DotNet10AkaMSDoNotCreateLinkPatterns = [
+            ...DefaultAkaMSDoNotCreateLinkPatterns,
+            new Regex(@"productversion", RegexOptions.IgnoreCase)
+        ];
+
         #region Target Channel Configs
         public static readonly List<TargetChannelConfig> ChannelInfos = new List<TargetChannelConfig>() {
 
@@ -811,7 +816,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: ["10.0"],
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
-                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DotNet10AkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet10Feeds,
                 symbolTargetType: SymbolPublishVisibility.Public),
 
@@ -822,7 +827,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: [ "10.0-workloads" ],
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
-                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DotNet10AkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet10WorkloadFeeds,
                 symbolTargetType: SymbolPublishVisibility.Public),
 
@@ -833,7 +838,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: [ "10.0.1xx", "10.0" ],
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
-                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DotNet10AkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet10Feeds,
                 symbolTargetType: SymbolPublishVisibility.Public),
 
@@ -844,11 +849,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: ["10.0.1xx-ub", "10.0-ub"],
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
-                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DotNet10AkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet10Feeds,
-                symbolTargetType: SymbolPublishVisibility.Public,
-                // Temporarily work around https://github.com/dotnet/source-build/issues/5004
-                flatten: false),
+                symbolTargetType: SymbolPublishVisibility.Public),
 
             // .NET 10 Preview 1,
             new TargetChannelConfig(
@@ -857,7 +860,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: ["10.0-preview1"],
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
-                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DotNet10AkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet10Feeds,
                 symbolTargetType: SymbolPublishVisibility.Public),
 
@@ -868,7 +871,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: ["10.0-preview2"],
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
-                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DotNet10AkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet10Feeds,
                 symbolTargetType: SymbolPublishVisibility.Public),
 
@@ -879,7 +882,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: ["10.0-preview3"],
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
-                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DotNet10AkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet10Feeds,
                 symbolTargetType: SymbolPublishVisibility.Public),
 
@@ -890,7 +893,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: ["10.0-preview4"],
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
-                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DotNet10AkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet10Feeds,
                 symbolTargetType: SymbolPublishVisibility.Public),
 
@@ -901,7 +904,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: ["10.0-preview5"],
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
-                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DotNet10AkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet10Feeds,
                 symbolTargetType: SymbolPublishVisibility.Public),
 
@@ -923,7 +926,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: ["10.0-preview7"],
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
-                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DotNet10AkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet10Feeds,
                 symbolTargetType: SymbolPublishVisibility.Public),
 
@@ -934,7 +937,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: ["10.0-rc1"],
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
-                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DotNet10AkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet10Feeds,
                 symbolTargetType: SymbolPublishVisibility.Public),
 
@@ -945,7 +948,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: ["internal/10.0-rc1"],
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
-                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DotNet10AkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet10InternalFeeds,
                 symbolTargetType: SymbolPublishVisibility.Internal),
 
@@ -956,7 +959,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: ["10.0-rc2"],
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
-                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DotNet10AkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet10Feeds,
                 symbolTargetType: SymbolPublishVisibility.Public),
 
@@ -967,7 +970,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: ["internal/10.0-rc2"],
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
-                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DotNet10AkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet10InternalFeeds,
                 symbolTargetType: SymbolPublishVisibility.Internal),
 
@@ -978,7 +981,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: ["10.0.1xx-rc1"],
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
-                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DotNet10AkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet10Feeds,
                 symbolTargetType: SymbolPublishVisibility.Public),
 
@@ -989,7 +992,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: ["internal/10.0.1xx-rc1"],
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
-                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DotNet10AkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet10InternalFeeds,
                 symbolTargetType: SymbolPublishVisibility.Internal),
 
@@ -1000,7 +1003,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: ["10.0.1xx-rc2"],
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
-                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DotNet10AkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet10Feeds,
                 symbolTargetType: SymbolPublishVisibility.Public),
 
@@ -1011,7 +1014,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: ["internal/10.0.1xx-rc2"],
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
-                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DotNet10AkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet10InternalFeeds,
                 symbolTargetType: SymbolPublishVisibility.Internal),
 
@@ -1022,7 +1025,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: ["10.0.1xx-preview1"],
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
-                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DotNet10AkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet10Feeds,
                 symbolTargetType: SymbolPublishVisibility.Public),
 
@@ -1033,7 +1036,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: ["10.0.1xx-preview2"],
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
-                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DotNet10AkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet10Feeds,
                 symbolTargetType: SymbolPublishVisibility.Public),
 
@@ -1044,7 +1047,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: ["10.0.1xx-preview3"],
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
-                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DotNet10AkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet10Feeds,
                 symbolTargetType: SymbolPublishVisibility.Public),
 
@@ -1055,7 +1058,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: ["10.0.1xx-preview4"],
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
-                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DotNet10AkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet10Feeds,
                 symbolTargetType: SymbolPublishVisibility.Public),
 
@@ -1066,7 +1069,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: ["10.0.1xx-preview5"],
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
-                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DotNet10AkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet10Feeds,
                 symbolTargetType: SymbolPublishVisibility.Public),
 
@@ -1077,7 +1080,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: ["10.0.1xx-preview6"],
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
-                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DotNet10AkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet10Feeds,
                 symbolTargetType: SymbolPublishVisibility.Public),
 
@@ -1088,7 +1091,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: ["10.0.1xx-preview7"],
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
-                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DotNet10AkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet10Feeds,
                 symbolTargetType: SymbolPublishVisibility.Public),
 


### PR DESCRIPTION
dotnet-install doesn't look up productVersion.txt via aka.ms links, so we don't need to make aka.ms links for them.

Also re-enable flattened links for .NET 10 UB.

Fixes https://github.com/dotnet/source-build/issues/5004

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
