### PR TITLE
Use VS 2022 images in Arcade & Publishing infra

### DIFF
--- a/azure-pipelines-unofficial.yml
+++ b/azure-pipelines-unofficial.yml
@@ -20,7 +20,7 @@ extends:
   parameters:
     pool:
       name: $(DncEngInternalBuildPool)
-      image: windows.vs2019.amd64
+      image: windows.vs2022.amd64
       os: windows
 
     stages:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ extends:
   parameters:
     pool:
       name: $(DncEngInternalBuildPool)
-      image: windows.vs2019.amd64
+      image: windows.vs2022.amd64
       os: windows
     sdl:
       policheck:

--- a/eng/common/core-templates/job/publish-build-assets.yml
+++ b/eng/common/core-templates/job/publish-build-assets.yml
@@ -80,7 +80,7 @@ jobs:
     # If it's not devdiv, it's dnceng
     ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
       name: NetCore1ESPool-Publishing-Internal
-      image: windows.vs2019.amd64
+      image: windows.vs2022.amd64
       os: windows
   steps:
   - ${{ if eq(parameters.is1ESPipeline, '') }}:

--- a/eng/common/core-templates/post-build/post-build.yml
+++ b/eng/common/core-templates/post-build/post-build.yml
@@ -293,11 +293,11 @@ stages:
         ${{ else }}:
           ${{ if eq(parameters.is1ESPipeline, true) }}:
             name: NetCore1ESPool-Publishing-Internal
-            image: windows.vs2019.amd64
+            image: windows.vs2022.amd64
             os: windows
           ${{ else }}:
             name: NetCore1ESPool-Publishing-Internal
-            demands: ImageOverride -equals windows.vs2019.amd64
+            demands: ImageOverride -equals windows.vs2022.amd64
       steps:
       - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
         parameters:

--- a/eng/common/templates/variables/pool-providers.yml
+++ b/eng/common/templates/variables/pool-providers.yml
@@ -23,7 +23,7 @@
 #
 #        pool:
 #           name: $(DncEngInternalBuildPool)
-#           demands: ImageOverride -equals windows.vs2019.amd64
+#           demands: ImageOverride -equals windows.vs2022.amd64
 variables:
   - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
     - template: /eng/common/templates-official/variables/pool-providers.yml

--- a/eng/promote-build.yml
+++ b/eng/promote-build.yml
@@ -69,7 +69,7 @@ extends:
         os: windows
       ${{ else }}:
         name: NetCore1ESPool-Publishing-Internal
-        image: windows.vs2019.amd64
+        image: windows.vs2022.amd64
         os: windows
     sdl:
       policheck:

--- a/eng/validate-sdk.yml
+++ b/eng/validate-sdk.yml
@@ -29,7 +29,7 @@ jobs:
     - template: /eng/common/templates-official/variables/pool-providers.yml@self
     pool:
       name: $(DncEngInternalBuildPool)
-      demands: ImageOverride -equals windows.vs2019.amd64
+      demands: ImageOverride -equals windows.vs2022.amd64
     preSteps:
     - checkout: self
       clean: true


### PR DESCRIPTION
It's about clearing this error:
<img width="2063" height="58" alt="image" src="https://github.com/user-attachments/assets/60531cb8-822b-462e-bfb4-f9b6bebb5ebd" />