### PR TITLE
Avoid emitting 3rd party signature warnings on composite r2r images

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -70,6 +70,7 @@
     <PackageVersion Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
     <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
     <PackageVersion Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" />
+    <PackageVersion Include="ILCompiler.Reflection.ReadyToRun.Experimental" Version="$(ILCompilerReflectionReadyToRunExperimentalVersion)" />
     <!-- sdk -->
     <PackageVersion Include="Microsoft.NET.Sdk.WorkloadManifestReader" Version="$(MicrosoftNetSdkWorkloadManifestReaderVersion)" />
   </ItemGroup>

--- a/NuGet.config
+++ b/NuGet.config
@@ -14,6 +14,7 @@
     <add key="dotnet9-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9-transport/nuget/v3/index.json" />
     <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
     <add key="dotnet10-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10-transport/nuget/v3/index.json" />
+    <add key="dotnet8-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8-transport/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <clear />
@@ -35,6 +36,10 @@
     </packageSource>
     <packageSource key="dotnet-libraries-transport">
       <package pattern="microsoft.*" />
+    </packageSource>
+    <!-- Required because the ilcompiler package cannot be unified onto .NET 9 yet. -->
+    <packageSource key="dotnet8-transport">
+      <package pattern="ilcompiler.*" />
     </packageSource>
     <packageSource key="dotnet9">
       <package pattern="microsoft.*" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -63,6 +63,13 @@
       <Uri>https://github.com/dotnet/diagnostics</Uri>
       <Sha>3007744d190d50dc586acdb761c4ce6c0d5bdc15</Sha>
     </Dependency>
+    <!-- This is pinned to an 8.0 version on purpose. It's used in SignTool to detect composite r2r images.
+         Signtool also depends on SRM and SCI, which are unified to 8.0.0 versions because it's a build task and 
+         needs to be loaded by desktop msbuild. -->
+    <Dependency Name="ILCompiler.Reflection.ReadyToRun.Experimental" Version="8.0.16-servicing.25211.10" Pinned="true">
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
+      <Sha>990ebf52fc408ca45929fd176d2740675a67fab8</Sha>
+    </Dependency>
     <!-- Necessary for source-build. The dependency is loaded in during built-time
          by consumers of NuGetRepack.Tasks, so we cannot use a ref pack for it -->
     <Dependency Name="System.IO.Packaging" Version="9.0.0-rc.2.24473.5">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -53,6 +53,7 @@
     <MicrosoftCodeAnalysisCSharpVersion>4.8.0</MicrosoftCodeAnalysisCSharpVersion>
     <MicrosoftNetCompilersToolsetVersion>4.8.0</MicrosoftNetCompilersToolsetVersion>
     <!-- runtime -->
+    <ILCompilerReflectionReadyToRunExperimentalVersion>8.0.16-servicing.25211.10</ILCompilerReflectionReadyToRunExperimentalVersion>
     <MicrosoftBclAsyncInterfacesVersion>9.0.0-rc.2.24473.5</MicrosoftBclAsyncInterfacesVersion>
     <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>9.0.0-rc.2.24473.5</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
     <MicrosoftExtensionsDependencyInjectionVersion>9.0.0-rc.2.24473.5</MicrosoftExtensionsDependencyInjectionVersion>

--- a/src/Microsoft.DotNet.SignTool/Microsoft.DotNet.SignTool.csproj
+++ b/src/Microsoft.DotNet.SignTool/Microsoft.DotNet.SignTool.csproj
@@ -8,7 +8,8 @@
     <Description>Build artifact signing tool</Description>
     <PackageTags>Arcade Build Tool Signing</PackageTags>
     <DevelopmentDependency>false</DevelopmentDependency>
-    <NoWarn>$(NoWarn);NU5128</NoWarn>
+    <!-- ILCompiler.Reflection.ReadyToRun.Experimental does not have a strong name. -->
+    <NoWarn>$(NoWarn);NU5128;CS8002</NoWarn>
     <!-- Copy assemblies into lib folder so they can be used as a development dependency -->
     <BuildTaskTargetFolder>lib</BuildTaskTargetFolder>
   </PropertyGroup>
