### PR TITLE
Revert "Remove "Source Build Complete" job"

### DIFF
--- a/eng/common/core-templates/jobs/jobs.yml
+++ b/eng/common/core-templates/jobs/jobs.yml
@@ -83,6 +83,7 @@ jobs:
   - template: /eng/common/core-templates/jobs/source-build.yml
     parameters:
       is1ESPipeline: ${{ parameters.is1ESPipeline }}
+      allCompletedJobId: Source_Build_Complete
       ${{ each parameter in parameters.sourceBuildParameters }}:
         ${{ parameter.key }}: ${{ parameter.value }}
 

--- a/eng/common/core-templates/jobs/source-build.yml
+++ b/eng/common/core-templates/jobs/source-build.yml
@@ -2,6 +2,12 @@ parameters:
   # This template adds arcade-powered source-build to CI. A job is created for each platform, as
   # well as an optional server job that completes when all platform jobs complete.
 
+  # The name of the "join" job for all source-build platforms. If set to empty string, the job is
+  # not included. Existing repo pipelines can use this job depend on all source-build jobs
+  # completing without maintaining a separate list of every single job ID: just depend on this one
+  # server job. By default, not included. Recommended name if used: 'Source_Build_Complete'.
+  allCompletedJobId: ''
+
   # See /eng/common/core-templates/job/source-build.yml
   jobNamePrefix: 'Source_Build'
 
@@ -24,6 +30,16 @@ parameters:
   enableInternalSources: false
 
 jobs:
+
+- ${{ if ne(parameters.allCompletedJobId, '') }}:
+  - job: ${{ parameters.allCompletedJobId }}
+    displayName: Source-Build Complete
+    pool: server
+    dependsOn:
+    - ${{ each platform in parameters.platforms }}:
+      - ${{ parameters.jobNamePrefix }}_${{ platform.name }}
+    - ${{ if eq(length(parameters.platforms), 0) }}:
+      - ${{ parameters.jobNamePrefix }}_${{ parameters.defaultManagedPlatform.name }}
 
 - ${{ each platform in parameters.platforms }}:
   - template: /eng/common/core-templates/job/source-build.yml


### PR DESCRIPTION
`Reverts dotnet/arcade#15950

This breaks the current arcade build and overall needs a closer look. The issue is that the `Source_Build_Complete` job serves as an internal join, in cases where source build is performed on multiple platforms. In this case, the source-build yaml generates the `_Complete` job, depending on all passed in platforms. To make this work, we need to hoist some information (`defaultManagedPlatform`) out of the source-build `jobs.yml`, and into the main `jobs.yml` so that we can generate a list of jobs that the source-build yml would generate.

One option might be to generate a _Complete job only in cases where the platform list is non-empty.