### PR TITLE
Switch `--add-source` to `--source` when installing .NET tools in Arcade scripts

### DIFF
--- a/eng/common/darc-init.ps1
+++ b/eng/common/darc-init.ps1
@@ -29,11 +29,11 @@ function InstallDarcCli ($darcVersion, $toolpath) {
   Write-Host "Installing Darc CLI version $darcVersion..."
   Write-Host 'You may need to restart your command window if this is the first dotnet tool you have installed.'
   if (-not $toolpath) {
-    Write-Host "'$dotnet' tool install $darcCliPackageName --version $darcVersion --add-source '$arcadeServicesSource' -v $verbosity -g"
-    & "$dotnet" tool install $darcCliPackageName --version $darcVersion --add-source "$arcadeServicesSource" -v $verbosity -g
+    Write-Host "'$dotnet' tool install $darcCliPackageName --version $darcVersion --source '$arcadeServicesSource' -v $verbosity -g"
+    & "$dotnet" tool install $darcCliPackageName --version $darcVersion --source "$arcadeServicesSource" -v $verbosity -g
   }else {
-    Write-Host "'$dotnet' tool install $darcCliPackageName --version $darcVersion --add-source '$arcadeServicesSource' -v $verbosity --tool-path '$toolpath'"
-    & "$dotnet" tool install $darcCliPackageName --version $darcVersion --add-source "$arcadeServicesSource" -v $verbosity --tool-path "$toolpath"
+    Write-Host "'$dotnet' tool install $darcCliPackageName --version $darcVersion --source '$arcadeServicesSource' -v $verbosity --tool-path '$toolpath'"
+    & "$dotnet" tool install $darcCliPackageName --version $darcVersion --source "$arcadeServicesSource" -v $verbosity --tool-path "$toolpath"
   }
 }
 

--- a/eng/common/darc-init.sh
+++ b/eng/common/darc-init.sh
@@ -73,9 +73,9 @@ function InstallDarcCli {
   echo "Installing Darc CLI version $darcVersion..."
   echo "You may need to restart your command shell if this is the first dotnet tool you have installed."
   if [ -z "$toolpath" ]; then
-    echo $($dotnet_root/dotnet tool install $darc_cli_package_name --version $darcVersion --add-source "$arcadeServicesSource" -v $verbosity -g)
+    echo $($dotnet_root/dotnet tool install $darc_cli_package_name --version $darcVersion --source "$arcadeServicesSource" -v $verbosity -g)
   else
-    echo $($dotnet_root/dotnet tool install $darc_cli_package_name --version $darcVersion --add-source "$arcadeServicesSource" -v $verbosity --tool-path "$toolpath")
+    echo $($dotnet_root/dotnet tool install $darc_cli_package_name --version $darcVersion --source "$arcadeServicesSource" -v $verbosity --tool-path "$toolpath")
   fi
 }
 

--- a/eng/common/post-build/redact-logs.ps1
+++ b/eng/common/post-build/redact-logs.ps1
@@ -49,8 +49,8 @@ try {
     Write-Host "Installing Binlog redactor CLI..."
     Write-Host "'$dotnet' new tool-manifest"
     & "$dotnet" new tool-manifest
-    Write-Host "'$dotnet' tool install $packageName --local --add-source '$PackageFeed' -v $verbosity --version $BinlogToolVersion"
-    & "$dotnet" tool install $packageName --local --add-source "$PackageFeed" -v $verbosity --version $BinlogToolVersion
+    Write-Host "'$dotnet' tool install $packageName --local --source '$PackageFeed' -v $verbosity --version $BinlogToolVersion"
+    & "$dotnet" tool install $packageName --local --source "$PackageFeed" -v $verbosity --version $BinlogToolVersion
 
     if (Test-Path $TokensFilePath) {
         Write-Host "Adding additional sensitive data for redaction from file: " $TokensFilePath

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/InstallDotNetToolTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/InstallDotNetToolTests.cs
@@ -174,7 +174,7 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 "net6.0",
                 "--arch",
                 "arm64",
-                "--add-source",
+                "--source",
                 "https://dev.azure.com/some/feed",
                 ToolName,
             };

--- a/src/Microsoft.DotNet.Helix/Sdk/InstallDotNetTool.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/InstallDotNetTool.cs
@@ -145,7 +145,7 @@ namespace Microsoft.DotNet.Helix.Sdk
 
             if (!string.IsNullOrEmpty(Source))
             {
-                args.Add("--add-source");
+                args.Add("--source");
                 args.Add(Source);
             }
 


### PR DESCRIPTION
We hit problems when https://github.com/dotnet/sdk/pull/52863 got introduced in combination with https://github.com/dotnet/arcade/pull/16628 in how we install tools in Arcade