### PR TITLE
Add xLocCustomPowerShellScript in OneLoc task

### DIFF
--- a/eng/common/core-templates/job/onelocbuild.yml
+++ b/eng/common/core-templates/job/onelocbuild.yml
@@ -22,6 +22,7 @@ parameters:
   GitHubOrg: dotnet
   MirrorRepo: ''
   MirrorBranch: main
+  xLocCustomPowerShellScript: ''
   condition: ''
   JobNameSuffix: ''
   is1ESPipeline: ''
@@ -97,6 +98,8 @@ jobs:
           gitHubOrganization: ${{ parameters.GitHubOrg }}
           mirrorRepo: ${{ parameters.MirrorRepo }}
           mirrorBranch: ${{ parameters.MirrorBranch }}
+        ${{ if ne(parameters.xLocCustomPowerShellScript, '') }}:
+          xLocCustomPowerShellScript: ${{ parameters.xLocCustomPowerShellScript }}
       condition: ${{ parameters.condition }}
 
     # Copy the locProject.json to the root of the Loc directory, then publish a pipeline artifact


### PR DESCRIPTION
### To double check:

Needed for NuGet.Client change https://github.com/NuGet/NuGet.Client/pull/7259.

We use OneLoc to localize our strings, unfortunately OneLoc returns the files with BOM, and when moved to VMR BOM is removed, creating a "back and forth" PR creation between VMR and OneLoc, examples: https://github.com/NuGet/NuGet.Client/pull/7256/changes
https://github.com/NuGet/NuGet.Client/pull/7251/changes

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
