### PR TITLE
Revert "[main] Source code updates from dotnet/dotnet"

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -87,7 +87,7 @@
     <PackageVersion Include="JetBrains.Annotations" Version="2018.2.1" />
     <PackageVersion Include="LZMA-SDK" Version="22.1.1" />
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="2.3.0" />
-    <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.23.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights" Version="$(MicrosoftApplicationInsightsVersion)" />
     <PackageVersion Include="Microsoft.Data.OData" Version="5.8.4" />
     <PackageVersion Include="Microsoft.DataServices.Client" Version="$(MicrosoftDataServicesClientVersion)" />
     <PackageVersion Include="Microsoft.Diagnostics.Runtime" Version="1.0.5" />
@@ -99,7 +99,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.OLE.Interop" Version="7.10.6071" />
     <PackageVersion Include="Mono.Options" Version="5.3.0.1" />
     <PackageVersion Include="Moq" Version="4.18.4" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageVersion Include="Octokit" Version="13.0.1" />
     <PackageVersion Include="Polly.Core" Version="8.4.1" />
     <PackageVersion Include="sn" Version="1.0.0" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
-  <Source Uri="https://github.com/dotnet/dotnet" Mapping="arcade" Sha="619d5633513d1b31c528db4360833fce52f51829" BarId="280198" />
+  <Source Uri="https://github.com/dotnet/dotnet" Mapping="arcade" Sha="b7ad826c308d3b0376ed21450271439a97f77f02" BarId="278405" />
   <ProductDependencies>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100-rc.1.25411.109",
+    "version": "10.0.100-preview.7.25372.107",
     "rollForward": "latestFeature",
     "paths": [
       ".dotnet",
@@ -9,7 +9,7 @@
     "errorMessage": "The required .NET SDK wasn't found. Please run ./eng/common/dotnet.cmd/sh to install it."
   },
   "tools": {
-    "dotnet": "10.0.100-rc.1.25411.109"
+    "dotnet": "10.0.100-preview.7.25372.107"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25422.3",


### PR DESCRIPTION
Reverts dotnet/arcade#16070

It's a backflow from a release/10 which breaks the codeflow