### PR TITLE
Fix tar writing issues by using new PaxTarEntry as a workaround

### DIFF
--- a/src/Microsoft.DotNet.SignTool/src/ZipData.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ZipData.cs
@@ -488,7 +488,8 @@ namespace Microsoft.DotNet.SignTool
                             using FileStream signedStream = File.OpenRead(signedPart.Value.FileSignInfo.FullPath);
                             entry.DataStream = signedStream;
                             entry.DataStream.Position = 0;
-                            writer.WriteEntry(entry);
+                            // Workaround issue with tar writing showing weird results: https://github.com/dotnet/sdk/issues/48513#issuecomment-2814323912
+                            writer.WriteEntry(new PaxTarEntry(entry));
 
                             log.LogMessage(MessageImportance.Low, $"Copying signed stream from {signedPart.Value.FileSignInfo.FullPath} to {FileSignInfo.FullPath} -> {relativeName}.");
                             continue;
@@ -497,7 +498,8 @@ namespace Microsoft.DotNet.SignTool
                         log.LogMessage(MessageImportance.Low, $"Didn't find signed part for nested file: {FileSignInfo.FullPath} -> {relativeName}");
                     }
 
-                    writer.WriteEntry(entry);
+                    // Workaround issue with tar writing showing weird results: https://github.com/dotnet/sdk/issues/48513#issuecomment-2814323912
+                    writer.WriteEntry(new PaxTarEntry(entry));
                 }
             }
 


### PR DESCRIPTION
### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
