### PR TITLE
Make OfficialBuildId settable on publish assets

### DIFF
--- a/eng/common/core-templates/job/publish-build-assets.yml
+++ b/eng/common/core-templates/job/publish-build-assets.yml
@@ -64,6 +64,11 @@ jobs:
       value: false
     # unconditional - needed for logs publishing (redactor tool version)
     - template: /eng/common/core-templates/post-build/common-variables.yml
+  - name: OfficialBuildId
+    ${{ if ne(parameters.officialBuildId, '') }}:
+      value: ${{ parameters.officialBuildId }}
+    ${{ else }}:
+      value: $(Build.BuildNumber)
 
   pool:
     # We don't use the collection uri here because it might vary (.visualstudio.com vs. dev.azure.com)
@@ -126,7 +131,7 @@ jobs:
           /p:ManifestsPath='$(Build.StagingDirectory)/AssetManifests'
           /p:IsAssetlessBuild=${{ parameters.isAssetlessBuild }}
           /p:MaestroApiEndpoint=https://maestro.dot.net
-          /p:OfficialBuildId=${{ parameters.officialBuildId }}
+          /p:OfficialBuildId=$(OfficialBuildId)
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}
     

--- a/eng/common/core-templates/job/publish-build-assets.yml
+++ b/eng/common/core-templates/job/publish-build-assets.yml
@@ -40,6 +40,8 @@ parameters:
 
   repositoryAlias: self
 
+  officialBuildId: ''
+
 jobs:
 - job: Asset_Registry_Publish
 
@@ -124,7 +126,7 @@ jobs:
           /p:ManifestsPath='$(Build.StagingDirectory)/AssetManifests'
           /p:IsAssetlessBuild=${{ parameters.isAssetlessBuild }}
           /p:MaestroApiEndpoint=https://maestro.dot.net
-          /p:OfficialBuildId=$(Build.BuildNumber)
+          /p:OfficialBuildId=${{ parameters.officialBuildId }}
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}
     

--- a/eng/common/core-templates/jobs/jobs.yml
+++ b/eng/common/core-templates/jobs/jobs.yml
@@ -44,6 +44,7 @@ parameters:
   artifacts: {}
   is1ESPipeline: ''
   repositoryAlias: self
+  officialBuildId: ''
 
 # Internal resources (telemetry, microbuild) can only be accessed from non-public projects,
 # and some (Microbuild) should only be applied to non-PR cases for internal builds.
@@ -116,3 +117,7 @@ jobs:
         artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
         signingValidationAdditionalParameters: ${{ parameters.signingValidationAdditionalParameters }}
         repositoryAlias: ${{ parameters.repositoryAlias }}
+        ${{ if ne(parameters.officialBuildId, '') }}:
+          officialBuildId: ${{ parameters.officialBuildId }}
+        ${{ else }}:
+          officialBuildId: $(Build.BuildNumber)


### PR DESCRIPTION
## Summary

The [Build.BuildNumber](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services) is a [settable value](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/run-number?view=azure-devops) in Azure Pipelines. When changed, it updates the run name for your pipeline (what you see as the name of a particular run of your pipeline).

Currently, `Build.BuildNumber` is used in part of Arcade's build processes, as it parses information out of this value. However, this doesn't work for publishing build assets if you change the value at any point in your pipeline via the `name` value or using the [updatebuildnumber logging command](https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#updatebuildnumber-override-the-automatically-generated-build-number). The solution was to allow the OfficialBuildId to be settable, but default to `Build.BuildNumber` if not provided. I've done this defaulting logic for both `jobs.yml` and `publish-build-assets.yml` as to not break any existing uses of these templates.

