### PR TITLE
Fix duplicated variables in publish-build-assets.yml

### DIFF
--- a/eng/common/core-templates/job/publish-build-assets.yml
+++ b/eng/common/core-templates/job/publish-build-assets.yml
@@ -136,8 +136,6 @@ jobs:
         scriptLocation: scriptPath
         scriptPath: $(System.DefaultWorkingDirectory)/eng/common/sdk-task.ps1
         arguments: -task PublishBuildAssets -restore -msbuildEngine dotnet
-          -runtimeSourceFeed https://ci.dot.net/internal 
-          -runtimeSourceFeedKey '$(dotnetbuilds-internal-container-read-token-base64)'
           /p:ManifestsPath='$(Build.StagingDirectory)/AssetManifests'
           /p:IsAssetlessBuild=${{ parameters.isAssetlessBuild }}
           /p:MaestroApiEndpoint=https://maestro.dot.net


### PR DESCRIPTION
This got accidentally added in https://github.com/dotnet/arcade/commit/412dad55d53c9fd4c60be8fef8e86107647a63a2

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
