### PR TITLE
Set AllowPtrToDetectTestRunRetryFiles to true

### DIFF
--- a/eng/common/core-templates/job/job.yml
+++ b/eng/common/core-templates/job/job.yml
@@ -73,6 +73,8 @@ jobs:
     templateContext: ${{ parameters.templateContext }}
 
   variables:
+  - name: AllowPtrToDetectTestRunRetryFiles
+    value: true
   - ${{ if ne(parameters.enableTelemetry, 'false') }}:
     - name: DOTNET_CLI_TELEMETRY_PROFILE
       value: '$(Build.Repository.Uri)'


### PR DESCRIPTION
`AllowPtrToDetectTestRunRetryFiles` is a new flag used by `PublishTestResults` Azure task. When set to true, it handles TRX files more correctly so that retried TRX files produced by Microsoft.Testing.Platform are considered correctly.

AFAIK, other test result formats (e.g, xunit) don't have an equivalent. And test retries will never be accounted for correctly during PublishTestResults.