### PR TITLE
Use `EnableMSTestRunner` instead of `UseMSTestRunner`

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/MSTest/MSTest.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/MSTest/MSTest.targets
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <UseMSTestMetaPackage Condition=" '$(UseMSTestMetaPackage)' == '' ">false</UseMSTestMetaPackage>
     <UseMSTestSdk Condition=" '$(UseMSTestSdk)' == '' ">false</UseMSTestSdk>
-    <UseMSTestRunner Condition=" '$(UseMSTestRunner)' == '' ">false</UseMSTestRunner>
+    <EnableMSTestRunner Condition=" '$(EnableMSTestRunner)' == '' ">false</EnableMSTestRunner>
   </PropertyGroup>
 
   <Target Name="_MSTestValidatePackageDeps" BeforeTargets="Build">
@@ -26,7 +26,7 @@
     <PackageReference Include="MSTest" Version="$(MSTestVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true" />
   </ItemGroup>  
 
-  <Import Project="..\VSTest.targets" Condition=" '$(UseMSTestRunner)' == 'false' " />
-  <Import Project="..\Microsoft.Testing.Platform.targets" Condition=" '$(UseMSTestRunner)' == 'true' " />
+  <Import Project="..\VSTest.targets" Condition=" '$(EnableMSTestRunner)' == 'false' " />
+  <Import Project="..\Microsoft.Testing.Platform.targets" Condition=" '$(EnableMSTestRunner)' == 'true' " />
 
 </Project>


### PR DESCRIPTION
Fixes #15875

Note: This change shouldn't be breaking because today, it's required to set both `EnableMSTestRunner` and `UseMSTestRunner`. If only `UseMSTestRunner` was used, then there is nothing that tells MSTest that it should use MTP.