### PR TITLE
Fix SignCheck EndOfStreamException on RPM symlink entries

### DIFF
--- a/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/ImageDosHeader.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Interop/PortableExecutable/ImageDosHeader.cs
@@ -101,9 +101,16 @@ namespace Microsoft.SignCheck.Interop.PortableExecutable
                 throw new ArgumentNullException("path");
             }
 
+            const int ImageDosHeaderSize = 64; // 30 × UInt16 + 1 × UInt32
             using (FileStream stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
             using (BinaryReader reader = new BinaryReader(stream))
             {
+                if (stream.Length < ImageDosHeaderSize)
+                {
+                    throw new InvalidDataException(
+                        $"File '{path}' is too small ({stream.Length} bytes) to contain a valid IMAGE_DOS_HEADER.");
+                }
+
                 reader.BaseStream.Seek(0, SeekOrigin.Begin);
 
                 var _imageDOSHeader = new IMAGE_DOS_HEADER

--- a/src/SignCheck/Microsoft.SignCheck/Verification/PortableExecutableVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/PortableExecutableVerifier.cs
@@ -37,18 +37,7 @@ namespace Microsoft.SignCheck.Verification
         {
             // Defer to the base implementation to check the AuthentiCode signature.
             SignatureVerificationResult svr = base.VerifySignature(path, parent, virtualPath);
-
-            try
-            {
-                PEHeader = new PortableExecutableHeader(svr.FullPath);
-            }
-            catch (Exception e) when (e is InvalidDataException or EndOfStreamException or IOException)
-            {
-                svr.AddDetail(DetailKeys.Error, SignCheckResources.DetailVerificationError, e.Message);
-                svr.IsSigned = false;
-                svr.AddDetail(DetailKeys.File, SignCheckResources.DetailSigned, svr.IsSigned);
-                return svr;
-            }
+            PEHeader = new PortableExecutableHeader(svr.FullPath);
 
             if (VerifyStrongNameSignature)
             {

--- a/src/SignCheck/Microsoft.SignCheck/Verification/PortableExecutableVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/PortableExecutableVerifier.cs
@@ -37,7 +37,18 @@ namespace Microsoft.SignCheck.Verification
         {
             // Defer to the base implementation to check the AuthentiCode signature.
             SignatureVerificationResult svr = base.VerifySignature(path, parent, virtualPath);
-            PEHeader = new PortableExecutableHeader(svr.FullPath);
+
+            try
+            {
+                PEHeader = new PortableExecutableHeader(svr.FullPath);
+            }
+            catch (Exception e) when (e is InvalidDataException or EndOfStreamException or IOException)
+            {
+                svr.AddDetail(DetailKeys.Error, SignCheckResources.DetailVerificationError, e.Message);
+                svr.IsSigned = false;
+                svr.AddDetail(DetailKeys.File, SignCheckResources.DetailSigned, svr.IsSigned);
+                return svr;
+            }
 
             if (VerifyStrongNameSignature)
             {

--- a/src/SignCheck/Microsoft.SignCheck/Verification/RpmVerifier.cs
+++ b/src/SignCheck/Microsoft.SignCheck/Verification/RpmVerifier.cs
@@ -24,11 +24,18 @@ namespace Microsoft.SignCheck.Verification
 
             using var stream = File.Open(archivePath, FileMode.Open);
             using RpmPackage rpmPackage = RpmPackage.Read(stream);
-            using var dataStream = File.Create(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
             using var archive = new CpioReader(rpmPackage.ArchiveStream, leaveOpen: false);
 
             while (archive.GetNextEntry() is CpioEntry entry)
             {
+                // Only yield regular files. Symlink entries contain just the target
+                // path string as data (not actual file content), which would be
+                // written to disk as a tiny file and break PE verification.
+                if ((entry.Mode & CpioEntry.FileKindMask) != CpioEntry.RegularFile)
+                {
+                    continue;
+                }
+
                 yield return new ArchiveEntry()
                 {
                     RelativePath = entry.Name,


### PR DESCRIPTION
## Problem

\RpmVerifier.ReadArchiveEntries\ yielded **all** CPIO entries from RPM payloads—including symlinks. In CPIO format, symlink entries contain just the target path string as data (e.g. \../../shared/foo.dll\, ~30 bytes), not actual file content. These got extracted to disk as tiny text files that then failed PE header parsing with \EndOfStreamException\, producing thousands of noisy errors like:

\\\
Outcome=\"Unsigned\" Error=\"Verification error: System.IO.EndOfStreamException: Unable to read beyond the end of the stream.
   at System.IO.BinaryReader.ReadUInt32()
   at Microsoft.SignCheck.Interop.PortableExecutable.IMAGE_DOS_HEADER.Read(String path)
   ...
\\\

The .NET SDK RPMs contain thousands of symlinked \.dll\ files, explaining the massive error volume.

## Fix

**Root cause** (\RpmVerifier.cs\):
- Filter CPIO entries to regular files only using the entry's mode field (\CpioEntry.FileKindMask\ / \CpioEntry.RegularFile\). This skips symlinks, directories, and other non-file entry types.
- Removed an unused \File.Create\ call that was creating a stray temp file.

**Defense-in-depth** (\ImageDosHeader.cs\):
- Validate file size >= 64 bytes in \IMAGE_DOS_HEADER.Read\ before attempting to read, producing a clear \InvalidDataException\ instead of the confusing \EndOfStreamException\ from \BinaryReader\.