### PR TITLE
Target channel validation

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/ProductionChannelValidatorTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/ProductionChannelValidatorTests.cs
@@ -1,0 +1,704 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.DotNet.Build.Tasks.Feed.Model;
+using Microsoft.DotNet.Build.Manifest;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
+{
+    public class ProductionChannelValidatorTests
+    {
+        private readonly Mock<IProductionChannelValidatorBuildInfoService> _mockAzureDevOpsService;
+        private readonly Mock<IBranchClassificationService> _mockBranchClassificationService;
+        private readonly Mock<ILogger<ProductionChannelValidator>> _mockLogger;
+
+        public ProductionChannelValidatorTests()
+        {
+            _mockAzureDevOpsService = new Mock<IProductionChannelValidatorBuildInfoService>();
+            _mockBranchClassificationService = new Mock<IBranchClassificationService>();
+            _mockLogger = new Mock<ILogger<ProductionChannelValidator>>();
+        }
+
+        private ProductionChannelValidator CreateValidator(ValidationMode validationMode)
+        {
+            return new ProductionChannelValidator(
+                _mockAzureDevOpsService.Object,
+                _mockBranchClassificationService.Object,
+                _mockLogger.Object,
+                validationMode);
+        }
+
+        private static ProductConstructionService.Client.Models.Build CreateTestBuild(
+            int id = 12345,
+            DateTimeOffset? dateProduced = null,
+            int staleness = 0,
+            bool released = false,
+            bool stable = false,
+            string commit = "abc123",
+            string azureDevOpsAccount = "dnceng",
+            string azureDevOpsProject = "internal",
+            int? azureDevOpsBuildId = 123456,
+            string azureDevOpsRepository = "https://dev.azure.com/dnceng/internal/_git/dotnet-runtime",
+            string azureDevOpsBranch = "refs/heads/main",
+            List<ProductConstructionService.Client.Models.Channel> channels = null,
+            List<ProductConstructionService.Client.Models.Asset> assets = null,
+            List<ProductConstructionService.Client.Models.BuildRef> dependencies = null,
+            List<ProductConstructionService.Client.Models.BuildIncoherence> incoherencies = null)
+        {
+            var build = new ProductConstructionService.Client.Models.Build(
+                id: id,
+                dateProduced: dateProduced ?? DateTimeOffset.UtcNow,
+                staleness: staleness,
+                released: released,
+                stable: stable,
+                commit: commit,
+                channels: channels ?? new List<ProductConstructionService.Client.Models.Channel>(),
+                assets: assets ?? new List<ProductConstructionService.Client.Models.Asset>(),
+                dependencies: dependencies ?? new List<ProductConstructionService.Client.Models.BuildRef>(),
+                incoherencies: incoherencies ?? new List<ProductConstructionService.Client.Models.BuildIncoherence>()
+            );
+
+            // Set the Azure DevOps properties using reflection since they might be read-only
+            // This is a test scenario, so it's acceptable to use reflection
+            build.AzureDevOpsAccount = azureDevOpsAccount;
+            build.AzureDevOpsProject = azureDevOpsProject;
+            build.AzureDevOpsBuildId = azureDevOpsBuildId;
+            build.AzureDevOpsRepository = azureDevOpsRepository;
+            build.AzureDevOpsBranch = azureDevOpsBranch;
+
+            return build;
+        }
+
+        private static TargetChannelConfig CreateProductionChannelConfig(int id = 1)
+        {
+            return new TargetChannelConfig(
+                id: id,
+                isInternal: false,
+                publishingInfraVersion: PublishingInfraVersion.Latest,
+                akaMSChannelNames: null,
+                akaMSCreateLinkPatterns: null,
+                akaMSDoNotCreateLinkPatterns: null,
+                targetFeeds: new TargetFeedSpecification[0],
+                symbolTargetType: SymbolPublishVisibility.None,
+                flatten: true,
+                isProduction: true);
+        }
+
+        private static TargetChannelConfig CreateNonProductionChannelConfig(int id = 2)
+        {
+            return new TargetChannelConfig(
+                id: id,
+                isInternal: false,
+                publishingInfraVersion: PublishingInfraVersion.Latest,
+                akaMSChannelNames: null,
+                akaMSCreateLinkPatterns: null,
+                akaMSDoNotCreateLinkPatterns: null,
+                targetFeeds: new TargetFeedSpecification[0],
+                symbolTargetType: SymbolPublishVisibility.None,
+                flatten: true,
+                isProduction: false);
+        }
+
+        [Theory]
+        [InlineData(ValidationMode.Enforce)]
+        [InlineData(ValidationMode.Audit)]
+        public async Task ValidateAsync_NullBuild_ThrowsArgumentNullException(ValidationMode validationMode)
+        {
+            // Arrange
+            var validator = CreateValidator(validationMode);
+            var targetChannel = CreateProductionChannelConfig();
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentNullException>(() => 
+                validator.ValidateAsync(null, targetChannel));
+        }
+
+        [Theory]
+        [InlineData(ValidationMode.Enforce)]
+        [InlineData(ValidationMode.Audit)]
+        public async Task ValidateAsync_NonProductionChannel_ReturnsSuccess(ValidationMode validationMode)
+        {
+            // Arrange
+            var validator = CreateValidator(validationMode);
+            var build = CreateTestBuild();
+            var targetChannel = CreateNonProductionChannelConfig();
+
+            // Act
+            var result = await validator.ValidateAsync(build, targetChannel);
+
+            // Assert
+            result.Should().Be(TargetChannelValidationResult.Success);
+            _mockAzureDevOpsService.Verify(x => x.GetBuildInfoAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()), Times.Never);
+            _mockBranchClassificationService.Verify(x => x.GetBranchClassificationsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Theory]
+        [InlineData(ValidationMode.Enforce)]
+        [InlineData(ValidationMode.Audit)]
+        public async Task ValidateAsync_ProductionChannel_ValidBuild_ReturnsSuccess(ValidationMode validationMode)
+        {
+            // Arrange
+            var validator = CreateValidator(validationMode);
+            var build = CreateTestBuild();
+            var targetChannel = CreateProductionChannelConfig();
+
+            _mockAzureDevOpsService
+                .Setup(x => x.GetBuildInfoAsync("dnceng", "internal", 123456))
+                .ReturnsAsync(new AzureDevOpsBuildInfo
+                {
+                    Project = new AzureDevOpsProject { Id = "project-guid-123", Name = "internal" },
+                    Repository = new AzureDevOpsRepository { Id = "repo-guid-456", Name = "dotnet-runtime" },
+                    Tags = new List<string> { "1ES.PT.Official", "other-tag" }
+                });
+
+            _mockBranchClassificationService
+                .Setup(x => x.GetBranchClassificationsAsync("dnceng", "project-guid-123", "repo-guid-456"))
+                .ReturnsAsync(new BranchClassificationResponse
+                {
+                    Status = "Success",
+                    BranchClassifications = new List<BranchClassification>
+                    {
+                        new BranchClassification { BranchName = "main", Classification = "production" },
+                        new BranchClassification { BranchName = "release/*", Classification = "production" }
+                    }
+                });
+
+            // Act
+            var result = await validator.ValidateAsync(build, targetChannel);
+
+            // Assert
+            result.Should().Be(TargetChannelValidationResult.Success);
+            _mockAzureDevOpsService.Verify(x => x.GetBuildInfoAsync("dnceng", "internal", 123456), Times.Once);
+            _mockBranchClassificationService.Verify(x => x.GetBranchClassificationsAsync("dnceng", "project-guid-123", "repo-guid-456"), Times.Once);
+        }
+
+        [Theory]
+        [InlineData(ValidationMode.Enforce, TargetChannelValidationResult.Fail)]
+        [InlineData(ValidationMode.Audit, TargetChannelValidationResult.AuditOnlyFailure)]
+        public async Task ValidateAsync_ProductionChannel_MissingRequiredTag_ReturnsExpectedResult(ValidationMode validationMode, TargetChannelValidationResult expectedResult)
+        {
+            // Arrange
+            var validator = CreateValidator(validationMode);
+            var build = CreateTestBuild();
+            var targetChannel = CreateProductionChannelConfig();
+
+            _mockAzureDevOpsService
+                .Setup(x => x.GetBuildInfoAsync("dnceng", "internal", 123456))
+                .ReturnsAsync(new AzureDevOpsBuildInfo
+                {
+                    Project = new AzureDevOpsProject { Id = "project-guid-123", Name = "internal" },
+                    Repository = new AzureDevOpsRepository { Id = "repo-guid-456", Name = "dotnet-runtime" },
+                    Tags = new List<string> { "other-tag", "another-tag" }
+                });
+
+            // Act
+            var result = await validator.ValidateAsync(build, targetChannel);
+
+            // Assert
+            result.Should().Be(expectedResult);
+            _mockAzureDevOpsService.Verify(x => x.GetBuildInfoAsync("dnceng", "internal", 123456), Times.Once);
+            _mockBranchClassificationService.Verify(x => x.GetBranchClassificationsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Theory]
+        [InlineData(ValidationMode.Enforce, TargetChannelValidationResult.Fail)]
+        [InlineData(ValidationMode.Audit, TargetChannelValidationResult.AuditOnlyFailure)]
+        public async Task ValidateAsync_ProductionChannel_NonProductionBranch_ReturnsExpectedResult(ValidationMode validationMode, TargetChannelValidationResult expectedResult)
+        {
+            // Arrange
+            var validator = CreateValidator(validationMode);
+            var build = CreateTestBuild(azureDevOpsBranch: "refs/heads/feature/test");
+            var targetChannel = CreateProductionChannelConfig();
+
+            _mockAzureDevOpsService
+                .Setup(x => x.GetBuildInfoAsync("dnceng", "internal", 123456))
+                .ReturnsAsync(new AzureDevOpsBuildInfo
+                {
+                    Project = new AzureDevOpsProject { Id = "project-guid-123", Name = "internal" },
+                    Repository = new AzureDevOpsRepository { Id = "repo-guid-456", Name = "dotnet-runtime" },
+                    Tags = new List<string> { "1ES.PT.Official" }
+                });
+
+            _mockBranchClassificationService
+                .Setup(x => x.GetBranchClassificationsAsync("dnceng", "project-guid-123", "repo-guid-456"))
+                .ReturnsAsync(new BranchClassificationResponse
+                {
+                    Status = "Success",
+                    BranchClassifications = new List<BranchClassification>
+                    {
+                        new BranchClassification { BranchName = "main", Classification = "production" },
+                        new BranchClassification { BranchName = "release/*", Classification = "production" }
+                    }
+                });
+
+            // Act
+            var result = await validator.ValidateAsync(build, targetChannel);
+
+            // Assert
+            result.Should().Be(expectedResult);
+        }
+
+        [Theory]
+        [InlineData(ValidationMode.Enforce, TargetChannelValidationResult.Fail)]
+        [InlineData(ValidationMode.Audit, TargetChannelValidationResult.AuditOnlyFailure)]
+        public async Task ValidateAsync_NonAzureDevOpsRepository_WithValidTags_ReturnsExpectedResult(ValidationMode validationMode, TargetChannelValidationResult expectedResult)
+        {
+            // Arrange
+            var validator = CreateValidator(validationMode);
+            var build = CreateTestBuild(
+                azureDevOpsRepository: "https://github.com/dotnet/runtime",
+                azureDevOpsAccount: "dnceng",
+                azureDevOpsProject: "internal",
+                azureDevOpsBuildId: 123456
+            );
+            var targetChannel = CreateProductionChannelConfig();
+
+            _mockAzureDevOpsService
+                .Setup(x => x.GetBuildInfoAsync("dnceng", "internal", 123456))
+                .ReturnsAsync(new AzureDevOpsBuildInfo
+                {
+                    Project = new AzureDevOpsProject { Id = "project-guid-123", Name = "internal" },
+                    Repository = new AzureDevOpsRepository { Id = "repo-guid-456", Name = "https://github.com/dotnet/runtime" },
+                    Tags = new List<string> { "1ES.PT.Official" }
+                });
+
+            // Act
+            var result = await validator.ValidateAsync(build, targetChannel);
+
+            // Assert
+            result.Should().Be(expectedResult);
+            _mockAzureDevOpsService.Verify(x => x.GetBuildInfoAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()), Times.Once);
+            _mockBranchClassificationService.Verify(x => x.GetBranchClassificationsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Theory]
+        [InlineData(ValidationMode.Enforce, TargetChannelValidationResult.Fail)]
+        [InlineData(ValidationMode.Audit, TargetChannelValidationResult.AuditOnlyFailure)]
+        public async Task ValidateAsync_ProductionChannel_MissingAzureDevOpsInfo_ReturnsExpectedResult(ValidationMode validationMode, TargetChannelValidationResult expectedResult)
+        {
+            // Arrange - Azure DevOps repository but missing Azure DevOps build metadata
+            var validator = CreateValidator(validationMode);
+            var build = CreateTestBuild(
+                azureDevOpsRepository: "https://dev.azure.com/dnceng/internal/_git/dotnet-runtime", // Azure DevOps repo
+                azureDevOpsAccount: null,    // But missing metadata
+                azureDevOpsProject: null,
+                azureDevOpsBuildId: null
+            );
+            var targetChannel = CreateProductionChannelConfig();
+
+            // Act
+            var result = await validator.ValidateAsync(build, targetChannel);
+
+            // Assert
+            result.Should().Be(expectedResult);
+            _mockAzureDevOpsService.Verify(x => x.GetBuildInfoAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()), Times.Never);
+        }
+
+        [Theory]
+        [InlineData(ValidationMode.Enforce, "main", "main", TargetChannelValidationResult.Success)]
+        [InlineData(ValidationMode.Enforce, "master", "master", TargetChannelValidationResult.Success)]
+        [InlineData(ValidationMode.Enforce, "release/6.0", "release/*", TargetChannelValidationResult.Success)]
+        [InlineData(ValidationMode.Enforce, "release/6.0.1", "release/*", TargetChannelValidationResult.Success)]
+        [InlineData(ValidationMode.Enforce, "main", "~default", TargetChannelValidationResult.Success)]
+        [InlineData(ValidationMode.Enforce, "master", "~default", TargetChannelValidationResult.Success)]
+        [InlineData(ValidationMode.Enforce, "feature/test", "main", TargetChannelValidationResult.Fail)]
+        [InlineData(ValidationMode.Enforce, "develop", "release/*", TargetChannelValidationResult.Fail)]
+        [InlineData(ValidationMode.Enforce, "feature/test", "~default", TargetChannelValidationResult.Fail)]
+        [InlineData(ValidationMode.Audit, "main", "main", TargetChannelValidationResult.Success)]
+        [InlineData(ValidationMode.Audit, "master", "master", TargetChannelValidationResult.Success)]
+        [InlineData(ValidationMode.Audit, "release/6.0", "release/*", TargetChannelValidationResult.Success)]
+        [InlineData(ValidationMode.Audit, "release/6.0.1", "release/*", TargetChannelValidationResult.Success)]
+        [InlineData(ValidationMode.Audit, "main", "~default", TargetChannelValidationResult.Success)]
+        [InlineData(ValidationMode.Audit, "master", "~default", TargetChannelValidationResult.Success)]
+        [InlineData(ValidationMode.Audit, "feature/test", "main", TargetChannelValidationResult.AuditOnlyFailure)]
+        [InlineData(ValidationMode.Audit, "develop", "release/*", TargetChannelValidationResult.AuditOnlyFailure)]
+        [InlineData(ValidationMode.Audit, "feature/test", "~default", TargetChannelValidationResult.AuditOnlyFailure)]
+        public async Task ValidateAsync_BranchPatternMatching_WorksCorrectly(ValidationMode validationMode, string branchName, string pattern, TargetChannelValidationResult expectedResult)
+        {
+            // Arrange
+            var validator = CreateValidator(validationMode);
+            var build = CreateTestBuild(azureDevOpsBranch: $"refs/heads/{branchName}");
+            var targetChannel = CreateProductionChannelConfig();
+
+            _mockAzureDevOpsService
+                .Setup(x => x.GetBuildInfoAsync("dnceng", "internal", 123456))
+                .ReturnsAsync(new AzureDevOpsBuildInfo
+                {
+                    Project = new AzureDevOpsProject { Id = "project-guid-123", Name = "internal" },
+                    Repository = new AzureDevOpsRepository { Id = "repo-guid-456", Name = "dotnet-runtime" },
+                    Tags = new List<string> { "1ES.PT.Official" }
+                });
+
+            _mockBranchClassificationService
+                .Setup(x => x.GetBranchClassificationsAsync("dnceng", "project-guid-123", "repo-guid-456"))
+                .ReturnsAsync(new BranchClassificationResponse
+                {
+                    Status = "Success",
+                    BranchClassifications = new List<BranchClassification>
+                    {
+                        new BranchClassification { BranchName = pattern, Classification = "production" }
+                    }
+                });
+
+            // Act
+            var result = await validator.ValidateAsync(build, targetChannel);
+
+            // Assert
+            result.Should().Be(expectedResult);
+        }
+
+        [Theory]
+        [InlineData(ValidationMode.Enforce, TargetChannelValidationResult.Fail)]
+        [InlineData(ValidationMode.Audit, TargetChannelValidationResult.AuditOnlyFailure)]
+        public async Task ValidateAsync_AzureDevOpsServiceThrows_ReturnsExpectedResult(ValidationMode validationMode, TargetChannelValidationResult expectedResult)
+        {
+            // Arrange
+            var validator = CreateValidator(validationMode);
+            var build = CreateTestBuild();
+            var targetChannel = CreateProductionChannelConfig();
+
+            _mockAzureDevOpsService
+                .Setup(x => x.GetBuildInfoAsync("dnceng", "internal", 123456))
+                .ThrowsAsync(new InvalidOperationException("API Error"));
+
+            // Act
+            var result = await validator.ValidateAsync(build, targetChannel);
+
+            // Assert
+            result.Should().Be(expectedResult);
+        }
+
+        [Theory]
+        [InlineData(ValidationMode.Enforce, TargetChannelValidationResult.Fail)]
+        [InlineData(ValidationMode.Audit, TargetChannelValidationResult.AuditOnlyFailure)]
+        public async Task ValidateAsync_BranchClassificationServiceThrows_ReturnsExpectedResult(ValidationMode validationMode, TargetChannelValidationResult expectedResult)
+        {
+            // Arrange
+            var validator = CreateValidator(validationMode);
+            var build = CreateTestBuild();
+            var targetChannel = CreateProductionChannelConfig();
+
+            _mockAzureDevOpsService
+                .Setup(x => x.GetBuildInfoAsync("dnceng", "internal", 123456))
+                .ReturnsAsync(new AzureDevOpsBuildInfo
+                {
+                    Project = new AzureDevOpsProject { Id = "project-guid-123", Name = "internal" },
+                    Repository = new AzureDevOpsRepository { Id = "repo-guid-456", Name = "dotnet-runtime" },
+                    Tags = new List<string> { "1ES.PT.Official" }
+                });
+
+            _mockBranchClassificationService
+                .Setup(x => x.GetBranchClassificationsAsync("dnceng", "project-guid-123", "repo-guid-456"))
+                .ThrowsAsync(new InvalidOperationException("API Error"));
+
+            // Act
+            var result = await validator.ValidateAsync(build, targetChannel);
+
+            // Assert
+            result.Should().Be(expectedResult);
+        }
+
+        [Theory]
+        [InlineData(ValidationMode.Enforce, LogLevel.Debug, LogLevel.Error)]
+        [InlineData(ValidationMode.Audit, LogLevel.Debug, LogLevel.Warning)]
+        public async Task ValidateAsync_BranchClassificationServiceThrows_LogsCorrectly(ValidationMode validationMode, LogLevel expectedDebugLevel, LogLevel expectedValidationLevel)
+        {
+            // Arrange
+            var validator = CreateValidator(validationMode);
+            var build = CreateTestBuild();
+            var targetChannel = CreateProductionChannelConfig();
+
+            _mockAzureDevOpsService
+                .Setup(x => x.GetBuildInfoAsync("dnceng", "internal", 123456))
+                .ReturnsAsync(new AzureDevOpsBuildInfo
+                {
+                    Project = new AzureDevOpsProject { Id = "project-guid-123", Name = "internal" },
+                    Repository = new AzureDevOpsRepository { Id = "repo-guid-456", Name = "dotnet-runtime" },
+                    Tags = new List<string> { "1ES.PT.Official" }
+                });
+
+            _mockBranchClassificationService
+                .Setup(x => x.GetBranchClassificationsAsync("dnceng", "project-guid-123", "repo-guid-456"))
+                .ThrowsAsync(new InvalidOperationException("API Error"));
+
+            // Act
+            await validator.ValidateAsync(build, targetChannel);
+
+            // Assert
+            // Verify that debug logging is called for branch classification failures
+            _mockLogger.Verify(
+                x => x.Log(
+                    expectedDebugLevel,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Failed to fetch branch classifications for build")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+            
+            // Verify that validation mode appropriate logging is called
+            _mockLogger.Verify(
+                x => x.Log(
+                    expectedValidationLevel,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Error validating branch classification for build")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+        }
+
+        [Theory]
+        [InlineData(ValidationMode.Enforce)]
+        [InlineData(ValidationMode.Audit)]
+        public async Task ValidateAsync_RepositoryUrlExtraction_WorksCorrectly(ValidationMode validationMode)
+        {
+            // Arrange
+            var validator = CreateValidator(validationMode);
+            var repositoryUrl = "https://dev.azure.com/dnceng/internal/_git/dotnet-runtime";
+            var expectedRepoId = "dotnet-runtime";
+
+            var build = CreateTestBuild(azureDevOpsRepository: repositoryUrl);
+            var targetChannel = CreateProductionChannelConfig();
+
+            _mockAzureDevOpsService
+                .Setup(x => x.GetBuildInfoAsync("dnceng", "internal", 123456))
+                .ReturnsAsync(new AzureDevOpsBuildInfo
+                {
+                    Project = new AzureDevOpsProject { Id = "project-guid-123", Name = "internal" },
+                    Repository = new AzureDevOpsRepository { Id = "repo-guid-456", Name = expectedRepoId },
+                    Tags = new List<string> { "1ES.PT.Official" }
+                });
+
+            _mockBranchClassificationService
+                .Setup(x => x.GetBranchClassificationsAsync("dnceng", "project-guid-123", "repo-guid-456"))
+                .ReturnsAsync(new BranchClassificationResponse
+                {
+                    Status = "Success",
+                    BranchClassifications = new List<BranchClassification>
+                    {
+                        new BranchClassification { BranchName = "main", Classification = "production" }
+                    }
+                });
+
+            // Act
+            var result = await validator.ValidateAsync(build, targetChannel);
+
+            // Assert
+            result.Should().Be(TargetChannelValidationResult.Success);
+        }
+
+        [Theory]
+        [InlineData("refs/heads/main", "main")]
+        [InlineData("refs/heads/release/6.0", "release/6.0")]
+        [InlineData("main", "main")]
+        [InlineData("release/6.0", "release/6.0")]
+        public async Task ValidateAsync_BranchNameNormalization_WorksCorrectly(string inputBranch, string expectedNormalizedBranch)
+        {
+            // Arrange
+            var enforceValidator = CreateValidator(ValidationMode.Enforce);
+            var auditValidator = CreateValidator(ValidationMode.Audit);
+            var build = CreateTestBuild(azureDevOpsBranch: inputBranch);
+            var targetChannel = CreateProductionChannelConfig();
+
+            _mockAzureDevOpsService
+                .Setup(x => x.GetBuildInfoAsync("dnceng", "internal", 123456))
+                .ReturnsAsync(new AzureDevOpsBuildInfo
+                {
+                    Project = new AzureDevOpsProject { Id = "project-guid-123", Name = "internal" },
+                    Repository = new AzureDevOpsRepository { Id = "repo-guid-456", Name = "dotnet-runtime" },
+                    Tags = new List<string> { "1ES.PT.Official" }
+                });
+
+            _mockBranchClassificationService
+                .Setup(x => x.GetBranchClassificationsAsync("dnceng", "project-guid-123", "repo-guid-456"))
+                .ReturnsAsync(new BranchClassificationResponse
+                {
+                    Status = "Success",
+                    BranchClassifications = new List<BranchClassification>
+                    {
+                        new BranchClassification { BranchName = expectedNormalizedBranch, Classification = "production" }
+                    }
+                });
+
+            // Act - Test both validators for successful case
+            var enforceResult = await enforceValidator.ValidateAsync(build, targetChannel);
+            var auditResult = await auditValidator.ValidateAsync(build, targetChannel);
+
+            // Assert
+            enforceResult.Should().Be(TargetChannelValidationResult.Success);
+            auditResult.Should().Be(TargetChannelValidationResult.Success);
+        }
+
+        [Theory]
+        [InlineData(ValidationMode.Enforce, TargetChannelValidationResult.Fail)]
+        [InlineData(ValidationMode.Audit, TargetChannelValidationResult.AuditOnlyFailure)]
+        public async Task ValidateAsync_EmptyBranchClassifications_ReturnsExpectedResult(ValidationMode validationMode, TargetChannelValidationResult expectedResult)
+        {
+            // Arrange
+            var validator = CreateValidator(validationMode);
+            var build = CreateTestBuild();
+            var targetChannel = CreateProductionChannelConfig();
+
+            _mockAzureDevOpsService
+                .Setup(x => x.GetBuildInfoAsync("dnceng", "internal", 123456))
+                .ReturnsAsync(new AzureDevOpsBuildInfo
+                {
+                    Project = new AzureDevOpsProject { Id = "project-guid-123", Name = "internal" },
+                    Repository = new AzureDevOpsRepository { Id = "repo-guid-456", Name = "dotnet-runtime" },
+                    Tags = new List<string> { "1ES.PT.Official" }
+                });
+
+            _mockBranchClassificationService
+                .Setup(x => x.GetBranchClassificationsAsync("dnceng", "project-guid-123", "repo-guid-456"))
+                .ReturnsAsync(new BranchClassificationResponse
+                {
+                    Status = "Success",
+                    BranchClassifications = new List<BranchClassification>()
+                });
+
+            // Act
+            var result = await validator.ValidateAsync(build, targetChannel);
+
+            // Assert
+            result.Should().Be(expectedResult);
+        }
+
+        [Theory]
+        [InlineData(ValidationMode.Enforce, TargetChannelValidationResult.Fail)]
+        [InlineData(ValidationMode.Audit, TargetChannelValidationResult.AuditOnlyFailure)]
+        public async Task ValidateAsync_NullBranchClassificationResponse_ReturnsExpectedResult(ValidationMode validationMode, TargetChannelValidationResult expectedResult)
+        {
+            // Arrange
+            var validator = CreateValidator(validationMode);
+            var build = CreateTestBuild();
+            var targetChannel = CreateProductionChannelConfig();
+
+            _mockAzureDevOpsService
+                .Setup(x => x.GetBuildInfoAsync("dnceng", "internal", 123456))
+                .ReturnsAsync(new AzureDevOpsBuildInfo
+                {
+                    Project = new AzureDevOpsProject { Id = "project-guid-123", Name = "internal" },
+                    Repository = new AzureDevOpsRepository { Id = "repo-guid-456", Name = "dotnet-runtime" },
+                    Tags = new List<string> { "1ES.PT.Official" }
+                });
+
+            _mockBranchClassificationService
+                .Setup(x => x.GetBranchClassificationsAsync("dnceng", "project-guid-123", "repo-guid-456"))
+                .ReturnsAsync((BranchClassificationResponse)null);
+
+            // Act
+            var result = await validator.ValidateAsync(build, targetChannel);
+
+            // Assert
+            result.Should().Be(expectedResult);
+        }
+
+        [Theory]
+        [InlineData(ValidationMode.Enforce, TargetChannelValidationResult.Fail)]
+        [InlineData(ValidationMode.Audit, TargetChannelValidationResult.AuditOnlyFailure)]
+        public async Task ValidateAsync_UnexpectedExceptionInValidation_ReturnsExpectedResult(ValidationMode validationMode, TargetChannelValidationResult expectedResult)
+        {
+            // Arrange
+            var validator = CreateValidator(validationMode);
+            var build = CreateTestBuild();
+            var targetChannel = CreateProductionChannelConfig();
+
+            // Mock the Azure DevOps service to throw when fetching build info
+            // This simulates an unexpected exception during validation
+            _mockAzureDevOpsService
+                .Setup(x => x.GetBuildInfoAsync("dnceng", "internal", 123456))
+                .ThrowsAsync(new HttpRequestException("Network error"));
+
+            // Act
+            var result = await validator.ValidateAsync(build, targetChannel);
+
+            // Assert
+            result.Should().Be(expectedResult);
+        }
+
+        [Fact]
+        public void AzureDevOpsService_GetBuildInfoAsync_CallsCorrectEndpoint()
+        {
+            // Arrange
+            var mockHttpClient = new Mock<HttpClient>();
+            var mockLogger = new Mock<ILogger<AzureDevOpsService>>();
+            var service = new AzureDevOpsService(mockHttpClient.Object, mockLogger.Object);
+
+            // Note: This test would need to be expanded with proper HttpClient mocking
+            // which is more complex. For now, we're just verifying the interface structure.
+            
+            // Act & Assert - Just verifying method signature exists
+            Assert.True(typeof(IProductionChannelValidatorBuildInfoService).GetMethod(nameof(IProductionChannelValidatorBuildInfoService.GetBuildInfoAsync)) != null);
+        }
+
+        [Fact]
+        public async Task ValidateAsync_ValidationMode_DefaultsToEnforce()
+        {
+            // Arrange - Create validator without specifying ValidationMode (should default to Enforce)
+            var defaultValidator = new ProductionChannelValidator(
+                _mockAzureDevOpsService.Object,
+                _mockBranchClassificationService.Object,
+                _mockLogger.Object);
+
+            var build = CreateTestBuild(azureDevOpsBranch: "refs/heads/feature/test");
+            var targetChannel = CreateProductionChannelConfig();
+
+            _mockAzureDevOpsService
+                .Setup(x => x.GetBuildInfoAsync("dnceng", "internal", 123456))
+                .ReturnsAsync(new AzureDevOpsBuildInfo
+                {
+                    Project = new AzureDevOpsProject { Id = "project-guid-123", Name = "internal" },
+                    Repository = new AzureDevOpsRepository { Id = "repo-guid-456", Name = "dotnet-runtime" },
+                    Tags = new List<string> { "1ES.PT.Official" }
+                });
+
+            _mockBranchClassificationService
+                .Setup(x => x.GetBranchClassificationsAsync("dnceng", "project-guid-123", "repo-guid-456"))
+                .ReturnsAsync(new BranchClassificationResponse
+                {
+                    Status = "Success",
+                    BranchClassifications = new List<BranchClassification>
+                    {
+                        new BranchClassification { BranchName = "main", Classification = "production" }
+                    }
+                });
+
+            // Act
+            var result = await defaultValidator.ValidateAsync(build, targetChannel);
+
+            // Assert - Default should be Enforce mode, so non-production branch should return Fail
+            result.Should().Be(TargetChannelValidationResult.Fail);
+        }
+
+        [Fact]
+        public void PublishArtifactsInManifest_EnforceProduction_DefaultsToFalse()
+        {
+            // Arrange & Act
+            var task = new PublishArtifactsInManifest();
+
+            // Assert
+            task.EnforceProduction.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void PublishArtifactsInManifest_EnforceProduction_AcceptsValidValues(bool enforceProduction)
+        {
+            // Arrange & Act
+            var task = new PublishArtifactsInManifest();
+            task.EnforceProduction = enforceProduction;
+
+            // Assert
+            task.EnforceProduction.Should().Be(enforceProduction);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -54,9 +54,11 @@
     <Compile Include="..\Common\Internal\EnumExtensions.cs" />
   </ItemGroup>
 
-  <!-- Task is not supported on Framework -->
+  <!-- Most tasks are not supported on NETFramework. Add only those that we need -->
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <Compile Remove="src\PublishBuildToMaestro.cs" />
+    <Compile Remove="@(Compile)" />
+    <Compile Include="src\PushToBuildStorage.cs" />
+    <Compile Include="src\common\NativeMethods.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/AssetPublisherFactory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/AssetPublisherFactory.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if !NET472_OR_GREATER
 using Azure;
 using System;
 using Microsoft.Build.Utilities;
@@ -53,4 +52,3 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         }
     }
 }
-#endif

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/AzureDevOpsNugetFeedAssetPublisher.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/AzureDevOpsNugetFeedAssetPublisher.cs
@@ -9,7 +9,6 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using Microsoft.Build.Utilities;
 using Microsoft.DotNet.Build.Tasks.Feed.Model;
-#if !NET472_OR_GREATER
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
@@ -94,9 +93,3 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         }
     }
 }
-#else
-public class AzureDevOpsNugetFeedAssetPublisher : Task
-{
-    public override bool Execute() => throw new NotSupportedException("AzureDevOpsNugetFeedAssetPublisher depends on ProductConstructionService.Client, which has discontinued support for desktop frameworks.");
-}
-#endif

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/AzureStorageAssetPublisher.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/AzureStorageAssetPublisher.cs
@@ -7,14 +7,11 @@ using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Microsoft.Build.Utilities;
 using Microsoft.DotNet.Build.CloudTestTasks;
-#if !NET472_OR_GREATER
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
-#endif
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.DotNet.Build.Tasks.Feed
 {
-#if !NET472_OR_GREATER
     public abstract class AzureStorageAssetPublisher : IAssetPublisher
     {
         private readonly TaskLoggingHelper _log;
@@ -67,19 +64,4 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             }
         }
     }
-#else
-    public abstract class AzureStorageAssetPublisher : IAssetPublisher
-    {
-        private readonly TaskLoggingHelper _log;
-
-        protected AzureStorageAssetPublisher(TaskLoggingHelper log)
-        {
-            _log = log;
-        }
-
-        public abstract BlobClient CreateBlobClient(string blobPath);
-
-        public Task PublishAssetAsync(string file, string blobPath, PushOptions options, SemaphoreSlim clientThrottle = null) => throw new NotImplementedException();
-    }
-#endif
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/IAssetPublisher.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/IAssetPublisher.cs
@@ -2,18 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading;
-#if !NET472_OR_GREATER
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
-#endif
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.DotNet.Build.Tasks.Feed
 {
     public interface IAssetPublisher
     {
-#if !NET472_OR_GREATER
         LocationType LocationType { get; }
-#endif
 
         Task PublishAssetAsync(string file, string blobPath, PushOptions options, SemaphoreSlim clientThrottle = null);
     }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/ITargetChannelValidator.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/ITargetChannelValidator.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Microsoft.DotNet.Build.Tasks.Feed.Model;
+
+namespace Microsoft.DotNet.Build.Tasks.Feed
+{
+    public enum TargetChannelValidationResult
+    {
+        Success,
+        AuditOnlyFailure,
+        Fail
+    }
+
+    public enum ValidationMode
+    {
+        /// <summary>
+        /// In audit mode, validation failures are reported as AuditOnlyFailure instead of Fail.
+        /// This allows builds to be published but with warnings about validation issues.
+        /// </summary>
+        Audit,
+        
+        /// <summary>
+        /// In enforce mode, validation failures are reported as Fail, preventing builds from being published.
+        /// </summary>
+        Enforce
+    }
+
+    /// <summary>
+    /// Interface for validating whether a build can be published to production channels.
+    /// </summary>
+    public interface ITargetChannelValidator
+    {
+        /// <summary>
+        /// Validates whether the build can be published to the specified target channel.
+        /// </summary>
+        /// <param name="build">The build information from BAR</param>
+        /// <param name="targetChannel">The target channel the build will be published to</param>
+        /// <returns>ValidationResult indicating the outcome of the validation</returns>
+        Task<TargetChannelValidationResult> ValidateAsync(ProductConstructionService.Client.Models.Build build, TargetChannelConfig targetChannel);
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/ProductionChannelValidator.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/ProductionChannelValidator.cs
@@ -1,0 +1,477 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Build.Tasks.Feed.Model;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.Build.Tasks.Feed
+{
+    public class ProductionChannelValidator : ITargetChannelValidator
+    {
+        private const string RequiredAzureDevOpsTag = "1ES.PT.Official";
+        
+        private readonly IProductionChannelValidatorBuildInfoService _productionChannelValidatorBuildInfoService;
+        private readonly IBranchClassificationService _branchClassificationService;
+        private readonly ILogger<ProductionChannelValidator> _logger;
+        private readonly ValidationMode _validationMode;
+
+        public ProductionChannelValidator(
+            IProductionChannelValidatorBuildInfoService productionChannelValidatorBuildInfoService,
+            IBranchClassificationService branchClassificationService,
+            ILogger<ProductionChannelValidator> logger,
+            ValidationMode validationMode = ValidationMode.Enforce)
+        {
+            _productionChannelValidatorBuildInfoService = productionChannelValidatorBuildInfoService ?? throw new ArgumentNullException(nameof(productionChannelValidatorBuildInfoService));
+            _branchClassificationService = branchClassificationService ?? throw new ArgumentNullException(nameof(branchClassificationService));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _validationMode = validationMode;
+        }
+
+        public async Task<TargetChannelValidationResult> ValidateAsync(ProductConstructionService.Client.Models.Build build, TargetChannelConfig targetChannel)
+        {
+            if (build == null)
+            {
+                throw new ArgumentNullException(nameof(build));
+            }
+
+            // If the target channel is not a production channel, no validation is needed
+            if (!targetChannel.IsProduction)
+            {
+                _logger.LogInformation($"Target channel {targetChannel.Id} is not a production channel, skipping validation");
+                return TargetChannelValidationResult.Success;
+            }
+
+            _logger.LogInformation($"Validating build {build.Id} for production channel {targetChannel.Id}");
+
+            try
+            {
+                // Get build information from Azure DevOps which includes tags, project, and repository info
+                var buildInfo = await GetAzureDevOpsBuildInfoAsync(build);
+                if (buildInfo == null)
+                {
+                    return ApplyValidationMode(TargetChannelValidationResult.Fail);
+                }
+
+                // Step 1: Validate Azure DevOps build has the required tag - always return Fail if tags don't validate
+                var tagValidationResult = ValidateAzureDevOpsTags(build, buildInfo.Tags);
+                if (tagValidationResult != TargetChannelValidationResult.Success)
+                {
+                    return ApplyValidationMode(tagValidationResult);  // This will be Fail for missing/invalid tags
+                }
+
+                // Step 2: Now that tags are validated, check if this is an Azure DevOps repository
+                if (!IsAzureDevOpsRepository(build.AzureDevOpsRepository))
+                {
+                    LogValidationFailure($"Build {build.Id} repository '{build.AzureDevOpsRepository}' is not an Azure DevOps repository.");
+                    return ApplyValidationMode(TargetChannelValidationResult.Fail);
+                }
+
+                // Step 3: Validate that the branch is a production branch
+                var branchValidationResult = await ValidateBranchIsProductionAsync(build, buildInfo);
+                if (branchValidationResult != TargetChannelValidationResult.Success)
+                {
+                    return ApplyValidationMode(branchValidationResult);
+                }
+
+                _logger.LogInformation($"Build {build.Id} passed all production channel validations");
+                return TargetChannelValidationResult.Success;
+            }
+            catch (Exception ex)
+            {
+                LogValidationFailure(ex, $"Error validating build {build.Id} for production channel {targetChannel.Id}");
+                return ApplyValidationMode(TargetChannelValidationResult.Fail);
+            }
+        }
+
+        /// <summary>
+        /// Applies the validation mode to convert Fail results to AuditOnlyFailure when in Audit mode
+        /// </summary>
+        private TargetChannelValidationResult ApplyValidationMode(TargetChannelValidationResult result)
+        {
+            if (_validationMode == ValidationMode.Audit && result == TargetChannelValidationResult.Fail)
+            {
+                return TargetChannelValidationResult.AuditOnlyFailure;
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Logs a validation failure message based on the current validation mode.
+        /// In Audit mode, logs as a warning. In Enforce mode, logs as an error.
+        /// </summary>
+        private void LogValidationFailure(string message)
+        {
+            if (_validationMode == ValidationMode.Audit)
+            {
+                _logger.LogWarning(message);
+            }
+            else
+            {
+                _logger.LogError(message);
+            }
+        }
+
+        /// <summary>
+        /// Logs a validation failure message with exception based on the current validation mode.
+        /// In Audit mode, logs as a warning. In Enforce mode, logs as an error.
+        /// </summary>
+        private void LogValidationFailure(Exception exception, string message)
+        {
+            if (_validationMode == ValidationMode.Audit)
+            {
+                _logger.LogWarning(exception, message);
+            }
+            else
+            {
+                _logger.LogError(exception, message);
+            }
+        }
+
+        private static bool IsAzureDevOpsRepository(string repositoryUrl)
+        {
+            if (string.IsNullOrEmpty(repositoryUrl))
+                return false;
+
+            return repositoryUrl.Contains("dev.azure.com", StringComparison.OrdinalIgnoreCase) ||
+                   repositoryUrl.Contains("visualstudio.com", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private async Task<AzureDevOpsBuildInfo> GetAzureDevOpsBuildInfoAsync(ProductConstructionService.Client.Models.Build build)
+        {
+            // Extract Azure DevOps information from build
+            var azureDevOpsAccount = build.AzureDevOpsAccount;
+            var azureDevOpsProject = build.AzureDevOpsProject;
+            var azureDevOpsBuildId = build.AzureDevOpsBuildId;
+
+            if (string.IsNullOrEmpty(azureDevOpsAccount) || 
+                string.IsNullOrEmpty(azureDevOpsProject) || 
+                !azureDevOpsBuildId.HasValue)
+            {
+                LogValidationFailure($"Build {build.Id} missing Azure DevOps information for validation");
+                return null;
+            }
+
+            // Don't catch exceptions here - let them bubble up to the main catch block
+            // which will treat service communication failures as AuditOnlyFailure
+            return await _productionChannelValidatorBuildInfoService.GetBuildInfoAsync(azureDevOpsAccount, azureDevOpsProject, azureDevOpsBuildId.Value);
+        }
+
+        private TargetChannelValidationResult ValidateAzureDevOpsTags(ProductConstructionService.Client.Models.Build build, IReadOnlyList<string> tags)
+        {
+            try
+            {
+                _logger.LogDebug($"Validating Azure DevOps tags for build {build.Id}");
+
+                if (tags == null)
+                {
+                    LogValidationFailure($"Build {build.Id} has no tag information available");
+                    return TargetChannelValidationResult.Fail;
+                }
+
+                bool hasRequiredTag = tags.Contains(RequiredAzureDevOpsTag, StringComparer.OrdinalIgnoreCase);
+                
+                if (hasRequiredTag)
+                {
+                    _logger.LogDebug($"Build {build.Id} has required tag '{RequiredAzureDevOpsTag}'");
+                    return TargetChannelValidationResult.Success;
+                }
+                else
+                {
+                    LogValidationFailure($"Build {build.Id} does not have required tag '{RequiredAzureDevOpsTag}'. Found tags: {string.Join(", ", tags)}");
+                    return TargetChannelValidationResult.Fail;
+                }
+            }
+            catch (Exception ex)
+            {
+                LogValidationFailure(ex, $"Error validating Azure DevOps tags for build {build.Id}");
+                return TargetChannelValidationResult.Fail;
+            }
+        }
+
+        private async Task<TargetChannelValidationResult> ValidateBranchIsProductionAsync(ProductConstructionService.Client.Models.Build build, AzureDevOpsBuildInfo buildInfo)
+        {
+            // Extract repository and branch information
+            var azureDevOpsAccount = build.AzureDevOpsAccount;
+            var azureDevOpsBranch = build.AzureDevOpsBranch;
+
+            if (string.IsNullOrEmpty(azureDevOpsAccount) ||
+                string.IsNullOrEmpty(azureDevOpsBranch))
+            {
+                LogValidationFailure($"Build {build.Id} missing repository information for branch validation");
+                return TargetChannelValidationResult.Fail;
+            }
+
+            string projectId = buildInfo?.Project?.Id;
+            string repositoryId = buildInfo?.Repository?.Id;
+
+            if (string.IsNullOrEmpty(projectId))
+            {
+                LogValidationFailure($"Build {build.Id}: Could not find project GUID from build info");
+                return TargetChannelValidationResult.Fail;
+            }
+
+            if (string.IsNullOrEmpty(repositoryId))
+            {
+                LogValidationFailure($"Build {build.Id}: Could not find repository GUID from build info");
+                return TargetChannelValidationResult.Fail;
+            }
+
+            // Normalize branch name (remove refs/heads/ prefix if present)
+            var branchName = NormalizeBranchName(azureDevOpsBranch);
+
+            _logger.LogDebug($"Checking branch classification for {azureDevOpsAccount}/{projectId}/{repositoryId}, branch: {branchName}");
+
+            try
+            {
+                var branchClassifications = await _branchClassificationService.GetBranchClassificationsAsync(
+                    azureDevOpsAccount, projectId, repositoryId);
+
+                bool isProductionBranch = IsProductionBranch(branchName, branchClassifications);
+
+                if (isProductionBranch)
+                {
+                    _logger.LogDebug($"Branch '{branchName}' is classified as a production branch");
+                    return TargetChannelValidationResult.Success;
+                }
+                else
+                {
+                    LogValidationFailure($"Branch '{branchName}' is not classified as a production branch");
+                    return TargetChannelValidationResult.Fail;
+                }
+            }
+            catch (Exception ex)
+            {
+                // For branch classification service failures, always log as debug first
+                _logger.LogDebug(ex, $"Failed to fetch branch classifications for build {build.Id}");
+                
+                // Then apply validation mode specific logging
+                LogValidationFailure(ex, $"Error validating branch classification for build {build.Id}");
+                return TargetChannelValidationResult.Fail;
+            }
+        }
+
+        private static string NormalizeBranchName(string branchName)
+        {
+            if (string.IsNullOrEmpty(branchName))
+                return branchName;
+
+            // Remove refs/heads/ prefix if present
+            if (branchName.StartsWith("refs/heads/", StringComparison.OrdinalIgnoreCase))
+            {
+                return branchName.Substring("refs/heads/".Length);
+            }
+
+            return branchName;
+        }
+
+        private static bool IsProductionBranch(string branchName, BranchClassificationResponse branchClassifications)
+        {
+            if (branchClassifications?.BranchClassifications == null)
+                return false;
+
+            foreach (var classification in branchClassifications.BranchClassifications)
+            {
+                if (classification.Classification.Equals("production", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (MatchesBranchPattern(branchName, classification.BranchName))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static bool MatchesBranchPattern(string branchName, string pattern)
+        {
+            if (string.IsNullOrEmpty(branchName) || string.IsNullOrEmpty(pattern))
+                return false;
+
+            // Handle exact match
+            if (pattern.Equals(branchName, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            // Handle wildcard patterns (e.g., "release/*")
+            if (pattern.EndsWith("/*"))
+            {
+                var prefix = pattern.Substring(0, pattern.Length - 2);
+                return branchName.StartsWith(prefix + "/", StringComparison.OrdinalIgnoreCase);
+            }
+
+            // Handle special ~default pattern
+            if (pattern.Equals("~default", StringComparison.OrdinalIgnoreCase))
+            {
+                // This would require additional logic to determine the default branch
+                // For now, treat common default branch names as matching
+                return branchName.Equals("main", StringComparison.OrdinalIgnoreCase) ||
+                       branchName.Equals("master", StringComparison.OrdinalIgnoreCase);
+            }
+
+            return false;
+        }
+    }
+
+    // Interface definitions for dependency injection and testability
+    public interface IProductionChannelValidatorBuildInfoService
+    {
+        Task<AzureDevOpsBuildInfo> GetBuildInfoAsync(string account, string project, int buildId);
+    }
+
+    public interface IBranchClassificationService
+    {
+        Task<BranchClassificationResponse> GetBranchClassificationsAsync(string organizationName, string projectId, string repositoryId);
+    }
+
+    // Response models for Azure DevOps API
+    public class AzureDevOpsBuildInfo
+    {
+        public AzureDevOpsProject Project { get; set; }
+        public AzureDevOpsRepository Repository { get; set; }
+        public IReadOnlyList<string> Tags { get; set; }
+    }
+
+    public class AzureDevOpsProject
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class AzureDevOpsRepository
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    // Response models for the branch classification API
+    public class BranchClassificationResponse
+    {
+        public IReadOnlyList<BranchClassification> BranchClassifications { get; set; }
+        public string Status { get; set; }
+    }
+
+    public class BranchClassification
+    {
+        public string BranchName { get; set; }
+        public string Classification { get; set; }
+    }
+
+    // Implementation classes
+    public class AzureDevOpsService : IProductionChannelValidatorBuildInfoService
+    {
+        private readonly HttpClient _httpClient;
+        private readonly ILogger<AzureDevOpsService> _logger;
+        private readonly string _token;
+
+        public AzureDevOpsService(HttpClient httpClient, ILogger<AzureDevOpsService> logger, string token = null)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _token = token;
+            
+            // Configure authentication for Azure DevOps API using Basic authentication
+            if (!string.IsNullOrEmpty(_token))
+            {
+                _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+                    "Basic",
+                    Convert.ToBase64String(Encoding.ASCII.GetBytes($":{_token}")));
+            }
+        }
+
+        public async Task<AzureDevOpsBuildInfo> GetBuildInfoAsync(string account, string project, int buildId)
+        {
+            try
+            {
+                var url = $"https://dev.azure.com/{account}/{project}/_apis/build/builds/{buildId}?api-version=6.0";
+                _logger.LogDebug($"Fetching build info from: {url}");
+
+                var response = await _httpClient.GetAsync(url);
+                response.EnsureSuccessStatusCode();
+
+                var content = await response.Content.ReadAsStringAsync();
+                var buildResponse = JsonSerializer.Deserialize<AzureDevOpsBuildInfoResponse>(content, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                });
+
+                return new AzureDevOpsBuildInfo
+                {
+                    Project = buildResponse?.Project,
+                    Repository = buildResponse?.Repository,
+                    Tags = buildResponse?.Tags ?? new List<string>()
+                };
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, $"Error fetching build info for {account}/{project}/{buildId}");
+                throw;
+            }
+        }
+
+        private class AzureDevOpsBuildInfoResponse
+        {
+            public AzureDevOpsProject Project { get; set; }
+            public AzureDevOpsRepository Repository { get; set; }
+            public List<string> Tags { get; set; }
+        }
+    }
+
+    public class BranchClassificationService : IBranchClassificationService
+    {
+        private readonly HttpClient _httpClient;
+        private readonly ILogger<BranchClassificationService> _logger;
+        private readonly string _token;
+
+        public BranchClassificationService(HttpClient httpClient, ILogger<BranchClassificationService> logger, string token = null)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _token = token;
+        }
+
+        public async Task<BranchClassificationResponse> GetBranchClassificationsAsync(string organizationName, string projectId, string repositoryId)
+        {
+            try
+            {
+                var url = string.Format(CultureInfo.InvariantCulture, 
+                    "https://BranchClassification.app.prod.gitops.startclean.microsoft.com/api/getBranchClassifications/{0}/{1}/{2}", 
+                    organizationName, projectId, repositoryId);
+                _logger.LogDebug($"Fetching branch classifications from: {url}");
+
+                using var request = new HttpRequestMessage(HttpMethod.Get, url);
+                
+                // Add Bearer token authentication for branch classification service
+                if (!string.IsNullOrEmpty(_token))
+                {
+                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+                }
+
+                var response = await _httpClient.SendAsync(request);
+                response.EnsureSuccessStatusCode();
+
+                var content = await response.Content.ReadAsStringAsync();
+                var classification = JsonSerializer.Deserialize<BranchClassificationResponse>(content, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                });
+
+                return classification;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, $"Error fetching branch classifications for {organizationName}/{projectId}/{repositoryId}");
+                throw;
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs
@@ -5,13 +5,14 @@ using Microsoft.Arcade.Common;
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.Tasks.Feed.Model;
 using Microsoft.DotNet.Build.Manifest;
-#if !NET472_OR_GREATER
 using Microsoft.DotNet.ProductConstructionService.Client;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using System;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
@@ -213,8 +214,17 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public int NonStreamingPublishingMaxClients {get; set;}
 
+        /// <summary>
+        /// Whether to enforce production channel validation rules.
+        /// If true, validation failures prevent builds from being published (Fail).
+        /// If false, validation failures are reported as warnings but builds are allowed to be published (AuditOnlyFailure).
+        /// Default: false (audit mode)
+        /// </summary>
+        public bool EnforceProduction { get; set; } = false;
+
         private IBuildModelFactory _buildModelFactory;
         private IFileSystem _fileSystem;
+        private ITargetChannelValidator _targetChannelValidator;
 
         private PublishingConstants.BuildQuality _buildQuality;
 
@@ -227,14 +237,53 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             collection.TryAddSingleton<INupkgInfoFactory, NupkgInfoFactory>();
             collection.TryAddSingleton<IPackageArchiveReaderFactory, PackageArchiveReaderFactory>();
             collection.TryAddSingleton<IFileSystem, FileSystem>();
+            
+            // Register ProductionChannelValidator with the specified validation mode
+            collection.TryAddSingleton<ITargetChannelValidator>(provider =>
+            {
+                var buildInfoService = provider.GetRequiredService<IProductionChannelValidatorBuildInfoService>();
+                var branchClassificationService = provider.GetRequiredService<IBranchClassificationService>();
+                var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
+                var logger = loggerFactory.CreateLogger<ProductionChannelValidator>();
+                
+                // Convert EnforceProduction boolean to ValidationMode enum
+                var validationMode = EnforceProduction ? ValidationMode.Enforce : ValidationMode.Audit;
+                
+                return new ProductionChannelValidator(buildInfoService, branchClassificationService, logger, validationMode);
+            });
+            
+            // Add logging services
+            collection.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Debug));
+            
+            // Register AzureDevOpsService with proper authentication
+            collection.TryAddSingleton<IProductionChannelValidatorBuildInfoService>(provider =>
+            {
+                var httpClient = provider.GetRequiredService<HttpClient>();
+                var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
+                var logger = loggerFactory.CreateLogger<AzureDevOpsService>();
+                return new AzureDevOpsService(httpClient, logger, AzdoApiToken);
+            });
+            
+            // Register BranchClassificationService with proper authentication
+            collection.TryAddSingleton<IBranchClassificationService>(provider =>
+            {
+                var httpClient = provider.GetRequiredService<HttpClient>();
+                var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
+                var logger = loggerFactory.CreateLogger<BranchClassificationService>();
+                return new BranchClassificationService(httpClient, logger, AzdoApiToken);
+            });
+            
+            collection.TryAddSingleton<HttpClient>();
             collection.TryAddSingleton(Log);
         }
 
         public bool ExecuteTask(IBuildModelFactory buildModelFactory,
-            IFileSystem fileSystem)
+            IFileSystem fileSystem,
+            ITargetChannelValidator targetChannelValidator)
         {
             _buildModelFactory = buildModelFactory;
             _fileSystem = fileSystem;
+            _targetChannelValidator = targetChannelValidator;
 
             return ExecuteAsync().GetAwaiter().GetResult();
         }
@@ -358,7 +407,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 SymbolPublishingExclusionsFile = this.SymbolPublishingExclusionsFile,
                 PublishSpecialClrFiles = this.PublishSpecialClrFiles,
                 BuildQuality = this.BuildQuality,
-                ArtifactsBasePath =  this.ArtifactsBasePath,
+                ArtifactsBasePath = this.ArtifactsBasePath,
                 AzdoApiToken = this.AzdoApiToken,
                 BuildId = this.BuildId,
                 AzureDevOpsProject = this.AzureProject,
@@ -368,7 +417,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 SymbolRequestProject = this.SymbolRequestProject,
                 UseStreamingPublishing = this.UseStreamingPublishing,
                 StreamingPublishingMaxClients = this.StreamingPublishingMaxClients,
-                NonStreamingPublishingMaxClients = this.NonStreamingPublishingMaxClients
+                NonStreamingPublishingMaxClients = this.NonStreamingPublishingMaxClients,
+                EnforceProduction = this.EnforceProduction,
+                TargetChannelValidator = _targetChannelValidator
             };
         }
 
@@ -416,14 +467,10 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 SymbolRequestProject = this.SymbolRequestProject,
                 UseStreamingPublishing = this.UseStreamingPublishing,
                 StreamingPublishingMaxClients = this.StreamingPublishingMaxClients,
-                NonStreamingPublishingMaxClients = this.NonStreamingPublishingMaxClients
+                NonStreamingPublishingMaxClients = this.NonStreamingPublishingMaxClients,
+                EnforceProduction = this.EnforceProduction,
+                TargetChannelValidator = _targetChannelValidator
             };
         }
     }
 }
-#else
-public class PublishArtifactsInManifest : Microsoft.Build.Utilities.Task
-{
-    public override bool Execute() => throw new System.NotSupportedException("PublishArtifactsInManifest depends on ProductConstructionService.Client, which has discontinued support for desktop frameworks.");
-}
-#endif

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV3.cs
@@ -11,7 +11,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.Tasks.Feed.Model;
-#if !NET472_OR_GREATER
 using Microsoft.DotNet.ProductConstructionService.Client;
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
 using Microsoft.DotNet.Build.Manifest;
@@ -126,6 +125,13 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         return false;
                     }
 
+                    // Validate that the channel can be be used for this build
+                    if (!await ValidateTargetChannelAsync(buildInformation, targetChannelConfig))
+                    {
+                        Log.LogError($"Channel with ID '{targetChannelId}' is not valid for this build.");
+                        return false;
+                    }
+
                     Log.LogMessage(MessageImportance.High, $"Publishing to this target channel: {targetChannelConfig}");
 
                     List<string> shortLinkUrls = new List<string>();
@@ -229,9 +235,3 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         }
     }
 }
