### PR TITLE
Revert "Unblock publish"

### DIFF
--- a/eng/promote-build.yml
+++ b/eng/promote-build.yml
@@ -69,7 +69,7 @@ extends:
         os: windows
       ${{ else }}:
         name: NetCore1ESPool-Publishing-Internal
-        image: windows.vs2022.amd64
+        image: windows.vs2026.amd64
         os: windows
     sdl:
       policheck:


### PR DESCRIPTION
Reverts dotnet/arcade#16676
Fixes https://github.com/dotnet/arcade/issues/16677

The image got added back to the pool.