### PR TITLE
Remove unused tools from `dotnet-tools.json`

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -7,18 +7,6 @@
       "commands": [
         "secret-manager"
       ]
-    },
-    "microsoft.dnceng.patgeneratortool": {
-      "version": "1.1.0-beta.22580.1",
-      "commands": [
-        "pat-generator"
-      ]
-    },
-    "microsoft.dotnet.darc": {
-      "version": "1.1.0-beta.25230.8",
-      "commands": [
-        "darc"
-      ]
     }
   }
 }


### PR DESCRIPTION
Removed obsolete tools from `dotnet-tools.json`:
- `darc`
- `pat-generator`

