### PR TITLE
Replace Build.SourcesDirectory with Build.Repository.LocalPath

### DIFF
--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -702,7 +702,7 @@ The following task restores tools that are only available from internal feeds.
       feedsToUse: config
       restoreSolution: 'eng\common\internal\Tools.csproj'
       nugetConfigPath: 'eng\common\internal\NuGet.config'
-      restoreDirectory: '$(Build.SourcesDirectory)\.packages'
+      restoreDirectory: '$(Build.Repository.LocalPath)\.packages'
 ```
 
 [The tools](https://github.com/dotnet/arcade/blob/master/eng/common/internal/Tools.csproj) are restored conditionally based on which Arcade SDK features the repository uses (these are specified via `UsingToolXxx` properties).
@@ -745,7 +745,7 @@ The Build Pipeline needs to link the following variable group:
 - task: PublishBuildArtifacts@1
     displayName: Publish Logs
     inputs:
-      PathtoPublish: '$(Build.SourcesDirectory)\artifacts\log\$(BuildConfiguration)'
+      PathtoPublish: '$(Build.Repository.LocalPath)\artifacts\log\$(BuildConfiguration)'
       ArtifactName: '$(OperatingSystemName) $(BuildConfiguration)'
     continueOnError: true
     condition: not(succeeded())
@@ -887,7 +887,7 @@ The following build definition steps are required for successful generation of a
     inputs:
       dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
       buildNumber: 'ProfilingInputs/DevDiv/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
-      sourcePath: '$(Build.SourcesDirectory)\artifacts\OptProf\$(BuildConfiguration)\Data'
+      sourcePath: '$(Build.Repository.LocalPath)\artifacts\OptProf\$(BuildConfiguration)\Data'
       toLowerCase: false
       usePat: false
     displayName: 'OptProf - Publish to Artifact Services - ProfilingInputs'
@@ -900,7 +900,7 @@ The following build definition steps are required for successful generation of a
       vsMajorVersion: $(VisualStudio.MajorVersion)
       channelName: $(VisualStudio.ChannelName)
       manifests: $(VisualStudio.SetupManifestList)
-      outputFolder: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\Insertion'
+      outputFolder: '$(Build.Repository.LocalPath)\artifacts\VSSetup\$(BuildConfiguration)\Insertion'
     displayName: 'OptProf - Build VS bootstrapper'
     condition: succeeded()
 

--- a/Documentation/AzureDevOps/PhaseToJobSchemaChange.md
+++ b/Documentation/AzureDevOps/PhaseToJobSchemaChange.md
@@ -188,7 +188,7 @@ phases:
     - task: PublishBuildArtifacts@1
       displayName: Publish Logs to VSTS
       inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
+        PathtoPublish: '$(Build.Repository.LocalPath)/artifacts/log/$(_BuildConfig)'
         PublishLocation: Container
         ArtifactName: $(Agent.Os)_$(Agent.JobName)
       continueOnError: true
@@ -276,7 +276,7 @@ phases:
     - task: PublishBuildArtifacts@1
       displayName: Publish Logs to VSTS
       inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
+        PathtoPublish: '$(Build.Repository.LocalPath)/artifacts/log/$(_BuildConfig)'
         PublishLocation: Container
         ArtifactName: $(Agent.Os)_$(Agent.JobName)
       continueOnError: true

--- a/Documentation/AzureDevOps/SendingJobsToHelix.md
+++ b/Documentation/AzureDevOps/SendingJobsToHelix.md
@@ -100,7 +100,7 @@ The list of available Helix queues can be found on the [Helix homepage](https://
       # HelixConfiguration: '' -- any property that you would like to attached to a job
       # HelixPreCommands: '' -- any commands that you would like to run prior to running your job
       # HelixPostCommands: '' -- any commands that you would like to run after running your job
-      XUnitProjects: $(Build.SourcesDirectory)/HelloTests/HelloTests.csproj # specify your xUnit projects (semicolon delimited) here!
+      XUnitProjects: $(Build.Repository.LocalPath)/HelloTests/HelloTests.csproj # specify your xUnit projects (semicolon delimited) here!
       # XUnitWorkItemTimeout: '00:05:00' -- a timeout (specified as a System.TimeSpan string) for all work items created from XUnitProjects
       XUnitPublishTargetFramework: netcoreapp3.1 # specify your publish target framework here
       XUnitRuntimeTargetFramework: netcoreapp2.0 # specify the framework you want to use for the xUnit runner

--- a/Documentation/DependencyFlowOnboardingWithoutArcade.md
+++ b/Documentation/DependencyFlowOnboardingWithoutArcade.md
@@ -78,7 +78,7 @@ If you only have one Azure DevOps job that publishes assets, then you can add th
     azureSubscription: "Darc: Maestro Production"
     scriptType: ps
     scriptLocation: scriptPath
-    scriptPath: $(Build.SourcesDirectory)/eng/common/sdk-task.ps1
+    scriptPath: $(Build.Repository.LocalPath)/eng/common/sdk-task.ps1
     arguments: -task PublishBuildAssets
       -restore
       -msbuildEngine dotnet

--- a/Documentation/HowToAddPerfTestingToPipeline.md
+++ b/Documentation/HowToAddPerfTestingToPipeline.md
@@ -103,7 +103,7 @@ Performance testing has been fully tested in coreclr. Coreclr, corefx and other 
 
     # Test job depends on the corresponding build job
     dependsOn: build_Windows_NT_x64_Release
-    extraSetupParameters: -CoreRootDirectory $(Build.SourcesDirectory)\bin\tests\Windows_NT.x64.Release\Tests\Core_Root -Architecture x64
+    extraSetupParameters: -CoreRootDirectory $(Build.Repository.LocalPath)\bin\tests\Windows_NT.x64.Release\Tests\Core_Root -Architecture x64
 
     steps:
     # Download product build
@@ -121,7 +121,7 @@ Performance testing has been fully tested in coreclr. Coreclr, corefx and other 
       inputs:
         sourceFolder: $(System.ArtifactsDirectory)/Windows_NT_x64_Release_build
         contents: '**'
-        targetFolder: $(Build.SourcesDirectory)/bin/Product/Windows_NT.x64.Release
+        targetFolder: $(Build.Repository.LocalPath)/bin/Product/Windows_NT.x64.Release
 
     # Create Core_Root
     - script: build-test.cmd Release x64 skipmanaged skipnative

--- a/Documentation/OneLocBuild.md
+++ b/Documentation/OneLocBuild.md
@@ -182,7 +182,7 @@ The parameters that can be passed to the template are as follows:
 | **Parameter** | **Default Value** | **Notes** |
 |:-:|:-:|-|
 | `RepoType` | `'gitHub'` | Should be set to `'gitHub'` for GitHub-based repositories and `'azureDevOps'` for Azure DevOps-based ones. |
-| `SourcesDirectory` | `$(Build.SourcesDirectory)` | This is the root directory for your repository source code. |
+| `SourcesDirectory` | `$(Build.Repository.LocalPath)` | This is the root directory for your repository source code. |
 | `CreatePr` | `true` | When set to `true`, instructs the OneLocBuild task to make a PR back to the source repository containing the localized files. |
 | `AutoCompletePr` | `false` | When set to `true`, instructs the OneLocBuild task to autocomplete the created PR. Requires permissions to bypass any checks on the main branch. |
 | `ReusePr` | `true` | When set to `true`, instructs the OneLocBuild task to update an existing PR (if one exists) rather than open a new one to reduce PR noise. |

--- a/Documentation/Projects/Build Analysis/BuildRetryOnboard.md
+++ b/Documentation/Projects/Build Analysis/BuildRetryOnboard.md
@@ -21,7 +21,7 @@ Ex. \eng\BuildConfiguration\build-configuration.json
     ``` 
     - task: PublishPipelineArtifact@1
       inputs:
