### PR TITLE
Backport Entra credential fallback for dn-bot-all-orgs-build-rw-code-rw (WI 10724)

### DIFF
--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -62,17 +62,6 @@ secrets:
       organizations: dnceng
       scopes: build_execute code_write 
 
-  dn-bot-all-orgs-build-rw-code-rw:
-    type: azure-devops-access-token
-    parameters:
-      domainAccountName: dn-bot
-      domainAccountSecret:
-          location: helixkv
-          name: dn-bot-account-redmond
-      name: dn-bot-all-orgs-build
-      organizations: dnceng devdiv microsoft dotnet-security-partners
-      scopes: build_execute code_write
-
   #DotNet-AllOrgs-Darc-Pats
   dn-bot-devdiv-dnceng-rw-code-pat:
     type: azure-devops-access-token

--- a/eng/common/core-templates/steps/publish-logs.yml
+++ b/eng/common/core-templates/steps/publish-logs.yml
@@ -34,7 +34,6 @@ steps:
       '$(akams-client-id)'
       '$(microsoft-symbol-server-pat)'
       '$(symweb-symbol-server-pat)'
-      '$(dn-bot-all-orgs-build-rw-code-rw)'
       ${{parameters.CustomSensitiveDataList}}
   continueOnError: true
   condition: always()

--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -116,7 +116,6 @@ stages:
           /p:MsdlToken=$(microsoft-symbol-server-pat)
           /p:SymWebToken=$(symweb-symbol-server-pat)
           /p:BuildQuality='${{ parameters.buildQuality }}'
-          /p:AzdoApiToken='$(dn-bot-all-orgs-build-rw-code-rw)'
           /p:ArtifactsBasePath='$(Build.ArtifactStagingDirectory)/'
           /p:BuildId='$(AzDOBuildId)'
           /p:AzureDevOpsOrg='$(AzDOAccount)'

