### PR TITLE
[release/10.0] Enable microbuild preview plugin (backport of #16185)

### DIFF
--- a/eng/common/core-templates/job/job.yml
+++ b/eng/common/core-templates/job/job.yml
@@ -19,6 +19,7 @@ parameters:
   # publishing defaults
   artifacts: ''
   enableMicrobuild: false
+  enablePreviewMicrobuild: false
   enableMicrobuildForMacAndLinux: false
   microbuildUseESRP: true
   enablePublishBuildArtifacts: false
@@ -128,6 +129,7 @@ jobs:
     - template: /eng/common/core-templates/steps/install-microbuild.yml
       parameters:
         enableMicrobuild: ${{ parameters.enableMicrobuild }}
+        enablePreviewMicrobuild: ${{ parameters.enablePreviewMicrobuild }}
         enableMicrobuildForMacAndLinux: ${{ parameters.enableMicrobuildForMacAndLinux }}
         microbuildUseESRP: ${{ parameters.microbuildUseESRP }}
         continueOnError: ${{ parameters.continueOnError }}
@@ -150,6 +152,7 @@ jobs:
     - template: /eng/common/core-templates/steps/cleanup-microbuild.yml
       parameters:
         enableMicrobuild: ${{ parameters.enableMicrobuild }}
+        enablePreviewMicrobuild: ${{ parameters.enablePreviewMicrobuild }}
         enableMicrobuildForMacAndLinux: ${{ parameters.enableMicrobuildForMacAndLinux }}
         continueOnError: ${{ parameters.continueOnError }}
 

--- a/eng/common/core-templates/job/job.yml
+++ b/eng/common/core-templates/job/job.yml
@@ -20,6 +20,7 @@ parameters:
   artifacts: ''
   enableMicrobuild: false
   enablePreviewMicrobuild: false
+  microbuildPluginVersion: 'latest'
   enableMicrobuildForMacAndLinux: false
   microbuildUseESRP: true
   enablePublishBuildArtifacts: false
@@ -130,6 +131,7 @@ jobs:
       parameters:
         enableMicrobuild: ${{ parameters.enableMicrobuild }}
         enablePreviewMicrobuild: ${{ parameters.enablePreviewMicrobuild }}
+        microbuildPluginVersion: ${{ parameters.microbuildPluginVersion }}
         enableMicrobuildForMacAndLinux: ${{ parameters.enableMicrobuildForMacAndLinux }}
         microbuildUseESRP: ${{ parameters.microbuildUseESRP }}
         continueOnError: ${{ parameters.continueOnError }}

--- a/eng/common/core-templates/steps/install-microbuild-impl.yml
+++ b/eng/common/core-templates/steps/install-microbuild-impl.yml
@@ -1,0 +1,34 @@
+parameters:
+  - name: microbuildTaskInputs
+    type: object
+    default: {}
+
+  - name: microbuildEnv
+    type: object
+    default: {}
+
+  - name: enablePreviewMicrobuild
+    type: boolean
+    default: false
+
+  - name: condition
+    type: string
+
+  - name: continueOnError
+    type: boolean
+
+steps:
+- ${{ if eq(parameters.enablePreviewMicrobuild, 'true') }}:
+    - task: MicroBuildSigningPluginPreview@4
+      displayName: Install Preview MicroBuild plugin (Windows)
+      inputs: ${{ parameters.microbuildTaskInputs }}
+      env: ${{ parameters.microbuildEnv }}
+      continueOnError: ${{ parameters.continueOnError }}
+      condition: ${{ parameters.condition }}
+- ${{ else }}:
+  - task: MicroBuildSigningPlugin@4
+    displayName: Install MicroBuild plugin (Windows)
+    inputs: ${{ parameters.microbuildTaskInputs }}
+    env: ${{ parameters.microbuildEnv }}
+    continueOnError: ${{ parameters.continueOnError }}
+    condition: ${{ parameters.condition }}

--- a/eng/common/core-templates/steps/install-microbuild.yml
+++ b/eng/common/core-templates/steps/install-microbuild.yml
@@ -15,6 +15,8 @@ parameters:
   microbuildUseESRP: true
   # Microbuild installation directory
   microBuildOutputFolder: $(Agent.TempDirectory)/MicroBuild
+  # Microbuild version
+  microbuildPluginVersion: 'latest'
 
   continueOnError: false
 
@@ -71,14 +73,14 @@ steps:
     # YAML expansion, and Windows vs. Linux/Mac uses different service connections. However,
     # we can avoid including the MB install step if not enabled at all. This avoids a bunch of
     # extra pipeline authorizations, since most pipelines do not sign on non-Windows.
-    - template: /eng/common/core-templates/steps/install-microbuild-impl.yml@self
+    - template: /eng/common/core-templates/steps/install-microbuild-impl.yml
       parameters:
         enablePreviewMicrobuild: ${{ parameters.enablePreviewMicrobuild }}
         microbuildTaskInputs:
           signType: $(_SignType)
           zipSources: false
           feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-          workingDirectory: ${{ parameters.microBuildOutputFolder }}
+          version: ${{ parameters.microbuildPluginVersion }}
           ${{ if eq(parameters.microbuildUseESRP, true) }}:
             ConnectedServiceName: 'MicroBuild Signing Task (DevDiv)'
             ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
@@ -93,13 +95,14 @@ steps:
         condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'), in(variables['_SignType'], 'real', 'test'))
 
     - ${{ if eq(parameters.enableMicrobuildForMacAndLinux, true) }}:
-      - template: /eng/common/core-templates/steps/install-microbuild-impl.yml@self
+      - template: /eng/common/core-templates/steps/install-microbuild-impl.yml
         parameters:
           enablePreviewMicrobuild: ${{ parameters.enablePreviewMicrobuild }}
           microbuildTaskInputs:
             signType: $(_SignType)
             zipSources: false
             feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+            version: ${{ parameters.microbuildPluginVersion }}
             ${{ if eq(parameters.microbuildUseESRP, true) }}:
               ConnectedServiceName: 'MicroBuild Signing Task (DevDiv)'
               ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:

--- a/eng/common/core-templates/steps/install-microbuild.yml
+++ b/eng/common/core-templates/steps/install-microbuild.yml
@@ -4,6 +4,8 @@ parameters:
   # Enable install tasks for MicroBuild on Mac and Linux
   # Will be ignored if 'enableMicrobuild' is false or 'Agent.Os' is 'Windows_NT'
   enableMicrobuildForMacAndLinux: false
+  # Enable preview version of MB signing plugin
+  enablePreviewMicrobuild: false
   # Determines whether the ESRP service connection information should be passed to the signing plugin.
   # This overlaps with _SignType to some degree. We only need the service connection for real signing.
   # It's important that the service connection not be passed to the MicroBuildSigningPlugin task in this place.
@@ -69,29 +71,10 @@ steps:
     # YAML expansion, and Windows vs. Linux/Mac uses different service connections. However,
     # we can avoid including the MB install step if not enabled at all. This avoids a bunch of
     # extra pipeline authorizations, since most pipelines do not sign on non-Windows.
-    - task: MicroBuildSigningPlugin@4
-      displayName: Install MicroBuild plugin (Windows)
-      inputs:
-        signType: $(_SignType)
-        zipSources: false
-        feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-        ${{ if eq(parameters.microbuildUseESRP, true) }}:
-          ConnectedServiceName: 'MicroBuild Signing Task (DevDiv)'
-          ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
-            ConnectedPMEServiceName: 6cc74545-d7b9-4050-9dfa-ebefcc8961ea
-          ${{ else }}:
-            ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
-      env:
-        TeamName: $(_TeamName)
-        MicroBuildOutputFolderOverride: ${{ parameters.microBuildOutputFolder }}
-        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-      continueOnError: ${{ parameters.continueOnError }}
-      condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'), in(variables['_SignType'], 'real', 'test'))
-
-    - ${{ if eq(parameters.enableMicrobuildForMacAndLinux, true) }}:
-      - task: MicroBuildSigningPlugin@4
-        displayName: Install MicroBuild plugin (non-Windows)
-        inputs:
+    - template: /eng/common/core-templates/steps/install-microbuild-impl.yml@self
+      parameters:
+        enablePreviewMicrobuild: ${{ parameters.enablePreviewMicrobuild }}
+        microbuildTaskInputs:
           signType: $(_SignType)
           zipSources: false
           feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
@@ -99,12 +82,33 @@ steps:
           ${{ if eq(parameters.microbuildUseESRP, true) }}:
             ConnectedServiceName: 'MicroBuild Signing Task (DevDiv)'
             ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
-              ConnectedPMEServiceName: beb8cb23-b303-4c95-ab26-9e44bc958d39
+              ConnectedPMEServiceName: 6cc74545-d7b9-4050-9dfa-ebefcc8961ea
             ${{ else }}:
-              ConnectedPMEServiceName: c24de2a5-cc7a-493d-95e4-8e5ff5cad2bc
-        env:
+              ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
+        microbuildEnv:
           TeamName: $(_TeamName)
           MicroBuildOutputFolderOverride: ${{ parameters.microBuildOutputFolder }}
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         continueOnError: ${{ parameters.continueOnError }}
-        condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'),  eq(variables['_SignType'], 'real'))
+        condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'), in(variables['_SignType'], 'real', 'test'))
+
+    - ${{ if eq(parameters.enableMicrobuildForMacAndLinux, true) }}:
+      - template: /eng/common/core-templates/steps/install-microbuild-impl.yml@self
+        parameters:
+          enablePreviewMicrobuild: ${{ parameters.enablePreviewMicrobuild }}
+          microbuildTaskInputs:
+            signType: $(_SignType)
+            zipSources: false
+            feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+            ${{ if eq(parameters.microbuildUseESRP, true) }}:
+              ConnectedServiceName: 'MicroBuild Signing Task (DevDiv)'
+              ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+                ConnectedPMEServiceName: beb8cb23-b303-4c95-ab26-9e44bc958d39
+              ${{ else }}:
+                ConnectedPMEServiceName: c24de2a5-cc7a-493d-95e4-8e5ff5cad2bc
+          microbuildEnv:
+            TeamName: $(_TeamName)
+            MicroBuildOutputFolderOverride: ${{ parameters.microBuildOutputFolder }}
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          continueOnError: ${{ parameters.continueOnError }}
+          condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'),  eq(variables['_SignType'], 'real'))


### PR DESCRIPTION
Backport of #16185 to `release/10.0`.

## Why

PR #16185 added support for the MicroBuild preview signing plugin by introducing a new `enablePreviewMicrobuild` parameter and refactoring the install step to call either `MicroBuildSigningPlugin@4` or `MicroBuildSigningPluginPreview@4` based on that flag. Without this change on `release/10.0`, consumers that flow Arcade from this branch (e.g. dotnet/aspire on Arcade SHA `ecdd5c6a`) hit the warning:

> `Please use latest plugin version, version 5.4.0 used instead.`

Symptom seen in aspire pipeline 1602.

The original change was merged to `main` on 2025-10-06 and has been stable for 7+ months. It was never backported to `release/10.0`.

## What changed

Clean cherry-pick of upstream commit `ed075f46f1643382a9ff2490a985170e228db62d`:

- `eng/common/core-templates/job/job.yml` — thread new `enablePreviewMicrobuild` parameter through to `install-microbuild.yml` and `cleanup-microbuild.yml`.
- `eng/common/core-templates/steps/install-microbuild.yml` — refactored to delegate the actual MicroBuild task invocation to a new impl template (one call for Windows, one for Mac/Linux).
- `eng/common/core-templates/steps/install-microbuild-impl.yml` (new) — selects `MicroBuildSigningPluginPreview@4` vs `MicroBuildSigningPlugin@4` based on `enablePreviewMicrobuild`.

No other files touched.

## Validation

- Cherry-pick from `main` applied cleanly with auto-merge (no conflicts).
- All three YAML files parse successfully (`yaml.safe_load`).
- Diff against `origin/release/10.0` matches the intent of #16185 (parameter plumbing + impl-template split).
- No Arcade unit tests cover these templates; YAML validity + diff review is the bar for template-only changes.

## Notes

- Plugin task remains pinned to `@4` per current internal guidance — no `@5` bump.
- This is a structural port (not just a one-liner), keeping `release/10.0` aligned with `main` to simplify future flow.