### PR TITLE
Support using MSBuild from xcopy msbuild tool package though VS installation exists

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -414,7 +414,7 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
 
   # Locate Visual Studio installation or download x-copy msbuild.
   $vsInfo = LocateVisualStudio $vsRequirements
-  if ($vsInfo -ne $null) {
+  if ($vsInfo -ne $null -and $env:ToolsMSBuildUseXCopyMSBuild -eq $null) {
     # Ensure vsInstallDir has a trailing slash
     $vsInstallDir = Join-Path $vsInfo.installationPath "\"
     $vsMajorVersion = $vsInfo.installationVersion.Split('.')[0]


### PR DESCRIPTION
Fix https://github.com/dotnet/arcade/issues/15894

MSBuild old release branches needs the support to choose using MSBuild from xcopy msbuild tool package rather than VS installation.