### PR TITLE
Reapply "Use new HelixAPI `/job/{job}/results` endpoint (#15230)" (#1…

### DIFF
--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/JobCreationResult.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/JobCreationResult.cs
@@ -49,10 +49,6 @@ namespace Microsoft.DotNet.Helix.Client.Models
                 {
                     return false;
                 }
-                if (string.IsNullOrEmpty(ResultsUriRSAS))
-                {
-                    return false;
-                }
                 return true;
             }
         }

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/JobResultsUri.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/JobResultsUri.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Immutable;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.Helix.Client.Models
+{
+    public partial class JobResultsUri
+    {
+        public JobResultsUri()
+        {
+        }
+
+        [JsonProperty("ResultsUri")]
+        public string ResultsUri { get; set; }
+
+        [JsonProperty("ResultsUriRSAS")]
+        public string ResultsUriRSAS { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.Helix/JobSender/ISentJob.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/ISentJob.cs
@@ -24,17 +24,6 @@ namespace Microsoft.DotNet.Helix.Client
         string HelixCancellationToken { get; }
 
         /// <summary>
-        /// URI for blob storage container with the results.
-        /// </summary>
-        string ResultsContainerUri { get; }
-
-        /// <summary>
-        /// Shared Access Signature for access to the container with results.
-        /// Used for internal builds.
-        /// </summary>
-        string ResultsContainerReadSAS { get; }
-
-        /// <summary>
         /// Poll for the job to actually finish inside Helix.
         /// </summary>
         Task<JobPassFail> WaitAsync(int pollingIntervalMs = 10000, CancellationToken cancellationToken = default);

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -239,9 +239,9 @@ namespace Microsoft.DotNet.Helix.Client
             }
 
             string jobStartIdentifier = Guid.NewGuid().ToString("N");
-            var newJob = await JobApi.NewAsync(creationRequest, jobStartIdentifier, cancellationToken).ConfigureAwait(false);
+            var newJob = await JobApi.NewAsync(creationRequest, jobStartIdentifier, cancellationToken: cancellationToken).ConfigureAwait(false);
 
-            return new SentJob(JobApi, newJob, newJob.ResultsUri, newJob.ResultsUriRSAS);
+            return new SentJob(JobApi, newJob);
         }
 
         private void WarnForImpendingRemoval(Action<string> log, QueueInfo queueInfo) 

--- a/src/Microsoft.DotNet.Helix/JobSender/SentJob.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/SentJob.cs
@@ -9,20 +9,16 @@ namespace Microsoft.DotNet.Helix.Client
 {
     internal class SentJob : ISentJob
     {
-        public SentJob(IJob jobApi, JobCreationResult newJob, string resultsContainerUri, string resultsContainerReadSAS)
+        public SentJob(IJob jobApi, JobCreationResult newJob)
         {
             JobApi = jobApi;
             CorrelationId = newJob.Name;
             HelixCancellationToken = newJob.CancellationToken;
-            ResultsContainerUri = resultsContainerUri;
-            ResultsContainerReadSAS = resultsContainerReadSAS;
         }
 
         public IJob JobApi { get; }
         public string CorrelationId { get; }
         public string HelixCancellationToken { get; }
-        public string ResultsContainerUri { get; }
-        public string ResultsContainerReadSAS { get; }
 
         public Task<JobPassFail> WaitAsync(int pollingIntervalMs = 10000, CancellationToken cancellationToken = default)
         {

--- a/src/Microsoft.DotNet.Helix/Sdk/DownloadFromResultsContainer.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/DownloadFromResultsContainer.cs
@@ -26,8 +26,6 @@ namespace Microsoft.DotNet.Helix.Sdk
         [Required]
         public ITaskItem[] MetadataToWrite { get; set; }
 
-        public string ResultsContainerReadSAS { get; set; }
-
         private const string MetadataFile = "metadata.txt";
 
         private readonly CancellationTokenSource _cancellationSource = new CancellationTokenSource();
@@ -74,6 +72,7 @@ namespace Microsoft.DotNet.Helix.Sdk
 
                 // Use the Helix API to get the last possible iteration of the work item's execution 
                 var allAvailableFiles = await HelixApi.WorkItem.ListFilesAsync(workItemName, JobId, true, ct);
+                var resultsUri = await HelixApi.Job.ResultsAsync(JobId, ct);
 
                 DirectoryInfo destinationDir = Directory.CreateDirectory(Path.Combine(directoryPath, workItemName));
                 foreach (string file in filesToDownload)
@@ -109,14 +108,14 @@ namespace Microsoft.DotNet.Helix.Sdk
                         // If we have no read SAS token from the build, make a best-effort attempt using the URL from the Helix API.
                         // For restricted queues, there will be no read SAS token available to use in the Helix API's result
                         // (but hopefully the 'else' branch will be hit in this case)
-                        if (string.IsNullOrEmpty(ResultsContainerReadSAS)) 
+                        if (string.IsNullOrEmpty(resultsUri.ResultsUriRSAS)) 
                         {
                             blob = new BlobClient(new Uri(fileAvailableForDownload.Link), blobClientOptions);
                         }
                         else 
                         {
                             var strippedFileUri = new Uri(fileAvailableForDownload.Link.Substring(0, fileAvailableForDownload.Link.LastIndexOf('?')));
-                            blob = new BlobClient(strippedFileUri, new AzureSasCredential(ResultsContainerReadSAS), blobClientOptions);
+                            blob = new BlobClient(strippedFileUri, new AzureSasCredential(resultsUri.ResultsUriRSAS), blobClientOptions);
                         }
                         await blob.DownloadToAsync(destinationFile);
                     }

--- a/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
@@ -79,18 +79,6 @@ namespace Microsoft.DotNet.Helix.Sdk
         public string JobCancellationToken { get; set; }
 
         /// <summary>
-        ///   When the task finishes, the results container uri should be available in case we want to download files.
-        /// </summary>
-        [Output]
-        public string ResultsContainerUri { get; set; }
-
-        /// <summary>
-        ///   If the job is internal, we need to give the DownloadFromResultsContainer task the Write SAS to download files.
-        /// </summary>
-        [Output]
-        public string ResultsContainerReadSAS { get; set; }
-
-        /// <summary>
         ///   A collection of commands that will run for each work item before any work item commands.
         ///   Use a semicolon to delimit these and escape semicolons by percent coding them ('%3B').
         ///   NOTE: This is different behavior from the WorkItem PreCommands, where semicolons are escaped
@@ -270,8 +258,6 @@ namespace Microsoft.DotNet.Helix.Sdk
                 ISentJob job = await def.SendAsync(msg => Log.LogMessageFromText(msg, MessageImportance.Normal), cancellationToken);
                 JobCorrelationId = job.CorrelationId;
                 JobCancellationToken = job.HelixCancellationToken;
-                ResultsContainerUri = job.ResultsContainerUri;
-                ResultsContainerReadSAS = job.ResultsContainerReadSAS;
                 cancellationToken.ThrowIfCancellationRequested();
             }
 

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
@@ -59,15 +59,11 @@
                   HelixProperties="@(HelixProperties)">
       <Output TaskParameter="JobCorrelationId" PropertyName="HelixJobId"/>
       <Output TaskParameter="JobCancellationToken" PropertyName="HelixJobCancellationToken"/>
-      <Output TaskParameter="ResultsContainerUri" PropertyName="HelixResultsContainer"/>
-      <Output TaskParameter="ResultsContainerReadSAS" PropertyName="HelixResultsContainerReadSAS"/>
     </SendHelixJob>
     <ItemGroup>
       <SentJob Include="$(HelixJobId)">
         <WorkItemCount>@(HelixWorkItem->Count())</WorkItemCount>
         <HelixTargetQueue>$(HelixTargetQueue)</HelixTargetQueue>
-        <ResultsContainerUri>$(HelixResultsContainer)</ResultsContainerUri>
-        <ResultsContainerReadSAS>$(HelixResultsContainerReadSAS)</ResultsContainerReadSAS>
         <HelixJobCancellationToken>$(HelixJobCancellationToken)</HelixJobCancellationToken>
       </SentJob>
     </ItemGroup>

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/download-results/DownloadFromResultsContainer.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/download-results/DownloadFromResultsContainer.targets
@@ -21,16 +21,13 @@
       <_shouldDownloadResults Condition="'@(_workItemsWithDownloadMetadata)' != '' AND '$(HelixResultsDestinationDir)' != ''">true</_shouldDownloadResults>
     </PropertyGroup>
 
-    <Warning Text="DownloadFromResultsContainer will be skipped for job %(SentJob.Identity) because results container uri is empty" Condition="'%(SentJob.ResultsContainerUri)' == '' AND $(_shouldDownloadResults)" />
-
     <DownloadFromResultsContainer
-        Condition="$(_shouldDownloadResults) AND '%(SentJob.ResultsContainerUri)' != ''"
+        Condition="$(_shouldDownloadResults)"
         AccessToken="$(HelixAccessToken)"
         WorkItems="@(_workItemsWithDownloadMetadata)"
         OutputDirectory="$(HelixResultsDestinationDir)"
         MetadataToWrite="@(HelixDownloadResultsMetadata)"
-        JobId="%(SentJob.Identity)"
-        ResultsContainerReadSAS="%(SentJob.ResultsContainerReadSAS)" />
+        JobId="%(SentJob.Identity)" />
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/CSharp.cs
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/CSharp.cs
@@ -193,6 +193,17 @@ namespace Microsoft.DotNet.SwaggerGenerator.Languages
                 }
             }
 
