### PR TITLE
Download v3 pdb artifacts

### DIFF
--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -48,6 +48,20 @@ stages:
         downloadPath: '$(Build.ArtifactStagingDirectory)/BlobArtifacts'
 
     - task: DownloadPipelineArtifact@2
+      displayName: Download V3 PDB Artifacts
+      continueOnError: true
+      enabled: true
+      inputs:
+        buildType: specific
+        buildVersionToDownload: specific
+        project: $(AzDOProject)
+        pipeline: $(AzDOPipelineId)
+        buildId: $(AzDOBuildId)
+        downloadType: 'specific'
+        artifact: PdbArtifacts
+        downloadPath: '$(Build.ArtifactStagingDirectory)/PdbArtifacts'
+
+    - task: DownloadPipelineArtifact@2
       displayName: Download V4 Merged Manifest
       continueOnError: true
       enabled: true


### PR DESCRIPTION
This is required for old v3 style PDB artifact publishing V4 will not have this artifact.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
