### PR TITLE
Don't restore tools when doing a source-only build

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -38,8 +38,8 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <_ImportOrUseTooling>false</_ImportOrUseTooling>
-    <_ImportOrUseTooling Condition="'$(DotNetBuildSourceOnly)' != 'true' or ('$(DotNetBuildRepo)' == 'true' and '$(DotNetBuildOrchestrator)' != 'true')">true</_ImportOrUseTooling>
+    <!-- Don't restore the below nuget packages, repo tools and additional global.json runtimes when building source-only. -->
+    <_ImportOrUseTooling Condition="'$(_ImportOrUseTooling)' == '' and '$(DotNetBuildSourceOnly)' != 'true'">true</_ImportOrUseTooling>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(_ImportOrUseTooling)' == 'true'">


### PR DESCRIPTION
Tools started to get restored in repo souce-build over a year ago with https://github.com/dotnet/arcade/commit/72f32d7d6880a97b457553ff601c383aaf69c902. Chatted with @MichaelSimons offline and we shouldn't need any of those tools. This will clean-up repo source-build's prebuilt usage reports.

It might also make this change unnecessary (which was one of the reasons why I was looking into this): https://github.com/dotnet/dotnet/pull/306#discussion_r2076389345, cc @jkoritzinsky

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
