### PR TITLE
Add Entra credential fallback to CreateAzdoClient (Phase 1, WI 10141)

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -957,11 +957,64 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
             var client = new HttpClient(handler);
             client.Timeout = TimeSpan.FromSeconds(TimeoutInSeconds);
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
-                "Basic",
-                Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Format("{0}:{1}", "",
-                    tokenOverride ?? AzdoApiToken))));
+
+            string effectiveToken = tokenOverride ?? AzdoApiToken;
+            if (!string.IsNullOrEmpty(effectiveToken))
+            {
+                // Legacy PAT-based authentication
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+                    "Basic",
+                    Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Format("{0}:{1}", "", effectiveToken))));
+            }
+            else
+            {
+                // Entra-based authentication using DefaultIdentityTokenCredential
+                // This supports AzurePipelinesCredential (from AzureCLI@2), ManagedIdentity, WorkloadIdentity, and AzureCLI
+                var credential = new DefaultIdentityTokenCredential(
+                    new DefaultIdentityTokenCredentialOptions
+                    {
+                        ManagedIdentityClientId = ManagedIdentityClientId
+                    });
+                var tokenRequestContext = new global::Azure.Core.TokenRequestContext(new[] { "499b84ac-1321-427f-aa17-267ca6975798/.default" });
+                var accessToken = credential.GetToken(tokenRequestContext, CancellationToken.None);
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.Token);
+            }
+
             return client;
+        }
+
+        /// <summary>
+        /// Checks whether Entra-based credentials are available in the current environment.
+        /// Returns true if running inside an AzureCLI@2 task (AzurePipelinesCredential),
+        /// or if a ManagedIdentityClientId is configured.
+        /// </summary>
+        private bool HasEntraCredentialsAvailable()
+        {
+            // AzurePipelinesCredential environment (set by AzureCLI@2 task with addSpnToEnvironment: true)
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURESUBSCRIPTION_CLIENT_ID")) &&
+                !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURESUBSCRIPTION_TENANT_ID")) &&
+                !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURESUBSCRIPTION_SERVICE_CONNECTION_ID")) &&
+                !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SYSTEM_ACCESSTOKEN")) &&
+                !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SYSTEM_OIDCREQUESTURI")))
+            {
+                return true;
+            }
+
+            // WorkloadIdentityCredential environment
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("servicePrincipalId")) &&
+                !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("idToken")) &&
+                !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("tenantId")))
+            {
+                return true;
+            }
+
+            // Managed Identity is configured
+            if (!string.IsNullOrEmpty(ManagedIdentityClientId))
+            {
+                return true;
+            }
+
+            return false;
         }
 
         private SemaphoreSlim _createArtifactSemaphore = new SemaphoreSlim(1,1);
@@ -1942,9 +1995,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 Log.LogError($"The property {nameof(MaestroApiEndpoint)} is required but doesn't have a value set.");
             }
 
-            if (UseStreamingPublishing && string.IsNullOrEmpty(AzdoApiToken))
+            if (UseStreamingPublishing && string.IsNullOrEmpty(AzdoApiToken) && !HasEntraCredentialsAvailable())
             {
-                Log.LogError($"The property {nameof(AzdoApiToken)} is required when using streaming publishing, but doesn't have a value set.");
+                Log.LogError($"The property {nameof(AzdoApiToken)} is required when using streaming publishing (unless Entra credentials are available via AzureCLI@2 or Managed Identity), but doesn't have a value set.");
             }
 
             if (UseStreamingPublishing && string.IsNullOrEmpty(ArtifactsBasePath))


### PR DESCRIPTION
## Summary

Phase 1 of migrating the `dn-bot-all-orgs-build-rw-code-rw` PAT from Basic auth to Entra-based authentication in the V3 publishing pipeline.

**This PR contains only backward-compatible C# changes.** YAML and secret manifest changes will follow in Phase 2 after this SDK version flows to consumers.

### Why Phase 1/Phase 2?

The [original PR #16785](https://github.com/dotnet/arcade/pull/16785) was [reverted (#16792)](https://github.com/dotnet/arcade/pull/16792) because it combined C# code changes (shipped in the Arcade SDK NuGet package) with YAML changes (take effect immediately on merge). After merge, the Maestro Build Promotion pipeline was still running the **old** SDK version (which required `AzdoApiToken`), but the YAML had already **stopped passing it**, causing:

```
error : The property AzdoApiToken is required when using streaming publishing, but doesn't have a value set.
```

Build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2972977

### Changes (C# only, PublishArtifactsInManifestBase.cs)

- **`CreateAzdoClient()`**: When no PAT is provided, falls back to `DefaultIdentityTokenCredential` with bearer token for AzDO resource (`499b84ac-1321-427f-aa17-267ca6975798/.default`). Supports `AzurePipelinesCredential` (from AzureCLI@2 with `addSpnToEnvironment:true`), `ManagedIdentityCredential`, `WorkloadIdentityCredential`, and `AzureCliCredential`.
- **`HasEntraCredentialsAvailable()`**: New method to check for available Entra credentials, used in validation to avoid false errors when streaming publishing is configured without a PAT.
- **`AnyMissingRequiredBaseProperties()`**: Relaxed validation -- only errors on missing `AzdoApiToken` when Entra credentials are also unavailable.

### What is NOT in this PR (Phase 2)

After this SDK version builds and flows to consumers:
1. Remove `/p:AzdoApiToken='$(dn-bot-all-orgs-build-rw-code-rw)'` from `publish.yml`
2. Remove PAT from binlog redaction list in `publish-logs.yml`
3. Delete PAT entry from secret manifest (`product-builds-engkeyvault.yaml`)

### Identity details

- MI: `maestro-build-promotion-mi` (AppId: `6e870007-e236-4eb1-8734-8bf8cd54c748`)
- SC: `maestro-build-promotion` (ID: `df3b9892-c5c9-4d64-8b72-edd72e049305`, type: `azurerm`, auth: `WorkloadIdentityFederation`)
- Enrollment: Confirmed in `dnceng/internal` Readers group

Work Item: https://dev.azure.com/dnceng/internal/_workitems/edit/10141
