### PR TITLE
Add conflict resolution extension point for PR backport workflow

### DIFF
--- a/.github/workflows/backport-base.yml
+++ b/.github/workflows/backport-base.yml
@@ -25,7 +25,11 @@ on:
         type: string
         default: ''
       conflict_resolution_command:
-        description: 'Optional shell command to attempt automatic conflict resolution after a failed git am. If it eliminates merge conflicts, the backport proceeds.'
+        description: >-
+          Optional shell command to attempt automatic conflict resolution after a failed git am.
+          If the command eliminates merge conflicts, the backport proceeds automatically.
+          Do not run git commands from this parameter as they might have unintended side effects.
+          DO NOT PASS UNTRUSTED INPUT TO THIS PARAMETER.
         required: false
         type: string
 


### PR DESCRIPTION
Part of https://github.com/dotnet/dotnet-docker/issues/6653.

### Background

We want automated backports in [dotnet/dotnet-docker](https://github.com/dotnet/dotnet-docker), but the repo has hundreds of checked-in files that are generated from templates. The templates often have different output depending on the branch. This means backports frequently create merge conflicts. Regenerating all of the templated files resolves most merge conflicts.

### Changes

This PR adds an input to the backport workflow base that lets consuming workflows pass in a command that can be run to try and resolve merge conflicts. If there's a merge conflict, we run the custom conflict resolution command. If all of the merge conflicts/markers are resolved after the command is run, then we proceed with the pull request.

- Example of success:
  - Original PR: https://github.com/lbussell/dotnet-docker/pull/8#issuecomment-3438272440
  - Auto-generated PR: https://github.com/lbussell/dotnet-docker/pull/11
    - Of note here is that it added all modified files even if they didn't exist in the target branch, even though that's technically incorrect for this scenario. That this is by-design. If we wanted to fix this, we would make the dotnet-docker repo's template generation scripts delete the extra files.
- Example of failure: https://github.com/lbussell/dotnet-docker/pull/6#issuecomment-3439550012