### PR TITLE
[release/10.0] Update Windows pool images from VS2022 to VS2026 Preview Scout

### DIFF
--- a/eng/common/core-templates/job/source-index-stage1.yml
+++ b/eng/common/core-templates/job/source-index-stage1.yml
@@ -25,10 +25,10 @@ jobs:
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         name: $(DncEngPublicBuildPool)
-        image: windows.vs2022.amd64.open
+        image: windows.vs2026preview.scout.amd64.open
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: $(DncEngInternalBuildPool)
-        image: windows.vs2022.amd64
+        image: windows.vs2026preview.scout.amd64
 
   steps:
   - ${{ if eq(parameters.is1ESPipeline, '') }}:

--- a/eng/common/core-templates/post-build/post-build.yml
+++ b/eng/common/core-templates/post-build/post-build.yml
@@ -127,11 +127,11 @@ stages:
         ${{ else }}:
           ${{ if eq(parameters.is1ESPipeline, true) }}:
             name: $(DncEngInternalBuildPool)
-            image: windows.vs2022.amd64
+            image: windows.vs2026preview.scout.amd64
             os: windows
           ${{ else }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2022.amd64
+            demands: ImageOverride -equals windows.vs2026preview.scout.amd64
 
       steps:
         - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
@@ -175,7 +175,7 @@ stages:
             os: windows
           ${{ else }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2022.amd64          
+            demands: ImageOverride -equals windows.vs2026preview.scout.amd64
       steps:
         - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
           parameters:
@@ -236,7 +236,7 @@ stages:
             os: windows
           ${{ else }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2022.amd64          
+            demands: ImageOverride -equals windows.vs2026preview.scout.amd64
       steps:
         - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
           parameters:


### PR DESCRIPTION
Backport of https://github.com/dotnet/arcade/pull/16348 to release/10.0 to fix errors in signing validation job.