### PR TITLE
Remove orphaned dn-bot-securitytools-packaging-r PAT from secret-manager manifest

### DIFF
--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -135,18 +135,3 @@ secrets:
       name: dn-bot-ceapex-package-r
       organizations: ceapex
       scopes: packaging
-
-  # Token used for installing the Guardian CLI from the securitytools AzDO org
-  # The PAT is in the Guardian service connections in dnceng and devdiv:
-  # https://devdiv.visualstudio.com/DevDiv/_settings/adminservices?resourceId=e002c3af-b8a4-4ebe-816b-d4908648a66a
-  # https://dev.azure.com/dnceng/internal/_settings/adminservices?resourceId=d2604fd5-04f1-4957-afe3-3d3ea81a665b
-  dn-bot-securitytools-packaging-r:
-    type: azure-devops-access-token
-    parameters:
-      domainAccountName: dn-bot
-      domainAccountSecret:
-          location: helixkv
-          name: dn-bot-account-redmond
-      name: dn-bot-securitytools-packaging-r
-      organizations: securitytools
-      scopes: packaging


### PR DESCRIPTION
## Summary

Remove the `dn-bot-securitytools-packaging-r` PAT entry from the secret-manager manifest. This PAT is being rotated for no purpose - both GuardianConnect service connections that consumed it have been deleted.

## Investigation Findings

- **dnceng/internal GuardianConnect SC** (d2604fd5-04f1-4957-afe3-3d3ea81a665b): **Deleted**
- **devdiv/DevDiv GuardianConnect SC** (e002c3af-b8a4-4ebe-816b-d4908648a66a): **Deleted**
- The `execute-sdl.yml` template that referenced GuardianConnect has been removed from arcade main
- Modern SDL scanning uses 1ES Pipeline Template built-in scanning
- PAT is not in any AzDO variable groups
- No other consumers identified

## Impact

- Stops unnecessary PAT rotation (saves secret-manager cycles)
- PAT will naturally expire on 2026-05-17 and not be renewed
- No pipeline breakage - nothing currently consumes this PAT

## Work Item

Resolves [dnceng/internal#10152](https://dev.azure.com/dnceng/internal/_workitems/edit/10152)