### PR TITLE
Add detached signature CertificatesSignInfo

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -30,6 +30,8 @@
     <CertificatesSignInfo Include="MacDeveloperWithNotarization" MacCertificate="MacDeveloper" MacNotarizationAppName="dotnet" />
     <CertificatesSignInfo Include="MacDeveloperVNextWithNotarization" MacCertificate="MacDeveloperVNext" MacNotarizationAppName="dotnet" />
     <CertificatesSignInfo Include="MacDeveloperVNextHardenWithNotarization" MacCertificate="MacDeveloperVNextHarden" MacNotarizationAppName="dotnet" />
+    <!-- Certificates Which support detached signatures -->
+    <CertificatesSignInfo Include="LinuxSignTar" SupportsDetachedSignature="true" />
   </ItemGroup>
 
   <!-- Only publish packages that contain this build's Target RID in the name.

--- a/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -2773,7 +2773,7 @@ $@"
                 }),
                 new TaskItem("DetachedArchiveCert", new Dictionary<string, string>
                 {
-                    { "DetachedSignature", "true" }
+                    { "SupportsDetachedSignature", "true" }
                 }),
             };
 

--- a/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignToolTask.cs
@@ -367,7 +367,7 @@ namespace Microsoft.DotNet.SignTool
                     var macSigningOperation = certificateSignInfo.GetMetadata("MacCertificate");
                     var macNotarizationAppName = certificateSignInfo.GetMetadata("MacNotarizationAppName");
                     var collisionPriorityId = certificateSignInfo.GetMetadata(SignToolConstants.CollisionPriorityId);
-                    var detachedSignatureCertificate = certificateSignInfo.GetMetadata("DetachedSignature");
+                    var detachedSignatureCertificate = certificateSignInfo.GetMetadata("SupportsDetachedSignature");
                     bool detachedSignatureCertificateValue = false;
 
                     if (string.IsNullOrEmpty(macSigningOperation) != string.IsNullOrEmpty(macNotarizationAppName))


### PR DESCRIPTION
Related to https://github.com/dotnet/arcade/issues/16240

Sets the detached signature CertificatesSignInfo for the LinuxSignTar certificate.  This certificate is recommended by MicroBuild to sign linux tarballs with.  It is still TBD if we will use this certificate but it allows us to start signing tarballs to validate the E2E while we wait for final decision.

Renamed the `CertificatesSignInfo.DetachedSignature` property to `CertificatesSignInfo.SupportsDetachedSignature` to better indicate it is a Boolean.
