### PR TITLE
Formatting updates to CoreClrConfigurationDetection

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions.Shared/CoreClrConfigurationDetection.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions.Shared/CoreClrConfigurationDetection.cs
@@ -22,8 +22,10 @@ namespace Xunit
         public static bool IsTieredCompilation => string.Equals(GetEnvironmentVariableValue("TieredCompilation", "1"), "1", StringComparison.InvariantCulture);
         public static bool IsHeapVerify => string.Equals(GetEnvironmentVariableValue("HeapVerify"), "1", StringComparison.InvariantCulture);
 
-        public static bool IsInterpreterActive {
-            get {
+        public static bool IsCoreClrInterpreter
+        {
+            get
+            {
                 if (!string.IsNullOrWhiteSpace(GetEnvironmentVariableValue("Interpreter", "")))
                     return true;
                 if (int.TryParse(GetEnvironmentVariableValue("InterpMode", "0"), out int mode) && (mode > 0))
@@ -33,7 +35,7 @@ namespace Xunit
         }
 
         public static bool IsGCStress => !string.Equals(GetEnvironmentVariableValue("GCStress"), "0", StringComparison.InvariantCulture);
-        
+
         public static bool IsAnyJitStress => IsJitStress || IsJitStressRegs || IsJitMinOpts || IsTailCallStress;
 
         public static bool IsAnyJitOptimizationStress => IsAnyJitStress || IsTieredCompilation;


### PR DESCRIPTION
I was asked to rename this property before it gets used in dotnet/runtime. Also fixing a formatting nit.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
