### PR TITLE
Delete always-false condition from noble

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -295,9 +295,7 @@ while :; do
             ;;
         noble) # Ubuntu 24.04
             __CodeName=noble
-            if [[ -z "$__LLDB_Package" ]]; then
-                __LLDB_Package="liblldb-19-dev"
-            fi
+            __LLDB_Package="liblldb-19-dev"
             ;;
         stretch) # Debian 9
             __CodeName=stretch


### PR DESCRIPTION
```sh
sudo apt install -y python3-venv
rootfsEnv="/usr/local/share/rootfs"
sudo python3 -m venv "$rootfsEnv"
sudo "$rootfsEnv/bin/python" -m pip install aiohttp zstandard
PYTHON_EXECUTABLE="$rootfsEnv/bin/python" sudo eng/common/cross/build-rootfs.sh arm64 --rootfsdir /crossrootfs/arm64 --skipemulation
```

was failing to find liblldb 3.9 because that is unconditionally set at the beginning of the script.