### PR TITLE
Change VMR repository endpoint from 'dotnet' to 'public'

### DIFF
--- a/eng/common/templates/vmr-build-pr.yml
+++ b/eng/common/templates/vmr-build-pr.yml
@@ -33,7 +33,7 @@ resources:
   - repository: vmr
     type: github
     name: dotnet/dotnet
-    endpoint: dotnet
+    endpoint: public
     ref: refs/heads/main # Set to whatever VMR branch the PR build should insert into
 
 stages:


### PR DESCRIPTION
Porting the [same change made in msbuild](https://github.com/dotnet/msbuild/pull/13871/) to the common eng infra.
