### PR TITLE
Remove Microsoft.NET.Test.Sdk version override from Versions.props

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -50,8 +50,6 @@
     <MicrosoftiOSTemplatesVersion>15.2.302-preview.14.122</MicrosoftiOSTemplatesVersion>
     <MicrosoftiOSTemplatesVersion160527>16.0.527</MicrosoftiOSTemplatesVersion160527>
     <SystemCompositionVersion>9.0.0-preview.6.24327.7</SystemCompositionVersion>
-    <!-- vstest -->
-    <MicrosoftNetTestSdkVersion>17.5.0</MicrosoftNetTestSdkVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
We can use the default version from arcade.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
