### PR TITLE
Build.proj: pass TreatWarningsAsErrors to Restore when '--warnaserror false'.

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj
@@ -248,9 +248,18 @@
       </_ProjectToRestore>
     </ItemGroup>
 
+    <!--
+      Filter TreatWarningsAsErrors during Restore so CLI script builds and Visual Studio builds restore the same.
+      Don't ignore it when it set to 'false' to apply '-warnaserror false' from CLI script builds.
+    -->
+    <PropertyGroup>
+      <_RestoreRemoveProps>$(_RemoveProps)</_RestoreRemoveProps>
+      <_RestoreRemoveProps Condition="'$(TreatWarningsAsErrors)' != 'false'">$(_RestoreRemoveProps);TreatWarningsAsErrors</_RestoreRemoveProps>
+    </PropertyGroup>
+
     <MSBuild Projects="@(_ProjectToRestore)"
              Properties="@(_SolutionRestoreProps)"
-             RemoveProperties="$(_RemoveProps);TreatWarningsAsErrors"
+             RemoveProperties="$(_RestoreRemoveProps)"
              Targets="Restore"
              SkipNonexistentTargets="true"
              BuildInParallel="%(_ProjectToRestore.RestoreInParallel)"


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/15872.

@ViktorHofer ptal.