--- a/src/Microsoft.DotNet.ArcadeAzureIntegration/AzureCliCredentialWithAzNoUpdateWrapper.cs
+++ b/src/Microsoft.DotNet.ArcadeAzureIntegration/AzureCliCredentialWithAzNoUpdateWrapper.cs
@@ -1,0 +1,135 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.IO;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Identity;
+
+namespace Microsoft.DotNet.ArcadeAzureIntegration;
+
+
+// This class is an workaround for disable az cli auto update mechanism which cause timeout when waiting for
+// console input in case of new version of az available
+// - this wrppper will run "az config set auto-upgrade.enable=no" only once before first call to az for acquiring the token
+public class AzureCliCredentialWithAzNoUpdateWrapper : TokenCredential
+{
+    private readonly AzureCliCredential _azureCliCredential;
+
+    public AzureCliCredentialWithAzNoUpdateWrapper(AzureCliCredential azureCliCredential)
+    {
+        _azureCliCredential = azureCliCredential;
+    }
+
+    public static string? EnvProgramFilesX86 => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable("ProgramFiles(x86)"));
+    public static string? EnvProgramFiles => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable("ProgramFiles"));
+    public static string? EnvPath => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable("PATH"));
+
+    private static readonly string DefaultPathWindows = $"{EnvProgramFilesX86}\\Microsoft SDKs\\Azure\\CLI2\\wbin;{EnvProgramFiles}\\Microsoft SDKs\\Azure\\CLI2\\wbin";
+    private static readonly string DefaultWorkingDirWindows = Environment.GetFolderPath(Environment.SpecialFolder.System);
+    private const string DefaultPathNonWindows = "/usr/bin:/usr/local/bin";
+    private const string DefaultWorkingDirNonWindows = "/bin/";
+    private static readonly string DefaultPath = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? DefaultPathWindows : DefaultPathNonWindows;
+    private static readonly string DefaultWorkingDir = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? DefaultWorkingDirWindows : DefaultWorkingDirNonWindows;
+
+    private static string? GetNonEmptyStringOrNull(string? str)
+    {
+        return !string.IsNullOrEmpty(str) ? str : null;
+    }
+
+    private static SemaphoreSlim _azCliInitSemaphore = new SemaphoreSlim(1, 1);
+    private static bool _azCliInitialized = false;
+
+    private async Task SetUpAzAsync()
+    {
+        await _azCliInitSemaphore.WaitAsync();
+        try
+        {
+            if (_azCliInitialized) return;
+
+            string fileName;
+            string argument;
+            string command = $"az config set auto-upgrade.enable=no";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                fileName = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "cmd.exe");
+                argument = $"/d /c \"{command}\"";
+            }
+            else
+            {
+                fileName = "/bin/sh";
+                argument = $"-c \"{command}\"";
+            }
+
+            string path = !string.IsNullOrEmpty(EnvPath) ? EnvPath : DefaultPath;
+            var processInfo = new ProcessStartInfo
+            {
+                FileName = fileName,
+                Arguments = argument,
+                UseShellExecute = false,
+                ErrorDialog = false,
+                CreateNoWindow = true,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                WorkingDirectory = DefaultWorkingDir,
+                Environment = { { "PATH", path } }
+            };
+
+            using Process? process = Process.Start(processInfo);
+            if (process == null)
+            {
+                throw new InvalidOperationException("Failed to start process to disable auto update of Azure CLI");
+            }
+
+            using var tokenSource = new CancellationTokenSource();
+            tokenSource.CancelAfter(TimeSpan.FromSeconds(30));
+            await process.WaitForExitAsync(tokenSource.Token);
+
+            if (!process.HasExited)
+            {
+                // try clean up the process if it is still running after timeout
+                try { process.Kill(); } catch { /* ignore this excpetion */}
+                throw new InvalidOperationException("Could not finish az config command to disable auto update on time");
+            }
+
+            process.StandardInput.Close();
+            process.Close();
+        }
+        catch (Exception e)
+        {
+            // silent catch with direct console output as this is not a critical error
+            Console.WriteLine($"Warning - Disable auto update of Azure CLI failed: {e.Message}");
+        }
+        finally
+        {
+            _azCliInitialized = true;
+            _azCliInitSemaphore.Release();
+        }
+    }
+
+    public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken = default)
+    {
+        if (!_azCliInitialized)
+        {
+            SetUpAzAsync().Wait();
+        }
+        return _azureCliCredential.GetToken(requestContext, cancellationToken);
+    }
+
+    public override async ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken = default)
+    {
+        if (!_azCliInitialized)
+        {
+            await SetUpAzAsync();
+        }
+        return await _azureCliCredential.GetTokenAsync(requestContext, cancellationToken);
+    }
+}

