### PR TITLE
Provide an injection point for custom test reporting functionality

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VSTest.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VSTest.targets
@@ -70,6 +70,16 @@
       <_ResultsFileToDisplay Condition="!Exists('$(_ResultsFileToDisplay)')">%(TestToRun.ResultsStdOutPath)</_ResultsFileToDisplay>
     </PropertyGroup>
 
+    <!--
+      Allow running an arbitrary target after the tests have been executed. This is useful for running custom test reporting tools.
+    -->
+    <MSBuild Projects="$(OnTestsExecutedProject)"
+             Properties="$(OnTestsExecutedProperties);Project=$(MSBuildProjectName);LogFile=%(TestToRun.ResultsStdOutPath);TrxFile=%(TestToRun.ResultsTrxPath);ExitCode=$(_TestErrorCode);TestEnvironment=$(_TestEnvironment);TestAssembly=$(_TestAssembly);TargetFramework=%(TestToRun.TargetFramework)"
+             Targets="OnTestsExecuted"
+             SkipNonexistentProjects="true"
+             Condition=" Exists('$(OnTestsExecutedProject)') "
+             />
+
     <!-- 
       Ideally we would set ContinueOnError="ErrorAndContinue" so that when a test fails in multi-targeted test project
       we'll still run tests for all target frameworks. ErrorAndContinue doesn't work well on Linux though: https://github.com/Microsoft/msbuild/issues/3961.

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.Runner.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.Runner.targets
@@ -94,6 +94,16 @@
     </PropertyGroup>
 
     <!--
+      Allow running an arbitrary target after the tests have been executed. This is useful for running custom test reporting tools.
+    -->
+    <MSBuild Projects="$(OnTestsExecutedProject)"
+             Properties="$(OnTestsExecutedProperties);Project=$(MSBuildProjectName);LogFile=%(TestToRun.ResultsStdOutPath);TrxFile=%(TestToRun.ResultsTrxPath);ExitCode=$(_TestErrorCode);TestEnvironment=$(_TestEnvironment);TestAssembly=$(_TestAssembly);TargetFramework=%(TestToRun.TargetFramework)"
+             Targets="OnTestsExecuted"
+             SkipNonexistentProjects="true"
+             Condition=" Exists('$(OnTestsExecutedProject)') "
+             />
+
+    <!--
       Ideally we would set ContinueOnError="ErrorAndContinue" so that when a test fails in multi-targeted test project
       we'll still run tests for all target frameworks. ErrorAndContinue doesn't work well on Linux though: https://github.com/Microsoft/msbuild/issues/3961.
     -->

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnitV3/XUnitV3.Runner.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnitV3/XUnitV3.Runner.targets
@@ -80,6 +80,16 @@
     </PropertyGroup>
 
     <!--
+      Allow running an arbitrary target after the tests have been executed. This is useful for running custom test reporting tools.
+    -->
+    <MSBuild Projects="$(OnTestsExecutedProject)"
+             Properties="$(OnTestsExecutedProperties);Project=$(MSBuildProjectName);LogFile=%(TestToRun.ResultsStdOutPath);TrxFile=%(TestToRun.ResultsTrxPath);ExitCode=$(_TestErrorCode);TestEnvironment=$(_TestEnvironment);TestAssembly=$(_TestAssembly);TargetFramework=%(TestToRun.TargetFramework)"
+             Targets="OnTestsExecuted"
+             SkipNonexistentProjects="true"
+             Condition=" Exists('$(OnTestsExecutedProject)') "
+             />
+
+    <!--
       Ideally we would set ContinueOnError="ErrorAndContinue" so that when a test fails in multi-targeted test project
       we'll still run tests for all target frameworks. ErrorAndContinue doesn't work well on Linux though: https://github.com/Microsoft/msbuild/issues/3961.
     -->


### PR DESCRIPTION
The current test logging implementation makes it difficult to know what tests failed during test execution.
This especially affects GitHub Actions, which lack any test reporting functionality, and require developers to download logs and search for failures.

The injection point provides the ability to mitigate the issue by allowing to inject a custom test reporter project before a test run is terminated (in an event of a failure).


#### Before:

![image](https://github.com/user-attachments/assets/6051591d-93b4-4fad-b985-1b748b028ffd)
![image](https://github.com/user-attachments/assets/d85f3855-1393-4fad-beb5-14d482c0deee)

#### After

![image](https://github.com/user-attachments/assets/b0d7addd-4f42-4154-8379-5ff72725b8f3)
![image](https://github.com/user-attachments/assets/aa1aca25-faa8-49a2-afee-0c8ee9d1e5e2)


### Examples

A real-life example can be seen here: https://github.com/RussKie/aspire/actions/runs/14617272672/job/41008327227#step:6:303. This is achieved with https://github.com/dotnet/aspire/pull/8811/files#diff-2f47f8038028665e98b009c5afd2a2fba53b4c62d24a96729a50567dbe4e80de.

![image](https://github.com/user-attachments/assets/3f1fda97-6dac-4182-91b1-55b2d514e1d0)

