### PR TITLE
Remove self-reference from microbuild install and renovate templates

### DIFF
--- a/Documentation/Renovate.md
+++ b/Documentation/Renovate.md
@@ -197,7 +197,7 @@ variables:
   value: 'dotnet/your-repo-name'
 
 extends:
-  template: /eng/common/core-templates/stages/renovate.yml
+  template: /eng/common/core-templates/stages/renovate.yml@self
   parameters:
     dryRun: ${{ parameters.dryRun }}
     forceRecreatePR: ${{ parameters.forceRecreatePR }}
@@ -335,7 +335,7 @@ If you need different update schedules for different dependencies:
 
     ```yaml
     extends:
-      template: /eng/common/core-templates/stages/renovate.yml
+      template: /eng/common/core-templates/stages/renovate.yml@self
       parameters:
         dryRun: ${{ parameters.dryRun }}
         forceRecreatePR: ${{ parameters.forceRecreatePR }}

--- a/eng/common/template-guidance.md
+++ b/eng/common/template-guidance.md
@@ -31,7 +31,7 @@ extends:
     stages:
     - stage: build
       jobs:
-      - template: /eng/common/templates-official/jobs/jobs.yml
+      - template: /eng/common/templates-official/jobs/jobs.yml@self
         parameters:
           # 1ES makes use of outputs to reduce security task injection overhead
           templateContext:

--- a/eng/common/templates/vmr-build-pr.yml
+++ b/eng/common/templates/vmr-build-pr.yml
@@ -20,7 +20,7 @@ trigger: none
 pr: none
 
 variables:
-- template: /eng/common/templates/variables/pool-providers.yml
+- template: /eng/common/templates/variables/pool-providers.yml@self
 
 - name: skipComponentGovernanceDetection  # we run CG on internal builds only
   value: true


### PR DESCRIPTION
## Summary

For templates that reference other templates in Arcade, you cannot use `@self` as multi-repository scenarios may have `self` be a repository without Arcade in it. Therefore, the literal path here should be used. The `@` syntax should only be used if you're crossing a repository boundary (meaning, you need to explicitly denote files from a different repository).