### PR TITLE
Use CDN URL instead of blob in FindDotNetCliPackage

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/FindDotNetCliPackage.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/FindDotNetCliPackage.cs
@@ -109,7 +109,7 @@ namespace Microsoft.DotNet.Helix.Sdk
         {
             NormalizeParameters();
             var feeds = new List<ITaskItem>();
-            feeds.Add(new MSBuild.TaskItem("https://dotnetcli.blob.core.windows.net/dotnet"));
+            feeds.Add(new MSBuild.TaskItem("https://builds.dotnet.microsoft.com/dotnet"));
             feeds.Add(new MSBuild.TaskItem("https://ci.dot.net/public"));
             if (AdditionalFeeds != null)
             {


### PR DESCRIPTION
Noticed this while looking at https://github.com/dotnet/arcade/pull/16329, I think we shouldn't use the blob storage here either.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
