### PR TITLE
[release/10.0] Source code updates from dotnet/dotnet (cherry-pick of #16533)

### DIFF
--- a/eng/common/templates/steps/vmr-sync.yml
+++ b/eng/common/templates/steps/vmr-sync.yml
@@ -39,27 +39,6 @@ steps:
   workingDirectory: $(Agent.BuildDirectory)/repo
 
 - script: |
-    vmr_sha=$(grep -oP '(?<=Sha=")[^"]*' $(Agent.BuildDirectory)/repo/eng/Version.Details.xml)
-    echo "##vso[task.setvariable variable=vmr_sha]$vmr_sha"
-  displayName: Obtain the vmr sha from Version.Details.xml (Unix)
-  condition: ne(variables['Agent.OS'], 'Windows_NT')
-  workingDirectory: $(Agent.BuildDirectory)/repo
-
-- powershell: |
-    [xml]$xml = Get-Content -Path $(Agent.BuildDirectory)/repo/eng/Version.Details.xml
-    $vmr_sha = $xml.SelectSingleNode("//Source").Sha
-    Write-Output "##vso[task.setvariable variable=vmr_sha]$vmr_sha"
-  displayName: Obtain the vmr sha from Version.Details.xml (Windows)
-  condition: eq(variables['Agent.OS'], 'Windows_NT')
-  workingDirectory: $(Agent.BuildDirectory)/repo
-
-- script: |
-    git fetch --all
-    git checkout $(vmr_sha)
-  displayName: Checkout VMR at correct sha for repo flow
-  workingDirectory: ${{ parameters.vmrPath }}
-
-- script: |
     git config --global user.name "dotnet-maestro[bot]"
     git config --global user.email "dotnet-maestro[bot]@users.noreply.github.com"
   displayName: Set git author to dotnet-maestro[bot]

--- a/eng/common/templates/vmr-build-pr.yml
+++ b/eng/common/templates/vmr-build-pr.yml
@@ -34,6 +34,7 @@ resources:
     type: github
     name: dotnet/dotnet
     endpoint: dotnet
+    ref: refs/heads/main # Set to whatever VMR branch the PR build should insert into
 
 stages:
 - template: /eng/pipelines/templates/stages/vmr-build.yml@vmr

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -824,6 +824,11 @@ function MSBuild-Core() {
 
   $cmdArgs = "$($buildTool.Command) /m /nologo /clp:Summary /v:$verbosity /nr:$nodeReuse /p:ContinuousIntegrationBuild=$ci"
 
+  # Add -mt flag for MSBuild multithreaded mode if enabled via environment variable
+  if ($env:MSBUILD_MT_ENABLED -eq "1") {
+    $cmdArgs += ' -mt'
+  }
+
   if ($warnAsError) {
     $cmdArgs += ' /warnaserror /p:TreatWarningsAsErrors=true'
   }

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -526,7 +526,13 @@ function MSBuild-Core {
     }
   }
 
-  RunBuildTool "$_InitializeBuildToolCommand" /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse $warnaserror_switch /p:TreatWarningsAsErrors=$warn_as_error /p:ContinuousIntegrationBuild=$ci "$@"
+  # Add -mt flag for MSBuild multithreaded mode if enabled via environment variable
+  local mt_switch=""
+  if [[ "${MSBUILD_MT_ENABLED:-}" == "1" ]]; then
+    mt_switch="-mt"
+  fi
+
+  RunBuildTool "$_InitializeBuildToolCommand" /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse $warnaserror_switch $mt_switch /p:TreatWarningsAsErrors=$warn_as_error /p:ContinuousIntegrationBuild=$ci "$@"
 }
 
 function GetDarc {


### PR DESCRIPTION
Cherry-pick of https://github.com/dotnet/arcade/pull/16533 targeting release/10.0.

Excludes version number changes (eng/Version.Details.xml and global.json).

Changes included:
- Remove VMR sha checkout steps from vmr-sync.yml
- Add ref comment to vmr-build-pr.yml
- Add MSBUILD_MT_ENABLED support to tools.ps1 and tools.sh
- Add fallback reset logic to vmr-sync.ps1 and vmr-sync.sh

These scripts are used in MSBuild main which consumes arcade 10