### PR TITLE
Disable FullAssemblySigningSupported by default on non-Windows platforms

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,9 @@
 <Project>
 
+  <PropertyGroup>
+    <FullAssemblySigningSupported Condition="'$(FullAssemblySigningSupported)' == '' and '$(OS)' != 'Windows_NT'">false</FullAssemblySigningSupported>
+  </PropertyGroup>
+
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
   <PropertyGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/123010

## Summary
This PR changes the default value of `FullAssemblySigningSupported` to `false` for non-Windows builds within the Arcade SDK. This ensures a smoother developer experience on modern Linux distributions (like **RHEL 9/10**) where strict security policies disable RSA+SHA-1, which is required for strong-name signing.

## Context & Reasoning
As reported in [dotnet/runtime#123010](https://github.com/dotnet/runtime/issues/123010), building .NET repositories on modern Linux environments fails because the build system attempts full assembly signing using SHA-1 by default. Since full signing is typically only required for official Microsoft builds, we are moving the default to `false` for all non-Windows platforms.

This is the **second phase** of the plan discussed with @jkotas in [dotnet/runtime#123401](https://github.com/dotnet/runtime/pull/123401):

* **Phase 1 (Completed):** Patched the F# compiler and explicitly opted-in `dotnet/fsharp` to signing to maintain stability ([dotnet/fsharp#19242](https://github.com/dotnet/fsharp/pull/19242)).
* **Phase 2 (This PR):** Implement the global default change in Arcade to protect the entire ecosystem (SDK, ASP.NET, etc.) from similar build failures.

## Changes
* Modified the root `Directory.Build.props` to set `FullAssemblySigningSupported` to `false` on non-Windows platforms.
* Used a conditional check `Condition="'$(FullAssemblySigningSupported)' == ''"` to allow projects to manually opt-in if full signing is explicitly required.

## Validation
- [x] **Linux:** Verified that `FullAssemblySigningSupported` evaluates to `false` by default using a test project.
- [x] **Windows:** Confirmed that Windows builds remain unaffected (`true` by default).
- [x] **Bootstrapping:** Verified that the bootstrapping process (e.g., `XliffTasks`) completes successfully on Linux without requiring manual flags.

## Related Issues
* **Fixes:** dotnet/runtime#123010
* **Follow-up to:** dotnet/runtime#123401
* **Reference:** dotnet/fsharp#19242