### PR TITLE
Remove Default NgenArchitecture

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.VsixBuild.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.VsixBuild.targets
@@ -43,14 +43,12 @@
     <IsProductComponent>true</IsProductComponent>
 
     <Ngen Condition="'$(Ngen)' == ''">true</Ngen>
-    <NgenArchitecture Condition="'$(NgenArchitecture)' == ''">All</NgenArchitecture>
     <NgenPriority Condition="'$(NgenPriority)' == ''">3</NgenPriority>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(VisualStudioInsertionComponent)' != ''">
     <ProjectReference Update="@(ProjectReference)">
       <Ngen Condition="'%(Ngen)' == ''">true</Ngen>
-      <NgenArchitecture Condition="'%(NgenArchitecture)' == '' and '%(Ngen)' != 'false'">All</NgenArchitecture>
       <NgenPriority Condition="'%(NgenPriority)' == '' and '%(Ngen)' != 'false'">3</NgenPriority>
     </ProjectReference>
   </ItemGroup>


### PR DESCRIPTION
Default NgenArchitecture being set to "All" causes VS to produce NGEN images for 32-bit products that don't exist, it causes 32-bit NGEN images to be created despite there being no 32-bit version of VS.


### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
