### PR TITLE
Improve PublishBuildToMaestro retries

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishBuildToMaestroTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/PublishBuildToMaestroTests.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Net;
+using FluentAssertions;
+using Xunit;
+
+namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
+{
+    public class PublishBuildToMaestroTests
+    {
+        [Fact]
+        public void GetTimeToWait_ReadsGitHubRateLimitingHeaders()
+        {
+            // Unauthenticated requests to github that are rate limited don't use the Retry-After header,
+            // so we need to be able to handle their X-RateLimit-Reset header.
+
+            DateTime resetTime = DateTime.UtcNow.AddSeconds(5.0);
+            long unixTime = (long)(resetTime - DateTime.UnixEpoch).TotalSeconds;
+            var response = new System.Net.Http.HttpResponseMessage(HttpStatusCode.Forbidden)
+            {
+                Headers =
+                {
+                    { "X-RateLimit-Remaining", "0" },
+                    { "X-RateLimit-Reset", unixTime.ToString() },
+                }
+            };
+
+            TimeSpan? actual = PublishBuildToMaestro.GetTimeToWait(response);
+
+            actual.Should().NotBeNull();
+            actual.Should().BeCloseTo(resetTime - DateTime.UtcNow, TimeSpan.FromSeconds(1));
+        }
+
+        [Fact]
+        public void GetTimeToWait_NotWaitWhenNotLimited()
+        {
+            DateTime resetTime = DateTime.UtcNow.AddSeconds(5.0);
+            long unixTime = (long)(resetTime - DateTime.UnixEpoch).TotalSeconds;
+            var response = new System.Net.Http.HttpResponseMessage(HttpStatusCode.Forbidden)
+            {
+                Headers =
+                {
+                    { "X-RateLimit-Remaining", "1" },
+                    { "X-RateLimit-Reset", unixTime.ToString() },
+                }
+            };
+
+            TimeSpan? actual = PublishBuildToMaestro.GetTimeToWait(response);
+
+            actual.Should().BeNull();
+        }
+
+        [Fact]
+        public void GetTimeToWait_UsesRetryAfterDuration()
+        {
+            var response = new System.Net.Http.HttpResponseMessage(HttpStatusCode.Forbidden)
+            {
+                Headers =
+                {
+                    { "Retry-After", "5" },
+                }
+            };
+            TimeSpan? actual = PublishBuildToMaestro.GetTimeToWait(response);
+            actual.Should().NotBeNull();
+            actual.Should().BeCloseTo(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1));
+        }
+
+        [Fact]
+        public void GetTimeToWait_UsesRetryAfterDate()
+        {
+            DateTime resetTime = DateTime.UtcNow.AddSeconds(5.0);
+            var response = new System.Net.Http.HttpResponseMessage(HttpStatusCode.Forbidden)
+            {
+                Headers =
+                {
+                    { "Retry-After", resetTime.ToString("R") },
+                }
+            };
+            TimeSpan? actual = PublishBuildToMaestro.GetTimeToWait(response);
+            actual.Should().NotBeNull();
+            actual.Should().BeCloseTo(resetTime - DateTime.UtcNow, TimeSpan.FromSeconds(1));
+        }
+    }
+}


### PR DESCRIPTION
When I created my [previous PR adding retries](https://github.com/dotnet/arcade/pull/15990), I didn't pay attention to the http status code, or the headers that github returns. I just assumed they followed HTTP best practises.  Turns out they respond with 403 instead of 429, and don't provide Retry-After headers. Here are example headers:

<details>
<summary>response headers</summary>

```text
StatusCode: 403, ReasonPhrase: 'rate limit exceeded', Version: 1.1, Content: System.Net.Http.HttpConnectionResponseContent, Headers:
{
  Date: Thu, 31 Jul 2025 22:54:41 GMT
  Server: Varnish
  Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
  X-Content-Type-Options: nosniff
  X-Frame-Options: deny
  X-XSS-Protection: 1; mode=block
  Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'
  Access-Control-Allow-Origin: *
  Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-RateLimit-Used, X-RateLimit-Resource, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
  Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
  X-GitHub-Media-Type: github.v3; format=json
  X-RateLimit-Limit: 60
  X-RateLimit-Remaining: 0
  X-RateLimit-Reset: 1754003080
  X-RateLimit-Resource: core
  X-RateLimit-Used: 60
  X-GitHub-Request-Id: B230:15B9EB:14F46D:1B5021:688BF431
  Content-Type: application/json; charset=utf-8
  Content-Length: 280
}
```
</details>

This change allows us to optionally set the GITHUB_TOKEN environment variable to do authenticated requests. And also implements retries in a way that should work with github.


### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
