### PR TITLE
[release/6.0] Replace deprecated 1es-mariner-2 image with build.azurelinux.3.amd64

### DIFF
--- a/eng/common/templates-official/job/source-build.yml
+++ b/eng/common/templates-official/job/source-build.yml
@@ -56,7 +56,7 @@ jobs:
         demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: NetCore1ESPool-Svc-Internal
-        image: 1es-mariner-2
+        image: build.azurelinux.3.amd64
         os: linux
   ${{ if ne(parameters.platform.pool, '') }}:
     pool: ${{ parameters.platform.pool }}


### PR DESCRIPTION
The \1es-mariner-2\ image no longer exists in the \NetCore1ESPool-Svc-Internal\ pool, causing Source-Build (Managed) jobs to fail with:

\\\
Image 1es-mariner-2 doesn't exist in pool NetCore1ESPool-Svc-Internal
\\\

This replaces it with \uild.azurelinux.3.amd64\, which is what \elease/8.0\ and later branches use.

Follow-up to #16915 which fixed the \DotNet-Blob-Feed\ variable group issue on this branch.