### PR TITLE
Fix dotnetup channel name for aka.ms links

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/src/model/PublishingConstants.cs
@@ -1692,7 +1692,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.Model
                 id: 10506,
                 isInternal: false,
                 publishingInfraVersion: PublishingInfraVersion.Latest,
-                akaMSChannelNames: ["dotnetup/daily"],
+                akaMSChannelNames: ["dotnetup"],
                 akaMSCreateLinkPatterns: DotnetupAkaMSCreateLinkPatterns,
                 akaMSDoNotCreateLinkPatterns: DefaultAkaMSDoNotCreateLinkPatterns,
                 targetFeeds: DotNetToolsFeeds,


### PR DESCRIPTION
The dotnetup Daily channel TargetChannelConfig (added in #16813) set `akaMSChannelNames: ["dotnetup/daily"]`.

"daily" shouldn't have been part of this since Arcade includes the "BuildQuality" in the URL.  So with current logic, the resulting URL is `aka.ms/dotnet/dotnetup/daily/daily/dotnetup-<rid>[.exe]` (note the two "daily" segments).

This PR removes "daily" from the channel name.