### PR TITLE
Restrict ConditionalMemberKinds to reflect what ConditionalTestDiscoverer reflects on

### DIFF
--- a/src/Microsoft.DotNet.XUnitExtensions.Shared/StaticReflectionConstants.cs
+++ b/src/Microsoft.DotNet.XUnitExtensions.Shared/StaticReflectionConstants.cs
@@ -8,7 +8,8 @@ namespace Xunit
     internal static class StaticReflectionConstants
     {
         // ConditionalTestDiscoverer looks at all fields/methods/properties, recursively.
-        internal const DynamicallyAccessedMemberTypes ConditionalMemberKinds = DynamicallyAccessedMemberTypes.All;
+        internal const DynamicallyAccessedMemberTypes ConditionalMemberKinds =
+            DynamicallyAccessedMemberTypes.AllMethods | DynamicallyAccessedMemberTypes.AllFields | DynamicallyAccessedMemberTypes.AllProperties;
     }
 }
 
@@ -41,6 +42,20 @@ namespace System.Diagnostics.CodeAnalysis
         PublicEvents = 0x0800,
         NonPublicEvents = 0x1000,
         Interfaces = 0x2000,
+        NonPublicConstructorsWithInherited = NonPublicConstructors | 0x4000,
+        NonPublicMethodsWithInherited = NonPublicMethods | 0x8000,
+        NonPublicFieldsWithInherited = NonPublicFields | 0x10000,
+        NonPublicNestedTypesWithInherited = NonPublicNestedTypes | 0x20000,
+        NonPublicPropertiesWithInherited = NonPublicProperties | 0x40000,
+        NonPublicEventsWithInherited = NonPublicEvents | 0x80000,
+        PublicConstructorsWithInherited = PublicConstructors | 0x100000,
+        PublicNestedTypesWithInherited = PublicNestedTypes | 0x200000,
+        AllConstructors = PublicConstructorsWithInherited | NonPublicConstructorsWithInherited,
+        AllMethods = PublicMethods | NonPublicMethodsWithInherited,
+        AllFields = PublicFields | NonPublicFieldsWithInherited,
+        AllNestedTypes = PublicNestedTypesWithInherited | NonPublicNestedTypesWithInherited,
+        AllProperties = PublicProperties | NonPublicPropertiesWithInherited,
+        AllEvents = PublicEvents | NonPublicEventsWithInherited,
         All = ~None
     }
 }


### PR DESCRIPTION
Matching code is this:

https://github.com/dotnet/arcade/blob/302c3502814a662725657511a2f71978a41a66d4/src/Microsoft.DotNet.XUnitExtensions.Shared/Discoverers/ConditionalTestDiscoverer.cs#L170-L190

It doesn't flow through because xUnit abstracts away reflection.

The capture is unnecessarily broad and causes spurious warnings in dotnet/runtime repo.

Cc @dotnet/illink 