### PR TITLE
Register dotnetup Daily channel for publishing

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
@@ -380,6 +380,16 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
             new Regex(@"(^|[\\/])get-aspire-cli\.(ps1|sh)(\.sha512)?$", RegexOptions.IgnoreCase)
         ];
 
+        // dotnetup standalone executables for Linux/macOS have no file extension, so
+        // they don't match DefaultAkaMSCreateLinkPatterns (which is extension-based).
+        // This pattern matches dotnetup-{linux,osx}* binaries and their .sha512 checksums.
+        // Windows .exe binaries already match DefaultAkaMSCreateLinkPatterns.
+        public static readonly ImmutableList<Regex> DotnetupAkaMSCreateLinkPatterns =
+        [
+            ..DefaultAkaMSCreateLinkPatterns,
+            new Regex(@"(^|[\\/])dotnetup-(linux|osx)[a-z0-9-]*(\.sha512)?$", RegexOptions.IgnoreCase)
+        ];
+
         public static readonly ImmutableList<Regex> DefaultAkaMSDoNotCreateLinkPatterns =
         [
             new Regex(@"wixpack", RegexOptions.IgnoreCase),
@@ -1674,6 +1684,19 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 targetFeeds: GeneralTestingInternalFeeds,
                 symbolTargetType: SymbolPublishVisibility.Internal,
                 isProduction: false),
+
+            // dotnetup Daily — every CI build of the dotnetup installer tool from dotnet/sdk.
+            // Binaries are published to ci.dot.net/public/dotnetup/<SemVer>/ via DotNetToolsFeeds.
+            // Stable aka.ms links at aka.ms/dotnet/dotnetup/daily/<filename> always point at the latest build.
+            new TargetChannelConfig(
+                id: 10506,
+                isInternal: false,
+                publishingInfraVersion: PublishingInfraVersion.Latest,
+                akaMSChannelNames: ["dotnetup/daily"],
+                akaMSCreateLinkPatterns: DotnetupAkaMSCreateLinkPatterns,
+                akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
+                targetFeeds: DotNetToolsFeeds,
+                symbolTargetType: SymbolPublishVisibility.Public),
 
             #endregion
 


### PR DESCRIPTION
# Register `dotnetup Daily` channel for publishing

Wires up the new [`dotnetup Daily`](https://maestro.dot.net/channels) channel (id `10506`, created by [maestro-configuration#61048](https://dev.azure.com/dnceng/internal/_git/maestro-configuration/pullrequest/61048)) to publish via Arcade's `PublishArtifactsInManifest` flow.

## Background

`dotnetup` is a new NativeAOT installer tool built out of `dotnet/sdk` (see [dotnet/sdk#54254](https://github.com/dotnet/sdk/issues/54254)). Until now its standalone executables were copied to a private Azure blob via `az login`-gated scripts, which prevents anonymous installation and is operationally awkward. We're switching to BAR/channel-based publishing so:

- Daily binaries can be downloaded anonymously from `https://ci.dot.net/public/dotnetup/<SemVer>/<file>`.
- Stable `aka.ms/dotnet/dotnetup/daily/<file>` links always point at the latest build.
- The `Microsoft.Dotnet.Installation` NuGet package eventually flows through the same channel (replacing a direct `1ES.PublishNuget@1` step in the dotnetup pipeline) — defense in depth for MSRC scenarios.

End-to-end mechanics were validated by promoting BAR build [314208](https://maestro.dot.net/build/314208) to **General Testing** ([promotion build 2974290](https://dev.azure.com/dnceng/internal/_build/results?buildId=2974290)) — blobs landed correctly at `ci.dot.net/dev/dotnetup/0.1.3-preview.4.26263.3/...` with HTTP 200 anonymous access on all 16 binary/checksum assets.

## Configuration choices

| Knob | Value | Rationale |
|---|---|---|
| `id` | `10506` | Channel id assigned by BAR after maestro-configuration#61048 merged. |
| `isInternal` | `false` | Public channel — dotnetup needs anonymous download. |
| `publishingInfraVersion` | `Latest` | Same as other public channels. |
| `akaMSChannelNames` | `["dotnetup/daily"]` | Yields stable URLs at `aka.ms/dotnet/dotnetup/daily/<file>`. |
| `akaMSCreateLinkPatterns` | `DotnetupAkaMSCreateLinkPatterns` (new) | `Default*` is extension-based and skips our extensionless Linux/macOS binaries. |
| `targetFeeds` | `DotNetToolsFeeds` | Matt Mitchell's recommendation: packages → `dotnet-tools` feed (defense in depth — channel-based MSRC kill switch); installers → `ci.dot.net/public`. |
| `flatten` | (default `true`) | Strips the `dotnetup/<SemVer>/` prefix from the blob Id when constructing the aka.ms URL. |
| `symbolTargetType` | `Public` | Matches `.NET 6 Eng` etc. (no symbols today, but consistent posture). |

## New regex pattern

`DefaultAkaMSCreateLinkPatterns` matches files by extension (`.exe`, `.zip`, `.gz`, `.rpm`, …). The Windows binaries (`dotnetup-win-x64.exe`) match `\.exe$` and get aka.ms links. The Linux/macOS binaries are extensionless (`dotnetup-linux-x64`, `dotnetup-osx-arm64`, …) and silently fall through. `DotnetupAkaMSCreateLinkPatterns` adds:

```csharp
new Regex(@"(^|[\\/])dotnetup-(linux|osx)[a-z0-9-]*(\.sha512)?$", RegexOptions.IgnoreCase)
```

Modeled on `AspireAkaMSCreateLinkPatterns`, which solves the same problem for the extensionless `get-aspire-cli.{ps1,sh}` scripts.

## Rollout sequencing

This PR is one of three coordinated changes:

1. **maestro-configuration#61048** ✅ merged — creates the `dotnetup Daily` channel.
2. **This PR** — wires the channel through `PublishArtifactsInManifest`.
3. **maestro-configuration#61053** (open) — adds default-channel mapping `dotnet/sdk@release/dnup → dotnetup Daily` so every dotnetup CI build auto-promotes.

Plus the corresponding pipeline changes in `dotnet/sdk` (still on the `dotnetup-bar-experiment` branch; will be merged after this PR lands).

## Validation plan

After this PR merges:

1. Trigger a manual dotnetup build on the experiment branch (or wait for the next CI build once merged into `release/dnup`).
2. Promote to `dotnetup Daily` (`darc add-build-to-channel --id <BARId> --channel "dotnetup Daily"`).
3. Verify:
   - `ci.dot.net/public/dotnetup/<SemVer>/dotnetup-*` returns HTTP 200 for all 8 RID binaries and their `.sha512`.
   - `aka.ms/dotnet/dotnetup/daily/dotnetup-win-x64.exe` etc. resolve to the latest build.
   - `Microsoft.Dotnet.Installation` `.nupkg` (when added to the manifest) is restorable from the `dotnet-tools` feed.
