### PR TITLE
JobMonitor: Refactor/simplify the main runner class

### DIFF
--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.Design.md
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.Design.md
@@ -1,127 +1,341 @@
-# Helix Job Monitor Runner Design
+# JobMonitorRunner — Technical Specification
 
-The Helix Job Monitor is intended to be a resilient observer for Azure DevOps
-pipeline jobs and the Helix work submitted by those jobs. It must assume it may
-crash, time out, or be retried at any point. Any behavior that must survive a
-restart can only be reconstructed from durable external state:
+This document is a behavioral specification of the Helix job monitor runner.
+It describes *what* the runner must do, not *how* it currently does it.
 
-- Azure DevOps test run name markers written by the monitor.
-- Helix job properties written when jobs are submitted or resubmitted.
+The current source lives at [JobMonitorRunner.cs](JobMonitorRunner.cs); use
+it only as the reference implementation, not as the specification.
 
-The monitor should not rely on in-memory state to make decisions that must remain
-correct across restarts.
+---
 
-## Stage scope
+## 1. Purpose
 
-Each monitor invocation owns exactly one Azure DevOps stage unless it is
-explicitly configured to monitor all stages. In the normal stage-scoped mode, the
-monitor must only look at:
+The runner is the body of a standalone CLI invoked as a single job inside an
+Azure DevOps pipeline stage. Its job is to:
 
-- Azure DevOps timeline jobs that belong to the monitor's stage.
-- Helix jobs whose `System.StageName` property is empty or matches the monitor's
-  stage.
+- Observe the Helix jobs submitted from the same build (by the Helix SDK
+  submitter) and the Azure DevOps timeline jobs running alongside it.
+- Resubmit failed Helix work items once per invocation.
+- Upload Helix work-item test results to Azure DevOps.
+- Return an exit code that reflects whether the monitored pipeline jobs and
+  the latest completed Helix work items all succeeded.
 
-Stage scope applies to retry, test-result upload, and pass/fail calculation. A
-failed job or failed Helix work item from another stage must not be retried,
-uploaded, or used to fail this monitor invocation.
+## 2. Operating model
 
-## Durable state
+### 2.1 Stage scope
 
-### Azure DevOps test run name markers
+Each invocation owns exactly one Azure DevOps stage. All decisions (retry,
+completion gating, upload, pass/fail) consider only:
 
-The monitor appends a Helix job name marker to each Azure DevOps test run name
-it creates. The marker format is `[HelixJob:<helix-job-name>]`, so the full test
-run name is `{original-name} [HelixJob:<helix-job-name>]`. Completed test runs
-with that marker are used only to determine whether test results for a Helix job
-have already been uploaded.
+- Azure DevOps timeline jobs belonging to the monitor's stage.
+- Helix jobs whose `System.StageName` property matches the monitor's stage.
 
-The monitor uses the test run name instead of Azure DevOps test run tags because
-the Azure DevOps test runs API silently drops tags created with the run. Test run
-name markers do not determine whether Helix work should be retried, and test
-result upload success or failure does not determine whether the monitor passes or
-fails.
+Jobs and work items from other stages must not be retried, uploaded, or used
+to fail this invocation.
 
-### Helix job properties
+### 2.2 Durable state
 
-Helix job properties are the durable state for retry lineage. Resubmitted Helix
-jobs preserve the original job properties and add `PreviousHelixJobName`, which
-points to the Helix job that was resubmitted.
+The runner may crash, time out, or be retried at any point. Any behavior that
+must survive a restart can only be reconstructed from durable external state:
 
-This creates a chain of Helix job incarnations for the same logical work. The
-monitor uses that chain to find the latest incarnation of each job when deciding
-what to retry and what currently passes or fails.
+- **Azure DevOps test-run name markers** — the monitor appends
+  `[HelixJob:<helix-job-name>]` to each test-run name it creates. The
+  presence of that marker on a completed test run is the durable signal
+  that the corresponding Helix job's results have already been uploaded.
+  (Markers are used instead of test-run tags because the AzDO test-runs API
+  silently drops tags created with the run.)
+- **Helix job properties** — every resubmitted Helix job preserves the
+  original submitter's properties and adds `PreviousHelixJobName`, linking
+  to the job that was resubmitted. The chain of `PreviousHelixJobName`
+  links represents the incarnations of one logical piece of work.
 
-## Retry behavior
+In-memory state may be used freely within a single invocation but must never
+be the source of truth for cross-invocation correctness.
 
-Retry scheduling is separate from test result upload.
+### 2.3 Retry invariants
 
-1. Retry is performed only when the monitor starts.
-2. The monitor takes a Helix snapshot on entry and decides what to resubmit from
-   that snapshot.
-3. Work that fails after the monitor has started is not resubmitted during that
-   invocation. It can be resubmitted only by a later monitor invocation.
-4. A Helix job is considered for retry only if it is the latest completed
-   incarnation in its `PreviousHelixJobName` chain.
-5. If that latest completed incarnation has failed work items, only those failed
-   work items are resubmitted.
-6. Passing work items from the same Helix job are not included in the
-   resubmission.
-7. If a newer incarnation of a work item has completed and passed, older failed
-   incarnations must not cause another resubmission.
-8. If a newer incarnation is still running or waiting, it is not resubmitted
-   again on monitor entry.
+1. Retry runs exactly once per invocation, on entry, before polling begins.
+2. The set of work to resubmit is decided from a single Helix snapshot taken
+   on entry. Work that fails after the monitor has started is not
+   resubmitted during the current invocation; a later invocation may pick
+   it up.
+3. A Helix job is eligible for retry only if it is the latest completed
+   incarnation in its lineage chain (not superseded by a newer attempt).
+4. If that incarnation has failed work items, only the failed items are
+   resubmitted; passing items are not.
+5. If a newer incarnation of a work item has already completed and passed,
+   no further resubmission for that item occurs.
+6. If a newer incarnation is still running or waiting, no resubmission
+   occurs.
 
-This means repeated monitor retries should naturally submit fewer work items over
-time as newer incarnations complete successfully.
+Repeated monitor runs therefore submit progressively fewer work items as
+newer incarnations succeed.
 
-## Test result upload behavior
+### 2.4 Upload invariants
 
-Test result upload is also restart-resilient, but it is independent from retry.
+Upload is restart-resilient but logically independent from retry.
 
-1. Never upload the same Helix job's test results twice.
-2. Use Azure DevOps test run name markers on completed test runs to discover
-   which Helix jobs have already been uploaded by previous monitor invocations.
-3. For completed Helix jobs that have not been uploaded, upload all available
-   test results.
-4. Upload completed jobs in lineage order, from old to new. For example, if both
-   an original job and a resubmitted job have completed and neither has been
-   uploaded, upload the original job first and the resubmitted job second.
-5. Test result upload failures should be logged, but they do not affect the
-   monitor's pass/fail result.
+1. The same Helix job's test results are never uploaded twice. The durable
+   deduplication signal is the `[HelixJob:<name>]` marker on completed AzDO
+   test runs.
+2. For every completed Helix job not already uploaded, all available test
+   results are uploaded.
+3. Uploads happen in lineage order — oldest incarnation first. If both an
+   original job and its resubmission have completed and neither has been
+   uploaded, the original uploads first.
+4. Upload failures are logged but never affect pass/fail.
+5. A failed original Helix job may be resubmitted on entry and still have
+   its original test results uploaded during the same invocation if those
+   results were not uploaded earlier.
 
-This separation is important: a failed original Helix job may be resubmitted on
-entry and still have its original test results uploaded during the same monitor
-invocation if those results were not uploaded earlier.
+### 2.5 Pass/fail invariants
 
-## Monitor pass/fail behavior
+The exit code is determined by combining two checks:
 
-The monitor result must reflect both:
+- **AzDO side** — the monitor fails if any monitored AzDO job failed or
+  was canceled. Jobs whose work is being actively retried this invocation
+  are excluded from this check (their failure is represented by the
+  resubmitted Helix work).
+- **Helix side** — the monitor fails if the latest completed incarnation of
+  any submitted work item failed. A newer passing incarnation supersedes an
+  older failed one.
 
-- The Azure DevOps jobs it monitors.
-- The latest completed Helix work-item outcomes for submitted Helix work.
+Upload state never affects pass/fail.
 
-The monitor should fail when a monitored Azure DevOps job failed or was canceled,
-unless that Azure DevOps job's failure is represented by Helix work that the
-monitor is actively retrying on this invocation.
+Exit code is `0` only when both checks pass; otherwise `1`. Cancellation
+(timeout) also exits with `1`.
 
-The monitor should fail when the latest completed Helix incarnation for any work
-item failed. A newer passing incarnation supersedes an older failed incarnation.
+### 2.6 Crash and timeout resilience
 
-Test result upload state does not affect pass/fail. Uploads are reporting
-artifacts; Helix work-item state and monitored Azure DevOps job state determine
-the monitor result.
+The runner must be safe to re-run after any abrupt termination. In
+particular:
 
-## Crash and timeout resilience
+- Partial uploads must not cause duplicate uploads on the next run.
+- Retry candidates must be rediscovered from Helix job properties, not from
+  prior in-memory state.
+- Cancellation must drain in-flight uploads before exiting so partially
+  uploaded results are not lost.
+- On cancellation, in-flight Helix jobs should receive a best-effort cancel
+  request even though the runner's own cancellation token has already
+  fired. This requires a fresh, short-lived cancellation budget for the
+  cleanup path.
 
-Because the monitor may stop at any time:
+## 3. Inputs
 
-- It should be safe to rerun after partially uploading test results.
-- It should skip uploads for Helix jobs whose marker appears in completed Azure
-   DevOps test run names.
-- It should discover retry candidates again from Helix job properties on the
-  next entry.
-- It should not require any process-local memory from a prior invocation.
+The runner is configured by an options object. The semantically meaningful
+inputs are:
 
