### PR TITLE
Remove redundant AllowAutoRedirect on SocketsHttpHandler initialization

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/FindDotNetCliPackage.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/FindDotNetCliPackage.cs
@@ -61,10 +61,7 @@ namespace Microsoft.DotNet.Helix.Sdk
         public override void ConfigureServices(IServiceCollection collection)
         {
 #if NET
-            var socketsHandler = new SocketsHttpHandler
-            {
-                AllowAutoRedirect = true,
-            };
+            var socketsHandler = new SocketsHttpHandler();
             socketsHandler.SslOptions.CertificateChainPolicy = new X509ChainPolicy
             {
                 // Yes, check revocation.


### PR DESCRIPTION
This is the default, and shouldn't be specified. https://github.com/dotnet/runtime/blob/228a12c99c7819b45726a9a0e08f2e79c0091cae/src/libraries/Common/src/System/Net/Http/HttpHandlerDefaults.cs#L20