### PR TITLE
Target NetCurrent for Microsoft.DotNet.XUnitConsoleRunner test host

### DIFF
--- a/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
@@ -9,8 +9,7 @@
          NetMinimum causes TypeLoadException "format is invalid" when it is asked to load a
          NetCurrent test assembly that references newer BCL members. The consuming project
          selects the matching host via the packaged build props. -->
-    <TargetFrameworks>$(NetCurrent)</TargetFrameworks>
-    <TargetFrameworks Condition="'$(NetMinimum)' != '' and '$(NetMinimum)' != '$(NetCurrent)'">$(NetMinimum);$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);$(NetPrevious);$(NetMinimum)</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AssemblyName>xunit.console</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
@@ -1,11 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- Target NetCurrent so the test host can load test assemblies built against
-         the current .NET TFM. Using NetMinimum here causes TypeLoadException
-         "format is invalid" when loading newer-TFM test assemblies because the
-         minimum .NET runtime is selected and cannot resolve newer BCL members. -->
-    <TargetFramework>$(NetCurrent)</TargetFramework>
+    <!-- The console runner (xunit.console.dll) is a test host: it loads and runs test
+         assemblies in-process, so it must run on a .NET runtime whose version is at least
+         that of the test assemblies. Ship a host for both NetCurrent (for repos that build
+         against the in-development TFM, e.g. dotnet/runtime) and NetMinimum (for repos that
+         consume the latest Arcade while still on an older .NET SDK). A host built only for
+         NetMinimum causes TypeLoadException "format is invalid" when it is asked to load a
+         NetCurrent test assembly that references newer BCL members. The consuming project
+         selects the matching host via the packaged build props. -->
+    <TargetFrameworks>$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(NetMinimum)' != '' and '$(NetMinimum)' != '$(NetCurrent)'">$(NetMinimum);$(NetCurrent)</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AssemblyName>xunit.console</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -23,6 +28,7 @@
 
   <ItemGroup>
     <None Include="build\Microsoft.DotNet.XUnitConsoleRunner.props" Pack="true" PackagePath="build" />
+    <None Include="build\Microsoft.DotNet.XUnitConsoleRunner.targets" Pack="true" PackagePath="build" />
     <None Include="$(RepoRoot)LICENSE.txt" PackagePath="LICENSE.txt" Pack="true"/>
     <None Include="$(RepoRoot)THIRD-PARTY-NOTICES.txt" PackagePath="THIRD-PARTY-NOTICES.txt" Pack="true"/>
   </ItemGroup>
@@ -42,11 +48,18 @@
     <PackageReference Include="xunit.runner.reporters" />
   </ItemGroup>
 
-  <!-- Publish build assets and include them in the package under the tools directory. -->
+  <!-- Publish build assets and include them in the package under the tools directory.
+       The NetCurrent host keeps the historical 'tools/net' location so existing consumers
+       (and the default in the build props) continue to resolve it. Additional hosts (e.g.
+       NetMinimum) are placed under a TFM-specific folder and selected by the build props. -->
   <Target Name="_AddBuildOutputToPackage" DependsOnTargets="Publish">
+    <PropertyGroup>
+      <_XunitConsoleRunnerToolsSubDir Condition="'$(TargetFramework)' == '$(NetCurrent)'">net</_XunitConsoleRunnerToolsSubDir>
+      <_XunitConsoleRunnerToolsSubDir Condition="'$(TargetFramework)' != '$(NetCurrent)'">$(TargetFramework)</_XunitConsoleRunnerToolsSubDir>
+    </PropertyGroup>
     <ItemGroup>
       <TfmSpecificPackageFile Include="$(PublishDir)**" 
-                              PackagePath="tools/net/%(RecursiveDir)%(FileName)%(Extension)"/>
+                              PackagePath="tools/$(_XunitConsoleRunnerToolsSubDir)/%(RecursiveDir)%(FileName)%(Extension)"/>
     </ItemGroup>
   </Target>
 

--- a/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/src/Microsoft.DotNet.XUnitConsoleRunner.csproj
@@ -1,7 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetMinimum)</TargetFramework>
+    <!-- Target NetCurrent so the test host can load test assemblies built against
+         the current .NET TFM. Using NetMinimum here causes TypeLoadException
+         "format is invalid" when loading newer-TFM test assemblies because the
+         minimum .NET runtime is selected and cannot resolve newer BCL members. -->
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <OutputType>Exe</OutputType>
     <AssemblyName>xunit.console</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/Microsoft.DotNet.XUnitConsoleRunner/src/build/Microsoft.DotNet.XUnitConsoleRunner.props
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/src/build/Microsoft.DotNet.XUnitConsoleRunner.props
@@ -2,6 +2,9 @@
 <Project>
 
   <PropertyGroup>
+    <!-- Default to the NetCurrent host shipped under 'tools/net'. The consuming project's
+         framework is not reliably known when this props file is imported, so the
+         TFM-specific override lives in the companion .targets file. -->
     <XunitConsoleNetCoreAppPath>$(MSBuildThisFileDirectory)..\tools\net\xunit.console.dll</XunitConsoleNetCoreAppPath>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.XUnitConsoleRunner/src/build/Microsoft.DotNet.XUnitConsoleRunner.targets
