### PR TITLE
Remove temporary changes now that rebootstraps are completed

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -628,11 +628,7 @@ function GetSdkTaskProject([string]$taskName) {
   if (Test-Path $proj) {
     return $proj
   }
-  # TODO: Remove this fallback once all supported versions use the new layout.
-  $legacyProj = Join-Path $toolsetDir "SdkTasks\$taskName.proj"
-  if (Test-Path $legacyProj) {
-    return $legacyProj
-  }
+
   throw "Unable to find $taskName.proj in toolset at: $toolsetDir"
 }
 
@@ -708,23 +704,14 @@ function InitializeToolset() {
 
   $packageDir = Join-Path $nugetCache (Join-Path 'microsoft.dotnet.arcade.sdk' $toolsetVersion)
   $packageToolsetDir = Join-Path $packageDir 'toolset'
-  $packageToolsDir = Join-Path $packageDir 'tools'
 
-  # TODO: Remove the tools/ check once all supported versions have the toolset folder.
-  if (!(Test-Path $packageToolsetDir) -and !(Test-Path $packageToolsDir)) {
+  if (!(Test-Path $packageToolsetDir)) {
     Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "Arcade SDK package does not contain a toolset or tools folder: $packageDir"
     ExitWithExitCode 3
   }
 
   New-Item -ItemType Directory -Path $toolsetToolsDir -Force | Out-Null
-
-  # Copy toolset if present at the package root (new layout), otherwise fall back to tools
-  if (Test-Path $packageToolsetDir) {
-    Copy-Item -Path "$packageToolsetDir\*" -Destination $toolsetToolsDir -Recurse -Force
-  } else {
-    # TODO: Remove this fallback once all supported versions have the toolset folder.
-    Copy-Item -Path "$packageToolsDir\*" -Destination $toolsetToolsDir -Recurse -Force
-  }
+  Copy-Item -Path "$packageToolsetDir\*" -Destination $toolsetToolsDir -Recurse -Force
 
   if (Test-Path $buildProjPath) {
     $toolsetBuildProj = $buildProjPath

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -458,21 +458,13 @@ function InitializeToolset {
 
   local package_dir="$_GetNuGetPackageCachePath/microsoft.dotnet.arcade.sdk/$toolset_version"
 
-  # TODO: Remove the tools/ check once all supported versions have the toolset folder.
-  if [[ ! -d "$package_dir/toolset" && ! -d "$package_dir/tools" ]]; then
-    Write-PipelineTelemetryError -category 'InitializeToolset' "Arcade SDK package does not contain a toolset or tools folder: $package_dir"
+  if [[ ! -d "$package_dir/toolset" ]]; then
+    Write-PipelineTelemetryError -category 'InitializeToolset' "Arcade SDK package does not contain a toolset folder: $package_dir"
     ExitWithExitCode 3
   fi
 
   mkdir -p "$toolset_tools_dir"
-
-  # Copy toolset if present at the package root (new layout), otherwise fall back to tools
-  if [[ -d "$package_dir/toolset" ]]; then
-    cp -r "$package_dir/toolset/." "$toolset_tools_dir"
-  else
-    # TODO: Remove this fallback once all supported versions have the toolset folder.
-    cp -r "$package_dir/tools/." "$toolset_tools_dir"
-  fi
+  cp -r "$package_dir/toolset/." "$toolset_tools_dir"
 
   if [[ -a "$toolset_tools_dir/Build.proj" ]]; then
     toolset_build_proj="$toolset_tools_dir/Build.proj"
@@ -629,12 +621,7 @@ function GetSdkTaskProject {
     echo "$proj"
     return
   fi
-  # TODO: Remove this fallback once all supported versions use the new layout.
-  local legacyProj="$toolsetDir/SdkTasks/$taskName.proj"
-  if [[ -a "$legacyProj" ]]; then
-    echo "$legacyProj"
-    return
-  fi
+
   Write-PipelineTelemetryError -category 'Build' "Unable to find $taskName.proj in toolset at: $toolsetDir"
   ExitWithExitCode 3
 }


### PR DESCRIPTION
Both re-bootstraps, in the VMR and in arcade are merged which unblocks removing these TODOs.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
