### PR TITLE
[release/8.0] Vendor nuget-verification.ps1 instead of downloading it

### DIFF
--- a/eng/common/post-build/nuget-validation.ps1
+++ b/eng/common/post-build/nuget-validation.ps1
@@ -2,20 +2,13 @@
 # tool: https://github.com/NuGet/NuGetGallery/tree/jver-verify/src/VerifyMicrosoftPackage
 
 param(
-  [Parameter(Mandatory=$true)][string] $PackagesPath,           # Path to where the packages to be validated are
-  [Parameter(Mandatory=$true)][string] $ToolDestinationPath     # Where the validation tool should be downloaded to
+  [Parameter(Mandatory=$true)][string] $PackagesPath # Path to where the packages to be validated are
 )
 
 try {
   . $PSScriptRoot\post-build-utils.ps1
 
-  $url = 'https://raw.githubusercontent.com/NuGet/NuGetGallery/3e25ad135146676bcab0050a516939d9958bfa5d/src/VerifyMicrosoftPackage/verify.ps1'
-
-  New-Item -ItemType 'directory' -Path ${ToolDestinationPath} -Force
-
-  Invoke-WebRequest $url -OutFile ${ToolDestinationPath}\verify.ps1 
-
-  & ${ToolDestinationPath}\verify.ps1 ${PackagesPath}\*.nupkg
+  & $PSScriptRoot\nuget-verification.ps1 ${PackagesPath}\*.nupkg
 } 
 catch {
   Write-Host $_.ScriptStackTrace

--- a/eng/common/post-build/nuget-verification.ps1
+++ b/eng/common/post-build/nuget-verification.ps1
@@ -1,0 +1,121 @@
+<#
+.SYNOPSIS
+    Verifies that Microsoft NuGet packages have proper metadata.
+.DESCRIPTION
+    Downloads a verification tool and runs metadata validation on the provided NuGet packages. This script writes an
+    error if any of the provided packages fail validation. All arguments provided to this PowerShell script that do not
+    match PowerShell parameters are passed on to the verification tool downloaded during the execution of this script.
+.PARAMETER NuGetExePath
+    The path to the nuget.exe binary to use. If not provided, nuget.exe will be downloaded into the -DownloadPath
+    directory.
+.PARAMETER PackageSource
+    The package source to use to download the verification tool. If not provided, nuget.org will be used.
+.PARAMETER DownloadPath
+    The directory path to download the verification tool and nuget.exe to. If not provided,
+    %TEMP%\NuGet.VerifyNuGetPackage will be used.
+.PARAMETER args
+    Arguments that will be passed to the verification tool.
+.EXAMPLE
+    PS> .\verify.ps1 *.nupkg
+    Verifies the metadata of all .nupkg files in the currect working directory.
+.EXAMPLE
+    PS> .\verify.ps1 --help
+    Displays the help text of the downloaded verifiction tool.
+.LINK
+    https://github.com/NuGet/NuGetGallery/blob/master/src/VerifyMicrosoftPackage/README.md
+#>
+
+# This script was copied from https://github.com/NuGet/NuGetGallery/blob/3e25ad135146676bcab0050a516939d9958bfa5d/src/VerifyMicrosoftPackage/verify.ps1
+
+[CmdletBinding(PositionalBinding = $false)]
+param(
+   [string]$NuGetExePath,
+   [string]$PackageSource = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json",
+   [string]$DownloadPath,
+   [Parameter(ValueFromRemainingArguments = $true)]
+   [string[]]$args
+)
+
+# The URL to download nuget.exe.
+$nugetExeUrl = "https://dist.nuget.org/win-x86-commandline/v4.9.4/nuget.exe"
+
+# The package ID of the verification tool.
+$packageId = "NuGet.VerifyMicrosoftPackage"
+
+# The location that nuget.exe and the verification tool will be downloaded to.
+if (!$DownloadPath) {
+    $DownloadPath = (Join-Path $env:TEMP "NuGet.VerifyMicrosoftPackage")
+}
+
+$fence = New-Object -TypeName string -ArgumentList '=', 80
+
+# Create the download directory, if it doesn't already exist.
+if (!(Test-Path $DownloadPath)) {
+    New-Item -ItemType Directory $DownloadPath | Out-Null
+}
+Write-Host "Using download path: $DownloadPath"
+
+if ($NuGetExePath) {
+    $nuget = $NuGetExePath
+} else {
+    $downloadedNuGetExe = Join-Path $DownloadPath "nuget.exe"
+    
+    # Download nuget.exe, if it doesn't already exist.
+    if (!(Test-Path $downloadedNuGetExe)) {
+        Write-Host "Downloading nuget.exe from $nugetExeUrl..."
+        $ProgressPreference = 'SilentlyContinue'
+        try {
+            Invoke-WebRequest $nugetExeUrl -OutFile $downloadedNuGetExe
+            $ProgressPreference = 'Continue'
+        } catch {
+            $ProgressPreference = 'Continue'
+            Write-Error $_
+            Write-Error "nuget.exe failed to download."
+            exit
+        }
+    }
+
+    $nuget = $downloadedNuGetExe
+}
+
+Write-Host "Using nuget.exe path: $nuget"
+Write-Host " "
+
+# Download the latest version of the verification tool.
+Write-Host "Downloading the latest version of $packageId from $packageSource..."
+Write-Host $fence
+& $nuget install $packageId `
+    -Prerelease `
+    -OutputDirectory $DownloadPath `
+    -Source $PackageSource
+Write-Host $fence
+Write-Host " "
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "nuget.exe failed to fetch the verify tool."
+    exit
+}
+
+# Find the most recently downloaded tool
+Write-Host "Finding the most recently downloaded verification tool."
+$verifyProbePath = Join-Path $DownloadPath "$packageId.*"
+$verifyPath = Get-ChildItem -Path $verifyProbePath -Directory `
+    | Sort-Object -Property LastWriteTime -Descending `
+    | Select-Object -First 1
+$verify = Join-Path $verifyPath "tools\NuGet.VerifyMicrosoftPackage.exe"
+Write-Host "Using verification tool: $verify"
+Write-Host " "
+
+# Execute the verification tool.
+Write-Host "Executing the verify tool..."
+Write-Host $fence
+& $verify $args
+Write-Host $fence
+Write-Host " "
+
+# Respond to the exit code.
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "The verify tool found some problems."
+} else {
+    Write-Output "The verify tool succeeded."
+}

--- a/eng/common/templates-official/post-build/post-build.yml
+++ b/eng/common/templates-official/post-build/post-build.yml
@@ -134,8 +134,7 @@ stages:
           displayName: Validate
           inputs:
             filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/nuget-validation.ps1
-            arguments: -PackagesPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/ 
-              -ToolDestinationPath $(Agent.BuildDirectory)/Extract/ 
+            arguments: -PackagesPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/
 
     - job:
       displayName: Signing Validation

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -132,7 +132,6 @@ stages:
           inputs:
             filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/nuget-validation.ps1
             arguments: -PackagesPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/
-              -ToolDestinationPath $(Agent.BuildDirectory)/Extract/
 
     - job:
       displayName: Signing Validation

--- a/eng/configure-toolset.ps1
+++ b/eng/configure-toolset.ps1
@@ -3,7 +3,8 @@ function Test-FilesUseTelemetryOutput {
     $requireTelemetryExcludeFiles = @(
         "enable-cross-org-publishing.ps1",
         "performance-setup.ps1",
-        "retain-build.ps1" )
+        "retain-build.ps1",
+        "nuget-verification.ps1")
 
     $filesMissingTelemetry = Get-ChildItem -File -Recurse -Path "$PSScriptRoot\common" -Include "*.ps1" -Exclude $requireTelemetryExcludeFiles |
         Where-Object { -Not( $_ | Select-String -Pattern "Write-PipelineTelemetryError" )}


### PR DESCRIPTION
Extracted from https://github.com/dotnet/arcade/pull/14809

This is necessary so we can apply the CFS fix from https://github.com/dotnet/arcade/pull/16154
