### PR TITLE
Remove audit sources from NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -54,8 +54,4 @@
   <disabledPackageSources>
     <clear />
   </disabledPackageSources>
-  <auditSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </auditSources>
 </configuration>


### PR DESCRIPTION
The api.nuget.org source will clash with the CFSClean network isolation policy and the same data is provided by AzDO now.