@@ -28,6 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="NuGet.Packaging" />
+    <PackageReference Include="ILCompiler.Reflection.ReadyToRun.Experimental" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">

--- a/src/Microsoft.DotNet.SignTool/src/Configuration.cs
+++ b/src/Microsoft.DotNet.SignTool/src/Configuration.cs
@@ -505,7 +505,8 @@ namespace Microsoft.DotNet.SignTool
                     signInfo = signInfo.WithNotarization(macNotarizationAppName, _hashToCollisionIdMap[signedFileContentKey]);
                 }
 
-                if (signInfo.ShouldSign && peInfo != null)
+                // Do not check composite images, since they will have empty copyright info.
+                if (signInfo.ShouldSign && peInfo != null && !peInfo.IsCompositeImage)
                 {
                     bool isMicrosoftLibrary = IsMicrosoftLibrary(peInfo.Copyright);
                     bool isMicrosoftCertificate = !IsThirdPartyCertificate(signInfo.Certificate);
@@ -620,11 +621,11 @@ namespace Microsoft.DotNet.SignTool
                 return new PEInfo(isManaged, GetNativeLegalCopyright(fullPath));
             }
 
-            bool isCrossgened = ContentUtil.IsCrossgened(fullPath);
+            bool isCrossgened = ContentUtil.IsCrossgened(fullPath, out bool isCompositeImage);
             string publicKeyToken = ContentUtil.GetPublicKeyToken(fullPath);
 
             GetManagedTargetFrameworkAndCopyright(fullPath, out string targetFramework, out string copyright);
-            return new PEInfo(isManaged, isCrossgened, copyright, publicKeyToken, targetFramework);
+            return new PEInfo(isManaged, isCrossgened, isCompositeImage, copyright, publicKeyToken, targetFramework);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.SignTool/src/FileSignInfo.cs
+++ b/src/Microsoft.DotNet.SignTool/src/FileSignInfo.cs
@@ -76,7 +76,7 @@ namespace Microsoft.DotNet.SignTool
 
         internal bool IsManaged() => ContentUtil.IsManaged(FullPath);
 
-        internal bool IsCrossgened() => ContentUtil.IsCrossgened(FullPath);
+        internal bool IsCrossgened() => ContentUtil.IsCrossgened(FullPath, out var isComposite);
 
         internal bool IsVsix() => IsVsix(FileName);
 

--- a/src/Microsoft.DotNet.SignTool/src/PEInfo.cs
+++ b/src/Microsoft.DotNet.SignTool/src/PEInfo.cs
@@ -9,16 +9,18 @@ namespace Microsoft.DotNet.SignTool
     {
         internal bool IsManaged { get; }
         internal bool IsCrossgened { get; }
+        internal bool IsCompositeImage { get; }
         internal string Copyright { get; }
         internal string PublicKeyToken { get; }
         internal string TargetFramework { get; }
 
-        public PEInfo(bool isManaged, string copyright) : this(isManaged, false, copyright, null, null) { }
+        public PEInfo(bool isManaged, string copyright) : this(isManaged, false, false, copyright, null, null) { }
 
-        public PEInfo(bool isManaged, bool isCrossgened, string copyright, string publicKeyToken, string targetFramework)
+        public PEInfo(bool isManaged, bool isCrossgened, bool isCompositeImage, string copyright, string publicKeyToken, string targetFramework)
         {
             IsManaged = isManaged;
             IsCrossgened = isCrossgened;
+            IsCompositeImage = isCompositeImage;
             Copyright = copyright;
             PublicKeyToken = publicKeyToken;
             TargetFramework = targetFramework;


### PR DESCRIPTION
These images don't have valid copyright info. If we emit the warning, various repos will just fail. To detect these, we need to read the export table. To do so, we use runtime's ILCompiler.Reflection.ReadyToRun.Experimental package, which has some PEReader extensions.