### PR TITLE
Add additional algorithms

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/Utils.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Utils.cs
@@ -45,15 +45,15 @@ namespace Microsoft.SignCheck
         {
             switch (hashName.ToUpperInvariant())
             {
-                case "SHA256":
+                case "SHA256" or "SHA-256":
                     return SHA256.Create();
-                case "SHA1":
+                case "SHA1" or "SHA-1":
                     return SHA1.Create();
                 case "MD5":
                     return MD5.Create();
-                case "SHA384":
+                case "SHA384" or "SHA-384":
                     return SHA384.Create();
-                case "SHA512":
+                case "SHA512" or "SHA-512":
                     return SHA512.Create();
                 default:
                     throw new ArgumentException($"Unsupported hash algorithm name '{hashName}'", nameof(hashName));

--- a/src/SignCheck/Microsoft.SignCheck/Utils.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Utils.cs
@@ -56,7 +56,7 @@ namespace Microsoft.SignCheck
                 case "SHA512":
                     return SHA512.Create();
                 default:
-                    throw new ArgumentException("Unsupported hash algorithm name", nameof(hashName));
+                    throw new ArgumentException($"Unsupported hash algorithm name '{hashName}'", nameof(hashName));
             }
         }
 


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/4999

This pull request updates the `CreateHashAlgorithm` method in `Utils.cs` to enhance its usability and error reporting. The changes include support for additional hash algorithm name formats and improved exception messages.

- Updated the `CreateHashAlgorithm` method to recognize alternative hash algorithm name formats (e.g., "SHA-256" in addition to "SHA256").
- Enhanced the exception message for unsupported hash algorithms to include the invalid `hashName` provided.



