### PR TITLE
Unofficial/Official arcade build split

### DIFF
--- a/azure-pipelines-unofficial.yml
+++ b/azure-pipelines-unofficial.yml
@@ -1,0 +1,27 @@
+trigger: none
+
+variables:
+- template: /eng/common-variables.yml@self
+  parameters:
+    signType: test
+- template: /eng/common/templates-official/variables/pool-providers.yml@self
+
+resources:
+  containers:
+  - container: LinuxContainer
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-fpm-amd64
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+extends:
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: $(DncEngInternalBuildPool)
+      image: windows.vs2019.amd64
+      os: windows
+
+    stages:
+    - template: /eng/build.yml@self

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,8 @@ pr: none
 
 variables:
 - template: /eng/common-variables.yml@self
+  parameters:
+    signType: real
 - template: /eng/common/templates-official/variables/pool-providers.yml@self
 
 resources:
@@ -49,65 +51,8 @@ extends:
         enabled: true
 
     stages:
-    - stage: build
-      displayName: Build
-      jobs:
-      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
-        - template: /eng/common/templates-official/job/onelocbuild.yml@self
-          parameters:
-            MirrorRepo: arcade
-            LclSource: lclFilesFromPackage
-            LclPackageId: 'LCL-JUNO-PROD-ARCADE'
-      - template: /eng/common/templates-official/jobs/jobs.yml@self
-        parameters:
-          artifacts:
-            publish:
-              artifacts: true
-              logs: true
-              manifests: true
-          enableMicrobuild: true
-          enableSourceIndex: true
-          enableSourceBuild: true
-          workspace:
-            clean: all
-          jobs:
-          - job: Windows_NT
-            timeoutInMinutes: 90
-            strategy:
-              matrix:
-                Build_Release:
-                  _BuildConfig: Release
-            preSteps:
-            - checkout: self
-              fetchDepth: 0
-              clean: true
-            steps:
-            - script: eng\common\cibuild.cmd
-                -configuration $(_BuildConfig)
-                -prepareMachine
-                $(_InternalBuildArgs)
-                /p:Test=false
-              displayName: Windows Build / Publish
-
-    - stage: ValidateSdk
-      displayName: Validate Arcade SDK
-      dependsOn: build
-      jobs:
-      - template: /eng/validate-sdk.yml@self
-        parameters:
-          buildArgs: -configuration $(_BuildConfig)
-            -prepareMachine
-            $(_InternalBuildArgs)
-            /p:Test=false
-
-    - template: /eng/common/templates-official/post-build/post-build.yml@self
+    - template: /eng/build.yml@self
       parameters:
-        publishingInfraVersion: 3
-        # signing validation will not run, even if the below value is 'true', if the 'PostBuildSign' variable is set to 'true'
-        enableSigningValidation: false
-        # Sourcelink validation isn't passing for Arcade due to some regressions. This should be
-        # enabled back once this issue is resolved: https://github.com/dotnet/arcade/issues/2912
-        enableSourceLinkValidation: false
-        publishDependsOn:
-        - Validate
-        - ValidateSdk
+        ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+          oneLocEnabled: true
+        microbuildUseESRP: true

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -1,0 +1,73 @@
+parameters:
+- name: oneLocEnabled
+  default: false
+  type: boolean
+- name: microbuildUseESRP
+  default: false
+  type: boolean
+
+stages:
+- stage: build
+  displayName: Build
+  jobs:
+  - ${{ if eq(parameters.oneLocEnabled, true) }}:
+    - template: /eng/common/templates-official/job/onelocbuild.yml@self
+      parameters:
+        MirrorRepo: arcade
+        LclSource: lclFilesFromPackage
+        LclPackageId: 'LCL-JUNO-PROD-ARCADE'
+  - template: /eng/common/templates-official/jobs/jobs.yml@self
+    parameters:
+      artifacts:
+        publish:
+          artifacts: true
+          logs: true
+          manifests: true
+      enableMicrobuild: true
+      microbuildUseESRP: ${{ parameters.microbuildUseESRP }}
+      enableSourceIndex: true
+      enableSourceBuild: true
+      workspace:
+        clean: all
+      jobs:
+      - job: Windows_NT
+        timeoutInMinutes: 90
+        strategy:
+          matrix:
+            Build_Release:
+              _BuildConfig: Release
+        preSteps:
+        - checkout: self
+          fetchDepth: 0
+          clean: true
+        steps:
+        - script: eng\common\cibuild.cmd
+            -configuration $(_BuildConfig)
+            -prepareMachine
+            $(_InternalBuildArgs)
+            /p:Test=false
+          displayName: Windows Build / Publish
+
+- stage: ValidateSdk
+  displayName: Validate Arcade SDK
+  dependsOn: build
+  jobs:
+  - template: /eng/validate-sdk.yml@self
+    parameters:
+      microbuildUseESRP: ${{ parameters.microbuildUseESRP }}
+      buildArgs: -configuration $(_BuildConfig)
+        -prepareMachine
+        $(_InternalBuildArgs)
+        /p:Test=false
+
+- template: /eng/common/templates-official/post-build/post-build.yml@self
+  parameters:
+    publishingInfraVersion: 3
+    # signing validation will not run, even if the below value is 'true', if the 'PostBuildSign' variable is set to 'true'
+    enableSigningValidation: false
+    # Sourcelink validation isn't passing for Arcade due to some regressions. This should be
+    # enabled back once this issue is resolved: https://github.com/dotnet/arcade/issues/2912
+    enableSourceLinkValidation: false
+    publishDependsOn:
+    - Validate
+    - ValidateSdk

--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -1,3 +1,8 @@
+parameters:
+- name: signType
+  default: Test
+  type: string
+
 variables:
   # Cannot use key:value syntax in root defined variables
   - name: _TeamName
@@ -17,7 +22,7 @@ variables:
     - name: _RunAsInternal
       value: True
     - name: _SignType
-      value: real
+      value: ${{ parameters.signType }}
     # Publish-Build-Assets provides: BotAccount-dotnet-maestro-bot-PAT
     # DotNet-HelixApi-Access provides: HelixApiAccessToken
     - group: Publish-Build-Assets
@@ -25,7 +30,7 @@ variables:
     - group: SDL_Settings
     # DotNetPublishUsingPipelines can be removed when Arcade itself consumes a new Arcade version.
     - name: _InternalBuildArgs
-      value: /p:DotNetSignType=$(_SignType)
+      value: /p:DotNetSignType=${{ parameters.signType }}
         /p:TeamName=$(_TeamName)
         /p:DotNetPublishUsingPipelines=true
         /p:OfficialBuildId=$(BUILD.BUILDNUMBER)

--- a/eng/validate-sdk.yml
+++ b/eng/validate-sdk.yml
@@ -2,6 +2,8 @@ parameters:
   buildArgs: ''
   validateBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core-test/index.json
   buildConfig: Release
+  microbuildUseESRP: false
+
 
 jobs:
 - template: /eng/common/templates-official/job/job.yml@self
@@ -9,6 +11,7 @@ jobs:
     name: ValidateArcadeSDK
     displayName: Validate Arcade SDK
     enableMicrobuild: true
+    microbuildUseESRP: ${{ parameters.microbuildUseESRP }}
     artifacts:
       download:
         path: build_stage_artifacts


### PR DESCRIPTION
Create a YAML for a true unofficial internal pipeline. The unofficial pipeline mirrors the prod one, and can be used to create arcades for dev work in other repos. Note: After the arcade change to restrict channel publishing goes into effect, it won't be possible to use the non-prod pipeline to publish to anything but the "General*" channels

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
