### PR TITLE
Better error message when UseVSTestRunner is set along with MTP

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VSTest.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VSTest.targets
@@ -5,7 +5,7 @@
           Outputs="%(TestToRun.ResultsStdOutPath)"
           Condition="'$(SkipTests)' != 'true' and '@(TestToRun)' != ''">
 
-    <Error Text="UseVSTest shouldn't be used when using Microsoft.Testing.Platform" Condition="'$(EnableMSTestRunner)' == 'true' OR '$(EnableNUnitRunner)' == 'true' OR '$(UseMicrosoftTestingPlatformRunner)' == 'true'" File="VSTest" />
+    <Error Text="UseVSTestRunner property shouldn't be used when using Microsoft.Testing.Platform" Condition="'$(EnableMSTestRunner)' == 'true' OR '$(EnableNUnitRunner)' == 'true' OR '$(UseMicrosoftTestingPlatformRunner)' == 'true'" File="VSTest" />
 
     <PropertyGroup>
       <_TestEnvironment>%(TestToRun.EnvironmentDisplay)</_TestEnvironment>


### PR DESCRIPTION
The property name that controls the import of `VSTest.targets` is named UseVSTestRunner not UseVSTest. So I'm updating the error message