### PR TITLE
Change PackageReference to PackageDownload in SymStore.targets

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SymStore.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SymStore.targets
@@ -4,7 +4,7 @@
   <!-- This file is only imported in CI build. The conversion thus does not affect dev build. -->
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.DiaSymReader.Pdb2Pdb" Version="$(MicrosoftDiaSymReaderPdb2PdbVersion)" Condition="'$(UsingToolPdbConverter)' == 'true'" IsImplicitlyDefined="true" PrivateAssets="all" />
+    <PackageDownload Include="Microsoft.DiaSymReader.Pdb2Pdb" Version="[$(MicrosoftDiaSymReaderPdb2PdbVersion)]" Condition="'$(UsingToolPdbConverter)' == 'true'" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This allows removing the packaging workaround in symreader-converter

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
