### PR TITLE
Handle uninitialized secrets during log redaction

### DIFF
--- a/eng/common/core-templates/job/publish-build-assets.yml
+++ b/eng/common/core-templates/job/publish-build-assets.yml
@@ -140,7 +140,7 @@ jobs:
           /p:MaestroApiEndpoint=https://maestro.dot.net
           /p:OfficialBuildId=$(OfficialBuildId)
           -runtimeSourceFeed https://ci.dot.net/internal
-          -runtimeSourceFeedKey $(dotnetbuilds-internal-container-read-token-base64)
+          -runtimeSourceFeedKey '$(dotnetbuilds-internal-container-read-token-base64)'
 
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}
@@ -210,8 +210,8 @@ jobs:
             -ArtifactsPublishingAdditionalParameters '${{ parameters.artifactsPublishingAdditionalParameters }}'
             -SymbolPublishingAdditionalParameters '${{ parameters.symbolPublishingAdditionalParameters }}'
             -SkipAssetsPublishing '${{ parameters.isAssetlessBuild }}'
-            -runtimeSourceFeed https://ci.dot.net/internal 
-            -runtimeSourceFeedKey $(dotnetbuilds-internal-container-read-token-base64)
+            -runtimeSourceFeed https://ci.dot.net/internal
+            -runtimeSourceFeedKey '$(dotnetbuilds-internal-container-read-token-base64)'
 
     - ${{ if eq(parameters.enablePublishBuildArtifacts, 'true') }}:
       - template: /eng/common/core-templates/steps/publish-logs.yml

--- a/eng/common/core-templates/post-build/post-build.yml
+++ b/eng/common/core-templates/post-build/post-build.yml
@@ -334,4 +334,4 @@ stages:
               -SymbolPublishingAdditionalParameters '${{ parameters.symbolPublishingAdditionalParameters }}'
               -SkipAssetsPublishing '${{ parameters.isAssetlessBuild }}'
               -runtimeSourceFeed https://ci.dot.net/internal 
-              -runtimeSourceFeedKey $(dotnetbuilds-internal-container-read-token-base64)
+              -runtimeSourceFeedKey '$(dotnetbuilds-internal-container-read-token-base64)'

--- a/eng/common/core-templates/steps/publish-logs.yml
+++ b/eng/common/core-templates/steps/publish-logs.yml
@@ -26,10 +26,10 @@ steps:
     #  If the file exists - sensitive data for redaction will be sourced from it
     #  (single entry per line, lines starting with '# ' are considered comments and skipped)
     arguments: -InputPath '$(System.DefaultWorkingDirectory)/PostBuildLogs' 
-      -BinlogToolVersion ${{parameters.BinlogToolVersion}}
+      -BinlogToolVersion '${{parameters.BinlogToolVersion}}'
       -TokensFilePath '$(System.DefaultWorkingDirectory)/eng/BinlogSecretsRedactionFile.txt'
       -runtimeSourceFeed https://ci.dot.net/internal 
-      -runtimeSourceFeedKey $(dotnetbuilds-internal-container-read-token-base64)
+      -runtimeSourceFeedKey '$(dotnetbuilds-internal-container-read-token-base64)'
       '$(publishing-dnceng-devdiv-code-r-build-re)'
       '$(MaestroAccessToken)'
       '$(dn-bot-all-orgs-artifact-feeds-rw)'


### PR DESCRIPTION
Failed like [this](https://dev.azure.com/dnceng/internal/_build/results?buildId=2832526&view=logs&j=b11b921d-8982-5bb3-754b-b114d42fd804&t=fa11e8d2-a803-56ed-f5f6-1c30cb8b59b6)