-The monitor may still have useful in-memory state while a single invocation is
-running, but durable correctness must come from Azure DevOps test run name
-markers and Helix job properties.
+| Input | Purpose |
+| --- | --- |
+| Helix endpoint + access token | Talk to the Helix service. |
+| Organization, project, repository, branch, build reason | Compose the Helix `source` filter (see §5.1). |
+| Build ID | Scope Helix and AzDO queries to this build. |
+| AzDO collection URI + project | Construct the test-results URL used in failure reports. |
+| Stage name | Stage scope (see §2.1). |
+| Polling interval | Delay between poll iterations; a minimum floor applies. |
+| Maximum wait | Reported in the timeout message; the timeout itself is enforced by the caller through cancellation. |
+| Job monitor name | Identifier of the monitor's own AzDO timeline record; used to exclude it from pass/fail. |
+| Working directory | Local staging directory for downloaded test results. |
+| Verbose flag | Forces a status snapshot every poll. |
+
+## 4. External contracts
+
+The runner depends on two service interfaces. The contracts are described
+behaviorally; method names are illustrative.
+
+### 4.1 Helix service
+
+- **List jobs for a build** — given the source filter and build ID, return
+  all Helix jobs that the submitter recorded for the build. The source
+  filter must be derivable from build metadata in lockstep with the
+  submitter (see §5.1).
+- **List work items for a job** — return all work-item summaries.
+- **Download test results** — given a job and a set of work-item names,
+  download recognized result files into a working directory. Individual
+  per-work-item failures must not abort the batch.
+- **Cancel a job** — best-effort cancellation.
+- **Resubmit failed work items** — given the original job and a set of
+  failed work items, submit a new Helix job that contains only those items.
+  The new job must inherit the original's submitter identity (stage, job
+  name, display name, test-run name, queue) and link back via
+  `PreviousHelixJobName`. May return "not possible" (e.g. queue gone), in
+  which case the runner skips that retry.
+
+### 4.2 Azure DevOps service
+
+- **Get timeline records** — return the build's timeline.
+- **Get processed Helix job names** — extract Helix job names from
+  `[HelixJob:<name>]` markers on completed test runs. This is the durable
+  upload-dedup signal.
+- **Create test run / upload results / complete test run** — the standard
+  three-call sequence. Creation must reuse an in-progress test run with the
+  same name rather than creating a duplicate.
+
+## 5. Behavior
+
+### 5.1 Helix source filter
+
+On entry the runner derives a Helix `source` string from the build metadata
+(organization, project, repository, branch, build reason). This string must
+match what the Helix SDK submitter produced for the same build — for PR,
+scheduled, manual, IndividualCI, BatchedCI, and internal-official runs
+alike. Any change in derivation must be made in lockstep with the submitter,
+or the runner will silently fail to see its own jobs.
+
+### 5.2 Lifecycle
+
+1. Log the build and stage being monitored.
+2. Load the set of already-uploaded Helix job names (§2.2).
+3. Perform the one-shot retry pass (§5.3).
+4. Enter the poll loop (§5.4) until the build finishes or cancellation
+   fires.
+5. On cancellation (timeout), drain pending uploads, emit a timeout report
+   (§5.6), best-effort cancel in-flight Helix jobs (§2.6), and exit `1`.
+6. On normal completion, emit the final summary and exit per §2.5.
+
+### 5.3 Retry pass
+
+1. Take a Helix snapshot scoped to the stage.
+2. Reduce it to the latest incarnation of each lineage chain.
+3. For each completed latest incarnation that has failed work items, ask
+   the Helix service to resubmit just the failed items.
+4. Remember the AzDO submitter-job identifiers of successfully retried
+   work; these are the jobs to exclude from the AzDO failure check while
+   this invocation runs.
+5. Carry the snapshot plus the newly resubmitted jobs forward as the input
+   to the first poll iteration so the first iteration sees them
+   immediately. (Subsequent iterations refetch from Helix.)
+
+If nothing was eligible for retry, log that fact.
+
+### 5.4 Poll loop
+
+Each iteration:
+
+1. Check for cancellation.
+2. Fetch the AzDO timeline and the Helix snapshot, scoped to the stage.
+3. Update the in-memory view of each Helix job with the freshest snapshot
+   (so completion/failure transitions are not missed).
+4. Compute the set of completed Helix jobs (§5.5).
+5. **First pass — upload**: for each completed Helix job not already
+   uploaded (per §2.2), upload its test results and remember it as
+   processed. This pass is the only one that triggers uploads.
+6. **Second pass — outcome reconciliation**: for every completed Helix
+   job in scope, ensure its per-work-item outcomes are reflected in the
+   running outcome map (§5.7), processing lineage from oldest to newest so
+   newer incarnations supersede older ones. This pass must consider all
+   completed jobs — including ones uploaded by an earlier invocation —
+   because the outcome map is the only source for the pass/fail decision
+   and is not durable across invocations.
+7. Decide whether to log status this iteration. The decision uses the
+   verbose flag, whether any counts changed since the last status log, and
+   a maximum interval (so long-stable builds still emit periodic progress).
+8. Evaluate termination: all monitored AzDO jobs complete *and* all scoped
+   Helix jobs in the completed set. When true, wait for pending uploads,
+   emit the final report, and exit per §2.5.
+9. Otherwise sleep for the configured poll interval and repeat.
+
+### 5.5 Completion of a Helix job
+
+A Helix job is considered complete when the Helix service reports it
+finished or failed. As a fallback for jobs whose status transition has not
+yet been observed, the runner may treat a job as complete when every one of
+its expected work items has a terminal exit code. The fallback is only safe
+when the expected work-item count is known and non-zero.
+
+### 5.6 Timeout report
+
+On cancellation, the runner emits two grouped reports:
+
+- All scoped Helix jobs that are either not yet finished or finished but
+  not yet uploaded — each with its display name, status, expected
+  work-item count, and a clickable details URI.
+- All scoped non-monitor AzDO timeline jobs not yet in `completed` state —
+  each with its name, state, and result.
+
+If both groups are empty, emit a single critical-level note that nothing
+unfinished was tracked at the time of timeout (this means timeout fired
+during the brief window between completion and termination).
+
+### 5.7 Per-work-item outcome map
+
+The runner maintains an in-memory map from *logical work item* to its
+latest observed pass/fail status. A logical work item is identified by the
+work-item name plus a stable key that survives resubmission, so all
+incarnations of the same item collapse onto a single entry.
+
+The chain key must be deterministic and uniqueness-preserving:
+
+- A single AzDO matrix leg that fans out to multiple Helix queues must
+  produce distinct keys (one per queue) so per-queue failures are
+  preserved.
+- An original Helix job and its resubmission(s) on the same queue must
+  produce the same key so the latest incarnation overwrites the older one.
+- If lineage cannot be resolved (the predecessor link points outside the
+  jobs the runner has observed), the key falls back to a Helix-job-bound
+  identifier so independent jobs don't collide.
+
+The same key drives a parallel map of "failed work item console info" used
+to build the final failure report. When a later incarnation of a work item
+passes, its entry in that map is cleared.
+
+### 5.8 Failure reporting
+
+Failed Helix work items must produce clickable console-link warnings in the
+AzDO build log:
+
+- Once per failed work-item observation during status logs (deduplicated
+  across the invocation so we don't spam the same link).
+- Once per failed work item in a completed job during the upload pass
+  (same dedup).
+- At termination, a single aggregated error block listing every still-
+  failing work item, prefixed with the test-results URL for the build.
+
+Warnings use AzDO `task.logissue type=warning` formatting; the final
+aggregated error uses `task.logissue type=error`. Informational status
+lines are plain logger output.
+
+### 5.9 Test-result upload pipeline
+
+Uploads are fire-and-forget tasks tracked for later draining:
+
+- Each upload is queued asynchronously and tracked. Multiple uploads may
+  proceed concurrently.
+- An upload retries indefinitely on transient errors; only cancellation
+  exits the retry loop.
+- Both the normal-termination and cancellation paths wait for queued
+  uploads to drain before exiting. The cancellation drain uses a fresh
+  cancellation budget so uploads in progress when the runner token fires
+  are not abandoned.
+
+The upload sequence per job is: create (or reuse) a test run named
+`{TestRunName} [HelixJob:<name>]`, download results, upload them, complete
+the test run.
+
+### 5.10 Status logging
+
+When a status log is due, the runner emits a one-line summary of work
+counts (processed / completed / running / waiting jobs and work items). In
+verbose mode it additionally emits a tree-style breakdown per job and work
+item. The verbose tree is informational only.
+
+A Helix job is classified for status purposes as `Processed` (already
+uploaded), `Completed` (terminal but not yet uploaded), `Running` (has at
+least one work item), or `Waiting` (no work items observed yet).
+
+## 6. Externally observable formats
+
+These shapes are observed by other tools, downstream parsers, or tests and
+must be preserved:
+
+- AzDO test-run name marker: `[HelixJob:<helix-job-name>]`, appended to a
+  caller-supplied test-run name with a single space separator.
+- AzDO log decorations: `##vso[task.logissue type=warning]` for warnings,
+  `##vso[task.logissue type=error]` for errors. Informational lines use
+  plain logger output (no `##vso` prefix).
+- Test-results URL: the standard AzDO build-test-results-tab URL for the
+  build, used as the link in the final failure block.
+- A Helix work item is considered failed if its exit code is non-zero or
+  its state is not the terminal success state. A work item is considered
+  failed-and-terminal (worth reporting eagerly) when it is failed and not
+  still in flight.

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.Design.md
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.Design.md
@@ -1,341 +1,127 @@
-# JobMonitorRunner — Technical Specification
-
-This document is a behavioral specification of the Helix job monitor runner.
-It describes *what* the runner must do, not *how* it currently does it.
+# Helix Job Monitor Runner Design
+
+The Helix Job Monitor is intended to be a resilient observer for Azure DevOps
+pipeline jobs and the Helix work submitted by those jobs. It must assume it may
+crash, time out, or be retried at any point. Any behavior that must survive a
+restart can only be reconstructed from durable external state:
 
-The current source lives at [JobMonitorRunner.cs](JobMonitorRunner.cs); use
-it only as the reference implementation, not as the specification.
+- Azure DevOps test run name markers written by the monitor.
+- Helix job properties written when jobs are submitted or resubmitted.
 
----
+The monitor should not rely on in-memory state to make decisions that must remain
+correct across restarts.
 
-## 1. Purpose
+## Stage scope
 
-The runner is the body of a standalone CLI invoked as a single job inside an
-Azure DevOps pipeline stage. Its job is to:
+Each monitor invocation owns exactly one Azure DevOps stage unless it is
+explicitly configured to monitor all stages. In the normal stage-scoped mode, the
+monitor must only look at:
 
-- Observe the Helix jobs submitted from the same build (by the Helix SDK
-  submitter) and the Azure DevOps timeline jobs running alongside it.
-- Resubmit failed Helix work items once per invocation.
-- Upload Helix work-item test results to Azure DevOps.
-- Return an exit code that reflects whether the monitored pipeline jobs and
-  the latest completed Helix work items all succeeded.
-
-## 2. Operating model
-
-### 2.1 Stage scope
-
-Each invocation owns exactly one Azure DevOps stage. All decisions (retry,
-completion gating, upload, pass/fail) consider only:
+- Azure DevOps timeline jobs that belong to the monitor's stage.
+- Helix jobs whose `System.StageName` property is empty or matches the monitor's
+  stage.
 
-- Azure DevOps timeline jobs belonging to the monitor's stage.
-- Helix jobs whose `System.StageName` property matches the monitor's stage.
-
-Jobs and work items from other stages must not be retried, uploaded, or used
-to fail this invocation.
-
-### 2.2 Durable state
-
-The runner may crash, time out, or be retried at any point. Any behavior that
-must survive a restart can only be reconstructed from durable external state:
-
-- **Azure DevOps test-run name markers** — the monitor appends
-  `[HelixJob:<helix-job-name>]` to each test-run name it creates. The
-  presence of that marker on a completed test run is the durable signal
-  that the corresponding Helix job's results have already been uploaded.
-  (Markers are used instead of test-run tags because the AzDO test-runs API
-  silently drops tags created with the run.)
-- **Helix job properties** — every resubmitted Helix job preserves the
-  original submitter's properties and adds `PreviousHelixJobName`, linking
-  to the job that was resubmitted. The chain of `PreviousHelixJobName`
-  links represents the incarnations of one logical piece of work.
-
-In-memory state may be used freely within a single invocation but must never
-be the source of truth for cross-invocation correctness.
-
-### 2.3 Retry invariants
-
-1. Retry runs exactly once per invocation, on entry, before polling begins.
-2. The set of work to resubmit is decided from a single Helix snapshot taken
-   on entry. Work that fails after the monitor has started is not
-   resubmitted during the current invocation; a later invocation may pick
-   it up.
-3. A Helix job is eligible for retry only if it is the latest completed
-   incarnation in its lineage chain (not superseded by a newer attempt).
-4. If that incarnation has failed work items, only the failed items are
-   resubmitted; passing items are not.
-5. If a newer incarnation of a work item has already completed and passed,
-   no further resubmission for that item occurs.
-6. If a newer incarnation is still running or waiting, no resubmission
-   occurs.
-
-Repeated monitor runs therefore submit progressively fewer work items as
-newer incarnations succeed.
-
-### 2.4 Upload invariants
-
-Upload is restart-resilient but logically independent from retry.
-
-1. The same Helix job's test results are never uploaded twice. The durable
-   deduplication signal is the `[HelixJob:<name>]` marker on completed AzDO
-   test runs.
-2. For every completed Helix job not already uploaded, all available test
-   results are uploaded.
-3. Uploads happen in lineage order — oldest incarnation first. If both an
-   original job and its resubmission have completed and neither has been
-   uploaded, the original uploads first.
-4. Upload failures are logged but never affect pass/fail.
-5. A failed original Helix job may be resubmitted on entry and still have
-   its original test results uploaded during the same invocation if those
-   results were not uploaded earlier.
-
-### 2.5 Pass/fail invariants
-
-The exit code is determined by combining two checks:
-
-- **AzDO side** — the monitor fails if any monitored AzDO job failed or
-  was canceled. Jobs whose work is being actively retried this invocation
-  are excluded from this check (their failure is represented by the
-  resubmitted Helix work).
-- **Helix side** — the monitor fails if the latest completed incarnation of
-  any submitted work item failed. A newer passing incarnation supersedes an
-  older failed one.
-
-Upload state never affects pass/fail.
-
-Exit code is `0` only when both checks pass; otherwise `1`. Cancellation
-(timeout) also exits with `1`.
-
-### 2.6 Crash and timeout resilience
-
-The runner must be safe to re-run after any abrupt termination. In
-particular:
-
-- Partial uploads must not cause duplicate uploads on the next run.
-- Retry candidates must be rediscovered from Helix job properties, not from
-  prior in-memory state.
-- Cancellation must drain in-flight uploads before exiting so partially
-  uploaded results are not lost.
-- On cancellation, in-flight Helix jobs should receive a best-effort cancel
-  request even though the runner's own cancellation token has already
-  fired. This requires a fresh, short-lived cancellation budget for the
-  cleanup path.
-
-## 3. Inputs
-
-The runner is configured by an options object. The semantically meaningful
-inputs are:
-
-| Input | Purpose |
-| --- | --- |
-| Helix endpoint + access token | Talk to the Helix service. |
-| Organization, project, repository, branch, build reason | Compose the Helix `source` filter (see §5.1). |
-| Build ID | Scope Helix and AzDO queries to this build. |
-| AzDO collection URI + project | Construct the test-results URL used in failure reports. |
-| Stage name | Stage scope (see §2.1). |
-| Polling interval | Delay between poll iterations; a minimum floor applies. |
-| Maximum wait | Reported in the timeout message; the timeout itself is enforced by the caller through cancellation. |
-| Job monitor name | Identifier of the monitor's own AzDO timeline record; used to exclude it from pass/fail. |
-| Working directory | Local staging directory for downloaded test results. |
-| Verbose flag | Forces a status snapshot every poll. |
-
-## 4. External contracts
-
-The runner depends on two service interfaces. The contracts are described
-behaviorally; method names are illustrative.
-
-### 4.1 Helix service
-
-- **List jobs for a build** — given the source filter and build ID, return
-  all Helix jobs that the submitter recorded for the build. The source
-  filter must be derivable from build metadata in lockstep with the
-  submitter (see §5.1).
-- **List work items for a job** — return all work-item summaries.
-- **Download test results** — given a job and a set of work-item names,
-  download recognized result files into a working directory. Individual
-  per-work-item failures must not abort the batch.
-- **Cancel a job** — best-effort cancellation.
-- **Resubmit failed work items** — given the original job and a set of
-  failed work items, submit a new Helix job that contains only those items.
-  The new job must inherit the original's submitter identity (stage, job
-  name, display name, test-run name, queue) and link back via
-  `PreviousHelixJobName`. May return "not possible" (e.g. queue gone), in
-  which case the runner skips that retry.
-
-### 4.2 Azure DevOps service
-
-- **Get timeline records** — return the build's timeline.
-- **Get processed Helix job names** — extract Helix job names from
-  `[HelixJob:<name>]` markers on completed test runs. This is the durable
-  upload-dedup signal.
-- **Create test run / upload results / complete test run** — the standard
-  three-call sequence. Creation must reuse an in-progress test run with the
-  same name rather than creating a duplicate.
-
-## 5. Behavior
-
-### 5.1 Helix source filter
-
-On entry the runner derives a Helix `source` string from the build metadata
-(organization, project, repository, branch, build reason). This string must
-match what the Helix SDK submitter produced for the same build — for PR,
-scheduled, manual, IndividualCI, BatchedCI, and internal-official runs
-alike. Any change in derivation must be made in lockstep with the submitter,
-or the runner will silently fail to see its own jobs.
-
-### 5.2 Lifecycle
-
-1. Log the build and stage being monitored.
-2. Load the set of already-uploaded Helix job names (§2.2).
-3. Perform the one-shot retry pass (§5.3).
-4. Enter the poll loop (§5.4) until the build finishes or cancellation
-   fires.
-5. On cancellation (timeout), drain pending uploads, emit a timeout report
-   (§5.6), best-effort cancel in-flight Helix jobs (§2.6), and exit `1`.
-6. On normal completion, emit the final summary and exit per §2.5.
-
-### 5.3 Retry pass
-
-1. Take a Helix snapshot scoped to the stage.
-2. Reduce it to the latest incarnation of each lineage chain.
-3. For each completed latest incarnation that has failed work items, ask
-   the Helix service to resubmit just the failed items.
-4. Remember the AzDO submitter-job identifiers of successfully retried
-   work; these are the jobs to exclude from the AzDO failure check while
-   this invocation runs.
-5. Carry the snapshot plus the newly resubmitted jobs forward as the input
-   to the first poll iteration so the first iteration sees them
-   immediately. (Subsequent iterations refetch from Helix.)
-
-If nothing was eligible for retry, log that fact.
-
-### 5.4 Poll loop
-
-Each iteration:
-
-1. Check for cancellation.
-2. Fetch the AzDO timeline and the Helix snapshot, scoped to the stage.
-3. Update the in-memory view of each Helix job with the freshest snapshot
-   (so completion/failure transitions are not missed).
-4. Compute the set of completed Helix jobs (§5.5).
-5. **First pass — upload**: for each completed Helix job not already
-   uploaded (per §2.2), upload its test results and remember it as
-   processed. This pass is the only one that triggers uploads.
-6. **Second pass — outcome reconciliation**: for every completed Helix
-   job in scope, ensure its per-work-item outcomes are reflected in the
-   running outcome map (§5.7), processing lineage from oldest to newest so
-   newer incarnations supersede older ones. This pass must consider all
-   completed jobs — including ones uploaded by an earlier invocation —
-   because the outcome map is the only source for the pass/fail decision
-   and is not durable across invocations.
-7. Decide whether to log status this iteration. The decision uses the
-   verbose flag, whether any counts changed since the last status log, and
-   a maximum interval (so long-stable builds still emit periodic progress).
-8. Evaluate termination: all monitored AzDO jobs complete *and* all scoped
-   Helix jobs in the completed set. When true, wait for pending uploads,
-   emit the final report, and exit per §2.5.
-9. Otherwise sleep for the configured poll interval and repeat.
-
-### 5.5 Completion of a Helix job
-
-A Helix job is considered complete when the Helix service reports it
-finished or failed. As a fallback for jobs whose status transition has not
-yet been observed, the runner may treat a job as complete when every one of
-its expected work items has a terminal exit code. The fallback is only safe
-when the expected work-item count is known and non-zero.
-
-### 5.6 Timeout report
-
-On cancellation, the runner emits two grouped reports:
-
-- All scoped Helix jobs that are either not yet finished or finished but
-  not yet uploaded — each with its display name, status, expected
-  work-item count, and a clickable details URI.
-- All scoped non-monitor AzDO timeline jobs not yet in `completed` state —
-  each with its name, state, and result.
-
-If both groups are empty, emit a single critical-level note that nothing
-unfinished was tracked at the time of timeout (this means timeout fired
-during the brief window between completion and termination).
-
-### 5.7 Per-work-item outcome map
-
-The runner maintains an in-memory map from *logical work item* to its
-latest observed pass/fail status. A logical work item is identified by the
-work-item name plus a stable key that survives resubmission, so all
-incarnations of the same item collapse onto a single entry.
-
-The chain key must be deterministic and uniqueness-preserving:
-
-- A single AzDO matrix leg that fans out to multiple Helix queues must
-  produce distinct keys (one per queue) so per-queue failures are
-  preserved.
-- An original Helix job and its resubmission(s) on the same queue must
-  produce the same key so the latest incarnation overwrites the older one.
-- If lineage cannot be resolved (the predecessor link points outside the
-  jobs the runner has observed), the key falls back to a Helix-job-bound
-  identifier so independent jobs don't collide.
-
-The same key drives a parallel map of "failed work item console info" used
-to build the final failure report. When a later incarnation of a work item
-passes, its entry in that map is cleared.
-
-### 5.8 Failure reporting
-
-Failed Helix work items must produce clickable console-link warnings in the
-AzDO build log:
-
-- Once per failed work-item observation during status logs (deduplicated
-  across the invocation so we don't spam the same link).
-- Once per failed work item in a completed job during the upload pass
-  (same dedup).
-- At termination, a single aggregated error block listing every still-
-  failing work item, prefixed with the test-results URL for the build.
-
-Warnings use AzDO `task.logissue type=warning` formatting; the final
-aggregated error uses `task.logissue type=error`. Informational status
-lines are plain logger output.
-
-### 5.9 Test-result upload pipeline
-
-Uploads are fire-and-forget tasks tracked for later draining:
-
-- Each upload is queued asynchronously and tracked. Multiple uploads may
-  proceed concurrently.
-- An upload retries indefinitely on transient errors; only cancellation
-  exits the retry loop.
-- Both the normal-termination and cancellation paths wait for queued
-  uploads to drain before exiting. The cancellation drain uses a fresh
-  cancellation budget so uploads in progress when the runner token fires
-  are not abandoned.
-
-The upload sequence per job is: create (or reuse) a test run named
-`{TestRunName} [HelixJob:<name>]`, download results, upload them, complete
-the test run.
-
-### 5.10 Status logging
-
-When a status log is due, the runner emits a one-line summary of work
-counts (processed / completed / running / waiting jobs and work items). In
-verbose mode it additionally emits a tree-style breakdown per job and work
-item. The verbose tree is informational only.
-
-A Helix job is classified for status purposes as `Processed` (already
-uploaded), `Completed` (terminal but not yet uploaded), `Running` (has at
-least one work item), or `Waiting` (no work items observed yet).
-
-## 6. Externally observable formats
-
-These shapes are observed by other tools, downstream parsers, or tests and
-must be preserved:
-
-- AzDO test-run name marker: `[HelixJob:<helix-job-name>]`, appended to a
-  caller-supplied test-run name with a single space separator.
-- AzDO log decorations: `##vso[task.logissue type=warning]` for warnings,
-  `##vso[task.logissue type=error]` for errors. Informational lines use
-  plain logger output (no `##vso` prefix).
-- Test-results URL: the standard AzDO build-test-results-tab URL for the
-  build, used as the link in the final failure block.
-- A Helix work item is considered failed if its exit code is non-zero or
-  its state is not the terminal success state. A work item is considered
-  failed-and-terminal (worth reporting eagerly) when it is failed and not
-  still in flight.
+Stage scope applies to retry, test-result upload, and pass/fail calculation. A
+failed job or failed Helix work item from another stage must not be retried,
+uploaded, or used to fail this monitor invocation.
+
+## Durable state
+
+### Azure DevOps test run name markers
+
+The monitor appends a Helix job name marker to each Azure DevOps test run name
+it creates. The marker format is `[HelixJob:<helix-job-name>]`, so the full test
+run name is `{original-name} [HelixJob:<helix-job-name>]`. Completed test runs
+with that marker are used only to determine whether test results for a Helix job
+have already been uploaded.
+
+The monitor uses the test run name instead of Azure DevOps test run tags because
+the Azure DevOps test runs API silently drops tags created with the run. Test run
+name markers do not determine whether Helix work should be retried, and test
+result upload success or failure does not determine whether the monitor passes or
+fails.
+
+### Helix job properties
+
+Helix job properties are the durable state for retry lineage. Resubmitted Helix
+jobs preserve the original job properties and add `PreviousHelixJobName`, which
+points to the Helix job that was resubmitted.
+
+This creates a chain of Helix job incarnations for the same logical work. The
+monitor uses that chain to find the latest incarnation of each job when deciding
+what to retry and what currently passes or fails.
+
+## Retry behavior
+
+Retry scheduling is separate from test result upload.
+
+1. Retry is performed only when the monitor starts.
+2. The monitor takes a Helix snapshot on entry and decides what to resubmit from
+   that snapshot.
+3. Work that fails after the monitor has started is not resubmitted during that
+   invocation. It can be resubmitted only by a later monitor invocation.
+4. A Helix job is considered for retry only if it is the latest completed
+   incarnation in its `PreviousHelixJobName` chain.
+5. If that latest completed incarnation has failed work items, only those failed
+   work items are resubmitted.
+6. Passing work items from the same Helix job are not included in the
+   resubmission.
+7. If a newer incarnation of a work item has completed and passed, older failed
+   incarnations must not cause another resubmission.
+8. If a newer incarnation is still running or waiting, it is not resubmitted
+   again on monitor entry.
+
+This means repeated monitor retries should naturally submit fewer work items over
+time as newer incarnations complete successfully.
+
+## Test result upload behavior
+
+Test result upload is also restart-resilient, but it is independent from retry.
+
+1. Never upload the same Helix job's test results twice.
+2. Use Azure DevOps test run name markers on completed test runs to discover
+   which Helix jobs have already been uploaded by previous monitor invocations.
+3. For completed Helix jobs that have not been uploaded, upload all available
+   test results.
+4. Upload completed jobs in lineage order, from old to new. For example, if both
+   an original job and a resubmitted job have completed and neither has been
+   uploaded, upload the original job first and the resubmitted job second.
+5. Test result upload failures should be logged, but they do not affect the
+   monitor's pass/fail result.
+
+This separation is important: a failed original Helix job may be resubmitted on
+entry and still have its original test results uploaded during the same monitor
+invocation if those results were not uploaded earlier.
+
+## Monitor pass/fail behavior
+
+The monitor result must reflect both:
+
+- The Azure DevOps jobs it monitors.
+- The latest completed Helix work-item outcomes for submitted Helix work.
+
+The monitor should fail when a monitored Azure DevOps job failed or was canceled,
+unless that Azure DevOps job's failure is represented by Helix work that the
+monitor is actively retrying on this invocation.
+
+The monitor should fail when the latest completed Helix incarnation for any work
+item failed. A newer passing incarnation supersedes an older failed incarnation.
+
+Test result upload state does not affect pass/fail. Uploads are reporting
+artifacts; Helix work-item state and monitored Azure DevOps job state determine
+the monitor result.
+
+## Crash and timeout resilience
+
+Because the monitor may stop at any time:
+
+- It should be safe to rerun after partially uploading test results.
+- It should skip uploads for Helix jobs whose marker appears in completed Azure
+   DevOps test run names.
+- It should discover retry candidates again from Helix job properties on the
+  next entry.
+- It should not require any process-local memory from a prior invocation.
+
+The monitor may still have useful in-memory state while a single invocation is
+running, but durable correctness must come from Azure DevOps test run name
+markers and Helix job properties.

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
@@ -99,11 +99,9 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             }
             catch (OperationCanceledException)
             {
-                // Drain in-flight uploads before exiting. The uploads were started via Task.Run
-                // and are not bound to the runner's cancellation token; if we return without
-                // awaiting them, any results that hadn't reached AzDO yet are lost (and tests
-                // that observe UploadedJobNames immediately after a cancelled run see a partial
-                // set).
+                // Drain in-flight uploads before exiting. Uploads are started via Task.Run and are
+                // not awaited as part of the poll loop, so we need to await them here to avoid
+                // dropping results that were already in progress when the runner was cancelled.
                 await _uploads.DrainAsync(CancellationToken.None);
                 _reporter.ReportTimeout();
 

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
@@ -14,6 +14,12 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Helix.JobMonitor
 {
+    /// <summary>
+    /// Orchestrates the per-invocation lifecycle described in <c>JobMonitorRunner.Design.md</c>:
+    /// one-shot retry pass, poll loop (with upload + outcome reconciliation per iteration),
+    /// final summary on completion, and timeout/cancel handling. All heavy lifting
+    /// (status logging, uploads, state) lives in dedicated helpers.
+    /// </summary>
     internal sealed class JobMonitorRunner : IJobMonitorRunner, IDisposable
     {
         private readonly JobMonitorOptions _options;
@@ -23,34 +29,9 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         private readonly Func<TimeSpan, CancellationToken, Task> _delayFunc;
         private readonly string _helixSource;
 
-        /// <summary>
-        /// Tracks the latest outcome for each logical work item, keyed by
-        /// (SubmitterChainKey, WorkItemName). Using the submitter chain key (rather than just
-        /// the work-item name) ensures that two different AzDO jobs which happen to run
-        /// identically-named Helix work items do not overwrite each other's outcomes. Within
-        /// a single AzDO submitter chain, a resubmission still overwrites a prior failure
-        /// for the same work-item name because resubmitted Helix jobs inherit
-        /// <c>System.JobName</c>.
-        /// </summary>
-        private readonly Dictionary<(string ChainKey, string WorkItemName), bool> _workItemOutcomes = new(WorkItemOutcomeKeyComparer.Instance);
-        private readonly HashSet<string> _workItemOutcomeJobs = new(StringComparer.OrdinalIgnoreCase);
-
-        /// <summary>
-        /// Cache of every Helix job we have seen this run, indexed by job name, so that
-        /// <see cref="GetSubmitterChainKey"/> can walk back through <c>PreviousHelixJobName</c>
-        /// links when a submitter job name is not present on the job (e.g. unit-test
-        /// scenarios that submit Helix jobs without an AzDO submitter context).
-        /// </summary>
-        private readonly Dictionary<string, HelixJobInfo> _knownJobsByName = new(StringComparer.OrdinalIgnoreCase);
-
-        /// <summary>
-        /// Tracks which work item names belong to which Helix job, so resubmission only
-        /// resubmits items from the specific source job.
-        /// </summary>
-        private readonly Dictionary<string, HashSet<string>> _workItemsByJob = new(StringComparer.OrdinalIgnoreCase);
-        private readonly Dictionary<(string ChainKey, string WorkItemName), FailedWorkItemConsoleInfo> _failedWorkItemConsoleInfo = new(WorkItemOutcomeKeyComparer.Instance);
-        private readonly HashSet<string> _reportedFailedWorkItemConsoleLinks = new(StringComparer.OrdinalIgnoreCase);
-        private readonly List<Task> _pendingTestResultUploads = [];
+        private readonly MonitorState _state = new();
+        private readonly StatusReporter _reporter;
+        private readonly TestResultUploadQueue _uploads;
 
         /// <summary>
         /// Constructor for production use with real services.
@@ -95,438 +76,276 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 _options.TeamProject,
                 $"{_options.Organization}/{_options.RepositoryName}",
                 _options.SourceBranch);
+
+            _reporter = new StatusReporter(_logger, _options, _helix, _state);
+            _uploads = new TestResultUploadQueue(_logger, _options, _azdo, _helix, Delay);
         }
 
-        public Task<int> RunAsync(CancellationToken cancellationToken)
+        public async Task<int> RunAsync(CancellationToken cancellationToken)
         {
-            return RunCoreAsync(cancellationToken);
-        }
+            _reporter.LogMonitorStart();
 
-        private async Task<int> RunCoreAsync(CancellationToken cancellationToken)
-        {
-            _logger.LogInformation("Monitoring Helix jobs for stage {stage} of build {BuildId}:{nl}{collectionUri}{teamProject}/_build/results?buildId={BuildId}",
-                _options.StageName,
-                _options.BuildId,
-                Environment.NewLine,
-                _options.CollectionUri,
-                _options.TeamProject,
-                _options.BuildId);
-
-            IReadOnlySet<string> alreadyProcessed = await _azdo.GetProcessedHelixJobNamesAsync(cancellationToken);
-            HashSet<string> processedHelixJobs = new(alreadyProcessed, StringComparer.OrdinalIgnoreCase);
-            // Keyed by Helix job name so that each poll overwrites the cached snapshot with the
-            // latest state from Helix. Using a HashSet here would retain the first-seen snapshot
-            // (typically Status="running", Finished=null), which would cause ReportTimeout and
-            // CancelInFlightHelixJobsAsync to treat already-completed jobs as still in flight.
-            Dictionary<string, HelixJobInfo> associatedJobs = new(StringComparer.OrdinalIgnoreCase);
-            var latestTimelineRecords = new List<AzureDevOpsTimelineRecord>();
+            foreach (string job in await _azdo.GetProcessedHelixJobNamesAsync(cancellationToken))
+            {
+                _state.ProcessedHelixJobs.Add(job);
+            }
 
             try
             {
-                JobResubmissionResult jobResubmission = await ResubmitFailedJobsAsync(cancellationToken);
-
-                return await RunLoopAsync(
-                    processedHelixJobs,
-                    associatedJobs,
-                    latestTimelineRecords,
-                    jobResubmission,
-                    cancellationToken);
+                IReadOnlyList<HelixJobInfo> jobsForFirstPoll = await ExecuteRetryPassAsync(cancellationToken);
+                return await RunPollLoopAsync(jobsForFirstPoll, cancellationToken);
             }
             catch (OperationCanceledException)
             {
-                // Drain in-flight test-result uploads before exiting. The uploads were started
-                // via Task.Run and are not bound to the runner's cancellation token; if we
-                // return without awaiting them, any results that hadn't reached AzDO yet are
-                // lost (and tests that observe UploadedJobNames immediately after a cancelled
-                // run see a partial set).
-                await WaitForPendingTestResultUploadsAsync(CancellationToken.None);
-                ReportTimeout(associatedJobs.Values, processedHelixJobs, latestTimelineRecords);
+                // Drain in-flight uploads before exiting. The uploads were started via Task.Run
+                // and are not bound to the runner's cancellation token; if we return without
+                // awaiting them, any results that hadn't reached AzDO yet are lost (and tests
+                // that observe UploadedJobNames immediately after a cancelled run see a partial
+                // set).
+                await _uploads.DrainAsync(CancellationToken.None);
+                _reporter.ReportTimeout();
 
-                // On cancellation (typically the overall timeout), proactively cancel any
-                // Helix jobs we know about that haven't finished yet so they don't keep
-                // consuming queue capacity after the monitor exits. We use a short, bounded
-                // timeout that is independent of the runner's cancellation token (which is
-                // already cancelled) so the best-effort cancel calls actually run.
-                using (var cancelCts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
-                {
-                    await CancelInFlightHelixJobsAsync(associatedJobs.Values, processedHelixJobs, cancelCts.Token);
-                }
+                // Proactively cancel any Helix jobs we know about that haven't finished yet so
+                // they don't keep consuming queue capacity after the monitor exits. Bounded,
+                // independent cancellation budget because the runner's own token is already
+                // cancelled.
+                using var cancelCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                await CancelInFlightHelixJobsAsync(cancelCts.Token);
 
                 return 1;
             }
         }
 
-        private async Task CancelInFlightHelixJobsAsync(
-            IEnumerable<HelixJobInfo> associatedJobs,
-            HashSet<string> processedHelixJobs,
-            CancellationToken cancellationToken)
+        /// <summary>
+        /// One-shot retry pass executed on entry. Walks the current Helix snapshot, finds
+        /// the latest completed incarnation in each lineage chain, and resubmits any failed
+        /// work items on those jobs. Returns the (scoped snapshot ∪ resubmitted jobs) so
+        /// the first poll iteration sees the resubmissions immediately.
+        /// </summary>
+        private async Task<IReadOnlyList<HelixJobInfo>> ExecuteRetryPassAsync(CancellationToken cancellationToken)
         {
-            List<HelixJobInfo> inFlightJobs =
+            _reporter.LogRetryPassStart();
+
+            IReadOnlyList<HelixJobInfo> scopedJobs =
             [
-                ..GetLatestHelixJobAttempts(associatedJobs)
-                    .Where(j => !j.IsCompleted && !processedHelixJobs.Contains(j.JobName))
-                    .OrderBy(j => j.JobName, StringComparer.OrdinalIgnoreCase)
+                ..(await _helix.GetJobsForBuildAsync(_helixSource, _options.BuildId, cancellationToken))
+                    .Where(IsInScope)
             ];
 
-            if (inFlightJobs.Count == 0)
+            var resubmittedJobs = new List<HelixJobInfo>();
+
+            foreach (HelixJobInfo completedJob in MonitorState.GetLatestHelixJobAttempts(scopedJobs)
+                                                              .Where(j => j.IsCompleted))
             {
-                return;
+                IReadOnlyCollection<WorkItemSummary> failedWorkItems =
+                [
+                    ..(await _helix.ListWorkItemsAsync(completedJob.JobName, cancellationToken))
+                        .Where(wi => wi.IsFailed)
+                ];
+
+                if (failedWorkItems.Count == 0)
+                {
+                    continue;
+                }
+
+                HelixJobInfo resubmitted = await _helix.ResubmitWorkItemsAsync(completedJob, failedWorkItems, cancellationToken);
+                if (resubmitted is null)
+                {
+                    continue;
+                }
+
+                resubmittedJobs.Add(resubmitted);
+                _state.ResubmittedJobCount++;
+                _state.ResubmittedWorkItemCount += failedWorkItems.Count;
+                if (!string.IsNullOrEmpty(completedJob.SubmitterJobName))
+                {
+                    _state.RetryingHelixSubmitterJobs.Add(completedJob.SubmitterJobName);
+                }
             }
 
-            _logger.LogWarning("Cancellation requested. Attempting to cancel {Count} in-flight Helix job(s).", inFlightJobs.Count);
+            if (resubmittedJobs.Count == 0)
+            {
+                _reporter.LogRetryPassFoundNothing();
+            }
 
-            Task[] cancelTasks =
-            [
-                ..inFlightJobs.Select(async job =>
-                {
-                    try
-                    {
-                        await _helix.CancelJobAsync(job.JobName, cancellationToken);
-                        _logger.LogInformation("🛑 Requested cancellation of Helix job {JobName}.{nl}{JobUri}",
-                            job.DisplayName, Environment.NewLine, job.DetailsUri);
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        // Bounded cancel window elapsed; nothing more to do.
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogWarning(ex, "Failed to cancel Helix job {JobName}.", job.DisplayName);
-                    }
-                })
-            ];
-
-            await Task.WhenAll(cancelTasks);
+            return [.. scopedJobs, .. resubmittedJobs];
         }
 
-        private async Task<int> RunLoopAsync(
-            HashSet<string> processedHelixJobs,
-            Dictionary<string, HelixJobInfo> associatedJobs,
-            List<AzureDevOpsTimelineRecord> latestTimelineRecords,
-            JobResubmissionResult jobResubmission,
-            CancellationToken cancellationToken)
+        private async Task<int> RunPollLoopAsync(IReadOnlyList<HelixJobInfo> jobsForFirstPoll, CancellationToken cancellationToken)
         {
-            bool anyNonMonitorJobFailures = false;
-            int processedHelixJobCount = 0;
-            int allHelixJobCount = 0;
-            int completedJobsCount = -1;
-            DateTime lastPrintTime = DateTime.UtcNow;
+            var loopState = new PollLoopState();
 
             while (true)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                IReadOnlyList<AzureDevOpsTimelineRecord> timelineRecords = await _azdo.GetTimelineRecordsAsync(cancellationToken);
-                IReadOnlyList<HelixJobInfo> associatedJobsWithBuild = jobResubmission.JobsForFirstPoll ?? await _helix.GetJobsForBuildAsync(
-                    _helixSource,
-                    _options.BuildId,
-                    cancellationToken);
-                jobResubmission = jobResubmission with { JobsForFirstPoll = null };
+                int? exitCode = await PollOnceAsync(jobsForFirstPoll, loopState, cancellationToken);
+                jobsForFirstPoll = null; // first-poll seed is consumed
 
-                // Drop timeline records and Helix jobs that belong to other stages so they don't
-                // gate completion or contribute failures.
-                timelineRecords = HelixJobMonitorUtilities.FilterRecordsToStage(timelineRecords, _options.StageName);
-                associatedJobsWithBuild =
-                [
-                    ..associatedJobsWithBuild.Where(j =>
-                        string.IsNullOrEmpty(j.StageName)
-                        || string.Equals(j.StageName, _options.StageName, StringComparison.OrdinalIgnoreCase))
-                ];
-                latestTimelineRecords.Clear();
-                latestTimelineRecords.AddRange(timelineRecords);
-
-                // Overwrite per poll so the cached entry reflects the latest Helix-side state
-                // (in particular, the Finished timestamp transitioning from null to a value).
-                foreach (HelixJobInfo j in associatedJobsWithBuild)
+                if (exitCode.HasValue)
                 {
-                    associatedJobs[j.JobName] = j;
-                }
-
-                // Cache every job we have seen so GetSubmitterChainKey can follow the
-                // PreviousHelixJobName chain back to a root, even across polls.
-                foreach (HelixJobInfo j in associatedJobsWithBuild)
-                {
-                    _knownJobsByName[j.JobName] = j;
-                }
-
-                // Filter jobs to completed ones belonging to this build. Helix job summaries can
-                // omit Finished for failed jobs even after all work items have terminal exit codes.
-                IReadOnlyCollection<HelixJobInfo> completedJobs =
-                    await GetCompletedHelixJobsAsync(associatedJobsWithBuild, cancellationToken);
-                var completedJobNames = new HashSet<string>(
-                    completedJobs.Select(j => j.JobName),
-                    StringComparer.OrdinalIgnoreCase);
-
-                bool shouldLogStatus = _options.Verbose
-                    || allHelixJobCount != associatedJobsWithBuild.Count
-                    || completedJobsCount != completedJobs.Count
-                    || (DateTime.UtcNow - lastPrintTime) >= TimeSpan.FromMinutes(5);
-
-                foreach (HelixJobInfo job in completedJobs.Where(j => !processedHelixJobs.Contains(j.JobName)))
-                {
-                    await ProcessCompletedJobAsync(job, uploadTestResults: true, cancellationToken);
-                    processedHelixJobs.Add(job.JobName);
-                    processedHelixJobCount++;
-                }
-
-                foreach (HelixJobInfo job in OrderHelixJobsOldToNew(GetLatestHelixJobAttempts(associatedJobsWithBuild).Where(j => completedJobNames.Contains(j.JobName))))
-                {
-                    await ProcessCompletedJobAsync(job, uploadTestResults: false, cancellationToken);
-                }
-
-                PruneCompletedTestResultUploads();
-
-                if (shouldLogStatus)
-                {
-                    await LogHelixJobStatusAsync(associatedJobsWithBuild, completedJobNames, processedHelixJobs, cancellationToken);
-                    allHelixJobCount = associatedJobsWithBuild.Count;
-                    completedJobsCount = completedJobs.Count;
-                    lastPrintTime = DateTime.UtcNow;
-                }
-
-                anyNonMonitorJobFailures = HelixJobMonitorUtilities.HasFailedNonMonitorJobs(
-                    timelineRecords,
-                    _options.JobMonitorName,
-                    jobResubmission.RetryingHelixSubmitterJobs);
-                bool allPipelineJobsComplete = HelixJobMonitorUtilities.AreNonMonitorJobsComplete(timelineRecords, _options.JobMonitorName);
-                bool allHelixJobsComplete = associatedJobsWithBuild.Count == 0 || associatedJobsWithBuild.All(j => completedJobNames.Contains(j.JobName));
-
-                if (allPipelineJobsComplete && allHelixJobsComplete)
-                {
-                    await WaitForPendingTestResultUploadsAsync(cancellationToken);
-
-                    LogFinalFailedWorkItemConsoleInfo();
-
-                    bool anyWorkItemFailed = _workItemOutcomes.Values.Any(passed => !passed);
-                    int totalWorkItems = _workItemOutcomes.Count;
-                    int failedWorkItems = _workItemOutcomes.Values.Count(passed => !passed);
-                    _logger.LogInformation(
-                        "📊 Final summary:{nl}"
-                      + "   Jobs:       {TotalJobs} submitted / {ResubmittedJobs} resubmitted / {ProcessedJobs} processed{nl}"
-                      + "   Work items: {TotalWorkItems} submitted / {ResubmittedWorkItems} resubmitted / {FailedWorkItems} failed",
-                        Environment.NewLine,
-                        associatedJobs.Count,
-                        jobResubmission.ResubmittedJobCount,
-                        processedHelixJobCount,
-                        Environment.NewLine,
-                        totalWorkItems,
-                        jobResubmission.ResubmittedWorkItemCount,
-                        failedWorkItems);
-
-                    if (anyNonMonitorJobFailures)
-                    {
-                        _logger.LogError("One or more non-monitor pipeline jobs failed.");
-                        return 1;
-                    }
-
-                    if (anyWorkItemFailed)
-                    {
-                        return 1;
-                    }
-
-                    return 0;
+                    return exitCode.Value;
                 }
 
                 await Delay(cancellationToken);
             }
         }
 
-        private async Task<IReadOnlyCollection<HelixJobInfo>> GetCompletedHelixJobsAsync(
+        /// <summary>
+        /// One iteration of the poll loop. Returns a non-null exit code when termination
+        /// conditions are met (all pipeline + Helix work complete), otherwise null.
+        /// </summary>
+        private async Task<int?> PollOnceAsync(
+            IReadOnlyList<HelixJobInfo> jobsForFirstPoll,
+            PollLoopState loopState,
+            CancellationToken cancellationToken)
+        {
+            // Fetch fresh snapshots, scoped to the monitor's stage.
+            IReadOnlyList<AzureDevOpsTimelineRecord> timelineRecords =
+                HelixJobMonitorUtilities.FilterRecordsToStage(
+                    await _azdo.GetTimelineRecordsAsync(cancellationToken),
+                    _options.StageName);
+
+            IReadOnlyList<HelixJobInfo> scopedJobs =
+            [
+                ..(jobsForFirstPoll ?? await _helix.GetJobsForBuildAsync(_helixSource, _options.BuildId, cancellationToken))
+                    .Where(IsInScope)
+            ];
+
+            _state.LatestTimelineRecords.Clear();
+            _state.LatestTimelineRecords.AddRange(timelineRecords);
+            _state.ObserveJobs(scopedJobs);
+
+            // Helix job summaries can omit Finished for failed jobs even after all work
+            // items have terminal exit codes, so fall back to per-work-item status.
+            IReadOnlyCollection<HelixJobInfo> completedJobs = await GetCompletedJobsAsync(scopedJobs, cancellationToken);
+            var completedJobNames = new HashSet<string>(
+                completedJobs.Select(j => j.JobName),
+                StringComparer.OrdinalIgnoreCase);
+
+            // First pass: upload + reconcile for any newly-completed jobs.
+            foreach (HelixJobInfo job in completedJobs.Where(j => !_state.ProcessedHelixJobs.Contains(j.JobName)))
+            {
+                await ReconcileCompletedJobAsync(job, queueUpload: true, cancellationToken);
+                _state.ProcessedHelixJobs.Add(job.JobName);
+                _state.ProcessedJobCount++;
+            }
+
+            // Second pass: ensure outcomes for every completed scoped job are reflected in
+            // the running outcome map (oldest-incarnation first so newer ones supersede
+            // older ones). Idempotent — already-reconciled jobs early-return.
+            foreach (HelixJobInfo job in MonitorState.OrderHelixJobsOldToNew(
+                MonitorState.GetLatestHelixJobAttempts(scopedJobs)
+                    .Where(j => completedJobNames.Contains(j.JobName))))
+            {
+                await ReconcileCompletedJobAsync(job, queueUpload: false, cancellationToken);
+            }
+
+            _uploads.Prune();
+
+            bool shouldLogStatus = _options.Verbose
+                || loopState.LastObservedJobCount != scopedJobs.Count
+                || loopState.LastObservedCompletedCount != completedJobs.Count
+                || (DateTime.UtcNow - loopState.LastStatusLogAt) >= TimeSpan.FromMinutes(5);
+
+            if (shouldLogStatus)
+            {
+                await _reporter.LogPollStatusAsync(scopedJobs, completedJobNames, cancellationToken);
+                loopState.LastObservedJobCount = scopedJobs.Count;
+                loopState.LastObservedCompletedCount = completedJobs.Count;
+                loopState.LastStatusLogAt = DateTime.UtcNow;
+            }
+
+            bool anyNonMonitorFailure = HelixJobMonitorUtilities.HasFailedNonMonitorJobs(
+                timelineRecords,
+                _options.JobMonitorName,
+                _state.RetryingHelixSubmitterJobs);
+            bool allPipelineJobsComplete = HelixJobMonitorUtilities.AreNonMonitorJobsComplete(timelineRecords, _options.JobMonitorName);
+            bool allHelixJobsComplete = scopedJobs.Count == 0 || scopedJobs.All(j => completedJobNames.Contains(j.JobName));
+
+            if (!(allPipelineJobsComplete && allHelixJobsComplete))
+            {
+                return null;
+            }
+
+            await _uploads.DrainAsync(cancellationToken);
+            _reporter.LogFinalFailedWorkItems();
+            _reporter.LogFinalSummary(_state.AssociatedJobs.Count);
+
+            if (anyNonMonitorFailure)
+            {
+                _reporter.LogNonMonitorPipelineFailure();
+                return 1;
+            }
+
+            return _state.HasFailedWorkItem ? 1 : 0;
+        }
+
+        /// <summary>
+        /// Updates the per-work-item outcome map for one completed Helix job and (optionally)
+        /// queues a test-result upload. Idempotent: a second call without
+        /// <paramref name="queueUpload"/> early-returns if the outcomes were already recorded.
+        /// </summary>
+        private async Task ReconcileCompletedJobAsync(
+            HelixJobInfo helixJob,
+            bool queueUpload,
+            CancellationToken cancellationToken)
+        {
+            if (!queueUpload && _state.WorkItemOutcomeJobs.Contains(helixJob.JobName))
+            {
+                return;
+            }
+
+            _reporter.LogJobProcessingStart(helixJob);
+
+            IReadOnlyCollection<WorkItemSummary> workItems =
+                await _helix.ListWorkItemsAsync(helixJob.JobName, cancellationToken);
+            _reporter.LogFailedWorkItemConsoleLinks(helixJob, workItems.Where(wi => wi.IsFailed));
+
+            if (_state.WorkItemOutcomeJobs.Add(helixJob.JobName))
+            {
+                string chainKey = _state.GetSubmitterChainKey(helixJob);
+                var jobWorkItems = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (WorkItemSummary wi in workItems)
+                {
+                    // Within the same AzDO submitter chain (i.e. resubmissions of the same
+                    // logical AzDO job), the latest result overwrites the prior one for the
+                    // same work item name. Across different submitter chains the key differs,
+                    // so identically-named work items in different AzDO jobs are tracked
+                    // independently.
+                    _state.WorkItemOutcomes[(chainKey, wi.Name)] = !wi.IsFailed;
+                    _state.TrackFailedWorkItemConsoleInfo(helixJob, chainKey, wi);
+                    jobWorkItems.Add(wi.Name);
+                }
+
+                _state.WorkItemsByJob[helixJob.JobName] = jobWorkItems;
+            }
+
+            if (queueUpload)
+            {
+                _uploads.Enqueue(helixJob, workItems, cancellationToken);
+            }
+
+            _reporter.LogJobCompleted(helixJob, workItems);
+        }
+
+        private async Task<IReadOnlyCollection<HelixJobInfo>> GetCompletedJobsAsync(
             IReadOnlyList<HelixJobInfo> jobs,
             CancellationToken cancellationToken)
         {
-            var completedJobs = new List<HelixJobInfo>();
-
+            var completed = new List<HelixJobInfo>();
             foreach (HelixJobInfo job in jobs)
             {
                 if (job.IsCompleted || await AreAllWorkItemsTerminalAsync(job, cancellationToken))
                 {
-                    completedJobs.Add(job);
+                    completed.Add(job);
                 }
             }
 
-            return OrderHelixJobsOldToNew(completedJobs);
+            return MonitorState.OrderHelixJobsOldToNew(completed);
         }
 
-        private async Task LogHelixJobStatusAsync(
-            IReadOnlyList<HelixJobInfo> jobs,
-            HashSet<string> completedJobNames,
-            HashSet<string> processedJobNames,
-            CancellationToken cancellationToken)
-        {
-            List<HelixJobInfo> orderedJobs =
-            [
-                ..jobs
-                    .OrderBy(job => job.JobName, StringComparer.OrdinalIgnoreCase)
-            ];
-            var workItemsByJob = new Dictionary<string, IReadOnlyCollection<WorkItemSummary>>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (HelixJobInfo job in orderedJobs)
-            {
-                IReadOnlyCollection<WorkItemSummary> workItems = await _helix.ListWorkItemsAsync(job.JobName, cancellationToken);
-                LogFailedWorkItemConsoleLinks(job, [..workItems.Where(IsFailedWorkItem)]);
-                workItemsByJob[job.JobName] = workItems;
-            }
-
-            JobWorkItemStatusCounts counts = GetStatusCounts(orderedJobs, workItemsByJob, completedJobNames, processedJobNames);
-            _logger.LogInformation(
-                "ℹ️ Status: {ProcessedJobs} processed / {CompletedJobs} completed / {RunningJobs} running / {WaitingJobs} waiting jobs{nl}"
-              + "           {ProcessedWorkItems} processed / {CompletedWorkItems} completed / {RunningWorkItems} running / {WaitingWorkItems} waiting work items",
-                counts.ProcessedJobs,
-                counts.CompletedJobs,
-                counts.RunningJobs,
-                counts.WaitingJobs,
-                Environment.NewLine,
-                counts.ProcessedWorkItems,
-                counts.CompletedWorkItems,
-                counts.RunningWorkItems,
-                counts.WaitingWorkItems);
-
-            if (_options.Verbose)
-            {
-                LogVerboseHelixJobStatus(orderedJobs, workItemsByJob, completedJobNames, processedJobNames);
-            }
-        }
-
-        private static JobWorkItemStatusCounts GetStatusCounts(
-            IReadOnlyList<HelixJobInfo> jobs,
-            IReadOnlyDictionary<string, IReadOnlyCollection<WorkItemSummary>> workItemsByJob,
-            HashSet<string> completedJobNames,
-            HashSet<string> processedJobNames)
-        {
-            int processedJobs = 0;
-            int processedWorkItems = 0;
-            int completedJobs = 0;
-            int completedWorkItems = 0;
-            int runningJobs = 0;
-            int runningWorkItems = 0;
-            int waitingJobs = 0;
-            int waitingWorkItems = 0;
-
-            foreach (HelixJobInfo job in jobs)
-            {
-                IReadOnlyCollection<WorkItemSummary> workItems = workItemsByJob[job.JobName];
-
-                if (processedJobNames.Contains(job.JobName))
-                {
-                    processedJobs++;
-                    processedWorkItems += workItems.Count;
-                }
-
-                if (completedJobNames.Contains(job.JobName))
-                {
-                    completedJobs++;
-                    completedWorkItems += workItems.Count;
-                }
-                else if (workItems.Count > 0)
-                {
-                    runningJobs++;
-                    runningWorkItems += workItems.Count;
-                }
-                else
-                {
-                    waitingJobs++;
-                    waitingWorkItems += job.InitialWorkItemCount ?? 0;
-                }
-            }
-
-            return new JobWorkItemStatusCounts(
-                processedJobs,
-                processedWorkItems,
-                completedJobs,
-                completedWorkItems,
-                runningJobs,
-                runningWorkItems,
-                waitingJobs,
-                waitingWorkItems);
-        }
-
-        private void LogVerboseHelixJobStatus(
-            IReadOnlyList<HelixJobInfo> jobs,
-            IReadOnlyDictionary<string, IReadOnlyCollection<WorkItemSummary>> workItemsByJob,
-            HashSet<string> completedJobNames,
-            HashSet<string> processedJobNames)
-        {
-            if (jobs.Count == 0)
-            {
-                _logger.LogInformation("⏳ Helix job details:{nl}└─ no Helix jobs discovered yet", Environment.NewLine);
-                return;
-            }
-
-            var lines = new List<string>();
-            for (int jobIndex = 0; jobIndex < jobs.Count; jobIndex++)
-            {
-                HelixJobInfo job = jobs[jobIndex];
-                IReadOnlyCollection<WorkItemSummary> workItems = workItemsByJob[job.JobName];
-                AddVerboseJobLines(lines, job, workItems, GetJobStatus(job, workItems, completedJobNames, processedJobNames), isLastJob: jobIndex == jobs.Count - 1);
-            }
-
-            _logger.LogInformation("⏳ Helix job details:{nl}{JobDetails}",
-                Environment.NewLine,
-                string.Join(Environment.NewLine, lines));
-        }
-
-        private static void AddVerboseJobLines(
-            List<string> lines,
-            HelixJobInfo job,
-            IReadOnlyCollection<WorkItemSummary> workItems,
-            string jobStatus,
-            bool isLastJob)
-        {
-            string jobConnector = isLastJob ? "└─" : "├─";
-            string childPrefix = isLastJob ? "   " : "│  ";
-            lines.Add($"{jobConnector} 🧪 Helix job {job.DisplayName} [{jobStatus}]");
-
-            List<WorkItemSummary> orderedWorkItems =
-            [
-                ..workItems.OrderBy(wi => wi.Name, StringComparer.OrdinalIgnoreCase)
-            ];
-
-            if (orderedWorkItems.Count == 0)
-            {
-                lines.Add($"{childPrefix}└─ no work items reported yet");
-                return;
-            }
-
-            for (int workItemIndex = 0; workItemIndex < orderedWorkItems.Count; workItemIndex++)
-            {
-                WorkItemSummary workItem = orderedWorkItems[workItemIndex];
-                string workItemConnector = workItemIndex == orderedWorkItems.Count - 1 ? "└─" : "├─";
-                string console = IsFailedWorkItem(workItem)
-                    ? $" | Console: {GetConsoleOutputText(workItem.ConsoleOutputUri)}"
-                    : string.Empty;
-                lines.Add($"{childPrefix}{workItemConnector} {workItem.Name} ({FormatWorkItemState(workItem)}){console}");
-            }
-        }
-
-        private static string GetJobStatus(
-            HelixJobInfo job,
-            IReadOnlyCollection<WorkItemSummary> workItems,
-            HashSet<string> completedJobNames,
-            HashSet<string> processedJobNames)
-        {
-            if (processedJobNames.Contains(job.JobName))
-            {
-                return "Processed";
-            }
-
-            if (completedJobNames.Contains(job.JobName))
-            {
-                return "Completed";
-            }
-
-            return workItems.Count > 0 ? "Running" : "Waiting";
-        }
-
-        private static string FormatWorkItemState(WorkItemSummary workItem)
-        {
-            string exitCode = workItem.ExitCode.HasValue ? $", exit code {workItem.ExitCode.Value}" : string.Empty;
-            return $"{workItem.State}{exitCode}";
-        }
-
-        private async Task<bool> AreAllWorkItemsTerminalAsync(
-            HelixJobInfo job,
-            CancellationToken cancellationToken)
+        private async Task<bool> AreAllWorkItemsTerminalAsync(HelixJobInfo job, CancellationToken cancellationToken)
         {
             if (job.InitialWorkItemCount is not > 0)
             {
@@ -538,490 +357,44 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 && workItems.All(wi => wi.ExitCode.HasValue);
         }
 
-        private async Task ProcessCompletedJobAsync(
-            HelixJobInfo helixJob,
-            bool uploadTestResults,
-            CancellationToken cancellationToken)
+        private async Task CancelInFlightHelixJobsAsync(CancellationToken cancellationToken)
         {
-            if (!uploadTestResults && _workItemOutcomeJobs.Contains(helixJob.JobName))
+            List<HelixJobInfo> inFlightJobs =
+            [
+                ..MonitorState.GetLatestHelixJobAttempts(_state.AssociatedJobs.Values)
+                    .Where(j => !j.IsCompleted && !_state.ProcessedHelixJobs.Contains(j.JobName))
+                    .OrderBy(j => j.JobName, StringComparer.OrdinalIgnoreCase)
+            ];
+
+            if (inFlightJobs.Count == 0)
             {
                 return;
             }
 
-            _logger.LogInformation("Job {JobName} completed. Processing test results...{nl}{JobUri}", helixJob.DisplayName, Environment.NewLine, helixJob.DetailsUri);
+            _logger.LogWarning("Cancellation requested. Attempting to cancel {Count} in-flight Helix job(s).", inFlightJobs.Count);
 
-            IReadOnlyCollection<WorkItemSummary> workItems = await _helix.ListWorkItemsAsync(helixJob.JobName, cancellationToken);
-            LogFailedWorkItemConsoleLinks(helixJob, [..workItems.Where(wi => wi.IsFailed)]);
-
-            // Update per-work-item outcome tracking
-            if (_workItemOutcomeJobs.Add(helixJob.JobName))
-            {
-                string chainKey = GetSubmitterChainKey(helixJob);
-                var jobWorkItems = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                foreach (WorkItemSummary wi in workItems)
-                {
-                    // Within the same AzDO submitter chain (i.e. resubmissions of the same
-                    // logical AzDO job), the latest result overwrites the prior one for the
-                    // same work item name. Across different submitter chains the key differs,
-                    // so identically-named work items in different AzDO jobs are tracked
-                    // independently.
-                    _workItemOutcomes[(chainKey, wi.Name)] = !wi.IsFailed;
-                    TrackFailedWorkItemConsoleInfo(helixJob, chainKey, wi);
-                    jobWorkItems.Add(wi.Name);
-                }
-
-                _workItemsByJob[helixJob.JobName] = jobWorkItems;
-            }
-
-            int failedWorkItemCount = workItems.Count(wi => wi.IsFailed);
-            int successfulWorkItemCount = workItems.Count - failedWorkItemCount;
-
-            if (uploadTestResults)
-            {
-                QueueTestResultUpload(helixJob, workItems, cancellationToken);
-            }
-
-            _logger.LogInformation("{Icon} Job '{JobName}' {Status} ({PassedCount} passed, {FailedCount} failed){nl}{JobUri}",
-                failedWorkItemCount == 0 ? "✅" : "❌",
-                helixJob.DisplayName,
-                failedWorkItemCount == 0 ? "succeeded" : "failed",
-                successfulWorkItemCount,
-                failedWorkItemCount,
-                Environment.NewLine, helixJob.DetailsUri);
-        }
-
-        private void QueueTestResultUpload(
-            HelixJobInfo helixJob,
-            IReadOnlyCollection<WorkItemSummary> workItems,
-            CancellationToken cancellationToken)
-        {
-            IReadOnlyList<string> workItemNames = [.. workItems.Select(w => w.Name)];
-            Task uploadTask = Task.Run(
-                () => UploadTestResultsForJobAsync(helixJob, workItemNames, cancellationToken),
-                CancellationToken.None);
-            _pendingTestResultUploads.Add(uploadTask);
-        }
-
-        private async Task UploadTestResultsForJobAsync(
-            HelixJobInfo helixJob,
-            IReadOnlyCollection<string> workItemNames,
-            CancellationToken cancellationToken)
-        {
-            while (true)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                int testRunId = 0;
-
-                try
-                {
-                    testRunId = await _azdo.CreateTestRunAsync(helixJob.TestRunName, helixJob.JobName, cancellationToken);
-                    IReadOnlyList<WorkItemTestResults> downloadedFiles = await _helix.DownloadTestResultsAsync(
-                        helixJob.JobName,
-                        workItemNames,
-                        _options.WorkingDirectory,
-                        cancellationToken);
-
-                    int uploadedCount = await _azdo.UploadTestResultsAsync(testRunId, downloadedFiles, cancellationToken);
-                    await CompleteUploadedTestRunAsync(testRunId, helixJob, cancellationToken);
-
-                    _logger.LogInformation("{UploadedCount} test results for job '{JobName}' processed.",
-                        uploadedCount,
-                        helixJob.DisplayName);
-                    return;
-                }
-                catch (OperationCanceledException)
-                {
-                    throw;
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogDebug(ex,
-                        "Failed to upload test results for job {JobName} to Azure DevOps. Test run ID was {TestRunId}. Retrying after delay.",
-                        helixJob.DisplayName,
-                        testRunId);
-                    await Delay(cancellationToken);
-                }
-            }
-        }
-
-        private async Task CompleteUploadedTestRunAsync(
-            int testRunId,
-            HelixJobInfo helixJob,
-            CancellationToken cancellationToken)
-        {
-            while (true)
+            await Task.WhenAll(inFlightJobs.Select(async job =>
             {
                 try
                 {
-                    await _azdo.CompleteTestRunAsync(testRunId, cancellationToken);
-                    return;
+                    await _helix.CancelJobAsync(job.JobName, cancellationToken);
+                    _logger.LogWarning("🛑 Requested cancellation of Helix job {JobName}.{nl}{JobUri}",
+                        job.DisplayName, Environment.NewLine, job.DetailsUri);
                 }
                 catch (OperationCanceledException)
                 {
-                    throw;
+                    // Bounded cancel window elapsed; nothing more to do.
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogDebug(ex,
-                        "Failed to complete Azure DevOps test run {TestRunId} for job {JobName}. Retrying after delay.",
-                        testRunId,
-                        helixJob.JobName);
-                    await Delay(cancellationToken);
+                    _logger.LogWarning(ex, "Failed to cancel Helix job {JobName}.", job.DisplayName);
                 }
-            }
+            }));
         }
 
-        private void PruneCompletedTestResultUploads()
-        {
-            _pendingTestResultUploads.RemoveAll(static task => task.IsCompleted);
-        }
-
-        private async Task WaitForPendingTestResultUploadsAsync(CancellationToken cancellationToken)
-        {
-            PruneCompletedTestResultUploads();
-            if (_pendingTestResultUploads.Count == 0)
-            {
-                return;
-            }
-
-            // When test uploads are the last thing running, we want to speed it up
-            // Rate limiting should be dealt with by retry logic in the upload tasks
-            _options.TestResultUploadParallelism = 16;
-
-            _logger.LogInformation("Waiting for {Count} pending test result upload(s) to complete.", _pendingTestResultUploads.Count);
-            await Task.WhenAll(_pendingTestResultUploads);
-            PruneCompletedTestResultUploads();
-        }
-
-        private void LogFailedWorkItemConsoleLinks(HelixJobInfo helixJob, IReadOnlyCollection<WorkItemSummary> workItems)
-        {
-            foreach (WorkItemSummary workItem in workItems.OrderBy(wi => wi.Name, StringComparer.OrdinalIgnoreCase))
-            {
-                if (!_reportedFailedWorkItemConsoleLinks.Add(GetWorkItemKey(helixJob.JobName, workItem.Name)))
-                {
-                    continue;
-                }
-
-                _logger.LogInformation("❌ Work item '{WorkItemName}' in job '{JobName}' failed ({State}).{nl}Console: {ConsoleOutputUri}",
-                    workItem.Name,
-                    helixJob.DisplayName,
-                    FormatWorkItemState(workItem),
-                    Environment.NewLine,
-                    GetConsoleOutputText(workItem.ConsoleOutputUri));
-            }
-        }
-
-        private static bool IsUnfinishedWorkItem(WorkItemSummary workItem)
-            => !workItem.ExitCode.HasValue
-                && !string.Equals(workItem.State, "Finished", StringComparison.OrdinalIgnoreCase)
-                && !string.Equals(workItem.State, "Failed", StringComparison.OrdinalIgnoreCase)
-                && !string.Equals(workItem.State, "TimedOut", StringComparison.OrdinalIgnoreCase);
-
-        private static bool IsFailedWorkItem(WorkItemSummary workItem)
-            => workItem.IsFailed && !IsUnfinishedWorkItem(workItem);
-
-        private sealed record JobWorkItemStatusCounts(
-            int ProcessedJobs,
-            int ProcessedWorkItems,
-            int CompletedJobs,
-            int CompletedWorkItems,
-            int RunningJobs,
-            int RunningWorkItems,
-            int WaitingJobs,
-            int WaitingWorkItems);
-
-        private static string GetWorkItemKey(string jobName, string workItemName)
-            => $"{jobName}/{workItemName}";
-
-        private void TrackFailedWorkItemConsoleInfo(HelixJobInfo helixJob, string chainKey, WorkItemSummary workItem)
-        {
-            var key = (chainKey, workItem.Name);
-            if (workItem.IsFailed)
-            {
-                _failedWorkItemConsoleInfo[key] = new FailedWorkItemConsoleInfo(
-                    helixJob.DisplayName,
-                    workItem.Name,
-                    FormatWorkItemState(workItem),
-                    GetConsoleOutputText(workItem.ConsoleOutputUri));
-            }
-            else
-            {
-                _failedWorkItemConsoleInfo.Remove(key);
-            }
-        }
-
-        /// <summary>
-        /// Produces a key that rolls up work-item outcomes within a logical AzDO submitter
-        /// chain. When the job carries an AzDO <c>System.JobName</c>, the chain key is based
-        /// on that name combined with the Helix <c>QueueId</c> (so resubmissions of the same
-        /// AzDO job to the same queue share the same key while a single AzDO matrix leg that
-        /// fans out to multiple Helix queues — each producing its own Helix job under the
-        /// same <c>System.JobName</c> — stays distinct and cannot overwrite a sibling queue's
-        /// failure with a pass). When there is no submitter name (test scenarios, manual Helix
-        /// submissions), the chain is followed back through <c>PreviousHelixJobName</c> links
-        /// to the root and the root Helix job name is used instead, so that retries still
-        /// overwrite prior failures correctly.
-        /// </summary>
-        private string GetSubmitterChainKey(HelixJobInfo job)
-        {
-            if (!string.IsNullOrEmpty(job.SubmitterJobName))
-            {
-                return FormatSubmitterChainKey(job.SubmitterJobName, job.QueueId);
-            }
-
-            HelixJobInfo current = job;
-            var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            while (current is not null
-                && !string.IsNullOrEmpty(current.PreviousHelixJobName)
-                && visited.Add(current.JobName))
-            {
-                if (!_knownJobsByName.TryGetValue(current.PreviousHelixJobName, out HelixJobInfo previous))
-                {
-                    return $"helix:{current.PreviousHelixJobName}";
-                }
-
-                if (!string.IsNullOrEmpty(previous.SubmitterJobName))
-                {
-                    return FormatSubmitterChainKey(previous.SubmitterJobName, previous.QueueId);
-                }
-
-                current = previous;
-            }
-
-            return $"helix:{(current?.JobName ?? job.JobName)}";
-        }
-
-        private static string FormatSubmitterChainKey(string submitterJobName, string queueId)
-            => string.IsNullOrEmpty(queueId)
-                ? $"submitter:{submitterJobName}"
-                : $"submitter:{submitterJobName}|queue:{queueId}";
-
-        private void LogFinalFailedWorkItemConsoleInfo()
-        {
-            if (_failedWorkItemConsoleInfo.Count == 0)
-            {
-                return;
-            }
-
-            List<FailedWorkItemConsoleInfo> failures =
-            [
-                .._failedWorkItemConsoleInfo.Values
-                    .OrderBy(failure => failure.WorkItemName, StringComparer.OrdinalIgnoreCase)
-            ];
-
-            var lines = new List<string>();
-            for (int i = 0; i < failures.Count; i++)
-            {
-                FailedWorkItemConsoleInfo failure = failures[i];
-                string connector = i == failures.Count - 1 ? "└─" : "├─";
-                lines.Add($"{connector} {failure.WorkItemName} (Job: {failure.JobName}) ({failure.State})");
-                lines.Add($"{(i == failures.Count - 1 ? "   " : "│  ")}└─ Console: {failure.ConsoleOutput}");
-            }
-
-            _logger.LogError("❌ Failed work item console logs:{nl}Test results: {TestResultsUri}{nl}{FailedWorkItemConsoleLogs}",
-                Environment.NewLine,
-                GetTestResultsUri(),
-                Environment.NewLine,
-                string.Join(Environment.NewLine, lines));
-        }
-
-        private string GetTestResultsUri()
-            => $"{_options.CollectionUri}{_options.TeamProject}/_build/results?buildId={_options.BuildId}&view=ms.vss-test-web.build-test-results-tab";
-
-        private static string GetConsoleOutputText(string consoleOutputUri)
-            => string.IsNullOrEmpty(consoleOutputUri) ? "no console link available" : consoleOutputUri;
-
-        private async Task<JobResubmissionResult> ResubmitFailedJobsAsync(CancellationToken cancellationToken)
-        {
-            _logger.LogInformation("🔁 Checking for failed Helix jobs to resubmit the failed work items...");
-
-            var retryingHelixSubmitterJobs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            var resubmittedJobs = new List<HelixJobInfo>();
-            int resubmittedWorkItemCount = 0;
-
-            // This snapshot is taken when the monitor starts. Failed latest work items here are
-            // not retried again until the monitor starts again, even if they fail during this run.
-            IReadOnlyList<HelixJobInfo> allJobs = await _helix.GetJobsForBuildAsync(_helixSource, _options.BuildId, cancellationToken);
-            IReadOnlyList<HelixJobInfo> scopedJobs =
-            [
-                ..allJobs.Where(IsHelixJobInScope)
-            ];
-            IReadOnlyList<HelixJobInfo> latestJobs = GetLatestHelixJobAttempts(scopedJobs);
-            List<HelixJobInfo> completedHelixJobs =
-            [
-                ..latestJobs.Where(j => j.IsCompleted && IsHelixJobInScope(j))
-            ];
-
-            foreach (HelixJobInfo completedJob in completedHelixJobs)
-            {
-                IReadOnlyCollection<WorkItemSummary> workItems = await _helix.ListWorkItemsAsync(completedJob.JobName, cancellationToken);
-                IReadOnlyCollection<WorkItemSummary> failedWorkItems = [..workItems.Where(wi => wi.IsFailed)];
-
-                if (failedWorkItems.Count > 0)
-                {
-                    HelixJobInfo resubmittedJob = await _helix.ResubmitWorkItemsAsync(completedJob, failedWorkItems, cancellationToken);
-                    if (resubmittedJob != null)
-                    {
-                        resubmittedJobs.Add(resubmittedJob);
-                        resubmittedWorkItemCount += failedWorkItems.Count;
-
-                        if (!string.IsNullOrEmpty(completedJob.SubmitterJobName))
-                        {
-                            retryingHelixSubmitterJobs.Add(completedJob.SubmitterJobName);
-                        }
-                    }
-                }
-            }
-
-            if (resubmittedJobs.Count == 0)
-            {
-                _logger.LogInformation("No failed jobs found to resubmit");
-            }
-
-            return new JobResubmissionResult(
-                retryingHelixSubmitterJobs,
-                [..scopedJobs, ..resubmittedJobs],
-                resubmittedJobs.Count,
-                resubmittedWorkItemCount);
-        }
-
-        private bool IsHelixJobInScope(HelixJobInfo job)
-        {
-            return string.IsNullOrEmpty(job.StageName)
+        private bool IsInScope(HelixJobInfo job)
+            => string.IsNullOrEmpty(job.StageName)
                 || string.Equals(job.StageName, _options.StageName, StringComparison.OrdinalIgnoreCase);
-        }
-
-        private static IReadOnlyList<HelixJobInfo> GetLatestHelixJobAttempts(IEnumerable<HelixJobInfo> jobs)
-        {
-            var supersededJobNames = new HashSet<string>(
-                jobs
-                    .Select(j => j.PreviousHelixJobName)
-                    .Where(previousJobName => !string.IsNullOrEmpty(previousJobName)),
-                StringComparer.OrdinalIgnoreCase);
-
-            return
-            [
-                ..jobs.Where(j => !supersededJobNames.Contains(j.JobName))
-            ];
-        }
-
-        private static IReadOnlyList<HelixJobInfo> OrderHelixJobsOldToNew(IEnumerable<HelixJobInfo> jobs)
-        {
-            var jobByName = jobs.ToDictionary(j => j.JobName, StringComparer.OrdinalIgnoreCase);
-            return
-            [
-                ..jobs
-                    .OrderBy(j => GetHelixJobLineageDepth(j, jobByName))
-                    .ThenBy(j => j.JobName, StringComparer.OrdinalIgnoreCase)
-            ];
-        }
-
-        private static int GetHelixJobLineageDepth(HelixJobInfo job, Dictionary<string, HelixJobInfo> jobByName)
-        {
-            int depth = 0;
-            var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-            while (!string.IsNullOrEmpty(job.PreviousHelixJobName)
-                && visited.Add(job.PreviousHelixJobName)
-                && jobByName.TryGetValue(job.PreviousHelixJobName, out job))
-            {
-                depth++;
-            }
-
-            return depth;
-        }
-
-        private sealed record JobResubmissionResult(
-            HashSet<string> RetryingHelixSubmitterJobs,
-            IReadOnlyList<HelixJobInfo> JobsForFirstPoll,
-            int ResubmittedJobCount,
-            int ResubmittedWorkItemCount);
-
-        private sealed record FailedWorkItemConsoleInfo(
-            string JobName,
-            string WorkItemName,
-            string State,
-            string ConsoleOutput);
-
-        private sealed class WorkItemOutcomeKeyComparer : IEqualityComparer<(string ChainKey, string WorkItemName)>
-        {
-            public static readonly WorkItemOutcomeKeyComparer Instance = new();
-
-            public bool Equals((string ChainKey, string WorkItemName) x, (string ChainKey, string WorkItemName) y)
-                => StringComparer.OrdinalIgnoreCase.Equals(x.ChainKey, y.ChainKey)
-                    && StringComparer.OrdinalIgnoreCase.Equals(x.WorkItemName, y.WorkItemName);
-
-            public int GetHashCode((string ChainKey, string WorkItemName) obj)
-                => HashCode.Combine(
-                    obj.ChainKey is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(obj.ChainKey),
-                    obj.WorkItemName is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(obj.WorkItemName));
-        }
-
-        private void ReportTimeout(
-            IEnumerable<HelixJobInfo> latestAssociatedJobs,
-            HashSet<string> processedHelixJobs,
-            IReadOnlyList<AzureDevOpsTimelineRecord> latestTimelineRecords)
-        {
-            var timeout = TimeSpan.FromMinutes(_options.MaximumWaitMinutes);
-            var unfinishedHelixJobs = GetLatestHelixJobAttempts(latestAssociatedJobs)
-                .Where(j => !j.IsCompleted || !processedHelixJobs.Contains(j.JobName))
-                .OrderBy(j => j.JobName, StringComparer.OrdinalIgnoreCase)
-                .ToList();
-            var inProgressPipelineJobs = GetInProgressNonMonitorPipelineJobs(latestTimelineRecords, _options.JobMonitorName)
-                .OrderBy(r => r.Name ?? r.ReferenceName ?? r.Identifier ?? string.Empty, StringComparer.OrdinalIgnoreCase)
-                .ToList();
-
-            if (unfinishedHelixJobs.Count == 0 && inProgressPipelineJobs.Count == 0)
-            {
-                _logger.LogCritical("Helix Job Monitor timed out after {TimeoutMinutes} minute(s) ({Timeout}). No unfinished Helix or Azure DevOps jobs were tracked at the time of timeout.",
-                    timeout.TotalMinutes,
-                    timeout);
-                return;
-            }
-
-            if (unfinishedHelixJobs.Count > 0)
-            {
-                _logger.LogError(
-                    $"Helix Job Monitor timed out after {{TimeoutMinutes}} minute(s) ({{Timeout}}). {{UnfinishedCount}} Helix job(s) were unfinished or unprocessed:{Environment.NewLine}- {{UnfinishedJobs}}{Environment.NewLine}",
-                    timeout.TotalMinutes,
-                    timeout,
-                    unfinishedHelixJobs.Count,
-                    string.Join(Environment.NewLine + "- ", unfinishedHelixJobs.Select(FormatUnfinishedHelixJobForTimeoutLog)));
-            }
-
-            if (inProgressPipelineJobs.Count > 0)
-            {
-                _logger.LogError(
-                    $"At timeout, {{InProgressCount}} non-monitor Azure DevOps pipeline job(s) were still in progress or queued:{Environment.NewLine}- {{InProgressJobs}}{Environment.NewLine}",
-                    inProgressPipelineJobs.Count,
-                    string.Join(Environment.NewLine + "- ", inProgressPipelineJobs.Select(FormatInProgressPipelineJobForTimeoutLog)));
-            }
-        }
-
-        private static IEnumerable<AzureDevOpsTimelineRecord> GetInProgressNonMonitorPipelineJobs(
-            IReadOnlyList<AzureDevOpsTimelineRecord> timelineRecords,
-            string jobMonitorName)
-            => HelixJobMonitorUtilities.GetRelevantNonMonitorJobRecords(timelineRecords, jobMonitorName)
-                .Where(r => !string.Equals(r.State, "completed", StringComparison.OrdinalIgnoreCase));
-
-        private static string FormatUnfinishedHelixJobForTimeoutLog(HelixJobInfo helixJob)
-        {
-            string workItemCountText = helixJob.InitialWorkItemCount?.ToString() ?? "unknown";
-            return $"{helixJob.DisplayName} [status={helixJob.Status}, initialWorkItems={workItemCountText}]{Environment.NewLine}  {helixJob.DetailsUri}";
-        }
-
-        private static string FormatInProgressPipelineJobForTimeoutLog(AzureDevOpsTimelineRecord timelineRecord)
-        {
-            string state = string.IsNullOrEmpty(timelineRecord.State) ? "unknown" : timelineRecord.State;
-            string result = string.IsNullOrEmpty(timelineRecord.Result) ? "none" : timelineRecord.Result;
-            string name = string.IsNullOrEmpty(timelineRecord.Name) ? timelineRecord.ReferenceName : timelineRecord.Name;
-            if (string.IsNullOrEmpty(name))
-            {
-                name = timelineRecord.Identifier;
-            }
-
-            return $"{name} [state={state}, result={result}]";
-        }
 
         public void Dispose()
         {
@@ -1031,13 +404,16 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
         private Task Delay(CancellationToken cancellationToken)
             => _delayFunc(TimeSpan.FromSeconds(Math.Max(5, _options.PollingIntervalSeconds)), cancellationToken);
-    }
-}
 
