### PR TITLE
Add AnyApple to TestPlatforms

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions.Shared/TestPlatforms.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions.Shared/TestPlatforms.cs
@@ -13,7 +13,7 @@ namespace Xunit
         OSX = 4,
         FreeBSD = 8,
         NetBSD = 16,
-        illumos= 32,
+        illumos = 32,
         Solaris = 64,
         iOS = 128,
         tvOS = 256,
@@ -24,6 +24,7 @@ namespace Xunit
         Wasi = 8192,
         Haiku = 16384,
         AnyUnix = FreeBSD | Linux | NetBSD | OSX | illumos | Solaris | iOS | tvOS | MacCatalyst | Android | Browser | LinuxBionic | Wasi | Haiku,
+        AnyApple = OSX | iOS | tvOS | MacCatalyst,
         Any = ~0
     }
 }


### PR DESCRIPTION
In `dotnet/runtime` we have a number of tests that are either platform-specific or excluded for all Apple platforms.

This introduces an `AnyApple` enum member that combines macOS (OSX), tvOS, iOS, and MacCatalyst.

While we are here, fix a minor formatting issue with illumos.