-          targetPath: $(Build.SourcesDirectory)\eng\BuildConfiguration
+          targetPath: $(Build.Repository.LocalPath)\eng\BuildConfiguration
           artifactName: BuildConfiguration
    ``` 
 

--- a/Documentation/SBOMGenerationGuidance.md
+++ b/Documentation/SBOMGenerationGuidance.md
@@ -78,7 +78,7 @@ Arcade configurations. The template allows customization of behavior via the fol
 - `ManifestDirPath`: Determines where in the build agent the SBOM will be generated to, defaults to
   `$(Build.ArtifactStagingDirectory)/sbom`
 - `BuildDropPath` : Determines the directory that the SBOM tooling will use to find build outputs.
-  Defaults to $`(Build.SourcesDirectory)/artifacts` to match Arcade's convention. 
+  Defaults to $`(Build.Repository.LocalPath)/artifacts` to match Arcade's convention. 
 - `sbomContinueOnError`: By default the tasks are set up to not break the build and instead continue
   on error if anything goes wrong in the generation process.
 
@@ -246,7 +246,7 @@ for your release builds:
   ```
 
   It means that your build outputs might not match with the expected location for Arcade:
-  `$(Build.SourcesDirectory)/Artifacts`. In this case you should modify the `BuildDropPath`
+  `$(Build.Repository.LocalPath)/Artifacts`. In this case you should modify the `BuildDropPath`
   parameter of the template to point to your build's output directory. 
 
 - For any other problems with the tasks or templates, you can reach out to the [.NET Engineering

--- a/azure-pipelines-daily.yaml
+++ b/azure-pipelines-daily.yaml
@@ -27,9 +27,9 @@ stages:
         inputs:
           packageType: runtime
           version: 8.x
-          installationPath: $(Build.SourcesDirectory)/.dotnet
+          installationPath: $(Build.Repository.LocalPath)/.dotnet
 
-      - script: $(Build.SourcesDirectory)/.dotnet/dotnet.exe tool restore
+      - script: $(Build.Repository.LocalPath)/.dotnet/dotnet.exe tool restore
         displayName: Restore dotnet tools
 
       - task: AzureCLI@2

--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -164,7 +164,7 @@ stages:
               /p:DotNetSymbolServerTokenSymWeb=DryRunPTA
               /p:PDBArtifactsDirectory='$(Build.ArtifactStagingDirectory)/PDBArtifacts/'
               /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/'
-              /p:SymbolPublishingExclusionsFile='$(Build.SourcesDirectory)/eng/SymbolPublishingExclusionsFile.txt'
+              /p:SymbolPublishingExclusionsFile='$(Build.Repository.LocalPath)/eng/SymbolPublishingExclusionsFile.txt'
               /p:Configuration=Release
               /p:PublishToMSDL=false
         - powershell: eng\common\build.ps1
@@ -174,8 +174,8 @@ stages:
             -restore
             -test
             -warnAsError $false
-            -projects $(Build.SourcesDirectory)\tests\UnitTests.proj
-            /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.binlog
+            -projects $(Build.Repository.LocalPath)\tests\UnitTests.proj
+            /bl:$(Build.Repository.LocalPath)\artifacts\log\$(_BuildConfig)\Helix.binlog
             /p:RestoreUsingNuGetTargets=false
           displayName: Run Helix Tests
           env:
@@ -204,8 +204,8 @@ stages:
             --restore
             --test
             --warnAsError false
-            --projects $(Build.SourcesDirectory)/tests/UnitTests.proj
-            /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.binlog
+            --projects $(Build.Repository.LocalPath)/tests/UnitTests.proj
+            /bl:$(Build.Repository.LocalPath)/artifacts/log/$(_BuildConfig)/Helix.binlog
             /p:RestoreUsingNuGetTargets=false
           displayName: Run Helix Tests
           env:
@@ -249,8 +249,8 @@ stages:
             -restore
             -test
             -warnAsError false
-            -projects $(Build.SourcesDirectory)/tests/XHarness.Apple.SimulatorTests.proj
-            /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/XHarness.Apple.Simulator.Tests.binlog
+            -projects $(Build.Repository.LocalPath)/tests/XHarness.Apple.SimulatorTests.proj
+            /bl:$(Build.Repository.LocalPath)/artifacts/log/$(_BuildConfig)/XHarness.Apple.Simulator.Tests.binlog
             /p:RestoreUsingNuGetTargets=false
           displayName: XHarness Apple Simulator Helix Testing
           env:
@@ -279,8 +279,8 @@ stages:
             -restore
             -test
             -warnAsError false
-            -projects $(Build.SourcesDirectory)/tests/XHarness.Apple.DeviceTests.proj
-            /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.XHarness.Apple.Device.Tests.binlog
+            -projects $(Build.Repository.LocalPath)/tests/XHarness.Apple.DeviceTests.proj
+            /bl:$(Build.Repository.LocalPath)/artifacts/log/$(_BuildConfig)/Helix.XHarness.Apple.Device.Tests.binlog
             /p:RestoreUsingNuGetTargets=false
           displayName: XHarness Apple Device Helix Testing
           env:
@@ -309,8 +309,8 @@ stages:
             -restore
             -test
             -warnAsError false
-            -projects $(Build.SourcesDirectory)/tests/XHarness.Android.SimulatorTests.proj
-            /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.XHarness.Android.Simulator.Tests.binlog
+            -projects $(Build.Repository.LocalPath)/tests/XHarness.Android.SimulatorTests.proj
+            /bl:$(Build.Repository.LocalPath)/artifacts/log/$(_BuildConfig)/Helix.XHarness.Android.Simulator.Tests.binlog
             /p:RestoreUsingNuGetTargets=false
           displayName: XHarness Android Helix Testing (Linux)
           env:
@@ -338,8 +338,8 @@ stages:
             -restore
             -test
             -warnAsError $false
-            -projects $(Build.SourcesDirectory)\tests\XHarness.Android.DeviceTests.proj
-            /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.XHarness.Android.Device.Tests.binlog
+            -projects $(Build.Repository.LocalPath)\tests\XHarness.Android.DeviceTests.proj
+            /bl:$(Build.Repository.LocalPath)\artifacts\log\$(_BuildConfig)\Helix.XHarness.Android.Device.Tests.binlog
             /p:RestoreUsingNuGetTargets=false
           displayName: XHarness Android Helix Testing (Windows)
           env:

--- a/eng/common/SetupNugetSources.ps1
+++ b/eng/common/SetupNugetSources.ps1
@@ -10,8 +10,8 @@
 #    displayName: Setup Private Feeds Credentials
 #    condition: eq(variables['Agent.OS'], 'Windows_NT')
 #    inputs:
-#      filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-#      arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+#      filePath: $(Build.Repository.LocalPath)/eng/common/SetupNugetSources.ps1
+#      arguments: -ConfigFile $(Build.Repository.LocalPath)/NuGet.config -Password $Env:Token
 #    env:
 #      Token: $(dn-bot-dnceng-artifact-feeds-rw)
 #

--- a/eng/common/SetupNugetSources.sh
+++ b/eng/common/SetupNugetSources.sh
@@ -11,8 +11,8 @@
 #  - task: Bash@3
 #    displayName: Setup Internal Feeds
 #    inputs:
-#      filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
-#      arguments: $(Build.SourcesDirectory)/NuGet.config
+#      filePath: $(Build.Repository.LocalPath)/eng/common/SetupNugetSources.sh
+#      arguments: $(Build.Repository.LocalPath)/NuGet.config
 #    condition: ne(variables['Agent.OS'], 'Windows_NT')
 #  - task: NuGetAuthenticate@1
 #

--- a/eng/common/core-templates/job/job.yml
+++ b/eng/common/core-templates/job/job.yml
@@ -163,7 +163,7 @@ jobs:
       inputs:
         testResultsFormat: 'xUnit'
         testResultsFiles: '*.xml'
-        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+        searchFolder: '$(Build.Repository.LocalPath)/artifacts/TestResults/$(_BuildConfig)'
         testRunTitle: ${{ coalesce(parameters.testRunTitle, parameters.name, '$(System.JobName)') }}-xunit
         mergeTestResults: ${{ parameters.mergeTestResults }}
       continueOnError: true
@@ -174,7 +174,7 @@ jobs:
       inputs:
         testResultsFormat: 'VSTest'
         testResultsFiles: '*.trx'
-        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+        searchFolder: '$(Build.Repository.LocalPath)/artifacts/TestResults/$(_BuildConfig)'
         testRunTitle: ${{ coalesce(parameters.testRunTitle, parameters.name, '$(System.JobName)') }}-trx
         mergeTestResults: ${{ parameters.mergeTestResults }}
       continueOnError: true
@@ -218,7 +218,7 @@ jobs:
     - task: CopyFiles@2
       displayName: Gather buildconfiguration for build retry
       inputs:
-        SourceFolder: '$(Build.SourcesDirectory)/eng/common/BuildConfiguration'
+        SourceFolder: '$(Build.Repository.LocalPath)/eng/common/BuildConfiguration'
         Contents: '**'
         TargetFolder: '$(Build.ArtifactStagingDirectory)/eng/common/BuildConfiguration'
       continueOnError: true

--- a/eng/common/core-templates/job/onelocbuild.yml
+++ b/eng/common/core-templates/job/onelocbuild.yml
@@ -8,7 +8,7 @@ parameters:
   CeapexPat: $(dn-bot-ceapex-package-r) # PAT for the loc AzDO instance https://dev.azure.com/ceapex
   GithubPat: $(BotAccount-dotnet-bot-repo-PAT)
 
-  SourcesDirectory: $(Build.SourcesDirectory)
+  SourcesDirectory: $(Build.Repository.LocalPath)
   CreatePr: true
   AutoCompletePr: false
   ReusePr: true
@@ -68,7 +68,7 @@ jobs:
     - ${{ if ne(parameters.SkipLocProjectJsonGeneration, 'true') }}:
       - task: Powershell@2
         inputs:
-          filePath: $(Build.SourcesDirectory)/eng/common/generate-locproject.ps1
+          filePath: $(Build.Repository.LocalPath)/eng/common/generate-locproject.ps1
           arguments: $(_GenerateLocProjectArguments)
         displayName: Generate LocProject.json
         condition: ${{ parameters.condition }}
@@ -103,7 +103,7 @@ jobs:
     - task: CopyFiles@2
       displayName: Copy LocProject.json
       inputs:
-        SourceFolder: '$(Build.SourcesDirectory)/eng/Localize/'
+        SourceFolder: '$(Build.Repository.LocalPath)/eng/Localize/'
         Contents: 'LocProject.json'
         TargetFolder: '$(Build.ArtifactStagingDirectory)/loc'
       condition: ${{ parameters.condition }}

--- a/eng/common/core-templates/job/publish-build-assets.yml
+++ b/eng/common/core-templates/job/publish-build-assets.yml
@@ -117,7 +117,7 @@ jobs:
         azureSubscription: "Darc: Maestro Production"
         scriptType: ps
         scriptLocation: scriptPath
-        scriptPath: $(Build.SourcesDirectory)/eng/common/sdk-task.ps1
+        scriptPath: $(Build.Repository.LocalPath)/eng/common/sdk-task.ps1
         arguments: -task PublishBuildAssets -restore -msbuildEngine dotnet
           /p:ManifestsPath='$(Build.StagingDirectory)/AssetManifests'
           /p:IsAssetlessBuild=${{ parameters.isAssetlessBuild }}
@@ -137,7 +137,7 @@ jobs:
           Add-Content -Path $filePath -Value "$(DefaultChannels)"
           Add-Content -Path $filePath -Value $(IsStableBuild)
 
-          $symbolExclusionfile = "$(Build.SourcesDirectory)/eng/SymbolPublishingExclusionsFile.txt"
+          $symbolExclusionfile = "$(Build.Repository.LocalPath)/eng/SymbolPublishingExclusionsFile.txt"
           if (Test-Path -Path $symbolExclusionfile)
           {
             Write-Host "SymbolExclusionFile exists"
@@ -177,7 +177,7 @@ jobs:
           azureSubscription: "Darc: Maestro Production"
           scriptType: ps
           scriptLocation: scriptPath
-          scriptPath: $(Build.SourcesDirectory)/eng/common/post-build/publish-using-darc.ps1
+          scriptPath: $(Build.Repository.LocalPath)/eng/common/post-build/publish-using-darc.ps1
           arguments: >
             -BuildId $(BARBuildId)
             -PublishingInfraVersion 3

--- a/eng/common/core-templates/jobs/codeql-build.yml
+++ b/eng/common/core-templates/jobs/codeql-build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: DefaultGuardianVersion
         value: 0.109.0
       - name: GuardianPackagesConfigFile
-        value: $(Build.SourcesDirectory)\eng\common\sdl\packages.config
+        value: $(Build.Repository.LocalPath)\eng\common\sdl\packages.config
       - name: GuardianVersion
         value: ${{ coalesce(parameters.overrideGuardianVersion, '$(DefaultGuardianVersion)') }}
   

--- a/eng/common/core-templates/post-build/post-build.yml
+++ b/eng/common/core-templates/post-build/post-build.yml
@@ -154,7 +154,7 @@ stages:
         - task: PowerShell@2
           displayName: Validate
           inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/post-build/nuget-validation.ps1
+            filePath: $(Build.Repository.LocalPath)/eng/common/post-build/nuget-validation.ps1
             arguments: -PackagesPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/
 
     - job:
@@ -208,7 +208,7 @@ stages:
             filePath: eng\common\sdk-task.ps1
             arguments: -task SigningValidation -restore -msbuildEngine vs
               /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts'
-              /p:SignCheckExclusionsFile='$(Build.SourcesDirectory)/eng/SignCheckExclusionsFile.txt'
+              /p:SignCheckExclusionsFile='$(Build.Repository.LocalPath)/eng/SignCheckExclusionsFile.txt'
               ${{ parameters.signingValidationAdditionalParameters }}
 
         - template: /eng/common/core-templates/steps/publish-logs.yml
@@ -258,7 +258,7 @@ stages:
         - task: PowerShell@2
           displayName: Validate
           inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/post-build/sourcelink-validation.ps1
+            filePath: $(Build.Repository.LocalPath)/eng/common/post-build/sourcelink-validation.ps1
             arguments: -InputPath $(Build.ArtifactStagingDirectory)/BlobArtifacts/ 
               -ExtractPath $(Agent.BuildDirectory)/Extract/ 
               -GHRepoName $(Build.Repository.Name) 
@@ -313,7 +313,7 @@ stages:
             azureSubscription: "Darc: Maestro Production"
             scriptType: ps
             scriptLocation: scriptPath
-            scriptPath: $(Build.SourcesDirectory)/eng/common/post-build/publish-using-darc.ps1
+            scriptPath: $(Build.Repository.LocalPath)/eng/common/post-build/publish-using-darc.ps1
             arguments: >
               -BuildId $(BARBuildId)
               -PublishingInfraVersion ${{ parameters.publishingInfraVersion }}

--- a/eng/common/core-templates/post-build/setup-maestro-vars.yml
+++ b/eng/common/core-templates/post-build/setup-maestro-vars.yml
@@ -36,7 +36,7 @@ steps:
             $AzureDevOpsBuildId = $Env:Build_BuildId
           }
           else {
-            . $(Build.SourcesDirectory)\eng\common\tools.ps1
+            . $(Build.Repository.LocalPath)\eng\common\tools.ps1
             $darc = Get-Darc
             $buildInfo = & $darc get-build `
               --id ${{ parameters.BARBuildId }} `

--- a/eng/common/core-templates/steps/enable-internal-sources.yml
+++ b/eng/common/core-templates/steps/enable-internal-sources.yml
@@ -17,8 +17,8 @@ steps:
     - task: PowerShell@2
       displayName: Setup Internal Feeds
       inputs:
-        filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-        arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+        filePath: $(Build.Repository.LocalPath)/eng/common/SetupNugetSources.ps1
+        arguments: -ConfigFile $(Build.Repository.LocalPath)/NuGet.config -Password $Env:Token
       env:
         Token: ${{ parameters.legacyCredential }}
   # If running on dnceng (internal project), just use the default behavior for NuGetAuthenticate.
@@ -29,8 +29,8 @@ steps:
       - task: PowerShell@2
         displayName: Setup Internal Feeds
         inputs:
-          filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-          arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config
+          filePath: $(Build.Repository.LocalPath)/eng/common/SetupNugetSources.ps1
+          arguments: -ConfigFile $(Build.Repository.LocalPath)/NuGet.config
     - ${{ else }}:
       - template: /eng/common/templates/steps/get-federated-access-token.yml
         parameters:
@@ -39,8 +39,8 @@ steps:
       - task: PowerShell@2
         displayName: Setup Internal Feeds
         inputs:
-          filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-          arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $(dnceng-artifacts-feeds-read-access-token)
+          filePath: $(Build.Repository.LocalPath)/eng/common/SetupNugetSources.ps1
+          arguments: -ConfigFile $(Build.Repository.LocalPath)/NuGet.config -Password $(dnceng-artifacts-feeds-read-access-token)
   # This is required in certain scenarios to install the ADO credential provider.
   # It installed by default in some msbuild invocations (e.g. VS msbuild), but needs to be installed for others
   # (e.g. dotnet msbuild).

--- a/eng/common/core-templates/steps/generate-sbom.yml
+++ b/eng/common/core-templates/steps/generate-sbom.yml
@@ -6,7 +6,7 @@
 
 parameters:
   PackageVersion: 10.0.0
-  BuildDropPath: '$(Build.SourcesDirectory)/artifacts'
+  BuildDropPath: '$(Build.Repository.LocalPath)/artifacts'
   PackageName: '.NET'
   ManifestDirPath: $(Build.ArtifactStagingDirectory)/sbom
   IgnoreDirectories: ''

--- a/eng/common/core-templates/steps/install-microbuild.yml
+++ b/eng/common/core-templates/steps/install-microbuild.yml
@@ -12,7 +12,7 @@ parameters:
   # variable is not available in template expression. _SignType has a very large proliferation across .NET, so replacing it is tough.
   microbuildUseESRP: true
   # Location of the MicroBuild output folder
-  microBuildOutputFolder: '$(Build.SourcesDirectory)'
+  microBuildOutputFolder: '$(Build.Repository.LocalPath)'
 
   continueOnError: false
 

--- a/eng/common/core-templates/steps/publish-logs.yml
+++ b/eng/common/core-templates/steps/publish-logs.yml
@@ -12,22 +12,22 @@ steps:
   inputs:
     targetType: inline
     script: |
-      New-Item -ItemType Directory $(Build.SourcesDirectory)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
-      Move-Item -Path $(Build.SourcesDirectory)/artifacts/log/Debug/* $(Build.SourcesDirectory)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
+      New-Item -ItemType Directory $(Build.Repository.LocalPath)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
+      Move-Item -Path $(Build.Repository.LocalPath)/artifacts/log/Debug/* $(Build.Repository.LocalPath)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
   continueOnError: true
   condition: always()
     
 - task: PowerShell@2
   displayName: Redact Logs
   inputs:
-    filePath: $(Build.SourcesDirectory)/eng/common/post-build/redact-logs.ps1
+    filePath: $(Build.Repository.LocalPath)/eng/common/post-build/redact-logs.ps1
     # For now this needs to have explicit list of all sensitive data. Taken from eng/publishing/v3/publish.yml
-    # Sensitive data can as well be added to $(Build.SourcesDirectory)/eng/BinlogSecretsRedactionFile.txt'
+    # Sensitive data can as well be added to $(Build.Repository.LocalPath)/eng/BinlogSecretsRedactionFile.txt'
     #  If the file exists - sensitive data for redaction will be sourced from it
     #  (single entry per line, lines starting with '# ' are considered comments and skipped)
-    arguments: -InputPath '$(Build.SourcesDirectory)/PostBuildLogs' 
+    arguments: -InputPath '$(Build.Repository.LocalPath)/PostBuildLogs' 
       -BinlogToolVersion ${{parameters.BinlogToolVersion}}
-      -TokensFilePath '$(Build.SourcesDirectory)/eng/BinlogSecretsRedactionFile.txt'
+      -TokensFilePath '$(Build.Repository.LocalPath)/eng/BinlogSecretsRedactionFile.txt'
       '$(publishing-dnceng-devdiv-code-r-build-re)'
       '$(MaestroAccessToken)'
       '$(dn-bot-all-orgs-artifact-feeds-rw)'
@@ -44,7 +44,7 @@ steps:
 - task: CopyFiles@2
   displayName: Gather post build logs
   inputs:
-    SourceFolder: '$(Build.SourcesDirectory)/PostBuildLogs'
+    SourceFolder: '$(Build.Repository.LocalPath)/PostBuildLogs'
     Contents: '**'
     TargetFolder: '$(Build.ArtifactStagingDirectory)/PostBuildLogs'
   condition: always()

--- a/eng/common/core-templates/steps/source-index-stage1-publish.yml
+++ b/eng/common/core-templates/steps/source-index-stage1-publish.yml
@@ -20,7 +20,7 @@ steps:
   # Set working directory to temp directory so 'dotnet' doesn't try to use global.json and use the repo's sdk.
   workingDirectory: $(Agent.TempDirectory)
 
-- script: $(Agent.TempDirectory)/.source-index/tools/BinLogToSln -i ${{parameters.BinlogPath}} -r $(Build.SourcesDirectory) -n $(Build.Repository.Name) -o .source-index/stage1output
+- script: $(Agent.TempDirectory)/.source-index/tools/BinLogToSln -i ${{parameters.BinlogPath}} -r $(Build.Repository.LocalPath) -n $(Build.Repository.Name) -o .source-index/stage1output
   displayName: "Source Index: Process Binlog into indexable sln"
 
 - ${{ if and(ne(parameters.runAsPublic, 'true'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/common/template-guidance.md
+++ b/eng/common/template-guidance.md
@@ -50,7 +50,7 @@ extends:
           - task: CopyFiles@2
               displayName: Gather build output
               inputs:
-                SourceFolder: '$(Build.SourcesDirectory)/artifacts/marvel'
+                SourceFolder: '$(Build.Repository.LocalPath)/artifacts/marvel'
                 Contents: '**'
                 TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/marvel'
 ```

--- a/eng/common/templates-official/job/job.yml
+++ b/eng/common/templates-official/job/job.yml
@@ -3,7 +3,7 @@ parameters:
   enableSbom: true
   runAsPublic: false
   PackageVersion: 9.0.0
-  BuildDropPath: '$(Build.SourcesDirectory)/artifacts'
+  BuildDropPath: '$(Build.Repository.LocalPath)/artifacts'
 
 jobs:
 - template: /eng/common/core-templates/job/job.yml

--- a/eng/common/templates-official/variables/sdl-variables.yml
+++ b/eng/common/templates-official/variables/sdl-variables.yml
@@ -4,4 +4,4 @@ variables:
 - name: DefaultGuardianVersion
   value: 0.109.0
 - name: GuardianPackagesConfigFile
-  value: $(Build.SourcesDirectory)\eng\common\sdl\packages.config
+  value: $(Build.Repository.LocalPath)\eng\common\sdl\packages.config

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -6,7 +6,7 @@ parameters:
   enableSbom: true
   runAsPublic: false
   PackageVersion: 9.0.0
-  BuildDropPath: '$(Build.SourcesDirectory)/artifacts'
+  BuildDropPath: '$(Build.Repository.LocalPath)/artifacts'
 
 jobs:
 - template: /eng/common/core-templates/job/job.yml
@@ -77,7 +77,7 @@ jobs:
         parameters:
           is1ESPipeline: false
           args:
-            targetPath: '$(Build.SourcesDirectory)\eng\common\BuildConfiguration'
+            targetPath: '$(Build.Repository.LocalPath)\eng\common\BuildConfiguration'
             artifactName: 'BuildConfiguration'
             displayName: 'Publish build retry configuration'
             continueOnError: true

--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -25,7 +25,7 @@ stages:
         azureSubscription: "Darc: Maestro Production"
         scriptType: ps
         scriptLocation: scriptPath
-        scriptPath: $(Build.SourcesDirectory)/eng/publishing/v3/validate-and-locate-build.ps1
+        scriptPath: $(Build.Repository.LocalPath)/eng/publishing/v3/validate-and-locate-build.ps1
         arguments: >
           -BuildId ${{ parameters.BARBuildId }}
           -PromoteToChannelIds ${{ parameters.PromoteToChannelIds }}
@@ -102,7 +102,7 @@ stages:
     - task: PowerShell@2
       displayName: Enable cross-org publishing
       inputs:
-        filePath: $(Build.SourcesDirectory)/eng/common/enable-cross-org-publishing.ps1
+        filePath: $(Build.Repository.LocalPath)/eng/common/enable-cross-org-publishing.ps1
         arguments: -token $(dn-bot-all-orgs-artifact-feeds-rw)
 
     - task: AzureCLI@2
@@ -136,7 +136,7 @@ stages:
         azureSubscription: maestro-build-promotion
         scriptType: ps
         scriptLocation: scriptPath
-        scriptPath: $(Build.SourcesDirectory)/eng/common/sdk-task.ps1
+        scriptPath: $(Build.Repository.LocalPath)/eng/common/sdk-task.ps1
         arguments: >
           -task PublishArtifactsInManifest -restore -msbuildEngine dotnet
           /p:PublishingInfraVersion=3

--- a/eng/validate-sdk.yml
+++ b/eng/validate-sdk.yml
@@ -40,7 +40,7 @@ jobs:
         inlineScript: >
           .\eng\update-packagesource.ps1
           -gitHubPat $(BotAccount-dotnet-maestro-bot-PAT)
-          -packagesSource $(Build.SourcesDirectory)/build_stage_artifacts
+          -packagesSource $(Build.Repository.LocalPath)/build_stage_artifacts
     - script: eng\common\cibuild.cmd
         $(_BuildArgs)
       displayName: Build / Validate


### PR DESCRIPTION
## Summary

Currently, `Build.SourcesDirectory` is used to access the directory for which the code is checked out. However, this predefined variable does not work for multi-repo checkout situations. The proper variable that works for both single-checkout and multi-checkout pipelines is `Build.Repository.LocalPath`.

## Docs

https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services

### Build.SourcesDirectory
<img width="807" height="366" alt="image" src="https://github.com/user-attachments/assets/fd75dc0a-0578-4442-9093-a2853c0a036f" />

### Build.Repository.LocalPath
<img width="809" height="506" alt="image" src="https://github.com/user-attachments/assets/d034903e-3ab2-419e-9b05-e05f82be6988" />

## Rationale

I found this when trying to do a multi-checkout pipeline that uses Arcade within the primary repo. The SBOM generation task would fail because it couldn't locate the artifacts folder. Therefore, I figured that I should apply this change to all files in the repo to make them work properly with multi-checkout pipelines.