### PR TITLE
[release/6.0] Remove DotNet-Blob-Feed variable group

### DIFF
--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -18,10 +18,8 @@ variables:
       value: True
     - name: _SignType
       value: real
-    # DotNet-Blob-Feed provides: dotnetfeed-storage-access-key-1
     # Publish-Build-Assets provides: BotAccount-dotnet-maestro-bot-PAT
     # DotNet-HelixApi-Access provides: HelixApiAccessToken
-    - group: DotNet-Blob-Feed
     - group: Publish-Build-Assets
     - group: DotNet-HelixApi-Access
     - group: SDL_Settings

--- a/eng/validate-sdk.yml
+++ b/eng/validate-sdk.yml
@@ -22,7 +22,6 @@ jobs:
       name: NetCore1ESPool-Svc-Internal
       demands: ImageOverride -equals windows.vs2019.amd64
     variables:
-    - group: DotNet-Blob-Feed
     - group: Publish-Build-Assets
     - _BuildConfig: ${{ parameters.buildConfig }}
     - _BuildArgs: ${{ parameters.buildArgs }}


### PR DESCRIPTION
## Summary

The `DotNet-Blob-Feed` variable group no longer exists in the AzDO library, causing the `arcade-official-ci` pipeline on `release/6.0` to fail at YAML load time:

> An error occurred while loading the YAML build pipeline. Variable group was not found or is not authorized for use.

**Failed build:** https://dev.azure.com/dnceng/internal/_build/results?buildId=2986523&view=results

## Root Cause

The variable group `DotNet-Blob-Feed` (which provided `dotnetfeed-storage-access-key-1`) has been deleted from the AzDO variable group library. It was already removed from `main`, `release/8.0`, `release/9.0`, and `release/10.0` but was missed on `release/6.0`.

## Changes

Removed the `DotNet-Blob-Feed` group reference and its comment from `eng/common-variables.yml`. The variable it provided (`dotnetfeed-storage-access-key-1`) is not consumed anywhere in the pipeline YAML on this branch.