### PR TITLE
Throw error if no Visual Studio instance found

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -588,6 +588,11 @@ function LocateVisualStudio([object]$vsRequirements = $null){
     return $null
   }
 
+  if ($null -eq $vsInfo -or $vsInfo.Count -eq 0) {
+    throw "No instance of Visual Studio meeting the requirements specified was found. Requirements: $($args -join ' ')"
+    return $null
+  }
+
   # use first matching instance
   return $vsInfo[0]
 }


### PR DESCRIPTION
When we look for vs with a given component and it is not installed, show more informative message, instead of array indexing error.

<img width="1288" height="314" alt="image" src="https://github.com/user-attachments/assets/9567edaa-4a4c-45ea-9d69-ef4ea9cfcbb9" />


### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
