### PR TITLE
[8.0] Update FPM images

### DIFF
--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -45,7 +45,7 @@ variables:
 resources:
   containers:
   - container: LinuxContainer
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-fpm-amd64
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-fpm-amd64
 
 stages:
 - stage: build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ variables:
 resources:
   containers:
   - container: LinuxContainer
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-fpm-amd64
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-fpm-amd64
   repositories:
   - repository: 1ESPipelineTemplates
     type: git


### PR DESCRIPTION
Looks like we applied the pattern wrong. The .NET version number should match the branch. In most cases, 8.0 and 10.0 images have different content that can break customers / expectations. That may or may not be the case here, but we should rigorously follow the pattern.