### PR TITLE
Remove dn-bot-devdiv-drop-r-code-r PAT from secret manifest

### DIFF
--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -101,17 +101,6 @@ secrets:
       organizations: devdiv
       scopes: code_write drop_write
 
-  dn-bot-devdiv-drop-r-code-r:
-    type: azure-devops-access-token
-    parameters:
-      domainAccountName: dn-bot
-      domainAccountSecret:
-          location: helixkv
-          name: dn-bot-account-redmond
-      name: dn-bot-devdiv-drop-r-code-r
-      organizations: devdiv
-      scopes: code drop
-
   #DotNet-Symbol-Server-Pats
   microsoft-symbol-server-pat:
     type: azure-devops-access-token


### PR DESCRIPTION
## Summary

Removes the `dn-bot-devdiv-drop-r-code-r` PAT entry from the secret manifest. This PAT has been replaced by the `dnceng-devdiv-drop-r-code-r-wif` WIF service connection.

### Changes
- **Deleted** `dn-bot-devdiv-drop-r-code-r` entry from `.vault-config/product-builds-engkeyvault.yaml`

### Related
- WI: https://dev.azure.com/dnceng/internal/_workitems/edit/10147
- dotnet/dotnet PR: https://github.com/dotnet/dotnet/pull/6486 (YAML change to use WIF token)
- SC: `dnceng-devdiv-drop-r-code-r-wif` in dnceng/internal

### Merge order
1. **Merge dotnet/dotnet PR first** to switch pipelines to WIF
2. **Then merge this PR** to remove the PAT from the manifest