### PR TITLE
Add 'file' package to native dependencies

### DIFF
--- a/eng/common/native/install-dependencies.sh
+++ b/eng/common/native/install-dependencies.sh
@@ -24,16 +24,16 @@ case "$os" in
             apt update
 
             apt install -y build-essential gettext locales cmake llvm clang lld lldb liblldb-dev libunwind8-dev libicu-dev liblttng-ust-dev \
-                libssl-dev libkrb5-dev pigz cpio ninja-build
+                libssl-dev libkrb5-dev pigz cpio ninja-build file
 
             localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
         elif [ "$ID" = "fedora" ] || [ "$ID" = "rhel" ] || [ "$ID" = "azurelinux" ] || [ "$ID" = "centos" ]; then
             pkg_mgr="$(command -v tdnf 2>/dev/null || command -v dnf)"
-            $pkg_mgr install -y cmake llvm lld lldb clang python curl libicu-devel openssl-devel krb5-devel lttng-ust-devel pigz cpio ninja-build
+            $pkg_mgr install -y cmake llvm lld lldb clang python curl libicu-devel openssl-devel krb5-devel lttng-ust-devel pigz cpio ninja-build file
         elif [ "$ID" = "amzn" ]; then
-            dnf install -y cmake llvm lld lldb clang python libicu-devel openssl-devel krb5-devel lttng-ust-devel pigz cpio ninja-build
+            dnf install -y cmake llvm lld lldb clang python libicu-devel openssl-devel krb5-devel lttng-ust-devel pigz cpio ninja-build file
         elif [ "$ID" = "alpine" ]; then
-            apk add build-base cmake bash curl clang llvm llvm-dev lld lldb-dev krb5-dev lttng-ust-dev icu-dev openssl-dev pigz cpio ninja
+            apk add build-base cmake bash curl clang llvm llvm-dev lld lldb-dev krb5-dev lttng-ust-dev icu-dev openssl-dev pigz cpio ninja file
         else
             echo "Unsupported distro. distro: $ID"
             exit 1


### PR DESCRIPTION
It's required by `dotnet-runtime-deps-opensuse.15` rpm creation:

```sh
$ ./build.sh packs -c Release --cross --arch riscv64 --use-bootstrap

  Determining projects to restore...
  Tool 'coverlet.console' (version '6.0.4') was restored. Available commands: coverlet
  Tool 'dotnet-reportgenerator-globaltool' (version '5.4.3') was restored. Available commands: reportgenerator
  Tool 'microsoft.dotnet.xharness.cli' (version '11.0.0-prerelease.26204.1') was restored. Available commands: xharness
  Tool 'microsoft.visualstudio.slngen.tool' (version '12.0.15') was restored. Available commands: slngen
  
  Restore was successful.
  All projects are up-to-date for restore.
...
  Successfully created package '/runtime/artifacts/packages/Release/Shipping/Microsoft.NETCore.App.Crossgen2.linux-riscv64.11.0.0-dev.symbols.nupkg'.
  dotnet-host -> /runtime/artifacts/packages/Release/Shipping/dotnet-host-11.0.0-dev-riscv64.deb
  dotnet-host -> /runtime/artifacts/packages/Release/Shipping/dotnet-host-11.0.0-dev-newkey-riscv64.deb
  find: 'file': No such file or directory
  find: 'file': No such file or directory
  find: 'file': No such file or directory
  find: 'file': No such file or directory
  find: 'file': No such file or directory
  find: 'file': No such file or directory
  find: 'file': No such file or directory
  find: 'file': No such file or directory
  find: 'file': No such file or directory
  find: 'file': No such file or directory
  find: 'file': No such file or directory
```