### PR TITLE
Prefer pipeline tokens for VS drop auth (WI 10146)

### DIFF
--- a/Documentation/ArcadeSdk.md
+++ b/Documentation/ArcadeSdk.md
@@ -725,14 +725,17 @@ The Build Pipeline needs to link the following variable group:
 
 ### Publishing VS insertion artifacts to a drop
 
-This step is required for repositories that build VS insertion components.
+This step is required for repositories that build VS insertion components. For new or migrated pipelines, prefer the Artifact Services task with `usePat: false` so the upload can run with the pipeline identity instead of a long-lived PAT.
 
 ```yml
-- task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1
-  displayName: Upload VSTS Drop
+- task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0
+  displayName: Upload Azure DevOps Drop
   inputs:
-    DropName: $(VisualStudioDropName)
-    DropFolder: 'artifacts\VSSetup\$(BuildConfiguration)\Insertion'
+    dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
+    buildNumber: $(VisualStudioDropName)
+    sourcePath: '$(System.DefaultWorkingDirectory)\artifacts\VSSetup\$(BuildConfiguration)\Insertion'
+    toLowerCase: false
+    usePat: false
   condition: succeeded()
 ```
 
@@ -801,10 +804,10 @@ The IBC data acquisition is performed by an internal tool `drop.exe` provided by
 DevOps feed. The repository build definition thus must invoke Azure DevOps task that restores internal tools in order for
 IBC data embedding to work. See [Restoring internal tools](#restoring-internal-tools).
 
-To retrieve the data the tool needs to authenticate to the VS drop storage. The access token necessary for the authentication
-is passed via `VisualStudioDropAccessToken` property. If the account the official build of the repository is running on has
-an access to the VS drop storage, the build definition can pass `/p:VisualStudioDropAccessToken=$(System.AccessToken)` to
-the `/eng/common/CIBuild.cmd` script.
+To retrieve the data the tool needs to authenticate to the VS drop storage. Arcade uses the `VisualStudioDropAccessToken`
+property when provided. If the build wants a default token source without explicitly wiring the property on every invocation,
+it can set `VisualStudioDropAccessTokenFallback` (for example from a secure pipeline variable or other short-lived token source),
+and Arcade will use that value only when `VisualStudioDropAccessToken` is not explicitly supplied.
 
 The IBC data drop produced by a training run is identified by the name of the repository, the branch and the build number
 the trained binaries came from, and a training run id. An example of IBC data identifier is
@@ -849,8 +852,10 @@ The following build definition steps are required for successful generation of a
     # ... 
     /p:RepositoryName=$(Build.Repository.Name)
     /p:VisualStudioIbcSourceBranchName=$(VisualStudio.IbcSourceBranchName)
-    /p:VisualStudioDropAccessToken=$(System.AccessToken)
-    /p:VisualStudioDropName=$(VisualStudio.DropName)      # required by VS insertion component manifest generator
+    /p:VisualStudioDropName=$(VisualStudio.DropName)           # required by VS insertion component manifest generator
+    # /p:VisualStudioDropAccessToken=$(VisualStudioDropToken)   # optional explicit token override
+    env:
+      VisualStudioDropAccessTokenFallback: $(VisualStudioDropToken)  # optional fallback supplied by the pipeline
 
   # ...
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.AcquireOptimizationData.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/VisualStudio.AcquireOptimizationData.targets
@@ -8,6 +8,10 @@
       VisualStudioIbcDropId            The id of the drop. If specified, drop named 'OptimizationData/$(VisualStudioIbcRepositoryName)/$(VisualStudioIbcSourceBranchName)/$(VisualStudioIbcDropId)' is used.
                                        Otherwise, the most recent drop of name that matches 'OptimizationData/$(VisualStudioIbcRepositoryName)/$(VisualStudioIbcSourceBranchName)/*' is used.
       VisualStudioIbcDrop              The explicit drop to use. Overrides VisualStudioIbcSourceBranchName and VisualStudioIbcDropId
+      VisualStudioDropAccessToken      Optional Azure DevOps access token used to authenticate to the VS drop service.
+      VisualStudioDropAccessTokenFallback
+                                       Optional fallback token source. Used only when VisualStudioDropAccessToken is not explicitly set,
+                                       allowing the pipeline author to provide a secure default token without hard-coding the auth route.
   -->
   
   <PropertyGroup>
@@ -19,6 +23,7 @@
   <PropertyGroup>
     <EnableNgenOptimization Condition="'$(EnableNgenOptimization)' == '' and '$(Configuration)' == 'Release' and '$(OfficialBuild)' == 'true'">true</EnableNgenOptimization>
     <VisualStudioIbcRepositoryName Condition="'$(VisualStudioIbcRepositoryName)' == ''">$(RepositoryName)</VisualStudioIbcRepositoryName>
+    <VisualStudioDropAccessToken Condition="'$(VisualStudioDropAccessToken)' == '' and '$(VisualStudioDropAccessTokenFallback)' != ''">$(VisualStudioDropAccessTokenFallback)</VisualStudioDropAccessToken>
   </PropertyGroup>
   
   <!--
@@ -49,7 +54,7 @@
   </Target>
 
   <Target Name="_DownloadVisualStudioOptimizationDataOpt" Condition="$(_DropToolExists)">
-    <Error Text="VisualStudioDropAccessToken property has to be specified when EnableNgenOptimization and OfficialBuild is true" Condition="'$(VisualStudioDropAccessToken)' == '' and '$(OfficialBuild)' == 'true'"/>
+    <Error Text="VisualStudioDropAccessToken property or VisualStudioDropAccessTokenFallback property has to be specified when EnableNgenOptimization and OfficialBuild is true" Condition="'$(VisualStudioDropAccessToken)' == '' and '$(OfficialBuild)' == 'true'"/>
     <Error Text="VisualStudioIbcRepositoryName property has to be specified when EnableNgenOptimization is true and VisualStudioIbcDrop is not set" Condition="'$(VisualStudioIbcDrop)' == '' and '$(VisualStudioIbcRepositoryName)' == ''"/>
     <Error Text="VisualStudioIbcSourceBranchName property has to be specified when EnableNgenOptimization is true and VisualStudioIbcDrop is not set" Condition="'$(VisualStudioIbcDrop)' == '' and '$(VisualStudioIbcSourceBranchName)' == ''"/>
     <Error Text="VisualStudioIbcSourceBranchName property cannot be specified when using the VisualStudioIbcDrop property" Condition="'$(VisualStudioIbcDrop)' != '' and '$(VisualStudioIbcSourceBranchName)' != ''" />


### PR DESCRIPTION
## Summary
This starts the WI 10146 migration work by removing one shared long-lived PAT dependency from the Arcade VS drop path.

### Changes
- keep `VisualStudioDropAccessToken` as the explicit auth hook for VS drop access
- add `VisualStudioDropAccessTokenFallback` as an optional user-provided fallback used only when the explicit property is not set
- update the VS drop guidance in `Documentation/ArcadeSdk.md` to prefer PAT-free Artifact Services uploads with `usePat: false`

## Validation
- `get_errors` reports no issues in the edited files
- `./eng/common/dotnet.cmd build ./src/Microsoft.DotNet.Build.Tasks.VisualStudio/Microsoft.DotNet.Build.Tasks.VisualStudio.csproj -c Release -p:EnableNgenOptimization=false`

## Notes
This is the first shared-code step for WI 10146. The DevDiv consumer pipelines still need their repo-side WIF/Entra migration work and permissions updates before the PAT can be fully removed.

Refs: AB#10146