### PR TITLE
JobMonitor: report only still-running Helix jobs on timeout

### DIFF
--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
@@ -121,7 +121,11 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
             IReadOnlySet<string> alreadyProcessed = await _azdo.GetProcessedHelixJobNamesAsync(cancellationToken);
             HashSet<string> processedHelixJobs = new(alreadyProcessed, StringComparer.OrdinalIgnoreCase);
-            HashSet<HelixJobInfo> associatedJobs = new(HelixJobInfo.ByJobNameComparer);
+            // Keyed by Helix job name so that each poll overwrites the cached snapshot with the
+            // latest state from Helix. Using a HashSet here would retain the first-seen snapshot
+            // (typically Status="running", Finished=null), which would cause ReportTimeout and
+            // CancelInFlightHelixJobsAsync to treat already-completed jobs as still in flight.
+            Dictionary<string, HelixJobInfo> associatedJobs = new(StringComparer.OrdinalIgnoreCase);
 
             try
             {
@@ -141,7 +145,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 // lost (and tests that observe UploadedJobNames immediately after a cancelled
                 // run see a partial set).
                 await WaitForPendingTestResultUploadsAsync(CancellationToken.None);
-                ReportTimeout(associatedJobs, processedHelixJobs);
+                ReportTimeout(associatedJobs.Values, processedHelixJobs);
 
                 // On cancellation (typically the overall timeout), proactively cancel any
                 // Helix jobs we know about that haven't finished yet so they don't keep
@@ -150,7 +154,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 // already cancelled) so the best-effort cancel calls actually run.
                 using (var cancelCts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
                 {
-                    await CancelInFlightHelixJobsAsync(associatedJobs, processedHelixJobs, cancelCts.Token);
+                    await CancelInFlightHelixJobsAsync(associatedJobs.Values, processedHelixJobs, cancelCts.Token);
                 }
 
                 return 1;
@@ -202,7 +206,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
         private async Task<int> RunLoopAsync(
             HashSet<string> processedHelixJobs,
-            HashSet<HelixJobInfo> associatedJobs,
+            Dictionary<string, HelixJobInfo> associatedJobs,
             JobResubmissionResult jobResubmission,
             CancellationToken cancellationToken)
         {
@@ -233,7 +237,12 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                         || string.Equals(j.StageName, _options.StageName, StringComparison.OrdinalIgnoreCase))
                 ];
 
-                associatedJobs.UnionWith(associatedJobsWithBuild);
+                // Overwrite per poll so the cached entry reflects the latest Helix-side state
+                // (in particular, the Finished timestamp transitioning from null to a value).
+                foreach (HelixJobInfo j in associatedJobsWithBuild)
+                {
+                    associatedJobs[j.JobName] = j;
+                }
 
                 // Cache every job we have seen so GetSubmitterChainKey can follow the
                 // PreviousHelixJobName chain back to a root, even across polls.

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
@@ -1218,6 +1218,74 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
         }
 
         /// <summary>
+        /// Regression: a Helix job that was "running" in the first poll and "finished" in a
+        /// later poll must not be listed in the timeout error message or cancelled, because the
+        /// monitor's cached snapshot has to reflect the latest Helix-side state when the
+        /// timeout fires. Only jobs that are still genuinely in flight at timeout should be
+        /// reported / cancelled.
+        /// </summary>
+        [Fact]
+        public async Task MonitorTimesOut_DoesNotReportOrCancelJobsThatFinishedAfterFirstPoll()
+        {
+            var azdo = new FakeAzureDevOpsService();
+            var helix = new FakeHelixService();
+            var logger = new RecordingLogger();
+
+            azdo.AddTimelineResponse(
+                MonitorJob(),
+                PipelineJob("Test Linux", "inProgress"));
+
+            // Poll 1: both jobs running.
+            helix.AddResponse(jobs:
+            [
+                HelixJob("helix-good", "running"),
+                HelixJob("helix-stuck", "running"),
+            ]);
+            // Poll 2+: helix-good has finished on Helix, helix-stuck still running.
+            helix.AddResponse(
+                jobs:
+                [
+                    HelixJob("helix-good", "finished"),
+                    HelixJob("helix-stuck", "running"),
+                ],
+                passFailByJob: new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["helix-good"] = PassFail(passed: ["good-wi"]),
+                });
+
+            int pollCount = 0;
+            using var cts = new CancellationTokenSource();
+            var runner = new JobMonitorRunner(DefaultOptions(), logger, azdo, helix,
+                async (_, _) =>
+                {
+                    pollCount++;
+                    if (pollCount >= 2)
+                    {
+                        // Wait until helix-good's results have actually been uploaded before
+                        // cancelling, so the monitor has had a chance to record its terminal
+                        // state.
+                        Task completed = await Task.WhenAny(azdo.UploadCompleted.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+                        Assert.Same(azdo.UploadCompleted.Task, completed);
+                        cts.Cancel();
+                    }
+                });
+
+            int exitCode = await runner.RunAsync(cts.Token);
+
+            Assert.Equal(1, exitCode);
+
+            // helix-good must not appear in the timeout's "had not finished" list because its
+            // cached snapshot was overwritten with the latest (finished) state.
+            string timeoutMessage = Assert.Single(logger.Messages, m =>
+                m.Contains("Helix Job Monitor timed out", StringComparison.Ordinal));
+            Assert.Contains("helix-stuck", timeoutMessage, StringComparison.Ordinal);
+            Assert.DoesNotContain("helix-good", timeoutMessage, StringComparison.Ordinal);
+
+            // And the best-effort cancel pass must only target the still-in-flight job.
+            Assert.Equal(["helix-stuck"], helix.CanceledJobs.OrderBy(j => j, StringComparer.OrdinalIgnoreCase).ToArray());
+        }
+
+        /// <summary>
         /// The monitor times out while some pipeline jobs haven't submitted Helix work yet,
         /// but one job's Helix results were already uploaded. On relaunch, the monitor picks up:
         /// skips already-processed Helix jobs, processes the new ones that have now completed.


