### PR TITLE
WiX 5 update

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -99,7 +99,7 @@
     <MicrosoftManifestToolCrossPlatformVersion Condition="'$(MicrosoftManifestToolCrossPlatformVersion)' == ''">2.1.3</MicrosoftManifestToolCrossPlatformVersion>
     <MicrosoftVisualStudioEngMicroBuildPluginsSwixBuildVersion Condition="'$(MicrosoftVisualStudioEngMicroBuildPluginsSwixBuildVersion)' == ''">1.1.286</MicrosoftVisualStudioEngMicroBuildPluginsSwixBuildVersion>
     <MicrosoftSignedWixVersion Condition="'$(MicrosoftSignedWixVersion)' == ''">3.14.1-9323.2545153</MicrosoftSignedWixVersion>
-    <MicrosoftWixToolsetVersion Condition="'$(MicrosoftWixToolsetVersion)' == ''">5.0.2-dotnet.2690783</MicrosoftWixToolsetVersion>
+    <MicrosoftWixToolsetVersion Condition="'$(MicrosoftWixToolsetVersion)' == ''">5.0.2-dotnet.2718840</MicrosoftWixToolsetVersion>
   </PropertyGroup>
 
   <!-- RestoreSources overrides - defines DotNetRestoreSources variable if available -->

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/bundle/upgradePolicies.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/bundle/upgradePolicies.wxs
@@ -1,5 +1,5 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
-﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
   <Fragment>
     <!-- Bundle variables become unset if a search fails. The global key is retrieved first. If this fails,
          RemoveUpgradeRelatedBundle becomes unset, allowing the version specific search to potentially set 


### PR DESCRIPTION
Minor fixes related to WiX 5

* Packages have been resigned - previous build resigned package contents, including the raw engine. This results in errors when trying to extract the attached cabinets. The engine from the toolset should never be signed as it's modified when an actual bundle is produced.
* Fixing up some whitespace characters in the `upgradePolicies` file that caused the compiler to reject it.
