### PR TITLE
Set DeterministicTimestamps on nuget packages

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetPack.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetPack.cs
@@ -6,9 +6,10 @@ using NuGet;
 using NuGet.Versioning;
 using NuGet.Packaging;
 using System;
-using System.IO;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using NuGet.Common;
 
 namespace Microsoft.DotNet.Build.Tasks.Packaging
@@ -138,6 +139,12 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             set;
         }
 
+        public string DeterministicTimestamp
+        {
+            get;
+            set;
+        }
+
         public override bool Execute()
         {
             if (Nuspecs == null || Nuspecs.Length == 0)
@@ -261,6 +268,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             try
             {
                 PackageBuilder builder = new PackageBuilder(deterministic: Deterministic);
+                SetDeterministicTimestamp(builder, DeterministicTimestamp);
 
                 string baseDirectoryPath = (string.IsNullOrEmpty(BaseDirectory)) ? Path.GetDirectoryName(nuspecPath) : BaseDirectory;
                 builder.Populate(manifest.Metadata);
@@ -325,6 +333,30 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 }
                 Log.LogError($"Error when creating nuget {packageType} package from {nuspecPath}. {e}");
             }
+        }
+
+        private void SetDeterministicTimestamp(PackageBuilder packageBuilder, string deterministicTimestamp)
+        {
+            // Use reflection to set the PackageBuilder.DeterministicTimestamp
+            // property. This property may or may not be available depending on
+            // the NuGet.Client version.
+
+            var type = packageBuilder.GetType();
+            var deterministicTimestampPropertyName = "DeterministicTimestamp";
+            var propertyInfo = type.GetProperty(deterministicTimestampPropertyName, BindingFlags.Public | BindingFlags.Instance);
+            if (propertyInfo == null)
+            {
+                Log.LogMessage(LogImportance.Low, $"{type.FullName} does not contain property {deterministicTimestampPropertyName}. Not setting {nameof(deterministicTimestamp)}.");
+                return;
+            }
+
+            if (!propertyInfo.CanWrite)
+            {
+                Log.LogWarning($"{type.FullName}.{deterministicTimestampPropertyName} is not writable.");
+                return;
+            }
+
+            propertyInfo.SetValue(packageBuilder, deterministicTimestamp);
         }
 
         private Manifest TransformManifestToPackedPackageManifest(Manifest manifest)

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets
@@ -1275,6 +1275,10 @@
 
     <Message Condition="'$(_SkipCreatePackage)' == 'true'" Text="Skipping package creation for $(NuSpecPath) because the following files do not exist: @(_missingFiles)" />
 
+    <PropertyGroup>
+      <DeterministicTimestamp Condition="'$(DeterministicTimestamp)' == '' AND '$(SOURCE_DATE_EPOCH)' != ''">$(SOURCE_DATE_EPOCH)</DeterministicTimestamp>
+    </PropertyGroup>
+
     <NuGetPack Nuspecs="$(NuSpecPath)"
                OutputDirectory="$(PackageOutputPath)"
                ExcludeEmptyDirectories="true"
@@ -1287,6 +1291,7 @@
                AdditionalSymbolPackageExcludes="@(AdditionalSymbolPackageExcludes)"
                PackedPackageNamePrefix="$(PackedPackageNamePrefix)"
                Deterministic="$(Deterministic)"
+               DeterministicTimestamp="$(DeterministicTimestamp)"
                Condition="'$(_SkipCreatePackage)' != 'true'"/>
 
     <!-- Create a marker that records the path to the generated package -->


### PR DESCRIPTION
When creating NuGet packages, set the deterministic timestamp on them,
if possible. Setting the timestamp makes the nuget packages
reproducible/deterministic.

See the deterministic pack spec for details:
https://github.com/NuGet/Home/pull/14785

For the larger context on what I am trying to do, see:
https://github.com/dotnet/source-build/issues/4963

Resolves: #16623

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
