### PR TITLE
Change error file name to Microsoft.Testing.Platform instead of TestingPlatform

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Microsoft.Testing.Platform.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Microsoft.Testing.Platform.targets
@@ -82,7 +82,7 @@
       Ideally we would set ContinueOnError="ErrorAndContinue" so that when a test fails in multi-targeted test project
       we'll still run tests for all target frameworks. ErrorAndContinue doesn't work well on Linux though: https://github.com/Microsoft/msbuild/issues/3961.
     -->
-    <Error Text="Tests failed: $(_ResultsFileToDisplay) [$(_TestEnvironment)]" Condition="'$(_TestErrorCode)' != '0' and '$(_ErrorOnTestFailure)' != 'false'" File="TestingPlatform" />
+    <Error Text="Tests failed: $(_ResultsFileToDisplay) [$(_TestEnvironment)]" Condition="'$(_TestErrorCode)' != '0' and '$(_ErrorOnTestFailure)' != 'false'" File="Microsoft.Testing.Platform" />
 
     <ItemGroup>
       <FileWrites Include="@(_OutputFiles)"/>


### PR DESCRIPTION
Microsoft.Testing.Platform is the accurate/correct branding.

Currently, errors show in CI similar to:

> ##[error]TestingPlatform(0,0): error : (NETCORE_ENGINEERING_TELEMETRY=Build) Tests failed: D:\a\_work\1\s\artifacts\log\Release\Microsoft.TestPlatform.Client.UnitTests_net9.0_x64.log [net9.0|x64]

This rename will change the "TestingPlatform" part to "Microsoft.Testing.Platform".