### PR TITLE
Remove dnceng-symbol-server-pat from publish-logs.yml redaction list

### DIFF
--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -101,18 +101,6 @@ secrets:
       organizations: devdiv
       scopes: code drop
 
-  #DotNet-Symbol-Server-Pats
-  dnceng-symbol-server-pat:
-    type: azure-devops-access-token
-    parameters:
-      domainAccountName: dn-bot
-      domainAccountSecret:
-          location: helixkv
-          name: dn-bot-account-redmond
-      name: dn-bot-dnceng-symbol-server-pat
-      organizations: dnceng
-      scopes: symbols_manage
-
   #OneLocBuildVariables
   dn-bot-ceapex-package-r:
     type: azure-devops-access-token

--- a/eng/common/core-templates/steps/publish-logs.yml
+++ b/eng/common/core-templates/steps/publish-logs.yml
@@ -33,7 +33,6 @@ steps:
       '$(publishing-dnceng-devdiv-code-r-build-re)'
       '$(dn-bot-all-orgs-artifact-feeds-rw)'
       '$(akams-client-id)'
-      '$(dnceng-symbol-server-pat)'
       '$(dn-bot-all-orgs-build-rw-code-rw)'
       '$(System.AccessToken)'
       ${{parameters.CustomSensitiveDataList}}


### PR DESCRIPTION
## Summary

Remove the \dnceng-symbol-server-pat\ entry from the binlog redaction list in \ng/common/core-templates/steps/publish-logs.yml\.

## Motivation

PR #16688 migrated symbol upload authentication from PAT-based auth to \DefaultIdentityTokenCredential\ (Entra). The PAT is no longer functionally used for symbol publishing. This cleanup removes the now-unnecessary redaction entry.

## Changes

- Removed \'\'\ from the \edact-logs.ps1\ arguments in \publish-logs.yml\

## Related

- Fixes dnceng/internal#10150 (PAT Migration: dnceng-symbol-server-pat)
- Follow-up to #16688