### PR TITLE
Remove dn-bot-all-orgs-build-rw-code-rw PAT from publishing (Phase 2)

### DIFF
--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -45,17 +45,6 @@ secrets:
     parameters:
       description: Client id for akams app
 
-  dn-bot-all-orgs-build-rw-code-rw:
-    type: azure-devops-access-token
-    parameters:
-      domainAccountName: dn-bot
-      domainAccountSecret:
-          location: helixkv
-          name: dn-bot-account-redmond
-      name: dn-bot-all-orgs-build
-      organizations: dnceng devdiv dotnet-security-partners
-      scopes: build_execute code_write
-
   #AzureDevOps-Artifact-Feeds-Pats
   dn-bot-dnceng-artifact-feeds-rw:
     type: azure-devops-access-token

--- a/eng/common/core-templates/steps/publish-logs.yml
+++ b/eng/common/core-templates/steps/publish-logs.yml
@@ -34,7 +34,6 @@ steps:
       '$(dn-bot-all-orgs-artifact-feeds-rw)'
       '$(akams-client-id)'
       '$(dnceng-symbol-server-pat)'
-      '$(dn-bot-all-orgs-build-rw-code-rw)'
       '$(System.AccessToken)'
       ${{parameters.CustomSensitiveDataList}}
   continueOnError: true

--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -160,7 +160,6 @@ stages:
           /p:SymbolRequestProject='dotnet'
           ${{ parameters.symbolPublishingAdditionalParameters}}
           /p:BuildQuality='${{ parameters.buildQuality }}'
-          /p:AzdoApiToken='$(dn-bot-all-orgs-build-rw-code-rw)'
           /p:ArtifactsBasePath='$(Build.ArtifactStagingDirectory)/'
           /p:BuildId='$(AzDOBuildId)'
           /p:AzureDevOpsOrg='$(AzDOAccount)'


### PR DESCRIPTION
## Summary

Completes the PAT-to-Entra migration for \dn-bot-all-orgs-build-rw-code-rw\ (Phase 2 of 2).

**Phase 1** ([#16806](https://github.com/dotnet/arcade/pull/16806), merged 2026-05-12) added a backward-compatible Entra credential fallback to \CreateAzdoClient()\ — when \AzdoApiToken\ is empty/missing, the code falls through to \DefaultIdentityTokenCredential\ (bearer auth via the pipeline's WIF service connection identity).

Phase 1 SDK has shipped and flowed to consumers (e.g. aspnetcore at \11.0.0-beta.26272.101\).

## Changes (Phase 2)

1. **publish.yml** — Remove \/p:AzdoApiToken='\'\ parameter
2. **publish-logs.yml** — Remove PAT from binlog secret redaction list (no longer appears in builds)
3. **product-builds-engkeyvault.yaml** — Delete PAT entry from secret manifest

## Identity

The \maestro-build-promotion\ WIF service connection (\maestro-build-promotion-mi\, AppId: \6e870007-e236-4eb1-8734-8bf8cd54c748\) provides Entra auth. Already enrolled in dnceng/internal with Readers access.

## Post-merge steps

- [ ] Un-map \dn-bot-all-orgs-build-rw-code-rw\ from Variable Group 20 (\Publish-Build-Assets\)
- [ ] Un-map from Variable Group 110 (\DotNet-Source-Build-All-Orgs-Source-Access\)
- [ ] Monitor first post-merge build promotion for successful Entra auth

## Risk & Rollback

If the Entra fallback fails in production, revert this PR to restore PAT usage. The Phase 1 C# code is backward-compatible — re-adding the PAT line will make it use PAT auth again.

Resolves: https://dev.azure.com/dnceng/internal/_workitems/edit/10141