### PR TITLE
Remove dn-bot-devdiv-drop-rw-code-rw PAT from vault config

### DIFF
--- a/.vault-config/product-builds-engkeyvault.yaml
+++ b/.vault-config/product-builds-engkeyvault.yaml
@@ -78,17 +78,6 @@ secrets:
       name: dn-bot-all-orgs-artifact-feeds
       organizations: dnceng devdiv dotnet-security-partners
       scopes: packaging_write
-  
-  dn-bot-devdiv-drop-rw-code-rw:
-    type: azure-devops-access-token
-    parameters:
-      domainAccountName: dn-bot
-      domainAccountSecret:
-          location: helixkv
-          name: dn-bot-account-redmond
-      name: dn-bot-devdiv-drop-rw-code-rw
-      organizations: devdiv
-      scopes: code_write drop_write
 
   dn-bot-devdiv-drop-r-code-r:
     type: azure-devops-access-token


### PR DESCRIPTION
This PAT has been replaced by WIF service connection `dnceng-devdiv-drop-rw-code-rw-wif` across all consuming pipelines (roslyn, fsharp, vstest, interactive-window, test-templates, workload-versions).

Related work item: https://dev.azure.com/dnceng/internal/_workitems/edit/10146