### PR TITLE
Use -Svc pool for release/10.0 builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ extends:
     settings:
       networkIsolationPolicy: Permissive, CFSClean, CFSClean2
     pool:
-      name: $(DncEngInternalBuildPool)
+      name: NetCore1ESPool-Svc-Internal
       image: windows.vs2026.amd64
       os: windows
     sdl:

--- a/eng/validate-sdk.yml
+++ b/eng/validate-sdk.yml
@@ -28,7 +28,7 @@ jobs:
     - _ValidateBlobFeedUrl: ${{ parameters.validateBlobFeedUrl }}
     - template: /eng/common/templates-official/variables/pool-providers.yml@self
     pool:
-      name: $(DncEngInternalBuildPool)
+      name: NetCore1ESPool-Svc-Internal
       demands: ImageOverride -equals windows.vs2026.amd64
     preSteps:
     - checkout: self

--- a/eng/xcopy-msbuild/azure-pipelines-xcopy-msbuild.yml
+++ b/eng/xcopy-msbuild/azure-pipelines-xcopy-msbuild.yml
@@ -21,7 +21,7 @@ jobs:
 - job: Build
   displayName: Build xcopy-msbuild package
   pool: 
-    name: NetCore1ESPool-Internal
+    name: NetCore1ESPool-Svc-Internal
     demands: ImageOverride -equals windows.vs2026.amd64
   steps:
     - task: PowerShell@2


### PR DESCRIPTION
Servicing branches should use `-Svc` pools for proper billing separation (COGS) and queue isolation. The dynamic `pool-providers.yml` expression was not correctly routing these builds to the -Svc pool, resulting in arcade release builds running on R&D pools (`NetCore1ESPool-Internal`) instead of servicing pools (`NetCore1ESPool-Svc-Internal`).

This PR hardcodes `NetCore1ESPool-Svc-Internal` directly in `azure-pipelines.yml` and `eng/validate-sdk.yml` since this branch will always be a servicing branch.

**Files changed:**
- `azure-pipelines.yml` - Pool in extends.parameters.pool
- `eng/validate-sdk.yml` - Pool in ValidateArcadeSDK job