### PR TITLE
Don't use File.OpenWrite when trying to overwrite a file

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateChangelogFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateChangelogFile.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
 
         public override bool Execute()
         {
-            using GZipStream stream = new(File.OpenWrite(ChangelogOutputPath), CompressionLevel.Optimal);
+            using GZipStream stream = new(File.Create(ChangelogOutputPath), CompressionLevel.Optimal);
             using StreamWriter writer = new(stream, Encoding.ASCII);
             writer.WriteLine($"{PackageName} ({PackageVersion}) unstable; urgency=low");
             writer.WriteLine();

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateControlFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateControlFile.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
 
         public override bool Execute()
         {
-            using Stream stream = File.OpenWrite(ControlFileOutputPath);
+            using Stream stream = File.Create(ControlFileOutputPath);
             using StreamWriter writer = new(stream, Encoding.ASCII);
             writer.WriteLine($"Package: {PackageName}");
             writer.WriteLine($"Version: {PackageVersion}");

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateMD5SumsFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateMD5SumsFile.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
 
         public override bool Execute()
         {
-            using FileStream outputFile = File.OpenWrite(OutputFile);
+            using FileStream outputFile = File.Create(OutputFile);
             using StreamWriter writer = new(outputFile, Encoding.ASCII);
             ulong installedSize = 0;
             foreach (ITaskItem file in Files)

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateMacOSDistributionFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateMacOSDistributionFile.cs
@@ -117,7 +117,7 @@ namespace Microsoft.DotNet.SharedFramework.Sdk
                 document.Root.Add(choiceElements);
                 document.Root.Add(pkgRefElements);
                 document.Root.Add(scriptElement);
-                using XmlWriter writer = XmlWriter.Create(File.OpenWrite(DestinationFile));
+                using XmlWriter writer = XmlWriter.Create(File.Create(DestinationFile));
                 document.WriteTo(writer);
             }
             catch (Exception ex)

--- a/src/SignCheck/Microsoft.SignCheck/Verification/RpmVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/RpmVerifier.cs
@@ -24,7 +24,7 @@ namespace Microsoft.SignCheck.Verification
 
             using var stream = File.Open(archivePath, FileMode.Open);
             using RpmPackage rpmPackage = RpmPackage.Read(stream);
-            using var dataStream = File.OpenWrite(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
+            using var dataStream = File.Create(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
             using var archive = new CpioReader(rpmPackage.ArchiveStream, leaveOpen: false);
 
             while (archive.GetNextEntry() is CpioEntry entry)


### PR DESCRIPTION
File.OpenWrite will open an existing file which means if you write data that is shorter than the existing data the file will be corrupt. This is documented on https://learn.microsoft.com/en-us/dotnet/api/system.io.file.openwrite

> The OpenWrite method opens a file if one already exists for the file path, or creates a new file if one does not exist. For an existing file, it does not append the new text to the existing text. Instead, it overwrites the existing characters with the new characters. If you overwrite a longer string (such as "This is a test of the OpenWrite method") with a shorter string (such as "Second run"), the file will contain a mix of the strings ("Second runtest of the OpenWrite method").

The fix is to use  `File.Create` instead in cases where the intention is to create a new file or overwrite an existing one.

Noticed this while looking at https://github.com/dotnet/arcade/pull/15927, I sent the same change to runtime a while ago: https://github.com/dotnet/runtime/pull/93744