### PR TITLE
Fix NU1009 CPM conflict for xunit.v3.core

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -93,7 +93,6 @@
     <PackageVersion Include="Polly.Core" Version="8.4.1" />
     <PackageVersion Include="sn" Version="1.0.0" />
     <PackageVersion Include="xunit" Version="$(XUnitVersion)" />
-    <PackageVersion Include="xunit.v3.core" Version="$(XUnitV3Version)" />
     <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
     <PackageVersion Include="xunit.extensibility.core" Version="$(XUnitVersion)" />
     <PackageVersion Include="xunit.extensibility.execution" Version="$(XUnitVersion)" />

--- a/src/Microsoft.DotNet.XUnitAssert/tests/Microsoft.DotNet.XUnitAssert.Tests.csproj
+++ b/src/Microsoft.DotNet.XUnitAssert/tests/Microsoft.DotNet.XUnitAssert.Tests.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.v3.core" PrivateAssets="all" Publish="true" />
+    <PackageReference Include="xunit.v3.core" Version="$(XUnitV3Version)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true" />
     <!-- MTP packages added explicitly because DisableArcadeTestFramework prevents XUnitV3.targets from adding them -->
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="$(MicrosoftTestingPlatformVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true" />
     <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Version="$(MicrosoftTestingPlatformVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true" />


### PR DESCRIPTION
## Problem

Arcade commit 3290ea9 ("Add xunitv3assert #16555") introduced a NuGet Central Package Management (CPM) conflict:

- `XUnitV3.targets` defines `xunit.v3.core` as an **implicit** `PackageReference` (`IsImplicitlyDefined="true"`) with `Version` set directly
- `Directory.Packages.props` also defines a `<PackageVersion Include="xunit.v3.core">` entry

NuGet CPM rule: implicit PackageReferences **cannot** have a corresponding `<PackageVersion>` entry — they must set `Version` directly on the `<PackageReference>` item. This results in **NU1009** on any project that imports XUnitV3.targets.

This breaks the `Ubuntu2404_Ubuntu_BuildTests_x64` leg (the only leg running with `/p:DotNetBuildTests=true`) in the unified-build pipeline.

**Failing build:** https://dev.azure.com/dnceng-public/public/_build/results?buildId=1341950

## Fix

1. **Remove** the redundant `<PackageVersion Include="xunit.v3.core">` from `Directory.Packages.props`
2. **Mark** the direct reference in `XUnitAssert.Tests.csproj` as implicit with an inline `Version` — this project sets `DisableArcadeTestFramework=true` so it doesn't get the targets-based reference and needs its own version

## Validation

Both `XUnitV3Extensions.csproj` and `XUnitAssert.Tests.csproj` restore cleanly after the fix. No other `.csproj` files in the repo have direct `xunit.v3.core` references.