### PR TITLE
Fix notarization retry logging errors on intermediate attempts

### DIFF
--- a/src/Microsoft.DotNet.SignTool.Tests/FakeSignTool.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/FakeSignTool.cs
@@ -34,7 +34,8 @@ namespace Microsoft.DotNet.SignTool
 
         public override SigningStatus VerifyStrongNameSign(string fileFullPath) => SigningStatus.Signed;
 
-        public override bool RunMSBuild(IBuildEngine buildEngine, string projectFilePath, string binLogPath, string logPath, string errorLogPath)
+        // maxAttempts is currently unused in FakeSignTool
+        public override bool RunMSBuild(IBuildEngine buildEngine, string projectFilePath, string binLogPath, string logPath, string errorLogPath, int maxAttempts = 1)
             => buildEngine.BuildProjectFile(projectFilePath, null, null, null);
 
         internal static void SignFile(string path)

--- a/src/Microsoft.DotNet.SignTool.Tests/FakeSignTool.cs
+++ b/src/Microsoft.DotNet.SignTool.Tests/FakeSignTool.cs
@@ -34,8 +34,7 @@ namespace Microsoft.DotNet.SignTool
 
         public override SigningStatus VerifyStrongNameSign(string fileFullPath) => SigningStatus.Signed;
 
-        // maxAttempts is currently unused in FakeSignTool
-        public override bool RunMSBuild(IBuildEngine buildEngine, string projectFilePath, string binLogPath, string logPath, string errorLogPath, int maxAttempts = 1)
+        public override bool RunMSBuild(IBuildEngine buildEngine, string projectFilePath, string binLogPath, string logPath, string errorLogPath, bool suppressErrors = false)
             => buildEngine.BuildProjectFile(projectFilePath, null, null, null);
 
         internal static void SignFile(string path)

--- a/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.SignTool
             _dotnetTimeout = args.DotNetTimeout;
         }
 
-        public override bool RunMSBuild(IBuildEngine buildEngine, string projectFilePath, string binLogPath, string logPath, string errorLogPath, int maxAttempts = 1)
+        public override bool RunMSBuild(IBuildEngine buildEngine, string projectFilePath, string binLogPath, string logPath, string errorLogPath, bool suppressErrors = false)
         {
             if (_dotnetPath == null)
             {
@@ -55,43 +55,7 @@ namespace Microsoft.DotNet.SignTool
 
             Directory.CreateDirectory(_logDir);
 
-            if (maxAttempts > 1)
-            {
-                _log.LogMessage(MessageImportance.High, $"Starting MSBuild with up to {maxAttempts} attempts");
-            }
-
-            for (int attempt = 1; attempt <= maxAttempts; attempt++)
-            {
-                bool suppressErrors = attempt < maxAttempts;
-
-                if (maxAttempts > 1)
-                {
-                    _log.LogMessage(MessageImportance.High, $"Attempt {attempt} of {maxAttempts}");
-                }
-
-                // Use attempt-specific log file names when retrying to preserve logs from each attempt
-                string attemptBinLogPath = maxAttempts > 1 ? binLogPath.Replace(".binlog", $"-Attempt{attempt}.binlog") : binLogPath;
-                string attemptLogPath = maxAttempts > 1 ? logPath.Replace(".log", $"-Attempt{attempt}.log") : logPath;
-                string attemptErrorLogPath = maxAttempts > 1 ? errorLogPath.Replace(".error.log", $"-Attempt{attempt}.error.log") : errorLogPath;
-
-                bool succeeded = RunMSBuildProcess(projectFilePath, attemptBinLogPath, attemptLogPath, attemptErrorLogPath, suppressErrors);
-                if (succeeded)
-                {
-                    return true;
-                }
-
-                if (attempt < maxAttempts)
-                {
-                    _log.LogMessage(MessageImportance.High, $"MSBuild failed on attempt {attempt}. Retrying...");
-                }
-            }
-
-            if (maxAttempts > 1)
-            {
-                _log.LogError($"MSBuild failed after {maxAttempts} attempts on project '{projectFilePath}'");
-            }
-
-            return false;
+            return RunMSBuildProcess(projectFilePath, binLogPath, logPath, errorLogPath, suppressErrors);
         }
 
         private bool RunMSBuildProcess(string projectFilePath, string binLogPath, string logPath, string errorLogPath, bool suppressErrors)

--- a/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.SignTool
             _dotnetTimeout = args.DotNetTimeout;
         }
 
