### PR TITLE
[release/10.0] Use Entra credential for symbol upload, removing dnceng-symbol-server-pat

### DIFF
--- a/eng/common/core-templates/steps/publish-logs.yml
+++ b/eng/common/core-templates/steps/publish-logs.yml
@@ -35,7 +35,6 @@ steps:
       '$(akams-client-id)'
       '$(microsoft-symbol-server-pat)'
       '$(symweb-symbol-server-pat)'
-      '$(dnceng-symbol-server-pat)'
       '$(dn-bot-all-orgs-build-rw-code-rw)'
       '$(System.AccessToken)'
       ${{parameters.CustomSensitiveDataList}}

--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -12,7 +12,6 @@ stages:
     displayName: Publish Assets and Symbols
     timeoutInMinutes: 120
     variables:
-    - group: DotNet-Symbol-Server-Pats
     - group: AzureDevOps-Artifact-Feeds-Pats
     - group: Publish-Build-Assets
 
@@ -157,7 +156,6 @@ stages:
           /p:PDBArtifactsBasePath='$(Build.ArtifactStagingDirectory)/PDBArtifacts/'
           /p:SymbolPublishingExclusionsFile='$(Build.ArtifactStagingDirectory)/ReleaseConfigs/SymbolPublishingExclusionsFile.txt'
           /p:TempSymbolsAzureDevOpsOrg='dnceng'
-          /p:TempSymbolsAzureDevOpsOrgToken='$(dnceng-symbol-server-pat)'
           /p:SymbolRequestProject='dotnet'
           ${{ parameters.symbolPublishingAdditionalParameters}}
           /p:BuildQuality='${{ parameters.buildQuality }}'

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -22,6 +22,7 @@ using System.Threading.Tasks;
 using Microsoft.Arcade.Common;
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.Tasks.Feed.Model;
+using Azure.Core;
 using Azure.Identity;
 using Microsoft.DotNet.ProductConstructionService.Client;
 using Microsoft.DotNet.ProductConstructionService.Client.Models;
@@ -718,7 +719,15 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             Task<SymbolUploadHelper> CreatePublishSymbolHelper(string symbolPublishingExclusionsFile, bool publishSpecialClrFiles, bool dryRun)
             {
                 FrozenSet<string> exclusions = LoadExclusions(symbolPublishingExclusionsFile);
-                PATCredential creds = new(TempSymbolsAzureDevOpsOrgToken);
+
+                TokenCredential creds = string.IsNullOrEmpty(TempSymbolsAzureDevOpsOrgToken)
+                    ? new DefaultIdentityTokenCredential(
+                        new DefaultIdentityTokenCredentialOptions
+                        {
+                            ManagedIdentityClientId = ManagedIdentityClientId
+                        })
+                    : new PATCredential(TempSymbolsAzureDevOpsOrgToken);
+
                 TaskTracer tracer = new(Log, verbose: true);
 
                 SymbolPublisherOptions options = new(


### PR DESCRIPTION
## Summary

Cherry-pick of #16688 to release/10.0.

Migrates the symbol upload step from PAT-based authentication (dnceng-symbol-server-pat) to Entra-based authentication via DefaultIdentityTokenCredential.

See #16688 for full details.

Fixes AB#10150