### PR TITLE
Disable packageSourceMapping in NuGet config

### DIFF
--- a/eng/common/internal/NuGet.config
+++ b/eng/common/internal/NuGet.config
@@ -4,4 +4,7 @@
     <clear />
     <add key="dotnet-core-internal-tooling" value="https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <clear />
+  </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
Fixes MSBuild CI issues with restore: [link to the failed CI run](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=11793680&view=logs&j=bb592630-4b9d-53ad-3960-d954a70a95cf&t=cec29cdc-34bb-52dc-f525-f2be67883d7f).

Error message
```
Unable to resolve 'Microsoft.DotNet.Arcade.Sdk (= 9.0.0-beta.25302.2)' for '.NETStandard,Version=v0.0'. PackageSourceMapping is enabled, the following source(s) were not considered: dotnet-core-internal-tooling.
```

Investigation:
Fixing a malformed NuGet configuration in the msbuild repository (https://github.com/dotnet/dotnet/pull/550) enables the use of package source mappings for MSBuild repo, including the bits that flow to MSBuild from arcade. There is a NuGet configuration in arcade that clears the `packageSources` section without clearing the corresponding `packageSourceMapping`, leaving the feature on. Absence of the wild cards for `dotnet-core-internal-tooling` then causes errors in the MSBuild CI.

Changes:
This PR clears the `packageSourceMapping` disabling the feature for this NuGet config. Alternatively, we can add the wild card for `dotnet-core-internal-tooling`.