### PR TITLE
[release/10.0] Drop swidtag in correct Program Files folder per-arch

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/bundle/bundle.wxs
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/bundle/bundle.wxs
@@ -61,7 +61,15 @@
       </BootstrapperApplication>
     <?endif?>
 
-    <SoftwareTag Regid="microsoft.com" InstallPath="[ProgramFiles6432Folder]dotnet" />
+    <?if $(var.Platform)=x64?>
+      <SoftwareTag Regid="microsoft.com" InstallPath="[ProgramFiles64Folder]dotnet" />
+    <?endif?>
+    <?if $(var.Platform)=arm64?>
+      <SoftwareTag Regid="microsoft.com" InstallPath="[ProgramFiles64Folder]dotnet" />
+    <?endif?>
+    <?if $(var.Platform)=x86?>
+      <SoftwareTag Regid="microsoft.com" InstallPath="[ProgramFilesFolder]dotnet" />
+    <?endif?>
 
     <!-- Variables used solely for localization. -->
     <Variable Name="BUNDLEMONIKER" Type="string" Value="$(var.ProductMoniker) ($(var.TargetArchitectureDescription))" bal:Overridable="no" />

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/variables.wxi
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/variables.wxi
@@ -13,14 +13,11 @@
   <?define LCID  = "$(var.ProductLanguage)"?>
   <?define DowngradeErrorMessage  = "A newer version is already installed; please uninstall it and re-run setup."?>
 
-  <?define Platform   =   "$(sys.BUILDARCH)" ?>
-
-  <?if $(var.Platform)!=x86?>
-    <?if $(var.Platform)!=x64?>
-      <?if $(var.Platform)!=arm64?>
-        <?error Invalid Platform ($(var.Platform))?>
-      <?endif?>
-    <?endif?>
+  <?if $(var.Platform)~=x86?>
+  <?elseif $(var.Platform)~=x64?>
+  <?elseif $(var.Platform)~=arm64?>
+  <?else?>
+    <?error Invalid Platform ($(var.Platform))?>
   <?endif?>
 
   <?ifndef DependencyKey?>

--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/wix.targets
@@ -340,6 +340,7 @@
       <CandleVariables Include="BuildVersion" Value="$(MsiVersionString)" />
       <CandleVariables Include="NugetVersion" Value="$(Version)" />
       <CandleVariables Include="InstallerPlatform" Value="$(MsiArch)" />
+      <CandleVariables Include="Platform" Value="$(InstallerTargetArchitecture)" />
       <CandleVariables Include="TargetArchitectureDescription" Value="$(InstallerTargetArchitecture)$(CrossArchContentsBuildPart)" />
       <CandleVariables Include="UpgradeCode" Value="$(UpgradeCode)" />
       <CandleVariables Include="MajorUpgradeSchedule" Value="$(MajorUpgradeSchedule)" Condition="'$(MajorUpgradeSchedule)' != ''" />
@@ -379,7 +380,6 @@
       IgnoreStandardErrorWarningFormat="true"
       RetryDelayBase="2" />
 
-    <!-- TODO this fails on preprocessor directives -->
     <CreateWixBuildWixpack
       Cultures="en-us"
       DefineConstants="@(CandleVariables->'%(Identity)=%(Value)')"


### PR DESCRIPTION
Backport the changes from https://github.com/dotnet/arcade/pull/16162/files and https://github.com/dotnet/arcade/pull/16195