### PR TITLE
Merge MSBuild functions in tools.ps1/sh

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -602,7 +602,6 @@ function GetDefaultMSBuildEngine() {
 function InitializeNuGetPackageCachePath() {
   if ($env:NUGET_PACKAGES -eq $null) {
     # Use local cache on CI to ensure deterministic build.
-    # Avoid using the http cache as workaround for https://github.com/NuGet/Home/issues/3116
     # use global cache in dev builds to avoid cost of downloading packages.
     # For directory normalization, see also: https://github.com/NuGet/Home/issues/7968
     if ($useGlobalNuGetCache) {

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -748,60 +748,11 @@ function Stop-Processes() {
 #
 function MSBuild() {
   if ($ci) {
-    InitializeToolset | Out-Null
-
     $env:NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS = 20
     $env:NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS = 20
     Write-PipelineSetVariable -Name 'NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS' -Value '20'
     Write-PipelineSetVariable -Name 'NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS' -Value '20'
 
-    Enable-Nuget-EnhancedRetry
-  }
-
-  MSBuild-Core @args
-}
-
-#
-# Executes a dotnet command with arguments passed to the function.
-# Terminates the script if the command fails.
-#
-function DotNet() {
-  $dotnetRoot = InitializeDotNetCli -install:$restore
-  $dotnetPath = Join-Path $dotnetRoot (GetExecutableFileName 'dotnet')
-
-  $cmdArgs = ""
-  foreach ($arg in $args) {
-    if ($null -ne $arg -and $arg.Trim() -ne "") {
-      if ($arg.EndsWith('\')) {
-        $arg = $arg + "\"
-      }
-      $cmdArgs += " `"$arg`""
-    }
-  }
-
-  $env:ARCADE_BUILD_TOOL_COMMAND = "`"$dotnetPath`" $cmdArgs"
-
-  $exitCode = Exec-Process $dotnetPath $cmdArgs
-
-  if ($exitCode -ne 0) {
-    Write-Host "dotnet command failed with exit code $exitCode. Check errors above." -ForegroundColor Red
-
-    if ($ci -and $env:SYSTEM_TEAMPROJECT -ne $null -and !$fromVMR) {
-      Write-PipelineSetResult -Result "Failed" -Message "dotnet command execution failed."
-      ExitWithExitCode 0
-    } else {
-      ExitWithExitCode $exitCode
-    }
-  }
-}
-
-#
-# Executes msbuild (or 'dotnet msbuild') with arguments passed to the function.
-# The arguments are automatically quoted.
-# Terminates the script if the build fails.
-#
-function MSBuild-Core() {
-  if ($ci) {
     if (!$binaryLog -and !$excludeCIBinarylog) {
       Write-PipelineTelemetryError -Category 'Build' -Message 'Binary log must be enabled in CI build, or explicitly opted-out from with the -excludeCIBinarylog switch.'
       ExitWithExitCode 1
@@ -876,6 +827,40 @@ function MSBuild-Core() {
   }
 }
 
+#
+# Executes a dotnet command with arguments passed to the function.
+# Terminates the script if the command fails.
+#
+function DotNet() {
+  $dotnetRoot = InitializeDotNetCli -install:$restore
+  $dotnetPath = Join-Path $dotnetRoot (GetExecutableFileName 'dotnet')
+
+  $cmdArgs = ""
+  foreach ($arg in $args) {
+    if ($null -ne $arg -and $arg.Trim() -ne "") {
+      if ($arg.EndsWith('\')) {
+        $arg = $arg + "\"
+      }
+      $cmdArgs += " `"$arg`""
+    }
+  }
+
+  $env:ARCADE_BUILD_TOOL_COMMAND = "`"$dotnetPath`" $cmdArgs"
+
+  $exitCode = Exec-Process $dotnetPath $cmdArgs
+
+  if ($exitCode -ne 0) {
+    Write-Host "dotnet command failed with exit code $exitCode. Check errors above." -ForegroundColor Red
+
+    if ($ci -and $env:SYSTEM_TEAMPROJECT -ne $null -and !$fromVMR) {
+      Write-PipelineSetResult -Result "Failed" -Message "dotnet command execution failed."
+      ExitWithExitCode 0
+    } else {
+      ExitWithExitCode $exitCode
+    }
+  }
+}
+
 function GetMSBuildBinaryLogCommandLineArgument($arguments) {
   foreach ($argument in $arguments) {
     if ($argument -ne $null) {
@@ -914,6 +899,21 @@ function Get-Darc($version) {
     & $PSScriptRoot\darc-init.ps1 -toolpath $darcPath | Out-Host
   }
   return "$darcPath\darc.exe"
+}
+
+# If $ci flag is set, turn on (and log that we did) special environment variables for improved Nuget client retry logic.
+function Enable-Nuget-EnhancedRetry() {
+  if ($ci) {
+    Write-Host "Setting NUGET enhanced retry environment variables"
+    $env:NUGET_ENABLE_ENHANCED_HTTP_RETRY = 'true'
+    $env:NUGET_ENHANCED_MAX_NETWORK_TRY_COUNT = 6
+    $env:NUGET_ENHANCED_NETWORK_RETRY_DELAY_MILLISECONDS = 1000
+    $env:NUGET_RETRY_HTTP_429 = 'true'
+    Write-PipelineSetVariable -Name 'NUGET_ENABLE_ENHANCED_HTTP_RETRY' -Value 'true'
+    Write-PipelineSetVariable -Name 'NUGET_ENHANCED_MAX_NETWORK_TRY_COUNT' -Value '6'
+    Write-PipelineSetVariable -Name 'NUGET_ENHANCED_NETWORK_RETRY_DELAY_MILLISECONDS' -Value '1000'
+    Write-PipelineSetVariable -Name 'NUGET_RETRY_HTTP_429' -Value 'true'
+  }
 }
 
 . $PSScriptRoot\pipeline-logging-functions.ps1
@@ -960,19 +960,5 @@ if (!$disableConfigureToolsetImport) {
   }
 }
 
-#
-# If $ci flag is set, turn on (and log that we did) special environment variables for improved Nuget client retry logic.
-#
-function Enable-Nuget-EnhancedRetry() {
-    if ($ci) {
-      Write-Host "Setting NUGET enhanced retry environment variables"
-      $env:NUGET_ENABLE_ENHANCED_HTTP_RETRY = 'true'
-      $env:NUGET_ENHANCED_MAX_NETWORK_TRY_COUNT = 6
-      $env:NUGET_ENHANCED_NETWORK_RETRY_DELAY_MILLISECONDS = 1000
-      $env:NUGET_RETRY_HTTP_429 = 'true'
-      Write-PipelineSetVariable -Name 'NUGET_ENABLE_ENHANCED_HTTP_RETRY' -Value 'true'
-      Write-PipelineSetVariable -Name 'NUGET_ENHANCED_MAX_NETWORK_TRY_COUNT' -Value '6'
-      Write-PipelineSetVariable -Name 'NUGET_ENHANCED_NETWORK_RETRY_DELAY_MILLISECONDS' -Value '1000'
-      Write-PipelineSetVariable -Name 'NUGET_RETRY_HTTP_429' -Value 'true'
-    }
-}
+# Initialize the nuget package cache vars
+GetNuGetPackageCachePath | Out-Null

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -599,7 +599,7 @@ function GetDefaultMSBuildEngine() {
   ExitWithExitCode 1
 }
 
-function GetNuGetPackageCachePath() {
+function InitializeNuGetPackageCachePath() {
   if ($env:NUGET_PACKAGES -eq $null) {
     # Use local cache on CI to ensure deterministic build.
     # Avoid using the http cache as workaround for https://github.com/NuGet/Home/issues/3116
@@ -657,8 +657,6 @@ function InitializeToolset() {
     return $global:_InitializeToolset
   }
 
-  $nugetCache = GetNuGetPackageCachePath
-
   $toolsetVersion = Read-ArcadeSdkVersion
   $toolsetToolsDir = Join-Path $ToolsetDir $toolsetVersion
 
@@ -679,7 +677,7 @@ function InitializeToolset() {
     ExitWithExitCode 1
   }
 
-  $downloadArgs = @("package", "download", "Microsoft.DotNet.Arcade.Sdk@$toolsetVersion", "--verbosity", "minimal", "--prerelease", "--output", "$nugetCache")
+  $downloadArgs = @("package", "download", "Microsoft.DotNet.Arcade.Sdk@$toolsetVersion", "--verbosity", "minimal", "--prerelease", "--output", "$nugetPackageCachePath")
   $nugetConfig = $env:NUGET_CONFIG
   if (-not $nugetConfig) {
     # Search for any variation of nuget.config in the RepoRoot
@@ -696,7 +694,7 @@ function InitializeToolset() {
   }
   DotNet @downloadArgs
 
-  $packageDir = Join-Path $nugetCache (Join-Path 'microsoft.dotnet.arcade.sdk' $toolsetVersion)
+  $packageDir = Join-Path $nugetPackageCachePath (Join-Path 'microsoft.dotnet.arcade.sdk' $toolsetVersion)
   $packageToolsetDir = Join-Path $packageDir 'toolset'
 
   if (!(Test-Path $packageToolsetDir)) {
@@ -748,11 +746,6 @@ function Stop-Processes() {
 #
 function MSBuild() {
   if ($ci) {
-    $env:NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS = 20
-    $env:NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS = 20
-    Write-PipelineSetVariable -Name 'NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS' -Value '20'
-    Write-PipelineSetVariable -Name 'NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS' -Value '20'
-
     if (!$binaryLog -and !$excludeCIBinarylog) {
       Write-PipelineTelemetryError -Category 'Build' -Message 'Binary log must be enabled in CI build, or explicitly opted-out from with the -excludeCIBinarylog switch.'
       ExitWithExitCode 1
@@ -763,8 +756,6 @@ function MSBuild() {
       ExitWithExitCode 1
     }
   }
-
-  Enable-Nuget-EnhancedRetry
 
   $buildTool = InitializeBuildTool
 
@@ -901,21 +892,6 @@ function Get-Darc($version) {
   return "$darcPath\darc.exe"
 }
 
-# If $ci flag is set, turn on (and log that we did) special environment variables for improved Nuget client retry logic.
-function Enable-Nuget-EnhancedRetry() {
-  if ($ci) {
-    Write-Host "Setting NUGET enhanced retry environment variables"
-    $env:NUGET_ENABLE_ENHANCED_HTTP_RETRY = 'true'
-    $env:NUGET_ENHANCED_MAX_NETWORK_TRY_COUNT = 6
-    $env:NUGET_ENHANCED_NETWORK_RETRY_DELAY_MILLISECONDS = 1000
-    $env:NUGET_RETRY_HTTP_429 = 'true'
-    Write-PipelineSetVariable -Name 'NUGET_ENABLE_ENHANCED_HTTP_RETRY' -Value 'true'
-    Write-PipelineSetVariable -Name 'NUGET_ENHANCED_MAX_NETWORK_TRY_COUNT' -Value '6'
-    Write-PipelineSetVariable -Name 'NUGET_ENHANCED_NETWORK_RETRY_DELAY_MILLISECONDS' -Value '1000'
-    Write-PipelineSetVariable -Name 'NUGET_RETRY_HTTP_429' -Value 'true'
-  }
-}
-
 . $PSScriptRoot\pipeline-logging-functions.ps1
 
 $RepoRoot = Resolve-Path (Join-Path $PSScriptRoot '..\..\')
@@ -961,4 +937,4 @@ if (!$disableConfigureToolsetImport) {
 }
 
 # Initialize the nuget package cache vars
-GetNuGetPackageCachePath | Out-Null
+$nugetPackageCachePath = InitializeNuGetPackageCachePath

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -373,7 +373,7 @@ function InitializeBuildTool {
   _InitializeBuildToolCommand="msbuild"
 }
 
-function GetNuGetPackageCachePath {
+function InitializeNuGetPackageCachePath {
   if [[ -z ${NUGET_PACKAGES:-} ]]; then
     if [[ "$use_global_nuget_cache" == true ]]; then
       export NUGET_PACKAGES="$HOME/.nuget/packages/"
@@ -383,7 +383,7 @@ function GetNuGetPackageCachePath {
   fi
 
   # return value
-  _GetNuGetPackageCachePath=$NUGET_PACKAGES
+  _InitializeNuGetPackageCachePath=$NUGET_PACKAGES
 }
 
 function InitializeNativeTools() {
@@ -404,8 +404,6 @@ function InitializeToolset {
   if [[ -n "${_InitializeToolset:-}" ]]; then
     return
   fi
-
-  GetNuGetPackageCachePath
 
   ReadGlobalVersion "Microsoft.DotNet.Arcade.Sdk"
 
@@ -429,7 +427,7 @@ function InitializeToolset {
     ExitWithExitCode 2
   fi
 
-  local download_args=("package" "download" "Microsoft.DotNet.Arcade.Sdk@$toolset_version" "--verbosity" "minimal" "--prerelease" "--output" "$_GetNuGetPackageCachePath")
+  local download_args=("package" "download" "Microsoft.DotNet.Arcade.Sdk@$toolset_version" "--verbosity" "minimal" "--prerelease" "--output" "$_InitializeNuGetPackageCachePath")
   local nuget_config="${NUGET_CONFIG:-}"
   if [[ -z "$nuget_config" ]]; then
     # Search for any variation of nuget.config in the RepoRoot
@@ -446,7 +444,7 @@ function InitializeToolset {
   fi
   DotNet "${download_args[@]}"
 
-  local package_dir="$_GetNuGetPackageCachePath/microsoft.dotnet.arcade.sdk/$toolset_version"
+  local package_dir="$_InitializeNuGetPackageCachePath/microsoft.dotnet.arcade.sdk/$toolset_version"
 
   if [[ ! -d "$package_dir/toolset" ]]; then
     Write-PipelineTelemetryError -category 'InitializeToolset' "Arcade SDK package does not contain a toolset folder: $package_dir"
@@ -503,11 +501,6 @@ function DotNet {
 
 function MSBuild {
   if [[ "$ci" == true ]]; then
-    export NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS=20
-    export NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS=20
-    Write-PipelineSetVariable -name "NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS" -value "20"
-    Write-PipelineSetVariable -name "NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS" -value "20"
-
     if [[ "$binary_log" != true && "$exclude_ci_binary_log" != true ]]; then
       Write-PipelineTelemetryError -category 'Build'  "Binary log must be enabled in CI build, or explicitly opted-out from with the -noBinaryLog switch."
       ExitWithExitCode 1
@@ -657,4 +650,4 @@ if [[ -n "${useInstalledDotNetCli:-}" ]]; then
 fi
 
 # Initialize the nuget package cache vars
-GetNuGetPackageCachePath
+InitializeNuGetPackageCachePath

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -502,22 +502,12 @@ function DotNet {
 }
 
 function MSBuild {
-  local args=( "$@" )
-
   if [[ "$ci" == true ]]; then
-    InitializeToolset
-
     export NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS=20
     export NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS=20
     Write-PipelineSetVariable -name "NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS" -value "20"
     Write-PipelineSetVariable -name "NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS" -value "20"
-  fi
 
-  MSBuild-Core "${args[@]}"
-}
-
-function MSBuild-Core {
-  if [[ "$ci" == true ]]; then
     if [[ "$binary_log" != true && "$exclude_ci_binary_log" != true ]]; then
       Write-PipelineTelemetryError -category 'Build'  "Binary log must be enabled in CI build, or explicitly opted-out from with the -noBinaryLog switch."
       ExitWithExitCode 1
@@ -665,3 +655,6 @@ fi
 if [[ -n "${useInstalledDotNetCli:-}" ]]; then
   use_installed_dotnet_cli="$useInstalledDotNetCli"
 fi
+
+# Initialize the nuget package cache vars
+GetNuGetPackageCachePath


### PR DESCRIPTION
... and remove the InitializeToolset call from the functions by calling the nuget cache export function directly.

The `GetNuGetPackageCachePath` function all doesn't need a IF CI condition as the function is also unconditionally called in eng/common/build.ps1/sh.

The `MSBuild-Core` function is not used by anyone aside from the entry point in the VMR which I will update with the next re-bootstrap (just remove the `-Core` part from the function call).

Also remove a set of env vars that are already the default in NuGet now.

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
