### PR TITLE
SignCheck: report file and archive context on verification errors

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/SignCheckResources.Designer.cs
+++ b/src/SignCheck/Microsoft.SignCheck/SignCheckResources.Designer.cs
@@ -214,6 +214,15 @@ namespace Microsoft.SignCheck {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Verification error: {0}.
+        /// </summary>
+        internal static string DetailVerificationError {
+            get {
+                return ResourceManager.GetString("DetailVerificationError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Timestamp: {0:MM/dd/yy H:mm:ss} ({1}).
         /// </summary>
         internal static string DetailTimestamp {

--- a/src/SignCheck/Microsoft.SignCheck/SignCheckResources.resx
+++ b/src/SignCheck/Microsoft.SignCheck/SignCheckResources.resx
@@ -168,6 +168,9 @@
   <data name="DetailSkippedUnsupportedFileType" xml:space="preserve">
     <value>Skipped (unsupported file type)</value>
   </data>
+  <data name="DetailVerificationError" xml:space="preserve">
+    <value>Verification error: {0}</value>
+  </data>
   <data name="DetailTimestamp" xml:space="preserve">
     <value>Timestamp: {0:MM/dd/yy H:mm:ss} ({1})</value>
   </data>

--- a/src/SignCheck/Microsoft.SignCheck/Verification/ArchiveVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/ArchiveVerifier.cs
@@ -129,8 +129,17 @@ namespace Microsoft.SignCheck.Verification
                     // and we need to ensure they are extracted before we verify the MSIs.
                     foreach (string fullName in archiveMap.Keys)
                     {
-                        SignatureVerificationResult result = VerifyFile(archiveMap[fullName], svr.VirtualPath,
-                            Path.Combine(svr.VirtualPath, fullName), fullName);
+                        SignatureVerificationResult result;
+                        try
+                        {
+                            result = VerifyFile(archiveMap[fullName], svr.VirtualPath,
+                                Path.Combine(svr.VirtualPath, fullName), fullName);
+                        }
+                        catch (Exception e) when (e is not PlatformNotSupportedException)
+                        {
+                            result = SignatureVerificationResult.ErrorResult(
+                                archiveMap[fullName], svr.VirtualPath, Path.Combine(svr.VirtualPath, fullName), e);
+                        }
 
                         // Tag the full path into the result detail
                         result.AddDetail(DetailKeys.File, SignCheckResources.DetailFullName, fullName);

--- a/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationManager.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationManager.cs
@@ -130,7 +130,15 @@ namespace Microsoft.SignCheck.Verification
             {
                 FileVerifier fileVerifier = GetFileVerifier(file);
                 SignatureVerificationResult result;
-                result = fileVerifier.VerifySignature(file, parent: null, virtualPath: Path.GetFileName(file));
+
+                try
+                {
+                    result = fileVerifier.VerifySignature(file, parent: null, virtualPath: Path.GetFileName(file));
+                }
+                catch (Exception e)
+                {
+                    result = SignatureVerificationResult.ErrorResult(file, parent: null, virtualPath: Path.GetFileName(file), e);
+                }
 
                 if ((Options & SignatureVerificationOptions.GenerateExclusion) == SignatureVerificationOptions.GenerateExclusion)
                 {

--- a/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationResult.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/SignatureVerificationResult.cs
@@ -309,6 +309,23 @@ namespace Microsoft.SignCheck.Verification
         }
 
         /// <summary>
+        /// Creates a SignatureVerificationResult for a file that failed verification due to an unexpected error.
+        /// </summary>
+        /// <param name="path">The path to the file that caused the error.</param>
+        /// <param name="parent">The parent container of the file, or null for top-level files.</param>
+        /// <param name="virtualPath">The virtual path of the file.</param>
+        /// <param name="exception">The exception that occurred during verification.</param>
+        public static SignatureVerificationResult ErrorResult(string path, string parent, string virtualPath, Exception exception)
+        {
+            var signatureVerificationResult = new SignatureVerificationResult(path, parent, virtualPath);
+
+            signatureVerificationResult.AddDetail(DetailKeys.Error,
+                String.Format(SignCheckResources.DetailVerificationError, exception.ToString()));
+
+            return signatureVerificationResult;
+        }
+
+        /// <summary>
         /// Creates a SignatureVerificationResult for an excluded file type or file extension.
         /// </summary>
         /// <param name="path">The path to the excluded file.</param>


### PR DESCRIPTION
When a file inside an archive fails verification (e.g. EndOfStreamException reading a PE header), SignCheck now catches the exception, records an ErrorResult with the failing file name and archive path, and continues processing remaining files.

Changes:
- Add SignatureVerificationResult.ErrorResult() factory method
- Wrap per-file verification in ArchiveVerifier.VerifyContent with try-catch
- Wrap top-level verification in SignatureVerificationManager.VerifyFiles
- Add DetailVerificationError resource string

Contributes to https://github.com/dotnet/dotnet/issues/5526

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
