### PR TITLE
archives.targets: Fix creating tar.gz on Windows

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Archives/build/archives.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Archives/build/archives.targets
@@ -91,10 +91,10 @@
           DependsOnTargets="_CheckPigzAvailability"
           Condition="'$(SkipArchivesBuild)' != 'true'">
     <PropertyGroup>
-      <_OutputPathRoot>$(IntermediateOutputPath)output/</_OutputPathRoot>
+      <_OutputPathRoot>$([MSBuild]::NormalizePath($(IntermediateOutputPath), 'output'))</_OutputPathRoot>
       <_ArchiveFileName>$(ArchiveName)-$(Version)</_ArchiveFileName>
       <_ArchiveFileName Condition="'$(RuntimeIdentifier)' != ''">$(ArchiveName)-$(Version)-$(RuntimeIdentifier)</_ArchiveFileName>
-      <_DestinationFileName>$(PackageOutputPath)/$(_ArchiveFileName).$(ArchiveFormat)</_DestinationFileName>
+      <_DestinationFileName>$([MSBuild]::NormalizePath($(PackageOutputPath), '$(_ArchiveFileName).$(ArchiveFormat)'))</_DestinationFileName>
     </PropertyGroup>
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="PublishToDisk"
@@ -106,14 +106,16 @@
                   DestinationFile="$(_DestinationFileName)"
                   Condition="'$(ArchiveFormat)' == 'zip'"/>
     <!-- use parallel gzip implementation when available -->
-    <Exec Command="tar -C '$(_OutputPathRoot)' -cf - . | pigz &gt; '$(_DestinationFileName)'"
+    <Exec Command="tar -cf - . | pigz &gt; '$(_DestinationFileName)'"
           IgnoreExitCode="true"
           IgnoreStandardErrorWarningFormat="true"
+          WorkingDirectory="$(_OutputPathRoot)"
           Condition="'$(ArchiveFormat)' == 'tar.gz' and '$(_PigzFoundExitCode)' == '0'"/>
     <!-- otherwise, use built-in gzip feature (-z) -->
-    <Exec Command="tar -C '$(_OutputPathRoot)' -czf '$(_DestinationFileName)' ."
+    <Exec Command="tar -czf '$(_DestinationFileName)' ."
           IgnoreExitCode="true"
           IgnoreStandardErrorWarningFormat="true"
+          WorkingDirectory="$(_OutputPathRoot)"
           Condition="'$(ArchiveFormat)' == 'tar.gz' and '$(_PigzFoundExitCode)' != '0'"/>
 
     <Message Text="Successfully created archive -> '$(_DestinationFileName)' from '$(_OutputPathRoot)'" Importance="high" />
@@ -123,10 +125,10 @@
           DependsOnTargets="_CheckPigzAvailability"
           Condition="'$(CreateSymbolsArchive)' == 'true' and '$(SkipArchivesBuild)' != 'true'">
     <PropertyGroup>
-      <_SymbolsOutputPathRoot>$(IntermediateOutputPath)symbols/</_SymbolsOutputPathRoot>
+      <_SymbolsOutputPathRoot>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), 'symbols'))</_SymbolsOutputPathRoot>
       <_ArchiveFileName>$(SymbolsArchiveName)-$(Version)</_ArchiveFileName>
       <_ArchiveFileName Condition="'$(RuntimeIdentifier)' != ''">$(SymbolsArchiveName)-$(RuntimeIdentifier)-$(Version)</_ArchiveFileName>
-      <_DestinationFileName>$(PackageOutputPath)/$(_ArchiveFileName).$(ArchiveFormat)</_DestinationFileName>
+      <_DestinationFileName>$([MSBuild]::NormalizePath($(PackageOutputPath), '$(_ArchiveFileName).$(ArchiveFormat)'))</_DestinationFileName>
     </PropertyGroup>
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="PublishSymbolsToDisk"
@@ -138,14 +140,16 @@
                   DestinationFile="$(_DestinationFileName)"
                   Condition="'$(ArchiveFormat)' == 'zip'"/>
     <!-- use parallel gzip implementation when available -->
-    <Exec Command="tar -C '$(_OutputPathRoot)' -cf - . | pigz &gt; '$(_DestinationFileName)'"
+    <Exec Command="tar -cf - . | pigz &gt; '$(_DestinationFileName)'"
           IgnoreExitCode="true"
           IgnoreStandardErrorWarningFormat="true"
+          WorkingDirectory="$(_SymbolsOutputPathRoot)"
           Condition="'$(ArchiveFormat)' == 'tar.gz' and '$(_PigzFoundExitCode)' == '0'"/>
     <!-- otherwise, use built-in gzip feature (-z) -->
-    <Exec Command="tar -C '$(_OutputPathRoot)' -czf '$(_DestinationFileName)' ."
+    <Exec Command="tar -czf '$(_DestinationFileName)' ."
           IgnoreExitCode="true"
           IgnoreStandardErrorWarningFormat="true"
+          WorkingDirectory="$(_SymbolsOutputPathRoot)"
           Condition="'$(ArchiveFormat)' == 'tar.gz' and '$(_PigzFoundExitCode)' != '0'"/>
 
     <Message Text="Successfully created archive -> '$(_DestinationFileName)' from '$(_SymbolsOutputPathRoot)'" Importance="high" />


### PR DESCRIPTION
Creating .tar.gz arhives on windows from `_CreateArchive` target
fails silently with:

`tar: could not chdir to ''C:\Users\ankj\source\repos\aspire\artifacts\obj\Aspire.Cli.linux-arm64\Debug\net8.0\output/''`

Fixing the mismatched directory separators does not help, neither does
removing the trailing `/'`. Instead this whole thing can be side-stepped
by using `WorkingDirectory` parameter of the `Exec` task.

Also:
- fixes the path used in generation of the symbols tarball
- Construct the various paths using msbuild's `NormalizePath`, and
  `NormalizeDirectory` functions so they get the correct directory
  separators.

cc @joperezr 