### PR TITLE
Use repo bootstrap for Arcade daily secret sync

### DIFF
--- a/azure-pipelines-daily.yaml
+++ b/azure-pipelines-daily.yaml
@@ -25,6 +25,7 @@ stages:
         inputs:
           packageType: sdk
           useGlobalJson: true
+          includePreviewVersions: true
           installationPath: $(System.DefaultWorkingDirectory)/.dotnet
 
       - task: UseDotNet@2

--- a/azure-pipelines-daily.yaml
+++ b/azure-pipelines-daily.yaml
@@ -20,13 +20,11 @@ stages:
 
       steps:
       # Secret synchronization only needs the repo SDK plus local tools.
-      - task: UseDotNet@2
-        displayName: Install repo .NET SDK
-        inputs:
-          packageType: sdk
-          useGlobalJson: true
-          includePreviewVersions: true
-          installationPath: $(System.DefaultWorkingDirectory)/.dotnet
+      # Use the repo bootstrap so the exact preview SDK from global.json is installed reliably.
+      - script: |
+          call eng\common\dotnet.cmd --info
+          call eng\common\dotnet.cmd tool restore
+        displayName: Bootstrap repo SDK and restore dotnet tools
 
       - task: UseDotNet@2
         displayName: Install .NET 8 runtime
@@ -35,9 +33,6 @@ stages:
           version: 8.x
           installationPath: $(System.DefaultWorkingDirectory)/.dotnet
 
-      - script: dotnet tool restore
-        displayName: Restore dotnet tools
-
       - task: AzureCLI@2
         displayName: Run secret-manager synchronize
         inputs:
@@ -45,4 +40,4 @@ stages:
           scriptType: pscore
           scriptLocation: inlineScript
           inlineScript: |
-            Get-ChildItem .vault-config/*.yaml |% { dotnet secret-manager synchronize --skip-untracked $_}
+            Get-ChildItem .vault-config/*.yaml |% { & .\eng\common\dotnet.ps1 secret-manager synchronize --skip-untracked $_.FullName }


### PR DESCRIPTION
## Summary
- switch the daily secret-sync job from `UseDotNet@2` SDK acquisition to the repo's own `eng/common/dotnet` bootstrap
- restore the local dotnet tools through that same repo-pinned SDK path
- run `secret-manager` through the repo shim so the job stays on the exact SDK/toolset from `global.json`

## Why
The previous fix still failed in Azure DevOps while resolving the preview .NET 11 SDK. The repo bootstrap reliably installs the exact pinned SDK and gets the pipeline to the `secret-manager synchronize` step.

Related to AB#10139