### PR TITLE
Bump NuGet dependencies (weekly digest)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,7 @@ updates:
       - dependency-name: "Microsoft.DncEng.SecretManager"
       # Manually updated dependencies
       - dependency-name: "Microsoft.Build.NoTargets"
+      # Moq 4.20.x introduced the SponsorLink telemetry component, which raised
+      # privacy/compliance concerns across the .NET ecosystem. Stay pinned on
+      # 4.18.x until a vetted replacement (or a SponsorLink-free Moq) is adopted.
+      - dependency-name: "Moq"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -75,8 +75,8 @@
     <PackageVersion Include="Microsoft.Data.Services.Client" Version="5.8.4" />
     <PackageVersion Include="Microsoft.Diagnostics.Runtime" Version="1.0.5" />
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.84.0" />
-    <PackageVersion Include="Microsoft.OpenApi" Version="1.3.2" />
-    <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.3.2" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="1.6.29" />
+    <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.29" />
     <PackageVersion Include="Microsoft.Signed.Wix" Version="$(MicrosoftSignedWixVersion)" />
     <PackageVersion Include="Microsoft.WixToolset.Sdk" Version="$(MicrosoftWixToolsetSdkVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.OLE.Interop" Version="17.14.40260" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -74,7 +74,7 @@
     <PackageVersion Include="Microsoft.Data.OData" Version="5.8.4" />
     <PackageVersion Include="Microsoft.Data.Services.Client" Version="5.8.4" />
     <PackageVersion Include="Microsoft.Diagnostics.Runtime" Version="1.0.5" />
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.83.1" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.84.0" />
     <PackageVersion Include="Microsoft.OpenApi" Version="1.3.2" />
     <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.3.2" />
     <PackageVersion Include="Microsoft.Signed.Wix" Version="$(MicrosoftSignedWixVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -83,7 +83,7 @@
     <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Octokit" Version="14.0.0" />
-    <PackageVersion Include="Polly.Core" Version="8.4.1" />
+    <PackageVersion Include="Polly.Core" Version="8.6.6" />
     <PackageVersion Include="sn" Version="1.0.0" />
     <PackageVersion Include="xunit" Version="$(XUnitVersion)" />
     <PackageVersion Include="xunit.abstractions" Version="2.0.3" />


### PR DESCRIPTION
Weekly dependency digest from `@dependabot` 🤖

Bumps the following NuGet dependencies in `Directory.Packages.props`:

| Package | From | To |
|---|---|---|
| Microsoft.Identity.Client | 4.83.1 | 4.84.0 |
| Polly.Core | 8.4.1 | 8.6.6 |
| Microsoft.OpenApi | 1.3.2 | 1.6.29 |
| Microsoft.OpenApi.Readers | 1.3.2 | 1.6.29 |

Each bump is a separate commit for easy reverting/bisecting.

### Validated locally
`Build.cmd -pack` (clean) succeeds with 0 warnings / 0 errors.

### Deferred (need follow-up PRs with code changes)
- **Handlebars.Net 1.11.5 → 2.1.6** — API breaks in `Microsoft.DotNet.SwaggerGenerator.CodeGenerator` (`Action<TextWriter, object>` → `HandlebarsTemplate<TextWriter, object, object>`; `WriteSafeString` now requires `in EncodedTextWriter`).
- **Microsoft.ApplicationInsights 2.23.0 → 3.1.1** — `TelemetryClient.TrackEvent` no longer has a `metrics` parameter (used in `Microsoft.DotNet.SignTool/Telemetry.cs`).

Both require accompanying consumer-code updates, so they should land as standalone PRs rather than weekly bumps.

### Also in this PR
- **Moq** added to the `ignore` list in `.github/dependabot.yml` due to the 4.20.x SponsorLink concerns (pinned to 4.18.4).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
