### PR TITLE
Disable tests that require RSA+SHA-1 on platforms where RSA+SHA-1 is not available

### DIFF
--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -259,6 +259,8 @@ namespace Microsoft.DotNet.SignTool.Tests
             }
         }
 
+        public static bool PlatformSupportsStrongNameAlgorithm { get; } = StrongNameSupportHelper.GetPlatformSupportsRSASHA1();
+
         public SignToolTests(ITestOutputHelper output)
         {
             _tmpDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
@@ -703,7 +705,7 @@ namespace Microsoft.DotNet.SignTool.Tests
             });
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PlatformSupportsStrongNameAlgorithm))]
         public void SkipStrongNamingBinaryButDontSkipAuthenticode()
         {
             // List of files to be considered for signing
@@ -3076,7 +3078,7 @@ $@"
         /// <summary>
         /// Verify that flipbit works properly by flipping twice.
         /// </summary>
-        [Fact]
+        [ConditionalFact(nameof(PlatformSupportsStrongNameAlgorithm))]
         public void NoFlipButWriteShouldVerify()
         {
             // We're going to open the file and flip a bit in the checksum
@@ -3106,7 +3108,7 @@ $@"
 
         // This binary has had a resource added after it was strong name. This invalidated the checksum too,
         // so we write the expected checksum.
-        [Fact]
+        [ConditionalFact(nameof(PlatformSupportsStrongNameAlgorithm))]
         public void InvalidatedSNSignatureDoesNotValidate()
         {
             using var inputStream = File.OpenRead(GetResourcePath("InvalidatedStrongName.dll"));
@@ -3122,7 +3124,7 @@ $@"
             StrongNameHelper.IsSigned(outputStream).Should().BeFalse();
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PlatformSupportsStrongNameAlgorithm))]
         public void ValidStrongNameSignaturesValidate()
         {
             StrongNameHelper.IsSigned(GetResourcePath("SignedLibrary.dll")).Should().BeTrue();
@@ -3136,7 +3138,7 @@ $@"
             StrongNameHelper.IsSigned_Legacy(GetResourcePath("StrongNamedWithEcmaKey.dll"), s_snPath).Should().BeTrue();
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(PlatformSupportsStrongNameAlgorithm))]
         [InlineData("OpenSigned.dll", "OpenSignedCorrespondingKey.snk", true)]
         [InlineData("DelaySignedWithOpen.dll", "OpenSignedCorrespondingKey.snk", false)]
         public void SigningSignsAsExpected(string file, string key, bool initiallySigned)

--- a/src/Microsoft.DotNet.SignTool.Tests/StrongNameSupportHelper.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/StrongNameSupportHelper.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Security.Cryptography;
+
+namespace Microsoft.DotNet.SignTool.Tests
+{
+    internal static class StrongNameSupportHelper
+    {
+        internal static bool GetPlatformSupportsRSASHA1()
+        {
+            using (RSA rsa = RSA.Create(2048))
+            {
+                try
+                {
+                    rsa.SignData(Array.Empty<byte>(), HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1);
+                    return true;
+                }
+                catch (CryptographicException)
+                {
+                    return false;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request disables a handful of tests that exercise strong name signing for platforms that no longer support the cryptographic algorithm used in strong name signing.

Strong name signing depends on the use of RSA+SHA-1 digital signatures, as required by ECMA 335. However, some Linux distributions are starting to block the use of RSA+SHA-1 in their distribution's OpenSSL. Implementations of strong name signing that use .NET's `RSA` functionality will be unable to sign or verify RSA+SHA-1 signatures on platforms that have explicitly chosen to disable it.

Following a similar pattern that was done for [`dotnet/runtime`](https://github.com/dotnet/runtime/pull/67998), this disables strong name tests on platforms that are unable to produce or verify RSA+SHA-1 signatures.

Alma Linux 9 was identified as one of the impacted platforms at https://github.com/dotnet/arcade/pull/15790.

/cc @richlander @mmitche 