### PR TITLE
Fix CG alerts on release/9.0

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -18,5 +18,12 @@
      <!-- This package is upgraded to latest versions in product build and can be baselined for 
       the repo build. -->
     <UsagePattern IdentityGlob="System.IO.Packaging/*7.0.0*" />
+
+    <!-- These packages are updated for security patching (CVE-2026-33116, CVE-2026-26171) and
+      will be source-built in the product build. -->
+    <UsagePattern IdentityGlob="Microsoft.Bcl.Cryptography/*9.0.15*" />
+    <UsagePattern IdentityGlob="System.Formats.Asn1/*9.0.15*" />
+    <UsagePattern IdentityGlob="System.Security.Cryptography.Pkcs/*9.0.15*" />
+    <UsagePattern IdentityGlob="System.Security.Cryptography.Xml/*9.0.15*" />
   </IgnorePatterns>
 </UsageData>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -35,11 +35,11 @@
     <!-- nuget -->
     <!-- Important: Don't version higher than what's available in the toolset SDK as
          NuGet assemblies aren't redistributed with .NETCoreApp msbuild tasks. -->
-    <NuGetCommandsVersion>6.11.0</NuGetCommandsVersion>
-    <NuGetFrameworksVersion>6.11.0</NuGetFrameworksVersion>
-    <NuGetPackagingVersion>6.11.0</NuGetPackagingVersion>
-    <NuGetProjectModelVersion>6.11.0</NuGetProjectModelVersion>
-    <NuGetVersioningVersion>6.11.0</NuGetVersioningVersion>
+    <NuGetCommandsVersion>6.11.2</NuGetCommandsVersion>
+    <NuGetFrameworksVersion>6.11.2</NuGetFrameworksVersion>
+    <NuGetPackagingVersion>6.11.2</NuGetPackagingVersion>
+    <NuGetProjectModelVersion>6.11.2</NuGetProjectModelVersion>
+    <NuGetVersioningVersion>6.11.2</NuGetVersioningVersion>
     <!-- roslyn -->
     <MicrosoftCodeAnalysisCSharpVersion>4.8.0</MicrosoftCodeAnalysisCSharpVersion>
     <MicrosoftNetCompilersToolsetVersion>4.8.0</MicrosoftNetCompilersToolsetVersion>
@@ -69,7 +69,7 @@
     <SystemIOPackagingVersion>9.0.0-rc.2.24473.5</SystemIOPackagingVersion>
     <SystemReflectionMetadataVersion>9.0.0-rc.2.24473.5</SystemReflectionMetadataVersion>
     <SystemSecurityCryptographyPkcsVersion>9.0.0-rc.2.24473.5</SystemSecurityCryptographyPkcsVersion>
-    <SystemSecurityCryptographyXmlVersion>9.0.0-rc.2.24473.5</SystemSecurityCryptographyXmlVersion>
+    <SystemSecurityCryptographyXmlVersion>9.0.15</SystemSecurityCryptographyXmlVersion>
     <SystemTextEncodingsWebVersion>9.0.0-rc.2.24473.5</SystemTextEncodingsWebVersion>
     <SystemTextJsonVersion>9.0.0-rc.2.24473.5</SystemTextJsonVersion>
     <SystemFormatsAsn1Version>9.0.0-rc.2.24473.5</SystemFormatsAsn1Version>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -72,7 +72,7 @@
     <SystemSecurityCryptographyXmlVersion>9.0.15</SystemSecurityCryptographyXmlVersion>
     <SystemTextEncodingsWebVersion>9.0.0-rc.2.24473.5</SystemTextEncodingsWebVersion>
     <SystemTextJsonVersion>9.0.0-rc.2.24473.5</SystemTextJsonVersion>
-    <SystemFormatsAsn1Version>9.0.0-rc.2.24473.5</SystemFormatsAsn1Version>
+    <SystemFormatsAsn1Version>9.0.15</SystemFormatsAsn1Version>
     <!-- sdk -->
     <MicrosoftNETSdkWorkloadManifestReaderVersion>9.0.100-preview.6.24328.19</MicrosoftNETSdkWorkloadManifestReaderVersion>
     <!-- source-build-externals -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -68,7 +68,7 @@
     <SystemCompositionVersion>9.0.0-preview.6.24327.7</SystemCompositionVersion>
     <SystemIOPackagingVersion>9.0.0-rc.2.24473.5</SystemIOPackagingVersion>
     <SystemReflectionMetadataVersion>9.0.0-rc.2.24473.5</SystemReflectionMetadataVersion>
-    <SystemSecurityCryptographyPkcsVersion>9.0.0-rc.2.24473.5</SystemSecurityCryptographyPkcsVersion>
+    <SystemSecurityCryptographyPkcsVersion>9.0.15</SystemSecurityCryptographyPkcsVersion>
     <SystemSecurityCryptographyXmlVersion>9.0.15</SystemSecurityCryptographyXmlVersion>
     <SystemTextEncodingsWebVersion>9.0.0-rc.2.24473.5</SystemTextEncodingsWebVersion>
     <SystemTextJsonVersion>9.0.0-rc.2.24473.5</SystemTextJsonVersion>

--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "9.0.115",
+    "version": "9.0.116",
     "rollForward": "latestFeature"
   },
   "tools": {
-    "dotnet": "9.0.115"
+    "dotnet": "9.0.116"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.26180.1",


### PR DESCRIPTION
## Summary

Bump vulnerable package versions to resolve Component Governance alerts on the release/9.0 branch.

### Changes

| Package | Old Version | New Version | Advisory |
|---|---|---|---|
| NuGet.Commands | 6.11.0 | 6.11.2 | [GHSA-g4vj-cjjj-v7hg](https://github.com/advisories/GHSA-g4vj-cjjj-v7hg) |
| NuGet.Frameworks | 6.11.0 | 6.11.2 | GHSA-g4vj-cjjj-v7hg |
| NuGet.Packaging | 6.11.0 | 6.11.2 | GHSA-g4vj-cjjj-v7hg |
| NuGet.ProjectModel | 6.11.0 | 6.11.2 | GHSA-g4vj-cjjj-v7hg |
| NuGet.Versioning | 6.11.0 | 6.11.2 | GHSA-g4vj-cjjj-v7hg |
| System.Security.Cryptography.Xml | 9.0.0-rc.2.24473.5 | 9.0.15 | [CVE-2026-33116](https://github.com/advisories/GHSA-37gx-xxp4-5rgx), [CVE-2026-26171](https://github.com/advisories/GHSA-w3x6-4m5h-cxqf) |
| .NET SDK | 9.0.115 | 9.0.116 | DOTNET-Security-9.0 |