### PR TITLE
[release/9.0] Do not skip initially ignored extensions

### DIFF
--- a/src/Microsoft.DotNet.SignTool/src/SignInfo.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignInfo.cs
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.SignTool
         }
 
         internal SignInfo WithCertificateName(string value, string collisionPriorityId)
-            => new SignInfo(value, StrongName, collisionPriorityId, ShouldIgnore, IsAlreadySigned);
+            => new SignInfo(value, StrongName, collisionPriorityId, false, false);
 
         internal SignInfo WithCollisionPriorityId(string collisionPriorityId)
             => new SignInfo(Certificate, StrongName, collisionPriorityId, ShouldIgnore, IsAlreadySigned);


### PR DESCRIPTION
Ports a fix that was made in 10.0 as part of a larger change. If a file does not have an extension that has signing info (or if the signing info is None), then that file can't get signed, even with specific sign info.

This is because we don't clear the ignore bit after updating the sign info with the cert name.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
