### PR TITLE
Replace the _SignType conditional with a parameter for ESRP service connection information

### DIFF
--- a/eng/common/core-templates/job/job.yml
+++ b/eng/common/core-templates/job/job.yml
@@ -20,6 +20,7 @@ parameters:
   artifacts: ''
   enableMicrobuild: false
   enableMicrobuildForMacAndLinux: false
+  microbuildUseESRP: true
   enablePublishBuildArtifacts: false
   enablePublishBuildAssets: false
   enablePublishTestResults: false
@@ -128,6 +129,7 @@ jobs:
       parameters:
         enableMicrobuild: ${{ parameters.enableMicrobuild }}
         enableMicrobuildForMacAndLinux: ${{ parameters.enableMicrobuildForMacAndLinux }}
+        microbuildUseESRP: ${{ parameters.microbuildUseESRP }}
         continueOnError: ${{ parameters.continueOnError }}
 
   - ${{ if and(eq(parameters.runAsPublic, 'false'), eq(variables['System.TeamProject'], 'internal')) }}:

--- a/eng/common/core-templates/steps/install-microbuild.yml
+++ b/eng/common/core-templates/steps/install-microbuild.yml
@@ -4,8 +4,16 @@ parameters:
   # Enable install tasks for MicroBuild on Mac and Linux
   # Will be ignored if 'enableMicrobuild' is false or 'Agent.Os' is 'Windows_NT'
   enableMicrobuildForMacAndLinux: false
+  # Determines whether the ESRP service connection information should be passed to the signing plugin.
+  # This overlaps with _SignType to some degree. We only need the service connection for real signing.
+  # It's important that the service connection not be passed to the MicroBuildSigningPlugin task in this place.
+  # Doing so will cause the service connection to be authorized for the pipeline, which isn't allowed and won't work for non-prod.
+  # Unfortunately, _SignType can't be used to exclude the use of the service connection in non-real sign scenarios. The
+  # variable is not available in template expression. _SignType has a very large proliferation across .NET, so replacing it is tough.
+  microbuildUseESRP: true
   # Location of the MicroBuild output folder
   microBuildOutputFolder: '$(Build.SourcesDirectory)'
+
   continueOnError: false
 
 steps:
@@ -27,7 +35,7 @@ steps:
         signType: $(_SignType)
         zipSources: false
         feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-        ${{ if eq(variables['_SignType'], 'real') }}:
+        ${{ if eq(parameters.microbuildUseESRP, true) }}:
           ${{ if and(eq(parameters.enableMicrobuildForMacAndLinux, 'true'), ne(variables['Agent.Os'], 'Windows_NT')) }}:
             azureSubscription: 'MicroBuild Signing Task (DevDiv)'
             useEsrpCli: true

--- a/eng/common/core-templates/steps/install-microbuild.yml
+++ b/eng/common/core-templates/steps/install-microbuild.yml
@@ -29,6 +29,23 @@ steps:
           workingDirectory: ${{ parameters.microBuildOutputFolder }}
         condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
 
+    - script: |
+        REM Check if ESRP is disabled while SignType is real
+        if /I "${{ parameters.microbuildUseESRP }}"=="false" if /I "$(_SignType)"=="real" (
+          echo Error: ESRP must be enabled when SignType is real.
+          exit /b 1
+        )
+      displayName: 'Validate ESRP usage (Windows)'
+      condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'))
+    - script: |
+        # Check if ESRP is disabled while SignType is real
+        if [ "${{ parameters.microbuildUseESRP }}" = "false" ] && [ "$(_SignType)" = "real" ]; then
+          echo "Error: ESRP must be enabled when SignType is real."
+          exit 1
+        fi
+      displayName: 'Validate ESRP usage (Non-Windows)'
+      condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
+
     - task: MicroBuildSigningPlugin@4
       displayName: Install MicroBuild plugin
       inputs:
@@ -36,7 +53,7 @@ steps:
         zipSources: false
         feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
         ${{ if eq(parameters.microbuildUseESRP, true) }}:
-          ${{ if and(eq(parameters.enableMicrobuildForMacAndLinux, 'true'), ne(variables['Agent.Os'], 'Windows_NT')) }}:
+          ${{ if eq(parameters.enableMicrobuildForMacAndLinux, 'true') }}:
             azureSubscription: 'MicroBuild Signing Task (DevDiv)'
             useEsrpCli: true
           ${{ elseif eq(variables['System.TeamProject'], 'DevDiv') }}:


### PR DESCRIPTION
Use of the _SignType in the compile time expression does not work. Introduce a parameter for this.

I chose to use microbuildUseESRP rather than microbuildSignType because I don't want users to confuse use of the parameter with setting signing to test signing or real signing. _SignType is so prolific that it's hard to imagine getting rid of it at this point. So I chose just to have a parameter that indicates whether the service connection should be used. A user would pass false in test signing cases. This could be passed based on the value of _SignType if it's defined in the same file.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
