### PR TITLE
Revert "Replace nuget-verification with dotnet nuget verify using InitializeDotNetCli"

### DIFF
--- a/eng/common/core-templates/post-build/post-build.yml
+++ b/eng/common/core-templates/post-build/post-build.yml
@@ -154,7 +154,7 @@ stages:
       - task: PowerShell@2
         displayName: Validate
         inputs:
-          filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/nuget-verification.ps1
+          filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/nuget-validation.ps1
           arguments: -PackagesPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/
 
     - job:

--- a/eng/common/post-build/nuget-validation.ps1
+++ b/eng/common/post-build/nuget-validation.ps1
@@ -1,0 +1,22 @@
+# This script validates NuGet package metadata information using this 
+# tool: https://github.com/NuGet/NuGetGallery/tree/jver-verify/src/VerifyMicrosoftPackage
+
+param(
+  [Parameter(Mandatory=$true)][string] $PackagesPath # Path to where the packages to be validated are
+)
+
+# `tools.ps1` checks $ci to perform some actions. Since the post-build
+# scripts don't necessarily execute in the same agent that run the
+# build.ps1/sh script this variable isn't automatically set.
+$ci = $true
+$disableConfigureToolsetImport = $true
+. $PSScriptRoot\..\tools.ps1
+
+try {
+  & $PSScriptRoot\nuget-verification.ps1 ${PackagesPath}\*.nupkg
+} 
+catch {
+  Write-Host $_.ScriptStackTrace
+  Write-PipelineTelemetryError -Category 'NuGetValidation' -Message $_
+  ExitWithExitCode 1
+}

--- a/eng/common/post-build/nuget-verification.ps1
+++ b/eng/common/post-build/nuget-verification.ps1
@@ -1,66 +1,121 @@
 <#
 .SYNOPSIS
-    Verifies NuGet packages using dotnet nuget verify.
+    Verifies that Microsoft NuGet packages have proper metadata.
 .DESCRIPTION
-    Initializes the .NET CLI and runs 'dotnet nuget verify' on the provided NuGet packages. 
-    This script writes an error if any of the provided packages fail verification.
-.PARAMETER PackagesPath
-    Path to the directory containing NuGet packages to verify.
+    Downloads a verification tool and runs metadata validation on the provided NuGet packages. This script writes an
+    error if any of the provided packages fail validation. All arguments provided to this PowerShell script that do not
+    match PowerShell parameters are passed on to the verification tool downloaded during the execution of this script.
+.PARAMETER NuGetExePath
+    The path to the nuget.exe binary to use. If not provided, nuget.exe will be downloaded into the -DownloadPath
+    directory.
+.PARAMETER PackageSource
+    The package source to use to download the verification tool. If not provided, nuget.org will be used.
+.PARAMETER DownloadPath
+    The directory path to download the verification tool and nuget.exe to. If not provided,
+    %TEMP%\NuGet.VerifyNuGetPackage will be used.
+.PARAMETER args
+    Arguments that will be passed to the verification tool.
 .EXAMPLE
-    PS> .\nuget-verification.ps1 -PackagesPath C:\packages
-    Verifies all .nupkg files in the specified directory.
+    PS> .\verify.ps1 *.nupkg
+    Verifies the metadata of all .nupkg files in the currect working directory.
+.EXAMPLE
+    PS> .\verify.ps1 --help
+    Displays the help text of the downloaded verifiction tool.
+.LINK
+    https://github.com/NuGet/NuGetGallery/blob/master/src/VerifyMicrosoftPackage/README.md
 #>
 
+# This script was copied from https://github.com/NuGet/NuGetGallery/blob/3e25ad135146676bcab0050a516939d9958bfa5d/src/VerifyMicrosoftPackage/verify.ps1
+
+[CmdletBinding(PositionalBinding = $false)]
 param(
-  [Parameter(Mandatory=$true)][string] $PackagesPath # Path to where the packages to be validated are
+   [string]$NuGetExePath,
+   [string]$PackageSource = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json",
+   [string]$DownloadPath,
+   [Parameter(ValueFromRemainingArguments = $true)]
+   [string[]]$args
 )
 
-# `tools.ps1` checks $ci to perform some actions. Since the post-build
-# scripts don't necessarily execute in the same agent that run the
-# build.ps1/sh script this variable isn't automatically set.
-$ci = $true
-$disableConfigureToolsetImport = $true
-. $PSScriptRoot\..\tools.ps1
+# The URL to download nuget.exe.
+$nugetExeUrl = "https://dist.nuget.org/win-x86-commandline/v4.9.4/nuget.exe"
 
