### PR TITLE
Allow source-build cache setup if `SetUpSourceBuildIntermediateNupkgCache` is true

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
@@ -11,10 +11,6 @@
     <PackageReference Include="Microsoft.DotNet.SourceBuild.Tasks" Version="$(MicrosoftDotNetSourceBuildTasksVersion)" IsImplicitlyDefined="true" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <SetUpSourceBuildIntermediateNupkgCache Condition="'$(SetUpSourceBuildIntermediateNupkgCache)' == ''">true</SetUpSourceBuildIntermediateNupkgCache>
-  </PropertyGroup>
-
   <!-- Because the condition here is rather complex, it should read as the following:
       - Don't collect intermediates if running the product build
       - Otherwise, collect if we're forcing it using SetUpSourceBuildIntermediateNupkgCache

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -92,8 +92,13 @@
         Condition="'$(Restore)' == 'true'"/>
   </Target>
 
+  <PropertyGroup>
+    <SetUpSourceBuildIntermediateNupkgCache Condition="'$(SetUpSourceBuildIntermediateNupkgCache)' == ''">true</SetUpSourceBuildIntermediateNupkgCache>
+  </PropertyGroup>
+
   <Import Project="SourceBuild/SourceBuildArcadeTools.targets" Condition="'$(ArcadeBuildFromSource)' == 'true' or
-                                                                          '$(DotNetBuildRepo)' == 'true'" />
+                                                                          '$(DotNetBuildRepo)' == 'true' or
+                                                                          '$(SetUpSourceBuildIntermediateNupkgCache)' == 'true'" />
 
   <!-- Repository extensibility point -->
   <Import Project="$(RepositoryEngineeringDir)Tools.props" Condition="Exists('$(RepositoryEngineeringDir)Tools.props')" />


### PR DESCRIPTION
This PR unblocks https://github.com/dotnet/source-build-reference-packages/pull/1253 and resolves a regression introduced by https://github.com/dotnet/arcade/pull/15810.

The regression stems from changes that require passing `/p:DotNetBuildRepo=true` or `/p:ArcadeBuildFromSource=true` in order to set up the source-build intermediate cache. Due to the logic in [`DotNetBuild.props`](https://github.com/dotnet/source-build-reference-packages/blob/2bdf6b694572c45f6249c5406ae2303d678cda3f/eng/DotNetBuild.props#L24-L27), passing these properties when building dependency package projects causes infinite recursing.

To break the recursion and issues caused by the lack of SB intermediate cache, the import of `SourceBuildArcadeTools.targets` must be conditioned not only on `DotNetBuildRepo` or `ArcadeBuildFromSource`, but also on `SetUpSourceBuildIntermediateNupkgCache`.