### PR TITLE
[release/10.0] Update source-build to Azure-Linux-3-Amd64 image

### DIFF
--- a/eng/common/core-templates/job/source-build.yml
+++ b/eng/common/core-templates/job/source-build.yml
@@ -63,7 +63,7 @@ jobs:
           demands: ImageOverride -equals build.ubuntu.2004.amd64
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: $[replace(replace(eq(contains(coalesce(variables['System.PullRequest.TargetBranch'], variables['Build.SourceBranch'], 'refs/heads/main'), 'release'), 'true'), True, 'NetCore1ESPool-Svc-Internal'), False, 'NetCore1ESPool-Internal')]
-          image: 1es-mariner-2
+          image: Azure-Linux-3-Amd64
           os: linux
     ${{ else }}:
       pool:


### PR DESCRIPTION
Manual backport of https://github.com/dotnet/arcade/pull/16456.

A manual backport was necessary because the original change to upgrade to AzL3 was missing.
