### PR TITLE
Use deterministic values for _BuildNumber

### DIFF
--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
@@ -24,6 +24,10 @@
     <IsShippingVsix Condition="'$(IsShippingVsix)' == ''">$(IsShipping)</IsShippingVsix>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <DeterministicTimestamp Condition="'$(DeterministicTimestamp)' == '' and '$(SOURCE_DATE_EPOCH)' != ''">$(SOURCE_DATE_EPOCH)</DeterministicTimestamp>
+  </PropertyGroup>
+
   <!--
     Specification: https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md
 
@@ -44,7 +48,10 @@
       and should only be enabled when it's necessary to test-install the MSIs produced by the build.
     -->
     <_BuildNumber>$(OfficialBuildId)</_BuildNumber>
-    <_BuildNumber Condition="'$(OfficialBuildId)' == ''">$([System.DateTime]::Now.ToString(yyyyMMdd)).1</_BuildNumber>
+    <!-- Use DeterministicTimestamp before falling back to wall-clock -->
+    <_BuildNumber Condition="'$(_BuildNumber)' == '' and '$(DeterministicTimestamp)' != '' and '$(DeterministicTimestamp)' != 'true' and '$(DeterministicTimestamp)' != 'false' and !$(DeterministicTimestamp.Contains('-'))">$([System.DateTimeOffset]::FromUnixTimeSeconds($(DeterministicTimestamp)).UtcDateTime.ToString(yyyyMMdd)).1</_BuildNumber>
+    <_BuildNumber Condition="'$(_BuildNumber)' == '' and $(DeterministicTimestamp.Contains('-'))">$([System.DateTimeOffset]::Parse($(DeterministicTimestamp)).UtcDateTime.ToString(yyyyMMdd)).1</_BuildNumber>
+    <_BuildNumber Condition="'$(_BuildNumber)' == ''">$([System.DateTime]::Now.ToString(yyyyMMdd)).1</_BuildNumber>
 
     <!--
       OfficialBuildId is assumed to have format "20yymmdd.r" (the assumption is checked later in a target).

--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
+++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets
@@ -51,7 +51,7 @@
     <!-- Use DeterministicTimestamp before falling back to wall-clock -->
     <_BuildNumber Condition="'$(_BuildNumber)' == '' and '$(DeterministicTimestamp)' != '' and '$(DeterministicTimestamp)' != 'true' and '$(DeterministicTimestamp)' != 'false' and !$(DeterministicTimestamp.Contains('-'))">$([System.DateTimeOffset]::FromUnixTimeSeconds($(DeterministicTimestamp)).UtcDateTime.ToString(yyyyMMdd)).1</_BuildNumber>
     <_BuildNumber Condition="'$(_BuildNumber)' == '' and $(DeterministicTimestamp.Contains('-'))">$([System.DateTimeOffset]::Parse($(DeterministicTimestamp)).UtcDateTime.ToString(yyyyMMdd)).1</_BuildNumber>
-    <_BuildNumber Condition="'$(_BuildNumber)' == ''">$([System.DateTime]::Now.ToString(yyyyMMdd)).1</_BuildNumber>
+    <_BuildNumber Condition="'$(_BuildNumber)' == ''">$([System.DateTime]::UtcNow.ToString(yyyyMMdd)).1</_BuildNumber>
 
     <!--
       OfficialBuildId is assumed to have format "20yymmdd.r" (the assumption is checked later in a target).


### PR DESCRIPTION
Use `DeterministicTimestamp` and `SOURCE_BUILD_EPOCH` to set a deterministic date for _BuildNumber instead of DateTime.Now

`DeterministicTimetsamp` and `SOURCE_DATE_EPOCH` are defined and documented in this NuGet spec:
https://github.com/NuGet/Home/blob/dev/accepted/2026/deterministic-pack-revisited.md

### To double check:

* [ ] The right tests are in and the right validation has happened.  Guidance: https://github.com/dotnet/arcade/blob/main/Documentation/Validation.md
  - This will be exercised through https://github.com/dotnet/dotnet/pull/6622 
