### PR TITLE
Remove confusing Windows display name suffix from install-microbuild-impl.yml

### DIFF
--- a/eng/common/core-templates/steps/install-microbuild-impl.yml
+++ b/eng/common/core-templates/steps/install-microbuild-impl.yml
@@ -20,14 +20,14 @@ parameters:
 steps:
 - ${{ if eq(parameters.enablePreviewMicrobuild, 'true') }}:
     - task: MicroBuildSigningPluginPreview@4
-      displayName: Install Preview MicroBuild plugin (Windows)
+      displayName: Install Preview MicroBuild plugin
       inputs: ${{ parameters.microbuildTaskInputs }}
       env: ${{ parameters.microbuildEnv }}
       continueOnError: ${{ parameters.continueOnError }}
       condition: ${{ parameters.condition }}
 - ${{ else }}:
   - task: MicroBuildSigningPlugin@4
-    displayName: Install MicroBuild plugin (Windows)
+    displayName: Install MicroBuild plugin
     inputs: ${{ parameters.microbuildTaskInputs }}
     env: ${{ parameters.microbuildEnv }}
     continueOnError: ${{ parameters.continueOnError }}


### PR DESCRIPTION
This is used on both Windows and non-Windows cases.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
