### PR TITLE
[8] Replace Build.SourcesDirectory with System.DefaultWorkingDirectory

### DIFF
--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -649,7 +649,7 @@ The following task restores tools that are only available from internal feeds.
       feedsToUse: config
       restoreSolution: 'eng\common\internal\Tools.csproj'
       nugetConfigPath: 'NuGet.config'
-      restoreDirectory: '$(Build.SourcesDirectory)\.packages'
+      restoreDirectory: '$(System.DefaultWorkingDirectory)\.packages'
 ```
 
 [The tools](https://github.com/dotnet/arcade/blob/master/eng/common/internal/Tools.csproj) are restored conditionally based on which Arcade SDK features the repository uses (these are specified via `UsingToolXxx` properties).
@@ -692,7 +692,7 @@ The Build Pipeline needs to link the following variable group:
 - task: PublishBuildArtifacts@1
     displayName: Publish Logs
     inputs:
-      PathtoPublish: '$(Build.SourcesDirectory)\artifacts\log\$(BuildConfiguration)'
+      PathtoPublish: '$(System.DefaultWorkingDirectory)\artifacts\log\$(BuildConfiguration)'
       ArtifactName: '$(OperatingSystemName) $(BuildConfiguration)'
     continueOnError: true
     condition: not(succeeded())
@@ -834,7 +834,7 @@ The following build definition steps are required for successful generation of a
     inputs:
       dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
       buildNumber: 'ProfilingInputs/DevDiv/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
-      sourcePath: '$(Build.SourcesDirectory)\artifacts\OptProf\$(BuildConfiguration)\Data'
+      sourcePath: '$(System.DefaultWorkingDirectory)\artifacts\OptProf\$(BuildConfiguration)\Data'
       toLowerCase: false
       usePat: false
     displayName: 'OptProf - Publish to Artifact Services - ProfilingInputs'
@@ -847,7 +847,7 @@ The following build definition steps are required for successful generation of a
       vsMajorVersion: $(VisualStudio.MajorVersion)
       channelName: $(VisualStudio.ChannelName)
       manifests: $(VisualStudio.SetupManifestList)
-      outputFolder: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\Insertion'
+      outputFolder: '$(System.DefaultWorkingDirectory)\artifacts\VSSetup\$(BuildConfiguration)\Insertion'
     displayName: 'OptProf - Build VS bootstrapper'
     condition: succeeded()
 

--- a/Documentation/AzureDevOps/PhaseToJobSchemaChange.md
+++ b/Documentation/AzureDevOps/PhaseToJobSchemaChange.md
@@ -188,7 +188,7 @@ phases:
     - task: PublishBuildArtifacts@1
       displayName: Publish Logs to VSTS
       inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
+        PathtoPublish: '$(System.DefaultWorkingDirectory)/artifacts/log/$(_BuildConfig)'
         PublishLocation: Container
         ArtifactName: $(Agent.Os)_$(Agent.JobName)
       continueOnError: true
@@ -276,7 +276,7 @@ phases:
     - task: PublishBuildArtifacts@1
       displayName: Publish Logs to VSTS
       inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
+        PathtoPublish: '$(System.DefaultWorkingDirectory)/artifacts/log/$(_BuildConfig)'
         PublishLocation: Container
         ArtifactName: $(Agent.Os)_$(Agent.JobName)
       continueOnError: true

--- a/Documentation/AzureDevOps/SendingJobsToHelix.md
+++ b/Documentation/AzureDevOps/SendingJobsToHelix.md
@@ -100,7 +100,7 @@ The list of available Helix queues can be found on the [Helix homepage](https://
       # HelixConfiguration: '' -- any property that you would like to attached to a job
       # HelixPreCommands: '' -- any commands that you would like to run prior to running your job
       # HelixPostCommands: '' -- any commands that you would like to run after running your job
-      XUnitProjects: $(Build.SourcesDirectory)/HelloTests/HelloTests.csproj # specify your xUnit projects (semicolon delimited) here!
+      XUnitProjects: $(System.DefaultWorkingDirectory)/HelloTests/HelloTests.csproj # specify your xUnit projects (semicolon delimited) here!
       # XUnitWorkItemTimeout: '00:05:00' -- a timeout (specified as a System.TimeSpan string) for all work items created from XUnitProjects
       XUnitPublishTargetFramework: netcoreapp3.1 # specify your publish target framework here
       XUnitRuntimeTargetFramework: netcoreapp2.0 # specify the framework you want to use for the xUnit runner

--- a/Documentation/DependencyFlowOnboardingWithoutArcade.md
+++ b/Documentation/DependencyFlowOnboardingWithoutArcade.md
@@ -78,7 +78,7 @@ If you only have one Azure DevOps job that publishes assets, then you can add th
     azureSubscription: "Darc: Maestro Production"
     scriptType: ps
     scriptLocation: scriptPath
-    scriptPath: $(Build.SourcesDirectory)/eng/common/sdk-task.ps1
+    scriptPath: $(System.DefaultWorkingDirectory)/eng/common/sdk-task.ps1
     arguments: -task PublishBuildAssets
       -restore
       -msbuildEngine dotnet

--- a/Documentation/HowToAddPerfTestingToPipeline.md
+++ b/Documentation/HowToAddPerfTestingToPipeline.md
@@ -103,7 +103,7 @@ Performance testing has been fully tested in coreclr. Coreclr, corefx and other 
 
     # Test job depends on the corresponding build job
     dependsOn: build_Windows_NT_x64_Release
-    extraSetupParameters: -CoreRootDirectory $(Build.SourcesDirectory)\bin\tests\Windows_NT.x64.Release\Tests\Core_Root -Architecture x64
+    extraSetupParameters: -CoreRootDirectory $(System.DefaultWorkingDirectory)\bin\tests\Windows_NT.x64.Release\Tests\Core_Root -Architecture x64
 
     steps:
     # Download product build
@@ -121,7 +121,7 @@ Performance testing has been fully tested in coreclr. Coreclr, corefx and other 
       inputs:
         sourceFolder: $(System.ArtifactsDirectory)/Windows_NT_x64_Release_build
         contents: '**'
-        targetFolder: $(Build.SourcesDirectory)/bin/Product/Windows_NT.x64.Release
+        targetFolder: $(System.DefaultWorkingDirectory)/bin/Product/Windows_NT.x64.Release
 
     # Create Core_Root
     - script: build-test.cmd Release x64 skipmanaged skipnative

--- a/Documentation/OneLocBuild.md
+++ b/Documentation/OneLocBuild.md
@@ -180,7 +180,7 @@ The parameters that can be passed to the template are as follows:
 | **Parameter** | **Default Value** | **Notes** |
 |:-:|:-:|-|
 | `RepoType` | `'gitHub'` | Should be set to `'gitHub'` for GitHub-based repositories and `'azureDevOps'` for Azure DevOps-based ones. |
-| `SourcesDirectory` | `$(Build.SourcesDirectory)` | This is the root directory for your repository source code. |
+| `SourcesDirectory` | `$(System.DefaultWorkingDirectory)` | This is the root directory for your repository source code. |
 | `CreatePr` | `true` | When set to `true`, instructs the OneLocBuild task to make a PR back to the source repository containing the localized files. |
 | `AutoCompletePr` | `false` | When set to `true`, instructs the OneLocBuild task to autocomplete the created PR. Requires permissions to bypass any checks on the main branch. |
 | `ReusePr` | `true` | When set to `true`, instructs the OneLocBuild task to update an existing PR (if one exists) rather than open a new one to reduce PR noise. |

--- a/Documentation/Projects/Build Analysis/BuildRetryOnboard.md
+++ b/Documentation/Projects/Build Analysis/BuildRetryOnboard.md
@@ -19,7 +19,7 @@ Ex. \eng\BuildConfiguration\build-configuration.json
 
 	Ex.
 	``` 
