### PR TITLE
Update source-index package versions

### DIFF
--- a/eng/common/core-templates/steps/source-index-stage1-publish.yml
+++ b/eng/common/core-templates/steps/source-index-stage1-publish.yml
@@ -6,10 +6,10 @@ parameters:
 
 steps:
 - task: UseDotNet@2
-  displayName: "Source Index: Use .NET 9 SDK"
+  displayName: "Source Index: Use .NET 10 SDK"
   inputs:
     packageType: sdk
-    version: 9.0.x
+    version: 10.0.x
     installationPath: $(Agent.TempDirectory)/dotnet
     workingDirectory: $(Agent.TempDirectory)
 

--- a/eng/common/core-templates/steps/source-index-stage1-publish.yml
+++ b/eng/common/core-templates/steps/source-index-stage1-publish.yml
@@ -1,6 +1,6 @@
 parameters:
-  sourceIndexUploadPackageVersion: 2.0.0-20250906.1
-  sourceIndexProcessBinlogPackageVersion: 1.0.1-20250906.1
+  sourceIndexUploadPackageVersion: 2.0.0-20260521.2
+  sourceIndexProcessBinlogPackageVersion: 1.0.1-20260521.2
   sourceIndexPackageSource: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
   binlogPath: artifacts/log/Debug/Build.binlog
 


### PR DESCRIPTION
- sourceIndexUploadPackageVersion: 2.0.0-20260521.2
- sourceIndexProcessBinlogPackageVersion: 1.0.1-20260521.2

Aligns us with the version used in the VMR: https://github.com/dotnet/dotnet/pull/6746

Bumps source-index SDK version to 10.0. since that's required by the latest version.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