+++ b/src/Microsoft.DotNet.XUnitConsoleRunner/src/build/Microsoft.DotNet.XUnitConsoleRunner.targets
@@ -1,0 +1,15 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Project>
+
+  <!-- Imported after the consuming project has been evaluated, so $(TargetFramework) is set
+       for single-target projects (and for each inner build of multi-targeting projects).
+       If the package ships a host matching the consumer's .NET version (e.g. 'tools/net10.0'
+       for a net10.0 consumer), prefer it so the test host runs on the same runtime as the
+       test assemblies it loads. Otherwise the default 'tools/net' (NetCurrent) host from the
+       props file is used. -->
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(TargetFrameworkVersion)' != ''">
+    <_XunitConsoleRunnerConsumerHost>$(MSBuildThisFileDirectory)..\tools\net$(TargetFrameworkVersion.TrimStart('v'))\xunit.console.dll</_XunitConsoleRunnerConsumerHost>
+    <XunitConsoleNetCoreAppPath Condition="Exists('$(_XunitConsoleRunnerConsumerHost)')">$(_XunitConsoleRunnerConsumerHost)</XunitConsoleNetCoreAppPath>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
> [!NOTE]
> This pull request was drafted with assistance from GitHub Copilot (AI-generated content).

## Summary

Change `Microsoft.DotNet.XUnitConsoleRunner` (`xunit.console.dll`) to target `$(NetCurrent)` instead of `$(NetMinimum)`. The XUnitConsoleRunner is a **test host** that runs test assemblies built against the current .NET TFM, so its host runtime must also be the current TFM.

## Background

#16795 ("Downgrade TFM to NetMinimum") changed several Arcade projects from `$(BundledNETCoreAppTargetFramework)` to `$(NetMinimum)` to decouple Arcade from the installed .NET SDK. That change is appropriate for build-time MSBuild tasks, but the `Microsoft.DotNet.XUnitConsoleRunner` project produces `xunit.console.dll`, the test host executable shipped via the `Microsoft.DotNet.XUnitConsoleRunner` package and consumed by `Microsoft.DotNet.XHarness.TestRunners.Xunit`, RemoteExecutor, etc.

For RemoteExecutor, #16795 also added `<RollForward>Major</RollForward>` as mitigation. No equivalent mitigation was added for XUnitConsoleRunner, and `RollForward=Major` would not actually have helped here — once the .NET 10 host is selected, even forward-rolling can't load a test assembly that references members only present in net11's BCL.

## Repro / impact

Consumer: dotnet/runtime#128648 (a routine VMR backflow PR). The Wasm.Build.Tests Helix work items fail with:

```
TypeLoadException: Could not load type 'Wasm.Build.Tests.WasmTemplateTestsBase'
from assembly 'Wasm.Build.Tests, Version=11.0.0.0, ...' because the format is invalid.
```

23 of 24 work items fail per CLR-on-WASM job. Failing build: <https://dev.azure.com/dnceng-public/public/_build/results?buildId=1438863>. Baseline passing main build: <https://dev.azure.com/dnceng-public/public/_build/results?buildId=1438570>.

## Smoking-gun evidence

I diffed the entire Helix payload between a passing main build and the failing PR build (210 DLLs). Only six differ; five are inert (MVID-only or attribute-blob deltas). The substantive change is in `xunit.console.dll`:

```diff
-.assembly extern System.Runtime { .ver 11:0:0:0 }
+.assembly extern System.Runtime { .ver 10:0:0:0 }
...
-.custom instance void [System.Runtime]System.Runtime.Versioning.TargetFrameworkAttribute::.ctor(string)
-   = ( ... ".NETCoreApp,Version=v11.0" ... )
+.custom instance void [System.Runtime]System.Runtime.Versioning.TargetFrameworkAttribute::.ctor(string)
+   = ( ... ".NETCoreApp,Version=v10.0" ... )
```

And the host runtimeconfig:

| | tfm | framework.version |
|---|---|---|
| main (passing) | `net11.0` | `11.0.0-preview.5.26227.104` |
| PR (failing) | `net10.0` | `10.0.0` |

The .NET 10 host is then asked to load a test assembly that references `System.Runtime, Version=11.0.0.0` and types/members only present in net11 → `TypeLoadException`.

## Fix

```diff
-    <TargetFramework>$(NetMinimum)</TargetFramework>
+    <!-- Target NetCurrent so the test host can load test assemblies built against
+         the current .NET TFM. Using NetMinimum here causes TypeLoadException
+         "format is invalid" when loading newer-TFM test assemblies because the
+         minimum .NET runtime is selected and cannot resolve newer BCL members. -->
+    <TargetFramework>$(NetCurrent)</TargetFramework>
```

This preserves #16795's "decouple from the SDK" intent — `NetCurrent` is just an Arcade property, not the SDK's bundled TFM, and ref packs are NuGet-restored.

## Notes / open questions

- Validation against `dotnet/runtime` (Wasm.Build.Tests) will confirm the fix; happy to chase that with an arcade insertion once this is in.
- Did not touch `RemoteExecutor` — its `RollForward=Major` mitigation may also be insufficient for runtime/test-assembly cases, but that's a separate investigation.
- Should this be considered for a NetMinimum-targeted release branch too, if any consumer depends on it for test execution?

## Refs

- Regression source: #16795 (commit 98d7ce08)
- Failing consumer: dotnet/runtime#128648
