### PR TITLE
Fixup PME signing on Windows

### DIFF
--- a/eng/common/core-templates/steps/install-microbuild.yml
+++ b/eng/common/core-templates/steps/install-microbuild.yml
@@ -52,14 +52,11 @@ steps:
         signType: $(_SignType)
         zipSources: false
         feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-        ${{ if eq(parameters.microbuildUseESRP, true) }}:
-          ${{ if eq(parameters.enableMicrobuildForMacAndLinux, 'true') }}:
-            azureSubscription: 'MicroBuild Signing Task (DevDiv)'
-            useEsrpCli: true
-          ${{ elseif eq(variables['System.TeamProject'], 'DevDiv') }}:
-            ConnectedPMEServiceName: 6cc74545-d7b9-4050-9dfa-ebefcc8961ea
-          ${{ else }}:
-            ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
+        ConnectedServiceName: 'MicroBuild Signing Task (DevDiv)'
+        ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+          ConnectedPMEServiceName: 6cc74545-d7b9-4050-9dfa-ebefcc8961ea
+        ${{ else }}:
+          ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
       env:
         TeamName: $(_TeamName)
         MicroBuildOutputFolderOverride: ${{ parameters.microBuildOutputFolder }}


### PR DESCRIPTION
The condition for mac/linux signing was preventing the use of the connected pme service name on Windows. Based on chats with the MB folks, the format should be to always pass the ConnectedServiceName and ConnectedPMEServiceName.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
