### PR TITLE
[release/9.0] Use VS 2022 images in Arcade & Publishing infra

### DIFF
--- a/azure-pipelines-code-mirror.yml
+++ b/azure-pipelines-code-mirror.yml
@@ -16,7 +16,7 @@ extends:
 
     pool:
       name: $(DncEngInternalBuildPool)
-      image: windows.vs2019.amd64
+      image: windows.vs2022.amd64
       os: windows
 
     # devdiv has different agent pools

--- a/azure-pipelines-merge-mirror.yml
+++ b/azure-pipelines-merge-mirror.yml
@@ -21,7 +21,7 @@ jobs:
         # If it's not devdiv, it's dnceng
         ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
           name: $(DncEngInternalBuildPool)
-          demands: ImageOverride -equals windows.vs2019.amd64
+          demands: ImageOverride -equals windows.vs2022.amd64
       variables:
       - name: WorkingDirectoryName
         value: repo-dir

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -28,7 +28,7 @@ stages:
         timeoutInMinutes: 90
         pool:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals windows.vs2019.amd64.open
+          demands: ImageOverride -equals windows.vs2022.amd64.open
         preSteps:
         - checkout: self
           clean: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ extends:
   parameters:
     pool:
       name: $(DncEngInternalBuildPool)
-      image: windows.vs2019.amd64
+      image: windows.vs2022.amd64
       os: windows
     sdl:
       policheck:

--- a/eng/common/core-templates/job/publish-build-assets.yml
+++ b/eng/common/core-templates/job/publish-build-assets.yml
@@ -74,7 +74,7 @@ jobs:
     # If it's not devdiv, it's dnceng
     ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
       name: NetCore1ESPool-Publishing-Internal
-      image: windows.vs2019.amd64
+      image: windows.vs2022.amd64
       os: windows
   steps:
   - ${{ if eq(parameters.is1ESPipeline, '') }}:

--- a/eng/common/core-templates/post-build/post-build.yml
+++ b/eng/common/core-templates/post-build/post-build.yml
@@ -291,11 +291,11 @@ stages:
         ${{ else }}:
           ${{ if eq(parameters.is1ESPipeline, true) }}:          
             name: NetCore1ESPool-Publishing-Internal
-            image: windows.vs2019.amd64
+            image: windows.vs2022.amd64
             os: windows
           ${{ else }}:
             name: NetCore1ESPool-Publishing-Internal
-            demands: ImageOverride -equals windows.vs2019.amd64          
+            demands: ImageOverride -equals windows.vs2022.amd64          
       steps:
         - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
           parameters:

--- a/eng/common/templates/variables/pool-providers.yml
+++ b/eng/common/templates/variables/pool-providers.yml
@@ -23,7 +23,7 @@
 #
 #        pool:
 #           name: $(DncEngInternalBuildPool)
-#           demands: ImageOverride -equals windows.vs2019.amd64
+#           demands: ImageOverride -equals windows.vs2022.amd64
 variables:
   - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
     - template: /eng/common/templates-official/variables/pool-providers.yml

--- a/eng/promote-build.yml
+++ b/eng/promote-build.yml
@@ -69,7 +69,7 @@ extends:
         os: windows
       ${{ else }}:
         name: NetCore1ESPool-Publishing-Internal
-        image: windows.vs2019.amd64
+        image: windows.vs2022.amd64
         os: windows
 
     stages:

--- a/eng/validate-sdk.yml
+++ b/eng/validate-sdk.yml
@@ -26,7 +26,7 @@ jobs:
     - template: /eng/common/templates-official/variables/pool-providers.yml@self
     pool:
       name: $(DncEngInternalBuildPool)
-      demands: ImageOverride -equals windows.vs2019.amd64
+      demands: ImageOverride -equals windows.vs2022.amd64
     preSteps:
     - checkout: self
       clean: true


### PR DESCRIPTION
It's about clearing this error:
<img width="2063" height="58" alt="image" src="https://github.com/user-attachments/assets/60531cb8-822b-462e-bfb4-f9b6bebb5ebd" />