### PR TITLE
[release/8.0] Bump .NET and SDK to 8.0.124

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "8.0.123",
+    "version": "8.0.124",
     "rollForward": "latestFeature"
   },
   "tools": {
-    "dotnet": "8.0.123"
+    "dotnet": "8.0.124"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.25611.2",


### PR DESCRIPTION
Bump .NET and the SDK to latest 8.0 security release. CG is already complaining in consuming repos - [example](https://dev.azure.com/dnceng/internal/_git/dotnet-release/pullRequest/55055?discussionId=243930#1771322773)

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
