### PR TITLE
Remove unused nsubstitute package version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -96,7 +96,6 @@
     <PackageVersion Include="xunit.extensibility.execution" Version="$(XUnitVersion)" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="$(XUnitV3Version)" />
     <PackageVersion Include="xunit.runner.reporters" Version="$(XUnitVersion)" />
-    <PackageVersion Include="nsubstitute" Version="5.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Removed the nsubstitute package version from the project.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
