### PR TITLE
Use direct API access to push nuget packages

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishArtifactsInManifest.proj
@@ -16,7 +16,6 @@
       - BARBuildId                              : BAR ID of the build being published.
       - MaestroApiEndpoint                      : Maestro API/Token. Used for updating asset locations.
       - BuildAssetRegistryToken
-      - NugetPath                               : Full path to nuget.exe. Used for pushing to AzDO feeds.
       - PublishInstallersAndChecksums           : Whether installers & checksums should be published.
       - AzureDevOpsFeedsKey                     : Token used to publish to *any* AzDO feed in dnceng.
       - PublishSpecialClrFiles                  : If true, the special coreclr module indexed files like DBI, DAC and SOS are published
@@ -139,7 +138,6 @@
       AssetManifestPaths="@(ManifestFiles)"
       BlobAssetsBasePath="$(BlobBasePath)"
       PackageAssetsBasePath="$(PackageBasePath)"
-      NugetPath="$(NugetPath)"
       AkaMSClientId="$(AkaMSClientId)"
       AkaMSClientCertificate="$(AkaMSClientCertificate)"
       AkaMSTenant="$(AkaMSTenant)"

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishSignedAssets.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishSignedAssets.proj
@@ -13,7 +13,6 @@
       - NonShippingFolder                       : Location of the nonshipping assets about to be published.
       - FeedName                                : Name of the feed that will be created. This will
                                                   be appended by '-shipping' and '-nonshipping' depending the case
-      - NugetPath                               : Path to nuget.exe
       - AzdoTargetFeedPAT                       : Token to publish assets to feeds
   -->
 
@@ -63,8 +62,7 @@
       ShippingFeedName="$(ShippingAzdoPackageFeedURL)"
       NonShippingFeedName="$(NonShippingAzdoPackageFeedURL)"
       ShippingAssetsFolder="$(ShippingFolder)"
-      NonShippingAssetsFolder="$(NonShippingFolder)"
-      NugetPath="$(NugetPath)">
+      NonShippingAssetsFolder="$(NonShippingFolder)">
     </PublishSignedAssets>
   </Target>
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -112,12 +112,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public bool AllowInteractiveAuthentication { get; set; }
 
         /// <summary>
-        /// Directory where "nuget.exe" is installed. This will be used to publish packages.
-        /// </summary>
-        [Required]
-        public string NugetPath { get; set; }
-
-        /// <summary>
         /// Whether this build is internal or not. If true, extra checks are done to avoid accidental
         /// publishing of assets to public feeds or storage accounts.
         /// </summary>
@@ -343,7 +337,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 BARBuildId = this.BARBuildId,
                 MaestroApiEndpoint = this.MaestroApiEndpoint,
                 BuildAssetRegistryToken = this.BuildAssetRegistryToken,
-                NugetPath = this.NugetPath,
                 InternalBuild = this.InternalBuild,
                 SkipSafetyChecks = this.SkipSafetyChecks,
                 AkaMSClientId = this.AkaMSClientId,
@@ -393,7 +386,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 BARBuildId = this.BARBuildId,
                 MaestroApiEndpoint = this.MaestroApiEndpoint,
                 BuildAssetRegistryToken = this.BuildAssetRegistryToken,
-                NugetPath = this.NugetPath,
                 InternalBuild = this.InternalBuild,
                 SkipSafetyChecks = this.SkipSafetyChecks,
                 AkaMSClientId = this.AkaMSClientId,


### PR DESCRIPTION
Port some limited functionality over from the current staging/release pipeline implementation. Instead of Nuget.exe, use the v2 API to push packages. This is a significant win in time over nuget.exe, and provides better visibility when package conflicts show up.

Note, there is a LOT of clean-up that could happen for this bit of infra. Rather than going down that rabbit hole, we should just rewrite this in the future.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
