### PR TITLE
Add retry to 'dotnet tool restore' for transient network failures

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj
@@ -40,7 +40,17 @@
           Condition="'$(DotNetBuildFromSource)' != 'true' and Exists('$(_RepoToolManifest)')"
           BeforeTargets="Restore">
 
-    <Exec Command='"$(DotNetTool)" tool restore' WorkingDirectory="$(RepoRoot)" />
+    <!-- Retry once for transient network failures (e.g. Connection reset by peer on macOS agents) -->
+    <Exec Command='"$(DotNetTool)" tool restore'
+          WorkingDirectory="$(RepoRoot)"
+          IgnoreExitCode="true">
+      <Output TaskParameter="ExitCode" PropertyName="_ToolRestoreExitCode" />
+    </Exec>
+    <Warning Text="'dotnet tool restore' failed with exit code $(_ToolRestoreExitCode). Retrying..."
+             Condition="'$(_ToolRestoreExitCode)' != '0'" />
+    <Exec Command='"$(DotNetTool)" tool restore'
+          WorkingDirectory="$(RepoRoot)"
+          Condition="'$(_ToolRestoreExitCode)' != '0'" />
   </Target>
 
   <!-- Repository extensibility point -->


### PR DESCRIPTION
## Summary

The `RestoreRepoTools` target in `Tools.proj` calls `dotnet tool restore` with no retry logic. When macOS agents hit transient network errors like `Connection reset by peer`, the entire build fails with no chance of recovery.

This adds a single retry with a warning message, using the standard MSBuild `IgnoreExitCode` + conditional re-execution pattern.

## Observed Failures

- **dnceng/internal build [2929216](https://dev.azure.com/dnceng/internal/_build/results?buildId=2929216)** (main): `Connection reset by peer` during `dotnet tool restore` on MacCatalyst_Shortstack_arm64 — failed the entire main build
- **dnceng/internal build [2928853](https://dev.azure.com/dnceng/internal/_build/results?buildId=2928853)** (main): Similar network transient (npm ECONNRESET) on OSX_x64

## What Changed

The `<Exec>` for `dotnet tool restore` is wrapped with `IgnoreExitCode="true"` + `<Output>` to capture the exit code, then conditionally re-executed if the first attempt failed, with a warning message emitted for diagnostics.

Arcade already has retry infrastructure (`ExecWithRetries` task, `with_retries` shell function) but those aren't available in this MSBuild context. The inline pattern is minimal and self-contained.

/cc @dotnet/product-construction
