### PR TITLE
Fix InitializeNuGetPackageCachePath on non-Windows

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -596,9 +596,10 @@ function InitializeNuGetPackageCachePath() {
     # use global cache in dev builds to avoid cost of downloading packages.
     # For directory normalization, see also: https://github.com/NuGet/Home/issues/7968
     if ($useGlobalNuGetCache) {
-      $env:NUGET_PACKAGES = Join-Path $env:UserProfile '.nuget\packages\'
+      $userProfile = if (IsWindowsPlatform) { $env:UserProfile } else { $env:HOME }
+      $env:NUGET_PACKAGES = [IO.Path]::Combine($userProfile, '.nuget', 'packages') + [IO.Path]::DirectorySeparatorChar
     } else {
-      $env:NUGET_PACKAGES = Join-Path $RepoRoot '.packages\'
+      $env:NUGET_PACKAGES = [IO.Path]::Combine($RepoRoot, '.packages') + [IO.Path]::DirectorySeparatorChar
     }
   }
 


### PR DESCRIPTION
Since da58b41 ("Move `InitializeNuGetPackageCachePath` to script load time"), every dot-source of `eng/common/tools.ps1` runs this function. Scripts that don't go through `InitializeToolset` — notably `SetupNugetSources.ps1` — now hit it too.

On Linux/macOS the function falls into the `useGlobalNuGetCache` branch (since `$ci` defaults to `$false` for those callers) and tries:

```powershell
$env:NUGET_PACKAGES = Join-Path $env:UserProfile '.nuget\\packages\\'
```

`$env:UserProfile` is null on non-Windows, so `Join-Path` throws:

```
Cannot bind argument to parameter 'Path' because it is null.
```

This breaks the "Setup Internal Feeds" step in the VMR pipelines (and any other consumer that dot-sources `tools.ps1` outside of a build invocation).

Fix: use the existing `IsWindowsPlatform` helper to pick `$env:HOME` on non-Windows.