### PR TITLE
Switch publish jobs to -Svc pools for release/8.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ extends:
     settings:
       networkIsolationPolicy: Permissive, CFSClean, CFSClean2
     pool:
-      name: $(DncEngInternalBuildPool)
+      name: NetCore1ESPool-Svc-Internal
       image: windows.vs2022.amd64
       os: windows
     sdl:

--- a/eng/common/templates-official/job/publish-build-assets.yml
+++ b/eng/common/templates-official/job/publish-build-assets.yml
@@ -69,7 +69,7 @@ jobs:
       os: windows
     # If it's not devdiv, it's dnceng
     ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
-      name: NetCore1ESPool-Publishing-Internal
+      name: $(DncEngInternalBuildPool)
       image: windows.vs2022.amd64
       os: windows
   steps:

--- a/eng/common/templates-official/post-build/post-build.yml
+++ b/eng/common/templates-official/post-build/post-build.yml
@@ -260,7 +260,7 @@ stages:
           os: windows
         # If it's not devdiv, it's dnceng
         ${{ else }}:
-          name: NetCore1ESPool-Publishing-Internal
+          name: $(DncEngInternalBuildPool)
           image: windows.vs2022.amd64
           os: windows
       steps:

--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -67,7 +67,7 @@ jobs:
       demands: Cmd
     # If it's not devdiv, it's dnceng
     ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
-      name: NetCore1ESPool-Publishing-Internal
+      name: $(DncEngInternalBuildPool)
       demands: ImageOverride -equals windows.vs2022.amd64
 
   steps:

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -257,7 +257,7 @@ stages:
           demands: Cmd
         # If it's not devdiv, it's dnceng
         ${{ else }}:
-          name: NetCore1ESPool-Publishing-Internal
+          name: $(DncEngInternalBuildPool)
           demands: ImageOverride -equals windows.vs2022.amd64
       steps:
         - template: setup-maestro-vars.yml

--- a/eng/validate-sdk.yml
+++ b/eng/validate-sdk.yml
@@ -25,7 +25,7 @@ jobs:
     - _ValidateBlobFeedUrl: ${{ parameters.validateBlobFeedUrl }}
     - template: /eng/common/templates-official/variables/pool-providers.yml@self
     pool:
-      name: $(DncEngInternalBuildPool)
+      name: NetCore1ESPool-Svc-Internal
       demands: ImageOverride -equals windows.vs2022.amd64
     preSteps:
     - checkout: self


### PR DESCRIPTION
Replace hardcoded `NetCore1ESPool-Publishing-Internal` with the `DncEngInternalBuildPool` variable so publish/post-build jobs use -Svc pools on release branches via `pool-providers.yml` dynamic resolution.

### Changes
- `publish-build-assets.yml`: `NetCore1ESPool-Publishing-Internal` → ``
- `post-build.yml`: `NetCore1ESPool-Publishing-Internal` → ``

### Context
The Publish Assets stage was hardcoded to use `NetCore1ESPool-Publishing-Internal` regardless of branch. Since `pool-providers.yml` is already imported in these templates, using the variable ensures release branch builds run on -Svc pools as intended.