### PR TITLE
Fixup stream ownership and position after copy

### DIFF
--- a/src/Microsoft.DotNet.SignTool/src/Configuration.cs
+++ b/src/Microsoft.DotNet.SignTool/src/Configuration.cs
@@ -774,48 +774,49 @@ namespace Microsoft.DotNet.SignTool
             try
             {
                 var nestedParts = new Dictionary<string, ZipPart>();
-                
+
                 foreach (var entry in ZipData.ReadEntries(archivePath, _pathToContainerUnpackingDirectory, _tarToolPath, _pkgToolPath))
                 {
-                    if (entry.ContentHash == null)
+                    using (entry)
                     {
-                        // this might be just a pointer to a folder. We skip those.
-                        continue;
-                    }
+                        if (entry.ContentHash == null)
+                        {
+                            // this might be just a pointer to a folder. We skip those.
+                            continue;
+                        }
 
-                    var fileUniqueKey = new SignedFileContentKey(entry.ContentHash, Path.GetFileName(entry.RelativePath));
+                        var fileUniqueKey = new SignedFileContentKey(entry.ContentHash, Path.GetFileName(entry.RelativePath));
 
-                    if (!_whichPackagesTheFileIsIn.TryGetValue(fileUniqueKey, out var packages))
-                    {
-                        packages = new HashSet<string>();
-                    }
+                        if (!_whichPackagesTheFileIsIn.TryGetValue(fileUniqueKey, out var packages))
+                        {
+                            packages = new HashSet<string>();
+                        }
 
-                    packages.Add(Path.GetFileName(archivePath));
+                        packages.Add(Path.GetFileName(archivePath));
 
-                    _whichPackagesTheFileIsIn[fileUniqueKey] = packages;
+                        _whichPackagesTheFileIsIn[fileUniqueKey] = packages;
 
-                    // if we already encountered file that has the same content we can reuse its signed version when repackaging the container.
-                    var fileName = Path.GetFileName(entry.RelativePath);
-                    if (!_filesByContentKey.TryGetValue(fileUniqueKey, out var fileSignInfo))
-                    {
-                        string extractPathRoot = _useHashInExtractionPath ? fileUniqueKey.StringHash : _filesByContentKey.Count().ToString();
-                        string tempPath = Path.Combine(_pathToContainerUnpackingDirectory, extractPathRoot, entry.RelativePath);
-                        _log.LogMessage($"Extracting file '{fileName}' from '{archivePath}' to '{tempPath}'.");
+                        // if we already encountered file that has the same content we can reuse its signed version when repackaging the container.
+                        var fileName = Path.GetFileName(entry.RelativePath);
+                        if (!_filesByContentKey.TryGetValue(fileUniqueKey, out var fileSignInfo))
+                        {
+                            string extractPathRoot = _useHashInExtractionPath ? fileUniqueKey.StringHash : _filesByContentKey.Count().ToString();
+                            string tempPath = Path.Combine(_pathToContainerUnpackingDirectory, extractPathRoot, entry.RelativePath);
+                            _log.LogMessage($"Extracting file '{fileName}' from '{archivePath}' to '{tempPath}'.");
 
-                        Directory.CreateDirectory(Path.GetDirectoryName(tempPath));
+                            Directory.CreateDirectory(Path.GetDirectoryName(tempPath));
 
-                        entry.WriteToFile(tempPath);
+                            entry.WriteToFile(tempPath);
 
-                        _hashToCollisionIdMap.TryGetValue(fileUniqueKey, out string collisionPriorityId);
-                        PathWithHash nestedFile = new PathWithHash(tempPath, entry.ContentHash);
-                        fileSignInfo = TrackFile(nestedFile, zipFileSignInfo.File, collisionPriorityId);
-                    }
+                            _hashToCollisionIdMap.TryGetValue(fileUniqueKey, out string collisionPriorityId);
+                            PathWithHash nestedFile = new PathWithHash(tempPath, entry.ContentHash);
+                            fileSignInfo = TrackFile(nestedFile, zipFileSignInfo.File, collisionPriorityId);
+                        }
 
-                    entry.Dispose();
-
-                    if (fileSignInfo.ShouldTrack)
-                    {
-                        nestedParts.Add(entry.RelativePath, new ZipPart(entry.RelativePath, fileSignInfo));
+                        if (fileSignInfo.ShouldTrack)
+                        {
+                            nestedParts.Add(entry.RelativePath, new ZipPart(entry.RelativePath, fileSignInfo));
+                        }
                     }
                 }
 

--- a/src/Microsoft.DotNet.SignTool/src/ZipData.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ZipData.cs
@@ -654,7 +654,6 @@ namespace Microsoft.DotNet.SignTool
         {
             using var stream = File.Open(archivePath, FileMode.Open);
             using RpmPackage rpmPackage = RpmPackage.Read(stream);
-            using var dataStream = File.Create(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
             using var archive = new CpioReader(rpmPackage.ArchiveStream, leaveOpen: false);
 
             while (archive.GetNextEntry() is CpioEntry entry)

--- a/src/Microsoft.DotNet.SignTool/src/ZipDataEntry.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ZipDataEntry.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.SignTool
     {
         string _relativePath;
         Stream _stream;
-        bool streamOwned = false;
+        bool _streamOwned = false;
         ImmutableArray<byte> _contentHash;
 
         public ZipDataEntry(string relativePath, Stream contentStream) : this(relativePath, contentStream, contentStream?.Length ?? 0)
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.SignTool
                 // if we can't seek we need to copy the stream into a (seekable) MemoryStream so we can compute the content hash
                 _stream = new MemoryStream((int)contentSize);
                 contentStream.CopyTo(_stream);
-                streamOwned = true;
+                _streamOwned = true;
                 _stream.Position = 0;
             }
 
@@ -74,11 +74,11 @@ namespace Microsoft.DotNet.SignTool
 
         public void Dispose()
         {
-            if (streamOwned)
+            if (_streamOwned)
             {
                 _stream.Dispose();
-                _stream = null;
             }
+            _stream = null;
         }
     }
 }

--- a/src/Microsoft.DotNet.SignTool/src/ZipDataEntry.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ZipDataEntry.cs
@@ -12,6 +12,7 @@ namespace Microsoft.DotNet.SignTool
     {
         string _relativePath;
         Stream _stream;
+        bool streamOwned = false;
         ImmutableArray<byte> _contentHash;
 
         public ZipDataEntry(string relativePath, Stream contentStream) : this(relativePath, contentStream, contentStream?.Length ?? 0)
@@ -35,6 +36,8 @@ namespace Microsoft.DotNet.SignTool
                 // if we can't seek we need to copy the stream into a (seekable) MemoryStream so we can compute the content hash
                 _stream = new MemoryStream((int)contentSize);
                 contentStream.CopyTo(_stream);
+                streamOwned = true;
+                _stream.Position = 0;
             }
 
             // compute content hash and reset position back
@@ -71,8 +74,10 @@ namespace Microsoft.DotNet.SignTool
 
         public void Dispose()
         {
-            _stream.Dispose();
-            _stream = null;
+            if (streamOwned)
+            {
+                _stream.Dispose();
+                _stream = null;
+            }
         }
-    }
 }

--- a/src/Microsoft.DotNet.SignTool/src/ZipDataEntry.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ZipDataEntry.cs
@@ -80,4 +80,5 @@ namespace Microsoft.DotNet.SignTool
                 _stream = null;
             }
         }
+    }
 }


### PR DESCRIPTION
Two fixes:
- If an entry stream is not seekable, then we copy it to a new stream. This stream's position needs to be reset to zero before computing the hash, otherwise you'll just compute the hash of an empty stream.
- Fix up ownership of this stream. Unless the stream is copied, it is not owned by ZipDataEntry. The reason we are not delegating ownership to ZipDataEntry all-up is that the archive readers that are used have varying ownership of the underlying streams. Cases that use the archive readers do not leave underlying streams open. They own all of the entry streams. There are a couple cases where we extract to disk and then open a file. In those cases, it makes sense to align with the archive reader behavior and not delegate ownership.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
