### PR TITLE
JobMonitor: Fix gathering test results in Helix MonoQueue post-commands

### DIFF
--- a/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
+++ b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets
@@ -37,7 +37,7 @@
   <PropertyGroup Condition="'$(EnableHelixJobMonitor)' == 'true' and $(IsPosixShell)">
     <HelixPostCommands>
       $(HelixPostCommands);
-      find . -maxdepth 5 '(' -iname '*.trx' -o -iname 'testResults.xml' -o -iname 'test-results.xml' -o -iname 'test_results.xml' -o -iname 'junit-results.xml' -o -iname 'junitresults.xml' ')' -print0 | while IFS= read -r -d '' file%3B do mkdir -p "$HELIX_WORKITEM_UPLOAD_ROOT/%24(dirname "$file")" &amp;&amp; cp -f "$file" "$HELIX_WORKITEM_UPLOAD_ROOT/$file"%3B done || true
+      find . -maxdepth 5 '(' -iname '*.trx' -o -iname 'testResults.xml' -o -iname 'test-results.xml' -o -iname 'test_results.xml' -o -iname 'junit-results.xml' -o -iname 'junitresults.xml' ')' -print0 | xargs -0 -I {} sh -c 'mkdir -p "$HELIX_WORKITEM_UPLOAD_ROOT/$$(dirname "{}")" &amp;&amp; cp -f "{}" "$HELIX_WORKITEM_UPLOAD_ROOT/{}"' || true
     </HelixPostCommands>
   </PropertyGroup>
   <PropertyGroup Condition="'$(EnableHelixJobMonitor)' == 'true' and !$(IsPosixShell)">


### PR DESCRIPTION
Use `xargs` with `sh -c` instead of a `while-read` loop in `HelixPostCommands` to gather test result files (`.trx`, `testResults.xml`, etc.) into `HELIX_WORKITEM_UPLOAD_ROOT`.

The `dirname` subshell is escaped as `$$(dirname ...)` so MSBuild does not consume the `$(...)` as a property reference.

Split out of #16879.