### PR TITLE
Downgrade SBRP dependency from 9.0 to 8.0

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -121,9 +121,9 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>81cabf2857a01351e5ab578947c7403a5b128ad1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="9.0.0-alpha.1.24067.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.25615.3">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>0650b50b2a5263c735d12b5c36c5deb34e7e6b60</Sha>
+      <Sha>44b5b62182b48c34c4b6aef28943ec3f3e82f214</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="8.0.0-alpha.1.23475.1">


### PR DESCRIPTION
Caused by https://github.com/dotnet/arcade/commit/b7f1878753579e5c2665f2b192e21df68909c63f

Should address https://github.com/dotnet/runtime/pull/122396#issuecomment-3881528244