### PR TITLE
Standardize Azure DevOps URLs to dev.azure.com format

### DIFF
--- a/Documentation/Onboarding.md
+++ b/Documentation/Onboarding.md
@@ -28,7 +28,7 @@
     See the [Arcade documentation](README.md) for information on using various Arcade SDK sub-systems.
 
 - Set up pipelines
-  - Add pipeline to https://dnceng-public.visualstudio.com/public for public PR validation CI.
+  - Add pipeline to https://dev.azure.com/dnceng-public/public for public PR validation CI.
   - Add pipeline to https://dev.azure.com/dnceng/internal for internal validation CI and official builds.
   - Add pipeline to https://dev.azure.com/dnceng/internal for CodeQL compliance validation.
 

--- a/Documentation/OneLocBuild.md
+++ b/Documentation/OneLocBuild.md
@@ -1,7 +1,7 @@
 # Localization with OneLocBuild in Arcade
 
 As of April 1, 2021, all .NET repositories will be using OneLocBuild for localization. Documentation on this system can
-be found [here](https://ceapex.visualstudio.com/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task).
+be found [here](https://dev.azure.com/ceapex/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task).
 This system is **not a replacement for Xliff-Tasks**; rather, it is replacing the localization team's old system called
 Simple Loc. OneLocBuild coordinates getting translations for new and updated strings and merging them back into the
 repo. Xliff-Tasks will continue to be used in addition to OneLocBuild.
@@ -89,7 +89,7 @@ Depending on how often you want to release from the servicing branch you could:
   3. Merge the OneLocBuild PRs to your release branch.
   4. After the release, open another repo modification ticket to re-target your repository to the `main` branch again.
 
-* Register a servicing branch with the loc team using [this ticket](https://aka.ms/ceNewLoc) ([Here](https://ceapex.visualstudio.com/CEINTL/_workitems/edit/523494)'s an example). This allows the loc team to parse your servicing branch(es) while your default branch continues to be parsed. If you already have an old servicing branch parsed by the loc team, you could update it to point to a newer servicing branch. Here's what you would need to do to update the branch:
+* Register a servicing branch with the loc team using [this ticket](https://aka.ms/ceNewLoc) ([Here](https://dev.azure.com/ceapex/CEINTL/_workitems/edit/523494)'s an example). This allows the loc team to parse your servicing branch(es) while your default branch continues to be parsed. If you already have an old servicing branch parsed by the loc team, you could update it to point to a newer servicing branch. Here's what you would need to do to update the branch:
    1. Open a [repo modification ticket](https://aka.ms/ceChangeLocConfig) with the 
    loc team at least two weeks before the release and request that they re-target your servicing branch to new branch.
    2. Ask the loc team for a package Id for this servicing branch on the ticket. The value of the Package ID would then be substituted in the YAML of the OneLocBuild task.
@@ -192,9 +192,9 @@ The parameters that can be passed to the template are as follows:
 | `MirrorBranch` | `'main'` | The branch on GitHub to make a PR to (only used when using a mirrored repository). |
 | `UseCheckedInLocProjectJson` | `false` | When set to `true`, instructs the LocProject.json generation script to use build-time validation rather than build-time generation, as described above. |
 | `SkipLocProjectJsonGeneration` | `false` | When set to `true`, skips the LocProject.json generation in favor of using a checked-in LocProject.json.
-| `LanguageSet` | `VS_Main_Languages` | This defines the `LanguageSet` of the LocProject.json as described in the [OneLocBuild task documentation](https://ceapex.visualstudio.com/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task?anchor=languageset%2C-languages-(required)). |
-| `LclSource` | `LclFilesInRepo` | This passes the `LclSource` input to the OneLocBuild task as described in [its documentation](https://ceapex.visualstudio.com/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task?anchor=languageset%2C-languages-(required)). For most repos, this should be set to `LclFilesfromPackage`. |
-| `LclPackageId` | `''` | When `LclSource` is set to `LclFilesfromPackage`, this passes in the package ID as described in the [OneLocBuild task documentation](https://ceapex.visualstudio.com/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task?anchor=scenario-2%3A-lcl-files-from-a-package). |
+| `LanguageSet` | `VS_Main_Languages` | This defines the `LanguageSet` of the LocProject.json as described in the [OneLocBuild task documentation](https://dev.azure.com/ceapex/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task?anchor=languageset%2C-languages-(required)). |
+| `LclSource` | `LclFilesInRepo` | This passes the `LclSource` input to the OneLocBuild task as described in [its documentation](https://dev.azure.com/ceapex/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task?anchor=languageset%2C-languages-(required)). For most repos, this should be set to `LclFilesfromPackage`. |
+| `LclPackageId` | `''` | When `LclSource` is set to `LclFilesfromPackage`, this passes in the package ID as described in the [OneLocBuild task documentation](https://dev.azure.com/ceapex/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task?anchor=scenario-2%3A-lcl-files-from-a-package). |
 | `condition` | `''` | Allows for conditionalizing the template's steps on build-time variables. |
 | `JobNameSuffix` | `''` | Allows for custom job name suffix. This is helpful for disambiguation in case of need for more then one OneLocBuild job run - e.g. as a way to set multiple package IDs. |
 

--- a/Documentation/Policy/TestingMSBuildGuidance.md
+++ b/Documentation/Policy/TestingMSBuildGuidance.md
@@ -15,11 +15,11 @@ We are currently working on ways to improve our testability of Arcade, including
 
 ## How to Validate a Private Build
 
-1. Run a build of your Arcade branch on the [arcade-official-ci](https://dnceng.visualstudio.com/internal/_build?definitionId=6) Azure DevOps Pipeline
+1. Run a build of your Arcade branch on the [arcade-official-ci](https://dev.azure.com/dnceng/internal/_build?definitionId=6) Azure DevOps Pipeline
 2. [Promote your build](../Darc.md#add-build-to-channel) to the "General Testing" Maestro channel. 
 3. Create a branch of [Arcade Validation](https://github.com/dotnet/arcade-validation)
 4. Using darc, run `update-dependencies` ([update-dependencies documentation](../Darc.md#updating-dependencies-in-your-local-repository)) on your Arcade Validation branch to use the build of Arcade you just created in the previous steps. 
-5. Push your branch up to Azure DevOps Arcade Validation repository and run a build of your branch on the [dotnet-arcade-validation-official](https://dnceng.visualstudio.com/internal/_build?definitionId=282) to verify your changes. 
+5. Push your branch up to Azure DevOps Arcade Validation repository and run a build of your branch on the [dotnet-arcade-validation-official](https://dev.azure.com/dnceng/internal/_build?definitionId=282) to verify your changes. 
 6. It's not necessary to merge your Arcade Validation branch into the repo's main branch, so feel free to delete it when you're done validating your changes.
 
 If you want to also validate your private build of Arcade using a repository other than Arcade Validation, follow these steps. 

--- a/Documentation/Publishing.md
+++ b/Documentation/Publishing.md
@@ -13,7 +13,7 @@ V2 is a legacy publishing infrastructure that is no longer utilized. It's essent
 ### What is V3 publishing?
 
 In V3, a single job or stage 'Publish Using Darc' handles all publishing for all available channels. Even if the repo branch is associated to more than one default channel(s) there will be only one stage. V3 uses [`darc add-build-to-channel`](https://github.com/dotnet/arcade/blob/ec191f3d706d740bc7a87fbb98d94d916f81f0cb/Documentation/Darc.md#add-build-to-channel) to promote builds based on the current configured default channels for the branch just built.
-The [maestro promotion pipeline](https://dnceng.visualstudio.com/internal/_build?definitionId=750) is a pipeline used to publish the packages to the target channel(s).
+The [maestro promotion pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=750) is a pipeline used to publish the packages to the target channel(s).
 `Add-build-to-channel` queues a new build of this pipeline and waits for it to publish assets to the appropriate locations. The publishing job is run against Arcade's main branch by default, meaning that repositories do not need to take an Arcade update to be able to publish to newly created channels or get most publishing fixes.
 
 Example from arcade-validation:
@@ -162,7 +162,7 @@ Since the post-build stages will only trigger during builds that run in the inte
     ```
 
 1. Queue a build for your test branch
-1. Once the Build and Validate Build Assets stages complete, the *Publish Using Darc* stage should execute and publish the packages to the feed during the `Publish Using Darc` job. [Maestro Promotion Pipeline](https://dnceng.visualstudio.com/internal/_build?definitionId=750) is a pipeline used to publish the packages to the target channel. The job informs that a new build has been triggered in the promotion pipeline, and once it succeeds the build will be in the channel. The `Publish Using Darc` job calls [`darc add-build-to-channel`](https://github.com/dotnet/arcade/blob/ec191f3d706d740bc7a87fbb98d94d916f81f0cb/Documentation/Darc.md#add-build-to-channel) which waits until a build of the promotion pipeline publishes the assets.
+1. Once the Build and Validate Build Assets stages complete, the *Publish Using Darc* stage should execute and publish the packages to the feed during the `Publish Using Darc` job. [Maestro Promotion Pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=750) is a pipeline used to publish the packages to the target channel. The job informs that a new build has been triggered in the promotion pipeline, and once it succeeds the build will be in the channel. The `Publish Using Darc` job calls [`darc add-build-to-channel`](https://github.com/dotnet/arcade/blob/ec191f3d706d740bc7a87fbb98d94d916f81f0cb/Documentation/Darc.md#add-build-to-channel) which waits until a build of the promotion pipeline publishes the assets.
 
 :warning: It is possible that even if you add a default channel, and the build artifacts will get published to the Build Asset Registry, the artifacts won't get published to the NuGet feed. 
 
@@ -318,7 +318,7 @@ The publishing logs are stored inside an Azure DevOps artifacts container named 
 
 ### Where can I see publishing logs in V3?
 
-Under the `Publish Using Darc` job get the link to the newly queued build in the [Maestro promotion pipeline](https://dnceng.visualstudio.com/internal/_build?definitionId=750). The publishing logs are stored inside an Azure DevOps artifacts container named `PostBuildLogs`. 
+Under the `Publish Using Darc` job get the link to the newly queued build in the [Maestro promotion pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=750). The publishing logs are stored inside an Azure DevOps artifacts container named `PostBuildLogs`. 
 
 ### How to add a new channel to use V3 publishing?
 

--- a/Documentation/ReleaseRingsPlan.md
+++ b/Documentation/ReleaseRingsPlan.md
@@ -30,7 +30,7 @@ validation checks.
 * All legs succeed (we'll provide a manual override in case legs fail but failures are known and/or
   we don't want to block the pipeline due to this errors)
 
-### [Build Validation Ring (Candidate Validation channel)](https://dnceng.visualstudio.com/internal/_git/dotnet-release?path=%2Fdocumentation%2Frelease-validation.md)
+### [Build Validation Ring (Candidate Validation channel)](https://dev.azure.com/dnceng/internal/_git/dotnet-release?path=%2Fdocumentation%2Frelease-validation.md)
 
 * BinSkim validation
 * Packages validation

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Arcade is intended to provide well-understood and consistent mechanisms for cons
 |Repo Name|Current Build Status|
 |---|---|
 |Arcade Public CI|[![Build Status](https://dev.azure.com/dnceng-public/public/_apis/build/status%2Fdotnet%2Farcade%2Farcade-pr?branchName=main)](https://dev.azure.com/dnceng-public/public/_build/latest?definitionId=283&branchName=main)|
-|Arcade Official Build|[![Build Status](https://dnceng.visualstudio.com/internal/_apis/build/status/dotnet/arcade/arcade-official-ci?branchName=main)](https://dnceng.visualstudio.com/internal/_build/latest?definitionId=6&branchName=main)| 
-|Arcade Validation|[![Build Status](https://dnceng.visualstudio.com/internal/_apis/build/status/dotnet/arcade-validation/dotnet-arcade-validation-official?branchName=main)](https://dnceng.visualstudio.com/internal/_build/latest?definitionId=282&branchName=main)|
+|Arcade Official Build|[![Build Status](https://dev.azure.com/dnceng/internal/_apis/build/status/dotnet/arcade/arcade-official-ci?branchName=main)](https://dev.azure.com/dnceng/internal/_build/latest?definitionId=6&branchName=main)| 
+|Arcade Validation|[![Build Status](https://dev.azure.com/dnceng/internal/_apis/build/status/dotnet/arcade-validation/dotnet-arcade-validation-official?branchName=main)](https://dev.azure.com/dnceng/internal/_build/latest?definitionId=282&branchName=main)|
 
 ## Getting Started
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
@@ -41,13 +41,14 @@
     <!-- There are quite a few git repo forms:
       https://dnceng@dev.azure.com/dnceng/internal/_git/dotnet-arcade-services
       https://dev.azure.com/dnceng/internal/_git/dotnet-arcade-services
+      https://devdiv.visualstudio.com/devdiv/_git/DotNet-msbuild-Trusted (legacy, still supported)
       https://dev.azure.com/devdiv/DevDiv/_git/DotNet-msbuild-Trusted
       git@ssh.dev.azure.com:v3/dnceng/internal/dotnet-arcade-services
       Legacy visualstudio.com and vs-ssh.visualstudio.com forms are also supported.
     -->
     <!-- Set DisableSourceLinkUrlTranslation to true when building a tool for internal use where sources only come from internal URIs -->
     <DisableSourceLinkUrlTranslation Condition="'$(DisableSourceLinkUrlTranslation)' == ''">false</DisableSourceLinkUrlTranslation>
-    <_TranslateUrlPattern>(https://dnceng%40dev\.azure\.com/dnceng/internal/_git|https://dev\.azure\.com/dnceng/internal/_git|https://dnceng\.visualstudio\.com/internal/_git|dnceng%40vs-ssh\.visualstudio\.com:v3/dnceng/internal|git%40ssh\.dev\.azure\.com:v3/dnceng/internal|https://devdiv\.visualstudio\.com/devdiv/_git)/([^/-]+)-(.+)</_TranslateUrlPattern>
+    <_TranslateUrlPattern>(https://dnceng%40dev\.azure\.com/dnceng/internal/_git|https://dev\.azure\.com/dnceng/internal/_git|https://dnceng\.visualstudio\.com/internal/_git|dnceng%40vs-ssh\.visualstudio\.com:v3/dnceng/internal|git%40ssh\.dev\.azure\.com:v3/dnceng/internal|https://devdiv\.visualstudio\.com/devdiv/_git|https://dev\.azure\.com/devdiv/[Dd]ev[Dd]iv/_git)/([^/-]+)-(.+)</_TranslateUrlPattern>
     <_TranslateUrlReplacement>https://github.com/$2/$3</_TranslateUrlReplacement>
   </PropertyGroup>
 
@@ -56,15 +57,15 @@
           DependsOnTargets="$(SourceControlManagerUrlTranslationTargets)"
           BeforeTargets="SourceControlManagerPublishTranslatedUrls">
     <PropertyGroup>
-      <!-- Repositories mirrored on devdiv.visualstudio will have '-Trusted' added to their name and this needs to be stripped off before translation
+      <!-- Repositories mirrored on devdiv will have '-Trusted' added to their name and this needs to be stripped off before translation
            Eventually, all repos should move to dnceng/internal when possible. -->
-      <ScmRepositoryUrl Condition=" '$([MSBuild]::ValueOrDefault(`%(SourceRoot.ScmRepositoryUrl)`, ``).Contains(`devdiv.visualstudio`))' == 'true' ">$([MSBuild]::ValueOrDefault(`%(SourceRoot.ScmRepositoryUrl)`, ``).ToLower().Replace(`-trusted`,``))</ScmRepositoryUrl>
+      <ScmRepositoryUrl Condition=" '$([MSBuild]::ValueOrDefault(`%(SourceRoot.ScmRepositoryUrl)`, ``).Contains(`devdiv.visualstudio`))' == 'true' Or '$([MSBuild]::ValueOrDefault(`%(SourceRoot.ScmRepositoryUrl)`, ``).Contains(`dev.azure.com/devdiv`))' == 'true' ">$([MSBuild]::ValueOrDefault(`%(SourceRoot.ScmRepositoryUrl)`, ``).ToLower().Replace(`-trusted`,``))</ScmRepositoryUrl>
       <ScmRepositoryUrl>$([System.Text.RegularExpressions.Regex]::Replace($(ScmRepositoryUrl), $(_TranslateUrlPattern), $(_TranslateUrlReplacement)))</ScmRepositoryUrl>
     </PropertyGroup>
 
     <ItemGroup>
       <SourceRoot Update="@(SourceRoot)">
-        <ScmRepositoryUrl Condition="$([MSBuild]::ValueOrDefault(`%(SourceRoot.ScmRepositoryUrl)`, ``).Contains(`devdiv.visualstudio`))">$([MSBuild]::ValueOrDefault(`%(SourceRoot.ScmRepositoryUrl)`, ``).ToLower().Replace(`-trusted`,``))</ScmRepositoryUrl>
+        <ScmRepositoryUrl Condition="$([MSBuild]::ValueOrDefault(`%(SourceRoot.ScmRepositoryUrl)`, ``).Contains(`devdiv.visualstudio`)) Or $([MSBuild]::ValueOrDefault(`%(SourceRoot.ScmRepositoryUrl)`, ``).Contains(`dev.azure.com/devdiv`))">$([MSBuild]::ValueOrDefault(`%(SourceRoot.ScmRepositoryUrl)`, ``).ToLower().Replace(`-trusted`,``))</ScmRepositoryUrl>
       </SourceRoot>
       <SourceRoot Update="@(SourceRoot)">
         <ScmRepositoryUrl>$([System.Text.RegularExpressions.Regex]::Replace(%(SourceRoot.ScmRepositoryUrl), $(_TranslateUrlPattern), $(_TranslateUrlReplacement)))</ScmRepositoryUrl>

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets
@@ -35,16 +35,15 @@
 
   <!-- 
     The convention for names of Azure DevOps repositories mirrored from GitHub is "{GitHub org name}-{GitHub repository name}"
-    In the legacy devdiv.visualstudio instance, it is instead "{GitHub org name}-{GitHub repository name}-Trusted" with no guarantees for casing.
+    In the legacy DevDiv instance, it is instead "{GitHub org name}-{GitHub repository name}-Trusted" with no guarantees for casing.
   -->
   <PropertyGroup>
     <!-- There are quite a few git repo forms:
       https://dnceng@dev.azure.com/dnceng/internal/_git/dotnet-arcade-services
       https://dev.azure.com/dnceng/internal/_git/dotnet-arcade-services
-      https://dnceng.visualstudio.com/internal/_git/dotnet-arcade-services
-      https://devdiv.visualstudio.com/DevDiv/_git/DotNet-msbuild-Trusted
-      dnceng@vs-ssh.visualstudio.com:v3/dnceng/internal/dotnet-arcade-services
+      https://dev.azure.com/devdiv/DevDiv/_git/DotNet-msbuild-Trusted
       git@ssh.dev.azure.com:v3/dnceng/internal/dotnet-arcade-services
+      Legacy visualstudio.com and vs-ssh.visualstudio.com forms are also supported.
     -->
     <!-- Set DisableSourceLinkUrlTranslation to true when building a tool for internal use where sources only come from internal URIs -->
     <DisableSourceLinkUrlTranslation Condition="'$(DisableSourceLinkUrlTranslation)' == ''">false</DisableSourceLinkUrlTranslation>

--- a/src/Microsoft.DotNet.Build.Manifest.Tests/BuildModelFactoryTests.cs
+++ b/src/Microsoft.DotNet.Build.Manifest.Tests/BuildModelFactoryTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Build.Manifest.Tests
         private const string _testBuildBranch = "foobranch";
         private const string _testBuildCommit = "664996a16fa9228cfd7a55d767deb31f62a65f51";
         private const string _testAzdoBuildId = "89999999";
-        private const string _testInitialLocation = "https://dev.azure.com/dnceng/project/_apis/build/builds/id/artifacts";
+        private const string _testInitialLocation = "https://dnceng.visualstudio.com/project/_apis/build/builds/id/artifacts";
         private const string _normalizedTestInitialLocation = "https://dev.azure.com/dnceng/project/_apis/build/builds/id/artifacts";
         private static readonly string[] _defaultManifestBuildData = new string[]
         {
@@ -755,7 +755,7 @@ namespace Microsoft.DotNet.Build.Manifest.Tests
         }
 
         [Theory]
-        [InlineData("AzureDevOpsAccount", "https://dev.azure.com/dnceng", "https://dev.azure.com/devdiv")]
+        [InlineData("AzureDevOpsAccount", "https://dev.azure.com/dnceng", "https://dnceng.visualstudio.com")]
         [InlineData("AzureDevOpsBranch", "refs/heads/main", "main")]
         [InlineData("AzureDevOpsBuildDefinitionId", "100", "1001")]
         [InlineData("AzureDevOpsBuildId", "100", "1001")]

--- a/src/Microsoft.DotNet.Build.Manifest.Tests/BuildModelFactoryTests.cs
+++ b/src/Microsoft.DotNet.Build.Manifest.Tests/BuildModelFactoryTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Build.Manifest.Tests
         private const string _testBuildBranch = "foobranch";
         private const string _testBuildCommit = "664996a16fa9228cfd7a55d767deb31f62a65f51";
         private const string _testAzdoBuildId = "89999999";
-        private const string _testInitialLocation = "https://dnceng.visualstudio.com/project/_apis/build/builds/id/artifacts";
+        private const string _testInitialLocation = "https://dev.azure.com/dnceng/project/_apis/build/builds/id/artifacts";
         private const string _normalizedTestInitialLocation = "https://dev.azure.com/dnceng/project/_apis/build/builds/id/artifacts";
         private static readonly string[] _defaultManifestBuildData = new string[]
         {
@@ -755,7 +755,7 @@ namespace Microsoft.DotNet.Build.Manifest.Tests
         }
 
         [Theory]
-        [InlineData("AzureDevOpsAccount", "https://dev.azure.com/dnceng", "https://dnceng.visualstudio.com")]
+        [InlineData("AzureDevOpsAccount", "https://dev.azure.com/dnceng", "https://dev.azure.com/devdiv")]
         [InlineData("AzureDevOpsBranch", "refs/heads/main", "main")]
         [InlineData("AzureDevOpsBuildDefinitionId", "100", "1001")]
         [InlineData("AzureDevOpsBuildId", "100", "1001")]

--- a/src/Microsoft.DotNet.Build.Manifest/BuildModelFactory.cs
+++ b/src/Microsoft.DotNet.Build.Manifest/BuildModelFactory.cs
@@ -211,10 +211,10 @@ namespace Microsoft.DotNet.Build.Manifest
         }
 
         /// <summary>
-        // If repoUri includes the user in the account we remove it from URIs like
-        // https://dnceng@dev.azure.com/dnceng/internal/_git/repo
-        // If the URL uses the legacy "<account>.visualstudio.com" host, we replace it with
-        // "dev.azure.com/<account>" for consistency
+        /// If repoUri includes the user in the account we remove it from URIs like
+        /// https://dnceng@dev.azure.com/dnceng/internal/_git/repo.
+        /// If the URL uses the legacy "{account}.visualstudio.com" host, we replace it with
+        /// "dev.azure.com/{account}" for consistency.
         /// </summary>
         /// <param name="repoUri">The original url</param>
         /// <returns>Transformed url</returns>

--- a/src/Microsoft.DotNet.Build.Manifest/BuildModelFactory.cs
+++ b/src/Microsoft.DotNet.Build.Manifest/BuildModelFactory.cs
@@ -213,9 +213,8 @@ namespace Microsoft.DotNet.Build.Manifest
         /// <summary>
         // If repoUri includes the user in the account we remove it from URIs like
         // https://dnceng@dev.azure.com/dnceng/internal/_git/repo
-        // If the URL host is of the form "dnceng.visualstudio.com" like
-        // https://dnceng.visualstudio.com/internal/_git/repo we replace it to "dev.azure.com/dnceng"
-        // for consistency
+        // If the URL uses the legacy "<account>.visualstudio.com" host, we replace it with
+        // "dev.azure.com/<account>" for consistency
         /// </summary>
         /// <param name="repoUri">The original url</param>
         /// <returns>Transformed url</returns>


### PR DESCRIPTION
Update URLs from the legacy {org}.visualstudio.com format to the current dev.azure.com/{org} format in docs and source files. Tests pass (59/59).

Fixes AB#8519