### PR TITLE
[release/10.0] Enhance logging for file extraction and repackaging with matching permissions

### DIFF
--- a/src/Microsoft.DotNet.SignTool/src/Configuration.cs
+++ b/src/Microsoft.DotNet.SignTool/src/Configuration.cs
@@ -830,11 +830,12 @@ namespace Microsoft.DotNet.SignTool
 
                         // if we already encountered file that has the same content we can reuse its signed version when repackaging the container.
                         var fileName = Path.GetFileName(entry.RelativePath);
+                        string entryPerms = entry.UnixFileMode.HasValue ? Convert.ToString((uint)entry.UnixFileMode.Value, 8) : "default perms";
                         if (!_filesByContentKey.TryGetValue(fileUniqueKey, out var fileSignInfo))
                         {
                             string extractPathRoot = _useHashInExtractionPath ? fileUniqueKey.StringHash : _filesByContentKey.Count().ToString();
                             string tempPath = Path.Combine(_pathToContainerUnpackingDirectory, extractPathRoot, entry.RelativePath);
-                            _log.LogMessage($"Extracting file '{fileName}' from '{archivePath}' to '{tempPath}'.");
+                            _log.LogMessage($"Extracting file '{fileName}' from '{archivePath}' to '{tempPath}'. (Caching with perms: {entryPerms})");
 
                             Directory.CreateDirectory(Path.GetDirectoryName(tempPath));
 
@@ -844,6 +845,10 @@ namespace Microsoft.DotNet.SignTool
                             _hashToCollisionIdMap.TryGetValue(fileUniqueKey, out string collisionPriorityId);
                             PathWithHash nestedFile = new PathWithHash(tempPath, entry.ContentHash);
                             fileSignInfo = TrackFile(nestedFile, zipFileSignInfo.File, collisionPriorityId);
+                        }
+                        else
+                        {
+                            _log.LogMessage($"Reusing previously extracted file '{fileName}' for '{archivePath}'. (Archival perms: {entryPerms})");
                         }
 
                         if (fileSignInfo.ShouldTrack)

--- a/src/Microsoft.DotNet.SignTool/src/ZipData.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ZipData.cs
@@ -376,6 +376,15 @@ namespace Microsoft.DotNet.SignTool
 
         private void RepackPkgOrAppBundles(TaskLoggingHelper log, string tempDir, string dotNetPathTooling, string pkgToolPath)
         {
+#if NET472
+            throw new NotImplementedException("PKG manipulation is not supported on .NET Framework");
+#else
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                log.LogError("Pkg/AppBundle repackaging is not supported on Windows.");
+                return;
+            }
+
             string extractDir = Path.Combine(tempDir, Guid.NewGuid().ToString());
             try
             {
@@ -395,8 +404,12 @@ namespace Microsoft.DotNet.SignTool
                         continue;
                     }
 
-                    log.LogMessage(MessageImportance.Low, $"Copying signed stream from {signedPart.Value.FileSignInfo.FullPath} to {FileSignInfo.FullPath} -> {relativePath}.");
+                    // Preserve the original file mode from the PKG/App. The sign cache might bring if from an entry in an archive with different perms.
+                    UnixFileMode extractedFileMode = File.GetUnixFileMode(path);
+
+                    log.LogMessage(MessageImportance.Low, $"Copying signed stream from {signedPart.Value.FileSignInfo.FullPath} to {FileSignInfo.FullPath} -> {relativePath} (perms: {Convert.ToString((uint)extractedFileMode, 8)}).");
                     File.Copy(signedPart.Value.FileSignInfo.FullPath, path, overwrite: true);
+                    File.SetUnixFileMode(path, extractedFileMode);
                 }
 
                 if (!RunPkgProcess(srcPath: extractDir, dstPath: FileSignInfo.FullPath, "pack", dotNetPathTooling, pkgToolPath))
@@ -411,6 +424,7 @@ namespace Microsoft.DotNet.SignTool
                     Directory.Delete(extractDir, recursive: true);
                 }
             }
+#endif
         }
 
 #if NETFRAMEWORK
@@ -515,8 +529,7 @@ namespace Microsoft.DotNet.SignTool
                             entry.DataStream = signedStream;
                             entry.DataStream.Position = 0;
                             writer.WriteEntry(entry);
-
-                            log.LogMessage(MessageImportance.Low, $"Copying signed stream from {signedPart.Value.FileSignInfo.FullPath} to {FileSignInfo.FullPath} -> {relativeName}.");
+                            log.LogMessage(MessageImportance.Low, $"Copying signed stream from {signedPart.Value.FileSignInfo.FullPath} to {FileSignInfo.FullPath} -> {relativeName} (perms: {Convert.ToString((uint)entry.Mode, 8)}).");
                             continue;
                         }
 


### PR DESCRIPTION
When doing de-dupe of signing files, when a file is first found in a container with different permissions from other entries or where permissions aren't preserved by the format. When repackaging pkg, use the one that's in the container itself. This didn't affect tarballs since the stream contents are replaced, but the entry is preserved (on macOS). A better way to do this for future archival patterns is to append this data to the ZipPart and not to the ZipData, as the latter is the cached entry and not the part representing the data in the original archive. 