### PR TITLE
Fix StringBuilder race in SignTool RealSignTool.RunMSBuild

### DIFF
--- a/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
@@ -69,22 +69,16 @@ namespace Microsoft.DotNet.SignTool
 
                 var output = new StringBuilder();
                 var error = new StringBuilder();
-                var outputLock = new object();
-                var errorLock = new object();
 
-                // StringBuilder is not thread-safe and the OutputDataReceived/ErrorDataReceived
-                // events fire on background threads, so guard appends and the final ToString()
-                // with locks to avoid concurrent mutation (which can manifest as
-                // ArgumentOutOfRangeException 'chunkLength' inside StringBuilder.ToString()).
                 process.OutputDataReceived += (sender, e) =>
                 {
                     if (e.Data == null) return;
-                    lock (outputLock) { output.AppendLine(e.Data); }
+                    output.AppendLine(e.Data);
                 };
                 process.ErrorDataReceived += (sender, e) =>
                 {
                     if (e.Data == null) return;
-                    lock (errorLock) { error.AppendLine(e.Data); }
+                    error.AppendLine(e.Data);
                 };
 
                 process.Start();
@@ -122,15 +116,13 @@ namespace Microsoft.DotNet.SignTool
                     success = false;
                 }
 
-                string outputStr;
-                lock (outputLock) { outputStr = output.ToString().Trim(); }
+                string outputStr = output.ToString().Trim();
                 if (!string.IsNullOrWhiteSpace(outputStr))
                 {
                     File.WriteAllText(logPath, outputStr);
                 }
 
-                string errorStr;
-                lock (errorLock) { errorStr = error.ToString().Trim(); }
+                string errorStr = error.ToString().Trim();
                 if (!string.IsNullOrWhiteSpace(errorStr))
                 {
                     File.WriteAllText(errorLogPath, errorStr);

--- a/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
+++ b/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs
@@ -69,9 +69,23 @@ namespace Microsoft.DotNet.SignTool
 
                 var output = new StringBuilder();
                 var error = new StringBuilder();
+                var outputLock = new object();
+                var errorLock = new object();
 
-                process.OutputDataReceived += (sender, e) => output.AppendLine(e.Data);
-                process.ErrorDataReceived += (sender, e) => error.AppendLine(e.Data);
+                // StringBuilder is not thread-safe and the OutputDataReceived/ErrorDataReceived
+                // events fire on background threads, so guard appends and the final ToString()
+                // with locks to avoid concurrent mutation (which can manifest as
+                // ArgumentOutOfRangeException 'chunkLength' inside StringBuilder.ToString()).
+                process.OutputDataReceived += (sender, e) =>
+                {
+                    if (e.Data == null) return;
+                    lock (outputLock) { output.AppendLine(e.Data); }
+                };
+                process.ErrorDataReceived += (sender, e) =>
+                {
+                    if (e.Data == null) return;
+                    lock (errorLock) { error.AppendLine(e.Data); }
+                };
 
                 process.Start();
                 process.BeginOutputReadLine();
@@ -88,6 +102,14 @@ namespace Microsoft.DotNet.SignTool
                     process.WaitForExit();
                     success = false;
                 }
+                else
+                {
+                    // When WaitForExit(timeout) returns true, the asynchronous output/error
+                    // event handlers are not guaranteed to have drained. The parameterless
+                    // WaitForExit() overload blocks until they have, which is required before
+                    // reading the StringBuilders below.
+                    process.WaitForExit();
+                }
 
                 if (process.ExitCode != 0)
                 {
@@ -100,13 +122,15 @@ namespace Microsoft.DotNet.SignTool
                     success = false;
                 }
 
-                string outputStr = output.ToString().Trim();
+                string outputStr;
+                lock (outputLock) { outputStr = output.ToString().Trim(); }
                 if (!string.IsNullOrWhiteSpace(outputStr))
                 {
                     File.WriteAllText(logPath, outputStr);
                 }
-                
-                string errorStr = error.ToString().Trim();
+
+                string errorStr;
+                lock (errorLock) { errorStr = error.ToString().Trim(); }
                 if (!string.IsNullOrWhiteSpace(errorStr))
                 {
                     File.WriteAllText(errorLogPath, errorStr);


### PR DESCRIPTION
## Summary

Fixes an intermittent crash of `SignToolTask` observed e.g. in [build 2977839](https://dev.azure.com/dnceng/internal/_build/results?buildId=2977839&view=logs&j=595e44c8-424f-5de6-3262-bdb644f56258&t=f9f913c6-fa4a-5bef-cb12-948973fbad31) (`Validate_Signing_MacOS Real_Signing`):

```
error MSB4018: The "Microsoft.DotNet.SignTool.SignToolTask" task failed unexpectedly.
System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than or equal to the size of the collection. (Parameter ''chunkLength'')
   at System.Text.StringBuilder.ToString()
   at Microsoft.DotNet.SignTool.RealSignTool.RunMSBuild(...) in /_/src/Microsoft.DotNet.SignTool/src/RealSignTool.cs:line 103
```

## Root cause

`RealSignTool.RunMSBuild` redirects the child `dotnet build` stdout/stderr to a `StringBuilder` via async `OutputDataReceived` / `ErrorDataReceived` handlers, which fire on background threads. It then uses `process.WaitForExit(_dotnetTimeout)` (the timed overload).

Per the [`Process.WaitForExit(Int32)` documentation](https://learn.microsoft.com/dotnet/api/system.diagnostics.process.waitforexit#system-diagnostics-process-waitforexit(system-int32)), when that overload returns `true` the asynchronous output handlers are **not** guaranteed to have drained. You must call the parameterless `WaitForExit()` afterwards to ensure they have.

The previous code went straight to `output.ToString()`, which can run concurrently with an in-flight `output.AppendLine(...)` on a background thread. `StringBuilder` is not thread-safe, the internal chunk linked-list gets into an inconsistent state, and `ToString()` throws `ArgumentOutOfRangeException` on `chunkLength`.

This is intermittent and most likely to fire when the child process emits a burst of output close to exit — typical for the macOS notarization step.

## Fix

1. Call the parameterless `process.WaitForExit()` after `WaitForExit(timeout)` returns `true`, before reading the buffers — the documented way to wait for async output handlers to drain.
2. Belt-and-braces: lock around the `StringBuilder.AppendLine` calls in the event handlers and around the final `ToString()` reads so the buffers are mutated/read under a consistent lock. Also skip the null `e.Data` sentinel for clarity.

The timeout/Kill path is unchanged — it already calls the parameterless `WaitForExit()` after `Kill()`.
