### PR TITLE
[release/9.0] Backport `archives.targets: Fix creating tar.gz on Windows`

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Archives/build/archives.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Archives/build/archives.targets
@@ -80,11 +80,12 @@
   <Target Name="_CreateArchive"
           Condition="'$(SkipArchivesBuild)' != 'true'">
     <PropertyGroup>
-      <_OutputPathRoot>$([MSBuild]::NormalizePath($(IntermediateOutputPath), 'output'))</_OutputPathRoot>
+      <_OutputPathRoot>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), 'output'))</_OutputPathRoot>
       <_ArchiveFileName>$(ArchiveName)-$(Version)</_ArchiveFileName>
       <_ArchiveFileName Condition="'$(RuntimeIdentifier)' != ''">$(ArchiveName)-$(Version)-$(RuntimeIdentifier)</_ArchiveFileName>
       <_DestinationFileName>$([MSBuild]::NormalizePath($(PackageOutputPath), '$(_ArchiveFileName).$(ArchiveFormat)'))</_DestinationFileName>
     </PropertyGroup>
+    <MakeDir Directories="$(_OutputPathRoot)" />
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="PublishToDisk"
              Properties="OutputPath=$(_OutputPathRoot)" />
@@ -111,6 +112,7 @@
       <_ArchiveFileName Condition="'$(RuntimeIdentifier)' != ''">$(SymbolsArchiveName)-$(RuntimeIdentifier)-$(Version)</_ArchiveFileName>
       <_DestinationFileName>$([MSBuild]::NormalizePath($(PackageOutputPath), '$(_ArchiveFileName).$(ArchiveFormat)'))</_DestinationFileName>
     </PropertyGroup>
+    <MakeDir Directories="$(_SymbolsOutputPathRoot)" />
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="PublishSymbolsToDisk"
              Properties="SymbolsOutputPath=$(_SymbolsOutputPathRoot)" />


### PR DESCRIPTION
Backport #15913

```
commit debf97147dc2608d6e3b12f9c5c71d33fe4b7c7b
Author: Ankit Jain <radical@gmail.com>
Date:   Mon Jun 23 13:08:03 2025 -0400

    archives.targets: Fix creating tar.gz on Windows (#15913)
```

cc @danmoseley @joperezr @ViktorHofer 

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
