### PR TITLE
Do not sign .js files by default

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -78,7 +78,7 @@
     -->
     <FileExtensionSignInfo Include=".deb" CertificateName="LinuxSign" />
     <FileExtensionSignInfo Include=".jar" CertificateName="MicrosoftJARSHA2" />
-    <FileExtensionSignInfo Include=".js;.ps1;.psd1;.psm1;.psc1;.py" CertificateName="Microsoft400" />
+    <FileExtensionSignInfo Include=".ps1;.psd1;.psm1;.psc1;.py" CertificateName="Microsoft400" />
     <FileExtensionSignInfo Include=".dll;.exe;.mibc;.msi" CertificateName="Microsoft400" />
     <FileExtensionSignInfo Include=".nupkg" CertificateName="NuGet" />
     <FileExtensionSignInfo Include=".vsix" CertificateName="VsixSHA2" />
@@ -94,6 +94,10 @@
     <FileExtensionSignInfo Include=".app" CertificateName="MacDeveloper" />
     <!-- Runtime hardening is required for notarization. -->
     <FileExtensionSignInfo Include=".dylib" CertificateName="MacDeveloperHarden" />
+
+    <!-- Removing the default .js signing -->
+    <FileExtensionSignInfo Include=".js" CertificateName="BreakingSignatureChange" Condition="'$(NoSignJS)' != 'true'"/>
+    <FileExtensionSignInfo Include=".js" CertificateName="None" Condition="'$(NoSignJS)' == 'true'"/>
 
     <!-- Explicitly use the azure linux cert for azl binaries -->
     <AzureLinuxRPM Include="$(ArtifactsPackagesDir)**/*-azl-*.rpm" />

