### PR TITLE
Drop swidtag in correct Program Files folder per-arch

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/bundle/bundle.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/bundle/bundle.wxs
@@ -61,7 +61,10 @@
       </BootstrapperApplication>
     <?endif?>
 
-    <?if $(var.Platform)=x64 or $(var.Platform)=arm64?>
+    <?if $(var.Platform)=x64?>
+      <SoftwareTag Regid="microsoft.com" InstallPath="[ProgramFiles64Folder]dotnet" />
+    <?endif?>
+    <?if $(var.Platform)=arm64?>
       <SoftwareTag Regid="microsoft.com" InstallPath="[ProgramFiles64Folder]dotnet" />
     <?endif?>
     <?if $(var.Platform)=x86?>

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/bundle/bundle.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/bundle/bundle.wxs
@@ -61,7 +61,12 @@
       </BootstrapperApplication>
     <?endif?>
 
-    <SoftwareTag Regid="microsoft.com" InstallPath="[ProgramFiles6432Folder]dotnet" />
+    <?if $(var.Platform)=x64 or $(var.Platform)=arm64?>
+      <SoftwareTag Regid="microsoft.com" InstallPath="[ProgramFiles64Folder]dotnet" />
+    <?endif?>
+    <?if $(var.Platform)=x86?>
+      <SoftwareTag Regid="microsoft.com" InstallPath="[ProgramFilesFolder]dotnet" />
+    <?endif?>
 
     <!-- Variables used solely for localization. -->
     <Variable Name="BUNDLEMONIKER" Type="string" Value="$(var.ProductMoniker) ($(var.TargetArchitectureDescription))" bal:Overridable="no" />

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/wix.targets
@@ -340,7 +340,7 @@
       <CandleVariables Include="BuildVersion" Value="$(MsiVersionString)" />
       <CandleVariables Include="NugetVersion" Value="$(Version)" />
       <CandleVariables Include="InstallerPlatform" Value="$(MsiArch)" />
-      <CandleVariables Include="Platform" Value="$(MsiArch)" />
+      <CandleVariables Include="Platform" Value="$(InstallerTargetArchitecture)" />
       <CandleVariables Include="TargetArchitectureDescription" Value="$(InstallerTargetArchitecture)$(CrossArchContentsBuildPart)" />
       <CandleVariables Include="UpgradeCode" Value="$(UpgradeCode)" />
       <CandleVariables Include="MajorUpgradeSchedule" Value="$(MajorUpgradeSchedule)" Condition="'$(MajorUpgradeSchedule)' != ''" />


### PR DESCRIPTION
In bundles, `ProgramFiles6432Folder` is resolved based on the machine's architecture. So we need to calculate the folder ourselves.