### PR TITLE
JobMonitor: Preserve DockerTag/QueueAlias when resubmitting work items

### DIFF
--- a/src/Microsoft.DotNet.Helix/JobMonitor/Services/HelixService.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Services/HelixService.cs
@@ -23,6 +23,7 @@ namespace Microsoft.DotNet.Helix.JobMonitor
     {
         // Matches the "(alias)queueId" portion of a Helix target queue string. Mirrors the regex used by
         // JobDefinition.ParseQueueId in the Helix JobSender so resubmission parses queues identically.
+        // Part of the operatingSystem-property workaround; see ResolveTargetQueueSpec and dotnet/arcade#16964.
         private static readonly Regex s_queueAliasRegex = new(@"\((.+?)\)(.*)", RegexOptions.Compiled);
 
         private readonly ILogger _logger;
@@ -278,42 +279,19 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             string newJobListUri = AppendSasIfPresent(jobListBlobClient.Uri, container.ReadToken);
 
             // 5. Reconstruct the original target queue so the resubmitted work item runs in the same
-            //    execution environment (e.g. the same Docker container) as the original job.
-            //    Job.DetailsAsync only returns the resolved QueueId (Docker tag and queue alias stripped),
-            //    but the Helix SDK stamps the original TargetQueue string verbatim onto the
-            //    'operatingSystem' property (see Microsoft.DotNet.Helix.Sdk.MonoQueue.targets). We parse it
-            //    with the same logic the fresh submission path uses (JobDefinition.ParseQueueId) and fall
-            //    back to the resolved QueueId (no Docker tag/alias) when it is missing or unparseable.
-            string queueId = details.QueueId;
-            string dockerTag = null;
-            string queueAlias = null;
-
-            string originalTargetQueue = GetStringPropertyFromProperties(details.Properties, "operatingSystem");
-            if (!string.IsNullOrEmpty(originalTargetQueue))
-            {
-                (string parsedQueueId, string parsedDockerTag, string parsedQueueAlias) = ParseQueueId(originalTargetQueue);
-                if (!string.IsNullOrEmpty(parsedQueueId))
-                {
-                    queueId = parsedQueueId;
-                    dockerTag = parsedDockerTag;
-                    queueAlias = parsedQueueAlias;
-                }
-                else
-                {
-                    _logger.LogWarning(
-                        "Could not parse a queue id from the 'operatingSystem' property '{OperatingSystem}' of job '{JobName}'; resubmitting on resolved queue '{QueueId}' without a Docker tag.",
-                        originalTargetQueue, originalJobName, details.QueueId);
-                }
-            }
+            //    execution environment (e.g. the same Docker container) as the original job. The logic
+            //    used to recover the Docker tag / queue alias is intentionally isolated in a single
+            //    replaceable method (see ResolveTargetQueueSpec) because it is a temporary workaround.
+            TargetQueueSpec targetQueue = ResolveTargetQueueSpec(details, originalJobName);
 
             // 6. Build the new job creation request, copying over Source / Properties / Creator
             //    so the resubmitted job remains discoverable (BuildId, System.StageName, TestRunName, etc.).
-            var creationRequest = new JobCreationRequest(details.Type, newJobListUri, queueId)
+            var creationRequest = new JobCreationRequest(details.Type, newJobListUri, targetQueue.QueueId)
             {
                 Source = details.Source,
                 Creator = details.Creator,
-                DockerTag = dockerTag,
-                QueueAlias = queueAlias,
+                DockerTag = targetQueue.DockerTag,
+                QueueAlias = targetQueue.QueueAlias,
                 Properties = ConvertPropertiesToImmutableDictionary(details.Properties)
                     .SetItem(HelixJobInfo.PreviousHelixJobNamePropertyName, originalJobName),
             };
@@ -348,9 +326,49 @@ namespace Microsoft.DotNet.Helix.JobMonitor
             return newJobInfo;
         }
 
