### PR TITLE
Update expired uris to new versions

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -72,7 +72,7 @@ __AlpinePackages+=" krb5-dev"
 __AlpinePackages+=" openssl-dev"
 __AlpinePackages+=" zlib-dev"
 
-__FreeBSDBase="13.4-RELEASE"
+__FreeBSDBase="13.5-RELEASE"
 __FreeBSDPkg="1.21.3"
 __FreeBSDABI="13"
 __FreeBSDPackages="libunwind"
@@ -383,7 +383,7 @@ while :; do
             ;;
         freebsd14)
             __CodeName=freebsd
-            __FreeBSDBase="14.2-RELEASE"
+            __FreeBSDBase="14.3-RELEASE"
             __FreeBSDABI="14"
             __SkipUnmount=1
             ;;


### PR DESCRIPTION
https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1568

From the build we see that we're trying to download from a URI that no longer exists
```
#8 0.535 [0] Downloading 'https://download.freebsd.org/ftp/releases/amd64/amd64/14.2-RELEASE/base.txz' ...
#8 0.539 HTTP ERROR response 404 Not Found [https://download.freebsd.org/ftp/releases/amd64/amd64/14.2-RELEASE/base.txz]
#8 0.540 xz: (stdin): File format not recognized
#8 0.541 tar: Child returned status 1
```
looking at the freebsd download side we can see that this version no longer exists there https://download.freebsd.org/releases/amd64/amd64/