### PR TITLE
Make some rpm classes public

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/RpmHeader.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/RpmHeader.cs
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Build.Tasks.Installers
 {
-    internal sealed partial class RpmHeader<TEntryTag>(List<RpmHeader<TEntryTag>.Entry> entries)
+    public sealed partial class RpmHeader<TEntryTag>(List<RpmHeader<TEntryTag>.Entry> entries)
         where TEntryTag : struct, Enum
     {
 

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/RpmHeaderEntryType.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/RpmHeaderEntryType.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.DotNet.Build.Tasks.Installers
 {
-    internal enum RpmHeaderEntryType : uint
+    public enum RpmHeaderEntryType : uint
     {
         Null = 0,
         Char = 1,

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/RpmLead.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/RpmLead.cs
@@ -13,7 +13,7 @@ using System.Threading.Tasks;
 namespace Microsoft.DotNet.Build.Tasks.Installers
 {
     [StructLayout(LayoutKind.Sequential)]
-    internal struct RpmLead
+    public struct RpmLead
     {
         public string Name { get; set; }
         public byte Major { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/src/RpmPackage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/src/RpmPackage.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Build.Tasks.Installers
 {
-    internal sealed class RpmPackage(RpmLead lead, RpmHeader<RpmSignatureTag> signature, RpmHeader<RpmHeaderTag> header, MemoryStream archiveStream) : IDisposable
+    public sealed class RpmPackage(RpmLead lead, RpmHeader<RpmSignatureTag> signature, RpmHeader<RpmHeaderTag> header, MemoryStream archiveStream) : IDisposable
     {
         public RpmLead Lead { get; set; } = lead;
         public RpmHeader<RpmSignatureTag> Signature { get; set; } = signature;


### PR DESCRIPTION
This makes several RPM classes public so they can be used in other projects without a need for `InternalsVisibleTo`. New projects that would consume these classes are in a different repo.