### PR TITLE
[9.0] Build duplicates of all installer packages for new signing keys

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
@@ -148,15 +148,22 @@
       <ExeBundleInstallerFile>$(PackageOutputPath)$(InstallerFileNameWithoutExtension).exe</ExeBundleInstallerFile>
       <ExeBundleInstallerEngineFile>$(PackageOutputPath)$(InstallerFileNameWithoutExtension)-engine.exe</ExeBundleInstallerEngineFile>
     </PropertyGroup>
+  </Target>
 
-    <PropertyGroup Condition="'$(GenerateRpm)' == 'true'">
-      <CreateRPMForCblMariner>true</CreateRPMForCblMariner>
-      <!-- PackageTargetOS is a distro-specific version suffix, used for deps packages, including the one for CBL Mariner.
-           We do not want to create additional CBL Mariner named RPMs of those packages. -->
-      <CreateRPMForCblMariner Condition="'$(PackageTargetOS)' != ''">false</CreateRPMForCblMariner>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(CreateRPMForCblMariner)' == 'true'">
+  
+  <!--
+    Packages produced for CBL-Mariner must be signed with a special certificate.
+    Additionally, some distros use old keys (SHA-1 based) so there's a different cert for new packages.
+    RPM v4 doesn't support multiple signatures, so we must have two separate copies of the RPM for us to sign.
+    To solve this, we make copies of the packages with special names (which the Arcade SDK will sign with the correct certificate).
+    PackageTargetOS is a distro-specific version suffix, used for deps packages, including the one for CBL-Mariner.
+    As a result, we don't need to create a separate copy of the package for CBL-Mariner, but we do need to create a copy with the new key (unless the target is CBL-Mariner).
+  -->
+  <Target Name="_BuildMarinerRpm"
+          AfterTargets="GenerateRpm"
+          Condition="'$(PackageTargetOS)' != ''">
+    <!-- CBL-Mariner -->
+    <PropertyGroup>
       <!-- CBL-Mariner 1.0 -->
       <_CblMarinerVersionSuffix>cm.1</_CblMarinerVersionSuffix>
       <_InstallerBuildPartCblMariner>$(Version)-$(_CblMarinerVersionSuffix)-$(InstallerTargetArchitecture)</_InstallerBuildPartCblMariner>
@@ -168,6 +175,40 @@
       <_InstallerFileNameWithoutExtensionCblMariner2>$(InstallerName)-$(_InstallerBuildPartCblMariner2)$(CrossArchContentsBuildPart)</_InstallerFileNameWithoutExtensionCblMariner2>
       <_InstallerFileCblMariner2>$(PackageOutputPath)$(_InstallerFileNameWithoutExtensionCblMariner2)$(InstallerExtension)</_InstallerFileCblMariner2>
     </PropertyGroup>
+    <Copy SourceFiles="$(_InstallerFile)"
+          DestinationFiles="$(_InstallerFileCblMariner)"
+          OverwriteReadOnlyFiles="True"
+          SkipUnchangedFiles="False"
+          UseHardlinksIfPossible="False" />
+
+    <Message Text="$(MSBuildProjectName) -> $(_InstallerFileCblMariner)" Importance="high" />
+    <Copy SourceFiles="$(_InstallerFile)"
+          DestinationFiles="$(_InstallerFileCblMariner2)"
+          OverwriteReadOnlyFiles="True"
+          SkipUnchangedFiles="False"
+          UseHardlinksIfPossible="False" />
+
+    <Message Text="$(MSBuildProjectName) -> $(_InstallerFileCblMariner2)" Importance="high" />
+  </Target>
+
+  <Target Name="_BuildNewKeyLinuxPackage"
+          AfterTargets="GenerateRpm;GenerateDeb"
+          Condition="'$(PackageTargetOS)' != 'cm.1' and '$(PackageTargetOS)' != 'cm.2'">
+    <!-- Packages to be signed with the new key -->
+    <PropertyGroup>
+      <_NewKeyVersionSuffix>newkey</_NewKeyVersionSuffix>
+      <_InstallerBuildPartNewKey>$(Version)-$(_NewKeyVersionSuffix)-$(_InstallerArchSuffix)</_InstallerBuildPartNewKey>
+      <_InstallerBuildPartNewKey Condition="'$(PackageTargetOS)' != ''">$(Version)-$(PackageTargetOS)-$(_NewKeyVersionSuffix)-$(_InstallerArchSuffix)</_InstallerBuildPartNewKey>
+      <_InstallerFileNameWithoutExtensionNewKey>$(InstallerName)-$(_InstallerBuildPartNewKey)$(CrossArchContentsBuildPart)</_InstallerFileNameWithoutExtensionNewKey>
+      <_InstallerFileNewKey>$(PackageOutputPath)$(_InstallerFileNameWithoutExtensionNewKey)$(InstallerExtension)</_InstallerFileNewKey>
+    </PropertyGroup>
+    <Copy SourceFiles="$(_InstallerFile)"
+          DestinationFiles="$(_InstallerFileNewKey)"
+          OverwriteReadOnlyFiles="True"
+          SkipUnchangedFiles="False"
+          UseHardlinksIfPossible="False" />
+
+    <Message Text="$(MSBuildProjectName) -> $(_InstallerFileNewKey)" Importance="high" />
   </Target>
   
   <!--
@@ -330,26 +371,6 @@
           UseHardlinksIfPossible="False" />
 
     <Message Text="$(MSBuildProjectName) -> $(_InstallerFile)" Importance="high" />
-
-    <!-- CBL-Mariner 1.0 -->
-    <Copy Condition="'$(CreateRPMForCblMariner)' == 'true'"
-          SourceFiles="@(GeneratedRpmFiles)"
-          DestinationFiles="$(_InstallerFileCblMariner)"
-          OverwriteReadOnlyFiles="True"
-          SkipUnchangedFiles="False"
-          UseHardlinksIfPossible="False" />
-
-    <Message Text="$(MSBuildProjectName) -> $(_InstallerFileCblMariner)" Importance="high" />
-
-    <!-- CBL-Mariner 2.0 -->
-    <Copy Condition="'$(CreateRPMForCblMariner)' == 'true'"
-          SourceFiles="@(GeneratedRpmFiles)"
-          DestinationFiles="$(_InstallerFileCblMariner2)"
-          OverwriteReadOnlyFiles="True"
-          SkipUnchangedFiles="False"
-          UseHardlinksIfPossible="False" />
-
-    <Message Text="$(MSBuildProjectName) -> $(_InstallerFileCblMariner2)" Importance="high" />
   </Target>
 
   <Target Name="GetRpmInstallerJsonProperties"


### PR DESCRIPTION
Port of #16049 to 9.0

Contributes to https://github.com/dotnet/arcade/issues/16047

# Make duplicate deb/rpm packages so we can sign them with the new PMC key

## Description

PMC has added a new signing key for packages published to repositories for new Linux distributions they will add support for, such as Debian 13 and SLES vNext. Packages pushed to these feeds must be signed with the new key. Existing feeds will maintain the same keys. The .NET signing infrastructure requires us to have separate copies of the package files to have them signed with different keys. This PR introduces separate copies of the DEB and RPM installers to be signed with the new signing keys.

Contributes to https://github.com/dotnet/arcade/issues/16047

## Customer Impact

Without this change, we can't ship `.deb` installers for Debian 13. With this change, we can.

## Regression?

- [ ] Yes
- [X] No


## Risk

- [ ] High
- [ ] Medium
- [X] Low

[Justify the selection above]

## Verification

- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [X] Yes
- [ ] No
- [ ] N/A
