### PR TITLE
Revert workload resolver disable from shared eng/common scripts

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -162,12 +162,6 @@ function InitializeDotNetCli([bool]$install, [bool]$createSdkLocationFile) {
     $env:DOTNET_CLI_TELEMETRY_OPTOUT=1
   }
 
-  # Keep repo builds isolated from machine-installed SDK state and workload advertising.
-  # This avoids preview SDK builds picking up mismatched workloads on CI images.
-  $env:DOTNET_MULTILEVEL_LOOKUP = '0'
-  $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = '1'
-  $env:DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE = '1'
-
   # Find the first path on %PATH% that contains the dotnet.exe
   if ($useInstalledDotNetCli -and (-not $globalJsonHasRuntimes) -and ($env:DOTNET_INSTALL_DIR -eq $null)) {
     $dotnetExecutable = GetExecutableFileName 'dotnet'
@@ -230,9 +224,6 @@ function InitializeDotNetCli([bool]$install, [bool]$createSdkLocationFile) {
   Write-PipelinePrependPath -Path $dotnetRoot
 
   Write-PipelineSetVariable -Name 'DOTNET_NOLOGO' -Value '1'
-  Write-PipelineSetVariable -Name 'DOTNET_MULTILEVEL_LOOKUP' -Value '0'
-  Write-PipelineSetVariable -Name 'DOTNET_SKIP_FIRST_TIME_EXPERIENCE' -Value '1'
-  Write-PipelineSetVariable -Name 'DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE' -Value '1'
 
   return $global:_DotNetInstallDir = $dotnetRoot
 }
@@ -759,10 +750,6 @@ function MSBuild() {
   $buildTool = InitializeBuildTool
 
   $cmdArgs = "$($buildTool.Command) /m /nologo /clp:Summary /v:$verbosity /nr:$nodeReuse /p:ContinuousIntegrationBuild=$ci"
-
-  if ($ci -and $buildTool.Tool -eq 'dotnet') {
-    $cmdArgs += ' /p:MSBuildEnableWorkloadResolver=false'
-  }
 
   # Add -mt flag for MSBuild multithreaded mode if enabled via environment variable
   if ($env:MSBUILD_MT_ENABLED -eq "1") {

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -116,12 +116,6 @@ function InitializeDotNetCli {
     export DOTNET_CLI_TELEMETRY_OPTOUT=1
   fi
 
-  # Keep repo builds isolated from machine-installed SDK state and workload advertising.
-  # This avoids preview SDK builds picking up mismatched workloads on CI images.
-  export DOTNET_MULTILEVEL_LOOKUP=0
-  export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-  export DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE=1
-
   # LTTNG is the logging infrastructure used by Core CLR. Need this variable set
   # so it doesn't output warnings to the console.
   export LTTNG_HOME="$HOME"
@@ -167,9 +161,6 @@ function InitializeDotNetCli {
   Write-PipelinePrependPath -path "$dotnet_root"
 
   Write-PipelineSetVariable -name "DOTNET_NOLOGO" -value "1"
-  Write-PipelineSetVariable -name "DOTNET_MULTILEVEL_LOOKUP" -value "0"
-  Write-PipelineSetVariable -name "DOTNET_SKIP_FIRST_TIME_EXPERIENCE" -value "1"
-  Write-PipelineSetVariable -name "DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE" -value "1"
 
   # return value
   _InitializeDotNetCli="$dotnet_root"
@@ -552,12 +543,7 @@ function MSBuild {
     warnnotaserror_switch="/warnnotaserror:$warn_not_as_error /p:AdditionalWarningsNotAsErrors=$warn_not_as_error"
   fi
 
-  local workload_resolver_switch=""
-  if [[ "$ci" == true && -n "${_InitializeBuildToolCommand:-}" ]]; then
-    workload_resolver_switch="/p:MSBuildEnableWorkloadResolver=false"
-  fi
-
-  RunBuildTool "$_InitializeBuildToolCommand" /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse $warnaserror_switch $mt_switch $warnnotaserror_switch $workload_resolver_switch /p:TreatWarningsAsErrors=$warn_as_error /p:ContinuousIntegrationBuild=$ci "$@"
+  RunBuildTool "$_InitializeBuildToolCommand" /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse $warnaserror_switch $mt_switch $warnnotaserror_switch /p:TreatWarningsAsErrors=$warn_as_error /p:ContinuousIntegrationBuild=$ci "$@"
 }
 
 function GetDarc {


### PR DESCRIPTION
## Summary

This reverts the workload isolation changes from commit d16538151e667422c7b9f1e19721f327308ac1ca (part of PR #16719) which unconditionally set \MSBuildEnableWorkloadResolver=false\ in all CI builds via the shared \ng/common/tools.ps1\ and \ng/common/tools.sh\ scripts.

## Problem

This breaks repos that intentionally use .NET workloads — specifically MAUI (and potentially other repos targeting platform-specific TFMs like \
et11.0-ios\, \
et11.0-android\, etc.):

\\\
error NETSDK1208: The target platform identifier ios was not recognized.
This is because MSBuildEnableWorkloadResolver is set to false which disables
.NET SDK Workloads which is required for this identifier.
\\\

## Why this is safe

The original problem (Arcade daily pipeline picking up mismatched preview workloads on CI images) was already fully fixed by the other two commits in #16719:
- \9fdab79\ — Allow preview SDK install in Arcade daily
- \081955\ — Rewrite the daily pipeline to use repo bootstrap (avoids MSBuild entirely)

The daily pipeline now only does \dotnet tool restore\ for secret synchronization — it never invokes MSBuild, so the workload mismatch cannot occur.

## Changes

Removes from both \	ools.ps1\ and \	ools.sh\:
1. \DOTNET_MULTILEVEL_LOOKUP=0\, \DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1\, \DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE=1\ env vars and pipeline variables
2. \/p:MSBuildEnableWorkloadResolver=false\ from the MSBuild command line

Fixes #16931