### PR TITLE
Restore NUGET_PACKAGES export at CI initialization

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -748,6 +748,8 @@ function Stop-Processes() {
 #
 function MSBuild() {
   if ($ci) {
+    InitializeToolset | Out-Null
+
     $env:NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS = 20
     $env:NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS = 20
     Write-PipelineSetVariable -Name 'NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS' -Value '20'

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -505,6 +505,8 @@ function MSBuild {
   local args=( "$@" )
 
   if [[ "$ci" == true ]]; then
+    InitializeToolset
+
     export NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS=20
     export NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS=20
     Write-PipelineSetVariable -name "NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS" -value "20"


### PR DESCRIPTION
> [!NOTE]
> This PR was authored with assistance from GitHub Copilot.

Fixes #16898.

## Problem

#16814 ("Remove the Arcade msbuild logger") removed the `InitializeToolset` call from the `MSBuild` function in `eng/common/tools.{sh,ps1}` along with the ArcadeLogging.dll wiring. `InitializeToolset` had a load-bearing side effect: it calls `GetNuGetPackageCachePath`, which exports `NUGET_PACKAGES`.

Repos that enter Arcade via `eng/common/build.{sh,ps1}` are unaffected because `build.{sh,ps1}` calls `InitializeToolset` directly. Repos that enter via `eng/common/msbuild.{sh,ps1}` (e.g. dotnet/runtime's `src/tests/build.sh`) no longer get `NUGET_PACKAGES` exported.

The downstream effect:

- NuGet restore falls back to `~/.nuget/packages/`.
- `RepoLayout.props` still sets MSBuild's `$(NuGetPackageRoot)` to `$(RepoRoot)/.packages/` when `ContinuousIntegrationBuild=true`.
- Generated `.nuget.g.props` imports guarded by `Exists($(NuGetPackageRoot)…)` are silently skipped.
- Properties contributed by those imports (e.g. `XunitConsoleNetCoreAppPath`) end up undefined, and downstream targets fail. Example failure observed in dotnet/runtime CI:

  ```
  external.csproj(81,5): error : looks the package Microsoft.DotNet.XUnitConsoleRunner is not restored or missing xunit.console.dll.
  ```

## Fix

Restore the `InitializeToolset` call in the `MSBuild` function (gated on `$ci`), matching the location and gating semantics from before #16814.

- `InitializeToolset` is idempotent (caches via `_InitializeToolset` / `$global:_InitializeToolset`).
- `InitializeBuildTool` is not re-added: `MSBuild-Core` already calls it on its own code path, and `InitializeToolset` invokes `DotNet` / `InitializeDotNetCli` itself on the cold path when it needs to restore the Arcade SDK.
- Placing the call in the `MSBuild` function (rather than at `tools.{sh,ps1}` load time) ensures any repo-specific `configure-toolset.{sh,ps1}` overrides — including `use_global_nuget_cache` / `$useGlobalNuGetCache` — have already been imported before `GetNuGetPackageCachePath` runs.

## Validation

- `bash -n eng/common/tools.sh` passes.
- PowerShell parser validates `eng/common/tools.ps1`.
- See #16898 for full repro, binlog evidence, and discussion of alternative approaches.