+        // ----------------------------------------------------------------------------------------------
+        // WORKAROUND (tracked by https://github.com/dotnet/arcade/issues/16964)
+        //
+        // Determines the (queueId, dockerTag, queueAlias) to resubmit a job into the SAME execution
+        // environment as the original. Today Job.DetailsAsync only returns the *resolved* QueueId; the
+        // Docker tag and queue alias are stripped from the response. We recover them from the
+        // 'operatingSystem' property, which the Helix SDK stamps with the verbatim
+        // "(alias)queueId@dockerTag" target-queue string (see Microsoft.DotNet.Helix.Sdk/MonoQueue.targets),
+        // re-parsing it with the same logic the fresh submission path uses (JobDefinition.ParseQueueId).
+        // We fall back to the resolved QueueId (no Docker tag/alias) when the property is missing or
+        // unparseable.
+        //
+        // This is the single seam that should change once dotnet-helix-service PR 61770 ships and
+        // Microsoft.DotNet.Helix.Client is regenerated to expose JobDetails.DockerTag /
+        // JobDetails.QueueAlias: replace the body below with a direct read of those fields, then delete
+        // ParseQueueId and s_queueAliasRegex.
+        // ----------------------------------------------------------------------------------------------
+        private TargetQueueSpec ResolveTargetQueueSpec(JobDetails details, string originalJobName)
+        {
+            string originalTargetQueue = GetStringPropertyFromProperties(details.Properties, "operatingSystem");
+            if (!string.IsNullOrEmpty(originalTargetQueue))
+            {
+                (string parsedQueueId, string parsedDockerTag, string parsedQueueAlias) = ParseQueueId(originalTargetQueue);
+                if (!string.IsNullOrEmpty(parsedQueueId))
+                {
+                    return new TargetQueueSpec(parsedQueueId, parsedDockerTag, parsedQueueAlias);
+                }
+
+                _logger.LogWarning(
+                    "Could not parse a queue id from the 'operatingSystem' property '{OperatingSystem}' of job '{JobName}'; resubmitting on resolved queue '{QueueId}' without a Docker tag.",
+                    originalTargetQueue, originalJobName, details.QueueId);
+            }
+
+            return new TargetQueueSpec(details.QueueId, DockerTag: null, QueueAlias: null);
+        }
+
+        // The execution-environment coordinates used to (re)submit a Helix job.
+        private readonly record struct TargetQueueSpec(string QueueId, string DockerTag, string QueueAlias);
+
         // Splits a Helix target queue string of the form "(alias)queueId@dockerTag" into its parts.
         // Mirrors JobDefinition.ParseQueueId in the Helix JobSender so a resubmitted job reconstructs the
         // same (queueId, dockerTag, queueAlias) tuple the fresh submission path produced.