-static file class WorkItemExtensions
-{
-    extension(WorkItemSummary workItem)
-    {
-        public bool IsFailed => workItem.ExitCode != 0 || !workItem.State.Equals("Finished", StringComparison.OrdinalIgnoreCase);
+        /// <summary>
+        /// Mutable per-loop cursor used by <see cref="PollOnceAsync"/> to decide when to
+        /// emit a status log line.
+        /// </summary>
+        private sealed class PollLoopState
+        {
+            public int LastObservedJobCount { get; set; } = -1;
+            public int LastObservedCompletedCount { get; set; } = -1;
+            public DateTime LastStatusLogAt { get; set; } = DateTime.UtcNow;
+        }
     }
 }

--- a/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/JobMonitorRunner.cs
@@ -317,8 +317,6 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                     _state.TrackFailedWorkItemConsoleInfo(helixJob, chainKey, wi);
                     jobWorkItems.Add(wi.Name);
                 }
-
-                _state.WorkItemsByJob[helixJob.JobName] = jobWorkItems;
             }
 
             if (queueUpload)

--- a/src/Microsoft.DotNet.Helix/JobMonitor/MonitorState.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/MonitorState.cs
@@ -1,0 +1,247 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.DotNet.Helix.Client.Models;
+using Microsoft.DotNet.Helix.JobMonitor.Models;
+
+namespace Microsoft.DotNet.Helix.JobMonitor
+{
+    /// <summary>
+    /// Mutable container for every piece of runtime state the monitor accumulates while
+    /// observing a single invocation. Helpers (status reporter, upload queue, timeout
+    /// reporter) receive this by reference and read/update its fields directly so that the
+    /// runner's main loop is the only place that drives the lifecycle.
+    /// </summary>
+    internal sealed class MonitorState
+    {
+        /// <summary>
+        /// All Helix jobs the monitor has observed for this build, keyed by Helix job name.
+        /// Overwritten per poll so the cached entry reflects the latest Helix-side state
+        /// (in particular the <c>Finished</c> timestamp transitioning from null to a value).
+        /// </summary>
+        public Dictionary<string, HelixJobInfo> AssociatedJobs { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Cache of every Helix job we have seen this run, indexed by job name, so that
+        /// <see cref="GetSubmitterChainKey"/> can walk back through <c>PreviousHelixJobName</c>
+        /// links across polls.
+        /// </summary>
+        public Dictionary<string, HelixJobInfo> KnownJobsByName { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Helix jobs whose results have been uploaded to Azure DevOps in this or a prior
+        /// monitor invocation. Seeded on entry from the AzDO test-run name markers.
+        /// </summary>
+        public HashSet<string> ProcessedHelixJobs { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Tracks the latest outcome for each logical work item, keyed by
+        /// (SubmitterChainKey, WorkItemName). The chain key (not just the work-item name)
+        /// is used so that two AzDO jobs which happen to run identically-named Helix work
+        /// items do not overwrite each other's outcomes. Within a single AzDO submitter
+        /// chain, a resubmission still overwrites a prior failure for the same work-item
+        /// name because resubmitted Helix jobs inherit <c>System.JobName</c>.
+        /// </summary>
+        public Dictionary<(string ChainKey, string WorkItemName), bool> WorkItemOutcomes { get; }
+            = new(WorkItemOutcomeKeyComparer.Instance);
+
+        /// <summary>
+        /// Helix job names whose per-work-item outcomes have already been reconciled into
+        /// <see cref="WorkItemOutcomes"/>. Prevents the second reconciliation pass from
+        /// re-processing jobs that were observed in an earlier poll.
+        /// </summary>
+        public HashSet<string> WorkItemOutcomeJobs { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Tracks which work-item names belong to which Helix job, so resubmission only
+        /// resubmits items from the specific source job.
+        /// </summary>
+        public Dictionary<string, HashSet<string>> WorkItemsByJob { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Latest known console-link information for every failed work item, keyed the same
+        /// way as <see cref="WorkItemOutcomes"/>. Cleared per key when a later incarnation
+        /// passes. Used to build the final aggregated failure report.
+        /// </summary>
+        public Dictionary<(string ChainKey, string WorkItemName), FailedWorkItemConsoleInfo> FailedWorkItemConsoleInfo { get; }
+            = new(WorkItemOutcomeKeyComparer.Instance);
+
+        /// <summary>
+        /// Deduplication set for the per-failure console-link warnings emitted during
+        /// status logs and upload, so we don't spam the same link.
+        /// </summary>
+        public HashSet<string> ReportedFailedWorkItemConsoleLinks { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Last observed AzDO timeline records (scoped to the monitor's stage). Refreshed
+        /// every poll and consumed by the timeout report.
+        /// </summary>
+        public List<AzureDevOpsTimelineRecord> LatestTimelineRecords { get; } = [];
+
+        /// <summary>
+        /// AzDO submitter job names whose Helix work was resubmitted during the one-shot
+        /// retry pass. These jobs are excluded from the AzDO non-monitor failure check while
+        /// the current invocation runs (the failure is represented by the resubmitted work).
+        /// </summary>
+        public HashSet<string> RetryingHelixSubmitterJobs { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+        public int ResubmittedJobCount { get; set; }
+        public int ResubmittedWorkItemCount { get; set; }
+        public int ProcessedJobCount { get; set; }
+
+        public int FailedWorkItemCount => WorkItemOutcomes.Values.Count(passed => !passed);
+
+        public bool HasFailedWorkItem => WorkItemOutcomes.Values.Any(passed => !passed);
+
+        /// <summary>
+        /// Record a freshly-seen set of jobs into the per-poll and cross-poll caches.
+        /// </summary>
+        public void ObserveJobs(IEnumerable<HelixJobInfo> jobs)
+        {
+            foreach (HelixJobInfo job in jobs)
+            {
+                AssociatedJobs[job.JobName] = job;
+                KnownJobsByName[job.JobName] = job;
+            }
+        }
+
+        /// <summary>
+        /// Produces a key that rolls up work-item outcomes within a logical AzDO submitter
+        /// chain. When the job carries an AzDO <c>System.JobName</c>, the chain key is based
+        /// on that name combined with the Helix <c>QueueId</c> (so resubmissions of the same
+        /// AzDO job to the same queue share the same key while a single AzDO matrix leg that
+        /// fans out to multiple Helix queues — each producing its own Helix job under the
+        /// same <c>System.JobName</c> — stays distinct and cannot overwrite a sibling queue's
+        /// failure with a pass). When there is no submitter name (test scenarios, manual
+        /// Helix submissions), the chain is followed back through <c>PreviousHelixJobName</c>
+        /// links to the root and the root Helix job name is used instead, so that retries
+        /// still overwrite prior failures correctly.
+        /// </summary>
+        public string GetSubmitterChainKey(HelixJobInfo job)
+        {
+            if (!string.IsNullOrEmpty(job.SubmitterJobName))
+            {
+                return FormatSubmitterChainKey(job.SubmitterJobName, job.QueueId);
+            }
+
+            HelixJobInfo current = job;
+            var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            while (current is not null
+                && !string.IsNullOrEmpty(current.PreviousHelixJobName)
+                && visited.Add(current.JobName))
+            {
+                if (!KnownJobsByName.TryGetValue(current.PreviousHelixJobName, out HelixJobInfo previous))
+                {
+                    return $"helix:{current.PreviousHelixJobName}";
+                }
+
+                if (!string.IsNullOrEmpty(previous.SubmitterJobName))
+                {
+                    return FormatSubmitterChainKey(previous.SubmitterJobName, previous.QueueId);
+                }
+
+                current = previous;
+            }
+
+            return $"helix:{(current?.JobName ?? job.JobName)}";
+        }
+
+        private static string FormatSubmitterChainKey(string submitterJobName, string queueId)
+            => string.IsNullOrEmpty(queueId)
+                ? $"submitter:{submitterJobName}"
+                : $"submitter:{submitterJobName}|queue:{queueId}";
+
+        /// <summary>
+        /// From an arbitrary set of Helix jobs return only the leaves of each lineage chain —
+        /// jobs that are not pointed at by any other job's <c>PreviousHelixJobName</c>.
+        /// </summary>
+        public static IReadOnlyList<HelixJobInfo> GetLatestHelixJobAttempts(IEnumerable<HelixJobInfo> jobs)
+        {
+            var supersededJobNames = new HashSet<string>(
+                jobs.Select(j => j.PreviousHelixJobName)
+                    .Where(previousJobName => !string.IsNullOrEmpty(previousJobName)),
+                StringComparer.OrdinalIgnoreCase);
+
+            return [.. jobs.Where(j => !supersededJobNames.Contains(j.JobName))];
+        }
+
+        /// <summary>
+        /// Orders Helix jobs from oldest incarnation to newest by following the
+        /// <c>PreviousHelixJobName</c> link backwards. Used to ensure upload and outcome
+        /// reconciliation process lineage in the right order (older first, so newer
+        /// incarnations supersede older ones).
+        /// </summary>
+        public static IReadOnlyList<HelixJobInfo> OrderHelixJobsOldToNew(IEnumerable<HelixJobInfo> jobs)
+        {
+            var jobByName = jobs.ToDictionary(j => j.JobName, StringComparer.OrdinalIgnoreCase);
+            return
+            [
+                ..jobs
+                    .OrderBy(j => GetLineageDepth(j, jobByName))
+                    .ThenBy(j => j.JobName, StringComparer.OrdinalIgnoreCase)
+            ];
+        }
+
+        private static int GetLineageDepth(HelixJobInfo job, Dictionary<string, HelixJobInfo> jobByName)
+        {
+            int depth = 0;
+            var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            while (!string.IsNullOrEmpty(job.PreviousHelixJobName)
+                && visited.Add(job.PreviousHelixJobName)
+                && jobByName.TryGetValue(job.PreviousHelixJobName, out job))
+            {
+                depth++;
+            }
+
+            return depth;
+        }
+
+        /// <summary>
+        /// Tracks (or removes) the per-failure console-info record for a single observed
+        /// work item. Removal happens when a later incarnation passes.
+        /// </summary>
+        public void TrackFailedWorkItemConsoleInfo(HelixJobInfo helixJob, string chainKey, WorkItemSummary workItem)
+        {
+            var key = (chainKey, workItem.Name);
+            if (workItem.IsFailed)
+            {
+                FailedWorkItemConsoleInfo[key] = new FailedWorkItemConsoleInfo(
+                    helixJob.DisplayName,
+                    workItem.Name,
+                    workItem.FormattedState,
+                    GetConsoleOutputText(workItem.ConsoleOutputUri));
+            }
+            else
+            {
+                FailedWorkItemConsoleInfo.Remove(key);
+            }
+        }
+
+        public static string GetConsoleOutputText(string consoleOutputUri)
+            => string.IsNullOrEmpty(consoleOutputUri) ? "no console link available" : consoleOutputUri;
+    }
+
+    internal sealed record FailedWorkItemConsoleInfo(
+        string JobName,
+        string WorkItemName,
+        string State,
+        string ConsoleOutput);
+
+    internal sealed class WorkItemOutcomeKeyComparer : IEqualityComparer<(string ChainKey, string WorkItemName)>
+    {
+        public static readonly WorkItemOutcomeKeyComparer Instance = new();
+
+        public bool Equals((string ChainKey, string WorkItemName) x, (string ChainKey, string WorkItemName) y)
+            => StringComparer.OrdinalIgnoreCase.Equals(x.ChainKey, y.ChainKey)
+                && StringComparer.OrdinalIgnoreCase.Equals(x.WorkItemName, y.WorkItemName);
+
+        public int GetHashCode((string ChainKey, string WorkItemName) obj)
+            => HashCode.Combine(
+                obj.ChainKey is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(obj.ChainKey),
+                obj.WorkItemName is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(obj.WorkItemName));
+    }
+}

--- a/src/Microsoft.DotNet.Helix/JobMonitor/MonitorState.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/MonitorState.cs
@@ -56,12 +56,6 @@ namespace Microsoft.DotNet.Helix.JobMonitor
         public HashSet<string> WorkItemOutcomeJobs { get; } = new(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
-        /// Tracks which work-item names belong to which Helix job, so resubmission only
-        /// resubmits items from the specific source job.
-        /// </summary>
-        public Dictionary<string, HashSet<string>> WorkItemsByJob { get; } = new(StringComparer.OrdinalIgnoreCase);
-
-        /// <summary>
         /// Latest known console-link information for every failed work item, keyed the same
         /// way as <see cref="WorkItemOutcomes"/>. Cleared per key when a later incarnation
         /// passes. Used to build the final aggregated failure report.

--- a/src/Microsoft.DotNet.Helix/JobMonitor/StatusReporter.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/StatusReporter.cs
@@ -1,0 +1,402 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Helix.Client.Models;
+using Microsoft.DotNet.Helix.JobMonitor.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.Helix.JobMonitor
+{
+    /// <summary>
+    /// Owns every log line the monitor emits about progress, completions, failures, and
+    /// the timeout report. Reads from a shared <see cref="MonitorState"/> so the runner's
+    /// main loop only has to call into a small number of intent-named methods.
+    /// </summary>
+    internal sealed class StatusReporter
+    {
+        private readonly ILogger _logger;
+        private readonly JobMonitorOptions _options;
+        private readonly IHelixService _helix;
+        private readonly MonitorState _state;
+
+        public StatusReporter(ILogger logger, JobMonitorOptions options, IHelixService helix, MonitorState state)
+        {
+            _logger = logger;
+            _options = options;
+            _helix = helix;
+            _state = state;
+        }
+
+        public void LogMonitorStart()
+        {
+            _logger.LogInformation("Monitoring Helix jobs for stage {stage} of build {BuildId}:{nl}{collectionUri}{teamProject}/_build/results?buildId={BuildId}",
+                _options.StageName,
+                _options.BuildId,
+                Environment.NewLine,
+                _options.CollectionUri,
+                _options.TeamProject,
+                _options.BuildId);
+        }
+
+        public void LogRetryPassFoundNothing()
+        {
+            _logger.LogInformation("No failed jobs found to resubmit");
+        }
+
+        public void LogRetryPassStart()
+        {
+            _logger.LogInformation("🔁 Checking for failed Helix jobs to resubmit the failed work items...");
+        }
+
+        public void LogJobCompleted(HelixJobInfo helixJob, IReadOnlyCollection<WorkItemSummary> workItems)
+        {
+            int failedWorkItemCount = workItems.Count(wi => wi.IsFailed);
+            int successfulWorkItemCount = workItems.Count - failedWorkItemCount;
+
+            _logger.LogInformation("{Icon} Job '{JobName}' {Status} ({PassedCount} passed, {FailedCount} failed){nl}{JobUri}",
+                failedWorkItemCount == 0 ? "✅" : "❌",
+                helixJob.DisplayName,
+                failedWorkItemCount == 0 ? "succeeded" : "failed",
+                successfulWorkItemCount,
+                failedWorkItemCount,
+                Environment.NewLine, helixJob.DetailsUri);
+        }
+
+        public void LogJobProcessingStart(HelixJobInfo helixJob)
+        {
+            _logger.LogInformation("Job {JobName} completed. Processing test results...{nl}{JobUri}",
+                helixJob.DisplayName,
+                Environment.NewLine,
+                helixJob.DetailsUri);
+        }
+
+        /// <summary>
+        /// Emits one console-link warning per newly-observed failed work item (deduplicated
+        /// for the lifetime of this invocation).
+        /// </summary>
+        public void LogFailedWorkItemConsoleLinks(HelixJobInfo helixJob, IEnumerable<WorkItemSummary> workItems)
+        {
+            foreach (WorkItemSummary workItem in workItems.OrderBy(wi => wi.Name, StringComparer.OrdinalIgnoreCase))
+            {
+                if (!_state.ReportedFailedWorkItemConsoleLinks.Add($"{helixJob.JobName}/{workItem.Name}"))
+                {
+                    continue;
+                }
+
+                _logger.LogInformation("❌ Work item '{WorkItemName}' in job '{JobName}' failed ({State}).{nl}Console: {ConsoleOutputUri}",
+                    workItem.Name,
+                    helixJob.DisplayName,
+                    workItem.FormattedState,
+                    Environment.NewLine,
+                    MonitorState.GetConsoleOutputText(workItem.ConsoleOutputUri));
+            }
+        }
+
+        /// <summary>
+        /// Emits the one-line summary of work counts (and, in verbose mode, a tree of jobs
+        /// and work items). Also emits per-failure console-link warnings for any failed
+        /// work items observed in this poll that haven't been reported yet.
+        /// </summary>
+        public async Task LogPollStatusAsync(
+            IReadOnlyList<HelixJobInfo> jobs,
+            IReadOnlySet<string> completedJobNames,
+            CancellationToken cancellationToken)
+        {
+            List<HelixJobInfo> orderedJobs =
+            [
+                ..jobs.OrderBy(j => j.JobName, StringComparer.OrdinalIgnoreCase)
+            ];
+
+            var workItemsByJob = new Dictionary<string, IReadOnlyCollection<WorkItemSummary>>(StringComparer.OrdinalIgnoreCase);
+            foreach (HelixJobInfo job in orderedJobs)
+            {
+                IReadOnlyCollection<WorkItemSummary> workItems = await _helix.ListWorkItemsAsync(job.JobName, cancellationToken);
+                LogFailedWorkItemConsoleLinks(job, workItems.Where(wi => wi.IsFailedAndTerminal));
+                workItemsByJob[job.JobName] = workItems;
+            }
+
+            JobWorkItemStatusCounts counts = ComputeCounts(orderedJobs, workItemsByJob, completedJobNames);
+
+            _logger.LogInformation(
+                "ℹ️ Status: {ProcessedJobs} processed / {CompletedJobs} completed / {RunningJobs} running / {WaitingJobs} waiting jobs{nl}"
+              + "           {ProcessedWorkItems} processed / {CompletedWorkItems} completed / {RunningWorkItems} running / {WaitingWorkItems} waiting work items",
+                counts.ProcessedJobs,
+                counts.CompletedJobs,
+                counts.RunningJobs,
+                counts.WaitingJobs,
+                Environment.NewLine,
+                counts.ProcessedWorkItems,
+                counts.CompletedWorkItems,
+                counts.RunningWorkItems,
+                counts.WaitingWorkItems);
+
+            if (_options.Verbose)
+            {
+                LogVerboseTree(orderedJobs, workItemsByJob, completedJobNames);
+            }
+        }
+
+        public void LogFinalSummary(int totalAssociatedJobCount)
+        {
+            _logger.LogInformation(
+                "📊 Final summary:{nl}"
+              + "   Jobs:       {TotalJobs} submitted / {ResubmittedJobs} resubmitted / {ProcessedJobs} processed{nl}"
+              + "   Work items: {TotalWorkItems} submitted / {ResubmittedWorkItems} resubmitted / {FailedWorkItems} failed",
+                Environment.NewLine,
+                totalAssociatedJobCount,
+                _state.ResubmittedJobCount,
+                _state.ProcessedJobCount,
+                Environment.NewLine,
+                _state.WorkItemOutcomes.Count,
+                _state.ResubmittedWorkItemCount,
+                _state.FailedWorkItemCount);
+        }
+
+        public void LogNonMonitorPipelineFailure()
+        {
+            _logger.LogError("One or more non-monitor pipeline jobs failed.");
+        }
+
+        /// <summary>
+        /// Emits the final aggregated failure block (one block listing every still-failing
+        /// work item, prefixed with the test-results URL).
+        /// </summary>
+        public void LogFinalFailedWorkItems()
+        {
+            if (_state.FailedWorkItemConsoleInfo.Count == 0)
+            {
+                return;
+            }
+
+            List<FailedWorkItemConsoleInfo> failures =
+            [
+                .._state.FailedWorkItemConsoleInfo.Values
+                    .OrderBy(failure => failure.WorkItemName, StringComparer.OrdinalIgnoreCase)
+            ];
+
+            var lines = new List<string>();
+            for (int i = 0; i < failures.Count; i++)
+            {
+                FailedWorkItemConsoleInfo failure = failures[i];
+                bool isLast = i == failures.Count - 1;
+                string connector = isLast ? "└─" : "├─";
+                string childPrefix = isLast ? "   " : "│  ";
+                lines.Add($"{connector} {failure.WorkItemName} (Job: {failure.JobName}) ({failure.State})");
+                lines.Add($"{childPrefix}└─ Console: {failure.ConsoleOutput}");
+            }
+
+            _logger.LogError("❌ Failed work item console logs:{nl}Test results: {TestResultsUri}{nl}{FailedWorkItemConsoleLogs}",
+                Environment.NewLine,
+                GetTestResultsUri(),
+                Environment.NewLine,
+                string.Join(Environment.NewLine, lines));
+        }
+
+        /// <summary>
+        /// Emits the timeout report: groups of unfinished Helix jobs and in-progress AzDO
+        /// pipeline jobs, or a single critical-level note if nothing unfinished was tracked.
+        /// </summary>
+        public void ReportTimeout()
+        {
+            var timeout = TimeSpan.FromMinutes(_options.MaximumWaitMinutes);
+
+            List<HelixJobInfo> unfinishedHelixJobs =
+            [
+                ..MonitorState.GetLatestHelixJobAttempts(_state.AssociatedJobs.Values)
+                    .Where(j => !j.IsCompleted || !_state.ProcessedHelixJobs.Contains(j.JobName))
+                    .OrderBy(j => j.JobName, StringComparer.OrdinalIgnoreCase)
+            ];
+
+            List<AzureDevOpsTimelineRecord> inProgressPipelineJobs =
+            [
+                ..HelixJobMonitorUtilities
+                    .GetRelevantNonMonitorJobRecords(_state.LatestTimelineRecords, _options.JobMonitorName)
+                    .Where(r => !string.Equals(r.State, "completed", StringComparison.OrdinalIgnoreCase))
+                    .OrderBy(r => r.Name ?? r.ReferenceName ?? r.Identifier ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+            ];
+
+            if (unfinishedHelixJobs.Count == 0 && inProgressPipelineJobs.Count == 0)
+            {
+                _logger.LogCritical("Helix Job Monitor timed out after {TimeoutMinutes} minute(s) ({Timeout}). No unfinished Helix or Azure DevOps jobs were tracked at the time of timeout.",
+                    timeout.TotalMinutes,
+                    timeout);
+                return;
+            }
+
+            if (unfinishedHelixJobs.Count > 0)
+            {
+                _logger.LogError(
+                    $"Helix Job Monitor timed out after {{TimeoutMinutes}} minute(s) ({{Timeout}}). {{UnfinishedCount}} Helix job(s) were unfinished or unprocessed:{Environment.NewLine}- {{UnfinishedJobs}}{Environment.NewLine}",
+                    timeout.TotalMinutes,
+                    timeout,
+                    unfinishedHelixJobs.Count,
+                    string.Join(Environment.NewLine + "- ", unfinishedHelixJobs.Select(FormatUnfinishedHelixJob)));
+            }
+
+            if (inProgressPipelineJobs.Count > 0)
+            {
+                _logger.LogError(
+                    $"At timeout, {{InProgressCount}} non-monitor Azure DevOps pipeline job(s) were still in progress or queued:{Environment.NewLine}- {{InProgressJobs}}{Environment.NewLine}",
+                    inProgressPipelineJobs.Count,
+                    string.Join(Environment.NewLine + "- ", inProgressPipelineJobs.Select(FormatInProgressPipelineJob)));
+            }
+        }
+
+        private void LogVerboseTree(
+            IReadOnlyList<HelixJobInfo> jobs,
+            IReadOnlyDictionary<string, IReadOnlyCollection<WorkItemSummary>> workItemsByJob,
+            IReadOnlySet<string> completedJobNames)
+        {
+            if (jobs.Count == 0)
+            {
+                _logger.LogInformation("⏳ Helix job details:{nl}└─ no Helix jobs discovered yet", Environment.NewLine);
+                return;
+            }
+
+            var lines = new List<string>();
+            for (int jobIndex = 0; jobIndex < jobs.Count; jobIndex++)
+            {
+                HelixJobInfo job = jobs[jobIndex];
+                IReadOnlyCollection<WorkItemSummary> workItems = workItemsByJob[job.JobName];
+                AddVerboseJobLines(
+                    lines,
+                    job,
+                    workItems,
+                    GetJobStatus(job, workItems, completedJobNames),
+                    isLastJob: jobIndex == jobs.Count - 1);
+            }
+
+            _logger.LogInformation("⏳ Helix job details:{nl}{JobDetails}",
+                Environment.NewLine,
+                string.Join(Environment.NewLine, lines));
+        }
+
+        private static void AddVerboseJobLines(
+            List<string> lines,
+            HelixJobInfo job,
+            IReadOnlyCollection<WorkItemSummary> workItems,
+            string jobStatus,
+            bool isLastJob)
+        {
+            string jobConnector = isLastJob ? "└─" : "├─";
+            string childPrefix = isLastJob ? "   " : "│  ";
+            lines.Add($"{jobConnector} 🧪 Helix job {job.DisplayName} [{jobStatus}]");
+
+            List<WorkItemSummary> orderedWorkItems =
+            [
+                ..workItems.OrderBy(wi => wi.Name, StringComparer.OrdinalIgnoreCase)
+            ];
+
+            if (orderedWorkItems.Count == 0)
+            {
+                lines.Add($"{childPrefix}└─ no work items reported yet");
+                return;
+            }
+
+            for (int i = 0; i < orderedWorkItems.Count; i++)
+            {
+                WorkItemSummary workItem = orderedWorkItems[i];
+                string connector = i == orderedWorkItems.Count - 1 ? "└─" : "├─";
+                string console = workItem.IsFailedAndTerminal
+                    ? $" | Console: {MonitorState.GetConsoleOutputText(workItem.ConsoleOutputUri)}"
+                    : string.Empty;
+                lines.Add($"{childPrefix}{connector} {workItem.Name} ({workItem.FormattedState}){console}");
+            }
+        }
+
+        private string GetJobStatus(
+            HelixJobInfo job,
+            IReadOnlyCollection<WorkItemSummary> workItems,
+            IReadOnlySet<string> completedJobNames)
+        {
+            if (_state.ProcessedHelixJobs.Contains(job.JobName))
+            {
+                return "Processed";
+            }
+
+            if (completedJobNames.Contains(job.JobName))
+            {
+                return "Completed";
+            }
+
+            return workItems.Count > 0 ? "Running" : "Waiting";
+        }
+
+        private JobWorkItemStatusCounts ComputeCounts(
+            IReadOnlyList<HelixJobInfo> jobs,
+            IReadOnlyDictionary<string, IReadOnlyCollection<WorkItemSummary>> workItemsByJob,
+            IReadOnlySet<string> completedJobNames)
+        {
+            int processedJobs = 0, processedWorkItems = 0;
+            int completedJobs = 0, completedWorkItems = 0;
+            int runningJobs = 0, runningWorkItems = 0;
+            int waitingJobs = 0, waitingWorkItems = 0;
+
+            foreach (HelixJobInfo job in jobs)
+            {
+                IReadOnlyCollection<WorkItemSummary> workItems = workItemsByJob[job.JobName];
+
+                if (_state.ProcessedHelixJobs.Contains(job.JobName))
+                {
+                    processedJobs++;
+                    processedWorkItems += workItems.Count;
+                }
+
+                if (completedJobNames.Contains(job.JobName))
+                {
+                    completedJobs++;
+                    completedWorkItems += workItems.Count;
+                }
+                else if (workItems.Count > 0)
+                {
+                    runningJobs++;
+                    runningWorkItems += workItems.Count;
+                }
+                else
+                {
+                    waitingJobs++;
+                    waitingWorkItems += job.InitialWorkItemCount ?? 0;
+                }
+            }
+
+            return new JobWorkItemStatusCounts(
+                processedJobs, processedWorkItems,
+                completedJobs, completedWorkItems,
+                runningJobs, runningWorkItems,
+                waitingJobs, waitingWorkItems);
+        }
+
+        private string GetTestResultsUri()
+            => $"{_options.CollectionUri}{_options.TeamProject}/_build/results?buildId={_options.BuildId}&view=ms.vss-test-web.build-test-results-tab";
+
+        private static string FormatUnfinishedHelixJob(HelixJobInfo helixJob)
+        {
+            string workItemCountText = helixJob.InitialWorkItemCount?.ToString() ?? "unknown";
+            return $"{helixJob.DisplayName} [status={helixJob.Status}, initialWorkItems={workItemCountText}]{Environment.NewLine}  {helixJob.DetailsUri}";
+        }
+
+        private static string FormatInProgressPipelineJob(AzureDevOpsTimelineRecord timelineRecord)
+        {
+            string state = string.IsNullOrEmpty(timelineRecord.State) ? "unknown" : timelineRecord.State;
+            string result = string.IsNullOrEmpty(timelineRecord.Result) ? "none" : timelineRecord.Result;
+            string name = string.IsNullOrEmpty(timelineRecord.Name) ? timelineRecord.ReferenceName : timelineRecord.Name;
+            if (string.IsNullOrEmpty(name))
+            {
+                name = timelineRecord.Identifier;
+            }
+
+            return $"{name} [state={state}, result={result}]";
+        }
+
+        private sealed record JobWorkItemStatusCounts(
+            int ProcessedJobs, int ProcessedWorkItems,
+            int CompletedJobs, int CompletedWorkItems,
+            int RunningJobs, int RunningWorkItems,
+            int WaitingJobs, int WaitingWorkItems);
+    }
+}

--- a/src/Microsoft.DotNet.Helix/JobMonitor/TestResultUploadQueue.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/TestResultUploadQueue.cs
@@ -64,7 +64,14 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             }
 
             _logger.LogInformation("Waiting for {Count} pending test result upload(s) to complete.", _pending.Count);
-            await Task.WhenAll(_pending);
+            try
+            {
+                await Task.WhenAll(_pending).WaitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                // One or more upload tasks were cancelled; treat as best-effort drained.
+            }
             Prune();
         }
 

--- a/src/Microsoft.DotNet.Helix/JobMonitor/TestResultUploadQueue.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/TestResultUploadQueue.cs
@@ -1,0 +1,137 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Helix.Client.Models;
+using Microsoft.DotNet.Helix.JobMonitor.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.Helix.JobMonitor
+{
+    /// <summary>
+    /// Fire-and-forget queue for AzDO test-result uploads. Each queued upload runs as an
+    /// independent task with indefinite retry on transient errors. Both normal completion
+    /// and cancellation paths must drain the queue before exiting so that results in
+    /// flight when the runner exits are not abandoned.
+    /// </summary>
+    internal sealed class TestResultUploadQueue
+    {
+        private readonly ILogger _logger;
+        private readonly JobMonitorOptions _options;
+        private readonly IAzureDevOpsService _azdo;
+        private readonly IHelixService _helix;
+        private readonly Func<CancellationToken, Task> _delay;
+        private readonly List<Task> _pending = [];
+
+        public TestResultUploadQueue(
+            ILogger logger,
+            JobMonitorOptions options,
+            IAzureDevOpsService azdo,
+            IHelixService helix,
+            Func<CancellationToken, Task> delay)
+        {
+            _logger = logger;
+            _options = options;
+            _azdo = azdo;
+            _helix = helix;
+            _delay = delay;
+        }
+
+        public void Enqueue(HelixJobInfo helixJob, IReadOnlyCollection<WorkItemSummary> workItems, CancellationToken cancellationToken)
+        {
+            IReadOnlyList<string> workItemNames = [.. workItems.Select(w => w.Name)];
+            // Detached from the runner's cancellation token so that the drain path can finish
+            // in-flight uploads on its own cancellation budget when the runner is canceled.
+            Task uploadTask = Task.Run(() => UploadAsync(helixJob, workItemNames, cancellationToken), CancellationToken.None);
+            _pending.Add(uploadTask);
+        }
+
+        public void Prune()
+        {
+            _pending.RemoveAll(static task => task.IsCompleted);
+        }
+
+        public async Task DrainAsync(CancellationToken cancellationToken)
+        {
+            Prune();
+            if (_pending.Count == 0)
+            {
+                return;
+            }
+
+            _logger.LogInformation("Waiting for {Count} pending test result upload(s) to complete.", _pending.Count);
+            await Task.WhenAll(_pending);
+            Prune();
+        }
+
+        private async Task UploadAsync(
+            HelixJobInfo helixJob,
+            IReadOnlyCollection<string> workItemNames,
+            CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                int testRunId = 0;
+
+                try
+                {
+                    testRunId = await _azdo.CreateTestRunAsync(helixJob.TestRunName, helixJob.JobName, cancellationToken);
+                    IReadOnlyList<WorkItemTestResults> downloaded = await _helix.DownloadTestResultsAsync(
+                        helixJob.JobName,
+                        workItemNames,
+                        _options.WorkingDirectory,
+                        cancellationToken);
+
+                    int uploadedCount = await _azdo.UploadTestResultsAsync(testRunId, downloaded, cancellationToken);
+                    await CompleteTestRunAsync(testRunId, helixJob, cancellationToken);
+
+                    _logger.LogInformation("{UploadedCount} test results for job '{JobName}' processed.",
+                        uploadedCount,
+                        helixJob.DisplayName);
+                    return;
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex,
+                        "Failed to upload test results for job {JobName} to Azure DevOps. Test run ID was {TestRunId}. Retrying after delay.",
+                        helixJob.DisplayName,
+                        testRunId);
+                    await _delay(cancellationToken);
+                }
+            }
+        }
+
+        private async Task CompleteTestRunAsync(int testRunId, HelixJobInfo helixJob, CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                try
+                {
+                    await _azdo.CompleteTestRunAsync(testRunId, cancellationToken);
+                    return;
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex,
+                        "Failed to complete Azure DevOps test run {TestRunId} for job {JobName}. Retrying after delay.",
+                        testRunId,
+                        helixJob.JobName);
+                    await _delay(cancellationToken);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Helix/JobMonitor/WorkItemExtensions.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/WorkItemExtensions.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.DotNet.Helix.Client.Models;
+
+namespace Microsoft.DotNet.Helix.JobMonitor
+{
+    internal static class WorkItemExtensions
+    {
+        extension(WorkItemSummary workItem)
+        {
+            /// <summary>
+            /// A Helix work item is considered failed if its exit code is non-zero
+            /// or its state is not the terminal success state ("Finished").
+            /// </summary>
+            public bool IsFailed => workItem.ExitCode != 0
+                || !workItem.State.Equals("Finished", StringComparison.OrdinalIgnoreCase);
+
+            /// <summary>
+            /// True while the work item is still in flight (no exit code yet and no
+            /// terminal Helix state).
+            /// </summary>
+            public bool IsUnfinished => !workItem.ExitCode.HasValue
+                && !string.Equals(workItem.State, "Finished", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(workItem.State, "Failed", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(workItem.State, "TimedOut", StringComparison.OrdinalIgnoreCase);
+
+            /// <summary>
+            /// True when the work item is failed and not still in flight. This is the
+            /// "worth reporting eagerly" signal used by the status logger.
+            /// </summary>
+            public bool IsFailedAndTerminal => workItem.IsFailed && !workItem.IsUnfinished;
+
+            public string FormattedState
+            {
+                get
+                {
+                    string exitCode = workItem.ExitCode.HasValue
+                        ? $", exit code {workItem.ExitCode.Value}"
+                        : string.Empty;
+                    return $"{workItem.State}{exitCode}";
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
All 47 JobMonitorRunner tests pass with the refactored code.

## Refactor summary

**Modules created (alongside the runner):**
- `WorkItemExtensions.cs` — promoted the previously file-scoped `WorkItemSummary` helpers (`IsFailed`, `IsUnfinished`, `IsFailedAndTerminal`, `FormattedState`) to an `internal static` class so all modules share them.
- `MonitorState.cs` — single mutable state container holding every dictionary/set/counter that used to live as private fields on the runner. Also hosts the lineage helpers (`GetLatestHelixJobAttempts`, `OrderHelixJobsOldToNew`, `GetSubmitterChainKey`, `GetConsoleOutputText`) plus the `FailedWorkItemConsoleInfo` record and `WorkItemOutcomeKeyComparer`.
- `StatusReporter.cs` — all log output (poll status tree, start/retry/final-summary lines, timeout reporting). Takes `MonitorState` by reference and reads from it directly.
- `TestResultUploadQueue.cs` — fire-and-forget upload queue with retry, prune, and drain. Encapsulates the previous `_uploadTasks` field plus its surrounding logic.

**Slim JobMonitorRunner.cs (~350 lines, was ~1050):**
- `RunAsync` → seeds state → `ExecuteRetryPassAsync` → `RunPollLoopAsync`, with one `catch (OperationCanceledException)` block that drains uploads + reports timeout + cancels in-flight jobs.
- `ExecuteRetryPassAsync` — one-shot resubmission of failed work items found on entry.
- `RunPollLoopAsync` + `PollOnceAsync` — main loop. Per-iteration cursor lives in a private `PollLoopState` holder class (avoids `ref` params on async methods).
- `PollOnceAsync` follows the design doc exactly: snapshot → observe → completed-detection → upload+reconcile new → reconcile lineage outcomes → prune → conditional status log → termination check.
- `ReconcileCompletedJobAsync` — single idempotent method (replaces the dual-purpose `ProcessCompletedJobAsync` with a clearer name).
- Dead code removed: `_options.TestResultUploadParallelism = 16;` (no effect — `AzureDevOpsService` captures the value in its constructor).
