### PR TITLE
Fix typo in MTP.targets

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Microsoft.Testing.Platform/Microsoft.Testing.Platform.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Microsoft.Testing.Platform/Microsoft.Testing.Platform.targets
@@ -6,9 +6,11 @@
       <_TestEnvironment>%(TestToRun.EnvironmentDisplay)</_TestEnvironment>
       <_TestAssembly>%(TestToRun.Identity)</_TestAssembly>
       <_TestRunner>%(TestToRun.RunCommand)</_TestRunner>
+      <_RunArguments>%(TestToRun.RunArguments)</_RunArguments>
       <_TestRuntime>%(TestToRun.TestRuntime)</_TestRuntime>
       <_TestTimeout>%(TestToRun.TestTimeout)</_TestTimeout>
-      <_TestRunnerAdditionalArguments>%(TestToRun.RunArguments) %(TestToRun.TestRunnerAdditionalArguments)</_TestRunnerAdditionalArguments>
+      <_TestRunnerAdditionalArguments>%(TestToRun.TestRunnerAdditionalArguments)</_TestRunnerAdditionalArguments>
+      <_TestRunnerAdditionalArguments>$(_RunArguments) $(_TestRunnerAdditionalArguments)</_TestRunnerAdditionalArguments>
 
       <_TestResultDirectory>$([System.IO.Path]::GetDirectoryName('%(TestToRun.ResultsTrxPath)'))</_TestResultDirectory>
       <_TestResultTrxFileName>$([System.IO.Path]::GetFileName('%(TestToRun.ResultsTrxPath)'))</_TestResultTrxFileName>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Microsoft.Testing.Platform/Microsoft.Testing.Platform.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Microsoft.Testing.Platform/Microsoft.Testing.Platform.targets
@@ -8,7 +8,7 @@
       <_TestRunner>%(TestToRun.RunCommand)</_TestRunner>
       <_TestRuntime>%(TestToRun.TestRuntime)</_TestRuntime>
       <_TestTimeout>%(TestToRun.TestTimeout)</_TestTimeout>
-      <_TestRunnerAdditionalArguments>$(TestToRun.RunArguments) %(TestToRun.TestRunnerAdditionalArguments)</_TestRunnerAdditionalArguments>
+      <_TestRunnerAdditionalArguments>%(TestToRun.RunArguments) %(TestToRun.TestRunnerAdditionalArguments)</_TestRunnerAdditionalArguments>
 
       <_TestResultDirectory>$([System.IO.Path]::GetDirectoryName('%(TestToRun.ResultsTrxPath)'))</_TestResultDirectory>
       <_TestResultTrxFileName>$([System.IO.Path]::GetFileName('%(TestToRun.ResultsTrxPath)'))</_TestResultTrxFileName>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Microsoft.Testing.Platform/Microsoft.Testing.Platform.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Microsoft.Testing.Platform/Microsoft.Testing.Platform.targets
@@ -12,7 +12,7 @@
 
       <_TestResultDirectory>$([System.IO.Path]::GetDirectoryName('%(TestToRun.ResultsTrxPath)'))</_TestResultDirectory>
       <_TestResultTrxFileName>$([System.IO.Path]::GetFileName('%(TestToRun.ResultsTrxPath)'))</_TestResultTrxFileName>
-      <_TestRunnerArgs>"$(_TestRunner)" $(_TestRunnerAdditionalArguments) --no-progress --report-trx --report-trx-filename "$(_TestResultTrxFileName)" --results-directory "$(_TestResultDirectory)"</_TestRunnerArgs>
+      <_TestRunnerArgs>$(_TestRunnerAdditionalArguments) --no-progress --report-trx --report-trx-filename "$(_TestResultTrxFileName)" --results-directory "$(_TestResultDirectory)"</_TestRunnerArgs>
     </PropertyGroup>
 
     <!-- Validate that non-Core workloads use executable files, not DLL files -->


### PR DESCRIPTION
I broke this in my last PR :(

https://github.com/dotnet/arcade/issues/15997 tracks adding tests to avoid this kind of bugs.