### PR TITLE
[release/10.0] Remove legacyCredential PAT usage from Arcade templates

### DIFF
--- a/eng/common/core-templates/job/publish-build-assets.yml
+++ b/eng/common/core-templates/job/publish-build-assets.yml
@@ -122,9 +122,6 @@ jobs:
 
     # Populate internal runtime variables.
     - template: /eng/common/templates/steps/enable-internal-sources.yml
-      ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
-        parameters:
-            legacyCredential: $(dn-bot-dnceng-artifact-feeds-rw)
     
     - template: /eng/common/templates/steps/enable-internal-runtimes.yml
 

--- a/eng/common/core-templates/post-build/post-build.yml
+++ b/eng/common/core-templates/post-build/post-build.yml
@@ -352,8 +352,6 @@ stages:
 
         # Populate internal runtime variables.
         - template: /eng/common/templates/steps/enable-internal-sources.yml
-          parameters:
-            legacyCredential: $(dn-bot-dnceng-artifact-feeds-rw)
 
         - template: /eng/common/templates/steps/enable-internal-runtimes.yml
 


### PR DESCRIPTION
Backport of #16920 to release/10.0.

Removes the legacyCredential parameter from enable-internal-sources.yml calls, allowing DevDiv pipelines to use the WIF-backed `dnceng-artifacts-feeds-read` service connection instead of the PAT.

Fixes AB#10143