### PR TITLE
Update source-index tools

### DIFF
--- a/eng/common/core-templates/steps/source-index-stage1-publish.yml
+++ b/eng/common/core-templates/steps/source-index-stage1-publish.yml
@@ -1,6 +1,6 @@
 parameters:
-  sourceIndexUploadPackageVersion: 2.0.0-20250425.2
-  sourceIndexProcessBinlogPackageVersion: 1.0.1-20250515.1
+  sourceIndexUploadPackageVersion: 2.0.0-20250818.1
+  sourceIndexProcessBinlogPackageVersion: 1.0.1-20250818.1
   sourceIndexPackageSource: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
   binlogPath: artifacts/log/Debug/Build.binlog
 


### PR DESCRIPTION
Updating the version of the task + tool used to produce "stage1" source index data.

I'm only updating the package versions - since these still build with net9 I'm leaving the `9.0.x` SDK dependency, however this should really be made to use the SDK that the repo uses.  I'm not sure why it's done this way -- maybe at the time the repos were on an older SDK than was needed by the tools?  I'll see if I can go back and discover this in source history.