### PR TITLE
Add .cab to default FileExtensionSignInfo for signing

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/toolset/Sign.props
+++ b/src/Microsoft.DotNet.Arcade.Sdk/toolset/Sign.props
@@ -83,7 +83,7 @@
     <FileExtensionSignInfo Include=".deb" CertificateName="LinuxSign" />
     <FileExtensionSignInfo Include=".jar" CertificateName="MicrosoftJARSHA2" />
     <FileExtensionSignInfo Include=".ps1;.psd1;.psm1;.psc1;.py" CertificateName="Microsoft400" />
-    <FileExtensionSignInfo Include=".dll;.exe;.mibc;.msi" CertificateName="Microsoft400" />
+    <FileExtensionSignInfo Include=".dll;.exe;.mibc;.msi;.cab" CertificateName="Microsoft400" />
     <FileExtensionSignInfo Include=".nupkg" CertificateName="NuGet" />
     <FileExtensionSignInfo Include=".vsix" CertificateName="VsixSHA2" />
     <FileExtensionSignInfo Include=".zip" CertificateName="None" />


### PR DESCRIPTION
## Problem

Cabinet (.cab) files inside MSI containers are signable via Authenticode but are not included in the Arcade SDK's default `FileExtensionSignInfo` entries. This causes the SignTool to skip .cab files in all Arcade-based repos that produce MSIs, resulting in unsigned cabs flagged by the VS signing compliance scan.

This affects multiple repos: dotnet/runtime, dotnet/emsdk, dotnet/macios, dotnet/aspnetcore, and potentially the SDK — each producing WiX MSIs with embedded cabs that go unsigned.

## Fix

Add `.cab` to the existing `.dll;.exe;.mibc;.msi` line in `src/Microsoft.DotNet.Arcade.Sdk/toolset/Sign.props`:

```xml
<FileExtensionSignInfo Include=".dll;.exe;.mibc;.msi;.cab" CertificateName="Microsoft400" />
```

This ensures all Arcade-based repos get correct cab signing by default. Repos that set `UseDotNetCertificate=true` will automatically use `MicrosoftDotNet500` instead.

## Context

Suggested by @jkoritzinsky in dotnet/runtime#127242 — rather than adding `.cab` per-repo in each `eng/Signing.props`, centralizing it in Arcade fixes all repos at once and covers future repos automatically.

## Tracking

VS signing compliance: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2911494
