### PR TITLE
Remove dn-bot-dnceng-build-rw-code-rw PAT from secret manifest

### DIFF
--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -40,17 +40,6 @@ secrets:
       gitHubBotAccountSecret: BotAccount-dotnet-bot
       gitHubBotAccountName: dotnet-bot
 
-  dn-bot-dnceng-build-rw-code-rw:
-    type: azure-devops-access-token
-    parameters:
-      domainAccountName: dn-bot
-      domainAccountSecret:
-          location: helixkv
-          name: dn-bot-account-redmond
-      name: dn-bot-dnceng-build
-      organizations: dnceng
-      scopes: build_execute code_write
-
   akams-client-id:
     type: text
     parameters:


### PR DESCRIPTION
## Summary
Remove the `dn-bot-dnceng-build-rw-code-rw` PAT entry from the EngKeyVault secret manifest. All pipeline consumers have been migrated to WIF service connections.

## Migration PRs (all merged)
- arcade-validation: PR #5461
- dotnet-mirroring: PR #59473
- dotnet-release: PR #59565 (deprecated)
- dotnet-aspnetcore: PRs #66074, #66113, #66115
- microsoft/go-infra: PR #454
- dotnet/installer: PRs #20821, #20822
- dotnet/arcade: PRs #15827, #15834 (mirroring fixes)

## Follow-up
- `dotnet-arcade-services/vmr-synchronization.1.yaml` also has this PAT entry and needs a separate cleanup PR.

Part of: AB#10139