### PR TITLE
Fix reading container contents when DoNotUnpack is set

### DIFF
--- a/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
+++ b/src/Microsoft.DotNet.SignTool/src/BatchSignUtil.cs
@@ -281,8 +281,18 @@ namespace Microsoft.DotNet.SignTool
             {
                 if (file.IsUnpackableContainer())
                 {
-                    _log.LogMessage($"Repacking container: '{file.FileName}'");
-                    _batchData.ZipDataMap[file.FileContentKey].Repack(_log, _signTool.TempDir, _signTool.Wix3ToolsPath, _signTool.WixToolsPath, _signTool.TarToolPath, _signTool.PkgToolPath);
+                    if (_batchData.ZipDataMap.TryGetValue(file.FileContentKey, out var zipData))
+                    {
+                        _log.LogMessage($"Repacking container: '{file.FileName}'");
+                        zipData.Repack(_log, _signTool.TempDir, _signTool.Wix3ToolsPath, _signTool.WixToolsPath, _signTool.TarToolPath, _signTool.PkgToolPath);
+                    }
+                    else
+                    {
+                        if (!file.SignInfo.DoNotUnpack)
+                        {
+                            _log.LogError($"No zip data found for file '{file.FullPath}' to repack.");
+                        }
+                    }
                 }
                 else
                 {
@@ -294,9 +304,8 @@ namespace Microsoft.DotNet.SignTool
             // signed, don't need signing, and are repacked.
             bool isReady(FileSignInfo file)
             {
-                if (file.IsUnpackableContainer())
+                if (_batchData.ZipDataMap.TryGetValue(file.FileContentKey, out var zipData))
                 {
-                    var zipData = _batchData.ZipDataMap[file.FileContentKey];
                     return zipData.NestedParts.Values.All(x => (!x.FileSignInfo.SignInfo.ShouldSign ||
                         trackedSet.Contains(x.FileSignInfo.FileContentKey)) && !toRepackSet.Contains(x.FileSignInfo.FullPath)
                         );
@@ -664,10 +673,8 @@ namespace Microsoft.DotNet.SignTool
                 }
             }
 
-            if (file.IsUnpackableContainer())
+            if (_batchData.ZipDataMap.TryGetValue(file.FileContentKey, out var zipData))
             {
-                var zipData = _batchData.ZipDataMap[file.FileContentKey];
-
                 foreach (var nestedPart in zipData.NestedParts.Values)
                 {
                     VerifyAfterSign(log, nestedPart.FileSignInfo);


### PR DESCRIPTION
Was encountering `error MSB4018: System.Collections.Generic.KeyNotFoundException: The given key 'Microsoft.DotNet.SignTool.SignedFileContentKey' was not present in the dictionary` while trying to implement https://github.com/dotnet/release/issues/1416 (signing the source asset). 

I verified that the changes in this PR fix the errors and allow the source asset to skip unpacking.