### PR TITLE
Reduce the paths that binskim scans

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,6 +47,9 @@ extends:
         enabled: true
       tsa:
         enabled: true
+      binskim:
+        scanOutputDirectoryOnly: true
+        analyzeTargetGlob: +:f|**/artifacts/**/*.dll;+:f|**/artifacts/**/*.exe;-:f|**/*.Tests/**/*;-:f|**/wix/**/*;-:f|**/wix3/**/*;-:f|**/winterop.dll;
 
     stages:
     - template: /eng/build.yml@self


### PR DESCRIPTION
Reduce the paths to avoid a ton of noise from test assets, wix, etc. This noise is caused by Arcade's upload of output for validation.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