+        // Part of the operatingSystem-property workaround; see ResolveTargetQueueSpec and dotnet/arcade#16964.
         private static (string queueId, string dockerTag, string queueAlias) ParseQueueId(string value)
         {
             int index = value.IndexOf('@');

--- a/src/Microsoft.DotNet.Helix/JobMonitor/Services/HelixService.cs
+++ b/src/Microsoft.DotNet.Helix/JobMonitor/Services/HelixService.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Arcade.Common;
@@ -20,6 +21,10 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 {
     internal sealed class HelixService : IHelixService
     {
+        // Matches the "(alias)queueId" portion of a Helix target queue string. Mirrors the regex used by
+        // JobDefinition.ParseQueueId in the Helix JobSender so resubmission parses queues identically.
+        private static readonly Regex s_queueAliasRegex = new(@"\((.+?)\)(.*)", RegexOptions.Compiled);
+
         private readonly ILogger _logger;
         private readonly IHelixApi _helixApi;
         private readonly IBlobClientFactory _blobClientFactory;
@@ -272,12 +277,43 @@ namespace Microsoft.DotNet.Helix.JobMonitor
 
             string newJobListUri = AppendSasIfPresent(jobListBlobClient.Uri, container.ReadToken);
 
-            // 5. Build the new job creation request, copying over Source / Properties / Creator
+            // 5. Reconstruct the original target queue so the resubmitted work item runs in the same
+            //    execution environment (e.g. the same Docker container) as the original job.
+            //    Job.DetailsAsync only returns the resolved QueueId (Docker tag and queue alias stripped),
+            //    but the Helix SDK stamps the original TargetQueue string verbatim onto the
+            //    'operatingSystem' property (see Microsoft.DotNet.Helix.Sdk.MonoQueue.targets). We parse it
+            //    with the same logic the fresh submission path uses (JobDefinition.ParseQueueId) and fall
+            //    back to the resolved QueueId (no Docker tag/alias) when it is missing or unparseable.
+            string queueId = details.QueueId;
+            string dockerTag = null;
+            string queueAlias = null;
+
+            string originalTargetQueue = GetStringPropertyFromProperties(details.Properties, "operatingSystem");
+            if (!string.IsNullOrEmpty(originalTargetQueue))
+            {
+                (string parsedQueueId, string parsedDockerTag, string parsedQueueAlias) = ParseQueueId(originalTargetQueue);
+                if (!string.IsNullOrEmpty(parsedQueueId))
+                {
+                    queueId = parsedQueueId;
+                    dockerTag = parsedDockerTag;
+                    queueAlias = parsedQueueAlias;
+                }
+                else
+                {
+                    _logger.LogWarning(
+                        "Could not parse a queue id from the 'operatingSystem' property '{OperatingSystem}' of job '{JobName}'; resubmitting on resolved queue '{QueueId}' without a Docker tag.",
+                        originalTargetQueue, originalJobName, details.QueueId);
+                }
+            }
+
+            // 6. Build the new job creation request, copying over Source / Properties / Creator
             //    so the resubmitted job remains discoverable (BuildId, System.StageName, TestRunName, etc.).
-            var creationRequest = new JobCreationRequest(details.Type, newJobListUri, details.QueueId)
+            var creationRequest = new JobCreationRequest(details.Type, newJobListUri, queueId)
             {
                 Source = details.Source,
                 Creator = details.Creator,
+                DockerTag = dockerTag,
+                QueueAlias = queueAlias,
                 Properties = ConvertPropertiesToImmutableDictionary(details.Properties)
                     .SetItem(HelixJobInfo.PreviousHelixJobNamePropertyName, originalJobName),
             };
@@ -310,6 +346,29 @@ namespace Microsoft.DotNet.Helix.JobMonitor
                 HelixJobInfo.GetDetailsUri(newJob.Name));
 
             return newJobInfo;
+        }
+
+        // Splits a Helix target queue string of the form "(alias)queueId@dockerTag" into its parts.
+        // Mirrors JobDefinition.ParseQueueId in the Helix JobSender so a resubmitted job reconstructs the
+        // same (queueId, dockerTag, queueAlias) tuple the fresh submission path produced.
+        private static (string queueId, string dockerTag, string queueAlias) ParseQueueId(string value)
+        {
+            int index = value.IndexOf('@');
+            if (index < 0)
+            {
+                return (value, string.Empty, value);
+            }
+
+            string queueInfo = value.Substring(0, index);
+            string dockerTag = value.Substring(index + 1);
+
+            Match queueInfoSplit = s_queueAliasRegex.Match(queueInfo);
+            if (queueInfoSplit.Success && queueInfoSplit.Groups.Count == 3)
+            {
+                return (queueInfoSplit.Groups[2].Value, dockerTag, queueInfoSplit.Groups[1].Value);
+            }
+
+            return (queueInfo, dockerTag, queueInfo);
         }
 
         private static ImmutableDictionary<string, string> ConvertPropertiesToImmutableDictionary(JToken properties)

--- a/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelixServiceTests.cs
+++ b/src/Microsoft.DotNet.Helix/Sdk.Tests/Microsoft.DotNet.Helix.Sdk.Tests/HelixServiceTests.cs
@@ -242,6 +242,8 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
             Assert.False(string.IsNullOrEmpty(capturedIdempotencyKey));
             Assert.Equal("helix-type", capturedRequest.Type);
             Assert.Equal("queue-id", capturedRequest.QueueId);
+            Assert.Null(capturedRequest.DockerTag);
+            Assert.Null(capturedRequest.QueueAlias);
             Assert.Equal("https://account.blob.core.windows.net/container/job-list.json?read", capturedRequest.ListUri);
             Assert.Equal("source", capturedRequest.Source);
             Assert.Equal("creator", capturedRequest.Creator);
@@ -255,6 +257,108 @@ namespace Microsoft.DotNet.Helix.Sdk.Tests
                 It.Is<ContainerCreationRequest>(r => r.ExpirationInDays == 30 && r.DesiredName == "joblists" && r.TargetQueue == "queue-id"),
                 It.IsAny<CancellationToken>()),
                 Times.Once);
