### PR TITLE
Remove unused dn-dependabot-dnceng-package-rw-pat from secret manifest

### DIFF
--- a/.vault-config/dnceng-partners-kv.yaml
+++ b/.vault-config/dnceng-partners-kv.yaml
@@ -42,16 +42,6 @@ secrets:
       permissions: rl
       service: blob|file
 
-  dn-dependabot-dnceng-package-rw-pat:
-    type: azure-devops-access-token
-    parameters:
-      organizations: dnceng
-      scopes: packaging_write
-      domainAccountName: dn-dependabot
-      domainAccountSecret:
-        name: dn-dependabot-account-redmond
-        location: helixkv
-
   BotAccount-dotnet-bot-content-rw-grained-pat:
     type: github-access-token
     parameters:


### PR DESCRIPTION
## Summary

Removes the `dn-dependabot-dnceng-package-rw-pat` entry from `.vault-config/dnceng-partners-kv.yaml`. This stops secret-manager from continuously rotating a PAT that has no consumer.

## Evidence

| Check | Result |
|-------|--------|
| **User last accessed AzDO** | `2023-01-17` (3+ years ago) |
| **Audit log (90 days)** | 0 events for dn-dependabot |
| **Code references** | 0 consumers (only manifest + wiki docs) |
| **Variable groups** | `DncEng-Partners-Tokens` does NOT include this secret |
| **GitHub Dependabot config** | No `registries` section — no private feed auth |
| **AzDO Dependabot** | Explicitly disabled in arcade |
| **NuGet feeds** | All feeds are public (`dnceng/public/_packaging/*`) |

The current PAT version expires naturally on **2026-05-17** — no manual revocation needed.

## Related

- Work item: dnceng/internal#10153