### PR TITLE
Disable PR trigger for VMR Verification pipelines

### DIFF
--- a/eng/common/templates/vmr-build-pr.yml
+++ b/eng/common/templates/vmr-build-pr.yml
@@ -1,14 +1,5 @@
 trigger: none
-pr:
-  branches:
-    include:
-    - main
-    - release/*
-  paths:
-    exclude:
-    - documentation/*
-    - README.md
-    - CODEOWNERS
+pr: none
 
 variables:
 - template: /eng/common/templates/variables/pool-providers.yml@self


### PR DESCRIPTION
We need to disable automatic trigger of VMR Verification pipeline in repo PRs.

Two repos have created pipelines using this template (`deployment-tools` and `source-build-reference-packages`). While further changes are planned for this pipeline to enable conditioning of individual verification jobs, current implementation causes unnecessary extra build churn.

Very soon these pipelines will use repo-specific templates, which will reference the shared template. Proposed changes and related discussion are here: https://github.com/dotnet/source-build-reference-packages/pull/1262. See https://github.com/dotnet/source-build-reference-packages/pull/1262#issuecomment-2956501999 and https://github.com/dotnet/source-build-reference-packages/pull/1262#issuecomment-2959995621