### PR TITLE
[release/8.0] Add ability to opt-out of ESRP service connection use.

### DIFF
--- a/eng/common/templates-official/job/job.yml
+++ b/eng/common/templates-official/job/job.yml
@@ -21,6 +21,7 @@ parameters:
   # See schema documentation - https://github.com/dotnet/arcade/blob/master/Documentation/AzureDevOps/TemplateSchema.md
   artifacts: ''
   enableMicrobuild: false
+  microbuildUseESRP: true
   enablePublishBuildArtifacts: false
   enablePublishBuildAssets: false
   enablePublishTestResults: false
@@ -135,10 +136,11 @@ jobs:
           signType: $(_SignType)
           zipSources: false
           feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-          ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
-            ConnectedPMEServiceName: 6cc74545-d7b9-4050-9dfa-ebefcc8961ea
-          ${{ else }}:
-            ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
+          ${{ if eq(parameters.microbuildUseESRP, true) }}:
+            ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+              ConnectedPMEServiceName: 6cc74545-d7b9-4050-9dfa-ebefcc8961ea
+            ${{ else }}:
+              ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
         env:
           TeamName: $(_TeamName)
           MicroBuildOutputFolderOverride: '$(Agent.TempDirectory)'


### PR DESCRIPTION
I chose to use microbuildUseESRP rather than microbuildSignType because I don't want users to confuse use of the parameter with setting signing to test signing or real signing. _SignType is so prolific that it's hard to imagine getting rid of it at this point. So I chose just to have a parameter that indicates whether the service connection should be used. A user would pass false in test signing cases. This could be passed based on the value of _SignType if it's defined in the same file.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
