### PR TITLE
Update HelixTargetQueue to use osx.15.amd64.appletv.open

### DIFF
--- a/tests/XHarness.Apple.DeviceTests.proj
+++ b/tests/XHarness.Apple.DeviceTests.proj
@@ -10,7 +10,7 @@
   <!-- Test project which builds app bundle to run via XHarness -->
   <ItemGroup>
     <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)XHarness\XHarness.Apple.Device.Archived.proj" />
-    <HelixTargetQueue Include="osx.13.amd64.appletv.open" />
+    <HelixTargetQueue Include="osx.15.amd64.appletv.open" />
   </ItemGroup>
 
   <Target Name="Pack"/>


### PR DESCRIPTION
## Description

This PR updates HelixTargetQueue to use osx.15.amd64.appletv.open.