-#else
-public class PublishArtifactsInManifestV3 : Microsoft.Build.Utilities.Task
-{
-    public override bool Execute() => throw new NotSupportedException("PublishArtifactsInManifestV3 depends on ProductConstructionService.Client, which has discontinued support for desktop frameworks.");
-}
-#endif

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV4.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestV4.cs
@@ -11,7 +11,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.Tasks.Feed.Model;
-#if !NET472_OR_GREATER
 using Microsoft.DotNet.ProductConstructionService.Client;
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
 using Microsoft.DotNet.Build.Manifest;
@@ -119,6 +118,13 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     if (await client.Channels.GetChannelAsync(targetChannelId) == null)
                     {
                         Log.LogError($"Channel with ID '{targetChannelId}' does not exist in BAR.");
+                        return false;
+                    }
+
+                    // Validate that the channel can be be used for this build
+                    if (!await ValidateTargetChannelAsync(buildInformation, targetChannelConfig))
+                    {
+                        Log.LogError($"Channel with ID '{targetChannelId}' is not valid for this build.");
                         return false;
                     }
 
@@ -239,9 +245,3 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         }
     }
 }
-#else
-public class PublishArtifactsInManifestV4 : Microsoft.Build.Utilities.Task
-{
-    public override bool Execute() => throw new NotSupportedException("PublishArtifactsInManifestV4 depends on ProductConstructionService.Client, which has discontinued support for desktop frameworks.");
-}
-#endif

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/TaskTracer.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/TaskTracer.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if NET
 using Microsoft.Build.Framework;
 using MsBuildUtils = Microsoft.Build.Utilities;
 
