### PR TITLE
[release/8.0] Fix copying of cbl-mariner packages

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.singlerid.targets
@@ -158,7 +158,7 @@
   -->
   <Target Name="_BuildMarinerRpm"
           AfterTargets="GenerateRpm"
-          Condition="'$(PackageTargetOS)' != ''">
+          Condition="'$(PackageTargetOS)' == ''">
     <!-- CBL-Mariner -->
     <PropertyGroup>
       <!-- CBL-Mariner 1.0 -->


### PR DESCRIPTION
Code that creates copies RPM packages for `cm.1` and `cm.2` was moved to a new target that is conditioned on `PackageTargetOS` property. This property is only set for DEPS packages, which we do not need to copy.

The fix is to revert the condition to build the target when property is empty/missing.