-try {
-  $fence = New-Object -TypeName string -ArgumentList '=', 80
+# The package ID of the verification tool.
+$packageId = "NuGet.VerifyMicrosoftPackage"
 
-  # Initialize the dotnet CLI
-  $dotnetRoot = InitializeDotNetCli -install:$true
-  $dotnet = Join-Path $dotnetRoot (GetExecutableFileName 'dotnet')
-
-  Write-Host "Using dotnet: $dotnet"
-  Write-Host " "
-
-  # Get all .nupkg files in the packages path
-  $packageFiles = Get-ChildItem -Path $PackagesPath -Filter '*.nupkg' -File
-
-  if ($packageFiles.Count -eq 0) {
-      Write-Host "No .nupkg files found in $PackagesPath"
-      Write-Output "dotnet nuget verify succeeded (no packages to verify)."
-      return
-  }
-
-  # Get the full paths of the package files
-  $packagePaths = $packageFiles | ForEach-Object { $_.FullName }
-
-  # Execute dotnet nuget verify
-  Write-Host "Executing dotnet nuget verify..."
-  Write-Host $fence
-  & $dotnet nuget verify $packagePaths
-  Write-Host $fence
-  Write-Host " "
-
-  # Respond to the exit code.
-  if ($LASTEXITCODE -ne 0) {
-      Write-PipelineTelemetryError -Category 'NuGetValidation' -Message "dotnet nuget verify found some problems."
-      ExitWithExitCode 1
-  } else {
-      Write-Output "dotnet nuget verify succeeded."
-  }
+# The location that nuget.exe and the verification tool will be downloaded to.
+if (!$DownloadPath) {
+    $DownloadPath = (Join-Path $env:TEMP "NuGet.VerifyMicrosoftPackage")
 }
-catch {
-  Write-Host $_.ScriptStackTrace
-  Write-PipelineTelemetryError -Category 'NuGetValidation' -Message $_
-  ExitWithExitCode 1
+
+$fence = New-Object -TypeName string -ArgumentList '=', 80
+
+# Create the download directory, if it doesn't already exist.
+if (!(Test-Path $DownloadPath)) {
+    New-Item -ItemType Directory $DownloadPath | Out-Null
+}
+Write-Host "Using download path: $DownloadPath"
+
+if ($NuGetExePath) {
+    $nuget = $NuGetExePath
+} else {
+    $downloadedNuGetExe = Join-Path $DownloadPath "nuget.exe"
+    
+    # Download nuget.exe, if it doesn't already exist.
+    if (!(Test-Path $downloadedNuGetExe)) {
+        Write-Host "Downloading nuget.exe from $nugetExeUrl..."
+        $ProgressPreference = 'SilentlyContinue'
+        try {
+            Invoke-WebRequest $nugetExeUrl -OutFile $downloadedNuGetExe
+            $ProgressPreference = 'Continue'
+        } catch {
+            $ProgressPreference = 'Continue'
+            Write-Error $_
+            Write-Error "nuget.exe failed to download."
+            exit
+        }
+    }
+
+    $nuget = $downloadedNuGetExe
+}
+
+Write-Host "Using nuget.exe path: $nuget"
+Write-Host " "
+
+# Download the latest version of the verification tool.
+Write-Host "Downloading the latest version of $packageId from $packageSource..."
+Write-Host $fence
+& $nuget install $packageId `
+    -Prerelease `
+    -OutputDirectory $DownloadPath `
+    -Source $PackageSource
+Write-Host $fence
+Write-Host " "
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "nuget.exe failed to fetch the verify tool."
+    exit
+}
+
+# Find the most recently downloaded tool
+Write-Host "Finding the most recently downloaded verification tool."
+$verifyProbePath = Join-Path $DownloadPath "$packageId.*"
+$verifyPath = Get-ChildItem -Path $verifyProbePath -Directory `
+    | Sort-Object -Property LastWriteTime -Descending `
+    | Select-Object -First 1
+$verify = Join-Path $verifyPath "tools\NuGet.VerifyMicrosoftPackage.exe"
+Write-Host "Using verification tool: $verify"
+Write-Host " "
+
+# Execute the verification tool.
+Write-Host "Executing the verify tool..."
+Write-Host $fence
+& $verify $args
+Write-Host $fence
+Write-Host " "
+
+# Respond to the exit code.
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "The verify tool found some problems."
+} else {
+    Write-Output "The verify tool succeeded."
 }

--- a/eng/configure-toolset.ps1
+++ b/eng/configure-toolset.ps1
@@ -5,6 +5,7 @@ function Test-FilesUseTelemetryOutput {
         "enable-cross-org-publishing.ps1",
         "performance-setup.ps1",
         "retain-build.ps1",
+        "nuget-verification.ps1",
         "vmr-sync.ps1")
 
     $filesMissingTelemetry = Get-ChildItem -File -Recurse -Path "$PSScriptRoot\common" -Include "*.ps1" -Exclude $requireTelemetryExcludeFiles |


### PR DESCRIPTION
Reverts dotnet/arcade#16354

Unfortunately this won't work since we don't sign packages for builds in main and "dotnet nuget verify" doesn't seem to have an option to turn off the signing requirement.

Unbreaks the build of arcade-official.