### PR TITLE
Remove hardcoded Microsoft.Data.Services.Client property

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,8 +8,6 @@
   <!-- Version properties used outside of PackageReference items -->
   <PropertyGroup>
     <MicrosoftCciVersion>4.0.0-rc3-24214-00</MicrosoftCciVersion>
-    <!-- Keep Microsoft.Data.Services.Client package version in sync with Microsoft.Data.OData -->
-    <MicrosoftDataServicesClientVersion>5.8.4</MicrosoftDataServicesClientVersion>
     <MicrosoftSignedWixVersion>3.14.1-9323.2545153</MicrosoftSignedWixVersion>
     <MicrosoftWixToolsetSdkVersion>6.0.3-dotnet.4</MicrosoftWixToolsetSdkVersion>
     <!-- Overwrite XUnitVersion/XUnitAnalyzersVersion/XUnitRunnerConsoleVersion/XUnitRunnerVisualStudioVersion/MicrosoftTestingPlatformVersion that comes from the Arcade SDK to be in sync as Arcade doesn't use a live Arcade SDK.
@@ -76,7 +74,7 @@
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="2.3.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageVersion Include="Microsoft.Data.OData" Version="5.8.4" />
-    <PackageVersion Include="Microsoft.Data.Services.Client" Version="$(MicrosoftDataServicesClientVersion)" />
+    <PackageVersion Include="Microsoft.Data.Services.Client" Version="5.8.4" />
     <PackageVersion Include="Microsoft.Diagnostics.Runtime" Version="1.0.5" />
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.83.1" />
     <PackageVersion Include="Microsoft.OpenApi" Version="1.3.2" />


### PR DESCRIPTION
The property isn't used anymore outside of Directory.Packages.props. This allows dependabot to do its thing.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
