### PR TITLE
Revert "Fix SignCheck EndOfStreamException on truncated PE files"

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/PortableExecutableHeader.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/PortableExecutableHeader.cs
@@ -319,13 +319,6 @@ namespace Microsoft.SignCheck.Interop.PortableExecutable
             using (FileStream stream = new FileStream(Path, FileMode.Open, FileAccess.Read, FileShare.Read))
             using (BinaryReader reader = new BinaryReader(stream))
             {
-                // Guard against truncated files: ensure the stream is long enough to
-                // contain the optional header magic value at the calculated offset.
-                if (stream.Length < imageOptionalHeaderOffset + sizeof(UInt16))
-                {
-                    return;
-                }
-
                 reader.BaseStream.Seek(imageOptionalHeaderOffset, SeekOrigin.Begin);
 
                 // Retrieve the Magic field and then read the appropriate (32-bit or 64-bit) IMAGE_NT_OPTIONAL_HEADER

--- a/src/SignCheck/Microsoft.SignCheck/Verification/PortableExecutableVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/PortableExecutableVerifier.cs
@@ -37,19 +37,7 @@ namespace Microsoft.SignCheck.Verification
         {
             // Defer to the base implementation to check the AuthentiCode signature.
             SignatureVerificationResult svr = base.VerifySignature(path, parent, virtualPath);
-
-            try
-            {
-                PEHeader = new PortableExecutableHeader(svr.FullPath);
-            }
-            catch (Exception e) when (e is EndOfStreamException or IOException or InvalidOperationException)
-            {
-                // The file is not a valid PE (truncated, corrupt, or not actually a PE).
-                // Treat it as unsigned — do not let the exception propagate.
-                svr.IsSigned = false;
-                svr.AddDetail(DetailKeys.File, SignCheckResources.DetailSigned, svr.IsSigned);
-                return svr;
-            }
+            PEHeader = new PortableExecutableHeader(svr.FullPath);
 
             if (VerifyStrongNameSignature)
             {


### PR DESCRIPTION
Reverts dotnet/arcade#16607