### PR TITLE
Bump SDK version in global.json to 10.0-rc2

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100-rc.1.25420.111",
+    "version": "10.0.100-rc.2.25502.107",
     "rollForward": "latestFeature",
     "paths": [
       ".dotnet",
@@ -9,7 +9,7 @@
     "errorMessage": "The required .NET SDK wasn't found. Please run ./eng/common/dotnet.cmd/sh to install it."
   },
   "tools": {
-    "dotnet": "10.0.100-rc.1.25420.111"
+    "dotnet": "10.0.100-rc.2.25502.107"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.25524.1",


### PR DESCRIPTION
This is currently not happening through the dependency flow because of https://github.com/dotnet/arcade-services/issues/5406
