### PR TITLE
Allow overwriting detached signature

### DIFF
--- a/src/Microsoft.DotNet.SignTool/src/SignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignTool.cs
@@ -208,7 +208,7 @@ namespace Microsoft.DotNet.SignTool
             foreach (var fileInfo in detachedSignatureFiles)
             {
                 // Copy the signed content to .sig file
-                File.Copy(fileInfo.FullPath, fileInfo.DetachedSignatureFullPath);
+                File.Copy(fileInfo.FullPath, fileInfo.DetachedSignatureFullPath, overwrite: true);
                 _log.LogMessage($"Created detached signature file: {fileInfo.DetachedSignatureFullPath}");
 
                 // Restore the original file


### PR DESCRIPTION
Needed for https://github.com/dotnet/dotnet/pull/4560.

This enables creating a detached signature placeholder/artifact during the build (required for darc publishing), while the signature is actually generated and populated later during post-build signing.