### PR TITLE
[release/9.0] Allow passing additional args to the source-build job

### DIFF
--- a/eng/common/core-templates/job/source-build.yml
+++ b/eng/common/core-templates/job/source-build.yml
@@ -26,6 +26,8 @@ parameters:
   #   Specifies the build script to invoke to perform the build in the repo. The default
   #   './build.sh' should work for typical Arcade repositories, but this is customizable for
   #   difficult situations.
+  # buildArguments: ''
+  #   Specifies additional build arguments to pass to the build script.
   # jobProperties: {}
   #   A list of job properties to inject at the top level, for potential extensibility beyond
   #   container and pool.

--- a/eng/common/core-templates/steps/source-build.yml
+++ b/eng/common/core-templates/steps/source-build.yml
@@ -79,6 +79,7 @@ steps:
     ${{ coalesce(parameters.platform.buildScript, './build.sh') }} --ci \
       --configuration $buildConfig \
       --restore --build --pack $publishArgs -bl \
+      ${{ parameters.platform.buildArguments }} \
       $officialBuildArgs \
       $internalRuntimeDownloadArgs \
       $internalRestoreArgs \


### PR DESCRIPTION
Backport of https://github.com/dotnet/arcade/pull/15769 for release/9.0

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
