### PR TITLE
Fix SignCheck EndOfStreamException on truncated PE files

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/PortableExecutableHeader.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/PortableExecutableHeader.cs
@@ -319,6 +319,13 @@ namespace Microsoft.SignCheck.Interop.PortableExecutable
             using (FileStream stream = new FileStream(Path, FileMode.Open, FileAccess.Read, FileShare.Read))
             using (BinaryReader reader = new BinaryReader(stream))
             {
+                // Guard against truncated files: ensure the stream is long enough to
+                // contain the optional header magic value at the calculated offset.
+                if (stream.Length < imageOptionalHeaderOffset + sizeof(UInt16))
+                {
+                    return;
+                }
+
                 reader.BaseStream.Seek(imageOptionalHeaderOffset, SeekOrigin.Begin);
 
                 // Retrieve the Magic field and then read the appropriate (32-bit or 64-bit) IMAGE_NT_OPTIONAL_HEADER

--- a/src/SignCheck/Microsoft.SignCheck/Verification/PortableExecutableVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/PortableExecutableVerifier.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.IO;
 using Microsoft.SignCheck.Interop.PortableExecutable;
 using Microsoft.SignCheck.Logging;
 
@@ -34,7 +36,19 @@ namespace Microsoft.SignCheck.Verification
         {
             // Defer to the base implementation to check the AuthentiCode signature.
             SignatureVerificationResult svr = base.VerifySignature(path, parent, virtualPath);
-            PEHeader = new PortableExecutableHeader(svr.FullPath);
+
+            try
+            {
+                PEHeader = new PortableExecutableHeader(svr.FullPath);
+            }
+            catch (Exception e) when (e is EndOfStreamException or IOException or InvalidOperationException)
+            {
+                // The file is not a valid PE (truncated, corrupt, or not actually a PE).
+                // Treat it as unsigned — do not let the exception propagate.
+                svr.IsSigned = false;
+                svr.AddDetail(DetailKeys.File, SignCheckResources.DetailSigned, svr.IsSigned);
+                return svr;
+            }
 
             if (VerifyStrongNameSignature)
             {


### PR DESCRIPTION
## Summary

Fixes [dotnet/dotnet#5579](https://github.com/dotnet/dotnet/issues/5579)

`ReadImageNTHeaders()` calls `BinaryReader.ReadUInt16()` without checking whether the stream has enough remaining bytes. When SignCheck encounters a file extracted from a Linux package archive that is not a valid PE (or is truncated), this throws `EndOfStreamException`, crashing the entire Validate Signing step.

## Changes

**`PortableExecutableHeader.cs`** — Add a stream length guard in `ReadImageNTHeaders()` before the `ReadUInt16()` call. If the file is too short, the method returns early, leaving `OptionalHeaderMagic` unset. This causes `IsValidNTHeader` to return `false`, and the file is treated as a non-PE — which is the correct behavior.

**`PortableExecutableVerifier.cs`** — Defense-in-depth: wrap `new PortableExecutableHeader()` in a try-catch for `EndOfStreamException`, `IOException`, and `InvalidOperationException`. If the PE header can't be parsed, the file is reported as unsigned instead of crashing SignCheck.

## Context

Internal build [2929672](https://dev.azure.com/dnceng/internal/_build/results?buildId=2929672) (main, Mar 18) failed Validate Signing with:

```
System.IO.EndOfStreamException: Unable to read beyond the end of the stream.
   at System.IO.BinaryReader.ReadUInt16()
   at PortableExecutableHeader.ReadImageNTHeaders() :325
   at PortableExecutableVerifier.VerifySignature() :40
   at ArchiveVerifier.VerifyContent() :80
   at LinuxPackageVerifier.VerifySignature() :18
```

A file extracted from a Linux package was routed to the PE verifier, which tried to read NT headers from a non-PE file.