### PR TITLE
Update secret manager to generate compact tokens

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "microsoft.dnceng.secretmanager": {
-      "version": "1.1.0-beta.26261.2",
+      "version": "1.1.0-beta.26262.2",
       "commands": [
         "secret-manager"
       ]

--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -53,7 +53,7 @@ secrets:
           location: helixkv
           name: dn-bot-account-redmond
       name: dn-bot-all-orgs-build
-      organizations: dnceng devdiv microsoft dotnet-security-partners
+      organizations: dnceng devdiv dotnet-security-partners
       scopes: build_execute code_write
 
   #AzureDevOps-Artifact-Feeds-Pats
@@ -87,7 +87,7 @@ secrets:
           location: helixkv
           name: dn-bot-account-redmond
       name: dn-bot-all-orgs-artifact-feeds
-      organizations: dnceng devdiv microsoft dotnet-security-partners
+      organizations: dnceng devdiv dotnet-security-partners
       scopes: packaging_write
   
   dn-bot-devdiv-drop-rw-code-rw:

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -18,7 +18,7 @@ This file should be imported by eng/Versions.props
     <!-- dotnet-diagnostics dependencies -->
     <MicrosoftSymbolManifestGeneratorPackageVersion>8.0.0-preview.24461.2</MicrosoftSymbolManifestGeneratorPackageVersion>
     <!-- dotnet-dnceng dependencies -->
-    <MicrosoftDncEngSecretManagerPackageVersion>1.1.0-beta.26261.2</MicrosoftDncEngSecretManagerPackageVersion>
+    <MicrosoftDncEngSecretManagerPackageVersion>1.1.0-beta.26262.2</MicrosoftDncEngSecretManagerPackageVersion>
     <!-- dotnet-msbuild dependencies -->
     <MicrosoftBuildPackageVersion>17.12.50</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>17.12.50</MicrosoftBuildFrameworkPackageVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -120,9 +120,9 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>dc5fd7a8dce8309e4add8fd4bd5d8718f221b15a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DncEng.SecretManager" Version="1.1.0-beta.26261.2">
-      <Uri>https://github.com/dotnet/dnceng</Uri>
-      <Sha>fe34a4c64727a272e58670947430c1f38546cd34</Sha>
+    <Dependency Name="Microsoft.DncEng.SecretManager" Version="1.1.0-beta.26262.2">
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-dnceng</Uri>
+      <Sha>9013a137b3a1af2382ec7882f9448e83f90f2916</Sha>
     </Dependency>
     <!-- Dependencies required for source build to lift to the previously-source-built version. -->
     <Dependency Name="Microsoft.Build" Version="17.12.50">


### PR DESCRIPTION
Updates secret manager tooling to generate compact tokens, and removes `microsoft` org from Azure DevOps access token configurations in .vault-config.

Note: `symweb-symbol-server-pat` is scoped only to the `microsoft` org and was left untouched.