### PR TITLE
Fix ReleaseConfigs item pattern after PublishPipelineArtifact migration

### DIFF
--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -90,7 +90,7 @@ stages:
         downloadType: 'specific'
         artifact: ReleaseConfigs
         itemPattern: |
-          ReleaseConfigs/SymbolPublishingExclusionsFile.txt
+          **/SymbolPublishingExclusionsFile.txt
         downloadPath: '$(Build.ArtifactStagingDirectory)/ReleaseConfigs'
 
     - task: NuGetToolInstaller@1


### PR DESCRIPTION
## Symptom

The dotnet/dotnet (VMR) internal `dotnet-unified-build` definition has been failing in `Publish Using Darc` since [dotnet/dotnet#6342](https://github.com/dotnet/dotnet/pull/6342) "Re-Bootstrap to .NET 11.0.100-preview.5.26227.104" merged on 2026-05-06. Concretely the channel-promotion sub-build (`Maestro Build Promotion`) errors out in `Publish packages, blobs and symbols` with:

```
[Publish packages, blobs and symbols] PublishArtifactsInManifest.proj(128,5): error :
  [AddPackagesToRequest/<guid>/Microsoft.NETCore.App.Runtime.win-arm64.<ver>.symbols.nupkg]
  Multiple files '$mscordaccore.dll' found for runtime '...runtimes\win-arm64\native\coreclr.dll':
    ...tools\x64_arm64\mscordaccore.dll,
    ...runtimes\win-arm64\native\mscordaccore.dll.
  Multiple files with same name to be indexed under same runtime - aborting manifest creation.
  Failed to generate symbol manifest
```

The same flow also fails on roslyn-language-server linux-musl symbols with `Invalid ELF BuildID '<null>'` for `libe_sqlite3.so`. Both file paths (`tools/x64_arm64/mscordaccore.dll`, `tools/net10.0/linux-musl-*/libe_sqlite3.so`) are listed in [`runtime/eng/SymbolPublishingExclusionsFile.txt`](https://github.com/dotnet/runtime/blob/main/eng/SymbolPublishingExclusionsFile.txt) (the runtime entries date back to 2019) and mirrored at [the VMR root](https://github.com/dotnet/dotnet/blob/main/eng/SymbolPublishingExclusionsFile.txt).

Verified failures:
- [internal build 2969239](https://dev.azure.com/dnceng/internal/_build/results?buildId=2969239) — promotion sub-build [2969388](https://dev.azure.com/dnceng/internal/_build/results?buildId=2969388)
- internal build 2969080
- internal build 2968891 — first failing build, on commit `8bf09af` which IS PR #6342

The previous run [2968708](https://dev.azure.com/dnceng/internal/_build/results?buildId=2968708) (commit `d64191f`, before PR #6342) successfully promoted to the same `.NET 11.0.1xx SDK` channel. So the regression aligns one-to-one with PR #6342.

## Root cause

PR #6342 picked up an `eng/common` template change that switched the `ReleaseConfigs` artifact (which carries `SymbolPublishingExclusionsFile.txt` to the promotion sub-build) from `PublishBuildArtifacts` (legacy build artifacts, with the artifact name preserved as a path segment) to `PublishPipelineArtifact`:

```diff
-    - template: /eng/common/core-templates/steps/publish-build-artifacts.yml
-        pathToPublish: '$(Build.StagingDirectory)/ReleaseConfigs'
-        publishLocation: Container
+    - template: /eng/common/core-templates/steps/publish-pipeline-artifacts.yml
+        targetPath: '$(Build.StagingDirectory)/ReleaseConfigs'
         artifactName: ReleaseConfigs
```

The two artifact systems flatten paths differently:

- **Build artifacts**: artifact name is a path segment → `SymbolPublishingExclusionsFile.txt` ends up at `ReleaseConfigs/SymbolPublishingExclusionsFile.txt` inside the artifact.
- **Pipeline artifacts**: artifact name is metadata, not a path → the contents of `$(Build.StagingDirectory)/ReleaseConfigs` land at the artifact root, so the file is at `SymbolPublishingExclusionsFile.txt`.

`DownloadPipelineArtifact@2` in `eng/publishing/v3/publish.yml` still asks for the old prefixed pattern:

```yaml
itemPattern: |
  ReleaseConfigs/SymbolPublishingExclusionsFile.txt
```

That pattern matches nothing in the new layout. The step has `continueOnError: true`, so the failure is silent and the download produces an empty directory.

Downstream, [`PublishArtifactsInManifestBase.LoadExclusions`](https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs#L739-L772) sees a path that does not exist and logs:

```
Exclusions file ... not found. No exclusions will be applied.
```

With empty exclusions, every relative path inside each symbols nupkg reaches `SymbolManifestGenerator.GenerateManifest`, which rejects the long-tolerated dual-`mscordaccore.dll` layout (cross-targeting host `tools/x64_arm64/mscordaccore.dll` vs native `runtimes/win-arm64/native/mscordaccore.dll`) with the "Multiple files...same name to be indexed" error above.

By contrast, [`eng/common/core-templates/post-build/setup-maestro-vars.yml`](https://github.com/dotnet/arcade/blob/main/eng/common/core-templates/post-build/setup-maestro-vars.yml#L11-L15) downloads the same `ReleaseConfigs` artifact without `itemPattern` and reads `$(Build.StagingDirectory)/ReleaseConfigs/ReleaseConfigs.txt` — which works because the contents extract directly into `targetPath`.

## Fix

Drop the now-bogus `ReleaseConfigs/` prefix from `itemPattern` so the download matches the new pipeline-artifact layout. The `downloadPath` is unchanged, so the consumer's expected location (`$(Build.ArtifactStagingDirectory)/ReleaseConfigs/SymbolPublishingExclusionsFile.txt`, used at line 158 of the same file) stays correct.

```diff
         itemPattern: |
-          ReleaseConfigs/SymbolPublishingExclusionsFile.txt
+          SymbolPublishingExclusionsFile.txt
         downloadPath: '$(Build.ArtifactStagingDirectory)/ReleaseConfigs'
```

I also added a comment explaining the artifact-system mismatch so this doesn't regress next time the publishing template is touched.

## Validation

- Manually traced the artifact path through publish (`publish-build-assets.yml`) and download (`v3/publish.yml`) sides.
- Confirmed `setup-maestro-vars.yml` already uses the matching layout (no `itemPattern`, identical `targetPath`) and works.
- The arcade source path (`SymbolUploadHelper.cs`, `LoadExclusions`) is unchanged in the regression window — verifying this is purely a YAML wiring bug, not a behavior change in the helper or in `Microsoft.SymbolManifestGenerator` (whose pinned version `8.0.0-preview.24461.2` hasn't moved since 2025-08).