-        public override bool RunMSBuild(IBuildEngine buildEngine, string projectFilePath, string binLogPath, string logPath, string errorLogPath)
+        public override bool RunMSBuild(IBuildEngine buildEngine, string projectFilePath, string binLogPath, string logPath, string errorLogPath, int maxAttempts = 1)
         {
             if (_dotnetPath == null)
             {
@@ -55,6 +55,47 @@ namespace Microsoft.DotNet.SignTool
 
             Directory.CreateDirectory(_logDir);
 
+            if (maxAttempts > 1)
+            {
+                _log.LogMessage(MessageImportance.High, $"Starting MSBuild with up to {maxAttempts} attempts");
+            }
+
+            for (int attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                bool logErrorsAsWarnings = attempt < maxAttempts;
+
+                if (maxAttempts > 1)
+                {
+                    _log.LogMessage(MessageImportance.High, $"Attempt {attempt} of {maxAttempts}");
+                }
+
+                // Use attempt-specific log file names when retrying to preserve logs from each attempt
+                string attemptBinLogPath = maxAttempts > 1 ? binLogPath.Replace(".binlog", $"-Attempt{attempt}.binlog") : binLogPath;
+                string attemptLogPath = maxAttempts > 1 ? logPath.Replace(".log", $"-Attempt{attempt}.log") : logPath;
+                string attemptErrorLogPath = maxAttempts > 1 ? errorLogPath.Replace(".error.log", $"-Attempt{attempt}.error.log") : errorLogPath;
+
+                bool succeeded = RunMSBuildProcess(projectFilePath, attemptBinLogPath, attemptLogPath, attemptErrorLogPath, logErrorsAsWarnings);
+                if (succeeded)
+                {
+                    return true;
+                }
+
+                if (attempt < maxAttempts)
+                {
+                    _log.LogMessage(MessageImportance.High, $"MSBuild failed on attempt {attempt}. Retrying...");
+                }
+            }
+
+            if (maxAttempts > 1)
+            {
+                _log.LogError($"MSBuild failed after {maxAttempts} attempts on project '{projectFilePath}'");
+            }
+
+            return false;
+        }
+
+        private bool RunMSBuildProcess(string projectFilePath, string binLogPath, string logPath, string errorLogPath, bool logErrorsAsWarnings)
+        {
             using (var process = new Process())
             {
                 process.StartInfo = new ProcessStartInfo()
@@ -80,7 +121,10 @@ namespace Microsoft.DotNet.SignTool
                 bool success = true;
                 if (!process.WaitForExit(_dotnetTimeout))
                 {
-                    _log.LogError($"MSBuild process did not exit within '{_dotnetTimeout}' ms.");
+                    if (logErrorsAsWarnings)
+                        _log.LogWarning($"MSBuild process did not exit within '{_dotnetTimeout}' ms.");
+                    else
+                        _log.LogError($"MSBuild process did not exit within '{_dotnetTimeout}' ms.");
                     process.Kill();
                     process.WaitForExit();
                     success = false;
@@ -88,8 +132,12 @@ namespace Microsoft.DotNet.SignTool
 
                 if (process.ExitCode != 0)
                 {
-                    _log.LogError($"Failed to execute MSBuild on the project file '{projectFilePath}'" +
-                    $" with exit code '{process.ExitCode}'.");
+                    if (logErrorsAsWarnings)
+                        _log.LogWarning($"Failed to execute MSBuild on the project file '{projectFilePath}'" +
+                        $" with exit code '{process.ExitCode}'.");
+                    else
+                        _log.LogError($"Failed to execute MSBuild on the project file '{projectFilePath}'" +
+                        $" with exit code '{process.ExitCode}'.");
                     success = false;
                 }
 

--- a/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
@@ -55,11 +55,6 @@ namespace Microsoft.DotNet.SignTool
 
             Directory.CreateDirectory(_logDir);
 
-            return RunMSBuildProcess(projectFilePath, binLogPath, logPath, errorLogPath, suppressErrors);
-        }
-
-        private bool RunMSBuildProcess(string projectFilePath, string binLogPath, string logPath, string errorLogPath, bool suppressErrors)
-        {
             using (var process = new Process())
             {
                 process.StartInfo = new ProcessStartInfo()

--- a/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.SignTool
 
             for (int attempt = 1; attempt <= maxAttempts; attempt++)
             {
-                bool logErrorsAsWarnings = attempt < maxAttempts;
+                bool suppressErrors = attempt < maxAttempts;
 
                 if (maxAttempts > 1)
                 {
@@ -74,7 +74,7 @@ namespace Microsoft.DotNet.SignTool
                 string attemptLogPath = maxAttempts > 1 ? logPath.Replace(".log", $"-Attempt{attempt}.log") : logPath;
                 string attemptErrorLogPath = maxAttempts > 1 ? errorLogPath.Replace(".error.log", $"-Attempt{attempt}.error.log") : errorLogPath;
 
-                bool succeeded = RunMSBuildProcess(projectFilePath, attemptBinLogPath, attemptLogPath, attemptErrorLogPath, logErrorsAsWarnings);
+                bool succeeded = RunMSBuildProcess(projectFilePath, attemptBinLogPath, attemptLogPath, attemptErrorLogPath, suppressErrors);
                 if (succeeded)
                 {
                     return true;
@@ -94,7 +94,7 @@ namespace Microsoft.DotNet.SignTool
             return false;
         }
 
-        private bool RunMSBuildProcess(string projectFilePath, string binLogPath, string logPath, string errorLogPath, bool logErrorsAsWarnings)
+        private bool RunMSBuildProcess(string projectFilePath, string binLogPath, string logPath, string errorLogPath, bool suppressErrors)
         {
             using (var process = new Process())
             {
@@ -121,8 +121,8 @@ namespace Microsoft.DotNet.SignTool
                 bool success = true;
                 if (!process.WaitForExit(_dotnetTimeout))
                 {
-                    if (logErrorsAsWarnings)
-                        _log.LogWarning($"MSBuild process did not exit within '{_dotnetTimeout}' ms.");
+                    if (suppressErrors)
+                        _log.LogMessage(MessageImportance.High, $"MSBuild process did not exit within '{_dotnetTimeout}' ms.");
                     else
                         _log.LogError($"MSBuild process did not exit within '{_dotnetTimeout}' ms.");
                     process.Kill();
@@ -132,8 +132,8 @@ namespace Microsoft.DotNet.SignTool
 
                 if (process.ExitCode != 0)
                 {
-                    if (logErrorsAsWarnings)
-                        _log.LogWarning($"Failed to execute MSBuild on the project file '{projectFilePath}'" +
+                    if (suppressErrors)
+                        _log.LogMessage(MessageImportance.High, $"Failed to execute MSBuild on the project file '{projectFilePath}'" +
                         $" with exit code '{process.ExitCode}'.");
                     else
                         _log.LogError($"Failed to execute MSBuild on the project file '{projectFilePath}'" +

--- a/src/Microsoft.DotNet.SignTool/src/SignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignTool.cs
@@ -184,38 +184,36 @@ namespace Microsoft.DotNet.SignTool
                 var notarizeProjectPath = Path.Combine(dir, $"Round{round}-Notarize.proj");
                 File.WriteAllText(notarizeProjectPath, GenerateBuildFileContent(filesToNotarize, null, true));
 
-                // Notarization can be flaky, so allow up to 5 attempts
-                const int maxAttempts = 5;
-                string notarizeLogName = $"NotarizationRound{round}";
-
-                _log.LogMessage(MessageImportance.High, $"Starting notarization with up to {maxAttempts} attempts");
-
+                // Notarization can be flaky, so retry up to 5 times with no wait between retries
+                const int maxRetries = 5;
+                int attempt = 0;
                 bool notarizationSucceeded = false;
-                for (int attempt = 1; attempt <= maxAttempts; attempt++)
+                
+                _log.LogMessage(MessageImportance.High, $"Starting notarization with up to {maxRetries} attempts");
+                
+                while (attempt < maxRetries && !notarizationSucceeded)
                 {
-                    bool isLastAttempt = attempt == maxAttempts;
-
-                    _log.LogMessage(MessageImportance.High, $"Notarization attempt {attempt} of {maxAttempts}");
-
-                    string attemptSuffix = $"-Attempt{attempt}";
-                    bool result = RunMSBuild(buildEngine, notarizeProjectPath,
-                        Path.Combine(_args.LogDir, $"{notarizeLogName}{attemptSuffix}.binlog"),
-                        Path.Combine(_args.LogDir, $"{notarizeLogName}{attemptSuffix}.log"),
-                        Path.Combine(_args.LogDir, $"{notarizeLogName}{attemptSuffix}.error.log"),
-                        suppressErrors: !isLastAttempt);
-
-                    if (result)
+                    attempt++;
+                    _log.LogMessage(MessageImportance.High, $"Notarization attempt {attempt} of {maxRetries}");
+                    
+                    string notarizeLogName = $"NotarizationRound{round}-Attempt{attempt}";
+                    notarizationSucceeded = RunMSBuild(buildEngine, notarizeProjectPath, 
+                        Path.Combine(_args.LogDir, $"{notarizeLogName}.binlog"), 
+                        Path.Combine(_args.LogDir, $"{notarizeLogName}.log"), 
+                        Path.Combine(_args.LogDir, $"{notarizeLogName}.error.log"),
+                        suppressErrors: attempt < maxRetries);
+                    
+                    if (!notarizationSucceeded && attempt < maxRetries)
                     {
-                        notarizationSucceeded = true;
-                        break;
-                    }
-
-                    if (!isLastAttempt)
-                    {
-                        _log.LogMessage(MessageImportance.High, $"Notarization attempt {attempt} failed. Retrying...");
+                        _log.LogMessage(MessageImportance.High, $"Notarization failed on attempt {attempt}. Retrying...");
                     }
                 }
-
+                
+                if (!notarizationSucceeded)
+                {
+                    _log.LogError($"Notarization failed after {maxRetries} attempts");
+                }
+                
                 status = notarizationSucceeded;
             }
 

--- a/src/Microsoft.DotNet.SignTool/src/SignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignTool.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.SignTool
 
         public abstract SigningStatus VerifyStrongNameSign(string fileFullPath);
 
-        public abstract bool RunMSBuild(IBuildEngine buildEngine, string projectFilePath, string binLogPath, string logPath, string errorLogPath, int maxAttempts = 1);
+        public abstract bool RunMSBuild(IBuildEngine buildEngine, string projectFilePath, string binLogPath, string logPath, string errorLogPath, bool suppressErrors = false);
 
         public bool Sign(IBuildEngine buildEngine, int round, IEnumerable<FileSignInfo> files)
         {
@@ -183,15 +183,40 @@ namespace Microsoft.DotNet.SignTool
             {
                 var notarizeProjectPath = Path.Combine(dir, $"Round{round}-Notarize.proj");
                 File.WriteAllText(notarizeProjectPath, GenerateBuildFileContent(filesToNotarize, null, true));
-                
+
                 // Notarization can be flaky, so allow up to 5 attempts
                 const int maxAttempts = 5;
                 string notarizeLogName = $"NotarizationRound{round}";
-                status = RunMSBuild(buildEngine, notarizeProjectPath,
-                    Path.Combine(_args.LogDir, $"{notarizeLogName}.binlog"),
-                    Path.Combine(_args.LogDir, $"{notarizeLogName}.log"),
-                    Path.Combine(_args.LogDir, $"{notarizeLogName}.error.log"),
-                    maxAttempts);
+
+                _log.LogMessage(MessageImportance.High, $"Starting notarization with up to {maxAttempts} attempts");
+
+                bool notarizationSucceeded = false;
+                for (int attempt = 1; attempt <= maxAttempts; attempt++)
+                {
+                    bool isLastAttempt = attempt == maxAttempts;
+
+                    _log.LogMessage(MessageImportance.High, $"Notarization attempt {attempt} of {maxAttempts}");
+
+                    string attemptSuffix = $"-Attempt{attempt}";
+                    bool result = RunMSBuild(buildEngine, notarizeProjectPath,
+                        Path.Combine(_args.LogDir, $"{notarizeLogName}{attemptSuffix}.binlog"),
+                        Path.Combine(_args.LogDir, $"{notarizeLogName}{attemptSuffix}.log"),
+                        Path.Combine(_args.LogDir, $"{notarizeLogName}{attemptSuffix}.error.log"),
+                        suppressErrors: !isLastAttempt);
+
+                    if (result)
+                    {
+                        notarizationSucceeded = true;
+                        break;
+                    }
+
+                    if (!isLastAttempt)
+                    {
+                        _log.LogMessage(MessageImportance.High, $"Notarization attempt {attempt} failed. Retrying...");
+                    }
+                }
+
+                status = notarizationSucceeded;
             }
 
             return status;

--- a/src/Microsoft.DotNet.SignTool/src/SignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/SignTool.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.SignTool
 
         public abstract SigningStatus VerifyStrongNameSign(string fileFullPath);
 
-        public abstract bool RunMSBuild(IBuildEngine buildEngine, string projectFilePath, string binLogPath, string logPath, string errorLogPath);
+        public abstract bool RunMSBuild(IBuildEngine buildEngine, string projectFilePath, string binLogPath, string logPath, string errorLogPath, int maxAttempts = 1);
 
         public bool Sign(IBuildEngine buildEngine, int round, IEnumerable<FileSignInfo> files)
         {
@@ -184,36 +184,14 @@ namespace Microsoft.DotNet.SignTool
                 var notarizeProjectPath = Path.Combine(dir, $"Round{round}-Notarize.proj");
                 File.WriteAllText(notarizeProjectPath, GenerateBuildFileContent(filesToNotarize, null, true));
                 
-                // Notarization can be flaky, so retry up to 5 times with no wait between retries
-                const int maxRetries = 5;
-                int attempt = 0;
-                bool notarizationSucceeded = false;
-                
-                _log.LogMessage(MessageImportance.High, $"Starting notarization with up to {maxRetries} attempts");
-                
-                while (attempt < maxRetries && !notarizationSucceeded)
-                {
-                    attempt++;
-                    _log.LogMessage(MessageImportance.High, $"Notarization attempt {attempt} of {maxRetries}");
-                    
-                    string notarizeLogName = $"NotarizationRound{round}-Attempt{attempt}";
-                    notarizationSucceeded = RunMSBuild(buildEngine, notarizeProjectPath, 
-                        Path.Combine(_args.LogDir, $"{notarizeLogName}.binlog"), 
-                        Path.Combine(_args.LogDir, $"{notarizeLogName}.log"), 
-                        Path.Combine(_args.LogDir, $"{notarizeLogName}.error.log"));
-                    
-                    if (!notarizationSucceeded && attempt < maxRetries)
-                    {
-                        _log.LogMessage(MessageImportance.High, $"Notarization failed on attempt {attempt}. Retrying...");
-                    }
-                }
-                
-                if (!notarizationSucceeded)
-                {
-                    _log.LogError($"Notarization failed after {maxRetries} attempts");
-                }
-                
-                status = notarizationSucceeded;
+                // Notarization can be flaky, so allow up to 5 attempts
+                const int maxAttempts = 5;
+                string notarizeLogName = $"NotarizationRound{round}";
+                status = RunMSBuild(buildEngine, notarizeProjectPath,
+                    Path.Combine(_args.LogDir, $"{notarizeLogName}.binlog"),
+                    Path.Combine(_args.LogDir, $"{notarizeLogName}.log"),
+                    Path.Combine(_args.LogDir, $"{notarizeLogName}.error.log"),
+                    maxAttempts);
             }
 
             return status;

--- a/src/Microsoft.DotNet.SignTool/src/ValidationOnlySignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ValidationOnlySignTool.cs
@@ -55,7 +55,8 @@ namespace Microsoft.DotNet.SignTool
         public override SigningStatus VerifyStrongNameSign(string fileFullPath)
             => SigningStatus.Signed;
 
-        public override bool RunMSBuild(IBuildEngine buildEngine, string projectFilePath, string binLogPath, string logPath, string errorLogPath)
+        // maxAttempts is currently unused in ValidationOnlySignTool
+        public override bool RunMSBuild(IBuildEngine buildEngine, string projectFilePath, string binLogPath, string logPath, string errorLogPath, int maxAttempts = 1)
         {
             if (TestSign)
             {

--- a/src/Microsoft.DotNet.SignTool/src/ValidationOnlySignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/ValidationOnlySignTool.cs
@@ -55,8 +55,7 @@ namespace Microsoft.DotNet.SignTool
         public override SigningStatus VerifyStrongNameSign(string fileFullPath)
             => SigningStatus.Signed;
 
-        // maxAttempts is currently unused in ValidationOnlySignTool
-        public override bool RunMSBuild(IBuildEngine buildEngine, string projectFilePath, string binLogPath, string logPath, string errorLogPath, int maxAttempts = 1)
+        public override bool RunMSBuild(IBuildEngine buildEngine, string projectFilePath, string binLogPath, string logPath, string errorLogPath, bool suppressErrors = false)
         {
             if (TestSign)
             {


### PR DESCRIPTION
## Problem

The notarization retry loop in `SignTool.cs` calls `RunMSBuild` up to 5 times. However, `RealSignTool.RunMSBuild` calls `_log.LogError()` when MSBuild fails (timeout or non-zero exit code). Since MSBuild's `TaskLoggingHelper.LogError()` permanently marks the task as failed, intermediate retry failures poison the build even if a later retry succeeds. Additionally, using `LogWarning` for intermediate failures is unsafe because `MSBuildTreatAllWarningsAsErrors` can promote warnings to errors.

## Fix

Added a `bool suppressErrors` parameter to the abstract `RunMSBuild` method. The existing retry loop in `SignTool.AuthenticodeSignAndNotarize` passes `suppressErrors: true` for all intermediate attempts and `suppressErrors: false` only for the final attempt. `RealSignTool` uses this flag to branch between `LogMessage(MessageImportance.High)` (safe from warn-as-error) and `LogError`:

- Intermediate failures log via `LogMessage(MessageImportance.High)` — does not poison the build and is safe from warn-as-error promotion
- Only the final failure logs an error
- The existing per-attempt log file naming in `SignTool` is preserved unchanged
- The signing call site uses the default `suppressErrors: false`, preserving existing behavior

## Changes

- `SignTool.cs` - Updated abstract `RunMSBuild` signature to add `bool suppressErrors = false`; added `suppressErrors: attempt < maxRetries` to the notarization `RunMSBuild` call (loop structure and variable names are otherwise unchanged)
- `RealSignTool.cs` - Added `bool suppressErrors` parameter; branches on `suppressErrors` to use `LogMessage` vs `LogError`
- `ValidationOnlySignTool.cs` - Signature update (no behavioral change)
- `FakeSignTool.cs` - Signature update (test subclass)

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md