--- a/src/Microsoft.DotNet.ArcadeAzureIntegration/DefaultIdentityTokenCredential.cs
+++ b/src/Microsoft.DotNet.ArcadeAzureIntegration/DefaultIdentityTokenCredential.cs
@@ -1,0 +1,174 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Azure.Core;
+using Azure.Identity;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace Microsoft.DotNet.ArcadeAzureIntegration;
+
+
+// This implementation of TokenCredential will try to cover all common ways of
+// authentication to Azure services used in Arcade tooling
+public class DefaultIdentityTokenCredential : TokenCredential
+{
+    private readonly TokenCredential _tokenCredential;
+
+    public DefaultIdentityTokenCredential()
+        : this(new DefaultIdentityTokenCredentialOptions())
+    {
+    }
+
+    public DefaultIdentityTokenCredential(DefaultIdentityTokenCredentialOptions options)
+    {
+        _tokenCredential = CreateAvailableTokenCredential(options);
+    }
+
+    public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+    {
+        return _tokenCredential.GetTokenAsync(requestContext, cancellationToken);
+    }
+
+    public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+    {
+        return _tokenCredential.GetToken(requestContext, cancellationToken);
+    }
+
+    private static TokenCredential CreateAvailableTokenCredential(DefaultIdentityTokenCredentialOptions options)
+    {
+        TokenCredential? azurePipelinesCredential = GetAzurePipelinesCredentialForAzurePipelineTask();
+
+        if (options.UseAzurePipelineCredentialAloneIfConfigured)
+        {
+            if (azurePipelinesCredential != null)
+            {
+                if (!options.DisableShortCache)
+                {
+                    return new TokenCredentialShortCache(azurePipelinesCredential);
+                }
+                return azurePipelinesCredential;
+            }
+        }
+
+        List<TokenCredential> tokenCredentials = [];
+
+        // Add Azure Pipelines credential if the environment variables are set
+        if (azurePipelinesCredential != null)
+        {
+            if (!options.DisableShortCache)
+            {
+                azurePipelinesCredential = new TokenCredentialShortCache(azurePipelinesCredential);
+            }
+            tokenCredentials.Add(azurePipelinesCredential);
+        }
+
+        // Add Managed Identity credential
+        tokenCredentials.Add(new ManagedIdentityCredential(ManagedIdentityId.FromUserAssignedClientId(options.ManagedIdentityClientId)));
+
+        // Add work load identity credential if the environment variables are set
+        TokenCredential? workloadIdentityCredential = GetWorkloadIdentityCredentialForAzurePipelineTask();
+        if (workloadIdentityCredential != null)
+        {
+            if (!options.DisableShortCache)
+            {
+                workloadIdentityCredential = new TokenCredentialShortCache(workloadIdentityCredential);
+            }
+            tokenCredentials.Add(workloadIdentityCredential);
+        }
+
+        if (!options.ExcludeAzureCliCredential)
+        {
+            // Add Azure CLI credential as the last resort
+            // az command to disable auto update of the Azure CLI to avoid timeout waiting for
+            // console input will be called before first use of AzureCliCredential
+            TokenCredential azureCliCredential = new AzureCliCredentialWithAzNoUpdateWrapper(
+                new AzureCliCredential(new AzureCliCredentialOptions
+                {
+                    ProcessTimeout = TimeSpan.FromSeconds(30)
+                })
+            );
+            if (!options.DisableShortCache)
+            {
+                azureCliCredential = new TokenCredentialShortCache(azureCliCredential);
+            }
+            tokenCredentials.Add(azureCliCredential);
+        }
+
+        if (tokenCredentials.Count == 0)
+        {
+            throw new InvalidOperationException("No valid credential class detected and configured for authentication to Azure services.");
+        }
+
+        var ret = new ChainedTokenCredential(tokenCredentials.ToArray());
+        return ret;
+    }
+
+    private static object _workloadTokenFileLock = new object();
+    private static string? _workloadTokenFile = null;
+    private static string? _workloadToken = null;
+
+    // Create WorkloadIdentityCredential if the environment variables set by AzurePipeline are provided
+    private static WorkloadIdentityCredential? GetWorkloadIdentityCredentialForAzurePipelineTask()
+    {
+        string? servicePrincipalId = Environment.GetEnvironmentVariable("servicePrincipalId");
+        string? idToken = Environment.GetEnvironmentVariable("idToken");
+        string? tenantId = Environment.GetEnvironmentVariable("tenantId");
+
+        if (!string.IsNullOrEmpty(idToken) &&
+            !string.IsNullOrEmpty(tenantId) &&
+            !string.IsNullOrEmpty(servicePrincipalId))
+        {
+            lock (_workloadTokenFileLock)
+            {
+                if (idToken != _workloadToken)
+                {
+                    // create token file
+                    var tokenFileName = Path.GetTempFileName();
+                    File.WriteAllText(tokenFileName, idToken);
+                    _workloadTokenFile = tokenFileName;
+                    _workloadToken = idToken;
+                }
+                return new WorkloadIdentityCredential(new WorkloadIdentityCredentialOptions
+                {
+                    ClientId = servicePrincipalId,
+                    TokenFilePath = _workloadTokenFile,
+                    TenantId = tenantId,
+                });
+            }
+        }
+        return null;
+    }
+
+    // Create AzurePipelinesCredential if the environment variables set by AzureCli task and SYSTEM_ACCESSTOKEN are provided
+    private static AzurePipelinesCredential? GetAzurePipelinesCredentialForAzurePipelineTask()
+    {
+        string? systemAccessToken = Environment.GetEnvironmentVariable("SYSTEM_ACCESSTOKEN");
+        string? clientId = Environment.GetEnvironmentVariable("AZURESUBSCRIPTION_CLIENT_ID");
+        string? tenantId = Environment.GetEnvironmentVariable("AZURESUBSCRIPTION_TENANT_ID");
+        string? serviceConnectionId = Environment.GetEnvironmentVariable("AZURESUBSCRIPTION_SERVICE_CONNECTION_ID");
+
+        if (!string.IsNullOrEmpty(systemAccessToken) &&
+            !string.IsNullOrEmpty(clientId) &&
+            !string.IsNullOrEmpty(tenantId) &&
+            !string.IsNullOrEmpty(serviceConnectionId) &&
+            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SYSTEM_OIDCREQUESTURI")))
+        {
+            var credentialOptions = new AzurePipelinesCredentialOptions
+            {
+                TokenCachePersistenceOptions = new TokenCachePersistenceOptions
+                {
+                    Name = $"TokenCache-AzurePipelinesCredential-{serviceConnectionId}",
+                    UnsafeAllowUnencryptedStorage = false
+                }
+            };
+            return new AzurePipelinesCredential(tenantId, clientId, serviceConnectionId, systemAccessToken, credentialOptions);
+        }
+        return null;
+    }
+}

--- a/src/Microsoft.DotNet.ArcadeAzureIntegration/DefaultIdentityTokenCredentialOptions.cs
+++ b/src/Microsoft.DotNet.ArcadeAzureIntegration/DefaultIdentityTokenCredentialOptions.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+namespace Microsoft.DotNet.ArcadeAzureIntegration;
+
+
+public class DefaultIdentityTokenCredentialOptions
+{
+    public bool UseAzurePipelineCredentialAloneIfConfigured { get; set; } = true;
+    public string? ManagedIdentityClientId { get; set; } = null;
+    public bool ExcludeAzureCliCredential { get; set; }
+    public bool DisableShortCache { get; set; }
+}

--- a/src/Microsoft.DotNet.ArcadeAzureIntegration/Microsoft.DotNet.ArcadeAzureIntegration.csproj
+++ b/src/Microsoft.DotNet.ArcadeAzureIntegration/Microsoft.DotNet.ArcadeAzureIntegration.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NetMinimum)</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
+    <Compile Remove="AzureCliCredentialWithAzNoUpdateWrapper.cs" />
+    <Compile Remove="DefaultIdentityTokenCredential.cs" />
+    <Compile Remove="DefaultIdentityTokenCredentialOptions.cs" />
+    <Compile Remove="TokenCredentialShortCache.cs" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.DotNet.ArcadeAzureIntegration/TokenCredentialShortCache.cs
+++ b/src/Microsoft.DotNet.ArcadeAzureIntegration/TokenCredentialShortCache.cs
@@ -1,0 +1,89 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+
+namespace Microsoft.DotNet.ArcadeAzureIntegration;
+
+
+/// <summary>
+/// TokenCredentialShortCache is a wrapper around TokenCredential that caches the token for the same scope and request parameters.
+/// Cache time is short, 3 minutes only because we don't want to affect the expiration window that's still handled by the underlying TokenCredential implementation. 
+/// It helps with reducing the number of requests to Entra or AzureCLI external process during heavy paralellized operations.
+/// </summary>
+public class TokenCredentialShortCache : TokenCredential
+{
+    private const int CacheExpirationMinutes = 3;
+
+    public TokenCredentialShortCache(TokenCredential tokenCredential)
+    {
+        _tokenCredential = tokenCredential;
+    }
+
+    private TokenCredential _tokenCredential;
+    private ConcurrentDictionary<CacheKey, CachedToken> _tokenCache = new ConcurrentDictionary<CacheKey, CachedToken>();
+
+    public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+    {
+        return GetTokenAsync(requestContext, cancellationToken).Result;
+    }
+
+    public override async ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+    {
+        CacheKey cacheKey = new CacheKey
+        {
+            Scopes = string.Join(":", requestContext.Scopes),
+            Claims = requestContext.Claims,
+            TenantId = requestContext.TenantId,
+            IsCaeEnabled = requestContext.IsCaeEnabled
+        };
+
+        CachedToken cachedToken = _tokenCache.GetOrAdd(cacheKey, _ => new CachedToken());
+        var token = await cachedToken.GetToken(requestContext, () => {
+            return _tokenCredential.GetTokenAsync(requestContext, cancellationToken);
+        });
+
+        return token;
+    }
+
+    private record struct CacheKey
+    {
+        public required string Scopes { get; init; }
+        public required string? Claims { get; init; }
+        public required string? TenantId { get; init; }
+        public required bool IsCaeEnabled { get; init; }
+    }
+
+    private class CachedToken
+    {
+        private AccessToken? _token;
+        private DateTime _shortTimeCacheExpiresOn = DateTime.UtcNow;
+        private SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
+
+        public async ValueTask<AccessToken> GetToken(TokenRequestContext requestContext, Func<ValueTask<AccessToken>> getFreshToken)
+        {
+            await _semaphore.WaitAsync();
+            try
+            {
+                if (_token != null && _shortTimeCacheExpiresOn > DateTime.UtcNow)
+                {
+                    return _token.Value;
+                }
+
+                _token = await getFreshToken();
+                _shortTimeCacheExpiresOn = DateTime.UtcNow.AddMinutes(CacheExpirationMinutes);
+                return _token.Value;
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -46,6 +46,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Common\Microsoft.Arcade.Common\Microsoft.Arcade.Common.csproj" />
+    <ProjectReference Include="..\Microsoft.DotNet.ArcadeAzureIntegration\Microsoft.DotNet.ArcadeAzureIntegration.csproj" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
     <ProjectReference Include="..\Microsoft.DotNet.Deployment.Tasks.Links\Microsoft.DotNet.Deployment.Tasks.Links.csproj" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
     <ProjectReference Include="..\VersionTools\Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.csproj" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -32,6 +32,7 @@ using static Microsoft.DotNet.Build.Tasks.Feed.GeneralUtils;
 using static Microsoft.DotNet.Build.CloudTestTasks.AzureStorageUtils;
 using MsBuildUtils = Microsoft.Build.Utilities;
 using System.Security.Cryptography.X509Certificates;
+using Microsoft.DotNet.ArcadeAzureIntegration;
 
 namespace Microsoft.DotNet.Build.Tasks.Feed
 {
@@ -887,16 +888,70 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 BaseAddress = new Uri(address)
             };
             client.Timeout = TimeSpan.FromSeconds(TimeoutInSeconds);
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
-                "Basic",
-                Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Format("{0}:{1}", "",
-                    AzdoApiToken))));
+
+            if (!string.IsNullOrEmpty(AzdoApiToken))
+            {
+                // Legacy PAT-based authentication
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+                    "Basic",
+                    Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Format("{0}:{1}", "",
+                        AzdoApiToken))));
+            }
+            else
+            {
+                // Entra-based authentication using DefaultIdentityTokenCredential
+                // This supports AzurePipelinesCredential (from AzureCLI@2), ManagedIdentity, WorkloadIdentity, and AzureCLI
+                var credential = new DefaultIdentityTokenCredential(
+                    new DefaultIdentityTokenCredentialOptions
+                    {
+                        ManagedIdentityClientId = ManagedIdentityClientId
+                    });
+                var tokenRequestContext = new global::Azure.Core.TokenRequestContext(new[] { "499b84ac-1321-427f-aa17-267ca6975798/.default" });
+                var accessToken = credential.GetToken(tokenRequestContext, CancellationToken.None);
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.Token);
+            }
+
             client.DefaultRequestHeaders.Add(
                 "Accept",
                 $"application/xml;api-version={versionOverride ?? AzureDevOpsFeedsApiVersion}");
             return client;
         }
 
