### PR TITLE
Extend workitem list API with `ExitCode` and `ConsoleOutputUri`

### DIFF
--- a/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/WorkItemSummary.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/generated-code/Models/WorkItemSummary.cs
@@ -20,6 +20,12 @@ namespace Microsoft.DotNet.Helix.Client.Models
         [JsonProperty("DetailsUrl")]
         public string DetailsUrl { get; set; }
 
+        [JsonProperty("ExitCode")]
+        public int? ExitCode { get; set; }
+
+        [JsonProperty("ConsoleOutputUri")]
+        public string ConsoleOutputUri { get; set; }
+
         [JsonProperty("Job")]
         public string Job { get; set; }
 


### PR DESCRIPTION
The `/workitems` endpoint has been extended with optional `ExitCode` and `ConsoleOutputUri` fields so that it's no longer necessary to query the details of work items one by one

https://dev.azure.com/dnceng/internal/_git/dotnet-helix-service/pullrequest/58528