@@ -68,4 +67,3 @@ sealed internal class TaskTracer : Microsoft.SymbolStore.ITracer
         _log.LogMessage(_verbose ? MessageImportance.Normal : MessageImportance.Low, format, arguments);
     }
 }
-#endif

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AssetComparer.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/common/AssetComparer.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if !NET472_OR_GREATER
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
 using System.Collections.Generic;
 
@@ -39,4 +38,3 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         }
     }
 }
-#endif

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
@@ -80,7 +80,13 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
         public const string FeedStagingInternalForInstallers = "https://dotnetbuilds.blob.core.windows.net/internal";
         public const string FeedStagingInternalForChecksums = "https://dotnetbuilds.blob.core.windows.net/internal-checksums";
 
-        private const string FeedGeneralTesting = "https://pkgs.dev.azure.com/dnceng/public/_packaging/general-testing/nuget/v3/index.json";
+        public const string FeedDevForInstallers = "https://dotnetbuilds.blob.core.windows.net/dev";
+        public const string FeedDevForChecksums = "https://dotnetbuilds.blob.core.windows.net/dev-checksums";
+
+        public const string FeedDevInternalForInstallers = "https://dotnetbuilds.blob.core.windows.net/dev-internal";
+        public const string FeedDevInternalForChecksums = "https://dotnetbuilds.blob.core.windows.net/dev-internal-checksums";
+
+        private const string FeedDev = "https://pkgs.dev.azure.com/dnceng/public/_packaging/general-testing/nuget/v3/index.json";
 
         private const string FeedDotNetExperimental = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json";
 
