### PR TITLE
[SharedFramework SDK] Use the shared framework name instead of the package ID for the "main assembly" for composite mode.

### DIFF
--- a/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -62,11 +62,10 @@
     </ItemGroup>
     <!--
       The PrepareForReadyToRunCompilation task now requires the MainAssembly metadata to be set.
-      It's only used in composite mode, which we do not use, so create a ficticous $(PackageId).dll
-      to ensure we don't accidentally trigger any unexpected behavior.
+      It's only used in composite mode, so it won't show up in the outputs of the shared framework.
     -->
     <ItemGroup Condition="'@(IntermediateAssembly)' == ''">
-      <IntermediateAssembly Include="$(IntermediateOutputPath)/$(PackageId).dll" />
+      <IntermediateAssembly Include="$(IntermediateOutputPath)/$(SharedFrameworkName).dll" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Ensures that when we start using composite R2R in shared framework NuGet packages (such as in https://github.com/dotnet/runtime/pull/121186) that the RID isn't in the object name (so we don't need to list out all of the different RIDs).

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
