### PR TITLE
Use different PME connection on windows vs. non-windows

### DIFF
--- a/eng/common/core-templates/steps/install-microbuild.yml
+++ b/eng/common/core-templates/steps/install-microbuild.yml
@@ -47,8 +47,12 @@ steps:
       displayName: 'Validate ESRP usage (Non-Windows)'
       condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
 
+    # Two different MB install steps. This is due to not being able to use the agent OS during
+    # YAML expansion, and Windows vs. Linux/Mac uses different service connections. However,
+    # we can avoid including the MB install step if not enabled at all. This avoids a bunch of
+    # extra pipeline authorizations, since most pipelines do not sign on non-Windows.
     - task: MicroBuildSigningPlugin@4
-      displayName: Install MicroBuild plugin
+      displayName: Install MicroBuild plugin (Windows)
       inputs:
         signType: $(_SignType)
         zipSources: false
@@ -64,16 +68,24 @@ steps:
         MicroBuildOutputFolderOverride: ${{ parameters.microBuildOutputFolder }}
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       continueOnError: ${{ parameters.continueOnError }}
-      condition: and(
-        succeeded(),
-        or(
-          and(
-            eq(variables['Agent.Os'], 'Windows_NT'),
-            in(variables['_SignType'], 'real', 'test')
-          ),
-          and(
-            ${{ eq(parameters.enableMicrobuildForMacAndLinux, true) }},
-            ne(variables['Agent.Os'], 'Windows_NT'),
-            eq(variables['_SignType'], 'real')
-          )
-        ))
+      condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'), in(variables['_SignType'], 'real', 'test'))
+
+    - ${{ if eq(parameters.enableMicrobuildForMacAndLinux, true) }}:
+      - task: MicroBuildSigningPlugin@4
+        displayName: Install MicroBuild plugin (non-Windows)
+        inputs:
+          signType: $(_SignType)
+          zipSources: false
+          feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+          ${{ if eq(parameters.microbuildUseESRP, true) }}:
+            ConnectedServiceName: 'MicroBuild Signing Task (DevDiv)'
+            ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+              ConnectedPMEServiceName: beb8cb23-b303-4c95-ab26-9e44bc958d39
+            ${{ else }}:
+              ConnectedPMEServiceName: c24de2a5-cc7a-493d-95e4-8e5ff5cad2bc
+        env:
+          TeamName: $(_TeamName)
+          MicroBuildOutputFolderOverride: ${{ parameters.microBuildOutputFolder }}
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        continueOnError: ${{ parameters.continueOnError }}
+        condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'),  eq(variables['_SignType'], 'real'))


### PR DESCRIPTION
Finally got the PME signing on non-Windows to work. The SC ID is different for windows and non-windows, so we need to split the install step to account for this. We have to split the steps since the agent OS is not available at parse time.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