+        }
+
+        [Fact]
+        public async Task ResubmitWorkItemsAsync_PreservesDockerTagAndQueueAliasFromOperatingSystemProperty()
+        {
+            JobCreationRequest request = await ResubmitAndCaptureRequestAsync(
+                "(AlmaLinux.9.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-9-helix-amd64");
+
+            Assert.Equal("Ubuntu.2204.Amd64.Open", request.QueueId);
+            Assert.Equal("AlmaLinux.9.Amd64.Open", request.QueueAlias);
+            Assert.Equal("mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-9-helix-amd64", request.DockerTag);
+        }
+
+        [Fact]
+        public async Task ResubmitWorkItemsAsync_DockerQueueWithoutAliasPreservesDockerTag()
+        {
+            JobCreationRequest request = await ResubmitAndCaptureRequestAsync(
+                "ubuntu.2204.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-9-helix-amd64");
+
+            Assert.Equal("ubuntu.2204.amd64.open", request.QueueId);
+            Assert.Equal("ubuntu.2204.amd64.open", request.QueueAlias);
+            Assert.Equal("mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-9-helix-amd64", request.DockerTag);
+        }
+
+        [Fact]
+        public async Task ResubmitWorkItemsAsync_NonDockerOperatingSystemSetsQueueAliasAndEmptyDockerTag()
+        {
+            JobCreationRequest request = await ResubmitAndCaptureRequestAsync("Ubuntu.2204.Amd64.Open");
+
+            Assert.Equal("Ubuntu.2204.Amd64.Open", request.QueueId);
+            Assert.Equal("Ubuntu.2204.Amd64.Open", request.QueueAlias);
+            Assert.Equal(string.Empty, request.DockerTag);
+        }
+
+        [Fact]
+        public async Task ResubmitWorkItemsAsync_FallsBackToResolvedQueueWhenOperatingSystemUnparseable()
+        {
+            JobCreationRequest request = await ResubmitAndCaptureRequestAsync("@mcr.microsoft.com/only-a-docker-tag");
+
+            Assert.Equal("queue-id", request.QueueId);
+            Assert.Null(request.DockerTag);
+            Assert.Null(request.QueueAlias);
+        }
+
+        private static async Task<JobCreationRequest> ResubmitAndCaptureRequestAsync(string operatingSystem)
+        {
+            var api = CreateApi();
+            var properties = new JObject
+            {
+                ["BuildId"] = "123",
+                ["TestRunName"] = "custom run",
+                ["System.StageName"] = "test stage",
+            };
+            if (operatingSystem != null)
+            {
+                properties["operatingSystem"] = operatingSystem;
+            }
+
+            api.Job
+                .Setup(j => j.DetailsAsync("original-job", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new JobDetails("https://storage/job-list.json", null, "original-job", "wait", "source", "helix-type", "build")
+                {
+                    Creator = "creator",
+                    QueueId = "queue-id",
+                    Properties = properties,
+                });
+            api.Storage
+                .Setup(s => s.NewAsync(It.IsAny<ContainerCreationRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ContainerInformation(
+                    DateTimeOffset.Parse("2026-04-30T00:00:00Z"),
+                    DateTimeOffset.Parse("2026-05-30T00:00:00Z"),
+                    "creator",
+                    "container",
+                    "account",
+                    Guid.Empty,
+                    "region")
+                {
+                    ReadToken = "?read",
+                    WriteToken = "?write",
+                });
+
+            JobCreationRequest capturedRequest = null;
+            api.Job
+                .Setup(j => j.NewAsync(It.IsAny<JobCreationRequest>(), It.IsAny<string>(), null, It.IsAny<CancellationToken>()))
+                .Callback<JobCreationRequest, string, bool?, CancellationToken>((request, _, _, _) => capturedRequest = request)
+                .ReturnsAsync(new JobCreationResult("new-job", "summary", "results", null));
+
+            var blobClientFactory = new FakeBlobClientFactory
+            {
+                DownloadedText = """
+                [
+                  { "WorkItemId": "work-a", "Command": "run a", "PayloadUri": "payload-a" }
+                ]
+                """,
+                UploadedBlobUri = new Uri("https://account.blob.core.windows.net/container/job-list.json"),
+            };
+
+            await CreateService(api.Api.Object, blobClientFactory)
+                .ResubmitWorkItemsAsync(new HelixJobInfo("original-job", "finished"), [WorkItem("work-a")], CancellationToken.None);
+
+            Assert.NotNull(capturedRequest);
+            return capturedRequest;
         }
 
         private static HelixService CreateService(IHelixApi api, IBlobClientFactory blobClientFactory = null, IFileSystem fileSystem = null)


### PR DESCRIPTION
## Summary

Fixes #16961.

When the `JobMonitor` resubmits failed Helix work items, it builds the `JobCreationRequest` using only the resolved `QueueId` from `Job.DetailsAsync` (which has the Docker tag and queue alias stripped). As a result, a work item that originally ran **inside a Docker container** was re-run on the **bare host queue** — the wrong execution environment.

## Fix

The Helix SDK MSBuild targets stamp the original target queue string verbatim onto the job''s `operatingSystem` property (`HelixProperties Include="operatingSystem" Value="$(HelixTargetQueue)"` in `Microsoft.DotNet.Helix.Sdk.MonoQueue.targets`), in the `(alias)queueId@dockerTag` form. This is the same string the fresh submission path parses.

`HelixService.ResubmitWorkItemsAsync` now:
- Reads the `operatingSystem` property and parses it with the same logic the fresh submission path uses (`JobDefinition.ParseQueueId`), setting `QueueId`, `DockerTag`, and `QueueAlias` consistently — matching what a fresh Helix SDK submission would send.
- Falls back to the resolved `QueueId` with no Docker tag/alias when the property is absent or unparseable (preserving prior behavior).

This was validated to be the correct source of truth: `Job.DetailsAsync` does not expose `DockerTag`/`QueueAlias`, but the `operatingSystem` property is an exact copy of the original `TargetQueue`.

## Tests

Added unit tests in `HelixServiceTests` covering:
- Docker queue with alias → preserves `QueueId`, `QueueAlias`, `DockerTag`.
- Docker queue without alias → preserves `QueueId` and `DockerTag`.
- Non-Docker queue → sets `QueueId`/`QueueAlias`, empty `DockerTag` (mirrors fresh submission).
- Missing/unparseable `operatingSystem` → falls back to resolved `QueueId` with null Docker tag/alias.

All 126 tests in `Microsoft.DotNet.Helix.Sdk.Tests` pass.

## Notes

`ResultContainerPrefix` (also not copied on resubmission) is intentionally left out of scope per discussion on #16907 — it does not affect queue/Docker selection.
