### PR TITLE
Add opt-in isolated source-index tool restore

### DIFF
--- a/eng/common/core-templates/job/source-index-stage1.yml
+++ b/eng/common/core-templates/job/source-index-stage1.yml
@@ -3,6 +3,7 @@ parameters:
   sourceIndexBuildCommand: powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "eng/common/build.ps1 -restore -build -binarylog -ci"
   preSteps: []
   binlogPath: artifacts/log/Debug/Build.binlog
+  sourceIndexUseIsolatedNuGetConfig: false
   condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
   dependsOn: ''
   pool: ''
@@ -44,3 +45,4 @@ jobs:
   - template: /eng/common/core-templates/steps/source-index-stage1-publish.yml
     parameters:
       binLogPath: ${{ parameters.binLogPath }}
+      sourceIndexUseIsolatedNuGetConfig: ${{ parameters.sourceIndexUseIsolatedNuGetConfig }}

--- a/eng/common/core-templates/steps/source-index-stage1-publish.yml
+++ b/eng/common/core-templates/steps/source-index-stage1-publish.yml
@@ -2,6 +2,7 @@ parameters:
   sourceIndexUploadPackageVersion: 2.0.0-20250906.1
   sourceIndexProcessBinlogPackageVersion: 1.0.1-20250906.1
   sourceIndexPackageSource: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
+  sourceIndexUseIsolatedNuGetConfig: false
   binlogPath: artifacts/log/Debug/Build.binlog
 
 steps:
@@ -13,12 +14,72 @@ steps:
     installationPath: $(Agent.TempDirectory)/dotnet
     workingDirectory: $(Agent.TempDirectory)
 
-- script: |
-    $(Agent.TempDirectory)/dotnet/dotnet tool install BinLogToSln --version ${{parameters.sourceIndexProcessBinlogPackageVersion}} --source ${{parameters.sourceIndexPackageSource}} --tool-path $(Agent.TempDirectory)/.source-index/tools
-    $(Agent.TempDirectory)/dotnet/dotnet tool install UploadIndexStage1 --version ${{parameters.sourceIndexUploadPackageVersion}} --source ${{parameters.sourceIndexPackageSource}} --tool-path $(Agent.TempDirectory)/.source-index/tools
-  displayName: "Source Index: Download netsourceindex Tools"
-  # Set working directory to temp directory so 'dotnet' doesn't try to use global.json and use the repo's sdk.
-  workingDirectory: $(Agent.TempDirectory)
+- ${{ if or(eq(parameters.sourceIndexUseIsolatedNuGetConfig, true), eq(parameters.sourceIndexUseIsolatedNuGetConfig, 'true')) }}:
+  - powershell: |
+      $ErrorActionPreference = 'Stop'
+
+      $sourceIndexRoot = "$(Agent.TempDirectory)/.source-index"
+      $toolsDirectory = "$sourceIndexRoot/tools"
+      $dotnet = "$(Agent.TempDirectory)/dotnet/dotnet"
+
+      New-Item -ItemType Directory -Force -Path $sourceIndexRoot | Out-Null
+      New-Item -ItemType Directory -Force -Path $toolsDirectory | Out-Null
+
+      # Generate an isolated NuGet config so tool restore doesn't inherit machine/user-level
+      # package sources (e.g. nuget.org), which trips 1ES Network Isolation. The template
+      # emitted by 'dotnet new nugetconfig' includes <clear/> in <packageSources>, blocking
+      # inherited sources.
+      & $dotnet new nugetconfig --force --output $sourceIndexRoot
+      if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to create isolated NuGet config."
+        exit 1
+      }
+
+      $nugetConfig = Join-Path $sourceIndexRoot 'nuget.config'
+      if (-not (Test-Path $nugetConfig)) {
+        $generated = Get-ChildItem -Path $sourceIndexRoot -Filter 'nuget.config' -File -ErrorAction SilentlyContinue | Select-Object -First 1
+        if (-not $generated) { throw "Could not locate generated nuget.config under $sourceIndexRoot" }
+        $nugetConfig = $generated.FullName
+      }
+
+      # Remove the default NuGet.org source the template added so only the approved feed is contacted.
+      $nugetConfigXml = [xml](Get-Content -Raw $nugetConfig)
+      $nugetOrgSource = $nugetConfigXml.configuration.packageSources.add | Where-Object { $_.value -eq 'https://api.nuget.org/v3/index.json' } | Select-Object -First 1
+      if ($nugetOrgSource) {
+        & $dotnet nuget remove source $nugetOrgSource.key --configfile $nugetConfig
+        if ($LASTEXITCODE -ne 0) {
+          Write-Error "Failed to remove NuGet.org source '$($nugetOrgSource.key)'."
+          exit 1
+        }
+      }
+
+      & $dotnet nuget add source "${{parameters.sourceIndexPackageSource}}" --name source-index --configfile $nugetConfig
+      if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to add the source-index package source."
+        exit 1
+      }
+
+      & $dotnet tool install BinLogToSln --version ${{parameters.sourceIndexProcessBinlogPackageVersion}} --configfile $nugetConfig --tool-path $toolsDirectory
+      if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to install BinLogToSln."
+        exit 1
+      }
+
+      & $dotnet tool install UploadIndexStage1 --version ${{parameters.sourceIndexUploadPackageVersion}} --configfile $nugetConfig --tool-path $toolsDirectory
+      if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to install UploadIndexStage1."
+        exit 1
+      }
+    displayName: "Source Index: Download netsourceindex Tools"
+    # Set working directory to temp directory so 'dotnet' doesn't try to use global.json and use the repo's sdk.
+    workingDirectory: $(Agent.TempDirectory)
+- ${{ else }}:
+  - script: |
+      $(Agent.TempDirectory)/dotnet/dotnet tool install BinLogToSln --version ${{parameters.sourceIndexProcessBinlogPackageVersion}} --source ${{parameters.sourceIndexPackageSource}} --tool-path $(Agent.TempDirectory)/.source-index/tools
+      $(Agent.TempDirectory)/dotnet/dotnet tool install UploadIndexStage1 --version ${{parameters.sourceIndexUploadPackageVersion}} --source ${{parameters.sourceIndexPackageSource}} --tool-path $(Agent.TempDirectory)/.source-index/tools
+    displayName: "Source Index: Download netsourceindex Tools"
+    # Set working directory to temp directory so 'dotnet' doesn't try to use global.json and use the repo's sdk.
+    workingDirectory: $(Agent.TempDirectory)
 
 - script: $(Agent.TempDirectory)/.source-index/tools/BinLogToSln -i ${{parameters.BinlogPath}} -r $(System.DefaultWorkingDirectory) -n $(Build.Repository.Name) -o .source-index/stage1output
   displayName: "Source Index: Process Binlog into indexable sln"


