### PR TITLE
Remove symbol server PATs from publish-logs.yml redaction list [release/10.0]

### DIFF
--- a/eng/common/core-templates/steps/publish-logs.yml
+++ b/eng/common/core-templates/steps/publish-logs.yml
@@ -33,9 +33,6 @@ steps:
       '$(publishing-dnceng-devdiv-code-r-build-re)'
       '$(dn-bot-all-orgs-artifact-feeds-rw)'
       '$(akams-client-id)'
-      '$(microsoft-symbol-server-pat)'
-      '$(symweb-symbol-server-pat)'
-      '$(dnceng-symbol-server-pat)'
       '$(dn-bot-all-orgs-build-rw-code-rw)'
       '$(System.AccessToken)'
       ${{parameters.CustomSensitiveDataList}}


### PR DESCRIPTION
## Summary

Remove all three symbol server PAT entries from the binlog redaction list in `eng/common/core-templates/steps/publish-logs.yml` on the `release/10.0` branch.

## Motivation

PR #16688 (merged to main May 12, 2026) migrated symbol upload authentication from PAT-based auth to `DefaultIdentityTokenCredential` (Entra). The code fallback is already present on release/10.0. These PATs are no longer functionally needed and can be removed from the redaction list.

## Changes

- Removed `microsoft-symbol-server-pat` from redaction arguments
- Removed `symweb-symbol-server-pat` from redaction arguments  
- Removed `dnceng-symbol-server-pat` from redaction arguments

## Related

- dnceng/internal#10150 (dnceng-symbol-server-pat)
- dnceng/internal#10148 (microsoft-symbol-server-pat)
- dnceng/internal#10149 (symweb-symbol-server-pat)
- Follow-up to #16688