### PR TITLE
Add ninja to .NET build dependencies on macOS

### DIFF
--- a/eng/common/native/install-dependencies.sh
+++ b/eng/common/native/install-dependencies.sh
@@ -50,6 +50,7 @@ case "$os" in
         brew bundle --no-upgrade --file=- <<EOF
 brew "cmake"
 brew "icu4c"
+brew "ninja"
 brew "openssl@3"
 brew "pkgconf"
 brew "python3"


### PR DESCRIPTION
Add ninja to macOS .NET dependencies - it is required to build the mono subset when running something like `./build.sh -subset mono.runtime` (I got a really nondescript error when trying to build without it).

Replaces https://github.com/dotnet/runtime/pull/120461 (was told I need to open here, rather than on dotnet/runtime: https://github.com/dotnet/runtime/pull/120461#discussion_r2410795181).