@@ -145,22 +151,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
         {
             (Packages, FeedDotNet6InternalShipping, AssetSelection.ShippingOnly),
             (Packages, FeedDotNet6InternalTransport, AssetSelection.NonShippingOnly),
-            (InstallersAndSymbols, FeedStagingInternalForInstallers),
-            (TargetFeedContentType.Checksum, FeedStagingInternalForChecksums),
-        };
-
-        private static TargetFeedSpecification[] DotNet7Feeds =
-        {
-            (Packages, FeedDotNet7Shipping, AssetSelection.ShippingOnly),
-            (Packages, FeedDotNet7Transport, AssetSelection.NonShippingOnly),
-            (InstallersAndSymbols, FeedStagingForInstallers),
-            (TargetFeedContentType.Checksum, FeedStagingForChecksums),
-        };
-
-        private static TargetFeedSpecification[] DotNet7InternalFeeds =
-        {
-            (Packages, FeedDotNet7InternalShipping, AssetSelection.ShippingOnly),
-            (Packages, FeedDotNet7InternalTransport, AssetSelection.NonShippingOnly),
             (InstallersAndSymbols, FeedStagingInternalForInstallers),
             (TargetFeedContentType.Checksum, FeedStagingInternalForChecksums),
         };
@@ -303,8 +293,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
 
         private static TargetFeedSpecification[] GeneralTestingFeeds =
         {
-            (Packages, FeedGeneralTesting, AssetSelection.ShippingOnly),
-            (Packages, FeedGeneralTesting, AssetSelection.NonShippingOnly),
+            (Packages, FeedDev, AssetSelection.ShippingOnly),
+            (Packages, FeedDev, AssetSelection.NonShippingOnly),
             (InstallersAndSymbols, FeedStagingForInstallers),
             (TargetFeedContentType.Checksum, FeedStagingForChecksums),
         };