### PR DESCRIPTION
Fixes a misleading timeout error in the Helix Job Monitor where Helix jobs that had actually finished (and been processed) were reported as "had not finished" and best-effort cancelled.

## Symptom (noticed in #16899, build [1438541](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1438541))

The `osx.15.amd64.open` queue was starved, so two Helix jobs sat at `1 Finished + 24 Waiting` for the full 88-minute monitor window. The monitor correctly timed out — but the timeout error listed **all 8** Helix jobs as `"had not finished"`, including the 6 ubuntu/windows jobs that the same monitor instance had explicitly logged as succeeded/failed earlier.

This is the actual list emitted by `ReportTimeout` at 09:28:02, with markers showing what each entry really was at the time:

```
fail: Helix Job Monitor timed out after 88 minute(s) (01:28:00). 8 Helix job(s) had not finished:
      - https://helix.dot.net/api/2019-06-17/jobs/0390a674-703a-4954-b666-aabdc22e4532/details (ubuntu.2204.amd64.open)   ← ❌ wrong: already processed (Helix Finished 08:13:05, monitor logged as failed at 08:13:30)
      - https://helix.dot.net/api/2019-06-17/jobs/35ee9f09-cc38-4d24-9208-d2fd5c22bcb2/details (ubuntu.2204.amd64.open)   ← ❌ wrong: already processed (Helix Finished 08:12:51, monitor logged as succeeded at 08:12:58)
      - https://helix.dot.net/api/2019-06-17/jobs/391427a2-14a8-451a-a6ed-edb76cbd3def/details (osx.15.amd64.open)         ← ✅ correct: genuinely stuck, 24/25 work items still Waiting
      - https://helix.dot.net/api/2019-06-17/jobs/53f8eec1-f186-4597-a89a-cbf810b1c4b3/details (osx.15.amd64.open)         ← ✅ correct: genuinely stuck, 24/25 work items still Waiting
      - https://helix.dot.net/api/2019-06-17/jobs/5bce8cbe-f732-46ac-9b3d-3aa1fd404820/details (windows.11.amd64.client.open) ← ❌ wrong: already processed (Helix Finished 08:35:08, monitor logged as succeeded at 08:35:19)
      - https://helix.dot.net/api/2019-06-17/jobs/727a99f6-a27d-40b2-90ce-2edbf61ef181/details (ubuntu.2204.amd64.open)   ← ❌ wrong: already processed (Helix Finished 08:12:22, monitor logged as succeeded at 08:12:27)
      - https://helix.dot.net/api/2019-06-17/jobs/85ab4c7c-669b-4174-9d84-6ceb6134d81e/details (windows.11.amd64.client.open) ← ❌ wrong: already processed (Helix Finished 08:35:12, monitor logged as succeeded at 08:35:19)
      - https://helix.dot.net/api/2019-06-17/jobs/c81c694c-1c72-4de6-9dc6-7ae2d6be13c1/details (ubuntu.2204.amd64.open)   ← ❌ wrong: already processed (Helix Finished 08:12:47, monitor logged as failed at 08:12:59)
warn: Cancellation requested. Attempting to cancel 2 in-flight Helix job(s).
```

i.e. 6 of the 8 entries in the `"had not finished"` list were jobs the same monitor process had already finished and processed. The monitor also tried to cancel some of those already-finished jobs (harmless on Helix, but wasted API calls and noise in the log).

## Root cause

`JobMonitorRunner` cached every Helix job it had ever seen in a `HashSet<HelixJobInfo>` keyed by `JobName`:

```csharp
HashSet<HelixJobInfo> associatedJobs = new(HelixJobInfo.ByJobNameComparer);
...
associatedJobs.UnionWith(associatedJobsWithBuild);
```

`HashSet.UnionWith` **keeps the existing entry** when a duplicate is encountered, so the cached snapshot for each job was the **first** one seen — typically `Status="running"`, `Finished=null`, `IsCompleted=false`. The timeout path then read `IsCompleted` off these stale snapshots:

- `ReportTimeout` → listed every job whose cached `IsCompleted==false`, even ones already processed and uploaded.
- `CancelInFlightHelixJobsAsync` → tried to cancel them too.

## Fix

Switch the cache to `Dictionary<string, HelixJobInfo>` keyed by `JobName` and overwrite per poll, so the latest Helix-side snapshot wins. The two timeout-path consumers now read `.Values` and see the up-to-date `IsCompleted`.

## Test

New regression test `MonitorTimesOut_DoesNotReportOrCancelJobsThatFinishedAfterFirstPoll`:

- Poll 1 returns both `helix-good` and `helix-stuck` as `"running"`.
- Poll 2 returns `helix-good` as `"finished"` (with results) and `helix-stuck` still `"running"`.
- Cancellation fires after the second poll's upload completes.
- Asserts the timeout log mentions `helix-stuck` but not `helix-good`, and that only `helix-stuck` is cancelled.

Verified to fail against unfixed code with the exact same diagnostic the production logs showed, and pass after the fix. Full `JobMonitorRunnerTests` suite: 46/46 passing.

## Not addressed here

The original timeout in #16899 (osx.15.amd64.open queue starvation) is an infra issue, not an arcade bug. This PR only fixes the misleading reporting/cancellation behaviour around that timeout.
