### PR TITLE
Log Helix queue health summary on job submission (opt-in)

### DIFF
--- a/src/Microsoft.DotNet.Helix/Client/CSharp/JobCreationResult.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/JobCreationResult.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.Helix.Client.Models
+{
+    public partial class JobCreationResult
+    {
+        [JsonProperty("queueStats")]
+        public QueueStats QueueStats { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.Helix/Client/CSharp/QueueStats.cs
+++ b/src/Microsoft.DotNet.Helix/Client/CSharp/QueueStats.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.Helix.Client.Models
+{
+    public partial class QueueStats
+    {
+        [JsonProperty("queueName")]
+        public string QueueName { get; set; }
+
+        [JsonProperty("depth")]
+        public int? Depth { get; set; }
+
+        [JsonProperty("averageRunDuration")]
+        public TimeSpan? AverageRunDuration { get; set; }
+
+        [JsonProperty("estimatedWait")]
+        public TimeSpan? EstimatedWait { get; set; }
+
+        [JsonProperty("estimatedWaitMethod")]
+        public string EstimatedWaitMethod { get; set; }
+
+        [JsonProperty("generatedAt")]
+        public DateTimeOffset? GeneratedAt { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.Helix/JobSender/IJobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/IJobDefinition.cs
@@ -176,6 +176,13 @@ namespace Microsoft.DotNet.Helix.Client
         IJobDefinition WithMaxRetryCount(int? maxRetryCount);
 
         /// <summary>
+        /// Opts in to logging the preview Helix queue health summary (estimated wait, depth,
+        /// snapshot time) returned in the job creation response. Off by default.
+        /// </summary>
+        /// <returns>Fluent job builder.</returns>
+        IJobDefinition WithShowQueueStats(bool showQueueStats);
+
+        /// <summary>
         /// <para>Sends the fully specified job to execution.</para>
         /// 
         /// <para>This includes upload of all the provided correlation data, but does not

--- a/src/Microsoft.DotNet.Helix/JobSender/IJobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/IJobDefinition.cs
@@ -180,7 +180,7 @@ namespace Microsoft.DotNet.Helix.Client
         /// snapshot time) returned in the job creation response. Off by default.
         /// </summary>
         /// <returns>Fluent job builder.</returns>
-        IJobDefinition WithShowQueueStats(bool showQueueStats);
+        IJobDefinition WithQueueStats();
 
         /// <summary>
         /// <para>Sends the fully specified job to execution.</para>

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -287,18 +287,20 @@ namespace Microsoft.DotNet.Helix.Client
                 log("note : Helix queue health reporting is a preview feature; data and format may change.");
             }
 
-            log($"Helix queue '{queueId}' health{healthTag}:");
+            string queueName = string.IsNullOrEmpty(stats.QueueName) ? queueId : stats.QueueName;
+
+            log($"Helix queue '{queueName}' health{healthTag}:");
             log($"  Estimated wait : {estWait}   (queue depth: {depth}, avg run: {avgRun})");
             log($"  Snapshot taken : {snapshot}{staleTag}");
 
             if (overSla)
             {
-                log($"warning : Helix queue '{queueId}' estimated wait of {estWait} exceeds the {QueueWaitSlaThreshold.TotalMinutes:F0}-minute SLA - the queue is at capacity or unhealthy. Jobs may take longer than usual to start.");
+                log($"warning : Helix queue '{queueName}' estimated wait of {estWait} exceeds the {QueueWaitSlaThreshold.TotalMinutes:F0}-minute SLA - the queue is at capacity or unhealthy. Jobs may take longer than usual to start.");
             }
 
             if (stale)
             {
-                log($"warning : Helix queue '{queueId}' health snapshot is {FormatTimeSpan(snapshotAge)} old (threshold {SnapshotStaleThreshold.TotalMinutes:F0}m) - reported wait/depth may not reflect current queue state.");
+                log($"warning : Helix queue '{queueName}' health snapshot is {FormatTimeSpan(snapshotAge)} old (threshold {SnapshotStaleThreshold.TotalMinutes:F0}m) - reported wait/depth may not reflect current queue state.");
             }
 
             if (Interlocked.Exchange(ref s_firstRespondersHintShown, 1) == 0)

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -456,9 +456,9 @@ namespace Microsoft.DotNet.Helix.Client
             return this;
         }
 
-        public IJobDefinition WithShowQueueStats(bool showQueueStats)
+        public IJobDefinition WithQueueStats()
         {
-            ShowQueueStats = showQueueStats;
+            ShowQueueStats = true;
             return this;
         }
 

--- a/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
+++ b/src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs
@@ -47,6 +47,7 @@ namespace Microsoft.DotNet.Helix.Client
         public string ResultContainerPrefix { get; private set; }
         public IDictionary<IPayload, string> CorrelationPayloads { get; } = new Dictionary<IPayload, string>();
         public int? MaxRetryCount { get; private set; }
+        public bool ShowQueueStats { get; private set; }
         public string StorageAccountConnectionString { get; private set; }
         public string TargetContainerName { get; set; } = DefaultContainerName;
         public string TargetResultsContainerName { get; set; } = DefaultContainerName;
@@ -241,7 +242,106 @@ namespace Microsoft.DotNet.Helix.Client
             string jobStartIdentifier = Guid.NewGuid().ToString("N");
             var newJob = await JobApi.NewAsync(creationRequest, jobStartIdentifier, cancellationToken: cancellationToken).ConfigureAwait(false);
 
+            if (ShowQueueStats)
+            {
+                LogQueueStats(log, queueId, newJob?.QueueStats);
+            }
+
             return new SentJob(JobApi, newJob);
+        }
+
+        // Helix SLA threshold; estimated waits above this are flagged as queue-at-capacity / unhealthy.
+        private static readonly TimeSpan QueueWaitSlaThreshold = TimeSpan.FromMinutes(30);
+
+        // If the Observer snapshot is older than this, the reported numbers may not reflect current queue state.
+        private static readonly TimeSpan SnapshotStaleThreshold = TimeSpan.FromMinutes(15);
+
+        private const string FirstRespondersUrl = "https://teams.microsoft.com/l/channel/19%3Aafba3d1545dd45d7b79f34c1821f6055%40thread.skype/First%20Responders?groupId=4d73664c-9f2f-450d-82a5-c2f02756606d&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47";
+
+        private static int s_queueStatsHeaderShown;
+        private static int s_firstRespondersHintShown;
+
+        private static void LogQueueStats(Action<string> log, string queueId, Models.QueueStats stats)
+        {
+            if (log == null || stats == null)
+            {
+                return;
+            }
+
+            string depth = stats.Depth?.ToString(CultureInfo.InvariantCulture) ?? "unknown";
+            string avgRun = FormatTimeSpan(stats.AverageRunDuration);
+            string estWait = FormatTimeSpan(stats.EstimatedWait);
+            string snapshot = FormatSnapshotTime(stats.GeneratedAt);
+
+            bool overSla = stats.EstimatedWait is TimeSpan wait && wait > QueueWaitSlaThreshold;
+            TimeSpan? snapshotAge = stats.GeneratedAt is DateTimeOffset gen
+                ? DateTimeOffset.UtcNow - gen
+                : (TimeSpan?)null;
+            bool stale = snapshotAge is TimeSpan age && age > SnapshotStaleThreshold;
+
+            string healthTag = overSla ? " [AT CAPACITY]" : string.Empty;
+            string staleTag = stale ? " (stale)" : string.Empty;
+
+            if (Interlocked.Exchange(ref s_queueStatsHeaderShown, 1) == 0)
+            {
+                log("note : Helix queue health reporting is a preview feature; data and format may change.");
+            }
+
+            log($"Helix queue '{queueId}' health{healthTag}:");
+            log($"  Estimated wait : {estWait}   (queue depth: {depth}, avg run: {avgRun})");
+            log($"  Snapshot taken : {snapshot}{staleTag}");
+
+            if (overSla)
+            {
+                log($"warning : Helix queue '{queueId}' estimated wait of {estWait} exceeds the {QueueWaitSlaThreshold.TotalMinutes:F0}-minute SLA - the queue is at capacity or unhealthy. Jobs may take longer than usual to start.");
+            }
+
+            if (stale)
+            {
+                log($"warning : Helix queue '{queueId}' health snapshot is {FormatTimeSpan(snapshotAge)} old (threshold {SnapshotStaleThreshold.TotalMinutes:F0}m) - reported wait/depth may not reflect current queue state.");
+            }
+
+            if (Interlocked.Exchange(ref s_firstRespondersHintShown, 1) == 0)
+            {
+                log($"  Questions about Helix queue health? Reach the dnceng First Responders channel: {FirstRespondersUrl}");
+            }
+        }
+
+        private static string FormatTimeSpan(TimeSpan? value)
+        {
+            if (value is not TimeSpan ts)
+            {
+                return "unknown";
+            }
+
+            if (ts.TotalDays >= 1)
+            {
+                return $"{(int)ts.TotalDays}d {ts.Hours}h {ts.Minutes}m";
+            }
+            if (ts.TotalHours >= 1)
+            {
+                return $"{(int)ts.TotalHours}h {ts.Minutes}m";
+            }
+            if (ts.TotalMinutes >= 1)
+            {
+                return $"{(int)ts.TotalMinutes}m {ts.Seconds}s";
+            }
+            return $"{ts.Seconds}s";
+        }
+
+        private static string FormatSnapshotTime(DateTimeOffset? value)
+        {
+            if (value is not DateTimeOffset utc)
+            {
+                return "unknown";
+            }
+
+            DateTime local = utc.LocalDateTime;
+            string tz = TimeZoneInfo.Local.IsDaylightSavingTime(local)
+                ? TimeZoneInfo.Local.DaylightName
+                : TimeZoneInfo.Local.StandardName;
+
+            return $"{local.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture)} {tz}";
         }
 
         private void WarnForImpendingRemoval(Action<string> log, QueueInfo queueInfo) 
@@ -351,6 +451,12 @@ namespace Microsoft.DotNet.Helix.Client
         public IJobDefinition WithMaxRetryCount(int? maxRetryCount)
         {
             MaxRetryCount = maxRetryCount;
+            return this;
+        }
+
+        public IJobDefinition WithShowQueueStats(bool showQueueStats)
+        {
+            ShowQueueStats = showQueueStats;
             return this;
         }
 

--- a/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
@@ -148,6 +148,12 @@ namespace Microsoft.DotNet.Helix.Sdk
         /// </summary>
         public int MaxRetryCount { get; set; }
 
+        /// <summary>
+        /// When true, the preview Helix queue health summary (estimated wait, depth, snapshot
+        /// time) is logged after job submission. Off by default.
+        /// </summary>
+        public bool EnableShowHelixQueueStats { get; set; }
+
         private CommandPayload _commandPayload;
 
         protected override async Task ExecuteCore(CancellationToken cancellationToken)
@@ -175,7 +181,8 @@ namespace Microsoft.DotNet.Helix.Sdk
                 IJobDefinition def = currentHelixApi.Job.Define()
                     .WithType(Type)
                     .WithTargetQueue(TargetQueue)
-                    .WithMaxRetryCount(MaxRetryCount);
+                    .WithMaxRetryCount(MaxRetryCount)
+                    .WithShowQueueStats(EnableShowHelixQueueStats);
                 Log.LogMessage($"Initialized job definition with type '{Type}', and target queue '{TargetQueue}'");
 
                 if (!string.IsNullOrEmpty(Creator))

--- a/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs
@@ -181,8 +181,11 @@ namespace Microsoft.DotNet.Helix.Sdk
                 IJobDefinition def = currentHelixApi.Job.Define()
                     .WithType(Type)
                     .WithTargetQueue(TargetQueue)
-                    .WithMaxRetryCount(MaxRetryCount)
-                    .WithShowQueueStats(EnableShowHelixQueueStats);
+                    .WithMaxRetryCount(MaxRetryCount);
+                if (EnableShowHelixQueueStats)
+                {
+                    def = def.WithQueueStats();
+                }
                 Log.LogMessage($"Initialized job definition with type '{Type}', and target queue '{TargetQueue}'");
 
                 if (!string.IsNullOrEmpty(Creator))

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
@@ -84,6 +84,7 @@
                   BaseUri="$(HelixBaseUri)"
                   AccessToken="$(HelixAccessToken)"
                   MaxRetryCount="$(MaxRetryCount)"
+                  EnableShowHelixQueueStats="$(EnableShowHelixQueueStats)"
                   PreCommands="$(HelixPreCommands)"
                   PostCommands="$(HelixPostCommands)"
                   CorrelationPayloads="@(HelixCorrelationPayload)"

--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.props
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.props
@@ -30,6 +30,15 @@
     <EnableHelixJobMonitor Condition="'$(EnableHelixJobMonitor)' != 'true'">false</EnableHelixJobMonitor>
   </PropertyGroup>
 
+  <!--
+    Feature flag: when 'true', the Helix Sdk logs a preview queue-health summary (estimated wait,
+    queue depth, snapshot time) for each submitted job, plus warnings when the estimated wait
+    exceeds the SLA or the snapshot is stale. Off by default.
+  -->
+  <PropertyGroup>
+    <EnableShowHelixQueueStats Condition="'$(EnableShowHelixQueueStats)' != 'true'">false</EnableShowHelixQueueStats>
+  </PropertyGroup>
+
   <!-- TODO: Remove Architecture="*" on Runtime="NET" UsingTask declarations below when https://github.com/dotnet/msbuild/issues/13739 is fixed and a new msbuild is consumed with the fix. -->
   <UsingTask TaskName="SendHelixJob" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)" Runtime="NET" Architecture="*" TaskFactory="$(MicrosoftDotNetHelixSdkTasksFactory)" />
   <UsingTask TaskName="WaitForHelixJobCompletion" AssemblyFile="$(MicrosoftDotNetHelixSdkTasksAssembly)" Runtime="NET" Architecture="*" TaskFactory="$(MicrosoftDotNetHelixSdkTasksFactory)" />


### PR DESCRIPTION
## Summary

Surfaces the new `queueStats` block that `POST /api/jobs` now returns from the Helix service, so anyone submitting a Helix job through the Arcade SDK can see the **current health of their target queue at submit time** without having to dig into the portal.

The feature is **opt-in** via a new MSBuild property and a matching fluent-API method, so it adds **zero log noise** to builds that haven't opted in.

## User-visible change

### Opt-in
```xml
<PropertyGroup>
  <EnableShowHelixQueueStats>true</EnableShowHelixQueueStats>
</PropertyGroup>
```
or `/p:EnableShowHelixQueueStats=true`. Direct `Microsoft.DotNet.Helix.JobSender` callers use `.WithQueueStats()` on `IJobDefinition`.

### What lands in the build log

Healthy queue:
```
note : Helix queue health reporting is a preview feature; data and format may change.
Helix queue 'windows.10.amd64.open' health:
  Estimated wait : 0s   (queue depth: 0, avg run: 3m 26s)
  Snapshot taken : 2026-05-29 16:14 Pacific Daylight Time
  Questions about Helix queue health? Reach the dnceng First Responders channel: <teams url>
```

At-capacity queue (estimated wait exceeds the 30-minute SLA):
```
note : Helix queue health reporting is a preview feature; data and format may change.
Helix queue 'osx.15.amd64.open' health [AT CAPACITY]:
  Estimated wait : 1h 51m   (queue depth: 5864, avg run: 1m 24s)
  Snapshot taken : 2026-05-29 16:01 Pacific Daylight Time
warning : Helix queue 'osx.15.amd64.open' estimated wait of 1h 51m exceeds the 30-minute SLA - the queue is at capacity or unhealthy. Jobs may take longer than usual to start.
  Questions about Helix queue health? Reach the dnceng First Responders channel: <teams url>
```

Stale snapshot (> 15 min old): a second `warning :` line is emitted noting the age and threshold; the snapshot line also gets a ` (stale)` tag.

### Noise-control choices

- **Off by default.** Anyone who hasn't opted in sees no change in their logs.
- The preview-feature banner (`note :`) prints **once per process**.
- The First Responders Teams link prints **once per process**.
- Per-job summary is the same compact 2 lines plus optional 1ΓÇô2 warnings; emoji-free; ASCII dashes so it renders on any console codepage.
- Snapshot time is converted to the **user's local timezone** with the TZ name (e.g. `Pacific Daylight Time`) ΓÇö no more guessing UTC offsets.
- SLA warning uses the MSBuild `warning :` prefix so it shows up in PR build summaries and AzDO timeline issues.

## Implementation

| File | Change |
|---|---|
| `src/Microsoft.DotNet.Helix/Client/CSharp/QueueStats.cs` (new) | Newtonsoft.Json model bound to the `queueStats` JSON (`queueName`, `depth`, `averageRunDuration`, `estimatedWait`, `estimatedWaitMethod`, `generatedAt`). |
| `src/Microsoft.DotNet.Helix/Client/CSharp/JobCreationResult.cs` (new) | Partial-class extension exposing `QueueStats`. Keeps the generated `generated-code/Models/JobCreationResult.cs` untouched. |
| `src/Microsoft.DotNet.Helix/JobSender/IJobDefinition.cs` | Added `WithQueueStats()` fluent method. |
| `src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs` | Implements the new fluent method. After `JobApi.NewAsync(...)` returns, if the flag is on, calls `LogQueueStats(...)` which formats and emits the summary, SLA + stale warnings, and once-per-process banner / Teams link. |
| `src/Microsoft.DotNet.Helix/Sdk/SendHelixJob.cs` | New `EnableShowHelixQueueStats` task input piped into `.WithQueueStats()`. |
| `src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets` | Plumbs `EnableShowHelixQueueStats="$(EnableShowHelixQueueStats)"` onto the `<SendHelixJob />` element. |
| `src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.props` | Default value `EnableShowHelixQueueStats=false` (mirrors the existing `EnableHelixJobMonitor` pattern). |

## Validation

### Unit tests
- `Microsoft.DotNet.Helix.Sdk.Tests` ΓÇö **121/121 pass** with these changes.

### End-to-end against live `helix.dot.net`

I packed the modified packages locally (`11.0.0-dev`) into `arcade/artifacts/packages/Debug/NonShipping/` and consumed them from a separate scratch repo (`c:\repos\arcade-helix-stats-validate`) that imports `Microsoft.DotNet.Helix.Sdk` via a fork-pinned `NuGet.config`. From that repo:

1. **Gate OFF (default)** ΓÇö submitted a tiny job to `windows.10.amd64.open`. Build log contained only the existing `Sending Job to ...` / `Created job list at ...` / `Sent Helix Job; see work items at ...` lines. **Zero queue-health output**, confirming the opt-in gate works.

2. **Gate ON via `/p:EnableShowHelixQueueStats=true`** ΓÇö same submit, against the same queue. Build log included the full preview banner + health summary + First Responders link shown above. Queue happened to be healthy (depth 0), so no SLA warning.

3. **Gate ON against a backlogged queue (`osx.15.amd64.open`)** ΓÇö exercised separately via a local programmatic probe consuming `Microsoft.DotNet.Helix.JobSender` directly. Output included the `[AT CAPACITY]` tag and the `warning : ... exceeds the 30-minute SLA - ...` line shown above. Confirmed the once-per-process gating on both the banner and the Teams link by submitting twice in the same process and observing the second submission's output omits both.

### Stale-snapshot path
Live snapshots from the service were < 1 min old during validation, so the `(stale)` tag and "snapshot is N old" warning weren't observed live ΓÇö both are exercised by code review of [JobDefinition.cs](src/Microsoft.DotNet.Helix/JobSender/JobDefinition.cs) and gated by `SnapshotStaleThreshold = TimeSpan.FromMinutes(15)`.

## Out of scope

The Helix service is shipping additional `queueStats` fields (e.g. `P50Wait`, `P95Wait`, `HealthyCores`, `ObserverUiUrl`, `EstimatedWaitConfidence`). This PR intentionally only binds the fields needed to render the current preview summary; surfacing the richer telemetry can land in a follow-up once the field set stabilizes.
