### PR TITLE
Use local darc tool in vmr-sync scripts

### DIFF
--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -530,6 +530,7 @@ function GetDarc {
     fi
 
     "$eng_root/common/darc-init.sh" --toolpath "$darc_path" $version
+    darcTool="$darc_path/darc"
 }
 
 # Returns a full path to an Arcade SDK task project file.

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -530,7 +530,7 @@ function GetDarc {
     fi
 
     "$eng_root/common/darc-init.sh" --toolpath "$darc_path" $version
-    darcTool="$darc_path/darc"
+    darc_tool="$darc_path/darc"
 }
 
 # Returns a full path to an Arcade SDK task project file.

--- a/eng/common/vmr-sync.ps1
+++ b/eng/common/vmr-sync.ps1
@@ -103,14 +103,14 @@ Set-StrictMode -Version Latest
 Highlight 'Installing .NET, preparing the tooling..'
 . .\eng\common\tools.ps1
 $dotnetRoot = InitializeDotNetCli -install:$true
+$darc = Get-Darc
 $dotnet = "$dotnetRoot\dotnet.exe"
-& "$dotnet" tool restore
 
 Highlight "Starting the synchronization of VMR.."
 
 # Synchronize the VMR
 $darcArgs = (
-  "darc", "vmr", "forwardflow",
+  "vmr", "forwardflow",
   "--tmp", $tmpDir,
   "--$verbosity",
   $vmrDir
@@ -124,7 +124,7 @@ if ($azdevPat) {
   $darcArgs += ("--azdev-pat", $azdevPat)
 }
 
-& "$dotnet" $darcArgs
+& "$darc" $darcArgs
 
 if ($LASTEXITCODE -eq 0) {
   Highlight "Synchronization succeeded"

--- a/eng/common/vmr-sync.sh
+++ b/eng/common/vmr-sync.sh
@@ -188,7 +188,7 @@ fi
 
 export DOTNET_ROOT="$dotnetDir"
 
-"$darcTool" vmr forwardflow \
+"$darc_tool" vmr forwardflow \
   --tmp "$tmp_dir"             \
   $azdev_pat                   \
   --$verbosity                 \

--- a/eng/common/vmr-sync.sh
+++ b/eng/common/vmr-sync.sh
@@ -164,9 +164,9 @@ set -e
 highlight 'Installing .NET, preparing the tooling..'
 source "./eng/common/tools.sh"
 InitializeDotNetCli true
+GetDarc
 dotnetDir=$( cd ./.dotnet/; pwd -P )
 dotnet=$dotnetDir/dotnet
-"$dotnet" tool restore
 
 highlight "Starting the synchronization of VMR.."
 set +e
@@ -186,7 +186,9 @@ fi
 
 # Synchronize the VMR
 
-"$dotnet" darc vmr forwardflow \
+export DOTNET_ROOT="$dotnetDir"
+
+"$darcTool" vmr forwardflow \
   --tmp "$tmp_dir"             \
   $azdev_pat                   \
   --$verbosity                 \


### PR DESCRIPTION
This PR allows `vmr-sync` scripts to use a local darc tool. It also allows the use of the latest tool version.

Previously this was accomplished via global tool configuration in repo's `.config/dotnet-tools.json` which only exists in a small set of repos, i.e. `sdk` - https://github.com/dotnet/sdk/blob/main/.config/dotnet-tools.json

Verification build in `deployment-tools`, to exercise repo-level VMR verification: https://github.com/dotnet/deployment-tools/pull/464