### PR TITLE
Add LinuxSign500180PGP cert

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -32,6 +32,7 @@
     <CertificatesSignInfo Include="MacDeveloperVNextHardenWithNotarization" MacCertificate="MacDeveloperVNextHarden" MacNotarizationAppName="dotnet" />
     <!-- Certificates Which support detached signatures -->
     <CertificatesSignInfo Include="LinuxSignTar" SupportsDetachedSignature="true" />
+    <CertificatesSignInfo Include="LinuxSign500180PGP" SupportsDetachedSignature="true" />
   </ItemGroup>
 
   <!-- Only publish packages that contain this build's Target RID in the name.


### PR DESCRIPTION
Related to https://github.com/dotnet/release/issues/1416

Sets the detached signature CertificatesSignInfo for the LinuxSign500180PGP certificate. This is the certificate that source-build uses to sign source assets.