### PR TITLE
[docs] Update info about Helix System.AcessToken

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/Readme.md
+++ b/src/Microsoft.DotNet.Helix/Sdk/Readme.md
@@ -38,6 +38,12 @@ BUILD_REASON
 
 Also, make sure your helix project doesn't have `EnableAzurePipelinesReporter` set, or sets it to false, or building locally will fail with an error that looks like `SYSTEM_ACCESSTOKEN is not set`.
 
+When running Helix tests in Azure DevOps pipelines where results need to be published back to Azure DevOps, you'll need to set the environment variable:
+```yaml
+env:
+  SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure DevOps
+```
+
 Furthermore, when you need to make changes to Helix SDK, there's a way to run it locally with ease to test your changes in a tighter dev loop than having to have to wait for the full PR build.
 
 The repository contains E2E tests that utilize the Helix SDK to send test Helix jobs.


### PR DESCRIPTION
This pull request updates the documentation for running Helix tests in Azure DevOps pipelines. It adds a note about setting the `SYSTEM_ACCESSTOKEN` environment variable to ensure test results are published correctly.

Documentation updates:

* [`src/Microsoft.DotNet.Helix/Sdk/Readme.md`](diffhunk://#diff-36abb6af2750a9340fb1ccf98252d91108ee4311e6fe579072c4608b4de7c1b8R41-R46): Added instructions to set the `SYSTEM_ACCESSTOKEN` environment variable when running Helix tests in Azure DevOps pipelines to enable publishing results back to Azure DevOps.