### PR TITLE
Fix inter-branch merge PRs silently going stale after the first run

### DIFF
--- a/.github/workflows/scripts/inter-branch-merge.ps1
+++ b/.github/workflows/scripts/inter-branch-merge.ps1
@@ -126,10 +126,7 @@ function ResetFilesToTargetBranch($patterns, $targetBranch) {
         return
     }
 
-    # Configure git user for the commit
-    # Use GitHub Actions bot identity
-    Invoke-Block { & git config user.name "github-actions[bot]" }
-    Invoke-Block { & git config user.email "41898282+github-actions[bot]@users.noreply.github.com" }
+    # Note: git user.name/email must already be configured by the caller
 
     # Track which patterns had changes
     $processedPatterns = @()
@@ -242,47 +239,65 @@ try {
         $mergeOutput = & git merge --no-ff "origin/$MergeFromBranch" -m "Merge branch '$MergeFromBranch' into $MergeToBranch" 2>&1
         $mergeExitCode = $LASTEXITCODE
 
+        # Always log merge output for CI diagnostics
+        if ($mergeOutput) {
+            $mergeOutput | Write-Host
+        }
+
         if ($mergeExitCode -eq 0) {
             $createdMergeCommit = $true
         } else {
-            Write-Host "Merge produced conflicts. Checking if all conflicts are within ResetToTargetPaths..."
-
             # Get list of conflicting files
             [string[]] $conflictFiles = & git diff --name-only --diff-filter=U
 
-            # Check which conflicts fall outside ResetToTargetPaths patterns
-            $outsidePatternConflicts = @()
-            foreach ($file in $conflictFiles) {
-                $covered = $false
-                foreach ($pattern in $patterns) {
-                    if ($file -like $pattern) {
-                        $covered = $true
-                        break
+            # Abort the conflicted merge before proceeding.
+            # Use plain call (not Invoke-Block) because git merge --abort exits 128
+            # if there is no merge-in-progress (e.g. a non-conflict git failure).
+            & git merge --abort 2>&1 | Write-Host
+
+            if (-not $conflictFiles -or $conflictFiles.Count -eq 0) {
+                # Merge failed but produced no conflicts — unexpected git error.
+                # Fall back to source-only branch and let GitHub handle it.
+                Write-Host -f Yellow "Merge failed with exit code $mergeExitCode but no conflicts were detected."
+                Write-Host -f Yellow "Falling back to source-only branch."
+                Invoke-Block { & git checkout -B $mergeBranchName "origin/$MergeFromBranch" }
+            } else {
+                Write-Host "Merge produced conflicts. Checking if all conflicts are within ResetToTargetPaths..."
+
+                # Check which conflicts fall outside ResetToTargetPaths patterns
+                $outsidePatternConflicts = @()
+                foreach ($file in $conflictFiles) {
+                    $covered = $false
+                    foreach ($pattern in $patterns) {
+                        if ($file -like $pattern) {
+                            $covered = $true
+                            break
+                        }
+                    }
+                    if (-not $covered) {
+                        $outsidePatternConflicts += $file
                     }
                 }
-                if (-not $covered) {
-                    $outsidePatternConflicts += $file
+
+                if ($outsidePatternConflicts.Count -eq 0) {
+                    # All conflicts are in ResetToTargetPaths files which will be overwritten
+                    # by target branch content anyway, so it's safe to auto-resolve them.
+                    # Use -X ours (favor target) as a safety net: if ResetFilesToTargetBranch
+                    # misses a file due to pathspec differences, the merge commit already
+                    # has the target version rather than silently carrying source content.
+                    Write-Host "All conflicts are within ResetToTargetPaths patterns. Auto-resolving with -X ours (favor target)..."
+                    Invoke-Block { & git merge --no-ff "origin/$MergeFromBranch" -X ours -m "Merge branch '$MergeFromBranch' into $MergeToBranch" }
+                    $createdMergeCommit = $true
+                } else {
+                    # There are conflicts outside ResetToTargetPaths. We must NOT auto-resolve
+                    # these because it would hide real conflicts from the PR reviewer.
+                    # Fall back to the original behavior: create branch from source HEAD
+                    # so GitHub's merge button will surface the conflicts.
+                    Write-Host -f Yellow "Conflicts detected outside ResetToTargetPaths patterns:"
+                    $outsidePatternConflicts | % { Write-Host -f Yellow "  - $_" }
+                    Write-Host -f Yellow "Falling back to source-only branch so GitHub surfaces these conflicts in the PR."
+                    Invoke-Block { & git checkout -B $mergeBranchName "origin/$MergeFromBranch" }
                 }
-            }
-
-            # Abort the conflicted merge before proceeding
-            Invoke-Block { & git merge --abort }
-
-            if ($outsidePatternConflicts.Count -eq 0) {
-                # All conflicts are in ResetToTargetPaths files which will be overwritten
-                # by target branch content anyway, so it's safe to auto-resolve them.
-                Write-Host "All conflicts are within ResetToTargetPaths patterns. Auto-resolving with -X theirs..."
-                Invoke-Block { & git merge --no-ff "origin/$MergeFromBranch" -X theirs -m "Merge branch '$MergeFromBranch' into $MergeToBranch" }
-                $createdMergeCommit = $true
-            } else {
-                # There are conflicts outside ResetToTargetPaths. We must NOT auto-resolve
-                # these because it would hide real conflicts from the PR reviewer.
-                # Fall back to the original behavior: create branch from source HEAD
-                # so GitHub's merge button will surface the conflicts.
-                Write-Host -f Yellow "Conflicts detected outside ResetToTargetPaths patterns:"
-                $outsidePatternConflicts | % { Write-Host -f Yellow "  - $_" }
-                Write-Host -f Yellow "Falling back to source-only branch so GitHub surfaces these conflicts in the PR."
-                Invoke-Block { & git checkout -B $mergeBranchName "origin/$MergeFromBranch" }
             }
         }
 
@@ -345,10 +360,23 @@ try {
             if ($PSCmdlet.ShouldProcess("Update remote branch $mergeBranchName on $remoteName")) {
                 if ($createdMergeCommit) {
                     # Merge commits create non-fast-forwardable history on each run,
-                    # so we need --force to update the branch.
+                    # so we need --force to update the branch. But first check if the
+                    # remote has human-pushed commits that aren't in our local branch
+                    # to avoid silently overwriting manual conflict resolutions.
+                    [string[]] $extraCommits = & git rev-list "$mergeBranchName..origin/$mergeBranchName" 2>$null
+                    if ($extraCommits -and $extraCommits.Count -gt 0) {
+                        Write-Warning "Remote branch '$mergeBranchName' has $($extraCommits.Count) commit(s) not in the local branch. Skipping force push to avoid overwriting manual changes."
+                        throw "Remote branch has unmerged commits"
+                    }
                     Invoke-Block { & git push --force $remoteName "${mergeBranchName}:${mergeBranchName}" }
                 } else {
-                    Invoke-Block { & git push $remoteName "${mergeBranchName}:${mergeBranchName}" }
+                    # Try non-force push first. If it fails (e.g. remote diverged from
+                    # a previous merge-commit run), retry with --force.
+                    & git push $remoteName "${mergeBranchName}:${mergeBranchName}" 2>&1 | Write-Host
+                    if ($LASTEXITCODE -ne 0) {
+                        Write-Host "Non-force push failed (likely diverged history). Retrying with --force..."
+                        Invoke-Block { & git push --force $remoteName "${mergeBranchName}:${mergeBranchName}" }
+                    }
                 }
             }
             $prUpdatedSuccess = $true

--- a/.github/workflows/scripts/inter-branch-merge.ps1
+++ b/.github/workflows/scripts/inter-branch-merge.ps1
@@ -221,6 +221,9 @@ try {
 
     $mergeBranchName = "merge/$MergeFromBranch-to-$MergeToBranch"
 
+    # Track whether we created a merge commit (affects push strategy for PR updates)
+    $createdMergeCommit = $false
+
     # When ResetToTargetPaths is configured, we attempt to create a proper merge commit
     # so that the target branch content is included. If there are conflicts outside
     # the pattern list, we fall back to the original source-only behavior so that
@@ -239,7 +242,9 @@ try {
         $mergeOutput = & git merge --no-ff "origin/$MergeFromBranch" -m "Merge branch '$MergeFromBranch' into $MergeToBranch" 2>&1
         $mergeExitCode = $LASTEXITCODE
 
-        if ($mergeExitCode -ne 0) {
+        if ($mergeExitCode -eq 0) {
+            $createdMergeCommit = $true
+        } else {
             Write-Host "Merge produced conflicts. Checking if all conflicts are within ResetToTargetPaths..."
 
             # Get list of conflicting files
@@ -268,6 +273,7 @@ try {
                 # by target branch content anyway, so it's safe to auto-resolve them.
                 Write-Host "All conflicts are within ResetToTargetPaths patterns. Auto-resolving with -X theirs..."
                 Invoke-Block { & git merge --no-ff "origin/$MergeFromBranch" -X theirs -m "Merge branch '$MergeFromBranch' into $MergeToBranch" }
+                $createdMergeCommit = $true
             } else {
                 # There are conflicts outside ResetToTargetPaths. We must NOT auto-resolve
                 # these because it would hide real conflicts from the PR reviewer.
@@ -276,7 +282,7 @@ try {
                 Write-Host -f Yellow "Conflicts detected outside ResetToTargetPaths patterns:"
                 $outsidePatternConflicts | % { Write-Host -f Yellow "  - $_" }
                 Write-Host -f Yellow "Falling back to source-only branch so GitHub surfaces these conflicts in the PR."
-                Invoke-Block { & git checkout -B $mergeBranchName }
+                Invoke-Block { & git checkout -B $mergeBranchName "origin/$MergeFromBranch" }
             }
         }
 
@@ -337,7 +343,13 @@ try {
 
         try {
             if ($PSCmdlet.ShouldProcess("Update remote branch $mergeBranchName on $remoteName")) {
-                Invoke-Block { & git push $remoteName "${mergeBranchName}:${mergeBranchName}" }
+                if ($createdMergeCommit) {
+                    # Merge commits create non-fast-forwardable history on each run,
+                    # so we need --force to update the branch.
+                    Invoke-Block { & git push --force $remoteName "${mergeBranchName}:${mergeBranchName}" }
+                } else {
+                    Invoke-Block { & git push $remoteName "${mergeBranchName}:${mergeBranchName}" }
+                }
             }
             $prUpdatedSuccess = $true
         }

--- a/.github/workflows/scripts/inter-branch-merge.ps1
+++ b/.github/workflows/scripts/inter-branch-merge.ps1
@@ -358,6 +358,10 @@ try {
 
         try {
             if ($PSCmdlet.ShouldProcess("Update remote branch $mergeBranchName on $remoteName")) {
+                # Refresh the remote tracking ref for the merge branch so the
+                # human-commit safety check below uses current remote state.
+                & git fetch $remoteName $mergeBranchName 2>$null
+
                 if ($createdMergeCommit) {
                     # Merge commits create non-fast-forwardable history on each run,
                     # so we need --force to update the branch. But first check if the
@@ -371,9 +375,15 @@ try {
                     Invoke-Block { & git push --force $remoteName "${mergeBranchName}:${mergeBranchName}" }
                 } else {
                     # Try non-force push first. If it fails (e.g. remote diverged from
-                    # a previous merge-commit run), retry with --force.
+                    # a previous merge-commit run), retry with --force after checking
+                    # for human-pushed commits (same guard as the merge-commit path).
                     & git push $remoteName "${mergeBranchName}:${mergeBranchName}" 2>&1 | Write-Host
                     if ($LASTEXITCODE -ne 0) {
+                        [string[]] $extraCommits = & git rev-list "$mergeBranchName..origin/$mergeBranchName" 2>$null
+                        if ($extraCommits -and $extraCommits.Count -gt 0) {
+                            Write-Warning "Remote branch '$mergeBranchName' has $($extraCommits.Count) commit(s) not in the local branch. Skipping force push to avoid overwriting manual changes."
+                            throw "Remote branch has unmerged commits"
+                        }
                         Write-Host "Non-force push failed (likely diverged history). Retrying with --force..."
                         Invoke-Block { & git push --force $remoteName "${mergeBranchName}:${mergeBranchName}" }
                     }

--- a/.github/workflows/scripts/inter-branch-merge.ps1
+++ b/.github/workflows/scripts/inter-branch-merge.ps1
@@ -220,12 +220,31 @@ try {
     Write-Host $committersList
 
     $mergeBranchName = "merge/$MergeFromBranch-to-$MergeToBranch"
-    Invoke-Block { & git checkout -B $mergeBranchName  }
 
-    # Reset specified files to target branch if ResetToTargetPaths is configured
+    # When ResetToTargetPaths is configured, we need to create a proper merge commit
+    # so that the target branch content is included. Without this, the merge branch
+    # would just be the source branch with some files overwritten, missing all
+    # target-only changes (APIs, fixes, platform versions, etc.).
     if ($ResetToTargetPaths) {
+        # Configure git user for the merge commit
+        Invoke-Block { & git config user.name "github-actions[bot]" }
+        Invoke-Block { & git config user.email "41898282+github-actions[bot]@users.noreply.github.com" }
+
+        # Start from the target branch and merge source into it
+        Invoke-Block { & git checkout -B $mergeBranchName "origin/$MergeToBranch" }
+
+        # Merge source branch. Use -X theirs to auto-resolve conflicts in favor of
+        # the source branch, since ResetToTargetPaths will overwrite target-wins files
+        # in the next step anyway.
+        Invoke-Block { & git merge --no-ff "origin/$MergeFromBranch" -X theirs -m "Merge branch '$MergeFromBranch' into $MergeToBranch" }
+
         $patterns = $ResetToTargetPaths -split ";"
         ResetFilesToTargetBranch $patterns $MergeToBranch
+    }
+    else {
+        # Without ResetToTargetPaths, the original behavior is fine: create a branch
+        # from the source and let GitHub's merge button do the actual merge.
+        Invoke-Block { & git checkout -B $mergeBranchName }
     }
 
     $remoteName = 'origin'

--- a/.github/workflows/scripts/inter-branch-merge.ps1
+++ b/.github/workflows/scripts/inter-branch-merge.ps1
@@ -221,24 +221,65 @@ try {
 
     $mergeBranchName = "merge/$MergeFromBranch-to-$MergeToBranch"
 
-    # When ResetToTargetPaths is configured, we need to create a proper merge commit
-    # so that the target branch content is included. Without this, the merge branch
-    # would just be the source branch with some files overwritten, missing all
-    # target-only changes (APIs, fixes, platform versions, etc.).
+    # When ResetToTargetPaths is configured, we attempt to create a proper merge commit
+    # so that the target branch content is included. If there are conflicts outside
+    # the pattern list, we fall back to the original source-only behavior so that
+    # GitHub's merge button surfaces the real conflicts to the reviewer.
     if ($ResetToTargetPaths) {
         # Configure git user for the merge commit
         Invoke-Block { & git config user.name "github-actions[bot]" }
         Invoke-Block { & git config user.email "41898282+github-actions[bot]@users.noreply.github.com" }
 
+        $patterns = ($ResetToTargetPaths -split ";") | % { $_.Trim() } | ? { $_ }
+
         # Start from the target branch and merge source into it
         Invoke-Block { & git checkout -B $mergeBranchName "origin/$MergeToBranch" }
 
-        # Merge source branch. Use -X theirs to auto-resolve conflicts in favor of
-        # the source branch, since ResetToTargetPaths will overwrite target-wins files
-        # in the next step anyway.
-        Invoke-Block { & git merge --no-ff "origin/$MergeFromBranch" -X theirs -m "Merge branch '$MergeFromBranch' into $MergeToBranch" }
+        # Try a clean merge first
+        $mergeOutput = & git merge --no-ff "origin/$MergeFromBranch" -m "Merge branch '$MergeFromBranch' into $MergeToBranch" 2>&1
+        $mergeExitCode = $LASTEXITCODE
 
-        $patterns = $ResetToTargetPaths -split ";"
+        if ($mergeExitCode -ne 0) {
+            Write-Host "Merge produced conflicts. Checking if all conflicts are within ResetToTargetPaths..."
+
+            # Get list of conflicting files
+            [string[]] $conflictFiles = & git diff --name-only --diff-filter=U
+
+            # Check which conflicts fall outside ResetToTargetPaths patterns
+            $outsidePatternConflicts = @()
+            foreach ($file in $conflictFiles) {
+                $covered = $false
+                foreach ($pattern in $patterns) {
+                    if ($file -like $pattern) {
+                        $covered = $true
+                        break
+                    }
+                }
+                if (-not $covered) {
+                    $outsidePatternConflicts += $file
+                }
+            }
+
+            # Abort the conflicted merge before proceeding
+            Invoke-Block { & git merge --abort }
+
+            if ($outsidePatternConflicts.Count -eq 0) {
+                # All conflicts are in ResetToTargetPaths files which will be overwritten
+                # by target branch content anyway, so it's safe to auto-resolve them.
+                Write-Host "All conflicts are within ResetToTargetPaths patterns. Auto-resolving with -X theirs..."
+                Invoke-Block { & git merge --no-ff "origin/$MergeFromBranch" -X theirs -m "Merge branch '$MergeFromBranch' into $MergeToBranch" }
+            } else {
+                # There are conflicts outside ResetToTargetPaths. We must NOT auto-resolve
+                # these because it would hide real conflicts from the PR reviewer.
+                # Fall back to the original behavior: create branch from source HEAD
+                # so GitHub's merge button will surface the conflicts.
+                Write-Host -f Yellow "Conflicts detected outside ResetToTargetPaths patterns:"
+                $outsidePatternConflicts | % { Write-Host -f Yellow "  - $_" }
+                Write-Host -f Yellow "Falling back to source-only branch so GitHub surfaces these conflicts in the PR."
+                Invoke-Block { & git checkout -B $mergeBranchName }
+            }
+        }
+
         ResetFilesToTargetBranch $patterns $MergeToBranch
     }
     else {

--- a/.github/workflows/scripts/inter-branch-merge.ps1
+++ b/.github/workflows/scripts/inter-branch-merge.ps1
@@ -427,6 +427,11 @@ try {
                 # failed for a reason that left no merge in progress.
                 & git merge --abort 2>&1 | Write-Host
                 Write-Host -f Yellow "Could not merge $MergeFromBranch into the existing '$mergeBranchName' branch; it needs manual conflict resolution. The existing PR will be left unchanged."
+                # An Actions annotation rather than only a log line: this is the one outcome that
+                # needs a human, and it is invisible otherwise -- the push below is classified as a
+                # benign non-fast-forward so the job stays green, and -QuietComments suppresses the
+                # PR comment. Annotations surface on the run summary regardless of either.
+                Write-Host "::warning::Merge branch '$mergeBranchName' has conflicts that must be resolved by hand; the PR for $MergeFromBranch -> $MergeToBranch is no longer being updated."
             }
         }
     }
@@ -464,6 +469,7 @@ try {
                 # untouched and do not fail the job. Reset the exit code so the non-fast-forward
                 # rejection from git push does not propagate as the process exit code.
                 Write-Host -f Yellow "The existing PR branch '$mergeBranchName' has diverged and cannot be fast-forwarded; leaving the existing PR unchanged."
+                Write-Host "::warning::Could not update the PR branch '$mergeBranchName'; it has diverged and was not force-pushed over. The PR for $MergeFromBranch -> $MergeToBranch is stale until someone resolves it."
                 $global:LASTEXITCODE = 0
             }
             else {

--- a/.github/workflows/scripts/inter-branch-merge.ps1
+++ b/.github/workflows/scripts/inter-branch-merge.ps1
@@ -112,6 +112,18 @@ function GetCommitterGitHubName($sha) {
     return $null
 }
 
+function RemoteBranchExists($remoteName, $branchName) {
+    $lsRemoteOutput = & git ls-remote --heads $remoteName "refs/heads/$branchName" 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        # Fail loudly instead of assuming the branch is missing: treating an auth or network
+        # failure as "branch does not exist" would silently recreate the branch and discard
+        # whatever is already on the PR.
+        throw "Failed to query '$remoteName' for branch '$branchName'. Output: $lsRemoteOutput"
+    }
+
+    return [bool]$lsRemoteOutput
+}
+
 function ResetFilesToTargetBranch($patterns, $targetBranch) {
     if (-not $patterns -or $patterns.Count -eq 0) {
         return
@@ -220,13 +232,6 @@ try {
     Write-Host $committersList
 
     $mergeBranchName = "merge/$MergeFromBranch-to-$MergeToBranch"
-    Invoke-Block { & git checkout -B $mergeBranchName  }
-
-    # Reset specified files to target branch if ResetToTargetPaths is configured
-    if ($ResetToTargetPaths) {
-        $patterns = $ResetToTargetPaths -split ";"
-        ResetFilesToTargetBranch $patterns $MergeToBranch
-    }
 
     $remoteName = 'origin'
     $prOwnerName = $RepoOwner
@@ -271,6 +276,58 @@ try {
     $matchingPr = $resp.data.repository.pullRequests.nodes `
         | ? { $_.headRef.name -eq $mergeBranchName -and $_.headRef.repository.owner.login -eq $prOwnerName } `
         | select -First 1
+
+    # Build the merge branch.
+    #
+    # When an open PR already exists for this merge branch, update that branch by merging the
+    # source branch into it rather than recreating it from the source branch tip. Recreating the
+    # branch produces history that is not a descendant of what was pushed on the previous run --
+    # with ResetToTargetPaths the "Reset files to <target>" commit is regenerated with a new SHA
+    # every run, so the branch can never fast-forward -- and the push below is rejected as
+    # non-fast-forward, leaving the PR silently un-updated from then on. Merging into the existing
+    # branch keeps the push a fast-forward and preserves conflict resolutions that were pushed to
+    # the PR branch by hand.
+    $updatedExistingBranch = $false
+
+    if ($matchingPr -and (RemoteBranchExists $remoteName $mergeBranchName)) {
+        Invoke-Block { & git fetch --quiet $remoteName "refs/heads/${mergeBranchName}:refs/remotes/${remoteName}/${mergeBranchName}" }
+        Invoke-Block { & git checkout -B $mergeBranchName "refs/remotes/$remoteName/$mergeBranchName" }
+
+        # A merge commit needs an identity. ResetFilesToTargetBranch configures the same one.
+        Invoke-Block { & git config user.name "github-actions[bot]" }
+        Invoke-Block { & git config user.email "41898282+github-actions[bot]@users.noreply.github.com" }
+
+        # No -X ours/-X theirs: a conflict here needs a human, and must not be auto-resolved.
+        $mergeOutput = & git merge --no-edit "refs/remotes/$remoteName/$MergeFromBranch" 2>&1
+        $mergeExitCode = $LASTEXITCODE
+
+        if ($mergeOutput) {
+            $mergeOutput | Write-Host
+        }
+
+        if ($mergeExitCode -eq 0) {
+            $updatedExistingBranch = $true
+        }
+        else {
+            # Abort and fall back to recreating the branch from the source tip. That is what this
+            # script did before this branch existed: the push below is rejected as non-fast-forward
+            # and the existing PR is left untouched for someone to resolve by hand.
+            # Plain call, not Invoke-Block: `git merge --abort` exits non-zero when the merge failed
+            # for a reason that left no merge in progress.
+            & git merge --abort 2>&1 | Write-Host
+            Write-Host -f Yellow "Could not merge $MergeFromBranch into the existing '$mergeBranchName' branch; it needs manual conflict resolution. The existing PR will be left unchanged."
+        }
+    }
+
+    if (-not $updatedExistingBranch) {
+        Invoke-Block { & git checkout -B $mergeBranchName "refs/remotes/$remoteName/$MergeFromBranch" }
+    }
+
+    # Reset specified files to target branch if ResetToTargetPaths is configured
+    if ($ResetToTargetPaths) {
+        $patterns = $ResetToTargetPaths -split ";"
+        ResetFilesToTargetBranch $patterns $MergeToBranch
+    }
 
     if ($matchingPr) {
         $prUpdatedSuccess = $false

--- a/.github/workflows/scripts/inter-branch-merge.ps1
+++ b/.github/workflows/scripts/inter-branch-merge.ps1
@@ -358,40 +358,76 @@ try {
     # branch keeps the push a fast-forward and preserves conflict resolutions that were pushed to
     # the PR branch by hand.
     $updatedExistingBranch = $false
+    $mergeBranchHasDiverged = $false
 
     if ($matchingPr -and (RemoteBranchExists $remoteName $mergeBranchName)) {
-        Invoke-Block { & git fetch --quiet $remoteName "refs/heads/${mergeBranchName}:refs/remotes/${remoteName}/${mergeBranchName}" }
-        Invoke-Block { & git checkout -B $mergeBranchName "refs/remotes/$remoteName/$mergeBranchName" }
+        # Plain call, not Invoke-Block: the branch can be deleted between the check above and this
+        # fetch. Re-check rather than failing the run, but only treat a failure as "deleted" when
+        # the remote confirms it -- RemoteBranchExists still throws on an auth or network failure,
+        # so those keep failing loudly instead of silently recreating the branch.
+        & git fetch --quiet $remoteName "refs/heads/${mergeBranchName}:refs/remotes/${remoteName}/${mergeBranchName}" 2>&1 | Write-Host
+        $fetchFailed = $LASTEXITCODE -ne 0
 
-        # A merge commit needs an identity. ResetFilesToTargetBranch configures the same one.
-        Invoke-Block { & git config user.name "github-actions[bot]" }
-        Invoke-Block { & git config user.email "41898282+github-actions[bot]@users.noreply.github.com" }
-
-        # No -X ours/-X theirs: nothing outside ResetToTargetPaths is ever auto-resolved.
-        $mergeOutput = & git merge --no-edit "refs/remotes/$remoteName/$MergeFromBranch" 2>&1
-        $mergeExitCode = $LASTEXITCODE
-
-        if ($mergeOutput) {
-            $mergeOutput | Write-Host
+        if ($fetchFailed -and (RemoteBranchExists $remoteName $mergeBranchName)) {
+            throw "Failed to fetch existing merge branch '$mergeBranchName' from '$remoteName'."
         }
 
-        if ($mergeExitCode -eq 0) {
-            $updatedExistingBranch = $true
-        }
-        elseif ($ResetToTargetPaths -and (TryResolveResetPathConflicts ($ResetToTargetPaths -split ";") $MergeToBranch)) {
-            # Every conflicted file was one this script overwrites with the target branch's content
-            # anyway, and it has been set to that content. Finish the merge.
-            Invoke-Block { & git commit --no-edit }
-            $updatedExistingBranch = $true
+        if ($fetchFailed) {
+            Write-Host -f Yellow "Merge branch '$mergeBranchName' disappeared while it was being read; recreating it from $MergeFromBranch."
         }
         else {
-            # Abort and fall back to recreating the branch from the source tip. That is what this
-            # script did before this branch existed: the push below is rejected as non-fast-forward
-            # and the existing PR is left untouched for someone to resolve by hand.
-            # Plain call, not Invoke-Block: `git merge --abort` exits non-zero when the merge failed
-            # for a reason that left no merge in progress.
-            & git merge --abort 2>&1 | Write-Host
-            Write-Host -f Yellow "Could not merge $MergeFromBranch into the existing '$mergeBranchName' branch; it needs manual conflict resolution. The existing PR will be left unchanged."
+            # Only merge into the existing branch when it has diverged from the source branch. When
+            # it is still an ancestor of the source tip there is nothing on it to preserve and
+            # recreating it from the tip fast-forwards exactly as it always has, so the common case
+            # keeps running the code path it ran before this branch existed.
+            # Plain call, not Invoke-Block: `--is-ancestor` uses exit code 1 to mean "no", which is
+            # an answer rather than a failure.
+            & git merge-base --is-ancestor "refs/remotes/$remoteName/$mergeBranchName" "refs/remotes/$remoteName/$MergeFromBranch"
+            $isAncestorExitCode = $LASTEXITCODE
+
+            if ($isAncestorExitCode -ne 0 -and $isAncestorExitCode -ne 1) {
+                throw "Failed to compare '$mergeBranchName' with $MergeFromBranch (git merge-base --is-ancestor exited $isAncestorExitCode)."
+            }
+
+            $mergeBranchHasDiverged = $isAncestorExitCode -eq 1
+        }
+
+        if (-not $mergeBranchHasDiverged -and -not $fetchFailed) {
+            Write-Host "Merge branch '$mergeBranchName' has not diverged from $MergeFromBranch; recreating it from the source branch tip."
+        }
+        elseif ($mergeBranchHasDiverged) {
+            Invoke-Block { & git checkout -B $mergeBranchName "refs/remotes/$remoteName/$mergeBranchName" }
+
+            # A merge commit needs an identity. ResetFilesToTargetBranch configures the same one.
+            Invoke-Block { & git config user.name "github-actions[bot]" }
+            Invoke-Block { & git config user.email "41898282+github-actions[bot]@users.noreply.github.com" }
+
+            # No -X ours/-X theirs: nothing outside ResetToTargetPaths is ever auto-resolved.
+            $mergeOutput = & git merge --no-edit "refs/remotes/$remoteName/$MergeFromBranch" 2>&1
+            $mergeExitCode = $LASTEXITCODE
+
+            if ($mergeOutput) {
+                $mergeOutput | Write-Host
+            }
+
+            if ($mergeExitCode -eq 0) {
+                $updatedExistingBranch = $true
+            }
+            elseif ($ResetToTargetPaths -and (TryResolveResetPathConflicts ($ResetToTargetPaths -split ";") $MergeToBranch)) {
+                # Every conflicted file was one this script overwrites with the target branch's
+                # content anyway, and it has been set to that content. Finish the merge.
+                Invoke-Block { & git commit --no-edit }
+                $updatedExistingBranch = $true
+            }
+            else {
+                # Abort and fall back to recreating the branch from the source tip. That is what
+                # this script did before this branch existed: the push below is rejected as
+                # non-fast-forward and the existing PR is left untouched for manual resolution.
+                # Plain call, not Invoke-Block: `git merge --abort` exits non-zero when the merge
+                # failed for a reason that left no merge in progress.
+                & git merge --abort 2>&1 | Write-Host
+                Write-Host -f Yellow "Could not merge $MergeFromBranch into the existing '$mergeBranchName' branch; it needs manual conflict resolution. The existing PR will be left unchanged."
+            }
         }
     }
 

--- a/.github/workflows/scripts/inter-branch-merge.ps1
+++ b/.github/workflows/scripts/inter-branch-merge.ps1
@@ -146,6 +146,16 @@ function TryResolveResetPathConflicts($patterns, $targetBranch) {
         return $false
     }
 
+    # Pathspec magic (anything starting with ':', e.g. ':(attr:...)' or ':(exclude)') can select a
+    # different set of files depending on repository state, so which files a pattern covers is not
+    # guaranteed to still hold after resolving. Only ordinary paths and globs are safe to reason
+    # about here; anything else falls back to leaving the merge to a human.
+    $magicPatterns = @($patterns | Where-Object { $_ -and $_.Trim().StartsWith(':') })
+    if ($magicPatterns.Count -gt 0) {
+        Write-Host -f Yellow "ResetToTargetPaths uses pathspec magic ($($magicPatterns -join ', ')); not resolving conflicts automatically."
+        return $false
+    }
+
     $covered = @()
     foreach ($pattern in $patterns) {
         $pattern = $pattern.Trim()

--- a/.github/workflows/scripts/inter-branch-merge.ps1
+++ b/.github/workflows/scripts/inter-branch-merge.ps1
@@ -124,6 +124,66 @@ function RemoteBranchExists($remoteName, $branchName) {
     return [bool]$lsRemoteOutput
 }
 
+# Resolves merge conflicts that fall entirely within the ResetToTargetPaths patterns.
+#
+# Those files are expected to conflict: the merge branch holds the target branch's version of them
+# while the source branch keeps changing them. They are not conflicts anyone reviews -- the script
+# overwrites those exact paths with the target branch's content on every run no matter how the merge
+# turns out -- so taking the target's version here produces the same tree the script would have
+# produced anyway. Nothing outside the configured patterns is ever resolved: a single conflict
+# outside them makes this return $false so the caller aborts the merge and leaves it to a human.
+function TryResolveResetPathConflicts($patterns, $targetBranch) {
+    if (-not $patterns -or $patterns.Count -eq 0) {
+        return $false
+    }
+
+    $conflicted = @(& git diff --name-only --diff-filter=U)
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to list conflicted files after merging into the existing merge branch."
+    }
+
+    if ($conflicted.Count -eq 0) {
+        return $false
+    }
+
+    $covered = @()
+    foreach ($pattern in $patterns) {
+        $pattern = $pattern.Trim()
+        if (-not $pattern) {
+            continue
+        }
+
+        $matched = @(& git diff --name-only --diff-filter=U -- $pattern)
+        if ($LASTEXITCODE -eq 0 -and $matched.Count -gt 0) {
+            $covered += $matched
+        }
+    }
+
+    $covered = @($covered | Select-Object -Unique)
+
+    $uncovered = @($conflicted | Where-Object { $covered -notcontains $_ })
+    if ($uncovered.Count -gt 0) {
+        Write-Host -f Yellow "Conflicts outside ResetToTargetPaths, leaving them for manual resolution: $($uncovered -join ', ')"
+        return $false
+    }
+
+    foreach ($file in $covered) {
+        & git checkout "origin/$targetBranch" -- $file 2>&1 | Write-Host
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host -f Yellow "Could not take the '$targetBranch' version of '$file'."
+            return $false
+        }
+    }
+
+    $stillConflicted = @(& git diff --name-only --diff-filter=U)
+    if ($LASTEXITCODE -ne 0 -or $stillConflicted.Count -gt 0) {
+        return $false
+    }
+
+    Write-Host -f Green "Took the '$targetBranch' version of conflicted ResetToTargetPaths files: $($covered -join ', ')"
+    return $true
+}
+
 function ResetFilesToTargetBranch($patterns, $targetBranch) {
     if (-not $patterns -or $patterns.Count -eq 0) {
         return
@@ -297,7 +357,7 @@ try {
         Invoke-Block { & git config user.name "github-actions[bot]" }
         Invoke-Block { & git config user.email "41898282+github-actions[bot]@users.noreply.github.com" }
 
-        # No -X ours/-X theirs: a conflict here needs a human, and must not be auto-resolved.
+        # No -X ours/-X theirs: nothing outside ResetToTargetPaths is ever auto-resolved.
         $mergeOutput = & git merge --no-edit "refs/remotes/$remoteName/$MergeFromBranch" 2>&1
         $mergeExitCode = $LASTEXITCODE
 
@@ -306,6 +366,12 @@ try {
         }
 
         if ($mergeExitCode -eq 0) {
+            $updatedExistingBranch = $true
+        }
+        elseif ($ResetToTargetPaths -and (TryResolveResetPathConflicts ($ResetToTargetPaths -split ";") $MergeToBranch)) {
+            # Every conflicted file was one this script overwrites with the target branch's content
+            # anyway, and it has been set to that content. Finish the merge.
+            Invoke-Block { & git commit --no-edit }
             $updatedExistingBranch = $true
         }
         else {


### PR DESCRIPTION
## Problem

An inter-branch merge PR is updated **exactly once** and then silently stops updating. Every subsequent run is dropped without failing the job.

Each run rebuilds the merge branch from scratch:

```powershell
git checkout -B $mergeBranchName                    # from the source branch tip
ResetFilesToTargetBranch $patterns $MergeToBranch   # NEW commit, NEW sha, every run
git push origin $mergeBranchName:$mergeBranchName   # plain push, no force
```

Whenever the pushed branch is not an ancestor of what the next run builds, the push cannot fast-forward and is rejected:

```
git push origin merge/main-to-net11.0:merge/main-to-net11.0
 ! [rejected]  merge/main-to-net11.0 -> merge/main-to-net11.0 (non-fast-forward)
The existing PR branch 'merge/main-to-net11.0' has diverged and cannot be fast-forwarded;
leaving the existing PR unchanged.
```

The job reports **success**, and repos using `-QuietComments` get no PR comment either, so there is no signal at all. The PR just quietly goes stale until someone notices and merges by hand.

This is not new behavior from #17091 — the previous code also plain-pushed and only logged a warning. #17091 made the skip explicit and benign, which is correct given the branch it was handed, but the branch should not have been non-fast-forwardable in the first place.

### Two ways a branch becomes non-fast-forwardable

**1. `ResetToTargetPaths` is configured.** The `Reset files to <target>` commit is regenerated every run, so its parent is the source branch tip and it is never a descendant of the commit pushed last time. The branch therefore **can never fast-forward** — this fires on every single run.

Two runs 45 seconds apart in dotnet/maui, from the same `main` tip, show it clearly: the first pushed reset commit `177d5e64`, the second built `b99c21d027` and was rejected. The PR needed manual merges on Jul 24, Jul 25 (#36786) and Jul 27 to stay current.

**2. Someone pushes a commit to the merge branch.** This affects repos that do **not** use `ResetToTargetPaths`. Resolving conflicts by pushing to the merge branch is exactly what the PR body this script generates instructs contributors to do. Once that commit exists the branch has diverged from the source tip, and every later run is rejected the same way. Verified end to end: with no `ResetToTargetPaths` anywhere, a human commit on the branch causes the next source commit to never reach the PR.

Nothing is destroyed in either case — the push is rejected rather than forced, so work already on the branch survives. What is lost is every subsequent source commit, silently and indefinitely.

## Fix

When an open PR already exists for the merge branch **and that branch has diverged from the source tip**, merge the source branch **into that branch** instead of recreating it:

```powershell
if ($matchingPr -and (RemoteBranchExists $remoteName $mergeBranchName)) {
    git fetch origin refs/heads/$mergeBranchName:refs/remotes/origin/$mergeBranchName

    # Nothing on the branch to preserve? Recreate it from the tip, exactly as before.
    git merge-base --is-ancestor refs/remotes/origin/$mergeBranchName refs/remotes/origin/$MergeFromBranch
    if ($LASTEXITCODE -eq 1) {
        git checkout -B $mergeBranchName refs/remotes/origin/$mergeBranchName
        git merge --no-edit refs/remotes/origin/$MergeFromBranch
    }
}
```

- The push fast-forwards, so the PR keeps updating.
- Conflict resolutions pushed to the PR branch by hand are preserved rather than discarded.
- **The `merge-base --is-ancestor` gate keeps the blast radius small.** When the branch has not diverged there is nothing on it to preserve, so the script recreates it from the source tip and the run is byte-identical to today. Only genuinely diverged branches take the new path.
- **No conflicts are auto-resolved outside `ResetToTargetPaths`.** No `-X ours`, no `-X theirs`. If any conflicted file falls outside the configured patterns, the merge is aborted and the code falls back to the previous behavior — the push is rejected and the PR is left untouched for a human, exactly as today.
- The in-place update only happens when an **open PR** is found, so a leftover branch from an already-merged PR is still replaced rather than resurrected.
- No force-push, no `--force-with-lease`. The existing-PR path stays a plain fast-forward push.

`RemoteBranchExists` throws on `git ls-remote` failure rather than assuming "no branch", so an auth or network blip cannot cause the branch to be silently recreated. The fetch is allowed to fail only when a re-query confirms the branch was deleted between the check and the fetch; auth and network failures still fail the run.

### Conflicts inside `ResetToTargetPaths`

Merging the source branch in conflicts whenever the source branch changes a file the reset commit pinned to the target branch. In dotnet/maui that is `eng/Versions.props`, which dependency flow changes constantly — so without handling this, the merge would abort on most runs and the PR would still go stale.

Those files are not conflicts anyone adjudicates. `ResetFilesToTargetBranch` runs immediately afterwards and overwrites those exact paths with the target branch's content on **every** run, independent of how the merge turned out. The final content is therefore already deterministic and policy-driven; a human resolving the conflict by hand could not arrive at a different answer.

`TryResolveResetPathConflicts` takes the target branch's version for conflicted files covered by the configured patterns and lets the merge complete. It refuses to resolve, and the merge is aborted, when:

- any conflicted file falls **outside** the patterns (the uncovered paths are logged by name),
- taking the target's version fails for any file — e.g. the file was renamed into a covered glob and does not exist on the target branch,
- any conflict remains after resolving,
- the patterns use pathspec magic (anything starting with `:`, such as `:(attr:...)`), which can select different files depending on repository state.

The resulting merge commit still carries git's own `# Conflicts:` note in its message, so the conflict remains visible in history.

## Testing

An end-to-end harness runs the real script against real git repositories with a local bare repo as the remote and the GitHub API mocked.

**The bug reproduces against unmodified `main`** — same rejection message as the MAUI production log, and the new source commit never reaches the PR.

| Scenario | `main` | this PR |
|---|---|---|
| New source commits reach an existing PR | ❌ | ✅ |
| Source changes a `ResetToTargetPaths` file → PR still updates | ❌ | ✅ |
| Human commit on the branch, no `ResetToTargetPaths` → PR still updates | ❌ | ✅ |
| Human conflict-resolution commit preserved | ✅ | ✅ |
| Undiverged branch → takes the pre-existing rebuild path, no merge commit | ✅ | ✅ |
| Conflict outside the patterns → abort, PR untouched, job succeeds | ✅ | ✅ |
| A stale or aborted merge emits an Actions annotation (survives `-QuietComments`) | ❌ | ✅ |
| Conflict inside **and** outside → abort, nothing resolved | ✅ | ✅ |
| No merge left in progress after abort | ✅ | ✅ |
| Without `ResetToTargetPaths` → still fast-forwards | ✅ | ✅ |
| No open PR → stale branch replaced, not resurrected | ✅ | ✅ |

30/30 assertions pass on this branch; `main` fails 9.

