### PR TITLE
Disable CG and CodeQL for public project in shared job template

### DIFF
--- a/eng/common/core-templates/job/job.yml
+++ b/eng/common/core-templates/job/job.yml
@@ -75,6 +75,12 @@ jobs:
   variables:
   - name: AllowPtrToDetectTestRunRetryFiles
     value: true
+  # Component Governance detection and CodeQL are not run in the public project
+  - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+    - name: skipComponentGovernanceDetection
+      value: true
+    - name: Codeql.SkipTaskAutoInjection
+      value: true
   - ${{ if ne(parameters.enableTelemetry, 'false') }}:
     - name: DOTNET_CLI_TELEMETRY_PROFILE
       value: '$(Build.Repository.Uri)'

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -21,11 +21,6 @@ jobs:
     - ${{ each step in parameters.steps }}:
       - ${{ step }}
 
-    # we don't run CG in public
-    - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      - script: echo "##vso[task.setvariable variable=skipComponentGovernanceDetection]true"
-        displayName: Set skipComponentGovernanceDetection variable
-
     artifactPublishSteps:
     - ${{ if ne(parameters.artifacts.publish, '') }}:
       - ${{ if and(ne(parameters.artifacts.publish.artifacts, 'false'), ne(parameters.artifacts.publish.artifacts, '')) }}:


### PR DESCRIPTION
Set `skipComponentGovernanceDetection` and `Codeql.SkipTaskAutoInjection` in `core-templates/job/job.yml` for the public AzDO project, and remove the now-redundant settings from `templates/job/job.yml`