+            [HelperMethod]
+            public string MaybeCallToString(TypeReference reference)
+            {
+                if (reference != TypeReference.String)
+                {
+                    return ".ToString()";
+                }
+
+                return string.Empty;
+            }
+
             public string GetDefaultExpression(TypeReference reference, bool required)
             {
                 string typeElement = ResolveReference(reference, null);

--- a/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/MethodGroup.hb
+++ b/src/Microsoft.DotNet.SwaggerGenerator/Microsoft.DotNet.SwaggerGenerator.CodeGenerator/Languages/csharp/MethodGroup.hb
@@ -179,7 +179,7 @@ namespace {{pascalCaseNs Namespace}}
 
                 if ({{#notNullCheck Type Required}}{{camelCase Name}}{{/notNullCheck}})
                 {
-                    _req.Headers.Add("{{Name}}", {{camelCase Name}});
+                    _req.Headers.Add("{{Name}}", {{camelCase Name}}{{maybeCallToString Type}});
                 }
                 {{/each}}
                 {{#with BodyParameter}}


### PR DESCRIPTION
…5335)

This reverts commit 255d5e0c89958af276883a988108c2d616438805.

My understanding is that the root cause that led to the original reversion was fixed with https://dev.azure.com/dnceng/internal/_git/b446d7ab-be6b-4949-aa44-214eef7e35bb/commit/44f269dbbb186a8eae5ab24ef8bb5fe09b9db983. See https://dev.azure.com/dnceng/internal/_workitems/edit/7416 for some more context.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
