### PR TITLE
Set RestoreEnablePackagePruning default in props

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
@@ -20,6 +20,9 @@
     <PackageIcon>Icon.png</PackageIcon>
     <PackageIconFullPath>$(MSBuildThisFileDirectory)Assets\DotNetPackageIcon.png</PackageIconFullPath>
 
+    <!-- Turn on package pruning by default. -->
+    <RestoreEnablePackagePruning>true</RestoreEnablePackagePruning>
+
     <!-- Disable the message indicating we are using a preview SDK. That is understood and by design -->
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.targets
@@ -1,9 +1,9 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
 
-  <!-- Turn on package pruning by default for every TFM except for .NET Framework. -->
+  <!-- Explicitly turn off package pruning for .NET Framework which isn't supported. -->
   <PropertyGroup>
-    <RestoreEnablePackagePruning Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">true</RestoreEnablePackagePruning>
+    <RestoreEnablePackagePruning Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">false</RestoreEnablePackagePruning>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This allows repositories to opt-out. Helps with https://github.com/dotnet/source-build-reference-packages/pull/1352

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
