### PR TITLE
Enable ConditonalFact and ConditionalTheory for XUnit v3

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions.Shared/Attributes/ConditionalFactAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions.Shared/Attributes/ConditionalFactAttribute.cs
@@ -1,14 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-
-// Not adding the support for xunit.v3.
-// Still keeping the logic inside compatible with xunit.v3 in case we decided to add it.
-// For cases that used to do [ConditionalFact] in xunit.v2, they can now call Assert.Skip instead of throwing SkipTestException
-// In this case, [Fact] will just work because Assert.Skip is natively supported in xunit.v3
-// TODO: Evaluate whether or not we want to still expose this attribute in xunit.v3 for usages of CalleeType and ConditionMemberNames?
-#if !USES_XUNIT_3
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.DotNet.XUnitExtensions;
@@ -43,4 +35,3 @@ namespace Xunit
         }
     }
 }
-#endif

--- a/src/Microsoft.DotNet.XUnitExtensions.Shared/Attributes/ConditionalTheoryAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions.Shared/Attributes/ConditionalTheoryAttribute.cs
@@ -1,13 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// Not adding the support for xunit.v3.
-// Still keeping the logic inside compatible with xunit.v3 in case we decided to add it.
-// For cases that used to do [ConditionalTheory] in xunit.v2, they can now call Assert.Skip instead of throwing SkipTestException
-// In this case, [Fact] will just work because Assert.Skip is natively supported in xunit.v3
-// TODO: Evaluate whether or not we want to still expose this attribute in xunit.v3 for usages of CalleeType and ConditionMemberNames?
-#if !USES_XUNIT_3
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.DotNet.XUnitExtensions;
@@ -42,4 +35,3 @@ namespace Xunit
         }
     }
 }
-#endif

--- a/src/Microsoft.DotNet.XUnitExtensions.Shared/Discoverers/ConditionalFactDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions.Shared/Discoverers/ConditionalFactDiscoverer.cs
@@ -1,11 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// Not adding the support for xunit.v3.
-// This is used by ConditionalFact and ConditionalTheory which we no longer support in xunit.v3.
-// Still keeping the logic inside supporting xunit.v3 in case we decided to add it.
-#if !USES_XUNIT_3
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -60,4 +55,3 @@ namespace Microsoft.DotNet.XUnitExtensions
         }
     }
 }
-#endif

--- a/src/Microsoft.DotNet.XUnitExtensions.Shared/Discoverers/ConditionalTheoryDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions.Shared/Discoverers/ConditionalTheoryDiscoverer.cs
@@ -1,11 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// Not adding the support for xunit.v3.
-// This is used by ConditionalFact and ConditionalTheory which we no longer support in xunit.v3.
-// Still keeping the logic inside supporting xunit.v3 in case we decided to add it.
-#if !USES_XUNIT_3
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -138,4 +133,3 @@ namespace Microsoft.DotNet.XUnitExtensions
         }
     }
 }
-#endif

--- a/src/Microsoft.DotNet.XUnitExtensions.Shared/SkippedFactTestCase.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions.Shared/SkippedFactTestCase.cs
@@ -1,11 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// Not adding the support for xunit.v3.
-// This is used by ConditionalFact and ConditionalTheory which we no longer support in xunit.v3.
-// Still keeping the logic inside supporting xunit.v3 in case we decided to add it.
-#if !USES_XUNIT_3
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -79,4 +74,3 @@ namespace Microsoft.DotNet.XUnitExtensions
         }
     }
 }
-#endif

--- a/src/Microsoft.DotNet.XUnitExtensions.Shared/SkippedTestMessageBus.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions.Shared/SkippedTestMessageBus.cs
@@ -1,11 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// Not adding the support for xunit.v3.
-// This is used by ConditionalFact and ConditionalTheory which we no longer support in xunit.v3.
-// Still keeping the logic inside supporting xunit.v3 in case we decided to add it.
-#if !USES_XUNIT_3
-
 using System;
 using System.Linq;
 #if !USES_XUNIT_3
@@ -72,4 +67,3 @@ namespace Microsoft.DotNet.XUnitExtensions
         }
     }
 }
-#endif


### PR DESCRIPTION
dotnet/runtime has many thousands of tests that use these. We do not want to be changing all of them to alternatives.