### PR TITLE
Set MSBUILDDEBUGPATH in common build scripts for crash diagnostics

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -875,6 +875,12 @@ Create-Directory $ToolsetDir
 Create-Directory $TempDir
 Create-Directory $LogDir
 
+# Direct MSBuild crash diagnostics (MSB4166 failure.txt files) to a known location
+# under artifacts/log so they are captured as build artifacts in CI.
+if (-not $env:MSBUILDDEBUGPATH) {
+  $env:MSBUILDDEBUGPATH = Join-Path $LogDir 'MsbuildDebugLogs'
+}
+
 Write-PipelineSetVariable -Name 'Artifacts' -Value $ArtifactsDir
 Write-PipelineSetVariable -Name 'Artifacts.Toolset' -Value $ToolsetDir
 Write-PipelineSetVariable -Name 'Artifacts.Log' -Value $LogDir

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -598,6 +598,12 @@ mkdir -p "$toolset_dir"
 mkdir -p "$temp_dir"
 mkdir -p "$log_dir"
 
+# Direct MSBuild crash diagnostics (MSB4166 failure.txt files) to a known location
+# under artifacts/log so they are captured as build artifacts in CI.
+if [[ -z "${MSBUILDDEBUGPATH:-}" ]]; then
+  export MSBUILDDEBUGPATH="$log_dir/MsbuildDebugLogs"
+fi
+
 Write-PipelineSetVariable -name "Artifacts" -value "$artifacts_dir"
 Write-PipelineSetVariable -name "Artifacts.Toolset" -value "$toolset_dir"
 Write-PipelineSetVariable -name "Artifacts.Log" -value "$log_dir"


### PR DESCRIPTION
When MSBuild encounters a fatal internal error (MSB4166), it writes a `failure.txt` crash dump file. By default these go to the system temp directory, which CI pipelines typically don't collect as artifacts — making it hard to diagnose intermittent MSBuild crashes in CI.

This change sets `MSBUILDDEBUGPATH` in arcade's common build scripts (`tools.sh` and `tools.ps1`) to direct these crash diagnostics to `artifacts/log/<configuration>/MsbuildDebugLogs/`, which is already collected by CI pipelines.

Key design choices:
- **Guarded**: only sets `MSBUILDDEBUGPATH` if it isn't already defined, so repo-specific or user overrides are respected
- **No explicit mkdir**: MSBuild's `FrameworkDebugUtils.SetDebugPath()` creates the directory itself inside a try/catch when needed, avoiding `set -e` risk in bash and keeping the change minimal
- **No disk bloat**: without `MSBUILDDEBUGENGINE=1`, only crash dump files are written here (not verbose debug/scheduler logs), so the directory will be empty on healthy builds
- **Unconditional** (not CI-only): crash diagnostics are useful for local debugging too, and since only crash files land here, there's no performance or disk concern

Several repos (e.g., dotnet/runtime) already set `MSBUILDDEBUGPATH` in their own build scripts for specific subcomponents. This change provides the default for all arcade-based repos, filling the gap for top-level builds.

Relates to getting data to fix https://github.com/dotnet/runtime/issues/92290 and any other MSBuild crashes in any arcade repos
Supersedes https://github.com/dotnet/runtime/pull/126806

