### PR TITLE
Fix invalid underscore in Debian package version string

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.build.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.build.targets
@@ -171,7 +171,7 @@
         MaintainerEmail="dotnetpackages@dotnetfoundation.org"
         MaintainerName=".NET Team"
         PackageName="$(VersionedInstallerName)"
-        PackageVersion="$(InstallerPackageVersion)_$(InstallerPackageRelease)"
+        PackageVersion="$(InstallerPackageVersion)-$(InstallerPackageRelease)"
         ReleaseNotes="https://github.com/dotnet/core/tree/master/release-notes" />
   
     <ItemGroup>
@@ -210,7 +210,7 @@
     <CreateControlFile
         ControlFileOutputPath="@(_ControlFile)"
         PackageName="$(VersionedInstallerName)"
-        PackageVersion="$(InstallerPackageVersion)"
+        PackageVersion="$(InstallerPackageVersion)-$(InstallerPackageRelease)"
         PackageArchitecture="$(LinuxPackageArchitecture)"
         Maintainer=".NET Team &lt;dotnetpackages@dotnetfoundation.org&gt;"
         Description="$(_ShortDescription)%0A $(_PackageLongDescription)"


### PR DESCRIPTION
## Summary

Fixes dotnet/sdk#52602

Debian package versions were constructed with an underscore separator (e.g., `10.0.1_1`), which violates Debian versioning policy. The underscore character is not in the set of allowed characters (`A-Za-z0-9.+-:~`), causing packaging and dependency resolution failures on Debian-based systems.

## Changes

**File:** `src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.build.targets`

1. **Changelog version (line 174):** Changed separator from `_` to `-`
   - Before: `InstallerPackageVersion_InstallerPackageRelease` → `10.0.1_1`
   - After: `InstallerPackageVersion-InstallerPackageRelease` → `10.0.1-1`

2. **Control file version (line 213):** Added missing release number with `-` separator
   - Before: `InstallerPackageVersion` → `10.0.1`
   - After: `InstallerPackageVersion-InstallerPackageRelease` → `10.0.1-1`

This also fixes a version mismatch between the changelog and control file — they now both use the same Debian-standard `upstream_version-debian_revision` format.

## Impact Analysis

- **Deb:** Fixed — produces valid Debian version strings
- **RPM:** No impact — uses separate `PackageVersion`/`PackageRelease` parameters
- **macOS .pkg:** No impact — uses only `InstallerPackageVersion`
- **MSI/exe:** No impact — does not use these targets

## References

- Debian version format spec: https://dyn.manpages.debian.org/trixie/dpkg-dev/deb-version.7.en.html
- Existing test expectation confirms `Version: 2.1.104-1` format (dotnet/sdk `GivenDotNetLinuxInstallers.cs`)
