### PR TITLE
Fix Arcade bootstrap regressions

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
@@ -55,14 +55,14 @@
     <_BuildNumberR>$(_BuildNumber.Substring(9))</_BuildNumberR>
 
     <!-- SHORT_DATE := yy * 1000 + mm * 50 + dd -->
-    <VersionSuffixDateStamp>$([MSBuild]::Add($([MSBuild]::Add($([MSBuild]::Multiply($(_BuildNumberYY), 1000)), $([MSBuild]::Multiply($(_BuildNumberMM), 50)))), $(_BuildNumberDD)))</VersionSuffixDateStamp>
+    <VersionSuffixDateStamp>$([System.Decimal]::Add($([System.Decimal]::Add($([System.Decimal]::Multiply($(_BuildNumberYY), 1000)), $([System.Decimal]::Multiply($(_BuildNumberMM), 50))), $(_BuildNumberDD)))</VersionSuffixDateStamp>
 
     <!-- REVISION := r -->
     <VersionSuffixBuildOfTheDay>$(_BuildNumberR)</VersionSuffixBuildOfTheDay>
     <VersionSuffixBuildOfTheDayPadded>$(VersionSuffixBuildOfTheDay.PadLeft(2, $([System.Convert]::ToChar(`0`))))</VersionSuffixBuildOfTheDayPadded>
 
     <!-- PATCH_NUMBER := (SHORT_DATE - VersionBaseShortDate) * 100 + r -->
-    <_PatchNumber>$([MSBuild]::Add($([MSBuild]::Multiply($([MSBuild]::Subtract($(VersionSuffixDateStamp), $([MSBuild]::ValueOrDefault($(VersionBaseShortDate), 19000)))), 100)), $(_BuildNumberR)))</_PatchNumber>
+    <_PatchNumber>$([System.Decimal]::Add($([System.Decimal]::Multiply($([System.Decimal]::Subtract($(VersionSuffixDateStamp), $([MSBuild]::ValueOrDefault($(VersionBaseShortDate), 19000)))), 100)), $(_BuildNumberR)))</_PatchNumber>
   </PropertyGroup>
 
   <!--

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/Microsoft.DotNet.Build.Tasks.Workloads.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/Microsoft.DotNet.Build.Tasks.Workloads.Tests.csproj
@@ -33,15 +33,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="testassets\**\*" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="testassets\**\*" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>
 
   <!--
-    Defer staging package-cache test assets until build execution so one-shot
-    restore+build CI runs don't glob the nupkgs too early, but Helix test runs
-    still get the files copied into the testassets directory.
+    Defer discovering package-cache test assets until build execution so one-shot
+    restore+build CI runs don't glob the nupkgs too early, while both build and
+    publish outputs still include the files for Helix test runs.
   -->
-  <Target Name="StageDownloadedTestAssets" BeforeTargets="CopyFilesToOutputDirectory">
+  <Target Name="StageDownloadedTestAssets" AfterTargets="Build;Publish">
     <ItemGroup>
       <_DownloadedWixTools Include="$(NuGetPackageRoot)microsoft.signed.wix\$(MicrosoftSignedWixVersion)\tools\**\*" />
       <_DownloadedTestAssetPackage Include="$(NuGetPackageRoot)microsoft.net.workload.mono.toolchain.manifest-6.0.200\$(MicrosoftNETWorkloadMonoToolChainManifest_60200Version)\*.nupkg" />
@@ -66,6 +66,18 @@
     <Copy
       SourceFiles="@(_DownloadedTestAssetPackage)"
       DestinationFiles="@(_DownloadedTestAssetPackage->'$(TargetDir)testassets\%(Filename)%(Extension)')"
+      SkipUnchangedFiles="true" />
+
+    <Copy
+      Condition="'$(PublishDir)' != ''"
+      SourceFiles="@(_DownloadedWixTools)"
+      DestinationFiles="@(_DownloadedWixTools->'$(PublishDir)testassets\wix\%(RecursiveDir)%(Filename)%(Extension)')"
+      SkipUnchangedFiles="true" />
+
+    <Copy
+      Condition="'$(PublishDir)' != ''"
+      SourceFiles="@(_DownloadedTestAssetPackage)"
+      DestinationFiles="@(_DownloadedTestAssetPackage->'$(PublishDir)testassets\%(Filename)%(Extension)')"
       SkipUnchangedFiles="true" />
   </Target>
 

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/Microsoft.DotNet.Build.Tasks.Workloads.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/Microsoft.DotNet.Build.Tasks.Workloads.Tests.csproj
@@ -34,20 +34,30 @@
 
   <ItemGroup>
     <Content Include="testassets\**\*" CopyToOutputDirectory="PreserveNewest" />
-    <Content Include="$(NuGetPackageRoot)microsoft.signed.wix\$(MicrosoftSignedWixVersion)\tools\**\*" Link="testassets\wix\%(RecursiveDir)%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
-    <Content Include="$(NuGetPackageRoot)microsoft.net.workload.mono.toolchain.manifest-6.0.200\$(MicrosoftNETWorkloadMonoToolChainManifest_60200Version)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
-    <Content Include="$(NuGetPackageRoot)microsoft.net.workload.mono.toolchain.manifest-6.0.200\$(MicrosoftNETWorkloadMonoToolChainManifest_60200Version_604)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
-    <Content Include="$(NuGetPackageRoot)microsoft.net.workload.mono.toolchain.manifest-6.0.300\$(MicrosoftNETWorkloadMonoToolChainManifest_60300Version_6022)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
-    <Content Include="$(NuGetPackageRoot)microsoft.net.workload.mono.toolchain.manifest-6.0.300\$(MicrosoftNETWorkloadMonoToolChainManifest_60300Version_6021)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
-    <Content Include="$(NuGetPackageRoot)microsoft.ios.templates\$(MicrosoftiOSTemplatesVersion)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
-    <Content Include="$(NuGetPackageRoot)microsoft.ios.templates\$(MicrosoftiOSTemplatesVersion160527)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
-    <Content Include="$(NuGetPackageRoot)microsoft.net.workload.emscripten.manifest-6.0.200\$(MicrosoftNETWorkloadEmscriptenManifest_60200Version)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
-    <Content Include="$(NuGetPackageRoot)microsoft.net.workload.emscripten.net6.manifest-8.0.100-preview.6\$(MicrosoftNETWorkloadEmscriptenManifest_80100Preview6Version)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
-    <Content Include="$(NuGetPackageRoot)microsoft.net.runtime.emscripten.2.0.23.node.win-x64\$(MicrosoftNETRuntimeEmscripten2023Nodewin_x64)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
-    <Content Include="$(NuGetPackageRoot)microsoft.net.runtime.emscripten.2.0.23.python.win-x64\$(MicrosoftNETRuntimeEmscripten2023Pythonwin_x64)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
-    <Content Include="$(NuGetPackageRoot)microsoft.net.runtime.emscripten.2.0.23.sdk.win-x64\$(MicrosoftNETRuntimeEmscripten2023Sdkwin_x64)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
-    <Content Include="$(NuGetPackageRoot)microsoft.net.workloads.9.0.100\$(MicrosoftNETWorkloadBaselineVersion)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
   </ItemGroup>
+
+  <!--
+    Defer globbing package-cache test assets until build execution so one-shot
+    restore+build CI runs don't try to copy the .nupkgs before PackageDownload
+    has materialized them on disk.
+  -->
+  <Target Name="AddDownloadedTestAssets" BeforeTargets="GetCopyToOutputDirectoryItems">
+    <ItemGroup>
+      <Content Include="$(NuGetPackageRoot)microsoft.signed.wix\$(MicrosoftSignedWixVersion)\tools\**\*" Link="testassets\wix\%(RecursiveDir)%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+      <Content Include="$(NuGetPackageRoot)microsoft.net.workload.mono.toolchain.manifest-6.0.200\$(MicrosoftNETWorkloadMonoToolChainManifest_60200Version)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+      <Content Include="$(NuGetPackageRoot)microsoft.net.workload.mono.toolchain.manifest-6.0.200\$(MicrosoftNETWorkloadMonoToolChainManifest_60200Version_604)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+      <Content Include="$(NuGetPackageRoot)microsoft.net.workload.mono.toolchain.manifest-6.0.300\$(MicrosoftNETWorkloadMonoToolChainManifest_60300Version_6022)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+      <Content Include="$(NuGetPackageRoot)microsoft.net.workload.mono.toolchain.manifest-6.0.300\$(MicrosoftNETWorkloadMonoToolChainManifest_60300Version_6021)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+      <Content Include="$(NuGetPackageRoot)microsoft.ios.templates\$(MicrosoftiOSTemplatesVersion)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+      <Content Include="$(NuGetPackageRoot)microsoft.ios.templates\$(MicrosoftiOSTemplatesVersion160527)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+      <Content Include="$(NuGetPackageRoot)microsoft.net.workload.emscripten.manifest-6.0.200\$(MicrosoftNETWorkloadEmscriptenManifest_60200Version)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+      <Content Include="$(NuGetPackageRoot)microsoft.net.workload.emscripten.net6.manifest-8.0.100-preview.6\$(MicrosoftNETWorkloadEmscriptenManifest_80100Preview6Version)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+      <Content Include="$(NuGetPackageRoot)microsoft.net.runtime.emscripten.2.0.23.node.win-x64\$(MicrosoftNETRuntimeEmscripten2023Nodewin_x64)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+      <Content Include="$(NuGetPackageRoot)microsoft.net.runtime.emscripten.2.0.23.python.win-x64\$(MicrosoftNETRuntimeEmscripten2023Pythonwin_x64)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+      <Content Include="$(NuGetPackageRoot)microsoft.net.runtime.emscripten.2.0.23.sdk.win-x64\$(MicrosoftNETRuntimeEmscripten2023Sdkwin_x64)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+      <Content Include="$(NuGetPackageRoot)microsoft.net.workloads.9.0.100\$(MicrosoftNETWorkloadBaselineVersion)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+    </ItemGroup>
+  </Target>
 
   <ItemGroup>
     <None Remove="testassets\AliasedPacks.json" />

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/Microsoft.DotNet.Build.Tasks.Workloads.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads.Tests/Microsoft.DotNet.Build.Tasks.Workloads.Tests.csproj
@@ -37,26 +37,36 @@
   </ItemGroup>
 
   <!--
-    Defer globbing package-cache test assets until build execution so one-shot
-    restore+build CI runs don't try to copy the .nupkgs before PackageDownload
-    has materialized them on disk.
+    Defer staging package-cache test assets until build execution so one-shot
+    restore+build CI runs don't glob the nupkgs too early, but Helix test runs
+    still get the files copied into the testassets directory.
   -->
-  <Target Name="AddDownloadedTestAssets" BeforeTargets="GetCopyToOutputDirectoryItems">
+  <Target Name="StageDownloadedTestAssets" BeforeTargets="CopyFilesToOutputDirectory">
     <ItemGroup>
-      <Content Include="$(NuGetPackageRoot)microsoft.signed.wix\$(MicrosoftSignedWixVersion)\tools\**\*" Link="testassets\wix\%(RecursiveDir)%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
-      <Content Include="$(NuGetPackageRoot)microsoft.net.workload.mono.toolchain.manifest-6.0.200\$(MicrosoftNETWorkloadMonoToolChainManifest_60200Version)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
-      <Content Include="$(NuGetPackageRoot)microsoft.net.workload.mono.toolchain.manifest-6.0.200\$(MicrosoftNETWorkloadMonoToolChainManifest_60200Version_604)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
-      <Content Include="$(NuGetPackageRoot)microsoft.net.workload.mono.toolchain.manifest-6.0.300\$(MicrosoftNETWorkloadMonoToolChainManifest_60300Version_6022)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
-      <Content Include="$(NuGetPackageRoot)microsoft.net.workload.mono.toolchain.manifest-6.0.300\$(MicrosoftNETWorkloadMonoToolChainManifest_60300Version_6021)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
-      <Content Include="$(NuGetPackageRoot)microsoft.ios.templates\$(MicrosoftiOSTemplatesVersion)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
-      <Content Include="$(NuGetPackageRoot)microsoft.ios.templates\$(MicrosoftiOSTemplatesVersion160527)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
-      <Content Include="$(NuGetPackageRoot)microsoft.net.workload.emscripten.manifest-6.0.200\$(MicrosoftNETWorkloadEmscriptenManifest_60200Version)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
-      <Content Include="$(NuGetPackageRoot)microsoft.net.workload.emscripten.net6.manifest-8.0.100-preview.6\$(MicrosoftNETWorkloadEmscriptenManifest_80100Preview6Version)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
-      <Content Include="$(NuGetPackageRoot)microsoft.net.runtime.emscripten.2.0.23.node.win-x64\$(MicrosoftNETRuntimeEmscripten2023Nodewin_x64)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
-      <Content Include="$(NuGetPackageRoot)microsoft.net.runtime.emscripten.2.0.23.python.win-x64\$(MicrosoftNETRuntimeEmscripten2023Pythonwin_x64)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
-      <Content Include="$(NuGetPackageRoot)microsoft.net.runtime.emscripten.2.0.23.sdk.win-x64\$(MicrosoftNETRuntimeEmscripten2023Sdkwin_x64)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
-      <Content Include="$(NuGetPackageRoot)microsoft.net.workloads.9.0.100\$(MicrosoftNETWorkloadBaselineVersion)\*.nupkg" Link="testassets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+      <_DownloadedWixTools Include="$(NuGetPackageRoot)microsoft.signed.wix\$(MicrosoftSignedWixVersion)\tools\**\*" />
+      <_DownloadedTestAssetPackage Include="$(NuGetPackageRoot)microsoft.net.workload.mono.toolchain.manifest-6.0.200\$(MicrosoftNETWorkloadMonoToolChainManifest_60200Version)\*.nupkg" />
+      <_DownloadedTestAssetPackage Include="$(NuGetPackageRoot)microsoft.net.workload.mono.toolchain.manifest-6.0.200\$(MicrosoftNETWorkloadMonoToolChainManifest_60200Version_604)\*.nupkg" />
+      <_DownloadedTestAssetPackage Include="$(NuGetPackageRoot)microsoft.net.workload.mono.toolchain.manifest-6.0.300\$(MicrosoftNETWorkloadMonoToolChainManifest_60300Version_6022)\*.nupkg" />
+      <_DownloadedTestAssetPackage Include="$(NuGetPackageRoot)microsoft.net.workload.mono.toolchain.manifest-6.0.300\$(MicrosoftNETWorkloadMonoToolChainManifest_60300Version_6021)\*.nupkg" />
+      <_DownloadedTestAssetPackage Include="$(NuGetPackageRoot)microsoft.ios.templates\$(MicrosoftiOSTemplatesVersion)\*.nupkg" />
+      <_DownloadedTestAssetPackage Include="$(NuGetPackageRoot)microsoft.ios.templates\$(MicrosoftiOSTemplatesVersion160527)\*.nupkg" />
+      <_DownloadedTestAssetPackage Include="$(NuGetPackageRoot)microsoft.net.workload.emscripten.manifest-6.0.200\$(MicrosoftNETWorkloadEmscriptenManifest_60200Version)\*.nupkg" />
+      <_DownloadedTestAssetPackage Include="$(NuGetPackageRoot)microsoft.net.workload.emscripten.net6.manifest-8.0.100-preview.6\$(MicrosoftNETWorkloadEmscriptenManifest_80100Preview6Version)\*.nupkg" />
+      <_DownloadedTestAssetPackage Include="$(NuGetPackageRoot)microsoft.net.runtime.emscripten.2.0.23.node.win-x64\$(MicrosoftNETRuntimeEmscripten2023Nodewin_x64)\*.nupkg" />
+      <_DownloadedTestAssetPackage Include="$(NuGetPackageRoot)microsoft.net.runtime.emscripten.2.0.23.python.win-x64\$(MicrosoftNETRuntimeEmscripten2023Pythonwin_x64)\*.nupkg" />
+      <_DownloadedTestAssetPackage Include="$(NuGetPackageRoot)microsoft.net.runtime.emscripten.2.0.23.sdk.win-x64\$(MicrosoftNETRuntimeEmscripten2023Sdkwin_x64)\*.nupkg" />
+      <_DownloadedTestAssetPackage Include="$(NuGetPackageRoot)microsoft.net.workloads.9.0.100\$(MicrosoftNETWorkloadBaselineVersion)\*.nupkg" />
     </ItemGroup>
+
+    <Copy
+      SourceFiles="@(_DownloadedWixTools)"
+      DestinationFiles="@(_DownloadedWixTools->'$(TargetDir)testassets\wix\%(RecursiveDir)%(Filename)%(Extension)')"
+      SkipUnchangedFiles="true" />
+
+    <Copy
+      SourceFiles="@(_DownloadedTestAssetPackage)"
+      DestinationFiles="@(_DownloadedTestAssetPackage->'$(TargetDir)testassets\%(Filename)%(Extension)')"
+      SkipUnchangedFiles="true" />
   </Target>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Msi/MsiBase.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Msi/MsiBase.wix.cs
@@ -128,6 +128,8 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Msi
             // Candle expects the output path to be terminated with a single '\'.
             CompilerOutputPath = Utils.EnsureTrailingSlash(Path.Combine(baseIntermediateOutputPath, "wixobj", metadata.Id, $"{metadata.PackageVersion}", platform));
             WixSourceDirectory = Path.Combine(baseIntermediateOutputPath, "src", "wix", metadata.Id, $"{metadata.PackageVersion}", platform);
+            Directory.CreateDirectory(CompilerOutputPath);
+            Directory.CreateDirectory(WixSourceDirectory);
             Metadata = metadata;
         }
 


### PR DESCRIPTION
## Summary
- fix preview MSBuild version stamping during Arcade bootstrap
- defer workload test asset package discovery until build execution
- unblock the Validate Arcade SDK self-bootstrap path

## Validation
- local bootstrap repro passed
- PR validation requested on this branch