### PR TITLE
[WiX 5] Update LSS for localization

### DIFF
--- a/eng/common/generate-locproject.ps1
+++ b/eng/common/generate-locproject.ps1
@@ -112,7 +112,7 @@ $locJson = @{
         @{
             LanguageSet = $LanguageSet
             CloneLanguageSet = "WiX_CloneLanguages"
-            LssFiles = @( "wxl_loc.lss" )
+            LssFiles = @( "wxl_loc.lss", "P210WxlSchemaV4.lss" )
             LocItems = @(
                 $wxlFiles | ForEach-Object {
                     $outputPath = "$($_.Directory.FullName | Resolve-Path -Relative)\"


### PR DESCRIPTION
Schema for .wxl files changed in v5. OneLoc already has an updated settings file for the XML parser (210). We just need to include it in the generate localization project. See [this workitem](https://ceapex.visualstudio.com/CEINTL/_workitems/edit/1043427)

Running locally, this now generates the following section

```json
 {
                         "LanguageSet":  "VS_Main_Languages",
                         "CloneLanguageSet":  "WiX_CloneLanguages",
                         "LocItems":  [
                                          {
                                              "SourceFile":  ".\\Layout\\pkg\\windows\\bundles\\sdk\\LCID\\bundle.wxl",
                                              "CopyOption":  "LangIDOnPath",
                                              "OutputPath":  ".\\Layout\\pkg\\windows\\bundles\\sdk\\LCID\\"
                                          }
                                      ],
                         "LssFiles":  [
                                          "wxl_loc.lss",
                                          "P210WxlSchemaV4.lss"
                                      ]
                     },
```