### PR TITLE
Set OutputType to Exe for xunit.v3, MSTest+MTP, and NUnit+MTP

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/BeforeNETSdkTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/BeforeNETSdkTargets.targets
@@ -2,10 +2,12 @@
 <Project>
   <Import Project="RuntimeIdentifierInference.BeforeNETSdkTargets.targets" />
 
-  <!-- XUnitV3, MSTest+MTP, and NUnit+MTP projects should be executables. -->
-  <!-- To make it easier for repos to migrate, we want to set OutputType for them automatically when we can detect this. -->
-  <!-- OutputType needs to be set before BeforeCommon.targets. It's too late to set it in Directory.Build.targets for example -->
-  <!-- See https://github.com/dotnet/sdk/blob/7a4d106916cf8ee38a3b0f44330062662a994d58/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets#L24 -->
-  <!-- Just in case this caused an issue somewhere, it can be disabled by setting DisableArcadeTestOutputType to true -->
-  <OutputType Condition="'$(DisableArcadeTestOutputType)' != 'true' and '$(IsTestProject)' == 'true' and ('$(TestRunnerName)' == 'XUnitV3' or '$(UseMSTestRunner)' == 'true' or '$(UseNUnitRunner)' == 'true')">Exe</OutputType>
+  <PropertyGroup>
+    <!-- XUnitV3, MSTest+MTP, and NUnit+MTP projects should be executables. -->
+    <!-- To make it easier for repos to migrate, we want to set OutputType for them automatically when we can detect this. -->
+    <!-- OutputType needs to be set before BeforeCommon.targets. It's too late to set it in Directory.Build.targets for example -->
+    <!-- See https://github.com/dotnet/sdk/blob/7a4d106916cf8ee38a3b0f44330062662a994d58/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets#L24 -->
+    <!-- Just in case this caused an issue somewhere, it can be disabled by setting DisableArcadeTestOutputType to true -->
+    <OutputType Condition="'$(DisableArcadeTestOutputType)' != 'true' and '$(IsTestProject)' == 'true' and ('$(TestRunnerName)' == 'XUnitV3' or '$(UseMSTestRunner)' == 'true' or '$(UseNUnitRunner)' == 'true')">Exe</OutputType>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
@ViktorHofer I'm trying to experiment if this can reduce the noise when migrating repos.

I chose to do it in BeforeNETSdkTargets so that:

1. It's not too early in a way that `UseMSTestRunner`, `UseNUnitRunner`, or `TestRunnerName` are not set yet.
2. It's not too late that Sdk could already have done something based on `OutputType`. Note that Microsoft.NET.Test.Sdk (vstest) tries to set OutputType too late (NuGet targets), and is already too fragile and causes issues in certain cases that I can't recall for now.

An alternative is to do this in `Tests.props`, but that requires repos to set `UseMSTestRunner`, `UseNUnitRunner`, or `TestRunnerName` before Arcade Sdk.props is imported. I tried to do it at the latest possible point.