@@ -1305,7 +1295,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
                 akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
                 targetFeeds: GeneralTestingFeeds,
-                symbolTargetType: SymbolPublishVisibility.Public),
+                symbolTargetType: SymbolPublishVisibility.Public,
+                isProduction: false),
 
             // General Testing Internal,
             new TargetChannelConfig(
@@ -1316,7 +1307,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
                 akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
                 targetFeeds: GeneralTestingInternalFeeds,
-                symbolTargetType: SymbolPublishVisibility.Internal),
+                symbolTargetType: SymbolPublishVisibility.Internal,
+                isProduction: false),
 
             // VS 16.6,
             new TargetChannelConfig(

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetChannelConfig.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/TargetChannelConfig.cs
@@ -47,6 +47,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
 
         public bool IsInternal { get; }
 
+        /// <summary>
+        /// Whether this channel is a production channel vs. a non-production channel.
+        /// Non-production channels are typically used for testing purposes.
+        /// </summary>
+        public bool IsProduction { get; }
+
         public bool Flatten { get; }
 
         public TargetChannelConfig(
@@ -58,7 +64,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
             ImmutableList<Regex> akaMSDoNotCreateLinkPatterns,
             IEnumerable<TargetFeedSpecification> targetFeeds,
             SymbolPublishVisibility symbolTargetType,
-            bool flatten = true)
+            bool flatten = true,
+            bool isProduction = true)
         {
 
             Id = id;
@@ -68,6 +75,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
             TargetFeeds = targetFeeds.ToImmutableList();
             SymbolTargetType = symbolTargetType;
             Flatten = flatten;
+            IsProduction = isProduction;
             AkaMSCreateLinkPatterns = akaMSCreateLinkPatterns ?? ImmutableList<Regex>.Empty;
             AkaMSDoNotCreateLinkPatterns = akaMSDoNotCreateLinkPatterns ?? ImmutableList<Regex>.Empty;
         }
