### PR TITLE
Update post-build.yml

### DIFF
--- a/eng/common/core-templates/post-build/post-build.yml
+++ b/eng/common/core-templates/post-build/post-build.yml
@@ -193,7 +193,6 @@ stages:
             buildId: $(AzDOBuildId)
             artifactName: PackageArtifacts
             checkDownloadedFiles: true
-            itemPattern: **
 
         # This is necessary whenever we want to publish/restore to an AzDO private feed
         # Since sdk-task.ps1 tries to restore packages we need to do this authentication here

--- a/eng/common/core-templates/post-build/post-build.yml
+++ b/eng/common/core-templates/post-build/post-build.yml
@@ -193,9 +193,7 @@ stages:
             buildId: $(AzDOBuildId)
             artifactName: PackageArtifacts
             checkDownloadedFiles: true
-            itemPattern: |
-              **
-              !**/Microsoft.SourceBuild.Intermediate.*.nupkg
+            itemPattern: **
 
         # This is necessary whenever we want to publish/restore to an AzDO private feed
         # Since sdk-task.ps1 tries to restore packages we need to do this authentication here


### PR DESCRIPTION
Arcade 10 doesn't produce source-build intermediate packages anymore.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
