### PR TITLE
Add dotnet helper scripts for acquiring SDK and one shot execs

### DIFF
--- a/eng/common/dotnet.cmd
+++ b/eng/common/dotnet.cmd
@@ -1,0 +1,15 @@
+@echo off
+
+powershell -ExecutionPolicy ByPass -NoProfile -Command "& { . '%~dp0tools.ps1'; InitializeDotNetCli $true $true }"
+
+if NOT [%ERRORLEVEL%] == [0] (
+  echo Failed to install or invoke dotnet... 1>&2
+  exit /b %ERRORLEVEL%
+)
+
+:: Invoke acquired SDK with args if they are provided
+if NOT "%~1" == "" (
+  set /p dotnetPath=<%~dp0..\..\artifacts\toolset\sdk.txt
+  set DOTNET_NOLOGO=1
+  call "%dotnetPath%\dotnet.exe" %*
+)

--- a/eng/common/dotnet.cmd
+++ b/eng/common/dotnet.cmd
@@ -1,15 +1,7 @@
 @echo off
 
-powershell -ExecutionPolicy ByPass -NoProfile -Command "& { . '%~dp0tools.ps1'; InitializeDotNetCli $true $true }"
+:: This script is used to install the .NET SDK.
+:: It will also invoke the SDK with any provided arguments.
 
-if NOT [%ERRORLEVEL%] == [0] (
-  echo Failed to install or invoke dotnet... 1>&2
-  exit /b %ERRORLEVEL%
-)
-
-:: Invoke acquired SDK with args if they are provided
-if NOT "%~1" == "" (
-  set /p dotnetPath=<%~dp0..\..\artifacts\toolset\sdk.txt
-  set DOTNET_NOLOGO=1
-  call "%dotnetPath%\dotnet.exe" %*
-)
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0dotnet.ps1""" %*"
+exit /b %ErrorLevel%

--- a/eng/common/dotnet.ps1
+++ b/eng/common/dotnet.ps1
@@ -1,0 +1,11 @@
+# This script is used to install the .NET SDK.
+# It will also invoke the SDK with any provided arguments.
+
+. $PSScriptRoot\tools.ps1
+$dotnetRoot = InitializeDotNetCli -install:$true
+
+# Invoke acquired SDK with args if they are provided
+if ($args.count -gt 0) {
+  $env:DOTNET_NOLOGO=1
+  & "$dotnetRoot\dotnet.exe" $args
+}

--- a/eng/common/dotnet.sh
+++ b/eng/common/dotnet.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+source="${BASH_SOURCE[0]}"
+# resolve $SOURCE until the file is no longer a symlink
+while [[ -h $source ]]; do
+  scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+  source="$(readlink "$source")"
+
+  # if $source was a relative symlink, we need to resolve it relative to the path where the
+  # symlink file was located
+  [[ $source != /* ]] && source="$scriptroot/$source"
+done
+scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+
+source $scriptroot/tools.sh
+InitializeDotNetCli true # install
+
+# Invoke acquired SDK with args if they are provided
+if [[ $# > 0 ]]; then
+  __dotnetDir=${_InitializeDotNetCli}
+  dotnetPath=${__dotnetDir}/dotnet
+  ${dotnetPath} "$@"
+fi

--- a/eng/common/dotnet.sh
+++ b/eng/common/dotnet.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# This script is used to install the .NET SDK.
+# It will also invoke the SDK with any provided arguments.
+
 source="${BASH_SOURCE[0]}"
 # resolve $SOURCE until the file is no longer a symlink
 while [[ -h $source ]]; do

--- a/eng/configure-toolset.ps1
+++ b/eng/configure-toolset.ps1
@@ -1,6 +1,7 @@
 . $PSScriptRoot\common\pipeline-logging-functions.ps1
 function Test-FilesUseTelemetryOutput {
     $requireTelemetryExcludeFiles = @(
+        "dotnet.ps1",
         "enable-cross-org-publishing.ps1",
         "performance-setup.ps1",
         "retain-build.ps1",

--- a/eng/configure-toolset.sh
+++ b/eng/configure-toolset.sh
@@ -13,6 +13,7 @@ function Test-FilesUseTelemetryOutput {
         'eng/common/cross/build-android-rootfs.sh'
         'eng/common/cross/build-rootfs.sh'
         'eng/common/darc-init.sh'
+        'eng/common/dotnet.sh'
         'eng/common/msbuild.sh'
         'eng/common/performance/performance-setup.sh'
         'eng/common/vmr-sync.sh'

--- a/global.json
+++ b/global.json
@@ -1,7 +1,9 @@
 {
   "sdk": {
     "version": "10.0.100-preview.6.25302.104",
-    "rollForward": "latestFeature"
+    "rollForward": "latestFeature",
+    "paths": [ ".dotnet", "$host$" ],
+    "errorMessage": "The required .NET SDK wasn't found. Please run ./eng/common/dotnet.cmd/sh to install it."
   },
   "tools": {
     "dotnet": "10.0.100-preview.6.25302.104"


### PR DESCRIPTION
... also add the new global.json paths feature to Arcade's global.json. I'm reusing the scripts from dotnet/runtime with slight modifications.

Several teams asked for this. Now that we have the global.json `paths` feature, we still need a script that acquires the correct .NET SDK if not already installed (repo local or machine wide).

### Example usage

#### Install
```sh
./eng/common/dotnet.sh
```

#### Install and invoke dotnet
```sh
./eng/common/dotnet.sh build src\...
```

#### Install once and perform dev innerloop stuff
Needs the global.json `paths` change in the respective repo and a .NET SDK >= 10.0 P3 installed machine wide.

```sh
# Invoke once to install the required .NET SDK specified in global.json
./eng/common/dotnet.sh

# Dev innerloop examples
# Don't need to run in the same terminal session as the above command
# All the dotnet execs will use the correct .NET SDK
dotnet build src\x.csproj
dotnet test src\x.csproj
dotnet pack src\x.csproj
```

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
