### PR TITLE
Pipe through the abilty to set the MB plugin version

### DIFF
--- a/eng/common/core-templates/job/job.yml
+++ b/eng/common/core-templates/job/job.yml
@@ -20,6 +20,7 @@ parameters:
   artifacts: ''
   enableMicrobuild: false
   enablePreviewMicrobuild: false
+  microbuildPluginVersion: 'latest'
   enableMicrobuildForMacAndLinux: false
   microbuildUseESRP: true
   enablePublishBuildArtifacts: false
@@ -130,6 +131,7 @@ jobs:
       parameters:
         enableMicrobuild: ${{ parameters.enableMicrobuild }}
         enablePreviewMicrobuild: ${{ parameters.enablePreviewMicrobuild }}
+        microbuildPluginVersion: ${{ parameters.microbuildPluginVersion }}
         enableMicrobuildForMacAndLinux: ${{ parameters.enableMicrobuildForMacAndLinux }}
         microbuildUseESRP: ${{ parameters.microbuildUseESRP }}
         continueOnError: ${{ parameters.continueOnError }}
@@ -156,6 +158,7 @@ jobs:
       parameters:
         enableMicrobuild: ${{ parameters.enableMicrobuild }}
         enablePreviewMicrobuild: ${{ parameters.enablePreviewMicrobuild }}
+        microbuildPluginVersion: ${{ parameters.microbuildPluginVersion }}
         enableMicrobuildForMacAndLinux: ${{ parameters.enableMicrobuildForMacAndLinux }}
         continueOnError: ${{ parameters.continueOnError }}
 

--- a/eng/common/core-templates/steps/install-microbuild.yml
+++ b/eng/common/core-templates/steps/install-microbuild.yml
@@ -16,6 +16,8 @@ parameters:
   # Location of the MicroBuild output folder
   # NOTE: There's something that relies on this being in the "default" source directory for tasks such as Signing to work properly.
   microBuildOutputFolder: '$(Build.SourcesDirectory)'
+  # Microbuild version
+  microbuildPluginVersion: 'latest'
 
   continueOnError: false
 
@@ -60,6 +62,7 @@ steps:
           signType: $(_SignType)
           zipSources: false
           feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+          version: ${{ parameters.microbuildPluginVersion }}
           ${{ if eq(parameters.microbuildUseESRP, true) }}:
             ConnectedServiceName: 'MicroBuild Signing Task (DevDiv)'
             ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
@@ -81,6 +84,7 @@ steps:
             signType: $(_SignType)
             zipSources: false
             feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+            version: ${{ parameters.microbuildPluginVersion }}
             ${{ if eq(parameters.microbuildUseESRP, true) }}:
               ConnectedServiceName: 'MicroBuild Signing Task (DevDiv)'
               ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:


### PR DESCRIPTION
For use in the MB preview plugin validation pipeline.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
