### PR TITLE
Verify .js signatures with SignCheck on .NET Core

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/Verification/AuthentiCodeVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/AuthentiCodeVerifier.cs
@@ -3,9 +3,15 @@
 
 using System;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Pkcs;
 using Microsoft.SignCheck.Logging;
+#if NET
+using System.Reflection.PortableExecutable;
+#endif
 
 namespace Microsoft.SignCheck.Verification
 {
@@ -14,15 +20,20 @@ namespace Microsoft.SignCheck.Verification
     /// </summary>
     public class AuthentiCodeVerifier : FileVerifier
     {
-
+        ISecurityInfoProvider _securityInfoProvider = new AuthentiCodeSecurityInfoProvider();
         protected bool FinalizeResult
         {
             get;
             set;
         } = true;
 
-        public AuthentiCodeVerifier(Log log, Exclusions exclusions, SignatureVerificationOptions options, string fileExtension) : base(log, exclusions, options, fileExtension)
+        public AuthentiCodeVerifier(Log log, Exclusions exclusions, SignatureVerificationOptions options, string fileExtension, ISecurityInfoProvider securityInfoProvider = null)
+            : base(log, exclusions, options, fileExtension)
         {
+            if (securityInfoProvider != null)
+            {
+                _securityInfoProvider = securityInfoProvider;
+            }
         }
 
         public override SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath)
@@ -42,7 +53,7 @@ namespace Microsoft.SignCheck.Verification
         protected SignatureVerificationResult VerifyAuthentiCode(string path, string parent, string virtualPath)
         {
             var svr = new SignatureVerificationResult(path, parent, virtualPath);
-            svr.IsAuthentiCodeSigned = AuthentiCode.IsSigned(path, svr);
+            svr.IsAuthentiCodeSigned = AuthentiCode.IsSigned(path, svr, _securityInfoProvider);
             svr.IsSigned = svr.IsAuthentiCodeSigned;
 
             // TODO: Should only check if there is a signature, even if it's invalid
@@ -50,7 +61,7 @@ namespace Microsoft.SignCheck.Verification
             {
                 try
                 {
-                    svr.Timestamps = AuthentiCode.GetTimestamps(path).ToList();
+                    svr.Timestamps = AuthentiCode.GetTimestamps(path, _securityInfoProvider).ToList();
 
                     foreach (Timestamp timestamp in svr.Timestamps)
                     {
@@ -72,6 +83,50 @@ namespace Microsoft.SignCheck.Verification
             svr.AddDetail(DetailKeys.AuthentiCode, SignCheckResources.DetailSignedAuthentiCode, svr.IsAuthentiCodeSigned);
 
             return svr;
+        }
+    }
+
+    public class AuthentiCodeSecurityInfoProvider : ISecurityInfoProvider
+    {
+        public SignedCms ReadSecurityInfo(string path)
+        {
+#if NET
+            using (FileStream fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (PEReader peReader = new PEReader(fs))
+            {
+                var securityDirectory = peReader.PEHeaders.PEHeader.CertificateTableDirectory;
+                if (securityDirectory.RelativeVirtualAddress != 0 && securityDirectory.Size != 0)
+                {
+                    int securityHeaderSize = 8; // 4(length of cert) + 2(cert revision) + 2(cert type)
+                    if (securityDirectory.Size <= securityHeaderSize)
+                    {
+                        // No security entry - just the header
+                        return null;
+                    }
+
+                    // Skip the header
+                    fs.Position = securityDirectory.RelativeVirtualAddress + securityHeaderSize;
+                    byte[] securityEntry = new byte[securityDirectory.Size - securityHeaderSize];
+
+                    // Ensure the stream has enough data to read
+                    if (fs.Length < fs.Position + securityEntry.Length)
+                    {
+                        throw new CryptographicException($"File '{path}' is too small to contain a valid security entry.");
+                    }
+
+                    // Read the security entry
+                    fs.ReadExactly(securityEntry);
+
+                    // Decode the security entry
+                    var signedCms = new SignedCms();
+                    signedCms.Decode(securityEntry);
+                    return signedCms;
+                }
+            }
+            return null;
+#else
+            throw new NotSupportedException("Not supported on .NET Framework");
+#endif
         }
     }
 }

--- a/src/SignCheck/Microsoft.SignCheck/Verification/ISecurityInfoProvider.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/ISecurityInfoProvider.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Security.Cryptography.Pkcs;
+
+namespace Microsoft.SignCheck.Verification
+{
+    public interface ISecurityInfoProvider
+    {
+        /// <summary>
+        /// Reads the security information from the specified path.
+        /// </summary>
+        /// <param name="path">The path to the file.</param>
+        /// <returns>A SignedCms object containing the security information.</returns>
+        SignedCms ReadSecurityInfo(string path);
+    }
+}

--- a/src/SignCheck/Microsoft.SignCheck/Verification/JavaScriptVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/JavaScriptVerifier.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Security.Cryptography.Pkcs;
+using System.Text.RegularExpressions;
+using Microsoft.SignCheck.Logging;
+
+namespace Microsoft.SignCheck.Verification
+{
+    public class JavaScriptVerifier : AuthentiCodeVerifier
+    {
+
+        public JavaScriptVerifier(Log log, Exclusions exclusions, SignatureVerificationOptions options)
+            : base(log, exclusions, options, ".js", new JavaScriptSecurityInfoProvider() ) { }
+
+        public override SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath)
+            => base.VerifySignature(path, parent, virtualPath);
+
+        public class JavaScriptSecurityInfoProvider : ISecurityInfoProvider
+        {
+            public SignedCms ReadSecurityInfo(string path)
+            {
+                string content = File.ReadAllText(path);
+                string pattern = @"(?<=\/\/ SIG \/\/ Begin signature block\s)([\s\S]*?)(?=\/\/ SIG \/\/ End signature block)";
+                Match match = Regex.Match(content, pattern);
+
+                if (match.Success)
+                {
+                    string signatureBlock = Regex.Replace(match.Groups[1].Value, @"^// SIG //\s?", "", RegexOptions.Multiline);
+                    byte[] signatureBytes = Convert.FromBase64String(signatureBlock);
+  
+                    // Decode the signature block
+                    SignedCms signedCms = new SignedCms();
+                    signedCms.Decode(signatureBytes);
+
+                    return signedCms;
+                }
+
+                return null;
+            }
+        }
+    }
+}

--- a/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationManager.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationManager.cs
@@ -87,7 +87,6 @@ namespace Microsoft.SignCheck.Verification
             Options = options;
 
 #if NETFRAMEWORK
-            AddFileVerifier(new AuthentiCodeVerifier(log, exclusions, options, ".js"));
             AddFileVerifier(new AuthentiCodeVerifier(log, exclusions, options, ".psd1"));
             AddFileVerifier(new AuthentiCodeVerifier(log, exclusions, options, ".psm1"));
             AddFileVerifier(new AuthentiCodeVerifier(log, exclusions, options, ".ps1"));
@@ -112,6 +111,7 @@ namespace Microsoft.SignCheck.Verification
             AddFileVerifier(new RpmVerifier(log, exclusions, options));
 #endif
             AddFileVerifier(new ExeVerifier(log, exclusions, options, ".exe"));
+            AddFileVerifier(new JavaScriptVerifier(log, exclusions, options));
             AddFileVerifier(new LzmaVerifier(log, exclusions, options));
             AddFileVerifier(new NupkgVerifier(log, exclusions, options));
             AddFileVerifier(new PortableExecutableVerifier(log, exclusions, options, ".dll"));


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/5001

Sample results:
```
<SignCheckResults>
	<File Name="blazor.webview.js" Outcome="Signed" AuthentiCode="Timestamp: 03/31/25 12:07:41 (sha256RSA), AuthentiCode signed: True" />
</SignCheckResults>
```