### PR TITLE
Revert "Remove dn-bot-devdiv-drop-r-code-r PAT from secret manifest"

### DIFF
--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -101,6 +101,17 @@ secrets:
       organizations: devdiv
       scopes: code_write drop_write
 
+  dn-bot-devdiv-drop-r-code-r:
+    type: azure-devops-access-token
+    parameters:
+      domainAccountName: dn-bot
+      domainAccountSecret:
+          location: helixkv
+          name: dn-bot-account-redmond
+      name: dn-bot-devdiv-drop-r-code-r
+      organizations: devdiv
+      scopes: code drop
+
   #DotNet-Symbol-Server-Pats
   microsoft-symbol-server-pat:
     type: azure-devops-access-token


### PR DESCRIPTION
Reverts dotnet/arcade#16779 because https://github.com/dotnet/dotnet/pull/6486 is still open