### PR TITLE
Refactor vsRequirements assignment logic in tools.ps1

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -547,19 +547,26 @@ function LocateVisualStudio([object]$vsRequirements = $null){
     })
   }
 
-  if (!$vsRequirements) { $vsRequirements = $GlobalJson.tools.vs }
+  if (!$vsRequirements) {
+    if (Get-Member -InputObject $GlobalJson.tools -Name 'vs' -ErrorAction SilentlyContinue) {
+      $vsRequirements = $GlobalJson.tools.vs
+    } else {
+      $vsRequirements = $null
+    }
+  }
+
   $args = @('-latest', '-format', 'json', '-requires', 'Microsoft.Component.MSBuild', '-products', '*')
 
   if (!$excludePrereleaseVS) {
     $args += '-prerelease'
   }
 
-  if (Get-Member -InputObject $vsRequirements -Name 'version') {
+  if ($vsRequirements -and (Get-Member -InputObject $vsRequirements -Name 'version' -ErrorAction SilentlyContinue)) {
     $args += '-version'
     $args += $vsRequirements.version
   }
 
-  if (Get-Member -InputObject $vsRequirements -Name 'components') {
+  if ($vsRequirements -and (Get-Member -InputObject $vsRequirements -Name 'components' -ErrorAction SilentlyContinue)) {
     foreach ($component in $vsRequirements.components) {
       $args += '-requires'
       $args += $component


### PR DESCRIPTION
Because 17.14 went stable, we needed a way to run vswhere, find the VS node, and enable preview SDKs. Noah found a way to do this but he had to modify tools.ps1 because the SDK repo didn't have a VS node in our global.json

https://github.com/dotnet/sdk/pull/51558/files#diff-72b8f8e899b94872c6ead31fd06ec109da15bcb9ad2af6e78103d6763a31c637

Porting his change here to see if folks want this centrally. Alternatively, I'm trying adding the vs node to global.json to see if it unblocks us.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
