### PR TITLE
[SignTool] Improve memory usage for large files when DryRun signing

### DIFF
--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -453,9 +453,9 @@ namespace Microsoft.DotNet.SignTool.Tests
 
         private string ExtractArchiveFromDebPackage(string debianPackage, string archiveName, string destinationFolder)
         {
-            var (relativePath, content, contentSize) = ZipData.ReadDebContainerEntries(debianPackage, archiveName).Single();
+            var (relativePath, entry) = ZipData.ReadDebContainerEntries(debianPackage, archiveName).Single();
             string archive = Path.Combine(destinationFolder, relativePath);
-            File.WriteAllBytes(archive, ((MemoryStream)content).ToArray());
+            entry.WriteToFile(archive);
             return archive;
         }
 

--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -453,8 +453,8 @@ namespace Microsoft.DotNet.SignTool.Tests
 
         private string ExtractArchiveFromDebPackage(string debianPackage, string archiveName, string destinationFolder)
         {
-            var (relativePath, entry) = ZipData.ReadDebContainerEntries(debianPackage, archiveName).Single();
-            string archive = Path.Combine(destinationFolder, relativePath);
+            var entry = ZipData.ReadDebContainerEntries(debianPackage, archiveName).Single();
+            string archive = Path.Combine(destinationFolder, entry.RelativePath);
             entry.WriteToFile(archive);
             return archive;
         }

--- a/src/Microsoft.DotNet.SignTool/src/VerifySignatures.cs
+++ b/src/Microsoft.DotNet.SignTool/src/VerifySignatures.cs
@@ -293,9 +293,9 @@ namespace Microsoft.DotNet.SignTool
 
         private static string ExtractDebContainerEntry(string debianPackage, string entryName, string workingDir)
         {
-            var (relativePath, content, contentSize) = ZipData.ReadDebContainerEntries(debianPackage, entryName).Single();
+            var (relativePath, entry) = ZipData.ReadDebContainerEntries(debianPackage, entryName).Single();
             string entryPath = Path.Combine(workingDir, relativePath);
-            File.WriteAllBytes(entryPath, ((MemoryStream)content).ToArray());
+            entry.WriteToFile(entryPath);
 
             return entryPath;
         }

--- a/src/Microsoft.DotNet.SignTool/src/VerifySignatures.cs
+++ b/src/Microsoft.DotNet.SignTool/src/VerifySignatures.cs
@@ -293,8 +293,8 @@ namespace Microsoft.DotNet.SignTool
 
         private static string ExtractDebContainerEntry(string debianPackage, string entryName, string workingDir)
         {
-            var (relativePath, entry) = ZipData.ReadDebContainerEntries(debianPackage, entryName).Single();
-            string entryPath = Path.Combine(workingDir, relativePath);
+            var entry = ZipData.ReadDebContainerEntries(debianPackage, entryName).Single();
+            string entryPath = Path.Combine(workingDir, entry.RelativePath);
             entry.WriteToFile(entryPath);
 
             return entryPath;

--- a/src/Microsoft.DotNet.SignTool/src/ZipDataEntry.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ZipDataEntry.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.IO.Compression;
+
+namespace Microsoft.DotNet.SignTool
+{
+    internal sealed class ZipDataEntry : IDisposable
+    {
+        Stream _stream;
+        ImmutableArray<byte> _contentHash;
+
+        public ZipDataEntry(Stream contentStream, long contentSize)
+        {
+            if (contentStream.CanSeek)
+            {
+                _stream = contentStream;
+            }
+            else
+            {
+                // if we can't seek we need to copy the stream into a (seekable) MemoryStream so we can compute the content hash
+                _stream = new MemoryStream((int)contentSize);
+                contentStream.CopyTo(_stream);
+            }
+
+            // compute content hash and reset position back
+            _contentHash = ContentUtil.GetContentHash(_stream);
+            _stream.Position = 0;
+        }
+
+        public ZipDataEntry(ZipArchiveEntry zipArchiveEntry)
+        {
+            // the stream returned by zipArchiveEntry.Open() isn't seekable,
+            // we can avoid creating a MemoryStream copy by just opening a separate instance for computing the content hash
+            using var contentHashStream = zipArchiveEntry.Open();
+            _contentHash = ContentUtil.GetContentHash(contentHashStream);
+
+            // this will already be at position 0
+            _stream = zipArchiveEntry.Open();
+        }
+        public ImmutableArray<byte> ContentHash => _contentHash;
+
+        public void WriteToFile(string path)
+        {
+            using var fs = File.Create(path);
+            _stream.CopyTo(fs);
+        }
+
+        public void Dispose()
+        {
+            _stream.Dispose();
+            _stream = null;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.StrongName/Verification.cs
+++ b/src/Microsoft.DotNet.StrongName/Verification.cs
@@ -67,6 +67,12 @@ namespace Microsoft.DotNet.StrongName
                     return false;
                 }
 
+                // If the checksum isn't set, then it's not signed.
+                if (peHeaders.PEHeader.CheckSum == 0)
+                {
+                    return false;
+                }
+
                 // Reset position before creating the blob builder.
                 peStream.Position = 0;
                 byte[] peBuffer = Utils.ReadPEToBuffer(peStream);


### PR DESCRIPTION
We can avoid creating a MemoryStream copy of files in .nupkg by calling ZipArchiveEntry.Open() separately for computing the content hash.

This drops the memory usage from 1.1GB to 170MB (30MB with second fix, see below) when processing the android runtime pack.

Contributes to https://github.com/dotnet/dotnet/issues/969