### PR TITLE
Fix VS target hook points in Arcade SDK

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/toolset/VisualStudio.BuildIbcTrainingInputs.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/toolset/VisualStudio.BuildIbcTrainingInputs.targets
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.VisualStudio" />
   </ItemGroup>
 
-  <Target Name="_BuildTrainingInputs" BeforeTargets="AfterBuild">
+  <Target Name="_BuildTrainingInputs" BeforeTargets="Pack">
     <Error Condition="('$(VisualStudioDropName)' == '' or '$(RepositoryName)' == '') and '$(OfficialBuild)' == 'true'"
            Text="Properties VisualStudioDropName and RepositoryName must be specified in official build that produces Visual Studio insertion components." />
 

--- a/src/Microsoft.DotNet.Arcade.Sdk/toolset/VisualStudio.InsertionManifests.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/toolset/VisualStudio.InsertionManifests.targets
@@ -15,7 +15,7 @@
     This is important since the manifest contain hashes of the VSIX files.
   -->
   <Target Name="GenerateVisualStudioInsertionManifests"
-          BeforeTargets="AfterPack"
+          BeforeTargets="Pack"
           Outputs="%(_StubDirs.Identity)"
           Condition="'@(_StubDirs)' != ''">
     <PropertyGroup>


### PR DESCRIPTION
Regressed with https://github.com/dotnet/arcade/commit/ea5fa1675a08347dde19aee855e04a21bd8586b4

Use standard hook points that are called by Build.proj (when invoking AfterSigning.proj) instead of these cutom ones.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
