### PR TITLE
Only run source index for main builds

### DIFF
--- a/eng/common/core-templates/job/source-index-stage1.yml
+++ b/eng/common/core-templates/job/source-index-stage1.yml
@@ -3,7 +3,7 @@ parameters:
   sourceIndexBuildCommand: powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "eng/common/build.ps1 -restore -build -binarylog -ci"
   preSteps: []
   binlogPath: artifacts/log/Debug/Build.binlog
-  condition: ''
+  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
   dependsOn: ''
   pool: ''
   is1ESPipeline: ''


### PR DESCRIPTION
Set the default value for the condition to check for main branch, following what repos like wpf do: https://github.com/dotnet/wpf/blob/b0eef594c3cf95fed8d75e819c94f6eba65da826/eng/pipeline.yml#L25-L26

This also allows someone to override the condition if they want to.

Fixes an issue where servicing branches were running source indexing (and missing fixes like https://github.com/dotnet/arcade/pull/16278).