### PR TITLE
JobMonitor: Include QueueId in submitter chain key so cross-queue work-item outcomes don't overwrite each other

### DIFF
--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
@@ -748,18 +748,20 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         /// <summary>
         /// Produces a key that rolls up work-item outcomes within a logical AzDO submitter
         /// chain. When the job carries an AzDO <c>System.JobName</c>, the chain key is based
-        /// on that name (so resubmissions of the same AzDO job share the same key while two
-        /// independent AzDO jobs running identically-named work items stay distinct). When
-        /// there is no submitter name (test scenarios, manual Helix submissions), the chain
-        /// is followed back through <c>PreviousHelixJobName</c> links to the root and the
-        /// root Helix job name is used instead, so that retries still overwrite prior
-        /// failures correctly.
+        /// on that name combined with the Helix <c>QueueId</c> (so resubmissions of the same
+        /// AzDO job to the same queue share the same key while a single AzDO matrix leg that
+        /// fans out to multiple Helix queues — each producing its own Helix job under the
+        /// same <c>System.JobName</c> — stays distinct and cannot overwrite a sibling queue's
+        /// failure with a pass). When there is no submitter name (test scenarios, manual Helix
+        /// submissions), the chain is followed back through <c>PreviousHelixJobName</c> links
+        /// to the root and the root Helix job name is used instead, so that retries still
+        /// overwrite prior failures correctly.
         /// </summary>
         private string GetSubmitterChainKey(HelixJobInfo job)
         {
             if (!string.IsNullOrEmpty(job.SubmitterJobName))
             {
-                return $"submitter:{job.SubmitterJobName}";
+                return FormatSubmitterChainKey(job.SubmitterJobName, job.QueueId);
             }
 
             HelixJobInfo current = job;
@@ -775,7 +777,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
                 if (!string.IsNullOrEmpty(previous.SubmitterJobName))
                 {
-                    return $"submitter:{previous.SubmitterJobName}";
+                    return FormatSubmitterChainKey(previous.SubmitterJobName, previous.QueueId);
                 }
 
                 current = previous;
@@ -783,6 +785,11 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
             return $"helix:{(current?.JobName ?? job.JobName)}";
         }
+
+        private static string FormatSubmitterChainKey(string submitterJobName, string queueId)
+            => string.IsNullOrEmpty(queueId)
+                ? $"submitter:{submitterJobName}"
+                : $"submitter:{submitterJobName}|queue:{queueId}";
 
         private void LogFinalFailedWorkItemConsoleInfo()
         {

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/JobMonitorRunnerTests.cs
@@ -610,6 +610,47 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             Assert.Equal(1, exitCode);
         }
 
+        /// <summary>
+        /// Regression: a single AzDO matrix leg (one <c>System.JobName</c>) fans out to
+        /// multiple Helix queues — each queue produces its own Helix job sharing the same
+        /// <c>SubmitterJobName</c>. A work item with the same name (e.g.
+        /// <c>Microsoft.DotNet.Helix.Sdk.Tests.dll</c>) runs in every queue; it fails on one
+        /// queue and passes on another. The earlier queue's failure must NOT be overwritten
+        /// by the later queue's pass on the same submitter, and the monitor must exit
+        /// non-zero. This mirrors the production scenario where eight Helix jobs (two
+        /// configurations × three queues + extras) reported "0 failed" in the final summary
+        /// even though one work item failed.
+        /// </summary>
+        [Fact]
+        public async Task OneSubmitter_FansOutToMultipleQueues_SameWorkItemName_FailureNotOverwrittenByPass()
+        {
+            var azdo = new FakeAzureDevOpsService();
+            var helix = new FakeHelixService();
+
+            azdo.AddTimelineResponse(
+                MonitorJob(),
+                PipelineJob("Linux_Build_Debug", "completed", "succeeded"));
+
+            helix.AddResponse(
+                jobs:
+                [
+                    HelixJob("helix-ubuntu", "finished", submitterJobName: "Linux_Build_Debug", queueId: "ubuntu.2204.amd64.open"),
+                    HelixJob("helix-osx", "finished", submitterJobName: "Linux_Build_Debug", queueId: "osx.15.amd64.open"),
+                    HelixJob("helix-windows", "finished", submitterJobName: "Linux_Build_Debug", queueId: "windows.11.amd64.client.open"),
+                ],
+                passFailByJob: new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["helix-ubuntu"] = PassFail(failed: ["Microsoft.DotNet.Helix.Sdk.Tests.dll"]),
+                    ["helix-osx"] = PassFail(passed: ["Microsoft.DotNet.Helix.Sdk.Tests.dll"]),
+                    ["helix-windows"] = PassFail(passed: ["Microsoft.DotNet.Helix.Sdk.Tests.dll"]),
+                });
+
+            var runner = CreateRunner(azdo, helix);
+            int exitCode = await runner.RunAsync(CancellationToken.None);
+
+            Assert.Equal(1, exitCode);
+        }
+
         [Fact]
         public async Task StageRerun_UploadsNewHelixWorkItemsWithoutReuploadingPreviousWorkItems()
         {


### PR DESCRIPTION
A single AzDO matrix leg can fan out to multiple Helix queues, each producing its own Helix job under the same `System.JobName`. The previous submitter chain key was based on `System.JobName` only, so jobs from different queues collided in the work-item outcome dictionary — a later-arriving pass could overwrite an earlier failure (or vice versa) from a sibling queue.

This change combines `System.JobName` with the Helix `QueueId` when building the submitter chain key, so:

- Resubmissions of the same AzDO job to the same queue still share the same key (retries overwrite prior outcomes correctly).
- Sibling Helix jobs on different queues under the same AzDO job now stay distinct.

Includes a test that reproduces the cross-queue overwrite.

Split out of #16879.