### PR TITLE
Generate catalog files for .js files in workload pack MSIs

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CatalogFileGenerator.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CatalogFileGenerator.cs
@@ -1,0 +1,163 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.Build.Tasks.Workloads
+{
+    /// <summary>
+    /// Generates a catalog (.cat) file for .js files in a directory.
+    /// JS files are customer-modifiable runtime/toolchain files that cannot be
+    /// directly Authenticode-signed. A .cat catalog provides integrity verification
+    /// without preventing modification. The .cat file is then signed by the Arcade
+    /// signing infrastructure via FileExtensionSignInfo.
+    /// </summary>
+    internal static class CatalogFileGenerator
+    {
+        /// <summary>
+        /// Generates a .cat catalog file covering all .js files in the specified directory.
+        /// The .cat file is placed in the root of the directory so WiX Heat will include it
+        /// in the MSI alongside the .js files.
+        /// </summary>
+        /// <param name="sourceDirectory">The directory to search for .js files.</param>
+        /// <param name="catalogName">The base name for the catalog file (without extension).</param>
+        /// <param name="log">Optional logger for diagnostic messages.</param>
+        /// <returns>The path to the generated .cat file, or null if no .js files were found or makecat.exe is unavailable.</returns>
+        public static string? GenerateCatalog(string sourceDirectory, string catalogName, TaskLoggingHelper? log = null)
+        {
+            if (string.IsNullOrWhiteSpace(sourceDirectory) || !Directory.Exists(sourceDirectory))
+            {
+                return null;
+            }
+
+            string[] jsFiles = Directory.GetFiles(sourceDirectory, "*.js", SearchOption.AllDirectories);
+            if (jsFiles.Length == 0)
+            {
+                return null;
+            }
+
+            string? makecatPath = FindMakecat();
+            if (makecatPath == null)
+            {
+                log?.LogMessage(MessageImportance.Normal,
+                    "makecat.exe not found. Skipping catalog generation for .js files. " +
+                    "Catalog signing requires the Windows SDK.");
+                return null;
+            }
+
+            string catOutputPath = Path.Combine(sourceDirectory, $"{catalogName}.cat");
+            string cdfPath = Path.ChangeExtension(catOutputPath, ".cdf");
+
+            // Generate the CDF (Catalog Definition File)
+            using (StreamWriter writer = new(cdfPath))
+            {
+                writer.WriteLine("[CatalogHeader]");
+                writer.WriteLine($"Name={catOutputPath}");
+                writer.WriteLine("CatalogVersion=2");
+                writer.WriteLine("HashAlgorithms=SHA256");
+                writer.WriteLine();
+                writer.WriteLine("[CatalogFiles]");
+
+                int index = 0;
+                foreach (string jsFile in jsFiles)
+                {
+                    string fileName = Path.GetFileName(jsFile);
+                    // Use a sanitized label: remove non-alphanumeric chars except dots and hyphens
+                    string label = $"js_{index}_{SanitizeLabel(fileName)}";
+                    writer.WriteLine($"<hash>{label}={jsFile}");
+                    index++;
+                }
+            }
+
+            log?.LogMessage(MessageImportance.Low,
+                $"Generated CDF with {jsFiles.Length} .js files at {cdfPath}");
+
+            // Run makecat.exe to produce the .cat file
+            ProcessStartInfo psi = new()
+            {
+                FileName = makecatPath,
+                Arguments = $"\"{cdfPath}\"",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+            using Process process = Process.Start(psi)!;
+            string stdout = process.StandardOutput.ReadToEnd();
+            string stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            if (process.ExitCode != 0)
+            {
+                log?.LogWarning($"makecat.exe failed with exit code {process.ExitCode}. " +
+                    $"stdout: {stdout} stderr: {stderr}");
+                return null;
+            }
+
+            if (!File.Exists(catOutputPath))
+            {
+                log?.LogWarning($"makecat.exe completed but catalog file was not created: {catOutputPath}");
+                return null;
+            }
+
+            log?.LogMessage(MessageImportance.Normal,
+                $"Generated catalog file covering {jsFiles.Length} .js files: {catOutputPath}");
+
+            // Clean up the CDF file - it's not needed in the MSI
+            try { File.Delete(cdfPath); } catch { /* best effort */ }
+
+            return catOutputPath;
+        }
+
+        /// <summary>
+        /// Finds makecat.exe from the Windows SDK.
+        /// </summary>
+        private static string? FindMakecat()
+        {
+            // Try PATH first
+            string? pathResult = FindInPath("makecat.exe");
+            if (pathResult != null) return pathResult;
+
+            // Search Windows SDK locations
+            string programFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+            string sdkRoot = Path.Combine(programFilesX86, "Windows Kits", "10", "bin");
+
+            if (Directory.Exists(sdkRoot))
+            {
+                // Find the latest version's x64 directory
+                return Directory.GetFiles(sdkRoot, "makecat.exe", SearchOption.AllDirectories)
+                    .Where(f => f.Contains("x64", StringComparison.OrdinalIgnoreCase))
+                    .OrderByDescending(f => f)
+                    .FirstOrDefault();
+            }
+
+            return null;
+        }
+
+        private static string? FindInPath(string fileName)
+        {
+            string? pathVar = Environment.GetEnvironmentVariable("PATH");
+            if (pathVar == null) return null;
+
+            foreach (string dir in pathVar.Split(Path.PathSeparator))
+            {
+                string fullPath = Path.Combine(dir, fileName);
+                if (File.Exists(fullPath)) return fullPath;
+            }
+
+            return null;
+        }
+
+        private static string SanitizeLabel(string name) =>
+            new(name.Select(c => char.IsLetterOrDigit(c) || c == '.' || c == '-' ? c : '_').ToArray());
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/CreateVisualStudioWorkload.wix.cs
@@ -338,6 +338,12 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                 Log.LogMessage(MessageImportance.Low, string.Format(Strings.BuildExtractingPackage, data.Package.PackagePath));
                 data.Package.Extract();
 
+                // Generate a catalog (.cat) file for any .js files in the extracted package.
+                // JS files are customer-modifiable and cannot be directly Authenticode-signed.
+                // The .cat provides integrity verification and is signed via FileExtensionSignInfo.
+                CatalogFileGenerator.GenerateCatalog(data.Package.DestinationDirectory,
+                    data.Package.ShortName, Log);
+
                 // Enumerate over the platforms and build each MSI once.
                 _ = Parallel.ForEach(data.FeatureBands.Keys, platform =>
                 {
@@ -384,6 +390,10 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
                 foreach (var pack in packGroup.Packs)
                 {
                     pack.Extract();
+
+                    // Generate catalog for .js files in each pack of the group.
+                    CatalogFileGenerator.GenerateCatalog(pack.DestinationDirectory,
+                        pack.ShortName, Log);
                 }
 
                 foreach (var platform in packGroup.ManifestsPerPlatform.Keys)


### PR DESCRIPTION
## Problem

The Visual Studio signing scan flags unsigned `.js` files across .NET workload pack MSI payloads. These are customer-modifiable runtime/toolchain files (e.g., Mono browser-wasm, Emscripten SDK) that cannot be directly Authenticode-signed because modifying a signed file breaks the signature.

This affects multiple workload packs across multiple repos:
- **Mono browser-wasm** (dotnet/runtime): 198 .js files
- **Emscripten SDK** (dotnet/emsdk): ~14,468 .js files
- Any future workload pack containing .js files

## Root Cause

Workload packs are built as NuPkgs on Linux (in the VMR), then converted to MSIs by `CreateVisualStudioWorkload` on Windows. The `.js` files inside the NuPkgs are never signed because:
1. `eng/Signing.props` in each repo sets `.js` to `CertificateName="None"` (correct — they're customer-modifiable)
2. No catalog (.cat) file is generated to provide integrity verification

Previous attempts to add catalog generation in the individual repos (dotnet/runtime#127242, dotnet/emsdk#1671) hook into the **pack build phase** which runs on Linux — where `makecat.exe` is unavailable.

## Fix

Generate the `.cat` catalog file in `CreateVisualStudioWorkload.wix.cs` — the Arcade task that converts NuPkgs to MSIs. This runs on **Windows** during the MSI generation phase, where `makecat.exe` is available from the Windows SDK.

### Insertion point

After each package is extracted (`data.Package.Extract()`) and before WiX Heat harvests the files for the MSI, call `CatalogFileGenerator.GenerateCatalog()` to:
1. Scan the extracted directory for `.js` files
2. Generate a CDF (Catalog Definition File) listing all `.js` files
3. Run `makecat.exe` to produce a `.cat` file
4. Place the `.cat` in the extraction directory so Heat includes it in the MSI

The `.cat` file is then signed by the Arcade signing infrastructure via `FileExtensionSignInfo Include=".cat" CertificateName="Microsoft400"` in each repo's `eng/Signing.props`.

### Why this is the right layer

| Approach | Runs on | Works in VMR? | Covers all repos? |
|----------|---------|---------------|-------------------|
| Per-repo sfxproj target (dotnet/runtime#127242) | Linux (pack phase) | No | No |
| Per-repo emsdk.proj target (dotnet/emsdk#1671) | Linux (pack phase) | No | No |
| **This PR: Arcade workload task** | **Windows (MSI phase)** | **Yes** | **Yes** |

## Changes

| File | Change |
|------|--------|
| `CatalogFileGenerator.cs` | New utility class — finds `makecat.exe`, generates CDF, produces `.cat` |
| `CreateVisualStudioWorkload.wix.cs` | Call `CatalogFileGenerator.GenerateCatalog()` after pack extraction, for both individual packs and pack groups |

## Per-repo requirements

Each repo still needs these entries in `eng/Signing.props` for the signing infrastructure to handle the files correctly:
```xml
<FileExtensionSignInfo Update=".js" CertificateName="None" />
<FileExtensionSignInfo Include=".cat" CertificateName="Microsoft400" />
```

## Related PRs

- dotnet/arcade#16742 — Add `.cab` to default `FileExtensionSignInfo` (same PR batch)
- dotnet/runtime#127242 — Original attempt in runtime repo (superseded)
- dotnet/runtime#127529 — Second attempt in runtime repo (superseded)
- dotnet/emsdk#1671 — Same pattern in emsdk (has same VMR limitation)

## Context

Suggested by @jkoritzinsky in [dotnet/runtime#127242 review](https://github.com/dotnet/runtime/pull/127242#discussion_r3121280922).

## Tracking

VS signing compliance: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2911494
