### PR TITLE
[9.0] Add optin for default channel registrations check(#15373)

### DIFF
--- a/eng/common/core-templates/post-build/post-build.yml
+++ b/eng/common/core-templates/post-build/post-build.yml
@@ -44,6 +44,11 @@ parameters:
     displayName: Publish installers and checksums
     type: boolean
     default: true
+    
+  - name: requireDefaultChannels
+    displayName: Fail the build if there are no default channel(s) registrations for the current build
+    type: boolean
+    default: false
 
   - name: SDLValidationParameters
     type: object
@@ -312,5 +317,6 @@ stages:
               -PublishingInfraVersion ${{ parameters.publishingInfraVersion }}
               -AzdoToken '$(System.AccessToken)'
               -WaitPublishingFinish true
+              -RequireDefaultChannels ${{ parameters.requireDefaultChannels }}
               -ArtifactsPublishingAdditionalParameters '${{ parameters.artifactsPublishingAdditionalParameters }}'
               -SymbolPublishingAdditionalParameters '${{ parameters.symbolPublishingAdditionalParameters }}'

--- a/eng/common/post-build/publish-using-darc.ps1
+++ b/eng/common/post-build/publish-using-darc.ps1
@@ -5,7 +5,8 @@ param(
   [Parameter(Mandatory=$false)][string] $MaestroApiEndPoint = 'https://maestro.dot.net',
   [Parameter(Mandatory=$true)][string] $WaitPublishingFinish,
   [Parameter(Mandatory=$false)][string] $ArtifactsPublishingAdditionalParameters,
-  [Parameter(Mandatory=$false)][string] $SymbolPublishingAdditionalParameters
+  [Parameter(Mandatory=$false)][string] $SymbolPublishingAdditionalParameters,
+  [Parameter(Mandatory=$false)][string] $RequireDefaultChannels
 )
 
 try {
@@ -32,6 +33,10 @@ try {
 
   if ("false" -eq $WaitPublishingFinish) {
     $optionalParams.Add("--no-wait") | Out-Null
+  }
+  
+  if ("true" -eq $RequireDefaultChannels) {
+    $optionalParams.Add("--default-channels-required") | Out-Null
   }
 
   & $darc add-build-to-channel `


### PR DESCRIPTION
Backport to 9.0. We want to use this in MSBuild, where we're consuming 9.0 arcade.

needed for https://github.com/dotnet/msbuild/pull/11751
### To double check:
* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
