### PR TITLE
Add DO-NOT-UNPACK support to SignCheck

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/SignCheckResources.Designer.cs
+++ b/src/SignCheck/Microsoft.SignCheck/SignCheckResources.Designer.cs
@@ -374,6 +374,15 @@ namespace Microsoft.SignCheck {
                 return ResourceManager.GetString("DiagSectionHeader", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Skipping archive extraction on {0}.
+        /// </summary>
+        internal static string DiagSkippingArchiveExtraction {
+            get {
+                return ResourceManager.GetString("DiagSkippingArchiveExtraction", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Skipping strong name signature check..

--- a/src/SignCheck/Microsoft.SignCheck/SignCheckResources.resx
+++ b/src/SignCheck/Microsoft.SignCheck/SignCheckResources.resx
@@ -222,6 +222,9 @@
   <data name="DiagSectionHeader" xml:space="preserve">
     <value>Found section header '{0}'.</value>
   </data>
+  <data name="DiagSkippingArchiveExtraction" xml:space="preserve">
+    <value>Skipping archive extraction on {0}.</value>
+  </data>
   <data name="DiagSkippingStrongName" xml:space="preserve">
     <value>Skipping strong name signature check.</value>
   </data>

--- a/src/SignCheck/Microsoft.SignCheck/Verification/ArchiveVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/ArchiveVerifier.cs
@@ -79,6 +79,18 @@ namespace Microsoft.SignCheck.Verification
         {
             if (VerifyRecursive)
             {
+                svr.IsDoNotUnpack = Exclusions.IsDoNotUnpack(
+                    svr.FullPath,
+                    Path.GetDirectoryName(svr.FullPath) ?? SignCheckResources.NA,
+                    svr.VirtualPath,
+                    svr.VirtualPath);
+
+                if (svr.IsDoNotUnpack)
+                {
+                    Log.WriteMessage(LogVerbosity.Detailed, SignCheckResources.DiagSkippingArchiveExtraction, svr.FullPath);
+                    return;
+                }
+
                 string tempPath = svr.TempPath;
                 CreateDirectory(tempPath);
                 Log.WriteMessage(LogVerbosity.Diagnostic, SignCheckResources.DiagExtractingFileContents, tempPath);

--- a/src/SignCheck/Microsoft.SignCheck/Verification/Exclusions.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/Exclusions.cs
@@ -22,6 +22,7 @@ namespace Microsoft.SignCheck.Verification
         private const string DoNotSign = "DO-NOT-SIGN";
         private const string General = "GENERAL";
         private const string IgnoreStrongName = "IGNORE-STRONG-NAME";
+        private const string DoNotUnpack = "DO-NOT-UNPACK";
 
         public int Count
         {
@@ -113,7 +114,7 @@ namespace Microsoft.SignCheck.Verification
         /// <returns></returns>
         public bool IsExcluded(string path, string parent, string virtualPath, string containerPath)
         {
-            IEnumerable<Exclusion> exclusions = _exclusions.Where(e => !e.Comment.Contains(IgnoreStrongName));
+            IEnumerable<Exclusion> exclusions = _exclusions.Where(e => !e.Comment.Contains(IgnoreStrongName) && !e.Comment.Contains(DoNotUnpack));
             return IsExcluded(path, parent, virtualPath, containerPath, General, exclusions);
         }
 
@@ -136,6 +137,14 @@ namespace Microsoft.SignCheck.Verification
             IEnumerable<Exclusion> noStrongNameExclusions = _exclusions.Where(e => e.Comment.Contains(IgnoreStrongName));
 
             return (noStrongNameExclusions.Count() > 0) && (IsExcluded(path, parent, virtualPath, containerPath, IgnoreStrongName, noStrongNameExclusions));
+        }
+
+        public bool IsDoNotUnpack(string path, string parent, string virtualPath, string containerPath)
+        {
+            // Get all the exclusions with DO-NOT-UNPACK markers and check only against those
+            IEnumerable<Exclusion> doNotUnpackExclusions = _exclusions.Where(e => e.Comment.Contains(DoNotUnpack));
+
+            return (doNotUnpackExclusions.Count() > 0) && (IsExcluded(path, parent, virtualPath, containerPath, DoNotUnpack, doNotUnpackExclusions));
         }
 
         /// <summary>

--- a/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationResult.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationResult.cs
@@ -89,6 +89,15 @@ namespace Microsoft.SignCheck.Verification
         }
 
         /// <summary>
+        /// True if this file was marked as DO-NOT-UNPACK.
+        /// </summary>
+        public bool IsDoNotUnpack
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// True if the file was excluded from verification, false otherwise.
         /// </summary>
         public bool IsExcluded

--- a/src/SignCheck/SignCheckTask/src/SignCheck.cs
+++ b/src/SignCheck/SignCheckTask/src/SignCheck.cs
@@ -106,6 +106,12 @@ namespace SignCheckTask
             set;
         }
 
+        public int TotalDoNotUnpackFiles
+        {
+            get;
+            set;
+        }
+
         public int TotalExcludedFiles
         {
             get;
@@ -299,7 +305,7 @@ namespace SignCheckTask
 
         private void ProcessExclusions(string exclusionsFile)
         {
-            Log.WriteMessage(LogVerbosity.Diagnostic, SignCheckResources.scProcessExclusions);
+            Log.WriteMessage(LogVerbosity.Diagnostic, SignCheckResources.scProcessExclusions, exclusionsFile);
             Exclusions = new Exclusions(exclusionsFile);
         }
 
@@ -337,6 +343,11 @@ namespace SignCheckTask
                 {
                     TotalSkippedExcludedFiles++;
                     outcome = "SkippedExcluded";
+                }
+
+                if (result.IsDoNotUnpack)
+                {
+                    TotalDoNotUnpackFiles++;
                 }
 
                 // Regardless of the file status reporting settings, a container file like an MSI or NuGet package
@@ -443,7 +454,7 @@ namespace SignCheckTask
                     TimeSpan totalTime = endTime - startTime;
                     Log.WriteMessage(LogVerbosity.Minimum, String.Format(SignCheckResources.scTime, totalTime));
                     Log.WriteMessage(LogVerbosity.Minimum, String.Format(SignCheckResources.scStats,
-                        TotalFiles, TotalSignedFiles, TotalUnsignedFiles, TotalSkippedFiles, TotalExcludedFiles, TotalSkippedExcludedFiles));
+                        TotalFiles, TotalSignedFiles, TotalUnsignedFiles, TotalSkippedFiles, TotalExcludedFiles, TotalSkippedExcludedFiles, TotalDoNotUnpackFiles));
                 }
                 else
                 {

--- a/src/SignCheck/SignCheckTask/src/SignCheckResources.Designer.cs
+++ b/src/SignCheck/SignCheckTask/src/SignCheckResources.Designer.cs
@@ -169,7 +169,7 @@ namespace SignCheckTask {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Total Files: {0}, Signed: {1}, Unsigned: {2}, Skipped: {3}, Excluded: {4}, Skipped &amp; Excluded: {5}.
+        ///   Looks up a localized string similar to Total Files: {0}, Signed: {1}, Unsigned: {2}, Skipped: {3}, Excluded: {4}, Skipped &amp; Excluded: {5}, Not Unpacked: {6}.
         /// </summary>
         internal static string scStats {
             get {

--- a/src/SignCheck/SignCheckTask/src/SignCheckResources.resx
+++ b/src/SignCheck/SignCheckTask/src/SignCheckResources.resx
@@ -154,7 +154,7 @@
     <value>Signing issues found</value>
   </data>
   <data name="scStats" xml:space="preserve">
-    <value>Total Files: {0}, Signed: {1}, Unsigned: {2}, Skipped: {3}, Excluded: {4}, Skipped &amp; Excluded: {5}</value>
+    <value>Total Files: {0}, Signed: {1}, Unsigned: {2}, Skipped: {3}, Excluded: {4}, Skipped &amp; Excluded: {5}, Not Unpacked: {6}</value>
   </data>
   <data name="scSummary" xml:space="preserve">
     <value />


### PR DESCRIPTION
Related to https://github.com/dotnet/arcade/issues/16370
Needed for https://github.com/dotnet/dotnet/pull/4560

This PR allows files to skip unpacking in SignCheck

Exclusion in SignCheckExclusionsFile.txt:
```
;; ## Do Not Unpack ##
dotnet-source-*.tar.gz;; DO-NOT-UNPACK
```

SignCheck output:
```
Processing exclusions list in /workspace/dotnet/eng/SignCheckExclusionsFile.txt
Starting execution of SignCheck.
Skipping archive extraction on /workspace/temp/artifacts/assets/Release/source-build/dotnet-source-11.0.100-preview.1.26078.110.tar.gz.

Results

No signing issues found
Total Time: 00:00:00.0529113
Total Files: 1, Signed: 0, Unsigned: 0, Skipped: 1, Excluded: 0, Skipped & Excluded: 0, Not Unpacked: 1
```