### PR TITLE
PublishBuildToMaestro should have minimum retry delay

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishBuildToMaestro.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishBuildToMaestro.cs
@@ -567,9 +567,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         break;
                     }
 
-                    // due to latency in receiving the response and calculating the value, we may get a negative timespan
-                    // Clip to a minimum wait of 100ms
-                    timeSpan = Math.Max(timeSpan.Value, TimeSpan.FromMilliseconds(100));
+                    // Due to latency in receiving the response and calculating the value, we may have a negative timespan
+                    TimeSpan minWait = TimeSpan.FromMilliseconds(100);
+                    if (timeSpan < minWait)
+                    {
+                        timeSpan = minWait;
+                    }
 
                     Log.LogMessage(MessageImportance.High,
                         $"API rate limit exceeded, retrying in {timeSpan.Value.TotalSeconds} seconds. Retry attempt: {retry}");


### PR DESCRIPTION
NuGet's official builds occasionally fail because GitHub says API limit is reached, but when we calculate the retry period, it ends up being a negative number then Thread.Sleep throws, failing the build.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