+        /// <summary>
+        /// Checks whether Entra-based credentials are available in the current environment.
+        /// Returns true if running inside an AzureCLI@2 task (AzurePipelinesCredential),
+        /// or if a ManagedIdentityClientId is configured.
+        /// </summary>
+        private bool HasEntraCredentialsAvailable()
+        {
+            // AzurePipelinesCredential environment (set by AzureCLI@2 task with addSpnToEnvironment: true)
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURESUBSCRIPTION_CLIENT_ID")) &&
+                !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURESUBSCRIPTION_TENANT_ID")) &&
+                !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURESUBSCRIPTION_SERVICE_CONNECTION_ID")) &&
+                !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SYSTEM_ACCESSTOKEN")) &&
+                !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SYSTEM_OIDCREQUESTURI")))
+            {
+                return true;
+            }
+
+            // WorkloadIdentityCredential environment
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("servicePrincipalId")) &&
+                !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("idToken")) &&
+                !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("tenantId")))
+            {
+                return true;
+            }
+
+            // Managed Identity is configured
+            if (!string.IsNullOrEmpty(ManagedIdentityClientId))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private SemaphoreSlim _createArtifactSemaphore = new SemaphoreSlim(1,1);
         /// <summary>
         /// Gets the container Id, that is going to be used in another API call to download the assets
         /// ContainerId is the same for PackageArtifacts and BlobArtifacts
