### PR TITLE
Enable filtering for tests on coreclr interpreter

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions.Shared/Attributes/SkipOnCoreClrAttribute.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions.Shared/Attributes/SkipOnCoreClrAttribute.cs
@@ -26,6 +26,7 @@ namespace Xunit
         private static readonly Lazy<bool> s_isReleaseRuntime = new Lazy<bool>(() => CoreClrConfigurationDetection.IsReleaseRuntime);
         private static readonly Lazy<bool> s_isDebugRuntime = new Lazy<bool>(() => CoreClrConfigurationDetection.IsDebugRuntime);
         private static readonly Lazy<bool> s_isStressTest = new Lazy<bool>(() => CoreClrConfigurationDetection.IsStressTest);
+        private static readonly Lazy<bool> s_isCoreClrInterpreter = new Lazy<bool>(() => CoreClrConfigurationDetection.IsCoreClrInterpreter);
 
         private readonly TestPlatforms _testPlatforms = TestPlatforms.Any;
         private readonly RuntimeTestModes _testMode = RuntimeTestModes.Any;
@@ -58,7 +59,8 @@ namespace Xunit
             (stressMode.HasFlag(RuntimeTestModes.TailcallStress) && s_isTailCallStress.Value) ||
             (stressMode.HasFlag(RuntimeTestModes.JitStressRegs) && s_isJitStressRegs.Value) ||
             (stressMode.HasFlag(RuntimeTestModes.JitStress) && s_isJitStress.Value) ||
-            (stressMode.HasFlag(RuntimeTestModes.JitMinOpts) && s_isJitMinOpts.Value);
+            (stressMode.HasFlag(RuntimeTestModes.JitMinOpts) && s_isJitMinOpts.Value) ||
+            (stressMode.HasFlag(RuntimeTestModes.InterpreterActive) && s_isCoreClrInterpreter.Value);
 #endif
         internal SkipOnCoreClrAttribute() { }
 

--- a/src/Microsoft.DotNet.XUnitExtensions.Shared/Discoverers/SkipOnCoreClrDiscoverer.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions.Shared/Discoverers/SkipOnCoreClrDiscoverer.cs
@@ -25,6 +25,7 @@ namespace Microsoft.DotNet.XUnitExtensions
         private static readonly Lazy<bool> s_isReleaseRuntime = new Lazy<bool>(() => CoreClrConfigurationDetection.IsReleaseRuntime);
         private static readonly Lazy<bool> s_isDebugRuntime = new Lazy<bool>(() => CoreClrConfigurationDetection.IsDebugRuntime);
         private static readonly Lazy<bool> s_isStressTest = new Lazy<bool>(() =>  CoreClrConfigurationDetection.IsStressTest);
+        private static readonly Lazy<bool> s_isCoreClrInterpreter = new Lazy<bool>(() => CoreClrConfigurationDetection.IsCoreClrInterpreter);
 
         public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
         {
@@ -72,7 +73,8 @@ namespace Microsoft.DotNet.XUnitExtensions
             (stressMode.HasFlag(RuntimeTestModes.TailcallStress) && s_isTailCallStress.Value) ||
             (stressMode.HasFlag(RuntimeTestModes.JitStressRegs) && s_isJitStressRegs.Value) ||
             (stressMode.HasFlag(RuntimeTestModes.JitStress) && s_isJitStress.Value) ||
-            (stressMode.HasFlag(RuntimeTestModes.JitMinOpts) && s_isJitMinOpts.Value);
+            (stressMode.HasFlag(RuntimeTestModes.JitMinOpts) && s_isJitMinOpts.Value) ||
+            (stressMode.HasFlag(RuntimeTestModes.InterpreterActive) && s_isCoreClrInterpreter.Value);
     }
 }
 #endif


### PR DESCRIPTION
While the `CoreClrConfigurationDetection` and `RuntimeTestModes` were already modified to add support for coreclr interpreter detection, it was missing wiring in the `SkipOnCoreClrAttribute`. So setting the attribute with `RuntimeTestModes.InterpreterActive` on a test has no effect.

This change fixes it.
