### PR TITLE
Bump .NET SDK to 8.0.126

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "8.0.125",
+    "version": "8.0.126",
     "rollForward": "latestFeature"
   },
   "tools": {
-    "dotnet": "8.0.125"
+    "dotnet": "8.0.126"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.26168.3",


### PR DESCRIPTION
Upgrade .NET SDK from 8.0.125 to 8.0.126 to mitigate Component Governance alert [13370720](https://dev.azure.com/dnceng/internal/_componentGovernance/dotnet-arcade/alert/13370720?typeId=17469048).