-	- publish: $(Build.SourcesDirectory)\eng\BuildConfiguration
+	- publish: $(System.DefaultWorkingDirectory)\eng\BuildConfiguration
 	  artifact: BuildConfiguration
 	``` 
 

--- a/Documentation/SBOMGenerationGuidance.md
+++ b/Documentation/SBOMGenerationGuidance.md
@@ -76,7 +76,7 @@ Arcade configurations. The template allows customization of behavior via the fol
 - `ManifestDirPath`: Determines where in the build agent the SBOM will be generated to, defaults to
   `$(Build.ArtifactStagingDirectory)/sbom`
 - `BuildDropPath` : Determines the directory that the SBOM tooling will use to find build outputs.
-  Defaults to $`(Build.SourcesDirectory)/artifacts` to match Arcade's convention. 
+  Defaults to $`(System.DefaultWorkingDirectory)/artifacts` to match Arcade's convention. 
 - `sbomContinueOnError`: By default the tasks are set up to not break the build and instead continue
   on error if anything goes wrong in the generation process.
 
@@ -244,7 +244,7 @@ for your release builds:
   ```
 
   It means that your build outputs might not match with the expected location for Arcade:
-  `$(Build.SourcesDirectory)/Artifacts`. In this case you should modify the `BuildDropPath`
+  `$(System.DefaultWorkingDirectory)/Artifacts`. In this case you should modify the `BuildDropPath`
   parameter of the template to point to your build's output directory. 
 
 - For any other problems with the tasks or templates, you can reach out to the [.NET Engineering

--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -165,7 +165,7 @@ stages:
               /p:DotNetSymbolServerTokenSymWeb=DryRunPTA
               /p:PDBArtifactsDirectory='$(Build.ArtifactStagingDirectory)/PDBArtifacts/'
               /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/'
-              /p:SymbolPublishingExclusionsFile='$(Build.SourcesDirectory)/eng/SymbolPublishingExclusionsFile.txt'
+              /p:SymbolPublishingExclusionsFile='$(System.DefaultWorkingDirectory)/eng/SymbolPublishingExclusionsFile.txt'
               /p:Configuration=Release
               /p:PublishToMSDL=false
         - powershell: eng\common\build.ps1
@@ -175,8 +175,8 @@ stages:
             -restore
             -test
             -warnAsError $false
-            -projects $(Build.SourcesDirectory)\tests\UnitTests.proj
-            /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.binlog
+            -projects $(System.DefaultWorkingDirectory)\tests\UnitTests.proj
+            /bl:$(System.DefaultWorkingDirectory)\artifacts\log\$(_BuildConfig)\Helix.binlog
             /p:RestoreUsingNuGetTargets=false
           displayName: Run Helix Tests
           env:
@@ -205,8 +205,8 @@ stages:
             --restore
             --test
             --warnAsError false
-            --projects $(Build.SourcesDirectory)/tests/UnitTests.proj
-            /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.binlog
+            --projects $(System.DefaultWorkingDirectory)/tests/UnitTests.proj
+            /bl:$(System.DefaultWorkingDirectory)/artifacts/log/$(_BuildConfig)/Helix.binlog
             /p:RestoreUsingNuGetTargets=false
           displayName: Run Helix Tests
           env:
@@ -250,8 +250,8 @@ stages:
             -restore
             -test
             -warnAsError false
-            -projects $(Build.SourcesDirectory)/tests/XHarness.Apple.SimulatorTests.proj
-            /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/XHarness.Apple.Simulator.Tests.binlog
+            -projects $(System.DefaultWorkingDirectory)/tests/XHarness.Apple.SimulatorTests.proj
+            /bl:$(System.DefaultWorkingDirectory)/artifacts/log/$(_BuildConfig)/XHarness.Apple.Simulator.Tests.binlog
             /p:RestoreUsingNuGetTargets=false
           displayName: XHarness Apple Simulator Helix Testing
           env:
@@ -280,8 +280,8 @@ stages:
             -restore
             -test
             -warnAsError false
-            -projects $(Build.SourcesDirectory)/tests/XHarness.Apple.DeviceTests.proj
-            /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.XHarness.Apple.Device.Tests.binlog
+            -projects $(System.DefaultWorkingDirectory)/tests/XHarness.Apple.DeviceTests.proj
+            /bl:$(System.DefaultWorkingDirectory)/artifacts/log/$(_BuildConfig)/Helix.XHarness.Apple.Device.Tests.binlog
             /p:RestoreUsingNuGetTargets=false
           displayName: XHarness Apple Device Helix Testing
           env:
@@ -310,8 +310,8 @@ stages:
             -restore
             -test
             -warnAsError false
-            -projects $(Build.SourcesDirectory)/tests/XHarness.Android.SimulatorTests.proj
-            /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Helix.XHarness.Android.Simulator.Tests.binlog
+            -projects $(System.DefaultWorkingDirectory)/tests/XHarness.Android.SimulatorTests.proj
+            /bl:$(System.DefaultWorkingDirectory)/artifacts/log/$(_BuildConfig)/Helix.XHarness.Android.Simulator.Tests.binlog
             /p:RestoreUsingNuGetTargets=false
           displayName: XHarness Android Helix Testing (Linux)
           env:
@@ -339,8 +339,8 @@ stages:
             -restore
             -test
             -warnAsError $false
-            -projects $(Build.SourcesDirectory)\tests\XHarness.Android.DeviceTests.proj
-            /bl:$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Helix.XHarness.Android.Device.Tests.binlog
+            -projects $(System.DefaultWorkingDirectory)\tests\XHarness.Android.DeviceTests.proj
+            /bl:$(System.DefaultWorkingDirectory)\artifacts\log\$(_BuildConfig)\Helix.XHarness.Android.Device.Tests.binlog
             /p:RestoreUsingNuGetTargets=false
           displayName: XHarness Android Helix Testing (Windows)
           env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -124,4 +124,4 @@ extends:
           -TsaRepositoryName "Arcade"
           -TsaCodebaseName "Arcade"
           -TsaPublish $True
-          -PoliCheckAdditionalRunConfigParams @("UserExclusionPath < $(Build.SourcesDirectory)/eng/PoliCheckExclusions.xml")'
+          -PoliCheckAdditionalRunConfigParams @("UserExclusionPath < $(System.DefaultWorkingDirectory)/eng/PoliCheckExclusions.xml")'

--- a/eng/common/SetupNugetSources.ps1
+++ b/eng/common/SetupNugetSources.ps1
@@ -17,8 +17,8 @@
 #    displayName: Setup Private Feeds Credentials
 #    condition: eq(variables['Agent.OS'], 'Windows_NT')
 #    inputs:
-#      filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-#      arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+#      filePath: $(System.DefaultWorkingDirectory)/eng/common/SetupNugetSources.ps1
+#      arguments: -ConfigFile $(System.DefaultWorkingDirectory)/NuGet.config -Password $Env:Token
 #    env:
 #      Token: $(dn-bot-dnceng-artifact-feeds-rw)
 

--- a/eng/common/SetupNugetSources.sh
+++ b/eng/common/SetupNugetSources.sh
@@ -18,8 +18,8 @@
 #  - task: Bash@3
 #    displayName: Setup Private Feeds Credentials
 #    inputs:
-#      filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
-#      arguments: $(Build.SourcesDirectory)/NuGet.config $Token
+#      filePath: $(System.DefaultWorkingDirectory)/eng/common/SetupNugetSources.sh
+#      arguments: $(System.DefaultWorkingDirectory)/NuGet.config $Token
 #    condition: ne(variables['Agent.OS'], 'Windows_NT')
 #    env:
 #      Token: $(dn-bot-dnceng-artifact-feeds-rw)

--- a/eng/common/templates-official/job/job.yml
+++ b/eng/common/templates-official/job/job.yml
@@ -38,7 +38,7 @@ parameters:
 # Sbom related params
   enableSbom: true
   PackageVersion: 7.0.0
-  BuildDropPath: '$(Build.SourcesDirectory)/artifacts'
+  BuildDropPath: '$(System.DefaultWorkingDirectory)/artifacts'
   ManifestDirPath: $(Build.ArtifactStagingDirectory)/sbom
 
 jobs:
@@ -167,7 +167,7 @@ jobs:
       inputs:
         languages: ${{ coalesce(parameters.richCodeNavigationLanguage, 'csharp') }}
         environment: ${{ coalesce(parameters.richCodeNavigationEnvironment, 'production') }}
-        richNavLogOutputDirectory: $(Build.SourcesDirectory)/artifacts/bin
+        richNavLogOutputDirectory: $(System.DefaultWorkingDirectory)/artifacts/bin
         uploadRichNavArtifacts: ${{ coalesce(parameters.richCodeNavigationUploadArtifacts, false) }}
       continueOnError: true
 
@@ -226,7 +226,7 @@ jobs:
     - task: 1ES.PublishBuildArtifacts@1
       displayName: Publish Logs
       inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
+        PathtoPublish: '$(System.DefaultWorkingDirectory)/artifacts/log/$(_BuildConfig)'
         PublishLocation: Container
         ArtifactName: ${{ coalesce(parameters.enablePublishBuildArtifacts.artifactName, '$(Agent.Os)_$(Agent.JobName)' ) }}
       continueOnError: true
@@ -238,7 +238,7 @@ jobs:
       inputs:
         testResultsFormat: 'xUnit'
         testResultsFiles: '*.xml'
-        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+        searchFolder: '$(System.DefaultWorkingDirectory)/artifacts/TestResults/$(_BuildConfig)'
         testRunTitle: ${{ coalesce(parameters.testRunTitle, parameters.name, '$(System.JobName)') }}-xunit
         mergeTestResults: ${{ parameters.mergeTestResults }}
       continueOnError: true
@@ -249,7 +249,7 @@ jobs:
       inputs:
         testResultsFormat: 'VSTest'
         testResultsFiles: '*.trx'
-        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+        searchFolder: '$(System.DefaultWorkingDirectory)/artifacts/TestResults/$(_BuildConfig)'
         testRunTitle: ${{ coalesce(parameters.testRunTitle, parameters.name, '$(System.JobName)') }}-trx
         mergeTestResults: ${{ parameters.mergeTestResults }}
       continueOnError: true
@@ -265,7 +265,7 @@ jobs:
   - ${{ if eq(parameters.enableBuildRetry, 'true') }}:
     - task: 1ES.PublishPipelineArtifact@1
       inputs:
-        targetPath: '$(Build.SourcesDirectory)\eng\common\BuildConfiguration'
+        targetPath: '$(System.DefaultWorkingDirectory)\eng\common\BuildConfiguration'
         artifactName: 'BuildConfiguration'
       displayName: 'Publish build retry configuration'
       continueOnError: true

--- a/eng/common/templates-official/job/onelocbuild.yml
+++ b/eng/common/templates-official/job/onelocbuild.yml
@@ -8,7 +8,7 @@ parameters:
   CeapexPat: $(dn-bot-ceapex-package-r) # PAT for the loc AzDO instance https://dev.azure.com/ceapex
   GithubPat: $(BotAccount-dotnet-bot-repo-PAT)
 
-  SourcesDirectory: $(Build.SourcesDirectory)
+  SourcesDirectory: $(System.DefaultWorkingDirectory)
   CreatePr: true
   AutoCompletePr: false
   ReusePr: true
@@ -63,7 +63,7 @@ jobs:
     - ${{ if ne(parameters.SkipLocProjectJsonGeneration, 'true') }}:
       - task: Powershell@2
         inputs:
-          filePath: $(Build.SourcesDirectory)/eng/common/generate-locproject.ps1
+          filePath: $(System.DefaultWorkingDirectory)/eng/common/generate-locproject.ps1
           arguments: $(_GenerateLocProjectArguments)
         displayName: Generate LocProject.json
         condition: ${{ parameters.condition }}
@@ -106,7 +106,7 @@ jobs:
     - task: 1ES.PublishBuildArtifacts@1
       displayName: Publish LocProject.json
       inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/eng/Localize/'
+        PathtoPublish: '$(System.DefaultWorkingDirectory)/eng/Localize/'
         PublishLocation: Container
         ArtifactName: Loc
       condition: ${{ parameters.condition }}

--- a/eng/common/templates-official/job/publish-build-assets.yml
+++ b/eng/common/templates-official/job/publish-build-assets.yml
@@ -82,7 +82,7 @@ jobs:
         azureSubscription: "Darc: Maestro Production"
         scriptType: ps
         scriptLocation: scriptPath
-        scriptPath: $(Build.SourcesDirectory)/eng/common/sdk-task.ps1
+        scriptPath: $(System.DefaultWorkingDirectory)/eng/common/sdk-task.ps1
         arguments: >
           -task PublishBuildAssets -restore -msbuildEngine dotnet
           /p:ManifestsPath='$(Build.StagingDirectory)/Download/AssetManifests'
@@ -115,7 +115,7 @@ jobs:
       inputs:
         targetType: inline
         script: |
-          $symbolExclusionfile = "$(Build.SourcesDirectory)/eng/SymbolPublishingExclusionsFile.txt"
+          $symbolExclusionfile = "$(System.DefaultWorkingDirectory)/eng/SymbolPublishingExclusionsFile.txt"
           if(Test-Path -Path $symbolExclusionfile)
           {
             Write-Host "SymbolExclusionFile exists"
@@ -130,7 +130,7 @@ jobs:
       displayName: Publish SymbolPublishingExclusionsFile Artifact
       condition: eq(variables['SymbolExclusionFile'], 'true') 
       inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/eng/SymbolPublishingExclusionsFile.txt'
+        PathtoPublish: '$(System.DefaultWorkingDirectory)/eng/SymbolPublishingExclusionsFile.txt'
         PublishLocation: Container
         ArtifactName: ReleaseConfigs
 
@@ -146,7 +146,7 @@ jobs:
           azureSubscription: "Darc: Maestro Production"
           scriptType: ps
           scriptLocation: scriptPath
-          scriptPath: $(Build.SourcesDirectory)/eng/common/post-build/publish-using-darc.ps1
+          scriptPath: $(System.DefaultWorkingDirectory)/eng/common/post-build/publish-using-darc.ps1
           arguments: -BuildId $(BARBuildId)
             -PublishingInfraVersion 3
             -AzdoToken '$(System.AccessToken)'

--- a/eng/common/templates-official/job/publish-build-assets.yml
+++ b/eng/common/templates-official/job/publish-build-assets.yml
@@ -30,6 +30,8 @@ parameters:
 
   signingValidationAdditionalParameters: ''
 
+  repositoryAlias: self
+
 jobs:
 - job: Asset_Registry_Publish
 
@@ -65,6 +67,9 @@ jobs:
       os: windows
   steps:
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - checkout: ${{ parameters.repositoryAlias }}
+      fetchDepth: 3
+      clean: true
     - task: DownloadBuildArtifacts@0
       displayName: Download artifact
       inputs:

--- a/eng/common/templates-official/job/source-index-stage1.yml
+++ b/eng/common/templates-official/job/source-index-stage1.yml
@@ -59,7 +59,7 @@ jobs:
   - script: ${{ parameters.sourceIndexBuildCommand }}
     displayName: Build Repository
 
-  - script: $(Agent.TempDirectory)/.source-index/tools/BinLogToSln -i $(BinlogPath) -r $(Build.SourcesDirectory) -n $(Build.Repository.Name) -o .source-index/stage1output
+  - script: $(Agent.TempDirectory)/.source-index/tools/BinLogToSln -i $(BinlogPath) -r $(System.DefaultWorkingDirectory) -n $(Build.Repository.Name) -o .source-index/stage1output
     displayName: Process Binlog into indexable sln
 
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/common/templates-official/jobs/codeql-build.yml
+++ b/eng/common/templates-official/jobs/codeql-build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: DefaultGuardianVersion
         value: 0.109.0
       - name: GuardianPackagesConfigFile
-        value: $(Build.SourcesDirectory)\eng\common\sdl\packages.config
+        value: $(System.DefaultWorkingDirectory)\eng\common\sdl\packages.config
       - name: GuardianVersion
         value: ${{ coalesce(parameters.overrideGuardianVersion, '$(DefaultGuardianVersion)') }}
   

--- a/eng/common/templates-official/jobs/jobs.yml
+++ b/eng/common/templates-official/jobs/jobs.yml
@@ -40,6 +40,7 @@ parameters:
 
   enableSourceIndex: false
   sourceIndexParams: {}
+  repositoryAlias: self
 
 # Internal resources (telemetry, microbuild) can only be accessed from non-public projects,
 # and some (Microbuild) should only be applied to non-PR cases for internal builds.
@@ -95,3 +96,4 @@ jobs:
         enablePublishBuildArtifacts: ${{ parameters.enablePublishBuildArtifacts }}
         artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
         signingValidationAdditionalParameters: ${{ parameters.signingValidationAdditionalParameters }}
+        repositoryAlias: ${{ parameters.repositoryAlias }}

--- a/eng/common/templates-official/post-build/post-build.yml
+++ b/eng/common/templates-official/post-build/post-build.yml
@@ -133,7 +133,7 @@ stages:
         - task: PowerShell@2
           displayName: Validate
           inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/post-build/nuget-validation.ps1
+            filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/nuget-validation.ps1
             arguments: -PackagesPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/ 
               -ToolDestinationPath $(Agent.BuildDirectory)/Extract/ 
 
@@ -186,7 +186,7 @@ stages:
             filePath: eng\common\sdk-task.ps1
             arguments: -task SigningValidation -restore -msbuildEngine vs
               /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts'
-              /p:SignCheckExclusionsFile='$(Build.SourcesDirectory)/eng/SignCheckExclusionsFile.txt'
+              /p:SignCheckExclusionsFile='$(System.DefaultWorkingDirectory)/eng/SignCheckExclusionsFile.txt'
               ${{ parameters.signingValidationAdditionalParameters }}
 
         - template: ../steps/publish-logs.yml
@@ -230,7 +230,7 @@ stages:
         - task: PowerShell@2
           displayName: Validate
           inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/post-build/sourcelink-validation.ps1
+            filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/sourcelink-validation.ps1
             arguments: -InputPath $(Build.ArtifactStagingDirectory)/BlobArtifacts/ 
               -ExtractPath $(Agent.BuildDirectory)/Extract/ 
               -GHRepoName $(Build.Repository.Name) 
@@ -278,7 +278,7 @@ stages:
             azureSubscription: "Darc: Maestro Production"
             scriptType: ps
             scriptLocation: scriptPath
-            scriptPath: $(Build.SourcesDirectory)/eng/common/post-build/publish-using-darc.ps1
+            scriptPath: $(System.DefaultWorkingDirectory)/eng/common/post-build/publish-using-darc.ps1
             arguments: -BuildId $(BARBuildId) 
               -PublishingInfraVersion ${{ parameters.publishingInfraVersion }}
               -AzdoToken '$(System.AccessToken)'

--- a/eng/common/templates-official/post-build/trigger-subscription.yml
+++ b/eng/common/templates-official/post-build/trigger-subscription.yml
@@ -5,7 +5,7 @@ steps:
 - task: PowerShell@2
   displayName: Triggering subscriptions
   inputs:
-    filePath: $(Build.SourcesDirectory)/eng/common/post-build/trigger-subscriptions.ps1
+    filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/trigger-subscriptions.ps1
     arguments: -SourceRepo $(Build.Repository.Uri)
       -ChannelId ${{ parameters.ChannelId }}
       -MaestroApiAccessToken $(MaestroAccessToken)

--- a/eng/common/templates-official/steps/add-build-to-channel.yml
+++ b/eng/common/templates-official/steps/add-build-to-channel.yml
@@ -5,7 +5,7 @@ steps:
 - task: PowerShell@2
   displayName: Add Build to Channel
   inputs:
-    filePath: $(Build.SourcesDirectory)/eng/common/post-build/add-build-to-channel.ps1
+    filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/add-build-to-channel.ps1
     arguments: -BuildId $(BARBuildId) 
       -ChannelId ${{ parameters.ChannelId }}
       -MaestroApiAccessToken $(MaestroApiAccessToken)

--- a/eng/common/templates-official/steps/execute-sdl.yml
+++ b/eng/common/templates-official/steps/execute-sdl.yml
@@ -15,17 +15,17 @@ steps:
   
 - ${{ if ne(parameters.overrideGuardianVersion, '') }}:
   - pwsh: |
-      Set-Location -Path $(Build.SourcesDirectory)\eng\common\sdl
+      Set-Location -Path $(System.DefaultWorkingDirectory)\eng\common\sdl
       . .\sdl.ps1
-      $guardianCliLocation = Install-Gdn -Path $(Build.SourcesDirectory)\.artifacts -Version ${{ parameters.overrideGuardianVersion }}
+      $guardianCliLocation = Install-Gdn -Path $(System.DefaultWorkingDirectory)\.artifacts -Version ${{ parameters.overrideGuardianVersion }}
       Write-Host "##vso[task.setvariable variable=GuardianCliLocation]$guardianCliLocation"
     displayName: Install Guardian (Overridden)
 
 - ${{ if eq(parameters.overrideGuardianVersion, '') }}:
   - pwsh: |
-      Set-Location -Path $(Build.SourcesDirectory)\eng\common\sdl
+      Set-Location -Path $(System.DefaultWorkingDirectory)\eng\common\sdl
       . .\sdl.ps1
-      $guardianCliLocation = Install-Gdn -Path $(Build.SourcesDirectory)\.artifacts
+      $guardianCliLocation = Install-Gdn -Path $(System.DefaultWorkingDirectory)\.artifacts
       Write-Host "##vso[task.setvariable variable=GuardianCliLocation]$guardianCliLocation"
     displayName: Install Guardian
 
@@ -38,7 +38,7 @@ steps:
 - ${{ if eq(parameters.overrideParameters, '') }}:
   - powershell: ${{ parameters.executeAllSdlToolsScript }}
       -GuardianCliLocation $(GuardianCliLocation)
-      -NugetPackageDirectory $(Build.SourcesDirectory)\.packages
+      -NugetPackageDirectory $(System.DefaultWorkingDirectory)\.packages
       -AzureDevOpsAccessToken $(dn-bot-dotnet-build-rw-code-rw)
       ${{ parameters.additionalParameters }}
     displayName: Execute SDL
@@ -73,7 +73,7 @@ steps:
       flattenFolders: true
       sourceFolder:  $(Agent.BuildDirectory)/.gdn/rc/
       contents: '**/*.sarif'
-      targetFolder: $(Build.SourcesDirectory)/CodeAnalysisLogs
+      targetFolder: $(System.DefaultWorkingDirectory)/CodeAnalysisLogs
     condition: succeededOrFailed()
 
   # Use PublishBuildArtifacts because the SARIF extension only checks this case
@@ -81,6 +81,6 @@ steps:
   - task: PublishBuildArtifacts@1
     displayName: Publish SARIF files to CodeAnalysisLogs container
     inputs:
-      pathToPublish:  $(Build.SourcesDirectory)/CodeAnalysisLogs
+      pathToPublish:  $(System.DefaultWorkingDirectory)/CodeAnalysisLogs
       artifactName: CodeAnalysisLogs
     condition: succeededOrFailed()

--- a/eng/common/templates-official/steps/generate-sbom.yml
+++ b/eng/common/templates-official/steps/generate-sbom.yml
@@ -6,7 +6,7 @@
 
 parameters:
   PackageVersion: 8.0.0
-  BuildDropPath: '$(Build.SourcesDirectory)/artifacts'
+  BuildDropPath: '$(System.DefaultWorkingDirectory)/artifacts'
   PackageName: '.NET'
   ManifestDirPath: $(Build.ArtifactStagingDirectory)/sbom
   IgnoreDirectories: ''

--- a/eng/common/templates-official/steps/publish-logs.yml
+++ b/eng/common/templates-official/steps/publish-logs.yml
@@ -8,15 +8,15 @@ steps:
   inputs:
     targetType: inline
     script: |
-      New-Item -ItemType Directory $(Build.SourcesDirectory)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
-      Move-Item -Path $(Build.SourcesDirectory)/artifacts/log/Debug/* $(Build.SourcesDirectory)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
+      New-Item -ItemType Directory $(System.DefaultWorkingDirectory)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
+      Move-Item -Path $(System.DefaultWorkingDirectory)/artifacts/log/Debug/* $(System.DefaultWorkingDirectory)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
   continueOnError: true
   condition: always()
 
 - task: 1ES.PublishBuildArtifacts@1
   displayName: Publish Logs
   inputs:
-    PathtoPublish: '$(Build.SourcesDirectory)/PostBuildLogs'
+    PathtoPublish: '$(System.DefaultWorkingDirectory)/PostBuildLogs'
     PublishLocation: Container
     ArtifactName: PostBuildLogs
   continueOnError: true

--- a/eng/common/templates-official/steps/source-build.yml
+++ b/eng/common/templates-official/steps/source-build.yml
@@ -26,8 +26,8 @@ steps:
     internalRestoreArgs=
     if [ '$(dn-bot-dnceng-artifact-feeds-rw)' != '$''(dn-bot-dnceng-artifact-feeds-rw)' ]; then
       # Temporarily work around https://github.com/dotnet/arcade/issues/7709
-      chmod +x $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
-      $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh $(Build.SourcesDirectory)/NuGet.config $(dn-bot-dnceng-artifact-feeds-rw)
+      chmod +x $(System.DefaultWorkingDirectory)/eng/common/SetupNugetSources.sh
+      $(System.DefaultWorkingDirectory)/eng/common/SetupNugetSources.sh $(System.DefaultWorkingDirectory)/NuGet.config $(dn-bot-dnceng-artifact-feeds-rw)
       internalRestoreArgs='/p:CopyWipIntoInnerSourceBuildRepo=true'
 
       # The 'Copy WIP' feature of source build uses git stash to apply changes from the original repo.
@@ -101,7 +101,7 @@ steps:
 - task: CopyFiles@2
   displayName: Prepare BuildLogs staging directory
   inputs:
-    SourceFolder: '$(Build.SourcesDirectory)'
+    SourceFolder: '$(System.DefaultWorkingDirectory)'
     Contents: |
       **/*.log
       **/*.binlog
@@ -126,4 +126,4 @@ steps:
 - task: ComponentGovernanceComponentDetection@0
   displayName: Component Detection (Exclude upstream cache)
   inputs:
-    ignoreDirectories: '$(Build.SourcesDirectory)/artifacts/source-build/self/src/artifacts/obj/source-built-upstream-cache'
+    ignoreDirectories: '$(System.DefaultWorkingDirectory)/artifacts/source-build/self/src/artifacts/obj/source-built-upstream-cache'

--- a/eng/common/templates-official/variables/sdl-variables.yml
+++ b/eng/common/templates-official/variables/sdl-variables.yml
@@ -4,4 +4,4 @@ variables:
 - name: DefaultGuardianVersion
   value: 0.109.0
 - name: GuardianPackagesConfigFile
-  value: $(Build.SourcesDirectory)\eng\common\sdl\packages.config
+  value: $(System.DefaultWorkingDirectory)\eng\common\sdl\packages.config

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -37,7 +37,7 @@ parameters:
 # Sbom related params
   enableSbom: true
   PackageVersion: 7.0.0
-  BuildDropPath: '$(Build.SourcesDirectory)/artifacts'
+  BuildDropPath: '$(System.DefaultWorkingDirectory)/artifacts'
 
 jobs:
 - job: ${{ parameters.name }}
@@ -163,7 +163,7 @@ jobs:
       inputs:
         languages: ${{ coalesce(parameters.richCodeNavigationLanguage, 'csharp') }}
         environment: ${{ coalesce(parameters.richCodeNavigationEnvironment, 'production') }}
-        richNavLogOutputDirectory: $(Build.SourcesDirectory)/artifacts/bin
+        richNavLogOutputDirectory: $(System.DefaultWorkingDirectory)/artifacts/bin
         uploadRichNavArtifacts: ${{ coalesce(parameters.richCodeNavigationUploadArtifacts, false) }}
       continueOnError: true
 
@@ -220,7 +220,7 @@ jobs:
     - task: PublishBuildArtifacts@1
       displayName: Publish Logs
       inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
+        PathtoPublish: '$(System.DefaultWorkingDirectory)/artifacts/log/$(_BuildConfig)'
         PublishLocation: Container
         ArtifactName: ${{ coalesce(parameters.enablePublishBuildArtifacts.artifactName, '$(Agent.Os)_$(Agent.JobName)' ) }}
       continueOnError: true
@@ -232,7 +232,7 @@ jobs:
       inputs:
         testResultsFormat: 'xUnit'
         testResultsFiles: '*.xml'
-        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+        searchFolder: '$(System.DefaultWorkingDirectory)/artifacts/TestResults/$(_BuildConfig)'
         testRunTitle: ${{ coalesce(parameters.testRunTitle, parameters.name, '$(System.JobName)') }}-xunit
         mergeTestResults: ${{ parameters.mergeTestResults }}
       continueOnError: true
@@ -243,7 +243,7 @@ jobs:
       inputs:
         testResultsFormat: 'VSTest'
         testResultsFiles: '*.trx'
-        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+        searchFolder: '$(System.DefaultWorkingDirectory)/artifacts/TestResults/$(_BuildConfig)'
         testRunTitle: ${{ coalesce(parameters.testRunTitle, parameters.name, '$(System.JobName)') }}-trx
         mergeTestResults: ${{ parameters.mergeTestResults }}
       continueOnError: true
@@ -257,7 +257,7 @@ jobs:
         IgnoreDirectories: ${{ parameters.componentGovernanceIgnoreDirectories }}
 
   - ${{ if eq(parameters.enableBuildRetry, 'true') }}:
-    - publish: $(Build.SourcesDirectory)\eng\common\BuildConfiguration
+    - publish: $(System.DefaultWorkingDirectory)\eng\common\BuildConfiguration
       artifact: BuildConfiguration
       displayName: Publish build retry configuration
       continueOnError: true

--- a/eng/common/templates/job/onelocbuild.yml
+++ b/eng/common/templates/job/onelocbuild.yml
@@ -8,7 +8,7 @@ parameters:
   CeapexPat: $(dn-bot-ceapex-package-r) # PAT for the loc AzDO instance https://dev.azure.com/ceapex
   GithubPat: $(BotAccount-dotnet-bot-repo-PAT)
 
-  SourcesDirectory: $(Build.SourcesDirectory)
+  SourcesDirectory: $(System.DefaultWorkingDirectory)
   CreatePr: true
   AutoCompletePr: false
   ReusePr: true
@@ -60,7 +60,7 @@ jobs:
     - ${{ if ne(parameters.SkipLocProjectJsonGeneration, 'true') }}:
       - task: Powershell@2
         inputs:
-          filePath: $(Build.SourcesDirectory)/eng/common/generate-locproject.ps1
+          filePath: $(System.DefaultWorkingDirectory)/eng/common/generate-locproject.ps1
           arguments: $(_GenerateLocProjectArguments)
         displayName: Generate LocProject.json
         condition: ${{ parameters.condition }}
@@ -103,7 +103,7 @@ jobs:
     - task: PublishBuildArtifacts@1
       displayName: Publish LocProject.json
       inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/eng/Localize/'
+        PathtoPublish: '$(System.DefaultWorkingDirectory)/eng/Localize/'
         PublishLocation: Container
         ArtifactName: Loc
       condition: ${{ parameters.condition }}

--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -30,6 +30,8 @@ parameters:
 
   signingValidationAdditionalParameters: ''
 
+  repositoryAlias: self
+
 jobs:
 - job: Asset_Registry_Publish
 
@@ -63,6 +65,9 @@ jobs:
 
   steps:
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - checkout: ${{ parameters.repositoryAlias }}
+      fetchDepth: 3
+      clean: true
     - task: DownloadBuildArtifacts@0
       displayName: Download artifact
       inputs:

--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -80,7 +80,7 @@ jobs:
         azureSubscription: "Darc: Maestro Production"
         scriptType: ps
         scriptLocation: scriptPath
-        scriptPath: $(Build.SourcesDirectory)/eng/common/sdk-task.ps1
+        scriptPath: $(System.DefaultWorkingDirectory)/eng/common/sdk-task.ps1
         arguments: >
           -task PublishBuildAssets -restore -msbuildEngine dotnet
           /p:ManifestsPath='$(Build.StagingDirectory)/Download/AssetManifests'
@@ -111,7 +111,7 @@ jobs:
       inputs:
         targetType: inline
         script: |
-          $symbolExclusionfile = "$(Build.SourcesDirectory)/eng/SymbolPublishingExclusionsFile.txt"
+          $symbolExclusionfile = "$(System.DefaultWorkingDirectory)/eng/SymbolPublishingExclusionsFile.txt"
           if(Test-Path -Path $symbolExclusionfile)
           {
             Write-Host "SymbolExclusionFile exists"
@@ -126,7 +126,7 @@ jobs:
       displayName: Publish SymbolPublishingExclusionsFile Artifact
       condition: eq(variables['SymbolExclusionFile'], 'true')
       inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/eng/SymbolPublishingExclusionsFile.txt'
+        PathtoPublish: '$(System.DefaultWorkingDirectory)/eng/SymbolPublishingExclusionsFile.txt'
         PublishLocation: Container
         ArtifactName: ReleaseConfigs
 
@@ -142,7 +142,7 @@ jobs:
           azureSubscription: "Darc: Maestro Production"
           scriptType: ps
           scriptLocation: scriptPath
-          scriptPath: $(Build.SourcesDirectory)/eng/common/post-build/publish-using-darc.ps1
+          scriptPath: $(System.DefaultWorkingDirectory)/eng/common/post-build/publish-using-darc.ps1
           arguments: -BuildId $(BARBuildId) 
             -PublishingInfraVersion 3
             -AzdoToken '$(System.AccessToken)'

--- a/eng/common/templates/job/source-index-stage1.yml
+++ b/eng/common/templates/job/source-index-stage1.yml
@@ -58,7 +58,7 @@ jobs:
   - script: ${{ parameters.sourceIndexBuildCommand }}
     displayName: Build Repository
 
-  - script: $(Agent.TempDirectory)/.source-index/tools/BinLogToSln -i $(BinlogPath) -r $(Build.SourcesDirectory) -n $(Build.Repository.Name) -o .source-index/stage1output
+  - script: $(Agent.TempDirectory)/.source-index/tools/BinLogToSln -i $(BinlogPath) -r $(System.DefaultWorkingDirectory) -n $(Build.Repository.Name) -o .source-index/stage1output
     displayName: Process Binlog into indexable sln
 
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/common/templates/jobs/codeql-build.yml
+++ b/eng/common/templates/jobs/codeql-build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: DefaultGuardianVersion
         value: 0.109.0
       - name: GuardianPackagesConfigFile
-        value: $(Build.SourcesDirectory)\eng\common\sdl\packages.config
+        value: $(System.DefaultWorkingDirectory)\eng\common\sdl\packages.config
       - name: GuardianVersion
         value: ${{ coalesce(parameters.overrideGuardianVersion, '$(DefaultGuardianVersion)') }}
   

--- a/eng/common/templates/jobs/jobs.yml
+++ b/eng/common/templates/jobs/jobs.yml
@@ -40,6 +40,7 @@ parameters:
 
   enableSourceIndex: false
   sourceIndexParams: {}
+  repositoryAlias: self
 
 # Internal resources (telemetry, microbuild) can only be accessed from non-public projects,
 # and some (Microbuild) should only be applied to non-PR cases for internal builds.
@@ -95,3 +96,4 @@ jobs:
         enablePublishBuildArtifacts: ${{ parameters.enablePublishBuildArtifacts }}
         artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
         signingValidationAdditionalParameters: ${{ parameters.signingValidationAdditionalParameters }}
+        repositoryAlias: ${{ parameters.repositoryAlias }}

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -130,7 +130,7 @@ stages:
         - task: PowerShell@2
           displayName: Validate
           inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/post-build/nuget-validation.ps1
+            filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/nuget-validation.ps1
             arguments: -PackagesPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/
               -ToolDestinationPath $(Agent.BuildDirectory)/Extract/
 
@@ -180,7 +180,7 @@ stages:
             filePath: eng\common\sdk-task.ps1
             arguments: -task SigningValidation -restore -msbuildEngine vs
               /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts'
-              /p:SignCheckExclusionsFile='$(Build.SourcesDirectory)/eng/SignCheckExclusionsFile.txt'
+              /p:SignCheckExclusionsFile='$(System.DefaultWorkingDirectory)/eng/SignCheckExclusionsFile.txt'
               ${{ parameters.signingValidationAdditionalParameters }}
 
         - template: ../steps/publish-logs.yml
@@ -220,7 +220,7 @@ stages:
         - task: PowerShell@2
           displayName: Validate
           inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/post-build/sourcelink-validation.ps1
+            filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/sourcelink-validation.ps1
             arguments: -InputPath $(Build.ArtifactStagingDirectory)/BlobArtifacts/
               -ExtractPath $(Agent.BuildDirectory)/Extract/
               -GHRepoName $(Build.Repository.Name)
@@ -274,7 +274,7 @@ stages:
             azureSubscription: "Darc: Maestro Production"
             scriptType: ps
             scriptLocation: scriptPath
-            scriptPath: $(Build.SourcesDirectory)/eng/common/post-build/publish-using-darc.ps1
+            scriptPath: $(System.DefaultWorkingDirectory)/eng/common/post-build/publish-using-darc.ps1
             arguments: -BuildId $(BARBuildId)
               -PublishingInfraVersion ${{ parameters.publishingInfraVersion }}
               -AzdoToken '$(System.AccessToken)'

--- a/eng/common/templates/post-build/setup-maestro-vars.yml
+++ b/eng/common/templates/post-build/setup-maestro-vars.yml
@@ -32,7 +32,7 @@ steps:
             $AzureDevOpsBuildId = $Env:Build_BuildId
           }
           else {
-            . $(Build.SourcesDirectory)\eng\common\tools.ps1
+            . $(System.DefaultWorkingDirectory)\eng\common\tools.ps1
             $darc = Get-Darc
             $buildInfo = & $darc get-build `
               --id ${{ parameters.BARBuildId }} `

--- a/eng/common/templates/post-build/trigger-subscription.yml
+++ b/eng/common/templates/post-build/trigger-subscription.yml
@@ -5,7 +5,7 @@ steps:
 - task: PowerShell@2
   displayName: Triggering subscriptions
   inputs:
-    filePath: $(Build.SourcesDirectory)/eng/common/post-build/trigger-subscriptions.ps1
+    filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/trigger-subscriptions.ps1
     arguments: -SourceRepo $(Build.Repository.Uri)
       -ChannelId ${{ parameters.ChannelId }}
       -MaestroApiAccessToken $(MaestroAccessToken)

--- a/eng/common/templates/steps/add-build-to-channel.yml
+++ b/eng/common/templates/steps/add-build-to-channel.yml
@@ -5,7 +5,7 @@ steps:
 - task: PowerShell@2
   displayName: Add Build to Channel
   inputs:
-    filePath: $(Build.SourcesDirectory)/eng/common/post-build/add-build-to-channel.ps1
+    filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/add-build-to-channel.ps1
     arguments: -BuildId $(BARBuildId) 
       -ChannelId ${{ parameters.ChannelId }}
       -MaestroApiAccessToken $(MaestroApiAccessToken)

--- a/eng/common/templates/steps/execute-sdl.yml
+++ b/eng/common/templates/steps/execute-sdl.yml
@@ -15,17 +15,17 @@ steps:
   
 - ${{ if ne(parameters.overrideGuardianVersion, '') }}:
   - pwsh: |
-      Set-Location -Path $(Build.SourcesDirectory)\eng\common\sdl
+      Set-Location -Path $(System.DefaultWorkingDirectory)\eng\common\sdl
       . .\sdl.ps1
-      $guardianCliLocation = Install-Gdn -Path $(Build.SourcesDirectory)\.artifacts -Version ${{ parameters.overrideGuardianVersion }}
+      $guardianCliLocation = Install-Gdn -Path $(System.DefaultWorkingDirectory)\.artifacts -Version ${{ parameters.overrideGuardianVersion }}
       Write-Host "##vso[task.setvariable variable=GuardianCliLocation]$guardianCliLocation"
     displayName: Install Guardian (Overridden)
 
 - ${{ if eq(parameters.overrideGuardianVersion, '') }}:
   - pwsh: |
-      Set-Location -Path $(Build.SourcesDirectory)\eng\common\sdl
+      Set-Location -Path $(System.DefaultWorkingDirectory)\eng\common\sdl
       . .\sdl.ps1
-      $guardianCliLocation = Install-Gdn -Path $(Build.SourcesDirectory)\.artifacts
+      $guardianCliLocation = Install-Gdn -Path $(System.DefaultWorkingDirectory)\.artifacts
       Write-Host "##vso[task.setvariable variable=GuardianCliLocation]$guardianCliLocation"
     displayName: Install Guardian
 
@@ -40,7 +40,7 @@ steps:
 - ${{ if eq(parameters.overrideParameters, '') }}:
   - powershell: ${{ parameters.executeAllSdlToolsScript }}
       -GuardianCliLocation $(GuardianCliLocation)
-      -NugetPackageDirectory $(Build.SourcesDirectory)\.packages
+      -NugetPackageDirectory $(System.DefaultWorkingDirectory)\.packages
       ${{ parameters.additionalParameters }}
     displayName: Execute SDL
     continueOnError: ${{ parameters.sdlContinueOnError }}
@@ -76,7 +76,7 @@ steps:
       flattenFolders: true
       sourceFolder:  $(Agent.BuildDirectory)/.gdn/rc/
       contents: '**/*.sarif'
-      targetFolder: $(Build.SourcesDirectory)/CodeAnalysisLogs
+      targetFolder: $(System.DefaultWorkingDirectory)/CodeAnalysisLogs
     condition: succeededOrFailed()
 
   # Use PublishBuildArtifacts because the SARIF extension only checks this case
@@ -84,6 +84,6 @@ steps:
   - task: PublishBuildArtifacts@1
     displayName: Publish SARIF files to CodeAnalysisLogs container
     inputs:
-      pathToPublish:  $(Build.SourcesDirectory)/CodeAnalysisLogs
+      pathToPublish:  $(System.DefaultWorkingDirectory)/CodeAnalysisLogs
       artifactName: CodeAnalysisLogs
     condition: succeededOrFailed()

--- a/eng/common/templates/steps/generate-sbom.yml
+++ b/eng/common/templates/steps/generate-sbom.yml
@@ -6,7 +6,7 @@
 
 parameters:
   PackageVersion: 8.0.0
-  BuildDropPath: '$(Build.SourcesDirectory)/artifacts'
+  BuildDropPath: '$(System.DefaultWorkingDirectory)/artifacts'
   PackageName: '.NET'
   ManifestDirPath: $(Build.ArtifactStagingDirectory)/sbom
   IgnoreDirectories: ''

--- a/eng/common/templates/steps/publish-logs.yml
+++ b/eng/common/templates/steps/publish-logs.yml
@@ -8,15 +8,15 @@ steps:
   inputs:
     targetType: inline
     script: |
-      New-Item -ItemType Directory $(Build.SourcesDirectory)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
-      Move-Item -Path $(Build.SourcesDirectory)/artifacts/log/Debug/* $(Build.SourcesDirectory)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
+      New-Item -ItemType Directory $(System.DefaultWorkingDirectory)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
+      Move-Item -Path $(System.DefaultWorkingDirectory)/artifacts/log/Debug/* $(System.DefaultWorkingDirectory)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
   continueOnError: true
   condition: always()
 
 - task: PublishBuildArtifacts@1
   displayName: Publish Logs
   inputs:
-    PathtoPublish: '$(Build.SourcesDirectory)/PostBuildLogs'
+    PathtoPublish: '$(System.DefaultWorkingDirectory)/PostBuildLogs'
     PublishLocation: Container
     ArtifactName: PostBuildLogs
   continueOnError: true

--- a/eng/common/templates/steps/source-build.yml
+++ b/eng/common/templates/steps/source-build.yml
@@ -26,8 +26,8 @@ steps:
     internalRestoreArgs=
     if [ '$(dn-bot-dnceng-artifact-feeds-rw)' != '$''(dn-bot-dnceng-artifact-feeds-rw)' ]; then
       # Temporarily work around https://github.com/dotnet/arcade/issues/7709
-      chmod +x $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
-      $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh $(Build.SourcesDirectory)/NuGet.config $(dn-bot-dnceng-artifact-feeds-rw)
+      chmod +x $(System.DefaultWorkingDirectory)/eng/common/SetupNugetSources.sh
+      $(System.DefaultWorkingDirectory)/eng/common/SetupNugetSources.sh $(System.DefaultWorkingDirectory)/NuGet.config $(dn-bot-dnceng-artifact-feeds-rw)
       internalRestoreArgs='/p:CopyWipIntoInnerSourceBuildRepo=true'
 
       # The 'Copy WIP' feature of source build uses git stash to apply changes from the original repo.
@@ -101,7 +101,7 @@ steps:
 - task: CopyFiles@2
   displayName: Prepare BuildLogs staging directory
   inputs:
-    SourceFolder: '$(Build.SourcesDirectory)'
+    SourceFolder: '$(System.DefaultWorkingDirectory)'
     Contents: |
       **/*.log
       **/*.binlog
@@ -126,4 +126,4 @@ steps:
 - task: ComponentGovernanceComponentDetection@0
   displayName: Component Detection (Exclude upstream cache)
   inputs:
-    ignoreDirectories: '$(Build.SourcesDirectory)/artifacts/source-build/self/src/artifacts/obj/source-built-upstream-cache'
+    ignoreDirectories: '$(System.DefaultWorkingDirectory)/artifacts/source-build/self/src/artifacts/obj/source-built-upstream-cache'

--- a/eng/common/templates/variables/sdl-variables.yml
+++ b/eng/common/templates/variables/sdl-variables.yml
@@ -4,4 +4,4 @@ variables:
 - name: DefaultGuardianVersion
   value: 0.109.0
 - name: GuardianPackagesConfigFile
-  value: $(Build.SourcesDirectory)\eng\common\sdl\packages.config
+  value: $(System.DefaultWorkingDirectory)\eng\common\sdl\packages.config

--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -144,7 +144,7 @@ stages:
         - task: PowerShell@2
           displayName: Enable cross-org publishing
           inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/enable-cross-org-publishing.ps1
+            filePath: $(System.DefaultWorkingDirectory)/eng/common/enable-cross-org-publishing.ps1
             arguments: -token $(dn-bot-all-orgs-artifact-feeds-rw)
 
         - task: AzureCLI@2
@@ -162,7 +162,7 @@ stages:
         - task: PowerShell@2
           displayName: Publish packages, blobs and symbols
           inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/sdk-task.ps1
+            filePath: $(System.DefaultWorkingDirectory)/eng/common/sdk-task.ps1
             arguments: -task PublishArtifactsInManifest -restore -msbuildEngine dotnet
               /p:PublishingInfraVersion=3
               /p:BARBuildId=${{ parameters.BARBuildId }}

--- a/eng/validate-sdk.yml
+++ b/eng/validate-sdk.yml
@@ -39,7 +39,7 @@ jobs:
         inlineScript: >
           .\eng\update-packagesource.ps1
           -gitHubPat $(BotAccount-dotnet-maestro-bot-PAT)
-          -packagesSource $(Build.SourcesDirectory)/build_stage_artifacts
+          -packagesSource $(System.DefaultWorkingDirectory)/build_stage_artifacts
       displayName: Update package source
     - script: eng\common\cibuild.cmd
         $(_BuildArgs)


### PR DESCRIPTION
Backport of: https://github.com/dotnet/arcade/pull/16032

## Summary

This is a backport of the same [change to main](https://github.com/dotnet/arcade/pull/16032) to replace `Build.SourcesDirectory` with `System.DefaultWorkingDirectory`, and add the `repositoryAlias` for publishing assets. For more details, see the original PR.

This branch has more changes than the original because the files between unofficial and official are duplicated in this branch (which was done as a quick fix at the time).