### PR TITLE
[WiX 5]: Create parallel set of files for v5

### DIFF
--- a/src/Common/wix5/dotnethome_x64.wxs
+++ b/src/Common/wix5/dotnethome_x64.wxs
@@ -1,0 +1,41 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util" >
+  <?ifndef InstallerPlatform?>
+    <?define InstallerPlatform = "$(sys.BUILDARCH)"?>
+  <?endif?>
+
+  <!-- InstallerNativeMachine matches the expected values for image file machine constants
+       https://docs.microsoft.com/en-us/windows/win32/sysinfo/image-file-machine-constants -->
+  <?if $(InstallerPlatform)~=x86?>
+    <?define InstallerNativeMachine=332?>
+  <?elseif $(InstallerPlatform)~=x64?>
+    <?define InstallerNativeMachine=34404?>
+  <?elseif $(InstallerPlatform)~=arm64?>
+    <?define InstallerNativeMachine=43620?>
+  <?else?>
+    <?error Unknown platform, $(InstallerPlatform) ?>
+  <?endif?>
+
+  <Fragment>
+    <util:QueryNativeMachine />
+    
+    <!-- Identify when installing in emulation as when WIX_NATIVE_MACHINE does not match the installer 
+         native machine (where supported). Also detect running under WOW on x86 using VersionNT64, 
+         since WIX_NATIVE_MACHINE cannot be retrieved on older Windows builds. -->
+    <?if $(InstallerPlatform)~=x86?>
+      <SetProperty Action="Set_NON_NATIVE_ARCHITECTURE" Id="NON_NATIVE_ARCHITECTURE" Value="true" Before="CostFinalize" Condition="VersionNT64 OR WIX_NATIVE_MACHINE AND NOT WIX_NATIVE_MACHINE=$(InstallerNativeMachine)" />
+    <?else?>
+      <SetProperty Action="Set_NON_NATIVE_ARCHITECTURE" Id="NON_NATIVE_ARCHITECTURE" Value="true" Before="CostFinalize" Condition="WIX_NATIVE_MACHINE AND NOT WIX_NATIVE_MACHINE=$(InstallerNativeMachine)" />
+    <?endif?>
+  </Fragment>
+
+  <?if $(InstallerPlatform)~=x64?>
+  <Fragment>
+    <!-- When running in a non-native architecture and user hasn't specified install directory,
+         install to an x64 subdirectory.
+         This is only defined for x64, since x86 has redirection and no other native architecture can install ARM64 today -->
+    <SetProperty Action="Set_DOTNETHOME_NON_NATIVE_ARCHITECTURE" Id="DOTNETHOME" Value="[ProgramFiles64Folder]dotnet\x64\" After="Set_NON_NATIVE_ARCHITECTURE"
+                 Condition="NON_NATIVE_ARCHITECTURE AND NOT DOTNETHOME" />
+  </Fragment>
+  <?endif?>
+</Wix>

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/Microsoft.DotNet.Build.Tasks.Installers.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/Microsoft.DotNet.Build.Tasks.Installers.csproj
@@ -33,6 +33,10 @@
           Link="build\wix\product\dotnethome_x64.wxs"
           PackagePath="%(Link)"
           Pack="true" />
+    <None Include="..\Common\wix5\dotnethome_x64.wxs"
+          Link="build\wix5\product\dotnethome_x64.wxs"
+          PackagePath="%(Link)"
+          Pack="true" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/bundle/upgradePolicies.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/bundle/upgradePolicies.wxs
@@ -1,0 +1,37 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
+  <Fragment>
+    <!-- Bundle variables become unset if a search fails. The global key is retrieved first. If this fails,
+         RemoveUpgradeRelatedBundle becomes unset, allowing the version specific search to potentially set 
+         or override the bundle variable. -->
+    <util:RegistrySearch Id="RemovePreviousVersionRegistryKeySearch"
+                         Root="HKLM"
+                         Key="SOFTWARE\Microsoft\.NET"
+                         Value="RemovePreviousVersion"
+                         Result="value"
+                         Variable="RemoveUpgradeRelatedBundle"
+                         Bitness="always64" />
+
+    <!-- The version specific key matching the major/minor of the .NET bundle takes precedence. The first search
+         checks whether the registry value exists and creates a variable that can be used as a condition
+         to executes the second part of the search to retrieve it. If the value doesn't exist, RemoveUpgradeRelatedBundle
+         retains its original value, or if it wasn't set, will be assigned a proper default through the BA (wixstdba). -->
+    <util:RegistrySearch Id="RemoveSpecificPreviousVersionRegistryKeyExistsSearch" 
+                         After="RemovePreviousVersionRegistryKeySearch"
+                         Root="HKLM"
+                         Key="SOFTWARE\Microsoft\.NET\$(MajorVersion).$(MinorVersion)"
+                         Value="RemovePreviousVersion"
+                         Result="exists"
+                         Variable="RemoveSpecificPreviousVersionRegistryKeyExists"
+                         Bitness="always64" />
+    <util:RegistrySearch Id="RemoveSpecificPreviousVersionRegistryKeySearch"
+                         After="RemoveSpecificPreviousVersionRegistryKeyExistsSearch"
+                         Condition="RemoveSpecificPreviousVersionRegistryKeyExists=1"
+                         Root="HKLM"
+                         Key="SOFTWARE\Microsoft\.NET\$(MajorVersion).$(MinorVersion)"
+                         Value="RemovePreviousVersion"
+                         Result="value"
+                         Variable="RemoveUpgradeRelatedBundle"
+                         Bitness="always64" />
+  </Fragment>
+</Wix>


### PR DESCRIPTION
This is an initial conversion of some shared source files. Until all the v5 work is completed, we need to support v3 and v5 in parallel to avoid disrupting builds. The files being added are placed under a separate `wix5` folder inside the package and used by multiple repos.

![image](https://github.com/user-attachments/assets/96f6117e-3f01-453a-8e2a-6b6ff3900342)

## Changes

- Updated the namespace URLs to the latest v4 schema.
- Variable references no longer require using `$(var.)` prefix
- Inner text conditional expressions are moved to `Condition` attributes
- `Win64` attribute has been replaced with `Bitness`.  `Bitness="always64"` is equivalent to `Win64="yes"`.
- Replaced `$(var.Platform)` with `$(InstallerPlatform)` - this is initialized by the WiX SDK.

