### PR TITLE
Add Aspire aka.ms links for install scripts

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/GeneralTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/GeneralTests.cs
@@ -38,6 +38,23 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
         }
 
         [Theory]
+        [InlineData(8103)]
+        [InlineData(8104)]
+        [InlineData(8105)]
+        public void AspireChannelsAllowOnlyGetAspireCliInstallScripts(int channelId)
+        {
+            var channelConfig = PublishingConstants.ChannelInfos.Single(c => c.Id == channelId);
+
+            channelConfig.AkaMSCreateLinkPatterns.Any(pattern => pattern.IsMatch("assets/installers/foo.zip")).Should().BeTrue();
+            channelConfig.AkaMSCreateLinkPatterns.Any(pattern => pattern.IsMatch("assets/installers/get-aspire-cli.ps1")).Should().BeTrue();
+            channelConfig.AkaMSCreateLinkPatterns.Any(pattern => pattern.IsMatch("assets/installers/get-aspire-cli.ps1.sha512")).Should().BeTrue();
+            channelConfig.AkaMSCreateLinkPatterns.Any(pattern => pattern.IsMatch("assets/installers/get-aspire-cli.sh")).Should().BeTrue();
+            channelConfig.AkaMSCreateLinkPatterns.Any(pattern => pattern.IsMatch("assets/installers/get-aspire-cli.sh.sha512")).Should().BeTrue();
+            channelConfig.AkaMSCreateLinkPatterns.Any(pattern => pattern.IsMatch("assets/installers/install-other-tool.ps1")).Should().BeFalse();
+            channelConfig.AkaMSCreateLinkPatterns.Any(pattern => pattern.IsMatch("assets/installers/install-other-tool.sh")).Should().BeFalse();
+        }
+
+        [Theory]
         [InlineData("foo/bar/baz/bop.symbols.nupkg", true)]
         [InlineData("foo/bar/baz/bop.symbols.nupkg.sha512", false)]
         [InlineData("foo/bar/baz/bip.snupkg.sha512", false)]

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/LatestLinksManagerTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.Tests/LatestLinksManagerTests.cs
@@ -221,5 +221,47 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Tests
                 new AkaMSLink("prefix2/assets/plop/Microsoft.stuff.json.zip", "https://example.com/feed/assets/plop/Microsoft.stuff.json.zip")
             });
         }
+
+        [Fact]
+        public void GetLatestLinksToCreate_RestrictedInstallScriptPatternShouldOnlyIncludeGetAspireCli()
+        {
+            var taskLoggingHelper = new TaskLoggingHelper(new StubTask());
+            var assetsToPublish = new HashSet<string>
+            {
+                "assets/installers/get-aspire-cli.ps1",
+                "assets/installers/get-aspire-cli.ps1.sha512",
+                "assets/installers/get-aspire-cli.sh",
+                "assets/installers/get-aspire-cli.sh.sha512",
+                "assets/installers/install-other-tool.ps1",
+                "assets/installers/install-other-tool.sh",
+            };
+            var feedConfig = new TargetFeedConfig(
+                contentType: TargetFeedContentType.Other,
+                targetURL: "https://example.com/feed",
+                type: FeedType.AzureStorageContainer,
+                token: "",
+                latestLinkShortUrlPrefixes: ImmutableList.Create("dotnet/9/aspire/rc/daily"),
+                akaMSCreateLinkPatterns: PublishingConstants.AspireAkaMSCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: [],
+                assetSelection: AssetSelection.All,
+                isolated: false,
+                @internal: false,
+                allowOverwrite: false,
+                symbolPublishVisibility: SymbolPublishVisibility.None,
+                flatten: true
+            );
+
+            var manager = new LatestLinksManager("clientId", null, "tenant", "groupOwner", "createdBy", "owners", taskLoggingHelper);
+
+            var links = manager.GetLatestLinksToCreate(assetsToPublish, feedConfig, "https://example.com/feed/");
+
+            links.Should().BeEquivalentTo(new List<AkaMSLink>
+            {
+                new AkaMSLink("dotnet/9/aspire/rc/daily/get-aspire-cli.ps1", "https://example.com/feed/assets/installers/get-aspire-cli.ps1"),
+                new AkaMSLink("dotnet/9/aspire/rc/daily/get-aspire-cli.ps1.sha512", "https://example.com/feed/assets/installers/get-aspire-cli.ps1.sha512"),
+                new AkaMSLink("dotnet/9/aspire/rc/daily/get-aspire-cli.sh", "https://example.com/feed/assets/installers/get-aspire-cli.sh"),
+                new AkaMSLink("dotnet/9/aspire/rc/daily/get-aspire-cli.sh.sha512", "https://example.com/feed/assets/installers/get-aspire-cli.sh.sha512"),
+            });
+        }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
@@ -374,6 +374,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
             new Regex(@"productversion", RegexOptions.IgnoreCase)
         ];
 
+        public static readonly ImmutableList<Regex> AspireAkaMSCreateLinkPatterns =
+        [
+            ..DefaultAkaMSCreateLinkPatterns,
+            new Regex(@"(^|[\\/])get-aspire-cli\.(ps1|sh)(\.sha512)?$", RegexOptions.IgnoreCase)
+        ];
+
         public static readonly ImmutableList<Regex> DefaultAkaMSDoNotCreateLinkPatterns =
         [
             new Regex(@"wixpack", RegexOptions.IgnoreCase),
@@ -1563,7 +1569,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 isInternal: false,
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: ["9/aspire"],
-                akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
+                akaMSCreateLinkPatterns: AspireAkaMSCreateLinkPatterns,
                 akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet9Feeds,
                 symbolTargetType: SymbolPublishVisibility.Public),
@@ -1574,7 +1580,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 isInternal: false,
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: ["9/aspire/rc"],
-                akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
+                akaMSCreateLinkPatterns: AspireAkaMSCreateLinkPatterns,
                 akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet9Feeds,
                 symbolTargetType: SymbolPublishVisibility.Public),
@@ -1585,7 +1591,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 isInternal: false,
                 publishingInfraVersion: PublishingInfraVersion.Latest,
                 akaMSChannelNames: ["9/aspire/ga"],
-                akaMSCreateLinkPatterns: DefaultAkaMSCreateLinkPatterns,
+                akaMSCreateLinkPatterns: AspireAkaMSCreateLinkPatterns,
                 akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNet9Feeds,
                 symbolTargetType: SymbolPublishVisibility.Public),


### PR DESCRIPTION
## Summary
- extend the Aspire-specific aka.ms allowlist to include both `get-aspire-cli.ps1` and `get-aspire-cli.sh`
- update link-generation tests to cover both acquisition scripts and their checksum files
- document the Aspire-specific filename opt-in in publishing docs

## Why
Aspire already publishes both acquisition scripts as blob assets, but Arcade only created aka.ms links for the standard archive/package patterns. We need aka.ms links to be created for the Aspire acquisition scripts as well so both install entrypoints can be reached through the existing Aspire daily/rc/ga short-link structure.

## Validation
- `dotnet test src/Microsoft.DotNet.Build.Tasks.Feed.Tests/Microsoft.DotNet.Build.Tasks.Feed.Tests.csproj --filter "FullyQualifiedName~LatestLinksManagerTests|FullyQualifiedName~GeneralTests"`