### PR TITLE
[release/6.0] Install .NET 8 before running Publish Using Darc

### DIFF
--- a/eng/common/templates-official/post-build/post-build.yml
+++ b/eng/common/templates-official/post-build/post-build.yml
@@ -265,6 +265,10 @@ stages:
           BARBuildId: ${{ parameters.BARBuildId }}
           PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
 
+      - task: UseDotNet@2
+        inputs:
+          version: 8.0.x
+
       - task: AzureCLI@2
         displayName: Publish Using Darc
         inputs:

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -261,6 +261,10 @@ stages:
           BARBuildId: ${{ parameters.BARBuildId }}
           PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
 
+      - task: UseDotNet@2
+        inputs:
+          version: 8.0.x
+
       - task: AzureCLI@2
         displayName: Publish Using Darc
         inputs:


### PR DESCRIPTION
This is a manual backport of https://github.com/dotnet/arcade/pull/16263

This is causing build failures in Roslyn's 16.11 servicing branch ([see run](https://dev.azure.com/dnceng/internal/internal%20Team/_build/results?buildId=2883798&view=logs&j=226748d0-f812-5437-d3f0-2dd291f5666e&t=b3ecf0d0-598d-5874-6547-0432d3f07f6b&l=55))