@@ -84,6 +92,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 $"\n  {string.Join("\n  ", TargetFeeds.Select(f => $"{string.Join(", ", f.ContentTypes)} -> {f.FeedUrl}"))}" +
                 $"\n SymbolTargetType: '{SymbolTargetType}' " +
                 $"\n IsInternal: '{IsInternal}'" +
+                $"\n IsProduction: '{IsProduction}'" +
                 $"\n Flatten: '{Flatten}'";
         }
 
@@ -97,6 +106,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 PublishingInfraVersion == config.PublishingInfraVersion &&
                 Id == config.Id &&
                 IsInternal == config.IsInternal &&
+                IsProduction == config.IsProduction &&
                 Flatten == config.Flatten)
             {
                 return true;
@@ -129,6 +139,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
             hash.Add(PublishingInfraVersion);
             hash.Add(Id);
             hash.Add(IsInternal);
+            hash.Add(IsProduction);
             foreach(var akaMSChannelName in AkaMSChannelNames)
             {
                 hash.Add(akaMSChannelName);


### PR DESCRIPTION
Due to the upcoming split in team's official pipelines, we might end up having two pipelines that both publish to BAR (one official, one dev), and both want to get promoted to a channel. They may have overlapping package IDs. We can resolve this by ensuring they push to differnt endpoint sets. To do this, we will stop allowing builds that are not production (dev builds or some other build) to push to "production" channels. This is done by examining the build info of the incoming BAR build. If the AzDO build meant for a production channel does not have a 1ESPT.Official tag, then it is rejected. After that, we use the production branch API to check whether the branch built is production. If not, we fail.

Right now I have this set up so that all failures result in "audit only" failures. They will not block promotion immediately. I will examine the results of the promotion pipeline over time to validate that no valid promotions are getting caught up.

In addition, the following changes were made:
- Remove net framework support except in the PushToBuildStorage task.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
