### PR TITLE
Remove dn-bot-dnceng-universal-packages-rw PAT from secret manifest

### DIFF
--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -68,17 +68,6 @@ secrets:
       organizations: dnceng
       scopes: packaging_write
 
-  dn-bot-dnceng-universal-packages-rw:
-    type: azure-devops-access-token
-    parameters:
-      domainAccountName: dn-bot
-      domainAccountSecret:
-          location: helixkv
-          name: dn-bot-account-redmond
-      name: dn-bot-dnceng-universal-packages
-      organizations: dnceng
-      scopes: packaging_write
-
   dn-bot-all-orgs-artifact-feeds-rw:
     type: azure-devops-access-token
     parameters:


### PR DESCRIPTION
## Summary

Removes the `dn-bot-dnceng-universal-packages-rw` PAT entry from the secret manifest, stopping automatic rotation of this unused PAT.

## Background

The underlying code that previously consumed this PAT has been updated to use `AzureCliCredential` fallback:
- `PublishSignedAssets.cs` - falls back to Entra when PAT is empty
- `CreateAzureDevOpsFeed.cs` - falls back to Entra when PAT is empty

No main-branch YAML templates reference this PAT anymore. The old publishing v2 channel templates that passed this PAT as `/p:AzdoTargetFeedPAT` have been removed from arcade main branch.

## Impact

- Stops secret-manager from auto-rotating this PAT (currently expiring May 16, last rotated May 13)
- The existing Key Vault secret will naturally expire
- No pipeline breakage expected since the PAT is not consumed by any active pipeline

Resolves: https://dev.azure.com/dnceng/internal/_workitems/edit/10144