@@ -1792,9 +1847,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 Log.LogError($"The property {nameof(MaestroApiEndpoint)} is required but doesn't have a value set.");
             }
 
-            if (UseStreamingPublishing && string.IsNullOrEmpty(AzdoApiToken))
+            if (UseStreamingPublishing && string.IsNullOrEmpty(AzdoApiToken) && !HasEntraCredentialsAvailable())
             {
-                Log.LogError($"The property {nameof(AzdoApiToken)} is required when using streaming publishing, but doesn't have a value set.");
+                Log.LogError($"The property {nameof(AzdoApiToken)} is required when using streaming publishing (unless Entra credentials are available via AzureCLI@2 or Managed Identity), but doesn't have a value set.");
             }
 
             if (UseStreamingPublishing && string.IsNullOrEmpty(ArtifactsBasePath))


### PR DESCRIPTION
## Summary
Backports the Entra-based authentication fallback from main (PR #16806) to release/9.0.

The V3 publishing pipeline was failing because `dn-bot-all-orgs-build-rw-code-rw` expired on 2026-05-14. This change adds the Entra credential fallback so the publish task uses `AzurePipelinesCredential` from the existing `maestro-build-promotion` service connection (with `addSpnToEnvironment: true` already set on this branch).

## Changes
- Add `Microsoft.DotNet.ArcadeAzureIntegration` project (from main)
- Add Entra fallback to `CreateAzdoClient` in `PublishArtifactsInManifestBase`
- Remove `/p:AzdoApiToken` from `publish.yml`
- Remove PAT from `publish-logs.yml` redaction list
- Delete PAT entry from `product-builds-engkeyvault.yaml`

Work Item: https://dev.azure.com/dnceng/internal/_workitems/edit/10724