--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -28,7 +28,6 @@ namespace Microsoft.DotNet.SignTool.Tests
         // Default extension based signing information
         private static readonly Dictionary<string, List<SignInfo>> s_fileExtensionSignInfo = new Dictionary<string, List<SignInfo>>()
         {
-            {".js", new List<SignInfo>{ new SignInfo("JSCertificate") } },
             {".jar",  new List<SignInfo>{ new SignInfo("JARCertificate") } },
             {".ps1",  new List<SignInfo>{ new SignInfo("PSCertificate") } },
             {".psd1",  new List<SignInfo>{ new SignInfo("PSDCertificate") } },
@@ -53,7 +52,6 @@ namespace Microsoft.DotNet.SignTool.Tests
         private static readonly Dictionary<string, List<SignInfo>> s_fileExtensionSignInfoWithCollisionId = 
             new Dictionary<string, List<SignInfo>>()
         {
-            {".js", new List<SignInfo>{ new SignInfo("JSCertificate", collisionPriorityId: "123") } },
             {".jar", new List<SignInfo>{ new SignInfo("JARCertificate", collisionPriorityId: "123") } },
             { ".ps1", new List<SignInfo>{ new SignInfo("PSCertificate", collisionPriorityId: "123") } },
             { ".psd1", new List<SignInfo>{ new SignInfo("PSDCertificate", collisionPriorityId: "123") } },
@@ -81,10 +79,6 @@ namespace Microsoft.DotNet.SignTool.Tests
         // Default extension based signing information post build
         private static readonly ITaskItem[] s_fileExtensionSignInfoPostBuild = new ITaskItem[]
         {
-            new TaskItem(".js", new Dictionary<string, string> {
-                { "CertificateName", "JSCertificate" },
-                { SignToolConstants.CollisionPriorityId, "123" }
-            }),
             new TaskItem(".jar", new Dictionary<string, string> {
                 { "CertificateName", "JARCertificate" },
                 { SignToolConstants.CollisionPriorityId, "123" }
@@ -144,10 +138,6 @@ namespace Microsoft.DotNet.SignTool.Tests
             new TaskItem(".vsix", new Dictionary<string, string> {
                 { "CertificateName", "VsixSHA2" },
                 { SignToolConstants.CollisionPriorityId, "123" }
-            }),
-            new TaskItem(".js", new Dictionary<string, string> {
-                { "CertificateName", "JSCertificate" },
-                { SignToolConstants.CollisionPriorityId, "234" }
             }),
             new TaskItem(".jar", new Dictionary<string, string> {
                 { "CertificateName", "JARCertificate" },
@@ -2381,7 +2371,6 @@ $@"
             var itemsToSign = new List<ItemToSign>()
             {
                 new ItemToSign(CreateTestResource("dynalib.dylib"), "123"),
-                new ItemToSign(CreateTestResource("javascript.js"), "123"),
                 new ItemToSign(CreateTestResource("javatest.jar"), "123"),
                 new ItemToSign(CreateTestResource("power.ps1"), "123"),
                 new ItemToSign(CreateTestResource("powerc.psc1"), "123"),
@@ -2398,7 +2387,6 @@ $@"
             ValidateFileSignInfos(itemsToSign, strongNameSignInfo, fileSignInfo, s_fileExtensionSignInfoWithCollisionId, new[]
             {
                 "File 'dynalib.dylib' Certificate='DylibCertificate'",
-                "File 'javascript.js' Certificate='JSCertificate'",
                 "File 'javatest.jar' Certificate='JARCertificate'",
                 "File 'power.ps1' Certificate='PSCertificate'",
                 "File 'powerc.psc1' Certificate='PSCCertificate'",
@@ -2413,12 +2401,12 @@ $@"
             var fileExtensionSignInfo = new List<ITaskItem>();
 
             // Validate that multiple entries will collide and fail
-            fileExtensionSignInfo.Add(new TaskItem(".js", new Dictionary<string, string>
+            fileExtensionSignInfo.Add(new TaskItem(".ps1", new Dictionary<string, string>
             {
-                { "CertificateName", "JSCertificate" },
+                { "CertificateName", "PS1Certificate" },
                 { "CollisionPriorityId", "123" }
             }));
-            fileExtensionSignInfo.Add(new TaskItem(".js", new Dictionary<string, string>{
+            fileExtensionSignInfo.Add(new TaskItem(".ps1", new Dictionary<string, string>{
                 { "CertificateName", "None" },
                 { "CollisionPriorityId", "123" }
             }));
@@ -2432,17 +2420,17 @@ $@"
             var fileExtensionSignInfo = new List<ITaskItem>();
 
             // Validate that multiple entries will collide and fail
-            fileExtensionSignInfo.Add(new TaskItem(".js", new Dictionary<string, string>
+            fileExtensionSignInfo.Add(new TaskItem(".ps1", new Dictionary<string, string>
             {
-                { "CertificateName", "JSCertificate" },
+                { "CertificateName", "PS1Certificate" },
                 { "CollisionPriorityId", "123" }
             }));
-            fileExtensionSignInfo.Add(new TaskItem(".js", new Dictionary<string, string>{
+            fileExtensionSignInfo.Add(new TaskItem(".ps1", new Dictionary<string, string>{
                 { "CertificateName", "None" }
             }));
-            fileExtensionSignInfo.Add(new TaskItem(".js", new Dictionary<string, string>
+            fileExtensionSignInfo.Add(new TaskItem(".ps1", new Dictionary<string, string>
             {
-                { "CertificateName", "JSCertificate" },
+                { "CertificateName", "PS1Certificate" },
                 { "CollisionPriorityId", "456" }
             }));
 
@@ -2747,7 +2735,6 @@ $@"
             // List of files to be considered for signing
             var itemsToSign = new List<ItemToSign>()
             {
-                new ItemToSign(CreateTestResource("test.js"), "123"),
                 new ItemToSign(CreateTestResource("test.jar"), "123"),
                 new ItemToSign(CreateTestResource("test.ps1"), "123"),
                 new ItemToSign(CreateTestResource("test.psd1"), "123"),
@@ -2776,7 +2763,6 @@ $@"
             // Overriding information
             var fileSignInfo = new Dictionary<ExplicitCertificateKey, string>()
             {
-                { new ExplicitCertificateKey("test.js", collisionPriorityId: "123"), "JSCertificate" },
                 { new ExplicitCertificateKey("test.jar", collisionPriorityId: "123"), "JARCertificate" },
                 { new ExplicitCertificateKey("test.ps1", collisionPriorityId: "123"), "PS1Certificate" },
                 { new ExplicitCertificateKey("test.psd1", collisionPriorityId: "123"), "PSD1Certificate" },
@@ -2809,7 +2795,6 @@ $@"
 
             ValidateFileSignInfos(itemsToSign, strongNameSignInfo, fileSignInfo, s_fileExtensionSignInfo, new[]
             {
-                "File 'test.js' Certificate='JSCertificate'",
                 "File 'test.jar' Certificate='JARCertificate'",
                 "File 'test.ps1' Certificate='PS1Certificate'",
                 "File 'test.psd1' Certificate='PSD1Certificate'",

--- a/src/Microsoft.DotNet.SignTool/src/Configuration.cs
+++ b/src/Microsoft.DotNet.SignTool/src/Configuration.cs
@@ -481,6 +481,14 @@ namespace Microsoft.DotNet.SignTool
                     }
                 }
 
+                if (signInfo.Certificate != null && signInfo.Certificate.Equals("BreakingSignatureChange", StringComparison.OrdinalIgnoreCase))
+                {
+                    _log.LogWarning($"Skipping file '{file.FullPath}' because .js files are no longer signed by default. " +
+                        "To disable this warning, please explicitly define the FileExtensionSignInfo for the .js extension " +
+                        "or set the MSBuild property 'NoSignJS' to 'true'.");
+                    return new FileSignInfo(file, SignInfo.Ignore, wixContentFilePath: wixContentFilePath);
+                }
+
                 // If the file is already signed and we are not allowed to dual sign, and we are not doing a mac notarization operation,
                 // then we should not sign the file.
                 if (isAlreadyAuthenticodeSigned && !dualCertsAllowed && string.IsNullOrEmpty(macNotarizationAppName))


### PR DESCRIPTION
Example output:

```
/repos/arcade-validation# ./build.sh -sign
  /root/.nuget/packages/microsoft.dotnet.arcade.sdk/10.0.0-beta.29501.1/tools/Tools.proj                Restore (0.5s)
Restore complete (0.5s)
  Validation net10.0 succeeded (0.1s) → artifacts/bin/Validation/Debug/net10.0/Validation.dll
  Validation.Tests succeeded (0.5s) → artifacts/bin/Validation.Tests/Debug/net10.0/Validation.Tests.dll
  Sign succeeded (0.3s)
    /root/.nuget/packages/microsoft.dotnet.arcade.sdk/10.0.0-beta.29501.1/tools/Sign.proj(76,5): error : Skipping file '/root/repos/arcade-validation/artifacts/packages/Debug/NonShipping/blazor.webview.js' because .js files are no longer signed by default. To disable this warning, please explicitly define the FileExtensionSignInfo for the .js extension or set the MSBuild property 'NoSignJS' to 'true'.

Build failed with 1 error(s) in 2.4s
Build failed with exit code 1. Check errors above.
```
