### PR TITLE
Update the source build job's pool from 1es-mariner-2 to 1es-azurelinux-3

### DIFF
--- a/eng/common/templates-official/job/source-build.yml
+++ b/eng/common/templates-official/job/source-build.yml
@@ -61,7 +61,7 @@ jobs:
 
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: $[replace(replace(eq(contains(coalesce(variables['System.PullRequest.TargetBranch'], variables['Build.SourceBranch'], 'refs/heads/main'), 'release'), 'true'), True, 'NetCore1ESPool-Svc-Internal'), False, 'NetCore1ESPool-Internal')]
-        image: 1es-mariner-2
+        image: 1es-azurelinux-3
         os: linux
 
   ${{ if ne(parameters.platform.pool, '') }}:


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/5420

Manual backport of https://github.com/dotnet/arcade/pull/16336
