### PR TITLE
Remove symbol server PATs from release/8.0 publish.yml

### DIFF
--- a/eng/publishing/v3/publish.yml
+++ b/eng/publishing/v3/publish.yml
@@ -13,7 +13,6 @@ stages:
       displayName: Publish Assets and Symbols
       timeoutInMinutes: 120
       variables:
-        - group: DotNet-Symbol-Server-Pats
         - group: DotNetBuilds storage account tokens
         - group: AzureDevOps-Artifact-Feeds-Pats
         - group: DotNet-MSRC-Storage
@@ -159,6 +158,17 @@ stages:
               $token = (az account get-access-token --resource "$env:servicePrincipalId" | ConvertFrom-Json).accessToken
               echo "##vso[task.setvariable variable=MaestroToken;isOutput=true;isSecret=true]$token"
 
+        - task: AzureCLI@2
+          displayName: Get Symbol Server Token
+          name: GetSymbolToken
+          inputs:
+            azureSubscription: maestro-build-promotion
+            scriptType: ps
+            scriptLocation: inlineScript
+            inlineScript: |
+              $token = (az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query accessToken -o tsv)
+              echo "##vso[task.setvariable variable=SymbolServerToken;isOutput=true;isSecret=true]$token"
+
         - task: PowerShell@2
           displayName: Publish packages, blobs and symbols
           inputs:
@@ -182,8 +192,8 @@ stages:
               /p:PDBArtifactsBasePath='$(Build.ArtifactStagingDirectory)/PDBArtifacts/'
               /p:SymbolPublishingExclusionsFile='$(Build.ArtifactStagingDirectory)/ReleaseConfigs/SymbolPublishingExclusionsFile.txt'
               ${{ parameters.symbolPublishingAdditionalParameters}}
-              /p:MsdlToken=$(microsoft-symbol-server-pat)
-              /p:SymWebToken=$(symweb-symbol-server-pat)
+              /p:MsdlToken=$(GetSymbolToken.SymbolServerToken)
+              /p:SymWebToken=$(GetSymbolToken.SymbolServerToken)
               /p:BuildQuality='${{ parameters.buildQuality }}'
               /p:AzdoApiToken='$(dn-bot-all-orgs-build-rw-code-rw)'
               /p:ArtifactsBasePath='$(Build.ArtifactStagingDirectory)/'


### PR DESCRIPTION
## Summary

Removes `microsoft-symbol-server-pat` and `symweb-symbol-server-pat` from the release/8.0 publish pipeline by replacing them with an Entra bearer token from the `maestro-build-promotion` service connection.

## Approach

1. **New step Get Symbol Server Token** - Uses AzureCLI@2 with `maestro-build-promotion` SC to acquire a bearer token for the AzDO resource scope (`499b84ac-1321-427f-aa17-267ca6975798`)
2. **Replace PAT references** - `/p:MsdlToken` and `/p:SymWebToken` now reference the bearer token output variable instead of the PAT variables
3. **Remove DotNet-Symbol-Server-Pats variable group** - No longer needed

## Why this works

`symbol.exe` (used by `PublishSymbolsHelper.PublishAsync`) accepts both PATs and Entra bearer tokens via the `AzureDevOpsToken` env var. The `maestro-build-promotion` identity already successfully publishes symbols to MSDL and SymWeb on main.

## Context

Part of the PAT-to-Entra migration for WI 10149 (`symweb-symbol-server-pat`) and WI 10148 (`microsoft-symbol-server-pat`). The main branch migration was completed in PR #16808 (merged May 12). For this servicing branch, the YAML-only approach avoids risky C# code changes.

## Risk and Rollback

If `maestro-build-promotion` lacks permissions to a specific symbol server, symbol publishing will fail. Revert this PR to restore PAT usage.

Related: https://dev.azure.com/dnceng/internal/_workitems/edit/10149