### PR TITLE
Temporarily disable MicroBuild to unblock official build

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -22,7 +22,7 @@ stages:
         publish:
           artifacts: true
           logs: true
-      enableMicrobuild: true
+      enableMicrobuild: false
       microbuildUseESRP: ${{ parameters.microbuildUseESRP }}
       enablePublishBuildAssets: true
       enableSourceIndex: true

--- a/eng/validate-sdk.yml
+++ b/eng/validate-sdk.yml
@@ -10,7 +10,7 @@ jobs:
   parameters:
     name: ValidateArcadeSDK
     displayName: Validate Arcade SDK
-    enableMicrobuild: true
+    enableMicrobuild: false
     microbuildUseESRP: ${{ parameters.microbuildUseESRP }}
     artifacts:
       download:


### PR DESCRIPTION
MicroBuild signing is currently failing for unrelated reasons and is blocking the arcade official build.

The official build needs to succeed so the Entra credential fallback (#16806) flows to consumers, after which Phase 2 of the `dn-bot-all-orgs-build-rw-code-rw` PAT migration can proceed.

## Changes
- `eng/build.yml`: `enableMicrobuild: true` → `false` on the main build job
- `eng/validate-sdk.yml`: `enableMicrobuild: true` → `false` on the validate-sdk job

## Follow-up
Revert this change once MicroBuild is healthy again.