### PR TITLE
Fix Arcade daily secret sync bootstrap

### DIFF
--- a/azure-pipelines-daily.yaml
+++ b/azure-pipelines-daily.yaml
@@ -19,8 +19,13 @@ stages:
         demands: ImageOverride -equals windows.vs2026.amd64
 
       steps:
-      - script: restore.cmd -ci
-        displayName: Run restore.cmd
+      # Secret synchronization only needs the repo SDK plus local tools.
+      - task: UseDotNet@2
+        displayName: Install repo .NET SDK
+        inputs:
+          packageType: sdk
+          useGlobalJson: true
+          installationPath: $(System.DefaultWorkingDirectory)/.dotnet
 
       - task: UseDotNet@2
         displayName: Install .NET 8 runtime


### PR DESCRIPTION
## Summary
- replace the failing full restore.cmd -ci bootstrap in the daily secret-sync job
- install the repo SDK from global.json and restore local tools directly
- keep the existing secret-manager synchronize flow intact so the daily rotation job can run again

## Why
The scheduled dotnet-arcade-daily run is currently failing in the SynchronizeSecrets stage before secret rotation starts. This change narrows the bootstrap to only the SDK/runtime/tools required for secret synchronization.


Related to AB#10139
