### PR TITLE
[release/9.0] Allow disabling SB intermediate restore and prebuilt reporting

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
@@ -7,6 +7,7 @@
 
   <PropertyGroup>
     <MicrosoftDotNetSourceBuildTasksBuildDir>$(NuGetPackageRoot)microsoft.dotnet.sourcebuild.tasks\$(MicrosoftDotNetSourceBuildTasksVersion)\build\</MicrosoftDotNetSourceBuildTasksBuildDir>
+    <ReportPrebuiltUsage Condition="'$(ReportPrebuiltUsage)' == '' and '$(DotNetBuildSourceOnly)' == 'true'">true</ReportPrebuiltUsage>
   </PropertyGroup>
 
   <Import Project="$(MicrosoftDotNetSourceBuildTasksBuildDir)Microsoft.DotNet.SourceBuild.Tasks.props" />
@@ -62,6 +63,7 @@
   </Target>
 
   <Target Name="ReportPrebuiltUsage"
+          Condition="'$(ReportPrebuiltUsage)' == 'true'"
           DependsOnTargets="WritePrebuiltUsageData">
     <PropertyGroup>
       <FailOnPrebuiltBaselineError Condition="'$(FailOnPrebuiltBaselineError)' == ''">true</FailOnPrebuiltBaselineError>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
@@ -11,6 +11,10 @@
     <PackageReference Include="Microsoft.DotNet.SourceBuild.Tasks" Version="$(MicrosoftDotNetSourceBuildTasksVersion)" IsImplicitlyDefined="true" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <SetUpSourceBuildIntermediateNupkgCache Condition="'$(SetUpSourceBuildIntermediateNupkgCache)' == ''">true</SetUpSourceBuildIntermediateNupkgCache>
+  </PropertyGroup>
+
   <!-- Because the condition here is rather complex, it should read as the following:
       - Don't collect intermediates if running the product build
       - Otherwise, collect if we're forcing it using SetUpSourceBuildIntermediateNupkgCache
@@ -19,9 +23,10 @@
         - Building in DotNetBuild mode and we're in the inner repo and this is a source-only build -->
   <Target Name="CollectSourceBuildIntermediateNupkgDependencies"
           Condition="
-            '$(DotNetBuildFromSourceFlavor)' != 'Product' and '$(DotNetBuildOrchestrator)' != 'true' and
-            ('$(SetUpSourceBuildIntermediateNupkgCache)' == 'true' or
-            ('$(ArcadeBuildFromSource)' == 'true' and '$(ArcadeInnerBuildFromSource)' == 'true') or
+            '$(DotNetBuildFromSourceFlavor)' != 'Product' and
+            '$(DotNetBuildOrchestrator)' != 'true' and
+            '$(SetUpSourceBuildIntermediateNupkgCache)' == 'true' and
+            (('$(ArcadeBuildFromSource)' == 'true' and '$(ArcadeInnerBuildFromSource)' == 'true') or
             ('$(DotNetBuildPhase)' == 'InnerRepo' and '$(DotNetBuildSourceOnly)' == 'true'))"
           DependsOnTargets="GetSourceBuildIntermediateNupkgNameConvention"
           BeforeTargets="CollectPackageReferences">
@@ -45,11 +50,12 @@
          - If building in DotNetBuild mode and we're in the inner repo and this is a source-only build -->
   <Target Name="SetUpSourceBuildIntermediateNupkgCache"
           Condition="
-            '$(DotNetBuildFromSourceFlavor)' != 'Product' and '$(DotNetBuildOrchestrator)' != 'true' and
-            ('$(SetUpSourceBuildIntermediateNupkgCache)' == 'true' or
-              ('@(SourceBuildIntermediateNupkgReference)' != '' and
+            '$(DotNetBuildFromSourceFlavor)' != 'Product' and
+            '$(DotNetBuildOrchestrator)' != 'true' and
+            '$(SetUpSourceBuildIntermediateNupkgCache)' == 'true' and
+            '@(SourceBuildIntermediateNupkgReference)' != '' and
                 (('$(ArcadeBuildFromSource)' == 'true' and '$(ArcadeInnerBuildFromSource)' == 'true') or
-                 ('$(DotNetBuildPhase)' == 'InnerRepo' and '$(DotNetBuildSourceOnly)' == 'true'))))"
+                 ('$(DotNetBuildPhase)' == 'InnerRepo' and '$(DotNetBuildSourceOnly)' == 'true'))"
           AfterTargets="Restore">
     <ItemGroup>
       <IntermediateNupkgSourceDir Include="$([MSBuild]::NormalizeDirectory(

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -93,8 +93,7 @@
   </Target>
 
   <Import Project="SourceBuild/SourceBuildArcadeTools.targets" Condition="'$(ArcadeBuildFromSource)' == 'true' or
-                                                                          '$(DotNetBuildRepo)' == 'true' or
-                                                                          '$(SetUpSourceBuildIntermediateNupkgCache)' == 'true'" />
+                                                                          '$(DotNetBuildRepo)' == 'true'" />
 
   <!-- Repository extensibility point -->
   <Import Project="$(RepositoryEngineeringDir)Tools.props" Condition="Exists('$(RepositoryEngineeringDir)Tools.props')" />


### PR DESCRIPTION
Needed for repos that are on 9.0 Arcade: https://github.com/dotnet/source-build/issues/5034

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
