### PR TITLE
Backport Entra credential fallback for dn-bot-all-orgs-build-rw-code-rw (WI 10724)

### DIFF
--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -62,17 +62,6 @@ secrets:
       organizations: dnceng
       scopes: build_execute code_write 
 
-  dn-bot-all-orgs-build-rw-code-rw:
-    type: azure-devops-access-token
-    parameters:
-      domainAccountName: dn-bot
-      domainAccountSecret:
-          location: helixkv
-          name: dn-bot-account-redmond
-      name: dn-bot-all-orgs-build
-      organizations: dnceng devdiv microsoft dotnet-security-partners
-      scopes: build_execute code_write
-
   #DotNet-AllOrgs-Darc-Pats
   dn-bot-devdiv-dnceng-rw-code-pat:
     type: azure-devops-access-token

--- a/eng/common/core-templates/steps/publish-logs.yml
+++ b/eng/common/core-templates/steps/publish-logs.yml
@@ -36,7 +36,6 @@ steps:
       '$(microsoft-symbol-server-pat)'
       '$(symweb-symbol-server-pat)'
       '$(dnceng-symbol-server-pat)'
-      '$(dn-bot-all-orgs-build-rw-code-rw)'
       '$(System.AccessToken)'
       ${{parameters.CustomSensitiveDataList}}
   continueOnError: true

--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -134,6 +134,7 @@ stages:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       inputs:
         azureSubscription: maestro-build-promotion
+        addSpnToEnvironment: true
         scriptType: ps
         scriptLocation: scriptPath
         scriptPath: $(System.DefaultWorkingDirectory)/eng/common/sdk-task.ps1
@@ -161,7 +162,6 @@ stages:
           /p:SymbolRequestProject='dotnet'
           ${{ parameters.symbolPublishingAdditionalParameters}}
           /p:BuildQuality='${{ parameters.buildQuality }}'
-          /p:AzdoApiToken='$(dn-bot-all-orgs-build-rw-code-rw)'
           /p:ArtifactsBasePath='$(Build.ArtifactStagingDirectory)/'
           /p:BuildId='$(AzDOBuildId)'
           /p:AzureDevOpsOrg='$(AzDOAccount)'

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifestBase.cs
@@ -939,11 +939,64 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
             var client = new HttpClient(handler);
             client.Timeout = TimeSpan.FromSeconds(TimeoutInSeconds);
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
-                "Basic",
-                Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Format("{0}:{1}", "",
-                    tokenOverride ?? AzdoApiToken))));
+
+            string effectiveToken = tokenOverride ?? AzdoApiToken;
+            if (!string.IsNullOrEmpty(effectiveToken))
+            {
+                // Legacy PAT-based authentication
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+                    "Basic",
+                    Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Format("{0}:{1}", "", effectiveToken))));
+            }
+            else
+            {
+                // Entra-based authentication using DefaultIdentityTokenCredential
+                // This supports AzurePipelinesCredential (from AzureCLI@2), ManagedIdentity, WorkloadIdentity, and AzureCLI
+                var credential = new DefaultIdentityTokenCredential(
+                    new DefaultIdentityTokenCredentialOptions
+                    {
+                        ManagedIdentityClientId = ManagedIdentityClientId
+                    });
+                var tokenRequestContext = new global::Azure.Core.TokenRequestContext(new[] { "499b84ac-1321-427f-aa17-267ca6975798/.default" });
+                var accessToken = credential.GetToken(tokenRequestContext, CancellationToken.None);
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.Token);
+            }
+
             return client;
+        }
+
+        /// <summary>
+        /// Checks whether Entra-based credentials are available in the current environment.
+        /// Returns true if running inside an AzureCLI@2 task (AzurePipelinesCredential),
+        /// or if a ManagedIdentityClientId is configured.
+        /// </summary>
+        private bool HasEntraCredentialsAvailable()
+        {
+            // AzurePipelinesCredential environment (set by AzureCLI@2 task with addSpnToEnvironment: true)
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURESUBSCRIPTION_CLIENT_ID")) &&
+                !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURESUBSCRIPTION_TENANT_ID")) &&
+                !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURESUBSCRIPTION_SERVICE_CONNECTION_ID")) &&
+                !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SYSTEM_ACCESSTOKEN")) &&
+                !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SYSTEM_OIDCREQUESTURI")))
+            {
+                return true;
+            }
+
+            // WorkloadIdentityCredential environment
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("servicePrincipalId")) &&
+                !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("idToken")) &&
+                !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("tenantId")))
+            {
+                return true;
+            }
+
+            // Managed Identity is configured
+            if (!string.IsNullOrEmpty(ManagedIdentityClientId))
+            {
+                return true;
+            }
+
+            return false;
         }
 
         private SemaphoreSlim _createArtifactSemaphore = new SemaphoreSlim(1,1);
@@ -1924,9 +1977,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 Log.LogError($"The property {nameof(MaestroApiEndpoint)} is required but doesn't have a value set.");
             }
 
-            if (UseStreamingPublishing && string.IsNullOrEmpty(AzdoApiToken))
+            if (UseStreamingPublishing && string.IsNullOrEmpty(AzdoApiToken) && !HasEntraCredentialsAvailable())
             {
-                Log.LogError($"The property {nameof(AzdoApiToken)} is required when using streaming publishing, but doesn't have a value set.");
+                Log.LogError($"The property {nameof(AzdoApiToken)} is required when using streaming publishing (unless Entra credentials are available via AzureCLI@2 or Managed Identity), but doesn't have a value set.");
             }
 
             if (UseStreamingPublishing && string.IsNullOrEmpty(ArtifactsBasePath))


### PR DESCRIPTION
## Summary
Backports the Entra-based authentication fallback from main (PR #16806) to release/10.0.

The V3 publishing pipeline was failing because `dn-bot-all-orgs-build-rw-code-rw` expired on 2026-05-14. This change adds the Entra credential fallback so the publish task uses `AzurePipelinesCredential` from the `maestro-build-promotion` service connection.

## Changes
- Add Entra fallback to `CreateAzdoClient` in `PublishArtifactsInManifestBase`
- Add `addSpnToEnvironment: true` to Publish task
- Remove `/p:AzdoApiToken` from `publish.yml`
- Remove PAT from `publish-logs.yml` redaction list
- Delete PAT entry from `product-builds-engkeyvault.yaml`

Work Item: https://dev.azure.com/dnceng/internal/_workitems/edit/10724