### PR TITLE
Remove dn-bot-devdiv-drop-r-code-r PAT from secret manifest

### DIFF
--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -90,17 +90,6 @@ secrets:
       organizations: devdiv
       scopes: code_write drop_write
 
-  dn-bot-devdiv-drop-r-code-r:
-    type: azure-devops-access-token
-    parameters:
-      domainAccountName: dn-bot
-      domainAccountSecret:
-          location: helixkv
-          name: dn-bot-account-redmond
-      name: dn-bot-devdiv-drop-r-code-r
-      organizations: devdiv
-      scopes: code drop
-
   #OneLocBuildVariables
   dn-bot-ceapex-package-r:
     type: azure-devops-access-token


### PR DESCRIPTION
## Summary

Re-removes the \dn-bot-devdiv-drop-r-code-r\ PAT entry from the secret manifest. The original removal (arcade#16779, merged May 12) was accidentally undone by a later merge conflict resolution.

## Context

This PAT was migrated to a WIF service connection (\dnceng-devdiv-drop-r-code-r-wif\) in [dotnet/dotnet#6486](https://github.com/dotnet/dotnet/pull/6486) (merged May 20). The WIF approach is confirmed working on \main\ builds.

The secret-manager is still auto-rotating this PAT because the manifest entry persists. Removing it stops rotation and allows the secret to expire naturally (May 30).

AB#10147