### PR TITLE
Set ProgressPreference='SilentlyContinue' when downloading vswhere.exe

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -552,7 +552,8 @@ function LocateVisualStudio([object]$vsRequirements = $null){
 
   if (!(Test-Path $vsWhereExe)) {
     Create-Directory $vsWhereDir
-    Write-Host 'Downloading vswhere'
+    Write-Host 'Downloading vswhere $vswhereVersion'
+    $ProgressPreference = 'SilentlyContinue' # Don't display the console progress UI - it's a huge perf hit
     Retry({
       Invoke-WebRequest "https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/vswhere/$vswhereVersion/vswhere.exe" -OutFile $vswhereExe
     })


### PR DESCRIPTION
We do this before all the other Invoke-WebRequest calls in the script, let's try and see if this helps with the timeout issue we occasionally see in the fsharp build.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
