### PR TITLE
Allow for opt-out of binary log

### DIFF
--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -6,12 +6,13 @@ Param(
   [string] $msbuildEngine = $null,
   [switch] $restore,
   [switch] $prepareMachine,
+  [switch][Alias('nobl')]$excludeCIBinaryLog,
   [switch] $help,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 
 $ci = $true
-$binaryLog = $true
+$binaryLog = if ($excludeCIBinaryLog) { $false } else { $true }
 $warnAsError = $true
 
 . $PSScriptRoot\tools.ps1
@@ -27,6 +28,7 @@ function Print-Usage() {
   Write-Host "Advanced settings:"
   Write-Host "  -prepareMachine         Prepare machine for CI run"
   Write-Host "  -msbuildEngine <value>  Msbuild engine to use to run build ('dotnet', 'vs', or unspecified)."
+  Write-Host "  -excludeCIBinaryLog     When running on CI, allow no binary log (short: -nobl)"
   Write-Host ""
   Write-Host "Command line arguments not listed above are passed thru to msbuild."
 }
@@ -34,10 +36,11 @@ function Print-Usage() {
 function Build([string]$target) {
   $logSuffix = if ($target -eq 'Execute') { '' } else { ".$target" }
   $log = Join-Path $LogDir "$task$logSuffix.binlog"
+  $binaryLogArg = if ($binaryLog) { "/bl:$log" } else { "" }
   $outputPath = Join-Path $ToolsetDir "$task\"
 
   MSBuild $taskProject `
-    /bl:$log `
+    $binaryLogArg `
     /t:$target `
     /p:Configuration=$configuration `
     /p:RepoRoot=$RepoRoot `

--- a/eng/common/sdk-task.sh
+++ b/eng/common/sdk-task.sh
@@ -7,6 +7,10 @@ show_usage() {
     echo "  --verbosity <value>      Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]"
     echo "  --help                   Print help and exit"
     echo ""
+
+    echo "Advanced settings:"
+    echo "  --excludeCIBinarylog     Don't output binary log (short: -nobl)"
+    echo ""
     echo "Command line arguments not listed above are passed thru to msbuild."
 }
 
@@ -27,10 +31,12 @@ Build() {
     local log_suffix=""
     [[ "$target" != "Execute" ]] && log_suffix=".$target"
     local log="$log_dir/$task$log_suffix.binlog"
+    local binaryLogArg=""
+    [[ $binary_log == true ]] && binaryLogArg="/bl:$log"
     local output_path="$toolset_dir/$task/"
 
     MSBuild "$taskProject" \
-        /bl:"$log" \
+        $binaryLogArg \
         /t:"$target" \
         /p:Configuration="$configuration" \
         /p:RepoRoot="$repo_root" \
@@ -39,8 +45,10 @@ Build() {
         $properties
 }
 
+binary_log=true
 configuration="Debug"
 verbosity="minimal"
+exclude_ci_binary_log=false
 restore=false
 help=false
 properties=''
@@ -60,6 +68,11 @@ while (($# > 0)); do
       verbosity=$2
       shift 2
       ;;
+    --excludecibinarylog|--nobl)
+      binary_log=false
+      exclude_ci_binary_log=true
+      shift 1
+      ;;
     --help)
       help=true
       shift 1
@@ -72,7 +85,6 @@ while (($# > 0)); do
 done
 
 ci=true
-binaryLog=true
 warnAsError=true
 
 if $help; then


### PR DESCRIPTION
The binary log is always generated when running the SDK task scripts, as the scripts are designed to always build in CI. To provide an opt-out option, the excludeCIBinaryLog switch is needed. This opt-out is particularly important for running signing validation concurrently, as the first process will lock the binlog file, preventing other processes from accessing it.