### PR TITLE
Fix liblldb-dev version for noble

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -295,8 +295,8 @@ while :; do
             ;;
         noble) # Ubuntu 24.04
             __CodeName=noble
-            if [[ -n "$__LLDB_Package" ]]; then
-                __LLDB_Package="liblldb-18-dev"
+            if [[ -z "$__LLDB_Package" ]]; then
+                __LLDB_Package="liblldb-19-dev"
             fi
             ;;
         stretch) # Debian 9


### PR DESCRIPTION
noble (now?) has lldb v19 and the condition was supposed to check -z (empty) rather than -n (not empty).