### PR TITLE
Mark WorkItemExecution as passed when real test results exist

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/CreateFailedTestsForFailedWorkItems.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/CreateFailedTestsForFailedWorkItems.cs
@@ -26,8 +26,51 @@ namespace Microsoft.DotNet.Helix.Sdk
                 var testRunId = workItem.GetMetadata("TestRunId");
                 var failed = workItem.GetMetadata("Failed") == "true";
 
+                // If the work item failed, check whether there are already real test results
+                // reported for it. If so, those results already capture the failure details —
+                // marking WorkItemExecution as failed too is redundant and prevents Build Analysis
+                // from recognizing all failures as known issues.
+                if (failed)
+                {
+                    bool hasRealResults = await WorkItemHasTestResultsAsync(client, testRunId, jobName, workItemName);
+                    if (hasRealResults)
+                    {
+                        Log.LogMessage(MessageImportance.Normal,
+                            $"Work item {workItemName} already has test results reported; marking WorkItemExecution as passed.");
+                        failed = false;
+                    }
+                }
+
                 await CreateFakeTestResultAsync(client, testRunId, jobName, workItemName, failed);
             }
+        }
+
+        /// <summary>
+        /// Checks whether the test run already contains real test results for this work item.
+        /// Real results are posted by the reporter running on the Helix agent before the work item completes.
+        /// </summary>
+        private async Task<bool> WorkItemHasTestResultsAsync(HttpClient client, string testRunId, string jobName, string workItemName)
+        {
+            var data = await RetryAsync(
+                async () =>
+                {
+                    using (var req = new HttpRequestMessage(
+                        HttpMethod.Get,
+                        $"{CollectionUri}{TeamProject}/_apis/test/runs/{testRunId}/results?$top=1&$filter=automatedTestStorage eq '{workItemName}'&api-version=6.0"))
+                    {
+                        using (HttpResponseMessage res = await client.SendAsync(req))
+                        {
+                            return await ParseResponseAsync(req, res);
+                        }
+                    }
+                });
+
+            if (data != null && data["count"] != null)
+            {
+                return data.Value<int>("count") > 0;
+            }
+
+            return false;
         }
 
         private async Task<int> CreateFakeTestResultAsync(HttpClient client, string testRunId, string jobName, string workItemFriendlyName, bool failed)


### PR DESCRIPTION
## Summary

When a Helix work item fails and the test reporter has already posted real test results to the AzDO test run, the synthetic `WorkItemExecution` result is redundant. Marking it as failed prevents Build Analysis from going green even when all real test failures are matched to known issues.

## Problem

`CreateTestsForWorkItems` creates a synthetic `.WorkItemExecution` test result for every work item. If the work item failed, this result is marked as `Failed` with a generic error message: *"The Helix Work Item failed. Often this is due to a test crash."*

Build Analysis matches known-issue patterns against test `ErrorMessage` and `StackTrace` fields. The real test failures (e.g. `NoOpRebuild` timing out) get matched to known issues, but the synthetic `WorkItemExecution` entry has a generic message that doesn't match — so BA stays red.

**Example:** [dotnet/runtime#125373](https://github.com/dotnet/runtime/pull/125373) — BA correctly matched 3 test failures to known issues ([#116697](https://github.com/dotnet/runtime/issues/116697), [#124438](https://github.com/dotnet/runtime/issues/124438)), but the `RebuildTests.WorkItemExecution` entry kept BA red.

## Fix

Before creating the synthetic result, query the test run for existing results from this work item (using `automatedTestStorage`). If results exist, mark `WorkItemExecution` as passed — the real results already capture the failure details.

Work items that crash **without producing any test results** still get a failed `WorkItemExecution` entry — that's the case it was designed for.

## Trade-offs

- Adds one API call per failed work item (`$top=1` keeps it lightweight)
- If the API call fails, falls back to current behavior (marks as failed)
- Preserves the `WorkItemExecution` entry for genuine crashes with no test output