### PR TITLE
Fix dotnet.exe path quoting in wix.targets

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/wix.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/wix.targets
@@ -487,7 +487,7 @@
 
     <Copy SourceFiles="$(MangledNuspecFile)" DestinationFiles="$(VsInsertionNuspecFile)" />
 
-    <Exec Command="$(DotNetTool) pack &quot;$(VsInsertionNuspecFile)&quot; --property &quot;$(PackProperties)&quot; --version $(Version) -o &quot;$(ArtifactsNonShippingPackagesDir.TrimEnd('\\'))&quot;" StandardOutputImportance="normal" />
+    <Exec Command="&quot;$(DotNetTool)&quot; pack &quot;$(VsInsertionNuspecFile)&quot; --property &quot;$(PackProperties)&quot; --version $(Version) -o &quot;$(ArtifactsNonShippingPackagesDir.TrimEnd('\\'))&quot;" StandardOutputImportance="normal" />
 
     <Error
       Condition="!Exists('$(NupkgOutputFile)')"


### PR DESCRIPTION
Fixes an issue where the Exec command in GenerateVSInsertionNupkgCore target was not quoting the DotNetTool variable, causing build failures when dotnet.exe is installed in a path with spaces. Added proper quoting around the DotNetTool variable in the Exec command.