### PR DESCRIPTION
1ES Network Isolation reported `dotnet.exe` probing `api.nuget.org` during the source-index stage1 tool install step. The existing `dotnet tool install --source <dnceng feed>` commands add the approved feed, but still allow NuGet to inherit machine/user package sources.

## Summary

This adds an opt-in source-index parameter, `sourceIndexUseIsolatedNuGetConfig`, defaulting to `false` so existing consumers keep the current restore behavior.

When the parameter is set to `true`, the source-index stage1 publish template builds an isolated temporary `nuget.config` under `$(Agent.TempDirectory)/.source-index` before installing source-index tools. The opt-in path:

- Creates the source-index root and tools directory.
- Runs `dotnet new nugetconfig --force` using the stage1 SDK installed under `$(Agent.TempDirectory)/dotnet`.
- Removes the generated NuGet.org source from that temp config.
- Adds only the approved `source-index` feed from `sourceIndexPackageSource`.
- Installs `BinLogToSln` and `UploadIndexStage1` with `--configfile <temp nuget.config>` and the existing temp tool path.

The step still runs from `$(Agent.TempDirectory)` so it avoids the repo `global.json`, and native `dotnet` calls follow the existing Arcade YAML pattern of checking `$LASTEXITCODE` and failing with `Write-Error` / `exit 1`.

## Usage

Consumers can opt in through source-index parameters, for example:

```yaml
sourceIndexParams:
  sourceIndexUseIsolatedNuGetConfig: true
```

The lower-level source-index job/step templates also accept `sourceIndexUseIsolatedNuGetConfig: true` directly.

## Validation

- Parsed the changed YAML successfully.
- Parsed the embedded PowerShell successfully.
- Exercised the opt-in config generation, NuGet.org source removal, and `source-index` source addition flow locally. The final config contained only `<clear />` plus the dnceng `source-index` feed.