### PR TITLE
Handle TestToRun.Architecture in XUnitV3.Runner.targets

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnitV3/XUnitV3.Runner.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnitV3/XUnitV3.Runner.targets
@@ -28,7 +28,8 @@
 
       <!-- HACK: Some repos (at least dotnet/winforms) build+test for x86, but the generated apphost ends up 64-bit -->
       <!-- This is likely a misconfiguration on the repo, but to maintain the same behavior as xunit 2, we force running the assembly under x86 dotnet -->
-      <_TestRunner Condition="'%(TestToRun.Architecture)'=='x86' And Exists('$(DotNetRoot)x86\dotnet.exe')">$(DotNetRoot)x86\dotnet.exe exec $(_TestAssembly)</_TestRunner>
+      <_TestRunner Condition="'%(TestToRun.Architecture)'=='x86' And Exists('$(DotNetRoot)x86\dotnet.exe')">$(DotNetRoot)x86\dotnet.exe</_TestRunner>
+      <_TestRunnerArgs Condition="'%(TestToRun.Architecture)'=='x86' And Exists('$(DotNetRoot)x86\dotnet.exe')">exec "$(_TestAssembly)" $(_TestRunnerArgs)</_TestRunnerArgs>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(_TestRuntime)' == 'Core'">

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnitV3/XUnitV3.Runner.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnitV3/XUnitV3.Runner.targets
@@ -24,7 +24,10 @@
       <_TestRunnerArgs Condition="'$(UseMicrosoftTestingPlatformRunner)' != 'true'">%(TestToRun.RunArguments) $(_TestRunnerAdditionalArguments) -xml "%(TestToRun.ResultsXmlPath)" -html "%(TestToRun.ResultsHtmlPath)" -trx "%(TestToRun.ResultsTrxPath)"</_TestRunnerArgs>
       <_TestRunnerArgs Condition="'$(UseMicrosoftTestingPlatformRunner)' == 'true'">%(TestToRun.RunArguments) $(_TestRunnerAdditionalArguments) --results-directory "$(_TestResultDirectory)" --report-xunit --report-xunit-filename "$(_TestResultXmlFileName)" --report-xunit-html --report-xunit-html-filename "$(_TestResultHtmlFileName)" --report-trx --report-trx-filename "$(_TestResultTrxFileName)"</_TestRunnerArgs>
 
+      <TestDotNetRoot Condition="'$(TestDotNetRoot)' == '' AND '%(TestToRun.Architecture)'=='x86' And Exists('$(DotNetRoot)x86\dotnet.exe')">$(DotNetRoot)x86</TestDotNetRoot>
       <TestDotNetRoot Condition="'$(TestDotNetRoot)' == ''">$(DotNetRoot)</TestDotNetRoot>
+      <_DotNetRootArchEnvVar Condition="'%(TestToRun.Architecture)'=='x86'">;DOTNET_ROOT_X86=$(TestDotNetRoot)</_DotNetRootArchEnvVar>
+      <_DotNetRootArchEnvVar Condition="'%(TestToRun.Architecture)'=='arm64'">;DOTNET_ROOT_X64=$(TestDotNetRoot)</_DotNetRootArchEnvVar>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(_TestRuntime)' == 'Core'">
@@ -64,7 +67,7 @@
           WorkingDirectory="$(_TargetDir)"
           IgnoreExitCode="true"
           Timeout="$(_TestTimeout)"
-          EnvironmentVariables="DOTNET_ROOT=$(TestDotNetRoot);DOTNET_ROOT_X86=$(TestDotNetRoot)x86"
+          EnvironmentVariables="DOTNET_ROOT=$(TestDotNetRoot)$(_DotNetRootArchEnvVar)"
           ContinueOnError="WarnAndContinue">
       <Output TaskParameter="ExitCode" PropertyName="_TestErrorCode" />
     </Exec>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnitV3/XUnitV3.Runner.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnitV3/XUnitV3.Runner.targets
@@ -24,10 +24,11 @@
       <_TestRunnerArgs Condition="'$(UseMicrosoftTestingPlatformRunner)' != 'true'">%(TestToRun.RunArguments) $(_TestRunnerAdditionalArguments) -xml "%(TestToRun.ResultsXmlPath)" -html "%(TestToRun.ResultsHtmlPath)" -trx "%(TestToRun.ResultsTrxPath)"</_TestRunnerArgs>
       <_TestRunnerArgs Condition="'$(UseMicrosoftTestingPlatformRunner)' == 'true'">%(TestToRun.RunArguments) $(_TestRunnerAdditionalArguments) --results-directory "$(_TestResultDirectory)" --report-xunit --report-xunit-filename "$(_TestResultXmlFileName)" --report-xunit-html --report-xunit-html-filename "$(_TestResultHtmlFileName)" --report-trx --report-trx-filename "$(_TestResultTrxFileName)"</_TestRunnerArgs>
 
-      <TestDotNetRoot Condition="'$(TestDotNetRoot)' == '' AND '%(TestToRun.Architecture)'=='x86' And Exists('$(DotNetRoot)x86\dotnet.exe')">$(DotNetRoot)x86</TestDotNetRoot>
       <TestDotNetRoot Condition="'$(TestDotNetRoot)' == ''">$(DotNetRoot)</TestDotNetRoot>
-      <_DotNetRootArchEnvVar Condition="'%(TestToRun.Architecture)'=='x86'">;DOTNET_ROOT_X86=$(TestDotNetRoot)</_DotNetRootArchEnvVar>
-      <_DotNetRootArchEnvVar Condition="'%(TestToRun.Architecture)'=='arm64'">;DOTNET_ROOT_X64=$(TestDotNetRoot)</_DotNetRootArchEnvVar>
+
+      <!-- HACK: Some repos (at least dotnet/winforms) build+test for x86, but the generated apphost ends up 64-bit -->
+      <!-- This is likely a misconfiguration on the repo, but to maintain the same behavior as xunit 2, we force running the assembly under x86 dotnet -->
+      <_TestRunner Condition="'%(TestToRun.Architecture)'=='x86' And Exists('$(DotNetRoot)x86\dotnet.exe')">$(DotNetRoot)x86\dotnet.exe exec $(_TestAssembly)</_TestRunner>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(_TestRuntime)' == 'Core'">
@@ -67,7 +68,7 @@
           WorkingDirectory="$(_TargetDir)"
           IgnoreExitCode="true"
           Timeout="$(_TestTimeout)"
-          EnvironmentVariables="DOTNET_ROOT=$(TestDotNetRoot)$(_DotNetRootArchEnvVar)"
+          EnvironmentVariables="DOTNET_ROOT=$(TestDotNetRoot);DOTNET_ROOT_X86=$(TestDotNetRoot)x86"
           ContinueOnError="WarnAndContinue">
       <Output TaskParameter="ExitCode" PropertyName="_TestErrorCode" />
     </Exec>


### PR DESCRIPTION
Tested locally:

![image](https://github.com/user-attachments/assets/8bbe1837-9ee4-4c56-a146-bed8f4046888)

This aims to maintain the original behavior that used to exist for xunit 2:

https://github.com/dotnet/arcade/blob/e9208a724ccace0ffb8dcc119f03a3d1968e6232/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.Runner.targets#L31

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
